### PR TITLE
feat(nodes): adds support for max chunks per file

### DIFF
--- a/nodes/src/nodes/preprocessor_langchain/IInstance.py
+++ b/nodes/src/nodes/preprocessor_langchain/IInstance.py
@@ -33,12 +33,19 @@ class IInstance(IInstanceBase):
     chunkId: int = 0
     tableId: int = 0
 
+    def _remaining(self):
+        """Return remaining chunk budget for this file, or None if unlimited."""
+        max_chunks = self.IGlobal.preprocessor._max_chunks_per_file
+        if max_chunks is None:
+            return None
+        return max(0, max_chunks - self.chunkId)
+
     def _writeTableOrText(self, text: str, isTable: bool = False):
         # Fill in the metadata using new API
         metadata = DocMetadata(self, isTable=isTable)
 
-        # Chunk the document
-        textChunks = self.IGlobal.preprocessor.process(text)
+        # Chunk the document, passing remaining per-file budget
+        textChunks = self.IGlobal.preprocessor.process(text, remaining_chunks=self._remaining())
 
         # Create the documents
         documents: List[Doc] = []

--- a/nodes/src/nodes/preprocessor_langchain/langchain.py
+++ b/nodes/src/nodes/preprocessor_langchain/langchain.py
@@ -321,7 +321,11 @@ class PreProcessor(PreProcessorBase):
         return
 
     # Process a document by splitting it into chunks
-    def process(self, text: str, path: str = None) -> List[str]:
+    def process(self, text: str, path: str = None, remaining_chunks: int = None) -> List[str]:
+        # If caller says no budget left, skip splitting entirely
+        if remaining_chunks is not None and remaining_chunks <= 0:
+            return []
+
         # Grab the chunks
         textChunks = self._preprocessor.split_text(text)
 
@@ -336,9 +340,11 @@ class PreProcessor(PreProcessorBase):
                     fixed.extend(self._split_safely_by_tokens(ch, self._token_limit))
             textChunks = fixed
 
-        # Apply per-file chunk limit if configured
-        if self._max_chunks_per_file is not None and len(textChunks) > self._max_chunks_per_file:
-            textChunks = textChunks[:self._max_chunks_per_file]
+        # Apply chunk limit: use caller's remaining budget if provided,
+        # otherwise fall back to per-file config limit
+        limit = remaining_chunks if remaining_chunks is not None else self._max_chunks_per_file
+        if limit is not None and len(textChunks) > limit:
+            textChunks = textChunks[:limit]
 
-        # Return the raw text chunks
+        # Return the text chunks
         return textChunks

--- a/nodes/src/nodes/preprocessor_langchain/langchain.py
+++ b/nodes/src/nodes/preprocessor_langchain/langchain.py
@@ -146,7 +146,7 @@ class PreProcessor(PreProcessorBase):
         # Get the configuration to pass, excluding 'splitter'. We can't use
         # pop since it may be an IJson value which is not supported at this time
         # exclude internal keys that must never reach constructors
-        classConfig = {key: value for key, value in config.items() if key not in {'splitter', 'mode', 'strlen', 'tokens', 'hf_tokenizer', 'tokenizer', 'transform', 'max_model_tokens', 'bytes_per_token'}}
+        classConfig = {key: value for key, value in config.items() if key not in {'splitter', 'mode', 'strlen', 'tokens', 'hf_tokenizer', 'tokenizer', 'transform', 'max_model_tokens', 'bytes_per_token', 'max_chunks_per_file'}}
 
         # Determine the overlap and size
         chunk_size = self._splitSize
@@ -312,6 +312,10 @@ class PreProcessor(PreProcessorBase):
                 # Cap requested chunk size to the model's real max token budget
                 self._splitSize = min(self._splitSize, self._token_limit)
 
+        # Max chunks per file (0 or None = unlimited)
+        max_chunks = config.get('max_chunks_per_file')
+        self._max_chunks_per_file = int(max_chunks) if max_chunks else None
+
         # Set to none so we bind it on the first call
         self._preprocessor = self._getSplitter(provider, config)
         return
@@ -331,6 +335,10 @@ class PreProcessor(PreProcessorBase):
                 else:
                     fixed.extend(self._split_safely_by_tokens(ch, self._token_limit))
             textChunks = fixed
+
+        # Apply per-file chunk limit if configured
+        if self._max_chunks_per_file is not None and len(textChunks) > self._max_chunks_per_file:
+            textChunks = textChunks[:self._max_chunks_per_file]
 
         # Return the raw text chunks
         return textChunks

--- a/nodes/src/nodes/preprocessor_langchain/services.json
+++ b/nodes/src/nodes/preprocessor_langchain/services.json
@@ -155,6 +155,12 @@
 		// 
 		// String length
 		//
+		"langchain.splitter.max_chunks_per_file": {
+			"type": "number",
+			"title": "Max chunks per file",
+			"description": "Limit the number of chunks produced per file (0 = unlimited)",
+			"default": 0
+		},
 		"langchain.splitter.strlen": {
 			"type": "number",
 			"title": "String length",
@@ -206,7 +212,8 @@
 			"object": "default",
 			"properties": [
 				"langchain.splitter.default.splitter",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//
@@ -227,7 +234,8 @@
 			"properties": [
 				"langchain.splitter.recursive.splitter",
 				"langchain.splitter.recursive.separators",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//
@@ -248,7 +256,8 @@
 			"properties": [
 				"langchain.splitter.character.splitter",
 				"langchain.splitter.character.separator",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//
@@ -263,7 +272,8 @@
 			"object": "markdown",
 			"properties": [
 				"langchain.splitter.markdown.splitter",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//
@@ -278,7 +288,8 @@
 			"object": "latex",
 			"properties": [
 				"langchain.splitter.latex.splitter",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//
@@ -293,7 +304,8 @@
 			"object": "nltk",
 			"properties": [
 				"langchain.splitter.nltk.splitter",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//
@@ -368,7 +380,8 @@
 			"properties": [
 				"langchain.splitter.spacy.splitter",
 				"langchain.splitter.spacy.model",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//
@@ -384,7 +397,8 @@
 			"object": "custom",
 			"properties": [
 				"langchain.splitter.custom.splitter",
-				"langchain.splitter.mode"
+				"langchain.splitter.mode",
+				"langchain.splitter.max_chunks_per_file"
 			]
 		},
 		//


### PR DESCRIPTION
## Summary

- adds support to limit max chunks per file

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-file chunk limit for all splitter types (default, recursive, character, markdown, LaTeX, NLTK, spaCy, custom). Set max chunks per file (0 = unlimited).
  * Chunking now respects the configured per-file budget and will stop once the limit (or remaining budget) is reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->