### PR TITLE
fix: block SSRF in tool_http_request by validating resolved IPs

### DIFF
--- a/nodes/src/nodes/tool_http_request/http_driver.py
+++ b/nodes/src/nodes/tool_http_request/http_driver.py
@@ -31,9 +31,12 @@ guardrails (allowed methods + URL whitelist) are enforced before every request.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import re
+import socket
 from typing import Any, Dict, List, Set
+from urllib.parse import urlparse
 
 from ai.common.tools import ToolsBase
 
@@ -163,6 +166,25 @@ INPUT_SCHEMA: Dict[str, Any] = {
 }
 
 
+def _is_private_ip(url: str) -> bool:
+    """Return True if *url* resolves to a private, loopback, or reserved IP.
+
+    Performs DNS resolution so that hostnames pointing to internal addresses
+    (e.g. DNS rebinding) are also caught.
+    """
+    try:
+        hostname = urlparse(url).hostname
+        if not hostname:
+            return True
+        for info in socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP):
+            addr = ipaddress.ip_address(info[4][0])
+            if addr.is_private or addr.is_loopback or addr.is_reserved or addr.is_link_local:
+                return True
+    except (socket.gaierror, OSError, ValueError):
+        return True  # unresolvable or malformed → block
+    return False
+
+
 class HttpDriver(ToolsBase):
     def __init__(
         self,
@@ -171,6 +193,7 @@ class HttpDriver(ToolsBase):
         enabled_methods: Set[str],
         url_patterns: List[re.Pattern],
     ):
+        """Initialize the HTTP driver with security guardrails."""
         self._server_name = (server_name or '').strip() or 'http'
         self._tool_name = 'http_request'
         self._namespaced = f'{self._server_name}.{self._tool_name}'
@@ -250,19 +273,20 @@ class HttpDriver(ToolsBase):
         if method.upper() not in VALID_METHODS:
             raise ValueError(f'method must be one of {sorted(VALID_METHODS)}; got {method!r}')
         if method.upper() not in self._enabled_methods:
-            raise ValueError(
-                f'HTTP method "{method.upper()}" is not allowed. '
-                f'Enabled methods: {", ".join(sorted(self._enabled_methods))}'
-            )
+            raise ValueError(f'HTTP method "{method.upper()}" is not allowed. Enabled methods: {", ".join(sorted(self._enabled_methods))}')
 
-        # --- Guardrail: URL whitelist (empty list = allow all) ---
+        # --- Guardrail: URL validation ---
         url = input_obj.get('url')
         if not url or not isinstance(url, str):
             raise ValueError('url is required and must be a non-empty string')
+
+        # --- Guardrail: block private/internal IPs (SSRF protection) ---
+        if _is_private_ip(url):
+            raise ValueError(f'URL "{url}" resolves to a private or reserved IP address. Requests to internal/cloud-metadata networks are blocked.')
+
+        # --- Guardrail: URL whitelist (empty list = allow all) ---
         if self._url_patterns and not any(p.search(url) for p in self._url_patterns):
-            raise ValueError(
-                f'URL "{url}" does not match any allowed URL pattern.'
-            )
+            raise ValueError(f'URL "{url}" does not match any allowed URL pattern.')
 
         # --- Standard field validation ---
         auth = input_obj.get('auth')
@@ -280,9 +304,7 @@ class HttpDriver(ToolsBase):
                 raw = body.get('raw') or {}
                 ct = (raw.get('content_type') or 'application/json').strip().lower()
                 if ct not in VALID_RAW_CONTENT_TYPES:
-                    raise ValueError(
-                        f'body.raw.content_type must be one of {sorted(VALID_RAW_CONTENT_TYPES)}; got {ct!r}'
-                    )
+                    raise ValueError(f'body.raw.content_type must be one of {sorted(VALID_RAW_CONTENT_TYPES)}; got {ct!r}')
 
     def _tool_invoke(self, *, tool_name: str, input_obj: Any) -> Any:  # noqa: ANN401
         if not isinstance(input_obj, dict):


### PR DESCRIPTION
## Summary

- Add `_is_private_ip()` SSRF guard to the `tool_http_request` node
- Block requests to private, loopback, reserved, and link-local IP ranges
- Resolve hostnames via DNS before checking, catching DNS rebinding attacks
- Uses only stdlib (`ipaddress`, `socket`, `urllib.parse`) — no new dependencies

## Bug

The `http_request` tool lets AI agents make HTTP requests to arbitrary URLs. The only guardrail is a URL whitelist regex, but:

1. **Empty whitelist (the default) = all URLs allowed.** Line 262: `if self._url_patterns and not any(...)` short-circuits when `_url_patterns` is empty.
2. **Zero private IP validation.** No check anywhere prevents requests to `169.254.169.254` (cloud metadata), `127.0.0.1` (localhost), or RFC1918 ranges (`10.x`, `172.16-31.x`, `192.168.x`).
3. **Full response returned.** The agent receives status code, headers, and complete body — making this a full-read SSRF.

### Attack scenario

An AI agent (or a user manipulating the agent via prompt injection) calls the tool with:
```json
{"url": "http://169.254.169.254/latest/meta-data/iam/security-credentials/", "method": "GET"}
```

This returns AWS IAM credentials from the cloud metadata service. The same applies to GCP (`metadata.google.internal`), Azure (`169.254.169.254`), and any internal service on the network.

This is the same class of vulnerability behind the [Capital One breach (2019)](https://en.wikipedia.org/wiki/2019_Capital_One_data_breach) — SSRF to cloud metadata.

### Why `validateConfig` doesn't help

`validateConfig()` in `IGlobal.py` warns when the whitelist is empty (line 115-116), but doesn't block execution. Even with a whitelist, there's no IP-level check — a pattern matching `example.com` would still allow `http://example.com@169.254.169.254/` via URL authority confusion.

## Fix

Add `_is_private_ip(url)` which:
1. Parses the URL hostname via `urlparse`
2. Resolves via `socket.getaddrinfo()` — validates the **resolved IP**, not the hostname string (catches DNS rebinding)
3. Checks every resolved address against `is_private`, `is_loopback`, `is_reserved`, `is_link_local`
4. Blocks on match or DNS failure (fail-closed)

The check runs in `_tool_validate()` before the whitelist check, so it applies regardless of whitelist configuration.

## Test plan

- [ ] Verify requests to public URLs (e.g., `https://httpbin.org/get`) still work
- [ ] Verify requests to `http://169.254.169.254/` are blocked
- [ ] Verify requests to `http://127.0.0.1/` are blocked
- [ ] Verify requests to `http://10.0.0.1/` are blocked
- [ ] Verify a hostname resolving to a private IP is blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced security validation for HTTP requests to prevent Server-Side Request Forgery (SSRF) attacks by blocking requests to private, reserved, and internal IP addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->