### PR TITLE
fix(vscode): include README.md in vsix package

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "rocketride",
 	"displayName": "RocketRide",
 	"description": "RocketRide extension for Visual Studio Code",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"publisher": "rocketride",
 	"repository": {
 		"type": "git",

--- a/apps/vscode/scripts/tasks.js
+++ b/apps/vscode/scripts/tasks.js
@@ -158,7 +158,7 @@ function makeStageFilesAction() {
             const pkg = JSON.parse(await readFile(pkgPath));
             pkg.main = './rocketride.js';
             pkg.icon = 'rocketride-dark-icon.png';
-            pkg.files = ['rocketride.js', 'rocketride.js.map', 'webview/**', 'rocketride-dark-icon.png', 'rocketride-light-icon.png', 'docker.svg', 'onprem.svg', 'package.json', 'LICENSE', 'docs/**'];
+            pkg.files = ['rocketride.js', 'rocketride.js.map', 'webview/**', 'rocketride-dark-icon.png', 'rocketride-light-icon.png', 'docker.svg', 'onprem.svg', 'package.json', 'LICENSE', 'README.md', 'docs/**'];
             await writeFile(path.join(BUILD_DIR, 'package.json'), JSON.stringify(pkg, null, 2));
             const iconDark = path.join(APP_ROOT, 'rocketride-dark-icon.png');
             const iconLight = path.join(APP_ROOT, 'rocketride-light-icon.png');


### PR DESCRIPTION
## Summary

README.md was missing from the published .vsix because the staging step's `pkg.files` array didn't include it.

The `vscode:copy-readme` build step correctly copies `docs/README-vscode.md` → `apps/vscode/README.md`, but `makeStageFilesAction` explicitly sets `pkg.files` without `README.md`, so `vsce package` never picks it up.

## Fix

Added `'README.md'` to `pkg.files` in `apps/vscode/scripts/tasks.js`.

Also bumps VS Code extension version to 1.0.3 so the fix gets published.

## Test plan

- [ ] Build locally: `./builder vscode:build`
- [ ] Check `dist/vscode/*.vsix` contains `extension/README.md`