### PR TITLE
fix(docs): add missing setup guide referenced by CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ By participating in this project, you agree to abide by our Code of Conduct. Ple
 ### Making Changes
 
 1. Create a new branch from `develop`:
+
    ```bash
    git checkout develop
    git pull origin develop
@@ -36,6 +37,7 @@ By participating in this project, you agree to abide by our Code of Conduct. Ple
    ```
 
 2. Make your changes, ensuring:
+
    - Code follows the project style guidelines
    - All tests pass
    - New code has appropriate tests
@@ -62,6 +64,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 ### Pull Request Process
 
 1. Push your branch to GitHub:
+
    ```bash
    git push origin feature/your-feature-name
    ```
@@ -69,6 +72,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 2. Open a Pull Request against the `develop` branch
 
 3. Fill out the PR template with:
+
    - Description of changes
    - Related issue numbers
    - Testing performed
@@ -108,16 +112,18 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 
 ```bash
 # All tests
-pnpm run test
+./builder test
 
-# C++ tests only
-pnpm run test:native
+# C++ engine tests only
+./builder server:test
 
-# Python tests only
-pnpm run test:python
+# Python tests only (nodes, AI, clients)
+./builder nodes:test
+./builder ai:test
+./builder client-python:test
 
 # TypeScript tests only
-pnpm run test:typescript
+./builder client-typescript:test
 ```
 
 ### Writing Tests
@@ -163,4 +169,3 @@ If you have questions, feel free to:
 - Review closed issues for similar questions
 
 Thank you for contributing to RocketRide Engine!
-

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -92,21 +92,21 @@ For VS Code extension development details, see [README-vscode.md](../README-vsco
 
 ```bash
 # Run all tests
-pnpm run test
+./builder test
 
 # C++ engine tests only
-pnpm run test:native
+./builder server:test
 
-# Python tests only
-pnpm run test:python
+# Python tests only (nodes, AI, clients)
+./builder nodes:test
+./builder ai:test
+./builder client-python:test
 
 # TypeScript tests only
-pnpm run test:typescript
-
-# Test a specific module via the builder
-./builder nodes:test
-./builder server:test
 ./builder client-typescript:test
+
+# Other module tests
+./builder client-mcp:test
 ```
 
 For information on writing and running node-level tests, see [README-node-testing.md](../README-node-testing.md).


### PR DESCRIPTION
## Summary

- Create the missing `docs/setup/README.md` that `CONTRIBUTING.md` links to
- Provides a consolidated development environment setup guide

## Bug Description

**File**: `CONTRIBUTING.md` (line 17)

Step 3 of the Getting Started section links to `[Setup Guide](docs/setup/README.md)`, but this file does not exist. New contributors following the contribution guide immediately hit a dead link on their first step, creating a frustrating onboarding experience.

## Root Cause

The CONTRIBUTING.md was written with the expectation that a setup guide would be created, but the file was never added to the repository.

## Fix

Create `docs/setup/README.md` with a practical, consolidated setup guide covering:
- Prerequisites (Node.js, pnpm, Python, C++ toolchain)
- Clone and dependency installation
- Environment configuration
- Build commands
- Running the server
- Testing

Links to existing detailed docs (README-builder.md, README-engine.md) for deep dives rather than duplicating content.

#frontier-tower-hackathon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive setup guide for local development: prerequisites, OS-specific toolchain notes, cloning, dependency install, environment configuration, build and run workflows (including server and extension), expected outputs, and test instructions using builder-based commands.
  * Updated contributor guide formatting and replaced test scripts with builder-based test commands split by module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->