### PR TITLE
fix(server): skip rebuild when server is already built locally

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -425,6 +425,7 @@ function makeDownloadAction(options = {}) {
             task.output = 'Computing source hash...';
             const localHash = await contentHash(SERVER_DIR, { log: (msg) => { task.output = msg; } });
             ctx.contentHash = localHash;
+            ctx.serverAlreadyBuilt = false;
 
             if (options.force) {
                 task.output = 'Force rebuild requested';
@@ -448,6 +449,7 @@ function makeDownloadAction(options = {}) {
             if (!await getState('server.downloaded')
                 && await getState('server.contentHash') === localHash
                 && await getState('vcpkg.version') === localVcpkgVersion) {
+                ctx.serverAlreadyBuilt = true;
                 task.output = 'Server already built';
                 return;
             }
@@ -537,11 +539,13 @@ function makeDownloadAction(options = {}) {
 
                 await setState('server.downloaded', true);
                 ctx.downloaded = true;
+                ctx.serverAlreadyBuilt = false;
                 task.output = `Downloaded server from ${matchedTag}`;
 
             } catch {
                 await setState('server.downloaded', false);
                 ctx.downloaded = false;
+                ctx.serverAlreadyBuilt = false;
                 task.output = `Release ${matchedTag} download failed: Will compile from source`;
             }
         }
@@ -931,7 +935,7 @@ function makeBuildCoreAction() {
             'server:download',
             whenNot({
                 name: 'downloaded',
-                condition: (ctx) => ctx.downloaded,
+                condition: (ctx) => ctx.downloaded || ctx.serverAlreadyBuilt,
                 then: [
                     parallel([
                         'server:setup-tools',


### PR DESCRIPTION
## Summary
- Fixes a builder control-flow bug where `server:build-core` entered compile/setup steps even after `server:download` reported `Server already built`.
- Adds an explicit runtime context signal for the already-built path and reuses it in the `whenNot(downloaded)` guard.
- Keeps existing `ctx.downloaded` semantics unchanged for other flows (including `server:test`).

## Bug
`server:download` had an early-return branch for the local-cache hit (`Server already built`) but did not set any context value consumed by the following conditional in `server:build-core`.

As a result, `whenNot({ condition: (ctx) => ctx.downloaded })` evaluated to true and still ran compile/setup tasks.

## Steps to Reproduce
### Deterministic repro (pre-fix)
```bash
# From repo root, run build-core with verbose output
./builder server:build-core --verbose | tee /tmp/rr-server-build-core.log

# Observe contradictory markers in same run
rg -n "Server already built|Setup build tools" /tmp/rr-server-build-core.log
```
Expected (correct): If `Server already built` is hit, setup/compile should be skipped.

Actual (pre-fix): Both markers appear, e.g.:
- `Server already built`
- `Setup build tools`

## Root Cause
- In `packages/server/scripts/tasks.js`, `makeDownloadAction()` returned early on local build cache hit without setting a context flag for downstream flow control.
- `makeBuildCoreAction()` relied only on `ctx.downloaded` in `whenNot`, so the local-build-hit branch fell through to compile/setup.

## Fix
- Added `ctx.serverAlreadyBuilt` handling in `makeDownloadAction()`:
  - Reset to `false` at action start.
  - Set to `true` in the `Server already built` branch.
  - Explicitly set to `false` in download success/failure paths.
- Updated `makeBuildCoreAction()` condition:
  - From: `ctx.downloaded`
  - To: `ctx.downloaded || ctx.serverAlreadyBuilt`

## Why This Works
`server:build-core` now receives an explicit signal for both valid skip states:
- downloaded artifact state (`ctx.downloaded === true`), and
- local-built-up-to-date state (`ctx.serverAlreadyBuilt === true`).

So setup/compile steps are only executed when neither skip condition is true.

## Testing / Validation
### Targeted validation
```bash
./builder server:build-core --verbose | tee /tmp/rr-post-fix-final-build-core.log
rg -n "Server already built|Setup build tools|CMake version" /tmp/rr-post-fix-final-build-core.log
```
Outcome (post-fix):
- `Server already built` present
- `Setup build tools` absent

### Downstream validation
```bash
./builder client-python:build --verbose | tee /tmp/rr-final-client-python-build.log
rg -n "server:build-core|Server already built|Setup build tools" /tmp/rr-final-client-python-build.log
```
Outcome:
- `server:build-core` runs
- `Server already built` present
- `Setup build tools` absent

### Full suite command requested
```bash
./builder test --verbose | tee /tmp/rr-final-builder-test.log
```
Outcome on this environment:
- Blocked by local runtime artifact availability (`dist/server/engine` ENOENT) after forcing deterministic already-built state for branch-path verification.
- Command and failure are captured and reported.

## Type
fix

## Checklist
- [x] Tests added/updated (or justified if not possible)
- [x] Tested locally
- [ ] `./builder test` pass status (blocked in this environment; see Testing / Validation)
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues
- None linked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Build process now detects and skips recompilation when the server binary is already current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

#frontier-tower-hackathon

## Impact

This avoids unnecessary rebuild work on already-built local servers, improving reliability and reducing developer build time.

