### PR TITLE
feat(vscode): replace Docker run with pull + create deploy flow

### DIFF
--- a/apps/vscode/src/providers/PageDeployProvider.ts
+++ b/apps/vscode/src/providers/PageDeployProvider.ts
@@ -25,7 +25,7 @@
  * Deploy Page Provider
  *
  * Provides a webview panel for the Deploy page: deploy to RocketRide.ai cloud
- * or pull and run from GHCR.
+ * or pull and deploy from GHCR.
  */
 
 import * as vscode from 'vscode';
@@ -82,8 +82,8 @@ export class PageDeployProvider {
 					} else if (message.type === 'copyToClipboard' && typeof message.text === 'string') {
 						await vscode.env.clipboard.writeText(message.text);
 						vscode.window.showInformationMessage('Copied to clipboard.');
-					} else if (message.type === 'dockerRun') {
-						this.runDockerEngine();
+					} else if (message.type === 'dockerDeployLocal') {
+						this.deployDockerLocal();
 					}
 				} catch (err) {
 					vscode.window.showErrorMessage(`Deploy action failed: ${err instanceof Error ? err.message : String(err)}`);
@@ -104,16 +104,18 @@ export class PageDeployProvider {
 
 	private static readonly ENGINE_IMAGE = 'ghcr.io/rocketride-org/rocketride-engine:latest';
 
-	private runDockerEngine(): void {
+	private deployDockerLocal(): void {
 		try {
+			const image = PageDeployProvider.ENGINE_IMAGE;
 			const term = vscode.window.createTerminal({
-				name: 'RocketRide Engine',
+				name: 'RocketRide Deploy',
 				hideFromUser: false
 			});
 			term.show();
-			term.sendText(`docker run --rm -p 5565:5565 ${PageDeployProvider.ENGINE_IMAGE}`);
+			term.sendText(`docker pull ${image}`);
+			term.sendText(`docker create --name rocketride-engine -p 5565:5565 ${image}`);
 		} catch (err) {
-			vscode.window.showErrorMessage(`Failed to start Docker engine: ${err instanceof Error ? err.message : String(err)}`);
+			vscode.window.showErrorMessage(`Failed to deploy Docker image: ${err instanceof Error ? err.message : String(err)}`);
 		}
 	}
 

--- a/apps/vscode/src/providers/views/PageDeploy/PageDeploy.tsx
+++ b/apps/vscode/src/providers/views/PageDeploy/PageDeploy.tsx
@@ -31,7 +31,7 @@ import './styles.css';
 type PageDeployIncomingMessage =
 	| { type: 'init'; rocketrideLogoDarkUri?: string; rocketrideLogoLightUri?: string; dockerIconUri?: string; onpremIconUri?: string; engineImage?: string };
 
-type PageDeployOutgoingMessage = { type: 'ready' } | { type: 'copyToClipboard'; text: string } | { type: 'dockerRun' };
+type PageDeployOutgoingMessage = { type: 'ready' } | { type: 'copyToClipboard'; text: string } | { type: 'dockerDeployLocal' };
 
 export const PageDeploy: React.FC = () => {
 	const [logoDarkUri, setLogoDarkUri] = useState<string | undefined>();
@@ -39,7 +39,7 @@ export const PageDeploy: React.FC = () => {
 	const [dockerUri, setDockerUri] = useState<string | undefined>();
 	const [onpremUri, setOnpremUri] = useState<string | undefined>();
 	const [engineImage, setEngineImage] = useState('ghcr.io/rocketride-org/rocketride-engine:latest');
-	const [dockerRunning, setDockerRunning] = useState(false);
+	const [deploying, setDeploying] = useState(false);
 
 	const { sendMessage } = useMessaging<PageDeployOutgoingMessage, PageDeployIncomingMessage>({
 		onMessage: (message) => {
@@ -56,6 +56,8 @@ export const PageDeploy: React.FC = () => {
 	useEffect(() => {
 		sendMessage({ type: 'ready' });
 	}, [sendMessage]);
+
+	const remoteCommands = `docker pull ${engineImage}\ndocker create --name rocketride-engine -p 5565:5565 ${engineImage}`;
 
 	return (
 		<div className="deploy-app">
@@ -77,33 +79,37 @@ export const PageDeploy: React.FC = () => {
 						<img src={dockerUri} alt="Docker" className="deploy-panel-icon" />
 					)}
 					<div className="deploy-panel-content">
-						<h1 className="deploy-panel-title">Docker</h1>
+						<h1 className="deploy-panel-title">Deploy Image</h1>
 						<p className="deploy-panel-description">
-							Pull and run the RocketRide engine container. Requires Docker to be installed.
+							Download the RocketRide engine image and create a container.
+							Requires Docker to be installed.
 						</p>
 						<div className="deploy-panel-actions">
 							<button
 								type="button"
 								className="deploy-panel-btn deploy-panel-btn-primary"
-								disabled={dockerRunning}
+								disabled={deploying}
 								onClick={() => {
-									setDockerRunning(true);
-									sendMessage({ type: 'dockerRun' });
+									setDeploying(true);
+									sendMessage({ type: 'dockerDeployLocal' });
 								}}
 							>
-								{dockerRunning ? 'Engine started' : 'Run engine'}
+								{deploying ? 'Image deployed' : 'Deploy locally'}
 							</button>
 						</div>
 						<details className="deploy-panel-details">
-							<summary>Show commands</summary>
+							<summary>Deploy to a remote server</summary>
 							<div className="deploy-panel-commands">
-								<pre className="deploy-panel-code"><code>{`docker run --rm -p 5565:5565 ${engineImage}`}</code></pre>
+								<p className="deploy-panel-description">
+									Run these commands on your target server to pull the image and create a container:
+								</p>
+								<pre className="deploy-panel-code"><code>{remoteCommands}</code></pre>
 								<button
 									type="button"
 									className="deploy-panel-copy"
-									onClick={() => sendMessage({ type: 'copyToClipboard', text: `docker run --rm -p 5565:5565 ${engineImage}` })}
+									onClick={() => sendMessage({ type: 'copyToClipboard', text: remoteCommands })}
 								>
-									Copy run command
+									Copy commands
 								</button>
 							</div>
 						</details>


### PR DESCRIPTION
## Summary
- Replace `docker run --rm` with `docker pull` + `docker create --name rocketride-engine` so the container persists in Docker without auto-starting
- Rename "Run engine" button to "Deploy locally" and "Engine started" to "Image deployed"
- Replace "Show commands" expandable with "Deploy to a remote server" section containing copyable `docker pull` + `docker create` commands
- Use separate `term.sendText()` calls instead of `&&` chaining for cross-shell compatibility (PowerShell 5.1)

## Test plan
- [ ] Open the Deploy page in VS Code extension and verify the Docker panel title reads "Deploy Image"
- [ ] Click "Deploy locally" and verify it opens a terminal that runs `docker pull` followed by `docker create`
- [ ] Verify the container appears in Docker Desktop (stopped, not running)
- [ ] Expand "Deploy to a remote server" and verify the commands are correct
- [ ] Click "Copy commands" and verify clipboard contains both commands
- [ ] Test on Windows (PowerShell) to confirm no `&&` issues