### PR TITLE
fix(ai): repair debugging output

### DIFF
--- a/packages/client-python/src/rocketride/core/dap_base.py
+++ b/packages/client-python/src/rocketride/core/dap_base.py
@@ -122,7 +122,7 @@ class DAPBase:
         # Route the debugger output either through our kernel
         # or through logging depending on which one is running us
         try:
-            from rocketride import debug, Lvl
+            from rocketlib import debug, Lvl
 
             def _debug_message(message: str) -> None:
                 debug(Lvl.DebugOut, message)


### PR DESCRIPTION
## Summary

`DAPBase.__init__` incorrectly imported `debug` and `Lvl` from the `rocketride` client SDK, which does not export these symbols. This caused an `ImportError` that silently fell through to an unconfigured Python logger fallback, making all `debug_message()` and `debug_protocol()` calls invisible when running inside the engine.

Changed the import to `rocketlib`, which is the correct Python wrapper around the native engine bindings that exports both `debug` and `Lvl`.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Fixes #216
