### PR TITLE
fix(data): prevent zombie pipe detector from recycling pipes

### DIFF
--- a/packages/ai/src/ai/modules/data/data_conn.py
+++ b/packages/ai/src/ai/modules/data/data_conn.py
@@ -55,6 +55,7 @@ class DataConnPipe:
     semaphore_acquired: bool = False  # Track if semaphore was acquired for this pipe
     created_time: float = field(default_factory=time.time)  # Track when pipe was created
     last_activity_time: float = field(default_factory=time.time)  # Track last write/close activity
+    in_use: bool = False  # True while a sync operation (write) is actively running in a thread
 
 
 class DataConn(DAPConn):
@@ -353,6 +354,10 @@ class DataConn(DAPConn):
 
                 # Find pipes that haven't been used in the timeout period
                 for pipe_id, conn_pipe in list(self._pipe_map.items()):
+                    # Skip pipes that are actively processing (e.g. long LLM calls)
+                    if conn_pipe.in_use:
+                        continue
+
                     time_since_last_activity = current_time - conn_pipe.last_activity_time
 
                     if time_since_last_activity > self._pipe_timeout:
@@ -526,21 +531,22 @@ class DataConn(DAPConn):
         considered a zombie for another 60 seconds.
         """
 
+        # Resolve conn_pipe in the async scope so we can set in_use before dispatching
+        pipe_id = args.get('pipe_id', None)
+        if pipe_id is None:
+            raise ValueError('No pipe_id specified')
+
+        conn_pipe = self._pipe_map.get(pipe_id, None)
+        if not conn_pipe:
+            raise ValueError(f'Write pipe with id {pipe_id} not found')
+
+        if not conn_pipe.is_open:
+            raise ValueError(f'Write pipe with id {pipe_id} is not open')
+
+        if conn_pipe.has_failed:
+            raise ValueError(f'Write pipe with id {pipe_id} has failed')
+
         def write_sync():
-            pipe_id = args.get('pipe_id', None)
-            if pipe_id is None:
-                raise ValueError('No pipe_id specified')
-
-            # Retrieve the DataConnPipe instance from our mapping
-            conn_pipe = self._pipe_map.get(pipe_id, None)
-            if not conn_pipe:
-                raise ValueError(f'Write pipe with id {pipe_id} not found')
-
-            if not conn_pipe.is_open:
-                raise ValueError(f'Write pipe with id {pipe_id} is not open')
-
-            if conn_pipe.has_failed:
-                raise ValueError(f'Write pipe with id {pipe_id} has failed')
 
             # Get the data to write
             data: bytes = args.get('data', None)
@@ -629,8 +635,12 @@ class DataConn(DAPConn):
                 self.debug_message(f'Error handling write request: {e}')
                 raise
 
-        # Execute in thread
-        await asyncio.to_thread(write_sync)
+        # Execute in thread, marking pipe as in-use so the zombie detector skips it
+        conn_pipe.in_use = True
+        try:
+            await asyncio.to_thread(write_sync)
+        finally:
+            conn_pipe.in_use = False
         return self.build_response(request)
 
     async def _close(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
prevent zombie pipe detector from recycling pipes during active writes

The zombie pipe detector runs on a 60-second inactivity timer to clean up pipes where the client opened a connection but never called close (e.g. client crashed or disconnected). However, it was also able to reclaim pipes that were actively processing long-running operations like LLM API calls, since the activity timer is only reset at the start of _write, not during the synchronous work inside write_sync.

This caused a rare, intermittent crash in the response node:
  'NoneType' object has no attribute 'response'
  at nodes/src/nodes/response/IInstance.py:62

The race condition:
1. Client sends a chat question, _write dispatches write_sync to a thread
2. pipe.writeQuestions() calls the LLM node, which makes an API call
3. If the LLM call takes >60s, the zombie detector considers the pipe inactive and calls putPipe(), returning it to the endpoint pool
4. The pipe's IServiceFilterInstance chain is now available for reuse, and a subsequent open/close cycle can clear currentEntry (the C++ pointer backing instance.currentObject in Python)
5. The original thread's LLM call returns, calls writeAnswers on the response node, which accesses self.instance.currentObject.response — but currentObject is now None because currentEntry was cleared

The fix adds an `in_use` flag to DataConnPipe that is set before dispatching write_sync to a thread and cleared in a finally block after it returns. The zombie detector skips any pipe with in_use=True. This is safe because both the flag set/clear and the zombie check run on the asyncio event loop thread, so there is no race between them. Genuinely abandoned pipes (where write_sync has finished but the client never called close) still have in_use=False and are cleaned up normally.
