### PR TITLE
fix: Python client auth, TypeScript client Jest resolution, and server Python webhook GIL

### DIFF
--- a/packages/client-python/scripts/tasks.js
+++ b/packages/client-python/scripts/tasks.js
@@ -217,7 +217,9 @@ function makeRunPytestAction(options = {}) {
             const serverDir = path.join(PROJECT_ROOT, 'dist', 'server');
             const testEnv = {
                 ...process.env,
-                ROCKETRIDE_URI: serverUri
+                ROCKETRIDE_URI: serverUri,
+                // Ensure test default API key is set so server accepts WebSocket upgrade and DAP auth
+                ROCKETRIDE_APIKEY: process.env.ROCKETRIDE_APIKEY || 'MYAPIKEY'
             };
             
             // Use absolute paths since cwd is dist/server

--- a/packages/client-python/src/rocketride/core/transport_websocket.py
+++ b/packages/client-python/src/rocketride/core/transport_websocket.py
@@ -56,6 +56,7 @@ Usage (Internal):
 import json
 import asyncio
 from typing import Dict, Any, Union, Optional
+from urllib.parse import urlencode, urlparse, parse_qs
 from .constants import CONST_DEFAULT_SERVICE, CONST_SOCKET_TIMEOUT, CONST_WS_PING_INTERVAL, CONST_WS_PING_TIMEOUT
 
 # Optional dependency handling for websockets library
@@ -299,9 +300,18 @@ class TransportWebSocket(TransportBase):
             # Convert ms to seconds for websockets library, or use default
             effective_open_timeout = timeout / 1000.0 if timeout is not None else CONST_SOCKET_TIMEOUT
 
-            # Connect without auth on upgrade; first DAP message must be auth (sent by connect flow via request())
+            # Server requires auth at WebSocket upgrade (header or query). Pass auth as query param
+            # so the upgrade request is accepted; DAP auth command is still sent after connect.
+            connect_uri = self._uri
+            if self._auth:
+                parsed = urlparse(self._uri)
+                qs = parse_qs(parsed.query)
+                qs['auth'] = [self._auth]
+                new_query = urlencode(qs, doseq=True)
+                connect_uri = parsed._replace(query=new_query).geturl()
+
             self._websocket = await websockets.connect(
-                self._uri,
+                connect_uri,
                 ping_interval=CONST_WS_PING_INTERVAL,  # Send ping every 15 seconds
                 ping_timeout=CONST_WS_PING_TIMEOUT,  # Wait up to 60 seconds for pong
                 close_timeout=CONST_SOCKET_TIMEOUT,

--- a/packages/client-typescript/jest.config.js
+++ b/packages/client-typescript/jest.config.js
@@ -51,7 +51,9 @@ module.exports = {
 	verbose: true,
 
 	// Module name mapping for cleaner imports
+	// Resolve .js imports to .ts source so Jest finds TypeScript files (ESM-style imports)
 	moduleNameMapper: {
+		'^(\\.\\.?/.*)\\.js$': '$1',
 		'^@/(.*)$': '<rootDir>/src/$1',
-	}
+	},
 };

--- a/packages/server/engine-lib/test/python/engine.cpp
+++ b/packages/server/engine-lib/test/python/engine.cpp
@@ -47,5 +47,9 @@ TEST_CASE("python::config") {
 }
 
 TEST_CASE("python::webhook") {
-    REQUIRE_NO_ERROR(engine::python::loadModule("nodes.webhook", true));
+    // Hold GIL so the returned py::object (module) is destroyed while GIL is held.
+    // Otherwise pybind11 dec_ref runs without GIL and triggers PyGILState_Check() failure.
+    engine::python::LockPython lock;
+    auto result = engine::python::loadModule("nodes.webhook", true);
+    REQUIRE_NO_ERROR(result);
 }


### PR DESCRIPTION
## Summary

- Python client: Send auth on WebSocket upgrade via query param; set default ROCKETRIDE_APIKEY in builder test env.
- TypeScript client: Map .js imports to .ts in Jest so ESM-style imports resolve in tests.
- Server: Fix python::webhook test by holding the GIL when destroying the module returned by loadModule, avoiding pybind11 GIL assertion/SIGABRT.



## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->
