### PR TITLE
fix(mcp_client): fix tool invocation, add User-Agent, remove env field

### DIFF
--- a/nodes/src/nodes/mcp_client/IGlobal.py
+++ b/nodes/src/nodes/mcp_client/IGlobal.py
@@ -80,13 +80,7 @@ class IGlobal(IGlobalBase):
                         raise Exception('mcp_client args must be a list of strings')
                     args = [str(a) for a in args]
 
-                env = cfg.get('env')
-                if env is not None and not isinstance(env, dict):
-                    raise Exception('mcp_client env must be a dictionary of strings')
-                if isinstance(env, dict):
-                    env = {str(k): str(v) for k, v in env.items()}
-
-                self._client = McpStdioClient(command=command, args=args, env=env)
+                self._client = McpStdioClient(command=command, args=args)
 
             elif self.transport in ('sse', 'streamable-http'):
                 # Shared auth headers for HTTP transports
@@ -132,7 +126,6 @@ class IGlobal(IGlobalBase):
             tools = self._client.list_tools()
             self._cache_tools(tools)
 
-            # Build tool-provider driver after cache is ready.
             self.driver = McpDriver(
                 server_name=self.serverName,
                 list_namespaced_tools=self.list_namespaced_tools,
@@ -214,7 +207,7 @@ class IGlobal(IGlobalBase):
     def list_namespaced_tools(self) -> List[Dict[str, Any]]:
         out: List[Dict[str, Any]] = []
         for namespaced, tool in (self._tools_by_namespaced or {}).items():
-            out.append({'name': namespaced, 'description': tool.description, 'inputSchema': tool.inputSchema})
+            out.append({'name': namespaced, 'description': tool.description, 'input_schema': tool.inputSchema})
         return out
 
     def get_tool(self, *, server_name: str, tool_name: str) -> Optional[McpToolDef]:

--- a/nodes/src/nodes/mcp_client/mcp_driver.py
+++ b/nodes/src/nodes/mcp_client/mcp_driver.py
@@ -62,12 +62,14 @@ class McpDriver(ToolsBase):
         if missing:
             raise ValueError(f'Tool input missing required fields: {missing}')
 
+    _FRAMEWORK_KEYS = frozenset({'security_context'})
+
     def _tool_invoke(self, *, tool_name: str, input_obj: Any) -> Any:  # noqa: ANN401
         server_name, bare_tool = self._split_tool_name(tool_name)
         if input_obj is None:
             arguments: Dict[str, Any] = {}
         elif isinstance(input_obj, dict):
-            arguments = input_obj
+            arguments = {k: v for k, v in input_obj.items() if k not in self._FRAMEWORK_KEYS}
         else:
             raise ValueError('Tool input must be a JSON object (dict)')
 

--- a/nodes/src/nodes/mcp_client/mcp_sse_client.py
+++ b/nodes/src/nodes/mcp_client/mcp_sse_client.py
@@ -85,6 +85,7 @@ class McpSseClient:
         self._headers = {str(k): str(v) for k, v in (headers or {}).items()}
         # Recommended by SSE servers; harmless if already set.
         self._headers.setdefault('Accept', 'text/event-stream')
+        self._headers.setdefault('User-Agent', f'{client_name}/{client_version}')
 
         self._reader_thread: threading.Thread | None = None
         self._stop = threading.Event()

--- a/nodes/src/nodes/mcp_client/mcp_streamable_http_client.py
+++ b/nodes/src/nodes/mcp_client/mcp_streamable_http_client.py
@@ -97,6 +97,7 @@ class McpStreamableHttpClient:
         self._headers = {str(k): str(v) for k, v in (headers or {}).items()}
         # Required by the Streamable HTTP spec: list both content types.
         self._headers.setdefault('Accept', 'application/json, text/event-stream')
+        self._headers.setdefault('User-Agent', f'{client_name}/{client_version}')
 
         self._next_id = 1
         self._session_id: str | None = None

--- a/nodes/src/nodes/mcp_client/services.json
+++ b/nodes/src/nodes/mcp_client/services.json
@@ -84,13 +84,6 @@
 			"description": "Command line to launch MCP server (stdio transport). Example: python -m RocketRide_mcp",
 			"default": "python -m RocketRide_mcp"
 		},
-		"mcp_client.env": {
-			"type": "object",
-			"title": "Env",
-			"description": "Extra environment variables for the child process (stdio transport)",
-			"default": {}
-		},
-
 		"mcp_client.endpoint": {
 			"type": "string",
 			"title": "Endpoint",
@@ -124,8 +117,7 @@
 			"object": "stdio",
 			"title": "STDIO (subprocess)",
 			"properties": [
-				"mcp_client.commandLine",
-				"mcp_client.env"
+				"mcp_client.commandLine"
 			]
 		},
 		"mcp_client.http": {


### PR DESCRIPTION
- Return input_schema (not inputSchema) in tool descriptors to match agent framework
- Strip framework-injected keys (security_context) before forwarding to MCP server
- Add default User-Agent header to streamable-http and SSE transports (fixes Cloudflare 403)
- Remove mcp_client.env field from services.json and env handling from IGlobal.py
Here's the PR content ready to paste:

---

## Summary

- **Fix tool descriptor key mismatch**: Return `input_schema` instead of `inputSchema` in MCP client tool descriptors to match the agent framework's expected key, enabling proper tool parameter discovery
- **Strip framework-injected keys from tool arguments**: Filter out `security_context` (and other framework-internal keys) before forwarding tool call arguments to the remote MCP server, preventing server-side errors
- **Add default User-Agent header**: Set a default `User-Agent` on both Streamable HTTP and SSE transports to prevent Cloudflare 403 blocks on protected MCP endpoints
- **Remove `mcp_client.env` field**: Remove the unused `mcp_client.env` field definition from `services.json` and its associated parsing/validation logic from `IGlobal.py`

## Type

fix

## Testing

- [x] Tests added or updated in the next PR message
- [x] Tested locally
- [ x] `./builder test` passes

**Manual testing performed:**
- Tested end-to-end with Alpha Vantage MCP server via Streamable HTTP transport & rocketride_mcp STDIO Server
- Verified full tool workflow: discovery (TOOL_LIST), schema lookup (TOOL_GET), and execution (TOOL_CALL)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- No linked issues -->

---
<img width="442" height="410" alt="Screenshot 2026-03-03 at 10 11 02 PM" src="https://github.com/user-attachments/assets/96fc78f1-2b58-4930-ba77-af9517f50382" />
##Builder Test Passed