### PR TITLE
fix(builder): pass options to actions

### DIFF
--- a/nodes/scripts/tasks.js
+++ b/nodes/scripts/tasks.js
@@ -135,8 +135,8 @@ function makeRunPytestAction(options = {}) {
             const pytestArgs = ['-m', 'pytest', TEST_DIR, '-v', '--rootdir', PACKAGE_DIR];
 
             // Exclude skip_node tests by default (same as skip_nodes in pytest_generate_tests for dynamic tests)
-            const pytestOpts = options.pytest || ctx.options?.pytest;
-            const markersOpt = options.markers || ctx.options?.markers;
+            const pytestOpts = options.pytest;
+            const markersOpt = options.markers;
             const hasExplicitMarkers = (() => {
                 if (markersOpt) return true;
                 if (!pytestOpts) return false;
@@ -150,7 +150,7 @@ function makeRunPytestAction(options = {}) {
             }
 
             // Add any additional pytest options (from CLI or direct options)
-            // ctx.options comes from CLI args like --pytest="-s -v"
+            // options comes from CLI args like --pytest="-s -v"
             if (pytestOpts) {
                 // Handle both string and array formats
                 // CLI passes array like ["-v -s"], so split each element by spaces
@@ -164,8 +164,8 @@ function makeRunPytestAction(options = {}) {
             }
 
             // Allow filtering tests by marker or pattern
-            const markers = options.markers || ctx.options?.markers;
-            const pattern = options.pattern || ctx.options?.pattern;
+            const markers = options.markers;
+            const pattern = options.pattern;
             if (markers) {
                 pytestArgs.push('-m', markers);
             }

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -47,7 +47,6 @@ const PACKAGES_DIR = path.join(PROJECT_ROOT, 'packages');
 const SERVER_DIR = path.join(PACKAGES_DIR, 'server');
 const DIST_DIR = path.join(DIST_ROOT, 'server');
 const VCPKG_DIR = path.join(BUILD_ROOT, 'vcpkg');
-const BUILD_ARTIFACTS_DIR = path.join(BUILD_ROOT, 'artifacts');
 const DIST_ARTIFACTS_DIR = path.join(DIST_ROOT, 'artifacts');
 
 // =============================================================================
@@ -434,7 +433,7 @@ function makeDownloadAction(options = {}) {
                 return;
             }
 
-            if (ctx.options?.nodownload) {
+            if (options.nodownload) {
                 task.output = 'Download skipped (--nodownload)';
                 ctx.downloaded = false;
                 return;
@@ -527,12 +526,12 @@ function makeDownloadAction(options = {}) {
     };
 }
 
-function makeSetupToolsAction(_options = {}) {
+function makeSetupToolsAction(options = {}) {
     return {
         run: async (ctx, task) => {
             await runCompilerSetup({
-                autoinstall: !!(ctx.options && ctx.options.autoinstall),
-                verbose: !!(ctx.options && ctx.options.verbose),
+                autoinstall: options.autoinstall,
+                verbose: options.verbose,
                 onOutput: (line) => { task.output = line; },
                 task
             });
@@ -582,16 +581,16 @@ function makeConfigureServerAction(options = {}) {
                 cmakeArgs.push(`-DROCKETRIDE_UNITY_BATCH_SIZE:STRING=${options.batchSize}`);
             }
 
-            if (ctx.options.buildVersion) {
-                cmakeArgs.push(`-DCMAKE_PROJECT_VERSION:STRING=${ctx.options.buildVersion}`);
+            if (options.buildVersion) {
+                cmakeArgs.push(`-DCMAKE_PROJECT_VERSION:STRING=${options.buildVersion}`);
             }
 
-            if (ctx.options.buildHash) {
-                cmakeArgs.push(`-DROCKETRIDE_BUILD_HASH_SHORT:STRING=${ctx.options.buildHash}`);
+            if (options.buildHash) {
+                cmakeArgs.push(`-DROCKETRIDE_BUILD_HASH_SHORT:STRING=${options.buildHash}`);
             }
 
-            if (ctx.options.buildStamp) {
-                cmakeArgs.push(`-DROCKETRIDE_BUILD_STAMP:STRING=${ctx.options.buildStamp}`);
+            if (options.buildStamp) {
+                cmakeArgs.push(`-DROCKETRIDE_BUILD_STAMP:STRING=${options.buildStamp}`);
             }
 
             const baseEnv = isWindows() ? await getVsEnvironment() : process.env;
@@ -599,7 +598,7 @@ function makeConfigureServerAction(options = {}) {
                 ...baseEnv,
                 VCPKG_ROOT: path.join(BUILD_ROOT, 'vcpkg')  // Help vcpkg find itself faster
             };
-            await execCommand(cmakeArgs[0], cmakeArgs.slice(1), { task, env, verbose: !!(ctx.options && ctx.options.verbose) });
+            await execCommand(cmakeArgs[0], cmakeArgs.slice(1), { task, env, verbose: options.verbose });
 
             await updateServerState({
                 configured: true,
@@ -708,7 +707,7 @@ function makeCompileEngineAction(options = {}) {
 
             if (options.force) {
                 task.output = 'Cleaning build directory...';
-                await execCommand('cmake', ['--build', BUILD_ROOT, '--target', 'clean'], { task, env, verbose: !!(ctx.options && ctx.options.verbose) });
+                await execCommand('cmake', ['--build', BUILD_ROOT, '--target', 'clean'], { task, env, verbose: options.verbose});
             }
 
             const jobs = getParallelJobs();
@@ -718,7 +717,7 @@ function makeCompileEngineAction(options = {}) {
                 '--target', 'engine',
                 '--parallel', String(jobs)
             ];
-            await execCommand(cmakeArgs[0], cmakeArgs.slice(1), { task, env, verbose: !!(ctx.options && ctx.options.verbose) });
+            await execCommand(cmakeArgs[0], cmakeArgs.slice(1), { task, env, verbose: options.verbose });
 
             // Copy engine to dist
             await mkdir(DIST_DIR);
@@ -742,12 +741,12 @@ function makeCompileEngineAction(options = {}) {
     };
 }
 
-function makeCompileTestsAction() {
+function makeCompileTestsAction(options = {}) {
     return {
         locks: ['cmake'],
         run: async (ctx, task) => {
             // Check source hash to skip if nothing changed since last test build
-            if (!(ctx.options && ctx.options.force)) {
+            if (options.force) {
                 task.output = 'Checking for source changes...';
                 const [coreHash, libHash, cmakeHash] = await Promise.all([
                     fingerprint(path.join(SERVER_DIR, 'engine-core')),
@@ -778,12 +777,12 @@ function makeCompileTestsAction() {
             // Build aptest
             task.output = 'Building aptest...';
             const aptestArgs = ['--build', BUILD_ROOT, '--config', 'Release', '--target', 'aptest', '--parallel', String(jobs)];
-            await execCommand('cmake', aptestArgs, { task, env, verbose: !!(ctx.options && ctx.options.verbose) });
+            await execCommand('cmake', aptestArgs, { task, env, verbose: options.verbose });
 
             // Build engtest
             task.output = 'Building engtest...';
             const engtestArgs = ['--build', BUILD_ROOT, '--config', 'Release', '--target', 'engtest', '--parallel', String(jobs)];
-            await execCommand('cmake', engtestArgs, { task, env, verbose: !!(ctx.options && ctx.options.verbose) });
+            await execCommand('cmake', engtestArgs, { task, env, verbose: options.verbose });
 
             // Save test source hash after successful build
             if (ctx._testSrcHash) {
@@ -975,7 +974,6 @@ function makeCleanServerAction() {
                 path.join(BUILD_ROOT, 'engine-lib'),
                 path.join(BUILD_ROOT, 'packages'),
                 path.join(BUILD_ROOT, '_download_temp'),
-                BUILD_ARTIFACTS_DIR,
                 DIST_ARTIFACTS_DIR,
                 DIST_DIR
             ]);
@@ -1069,7 +1067,7 @@ function makePackageAction(options = {}) {
             const packageHash = await getState('server.pkgHash');
             if (!sourceHash) {
                 throw new Error('Content hash not found — build server first');
-            } else if (!_ctx.options.force && sourceHash === packageHash && await exists(distFile)) {
+            } else if (!options.force && sourceHash === packageHash && await exists(distFile)) {
                 _task.output = `Server package ${distFilename} is up to date`;
                 return;
             }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -144,7 +144,7 @@ function parseArgs(args) {
  * 
  * Looks for actions like "moduleName:command" with descriptions (public actions)
  */
-function expandGlobalCommands(globalCommands, registry) {
+function expandGlobalCommands(globalCommands, registry, options) {
     const requests = [];
 
     for (const command of globalCommands) {
@@ -153,7 +153,7 @@ function expandGlobalCommands(globalCommands, registry) {
             const actionDef = registry.getAction(actionName);
             if (actionDef) {
                 const actionObj = typeof actionDef.action === 'function'
-                    ? actionDef.action()
+                    ? actionDef.action(options)
                     : actionDef.action;
                 // Only expand to public actions (those with descriptions)
                 if (actionObj?.description) {
@@ -166,7 +166,7 @@ function expandGlobalCommands(globalCommands, registry) {
     return requests;
 }
 
-function showHelp(registry) {
+function showHelp(registry, options) {
     console.log(`
 Rocketride Build System
 
@@ -174,7 +174,7 @@ Usage: builder <action> [...] [options]
 
 Actions:`);
 
-    const commands = registry.listCommands();
+    const commands = registry.listCommands(options);
 
     // Group by module
     const grouped = {};
@@ -282,14 +282,14 @@ async function main() {
     }
 
     // Expand global commands (e.g., "build" -> "build:server", "build:chat-ui", etc.)
-    const expandedRequests = expandGlobalCommands(globalCommands, registry);
+    const expandedRequests = expandGlobalCommands(globalCommands, registry, options);
     const requests = [...explicitRequests, ...expandedRequests];
 
     // Handle --list-actions - show ALL registered actions across all modules
     if (options.listActions) {
         console.log('\nAll Registered Actions:\n');
 
-        const allActions = registry.listActions();
+        const allActions = registry.listActions(options);
         for (const action of allActions) {
             const desc = action.description ? ` - ${action.description}` : '';
             console.log(`  ${action.name}${desc}`);
@@ -313,7 +313,7 @@ async function main() {
 
     // Show help if requested or no commands given
     if (options.help || requests.length === 0) {
-        showHelp(registry);
+        showHelp(registry, options);
         process.exit(options.help ? 0 : 1);
     }
 
@@ -335,7 +335,7 @@ async function main() {
 
             if (actionDef) {
                 const actionObj = typeof actionDef.action === 'function'
-                    ? actionDef.action()
+                    ? actionDef.action(options)
                     : actionDef.action;
                 if (actionObj?.steps) {
                     printFlowDiagram({ steps: actionObj.steps });
@@ -364,9 +364,10 @@ async function main() {
             const availableActions = (mod.actions || [])
                 .map(a => a.name)
                 .filter(n => {
-                    const obj = typeof registry.getAction(n)?.action === 'function'
-                        ? registry.getAction(n).action()
-                        : registry.getAction(n)?.action;
+                    const def = registry.getAction(n);
+                    const obj = typeof def?.action === 'function'
+                        ? def.action(options)
+                        : def?.action;
                     return obj?.description;
                 });
             if (availableActions.length > 0) {

--- a/scripts/lib/action-runner.js
+++ b/scripts/lib/action-runner.js
@@ -82,22 +82,23 @@ function resetActionTracking() {
 
 /**
  * Resolve an action definition from registry or inline
- * 
+ *
  * @param {string|object} step - Step (string ref like 'vcpkg:clone' or { name, action })
+ * @param {object} options - Options
  * @returns {{ name: string, actionObj: object }} Resolved action
  */
-function resolveAction(step) {
+function resolveAction(step, options) {
     if (typeof step === 'string') {
         const found = registry.getAction(step);
         if (!found) {
             throw new Error(`Action not found in registry: ${step}`);
         }
-        const actionObj = typeof found.action === 'function' ? found.action() : found.action;
+        const actionObj = typeof found.action === 'function' ? found.action(options) : found.action;
         return { name: step, actionObj };
     }
-    
+
     const { name, action } = step;
-    const actionObj = typeof action === 'function' ? action() : action;
+    const actionObj = typeof action === 'function' ? action(options) : action;
     return { name, actionObj };
 }
 
@@ -179,8 +180,9 @@ function buildLeafTask(name, actionObj, logModule) {
  * @param {object} actionObj - Action definition
  * @param {Set} seen - Set of seen action names
  * @param {string} logModule - Module name for log collection
+ * @param {object} options - Options
  */
-function buildCompoundTask(name, actionObj, seen, logModule) {
+function buildCompoundTask(name, actionObj, seen, logModule, options) {
     // Check if already seen (for deduplication)
     if (!actionObj.multi && seen.has(name)) {
         return {
@@ -202,8 +204,8 @@ function buildCompoundTask(name, actionObj, seen, logModule) {
     }
     
     // Build children
-    const children = buildTaskTree(actionObj.steps, seen, logModule);
-    
+    const children = buildTaskTree(actionObj.steps, seen, logModule, options);
+
     // Add lock release and completion marker as final child
     // Note: We combine these into one task with empty title to minimize visual noise
     const hasLocks = actionObj.locks?.length || !actionObj.multi;
@@ -275,9 +277,10 @@ function buildCompoundTask(name, actionObj, seen, logModule) {
  * @param {object} parallel - Parallel definition
  * @param {Set} seen - Set of seen action names
  * @param {string} logModule - Module name for log collection
+ * @param {object} options - Options
  */
-function buildParallelTask(parallel, seen, logModule) {
-    const children = buildTaskTree(parallel.actions, seen, logModule);
+function buildParallelTask(parallel, seen, logModule, options) {
+    const children = buildTaskTree(parallel.actions, seen, logModule, options);
     
     return {
         title: parallel.title || 'Parallel tasks',
@@ -303,9 +306,10 @@ function buildParallelTask(parallel, seen, logModule) {
  * @param {object} sequence - Sequence definition
  * @param {Set} seen - Set of seen action names
  * @param {string} logModule - Module name for log collection
+ * @param {object} options - Options
  */
-function buildSequenceTask(sequence, seen, logModule) {
-    const children = buildTaskTree(sequence.steps, seen, logModule);
+function buildSequenceTask(sequence, seen, logModule, options) {
+    const children = buildTaskTree(sequence.steps, seen, logModule, options);
     
     return {
         title: sequence.title || 'Sequential tasks',
@@ -333,11 +337,12 @@ function buildSequenceTask(sequence, seen, logModule) {
  * @param {object} bracket - Bracket definition
  * @param {Set} seen - Set of seen action names
  * @param {string} logModule - Module name for log collection
+ * @param {object} options - Options
  * @returns {Array} Array of Listr2 task definitions (not a single task)
  */
-function buildBracketTask(bracket, seen, logModule) {
+function buildBracketTask(bracket, seen, logModule, options) {
     // Build inner tasks
-    const innerTasks = buildTaskTree(bracket.steps, seen, logModule);
+    const innerTasks = buildTaskTree(bracket.steps, seen, logModule, options);
     
     // Wrap inner tasks to catch errors but allow teardown to run
     const wrappedInnerTasks = innerTasks.map((innerTask, index) => ({
@@ -439,13 +444,14 @@ function buildBracketTask(bracket, seen, logModule) {
  * @param {object} when - When definition
  * @param {Set} seen - Set of seen action names
  * @param {string} logModule - Module name for log collection
+ * @param {object} options - Options
  */
-function buildWhenTask(when, seen, logModule) {
+function buildWhenTask(when, seen, logModule, options) {
     const variant = when._variant || 'when';
-    
+
     // Pre-build both branches so structure is known
-    const thenTasks = buildTaskTree(when.then, seen, logModule);
-    const elseTasks = when.else?.length ? buildTaskTree(when.else, seen, logModule) : [];
+    const thenTasks = buildTaskTree(when.then, seen, logModule, options);
+    const elseTasks = when.else?.length ? buildTaskTree(when.else, seen, logModule, options) : [];
     
     return {
         title: `? ${variant} ${when.name}`,
@@ -488,15 +494,16 @@ function buildWhenTask(when, seen, logModule) {
  * @param {string|object} step - Step definition
  * @param {Set} seen - Set of action names already seen (for deduplication)
  * @param {string} logModule - Module name for log collection
+ * @param {object} options - Options
  * @returns {object} Listr2 task definition
  */
-function buildTask(step, seen, logModule) {
+function buildTask(step, seen, logModule, options) {
     // String reference - action name like 'vcpkg:clone'
     if (typeof step === 'string') {
-        const { name, actionObj } = resolveAction(step);
-        
+        const { name, actionObj } = resolveAction(step, options);
+
         if (actionObj.steps && Array.isArray(actionObj.steps)) {
-            return buildCompoundTask(name, actionObj, seen, logModule);
+            return buildCompoundTask(name, actionObj, seen, logModule, options);
         } else {
             // Check deduplication for leaf actions
             if (!actionObj.multi && seen.has(name)) {
@@ -521,24 +528,24 @@ function buildTask(step, seen, logModule) {
     
     // Control flow types
     if (step._type === 'parallel') {
-        return buildParallelTask(step, seen, logModule);
+        return buildParallelTask(step, seen, logModule, options);
     }
     if (step._type === 'sequence') {
-        return buildSequenceTask(step, seen, logModule);
+        return buildSequenceTask(step, seen, logModule, options);
     }
     if (step._type === 'bracket') {
-        return buildBracketTask(step, seen, logModule);
+        return buildBracketTask(step, seen, logModule, options);
     }
     if (step._type === 'when') {
-        return buildWhenTask(step, seen, logModule);
+        return buildWhenTask(step, seen, logModule, options);
     }
-    
+
     // Object with name/action - inline action definition
     if (step.name && step.action) {
-        const { name, actionObj } = resolveAction(step);
-        
+        const { name, actionObj } = resolveAction(step, options);
+
         if (actionObj.steps && Array.isArray(actionObj.steps)) {
-            return buildCompoundTask(name, actionObj, seen, logModule);
+            return buildCompoundTask(name, actionObj, seen, logModule, options);
         } else {
             if (!actionObj.multi && seen.has(name)) {
                 return {
@@ -575,16 +582,17 @@ function buildTask(step, seen, logModule) {
  * @param {Array} steps - Array of step definitions
  * @param {Set} seen - Set of action names already seen (for deduplication)
  * @param {string} logModule - Module name for log collection (e.g., 'client-python:test')
+ * @param {object} options - Options
  * @returns {Array} Array of Listr2 task definitions
  */
-function buildTaskTree(steps, seen = new Set(), logModule = null) {
+function buildTaskTree(steps, seen = new Set(), logModule = null, options = {}) {
     if (!steps || steps.length === 0) {
         return [];
     }
-    
+
     // Use flatMap because some builders (brackets) return arrays
     return steps.flatMap(step => {
-        const result = buildTask(step, seen, logModule);
+        const result = buildTask(step, seen, logModule, options);
         return Array.isArray(result) ? result : [result];
     });
 }
@@ -605,10 +613,10 @@ async function runTaskCommand(command, options = {}, ctx = {}) {
     if (!command.steps || command.steps.length === 0) {
         return;
     }
-    
-    // Phase 1: Build complete task tree
-    const tasks = buildTaskTree(command.steps);
-    
+
+    // Phase 1: Build complete task tree (pass options so nested actions get them)
+    const tasks = buildTaskTree(command.steps, new Set(), null, options);
+
     // Phase 2: Execute via Listr2
     const runner = new Listr(tasks, {
         concurrent: false,
@@ -632,8 +640,8 @@ async function runTaskCommand(command, options = {}, ctx = {}) {
  * @param {object} options - Options
  * @returns {Listr} Configured Listr instance
  */
-function stepsToListr(parentTask, steps, _options = {}) {
-    const tasks = buildTaskTree(steps);
+function stepsToListr(parentTask, steps, options = {}) {
+    const tasks = buildTaskTree(steps, new Set(), null, options);
     
     return parentTask.newListr(tasks, {
         concurrent: false,

--- a/scripts/lib/registry.js
+++ b/scripts/lib/registry.js
@@ -87,7 +87,7 @@ class ModuleRegistry {
      * Actions with descriptions are shown in `builder --help`.
      * Actions without descriptions are internal/private but still callable.
      */
-    listCommands() {
+    listCommands(options) {
         const result = [];
 
         for (const [moduleName, mod] of this.modules) {
@@ -95,7 +95,7 @@ class ModuleRegistry {
 
             for (const actionDef of mod.actions) {
                 const actionObj = typeof actionDef.action === 'function'
-                    ? actionDef.action()
+                    ? actionDef.action(options)
                     : actionDef.action;
 
                 // Only list actions that have descriptions (public actions)
@@ -139,7 +139,7 @@ class ModuleRegistry {
      * List all registered actions across all modules
      * @returns {Array} Array of { name, description, module }
      */
-    listActions() {
+    listActions(options) {
         const actions = [];
 
         for (const [moduleName, mod] of this.modules) {
@@ -147,7 +147,7 @@ class ModuleRegistry {
 
             for (const actionDef of mod.actions) {
                 const actionObj = typeof actionDef.action === 'function'
-                    ? actionDef.action()
+                    ? actionDef.action(options)
                     : actionDef.action;
                 actions.push({
                     name: actionDef.name,

--- a/scripts/lib/runner.js
+++ b/scripts/lib/runner.js
@@ -74,13 +74,13 @@ class TaskRunner {
             throw new Error(`Unknown action '${actionName}'`);
         }
         
-        const actionObj = typeof actionDef.action === 'function' 
-            ? actionDef.action() 
+        const actionObj = typeof actionDef.action === 'function'
+            ? actionDef.action(this.options)
             : actionDef.action;
-        
+
         // Compound action with steps
         if (actionObj.steps && Array.isArray(actionObj.steps)) {
-            const childTasks = buildTaskTree(actionObj.steps, new Set(), actionName);
+            const childTasks = buildTaskTree(actionObj.steps, new Set(), actionName, this.options);
             
             return {
                 title: actionObj.description || actionName,


### PR DESCRIPTION
## Summary

The builder options are passed correctly to all builder actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CLI/config options (verbosity, build/version/hash/stamp, skip/force flags, test marker/pattern filters) are now applied consistently across build, test and packaging steps.

* **Chores**
  * Internal task and help listing flow updated so commands and help respect runtime options. No visible UI changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->