### PR TITLE
fix(tests): assert upload_time

### DIFF
--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -515,7 +515,7 @@ class TestDataOperations:
             assert upload_result['bytes_sent'] == len(test_content)
             assert upload_result['file_size'] == len(test_content)
             assert isinstance(upload_result['upload_time'], (int, float))
-            assert upload_result['upload_time'] > 0
+            assert upload_result['upload_time'] >= 0
             assert 'error' not in upload_result or upload_result['error'] is None
 
             # Validate processing result


### PR DESCRIPTION
## Summary

An unstable error occurred several times during the Google Hackathon in the Python client tests when checking that `upload_time > 0`. The upload may indeed be so fast that upload_time is zero. Fixed by checking `upload_time >= 0`

```
[FAILED] ================================== FAILURES ===================================
[FAILED] _____________ TestDataOperations.test_should_handle_file_uploads ______________
[FAILED] ..\..\packages\client-python\tests\RocketRideClient_test.py:518: in test_should_handle_file_uploads
[FAILED]     assert upload_result['upload_time'] > 0
[FAILED] E   assert 0.0 > 0
[FAILED] =========================== short test summary info ===========================
[FAILED] FAILED ..\..\packages\client-python\tests\RocketRideClient_test.py::TestDataOperations::test_should_handle_file_uploads - assert 0.0 > 0
[FAILED] ============= 1 failed, 42 passed, 6 skipped in 160.82s (0:02:40) =============
```

## Type

fix

## Related Issues

https://github.com/rocketride-org/rocketride-server/actions/runs/23373256718/job/68000930468?pr=304
https://github.com/rocketride-org/rocketride-server/actions/runs/23386796428/job/68079387305?pr=314
https://github.com/rocketride-org/rocketride-server/actions/runs/23389959952/job/68079385309?pr=320



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated file upload time validation to accept zero or positive values, improving test coverage for edge cases in upload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->