### PR TITLE
fix(nodes): resolve CodeQL alerts

### DIFF
--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -47,10 +47,6 @@ from .formatters import format_data
 # prevents runaway thread counts when the LLM issues many parallel calls.
 _MAX_WORKERS = 8
 
-# Hard timeout per individual tool call (seconds).  Prevents a slow external
-# API from blocking the entire wave indefinitely.
-_TOOL_TIMEOUT_S = 120
-
 # Indentation used by _describe() when rendering nested structures.
 _INDENT = '  '
 

--- a/nodes/src/nodes/agent_rocketride/planner.py
+++ b/nodes/src/nodes/agent_rocketride/planner.py
@@ -436,20 +436,6 @@ def plan(
     result = host.llm.invoke(IInvokeLLM(op='ask', question=wave_prompt)).getJson()
     debug(f'plan: result={json.dumps(result, ensure_ascii=False, default=str)[:500]}')
 
-    # Diagnostic trace file — append each REQUEST/RESULT pair for offline
-    # analysis.  Failures are silently swallowed so a missing/locked file
-    # never crashes the agent loop.
-    # try:
-    #     with open(r'C:\agents\agent.log', 'a', encoding='utf-8') as _f:
-    #         _ts = datetime.datetime.now().isoformat(timespec='seconds')
-    #         _f.write(f'\n{"=" * 80}\n[{_ts}] REQUEST\n{"=" * 80}\n')
-    #         _f.write(wave_prompt.getPrompt())
-    #         _f.write(f'\n{"=" * 80}\n[{_ts}] RESULT\n{"=" * 80}\n')
-    #         _f.write(json.dumps(result, ensure_ascii=False, indent=2, default=str))
-    #         _f.write('\n')
-    # except Exception as _e:
-    #     debug(f'plan: agent.txt write failed: {_e}')
-
     # If the LLM returned neither done=true nor tool_calls, the response is
     # malformed or empty.  Return {} to signal the outer loop to fall through
     # to the synthesis fallback rather than silently stalling.

--- a/nodes/src/nodes/tool_firecrawl/firecrawl_driver.py
+++ b/nodes/src/nodes/tool_firecrawl/firecrawl_driver.py
@@ -215,8 +215,8 @@ def _normalize_tool_input(input_obj: Any) -> Dict[str, Any]:
             parsed = _json.loads(input_obj)
             if isinstance(parsed, dict):
                 input_obj = parsed
-        except Exception:
-            pass
+        except Exception as e:
+            warning(f'firecrawl: failed to parse JSON input: {e}')
 
     if not isinstance(input_obj, dict):
         warning(f'firecrawl: unexpected input type {type(input_obj).__name__}: {input_obj!r}')

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -35,6 +35,7 @@ import time
 from typing import Any, Dict, Optional
 
 import requests
+from rocketlib import debug
 from requests.auth import HTTPBasicAuth
 
 DEFAULT_TIMEOUT_SECONDS = 30
@@ -179,8 +180,8 @@ def _build_response(resp: requests.Response, elapsed_ms: int) -> Dict[str, Any]:
     if 'json' in content_type or 'javascript' in content_type:
         try:
             parsed_json = resp.json()
-        except Exception:
-            pass
+        except Exception as e:
+            debug(f'http_client: failed to parse JSON response: {e}')
 
     return {
         'status_code': resp.status_code,


### PR DESCRIPTION
## Summary
- **executor.py**: Remove unused `_TOOL_TIMEOUT_S` global variable
- **planner.py**: Remove commented-out diagnostic trace file block
- **http_client.py**: Replace empty `except` with debug logging on JSON parse failure
- **firecrawl_driver.py**: Replace empty `except` with warning logging on JSON input parse failure

## Test plan
- [ ] Verify `./builder nodes:test` passes
- [ ] Confirm CodeQL alerts no longer fire on the four locations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error logging for JSON parsing failures in web scraping and HTTP request tool integrations
  
* **Chores**
  * Removed unused diagnostic logging and internal constants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->