### PR TITLE
fix: Hackathon Bug Bounty - fix 6 bugs across chroma, openai, qwen, and embedding

### DIFF
--- a/nodes/src/nodes/chroma/chroma.py
+++ b/nodes/src/nodes/chroma/chroma.py
@@ -159,7 +159,7 @@ class Store(DocumentStoreBase):
         if docFilter.isDeleted is not None:
             filters.append({'isDeleted': {'$eq': docFilter.isDeleted}})
         if docFilter.chunkIds:
-            filters.append({'chunkId': {'$in': docFilter.objectIds}})
+            filters.append({'chunkId': {'$in': docFilter.chunkIds}})
         # If we are min chunk id, add a condition
         if docFilter.minChunkId is not None:
             filters.append({'chunkId': {'$gte': docFilter.minChunkId}})
@@ -367,10 +367,10 @@ class Store(DocumentStoreBase):
             nonlocal ids, embeddings, metadatas, documents
             if object_ids_to_delete:
                 if len(object_ids_to_delete) > 1:
-                    filter_condition = {'$or': [{'meta.objectId': object_id} for object_id in object_ids_to_delete]}
+                    filter_condition = {'$or': [{'objectId': object_id} for object_id in object_ids_to_delete]}
                     self.collectionObj.delete(where=filter_condition)
                 else:
-                    filter_condition = {'meta.objectId': list(object_ids_to_delete.keys())[0]}
+                    filter_condition = {'objectId': list(object_ids_to_delete.keys())[0]}
                     self.collectionObj.delete(where=filter_condition)
                 object_ids_to_delete.clear()
 

--- a/nodes/src/nodes/embedding_openai/OpenAIEmbeddingWrapper.py
+++ b/nodes/src/nodes/embedding_openai/OpenAIEmbeddingWrapper.py
@@ -71,7 +71,7 @@ class OpenAIEmbeddingWrapper(EmbeddingBase):
 
         # Check it
         if self._embedding is None:
-            raise Exception(f'Could not instantiate embedding model ${self._model}')
+            raise Exception(f'Could not instantiate embedding model {self._model}')
 
         # Set the vector size
         self._updateVectorSize()

--- a/nodes/src/nodes/embedding_transformer/sentenceTransformer.py
+++ b/nodes/src/nodes/embedding_transformer/sentenceTransformer.py
@@ -88,7 +88,7 @@ class Embedding(EmbeddingBase):
 
         # Check it
         if self._embedding is None:
-            raise Exception(f'Could not instantiate embedding model ${self._model}')
+            raise Exception(f'Could not instantiate embedding model {self._model}')
 
         # Get the vector size and max tokens
         self._vectorSize = self._embedding.get_sentence_embedding_dimension()

--- a/nodes/src/nodes/llm_openai/openai_client.py
+++ b/nodes/src/nodes/llm_openai/openai_client.py
@@ -71,7 +71,7 @@ class Chat(ChatBase):
         elif isinstance(error, APIConnectionError):
             return True
         else:
-            return super().map_exception(error)
+            return False
 
     def map_exception(self, error):
         """

--- a/nodes/src/nodes/llm_qwen/qwen_client.py
+++ b/nodes/src/nodes/llm_qwen/qwen_client.py
@@ -90,7 +90,7 @@ class Chat(ChatBase):
         elif isinstance(error, APIConnectionError):
             return True
         else:
-            return super().map_exception(error)
+            return False
 
     def map_exception(self, error):
         """


### PR DESCRIPTION
## Summary
- Fix Chroma `_convertFilter`: `chunkIds` filter incorrectly used `docFilter.objectIds` instead of `docFilter.chunkIds`; delete filter in `addChunks` used non-existent `meta.objectId` path instead of `objectId`
- Fix OpenAI/Qwen `is_retryable_error`: fallback called `map_exception()` (returns exception object, always truthy) instead of returning `False`, causing unknown errors to always retry
- Fix f-string formatting in `OpenAIEmbeddingWrapper` and `sentenceTransformer`: used shell-style `${var}` instead of `{var}`

## Type
fix

## Testing
- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed chunk filtering accuracy in vector database operations when filtering by chunk IDs
  * Corrected error message formatting for embedding model initialization failures
  * Improved error classification in API error handling for language model clients

<!-- end of auto-generated comment: release notes by coderabbit.ai -->