### PR TITLE
fix: Preserve index URLs in constraints so install can resolve extra-index packages

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -452,6 +452,7 @@ def _compile_constraints(combined_path: str, constraints_path: str):
         '--python', sys.executable,  # Explicitly specify Python version to avoid mismatch
         '--index-strategy', 'unsafe-best-match',  # Check all indexes for best version
         '--no-build-isolation',  # Don't create temp venvs (engine.exe can't create venvs)
+        '--emit-index-url',  # Preserve --extra-index-url etc. so install/dry-run can find packages (e.g. torch+cu128)
     ], capture_output=True, text=True, check=False, stdin=subprocess.PIPE, encoding='utf-8', errors='replace')
 
     if result.returncode != 0:


### PR DESCRIPTION
### Problem

Constraint compilation runs `uv pip compile` on a combined requirements file that may include `--extra-index-url` (e.g. PyTorch cu128 in `packages/ai/src/ai/common/torch/requirements.txt`). The resolver uses those indexes and writes version pins to the constraints file but does **not** write the index directives into the output by default.

Later, `uv pip install` / dry-run use that constraints file with `-c constraints.txt` and no extra index. Packages that exist only on the extra index (e.g. `torch==2.10.0+cu128`) then fail with "not available" or "dependency error" because the default index (PyPI) doesn't have them.

### Solution

Add `--emit-index-url` to the `uv pip compile` call in `_compile_constraints()`. With this flag, uv writes all index URLs (including `--extra-index-url`) into the generated constraints file. Install and dry-run then read those directives from the constraints file and use the same indexes, so packages from extra indexes resolve and install correctly.

### Change

- **`packages/server/engine-lib/rocketlib-python/lib/depends.py`**: Pass `--emit-index-url` in the `uv pip compile` invocation so the constraints output preserves index configuration.

### Notes

- After merging, existing constraint caches may need to be invalidated (e.g. delete `constraints.txt` and the requirements hash in the engine cache) so the next run recompiles constraints with index URLs.
- Rebuild and redeploy so the updated `depends.py` is used.