### PR TITLE
chore: add automation workflows

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,57 @@
+module:server:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/server/**
+          - apps/engine/**
+
+module:nodes:
+  - changed-files:
+      - any-glob-to-any-file:
+          - nodes/**
+
+module:client-ts:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/client-typescript/**
+
+module:client-python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/client-python/**
+
+module:client-mcp:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/client-mcp/**
+
+module:ai:
+  - changed-files:
+      - any-glob-to-any-file:
+          - packages/ai/**
+
+module:vscode:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/vscode/**
+
+module:chat-ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/chat-ui/**
+
+module:dropper-ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - apps/dropper-ui/**
+
+ci/cd:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/**
+          - scripts/**
+
+docs:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - '**/*.md'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,18 @@
+name: Label PRs
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,35 @@
+name: Stale Issues and PRs
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not
+            had recent activity. It will be closed in 14 days if no further
+            activity occurs. If this issue is still relevant, please leave a
+            comment or remove the stale label.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it
+            has not had recent activity. It will be closed in 14 days if no
+            further activity occurs.
+          close-issue-message: >
+            This issue was closed because it has been stale for 14 days with no
+            activity. Feel free to reopen if this is still relevant.
+          days-before-stale: 90
+          days-before-close: 14
+          exempt-issue-labels: 'pinned,security,help wanted,good first issue'
+          exempt-pr-labels: 'pinned,security'
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":automergeMinor",
+    "schedule:weekdays"
+  ],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "description": "Group minor and patch updates",
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "minor-and-patch",
+      "automerge": true
+    },
+    {
+      "description": "Individual PRs for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "github-actions",
+      "automerge": true
+    },
+    {
+      "description": "Python dependencies",
+      "matchManagers": ["pip_requirements", "pip_setup"],
+      "groupName": "python-dependencies"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"]
+  }
+}


### PR DESCRIPTION
## Summary

- **Renovate** (`renovate.json`): Automated dependency update PRs with semantic commits, weekday scheduling, auto-merge for minor/patch updates, grouped GitHub Actions and Python dependency updates, and vulnerability alert labels.
- **PR auto-labeler** (`.github/labeler.yml` + `.github/workflows/labeler.yml`): Automatically labels PRs based on changed files, mapping to module labels (`module:server`, `module:nodes`, `module:client-ts`, etc.) plus `ci/cd` and `docs` labels.
- **Stale bot** (`.github/workflows/stale.yml`): Marks issues/PRs as stale after 90 days of inactivity and closes them after 14 more days. Exempts issues labeled `pinned`, `security`, `help wanted`, or `good first issue`.

## Notes

- Renovate requires the [Renovate GitHub App](https://github.com/apps/renovate) to be installed on the `rocketride-org` organization (admin action).
- The labeler uses `pull_request_target` for fork safety and syncs labels on each push.

## Test plan

- [ ] Verify Renovate onboarding PR appears after the GitHub App is installed
- [ ] Open a PR touching `nodes/` and confirm `module:nodes` label is applied
- [ ] Open a PR touching `.github/` and confirm `ci/cd` label is applied
- [ ] Verify stale workflow runs on schedule (or trigger manually via workflow_dispatch)