### PR TITLE
fix(ci): reduce nightly artifact retention to 3 days

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -117,6 +117,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: server-artifacts-${{ matrix.platform }}
+          retention-days: 3
           path: |
             ${{ github.workspace }}/dist/artifacts/*.zip
             ${{ github.workspace }}/dist/artifacts/*.tar.gz
@@ -128,6 +129,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: vscode-artifacts
+          retention-days: 3
           path: ${{ github.workspace }}/dist/vscode/*.vsix
           if-no-files-found: error
 
@@ -136,6 +138,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: mcp-client-artifacts
+          retention-days: 3
           path: |
             ${{ github.workspace }}/dist/clients/mcp/*.whl
             ${{ github.workspace }}/dist/clients/mcp/*.tar.gz
@@ -146,6 +149,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: python-client-artifacts
+          retention-days: 3
           path: |
             ${{ github.workspace }}/dist/clients/python/*.whl
             ${{ github.workspace }}/dist/clients/python/*.tar.gz
@@ -156,6 +160,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: typescript-client-artifacts
+          retention-days: 3
           path: ${{ github.workspace }}/dist/clients/typescript/*.tgz
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary
- Nightly builds produce ~600 MB of artifacts per run (server binaries for 3 platforms + clients + vscode)
- With the default 90-day retention, this quickly exhausts the org's 0.5 GB Actions storage quota
- Sets `retention-days: 3` on all nightly artifact uploads — sufficient since artifacts are only consumed within the same workflow run for the prerelease step

## Additional cleanup needed
- **Delete old NuGet package versions** from GitHub Packages (vcpkg binary cache) — this is what's actually consuming the 0.5 GB storage quota. Must be done via GitHub UI at https://github.com/orgs/rocketride-org/packages or with a PAT that has `delete:packages` scope
- **Delete old workflow artifacts** — can be done from the Actions tab or via API

## Test plan
- [ ] Verify nightly workflow still completes successfully (artifacts still available for prerelease job)
- [ ] Confirm old artifacts are auto-deleted after 3 days