### PR TITLE
fix(engine): serialize concurrent pipeline creation to prevent GIL starvation

### DIFF
--- a/packages/server/engine-lib/engLib/store/core/endpoint/endpoint.pipes.cpp
+++ b/packages/server/engine-lib/engLib/store/core/endpoint/endpoint.pipes.cpp
@@ -397,7 +397,30 @@ ErrorOr<ServicePipe> IServiceEndpoint::getPipe() noexcept {
         }
     }
 
-    // We don't have any available pipes, create one
+    // Serialize pipe creation — Python 3.12's GIL can starve threads when
+    // many concurrent buildInstancePipe() calls compete for the GIL on
+    // low-core machines (e.g. 2-core Windows CI runners with 16 pipelines).
+    util::Guard createGuard{[&] { m_pipeCreateLock.lock(); },
+                            [&] { m_pipeCreateLock.unlock(); }};
+
+    // Re-check: another thread may have created and released a pipe
+    // while we waited on the create lock
+    _block() {
+        util::Guard stackGuard{[&] { m_stackLock.lock(); },
+                               [&] { m_stackLock.unlock(); }};
+
+        for (int i = 0; i < m_instanceStacks.size(); i++) {
+            auto &stack = m_instanceStacks[i];
+            ServiceInstance &filter = stack[0];
+            ServicePipe &pipe = (ServicePipe &)filter;
+
+            if (pipe->busy) continue;
+            pipe->busy = true;
+            return pipe;
+        }
+    }
+
+    // No available pipes — create one (serialized by m_pipeCreateLock)
     auto result = buildInstancePipe();
 
     // If we got an error

--- a/packages/server/engine-lib/engLib/store/headers/endpoint.hpp
+++ b/packages/server/engine-lib/engLib/store/headers/endpoint.hpp
@@ -247,6 +247,7 @@ public:
     ServiceInstanceStacks m_instanceStacks;
 
     mutable async::Mutex m_stackLock;
+    mutable async::Mutex m_pipeCreateLock;
 
     //-----------------------------------------------------------------
     // These are valid to be called during beginFilterGlobal and


### PR DESCRIPTION
## Summary

- Fix Windows CI flake: `test_should_handle_16_concurrent_pipelines_with_unique_data` timing out with pipeline stuck in INITIALIZING state
- Root cause: Python 3.12 upgrade (commit 4cab474, PR #212) changed GIL behavior — 16 threads competing for the GIL during simultaneous `buildInstancePipe()` calls causes thread starvation on 2-core Windows runners
- Add `m_pipeCreateLock` mutex with double-checked locking in `getPipe()` to serialize pipeline creation while preserving fast-path pipe reuse

### What changed

**`endpoint.hpp`** — Add `m_pipeCreateLock` mutex alongside existing `m_stackLock`

**`endpoint.pipes.cpp`** — In `getPipe()`, after the fast-path check finds no available pipes:
1. Acquire `m_pipeCreateLock` to serialize creation
2. Re-check for available pipes (another thread may have created one while waiting)
3. Build new pipe if still needed (one at a time instead of thundering herd)

### Why this worked before Python 3.12

Python 3.10's GIL implementation handled 16-thread contention on 2-core machines without starvation. Python 3.12's revised GIL scheduling can starve individual threads when many compete simultaneously, causing indefinite waits during `beginFilterInstance()`.

## Test plan

- [ ] Windows CI passes `test_should_handle_16_concurrent_pipelines_with_unique_data`
- [ ] Ubuntu and macOS CI continue to pass (no regression from serialized creation)
- [ ] Verify no deadlock — `m_pipeCreateLock` and `m_stackLock` never held simultaneously in nested order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service endpoint reliability by optimizing concurrent pipe allocation. Enhanced serialization mechanisms reduce resource contention and prevent performance degradation during high-concurrency scenarios, ensuring more stable behavior under heavy loads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->