### PR TITLE
fix(ci): prefix tarball path with ./ for npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -251,7 +251,7 @@ jobs:
           else
             TARBALL=$(find release-assets -name '*.tgz' | head -n1)
             echo "Publishing ${TARBALL}"
-            npm publish "${TARBALL}" --access public
+            npm publish "./${TARBALL}" --access public
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- npm interprets `release-assets/rocketride-1.0.2.tgz` as a GitHub shorthand (`owner/repo`), causing `git ls-remote` instead of publishing the local file
- Fix: prefix with `./` so npm treats it as a local path

## Test plan
- [ ] Merge, then re-run the release workflow to publish TypeScript client