### PR TITLE
chore: add security and trust workflows

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,15 @@
+name: DCO Check
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  dco:
+    name: DCO
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tisonkun/actions-dco@v1.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,39 @@
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '20 7 * * 1'
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,24 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 - `test:` - Test additions or modifications
 - `chore:` - Build process or auxiliary tool changes
 
+### Developer Certificate of Origin (DCO)
+
+All commits must be signed off to certify that you have the right to submit the code under the project's MIT license. This is a lightweight alternative to a Contributor License Agreement.
+
+To sign off your commits, add the `-s` flag:
+
+```bash
+git commit -s -m "feat: add new feature"
+```
+
+This adds a `Signed-off-by` line to your commit message. If you forget, you can amend:
+
+```bash
+git commit --amend -s --no-edit
+```
+
+By signing off, you certify the [Developer Certificate of Origin](https://developercertificate.org/).
+
 ### Pull Request Process
 
 1. Push your branch to GitHub:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build](https://github.com/rocketride-org/rocketride-server/actions/workflows/build.yaml/badge.svg)](https://github.com/rocketride-org/rocketride-server/actions/workflows/build.yaml)
 [![CodeQL](https://github.com/rocketride-org/rocketride-server/actions/workflows/codeql.yml/badge.svg)](https://github.com/rocketride-org/rocketride-server/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/rocketride-org/rocketride-server/badge)](https://securityscorecards.dev/viewer/?uri=github.com/rocketride-org/rocketride-server)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js 18+](https://img.shields.io/badge/Node.js-18%2B-green.svg)](https://nodejs.org/)
 


### PR DESCRIPTION
## Summary

- Add OpenSSF Scorecard workflow (`.github/workflows/scorecard.yml`) that runs weekly and on pushes to `develop`, producing SARIF reports uploaded to GitHub Code Scanning
- Add DCO check workflow (`.github/workflows/dco.yml`) that enforces Developer Certificate of Origin sign-off on all pull requests
- Add OpenSSF Scorecard badge to README.md
- Add DCO instructions section to CONTRIBUTING.md explaining how to sign off commits

## Test plan

- [ ] Verify `scorecard.yml` workflow runs successfully on push to `develop` or via manual dispatch
- [ ] Verify `dco.yml` workflow runs on PRs and correctly flags unsigned commits
- [ ] Verify the Scorecard badge renders in README once the first workflow run completes
- [ ] Verify CONTRIBUTING.md DCO section renders correctly with proper formatting