### PR TITLE
feat(vscode): show pipeline errors/warnings in sidebar and link to status Errors tab

### DIFF
--- a/apps/vscode/src/providers/PageStatusProvider.ts
+++ b/apps/vscode/src/providers/PageStatusProvider.ts
@@ -45,6 +45,7 @@ import { ConfigManager } from '../config';
 import { ConnectionManager } from '../connection/connection';
 import { ConnectionStatus, ConnectionState } from '../shared/types';
 import type { PageStatusIncomingMessage, PageStatusOutgoingMessage } from '../shared/types/pageStatus';
+import { getPipelineFilesTreeProvider } from '../extension';
 
 /**
  * Interface for tracking monitoring state per view
@@ -505,6 +506,13 @@ export class PageStatusProvider {
 		// Update the status data - may be undefined if no status
 		this.taskStatusData.set(key, taskStatus);
 
+		// Refresh sidebar Pipelines tree so error/warning counts and lines update
+		try {
+			getPipelineFilesTreeProvider()?.refresh();
+		} catch {
+			// Sidebar may not be ready yet; ignore
+		}
+
 		// Update webview if it's active
 		try {
 			await this.updateWebview(projectId, sourceId);
@@ -512,6 +520,25 @@ export class PageStatusProvider {
 			this.logger.error(`Updating webview for ${key}: ${error}`);
 			throw error;
 		}
+	}
+
+	/**
+	 * Returns task status for a given project and source (for use by sidebar tree).
+	 */
+	public getTaskStatus(projectId: string, sourceId: string): TaskStatus | undefined {
+		return this.taskStatusData.get(`${projectId}.${sourceId}`);
+	}
+
+	/**
+	 * Reveals the Errors tab and scrolls to the Warnings or Errors section in the status page webview.
+	 * Call after show() so the panel is open. No-op if the panel for this project/source is not open.
+	 */
+	public revealErrorsSection(projectId: string, sourceId: string, section: 'errors' | 'warnings'): void {
+		const key = `${projectId}.${sourceId}`;
+		const viewState = this.webviewPanels.get(key);
+		if (!viewState || viewState.isDisposed) return;
+		viewState.panel.reveal(vscode.ViewColumn.One);
+		viewState.panel.webview.postMessage({ type: 'scrollToSection', section });
 	}
 
 	/**

--- a/apps/vscode/src/providers/SidebarFilesProvider.ts
+++ b/apps/vscode/src/providers/SidebarFilesProvider.ts
@@ -44,6 +44,13 @@ import { ConfigManager } from '../config';
 import { ConnectionManager } from '../connection/connection';
 import { GenericEvent, GenericResponse } from '../shared/types';
 
+/** Parsed location from structured error format (ErrorType*`message`*filepath:linenumber) */
+export interface ParsedErrWarnLine {
+	filePath: string;
+	lineNumber?: number;
+	label: string;
+}
+
 export interface PipelineFileItem {
 	label: string;
 	description?: string;
@@ -54,6 +61,16 @@ export interface PipelineFileItem {
 	parsedFile?: ParsedPipelineFile;
 	sourceComponent?: ParsedSourceComponent;
 	unknownTask?: UnknownTask;
+	/** Task execution errors (for pipelineSource and errorsFolder) */
+	taskErrors?: string[];
+	/** Task execution warnings (for pipelineSource and warningsFolder) */
+	taskWarnings?: string[];
+	/** Folder type for Errors (n) / Warnings (n) nodes */
+	folderType?: 'errors' | 'warnings';
+	/** Raw error/warning strings for folder children */
+	taskItems?: string[];
+	/** Parsed file path and line for errorLine/warningLine click-to-open */
+	errorLine?: ParsedErrWarnLine;
 }
 
 export interface UnknownTask {
@@ -357,6 +374,49 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 				this.logger.error(`Unable to stop pipeline: ${error}`);
 				vscode.window.showErrorMessage(`Failed to stop pipeline: ${error}`);
 			}
+		}),
+
+		vscode.commands.registerCommand('rocketride.sidebar.files.openFileAtLine', async (filePath: string, lineNumber?: number) => {
+			if (!filePath || typeof filePath !== 'string') return;
+			const line = typeof lineNumber === 'number' && lineNumber > 0 ? lineNumber : 1;
+			let uri: vscode.Uri;
+			if (path.isAbsolute(filePath)) {
+				uri = vscode.Uri.file(filePath);
+			} else {
+				const folders = vscode.workspace.workspaceFolders;
+				uri = folders?.length ? vscode.Uri.joinPath(folders[0].uri, filePath) : vscode.Uri.file(filePath);
+			}
+			try {
+				const doc = await vscode.workspace.openTextDocument(uri);
+				const range = new vscode.Range(line - 1, 0, line - 1, 0);
+				await vscode.window.showTextDocument(doc, { selection: range, preview: false });
+			} catch (e) {
+				this.logger.error(`Open file at line failed: ${e}`);
+				vscode.window.showErrorMessage(`Could not open ${path.basename(filePath)}: ${e}`);
+			}
+		}),
+
+		vscode.commands.registerCommand('rocketride.sidebar.files.revealErrorsSection', async (item?: PipelineFileItem) => {
+			if (!item || !item.resourceUri || !item.sourceComponent || !item.folderType) return;
+			const resourceUri = item.resourceUri as vscode.Uri;
+			const sourceComponent = item.sourceComponent as ParsedSourceComponent;
+			const parsedPipeline = this.getParsedPipeline(resourceUri);
+			if (!parsedPipeline?.isValid || !parsedPipeline.projectId) {
+				vscode.window.showErrorMessage(`Invalid pipeline file or missing project_id`);
+				return;
+			}
+			const projectId = parsedPipeline.projectId;
+			const sourceId = sourceComponent.id;
+			const services = this.connectionManager.getCachedServices()?.services ?? {};
+			const providerDef = sourceComponent.provider ? (services[sourceComponent.provider] as { title?: string } | undefined) : undefined;
+			const displayName = sourceComponent.name || providerDef?.title || sourceId;
+			const statusPageProvider = getStatusPageProvider();
+			if (!statusPageProvider) {
+				vscode.window.showErrorMessage('Status page provider not available');
+				return;
+			}
+			await statusPageProvider.show(displayName, resourceUri, projectId, sourceId);
+			statusPageProvider.revealErrorsSection(projectId, sourceId, item.folderType);
 		})
 	];
 
@@ -698,6 +758,32 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 	}
 
 	/**
+	 * Parses structured error/warning string (ErrorType*`message`*filepath:linenumber) for file path, line, and label.
+	 */
+	private parseErrWarnLine(raw: string, type: 'error' | 'warning'): ParsedErrWarnLine {
+		const parts = raw.split('*');
+		if (parts.length >= 3) {
+			const message = parts[1].replace(/^`|`$/g, '').trim();
+			const fileInfo = parts[2].trim();
+			const colonIndex = fileInfo.lastIndexOf(':');
+			let filePath = fileInfo;
+			let lineNumber: number | undefined;
+			if (colonIndex > 0) {
+				const lineStr = fileInfo.substring(colonIndex + 1);
+				const parsed = parseInt(lineStr, 10);
+				if (!isNaN(parsed)) {
+					filePath = fileInfo.substring(0, colonIndex);
+					lineNumber = parsed;
+				}
+			}
+			const fileName = filePath.split(/[/\\]/).pop() || filePath;
+			const label = lineNumber !== undefined ? `${fileName}:${lineNumber} — ${message}` : `${fileName} — ${message}`;
+			return { filePath, lineNumber, label };
+		}
+		return { filePath: '', label: raw };
+	}
+
+	/**
 	 * Updates VS Code context based on current data state
 	 */
 	private updateContextBasedOnData(): void {
@@ -730,6 +816,21 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 						return this.activePipelines.has(key);
 					});
 					contextValue = hasRunningComponents ? 'pipelineFile:running' : 'pipelineFile:stopped';
+					// Aggregate task errors/warnings across all sources for pipeline file description
+					const statusProvider = getStatusPageProvider();
+					let totalErrors = 0;
+					let totalWarnings = 0;
+					for (const comp of parsedFile.sourceComponents) {
+						const ts = statusProvider?.getTaskStatus(parsedFile.projectId!, comp.id);
+						totalErrors += ts?.errors?.length ?? 0;
+						totalWarnings += ts?.warnings?.length ?? 0;
+					}
+					if (totalErrors > 0 || totalWarnings > 0) {
+						const parts = [];
+						if (totalErrors > 0) parts.push(`${totalErrors} error${totalErrors !== 1 ? 's' : ''}`);
+						if (totalWarnings > 0) parts.push(`${totalWarnings} warning${totalWarnings !== 1 ? 's' : ''}`);
+						item.description = (item.description ? `${item.description} · ` : '') + parts.join(', ');
+					}
 				}
 			} else {
 				item.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
@@ -776,9 +877,14 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 					new vscode.ThemeColor(isActive ? 'charts.red' : 'descriptionForeground')
 				);
 
-				// Description: warnings only. The label already shows the name or id.
-				const warnText = comp.warnings.length > 0 ? `${comp.warnings.length} warning(s)` : '';
-				item.description = warnText;
+				// Description: parse-time warnings + task execution errors/warnings
+				const parts: string[] = [];
+				if (comp.warnings.length > 0) parts.push(`${comp.warnings.length} warning(s)`);
+				const errCount = element.taskErrors?.length ?? 0;
+				const warnCount = element.taskWarnings?.length ?? 0;
+				if (errCount > 0) parts.push(`${errCount} error${errCount !== 1 ? 's' : ''}`);
+				if (warnCount > 0) parts.push(`${warnCount} warning${warnCount !== 1 ? 's' : ''}`);
+				item.description = parts.length > 0 ? parts.join(', ') : '';
 
 				// Update context value to include running state
 				contextValue = isActive ? 'pipelineSource:running' : 'pipelineSource:stopped';
@@ -787,6 +893,13 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 				item.iconPath = new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground'));
 				item.description = '';
 			}
+		} else if (element.contextValue === 'errorsSection' || element.contextValue === 'warningsSection') {
+			item.iconPath = element.iconPath;
+			item.command = {
+				command: 'rocketride.sidebar.files.revealErrorsSection',
+				title: 'Go to section',
+				arguments: [element]
+			};
 		} else {
 			// Default icon for other items
 			item.iconPath = element.iconPath || new vscode.ThemeIcon('file-code');
@@ -882,27 +995,63 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 
 		// Return source components for expanded pipeline files (sorted by display name)
 		if (element.contextValue === 'pipelineFile' && element.parsedFile?.isValid) {
-			const sortedSources = [...element.parsedFile.sourceComponents].sort((a, b) => {
+			const parsedFile = element.parsedFile;
+			const projectId = parsedFile.projectId!;
+			const statusProvider = getStatusPageProvider();
+			const sortedSources = [...parsedFile.sourceComponents].sort((a, b) => {
 				const nameA = (a.name || a.id || '').toLowerCase();
 				const nameB = (b.name || b.id || '').toLowerCase();
 				return nameA.localeCompare(nameB, undefined, { sensitivity: 'base' });
 			});
 			const children = sortedSources.map(sourceComponent => {
-				// Use component name if available, otherwise use id for display
 				const displayName = sourceComponent.name || sourceComponent.id;
-
+				const taskStatus = statusProvider?.getTaskStatus(projectId, sourceComponent.id);
+				const taskErrors = taskStatus?.errors?.length ? taskStatus.errors : undefined;
+				const taskWarnings = taskStatus?.warnings?.length ? taskStatus.warnings : undefined;
+				const hasErrWarn = (taskErrors?.length ?? 0) + (taskWarnings?.length ?? 0) > 0;
 				return {
 					label: displayName,
-					description: undefined, // Keep it clean
+					description: undefined,
 					resourceUri: element.resourceUri,
 					contextValue: 'pipelineSource',
-					iconPath: new vscode.ThemeIcon('circle'), // Default icon for now
-					collapsibleState: vscode.TreeItemCollapsibleState.None,
-					sourceComponent: sourceComponent
+					iconPath: new vscode.ThemeIcon('circle'),
+					collapsibleState: hasErrWarn ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+					sourceComponent: sourceComponent,
+					taskErrors,
+					taskWarnings
 				} as PipelineFileItem;
 			});
-
 			return Promise.resolve(children);
+		}
+
+		// Return exactly two lines under a pipelineSource when there are errors/warnings: "Warnings" and/or "Errors"
+		if (element.contextValue === 'pipelineSource' && (element.taskErrors?.length || element.taskWarnings?.length)) {
+			const items: PipelineFileItem[] = [];
+			if (element.taskWarnings?.length) {
+				items.push({
+					label: 'Warnings',
+					description: `${element.taskWarnings.length}`,
+					resourceUri: element.resourceUri,
+					contextValue: 'warningsSection',
+					iconPath: new vscode.ThemeIcon('warning', new vscode.ThemeColor('editorWarning.foreground')),
+					collapsibleState: vscode.TreeItemCollapsibleState.None,
+					sourceComponent: element.sourceComponent,
+					folderType: 'warnings'
+				} as PipelineFileItem);
+			}
+			if (element.taskErrors?.length) {
+				items.push({
+					label: 'Errors',
+					description: `${element.taskErrors.length}`,
+					resourceUri: element.resourceUri,
+					contextValue: 'errorsSection',
+					iconPath: new vscode.ThemeIcon('error', new vscode.ThemeColor('errorForeground')),
+					collapsibleState: vscode.TreeItemCollapsibleState.None,
+					sourceComponent: element.sourceComponent,
+					folderType: 'errors'
+				} as PipelineFileItem);
+			}
+			return Promise.resolve(items);
 		}
 
 		// Return unknown tasks for expanded "Other" item

--- a/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
+++ b/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
@@ -100,6 +100,7 @@ export const PageStatus: React.FC = () => {
 	const [currentElapsed, setCurrentElapsed] = useState<number>(0);
 	const [traceLevel, setTraceLevel] = useState<TraceLevel>('none');
 	const [traceRows, setTraceRows] = useState<TraceRow[]>([]);
+	const [scrollToSectionTarget, setScrollToSectionTarget] = useState<'errors' | 'warnings' | null>(null);
 
 	// Refs for elapsed timer
 	const intervalRef = useRef<number | null>(null);
@@ -143,6 +144,11 @@ export const PageStatus: React.FC = () => {
 					}
 					case 'connectionState': {
 						setConnectionState(message.state);
+						break;
+					}
+					case 'scrollToSection': {
+						setActiveTab('errors');
+						setScrollToSectionTarget(message.section);
 						break;
 					}
 					case 'traceEvent': {
@@ -280,6 +286,17 @@ export const PageStatus: React.FC = () => {
 		};
 		// eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: only reset timer on completion state
 	}, [taskStatus?.completed, taskStatus?.startTime]);
+
+	/** Scroll to Errors or Warnings section when requested (e.g. from sidebar "Errors"/"Warnings" click) */
+	useEffect(() => {
+		if (activeTab !== 'errors' || !scrollToSectionTarget) return;
+		const id = `${scrollToSectionTarget}-section`;
+		const timer = requestAnimationFrame(() => {
+			document.getElementById(id)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+			setScrollToSectionTarget(null);
+		});
+		return () => cancelAnimationFrame(timer);
+	}, [activeTab, scrollToSectionTarget]);
 
 	// ========================================================================
 	// UTILITY FUNCTIONS
@@ -484,10 +501,14 @@ export const PageStatus: React.FC = () => {
 					aria-hidden={activeTab !== 'errors'}
 				>
 					{taskStatus && taskStatus.errors.length > 0 && (
-						<ErrWarnSection title="Errors" items={taskStatus.errors} type="error" />
+						<div id="errors-section">
+							<ErrWarnSection title="Errors" items={taskStatus.errors} type="error" />
+						</div>
 					)}
 					{taskStatus && taskStatus.warnings.length > 0 && (
-						<ErrWarnSection title="Warnings" items={taskStatus.warnings} type="warning" />
+						<div id="warnings-section">
+							<ErrWarnSection title="Warnings" items={taskStatus.warnings} type="warning" />
+						</div>
 					)}
 					{(!taskStatus || (taskStatus.errors.length === 0 && taskStatus.warnings.length === 0)) && (
 						<section className="status-section">

--- a/apps/vscode/src/shared/types/pageStatus.ts
+++ b/apps/vscode/src/shared/types/pageStatus.ts
@@ -45,6 +45,10 @@ export type PageStatusIncomingMessage
 			result?: string;
 			error?: string;
 		};
+	}
+	| {
+		type: 'scrollToSection';
+		section: 'errors' | 'warnings';
 	};
 
 export type PageStatusOutgoingMessage


### PR DESCRIPTION

## Summary

- Sidebar Pipelines tree: show error and warning counts on pipeline file and source names when task status has errors/warnings.
- Under each source with issues, show exactly two lines: "Warnings" (if any) and "Errors" (if any); no expandable folders or per-message lines.
- Clicking "Warnings" or "Errors" in the sidebar opens the pipeline status page (if needed), switches to the Errors tab, and scrolls to the corresponding Warnings or Errors section.
- PageStatusProvider: add getTaskStatus(projectId, sourceId) for the sidebar; call sidebar refresh from updateStatus() so counts update when task status changes.
- Status webview: handle scrollToSection (errors | warnings), set active tab to Errors and scroll to #errors-section or #warnings-section.
- Add revealErrorsSection(projectId, sourceId, section) and rocketride.sidebar.files.revealErrorsSection command.

<img width="422" height="166" alt="image" src="https://github.com/user-attachments/assets/5935d11f-c4e7-4f35-bc44-bf1f3ffe36ee" />

## Type

feat

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->
