### PR TITLE
fix(server): check prerelease builds when downloading pre-built binaries

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -77,6 +77,7 @@ async function getDistInfo(options = {}) {
     const { version } = await loadPackageJson();
     const platform = getPlatformInfo(options);
     const releaseTag = `server-v${version}`;
+    const prereleaseTag = `${releaseTag}-prerelease`;
     const baseName = `rocketride-${releaseTag}-${platform.name}`;
     const manifestFilename = `${baseName}.manifest.json`;
     const distFilename = `${baseName}.${platform.ext}`;
@@ -84,6 +85,7 @@ async function getDistInfo(options = {}) {
 
     return {
         releaseTag: releaseTag,
+        prereleaseTag: prereleaseTag,
         baseName: baseName,
         manifestFilename: manifestFilename,
         distFilename: distFilename,
@@ -459,25 +461,33 @@ function makeCheckPrebuiltAction(options = {}) {
             }
 
             const {
-                releaseTag, manifestFilename, distFilename, symDistFilename
+                releaseTag, prereleaseTag, manifestFilename, distFilename, symDistFilename
             } = await getDistInfo(options);
 
-            let serverHash = null;
+            // Try stable release first, then prerelease
+            const tagsToTry = [releaseTag, prereleaseTag];
+            let matchedTag = null;
 
-            try {
-                // Fetch release manifest and compare content hash
-                const manifestPath = await downloadGitHubFile(releaseTag, manifestFilename, task);
-                if (manifestPath) {
-                    const manifest = await readJson(manifestPath);
-                    await setState('server.releaseManifest', manifest);
-                    serverHash = manifest?.server?.contentHash;
+            for (const tag of tagsToTry) {
+                try {
+                    task.output = `Checking ${tag}...`;
+                    const manifestPath = await downloadGitHubFile(tag, manifestFilename, task);
+                    if (manifestPath) {
+                        const manifest = await readJson(manifestPath);
+                        const serverHash = manifest?.server?.contentHash;
+                        if (localHash === serverHash) {
+                            await setState('server.releaseManifest', manifest);
+                            matchedTag = tag;
+                            break;
+                        }
+                    }
+                } catch {
+                    // Manifest not available for this tag — try next
                 }
-            } catch {
-                // Manifest not available — cannot verify, must compile
             }
 
-            if (localHash !== serverHash) {
-                task.output = 'Source differs from release — will compile';
+            if (!matchedTag) {
+                task.output = 'Source differs from all releases — will compile';
                 await setState('server.contentHash', null);
                 await setState('server.downloaded', false);
                 ctx.downloaded = false;
@@ -491,8 +501,8 @@ function makeCheckPrebuiltAction(options = {}) {
             }
 
             try {
-                task.output = `Downloading ${distFilename}...`;
-                const distPath = await downloadGitHubFile(releaseTag, distFilename, task);
+                task.output = `Downloading ${distFilename} from ${matchedTag}...`;
+                const distPath = await downloadGitHubFile(matchedTag, distFilename, task);
                 if (!distPath)
                     throw new Error(`Dist file ${distFilename} cannot be downloaded`);
                 task.output = `Downloaded ${distFilename}`;
@@ -500,7 +510,7 @@ function makeCheckPrebuiltAction(options = {}) {
                 let symDistPath = null;
                 if (symDistFilename) {
                     task.output = `Downloading ${symDistFilename}...`;
-                    symDistPath = await downloadGitHubFile(releaseTag, symDistFilename, task);
+                    symDistPath = await downloadGitHubFile(matchedTag, symDistFilename, task);
                     if (symDistPath)
                         task.output = `Downloaded ${symDistFilename}`;
                     else
@@ -520,13 +530,13 @@ function makeCheckPrebuiltAction(options = {}) {
                 await setState('server.contentHash', localHash);
                 await setState('server.downloaded', true);
                 ctx.downloaded = true;
-                task.output = `Downloaded server ${releaseTag}`;
+                task.output = `Downloaded server from ${matchedTag}`;
 
             } catch {
                 await setState('server.contentHash', null);
                 await setState('server.downloaded', false);
                 ctx.downloaded = false;
-                task.output = `Release ${releaseTag} download failed: Will compile from source`;
+                task.output = `Release ${matchedTag} download failed: Will compile from source`;
             }
         }
     };


### PR DESCRIPTION
The build system's download-or-compile logic (`makeCheckPrebuiltAction`) determines whether to download a pre-built server binary or compile from source by comparing a content hash of the local source tree against the manifest stored in a GitHub Release.

Previously, it only checked the stable release tag (`server-v{version}`), which is published from the `main` branch. Developers building from `develop` — where active development happens — would always get a content hash mismatch because `develop` has diverged from `main`. This forced a full C++ compile (~20+ minutes) on every clean build, even though the nightly workflow had already built and published the exact same source as a prerelease (`server-v{version}-prerelease`).

This change makes the download logic try both tags in order:

  1. `server-v{version}` (stable) — matches when building from `main`
  2. `server-v{version}-prerelease` (nightly) — matches when building from `develop`, since nightlies are built from that branch

If either manifest's content hash matches the local source, the pre-built binary is downloaded. If neither matches, compilation proceeds as before.

This dramatically reduces build times for developers and CI jobs that build from the `develop` branch, since the nightly prerelease binary can be reused instead of recompiling from source.