### PR TITLE
chore: add dev container and copilot instructions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+  "name": "RocketRide Engine",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu-22.04",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    },
+    "ghcr.io/devcontainers/features/java:1": {
+      "version": "17",
+      "installMaven": "true"
+    },
+    "ghcr.io/devcontainers-extra-features/cmake:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@latest --activate",
+  "postStartCommand": "echo 'Run ./builder build to build all modules'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-python.python",
+        "dbaeumer.vscode-eslint",
+        "charliermarsh.ruff",
+        "esbenp.prettier-vscode"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "editor.formatOnSave": true
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,60 @@
+# Copilot Instructions for RocketRide Engine
+
+## Build System
+
+This project uses a custom declarative JS-based builder (NOT npm/pnpm scripts). Entry point: `./builder`
+
+```bash
+./builder build                        # Full build (all modules, parallel)
+./builder build --sequential           # Sequential if parallel fails
+./builder <module>:<command>           # Per-module command
+./builder test                         # All tests
+./builder clean                        # Clean all
+```
+
+Key modules: `server`, `ai`, `client-typescript`, `client-python`, `client-mcp`, `nodes`, `chat-ui`, `dropper-ui`, `vscode`.
+
+## Architecture
+
+```
+Apps (chat-ui, dropper-ui, vscode) → Client SDKs (TS/Python/MCP via WebSocket)
+  → C++ Engine (DAP protocol) → Pipeline Orchestrator → Python Nodes (50+)
+  → External Services (LLMs, vector DBs, storage)
+```
+
+- `apps/` — Runnable applications: React UIs, VSCode extension, C++ engine
+- `packages/server/` — C++ core: engine-core (apLib) and engine-lib (engLib)
+- `packages/client-*` — Client SDKs using DAP protocol over WebSocket
+- `nodes/src/nodes/` — 50+ Python pipeline nodes
+- `packages/ai/` — AI/ML modules
+- `scripts/` — Build system
+
+## Conventions
+
+- **Conventional Commits**: `feat:`, `fix:`, `docs:`, `style:`, `refactor:`, `test:`, `chore:`
+- **Branching**: `develop` (default), `release/**`, `feature/*`, `bugfix/*`, `hotfix/*`
+- **MIT license header** required on all new source files
+- **TypeScript**: Strict mode, ES2022, ESNext modules. Unused vars prefixed with `_`
+- **Python**: Single quotes, ruff for linting/formatting, PEP 257 docstrings, Python 3.10+
+- **C++**: C++17 standard
+
+## Testing
+
+```bash
+./builder nodes:test                   # Contract tests (no server needed)
+./builder nodes:test-full              # Integration tests (starts server)
+./builder server:test                  # C++ engine tests
+./builder client-typescript:test       # TypeScript SDK tests
+```
+
+## Linting
+
+```bash
+npx eslint .                           # TypeScript/JavaScript
+ruff check nodes/                      # Python
+ruff format nodes/                     # Python formatting
+```
+
+## Environment
+
+Only Node.js 18+ is required. Everything else (pnpm, C++ toolchains, Python, Java) is auto-installed by the build system.


### PR DESCRIPTION
## Summary

- Add Dev Container configuration (`.devcontainer/devcontainer.json`) for GitHub Codespaces with Node.js 20, Python 3.11, Java 17, CMake, GitHub CLI, and recommended VS Code extensions
- Add GitHub Copilot project instructions (`.github/copilot-instructions.md`) derived from existing project documentation covering the custom build system, architecture, conventions, testing, and linting

## Test plan

- [ ] Open the repository in a GitHub Codespace and verify the container builds successfully with all features installed
- [ ] Verify `corepack enable && corepack prepare pnpm@latest --activate` runs on container creation
- [ ] Confirm recommended VS Code extensions are suggested on Codespace launch
- [ ] Verify copilot-instructions.md content is accurate against CLAUDE.md