### PR TITLE
feat(ai): add PyTorch model loader (ai.common.models.torch)

### DIFF
--- a/packages/ai/src/ai/common/models/__init__.py
+++ b/packages/ai/src/ai/common/models/__init__.py
@@ -12,6 +12,7 @@ Subpackages:
 - audio: Whisper (transcription)
 - gliner: GLiNER (zero-shot NER)
 - ocr: EasyOCR, DocTR, Surya, TrOCR
+- torch: PyTorch model loader (torch.load wrapper)
 - transformers: SentenceTransformer, pipeline, AutoModel, AutoTokenizer
 
 The loaders use a unified interface so the model server can work with any
@@ -26,6 +27,9 @@ from .audio import Whisper, WhisperLoader
 
 # GLiNER models (zero-shot NER)
 from .gliner import GLiNER, GLiNERLoader
+
+# PyTorch model loader
+from .torch import TorchLoader
 
 # OCR models
 from .ocr import EasyOCR, EasyOCRLoader
@@ -49,6 +53,8 @@ __all__ = [
     # GLiNER
     'GLiNER',
     'GLiNERLoader',
+    # Torch
+    'TorchLoader',
     # OCR
     'EasyOCR',
     'EasyOCRLoader',

--- a/packages/ai/src/ai/common/models/torch/__init__.py
+++ b/packages/ai/src/ai/common/models/torch/__init__.py
@@ -1,0 +1,233 @@
+"""
+ai.common.models.torch — PyTorch model loader with automatic local/remote detection.
+
+Usage (replaces bare ``import torch`` for model loading):
+
+    import ai.common.models.torch as torch
+
+    model = torch.load('path/to/model.pt')   # returns _TorchWrapper
+    output = model(inputs)                    # runs locally or via model server
+
+    # Control gradient tracking — works in both local and server mode:
+    with torch.no_grad():
+        output = model(inputs)
+
+In local mode ``no_grad`` delegates to the real ``torch.no_grad()``.
+In server mode it passes ``no_grad=True`` as a per-request parameter so the
+server applies ``torch.no_grad()`` on its side during that inference call.
+No persistent server state is involved.
+"""
+
+import threading
+from typing import Any, Optional
+
+from ..base import get_model_server_address, ModelClient
+from .torch_loader import TorchLoader
+
+
+# ---------------------------------------------------------------------------
+# Thread-local gradient context tracking
+# ---------------------------------------------------------------------------
+
+_ctx = threading.local()
+
+
+def _is_no_grad() -> bool:
+    return getattr(_ctx, 'no_grad', False)
+
+
+class no_grad:
+    """
+    Context manager that disables gradient computation.
+
+    - **Local mode**: equals the real ``torch.no_grad()`` — delegates entirely.
+    - **Server mode**: only sets a thread-local flag (no local torch ops);
+      ``_TorchWrapper.__call__`` reads it and passes ``no_grad=True`` in the
+      inference request so the server applies ``torch.no_grad()`` on its side.
+
+    Usage::
+
+        with torch.no_grad():
+            output = model(inputs)
+    """
+
+    def __init__(self):
+        """Select behaviour based on whether a model server is present."""
+        self._server_mode = bool(get_model_server_address())
+        if not self._server_mode:
+            from ai.common.torch import torch  # pylint: disable=import-outside-toplevel
+            self._real = torch.no_grad()
+        else:
+            self._real = None
+
+    def __enter__(self):
+        """Disable gradients: set flag (server) or enter real context (local)."""
+        _ctx.no_grad = True
+        if self._real is not None:
+            self._real.__enter__()
+        return self
+
+    def __exit__(self, *args):
+        """Re-enable gradients: clear flag (server) or exit real context (local)."""
+        _ctx.no_grad = False
+        if self._real is not None:
+            return self._real.__exit__(*args)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Model wrapper
+# ---------------------------------------------------------------------------
+
+
+class _TorchWrapper:
+    """
+    Callable wrapper returned by ``torch.load()``.
+
+    In local mode the underlying ``nn.Module`` (or any callable) is held
+    directly and called on ``__call__``.
+
+    In server mode inference is routed through ``ModelClient``.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        device: Optional[str] = None,
+    ):
+        """
+        Load a PyTorch model and set up local or remote routing.
+
+        Args:
+            model_path: Path to the ``.pt`` file (torch.save format)
+            device: Force device: ``'cpu'``, ``'cuda'``, ``'cuda:N'``,
+                    ``'server'`` (force remote), or ``None`` (auto-detect)
+        """
+        self.model_path = model_path
+        self.device = device
+
+        server_addr = get_model_server_address()
+        should_proxy = server_addr and (device is None or device == 'server')
+
+        if should_proxy:
+            # === REMOTE MODE ===
+            self._proxy_mode = True
+            host, port = server_addr
+            self._client = ModelClient(port, host)
+            self._model = None
+            self._metadata: dict = {}
+            self._init_proxy()
+        else:
+            # === LOCAL MODE ===
+            self._proxy_mode = False
+            self._client = None
+            self._model, self._metadata, _ = TorchLoader.load(
+                model_path,
+                device=device if device != 'server' else None,
+            )
+
+    def _init_proxy(self) -> None:
+        """Load model on server and store metadata."""
+        self._client.load_model(
+            model_name=self.model_path,
+            model_type='torch',
+        )
+        self._metadata = self._client.metadata
+
+    def __call__(self, inputs: Any) -> Any:
+        """
+        Run inference.
+
+        Respects the active ``torch.no_grad()`` context in both local and
+        server mode — see module docstring for details.
+
+        Args:
+            inputs: A single input tensor / list.
+
+        Returns:
+            Model output as Python-native lists (JSON-serialisable).
+        """
+        if self._proxy_mode:
+            return self._call_remote(inputs)
+        else:
+            return self._call_local(inputs)
+
+    def _call_local(self, inputs: Any) -> Any:
+        """Run inference locally by calling the model directly."""
+        from ai.common.torch import torch
+
+        device = self._metadata.get('device', 'cpu')
+
+        if isinstance(inputs, torch.Tensor):
+            tensor = inputs.to(device)
+        else:
+            tensor = torch.tensor(inputs, dtype=torch.float32, device=device)
+
+        output = self._model(tensor)
+
+        if isinstance(output, torch.Tensor):
+            return output.cpu().tolist()
+        if isinstance(output, (tuple, list)):
+            return [r.cpu().tolist() if isinstance(r, torch.Tensor) else r for r in output]
+        return output
+
+    def _call_remote(self, inputs: Any) -> Any:
+        """Route inference to the model server, forwarding the no_grad flag."""
+        payload = {
+            'inputs': [inputs],
+            'output_fields': ['output'],
+        }
+        if _is_no_grad():
+            payload['no_grad'] = True
+
+        result = self._client.send_command('inference', payload)
+        results = result.get('result', [])
+        if results:
+            item = results[0]
+            if isinstance(item, dict):
+                return item.get('output')
+            return item
+        return None
+
+    def to(self, device: str) -> '_TorchWrapper':
+        """Move model to device (local mode only)."""
+        if not self._proxy_mode and self._model is not None and hasattr(self._model, 'to'):
+            self._model.to(device)
+            self._metadata['device'] = device
+        return self
+
+    @property
+    def metadata(self) -> dict:
+        """Return model metadata dict."""
+        return self._metadata
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def load(model_path: str, device: Optional[str] = None) -> _TorchWrapper:
+    """
+    Load a PyTorch model from *model_path* and return a callable wrapper.
+
+    Example::
+
+        import ai.common.models.torch as torch
+
+        model = torch.load('weights/classifier.pt')
+
+        with torch.no_grad():
+            output = model(input_data)
+
+    Args:
+        model_path: Path to the ``.pt`` file produced by ``torch.save``.
+        device: Target device, or ``None`` for auto-detection.
+
+    Returns:
+        :class:`_TorchWrapper` that can be called like the original model.
+    """
+    return _TorchWrapper(model_path, device=device)
+
+
+__all__ = ['load', 'no_grad', 'TorchLoader', '_TorchWrapper']

--- a/packages/ai/src/ai/common/models/torch/torch_loader.py
+++ b/packages/ai/src/ai/common/models/torch/torch_loader.py
@@ -1,0 +1,229 @@
+"""
+TorchLoader: Load/preprocess/inference/postprocess for PyTorch .pt models.
+
+Used by:
+- Model server (directly calls static methods)
+- torch.load() wrapper (for local mode)
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from ..base import BaseLoader
+
+logger = logging.getLogger('rocketlib.models.torch')
+
+
+class TorchLoader(BaseLoader):
+    """
+    Static loader for PyTorch models (.pt / torch.save format).
+
+    Used by:
+    - Model server (directly calls static methods)
+    - _TorchWrapper (for local mode)
+
+    Key characteristics:
+    - File path is the model identity
+    - Accepts generic tensor inputs (Python lists converted to tensors)
+    - Returns generic tensor outputs (converted back to Python lists)
+    - Stateless after loading (thread-safe)
+    """
+
+    LOADER_TYPE: str = 'torch'
+    _DEFAULTS: dict = {}
+
+    @staticmethod
+    def load(
+        model_name: str,
+        device: Optional[str] = None,
+        allocate_gpu: Optional[callable] = None,
+        exclude_gpus: Optional[List[int]] = None,
+    ) -> Tuple[Any, Dict[str, Any], int]:
+        """
+        Load a PyTorch model from a .pt file.
+
+        Two modes:
+        - Local mode (device specified): Load directly to device
+        - Server mode (allocate_gpu provided): CPU-first, measure, allocate, move
+
+        Args:
+            model_name: Path to .pt file
+            device: Device for local mode ('cuda:0', 'cpu', etc.)
+            allocate_gpu: Callback for server mode (memory_gb, exclude_gpus) -> (gpu_index, device_str)
+            exclude_gpus: GPUs to exclude (server mode)
+
+        Returns:
+            Tuple of (model_object, metadata_dict, gpu_index)
+        """
+        from ai.common.torch import torch   # pylint: disable=import-outside-toplevel
+
+        exclude_gpus = exclude_gpus or []
+
+        if allocate_gpu:
+            # === SERVER MODE: CPU-first for accurate memory measurement ===
+            logger.info('Loading torch model %s to CPU...', model_name)
+            model = torch.load(model_name, map_location='cpu', weights_only=False)
+            if hasattr(model, 'eval'):
+                model.eval()
+
+            memory_gb = TorchLoader._get_memory_footprint(model)
+            logger.debug('Measured memory footprint: %.2f GB', memory_gb)
+
+            gpu_index, device = allocate_gpu(memory_gb, exclude_gpus)
+            logger.info('Allocated GPU %d (%s) for %s', gpu_index, device, model_name)
+
+            if hasattr(model, 'to'):
+                model.to(device)
+            if hasattr(model, 'eval'):
+                model.eval()
+        else:
+            # === LOCAL MODE: Load directly to specified device ===
+            if device is None:
+                device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
+
+            logger.info('Loading torch model %s to %s', model_name, device)
+            model = torch.load(model_name, map_location=device, weights_only=False)
+            if hasattr(model, 'to'):
+                model.to(device)
+            if hasattr(model, 'eval'):
+                model.eval()
+
+            gpu_index = int(device.split(':')[1]) if ':' in device else (0 if device == 'cuda' else -1)
+            memory_gb = TorchLoader._get_memory_footprint(model)
+
+        metadata = {
+            'device': device,
+            'model_name': model_name,
+            'loader': 'torch',
+            'estimated_memory_gb': memory_gb,
+        }
+
+        return model, metadata, gpu_index
+
+    @staticmethod
+    def preprocess(model: Any, inputs: List[Any], metadata: Optional[Dict] = None) -> Dict[str, Any]:
+        """
+        Preprocess inputs for a PyTorch model.
+
+        Converts Python lists/scalars to tensors. Inputs can be:
+        - A list of tensors (one per batch item)
+        - A list of lists (converted to float tensors)
+
+        Args:
+            model: The PyTorch model (unused but kept for API consistency)
+            inputs: List of input items (lists or tensors)
+            metadata: Optional metadata dict
+
+        Returns:
+            Dict with 'inputs' key containing a stacked tensor
+        """
+        from ai.common.torch import torch   # pylint: disable=import-outside-toplevel
+
+        device = metadata.get('device', 'cuda:0') if metadata else 'cuda:0'
+
+        processed = []
+        for item in inputs:
+            if isinstance(item, torch.Tensor):
+                processed.append(item.to(device))
+            else:
+                processed.append(torch.tensor(item, dtype=torch.float32, device=device))
+
+        return {
+            'inputs': processed,
+            'batch_size': len(inputs),
+        }
+
+    @staticmethod
+    def inference(
+        model: Any,
+        preprocessed: Dict[str, Any],
+        metadata: Optional[Dict] = None,
+        stream: Optional[Any] = None,
+    ) -> Any:
+        """
+        Run inference with a PyTorch model.
+
+        Args:
+            model: The PyTorch model or ModelInstanceWrapper
+            preprocessed: Output from preprocess()
+            metadata: Optional metadata dict
+            stream: Optional CUDA stream (unused)
+
+        Returns:
+            List of model outputs (tensors or tuples)
+        """
+        from ai.common.torch import torch   # pylint: disable=import-outside-toplevel
+
+        # Handle ModelInstanceWrapper (server mode)
+        if hasattr(model, 'model_obj'):
+            actual_model = model.model_obj
+            device = model.metadata.get('device', 'cuda:0')
+        else:
+            actual_model = model
+            device = metadata.get('device', 'cuda:0') if metadata else 'cuda:0'
+
+        inputs = preprocessed['inputs']
+        results = []
+
+        with torch.no_grad():
+            for tensor in inputs:
+                output = actual_model(tensor.to(device, non_blocking=True))
+                results.append(output)
+
+        return results
+
+    @staticmethod
+    def postprocess(
+        model: Any,
+        raw_output: Any,
+        batch_size: int,
+        output_fields: List[str],
+    ) -> List[Dict[str, Any]]:
+        """
+        Postprocess PyTorch model output.
+
+        Converts tensors to Python-native lists for JSON serialisation.
+
+        Args:
+            model: The model (unused but kept for API consistency)
+            raw_output: List of outputs from inference()
+            batch_size: Expected batch size
+            output_fields: Fields to extract (e.g., ['output'])
+
+        Returns:
+            List of dicts with 'output' key containing list values
+        """
+        from ai.common.torch import torch   # pylint: disable=import-outside-toplevel
+        from ..extract import extract_outputs   # pylint: disable=import-outside-toplevel
+
+        results = []
+        if batch_size > len(raw_output):
+            logger.warning('batch_size (%d) exceeds raw_output length (%d); with None', batch_size, len(raw_output))
+        for i in range(batch_size):
+            raw = raw_output[i] if i < len(raw_output) else None
+            if raw is None:
+                item_output = {'output': None}
+            elif isinstance(raw, torch.Tensor):
+                item_output = {'output': raw.cpu().tolist()}
+            elif isinstance(raw, (tuple, list)):
+                item_output = {'output': [r.cpu().tolist() if isinstance(r, torch.Tensor) else r for r in raw]}
+            else:
+                item_output = {'output': raw}
+
+            extracted = extract_outputs(item_output, output_fields)
+            results.append(extracted)
+
+        return results
+
+    @staticmethod
+    def _get_memory_footprint(model: Any) -> float:
+        """Estimate GPU memory footprint from a loaded model."""
+        try:
+            if hasattr(model, 'parameters'):
+                total_params = sum(p.numel() for p in model.parameters())
+                bytes_per_param = 4
+                total_bytes = total_params * bytes_per_param * 1.2  # 20% overhead
+                return total_bytes / (1024**3)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.debug('Failed to estimate memory footprint: %s', e)
+        return 0.1  # default estimate for non-nn.Module objects


### PR DESCRIPTION
## Summary

- TorchLoader(BaseLoader): load/preprocess/inference/postprocess for torch.save/.pt files; device placement follows TransformersLoader pattern
- _TorchWrapper: callable returned by torch.load(); auto-routes to model server or local execution
- torch.no_grad(): custom context manager — delegates to real torch.no_grad() locally, passes no_grad=True per-request in server mode via thread-local flag

## Type

feat

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Relates to https://github.com/rocketride-ai/rocketride-saas/pull/15


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds PyTorch model support with unified local vs. remote inference routing.
  * Gradient-control context honored for both local and remote inference.
  * Callable model wrapper that normalizes inputs/outputs and exposes model metadata.
  * Automatic device management with GPU memory estimation and allocation hints.
  * PyTorch loader exposed in the public API for easy discovery and use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->