### PR TITLE
fix(security): replace dangerouslyAllowAllBuilds with explicit build script allowlist

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,21 +1,30 @@
 # Rocketride Engine Monorepo Workspace Configuration
 # This file defines which directories contain packages in the monorepo
 
-# Allow all dependency postinstall/preinstall scripts to run (disables the
-# default allow-list). Only enable if you trust your dependency graph.
-# See: https://pnpm.io/npmrc#dangerouslyallowallbuilds
-dangerouslyAllowAllBuilds: true
+# Only allow postinstall/install scripts for known, trusted packages that
+# require native compilation or binary downloads.
+# See: https://pnpm.io/npmrc#onlybuiltdependencies
+onlyBuiltDependencies:
+  - '@homebridge/node-pty-prebuilt-multiarch'
+  - 'core-js'
+  - 'cpu-features'
+  - 'esbuild'
+  - 'keytar'
+  - 'lefthook'
+  - 'protobufjs'
+  - 'ssh2'
+  - 'unrs-resolver'
 
 # Mute deprecation warnings for known deprecated (transitive) dependencies.
 # See: https://pnpm.io/npmrc#alloweddeprecatedversions
 allowedDeprecatedVersions:
-  "@mui/styles": "*"
-  glob: "*"
-  deep-diff: "*"
-  popper.js: "*"
-  rimraf: "*"
-  stable: "*"
-  whatwg-encoding: "*"
+  '@mui/styles': '*'
+  glob: '*'
+  deep-diff: '*'
+  popper.js: '*'
+  rimraf: '*'
+  stable: '*'
+  whatwg-encoding: '*'
 
 packages:
   # Shared UI components
@@ -31,4 +40,3 @@ packages:
 
   # Examples
   - 'examples/*'
-


### PR DESCRIPTION
## Summary

- Remove `dangerouslyAllowAllBuilds: true` from pnpm workspace configuration
- Replace with explicit `onlyBuiltDependencies` allowlist of packages that require postinstall scripts

## Bug Description

**File**: `pnpm-workspace.yaml`

The `dangerouslyAllowAllBuilds: true` setting disables pnpm's default protection against arbitrary postinstall script execution. This means every transitive dependency in the dependency tree is allowed to run code during `pnpm install`, creating a significant supply chain attack vector.

A single compromised package anywhere in the dependency graph could execute arbitrary code on developer machines and CI runners during installation.

## Root Cause

The flag was likely enabled early in development to avoid investigating which packages need build scripts, and was never revisited.

## Fix

- Remove `dangerouslyAllowAllBuilds: true`
- Add `onlyBuiltDependencies` with an explicit allowlist of packages that genuinely require postinstall scripts (native addons, binary downloads)
- All other packages' install scripts are blocked by default

## Testing

- Verified `pnpm install` completes successfully with the allowlist
- Verified no packages are broken by the restricted script execution

#frontier-tower-hackathon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process security by updating the configuration to restrict installation script execution to a curated allowlist of packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->