### PR TITLE
fix(ui): Adjust welcome page

### DIFF
--- a/apps/vscode/src/providers/PageConnectionProvider.ts
+++ b/apps/vscode/src/providers/PageConnectionProvider.ts
@@ -91,7 +91,7 @@ export class PageConnectionProvider implements vscode.WebviewViewProvider {
 					break;
 
 			case 'openDocs':
-				vscode.env.openExternal(vscode.Uri.parse('https://docs.rocketride.ai'));
+				vscode.env.openExternal(vscode.Uri.parse('https://docs.rocketride.org'));
 				break;
 
 			case 'openDeploy':

--- a/apps/vscode/src/providers/PageWelcomeProvider.ts
+++ b/apps/vscode/src/providers/PageWelcomeProvider.ts
@@ -168,7 +168,7 @@ export class PageWelcomeProvider {
 				apiKey,
 				hasApiKey: this.configManager.hasApiKey(),
 				autoConnect: workspaceConfig.get('autoConnect', true),
-				localEngineVersion: workspaceConfig.get('local.engineVersion', 'latest'),
+				localEngineVersion: workspaceConfig.get('local.engineVersion', 'prerelease'),
 			}
 		});
 	}

--- a/apps/vscode/src/providers/views/PageSettings/ConnectionSettings.tsx
+++ b/apps/vscode/src/providers/views/PageSettings/ConnectionSettings.tsx
@@ -165,7 +165,7 @@ export const ConnectionSettings: React.FC<ConnectionSettingsProps> = ({
 								onClick={toggleApiKeyVisibility}
 								title={showApiKey ? 'Hide API key' : 'Show API key'}
 							>
-								{showApiKey ? '🙈' : '👁'}
+								{showApiKey ? '🙈' : '🔍'}
 							</button>
 							{settings.apiKey.trim() && (
 								<button

--- a/apps/vscode/src/providers/views/PageSettings/EnvVariablesSettings.tsx
+++ b/apps/vscode/src/providers/views/PageSettings/EnvVariablesSettings.tsx
@@ -237,7 +237,7 @@ export const EnvVariablesSettings: React.FC<EnvVariablesSettingsProps> = ({
 													onClick={() => toggleValueVisibility(key)}
 													title={isVisible ? 'Hide value' : 'Show value'}
 												>
-													{isVisible ? '🙈' : '👁'}
+													{isVisible ? '🙈' : '🔍'}
 												</button>
 											</>
 										)}

--- a/apps/vscode/src/providers/views/PageWelcome/PageWelcome.tsx
+++ b/apps/vscode/src/providers/views/PageWelcome/PageWelcome.tsx
@@ -71,7 +71,7 @@ type OutgoingMessage =
 
 const MODE_DESCRIPTIONS: Record<string, string> = {
 	cloud: 'Connect to RocketRide.ai cloud. Requires an API key from your account dashboard.',
-	onprem: 'Connect to your own hosted RocketRide server. Requires server URL and API key.',
+	onprem: 'Connect to your own hosted RocketRide server.',
 	local: 'Run the engine locally on your machine. The extension will download and manage the engine for you.'
 };
 
@@ -86,7 +86,7 @@ export const PageWelcome: React.FC = () => {
 		apiKey: '',
 		hasApiKey: false,
 		autoConnect: true,
-		localEngineVersion: 'latest',
+		localEngineVersion: 'prerelease',
 	});
 
 	const [logoLightUri, setLogoLightUri] = useState<string | undefined>();
@@ -185,7 +185,8 @@ export const PageWelcome: React.FC = () => {
 		sendMessage({ type: 'testConnection', settings });
 	};
 
-	const needsApiKey = settings.connectionMode === 'cloud' || settings.connectionMode === 'onprem';
+	const isCloud = settings.connectionMode === 'cloud';
+	const needsApiKey = settings.connectionMode === 'onprem';
 
 	// ========================================================================
 	// RENDER
@@ -199,7 +200,6 @@ export const PageWelcome: React.FC = () => {
 					{logoLightUri ? <img src={logoLightUri} alt="RocketRide" /> : '\u{1F680}'}
 				</div>
 				<div className="welcome-brand-name">RocketRide</div>
-				<div className="welcome-brand-sub">Engine</div>
 				<div className="welcome-tagline">
 					High-performance data processing<br />
 					with AI/ML integration
@@ -207,18 +207,18 @@ export const PageWelcome: React.FC = () => {
 
 				<ul className="welcome-features">
 					<li><span className="welcome-feature-icon">&#9670;</span> Visual pipeline editor</li>
-					<li><span className="welcome-feature-icon">&#9670;</span> 50+ processing nodes</li>
-					<li><span className="welcome-feature-icon">&#9670;</span> LLM &amp; embedding support</li>
-					<li><span className="welcome-feature-icon">&#9670;</span> Vector database integration</li>
-					<li><span className="welcome-feature-icon">&#9670;</span> Cloud, on-prem, or local</li>
-					<li><span className="welcome-feature-icon">&#9670;</span> TypeScript &amp; Python SDKs</li>
+					<li><span className="welcome-feature-icon">&#9670;</span> High-performance C++ engine</li>
+					<li><span className="welcome-feature-icon">&#9670;</span> 50+ pipeline nodes with AI/ML</li>
+					<li><span className="welcome-feature-icon">&#9670;</span> Multi-agent workflows</li>
+					<li><span className="welcome-feature-icon">&#9670;</span> Tool and model agnostic</li>
+					<li><span className="welcome-feature-icon">&#9670;</span> TypeScript, Python &amp; MCP SDKs</li>
 				</ul>
 
 				<div className="welcome-divider" />
 
 				<div className="welcome-links">
-					<a href="#" onClick={(e) => { e.preventDefault(); sendMessage({ type: 'openExternal', url: 'https://docs.rocketride.ai' }); }}>Documentation</a>
-					<a href="#" onClick={(e) => { e.preventDefault(); sendMessage({ type: 'openExternal', url: 'https://support.rocketride.ai' }); }}>Support</a>
+					<a href="#" onClick={(e) => { e.preventDefault(); sendMessage({ type: 'openExternal', url: 'https://docs.rocketride.org' }); }}>Documentation</a>
+					<a href="#" onClick={(e) => { e.preventDefault(); sendMessage({ type: 'openExternal', url: 'https://discord.gg/9hr3tdZmEG' }); }}>Discord</a>
 				</div>
 			</div>
 
@@ -244,7 +244,20 @@ export const PageWelcome: React.FC = () => {
 					</div>
 				</div>
 
-				{/* API Key — Cloud / On-prem */}
+				{/* Coming Soon — Cloud */}
+				{isCloud && (
+					<div className="welcome-coming-soon">
+						<div className="welcome-coming-soon-icon">&#9729;</div>
+						<div className="welcome-coming-soon-title">Coming Soon</div>
+						<div className="welcome-coming-soon-text">
+							RocketRide Cloud is under active development.<br />
+							Stay tuned for managed cloud hosting with zero setup.
+						</div>
+					</div>
+				)}
+
+
+				{/* API Key — On-prem */}
 				{needsApiKey && (
 					<div className="welcome-form-group">
 						<label htmlFor="apiKey">API Key</label>
@@ -333,8 +346,8 @@ export const PageWelcome: React.FC = () => {
 					</>
 				)}
 
-				{/* Auto-connect — non-local only */}
-				{settings.connectionMode !== 'local' && (
+				{/* Auto-connect — on-prem only */}
+				{settings.connectionMode === 'onprem' && (
 					<div className="welcome-form-group welcome-checkbox-row">
 						<input
 							type="checkbox"
@@ -355,10 +368,10 @@ export const PageWelcome: React.FC = () => {
 
 				{/* Action buttons */}
 				<div className="welcome-button-row">
-					<button onClick={handleSaveAndConnect}>
+					<button onClick={handleSaveAndConnect} disabled={isCloud}>
 						Save &amp; Connect
 					</button>
-					{settings.connectionMode !== 'local' && (
+					{settings.connectionMode === 'onprem' && (
 						<button className="secondary" onClick={handleTestConnection}>
 							Test Connection
 						</button>

--- a/apps/vscode/src/providers/views/PageWelcome/styles.css
+++ b/apps/vscode/src/providers/views/PageWelcome/styles.css
@@ -126,7 +126,7 @@ body.vscode-high-contrast .welcome-logo .logo-dark {
 }
 
 .welcome-feature-icon {
-	color: #F25B32;
+	color: var(--vscode-textLink-foreground);
 	font-size: 14px;
 	width: 18px;
 	text-align: center;
@@ -222,6 +222,36 @@ body.vscode-high-contrast .welcome-logo .logo-dark {
 
 .welcome-password-row input {
 	flex: 1;
+}
+
+/* Coming Soon banner */
+.welcome-coming-soon {
+	text-align: center;
+	padding: 32px 20px;
+	margin-bottom: 20px;
+	border: 1px dashed var(--vscode-widget-border);
+	border-radius: 6px;
+	background: rgba(255, 255, 255, 0.02);
+}
+
+.welcome-coming-soon-icon {
+	font-size: 40px;
+	margin-bottom: 12px;
+	opacity: 0.6;
+}
+
+.welcome-coming-soon-title {
+	font-size: 16px;
+	font-weight: 600;
+	color: var(--vscode-foreground);
+	margin-bottom: 8px;
+	letter-spacing: 0.5px;
+}
+
+.welcome-coming-soon-text {
+	font-size: 12px;
+	color: var(--vscode-descriptionForeground);
+	line-height: 1.6;
 }
 
 /* Mode description box */


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

  - Removed "Engine" subtitle from the left branding panel
  - Adjusted links to documentation and support
  - Updated bullet points to: Visual pipeline editor, High-performance C++      
  engine, 50+ pipeline nodes with AI/ML, Multi-agent workflows, Tool and model
  agnostic, TypeScript Python & MCP SDKs
  - Diamond bullet icons changed from orange/red to link blue
  - "Cloud (RocketRide.ai)" now shows a "Coming Soon" card with disabled Save &
  Connect button
  - Documentation link changed from docs.rocketride.ai to docs.rocketride.org
  - Support link replaced with Discord (discord.gg/9hr3tdZmEG)
  - On-prem description shortened — removed "Requires server URL and API key."
  - Default engine version changed from <Latest> to <Prerelease> (both in
  component state and provider fallback)
  - Eye emoji replaced with magnifying glass for show/hide toggles in advanced settings page (eye was creepy)

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
fix/refactor

## Testing

- [ ] Tests added or updated
- [X] Tested locally
- [X] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->
