### PR TITLE
chore: add governance model and architecture decision records

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,57 @@
+# Governance
+
+This document describes the governance model for the RocketRide Engine project.
+
+## Roles
+
+### Contributor
+
+Anyone who submits a pull request, opens an issue, or participates in discussions.
+
+- Can submit pull requests
+- Can open and comment on issues
+- Can participate in GitHub Discussions
+
+### Reviewer
+
+Trusted contributors with a track record of quality contributions in a specific area.
+
+- Can review and approve pull requests in their area of expertise
+- Listed in [CODEOWNERS](.github/CODEOWNERS)
+- Nominated by maintainers based on sustained contribution quality
+
+### Maintainer
+
+Core project stewards responsible for the overall direction and health of the project.
+
+- Can merge pull requests
+- Can create releases
+- Can modify CI/CD configuration and repository settings
+- Responsible for enforcing the [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Decision Making
+
+- **Routine changes** (bug fixes, small features, documentation): approved by one maintainer
+- **Significant changes** (new modules, architectural changes, breaking changes): require discussion in a GitHub Issue or Discussion before implementation, and approval from two maintainers
+- **Governance changes**: require consensus among maintainers
+
+## Becoming a Reviewer or Maintainer
+
+There is no formal application process. Maintainers identify active contributors who demonstrate:
+
+- Consistent, high-quality contributions
+- Understanding of the project's architecture and goals
+- Constructive participation in code reviews and discussions
+- Alignment with the project's [Code of Conduct](CODE_OF_CONDUCT.md)
+
+## Escalation
+
+If you disagree with a decision, you can:
+
+1. Discuss in the relevant issue or pull request
+2. Open a GitHub Discussion for broader community input
+3. Contact the maintainers at maintainers@rocketride.ai
+
+## Changes to Governance
+
+This governance model is intentionally lightweight and will evolve as the community grows. Changes are proposed via pull request and require maintainer consensus.

--- a/docs/adr/0001-custom-build-system.md
+++ b/docs/adr/0001-custom-build-system.md
@@ -1,0 +1,42 @@
+# Custom Declarative Build System
+
+## Status
+
+Accepted
+
+## Context
+
+RocketRide Engine is a multi-language project spanning C++ (core engine), TypeScript (client SDKs, UIs, VSCode extension), Python (pipeline nodes, AI modules), and Java (Tika integration). Each module has different toolchains, dependencies, and build steps.
+
+Standard build tools present challenges for this project:
+
+- **npm scripts / pnpm**: Limited to JavaScript/TypeScript; poor C++ and Python support
+- **Make / CMake**: Strong C++ support but weak for JS/Python orchestration
+- **Bazel / Buck**: Powerful but high complexity and steep learning curve for contributors
+- **Nx / Turborepo**: JS-focused monorepo tools; limited multi-language support
+
+## Decision
+
+We use a custom declarative JS-based build system (`./builder`) with the following design:
+
+- **Module registry**: Each module registers itself via a `scripts/tasks.js` file exporting `{ description, actions[] }`
+- **Auto-discovery**: The registry scans for `scripts/tasks.js` files to find all modules
+- **Incremental builds**: Fingerprint-based state tracking in `build/state.json`
+- **Parallel execution**: Modules build concurrently by default (`--sequential` fallback available)
+- **Auto-provisioning**: Required tools (pnpm, Python, Java/Maven, vcpkg) are downloaded automatically — only Node.js 18+ is a prerequisite
+
+## Consequences
+
+### Positive
+
+- Single entry point (`./builder`) for all languages and modules
+- Contributors only need Node.js installed — everything else is auto-provisioned
+- Declarative module definitions are easy to understand and extend
+- Incremental builds via fingerprinting reduce rebuild times
+- Parallel builds maximize throughput
+
+### Negative
+
+- Custom system requires documentation and learning (mitigated by `--help` and docs)
+- Not a standard tool — no ecosystem of plugins or community support
+- Build system itself must be maintained as a project dependency

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,48 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the RocketRide Engine project.
+
+ADRs document significant architectural decisions made during the project's development. They provide context for why certain choices were made and what alternatives were considered.
+
+## Format
+
+We use the [MADR](https://adr.github.io/madr/) (Markdown Any Decision Records) template.
+
+## Index
+
+| # | Title | Status | Date |
+|---|-------|--------|------|
+| [0001](0001-custom-build-system.md) | Custom build system | Accepted | 2024-01-15 |
+
+## Creating a New ADR
+
+1. Copy the template below
+2. Number it sequentially (e.g., `0002-your-decision.md`)
+3. Fill in the sections
+4. Submit via pull request
+
+### Template
+
+```
+# [short title]
+
+## Status
+
+[Proposed | Accepted | Deprecated | Superseded by [ADR-XXXX](XXXX-title.md)]
+
+## Context
+
+[Describe the issue motivating this decision]
+
+## Decision
+
+[Describe the decision and its rationale]
+
+## Consequences
+
+### Positive
+- [benefit]
+
+### Negative
+- [tradeoff]
+```


### PR DESCRIPTION
## Summary

- Add `GOVERNANCE.md` defining contributor, reviewer, and maintainer roles along with the decision-making process
- Initialize `docs/adr/` with a MADR-based ADR template and index
- Add ADR-0001 documenting the rationale for the custom declarative build system

## Test plan

- [ ] Verify all three files render correctly on GitHub
- [ ] Confirm internal links (CODEOWNERS, CODE_OF_CONDUCT.md) resolve once those files exist
- [ ] Review ADR-0001 accuracy against current build system behavior