### PR TITLE
fix(security): replace hardcoded token seed with per-process random default

### DIFF
--- a/packages/ai/src/ai/account/account.py
+++ b/packages/ai/src/ai/account/account.py
@@ -1,4 +1,5 @@
 import os
+import secrets
 import httpx
 import json
 import hashlib
@@ -52,13 +53,12 @@ class Account:
         # Retrieve the API key validation endpoint from the LS_APIKEY environment variable.
         self._endpoint_account: Optional[str] = os.environ.get('LS_APIKEY')
 
-        # The seed is used to create tokens. It is completely random and used to
-        # add to the token generation. This helps in the randomization of the
-        # token, and makes it almost impossible to reverse a token to its root values
+        # The seed is used to create tokens. A unique random seed is generated
+        # per process by default to prevent token prediction. Override via the
+        # ROCKETRIDE_TOKEN_SEED env var if tokens must be stable across restarts.
         #
-        # IF YOU CHANGE THIS, IT WILL INVALIDATE ALL TOKENS ISSUE ENMASS. SO,
-        # ONLY DO THIS IS ABSOLUTELY NECESSARY!!!
-        self._seed = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
+        # NOTE: Changing the seed invalidates all previously issued tokens.
+        self._seed = os.environ.get('ROCKETRIDE_TOKEN_SEED') or secrets.token_hex(32)
 
     def generate_token(self, content: Dict[str, Any], prefix: str = ''):
         """


### PR DESCRIPTION
## Summary

- Replace hardcoded token generation seed with a cryptographically random per-process default
- Allow override via ROCKETRIDE_TOKEN_SEED env var for deployments needing stable tokens across restarts

## Bug

`packages/ai/src/ai/account/account.py` line 61 has:
```python
self._seed = 'f47ac10b-58cc-4372-a567-0e02b2c3d479'
```

The comment claims this seed "makes it almost impossible to reverse a token to its root values," but the seed is a hardcoded constant in a public repository. Every RocketRide deployment uses the same seed, so it provides zero additional security — anyone can read the source and compute valid tokens for known inputs.

## Fix

```python
self._seed = os.environ.get('ROCKETRIDE_TOKEN_SEED') or secrets.token_hex(32)
```

- Default: generate a random 32-byte hex seed per process using `secrets.token_hex(32)`
- Override: set `ROCKETRIDE_TOKEN_SEED` env var for deployments that need tokens to survive restarts
- Updated comment to accurately describe the behavior

## Test plan

- [ ] Token generation still works (generate_token returns a hex string)
- [ ] Different process starts produce different tokens for the same input (seed is random)
- [ ] Setting ROCKETRIDE_TOKEN_SEED env var produces stable tokens across restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)