### PR TITLE
feat(chat-ui): surface pipeline result keys as message labels

### DIFF
--- a/apps/chat-ui/src/components/Message.tsx
+++ b/apps/chat-ui/src/components/Message.tsx
@@ -32,10 +32,10 @@ interface MessageProps {
 
 /**
  * Individual message bubble component
- * 
+ *
  * Displays a single message with appropriate styling based on sender.
  * Bot messages use markdown rendering, user messages display as plain text.
- * 
+ *
  * @param message - Message data to display
  */
 export const Message: React.FC<MessageProps> = ({ message }) => {
@@ -48,6 +48,7 @@ export const Message: React.FC<MessageProps> = ({ message }) => {
 					</div>
 					<div className="message-timestamp">
 						{message.timestamp}
+						{message.resultKey && <span className="message-result-key">{message.resultKey}</span>}
 					</div>
 				</div>
 			</div>

--- a/apps/chat-ui/src/hooks/useChatMessages.ts
+++ b/apps/chat-ui/src/hooks/useChatMessages.ts
@@ -63,7 +63,7 @@ export const useChatMessages = () => {
 		userMessage: string,
 		client: any,
 		authToken: string
-	): Promise<string[]> => {
+	): Promise<ReturnType<typeof extractTextFromResult>> => {
 		try {
 			if (!client || !authToken) {
 				throw new Error('Not connected to RocketRide. Please refresh the page.');
@@ -75,6 +75,8 @@ export const useChatMessages = () => {
 				expectJson: false
 			});
 
+			question.addInstruction('Format', 'I am using markdown, so try to format responses nicely.')
+			question.addInstruction('Tools', 'Never return just the tool output.')
 			question.addQuestion(userMessage);
 
 			// Include last 6 messages for context - helps AI maintain conversation flow
@@ -95,7 +97,7 @@ export const useChatMessages = () => {
 			// Extract text responses from result
 			const textResponses = extractTextFromResult(result);
 
-			return textResponses.length > 0 ? textResponses : ['No valid response received'];
+			return textResponses.length > 0 ? textResponses : [{ text: 'No valid response received', key: '' }];
 
 		} catch (error) {
 			console.error('Error sending message via SDK:', error);
@@ -136,9 +138,10 @@ export const useChatMessages = () => {
 			// Add bot response(s) to chat
 			const botResponses: Message[] = answers.map((answer, index) => ({
 				id: Date.now() + index + 1,
-				text: answer,
-				sender: 'bot',
-				timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+				text: answer.text,
+				sender: 'bot' as const,
+				timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+				...(answer.key ? { resultKey: answer.key } : {})
 			}));
 
 			setMessages(prev => [...prev, ...botResponses]);

--- a/apps/chat-ui/src/styles.css
+++ b/apps/chat-ui/src/styles.css
@@ -266,6 +266,17 @@ body {
 	color: var(--text-muted);
 }
 
+.message-result-key::before {
+	content: '·';
+	margin-right: 0.3rem;
+}
+
+.message-result-key {
+	font-size: 0.7rem;
+	color: var(--text-muted);
+	font-style: italic;
+}
+
 /* Typing Indicator */
 .typing-indicator {
 	display: flex;

--- a/apps/chat-ui/src/types/chat.types.ts
+++ b/apps/chat-ui/src/types/chat.types.ts
@@ -34,6 +34,7 @@ export interface Message {
 	text: string;
 	sender: 'user' | 'bot' | 'system';
 	timestamp: string;
+	resultKey?: string | undefined;
 }
 
 /**

--- a/apps/chat-ui/src/utils/pipelineUtils.ts
+++ b/apps/chat-ui/src/utils/pipelineUtils.ts
@@ -39,12 +39,17 @@ import { PIPELINE_RESULT } from 'rocketride';
  * // If result has: { result_types: { "answers": "answers" }, answers: ["Hello", "World"] }
  * // Returns: ["Hello", "World"]
  */
-export const extractTextFromResult = (result: PIPELINE_RESULT): string[] => {
-	const textResponses: string[] = [];
+export interface TextResult {
+	text: string;
+	key: string;
+}
+
+export const extractTextFromResult = (result: PIPELINE_RESULT): TextResult[] => {
+	const textResponses: TextResult[] = [];
 
 	// If we didn't get any result types, make sure they were returned
 	if (!result.result_types) {
-		textResponses.push('### I don\'t see any answers in there...\nAre you sure you returned them in your pipeline?');
+		textResponses.push({ text: '### I don\'t see any answers in there...\nAre you sure you returned them in your pipeline?', key: '' });
 		return textResponses;
 	}
 
@@ -54,10 +59,10 @@ export const extractTextFromResult = (result: PIPELINE_RESULT): string[] => {
 			const fieldData = result[fieldName];
 
 			if (Array.isArray(fieldData)) {
-				// Add all non-empty text items from this field
-				textResponses.push(...fieldData.filter(item => typeof item === 'string' && item.trim()));
+				fieldData.filter(item => typeof item === 'string' && item.trim())
+					.forEach(item => textResponses.push({ text: item, key: fieldName }));
 			} else if (typeof fieldData === 'string' && fieldData.trim()) {
-				textResponses.push(fieldData);
+				textResponses.push({ text: fieldData, key: fieldName });
 			}
 		}
 	}


### PR DESCRIPTION
Adds optional labeling of bot messages with the pipeline result field name (e.g. "answers", "summary") that produced each response, giving users visibility into which part of the pipeline generated a given reply.

Changes:
- `chat.types.ts`: Added optional `resultKey` field to the `Message` interface to carry the pipeline result field name through to the UI.

- `pipelineUtils.ts`: Refactored `extractTextFromResult` to return `TextResult[]` (objects with `text` and `key`) instead of plain `string[]`, preserving the originating result field name alongside each extracted string.

- `useChatMessages.ts`:
  - Updated `sendMessage` return type to match the new `TextResult[]` signature.
  - Conditionally spreads `resultKey` onto bot `Message` objects when a non-empty key is present.
  - Added two AI formatting instructions to the question payload: markdown formatting guidance and a directive to never return raw tool output.

- `Message.tsx`: Renders `resultKey` inline with the timestamp as a small italic label (preceded by a "·" separator) when present.

- `styles.css`: Added `.message-result-key` and `.message-result-key::before` rules to style the label as muted, small italic text consistent with the existing timestamp style.
