### PR TITLE
feat(ui): Break out tooling connections in agent nodes for ease of use

### DIFF
--- a/nodes/src/nodes/agent_crewai/services.json
+++ b/nodes/src/nodes/agent_crewai/services.json
@@ -20,6 +20,11 @@
 		"tool": {
 			"description": "Tools available to the agent (via control-plane invoke)",
 			"min": 0
+		},
+		"memory": {
+			"description": "Keyed memory for the agent (via control-plane invoke)",
+			"min": 0,
+			"max": 1
 		}
 	},
 	"lanes": {

--- a/nodes/src/nodes/agent_langchain/services.json
+++ b/nodes/src/nodes/agent_langchain/services.json
@@ -20,6 +20,11 @@
 		"tool": {
 			"description": "Tools available to the agent (via control-plane invoke)",
 			"min": 0
+		},
+		"memory": {
+			"description": "Keyed memory for the agent (via control-plane invoke)",
+			"min": 0,
+			"max": 1
 		}
 	},
 	"lanes": {

--- a/packages/shared-ui/src/hooks/useConnectedLane.tsx
+++ b/packages/shared-ui/src/hooks/useConnectedLane.tsx
@@ -72,7 +72,7 @@ export function useConnectedLane(
 				if (edge.target !== nodeId) return false;
 
 				// Invoke edges use a special "invoke-source" handle and encode the class type differently
-				if (edge.sourceHandle === 'invoke-source') {
+				if (edge.sourceHandle?.startsWith('invoke-source')) {
 					if (edge.sourceHandle) {
 						const handleParts = edge.sourceHandle.split('-');
 						// Rejoin everything after "invoke-" to support multi-segment class types

--- a/packages/shared-ui/src/modules/project-canvas/FlowContext.tsx
+++ b/packages/shared-ui/src/modules/project-canvas/FlowContext.tsx
@@ -974,7 +974,7 @@ export const FlowProvider = ({
 
 					const nd = node.data as INodeData;
 					// Distinguish between invoke (control-flow) and lane (data-flow) connections
-					if (params.sourceHandle === 'invoke-source') {
+					if (params.sourceHandle?.startsWith('invoke-source')) {
 						// Extract the target class type from the handle ID suffix
 						const classType = params.targetHandle?.split('-')?.at(-1) ?? '';
 						const controlConnections: IControl[] = nd.controlConnections || [];
@@ -1042,7 +1042,7 @@ export const FlowProvider = ({
 							if (!edgeToRemove || edgeToRemove.target !== node.id) return;
 
 							const und = updatedNode.data as INodeData;
-							if (edgeToRemove.sourceHandle === 'invoke-source') {
+							if (edgeToRemove.sourceHandle?.startsWith('invoke-source')) {
 								// Remove the matching control connection entry
 								const controlConnections: IControl[] =
 									und.controlConnections || [];

--- a/packages/shared-ui/src/modules/project-canvas/components/handles/invoke/InvokeHandle.tsx
+++ b/packages/shared-ui/src/modules/project-canvas/components/handles/invoke/InvokeHandle.tsx
@@ -23,11 +23,14 @@
 
 import { CSSProperties, MouseEvent as ReactMouseEvent, ReactElement, useMemo } from 'react';
 import { HandleProps, Handle as RFHandle } from '@xyflow/react';
-import { Box, useTheme } from '@mui/material';
+import { Box, Typography, useTheme } from '@mui/material';
 import pxToRem from '../../../../../utils/pxToRem';
 import { handleStyles } from '../../styles';
 import { brandOrange } from '../../../../../theme';
 import { isInVSCode } from '../../../../../utils/vscode';
+
+/** Lane label color — matches the color used for lane body text. */
+const labelColor = isInVSCode() ? 'text.disabled' : '#838383';
 
 const inVSCode = isInVSCode();
 
@@ -100,6 +103,26 @@ export default function InvokeHandle({
 
 	return (
 		<div style={{ position: 'relative', margin: '0 20px' }}>
+			{invokeType && (
+				<Typography
+					variant="caption"
+					sx={{
+						position: 'absolute',
+						bottom: '100%',
+						left: '50%',
+						transform: 'translateX(-50%)',
+						fontSize: '0.5rem',
+						lineHeight: 1,
+						color: labelColor,
+						marginBottom: `${pxToRem(6)}rem`,
+						pointerEvents: 'none',
+						userSelect: 'none',
+						whiteSpace: 'nowrap',
+					}}
+				>
+					{invokeType === 'llm' ? 'LLM' : invokeType.charAt(0).toUpperCase() + invokeType.slice(1)}
+				</Typography>
+			)}
 			<RFHandle
 				{...props}
 				type={type}

--- a/packages/shared-ui/src/modules/project-canvas/components/lanes/Lanes.tsx
+++ b/packages/shared-ui/src/modules/project-canvas/components/lanes/Lanes.tsx
@@ -209,11 +209,14 @@ export default function Lanes({ nodeId, lanes, layout, data }: IProps): ReactEle
 
 			// --- Invoke edge validation ---
 			if (
-				edge.sourceHandle === 'invoke-source' &&
+				edge.sourceHandle?.startsWith('invoke-source') &&
 				edge.targetHandle?.indexOf('invoke-target') !== -1
 			) {
 				// Extract the invoked class type from the target handle ID (last segment)
 				const invokeType = edge?.targetHandle?.split('-').at(-1);
+				// Ensure the source invoke key matches the target class type
+				const sourceKey = edge.sourceHandle?.split('-').slice(2).join('-');
+				if (sourceKey && invokeType && sourceKey !== invokeType) return false;
 
 				const sourceNode = nodeMap?.[edge.source];
 				const targetNode = nodeMap?.[edge.target];
@@ -231,7 +234,7 @@ export default function Lanes({ nodeId, lanes, layout, data }: IProps): ReactEle
 				// Count existing invoke edges of the same type from this source to enforce max
 				const _edges = edges.filter(
 					(e: Edge) =>
-						e.sourceHandle === 'invoke-source' &&
+						e.sourceHandle?.startsWith('invoke-source') &&
 						e.source === edge.source &&
 						e.targetHandle === edge.targetHandle
 				);

--- a/packages/shared-ui/src/modules/project-canvas/components/node-footer/index.style.ts
+++ b/packages/shared-ui/src/modules/project-canvas/components/node-footer/index.style.ts
@@ -33,7 +33,7 @@ export const styles = {
 		borderTop: '1px solid',
 		borderColor: 'divider',
 		backgroundColor: 'background.paper',
-		padding: '0.4rem 0.6rem',
+		padding: '0.4rem 0.6rem 0.2rem',
 		fontSize: '0.65rem',
 		borderRadius: 0,
 	},

--- a/packages/shared-ui/src/modules/project-canvas/components/nodes/node/Node.tsx
+++ b/packages/shared-ui/src/modules/project-canvas/components/nodes/node/Node.tsx
@@ -122,15 +122,18 @@ export default function Node({
 	const validateConnection = useCallback(
 		(edge: Edge | Connection) => {
 			if (edge.source === edge.target) return false;
-			if (edge.sourceHandle === 'invoke-source' && edge.targetHandle?.indexOf('invoke-target') !== -1) {
+			if (edge.sourceHandle?.startsWith('invoke-source') && edge.targetHandle?.indexOf('invoke-target') !== -1) {
 				const invokeType = edge?.targetHandle?.split('-').at(-1);
+				// Ensure the source invoke key matches the target class type
+				const sourceKey = edge.sourceHandle?.split('-').slice(2).join('-');
+				if (sourceKey && invokeType && sourceKey !== invokeType) return false;
 				const sourceNode = nodeMap?.[edge.source];
 				const targetNode = nodeMap?.[edge.target];
 				if (sourceNode?.parentId != targetNode?.parentId) return false;
 				const inv = (sourceNode?.data as INodeData)?.invoke?.[invokeType!] as { min?: number; max?: number } | undefined;
 				if (inv == null || (inv != null && inv.min == null && inv.max == null)) return true;
 				const existing = edges.filter(
-					(e: Edge) => e.sourceHandle === 'invoke-source' && e.source === edge.source && e.targetHandle === edge.targetHandle
+					(e: Edge) => e.sourceHandle?.startsWith('invoke-source') && e.source === edge.source && e.targetHandle === edge.targetHandle
 				);
 				if (existing.length >= inv.max!) return false;
 				return true;
@@ -210,7 +213,7 @@ export default function Node({
 					))}
 				</Box>
 			)}
-			<Box key={id} sx={styles.nodeContent}>
+			<Box key={id} sx={{ ...styles.nodeContent, ...(hasInvokeSource ? { paddingBottom: '1.2rem' } : {}) }}>
 				<Box sx={styles.cornerCapTop} />
 				<Box sx={styles.headerWrapper}>
 					<ProjectNodeHeader
@@ -238,27 +241,31 @@ export default function Node({
 				/>
 				<Box sx={styles.cornerCapBottom} />
 			</Box>
-			{/* Bottom invoke source handle — positioned below the node border */}
+			{/* Bottom invoke source handles — diamonds on the bottom edge, labels inside the node */}
 			{hasInvokeSource && (
 				<Box sx={{ position: 'absolute', bottom: 0, left: 0, right: 0, display: 'flex', justifyContent: 'center', transform: 'translateY(50%)', zIndex: 1 }}>
-					<InvokeHandle
-						id={`invoke-source`}
-						type="source"
-						position={Position.Bottom}
-						isConnected={edges.some(
-							(edge: Edge) =>
-								edge.sourceHandle === `invoke-source` && edge.source === id
-						)}
-						isValidConnection={validateConnection}
-						selected={
-							selectedHandle
-								? selectedHandle[0] === id && selectedHandle[1] === 'invoke-source'
-								: false
-						}
-						onClick={(event) =>
-							handleInvokeClick(event, 'invoke-source', invokeSourceKeys)
-						}
-					/>
+					{invokeSourceKeys.map((key: string) => (
+						<InvokeHandle
+							key={key}
+							id={`invoke-source-${key}`}
+							type="source"
+							position={Position.Bottom}
+							invokeType={key}
+							isConnected={edges.some(
+								(edge: Edge) =>
+									edge.sourceHandle === `invoke-source-${key}` && edge.source === id
+							)}
+							isValidConnection={validateConnection}
+							selected={
+								selectedHandle
+									? selectedHandle[0] === id && selectedHandle[1] === `invoke-source-${key}`
+									: false
+							}
+							onClick={(event) =>
+								handleInvokeClick(event, `invoke-source-${key}`, [key])
+							}
+						/>
+					))}
 				</Box>
 			)}
 		</>

--- a/packages/shared-ui/src/modules/project-canvas/components/nodes/node/index.style.ts
+++ b/packages/shared-ui/src/modules/project-canvas/components/nodes/node/index.style.ts
@@ -34,7 +34,7 @@ const inVSCode = isInVSCode();
  */
 export const styles = {
 	flowRoot: {
-		width: '10rem',
+		width: '11rem',
 		backgroundColor: inVSCode ? 'background.paper' : '#fff',
 		boxShadow: inVSCode
 			? 'none'
@@ -61,7 +61,7 @@ export const styles = {
 	},
 	cornerCapBottom: {
 		position: 'relative',
-		height: '4px',
+		height: 0,
 		backgroundColor: 'background.default',
 		borderRadius: '0 0 3px 3px',
 	},

--- a/packages/shared-ui/src/modules/project-canvas/helpers.tsx
+++ b/packages/shared-ui/src/modules/project-canvas/helpers.tsx
@@ -367,7 +367,7 @@ export const computeEdgesFromNodes = (nodes: Node[]): Edge[] => {
 					id: uuid(),
 					source: control.from,
 					target: node.id,
-					sourceHandle: 'invoke-source',
+					sourceHandle: `invoke-source-${control.classType}`,
 					targetHandle: `invoke-target-${control.classType}`,
 				});
 			});

--- a/packages/shared-ui/src/utils/get-icon-path.ts
+++ b/packages/shared-ui/src/utils/get-icon-path.ts
@@ -199,6 +199,8 @@ const THEME_DYNAMIC_ICONS: ReadonlySet<string> = new Set([
 	'anthropic', 'ollama', 'openai', 'perplexity', 'xai',
 	// Tools
 	'http', 'mcp', 'memory',
+	// Agents
+	'langchain',
 	// Database
 	'mysql',
 	// Image processing


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->
On our agent node we had an invoke handler that was unlabeled and a little opaque for any new user. These changes allow for more clear connections and invocations to be drawn with agents as well as a handful of additional UI enhancements:
  Invoke handle labels
  - Agent nodes (RocketRide Wave, LangChain, CrewAI) now show separate labeled diamond connectors at the bottom - LLM, Memory, Tool
  - Labels sit inside the node above the diamonds; diamonds sit on the bottom edge with lines flowing out below
  - Labels use a background color to mask edge lines, making lines appear to start below the labels
  - Label font size (0.5rem) and color (#838383 / text.disabled) match existing lane labels

  Per-key source handles
  - Single invoke-source handle split into invoke-source-{key} (e.g., invoke-source-tool, invoke-source-llm, invoke-source-memory)
  - Connection validation enforces source key must match target class type
  - All references across FlowContext.tsx, Lanes.tsx, helpers.tsx, useConnectedLane.tsx updated to use .startsWith('invoke-source')

  Memory support for LangChain & CrewAI
  - Added optional memory invoke key (min: 0, max: 1) to both agent_langchain/services.json and agent_crewai/services.json

  Icon theming
  - LangChain icon added to THEME_DYNAMIC_ICONS in get-icon-path.ts — black in light mode, white in dark mode via CSS filter
  - RocketRide icon keeps brand colors (navy #1E1A34 rocket + red #F93822 flame)

  Node sizing & spacing
  - Node width: 10rem → 11rem
  - Nodes with invoke handles get 1.2rem bottom padding for label breathing room
  - cornerCapBottom height reduced from 4px to 0 to eliminate gap below the pipes footer
  - Footer bottom padding reduced from 0.4rem to 0.2rem
  
<img width="1258" height="343" alt="Screenshot 2026-03-16 at 5 51 10 PM" src="https://github.com/user-attachments/assets/61ba6e69-8c15-40bf-94fe-a74da5479c1a" />



## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [X] Tested locally
- [X] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

<!-- Link related issues: Fixes #123, Closes #456, Related to #789 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added memory support to agent invoke capabilities for both CrewAI and LangChain agents.
  * Added visual labels to invoke handles displaying agent type information.

* **Style**
  * Refined node layout with adjusted sizing and styling.
  * Enhanced theme-aware icon coloring support for LangChain agents.

* **Refactor**
  * Improved invoke connection validation and handle matching logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->