### PR TITLE
fix: prevent path traversal in local_text_output file writes

### DIFF
--- a/nodes/src/nodes/local_text_output/IInstance.py
+++ b/nodes/src/nodes/local_text_output/IInstance.py
@@ -100,12 +100,21 @@ class IInstance(IInstanceBase):
 
                 # Create the full target path by joining with output directory
                 # e.g. /Users/username/Desktop/Hackathon/folder1/gradient_terms_of_use.txt
-                file_path = os.path.normpath(os.path.join(output_path, file))
-
-                # Validate the resolved path stays within the output directory
-                resolved_output = os.path.normpath(output_path)
-                if not file_path.startswith(resolved_output + os.sep) and file_path != resolved_output:
-                    raise Exception(f'Path traversal detected: {file} resolves outside output directory')
+                resolved_output = os.path.realpath(output_path)
+                candidate_path = os.path.realpath(
+                    os.path.join(resolved_output, file.lstrip('/\\'))
+                )
+                try:
+                    is_within_output = (
+                        os.path.commonpath([resolved_output, candidate_path]) == resolved_output
+                    )
+                except ValueError:
+                    is_within_output = False
+                if not is_within_output:
+                    raise ValueError(
+                        f'Path traversal detected: {file} resolves outside output directory'
+                    )
+                file_path = candidate_path
 
                 # Create all necessary subdirectories
                 target_dir = os.path.dirname(file_path)


### PR DESCRIPTION
## Summary

- Add path normalization and containment check in `local_text_output` to prevent writing files outside the output directory

## Bug

`nodes/src/nodes/local_text_output/IInstance.py` builds output file paths via `os.path.join(output_path, file)` where `file` is derived from the input document's relative path. If the relative path contains `../` sequences, the resolved path escapes the intended output directory, allowing writes to arbitrary locations on the filesystem.

## Fix

- Apply `os.path.normpath()` to the joined path to resolve `../` sequences
- Verify the normalized path starts with the normalized output directory
- Raise an exception if traversal is detected (caught by existing error handler)

## Test plan

- [ ] Output with normal relative paths works as before
- [ ] Input containing `../` in the path raises an error instead of writing outside the output directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for file output: the system now validates destinations before saving to prevent path traversal, ensuring files are written only to intended directories. Unsafe write attempts are blocked and will emit a warning instead of writing outside the target folder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->