### PR TITLE
fix(engine,vscode): fix missing monitor output

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,6 @@
 			"type": "shell",
 			"command": "./builder",
 			"args": [
-				"vscode:clean",
 				"vscode:build"
 			],
 			"options": {

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -107,13 +107,13 @@
 					"default": "latest",
 					"description": "Engine version to download. 'latest' for newest stable, 'prerelease' for newest prerelease, or a specific tag like 'server-v3.1.1'."
 				},
-				"rocketride.local.engineArgs": {
+				"rocketride.engineArgs": {
 					"type": "array",
 					"items": {
 						"type": "string"
 					},
 					"default": [],
-					"description": "Additional arguments for local engine startup"
+					"description": "Additional arguments passed to the engine subprocess (applies to all connection modes)"
 				},
 				"rocketride.autoConnect": {
 					"type": "boolean",

--- a/apps/vscode/scripts/tasks.js
+++ b/apps/vscode/scripts/tasks.js
@@ -183,6 +183,9 @@ function makeStageFilesAction() {
                 }
             }
 
+            // Write .vscodeignore so vsce excludes the engine directory (downloaded at runtime)
+            await writeFile(path.join(BUILD_DIR, '.vscodeignore'), 'engine/**\n');
+
             await saveVscodeAndSharedUiHashes(srcHash, sharedUiHash);
             task.output = 'Manifest staged in build/vscode';
         }

--- a/apps/vscode/src/config.ts
+++ b/apps/vscode/src/config.ts
@@ -47,14 +47,15 @@ export interface ConfigManagerInfo {
 	/** Default path for creating new pipeline files */
 	defaultPipelinePath: string;
 
+	/** Additional engine arguments (passed to engine subprocess in all connection modes) */
+	engineArgs: string[];
+
 	/** Local configuration */
 	local: {
 		/** Local host address (default: 'localhost') */
 		host: string;
 		/** Local port (default: 5565) */
 		port: number;
-		/** Additional engine arguments */
-		engineArgs: string[];
 		/** Engine version to download: 'latest', 'prerelease', or a specific tag */
 		engineVersion: string;
 	};
@@ -96,10 +97,10 @@ export class ConfigManager {
 		hostUrl: 'http://localhost:5565',
 		deployUrl: '',
 		defaultPipelinePath: '',
+		engineArgs: [],
 		local: {
 			host: '',
 			port: 5565,
-			engineArgs: [],
 			engineVersion: 'latest',
 		},
 		autoConnect: true,
@@ -204,10 +205,10 @@ export class ConfigManager {
 			hostUrl: hostUrl,
 			deployUrl: deployUrl,
 			defaultPipelinePath: config.get('defaultPipelinePath', 'pipelines'),
+			engineArgs: config.get('engineArgs', []),
 			local: {
 				host: parsedHost,
 				port: parsedPort,
-				engineArgs: config.get('local.engineArgs', []),
 				engineVersion: config.get('local.engineVersion', 'latest')
 			},
 			autoConnect: config.get('autoConnect', true),

--- a/apps/vscode/src/connection/connection.ts
+++ b/apps/vscode/src/connection/connection.ts
@@ -109,7 +109,6 @@ export class ConnectionManager extends EventEmitter {
 			// before running a single disconnect/reconnect cycle.
 			if (this.configChangeTimeout) {
 				clearTimeout(this.configChangeTimeout);
-			} else {
 			}
 			this.configChangeTimeout = setTimeout(() => {
 				this.configChangeTimeout = undefined;
@@ -301,7 +300,6 @@ export class ConnectionManager extends EventEmitter {
 			this.manager.removeAllListeners();
 			await this.manager.stop();
 			this.manager = undefined;
-		} else {
 		}
 	}
 
@@ -321,7 +319,7 @@ export class ConnectionManager extends EventEmitter {
 						const text = String(body.output).trimEnd();
 						if (text) {
 							const source = body.__id ? `[${body.__id}] ` : '';
-							this.logger.output(`${icons.receive} ${source}${text}`);
+							this.logger.console(`    ${source}${text}`);
 						}
 					}
 				} else if (message.event?.startsWith('apaevt_')) {
@@ -529,7 +527,6 @@ export class ConnectionManager extends EventEmitter {
 				} catch {
 					// Error handled within _connect()
 				}
-			} else {
 			}
 		}, delayMs);
 	}
@@ -696,7 +693,6 @@ export class ConnectionManager extends EventEmitter {
 			// Fire-and-forget disconnect; don't await to avoid blocking disposal
 			this.client.disconnect().catch(() => { /* ignore */ });
 			this.client = undefined;
-		} else {
 		}
 	}
 

--- a/apps/vscode/src/connection/engine-manager.ts
+++ b/apps/vscode/src/connection/engine-manager.ts
@@ -44,7 +44,7 @@ export class EngineManager extends BaseManager {
 	private child?: ChildProcess;
 	private started = false;
 
-	constructor(extensionPath: string) {
+constructor(extensionPath: string) {
 		super();
 		this.installer = new EngineInstaller(extensionPath);
 	}
@@ -132,7 +132,7 @@ export class EngineManager extends BaseManager {
 			'./ai/eaas.py',
 			`--host=${config.local.host}`,
 			`--port=${config.local.port}`,
-			...config.local.engineArgs
+			...config.engineArgs
 		];
 
 		await this.startProcess(executablePath, args);
@@ -216,8 +216,9 @@ export class EngineManager extends BaseManager {
 			this.child.stdout?.on('data', (data) => {
 				const output = data.toString();
 				for (const message of output.split('\n')) {
-					if (message.trim()) {
-						this.logger.output(`${icons.message} ${message.trim()}`);
+					const msg = message.trim();
+					if (msg) {
+						this.logger.console(msg.trim());
 						if (message.trim().includes('Uvicorn running')) {
 							tryResolveReady();
 						}
@@ -225,12 +226,13 @@ export class EngineManager extends BaseManager {
 				}
 			});
 
-			// Monitor stderr (all engine stdio goes to RocketRide output)
+			// Monitor stderr
 			this.child.stderr?.on('data', (data) => {
 				const output = data.toString();
 				for (const message of output.split('\n')) {
-					if (message.trim()) {
-						this.logger.output(`${icons.message} ${message.trim()}`);
+					const msg = message.trim();
+					if (msg) {
+						this.logger.console(msg.trim());
 						if (message.trim().includes('Uvicorn running')) {
 							tryResolveReady();
 						}

--- a/apps/vscode/src/debugger/session.ts
+++ b/apps/vscode/src/debugger/session.ts
@@ -259,6 +259,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 		try {
 			if (this.isLaunchRequest(message)) {
 				message.arguments.pipeline = this.pipeline;
+				message.arguments.args = this.configManager.getConfig().engineArgs;
 
 			} else if (this.isAttachRequest(message)) {
 				this.token = message.arguments?.token;

--- a/apps/vscode/src/providers/PageSettingsProvider.ts
+++ b/apps/vscode/src/providers/PageSettingsProvider.ts
@@ -224,7 +224,7 @@ export class PageSettingsProvider {
 
 			// Local engine settings
 			localEngineVersion: workspaceConfig.get('local.engineVersion', 'latest'),
-			localEngineArgs: workspaceConfig.get('local.engineArgs', []),
+			localEngineArgs: workspaceConfig.get('engineArgs', []),
 
 			// Debugging settings
 			pipelineRestartBehavior: workspaceConfig.get('pipelineRestartBehavior', 'prompt'),
@@ -278,7 +278,7 @@ export class PageSettingsProvider {
 				await workspaceConfig.update('local.engineVersion', settings.localEngineVersion, vscode.ConfigurationTarget.Global);
 			}
 			if (settings.localEngineArgs !== undefined) {
-				await workspaceConfig.update('local.engineArgs', settings.localEngineArgs, vscode.ConfigurationTarget.Global);
+				await workspaceConfig.update('engineArgs', settings.localEngineArgs, vscode.ConfigurationTarget.Global);
 			}
 
 			// Save debugging settings

--- a/apps/vscode/src/providers/PageStatusProvider.ts
+++ b/apps/vscode/src/providers/PageStatusProvider.ts
@@ -850,7 +850,8 @@ export class PageStatusProvider {
 							projectId: viewState.projectId,
 							source: viewState.sourceId,
 							pipeline: pipelineTransformed,
-							pipelineTraceLevel: 'full'
+							pipelineTraceLevel: 'full',
+							args: ConfigManager.getInstance().getConfig().engineArgs
 						});
 					} catch (error: unknown) {
 						this.logger.error(`Unable to execute pipeline: ${error}`);

--- a/apps/vscode/src/providers/SidebarFilesProvider.ts
+++ b/apps/vscode/src/providers/SidebarFilesProvider.ts
@@ -230,7 +230,8 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 					projectId: projectId,
 					source: sourceId,
 					pipeline: pipelineTransformed,
-					pipelineTraceLevel: 'full'
+					pipelineTraceLevel: 'full',
+					args: ConfigManager.getInstance().getConfig().engineArgs
 				});
 			} catch (error) {
 				vscode.window.showErrorMessage(`Failed to run pipeline: ${error}`);

--- a/apps/vscode/src/shared/util/output.ts
+++ b/apps/vscode/src/shared/util/output.ts
@@ -140,21 +140,15 @@ class OutputLogger {
 	/** Static instance holder for singleton pattern implementation */
 	private static instance: OutputLogger;
 
-	/** VS Code OutputChannel instance for writing log messages to the Output panel */
+	/** Extension channel: DAP traffic, connection lifecycle, diagnostics */
 	private readonly outputChannel: vscode.OutputChannel;
 
-	/**
-	 * Private constructor to enforce singleton pattern.
-	 * 
-	 * Creates a new VS Code OutputChannel with the name "RocketRide".
-	 * This channel will appear in VS Code's Output panel dropdown,
-	 * allowing users to view extension-specific logs separately from
-	 * other extensions and VS Code's internal logs.
-	 */
+	/** Console channel: plain server output (stdout/stderr from pipelines) */
+	private readonly consoleChannel: vscode.OutputChannel;
+
 	private constructor() {
-		// Create a named output channel that appears in VS Code's Output panel
-		// The name "RocketRide" will be visible in the Output panel's dropdown selector
-		this.outputChannel = vscode.window.createOutputChannel('RocketRide');
+		this.outputChannel = vscode.window.createOutputChannel('Rocket Ride: Extension');
+		this.consoleChannel = vscode.window.createOutputChannel('Rocket Ride: Console');
 	}
 
 	/**
@@ -194,44 +188,21 @@ class OutputLogger {
 	 * @param message The message to log - can include emojis, formatting, or plain text
 	 */
 	public output(message: string): void {
-		// Append the message to the output channel with a newline
-		// This ensures each log entry appears on its own line in the Output panel
 		this.outputChannel.appendLine(message);
 	}
 
 	/**
-	 * Logs a message to the output channel.
-	 * 
-	 * Messages are appended as new lines to the output channel, making them
-	 * visible in VS Code's Output panel when the "RocketRide" channel is selected.
-	 * 
-	 * The method supports any string content, including formatted messages with
-	 * icons, timestamps, or structured data. No automatic formatting is applied,
-	 * giving callers full control over message presentation.
-	 * 
-	 * @param message The message to log - can include emojis, formatting, or plain text
+	 * Logs plain text to the "Rocket Ride: Console" output channel.
 	 */
+	public console(message: string): void {
+		this.consoleChannel.appendLine(message);
+	}
+
 	public error(message: string): void {
-		// Append the message to the output channel with a newline
-		// This ensures each log entry appears on its own line in the Output panel
 		this.output(`${icons.error} ${message}`);
 	}
 
-	/**
-	 * Logs a message to the output channel.
-	 * 
-	 * Messages are appended as new lines to the output channel, making them
-	 * visible in VS Code's Output panel when the "RocketRide" channel is selected.
-	 * 
-	 * The method supports any string content, including formatted messages with
-	 * icons, timestamps, or structured data. No automatic formatting is applied,
-	 * giving callers full control over message presentation.
-	 * 
-	 * @param message The message to log - can include emojis, formatting, or plain text
-	 */
 	public info(message: string): void {
-		// Append the message to the output channel with a newline
-		// This ensures each log entry appears on its own line in the Output panel
 		this.output(`${icons.info} ${message}`);
 	}
 

--- a/packages/ai/src/ai/eaas.py
+++ b/packages/ai/src/ai/eaas.py
@@ -40,7 +40,6 @@ from typing import Any, Dict
 
 from ai.web import WebServer
 
-
 def create_parser() -> argparse.ArgumentParser:
     """Create argument parser for EAAS server."""
     parser = argparse.ArgumentParser(
@@ -129,9 +128,6 @@ async def run(config: Dict[str, Any] = None) -> None:
         config['base_port'] = args.base_port
         config['verbose'] = args.verbose
 
-    print('[EAAS_SERVER] Configuration:')
-    print(f'  Host: {config["host"]}')
-    print(f'  Port: {config["port"]}')
     if config.get('modelserver'):
         print(f'  Model Server: {config["modelserver"]}')
     if config.get('verbose'):

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1075,9 +1075,6 @@ class Task(DAPBase):
                 message,
             )
 
-            # Output the message to the console
-            debug(output_message)
-
         else:
             # Forward to debugging clients
             await self._forward_task_event(

--- a/packages/ai/src/ai/node.py
+++ b/packages/ai/src/ai/node.py
@@ -7,7 +7,7 @@ import threading
 if sys.path and (sys.path[0].endswith('ai') or sys.path[0].endswith('ai\\') or sys.path[0].endswith('ai/')):
     sys.path.pop(0)
 
-# Import generated gRPC code early to resolve absolute import dependencies.
+# Import directly from C++
 from engLib import debug
 
 # Global shared event loop for async operations in worker threads

--- a/packages/server/engine-lib/engLib/python/init.cpp
+++ b/packages/server/engine-lib/engLib/python/init.cpp
@@ -201,6 +201,10 @@ Error setConfig(int argc, wchar_t **argv) {
     // Parse the argv we set
     g_config.parse_argv = 1;
 
+    // Disable Python stdio buffering so print() output reaches piped
+    // stdout immediately (e.g. when spawned by VS Code with stdio: 'pipe')
+    g_config.buffered_stdio = 0;
+
     // Setup the arguments
     if (auto ccode = checkStatus(::PyConfig_SetArgv(&g_config, argc, argv)))
         return ccode;


### PR DESCRIPTION
## Summary

- Fix missing Python `print()` output (e.g. ASCII banner) when engine is spawned by VS Code with piped stdio, by disabling Python's default stdio buffering (`buffered_stdio = 0` in `PyConfig_InitIsolatedConfig`)
- Move `engineArgs` from `rocketride.local.engineArgs` to top-level `rocketride.engineArgs` and forward it through DAP launch/execute requests so engine arguments apply to all connection modes
- Split single "RocketRide" VS Code output channel into "Rocket Ride: Extension" (DAP traffic, diagnostics) and "Rocket Ride: Console" (plain engine stdout/stderr) for cleaner log separation

fix, refactor

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

