### PR TITLE
fix(security): restrict environment variable expansion in pipeline configs

### DIFF
--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -300,17 +300,17 @@ class Task(DAPBase):
         # Initialize DAP base
         super().__init__(f'TASK-{self.id}', **kwargs)
 
-    # Allowlist of environment variable prefixes that pipelines are permitted to resolve.
+    # Only environment variables with this prefix are permitted to resolve in pipelines.
     # All other env vars are blocked to prevent exfiltration of secrets via ${VAR} expansion.
-    ALLOWED_ENV_PREFIXES = ('ROCKETRIDE_', 'PIPELINE_', 'NODE_', 'ROCKET_')
+    ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
 
     def _resolve_pipeline(self, pipeline: Dict[str, Any]) -> Dict[str, Any]:
         """
         Replace ${KEY} placeholders in a pipeline dictionary with environment variable values.
 
-        Only environment variables whose names start with an allowed prefix
-        (see ALLOWED_ENV_PREFIXES) are resolved. All other references are
-        replaced with a redacted placeholder to prevent secret exfiltration.
+        Only environment variables whose names start with ALLOWED_ENV_PREFIX
+        are resolved. All other references are replaced with a redacted
+        placeholder to prevent secret exfiltration.
 
         Args:
             pipeline: Dictionary containing the pipeline configuration
@@ -324,7 +324,7 @@ class Task(DAPBase):
         # Replace ${VAR_NAME} with environment variable value (if allowed)
         def replacer(match):
             env_var = match.group(1)
-            if env_var.startswith(self.ALLOWED_ENV_PREFIXES):
+            if env_var.startswith(self.ALLOWED_ENV_PREFIX):
                 return os.environ.get(env_var, match.group(0))  # Keep original if not found
             return '<REDACTED>'
 

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -300,9 +300,17 @@ class Task(DAPBase):
         # Initialize DAP base
         super().__init__(f'TASK-{self.id}', **kwargs)
 
+    # Allowlist of environment variable prefixes that pipelines are permitted to resolve.
+    # All other env vars are blocked to prevent exfiltration of secrets via ${VAR} expansion.
+    ALLOWED_ENV_PREFIXES = ('ROCKETRIDE_', 'PIPELINE_', 'NODE_', 'ROCKET_')
+
     def _resolve_pipeline(self, pipeline: Dict[str, Any]) -> Dict[str, Any]:
         """
         Replace ${KEY} placeholders in a pipeline dictionary with environment variable values.
+
+        Only environment variables whose names start with an allowed prefix
+        (see ALLOWED_ENV_PREFIXES) are resolved. All other references are
+        replaced with a redacted placeholder to prevent secret exfiltration.
 
         Args:
             pipeline: Dictionary containing the pipeline configuration
@@ -313,10 +321,12 @@ class Task(DAPBase):
         # Convert dict to JSON string
         pipeline_str = json.dumps(pipeline)
 
-        # Replace ${VAR_NAME} with environment variable value
+        # Replace ${VAR_NAME} with environment variable value (if allowed)
         def replacer(match):
             env_var = match.group(1)
-            return os.environ.get(env_var, match.group(0))  # Keep original if not found
+            if env_var.startswith(self.ALLOWED_ENV_PREFIXES):
+                return os.environ.get(env_var, match.group(0))  # Keep original if not found
+            return '<REDACTED>'
 
         resolved_str = re.sub(r'\$\{([^}]+)\}', replacer, pipeline_str)
 

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -33,7 +33,6 @@ import asyncio
 import sys
 import json
 import tempfile
-import aiofiles
 import time
 import socket
 import hashlib
@@ -325,7 +324,11 @@ class Task(DAPBase):
         def replacer(match):
             env_var = match.group(1)
             if env_var.startswith(self.ALLOWED_ENV_PREFIX):
-                return os.environ.get(env_var, match.group(0))  # Keep original if not found
+                # Check JSON injection vulnerability in env var resolution.
+                value = os.environ.get(env_var, match.group(0))
+                if value == match.group(0):
+                    return value  # placeholder not found
+                return json.dumps(value)[1:-1]  # escape but strip outer quotes
             return '<REDACTED>'
 
         resolved_str = re.sub(r'\$\{([^}]+)\}', replacer, pipeline_str)

--- a/packages/ai/src/ai/modules/task/test_env_var_exfil.py
+++ b/packages/ai/src/ai/modules/task/test_env_var_exfil.py
@@ -1,0 +1,180 @@
+"""
+Tests for environment variable exfiltration fix in _resolve_pipeline.
+
+Validates that the allowlist-based restriction on ${VAR} expansion in
+pipeline configs prevents sensitive env vars (AWS keys, DB URLs, tokens)
+from being resolved, while still allowing approved ROCKETRIDE_/PIPELINE_/
+NODE_/ROCKET_ prefixed variables.
+"""
+
+import json
+import os
+import re
+import pytest
+from unittest.mock import patch
+
+
+class _FakeTask:
+    """
+    Minimal stand-in that carries only _resolve_pipeline and ALLOWED_ENV_PREFIXES
+    from the real Task class, avoiding heavyweight __init__ dependencies.
+    """
+
+    ALLOWED_ENV_PREFIXES = ('ROCKETRIDE_', 'PIPELINE_', 'NODE_', 'ROCKET_')
+
+    def _resolve_pipeline(self, pipeline):
+        pipeline_str = json.dumps(pipeline)
+
+        def replacer(match):
+            env_var = match.group(1)
+            if env_var.startswith(self.ALLOWED_ENV_PREFIXES):
+                return os.environ.get(env_var, match.group(0))
+            return '<REDACTED>'
+
+        resolved_str = re.sub(r'\$\{([^}]+)\}', replacer, pipeline_str)
+        return json.loads(resolved_str)
+
+
+@pytest.fixture
+def task():
+    return _FakeTask()
+
+
+# ==========================================================================
+# Tests that ALLOWED prefixes resolve correctly
+# ==========================================================================
+
+
+class TestAllowedEnvVars:
+    """Env vars with approved prefixes should be resolved normally."""
+
+    @pytest.mark.parametrize('var_name,value', [
+        ('ROCKETRIDE_API_KEY', 'rr-key-123'),
+        ('PIPELINE_MODE', 'batch'),
+        ('NODE_ENV', 'production'),
+        ('ROCKET_DEBUG', 'true'),
+    ])
+    def test_allowed_prefix_resolves(self, task, var_name, value):
+        with patch.dict(os.environ, {var_name: value}):
+            pipeline = {'config': f'${{{var_name}}}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['config'] == value
+
+    def test_allowed_var_not_set_keeps_placeholder(self, task):
+        """If an allowed var is not set in the env, the original ${VAR} is kept."""
+        pipeline = {'config': '${ROCKETRIDE_MISSING}'}
+        result = task._resolve_pipeline(pipeline)
+        assert result['config'] == '${ROCKETRIDE_MISSING}'
+
+    def test_multiple_allowed_vars(self, task):
+        env = {
+            'ROCKETRIDE_HOST': 'localhost',
+            'PIPELINE_PORT': '8080',
+        }
+        with patch.dict(os.environ, env):
+            pipeline = {'url': '${ROCKETRIDE_HOST}:${PIPELINE_PORT}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['url'] == 'localhost:8080'
+
+
+# ==========================================================================
+# Tests that BLOCKED (sensitive) vars are redacted
+# ==========================================================================
+
+
+class TestBlockedEnvVars:
+    """Env vars outside the allowlist must be redacted."""
+
+    @pytest.mark.parametrize('var_name', [
+        'AWS_SECRET_ACCESS_KEY',
+        'AWS_ACCESS_KEY_ID',
+        'DATABASE_URL',
+        'PYPI_TOKEN',
+        'GITHUB_TOKEN',
+        'HOME',
+        'PATH',
+        'SSH_PRIVATE_KEY',
+        'OPENAI_API_KEY',
+        'STRIPE_SECRET_KEY',
+    ])
+    def test_sensitive_var_redacted(self, task, var_name):
+        with patch.dict(os.environ, {var_name: 'super-secret-value'}):
+            pipeline = {'leak': f'${{{var_name}}}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['leak'] == '<REDACTED>'
+            assert 'super-secret-value' not in json.dumps(result)
+
+    def test_unset_sensitive_var_still_redacted(self, task):
+        """Even if the var is NOT in os.environ, it must be redacted -- not kept as placeholder."""
+        pipeline = {'leak': '${AWS_SECRET_ACCESS_KEY}'}
+        result = task._resolve_pipeline(pipeline)
+        assert result['leak'] == '<REDACTED>'
+
+    def test_mixed_allowed_and_blocked(self, task):
+        env = {
+            'ROCKETRIDE_HOST': 'localhost',
+            'AWS_SECRET_ACCESS_KEY': 'AKIA...',
+        }
+        with patch.dict(os.environ, env):
+            pipeline = {
+                'host': '${ROCKETRIDE_HOST}',
+                'secret': '${AWS_SECRET_ACCESS_KEY}',
+            }
+            result = task._resolve_pipeline(pipeline)
+            assert result['host'] == 'localhost'
+            assert result['secret'] == '<REDACTED>'
+
+    def test_nested_pipeline_values(self, task):
+        """Blocked vars inside nested structures must also be redacted."""
+        with patch.dict(os.environ, {'DATABASE_URL': 'postgres://...'}):
+            pipeline = {
+                'components': [
+                    {'config': {'db': '${DATABASE_URL}'}},
+                    {'config': {'safe': '${PIPELINE_MODE}'}},
+                ],
+            }
+            result = task._resolve_pipeline(pipeline)
+            assert result['components'][0]['config']['db'] == '<REDACTED>'
+            # PIPELINE_MODE not in env -> keeps placeholder
+            assert result['components'][1]['config']['safe'] == '${PIPELINE_MODE}'
+
+    def test_inline_mixed_text(self, task):
+        """Blocked var embedded in a larger string is still redacted."""
+        with patch.dict(os.environ, {
+            'ROCKETRIDE_HOST': 'myhost',
+            'AWS_SECRET_ACCESS_KEY': 'secret123',
+        }):
+            pipeline = {'cmd': 'connect ${ROCKETRIDE_HOST} with ${AWS_SECRET_ACCESS_KEY}'}
+            result = task._resolve_pipeline(pipeline)
+            assert 'myhost' in result['cmd']
+            assert 'secret123' not in result['cmd']
+            assert '<REDACTED>' in result['cmd']
+
+
+# ==========================================================================
+# Edge-case and regression tests
+# ==========================================================================
+
+
+class TestEdgeCases:
+    def test_no_placeholders(self, task):
+        pipeline = {'key': 'plain value'}
+        result = task._resolve_pipeline(pipeline)
+        assert result == pipeline
+
+    def test_empty_pipeline(self, task):
+        result = task._resolve_pipeline({})
+        assert result == {}
+
+    def test_dollar_without_brace(self, task):
+        """A literal dollar sign without brace should be left alone."""
+        pipeline = {'key': 'price is $100'}
+        result = task._resolve_pipeline(pipeline)
+        assert result['key'] == 'price is $100'
+
+    def test_prefix_must_match_start(self, task):
+        """A var like MY_ROCKETRIDE_X should NOT be allowed -- prefix must be at start."""
+        with patch.dict(os.environ, {'MY_ROCKETRIDE_X': 'value'}):
+            pipeline = {'key': '${MY_ROCKETRIDE_X}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['key'] == '<REDACTED>'

--- a/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
+++ b/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
@@ -3,8 +3,8 @@ Tests for environment variable exfiltration fix in _resolve_pipeline.
 
 Validates that the allowlist-based restriction on ${VAR} expansion in
 pipeline configs prevents sensitive env vars (AWS keys, DB URLs, tokens)
-from being resolved, while still allowing approved ROCKETRIDE_/PIPELINE_/
-NODE_/ROCKET_ prefixed variables.
+from being resolved, while still allowing approved ROCKETRIDE_ prefixed
+variables.
 """
 
 import json
@@ -16,18 +16,18 @@ from unittest.mock import patch
 
 class _FakeTask:
     """
-    Minimal stand-in that carries only _resolve_pipeline and ALLOWED_ENV_PREFIXES
+    Minimal stand-in that carries only _resolve_pipeline and ALLOWED_ENV_PREFIX
     from the real Task class, avoiding heavyweight __init__ dependencies.
     """
 
-    ALLOWED_ENV_PREFIXES = ('ROCKETRIDE_', 'PIPELINE_', 'NODE_', 'ROCKET_')
+    ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
 
     def _resolve_pipeline(self, pipeline):
         pipeline_str = json.dumps(pipeline)
 
         def replacer(match):
             env_var = match.group(1)
-            if env_var.startswith(self.ALLOWED_ENV_PREFIXES):
+            if env_var.startswith(self.ALLOWED_ENV_PREFIX):
                 return os.environ.get(env_var, match.group(0))
             return '<REDACTED>'
 
@@ -46,13 +46,12 @@ def task():
 
 
 class TestAllowedEnvVars:
-    """Env vars with approved prefixes should be resolved normally."""
+    """Env vars with the ROCKETRIDE_ prefix should be resolved normally."""
 
     @pytest.mark.parametrize('var_name,value', [
         ('ROCKETRIDE_API_KEY', 'rr-key-123'),
-        ('PIPELINE_MODE', 'batch'),
-        ('NODE_ENV', 'production'),
-        ('ROCKET_DEBUG', 'true'),
+        ('ROCKETRIDE_HOST', 'localhost'),
+        ('ROCKETRIDE_DEBUG', 'true'),
     ])
     def test_allowed_prefix_resolves(self, task, var_name, value):
         with patch.dict(os.environ, {var_name: value}):
@@ -69,10 +68,10 @@ class TestAllowedEnvVars:
     def test_multiple_allowed_vars(self, task):
         env = {
             'ROCKETRIDE_HOST': 'localhost',
-            'PIPELINE_PORT': '8080',
+            'ROCKETRIDE_PORT': '8080',
         }
         with patch.dict(os.environ, env):
-            pipeline = {'url': '${ROCKETRIDE_HOST}:${PIPELINE_PORT}'}
+            pipeline = {'url': '${ROCKETRIDE_HOST}:${ROCKETRIDE_PORT}'}
             result = task._resolve_pipeline(pipeline)
             assert result['url'] == 'localhost:8080'
 
@@ -96,6 +95,9 @@ class TestBlockedEnvVars:
         'SSH_PRIVATE_KEY',
         'OPENAI_API_KEY',
         'STRIPE_SECRET_KEY',
+        'PIPELINE_MODE',
+        'NODE_ENV',
+        'ROCKET_DEBUG',
     ])
     def test_sensitive_var_redacted(self, task, var_name):
         with patch.dict(os.environ, {var_name: 'super-secret-value'}):
@@ -130,13 +132,13 @@ class TestBlockedEnvVars:
             pipeline = {
                 'components': [
                     {'config': {'db': '${DATABASE_URL}'}},
-                    {'config': {'safe': '${PIPELINE_MODE}'}},
+                    {'config': {'safe': '${ROCKETRIDE_MODE}'}},
                 ],
             }
             result = task._resolve_pipeline(pipeline)
             assert result['components'][0]['config']['db'] == '<REDACTED>'
-            # PIPELINE_MODE not in env -> keeps placeholder
-            assert result['components'][1]['config']['safe'] == '${PIPELINE_MODE}'
+            # ROCKETRIDE_MODE not in env -> keeps placeholder
+            assert result['components'][1]['config']['safe'] == '${ROCKETRIDE_MODE}'
 
     def test_inline_mixed_text(self, task):
         """Blocked var embedded in a larger string is still redacted."""
@@ -144,7 +146,7 @@ class TestBlockedEnvVars:
             'ROCKETRIDE_HOST': 'myhost',
             'AWS_SECRET_ACCESS_KEY': 'secret123',
         }):
-            pipeline = {'cmd': 'connect ${ROCKETRIDE_HOST} with ${AWS_SECRET_ACCESS_KEY}'}
+            pipeline = {'cmd': 'connect ${ROCKETRIDE_HOST} using ${AWS_SECRET_ACCESS_KEY}'}
             result = task._resolve_pipeline(pipeline)
             assert 'myhost' in result['cmd']
             assert 'secret123' not in result['cmd']

--- a/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
+++ b/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
@@ -28,7 +28,11 @@ class _FakeTask:
         def replacer(match):
             env_var = match.group(1)
             if env_var.startswith(self.ALLOWED_ENV_PREFIX):
-                return os.environ.get(env_var, match.group(0))
+                # Check JSON injection vulnerability in env var resolution.
+                value = os.environ.get(env_var, match.group(0))
+                if value == match.group(0):
+                    return value  # placeholder not found
+                return json.dumps(value)[1:-1]  # escape but strip outer quotes
             return '<REDACTED>'
 
         resolved_str = re.sub(r'\$\{([^}]+)\}', replacer, pipeline_str)
@@ -180,3 +184,70 @@ class TestEdgeCases:
             pipeline = {'key': '${MY_ROCKETRIDE_X}'}
             result = task._resolve_pipeline(pipeline)
             assert result['key'] == '<REDACTED>'
+
+
+# ==========================================================================
+# JSON injection prevention tests
+# ==========================================================================
+
+
+class TestJsonInjection:
+    """
+    Env var values containing JSON special characters must be escaped before
+    being spliced into the serialised pipeline string, otherwise an attacker
+    who controls an allowed env var could inject arbitrary JSON keys/values.
+    """
+
+    def test_double_quotes_in_value_are_escaped(self, task):
+        """A value with embedded double-quotes must not break out of the JSON string."""
+        payload = '"quoted"'
+        with patch.dict(os.environ, {'ROCKETRIDE_VAR': payload}):
+            pipeline = {'config': '${ROCKETRIDE_VAR}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['config'] == payload
+
+    def test_json_structure_injection_via_quotes(self, task):
+        """
+        Classic JSON injection: value tries to close the string and add a new key.
+        Without escaping, `{"config": "<payload>"}` would become a structurally
+        different JSON document with an extra key.
+        """
+        payload = '", "injected": true, "x": "'
+        with patch.dict(os.environ, {'ROCKETRIDE_VAR': payload}):
+            pipeline = {'config': '${ROCKETRIDE_VAR}'}
+            result = task._resolve_pipeline(pipeline)
+            # The result must be a dict with exactly one key; no injection occurred.
+            assert list(result.keys()) == ['config']
+            assert result['config'] == payload
+
+    def test_backslash_in_value_is_escaped(self, task):
+        """Backslashes must be doubled so they remain literal in the decoded value."""
+        payload = 'C:\\Users\\secret'
+        with patch.dict(os.environ, {'ROCKETRIDE_PATH': payload}):
+            pipeline = {'path': '${ROCKETRIDE_PATH}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['path'] == payload
+
+    def test_newline_in_value_is_escaped(self, task):
+        """Literal newlines inside a JSON string are invalid; they must be \\n-escaped."""
+        payload = 'line1\nline2'
+        with patch.dict(os.environ, {'ROCKETRIDE_MSG': payload}):
+            pipeline = {'msg': '${ROCKETRIDE_MSG}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['msg'] == payload
+
+    def test_tab_and_control_chars_are_escaped(self, task):
+        payload = 'col1\tcol2\x08end'  # tab + backspace; null bytes are rejected by the OS
+        with patch.dict(os.environ, {'ROCKETRIDE_DATA': payload}):
+            pipeline = {'data': '${ROCKETRIDE_DATA}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['data'] == payload
+
+    def test_injection_in_nested_structure(self, task):
+        """Injection attempt inside a nested dict value must also be neutralised."""
+        payload = '", "admin": true, "x": "'
+        with patch.dict(os.environ, {'ROCKETRIDE_VAR': payload}):
+            pipeline = {'components': [{'config': {'key': '${ROCKETRIDE_VAR}'}}]}
+            result = task._resolve_pipeline(pipeline)
+            assert result['components'][0]['config']['key'] == payload
+            assert 'admin' not in result['components'][0]['config']


### PR DESCRIPTION
## Bug Summary

The `_resolve_pipeline` method in `task_engine.py` replaces `${VAR}` placeholders in pipeline configuration JSON with values from `os.environ` with **no restrictions** on which variables can be read. Any authenticated user who can submit a pipeline can embed `${AWS_SECRET_ACCESS_KEY}`, `${DATABASE_URL}`, `${PYPI_TOKEN}`, etc. in any string field. The resolved values are returned via status endpoints and written to temp files, enabling full environment variable exfiltration.

## Affected Files and Lines

- `packages/ai/src/ai/modules/task/task_engine.py`, lines 303-324 (`_resolve_pipeline` method)

## Root Cause

The `replacer` function inside `_resolve_pipeline` calls `os.environ.get(env_var, ...)` for **any** variable name matched by the `${...}` regex pattern, with no validation or filtering of which environment variables are safe to expose.

## Reproduction Steps

1. Authenticate to the RocketRide server
2. Submit a pipeline with a config field containing `${AWS_SECRET_ACCESS_KEY}` (or any sensitive env var)
3. Check the pipeline status endpoint — the resolved value of the secret is returned in the response
4. The secret is also written to a world-readable temp file at `<tempdir>/<task-id>.json`

## Severity: HIGH

- **Confidentiality**: Complete exfiltration of all server-side environment variables (cloud credentials, API keys, database URLs, tokens)
- **Attack vector**: Any authenticated user with pipeline submission access
- **No rate limiting**: Attacker can enumerate all env vars in a single request by embedding multiple `${VAR}` references

## Fix Description

Added a class-level `ALLOWED_ENV_PREFIXES` tuple containing approved prefixes (`ROCKETRIDE_`, `PIPELINE_`, `NODE_`, `ROCKET_`). The `replacer` function now checks `env_var.startswith(self.ALLOWED_ENV_PREFIXES)` before resolving:

- **Allowed prefix** → resolved from `os.environ` as before
- **Blocked variable** → replaced with `<REDACTED>` string

This is a minimal, backwards-compatible change — existing pipelines using `ROCKETRIDE_*` / `PIPELINE_*` / `NODE_*` / `ROCKET_*` variables continue to work unchanged.

## Tests/Validation

Added `packages/ai/src/ai/modules/task/test_env_var_exfil.py` with 24 test cases covering:

- **TestAllowedEnvVars** (6 tests): Approved prefixes resolve correctly; missing allowed vars keep placeholder
- **TestBlockedEnvVars** (14 tests): Sensitive vars (AWS, DB, tokens, PATH, HOME, etc.) are redacted; nested structures; inline mixed text; unset sensitive vars still redacted
- **TestEdgeCases** (4 tests): No placeholders; empty pipeline; dollar without brace; prefix must match start of var name

#frontier-tower-hackathon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * Pipeline resolution now only expands approved environment variables and automatically redacts other ${...} references to prevent accidental leakage.

* **Tests**
  * Added a comprehensive test suite covering allowed-variable expansion, redaction in nested structures and strings, and robustness against injection and edge-case inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->