### PR TITLE
fix(security): pin twine, vsce, and ovsx versions in release pipeline

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -127,7 +127,7 @@ jobs:
       - name: Publish rocketride to PyPI
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-python'
         run: |
-          pip install twine
+          pip install twine==6.1.0
           VERSION="${{ matrix.version }}"
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/rocketride/${VERSION}/json")
           if [ "$STATUS" = "200" ]; then
@@ -142,7 +142,7 @@ jobs:
       - name: Publish rocketride-mcp to PyPI
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-mcp'
         run: |
-          pip install twine
+          pip install twine==6.1.0
           VERSION="${{ matrix.version }}"
           STATUS=$(curl -s -o /dev/null -w "%{http_code}" "https://pypi.org/pypi/rocketride-mcp/${VERSION}/json")
           if [ "$STATUS" = "200" ]; then
@@ -164,7 +164,7 @@ jobs:
       - name: Publish to VS Code Marketplace
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'vscode'
         run: |
-          npm install -g @vscode/vsce
+          npm install -g @vscode/vsce@3.7.1
           VSIX=$(find release-assets -name '*.vsix' | head -n1)
           echo "Publishing ${VSIX}"
           OUTPUT=$(vsce publish --packagePath "${VSIX}" 2>&1) && exit 0
@@ -180,7 +180,7 @@ jobs:
       - name: Publish to Open VSX
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'vscode'
         run: |
-          npm install -g ovsx
+          npm install -g ovsx@0.10.9
           VSIX=$(find release-assets -name '*.vsix' | head -n1)
           echo "Publishing ${VSIX}"
           OUTPUT=$(ovsx publish "${VSIX}" -p "$OVSX_PAT" 2>&1) && exit 0


### PR DESCRIPTION
## Bug Summary

The release workflow (`.github/workflows/_release.yaml`) installs `twine`, `@vscode/vsce`, and `ovsx` **without version pinning** in steps that have direct access to publishing secrets (`PYPI_TOKEN`, `VSCE_PAT`, `OVSX_PAT`). A supply chain compromise of any of these packages would give an attacker arbitrary code execution in the release pipeline with access to all publishing credentials, enabling them to publish malicious versions of RocketRide to PyPI, VS Code Marketplace, and Open VSX.

## Affected Files and Lines

- `.github/workflows/_release.yaml`
  - **Line 130**: `pip install twine` (has `TWINE_PASSWORD=${{ secrets.PYPI_TOKEN }}` in env)
  - **Line 145**: `pip install twine` (has `TWINE_PASSWORD=${{ secrets.PYPI_TOKEN }}` in env)
  - **Line 167**: `npm install -g @vscode/vsce` (has `VSCE_PAT=${{ secrets.VSCE_PAT }}` in env)
  - **Line 183**: `npm install -g ovsx` (has `OVSX_PAT=${{ secrets.OVSX_PAT }}` in env)

## Root Cause

Unpinned package installs (`pip install twine`, `npm install -g @vscode/vsce`, `npm install -g ovsx`) resolve to whatever version is "latest" at install time. If an attacker compromises any of these packages on npm/PyPI (via account takeover, typosquatting, or registry compromise), the release workflow would automatically pull the malicious version and execute it with full access to publishing secrets.

## Reproduction Steps

1. Open `.github/workflows/_release.yaml`
2. Observe lines 130, 145, 167, and 183 install packages without any version constraint
3. Note that each of these steps has publishing secrets (`PYPI_TOKEN`, `VSCE_PAT`, `OVSX_PAT`) injected as environment variables
4. A compromised package version would execute arbitrary code with access to these secrets during `pip install` or `npm install` (via postinstall scripts for npm, or setup.py for pip)

## Severity: HIGH

- **Impact**: Full compromise of all publishing credentials (PyPI, VS Code Marketplace, Open VSX), enabling an attacker to publish malicious versions of RocketRide to all distribution channels
- **Likelihood**: Medium — supply chain attacks on popular packages are an active and growing threat vector (cf. ua-parser-js, event-stream, codecov)
- **CVSS estimate**: ~8.0 (High)

## Fix Description

Pin each package to a specific known-good version:

- `pip install twine==6.1.0` (lines 130, 145)
- `npm install -g @vscode/vsce@3.7.1` (line 167)
- `npm install -g ovsx@0.10.9` (line 183)

This ensures that even if a malicious version is published to a registry, the release pipeline will not automatically pull it. Version bumps should be done deliberately via PR review.

## Tests/Validation

- The change is purely declarative (YAML workflow pinning) — no runtime tests apply
- Verified that `twine==6.1.0`, `@vscode/vsce@3.7.1`, and `ovsx@0.10.9` are the current latest stable versions on their respective registries
- The diff is minimal: exactly 4 lines changed, one per unpinned install
- No functional behavior changes — only the installed version is locked

#frontier-tower-hackathon