### PR TITLE
fix(ci): reduce workflow noise on PRs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,10 +3,32 @@ name: CodeQL
 on:
   push:
     branches: [develop, main, 'release/**']
+    paths:
+      - '**.ts'
+      - '**.tsx'
+      - '**.js'
+      - '**.mjs'
+      - '**.py'
+      - 'packages/**'
+      - 'apps/**'
+      - 'nodes/**'
   pull_request:
     branches: [develop, main, 'release/**']
+    paths:
+      - '**.ts'
+      - '**.tsx'
+      - '**.js'
+      - '**.mjs'
+      - '**.py'
+      - 'packages/**'
+      - 'apps/**'
+      - 'nodes/**'
   schedule:
     - cron: '17 4 * * 1'  # Weekly Monday 4:17 UTC
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 permissions:
   actions: read

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -12,6 +12,10 @@ on:
   schedule:
     - cron: '42 3 * * 1'  # Weekly Monday 3:42 UTC
 
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   security-events: write

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -3,6 +3,17 @@ name: Dependency Review
 on:
   pull_request:
     branches: [develop, main, 'release/**']
+    paths:
+      - '**/package.json'
+      - '**/pnpm-lock.yaml'
+      - '**/pyproject.toml'
+      - '**/requirements*.txt'
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: [opened, reopened, edited, synchronize]
 
+concurrency:
+  group: ${{ github.event.pull_request.head.ref || github.run_id }}-${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   validate-pr-title:
     name: Validate PR title


### PR DESCRIPTION
## Summary
- Add **concurrency groups** to CodeQL, Dependency Review, Container Scan, and Lint PR — cancels stale runs when new commits are pushed
- Add **path filtering** to CodeQL (source code changes only) and Dependency Review (lockfiles/manifests only) — skips irrelevant PRs entirely
- Build Server and Lint PR still run on every PR (intentional)

## What this fixes
Every PR was triggering 5-6 workflows simultaneously, cluttering the Actions page. Now:
- Docs-only or config-only PRs skip CodeQL and Dependency Review
- Rapid pushes cancel in-flight runs instead of queuing duplicates

## Test plan
- [ ] Open a docs-only PR — verify CodeQL and Dependency Review do NOT trigger
- [ ] Open a source code PR — verify all workflows still trigger
- [ ] Push twice quickly to a PR — verify the first run is cancelled