### PR TITLE
fix(ui): Fix notification banner and remove emoji from button

### DIFF
--- a/apps/vscode/src/providers/components/StatusSection/StatusSection.tsx
+++ b/apps/vscode/src/providers/components/StatusSection/StatusSection.tsx
@@ -328,7 +328,7 @@ export const StatusSection: React.FC<StatusSectionProps> = ({
 										}
 									}}
 								>
-									🔑 Endpoint Info
+									Endpoint Info
 								</button>
 							)}
 						</>

--- a/packages/shared-ui/src/theme.ts
+++ b/packages/shared-ui/src/theme.ts
@@ -380,7 +380,7 @@ export const createVSCodeTheme = () => {
 			MuiSnackbar: {
 				styleOverrides: {
 					root: {
-						background: '#ffffff',
+						background: 'transparent',
 					},
 					anchorOriginBottomRight: {
 						bottom: `${pxToRem(62)}rem !important`,
@@ -573,7 +573,7 @@ export const theme = createTheme({
 		MuiSnackbar: {
 			styleOverrides: {
 				root: {
-					background: '#ffffff',
+					background: 'transparent',
 				},
 				anchorOriginBottomRight: {
 					bottom: `${pxToRem(62)}rem !important`,


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

Two tiny changes, made the root of MUI snackbar transparent so that when we close out of the notification banner that appears when stopping the pipeline - we don't see a random white "bar"... Additionally this removes the key emoji from the "Endpoint Info" button in the status page specifically as per discussions in the SF office today about minor UI tweaks.

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [X] Tested locally
- [X] `./builder test` passes

## Checklist

- [X] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [X] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->
