### PR TITLE
fix: resolve undefined variable and wrong field prefix in Astra_DB getPaths()

### DIFF
--- a/nodes/src/nodes/astra_db/astra_db.py
+++ b/nodes/src/nodes/astra_db/astra_db.py
@@ -316,18 +316,18 @@ class Store(DocumentStoreBase):
             return {}
 
         # Build match stage filter
-        match_filter = {'metadata.chunkId': 0}
+        match_filter = {'meta.chunkId': 0}
 
         if parent is not None:
-            match_filter['metadata.parent'] = parent
+            match_filter['meta.parent'] = parent
 
         # Use aggregation pipeline
         pipeline = [
             {'$match': match_filter},
             {
                 '$group': {
-                    '_id': '$metadata.parent',
-                    'objectId': {'$first': '$metadata.objectId'},  # Get any objectId for this parent
+                    '_id': '$meta.parent',
+                    'objectId': {'$first': '$meta.objectId'},
                 }
             },
             {'$skip': offset},
@@ -335,7 +335,8 @@ class Store(DocumentStoreBase):
         ]
 
         # Execute aggregation
-        results = self.collection.aggregate(pipeline)
+        collection = self.database.get_collection(self.collection_name)
+        results = collection.aggregate(pipeline)
 
         # Build paths dictionary
         paths: Dict[str, str] = {}


### PR DESCRIPTION
## Summary

- Fix two bugs in `getPaths()` method of the Astra_DB document store that cause a runtime crash and incorrect queries

## Bug Description

**File:** `nodes/src/nodes/astra_db/astra_db.py` (lines 318–338)  
**Method:** `getPaths()`  
**Severity:** Critical — method is completely non-functional

### Bug 1: Undefined variable `self.collection` (line 338)

```python
results = self.collection.aggregate(pipeline)  # AttributeError!
```

`self.collection` is **never assigned** anywhere in the `Store` class. Every other method in the file correctly retrieves the collection via:

```python
collection = self.database.get_collection(self.collection_name)
```

This pattern appears at lines 238, 256, 279, 300, 360, 440, 459, 478, 498 — but `getPaths()` was written with `self.collection` instead, causing an immediate `AttributeError` crash whenever the method is called.

### Bug 2: Wrong field prefix `metadata.*` instead of `meta.*` (lines 319, 322, 329, 330)

```python
match_filter = {'metadata.chunkId': 0}           # Wrong: 'metadata.'
match_filter['metadata.parent'] = parent          # Wrong: 'metadata.'
'_id': '$metadata.parent',                        # Wrong: 'metadata.'
'objectId': {'$first': '$metadata.objectId'},     # Wrong: 'metadata.'
```

The document schema stores metadata under the `meta` field (as used consistently across every other method in the file):

```python
# Line 152: filter_dict['meta.nodeId'] = docFilter.nodeId
# Line 155: filter_dict['meta.isTable'] = docFilter.isTable
# Line 162: filter_dict['meta.parent'] = ...
# Line 170: filter_dict['meta.objectId'] = ...
# Line 178: filter_dict['meta.chunkId'] = ...
# Line 417: 'meta': chunk.metadata.__dict__,  # Document insertion
```

The `getPaths()` method uses `metadata.*` instead of `meta.*`, so even if Bug 1 were fixed in isolation, the aggregation pipeline would match zero documents and return an empty result.

## Root Cause

Copy-paste error — `getPaths()` was likely written separately from the other methods (possibly from a MongoDB tutorial that uses `metadata` as the default field name) and never updated to match the actual document schema or class API patterns.

## Fix

1. **Line 338:** Replace `self.collection.aggregate(pipeline)` with the standard pattern:
   ```python
   collection = self.database.get_collection(self.collection_name)
   results = collection.aggregate(pipeline)
   ```

2. **Lines 319, 322, 329, 330:** Replace `metadata.` with `meta.` to match the document schema used throughout the file.

### Verification

The fix is provable by inspection:

| Evidence | Location |
|----------|----------|
| `self.collection` never assigned | `grep 'self.collection[^_]'` → only line 338 |
| `self.collection_name` used everywhere else | Lines 65, 107, 134, 238, 256, 279, 300, 360, 440, 459, 478, 498 |
| `meta.*` field prefix used everywhere else | Lines 152, 155, 158, 162, 166, 170, 174, 178, 417, 438, 456, 460, 475, 503 |
| `metadata.*` only in broken `getPaths()` | Lines 319, 322, 329, 330 |

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] All pre-commit hooks pass

#frontier-tower-hackathon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Astra DB aggregation queries for improved field naming and collection resolution, ensuring more reliable data retrieval operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->