### PR TITLE
fix(ci): add explicit token permissions to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -59,14 +58,8 @@ jobs:
     timeout-minutes: 90
     runs-on: ${{ matrix.runner }}
     permissions:
-      actions: read
-      checks: read
       contents: read
       packages: write
-      pull-requests: write
-      repository-projects: read
-      security-events: read
-      statuses: read
     strategy:
       fail-fast: false
       matrix:
@@ -138,9 +131,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      actions: read
       contents: read
-      packages: write
       security-events: write
     strategy:
       fail-fast: false
@@ -173,7 +164,6 @@ jobs:
     timeout-minutes: 90
     continue-on-error: true
     permissions:
-      actions: read
       contents: read
       packages: write
       security-events: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,7 @@ concurrency:
   cancel-in-progress: false
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 on:
   push:
@@ -19,6 +18,8 @@ jobs:
   init:
     name: Initialize versions
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       server_version: ${{ steps.init.outputs.server_version }}
       vscode_version: ${{ steps.init.outputs.vscode_version }}
@@ -57,6 +58,9 @@ jobs:
     needs: init
     timeout-minutes: 90
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     env:
       GH_TOKEN: ${{ github.token }}
       VCPKG_NUGET_USER: ${{ github.repository_owner }}
@@ -362,6 +366,9 @@ jobs:
     needs: [init, publish]
     if: needs.init.outputs.server_tag_exists == 'false'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Remove unnecessary `packages: write` from CI `init` and `codeql` (JS/Python) jobs that only need read access
- Remove overly broad permissions from CI `build` job (was listing 7 permissions, now only `contents: read` + `packages: write` for NuGet cache)
- Restrict release workflow top-level permissions from `contents: write` + `packages: write` to `contents: read`, adding explicit per-job permissions to `init`, `build`, and `docker` jobs
- `publish` job already had correct per-job permissions (`contents: write` + `id-token: write`)

## Test plan
- [ ] CI workflow runs successfully on this PR (init, build, codeql jobs)
- [ ] Scorecard Token-Permissions alerts resolve for the flagged lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration and release workflow configurations to reduce and reorganize system-level permissions, maintaining essential functionality while refining security configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->