### PR TITLE
fix(ci): add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   init:


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` to the release workflow so it can be manually triggered from the Actions UI

## Test plan
- [ ] "Run workflow" button appears on Actions > Release page after merge