### PR TITLE
fix: update pnpm-lock.yaml for pnpm 10 compatibility

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -328,14 +328,6 @@ importers:
         specifier: ^5.8.3
         version: 5.9.3
 
-  nodes: {}
-
-  packages/ai: {}
-
-  packages/client-mcp: {}
-
-  packages/client-python: {}
-
   packages/client-typescript:
     dependencies:
       commander:
@@ -376,10 +368,6 @@ importers:
       ws:
         specifier: ^8.18.3
         version: 8.19.0
-
-  packages/server/engine-core: {}
-
-  packages/server/engine-lib: {}
 
   packages/shared-ui:
     dependencies:
@@ -624,8 +612,6 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
-
-  packages/tika: {}
 
 packages:
 


### PR DESCRIPTION
## Summary
- Remove empty workspace entries (`nodes: {}`, `packages/ai: {}`, etc.) from `pnpm-lock.yaml` that pnpm 9 wrote but pnpm 10 rejects
- Fixes `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` when running `pnpm install --frozen-lockfile` in CI

## Test plan
- [x] `pnpm install --frozen-lockfile` passes locally with pnpm 10.30.3
- [ ] CI build passes on all platforms