### PR TITLE
fix: Performance Metrics reset on tab switch (closes #137)

### DIFF
--- a/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
+++ b/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
@@ -431,22 +431,38 @@ export const PageStatus: React.FC = () => {
 				</div>
 			</div>
 
-			{/* Tab bar — outside the box, content boxed by .tab-content CSS */}
+			{/* Tab bar — outside the box, content boxed by .tab-content CSS. All panels always mounted so Performance Metrics state is preserved on tab switch. */}
 			<TabPanel tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab}>
-				{activeTab === 'status' && (
+				<div
+					className={activeTab === 'status' ? 'tab-panel' : 'tab-panel tab-panel-hidden'}
+					role="tabpanel"
+					aria-hidden={activeTab !== 'status'}
+				>
 					<StatusSection taskStatus={taskStatus} currentElapsed={currentElapsed} />
-				)}
-				{activeTab === 'tokens' && (
+				</div>
+				<div
+					className={activeTab === 'tokens' ? 'tab-panel' : 'tab-panel tab-panel-hidden'}
+					role="tabpanel"
+					aria-hidden={activeTab !== 'tokens'}
+				>
 					<TokenSection taskStatus={taskStatus} />
-				)}
-				{activeTab === 'flow' && (
+				</div>
+				<div
+					className={activeTab === 'flow' ? 'tab-panel' : 'tab-panel tab-panel-hidden'}
+					role="tabpanel"
+					aria-hidden={activeTab !== 'flow'}
+				>
 					<PipelineFlowSection
 						taskStatus={taskStatus}
 						viewMode={viewMode}
 						onViewModeChange={handleViewModeChange}
 					/>
-				)}
-				{activeTab === 'trace' && (
+				</div>
+				<div
+					className={activeTab === 'trace' ? 'tab-panel' : 'tab-panel tab-panel-hidden'}
+					role="tabpanel"
+					aria-hidden={activeTab !== 'trace'}
+				>
 					<TraceSection
 						traceLevel={traceLevel}
 						onTraceLevelChange={setTraceLevel}
@@ -461,25 +477,27 @@ export const PageStatus: React.FC = () => {
 							setTraceRows([]);
 						}}
 					/>
-				)}
-				{activeTab === 'errors' && (
-					<>
-						{taskStatus && taskStatus.errors.length > 0 && (
-							<ErrWarnSection title="Errors" items={taskStatus.errors} type="error" />
-						)}
-						{taskStatus && taskStatus.warnings.length > 0 && (
-							<ErrWarnSection title="Warnings" items={taskStatus.warnings} type="warning" />
-						)}
-						{(!taskStatus || (taskStatus.errors.length === 0 && taskStatus.warnings.length === 0)) && (
-							<section className="status-section">
-								<header className="section-header">Errors &amp; Warnings</header>
-								<div className="section-content">
-									<div className="no-data">No errors or warnings</div>
-								</div>
-							</section>
-						)}
-					</>
-				)}
+				</div>
+				<div
+					className={activeTab === 'errors' ? 'tab-panel' : 'tab-panel tab-panel-hidden'}
+					role="tabpanel"
+					aria-hidden={activeTab !== 'errors'}
+				>
+					{taskStatus && taskStatus.errors.length > 0 && (
+						<ErrWarnSection title="Errors" items={taskStatus.errors} type="error" />
+					)}
+					{taskStatus && taskStatus.warnings.length > 0 && (
+						<ErrWarnSection title="Warnings" items={taskStatus.warnings} type="warning" />
+					)}
+					{(!taskStatus || (taskStatus.errors.length === 0 && taskStatus.warnings.length === 0)) && (
+						<section className="status-section">
+							<header className="section-header">Errors &amp; Warnings</header>
+							<div className="section-content">
+								<div className="no-data">No errors or warnings</div>
+							</div>
+						</section>
+					)}
+				</div>
 			</TabPanel>
 
 			{/* Endpoint Info Modal */}

--- a/apps/vscode/src/providers/views/PageStatus/styles.css
+++ b/apps/vscode/src/providers/views/PageStatus/styles.css
@@ -203,6 +203,11 @@
 	margin-right: 20px;
 }
 
+/* Hide inactive tab panels while keeping them mounted (preserves Performance Metrics state on tab switch) */
+.tab-panel-hidden {
+	display: none;
+}
+
 /* Neutralize nested section wrappers inside tabs */
 .tab-content .status-section,
 .tab-content .pipeline {


### PR DESCRIPTION
### Problem

When the pipeline was running, switching from the **Status** tab to Tokens or Errors and back to Status caused the Performance Metrics graph to reset to zero instead of continuing.

### Root cause

Tab content was **conditionally rendered** (e.g. `{activeTab === 'status' && <StatusSection ... />}`). Leaving the Status tab **unmounted** `StatusSection`; switching back **remounted** it. On remount, `StatusSection`’s init effect ran again (600 zero `dataPoints`) and the 1s sampling interval restarted, so the graph appeared to start over.

### Solution

- **`PageStatus.tsx`:** All tab panels (Status, Tokens, Flow, Trace, Errors) are always rendered. Each panel is wrapped in a `div` with class `tab-panel` and `tab-panel-hidden` when inactive, plus `role="tabpanel"` and `aria-hidden` for accessibility. Only the active panel is visible; the rest stay mounted but hidden.
- **`PageStatus/styles.css`:** Added `.tab-panel-hidden { display: none; }` so inactive panels take no space while remaining in the DOM.

`StatusSection` (and its `dataPoints`, sampling interval, and refs) now stays mounted when switching tabs, so the Performance Metrics graph continues across tab switches.

### Verification

1. Start a pipeline and let the Performance Metrics graph show data.
2. Switch to Tokens, then to Errors, then back to Status.
3. Confirm the graph continues from where it left off (no reset to zero).

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->
