### PR TITLE
docs: document Pydantic serialization fix and expand chat pipeline examples

### DIFF
--- a/apps/vscode/docs/api/ROCKETRIDE_COMMON_MISTAKES.md
+++ b/apps/vscode/docs/api/ROCKETRIDE_COMMON_MISTAKES.md
@@ -2,7 +2,7 @@
 
 A comprehensive guide to avoiding common pitfalls when building RocketRide pipelines and applications.
 
-**Last Updated:** October 19, 2025
+**Last Updated:** March 3, 2026
 
 ---
 
@@ -14,6 +14,7 @@ A comprehensive guide to avoiding common pitfalls when building RocketRide pipel
 - [Language-Specific SDK Mistakes](#language-specific-sdk-mistakes)
 - [Component Configuration Mistakes](#component-configuration-mistakes)
 - [Data Flow Mistakes](#data-flow-mistakes)
+- [Engine Extension (Python–C++ Interop)](#engine-extension-python-c-interop)
 - [Quick Reference](#quick-reference)
 
 ---
@@ -1173,6 +1174,35 @@ Component exists but isn't connected to the data flow.
 ```
 
 **Rule:** Every non-source component should be reachable from the source component.
+
+---
+
+## Engine Extension (Python–C++ Interop)
+
+### Mistake 19: Passing Raw Pydantic Models to C++ JSON Utilities
+
+**Applies to:** Code extending the engine (custom nodes, filter callbacks) that passes Python objects to C++ JSON helpers.
+
+**Problem:**
+```python
+# Custom node or filter callback - passing Pydantic BaseModel directly
+from rocketride.schema import Question
+
+question = Question()
+# ...
+dictToJson(question)  # ERROR: C++ engine crash (pyjson.hpp)
+```
+
+**Why This Happens:**
+The C++ engine's JSON utilities expect plain Python dicts. Pydantic `BaseModel` instances are not directly serializable by the engine's `dictToJson` and similar functions—passing them causes a crash.
+
+**Solution:**
+```python
+# Convert to plain dict before passing to C++ JSON utilities
+dictToJson(question.model_dump())  # CORRECT
+```
+
+**Rule:** When passing Pydantic models (`Question`, `Answer`, `IInvokeLLM`, `IInvokeTool`, etc.) to the engine's JSON serialization layer, always call `.model_dump()` first to convert them to plain dicts.
 
 ---
 

--- a/apps/vscode/docs/api/ROCKETRIDE_QUICKSTART.md
+++ b/apps/vscode/docs/api/ROCKETRIDE_QUICKSTART.md
@@ -196,6 +196,66 @@ npx tsx main.ts
 
 ---
 
+## Chat Pipeline (Q&A with LLM)
+
+Chat pipelines with `chat` source, LLM nodes, and Q&A flow (questions → answers) work end-to-end. Use this pattern for conversational interfaces.
+
+### Minimal Chat Pipeline (`chat.pipe`)
+```json
+{
+  "pipeline": {
+    "project_id": "e30fee74-0f71-4af2-8dab-5d89deee8f84",
+    "source": "chat_1",
+    "components": [
+      {"id": "chat_1", "provider": "chat", "config": {}},
+      {"id": "llm_1", "provider": "llm_openai", "config": {"profile": "openai-5", "openai-5": {"apikey": "${ROCKETRIDE_OPENAI_KEY}"}}, "input": [{"lane": "questions", "from": "chat_1"}]},
+      {"id": "response_1", "provider": "response", "config": {}, "input": [{"lane": "answers", "from": "llm_1"}]}
+    ]
+  }
+}
+```
+
+### Python: Chat with Question/Answer
+```python
+import asyncio
+from rocketride import RocketRideClient
+from rocketride.schema import Question
+
+async def main():
+    client = RocketRideClient()
+    await client.connect()
+    result = await client.use(filepath='chat.pipe')
+    token = result['token']
+
+    q = Question()
+    q.addQuestion("Hello, how are you?")
+    response = await client.chat(token, q)
+    print("Answer:", response.get('answers', [None])[0])
+
+    await client.disconnect()
+asyncio.run(main())
+```
+
+### TypeScript: Chat with Question/Answer
+```typescript
+import { RocketRideClient, Question } from 'rocketride';
+
+const client = new RocketRideClient();
+await client.connect();
+const { token } = await client.use({ filepath: 'chat.pipe' });
+
+const question = new Question();
+question.addQuestion('Hello, how are you?');
+const response = await client.chat(token, question);
+console.log('Answer:', response.answers?.[0]);
+
+await client.disconnect();
+```
+
+> **Note:** Use `client.chat()` for chat pipelines; use `client.send()` for webhook pipelines. See ROCKETRIDE_COMMON_MISTAKES.md for source/method matching.
+
+---
+
 ## Key Patterns to Remember
 
 ### Always Do This:

--- a/apps/vscode/docs/api/ROCKETRIDE_README.md
+++ b/apps/vscode/docs/api/ROCKETRIDE_README.md
@@ -11,7 +11,7 @@ Use RocketRide when building AI pipelines, document processing workflows, or dat
 - **Question answering** with sources and citations from documents
 
 ### AI-Powered Data Processing
-- **LLM workflows**: Summarization, classification, extraction, translation using GPT-4, Claude, Gemini, Mistral, etc.
+- **LLM workflows**: Summarization, classification, extraction, translation using GPT-4, Claude, Gemini, Mistral, etc. Chat pipelines with `chat` source, LLM nodes, and Q&A flow (questions → answers) are stable and work end-to-end.
 - **Batch AI processing**: Run LLMs over datasets (summarize reports, extract structured data from invoices, classify support tickets, etc.)
 - **Multi-step AI pipelines**: Chain multiple LLM operations with transformations
 

--- a/docs/README-engine.md
+++ b/docs/README-engine.md
@@ -258,6 +258,12 @@ packages/server/
 
 ---
 
+## Python Integration
+
+When extending the engine with Python (custom nodes, filter callbacks), Pydantic models (`Question`, `Answer`, `IInvokeLLM`, `IInvokeTool`, etc.) must be converted to plain dicts via `.model_dump()` before passing to C++ JSON utilities—passing raw `BaseModel` instances causes crashes. See `ROCKETRIDE_COMMON_MISTAKES.md` (Mistake 19) for details.
+
+---
+
 ## Dependencies
 
 - **Boost** -- filesystem, threading


### PR DESCRIPTION
## Summary


Update docs to match the Pydantic serialization change in the engine (`binder.cpp`, `filter.callbacks.target.cpp`). The engine now calls `.model_dump()` before passing Pydantic models into C++ JSON utilities, which fixes the crash.

## Changes

- **ROCKETRIDE_COMMON_MISTAKES.md**: Added Mistake 19 — do not pass raw Pydantic models to C++ JSON utilities; use `.model_dump()`.
- **ROCKETRIDE_QUICKSTART.md**: Added "Chat Pipeline (Q&A with LLM)" section with Python and TypeScript examples.
- **ROCKETRIDE_README.md**: Clarified that chat + LLM pipelines work end-to-end.
- **docs/README-engine.md**: Added "Python Integration" section describing the Pydantic serialization requirement.

-

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Fix https://github.com/rocketride-org/rocketride-server/issues/135
