### PR TITLE
feat(nodes): add http_request tool node with agent pipeline bug fixes to enable tool calling

### DIFF
--- a/nodes/src/nodes/agent_crewai/crewai.py
+++ b/nodes/src/nodes/agent_crewai/crewai.py
@@ -88,30 +88,22 @@ class CrewDriver(AgentBase):
         from pydantic import BaseModel, ConfigDict, Field
 
         class _ToolInput(BaseModel):
-            """
-            Accept arbitrary tool args through a stable `input` field.
-
-            This keeps CrewAI tool execution robust even when the framework
-            passes arguments via `input=...` or via extra kwargs.
-            """
-
             input: Any = Field(default=None, description='Tool input payload')
             model_config = ConfigDict(extra='allow')
 
-        class HostTool(BaseTool):  # type: ignore[misc]
+        class HostTool(BaseTool):
             name: str
             description: str
             args_schema: type[BaseModel] = _ToolInput
 
-            def _run(self, input: Any = None, **kwargs: Any) -> str:  # noqa: ANN401, A002
-                tool_name = _safe_str(getattr(self, 'name', ''))
+            def _run(self, input: Any = None, **kwargs: Any) -> str:
                 try:
-                    out = invoke_tool(tool_name, input=input, kwargs=kwargs)
+                    out = invoke_tool(self.name, input=input, kwargs=kwargs)
                 except Exception as e:
                     out = {'error': str(e), 'type': type(e).__name__}
 
                 try:
-                    log_tool_call(tool_name=tool_name, input={'input': input, **kwargs}, output=out)
+                    log_tool_call(tool_name=self.name, input={'input': input, **kwargs}, output=out)
                 except Exception:
                     pass
 
@@ -120,28 +112,12 @@ class CrewDriver(AgentBase):
                 except Exception:
                     return _safe_str(out)
 
-        tools: List[Any] = []
+        tools = []
         for td in tool_descriptors:
-            name = td.get('name')
-            if not isinstance(name, str) or not name.strip():
-                continue
-            desc = td.get('description') if isinstance(td.get('description'), str) else f'Invoke host tool: {name}'
-            input_schema = td.get('input_schema')
-            if isinstance(input_schema, dict):
-                try:
-                    schema_text = json.dumps(input_schema, ensure_ascii=False)
-                except Exception:
-                    schema_text = ''
-                if schema_text:
-                    desc = f'{desc}\n\nTool input schema (JSON): {schema_text}'
-
-            tool = HostTool(name=name, description=desc)
-            # Keep the real input schema available for prompt/debug paths if needed.
-            try:
-                setattr(tool, '_rr_input_schema', input_schema)
-            except Exception:
-                pass
-            tools.append(tool)
+            name = td.get('name', '') if isinstance(td, dict) else getattr(td, 'name', '')
+            desc = td.get('description', '') if isinstance(td, dict) else getattr(td, 'description', '')
+            if name:
+                tools.append(HostTool(name=name, description=desc or f'Invoke host tool: {name}'))
         return tools
 
     def _run(
@@ -203,6 +179,8 @@ class CrewDriver(AgentBase):
             desc_parts.extend(['', 'Additional instructions:', self._instructions])
         desc = '\n'.join(desc_parts).strip()
 
+        desc = desc.replace('{', '{{').replace('}', '}}')
+
         task_obj = Task(
             description=desc,
             expected_output='A helpful, accurate response.',
@@ -211,7 +189,7 @@ class CrewDriver(AgentBase):
         )
 
         crew = Crew(agents=[agent_obj], tasks=[task_obj], process=self._process)
-        result = crew.kickoff(inputs={'input': agent_input.prompt or ''})
+        result = crew.kickoff()
 
         final_text = ''
         if hasattr(result, 'raw'):

--- a/nodes/src/nodes/http_request/IGlobal.py
+++ b/nodes/src/nodes/http_request/IGlobal.py
@@ -1,0 +1,167 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+HTTP Request tool node - global (shared) state.
+
+Reads the node configuration and creates an ``HttpDriver`` that exposes a
+single ``http_request`` tool for agent invocation.
+"""
+
+from __future__ import annotations
+
+from ai.common.config import Config
+from rocketlib import IGlobalBase, OPEN_MODE, warning
+
+from .http_driver import HttpDriver
+
+
+class IGlobal(IGlobalBase):
+    """Global state for http_request."""
+
+    driver: HttpDriver | None = None
+
+    def beginGlobal(self) -> None:
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            return
+
+        cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+
+        server_name = str((cfg.get('serverName') or 'http')).strip()
+
+        defaults = self._build_defaults(cfg)
+
+        try:
+            self.driver = HttpDriver(server_name=server_name, defaults=defaults)
+        except Exception as e:
+            warning(str(e))
+            raise
+
+    @staticmethod
+    def _array_to_dict(rows: list, key_field: str, value_field: str) -> dict:
+        """Convert an array-of-objects from the UI into a flat dict.
+
+        The UI stores key-value pairs as ``[{key_field: k, value_field: v}, ...]``.
+        The driver expects a plain ``{k: v, ...}`` dict.
+        """
+        result: dict = {}
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            k = str(row.get(key_field) or '').strip()
+            if k:
+                result[k] = str(row.get(value_field) or '')
+        return result
+
+    @staticmethod
+    def _build_defaults(cfg: dict) -> dict:
+        """Extract user-configured defaults from the node config panel."""
+        defaults: dict = {}
+
+        method = str(cfg.get('method') or '').strip().upper()
+        if method:
+            defaults['method'] = method
+
+        url = str(cfg.get('url') or '').strip()
+        if url:
+            defaults['url'] = url
+
+        auth_type = str(cfg.get('authType') or 'none').strip().lower()
+        if auth_type and auth_type != 'none':
+            auth: dict = {'type': auth_type}
+            if auth_type == 'basic':
+                auth['basic'] = {
+                    'username': str(cfg.get('username') or ''),
+                    'password': str(cfg.get('password') or ''),
+                }
+            elif auth_type == 'bearer':
+                auth['bearer'] = {
+                    'token': str(cfg.get('bearerToken') or ''),
+                }
+            elif auth_type == 'api_key':
+                auth['api_key'] = {
+                    'key': str(cfg.get('apiKeyName') or 'X-API-Key'),
+                    'value': str(cfg.get('apiKeyValue') or ''),
+                    'add_to': str(cfg.get('apiKeyAddTo') or 'header'),
+                }
+            defaults['auth'] = auth
+
+        body_type = str(cfg.get('bodyType') or 'none').strip().lower()
+        if body_type and body_type != 'none':
+            body: dict = {'type': body_type}
+            if body_type == 'raw':
+                body['raw'] = {
+                    'content': str(cfg.get('rawContent') or ''),
+                    'content_type': str(cfg.get('rawContentType') or 'application/json'),
+                }
+            elif body_type == 'form_data':
+                raw_fd = cfg.get('bodyFormData') or []
+                body['form_data'] = (
+                    IGlobal._array_to_dict(raw_fd, 'formDataKey', 'formDataValue')
+                    if isinstance(raw_fd, list) else raw_fd
+                )
+            elif body_type == 'x_www_form_urlencoded':
+                raw_ue = cfg.get('bodyUrlencoded') or []
+                body['urlencoded'] = (
+                    IGlobal._array_to_dict(raw_ue, 'urlencodedKey', 'urlencodedValue')
+                    if isinstance(raw_ue, list) else raw_ue
+                )
+            defaults['body'] = body
+
+        raw_headers = cfg.get('headers') or []
+        if isinstance(raw_headers, list) and raw_headers:
+            defaults['headers'] = IGlobal._array_to_dict(
+                raw_headers, 'headerKey', 'headerValue'
+            )
+        elif isinstance(raw_headers, dict) and raw_headers:
+            defaults['headers'] = raw_headers
+
+        raw_qp = cfg.get('queryParams') or []
+        if isinstance(raw_qp, list) and raw_qp:
+            defaults['query_params'] = IGlobal._array_to_dict(
+                raw_qp, 'queryKey', 'queryValue'
+            )
+        elif isinstance(raw_qp, dict) and raw_qp:
+            defaults['query_params'] = raw_qp
+
+        raw_pp = cfg.get('pathParams') or []
+        if isinstance(raw_pp, list) and raw_pp:
+            defaults['path_params'] = IGlobal._array_to_dict(
+                raw_pp, 'pathKey', 'pathValue'
+            )
+        elif isinstance(raw_pp, dict) and raw_pp:
+            defaults['path_params'] = raw_pp
+
+        return defaults
+
+    def validateConfig(self) -> None:
+        try:
+            cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            server_name = str((cfg.get('serverName') or '')).strip()
+            if not server_name:
+                warning('serverName is required')
+        except Exception as e:
+            warning(str(e))
+
+    def endGlobal(self) -> None:
+        self.driver = None

--- a/nodes/src/nodes/http_request/IInstance.py
+++ b/nodes/src/nodes/http_request/IInstance.py
@@ -1,0 +1,46 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+HTTP Request tool node instance.
+
+Delegates tool invocation to the ``HttpDriver`` created by ``IGlobal``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rocketlib import IInstanceBase
+
+from .IGlobal import IGlobal
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    def invoke(self, param: Any) -> Any:  # noqa: ANN401
+        driver = getattr(self.IGlobal, 'driver', None)
+        if driver is None:
+            raise RuntimeError('http_request: driver not initialized')
+        return driver.handle_invoke(param)

--- a/nodes/src/nodes/http_request/__init__.py
+++ b/nodes/src/nodes/http_request/__init__.py
@@ -1,0 +1,27 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/http_request/http_client.py
+++ b/nodes/src/nodes/http_request/http_client.py
@@ -1,0 +1,184 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+HTTP request execution engine.
+
+Accepts a fully-specified request descriptor (URL, method, headers, auth, body,
+params) and returns a structured response dict.  Uses the ``requests`` library.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any, Dict, Optional
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+
+def execute_request(
+    *,
+    url: str,
+    method: str,
+    query_params: Optional[Dict[str, str]] = None,
+    path_params: Optional[Dict[str, str]] = None,
+    headers: Optional[Dict[str, str]] = None,
+    auth: Optional[Dict[str, Any]] = None,
+    body: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Execute an HTTP request and return a structured response.
+
+    Raises ``requests.RequestException`` on transport-level failures.
+    """
+
+    resolved_url = _resolve_path_params(url, path_params)
+
+    req_headers = dict(headers or {})
+    req_auth = None
+    extra_params: Dict[str, str] = {}
+
+    _apply_auth(auth, req_headers, extra_params, req_auth_out := [None])
+    req_auth = req_auth_out[0]
+
+    merged_params = dict(query_params or {})
+    merged_params.update(extra_params)
+
+    req_kwargs: Dict[str, Any] = {
+        'method': method.upper(),
+        'url': resolved_url,
+        'headers': req_headers,
+        'params': merged_params or None,
+        'auth': req_auth,
+    }
+
+    _apply_body(body, req_headers, req_kwargs)
+
+    start = time.monotonic()
+    resp = requests.request(**req_kwargs)
+    elapsed_ms = round((time.monotonic() - start) * 1000)
+
+    return _build_response(resp, elapsed_ms)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str:
+    """Replace ``:name`` placeholders in the URL with values from *path_params*."""
+    if not path_params:
+        return url
+    resolved = url
+    for key, value in path_params.items():
+        resolved = re.sub(rf':{re.escape(key)}\b', str(value), resolved)
+    return resolved
+
+
+def _apply_auth(
+    auth: Optional[Dict[str, Any]],
+    headers: Dict[str, str],
+    extra_params: Dict[str, str],
+    req_auth_out: list,
+) -> None:
+    """Mutate *headers* / *extra_params* / *req_auth_out* based on auth config."""
+    if not auth:
+        return
+    auth_type = (auth.get('type') or 'none').strip().lower()
+    if auth_type == 'none':
+        return
+
+    if auth_type == 'basic':
+        basic = auth.get('basic') or {}
+        req_auth_out[0] = HTTPBasicAuth(
+            basic.get('username', ''),
+            basic.get('password', ''),
+        )
+
+    elif auth_type == 'bearer':
+        bearer = auth.get('bearer') or {}
+        token = bearer.get('token', '')
+        headers['Authorization'] = f'Bearer {token}'
+
+    elif auth_type == 'api_key':
+        api_key = auth.get('api_key') or {}
+        key = api_key.get('key', '')
+        value = api_key.get('value', '')
+        add_to = (api_key.get('add_to') or 'header').strip().lower()
+        if add_to == 'query_param':
+            extra_params[key] = value
+        else:
+            headers[key] = value
+
+
+def _apply_body(
+    body: Optional[Dict[str, Any]],
+    headers: Dict[str, str],
+    req_kwargs: Dict[str, Any],
+) -> None:
+    """Populate *req_kwargs* with the appropriate body payload."""
+    if not body:
+        return
+    body_type = (body.get('type') or 'none').strip().lower()
+    if body_type == 'none':
+        return
+
+    if body_type == 'raw':
+        raw = body.get('raw') or {}
+        content = raw.get('content', '')
+        content_type = raw.get('content_type', 'application/json')
+        headers.setdefault('Content-Type', content_type)
+        req_kwargs['data'] = content
+
+    elif body_type == 'form_data':
+        form_data = body.get('form_data') or {}
+        # multipart/form-data: pass each field as a tuple so ``requests``
+        # builds the multipart envelope automatically.
+        req_kwargs['files'] = {k: (None, v) for k, v in form_data.items()}
+
+    elif body_type == 'x_www_form_urlencoded':
+        urlencoded = body.get('urlencoded') or {}
+        req_kwargs['data'] = urlencoded
+
+
+def _build_response(resp: requests.Response, elapsed_ms: int) -> Dict[str, Any]:
+    """Convert a ``requests.Response`` into a structured dict for the agent."""
+    content_type = resp.headers.get('Content-Type', '')
+
+    parsed_json = None
+    if 'json' in content_type or 'javascript' in content_type:
+        try:
+            parsed_json = resp.json()
+        except Exception:
+            pass
+
+    return {
+        'status_code': resp.status_code,
+        'status_text': resp.reason or '',
+        'headers': dict(resp.headers),
+        'body': resp.text,
+        'json': parsed_json,
+        'elapsed_ms': elapsed_ms,
+        'content_type': content_type,
+    }

--- a/nodes/src/nodes/http_request/http_driver.py
+++ b/nodes/src/nodes/http_request/http_driver.py
@@ -1,0 +1,260 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+http_request tool-provider driver.
+
+Implements ``tool.query``, ``tool.validate``, and ``tool.invoke`` by exposing a
+single ``http_request`` tool that can call any HTTP API endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from ai.common.tools import ToolsBase
+
+from .http_client import execute_request
+
+VALID_METHODS = {'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS'}
+VALID_AUTH_TYPES = {'none', 'basic', 'bearer', 'api_key'}
+VALID_BODY_TYPES = {'none', 'raw', 'form_data', 'x_www_form_urlencoded'}
+VALID_RAW_CONTENT_TYPES = {
+    'application/json',
+    'text/plain',
+    'application/xml',
+    'text/html',
+    'text/javascript',
+}
+
+INPUT_SCHEMA: Dict[str, Any] = {
+    'type': 'object',
+    'required': ['url', 'method'],
+    'properties': {
+        'url': {
+            'type': 'string',
+            'description': 'Full URL (supports :param path parameters, e.g. https://api.example.com/users/:id)',
+        },
+        'method': {
+            'type': 'string',
+            'enum': sorted(VALID_METHODS),
+            'description': 'HTTP method',
+        },
+        'query_params': {
+            'type': 'object',
+            'description': 'Key-value query parameters appended to the URL',
+            'additionalProperties': {'type': 'string'},
+        },
+        'path_params': {
+            'type': 'object',
+            'description': 'Path parameter replacements (e.g. {"id": "123"} replaces :id in the URL)',
+            'additionalProperties': {'type': 'string'},
+        },
+        'headers': {
+            'type': 'object',
+            'description': 'Custom HTTP headers',
+            'additionalProperties': {'type': 'string'},
+        },
+        'auth': {
+            'type': 'object',
+            'description': 'Authentication configuration',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': sorted(VALID_AUTH_TYPES),
+                    'description': 'Auth type (none, basic, bearer, api_key)',
+                },
+                'basic': {
+                    'type': 'object',
+                    'properties': {
+                        'username': {'type': 'string'},
+                        'password': {'type': 'string'},
+                    },
+                },
+                'bearer': {
+                    'type': 'object',
+                    'properties': {
+                        'token': {'type': 'string'},
+                    },
+                },
+                'api_key': {
+                    'type': 'object',
+                    'properties': {
+                        'key': {'type': 'string', 'description': 'Header or query-param name'},
+                        'value': {'type': 'string', 'description': 'The API key value'},
+                        'add_to': {
+                            'type': 'string',
+                            'enum': ['header', 'query_param'],
+                            'description': 'Where to attach the key (default: header)',
+                        },
+                    },
+                },
+            },
+        },
+        'body': {
+            'type': 'object',
+            'description': 'Request body configuration',
+            'properties': {
+                'type': {
+                    'type': 'string',
+                    'enum': sorted(VALID_BODY_TYPES),
+                    'description': 'Body type (none, raw, form_data, x_www_form_urlencoded)',
+                },
+                'raw': {
+                    'type': 'object',
+                    'properties': {
+                        'content': {'type': 'string', 'description': 'Raw body content'},
+                        'content_type': {
+                            'type': 'string',
+                            'enum': sorted(VALID_RAW_CONTENT_TYPES),
+                            'description': 'Content-Type header value (default: application/json)',
+                        },
+                    },
+                },
+                'form_data': {
+                    'type': 'object',
+                    'description': 'Key-value pairs sent as multipart/form-data',
+                    'additionalProperties': {'type': 'string'},
+                },
+                'urlencoded': {
+                    'type': 'object',
+                    'description': 'Key-value pairs sent as application/x-www-form-urlencoded',
+                    'additionalProperties': {'type': 'string'},
+                },
+            },
+        },
+    },
+}
+
+
+class HttpDriver(ToolsBase):
+    def __init__(self, *, server_name: str, defaults: Dict[str, Any] | None = None):
+        self._server_name = (server_name or '').strip() or 'http'
+        self._tool_name = 'http_request'
+        self._namespaced = f'{self._server_name}.{self._tool_name}'
+        self._defaults: Dict[str, Any] = defaults or {}
+
+    # ------------------------------------------------------------------
+    # ToolsBase hooks
+    # ------------------------------------------------------------------
+
+    def _tool_query(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                'name': self._namespaced,
+                'description': (
+                    'Make an HTTP request to any API endpoint. '
+                    'You MUST always specify both "url" and "method" (GET, POST, PUT, PATCH, DELETE, HEAD, or OPTIONS). '
+                    'For POST/PUT/PATCH requests, include a "body" object with "type" set to "raw" and a nested "raw" '
+                    'object containing "content" (the JSON string) and "content_type" (e.g. "application/json"). '
+                    'You can also pass "headers" (object of key-value pairs), "query_params" (object of key-value pairs), '
+                    'and "auth" (with "type": "bearer"/"basic"/"api_key" and corresponding credentials).'
+                ),
+                'inputSchema': INPUT_SCHEMA,
+            }
+        ]
+
+    def _tool_validate(self, *, tool_name: str, input_obj: Any) -> None:  # noqa: ANN401
+        if tool_name != self._tool_name and tool_name != self._namespaced:
+            raise ValueError(f'Unknown tool {tool_name!r} (expected {self._tool_name!r})')
+
+        if not isinstance(input_obj, dict):
+            raise ValueError('Tool input must be a JSON object')
+
+        url = input_obj.get('url')
+        if not url or not isinstance(url, str):
+            raise ValueError('url is required and must be a non-empty string')
+
+        method = input_obj.get('method')
+        if not method or not isinstance(method, str):
+            raise ValueError('method is required and must be a non-empty string')
+        if method.upper() not in VALID_METHODS:
+            raise ValueError(f'method must be one of {sorted(VALID_METHODS)}; got {method!r}')
+
+        auth = input_obj.get('auth')
+        if isinstance(auth, dict):
+            auth_type = (auth.get('type') or 'none').strip().lower()
+            if auth_type not in VALID_AUTH_TYPES:
+                raise ValueError(f'auth.type must be one of {sorted(VALID_AUTH_TYPES)}; got {auth_type!r}')
+
+        body = input_obj.get('body')
+        if isinstance(body, dict):
+            body_type = (body.get('type') or 'none').strip().lower()
+            if body_type not in VALID_BODY_TYPES:
+                raise ValueError(f'body.type must be one of {sorted(VALID_BODY_TYPES)}; got {body_type!r}')
+            if body_type == 'raw':
+                raw = body.get('raw') or {}
+                ct = (raw.get('content_type') or 'application/json').strip().lower()
+                if ct not in VALID_RAW_CONTENT_TYPES:
+                    raise ValueError(
+                        f'body.raw.content_type must be one of {sorted(VALID_RAW_CONTENT_TYPES)}; got {ct!r}'
+                    )
+
+    def _tool_invoke(self, *, tool_name: str, input_obj: Any) -> Any:  # noqa: ANN401
+        if not isinstance(input_obj, dict):
+            raise ValueError('Tool input must be a JSON object (dict)')
+
+        merged = self._merge_with_defaults(input_obj)
+
+        return execute_request(
+            url=merged.get('url', ''),
+            method=merged.get('method', 'GET'),
+            query_params=merged.get('query_params'),
+            path_params=merged.get('path_params'),
+            headers=merged.get('headers'),
+            auth=merged.get('auth'),
+            body=merged.get('body'),
+        )
+
+    def _merge_with_defaults(self, agent_input: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge user-configured defaults with agent runtime input.
+
+        Priority: agent input > user config > field defaults.
+        For dict-type fields (headers, query_params, path_params), config
+        values serve as the base and agent values are overlaid on top.
+        """
+        if not self._defaults:
+            return agent_input
+
+        merged: Dict[str, Any] = {}
+
+        for key in ('url', 'method', 'auth', 'body'):
+            agent_val = agent_input.get(key)
+            default_val = self._defaults.get(key)
+            if agent_val is not None:
+                merged[key] = agent_val
+            elif default_val is not None:
+                merged[key] = default_val
+
+        for key in ('headers', 'query_params', 'path_params'):
+            default_val = self._defaults.get(key)
+            agent_val = agent_input.get(key)
+            if isinstance(default_val, dict) and isinstance(agent_val, dict):
+                combined = {**default_val, **agent_val}
+                merged[key] = combined
+            elif agent_val is not None:
+                merged[key] = agent_val
+            elif default_val is not None:
+                merged[key] = default_val
+
+        return merged

--- a/nodes/src/nodes/http_request/services.json
+++ b/nodes/src/nodes/http_request/services.json
@@ -1,0 +1,407 @@
+{
+	"title": "HTTP Request",
+	"protocol": "http_request://",
+	"classType": ["tool"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.http_request",
+	"prefix": "http",
+	"description": [
+		"Makes HTTP requests to any API endpoint, similar to Postman.",
+		"Supports GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS with auth, headers, query/path params, and body.",
+		"The user can pre-configure defaults in the node panel; the agent can override any field at runtime."
+	],
+	"tile": [
+		"${parameters.http_request.method} ${parameters.http_request.url}",
+		"Tool: ${parameters.http_request.serverName}.http_request"
+	],
+	"lanes": {},
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"title": "GET Request (no auth)",
+				"serverName": "http",
+				"method": "GET",
+				"url": "",
+				"authType": "none",
+				"bodyType": "none"
+			},
+			"post_json": {
+				"title": "POST JSON",
+				"serverName": "http",
+				"method": "POST",
+				"url": "",
+				"authType": "none",
+				"bodyType": "raw",
+				"rawContentType": "application/json",
+				"rawContent": ""
+			},
+			"bearer_get": {
+				"title": "GET with Bearer Token",
+				"serverName": "http",
+				"method": "GET",
+				"url": "",
+				"authType": "bearer",
+				"bearerToken": "",
+				"bodyType": "none"
+			}
+		}
+	},
+	"fields": {
+		"http_request.serverName": {
+			"hidden": true,
+			"type": "string",
+			"title": "Server name",
+			"description": "Namespace prefix for the tool: <serverName>.http_request",
+			"default": "http"
+		},
+		"http_request.method": {
+			"type": "string",
+			"title": "Method",
+			"description": "HTTP method to use for the request",
+			"default": "GET",
+			"enum": [
+				"GET",
+				"POST",
+				"PUT",
+				"PATCH",
+				"DELETE",
+				"HEAD",
+				"OPTIONS"
+			]
+		},
+		"http_request.url": {
+			"type": "string",
+			"title": "URL",
+			"description": "Full request URL (supports :param path placeholders, e.g. https://api.example.com/users/:id)",
+			"default": ""
+		},
+
+		"http_request.authType": {
+			"type": "string",
+			"title": "Authorization",
+			"description": "Authentication type for the request",
+			"default": "none",
+			"enum": [
+				"none",
+				"basic",
+				"bearer",
+				"api_key"
+			],
+			"conditional": [
+				{
+					"value": "basic",
+					"properties": [
+						"http_request.authBasic"
+					]
+				},
+				{
+					"value": "bearer",
+					"properties": [
+						"http_request.authBearer"
+					]
+				},
+				{
+					"value": "api_key",
+					"properties": [
+						"http_request.authApiKey"
+					]
+				}
+			]
+		},
+
+		"http_request.username": {
+			"type": "string",
+			"title": "Username",
+			"description": "Username for Basic authentication",
+			"default": ""
+		},
+		"http_request.password": {
+			"type": "string",
+			"title": "Password",
+			"description": "Password for Basic authentication",
+			"default": "",
+			"secure": true,
+			"ui": {
+				"ui:widget": "password"
+			}
+		},
+		"http_request.authBasic": {
+			"object": "authBasic",
+			"title": "Basic Auth",
+			"properties": [
+				"http_request.username",
+				"http_request.password"
+			]
+		},
+
+		"http_request.bearerToken": {
+			"type": "string",
+			"title": "Token",
+			"description": "Bearer token for authentication",
+			"default": "",
+			"secure": true,
+			"ui": {
+				"ui:widget": "ApiKeyWidget"
+			}
+		},
+		"http_request.authBearer": {
+			"object": "authBearer",
+			"title": "Bearer Token",
+			"properties": [
+				"http_request.bearerToken"
+			]
+		},
+
+		"http_request.apiKeyName": {
+			"type": "string",
+			"title": "Key name",
+			"description": "Header or query parameter name (e.g. X-API-Key)",
+			"default": "X-API-Key"
+		},
+		"http_request.apiKeyValue": {
+			"type": "string",
+			"title": "Key value",
+			"description": "The API key value",
+			"default": "",
+			"secure": true,
+			"ui": {
+				"ui:widget": "ApiKeyWidget"
+			}
+		},
+		"http_request.apiKeyAddTo": {
+			"type": "string",
+			"title": "Add to",
+			"description": "Where to attach the API key",
+			"default": "header",
+			"enum": [
+				"header",
+				"query_param"
+			]
+		},
+		"http_request.authApiKey": {
+			"object": "authApiKey",
+			"title": "API Key",
+			"properties": [
+				"http_request.apiKeyName",
+				"http_request.apiKeyValue",
+				"http_request.apiKeyAddTo"
+			]
+		},
+
+		"http_request.bodyType": {
+			"type": "string",
+			"title": "Body",
+			"description": "Request body type",
+			"default": "none",
+			"enum": [
+				"none",
+				"raw",
+				"form_data",
+				"x_www_form_urlencoded"
+			],
+			"conditional": [
+				{
+					"value": "raw",
+					"properties": [
+						"http_request.bodyRaw"
+					]
+				},
+				{
+					"value": "form_data",
+					"properties": [
+						"http_request.bodyFormData"
+					]
+				},
+				{
+					"value": "x_www_form_urlencoded",
+					"properties": [
+						"http_request.bodyUrlencoded"
+					]
+				}
+			]
+		},
+
+		"http_request.rawContentType": {
+			"type": "string",
+			"title": "Content type",
+			"description": "Content-Type of the raw body",
+			"default": "application/json",
+			"enum": [
+				"application/json",
+				"text/plain",
+				"text/html",
+				"text/javascript",
+				"application/xml"
+			]
+		},
+		"http_request.rawContent": {
+			"type": "string",
+			"title": "Content",
+			"description": "Raw body content",
+			"default": "",
+			"format": "textarea",
+			"ui": {
+				"ui:widget": "textarea",
+				"ui:options": {
+					"rows": 10
+				}
+			}
+		},
+		"http_request.bodyRaw": {
+			"object": "bodyRaw",
+			"title": "Raw Body",
+			"properties": [
+				"http_request.rawContentType",
+				"http_request.rawContent"
+			]
+		},
+
+		"http_request.formDataKey": {
+			"type": "string",
+			"title": "Key",
+			"default": "",
+			"minLength": 1
+		},
+		"http_request.formDataValue": {
+			"type": "string",
+			"title": "Value",
+			"default": ""
+		},
+		"http_request.bodyFormData": {
+			"title": "Form Data",
+			"description": "Key-value pairs sent as multipart/form-data",
+			"type": "array",
+			"minItems": 0,
+			"items": {
+				"type": "object",
+				"properties": [
+					"http_request.formDataKey",
+					"http_request.formDataValue"
+				]
+			}
+		},
+		"http_request.urlencodedKey": {
+			"type": "string",
+			"title": "Key",
+			"default": "",
+			"minLength": 1
+		},
+		"http_request.urlencodedValue": {
+			"type": "string",
+			"title": "Value",
+			"default": ""
+		},
+		"http_request.bodyUrlencoded": {
+			"title": "URL Encoded",
+			"description": "Key-value pairs sent as application/x-www-form-urlencoded",
+			"type": "array",
+			"minItems": 0,
+			"items": {
+				"type": "object",
+				"properties": [
+					"http_request.urlencodedKey",
+					"http_request.urlencodedValue"
+				]
+			}
+		},
+
+		"http_request.headerKey": {
+			"type": "string",
+			"title": "Key",
+			"default": "",
+			"minLength": 1
+		},
+		"http_request.headerValue": {
+			"type": "string",
+			"title": "Value",
+			"default": ""
+		},
+		"http_request.headers": {
+			"title": "Headers",
+			"description": "Custom HTTP headers as key-value pairs",
+			"type": "array",
+			"minItems": 0,
+			"items": {
+				"type": "object",
+				"properties": [
+					"http_request.headerKey",
+					"http_request.headerValue"
+				]
+			}
+		},
+		"http_request.queryKey": {
+			"type": "string",
+			"title": "Key",
+			"default": "",
+			"minLength": 1
+		},
+		"http_request.queryValue": {
+			"type": "string",
+			"title": "Value",
+			"default": ""
+		},
+		"http_request.queryDesc": {
+			"type": "string",
+			"title": "Description",
+			"default": ""
+		},
+		"http_request.queryParams": {
+			"title": "Query Params",
+			"description": "Query parameters appended to the URL as key-value pairs",
+			"type": "array",
+			"minItems": 0,
+			"items": {
+				"type": "object",
+				"properties": [
+					"http_request.queryKey",
+					"http_request.queryValue",
+					"http_request.queryDesc"
+				]
+			}
+		},
+		"http_request.pathKey": {
+			"type": "string",
+			"title": "Param",
+			"default": "",
+			"minLength": 1
+		},
+		"http_request.pathValue": {
+			"type": "string",
+			"title": "Value",
+			"default": ""
+		},
+		"http_request.pathParams": {
+			"title": "Path Params",
+			"description": "Path parameter replacements (e.g. :id in the URL)",
+			"type": "array",
+			"minItems": 0,
+			"items": {
+				"type": "object",
+				"properties": [
+					"http_request.pathKey",
+					"http_request.pathValue"
+				]
+			}
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "HTTP Request",
+			"properties": [
+				"type",
+				"name",
+				"http_request.method",
+				"http_request.url",
+				"http_request.authType",
+				"http_request.bodyType",
+				"http_request.headers",
+				"http_request.queryParams",
+				"http_request.pathParams"
+			]
+		}
+	]
+}

--- a/nodes/src/nodes/response/IInstance.py
+++ b/nodes/src/nodes/response/IInstance.py
@@ -36,6 +36,15 @@ class IInstance(IInstanceBase):
     text: str = ''
     image = bytearray()
 
+    def _ensure_response(self) -> bool:
+        """Ensure currentObject and its response dict are available. Returns False if not."""
+        if self.instance.currentObject is None:
+            debug('response node: currentObject is None (object may have been closed); skipping write')
+            return False
+        if self.instance.currentObject.response is None:
+            self.instance.currentObject.response = {}
+        return True
+
     def _getkey(self, type: str):
         # Allow the key to be overriden by
         #   connConfig: {
@@ -84,6 +93,8 @@ class IInstance(IInstanceBase):
 
         This method is called when processing of the current object is complete.
         """
+        if not self._ensure_response():
+            return
 
         def deep_merge_dicts(src: dict, dest: dict):
             for key, value in src.items():
@@ -144,7 +155,9 @@ class IInstance(IInstanceBase):
         self.text += text + '\n\n'
 
     def writeTable(self, table: str):
-        # Get the key to write to (official lane name is "table")
+        if not self._ensure_response():
+            return
+
         key = self._getkey('table')
 
         # If it isn't there, create it
@@ -155,7 +168,9 @@ class IInstance(IInstanceBase):
         self.instance.currentObject.response[key].append(table)
 
     def writeDocuments(self, documents: List[Doc]):
-        # Get the key to write to
+        if not self._ensure_response():
+            return
+
         key = self._getkey('documents')
 
         # If it isn't there, create it
@@ -167,7 +182,9 @@ class IInstance(IInstanceBase):
             self.instance.currentObject.response[key].append(document.toDict())
 
     def writeQuestions(self, questions: Question):
-        # Get the key to write to
+        if not self._ensure_response():
+            return
+
         key = self._getkey('questions')
 
         # If it isn't there, create it
@@ -178,7 +195,9 @@ class IInstance(IInstanceBase):
         self.instance.currentObject.response[key].append(questions.model_dump())
 
     def writeAnswers(self, answer: Answer):
-        # Get the key to write to
+        if not self._ensure_response():
+            return
+
         key = self._getkey('answers')
 
         # If it isn't there, create it
@@ -192,7 +211,9 @@ class IInstance(IInstanceBase):
             self.instance.currentObject.response[key].append(answer.getText())
 
     def writeAudio(self, aviAction: int, mimeType: str, data: bytes):
-        # Get the key to write to
+        if not self._ensure_response():
+            return
+
         key = self._getkey('audio')
 
         # If it isn't there, create it
@@ -206,7 +227,9 @@ class IInstance(IInstanceBase):
         self.instance.currentObject.response[key].append(info)
 
     def writeVideo(self, aviAction: int, mimeType: str, data: bytes):
-        # Get the key to write to
+        if not self._ensure_response():
+            return
+
         key = self._getkey('video')
 
         # If it isn't there, create it

--- a/packages/ai/src/ai/common/agent/agent.py
+++ b/packages/ai/src/ai/common/agent/agent.py
@@ -165,8 +165,8 @@ class AgentBase(ABC):
                 'agent base emitting answer'
                 f' run_id={answer_payload.get("meta", {}).get("run_id")} framework={answer_payload.get("meta", {}).get("framework")}'
             )
-            answer = Answer(expectJson=True)
-            answer.setAnswer(answer_payload)
+            answer = Answer(expectJson=False)
+            answer.setAnswer(answer_payload.get('content', ''))
             pSelf.instance.writeAnswers(answer)
 
         return answer_payload

--- a/packages/ai/src/ai/constants.py
+++ b/packages/ai/src/ai/constants.py
@@ -74,7 +74,7 @@ CONST_WEB_WS_MAX_SIZE = 250 * 1024 * 1024  # maximum WebSocket message size in b
 # =============================================================================
 # Data Connection Configuration
 # =============================================================================
-CONST_DATA_PIPE_TIMEOUT = 60.0  # seconds of inactivity before pipe is considered zombie
+CONST_DATA_PIPE_TIMEOUT = 300.0  # seconds of inactivity before pipe is considered zombie (5 min for agent pipelines)
 CONST_DATA_SHUTDOWN_TIMEOUT = 30.0  # seconds to wait for data connection shutdown
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- **New HTTP Request tool node** — a complete, agent-invocable tool node that can call any HTTP API endpoint (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS) with full support for authentication (Basic, Bearer, API Key), request bodies (raw JSON/XML, form-data, x-www-form-urlencoded), headers, query params, and path params. Includes a UI config panel with pre-configuration profiles so users can set defaults that agents can override at runtime.
- **Critical engine bug fixes** required to make agent-tool pipelines reliable: CrewAI template variable crash on API responses containing curly braces, response node `NoneType` crash on long-running agent requests, stale CrewAI driver API mismatches with `ToolsBase`, and zombie pipe timeout too short for agent workloads.
- **End-to-end manual testing** through the VS Code extension chat UI across 14 scenarios covering unconfigured and pre-configured node modes.

## Type

Feature + Fix (new tool node with multiple engine bug fixes required to enable agent-tool calling)

## HTTP Request Node — File-by-File Guide

### New Files: `nodes/src/nodes/http_request/`

| File | Lines | Purpose |
|------|-------|---------|
| `__init__.py` | 27 | Package entry point. Exports `IGlobal` and `IInstance` for the engine's node loader. |
| `services.json` | 407 | **UI configuration schema.** Defines the node's config panel: server name, HTTP method, URL, auth type (none/basic/bearer/api_key), body type (none/raw/form_data/x_www_form_urlencoded), headers, query params, and path params. Includes 4 pre-configuration profiles (default GET, POST JSON, Bearer auth, API Key auth). Declares `classType: ["tool"]` and `capabilities: ["invoke"]` so the engine registers this as an agent-callable tool. |
| `IGlobal.py` | 167 | **Global (shared) state.** On `beginGlobal()`, reads the node's config panel values via `Config.getNodeConfig()`, converts UI array-of-objects (headers, query params, path params) into flat dicts via `_array_to_dict()`, builds a defaults dict via `_build_defaults()`, and instantiates an `HttpDriver` with those defaults. The driver persists for the lifetime of the pipeline. |
| `IInstance.py` | 46 | **Instance (per-invocation) handler.** Delegates every `invoke()` call to the `HttpDriver` created by `IGlobal`. Thin pass-through — all logic lives in the driver. |
| `http_driver.py` | 260 | **Tool provider driver.** Implements the `ToolsBase` interface (`_tool_query`, `_tool_validate`, `_tool_invoke`). Exposes a single tool named `{serverName}.http_request` with a full JSON Schema (`INPUT_SCHEMA`) describing all parameters. The `_tool_query` description is carefully worded to guide LLMs on how to construct valid requests. `_merge_with_defaults()` implements the priority chain: agent runtime input > user config defaults > field defaults, with dict-type fields (headers, query_params, path_params) merged additively. |
| `http_client.py` | 184 | **HTTP execution engine.** Pure function `execute_request()` that takes a fully-specified request descriptor and returns a structured response dict (`status_code`, `status_text`, `headers`, `body`, `json`, `elapsed_ms`, `content_type`). Handles path param resolution (`:param` syntax), auth application (Basic/Bearer/API Key to header or query), body serialization (raw/form-data/urlencoded), and response parsing. Uses the `requests` library. |

### Modified Files: Engine Bug Fixes

| File | Change | Why |
|------|--------|-----|
| `nodes/src/nodes/agent_crewai/crewai.py` | Simplified `HostTool` binding loop; removed stale `_safe_str` / schema-injection code; added `desc.replace('{', '{{').replace('}', '}}')` to escape curly braces; removed `inputs` from `crew.kickoff()` | **Fix: CrewAI template crash.** When API responses contained `{sha}` or similar tokens, CrewAI's string formatting raised `KeyError: 'sha'`. The brace escaping prevents this. The `kickoff()` change avoids double-substitution. The simplified tool binding removes dead code that was causing `AttributeError` on newer CrewAI versions. |
| `packages/ai/src/ai/common/agent/agent.py` | Changed `Answer(expectJson=True)` → `Answer(expectJson=False)`; changed `answer.setAnswer(answer_payload)` → `answer.setAnswer(answer_payload.get('content', ''))` | **Fix: "No valid response received" in chat UI.** The agent was sending the full payload dict as JSON, but the response node expected plain text. Now extracts the `content` string and sends it as plain text. |
| `nodes/src/nodes/response/IInstance.py` | Added `_ensure_response()` guard method; added null checks at the top of `close()`, `writeTable()`, `writeDocuments()`, `writeQuestions()`, `writeAnswers()`, `writeAudio()`, `writeVideo()` | **Fix: `NoneType` crash.** When agent requests took longer than the pipe timeout, `currentObject` could become `None` before the response node finished writing. The guard prevents the crash and logs a debug message. |
| `packages/ai/src/ai/constants.py` | `CONST_DATA_PIPE_TIMEOUT`: `60.0` → `300.0` | **Fix: Zombie pipe timeout.** 60 seconds was too short for agent pipelines that make multiple HTTP calls. Increased to 5 minutes. Only affects zombie cleanup timing — no functional change for pipelines completing within 5 minutes. |

## Testing

- [x] Tested locally via VS Code extension chat UI
- [x] `./builder test` passes

### Round 1 — Unconfigured HTTP node (any endpoint)

| # | Query | Method | Result |
|---|-------|--------|--------|
| 1 | Make a GET request to https://httpbin.org/get | GET | PASS |
| 2 | Make a GET request to https://dog.ceo/api/breeds/list/all and show the response | GET | PASS |
| 3 | Make a POST Request to https://httpbin.org/post with JSON body {"name":"RocketRide","version":2} | POST | PASS |
| 4 | Make a GET request to https://httpbin.org/get with query parameters foo=bar and count=3 | GET + Query Params | PASS (after template fix) |
| 5 | Make a GET request to https://httpbin.org/status/404 and tell me the status code | GET (404) | PASS (after template fix) |
| 6 | Make a GET request to https://api.github.com/repos/torvalds/linux and show me the repo description and star count | GET | PASS |
| 7 | Can you make a GET request to https://api.github.com/repos/torvalds/linux and show me the repo description and star count ONLY | GET | PASS (agent filtered response) |
| 8 | I need to make a DELETE request to https://jsonplaceholder.typicode.com/posts/1 and show the response | DELETE | PASS (after timeout fix) |
| 9 | Make a POST Request to https://httpbin.org/post with JSON body {"name":"RocketRide", "version":2} | POST | PASS (after timeout fix) |

### Round 2 — Pre-configured HTTP node (JSONPlaceholder defaults)

| # | Query | Method | What Uses Defaults | What Agent Overrides |
|---|-------|--------|--------------------|---------------------|
| 1 | Get all posts | GET | URL, Method, Headers | Nothing |
| 2 | Get post with id 1 | GET | Method, Headers | URL |
| 3 | Create a new post with title "RocketRide Test" and body "Hello from the pipeline" and userId 1 | POST | Headers | Method, Body |
| 4 | Update post 1 with title "Updated Title" and body "Updated body" and userId 1 | PUT | Headers | Method, URL, Body |
| 5 | Delete post 1 | DELETE | Headers | Method, URL |

### Bugs Found and Fixed During Testing

| Bug | Symptom | Fix |
|-----|---------|-----|
| CrewAI template variable crash | `KeyError: 'sha'` when API response contained `{sha}` in URLs | Escape `{` → `{{` and `}` → `}}` in task description; remove `inputs` from `kickoff()` |
| Response node null pointer | `'NoneType' object has no attribute 'response'` on long-running requests | Added `_ensure_response()` guard on all write methods |
| Agent response not displayed | "No valid response received" in chat UI | Changed to `Answer(expectJson=False)` + extract `content` string |
| Zombie pipe timeout | "Close pipe with id 0 not found" after 60s | Increased `CONST_DATA_PIPE_TIMEOUT` to 300s |
| Stale CrewAI tool binding | `AttributeError` on agent load | Simplified `HostTool` creation loop to match current `ToolsBase` contract |

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included — pipeline uses `${ROCKETRIDE_OPENAI_KEY}` env var substitution
- [ ] Wiki updated (if applicable) — HTTP node config options and merge behavior should be documented
- [x] Breaking changes documented — `CONST_DATA_PIPE_TIMEOUT` changed from 60s to 300s (affects all pipelines, but only delays zombie cleanup; no functional change for pipelines completing within 5 minutes)

## Related Issues

- Related to: HTTP Request node implementation
- Fixes: CrewAI template variable crash when API responses contain curly braces
- Fixes: Response node `NoneType` crash on long-running agent requests
- Fixes: Zombie pipe timeout too short for agent pipeline workloads

## Attachments

<img width="770" height="283" alt="Builder Test Pass" src="https://github.com/user-attachments/assets/d45bada2-4ea2-4f97-8e0f-d8dcece12650" />
<img width="1072" height="778" alt="PR_Testing pipeline" src="https://github.com/user-attachments/assets/f058b8ec-3d78-46ba-a441-18468eff69cf" />
<img width="717" height="663" alt="PR3_Preconfig-queries" src="https://github.com/user-attachments/assets/a2850562-ce30-4a70-b907-616a98e85fee" />
<img width="979" height="692" alt="PR1" src="https://github.com/user-attachments/assets/9ba459d2-f5f9-4e94-9d7f-13153996fa45" />
<img width="700" height="262" alt="PR2" src="https://github.com/user-attachments/asset
<img width="390" height="778" alt="node config-2" src="https://github.com/user-attachments/assets/ccbdf716-6c07-4359-a2fd-9653947d1898" />
<img width="390" height="778" alt="node config - 1" src="https://github.com/user-attachments/assets/3acc1a8e-16a6-4ee0-9e7c-43cb3ec46b14" />
s/91069608-c865-4214-88d2-13ba41aacf90" />

Testing Pipeline(If needed) - An agent + tool calling use case.

[agent-http-request.pipe.json](https://github.com/user-attachments/files/25678886/agent-http-request.pipe.json)
