### PR TITLE
fix(engine): Add pydantic model and callable serialization to pyjson

### DIFF
--- a/packages/server/engine-lib/engLib/python/pyjson.hpp
+++ b/packages/server/engine-lib/engLib/python/pyjson.hpp
@@ -119,6 +119,23 @@ public:
             }
             return value;
         }
+
+        // Pydantic v2 model — call .model_dump() to get a plain dict
+        if (py::hasattr(obj, "model_dump")) {
+            py::dict d = obj.attr("model_dump")();
+            return dictToJson(d);
+        }
+        // Pydantic v1 model — call .dict() to get a plain dict
+        if (py::hasattr(obj, "dict") && py::hasattr(obj, "__fields__")) {
+            py::dict d = obj.attr("dict")();
+            return dictToJson(d);
+        }
+        // Any callable (function, method, builtin, partial, etc.) — not serializable
+        if (PyCallable_Check(obj.ptr())) {
+            json::Value value{"<method>"};
+            return value;
+        }
+        
         throw std::runtime_error(
             "dictToJson not implemented for this type of object: " +
             py::repr(obj).cast<std::string>());


### PR DESCRIPTION
The dictToJson function previously only handled primitive types, lists, tuples, and dicts, throwing an exception for anything else. This caused failures when Python objects contained pydantic models or method/function references as values.

- Add pydantic v2 support via model_dump() serialization
- Add pydantic v1 fallback via dict() with __fields__ guard
- Add catch-all for callables (functions, methods, builtins, partials) using PyCallable_Check, returning "<method>" placeholder
- Order: pydantic checks before callable check, since pydantic model classes are technically callable
- The issue manifested itself when tracing through invoke calls which were obtaining a function reference or passing a pydantic object
