### PR TITLE
fix(tika): ignore pom.xml

### DIFF
--- a/packages/tika/scripts/tasks.js
+++ b/packages/tika/scripts/tasks.js
@@ -62,7 +62,7 @@ const MAVEN_DIR = path.join(JAVA_DIR, 'maven');
 const MAVEN = path.join(MAVEN_DIR, 'bin', 'mvn');
 
 // Glob patterns to ignore when syncing
-const IGNORE = ['**/target/**', '**/node_modules/**', '**/.git/**', '**/scripts/**'];
+const IGNORE = ['**/target/**', '**/node_modules/**', '**/.git/**', '**/scripts/**', '**/lib/tika/pom.xml'];
 
 // ============================================================================
 // Helpers


### PR DESCRIPTION
## Summary

Tika’s source code sync always detected changes caused by the pom.xml file generated runtime during the build process, and this resulted in a rebuild.

To resolve this, pom.xml has been added to the sync ignores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file synchronization to exclude additional build configuration files from sync operations, preventing those files from being considered during syncing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->