### PR TITLE
fix(docker): remove healthcheck that pings unsupported root endpoint

### DIFF
--- a/docker/Dockerfile.engine
+++ b/docker/Dockerfile.engine
@@ -3,7 +3,6 @@ FROM ubuntu:jammy
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
        ca-certificates \
-       curl \
        libc++1 \
        libc++abi1 \
        libgomp1 \
@@ -17,8 +16,5 @@ WORKDIR /opt/rocketride
 USER rocketride
 
 EXPOSE 5565
-
-HEALTHCHECK --interval=10s --timeout=3s --start-period=30s --retries=3 \
-    CMD curl -sS -o /dev/null -w '%{http_code}' http://localhost:5565/ | grep -q '401' || exit 1
 
 ENTRYPOINT ["./engine", "./ai/eaas.py"]


### PR DESCRIPTION
## Summary
- Removes the `HEALTHCHECK` directive from `Dockerfile.engine` — it was hitting `GET /` every 10s, which is not a supported endpoint on the engine
- Removes `curl` from the image since it was only needed for the healthcheck, reducing image size

## Test plan
- [ ] Build and run the Docker image, verify no more `GET /` spam in logs
- [ ] Verify container runs without healthcheck errors in Docker Desktop