### PR TITLE
Fix/client send objinfo

### DIFF
--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -857,8 +857,14 @@ export class RocketRideClient extends DAPClient {
 			throw new Error('data must be either a string or Uint8Array');
 		}
 
+		// Include size so parse filter does not skip as "empty"
+		const objinfoWithSize = {
+			...objinfo,
+			size: buffer.length,
+		};
+
 		// Create and use a temporary pipe for the data
-		const pipe = await this.pipe(token, objinfo, mimetype);
+		const pipe = await this.pipe(token, objinfoWithSize, mimetype);
 
 		try {
 			await pipe.open();


### PR DESCRIPTION
The TypeScript client did not set size or name in objinfo when calling send().  Because of that, the server received entries with invalid metadata, and the pipeline rejected or mishandled the objects.

## Fix
Include size – Set size: buffer.length so the server gets the correct object size.


After the update with the test pipeline, we can see chunks in the Qdrant DB
<img width="1161" height="788" alt="Captura de pantalla 2026-02-22 a las 10 18 15" src="https://github.com/user-attachments/assets/d66e15dd-809b-4f19-b1ad-14f495596d33" />

