### PR TITLE
fix(vscode): shorten "Pipeline Flow" tab label to "Flow"

### DIFF
--- a/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
+++ b/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
@@ -382,7 +382,7 @@ export const PageStatus: React.FC = () => {
 	const tabs = [
 		{ id: 'status', label: 'Status' },
 		{ id: 'tokens', label: 'Tokens' },
-		{ id: 'flow', label: 'Pipeline Flow' },
+		{ id: 'flow', label: 'Flow' },
 		{ id: 'trace', label: 'Trace' },
 		{ id: 'errors', label: 'Errors', badge: errorCount > 0 ? <WarningIcon size={14} /> : undefined }
 	];


### PR DESCRIPTION
The tab bar uses uppercase small-caps styling, so shorter labels reduce visual clutter and keep all five tabs comfortably visible without truncation on narrow panels.
==