### PR TITLE
server:package paths and artifact names; VS Code installer and connec…

### DIFF
--- a/apps/vscode/src/connection/connection.ts
+++ b/apps/vscode/src/connection/connection.ts
@@ -189,8 +189,7 @@ export class ConnectionManager extends EventEmitter {
 			return;
 		}
 
-		const wsUrl = this.configManager.getWebSocketUrl();
-		this.logger.output(`${icons.connecting} Connecting to ${wsUrl}...`);
+		this.logger.output(`${icons.connecting} Connecting...`);
 
 		this.updateConnectionStatus({
 			state: ConnectionState.CONNECTING,
@@ -291,7 +290,10 @@ export class ConnectionManager extends EventEmitter {
 	}
 
 	private async _connectClientWithRetries(): Promise<void> {
-		this.updateConnectionStatus({ state: ConnectionState.CONNECTING });
+		this.updateConnectionStatus({
+			state: ConnectionState.CONNECTING,
+			progressMessage: undefined
+		});
 
 		// Clean up any previous client
 		if (this.client) {
@@ -304,6 +306,9 @@ export class ConnectionManager extends EventEmitter {
 
 		while (attempts < maxAttempts && this.connectionStatus.state === 'connecting') {
 			try {
+				if (attempts > 0) {
+					this.updateConnectionStatus({ progressMessage: 'Attempting connection...' });
+				}
 				this.client = this.createClient();
 				await this.client.connect(5000);
 				this.onConnectionEstablished();
@@ -318,18 +323,19 @@ export class ConnectionManager extends EventEmitter {
 					this.client = undefined;
 				}
 
-				if (!this.retryingMessageShown) {
-					this.logger.output(`${icons.loading} Retrying connection...`);
-					this.retryingMessageShown = true;
-				}
-
 				if (attempts >= maxAttempts) {
 					const msg = error instanceof Error ? error.message : String(error);
+					this.logger.output(`${icons.error} Connection failed after ${maxAttempts} attempts: ${msg}`);
 					throw new Error(`Connection failed after ${maxAttempts} attempts: ${msg}`);
 				}
 
 				if (this.connectionStatus.state === 'connecting') {
 					const delayMs = this.getBackoffDelayMs(attempts - 1);
+					const delaySec = Math.round(delayMs / 1000);
+					this.logger.output(`${icons.info} Connection attempt ${attempts} failed, waiting ${delaySec}s...`);
+					this.updateConnectionStatus({
+						progressMessage: `Waiting ${delaySec}s before next attempt`
+					});
 					await this.delay(delayMs);
 				}
 			}
@@ -355,7 +361,7 @@ export class ConnectionManager extends EventEmitter {
 
 		const executablePath = this.engineInstaller!.getExecutablePath();
 
-		this.logger.output(`${icons.launch} Starting local engine at ${config.local.host}:${config.local.port}`);
+		this.logger.output(`${icons.launch} Starting local server at ${config.local.host}:${config.local.port}`);
 
 		if (this.dapServer) {
 			this.dapServer.removeAllListeners();
@@ -376,11 +382,11 @@ export class ConnectionManager extends EventEmitter {
 			await this.dapServer.startServer(executablePath, args);
 
 			this.dapServer.on('terminated', (details) => {
-				this.logger.output(`${icons.warning} Local engine terminated (code=${details.code}, signal=${details.signal})`);
+				this.logger.output(`${icons.warning} Local server terminated (code=${details.code}, signal=${details.signal})`);
 				this.handleConnectionLoss();
 			});
 
-			this.logger.output(`${icons.success} Local engine started and ready`);
+			this.logger.output(`${icons.success} Local server started`);
 		} catch (error) {
 			this.updateConnectionStatus({ state: ConnectionState.DISCONNECTED });
 			throw error;
@@ -392,7 +398,8 @@ export class ConnectionManager extends EventEmitter {
 			state: ConnectionState.CONNECTED,
 			lastConnected: new Date(),
 			lastError: undefined,
-			retryAttempt: 0
+			retryAttempt: 0,
+			progressMessage: undefined
 		});
 
 		this.resetRetryState();
@@ -436,6 +443,7 @@ export class ConnectionManager extends EventEmitter {
 		}
 
 		const errorMessage = error instanceof Error ? error.message : String(error);
+		this.logger.output(`${icons.error} ${errorMessage}`);
 
 		const shouldReconnect = !this.isManualDisconnect &&
 			this.connectionStatus.hasCredentials &&
@@ -477,15 +485,18 @@ export class ConnectionManager extends EventEmitter {
 			return;
 		}
 
-		if (this.connectionStatus.retryAttempt === 0) {
-			this.logger.output(`${icons.info} Waiting for connection...`);
-		}
-
 		const delayMs = this.getBackoffDelayMs(this.connectionStatus.retryAttempt);
+		const delaySec = Math.round(delayMs / 1000);
+		this.logger.output(`${icons.info} Waiting ${delaySec}s before retrying...`);
+		this.updateConnectionStatus({
+			progressMessage: `Waiting ${delaySec}s before next attempt`
+		});
 		this.reconnectTimeout = setTimeout(async () => {
 			if (this.connectionStatus.state === 'connecting' && !this.isManualDisconnect && !this.isDisposing) {
+				this.logger.output(`${icons.connecting} Reconnecting...`);
 				this.updateConnectionStatus({
-					retryAttempt: this.connectionStatus.retryAttempt + 1
+					retryAttempt: this.connectionStatus.retryAttempt + 1,
+					progressMessage: 'Attempting connection...'
 				});
 
 				try {
@@ -647,7 +658,7 @@ export class ConnectionManager extends EventEmitter {
 		if (this.dapServer) {
 			this.updateConnectionStatus({ state: ConnectionState.STOPPING_ENGINE });
 
-			this.logger.output(`${icons.stop} Stopping local engine...`);
+			this.logger.output(`${icons.stop} Stopping local server...`);
 
 			this.dapServer.removeAllListeners();
 			this.dapServer.stopServer();

--- a/apps/vscode/src/connection/engine-installer.ts
+++ b/apps/vscode/src/connection/engine-installer.ts
@@ -55,7 +55,7 @@ interface PlatformInfo {
 }
 
 export class EngineInstaller {
-	private static readonly GITHUB_OWNER = 'rocketride-ai';
+	private static readonly GITHUB_OWNER = 'rocketride-org';
 	private static readonly GITHUB_REPO = 'rocketride-server';
 
 	private readonly engineDir: string;
@@ -114,7 +114,7 @@ export class EngineInstaller {
 		token?: vscode.CancellationToken,
 		githubToken?: string
 	): Promise<string> {
-		this.logger.output(`${icons.info} Engine not found, downloading latest release...`);
+		this.logger.output(`${icons.info} Server not found locally, downloading...`);
 
 		// Fetch latest release info from GitHub
 		progress?.report({ message: 'Fetching latest release info...' });
@@ -138,7 +138,7 @@ export class EngineInstaller {
 			fs.mkdirSync(this.engineDir, { recursive: true });
 
 			// Extract
-			progress?.report({ message: 'Extracting engine...' });
+			progress?.report({ message: 'Extracting server...' });
 			await this.extractArchive(tmpPath, this.engineDir);
 
 			// Set executable permissions on Unix
@@ -151,8 +151,8 @@ export class EngineInstaller {
 				);
 			}
 
-			this.logger.output(`${icons.success} Engine installed successfully at ${this.engineDir}`);
-			progress?.report({ message: 'Engine ready!' });
+			this.logger.output(`${icons.success} Server installed at ${this.engineDir}`);
+			progress?.report({ message: 'Server ready!' });
 
 			return this.getExecutablePath();
 		} finally {
@@ -171,18 +171,24 @@ export class EngineInstaller {
 		this.throwIfCancelled(token);
 
 		const octokit = await this.createOctokit(githubToken);
-		const { data } = await octokit.repos.getLatestRelease({
+		const { data } = await octokit.repos.listReleases({
 			owner: EngineInstaller.GITHUB_OWNER,
-			repo: EngineInstaller.GITHUB_REPO
+			repo: EngineInstaller.GITHUB_REPO,
+			per_page: 1
 		});
 
-		if (!data.tag_name || !data.assets || data.assets.length === 0) {
-			throw new Error('Invalid release data from GitHub API');
+		if (data.length === 0) {
+			throw new Error('No releases found on GitHub');
+		}
+
+		const release = data[0];
+		if (!release.tag_name || !release.assets || release.assets.length === 0) {
+			throw new Error(`Release ${release.tag_name} has no assets`);
 		}
 
 		return {
-			tag_name: data.tag_name,
-			assets: data.assets.map(a => ({
+			tag_name: release.tag_name,
+			assets: release.assets.map(a => ({
 				id: a.id,
 				name: a.name,
 				browser_download_url: a.browser_download_url,
@@ -209,7 +215,7 @@ export class EngineInstaller {
 
 	private getPlatformAssetName(tagName: string): string {
 		const info = this.getPlatformInfo();
-		return `engine-${tagName}-${info.name}.${info.ext}`;
+		return `rocketride-${tagName}-${info.name}.${info.ext}`;
 	}
 
 	private findPlatformAsset(release: ReleaseInfo): ReleaseAsset {

--- a/apps/vscode/src/providers/SidebarConnectionProvider.ts
+++ b/apps/vscode/src/providers/SidebarConnectionProvider.ts
@@ -265,14 +265,17 @@ export class SidebarConnectionProvider implements vscode.TreeDataProvider<Connec
 			items.push(errorItem);
 		}
 
-		// Show progress message (e.g. download progress) during connecting states
-		if (connectionState.progressMessage && this.isConnectingState(connectionState.state)) {
-			const progressItem = new ConnectionItem(
-				connectionState.progressMessage,
-				vscode.TreeItemCollapsibleState.None,
-				'progress-detail'
-			);
-			items.push(progressItem);
+		// Show detail line during connecting states: progressMessage or state-based fallback
+		if (this.isConnectingState(connectionState.state)) {
+			const detail = connectionState.progressMessage || this.getStateDetail(connectionState);
+			if (detail) {
+				const progressItem = new ConnectionItem(
+					detail,
+					vscode.TreeItemCollapsibleState.None,
+					'progress-detail'
+				);
+				items.push(progressItem);
+			}
 		}
 
 		// Blank line after status/retry info
@@ -353,6 +356,27 @@ export class SidebarConnectionProvider implements vscode.TreeDataProvider<Connec
 	}
 
 	/**
+	 * Returns a detail string describing what is happening in the current state
+	 */
+	private getStateDetail(connectionState: ConnectionStatus): string {
+		switch (connectionState.state) {
+			case 'downloading-engine':
+				return 'Downloading server...';
+			case 'starting-engine':
+				return 'Starting server...';
+			case 'connecting':
+				if (connectionState.retryAttempt > 0) {
+					return 'Retrying...';
+				}
+				return 'Connecting to server...';
+			case 'stopping-engine':
+				return 'Stopping server...';
+			default:
+				return '';
+		}
+	}
+
+	/**
 	 * Generates status label with animated dots for connecting states
 	 */
 	private getStatusLabel(connectionState: ConnectionStatus): string {
@@ -370,29 +394,19 @@ export class SidebarConnectionProvider implements vscode.TreeDataProvider<Connec
 
 		switch (connectionState.state) {
 			case 'connected':
-				return `Connected (${connectionState.connectionMode})`;
+				return 'Connected';
 
-			case 'downloading-engine': {
-				const downloadingDots = getConnectingDots(connectionState.retryAttempt);
-				return `Downloading Engine${downloadingDots}`;
-			}
-
-			case 'starting-engine': {
-				const startingDots = getConnectingDots(connectionState.retryAttempt);
-				return `Starting Engine${startingDots}`;
-			}
-
-			case 'connecting': {
+			case 'downloading-engine':
+			case 'starting-engine':
+			case 'connecting':
+			case 'stopping-engine': {
 				const connectingDots = getConnectingDots(connectionState.retryAttempt);
 				return `Connecting${connectingDots}`;
 			}
 
-			case 'stopping-engine':
-				return `Stopping Engine...`;
-
 			case 'disconnected':
 			default:
-				return `Disconnected`;
+				return 'Disconnected';
 		}
 	}
 
@@ -425,26 +439,26 @@ export class SidebarConnectionProvider implements vscode.TreeDataProvider<Connec
 				return `Successfully connected to ${config.hostUrl} in ${connectionState.connectionMode} mode`;
 
 			case 'downloading-engine':
-				return 'Downloading engine from GitHub releases...';
+				return 'Downloading RocketRide server from GitHub releases...';
 
 			case 'starting-engine':
-				return 'Starting local engine process...';
+				return 'Starting local RocketRide server...';
 
 			case 'connecting':
 				if (connectionState.connectionMode === 'local') {
 					if (connectionState.retryAttempt > 0) {
-						return `Engine started, retrying WebSocket connection (attempt ${connectionState.retryAttempt}/${connectionState.maxRetryAttempts})...`;
+						return 'Server started, retrying connection...';
 					}
-					return 'Engine started, connecting to WebSocket...';
+					return 'Server started, connecting...';
 				} else {
 					if (connectionState.retryAttempt > 0) {
-						return `Retrying connection (attempt ${connectionState.retryAttempt}/${connectionState.maxRetryAttempts})...`;
+						return 'Retrying connection...';
 					}
 					return 'Connecting to server...';
 				}
 
 			case 'stopping-engine':
-				return 'Stopping local engine process...';
+				return 'Stopping local RocketRide server...';
 
 			case 'disconnected':
 			default:

--- a/apps/vscode/src/providers/views/PageConnection/PageConnection.tsx
+++ b/apps/vscode/src/providers/views/PageConnection/PageConnection.tsx
@@ -105,20 +105,14 @@ export const PageConnection: React.FC = () => {
 	const getStatusLabel = (): string => {
 		if (!connectionData) return 'Loading...';
 
-		const { state, connectionMode } = connectionData.connectionState;
-		const modeLabel = connectionMode === 'onprem' ? 'On-prem' : connectionMode === 'cloud' ? 'Cloud' : 'Local';
-
-		switch (state) {
+		switch (connectionData.connectionState.state) {
 			case 'connected':
-				return `Connected (${modeLabel})`;
+				return 'Connected';
 			case 'downloading-engine':
-				return `Downloading Engine${getAnimatedDots()}`;
 			case 'starting-engine':
-				return `Starting Engine${getAnimatedDots()}`;
 			case 'connecting':
-				return `Connecting${getAnimatedDots()}`;
 			case 'stopping-engine':
-				return 'Stopping Engine...';
+				return `Connecting${getAnimatedDots()}`;
 			case 'disconnected':
 			default:
 				return 'Disconnected';
@@ -159,13 +153,32 @@ export const PageConnection: React.FC = () => {
 		}
 	};
 
-	/** Single line for status detail: "" -> "Fetching..." -> "No release info." (or short error). Keeps layout stable. */
 	const getStatusDetailLine = (): string => {
 		if (!connectionData) return '';
-		const { lastError, progressMessage } = connectionData.connectionState;
-		const connecting = isConnecting;
-		if (connecting && progressMessage) return progressMessage;
-		if (connecting && lastError) {
+		const { state, lastError, progressMessage } = connectionData.connectionState;
+
+		// Show progressMessage first if available (e.g. download progress, retry wait)
+		if (isConnecting && progressMessage) return progressMessage;
+
+		// State-specific detail
+		switch (state) {
+			case 'downloading-engine':
+				return 'Downloading server...';
+			case 'starting-engine':
+				return 'Starting server...';
+			case 'connecting':
+				if (connectionData.connectionState.retryAttempt > 0) {
+					return 'Retrying...';
+				}
+				return 'Connecting to server...';
+			case 'stopping-engine':
+				return 'Stopping server...';
+			default:
+				break;
+		}
+
+		// Show error for connecting states
+		if (isConnecting && lastError) {
 			const lower = lastError.toLowerCase();
 			if (lower.includes('rate limit') || lower.includes('github')) return 'No release info.';
 			return lastError.length > 40 ? lastError.slice(0, 37) + '...' : lastError;
@@ -248,7 +261,7 @@ export const PageConnection: React.FC = () => {
 							onClick={handleConnect}
 							disabled={isConnecting || needsApiKeySetup}
 						>
-							{isConnecting ? 'Connecting...' : 'Connect'}
+							Connect
 						</button>
 					)}
 			<button

--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -13,8 +13,8 @@ from fastapi.responses import HTMLResponse, PlainTextResponse
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.routing import compile_path
 from rocketlib import debug
-from ai.constants import CONST_DEFAULT_WEB_PORT, CONST_DEFAULT_WEB_HOST, CONST_WEB_WS_MAX_SIZE
 from rocketride import CONST_WS_PING_INTERVAL, CONST_WS_PING_TIMEOUT
+from ai.constants import CONST_DEFAULT_WEB_PORT, CONST_DEFAULT_WEB_HOST, CONST_WEB_WS_MAX_SIZE
 from ai.web import exception, error, Result
 from ai.account import Account, AccountInfo, Reporter
 from .middleware import AuthMiddleware

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -23,7 +23,8 @@ const PACKAGES_DIR = path.join(PROJECT_ROOT, 'packages');
 const SERVER_DIR = path.join(PACKAGES_DIR, 'server');
 const DIST_DIR = path.join(PROJECT_ROOT, 'dist', 'server');
 const VCPKG_DIR = path.join(BUILD_DIR, 'vcpkg');
-const ARTIFACTS_DIR = path.join(PROJECT_ROOT, 'artifacts');
+const BUILD_ARTIFACTS_DIR = path.join(PROJECT_ROOT, 'build', 'artifacts');
+const DIST_ARTIFACTS_DIR = path.join(PROJECT_ROOT, 'dist', 'artifacts');
 
 // Get package info (loaded async)
 let VERSION = '0.0.0';
@@ -1014,7 +1015,8 @@ function makeCleanServerAction() {
                 path.join(BUILD_DIR, 'engine-lib'),
                 path.join(BUILD_DIR, 'packages'),
                 path.join(BUILD_DIR, '_download_temp'),
-                ARTIFACTS_DIR,
+                BUILD_ARTIFACTS_DIR,
+                DIST_ARTIFACTS_DIR,
                 DIST_DIR
             ]);
 
@@ -1100,13 +1102,13 @@ function makePackageAction(options = {}) {
         run: async (_ctx, _task) => {
             const { version } = await loadPackageJson();
             const platform = getPlatformInfo(options);
-            const distFilename = `engine-v${version}-${platform.name}.${platform.ext}`;
-            const distPath = path.join(ARTIFACTS_DIR, distFilename);
-            const symDistPath = isWindows() ? path.join(ARTIFACTS_DIR, `engine-v${version}-${platform.name}.symbols.${platform.ext}`) : null;
+            const distFilename = `rocketride-v${version}-${platform.name}.${platform.ext}`;
+            const distPath = path.join(DIST_ARTIFACTS_DIR, distFilename);
+            const symDistPath = isWindows() ? path.join(DIST_ARTIFACTS_DIR, `rocketride-v${version}-${platform.name}.symbols.${platform.ext}`) : null;
             const symFilename = isWindows() ? 'engine.pdb' : null;
 
             // temp dir for packaging
-            options.destDir = path.join(ARTIFACTS_DIR, `engine-v${version}-${platform.name}`);
+            options.destDir = path.join(BUILD_ARTIFACTS_DIR, `rocketride-v${version}-${platform.name}`);
 
             const sourceHash = await getState('server.srcHash');
             const packageHash = await getState('server.pkgHash');
@@ -1131,7 +1133,7 @@ function makePackageAction(options = {}) {
                     syncDir(path.join(DIST_DIR, 'java'), path.join(options.destDir, 'java')),
                     syncDir(path.join(PROJECT_ROOT, 'nodes', 'src', 'nodes'), path.join(options.destDir, 'nodes')),
                     syncDir(path.join(PACKAGES_DIR, 'ai', 'src', 'ai'), path.join(options.destDir, 'ai')),
-                    syncDir(path.join(PACKAGES_DIR, 'client-python', 'src', 'clients', 'python'), path.join(options.destDir, 'clients', 'python')),
+                    syncDir(path.join(PACKAGES_DIR, 'client-python', 'src', 'rocketride'), path.join(options.destDir, 'rocketride')),
                     (async(options) => {
                         const exeExt = isWindows() ? '.exe' : '';
                         const enginePaths = [
@@ -1149,6 +1151,7 @@ function makePackageAction(options = {}) {
                 _task.output = `Prepared files for packaging ${distFilename}`;
 
                 _task.output = `Packaging ${distFilename}...`;
+                await mkdir(DIST_ARTIFACTS_DIR);
                 await removeFile(distPath);
                 await createArchive(distPath, options.destDir, ".");
                 _task.output = `Packaged ${distFilename}`;
@@ -1169,10 +1172,8 @@ function makePackageAction(options = {}) {
                     await removeFile(symDistPath);
                 }
                 throw err;
-
-            } finally {
-                await removeDir(options.destDir);
             }
+            // Leave options.destDir (./build/artifacts/rocketride-v*...) in place for testing
         }
     };
 }


### PR DESCRIPTION
…tion UX

Server package (server:package)
------------------------------
- Staging dir: ./artifacts → ./build/artifacts (BUILD_ARTIFACTS_DIR). Output archives: ./artifacts → ./dist/artifacts (DIST_ARTIFACTS_DIR). Why: Keep build staging under ./build and distributable outputs under ./dist so artifact layout matches common conventions and is easier to .gitignore.
- Artifact names: engine-v* → rocketride-v* (e.g. rocketride-v3.2.0-win64.zip). Why: Align artifact naming with product name and avoid confusion with generic "engine" in logs and release pages.
- Package Python client from packages/client-python/src/rocketride into package dir rocketride/ (was clients/python). Why: Python client was renamed to the rocketride package; package layout must match so the server can import it at runtime.
- Create ./dist/artifacts before writing archives. Why: Ensures the output directory exists so createArchive does not fail.
- Do not remove staging dir after package; leave ./build/artifacts/rocketride-v*/ in place for local testing. Why: Allows running and debugging the packaged server from disk without re-extracting the zip.
- server:clean: remove BUILD_ARTIFACTS_DIR and DIST_ARTIFACTS_DIR instead of ARTIFACTS_DIR. Why: Clean should remove the directories that server:package now uses.

VS Code engine installer
------------------------
- GitHub owner: rocketride-ai → rocketride-org. Why: Point at the correct GitHub org for releases.
- Fetch release via listReleases({ per_page: 1 }) instead of getLatestRelease. Why: Avoids relying on deprecated or inconsistent getLatestRelease behavior; first page of releases is the latest.
- Expected asset name: engine-* → rocketride-* (getPlatformAssetName) to match new server package artifacts. Why: Installer looks up release assets by exact name; published artifacts are now rocketride-v*.zip so the expected name must match.
- User-facing copy: "Engine" → "Server" (logs and progress). Why: Users see "RocketRide server"; "engine" is an internal term.

Connection manager and UI
--------------------------
- connection.ts: Stop logging full WebSocket URL on connect. Add progressMessage to connection status; log retry attempts, wait times, and errors; use "server" in logs instead of "engine". Why: Avoid logging sensitive or long URLs; give users clear feedback during retries and failures; consistent "server" wording.
- SidebarConnectionProvider: Add getStateDetail() for progress detail during connecting states; simplify status labels to "Connected" / "Disconnected" / "Connecting..."; tooltips say "RocketRide server" instead of "engine". Why: Single "Connecting" label with a detail line avoids label churn and keeps tooltips accurate and user-friendly.
- PageConnection: Status label is "Connected" (no mode); connecting states show "Connecting" + dots with state-based detail line; Connect button label stays "Connect". Why: Simpler status line; detail (e.g. "Downloading server...") is in the subline; button text does not need to change to "Connecting...".

AI web server
-------------
- server.py: Reorder imports (rocketride before ai.constants). Why: Satisfy linter/formatting (e.g. third-party before local).