### PR TITLE
feat(engine): sse

### DIFF
--- a/apps/chat-ui/src/hooks/useChatMessages.ts
+++ b/apps/chat-ui/src/hooks/useChatMessages.ts
@@ -90,15 +90,14 @@ export const useChatMessages = () => {
 			const result: PIPELINE_RESULT = await client.chat({
 				token: authToken,
 				question: question,
-				onSSE: async (body: Record<string, unknown>) => {
-					const text = body.message as string | undefined;
-					const sseType = (body.type as string | undefined) ?? 'thinking';
+				onSSE: async (type: string, data: Record<string, unknown>) => {
+					const text = data.message as string | undefined;
 					if (text) {
 						setMessages(prev => [...prev, {
 							id: Date.now(),
 							text,
 							sender: 'status',
-							sseType: sseType as 'thinking' | 'acting' | 'confirm',
+							sseType: type,
 							timestamp: new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
 						}]);
 					}

--- a/apps/chat-ui/src/types/chat.types.ts
+++ b/apps/chat-ui/src/types/chat.types.ts
@@ -35,7 +35,7 @@ export interface Message {
 	sender: 'user' | 'bot' | 'system' | 'status';
 	timestamp: string;
 	resultKey?: string | undefined;
-	sseType?: 'thinking' | 'acting' | 'confirm';
+	sseType?: string;
 }
 
 /**

--- a/nodes/src/nodes/agent_rocketride/rocketride_agent.py
+++ b/nodes/src/nodes/agent_rocketride/rocketride_agent.py
@@ -101,7 +101,7 @@ class RocketRideDriver(AgentBase):
         """
         run_id = ctx.get('run_id', '')
         debug(f'rocketride wave _run start run_id={run_id}')
-        self.sendSSE('thinking', 'Analyzing your request...')
+        self.sendSSE('thinking', message='Analyzing your request...')
 
         # waves accumulates the full history of every tool call and its result
         # summary.  It is passed to plan_wave() each iteration so the planner
@@ -120,7 +120,7 @@ class RocketRideDriver(AgentBase):
 
         for wave_num in range(self._max_waves):
             debug(f'rocketride wave wave_num={wave_num} run_id={run_id}')
-            self.sendSSE('thinking', f'Planning step {wave_num + 1}...')
+            self.sendSSE('thinking', message=f'Planning step {wave_num + 1}...')
 
             # Run the planner — one LLM call with all tool descriptions.
             # Returns either {"done": true, "answer": "..."} or {"tool_calls": [...]}
@@ -169,14 +169,14 @@ class RocketRideDriver(AgentBase):
             # what the agent is doing this turn.  Shown in the "thinking" panel.
             thought = safe_str(result.get('thought', ''))
             if thought:
-                self.sendSSE('thinking', thought)
+                self.sendSSE('thinking', message=thought)
 
             # ------------------------------------------------------------------
             # Done — resolve answer refs and return
             # ------------------------------------------------------------------
 
             if result.get('done'):
-                self.sendSSE('thinking', 'Generating final answer...')
+                self.sendSSE('thinking', message='Generating final answer...')
                 answer = safe_str(result.get('answer', ''))
 
                 # Resolve {{memory.ref:key:format:path}} references in the answer.
@@ -203,7 +203,7 @@ class RocketRideDriver(AgentBase):
 
             # Inform the UI which tools are about to run this wave
             tool_names = [c.get('tool', '?') for c in tool_calls]
-            self.sendSSE('thinking', f'Running: {", ".join(tool_names)}', {'wave': wave_num + 1, 'tools': tool_names})
+            self.sendSSE('thinking', message=f'Running: {", ".join(tool_names)}', wave=wave_num + 1, tools=tool_names)
 
             # Execute all tool calls in this wave concurrently.  Each result is
             # stored in memory under "wave-N.rM" and a structural summary is
@@ -211,7 +211,7 @@ class RocketRideDriver(AgentBase):
             # as context; the full result stays in memory for later peek access.
             results = execute_wave(tool_calls, host=host, wave_name=f'wave-{wave_num}')
             waves.append({'wave_num': wave_num, 'calls': tool_calls, 'results': results})
-            self.sendSSE('thinking', f'Step {wave_num + 1} complete', {'results': len(results)})
+            self.sendSSE('thinking', message=f'Step {wave_num + 1} complete', results=len(results))
 
         # ------------------------------------------------------------------
         # Synthesis fallback — max waves reached without done=true
@@ -222,7 +222,7 @@ class RocketRideDriver(AgentBase):
         # from everything that was gathered.  This prevents the agent from
         # silently returning nothing after a long run.
         debug(f'rocketride wave max waves reached run_id={run_id}, synthesizing final answer')
-        self.sendSSE('thinking', 'Synthesizing final answer...')
+        self.sendSSE('thinking', message='Synthesizing final answer...')
         return self._synthesize(agent_input=agent_input, waves=waves, host=host), trace
 
     # ------------------------------------------------------------------

--- a/packages/ai/src/ai/common/agent/agent.py
+++ b/packages/ai/src/ai/common/agent/agent.py
@@ -16,7 +16,7 @@ import json
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional
 
-from rocketlib import debug, error, monitorSSE
+from rocketlib import debug, error
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
 
@@ -46,7 +46,7 @@ class AgentBase(ABC):
     _AGENT_TOOL_NAME: str = 'run_agent'
 
     _host: Optional[AgentHostServices] = None
-    _pipe_id: int = 0
+    _invoker: Any = None
 
     def __init__(
         self,
@@ -132,14 +132,12 @@ class AgentBase(ABC):
                 started_at=started_at,
             )
 
-            # Capture pipe_id from the instance so sendSSE() can use it
-            try:
-                self._pipe_id = iInstance.instance.pipeId
-            except Exception:
-                self._pipe_id = 0
+            # Save the invoker so sendSSE() can delegate to self.instance.sendSSE()
+            self._invoker = iInstance
 
             # Build up the context so we know what we are doing
-            runtime_ctx = {'run_id': run_id, 'task_id': task_id, 'framework': self.FRAMEWORK, 'pipe_id': self._pipe_id}
+            pipe_id = iInstance.instance.pipeId if iInstance and iInstance.instance else 0
+            runtime_ctx = {'run_id': run_id, 'task_id': task_id, 'framework': self.FRAMEWORK, 'pipe_id': pipe_id}
 
             # And execute
             content, raw = self._run(
@@ -331,20 +329,20 @@ class AgentBase(ABC):
     # ---------------------------------------------------------------------
     # Engine utilities
     # ---------------------------------------------------------------------
-    def sendSSE(self, type: str, message: str, data: Optional[Dict[str, Any]] = None) -> None:
+    def sendSSE(self, type: str, **data) -> None:
         """
         Send a real-time SSE status update to the UI for this agent's pipe.
 
-        Wraps ``monitorSSE`` using the ``pipe_id`` captured at the start of
-        the current ``run_agent`` invocation.  Safe to call from ``_run`` or
-        any helper it delegates to.
+        Delegates to ``self._invoker.instance.sendSSE()`` using the invoker
+        captured at the start of the current ``run_agent`` invocation.
+        Safe to call from ``_run`` or any helper it delegates to.
 
         Args:
-            type:    Event type ('thinking', 'acting', 'confirm').
-            message: Human-readable status string shown in the chat UI.
-            data:    Optional structured payload included in the event body.
+            type:    Event type string (e.g. 'thinking', 'acting', 'confirm').
+            **data:  Keyword arguments included as the event data payload.
         """
-        monitorSSE(self._pipe_id, type, message, data)
+        if self._invoker and self._invoker.instance:
+            self._invoker.instance.sendSSE(type, **data)
 
     def _agent_id(self, pSelf: Any) -> str:
         """Return the logical agent identifier used in answer metadata."""

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -116,8 +116,8 @@ class DataMixin(DAPClient):
                 objinfo: Optional metadata about the data
                 mime_type: MIME type of data (e.g., "text/csv", "application/json")
                 provider: Optional provider specification
-                on_sse: Optional async callback(body: dict) called for each SSE event
-                        emitted by the pipeline node for this specific pipe
+                on_sse: Optional async callback(type: str, data: dict) called for each SSE
+                        event emitted by the pipeline node for this specific pipe
             """
             self._client = client
             self._token = token
@@ -334,6 +334,7 @@ class DataMixin(DAPClient):
         data: Union[str, bytes],
         objinfo: Dict[str, Any] = None,
         mimetype: str = None,
+        on_sse=None,
     ) -> PIPELINE_RESULT:
         """
         Send data to a running pipeline.
@@ -386,7 +387,7 @@ class DataMixin(DAPClient):
             raise ValueError('data must be either a string or bytes')
 
         # Create and use a temporary pipe for the data
-        pipe = await self.pipe(token, self._objinfo_with_size(objinfo, len(buffer)), mimetype)
+        pipe = await self.pipe(token, self._objinfo_with_size(objinfo, len(buffer)), mimetype, on_sse=on_sse)
 
         try:
             await pipe.open()

--- a/packages/client-python/src/rocketride/mixins/events.py
+++ b/packages/client-python/src/rocketride/mixins/events.py
@@ -296,7 +296,7 @@ class EventMixin(DAPClient):
             callback = self._sse_pipe_callbacks.get(pipe_id)
             if callback is not None:
                 try:
-                    await callback(event_body)
+                    await callback(event_body.get('type', ''), event_body.get('data', {}))
                 except Exception as e:
                     self.debug_message(f'Error in SSE callback for pipe {pipe_id}: {e}')
 

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -63,7 +63,7 @@ export class DataPipe {
 	private _pipeId?: number;
 	private _opened = false;
 	private _closed = false;
-	private _onSSE?: (body: Record<string, unknown>) => Promise<void>;
+	private _onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
 
 	/**
 	 * Creates a new DataPipe instance.
@@ -82,7 +82,7 @@ export class DataPipe {
 		objinfo: Record<string, unknown> = {},
 		mimeType = 'application/octet-stream',
 		provider?: string,
-		onSSE?: (body: Record<string, unknown>) => Promise<void>
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
 	) {
 		this._client = client;
 		this._token = token;
@@ -267,7 +267,7 @@ export class RocketRideClient extends DAPClient {
 	private _dapSend?: (event: unknown) => void;
 	private _nextChatId = 1;
 	/** Maps pipe_id → SSE callback for pipe-scoped real-time event dispatch. */
-	readonly _ssePipeCallbacks = new Map<number, (body: Record<string, unknown>) => Promise<void>>();
+	readonly _ssePipeCallbacks = new Map<number, (type: string, data: Record<string, unknown>) => Promise<void>>();
 
 	// Persistence properties for automatic reconnection
 	private _persist: boolean = false;
@@ -540,9 +540,27 @@ export class RocketRideClient extends DAPClient {
 	 * Must be called before executing pipelines or other operations.
 	 * In persist mode, enables automatic reconnection on disconnect and on initial failure
 	 * (calls onConnectError on each failed attempt and keeps retrying).
-	 * @param timeout - Optional overall timeout in ms for the connect + auth handshake.
+	 * @param options - Optional timeout (number) or connection parameters object with uri, auth, and timeout.
 	 */
-	async connect(timeout?: number): Promise<void> {
+	async connect(options?: number | { uri?: string; auth?: string; timeout?: number }): Promise<void> {
+		let uri: string | undefined;
+		let auth: string | undefined;
+		let timeout: number | undefined;
+
+		if (typeof options === 'number') {
+			timeout = options;
+		} else if (options) {
+			({ uri, auth, timeout } = options);
+		}
+
+		// Apply optional overrides so they're used for this connect
+		if (uri !== undefined) {
+			this._setUri(uri);
+		}
+		if (auth !== undefined) {
+			this._setAuth(auth);
+		}
+
 		this._manualDisconnect = false;
 		this._currentReconnectDelay = 250;
 		this._retryStartTime = undefined;
@@ -977,9 +995,10 @@ export class RocketRideClient extends DAPClient {
 		token: string,
 		objinfo: Record<string, unknown> = {},
 		mimeType?: string,
-		provider?: string
+		provider?: string,
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
 	): Promise<DataPipe> {
-		return new DataPipe(this, token, objinfo, mimeType, provider);
+		return new DataPipe(this, token, objinfo, mimeType, provider, onSSE);
 	}
 
 	/**
@@ -989,7 +1008,8 @@ export class RocketRideClient extends DAPClient {
 		token: string,
 		data: string | Uint8Array,
 		objinfo: Record<string, unknown> = {},
-		mimetype?: string
+		mimetype?: string,
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
 	): Promise<PIPELINE_RESULT | undefined> {
 		// Convert string to bytes if needed
 		let buffer: Uint8Array;
@@ -1002,7 +1022,7 @@ export class RocketRideClient extends DAPClient {
 		}
 
 		// Create and use a temporary pipe for the data
-		const pipe = await this.pipe(token, this._objinfoWithSize(objinfo, buffer.length), mimetype);
+		const pipe = await this.pipe(token, this._objinfoWithSize(objinfo, buffer.length), mimetype, undefined, onSSE);
 
 		try {
 			await pipe.open();
@@ -1202,7 +1222,7 @@ export class RocketRideClient extends DAPClient {
 	async chat(options: {
 		token: string;
 		question: Question;
-		onSSE?: (body: Record<string, unknown>) => Promise<void>;
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
 	}): Promise<PIPELINE_RESULT> {
 		const { token, question, onSSE } = options;
 
@@ -1217,14 +1237,7 @@ export class RocketRideClient extends DAPClient {
 			this._nextChatId += 1;
 
 			// Create pipe instance
-			const pipe = new DataPipe(
-				this,
-				token,
-				objinfo,
-				'application/rocketride-question',
-				'chat',
-				onSSE
-			);
+			const pipe = await this.pipe(token, objinfo, 'application/rocketride-question', 'chat', onSSE);
 
 			try {
 				// Open the communication channel to the AI
@@ -1318,7 +1331,10 @@ export class RocketRideClient extends DAPClient {
 				const cb = this._ssePipeCallbacks.get(pipeId);
 				if (cb) {
 					try {
-						await cb(eventBody as Record<string, unknown>);
+						const body = eventBody as Record<string, unknown>;
+						const type = (body.type as string) ?? '';
+						const data = (body.data as Record<string, unknown>) ?? {};
+						await cb(type, data);
 					} catch (error) {
 						this.debugMessage(`Error in SSE callback for pipe ${pipeId}: ${error}`);
 					}

--- a/packages/server/engine-lib/rocketlib-python/lib/rocketlib/engine.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/rocketlib/engine.py
@@ -107,18 +107,17 @@ def monitorOther(*args) -> None:
 globals()['monitorOther'] = engLib.monitorOther  # noqa
 
 
-def monitorSSE(pipe_id: int, type: str, message: str, data: dict = None) -> None:
+def monitorSSE(pipe_id: int, type: str, data: dict = None) -> None:
     """
     Send a real-time SSE event to the UI for the current pipe.
 
     Args:
         pipe_id: The current pipe's ID (self.instance.pipeId)
-        type:    Event type ('thinking', 'acting', 'confirm')
-        message: Human-readable message to display in the UI
-        data:    Optional structured data dict to include in the event
+        type:    Event type string (e.g. 'thinking', 'acting', 'confirm')
+        data:    Optional dict payload to include in the event (passed as-is from kwargs)
     """
     import json
-    payload = {'pipe_id': pipe_id, 'type': type, 'message': message}
+    payload = {'pipe_id': pipe_id, 'type': type}
     if data:
         payload['data'] = data
     engLib.monitorOther('SSE', json.dumps(payload, separators=(',', ':')))

--- a/packages/server/engine-lib/rocketlib-python/lib/rocketlib/filters.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/rocketlib/filters.py
@@ -520,6 +520,10 @@ class IFilterInstance(IServiceFilterInstance, Protocol):
         """
         ...
 
+    def sendSSE(self, type: str, **data) -> None:
+        """Send a real-time SSE event to the UI for this pipe."""
+        ...
+
 
 class IInstanceBase:
     """
@@ -677,17 +681,26 @@ Monkey patch the C++ methods as needed
 
 
 def _patch_classes():
-    """Add Python methods to C++ classes."""
+    """Add Python methods to C++ classes.
+    
+    These are monkey patched on to the C++ so we can maintain our 
+    pattern of calling into the engine's self.instance.*.
+    """
 
     def invoke(self, classType: str, *args, nodeId: str = "", **kwargs) -> Any:
         control = IInvoke(args=args, kwargs=kwargs, result=None)
         self.control(classType, control, nodeId=nodeId)
         return control.result
 
+    def sendSSE(self, type: str, **data) -> None:
+        from .engine import monitorSSE
+        monitorSSE(self.pipeId, type, data or None)
+
     # Add to the actual C++ class
     from engLib import IFilterInstance as Impl_IFilterInstance
 
     Impl_IFilterInstance.invoke = invoke
+    Impl_IFilterInstance.sendSSE = sendSSE
 
 
 # Apply patches


### PR DESCRIPTION
Add generic sendSSE to IFilterInstance and unify SSE callback signatures

Previously only AgentBase could send SSE events, using a monitorSSE() helper with a fixed (pipe_id, type, message, data) signature that coupled SSE to agent nodes only. This change makes SSE a first-class capability of any pipeline node by adding sendSSE() to the IFilterInstance protocol.

Server-side changes:
- Add sendSSE(**data) to IFilterInstance protocol and monkey-patch it onto the C++ Impl_IFilterInstance class (filters.py)
- Simplify monitorSSE() to (pipe_id, type, data) — message is now just another key in the data dict, removing the special-case parameter (engine.py)
- AgentBase.sendSSE() delegates to self._invoker.instance.sendSSE() instead of calling monitorSSE() directly, so agents use the same code path as any node (agent.py)
- Use **kwargs signature so callers write sendSSE('thinking', message=...) instead of sendSSE('thinking', {'message': ...}) (all server files)
- Update all call sites in rocketride_agent.py to the new kwargs style

Client-side changes:
- Update SSE callback signature from cb(body) to cb(type, data) across both TypeScript and Python client SDKs, so consumers receive pre-extracted type and data instead of raw event bodies (client.ts, events.py, data.py)
- Add onSSE parameter to TS pipe() and send() — previously only chat() accepted SSE callbacks; add on_sse to Python send() for parity
- Refactor TS chat() to use this.pipe() instead of creating DataPipe directly, matching the Python SDK pattern
- Widen TS connect() to accept { uri, auth, timeout } options object in addition to plain timeout number, matching the Python SDK
- Update chat-ui onSSE handler to match new (type, data) signature and widen sseType from a string literal union to string to allow custom event types (useChatMessages.ts, chat.types.ts)

## Server usage — any node driver can now send SSE events directly:

    class MyNode(IInstanceBase):
        def writeText(self, pSelf, text):
            self.instance.sendSSE('status', message='Processing text...')
            # ... process text ...
            self.instance.sendSSE('status', message='Done', chars=len(text))

## Client usage — receiving SSE events via the TypeScript SDK:

    // Using chat() — AI conversations with real-time status
    const result = await client.chat({
        token,
        question,
        onSSE: async (type, data) => {
            console.log(`[${type}] ${data.message}`);
        }
    });

    // Using pipe() — streaming data with SSE events
    const pipe = await client.pipe(token, objinfo, mimeType, provider,
        async (type, data) => {
            console.log(`[${type}] ${data.message}`);
        }
    );
    await pipe.open();
    await pipe.write(buffer);
    const result = await pipe.close();

    // Using send() — one-shot data with SSE events
    const result = await client.send(token, data, objinfo, mimetype,
        async (type, data) => {
            console.log(`[${type}] ${data.message}`);
        }
    );


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured server-sent event callback signatures across client libraries (TypeScript and Python) to use structured event parameters (type and data) instead of a single body parameter, improving consistency and standardization of event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->