### PR TITLE
fix(build): fix broken step in build system

### DIFF
--- a/packages/tika/scripts/tasks.js
+++ b/packages/tika/scripts/tasks.js
@@ -23,14 +23,14 @@
 
 /**
  * Build tasks for @rocketride/tika
- * 
+ *
  * Commands:
  *   build - Build Java modules and copy to dist
  *   clean - Remove build artifacts
  */
 const path = require('path');
-const { 
-    execCommand, syncDir, formatSyncStats, 
+const {
+    execCommand, syncDir, formatSyncStats,
     removeDirs, removeFile, PROJECT_ROOT,
     exists, readDir, readFile, writeFile, mkdir, copyFile,
     parallel
@@ -75,7 +75,7 @@ async function getJavaEnv() {
             jdkPath = path.join(JDK_DIR, subdirs[0]);
         }
     }
-    
+
     let mavenPath = MAVEN_DIR;
     if (await exists(MAVEN_DIR)) {
         const subdirs = (await readDir(MAVEN_DIR)).filter(d => d.startsWith('apache-maven-'));
@@ -83,7 +83,7 @@ async function getJavaEnv() {
             mavenPath = path.join(MAVEN_DIR, subdirs[0]);
         }
     }
-    
+
     return {
         jdkPath,
         mavenPath,
@@ -124,7 +124,7 @@ function makeSyncTikaSourceAction(options = {}) {
 function makeBuildDbgconnAction(options = {}) {
     const buildDbgconnDir = path.join(BUILD_DIR, 'lib', 'dbgconn');
     const distDbgconnJar = path.join(DIST_DIR, 'lib', 'dbgconn.jar');
-    
+
     return {
         locks: ['tika'],
         run: async (ctx, task) => {
@@ -133,9 +133,9 @@ function makeBuildDbgconnAction(options = {}) {
                 task.output = 'Already built';
                 return;
             }
-            
+
             const { env, mavenPath } = await getJavaEnv();
-            
+
             await execCommand(path.join(mavenPath, 'bin', 'mvn'), ['clean', 'compile', 'package', '-q'], {
                 task,
                 cwd: buildDbgconnDir,
@@ -148,7 +148,7 @@ function makeBuildDbgconnAction(options = {}) {
 function makeBuildTikaJarAction(options = {}) {
     const buildTikaDir = path.join(BUILD_DIR, 'lib', 'tika');
     const distTikaJar = path.join(DIST_DIR, 'lib', 'tika.jar');
-    
+
     return {
         locks: ['tika'],
         run: async (ctx, task) => {
@@ -157,24 +157,24 @@ function makeBuildTikaJarAction(options = {}) {
                 task.output = 'Already built';
                 return;
             }
-            
+
             const tikaVersion = await loadPackageJson();
             const { env, mavenPath } = await getJavaEnv();
-            
+
             // Generate pom.xml from template
             const pomTemplate = await readFile(path.join(buildTikaDir, 'pom-template.xml'));
             let osClassifier;
             if (process.platform === 'win32') osClassifier = 'win-x86_64';
             else if (process.platform === 'darwin') osClassifier = 'osx-x86_64';
             else osClassifier = 'linux-x86_64';
-            
+
             const pomContent = pomTemplate
                 .replace(/@ROCKETRIDE_TIKA_VERSION@/g, tikaVersion)
                 .replace(/@ROCKETRIDE_OPERATING_SYSTEM@/g, osClassifier);
             await writeFile(path.join(buildTikaDir, 'pom.xml'), pomContent);
-            
+
             task.output = 'Generated pom.xml, building...';
-            
+
             await execCommand(path.join(mavenPath, 'bin', 'mvn'), ['clean', 'compile', 'package', 'dependency:copy-dependencies', '-q'], {
                 task,
                 cwd: buildTikaDir,
@@ -189,21 +189,21 @@ function makeCopyTikaOutputsAction(options = {}) {
     const buildTikaDir = path.join(BUILD_DIR, 'lib', 'tika');
     const distDbgconnJar = path.join(DIST_DIR, 'lib', 'dbgconn.jar');
     const distTikaJar = path.join(DIST_DIR, 'lib', 'tika.jar');
-    
+
     return {
         locks: ['tika'],
         run: async (ctx, task) => {
             // Skip if already copied
-            if (!options.force && !ctx.tikaSourceChanged && 
+            if (!options.force && !ctx.tikaSourceChanged &&
                 await exists(distDbgconnJar) && await exists(distTikaJar)) {
                 task.output = 'Already copied';
                 return;
             }
-            
+
             const tikaVersion = await loadPackageJson();
             const libDir = path.join(DIST_DIR, 'lib');
             await mkdir(libDir);
-            
+
             // Copy JRE to dist
             const jreDist = path.join(DIST_DIR, 'jre');
             const jreSrc = await getJrePath();
@@ -212,13 +212,13 @@ function makeCopyTikaOutputsAction(options = {}) {
                 const jreStats = await syncDir(jreSrc, jreDist);
                 task.output = `JRE: ${formatSyncStats(jreStats)}`;
             }
-            
+
             // Copy tika-config.xml
             const tikaConfig = path.join(buildTikaDir, 'tika-config.xml');
             if (await exists(tikaConfig)) {
                 await copyFile(tikaConfig, path.join(DIST_DIR, 'tika-config.xml'));
             }
-            
+
             // Copy dbgconn.jar
             const dbgconnJarWithDeps = path.join(buildDbgconnDir, 'target', 'dbgconn-2.0-jar-with-dependencies.jar');
             const dbgconnJar = path.join(buildDbgconnDir, 'target', 'dbgconn-2.0.jar');
@@ -227,13 +227,13 @@ function makeCopyTikaOutputsAction(options = {}) {
             } else if (await exists(dbgconnJar)) {
                 await copyFile(dbgconnJar, path.join(libDir, 'dbgconn.jar'));
             }
-            
+
             // Copy tika.jar
             const tikaJar = path.join(buildTikaDir, 'target', `tika-${tikaVersion}.jar`);
             if (await exists(tikaJar)) {
                 await copyFile(tikaJar, path.join(libDir, 'tika.jar'));
             }
-            
+
             // Copy tika dependencies
             const tikaDepsDir = path.join(buildTikaDir, 'target', 'dependency');
             if (await exists(tikaDepsDir)) {
@@ -254,14 +254,28 @@ function makeCopyTikaOutputsAction(options = {}) {
 module.exports = {
     name: 'tika',
     description: 'Java/Tika Document Parser',
-    
+
     actions: [
         // Internal actions
         { name: 'tika:sync-source', action: makeSyncTikaSourceAction },
         { name: 'tika:build-dbgconn', action: makeBuildDbgconnAction },
         { name: 'tika:build-jar', action: makeBuildTikaJarAction },
         { name: 'tika:sync', action: makeCopyTikaOutputsAction },
-        
+
+        // Public action
+        { name: 'tika:build', action: () => ({
+            description: 'Build Java/Tika document parser',
+            steps: [
+                'java:submodule-build',
+                'tika:sync-source',
+                parallel([
+                    'tika:build-dbgconn',
+                    'tika:build-jar'
+                ], 'Build Java modules'),
+                'tika:sync'
+            ]
+        })},
+
         // Submodule actions (called by server:build-core / server:clean-all)
         { name: 'tika:submodule-build', action: () => ({
             steps: [


### PR DESCRIPTION
https://github.com/rocketride-org/rocketride-server/issues/58

Add a top-level tika:build action that orchestrates the full Java/Tika build pipeline: submodule build, source sync, parallel module builds, and output sync.
