### PR TITLE
chore: pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,11 +61,11 @@ jobs:
             vcpkg_cmd: ./build/vcpkg/vcpkg
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
       - name: Set up vcpkg

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,17 +34,17 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
         with:
           category: "/language:${{ matrix.language }}"
 
@@ -56,12 +56,12 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
 
@@ -81,7 +81,7 @@ jobs:
             -Source "${{ env.NUGET_FEED_URL }}"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
         with:
           languages: cpp
           build-mode: manual
@@ -96,6 +96,6 @@ jobs:
         run: ./builder server:build --verbose --autoinstall
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
         with:
           category: "/language:cpp"

--- a/.github/workflows/container-scan.yml
+++ b/.github/workflows/container-scan.yml
@@ -28,7 +28,7 @@ jobs:
           - Dockerfile.engine
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install Trivy
         run: |
@@ -47,7 +47,7 @@ jobs:
             --ignore-unfixed
 
       - name: Upload Trivy SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ae9ef3a1d2e3413523c3741725c30064970cc0d4 # v3
         if: always()
         with:
           sarif_file: 'trivy-${{ matrix.dockerfile }}.sarif'

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@05fe4576374b728f0c523d6a13d64c25081e0803 # v4
         with:
           fail-on-severity: high
           deny-licenses: AGPL-3.0-only, AGPL-3.0-or-later

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,7 +22,7 @@ jobs:
       startsWith(github.event.release.tag_name, 'server-v')
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Determine version
         id: version
@@ -64,17 +64,17 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: docker/Dockerfile.engine

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -12,6 +12,6 @@ jobs:
       pull-requests: read
     steps:
       - name: Validate PR title
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -26,7 +26,7 @@ jobs:
       client_typescript_version: ${{ steps.init.outputs.client_typescript_version }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Extract versions
         id: init
         run: |
@@ -68,11 +68,11 @@ jobs:
             vcpkg_cmd: ./build/vcpkg/vcpkg
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
       - name: Set up vcpkg
@@ -113,7 +113,7 @@ jobs:
         run: ${{ matrix.builder_cmd }} package --verbose
 
       - name: Upload server artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: server-artifacts-${{ matrix.platform }}
           path: |
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload VS Code extension
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: vscode-artifacts
           path: ${{ github.workspace }}/dist/vscode/*.vsix
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload MCP client
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mcp-client-artifacts
           path: |
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload Python client
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-client-artifacts
           path: |
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload TypeScript client
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: typescript-client-artifacts
           path: ${{ github.workspace }}/dist/clients/typescript/*.tgz
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -225,10 +225,10 @@ jobs:
             download_pattern: vscode-artifacts
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: ${{ matrix.download_pattern }}
           merge-multiple: true
@@ -245,7 +245,7 @@ jobs:
           git push -f origin "${{ matrix.tag_name }}"
 
       - name: Create GitHub prerelease
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ matrix.tag_name }}
           name: RocketRide ${{ matrix.name }} v${{ matrix.version }} (prerelease)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       client_typescript_version: ${{ steps.init.outputs.client_typescript_version }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Extract versions
         id: init
         run: |
@@ -68,11 +68,11 @@ jobs:
             vcpkg_cmd: ./build/vcpkg/vcpkg
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: 10
       - name: Set up vcpkg
@@ -113,7 +113,7 @@ jobs:
         run: ${{ matrix.builder_cmd }} package --verbose
 
       - name: Upload server artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: server-artifacts-${{ matrix.platform }}
           path: |
@@ -124,7 +124,7 @@ jobs:
 
       - name: Upload VS Code extension
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: vscode-artifacts
           path: ${{ github.workspace }}/dist/vscode/*.vsix
@@ -132,7 +132,7 @@ jobs:
 
       - name: Upload MCP client
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mcp-client-artifacts
           path: |
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload Python client
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-client-artifacts
           path: |
@@ -152,7 +152,7 @@ jobs:
 
       - name: Upload TypeScript client
         if: matrix.platform == 'ubuntu'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: typescript-client-artifacts
           path: ${{ github.workspace }}/dist/clients/typescript/*.tgz
@@ -194,7 +194,7 @@ jobs:
             download_pattern: vscode-artifacts
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
@@ -210,7 +210,7 @@ jobs:
 
       - name: Download artifacts
         if: steps.tag_check.outputs.exists == 'false'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: ${{ matrix.download_pattern }}
           merge-multiple: true
@@ -223,7 +223,7 @@ jobs:
       # --- npm: rocketride ---
       - name: Set up Node.js
         if: steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-typescript'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           registry-url: https://registry.npmjs.org
@@ -245,7 +245,7 @@ jobs:
       # --- PyPI: rocketride ---
       - name: Set up Python
         if: steps.tag_check.outputs.exists == 'false' && (matrix.type == 'client-python' || matrix.type == 'client-mcp')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
@@ -283,7 +283,7 @@ jobs:
       # --- VS Code Marketplace + Open VSX ---
       - name: Set up Node.js for vsce
         if: steps.tag_check.outputs.exists == 'false' && matrix.type == 'vscode'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
 
@@ -330,7 +330,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           tag_name: ${{ matrix.tag_name }}
           name: RocketRide ${{ matrix.name }} v${{ matrix.version }}


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in workflow files to their full SHA commit hashes instead of mutable version tags
- Each pinned reference includes a version comment (e.g., `# v4`) for easy identification of the original version
- Covers all 8 workflow files: build, codeql, container-scan, dependency-review, docker-publish, lint-pr, nightly, and release

## Why

Using mutable version tags (e.g., `@v4`) for GitHub Actions means a compromised upstream action could silently inject malicious code into CI pipelines. Pinning to immutable SHA hashes prevents tag-based supply chain attacks such as the tj-actions/changed-files incident.

This is also a requirement for achieving a good OpenSSF Scorecard score under the Pinned-Dependencies check.

## Test plan

- [ ] Verify the Build server workflow passes on all three platforms (Ubuntu, Windows, macOS)
- [ ] Verify the Lint PR workflow validates this PR title
- [ ] Verify the Dependency Review workflow runs on this PR
- [ ] Confirm no uses: lines reference mutable tags (all use 40-character SHA hashes)
- [ ] Confirm .lock.yml files were not modified