### PR TITLE
fix(builder): server:download - cache release manifests

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -34,7 +34,7 @@ const {
     removeDirs, syncDir, syncFile, removeFiles,
     formatSyncStats,
     execCommand, PROJECT_ROOT, BUILD_ROOT, DIST_ROOT, isWindows, isMac, isLinux,
-    exists, readFile, readJson, mkdir, copyFile, removeFile,
+    exists, readFile, readJson, writeJson, mkdir, copyFile, removeFile,
     loadPackageJson, downloadGitHubFile, createArchive, extractArchive,
     parallel, whenNot, fingerprint, contentHash,
     taskDebug,
@@ -429,13 +429,26 @@ function makeDownloadAction(options = {}) {
             if (options.force) {
                 task.output = 'Force rebuild requested';
                 await setState('server.contentHash', null);
+                await setState('server.downloaded', false);
                 ctx.downloaded = false;
                 return;
             }
 
             if (options.nodownload) {
                 task.output = 'Download skipped (--nodownload)';
+                await setState('server.downloaded', false);
                 ctx.downloaded = false;
+                return;
+            }
+
+            // Get local vcpkg version
+            const { getVcpkgVersion } = require('../../vcpkg/scripts/tasks');
+            const localVcpkgVersion = await getVcpkgVersion();
+
+            if (!await getState('server.downloaded')
+                && await getState('server.contentHash') === localHash
+                && await getState('vcpkg.version') === localVcpkgVersion) {
+                task.output = 'Server already built';
                 return;
             }
 
@@ -445,29 +458,40 @@ function makeDownloadAction(options = {}) {
 
             // Try stable release first, then prerelease
             const tagsToTry = [releaseTag, prereleaseTag];
+            let releaseAvailable = false;
             let matchedTag = null;
 
             for (const tag of tagsToTry) {
-                try {
-                    task.output = `Checking ${tag}...`;
-                    const manifestPath = await downloadGitHubFile(tag, manifestFilename, task);
-                    if (manifestPath) {
-                        const manifest = await readJson(manifestPath);
-                        if (manifest?.vcpkg?.version !== require('../../vcpkg/scripts/tasks').VCPKG_VERSION) {
-                            task.output = 'Download skipped: vcpkg version mismatch';
-                            ctx.downloaded = false;
-                            return;
-                        }
-                        const serverHash = manifest?.server?.contentHash;
-                        if (localHash === serverHash) {
-                            await setState('server.releaseManifest', manifest);
-                            matchedTag = tag;
-                            break;
-                        }
-                    }
-                } catch {
-                    // Manifest not available for this tag — try next
+                task.output = `Checking release ${tag}...`;
+
+                let manifest = null;
+                const manifestPath = await downloadGitHubFile(tag, manifestFilename, task);
+                if (manifestPath) {
+                    manifest = await readJson(manifestPath);
                 }
+
+                if (manifest) {
+                    task.output = `Release ${tag} available`;
+                    releaseAvailable = true;
+                } else {
+                    task.output = `Release ${tag} not available`;
+                    continue;
+                }
+
+                const serverHash = manifest?.server?.contentHash;
+                const serverVcpkgVersion = manifest?.vcpkg?.version;
+                if (localHash === serverHash && localVcpkgVersion === serverVcpkgVersion) {
+                    matchedTag = tag;
+                    break;
+                }
+            }
+
+            if (!releaseAvailable) {
+                task.output = 'No releases available - will compile';
+                await setState('server.contentHash', null);
+                await setState('server.downloaded', false);
+                ctx.downloaded = false;
+                return;
             }
 
             if (!matchedTag) {
@@ -511,13 +535,11 @@ function makeDownloadAction(options = {}) {
                     task.output = `Extracted ${symDistFilename}`;
                 }
 
-                await setState('server.contentHash', localHash);
                 await setState('server.downloaded', true);
                 ctx.downloaded = true;
                 task.output = `Downloaded server from ${matchedTag}`;
 
             } catch {
-                await setState('server.contentHash', null);
                 await setState('server.downloaded', false);
                 ctx.downloaded = false;
                 task.output = `Release ${matchedTag} download failed: Will compile from source`;
@@ -1096,8 +1118,10 @@ function makePackageAction(options = {}) {
 
                 await setState('server.pkgHash', sourceHash);
 
-                // Copy state.json as build manifest for download validation
-                await copyFile(STATE_FILE, path.join(DIST_ARTIFACTS_DIR, manifestFilename));
+                // Copy state.json without releases as build manifest for download validation
+                const state = await readJson(STATE_FILE);
+                delete state.server.releases;
+                await writeJson(path.join(DIST_ARTIFACTS_DIR, manifestFilename), state);
 
             } catch (err) {
                 await removeFile(distFile);

--- a/packages/vcpkg/scripts/tasks.js
+++ b/packages/vcpkg/scripts/tasks.js
@@ -38,14 +38,12 @@ const VCPKG_DIR = path.join(BUILD_ROOT, 'vcpkg');
 const VCPKG_INSTALLED_DIR = path.join(BUILD_ROOT, 'vcpkg_installed');
 
 // Read vcpkg version from package.json (loaded async in tasks)
-let VCPKG_VERSION = '2024.11.16';
-let packageJsonLoaded = false;
+let VCPKG_VERSION = null;
 
-async function loadPackageJson() {
-    if (!packageJsonLoaded) {
+async function getVcpkgVersion() {
+    if (!VCPKG_VERSION) {
         const packageJson = await readJson(path.join(PROJECT_ROOT, 'package.json'));
         VCPKG_VERSION = packageJson.vcpkg?.version || '2024.11.16';
-        packageJsonLoaded = true;
     }
     return VCPKG_VERSION;
 }
@@ -71,7 +69,7 @@ function makeCloneVcpkgAction(options = {}) {
         locks: ['vcpkg'],
         outputLines: 1,
         run: async (ctx, task) => {
-            const version = await loadPackageJson();
+            const version = await getVcpkgVersion();
             const vcpkgVersion = await getState('vcpkg.version');
 
             // Skip if already cloned
@@ -167,3 +165,4 @@ module.exports = {
 
 // Export for direct use
 module.exports.VCPKG_DIR = VCPKG_DIR;
+module.exports.getVcpkgVersion = getVcpkgVersion;

--- a/scripts/lib/download.js
+++ b/scripts/lib/download.js
@@ -12,7 +12,6 @@ const path = require('path');
 const https = require('https');
 const AdmZip = require('adm-zip');
 const tar = require('tar');
-const { execCommand } = require('./exec');
 const { exists, rm, mkdir, unlink, isFile, isDirectory, createWriteStream, writeFile, readJson } = require('./fs');
 const { getState, setState } = require('./state');
 
@@ -48,12 +47,10 @@ async function loadPackageJson() {
  */
 async function downloadFile(url, filename, task) {
     const destPath = path.join(DOWNLOADS_DIR, filename);
-    // Escape dots in filename to prevent state key path issues (e.g., "maven-3.9.6.tar.gz" → "maven-3_9_6_tar_gz")
-    const safeFilename = filename.replace(/\./g, '_');
-    const stateKey = `downloads.${safeFilename}`;
+    const stateKey = ['downloads', url];
     
     // Check if already downloaded (atomic read)
-    if (await getState(stateKey) === true && await exists(destPath)) {
+    if (await getState(stateKey) && await exists(destPath)) {
         return destPath;
     }
     
@@ -64,35 +61,31 @@ async function downloadFile(url, filename, task) {
     await _download(url, destPath, task);
     
     // Mark as downloaded (atomic write)
-    await setState(stateKey, true);
+    await setState(stateKey, filename);
     
     return destPath;
 }
 
 async function downloadGitHubFile(releaseTag, filename, task) {
     const { repo } = await loadPackageJson();
-
-    try {
-        await execCommand('gh', [
-            'release', 'download', releaseTag,
-            '--repo', repo,
-            '--pattern', filename,
-            '--dir', DOWNLOADS_DIR,
-            '--clobber'
-        ], { task, silent: true});
-        return path.join(DOWNLOADS_DIR, filename);
-    } catch (err) {
-        task.output = `GitHub CLI download failed ${releaseTag}/${filename}: ${err.message.trim().replace(/\n/g, ' ')}`;
-    }
-
     const fileurl = `https://github.com/${repo}/releases/download/${releaseTag}/${filename}`;
     try {
-        return await downloadFile(fileurl, filename, task);
+        let downloadName = null;
+        if (releaseTag.endsWith('-prerelease')) {
+            // Add tag and timestamp to the pre-release file name to update pre-releases daily
+            const { name, ext } = path.parse(filename);
+            const today = new Date().toISOString().split('T')[0].replace(/-/g, ''); // 'yyyyMMdd'
+            downloadName = `${releaseTag}_${name}-${today}${ext}`;
+        } else {
+            // Add tag to the release filename
+            downloadName = `${releaseTag}_${filename}`;
+        }
+        return await downloadFile(fileurl, downloadName, task);
     } catch (err) {
-        task.output = `GitHub API download failed ${fileurl}: ${err.message.trim().replace(/\n/g, ' ')}`;
+        if (err.message && err.message.includes('HTTP 404'))
+            return null;
+        throw err;
     }
-
-    return null;
 }
 
 /**


### PR DESCRIPTION
## Summary

### Issue 1: File Name Conflicts

**Problem:** Releases and pre-releases download with identical filenames, causing overwrites.

**Solution:** Append tags like -to distinguish them.

**Example:**

```
https://github.com/.../server-v3.1.0/rocketride-server-v3.1.0-win64.manifest.json
=> /downloads/server-v3.1.0_rocketride-server-v3.1.0-win64.manifest.json
```

### Issue 2: Outdated Pre-Releases

**Problem:** Nightly pre-release builds make downloaded files obsolete quickly.

**Solution:** Include timestamps in pre-release filenames for versioning and forcing daily updates.

**Example:**

```
https://github.com/.../server-v3.1.0-prerelease/rocketride-server-v3.1.0-win64.manifest.json
=> /downloads/server-v3.1.0-prerelease_rocketride-server-v3.1.0-win64.manifest-20260317.json
```

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smarter download flow with per-release-tag checks, manifest-based version/hash matching, clearer progress/status messages, and distinct handling for “no release” vs “compile from source.”
  * Avoids unnecessary re-downloads by respecting cached downloaded state and lazy vcpkg version resolution.
  * Direct HTTP release downloads with improved filename handling and 404-as-null behavior.

* **Chores**
  * Packaging emits manifests without embedded release lists.
  * New utilities exposed for retrieving vcpkg version and writing JSON manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->