### PR TITLE
fix(server): use runtime-relative path for static UI files

### DIFF
--- a/packages/ai/src/ai/modules/dropper/dropper.py
+++ b/packages/ai/src/ai/modules/dropper/dropper.py
@@ -6,13 +6,16 @@ with proper authentication handling via cookies and query parameters.
 """
 
 import os
+import sys
 from pathlib import Path
 from fastapi.responses import FileResponse
 from ai.web import Request
 
-# Compute the root directory for dropper static files
-# This points to the 'dropper' subdirectory relative to this module's location
-dropper_root = os.path.dirname(os.path.realpath(__file__)) + '/dropperUI/dist'
+# Directory containing engine.exe
+root_dir = os.path.dirname(sys.executable)
+
+# Dropper static files: ./static/dropper (server cwd is dist/server)
+dropper_root = os.path.join(root_dir, 'static', 'dropper')
 
 next_dropper_id = 1
 


### PR DESCRIPTION
## Summary

The dropper module was resolving its UI static files relative to `__file__`, which pointed to a dropperUI/dist subdirectory that doesn't exist in the build output. This caused a "file does not exist" error when starting a dropper node. Updated to use sys.executable-based path resolution matching the pattern used by the chat module, pointing to the correct static/dropper directory populated by the dropper-ui build.

<img width="2244" height="1010" alt="Screenshot 2026-02-26 at 1 07 14 PM" src="https://github.com/user-attachments/assets/9dc9f8c2-25f8-4445-a8f4-4cd7733d1ce8" />

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->
