### PR TITLE
fix(vscode): add startup migrations for settings and legacy files

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -23,10 +23,12 @@
 
 /**
  * Main Extension Entry Point
- * 
+ *
  * Coordinates all extension providers and manages the overall extension lifecycle.
  */
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
 import { getLogger } from './shared/util/output';
 import { icons } from './shared/util/icons';
 
@@ -44,7 +46,6 @@ import { BarStatus } from './providers/BarStatusProvider';
 import { PageWelcomeProvider } from './providers/PageWelcomeProvider';
 import { SidebarConnectionProvider } from './providers/SidebarConnectionProvider';
 
-
 // Core managers
 let connectionManager: ConnectionManager | undefined;
 let configManager: ConfigManager | undefined;
@@ -61,8 +62,39 @@ let pageWelcome: PageWelcomeProvider | undefined;
 let sidebarConnection: SidebarConnectionProvider | undefined;
 
 /**
+ * One-time migrations for settings/files that changed between extension versions.
+ * Safe to run on every startup — each migration is idempotent.
+ */
+async function runMigrations(context: vscode.ExtensionContext): Promise<void> {
+	const logger = getLogger();
+	const config = vscode.workspace.getConfiguration('rocketride');
+
+	// Migration 1: engineArgs array → string (v1.0.0 → v1.0.2)
+	const engineArgs = config.inspect<unknown>('engineArgs');
+	const migrateArgs = async (scope: vscode.ConfigurationTarget, value: unknown) => {
+		if (Array.isArray(value)) {
+			const joined = (value as string[]).join(' ');
+			await config.update('engineArgs', joined, scope);
+			logger.output(`${icons.info} Migrated rocketride.engineArgs from array to string (${scope === vscode.ConfigurationTarget.Global ? 'global' : 'workspace'})`);
+		}
+	};
+	if (engineArgs?.globalValue !== undefined) await migrateArgs(vscode.ConfigurationTarget.Global, engineArgs.globalValue);
+	if (engineArgs?.workspaceValue !== undefined) await migrateArgs(vscode.ConfigurationTarget.Workspace, engineArgs.workspaceValue);
+
+	// Migration 2: Remove old engine directory from extensionPath (v1.0.0 stored engine inside the extension folder)
+	const oldEngineDir = path.join(context.extensionPath, 'engine');
+	try {
+		await fs.promises.access(oldEngineDir);
+		await fs.promises.rm(oldEngineDir, { recursive: true });
+		logger.output(`${icons.info} Removed legacy engine directory: ${oldEngineDir}`);
+	} catch {
+		// Directory doesn't exist or couldn't be removed — nothing to do
+	}
+}
+
+/**
  * Extension activation entry point
- * 
+ *
  * @param context VS Code extension context
  */
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
@@ -73,163 +105,150 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 	configManager = ConfigManager.getInstance();
 	await configManager.initialize(context);
 
+	// Run one-time migrations (idempotent — safe on every startup)
+	await runMigrations(context);
+
 	// Set initial context
 	vscode.commands.executeCommand('setContext', 'rocketride.connected', false);
 
 	try {
-		await vscode.window.withProgress({
-			location: vscode.ProgressLocation.Notification,
-			title: "Initializing RocketRide Extension",
-			cancellable: false
-		}, async (progress) => {
-			//-------------------------------------
-			// Load configuration
-			//-------------------------------------
-			logger.output(`${icons.info} Loading configuration...`);
-			progress.report({ increment: 10, message: "Loading configuration..." });
-			await sleep(200);
+		await vscode.window.withProgress(
+			{
+				location: vscode.ProgressLocation.Notification,
+				title: 'Initializing RocketRide Extension',
+				cancellable: false,
+			},
+			async (progress) => {
+				//-------------------------------------
+				// Load configuration
+				//-------------------------------------
+				logger.output(`${icons.info} Loading configuration...`);
+				progress.report({ increment: 10, message: 'Loading configuration...' });
+				await sleep(200);
 
-			//-------------------------------------
-			// Load status bar
-			//-------------------------------------
-			logger.output(`${icons.info} Loading status bar...`);
-			progress.report({ increment: 20, message: "Loading status bar..." });
-			barStatus = new BarStatus(context);
-			barStatus.setInitializing();
+				//-------------------------------------
+				// Load status bar
+				//-------------------------------------
+				logger.output(`${icons.info} Loading status bar...`);
+				progress.report({ increment: 20, message: 'Loading status bar...' });
+				barStatus = new BarStatus(context);
+				barStatus.setInitializing();
 
-			//-------------------------------------
-			// Create connection manager
-			//-------------------------------------
-			logger.output(`${icons.info} Creating connection manager...`);
-			progress.report({ increment: 30, message: "Creating connection manager..." });
-			connectionManager = ConnectionManager.getInstance();
-			connectionManager.setEnginesRoot(context.globalStorageUri.fsPath);
+				//-------------------------------------
+				// Create connection manager
+				//-------------------------------------
+				logger.output(`${icons.info} Creating connection manager...`);
+				progress.report({ increment: 30, message: 'Creating connection manager...' });
+				connectionManager = ConnectionManager.getInstance();
+				connectionManager.setEnginesRoot(context.globalStorageUri.fsPath);
 
-			//-------------------------------------
-			// Create status bar
-			//-------------------------------------
-			logger.output(`${icons.info} Creating status bar...`);
-			progress.report({ increment: 40, message: "Creating status providers..." });
+				//-------------------------------------
+				// Create status bar
+				//-------------------------------------
+				logger.output(`${icons.info} Creating status bar...`);
+				progress.report({ increment: 40, message: 'Creating status providers...' });
 
-			//-------------------------------------
-			// Register tree data providers
-			//-------------------------------------
-			logger.output(`${icons.info} Creating tree providers...`);
-			progress.report({ increment: 50, message: "Creating tree providers..." });
+				//-------------------------------------
+				// Register tree data providers
+				//-------------------------------------
+				logger.output(`${icons.info} Creating tree providers...`);
+				progress.report({ increment: 50, message: 'Creating tree providers...' });
 
-			sidebarFiles = new SidebarFilesProvider(context);
-			const pipelineFilesTreeDataProvider = vscode.window.registerTreeDataProvider('rocketride.provider.files', sidebarFiles);
+				sidebarFiles = new SidebarFilesProvider(context);
+				const pipelineFilesTreeDataProvider = vscode.window.registerTreeDataProvider('rocketride.provider.files', sidebarFiles);
 
-			// Register connection webview provider
-			pageConnection = new PageConnectionProvider(context.extensionUri);
-			const connectionWebviewProvider = vscode.window.registerWebviewViewProvider(
-				PageConnectionProvider.viewType,
-				pageConnection
-			);
+				// Register connection webview provider
+				pageConnection = new PageConnectionProvider(context.extensionUri);
+				const connectionWebviewProvider = vscode.window.registerWebviewViewProvider(PageConnectionProvider.viewType, pageConnection);
 
-			sidebarConnection = new SidebarConnectionProvider(context);
+				sidebarConnection = new SidebarConnectionProvider(context);
 
-			context.subscriptions.push(
-				pipelineFilesTreeDataProvider,
-				connectionWebviewProvider,
-				sidebarConnection
-			);
+				context.subscriptions.push(pipelineFilesTreeDataProvider, connectionWebviewProvider, sidebarConnection);
 
-			//-------------------------------------
-			// Create webview providers
-			//-------------------------------------
-			logger.output(`${icons.info} Creating webview providers...`);
-			progress.report({ increment: 60, message: "Creating webview providers..." });
+				//-------------------------------------
+				// Create webview providers
+				//-------------------------------------
+				logger.output(`${icons.info} Creating webview providers...`);
+				progress.report({ increment: 60, message: 'Creating webview providers...' });
 
-		pageSettings = new PageSettingsProvider(context.extensionUri);
-		pageStatus = new PageStatusProvider(context);
-		pageDeploy = new PageDeployProvider(context);
-		pageWelcome = new PageWelcomeProvider(context, context.extensionUri);
+				pageSettings = new PageSettingsProvider(context.extensionUri);
+				pageStatus = new PageStatusProvider(context);
+				pageDeploy = new PageDeployProvider(context);
+				pageWelcome = new PageWelcomeProvider(context, context.extensionUri);
 
-			// Register custom editor provider
-			pageEditor = new PageEditorProvider(context);
-			const pageEditorRegistration = vscode.window.registerCustomEditorProvider(
-				'rocketride.PageEditor',
-				pageEditor,
-				{
+				// Register custom editor provider
+				pageEditor = new PageEditorProvider(context);
+				const pageEditorRegistration = vscode.window.registerCustomEditorProvider('rocketride.PageEditor', pageEditor, {
 					webviewOptions: {
-						retainContextWhenHidden: true // Better performance for complex editors
+						retainContextWhenHidden: true, // Better performance for complex editors
 					},
-					supportsMultipleEditorsPerDocument: false // One editor per file
-				}
-			);
-
-			//-------------------------------------
-			// Register utility commands
-			//-------------------------------------
-			logger.output(`${icons.info} Registering utility commands...`);
-			progress.report({ increment: 70, message: "Registering commands and components..." });
-			registerUtilityCommands(context);
-
-			//-------------------------------------
-			// Register debugger (disabled — see debugger/adapter.ts to re-enable)
-			//-------------------------------------
-			// registerDebugger(context);
-
-			//-------------------------------------
-			// Set up event handlers
-			//-------------------------------------
-			logger.output(`${icons.info} Setting up event handlers...`);
-			progress.report({ increment: 90, message: "Setting up event handlers..." });
-			setupConnectionEventHandlers();
-
-		// Add all providers to context subscriptions for proper cleanup
-		context.subscriptions.push(
-			pageEditorRegistration,
-			pageSettings,
-			pageEditor,
-			pageConnection,
-			sidebarFiles,
-			pageStatus,
-			pageWelcome!
-		);
-
-			//-------------------------------------
-			// Update tree providers with initial data
-			//-------------------------------------
-			logger.output(`${icons.info} Refreshing providers...`);
-			progress.report({ increment: 100, message: "Refreshing providers..." });
-			await refreshAllProviders();
-
-			//-------------------------------------
-			// Initialize connection / welcome flow
-			//-------------------------------------
-			vscode.commands.executeCommand('setContext', 'rocketride.loaded', true);
-			vscode.commands.executeCommand('setContext', 'rocketride.connected', false);
-
-			logger.output(`${icons.info} Initializing status bar...`);
-			progress.report({ increment: 120, message: "Setup status bar" });
-			barStatus.initializeConnectionManager();
-			context.subscriptions.push(barStatus);
-
-			const welcomeDismissed = pageWelcome?.isDismissed() ?? true;
-			if (!welcomeDismissed) {
-				// First run: show welcome page, don't auto-connect
-				logger.output(`${icons.info} First run detected — showing welcome page`);
-				progress.report({ increment: 110, message: "Showing welcome..." });
-				barStatus.setNeedsSetup();
-				pageWelcome!.show();
-			} else {
-				// Normal flow: auto-connect
-				logger.output(`${icons.info} Initializing connections...`);
-				progress.report({ increment: 110, message: "Starting connections..." });
-				barStatus.setReady();
-				connectionManager.initialize().catch(error => {
-					console.error('[ROCKETRIDE] Connection initialization failed:', error);
+					supportsMultipleEditorsPerDocument: false, // One editor per file
 				});
-			}
 
-		//-------------------------------------
-		// And done...
-		//-------------------------------------
-		logger.output(`${icons.info} Completed initializing`);
-		progress.report({ increment: 130, message: "Complete" });
-	});
+				//-------------------------------------
+				// Register utility commands
+				//-------------------------------------
+				logger.output(`${icons.info} Registering utility commands...`);
+				progress.report({ increment: 70, message: 'Registering commands and components...' });
+				registerUtilityCommands(context);
+
+				//-------------------------------------
+				// Register debugger (disabled — see debugger/adapter.ts to re-enable)
+				//-------------------------------------
+				// registerDebugger(context);
+
+				//-------------------------------------
+				// Set up event handlers
+				//-------------------------------------
+				logger.output(`${icons.info} Setting up event handlers...`);
+				progress.report({ increment: 90, message: 'Setting up event handlers...' });
+				setupConnectionEventHandlers();
+
+				// Add all providers to context subscriptions for proper cleanup
+				context.subscriptions.push(pageEditorRegistration, pageSettings, pageEditor, pageConnection, sidebarFiles, pageStatus, pageWelcome!);
+
+				//-------------------------------------
+				// Update tree providers with initial data
+				//-------------------------------------
+				logger.output(`${icons.info} Refreshing providers...`);
+				progress.report({ increment: 100, message: 'Refreshing providers...' });
+				await refreshAllProviders();
+
+				//-------------------------------------
+				// Initialize connection / welcome flow
+				//-------------------------------------
+				vscode.commands.executeCommand('setContext', 'rocketride.loaded', true);
+				vscode.commands.executeCommand('setContext', 'rocketride.connected', false);
+
+				logger.output(`${icons.info} Initializing status bar...`);
+				progress.report({ increment: 120, message: 'Setup status bar' });
+				barStatus.initializeConnectionManager();
+				context.subscriptions.push(barStatus);
+
+				const welcomeDismissed = pageWelcome?.isDismissed() ?? true;
+				if (!welcomeDismissed) {
+					// First run: show welcome page, don't auto-connect
+					logger.output(`${icons.info} First run detected — showing welcome page`);
+					progress.report({ increment: 110, message: 'Showing welcome...' });
+					barStatus.setNeedsSetup();
+					pageWelcome!.show();
+				} else {
+					// Normal flow: auto-connect
+					logger.output(`${icons.info} Initializing connections...`);
+					progress.report({ increment: 110, message: 'Starting connections...' });
+					barStatus.setReady();
+					connectionManager.initialize().catch((error) => {
+						console.error('[ROCKETRIDE] Connection initialization failed:', error);
+					});
+				}
+
+				//-------------------------------------
+				// And done...
+				//-------------------------------------
+				logger.output(`${icons.info} Completed initializing`);
+				progress.report({ increment: 130, message: 'Complete' });
+			}
+		);
 
 		logger.output(`${icons.success} RocketRide extension activated successfully`);
 	} catch (error) {
@@ -246,7 +265,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
  * Simple sleep utility for activation delays
  */
 function sleep(ms: number): Promise<void> {
-	return new Promise(resolve => setTimeout(resolve, ms));
+	return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -257,10 +276,10 @@ function registerUtilityCommands(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand('rocketride.refresh', async () => {
 			await refreshAllProviders();
 			vscode.window.showInformationMessage('RocketRide views refreshed');
-		})
+		}),
 	];
 
-	commands.forEach(command => context.subscriptions.push(command));
+	commands.forEach((command) => context.subscriptions.push(command));
 }
 
 /**


### PR DESCRIPTION
Adds an idempotent `runMigrations()` function that runs on every extension activation to handle breaking changes between versions:

Current migrations:
* rocketride.engineArgs changed from [] to a single string
* <extension>/engine is not longer where the download local engine is stored. Move to global to share amount instances 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration settings are now automatically migrated to a compatible format during extension startup.
  * Legacy engine files are cleaned up during initialization to prevent potential conflicts.

* **Chores**
  * Reorganized extension startup sequence to improve connection establishment and welcome flow.
  * Improved startup integration with the connection manager for more reliable initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->