### PR TITLE
feat(builder): tika tests

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -1067,6 +1067,7 @@ function makeTestAction() {
                     'server:compile-tests',
                     'server:copy-test-data',
                     parallel([
+                        'tika:submodule-test',
                         'server:run-aptest',
                         'server:run-engtest'
                     ], 'Run tests')

--- a/packages/tika/lib/dbgconn/build.cmd
+++ b/packages/tika/lib/dbgconn/build.cmd
@@ -1,8 +1,0 @@
-@ECHO OFF
-
-for %%i in ("%~dp0..\..\..\..\vcpkg\installed\java") do set JAVA_ROOT=%%~fi
-set "JAVA_HOME=%JAVA_ROOT%\jdk"
-set "JAVA_MAVEN=%JAVA_ROOT%\maven\bin\mvn"
-
-call %JAVA_MAVEN% clean compile assembly:single -q || exit /b
-call %JAVA_MAVEN% test -q || exit /b 1

--- a/packages/tika/lib/dbgconn/build.sh
+++ b/packages/tika/lib/dbgconn/build.sh
@@ -1,6 +1,0 @@
-export JAVA_ROOT=$(cd ../../../../vcpkg/installed/java && pwd)
-export JAVA_HOME=$JAVA_ROOT/jdk
-export JAVA_MAVEN=$JAVA_ROOT/maven/bin/mvn
-
-$JAVA_MAVEN clean compile assembly:single -q || exit 1
-$JAVA_MAVEN test -q || exit 1

--- a/packages/tika/lib/tika/build.cmd
+++ b/packages/tika/lib/tika/build.cmd
@@ -1,8 +1,0 @@
-@ECHO OFF
-
-for %%i in ("%~dp0..\..\..\..\vcpkg\installed\java") do set JAVA_ROOT=%%~fi
-set "JAVA_HOME=%JAVA_ROOT%\jdk"
-set "JAVA_MAVEN=%JAVA_ROOT%\maven\bin\mvn"
-
-call %JAVA_MAVEN% clean compile package dependency:copy-dependencies -q || exit /b
-call %JAVA_MAVEN% test -q || exit /b

--- a/packages/tika/lib/tika/build.sh
+++ b/packages/tika/lib/tika/build.sh
@@ -1,6 +1,0 @@
-export JAVA_ROOT=$(cd ../../../../vcpkg/installed/java && pwd)
-export JAVA_HOME=$JAVA_ROOT/jdk
-export JAVA_MAVEN=$JAVA_ROOT/maven/bin/mvn
-
-$JAVA_MAVEN clean compile package dependency:copy-dependencies -q || exit 1
-$JAVA_MAVEN test -q || exit 1

--- a/packages/tika/scripts/tasks.js
+++ b/packages/tika/scripts/tasks.js
@@ -147,6 +147,26 @@ function makeBuildTikaJarAction(options = {}) {
     };
 }
 
+function makeTestDbgconnAction() {
+    const buildDbgconnDir = path.join(BUILD_DIR, 'lib', 'dbgconn');
+
+    return {
+        run: async (_ctx, task) => {
+            await execMaven(['test', '-q'], { task, cwd: buildDbgconnDir });
+        }
+    };
+}
+
+function makeTestTikaJarAction() {
+    const buildTikaDir = path.join(BUILD_DIR, 'lib', 'tika');
+
+    return {
+        run: async (_ctx, task) => {
+            await execMaven(['test', '-q'], { task, cwd: buildTikaDir });
+        }
+    };
+}
+
 function makeCopyTikaOutputsAction(options = {}) {
     const buildDbgconnDir = path.join(BUILD_DIR, 'lib', 'dbgconn');
     const buildTikaDir = path.join(BUILD_DIR, 'lib', 'tika');
@@ -211,6 +231,8 @@ module.exports = {
         { name: 'tika:build-dbgconn', action: makeBuildDbgconnAction },
         { name: 'tika:build-jar', action: makeBuildTikaJarAction },
         { name: 'tika:sync', action: makeCopyTikaOutputsAction },
+        { name: 'tika:test-dbgconn', action: makeTestDbgconnAction },
+        { name: 'tika:test-jar', action: makeTestTikaJarAction },
 
         // Submodule actions (called by server:build-core / server:clean-all)
         { name: 'tika:submodule-build', action: () => ({
@@ -223,6 +245,15 @@ module.exports = {
                 ], 'Build Java modules'),
                 'tika:sync'
             ]
+        })},
+        { name: 'tika:submodule-test', action: () => ({
+            steps: [
+                'tika:submodule-build',
+                parallel([
+                    'tika:test-dbgconn',
+                    'tika:test-jar'
+                ], 'Test Java modules')
+            ]                
         })},
         { name: 'tika:submodule-clean', action: () => ({
             run: async (ctx, task) => {


### PR DESCRIPTION
## Summary

Add Tika tests.

When we switched to the builder, we lost the ability to run Tika tests. Tika tests are implemented via the `tika:submodule-build` action and integrated into the `server:build` action.

## Type

chore


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced Java module testing infrastructure with improved parallel test execution.

* **Chores**
  * Streamlined build configuration by removing legacy build scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->