### PR TITLE
chore: bump package versions for hackathon release

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "rocketride",
 	"displayName": "RocketRide",
 	"description": "RocketRide extension for Visual Studio Code",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"publisher": "rocketride",
 	"repository": {
 		"type": "git",

--- a/packages/client-mcp/pyproject.toml
+++ b/packages/client-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride-mcp"
-version = "1.0.3"
+version = "1.0.4"
 description = "RocketRide MCP stdio server that streams local files to RocketRide EaaS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride"
-version = "1.0.3"
+version = "1.0.4"
 description = "RocketRide Pipeline Python Client SDK"
 readme = "README.md"
 authors = [

--- a/packages/client-typescript/package.json
+++ b/packages/client-typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"author": "RocketRide, Inc.",
 	"license": "MIT",
 	"description": "TypeScript client for RocketRide data processing and AI services",


### PR DESCRIPTION
## Summary

Bump package versions to trigger a new release with updated READMEs.

Previous release (v1.0.1/1.0.3) already had the README content baked into the .vsix, but the publish was skipped because the git tags already existed.

Version bumps:
- VS Code extension: 1.0.1 → 1.0.2
- TypeScript client: 1.0.3 → 1.0.4
- Python client: 1.0.3 → 1.0.4
- MCP client: 1.0.3 → 1.0.4

No code changes. Version bump only.