### PR TITLE
fix: use individual usernames in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # Default owners for everything
-* @anirudhk-tech @asclearuc @dsapandora @dylan-savage @jmaionchi @jmaionchi-ai @JoshuaDarron @kwit75 @luisson10 @Rod-Christensen @ryan-t-christensen @shashidharbabu @stepmikhaylov
+* @jmaionchi @Rod-Christensen @stepmikhaylov
+
+# DevOps maintainers
+/.github/ @kwit75


### PR DESCRIPTION
## Summary
- CODEOWNERS referenced 7 non-existent teams (`maintainers`, `engine`, `nodes`, `sdk`, `ai`, `frontend`, `vscode`), causing GitHub to silently skip code owner review requirements
- This allowed PRs (e.g. #220) to be merged without proper code owner approval despite `require_code_owner_reviews: true` being enabled on branch protection
- Replaced all team references with individual org member usernames as a catch-all

## Test plan
- [ ] Verify CODEOWNERS syntax is valid (GitHub shows no warnings on the file)
- [ ] Open a test PR and confirm code owner review is requested from org members