### PR TITLE
fix(builder): overlay root env vars

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -101,6 +101,8 @@ function parseArgs(args) {
             const paths = require('./lib/paths');
             paths.BUILD_ROOT = path.join(options.overlayRoot, 'build');
             paths.DIST_ROOT = path.join(options.overlayRoot, 'dist');
+            process.env.ROCKETRIDE_BUILD_ROOT = paths.BUILD_ROOT;
+            process.env.ROCKETRIDE_DIST_ROOT = paths.DIST_ROOT;
         } else if (arg === '--nodownload') {
             options.nodownload = true;
         } else if (arg.startsWith('--arch=')) {

--- a/scripts/lib/exec.js
+++ b/scripts/lib/exec.js
@@ -10,7 +10,6 @@ const path = require('path');
 const fs = require('fs');
 const { logOutput } = require('./log');
 const { taskDebug } = require('./debug');
-const { BUILD_ROOT, DIST_ROOT } = require('./paths');
 
 /** Windows: extension order and how to run. Used for resolution and execution. */
 const WIN_EXTENSIONS = [
@@ -98,11 +97,7 @@ async function execCommand(command, args, options = {}) {
     const {
         cwd = process.cwd(),
         task = null,
-        env = {
-            ...process.env,
-            ROCKETRIDE_BUILD_ROOT: BUILD_ROOT,
-            ROCKETRIDE_DIST_ROOT: DIST_ROOT
-        },
+        env = process.env,
         onOutput = null,
         collect = false,
         logModule = null,


### PR DESCRIPTION
Set the vars for the build/dist roots on process.env directly