### PR TITLE
* Update version numbers so things get pushed out correctly

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 RocketRide Data Processing Engine
-Copyright 2024-2026 RocketRide, Inc.
+Copyright 2026 Aparavi Software AG
 
 This product includes software developed by third parties.
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "rocketride",
 	"displayName": "RocketRide",
 	"description": "RocketRide extension for Visual Studio Code",
-	"version": "0.0.1",
+	"version": "1.0.0",
 	"publisher": "rocketride",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride-server",
-	"version": "1.0.3",
+	"version": "3.1.0",
 	"description": "RocketRide Server - A high-performance data processing engine with modular nodes, AI capabilities, and cross-platform clients",
 	"private": true,
 	"license": "MIT",

--- a/packages/client-mcp/pyproject.toml
+++ b/packages/client-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride-mcp"
-version = "0.1.0"
+version = "1.0.2"
 description = "RocketRide MCP stdio server that streams local files to RocketRide EaaS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride"
-version = "1.0.1"
+version = "1.0.2"
 description = "RocketRide Pipeline Python Client SDK"
 readme = "README.md"
 authors = [

--- a/packages/client-typescript/package.json
+++ b/packages/client-typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"author": "RocketRide, Inc.",
 	"license": "MIT",
 	"description": "TypeScript client for RocketRide data processing and AI services",


### PR DESCRIPTION
## Summary

* Updated version numbers to:

| Package                       | Type   | Version |
|-------------------------------|--------|---------|
| `rocketride` (root)           | Node   | 3.1.0   |
| `apps/chat-ui`                | Node   | 2.0.0   |
| `apps/dropper-ui`             | Node   | 2.0.0   |
| `apps/vscode`                 | Node   | 1.0.0   |
| `packages/client-typescript`  | Node   | 1.0.2   |
| `packages/shared-ui`          | Node   | 1.0.0   |
| `packages/client-python`      | Python | 1.0.2   |
| `packages/client-mcp`         | Python | 1.0.2   |


## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes
