### PR TITLE
fix(ai): skip forwarding flow events when pipeline tracing is not enables

### DIFF
--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1055,11 +1055,13 @@ class Task(DAPBase):
             # Send out a status update when needed
             self._status_updated = True
 
-            # Forward the actual event
-            await self._forward_task_event(
-                EVENT_TYPE.FLOW,
-                flow
-            )
+            # If this task is started with tracing
+            if self._pipelineTraceLevel:
+                # Forward off the event
+                await self._forward_task_event(
+                    EVENT_TYPE.FLOW,
+                    flow
+                )
 
         # Handle debug output
         elif event_type == 'output':


### PR DESCRIPTION
## Summary

apaevt_flow was being sent with empty info when received from the subprocess. The subprocess still sends flow events to the main process so pipeline tracing is visible, but forwarding them to the client shows empty "enter" states since tracing is not enabled.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes