### PR TITLE
fix(docs): correct supported versions in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,9 +6,8 @@ We release security patches for the following versions:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 3.x.x   | :white_check_mark: |
-| 2.x.x   | :x:                |
-| 1.x.x   | :x:                |
+| 3.1.x   | :white_check_mark: |
+| < 3.1   | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -61,4 +60,3 @@ RocketRide Engine includes several security features:
 - **Audit Logging**: Comprehensive activity logging
 
 Thank you for helping keep RocketRide Engine secure!
-


### PR DESCRIPTION
## Summary

- Fix the supported versions table in SECURITY.md to accurately reflect the current project version

## Bug Description

**File**: `SECURITY.md`

The supported versions table lists `3.x.x` as supported and `2.x.x` / `1.x.x` as unsupported. While the project is at version 3.1.1 (per `package.json`), the table format misleadingly implies that formal 1.x and 2.x release lines existed and are now deprecated. This creates confusion about the project's versioning history and support policy.

## Root Cause

The security policy was likely generated from a template and not updated to match the project's actual versioning scheme.

## Fix

Update the version table to reflect that only the current minor release (3.1.x) receives security patches, with all older versions unsupported.

#frontier-tower-hackathon