### PR TITLE
chore(ci): build version, hash and timestamp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,32 @@ env:
 #  Build
 # ---------------------------------------------------------------------------
 jobs:
+  init:
+    name: Initialize
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - name: Set up variables
+        id: vars
+        run: |
+          VERSION=$(jq -r '.version' package.json)
+          echo "FULL_VERSION=$VERSION.${{ github.run_number }}" >> $GITHUB_OUTPUT
+          echo "BUILD_HASH=$(echo ${{ github.sha }} | cut -c1-8)" >> $GITHUB_OUTPUT
+          echo "BUILD_STAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")" >> $GITHUB_OUTPUT
+          cat $GITHUB_OUTPUT
+    outputs:
+      FULL_VERSION: ${{ steps.vars.outputs.FULL_VERSION }}
+      BUILD_HASH: ${{ steps.vars.outputs.BUILD_HASH }}
+      BUILD_STAMP: ${{ steps.vars.outputs.BUILD_STAMP }}
+
   build:
     name: Build / ${{ matrix.label }}
+    needs: init
     if: github.event_name != 'schedule'
     timeout-minutes: 90
     runs-on: ${{ matrix.runner }}
@@ -100,7 +124,8 @@ jobs:
             -Source "${{ env.NUGET_FEED_URL }}"
 
       - name: Build
-        run: ${{ matrix.builder_cmd }} build --verbose --autoinstall
+        run: |
+          ${{ matrix.builder_cmd }} build --verbose --autoinstall --version=${{ needs.init.outputs.FULL_VERSION }} --hash=${{ needs.init.outputs.BUILD_HASH }} --stamp=${{ needs.init.outputs.BUILD_STAMP }}
 
       - name: Test
         run: ${{ matrix.builder_cmd }} test --verbose

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -599,6 +599,18 @@ function makeConfigureServerAction(options = {}) {
                 cmakeArgs.push(`-DROCKETRIDE_UNITY_BATCH_SIZE:STRING=${options.batchSize}`);
             }
 
+            if (ctx.options.buildVersion) {
+                cmakeArgs.push(`-DCMAKE_PROJECT_VERSION:STRING=${ctx.options.buildVersion}`);
+            }
+
+            if (ctx.options.buildHash) {
+                cmakeArgs.push(`-DROCKETRIDE_BUILD_HASH_SHORT:STRING=${ctx.options.buildHash}`);
+            }
+
+            if (ctx.options.buildStamp) {
+                cmakeArgs.push(`-DROCKETRIDE_BUILD_STAMP:STRING=${ctx.options.buildStamp}`);
+            }
+
             const baseEnv = isWindows() ? await getVsEnvironment() : process.env;
             const env = {
                 ...baseEnv,

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -46,7 +46,10 @@ function parseArgs(args) {
         listDeps: false,
         listModules: false,
         logFile: null,    // Log file for test output
-        overlayRoot: null // Root directory for overlay
+        overlayRoot: null, // Root directory for overlay
+        buildVersion: null,
+        buildHash: null,
+        buildStamp: null,
     };
     const globalCommands = [];  // Commands without module (e.g., just "build")
     
@@ -103,6 +106,12 @@ function parseArgs(args) {
                 console.error(`Invalid --arch value: ${archValue}. Use 'arm' or 'intel'.`);
                 process.exit(1);
             }
+        } else if (arg.startsWith('--version=')) {
+            options.buildVersion = arg.substring('--version='.length);
+        } else if (arg.startsWith('--hash=')) {
+            options.buildHash = arg.substring('--hash='.length);
+        } else if (arg.startsWith('--stamp=')) {
+            options.buildStamp = arg.substring('--stamp='.length);
         } else if (arg.includes(':')) {
             // Unified model: action names like "server:build", "nodes:sync"
             // Extract module from action name (first part before colon)
@@ -191,6 +200,9 @@ Options:
   --testport=N        Use existing server on port N for tests (skip build/start)
   --log=FILE          Write output to FILE (grouped by module)
   --overlay-root=DIR  Set overlay root directory
+  --version=VERSION   Set full build version x.x.x.x
+  --hash=HASH         Set build hash
+  --stamp=STAMP       Set build stamp
   --list-modules      List all registered modules
   --list-actions      List all registered actions (including internal)
   --list-deps         Show pipeline flow diagram for specified actions


### PR DESCRIPTION
Specify full version, hash and timestamp when building:
```
> ./dist/server/engine --version
Version: 3.1.0.123 hash: 96b9fcb1 stamp: 2026-03-08T21:34:25Z
```