### PR TITLE
Ensure that size is passed when object are send to pipeline

### DIFF
--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -269,6 +269,13 @@ class DataMixin(DAPClient):
         """Initialize data operations."""
         super().__init__(**kwargs)
 
+    @staticmethod
+    def _objinfo_with_size(objinfo: Dict[str, Any] = None, size: int = 0) -> Dict[str, Any]:
+        """Return objinfo with size set; never 0 (parse filter skips "empty")."""
+        out = dict(objinfo) if objinfo else {}
+        out['size'] = size if size else 1
+        return out
+
     async def pipe(self, token: str, objinfo: Dict[str, Any] = None, mime_type: str = None, provider: str = None) -> DataPipe:
         r"""
         Create a data pipe for streaming operations.
@@ -362,7 +369,7 @@ class DataMixin(DAPClient):
             raise ValueError('data must be either a string or bytes')
 
         # Create and use a temporary pipe for the data
-        pipe = await self.pipe(token, objinfo, mimetype)
+        pipe = await self.pipe(token, self._objinfo_with_size(objinfo, len(buffer)), mimetype)
 
         try:
             await pipe.open()
@@ -533,13 +540,8 @@ class DataMixin(DAPClient):
                 # Get file size for progress tracking
                 file_size = os.path.getsize(filepath)
 
-                # Add file size to metadata
-                if 'size' not in objinfo:
-                    objinfo = dict(objinfo)
-                    objinfo['size'] = file_size
-
                 # Step 1: Create and open pipe (waits for server to allocate)
-                pipe = await self.pipe(token, objinfo, mimetype)
+                pipe = await self.pipe(token, self._objinfo_with_size(objinfo, file_size), mimetype)
                 self.debug_message(f'Opening pipe for {filepath}')
                 await pipe.open()
                 self.debug_message(f'Pipe {pipe.pipe_id} opened for {filepath}')

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -826,6 +826,11 @@ export class RocketRideClient extends DAPClient {
 	// DATA METHODS
 	// ============================================================================
 
+	/** Return objinfo with size set; never 0 (parse filter skips "empty"). */
+	private _objinfoWithSize(objinfo: Record<string, unknown>, size: number): Record<string, unknown> {
+		return { ...objinfo, size: size || 1 };
+	}
+
 	/**
 	 * Create a data pipe for streaming operations.
 	 */
@@ -858,7 +863,7 @@ export class RocketRideClient extends DAPClient {
 		}
 
 		// Create and use a temporary pipe for the data
-		const pipe = await this.pipe(token, objinfo, mimetype);
+		const pipe = await this.pipe(token, this._objinfoWithSize(objinfo, buffer.length), mimetype);
 
 		try {
 			await pipe.open();
@@ -953,18 +958,22 @@ export class RocketRideClient extends DAPClient {
 			let error: string | undefined;
 			let result: PIPELINE_RESULT | undefined;
 
-			const fullObjinfo = {
-				name: file.name,
-				size: file.size,
-				...objinfo,
-			};
+			// Get file size: from filesystem when filepath in objinfo (Node.js), else file.size (same as Python os.path.getsize)
+			let fileSize = file.size;
+			if (typeof window === 'undefined' && objinfo?.filepath && typeof objinfo.filepath === 'string') {
+				try {
+					const fs = require('fs');
+					fileSize = fs.statSync(objinfo.filepath as string).size;
+				} catch {
+					// fallback to file.size
+				}
+			}
 
 			const finalMimetype = mimetype || file.type || 'application/octet-stream';
-			const fileSize = file.size;
 
 			try {
 				// Step 1: Create and open pipe (waits for server to allocate)
-				pipe = await this.pipe(token, fullObjinfo, finalMimetype);
+				pipe = await this.pipe(token, this._objinfoWithSize({ name: file.name, ...objinfo }, fileSize), finalMimetype);
 				await pipe.open();
 
 				// Step 2: Send status update AFTER we have the pipe


### PR DESCRIPTION
On the server, the parse filter skips empty entries: if object.size() is 0, it skips the object and logs “because the file is empty” (around https://github.com/rocketride-org/rocketride-server/blob/develop/packages/server/engine-lib/engLib/store/filters/parse/parse-instance.cpp#L617). 

To avoid that, the client always sends size ≥ 1 when opening the pipe. Both clients use new helper (_objinfo_with_size / _objinfoWithSize) for send() and send_files(). 

It always sets the size from the actual data (buffer length or file size) and ensures it’s never 0.
