### PR TITLE
feat(builder): package nodes from overlay root

### DIFF
--- a/nodes/scripts/tasks.js
+++ b/nodes/scripts/tasks.js
@@ -31,6 +31,7 @@
  */
 const path = require('path');
 const {
+    exists,
     syncDir,
     formatSyncStats,
     removeDir,
@@ -54,11 +55,21 @@ const ENGINE = path.join(DIST_ROOT, 'server', 'engine');
 // Action Factories
 // ============================================================================
 
-function makeSyncNodesAction() {
+function makeSyncNodesAction(options = {}) {
     return {
         run: async (ctx, task) => {
             task.output = 'Scanning for changes...';
-            const stats = await syncDir(SRC_DIR, DIST_DIR, { package: true });
+
+            const stats = {};
+            await syncDir(SRC_DIR, DIST_DIR, { mirror: false, package: true }, stats);
+
+            if (options.overlayRoot) {
+                const overlaySrcDir = path.join(options.overlayRoot, 'nodes', 'src', 'nodes');
+                if (await exists(overlaySrcDir)) {
+                    await syncDir(overlaySrcDir, DIST_DIR, { mirror: false, package: true }, stats);
+                }
+            }
+
             task.output = formatSyncStats(stats);
         }
     };

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -92,12 +92,7 @@ function parseArgs(args) {
             options.logFile = arg.substring('--log='.length);
             currentLogFile = options.logFile; // For signal handlers
         } else if (arg.startsWith('--overlay-root=')) {
-            const overlayRoot = arg.substring('--overlay-root='.length);
-            if (path.isAbsolute(overlayRoot)) {
-                options.overlayRoot = overlayRoot;
-            } else {
-                options.overlayRoot = path.join(process.cwd(), overlayRoot);
-            }
+            options.overlayRoot = path.resolve(arg.substring('--overlay-root='.length));
             const paths = require('./lib/paths');
             paths.BUILD_ROOT = path.join(options.overlayRoot, 'build');
             paths.DIST_ROOT = path.join(options.overlayRoot, 'dist');


### PR DESCRIPTION
## Summary

Packaging external nodes in overlay root mode.

Since the structure is intended to be the same for both open-source nodes and external proprietary nodes in overlay root mode, I have decided to include external nodes in the distribution package with our open-source builder.

## Type

feature

## Related Issues

Addressing #226 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added overlay synchronization support to the build process, enabling content from additional source directories to be included in the distribution output.

* **Refactor**
  * Improved path resolution logic for overlay configurations to ensure consistent absolute path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->