### PR TITLE
fix(ci): per-module prerelease tags in nightly workflow

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -255,7 +255,9 @@ jobs:
           tag_name: ${{ matrix.tag_name }}
           name: RocketRide ${{ matrix.name }} v${{ matrix.version }} (prerelease)
           prerelease: true
-          generate_release_notes: true
+          generate_release_notes: false
+          body: |
+            Automated prerelease from `develop`.
           files: release-assets/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Replace single `nightly-YYYYMMDD` tag/release with per-module prerelease tags
- Each module gets its own GitHub Release marked as prerelease:
  - `server-v1.0.3-prerelease`
  - `client-typescript-v1.0.1-prerelease`
  - `client-python-v1.0.1-prerelease`
  - `client-mcp-v0.1.0-prerelease`
  - `vscode-v0.0.1-prerelease`
- Tags are force-updated on re-runs (same as before with nightly tag)
- Matches the release workflow's per-module pattern

## Test plan
- [ ] Trigger nightly via workflow_dispatch
- [ ] Verify 5 separate prerelease tags are created
- [ ] Verify each has the correct artifacts attached