### PR TITLE
fix(security): prevent path traversal in S3 and Azure store providers

### DIFF
--- a/packages/ai/src/ai/account/store_providers/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure.py
@@ -340,7 +340,13 @@ class AzureBlobStore(IStore):
 
     def _get_blob_name(self, path: str) -> str:
         """Convert relative path to blob name."""
+        import posixpath
+
         path = path.replace('\\', '/')
         if self._prefix:
-            return f'{self._prefix}/{path}'
-        return path
+            full_name = posixpath.normpath(f'{self._prefix}/{path}')
+            # Ensure the resolved name stays within the prefix
+            if not full_name.startswith(self._prefix + '/') and full_name != self._prefix:
+                raise StorageError(f'Path traversal detected: {path}')
+            return full_name
+        return posixpath.normpath(path)

--- a/packages/ai/src/ai/account/store_providers/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3.py
@@ -348,7 +348,13 @@ class S3Store(IStore):
 
     def _get_key(self, path: str) -> str:
         """Convert relative path to S3 key."""
+        import posixpath
+
         path = path.replace('\\', '/')
         if self._prefix:
-            return f'{self._prefix}/{path}'
-        return path
+            full_key = posixpath.normpath(f'{self._prefix}/{path}')
+            # Ensure the resolved key stays within the prefix
+            if not full_key.startswith(self._prefix + '/') and full_key != self._prefix:
+                raise StorageError(f'Path traversal detected: {path}')
+            return full_key
+        return posixpath.normpath(path)

--- a/packages/ai/tests/ai/account/test_path_traversal.py
+++ b/packages/ai/tests/ai/account/test_path_traversal.py
@@ -1,0 +1,135 @@
+"""Tests for path traversal prevention in S3 and Azure store providers.
+
+These tests validate that _get_key (S3) and _get_blob_name (Azure) reject
+path traversal attempts (e.g., ../../other-tenant/) while allowing legitimate
+nested paths and safe relative references within the prefix boundary.
+
+The tests construct store instances via object.__new__ to avoid __init__
+side effects and external dependencies (boto3, azure SDK, etc.).
+"""
+
+import pytest
+
+from ai.account.store import StorageError
+from ai.account.store_providers.s3 import S3Store
+from ai.account.store_providers.azure import AzureBlobStore
+
+
+# ===========================================================================
+# S3 path traversal tests
+# ===========================================================================
+
+
+class TestS3PathTraversal:
+    """Test path traversal prevention in S3Store._get_key."""
+
+    def _make_store(self, prefix: str = 'tenant-123/data') -> S3Store:
+        """Create an S3Store instance without connecting to AWS."""
+        store = object.__new__(S3Store)
+        store._bucket = 'test-bucket'
+        store._prefix = prefix
+        store._s3_client = None
+        store._access_key_id = None
+        store._secret_access_key = None
+        store._region = 'us-east-1'
+        return store
+
+    def test_normal_path(self):
+        """Normal paths should resolve correctly."""
+        store = self._make_store()
+        assert store._get_key('file.txt') == 'tenant-123/data/file.txt'
+
+    def test_nested_path(self):
+        """Nested subdirectory paths should resolve correctly."""
+        store = self._make_store()
+        assert store._get_key('subdir/file.txt') == 'tenant-123/data/subdir/file.txt'
+
+    def test_traversal_with_dotdot(self):
+        """../../ escaping the prefix must be rejected."""
+        store = self._make_store()
+        with pytest.raises(StorageError, match='Path traversal detected'):
+            store._get_key('../../other-tenant/secrets.txt')
+
+    def test_traversal_single_dotdot(self):
+        """Single ../ escaping a shallow prefix must be rejected."""
+        store = self._make_store(prefix='tenant-123')
+        with pytest.raises(StorageError, match='Path traversal detected'):
+            store._get_key('../other-tenant/file.txt')
+
+    def test_traversal_backslash(self):
+        """Backslash-based traversal must be rejected."""
+        store = self._make_store()
+        with pytest.raises(StorageError, match='Path traversal detected'):
+            store._get_key('..\\..\\other-tenant\\secrets.txt')
+
+    def test_safe_internal_dotdot(self):
+        """A ../ that stays within the prefix boundary should be allowed."""
+        store = self._make_store()
+        result = store._get_key('subdir/../file.txt')
+        assert result == 'tenant-123/data/file.txt'
+
+    def test_no_prefix_normalization(self):
+        """Without a prefix, paths should still be normalized."""
+        store = self._make_store(prefix='')
+        result = store._get_key('subdir/../file.txt')
+        assert result == 'file.txt'
+
+
+# ===========================================================================
+# Azure path traversal tests
+# ===========================================================================
+
+
+class TestAzurePathTraversal:
+    """Test path traversal prevention in AzureBlobStore._get_blob_name."""
+
+    def _make_store(self, prefix: str = 'tenant-123/data') -> AzureBlobStore:
+        """Create an AzureBlobStore instance without connecting to Azure."""
+        store = object.__new__(AzureBlobStore)
+        store._container = 'test-container'
+        store._prefix = prefix
+        store._blob_service_client = None
+        store._account_name = None
+        store._account_key = None
+        store._connection_string = None
+        return store
+
+    def test_normal_path(self):
+        """Normal paths should resolve correctly."""
+        store = self._make_store()
+        assert store._get_blob_name('file.txt') == 'tenant-123/data/file.txt'
+
+    def test_nested_path(self):
+        """Nested subdirectory paths should resolve correctly."""
+        store = self._make_store()
+        assert store._get_blob_name('subdir/file.txt') == 'tenant-123/data/subdir/file.txt'
+
+    def test_traversal_with_dotdot(self):
+        """../../ escaping the prefix must be rejected."""
+        store = self._make_store()
+        with pytest.raises(StorageError, match='Path traversal detected'):
+            store._get_blob_name('../../other-tenant/secrets.txt')
+
+    def test_traversal_single_dotdot(self):
+        """Single ../ escaping a shallow prefix must be rejected."""
+        store = self._make_store(prefix='tenant-123')
+        with pytest.raises(StorageError, match='Path traversal detected'):
+            store._get_blob_name('../other-tenant/file.txt')
+
+    def test_traversal_backslash(self):
+        """Backslash-based traversal must be rejected."""
+        store = self._make_store()
+        with pytest.raises(StorageError, match='Path traversal detected'):
+            store._get_blob_name('..\\..\\other-tenant\\secrets.txt')
+
+    def test_safe_internal_dotdot(self):
+        """A ../ that stays within the prefix boundary should be allowed."""
+        store = self._make_store()
+        result = store._get_blob_name('subdir/../file.txt')
+        assert result == 'tenant-123/data/file.txt'
+
+    def test_no_prefix_normalization(self):
+        """Without a prefix, paths should still be normalized."""
+        store = self._make_store(prefix='')
+        result = store._get_blob_name('subdir/../file.txt')
+        assert result == 'file.txt'


### PR DESCRIPTION
## Bug Summary

The S3 and Azure storage providers lack path traversal validation in their key/blob-name construction methods. Unlike `FilesystemStore`, which properly uses `Path.resolve()` and `Path.relative_to()` to prevent `../` escapes, the cloud providers simply concatenate the configured prefix with the user-supplied path. A `project_id` or `source` parameter containing `../../other-user/` can escape the intended directory structure and access other tenants' data on S3/Azure.

## Affected Files and Lines

- `packages/ai/src/ai/account/store_providers/s3.py` — `S3Store._get_key()` (lines 349-354)
- `packages/ai/src/ai/account/store_providers/azure.py` — `AzureBlobStore._get_blob_name()` (lines 341-346)

## Root Cause

Both methods perform only a backslash-to-forward-slash replacement and then concatenate the prefix with the path:

```python
def _get_key(self, path: str) -> str:
    path = path.replace('\\', '/')
    if self._prefix:
        return f'{self._prefix}/{path}'
    return path
```

No normalization or boundary check is applied, so `../` sequences in the path escape the prefix boundary.

## Reproduction Steps

1. Configure an S3Store or AzureBlobStore with prefix `tenant-A/data`
2. Call `_get_key('../../tenant-B/secrets.txt')` (or the Azure equivalent)
3. **Before fix**: returns `tenant-A/data/../../tenant-B/secrets.txt`, which S3/Azure resolves to `tenant-B/secrets.txt` — cross-tenant access
4. **After fix**: raises `StorageError('Path traversal detected: ...')`

## Severity: HIGH

Cross-tenant data access in a multi-tenant cloud storage system. Any API endpoint that accepts user-supplied file paths and passes them through to the store providers is affected.

## Fix Description

Added path traversal validation to both `_get_key()` (S3) and `_get_blob_name()` (Azure):
1. Use `posixpath.normpath()` to canonicalize the full key/blob-name (resolves `../` sequences)
2. Verify the normalized result still starts with the configured prefix
3. Raise `StorageError` if traversal is detected

This mirrors the approach used by `FilesystemStore._get_full_path()`, which uses `Path.resolve()` + `Path.relative_to()` for the same purpose.

## Tests/Validation

Added `packages/ai/tests/ai/account/test_path_traversal.py` with 14 test cases (7 per provider) covering:
- Normal paths resolve correctly
- Nested subdirectory paths work
- `../../` escaping the prefix is rejected
- Single `../` escaping a shallow prefix is rejected
- Backslash-based traversal (`..\\..\\`) is rejected
- Safe internal `../` (stays within prefix) is allowed
- No-prefix mode still normalizes paths

#frontier-tower-hackathon