### PR TITLE
fix: API key lost when switching models

### DIFF
--- a/packages/shared-ui/src/components/rjsf-theme/api-key-widget/ApiKeyWidget.tsx
+++ b/packages/shared-ui/src/components/rjsf-theme/api-key-widget/ApiKeyWidget.tsx
@@ -75,6 +75,15 @@ const ApiKeyWidget: FC<WidgetProps> = ({
 
 	const inputRef = useRef<HTMLInputElement>(null);
 
+	// Sync when an external update provides a value while the widget is showing empty
+	// (e.g., credential carry-over during a profile/model switch)
+	useEffect(() => {
+		if (value && !tempValue) {
+			setTempValue(getMaskedValue(value));
+			setMaskApiKey(true);
+		}
+	}, [value, tempValue]);
+
 	// When in masked mode, scroll the input to the end so the visible trailing characters are shown
 	useEffect(() => {
 		if (inputRef.current && maskApiKey) {

--- a/packages/shared-ui/src/modules/project-canvas/components/panels/node/NodePanel.tsx
+++ b/packages/shared-ui/src/modules/project-canvas/components/panels/node/NodePanel.tsx
@@ -52,7 +52,9 @@ import UnsavedFormPrompt from '../../UnsavedFormPrompt';
 import { useTranslation } from 'react-i18next';
 import {
 	AuthTokensRef,
+	ProfileCredentialsRef,
 	persistTokensFromFormData,
+	carryOverProfileCredentials,
 	mergeAuthTokensIntoFormData,
 	persistOAuthTokensAndSave,
 } from './authTokenHelpers';
@@ -88,6 +90,9 @@ export default function NodePanel({ onClose }: IBasePanelProps): ReactNode {
 	// CRITICAL: Use refs to persist authentication tokens across re-renders
 	// This prevents tokens from being lost when RJSF drops hidden fields
 	const persistedAuthTokens = useRef<AuthTokensRef>({});
+	// Stores credentials from the previous profile during a model switch so they
+	// survive multiple RJSF onChange cycles within the same switch operation
+	const profileCredentials = useRef<ProfileCredentialsRef['current']>({});
 
 	const [searchParams] = useSearchParams();
 
@@ -202,8 +207,14 @@ export default function NodePanel({ onClose }: IBasePanelProps): ReactNode {
 		// CRITICAL: Preserve hidden authentication tokens during form updates
 		// RJSF drops hidden fields, so we must merge them back from previous state
 		const previousFormData = (selectedNode?.data as INodeData)?.formData || {};
-		const mergedFormData = mergeAuthTokensIntoFormData(
+		const withCarriedCreds = carryOverProfileCredentials(
 			formData ?? {},
+			previousFormData,
+			formValues,
+			profileCredentials
+		);
+		const mergedFormData = mergeAuthTokensIntoFormData(
+			withCarriedCreds,
 			previousFormData,
 			persistedAuthTokens
 		);
@@ -253,8 +264,14 @@ export default function NodePanel({ onClose }: IBasePanelProps): ReactNode {
 			// CRITICAL: Preserve hidden parameters (like userToken) that RJSF drops
 			// These are authentication credentials that must persist across form updates
 			const previousFormData = (selectedNode?.data as INodeData)?.formData || {};
-			const mergedFormData = mergeAuthTokensIntoFormData(
+			const withCarriedCreds = carryOverProfileCredentials(
 				formData ?? {},
+				previousFormData,
+				formValues,
+				profileCredentials
+			);
+			const mergedFormData = mergeAuthTokensIntoFormData(
+				withCarriedCreds,
 				previousFormData,
 				persistedAuthTokens
 			);

--- a/packages/shared-ui/src/modules/project-canvas/components/panels/node/authTokenHelpers.ts
+++ b/packages/shared-ui/src/modules/project-canvas/components/panels/node/authTokenHelpers.ts
@@ -97,6 +97,82 @@ export function persistTokensFromFormData(
 }
 
 /**
+ * Ref that stores credentials from the previous profile so they survive
+ * multiple RJSF onChange cycles during a single profile switch.
+ */
+export type ProfileCredentialsRef = {
+	current: Record<string, unknown>;
+};
+
+/**
+ * Carries over credential fields (e.g. apikey) when the user switches between
+ * model profiles within the same provider.
+ *
+ * Each model profile stores its credentials in a separate conditional branch
+ * (e.g. "openai-4o": { "apikey": "..." }). When RJSF switches branches it
+ * drops the old profile object and may fire onChange multiple times. On the
+ * first call we detect the switch and stash the old credentials in a ref;
+ * on subsequent calls we restore from the ref so RJSF defaults can't
+ * overwrite the carried-over values.
+ */
+export function carryOverProfileCredentials(
+	formData: FormDataWithParameters,
+	previousFormData: FormDataWithParameters,
+	currentFormValues: FormDataWithParameters,
+	credentialsRef: ProfileCredentialsRef
+): FormDataWithParameters {
+	const newProfile = formData?.profile;
+	if (!newProfile) return formData;
+
+	const stateProfile = currentFormValues?.profile;
+	const savedProfile = previousFormData?.profile;
+
+	// Detect a fresh profile switch: the incoming profile differs from what
+	// React state currently holds (first onChange of the switch).
+	if (stateProfile && stateProfile !== newProfile) {
+		// Stash the old profile's credentials in the ref so they survive
+		// subsequent onChange calls where formValues has already been updated.
+		const oldData =
+			(currentFormValues?.[stateProfile] as Record<string, unknown>) ??
+			(previousFormData?.[stateProfile] as Record<string, unknown>);
+		if (oldData && typeof oldData === 'object') {
+			credentialsRef.current = { ...oldData };
+		}
+	} else if (savedProfile && savedProfile !== newProfile && !Object.keys(credentialsRef.current).length) {
+		// formValues already updated but ref is empty — seed from saved data
+		const oldData = previousFormData?.[savedProfile] as Record<string, unknown>;
+		if (oldData && typeof oldData === 'object') {
+			credentialsRef.current = { ...oldData };
+		}
+	}
+
+	// Nothing stashed → nothing to carry over
+	if (!Object.keys(credentialsRef.current).length) return formData;
+
+	const newProfileData = formData?.[newProfile] as Record<string, unknown> | undefined;
+	const newProfileObj = (newProfileData ?? {}) as Record<string, unknown>;
+	const updatedProfile = { ...newProfileObj };
+	let changed = false;
+
+	for (const key of Object.keys(credentialsRef.current)) {
+		if (!updatedProfile[key] && credentialsRef.current[key]) {
+			updatedProfile[key] = credentialsRef.current[key];
+			changed = true;
+		}
+	}
+
+	if (!changed) return formData;
+
+	// Clear the ref once the new profile has accepted the credentials,
+	// so we don't keep overwriting on every subsequent onChange.
+	if (newProfile === stateProfile) {
+		credentialsRef.current = {};
+	}
+
+	return { ...formData, [newProfile]: updatedProfile };
+}
+
+/**
  * Merges preserved authentication tokens back into formData
  * RJSF drops hidden fields, so we must merge tokens from previous state and ref
  */


### PR DESCRIPTION
When a user switches between model profiles within the same provider (e.g. switching from gpt-4o to gpt-4o-mini), RJSF would drop the old profile's conditional branch and fire onChange multiple times, causing entered credentials (like API keys) to be wiped. This PR introduces a carryOverProfileCredentials helper that detects the profile switch on the first onChange cycle, stashes the old profile's credentials in a ref, and merges them into the new profile object on subsequent cycles — preserving credentials across the entire switch. A companion useEffect in ApiKeyWidget ensures the masked input re-syncs when a value is supplied externally after the widget has already rendered empty.