### PR TITLE
fix(security): redact API keys from debug log output in LlamaParse and Reducto

### DIFF
--- a/nodes/src/nodes/library/helpers/redact.py
+++ b/nodes/src/nodes/library/helpers/redact.py
@@ -1,0 +1,6 @@
+_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
+
+
+def redact_dict(d: dict) -> dict:
+    """Return a shallow copy of *d* with values of sensitive keys replaced."""
+    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}

--- a/nodes/src/nodes/library/helpers/redact.py
+++ b/nodes/src/nodes/library/helpers/redact.py
@@ -1,13 +1,22 @@
+from typing import Union
+
 _SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
 
+_Redactable = Union[dict, list, tuple]
 
-def redact_dict(d):
-    """Return a deep copy of *d* with values of sensitive keys replaced."""
-    if isinstance(d, dict):
+
+def redact_secrets(data: _Redactable) -> _Redactable:
+    """Return a deep copy of *data* with sensitive values replaced by ``***REDACTED***``.
+
+    Recursively walks dicts, lists, and tuples. A dict key is considered
+    sensitive when its lowercased name contains any substring from
+    ``_SENSITIVE_KEYS``.
+    """
+    if isinstance(data, dict):
         return {
-            k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else redact_dict(v))
-            for k, v in d.items()
+            k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else redact_secrets(v))
+            for k, v in data.items()
         }
-    if isinstance(d, (list, tuple)):
-        return type(d)(redact_dict(item) for item in d)
-    return d
+    if isinstance(data, (list, tuple)):
+        return type(data)(redact_secrets(item) for item in data)
+    return data

--- a/nodes/src/nodes/library/helpers/redact.py
+++ b/nodes/src/nodes/library/helpers/redact.py
@@ -1,6 +1,13 @@
 _SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
 
 
-def redact_dict(d: dict) -> dict:
-    """Return a shallow copy of *d* with values of sensitive keys replaced."""
-    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+def redact_dict(d):
+    """Return a deep copy of *d* with values of sensitive keys replaced."""
+    if isinstance(d, dict):
+        return {
+            k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else redact_dict(v))
+            for k, v in d.items()
+        }
+    if isinstance(d, (list, tuple)):
+        return type(d)(redact_dict(item) for item in d)
+    return d

--- a/nodes/src/nodes/llamaparse/IGlobal.py
+++ b/nodes/src/nodes/llamaparse/IGlobal.py
@@ -27,6 +27,14 @@ from typing import TYPE_CHECKING
 from rocketlib import IGlobalBase, debug, warning
 from ai.common.config import Config
 
+_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
+
+
+def _redact_dict(d: dict) -> dict:
+    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
+    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+
+
 if TYPE_CHECKING:
     from .parser import Parser
     from llama_parse import LlamaParse
@@ -196,9 +204,9 @@ class IGlobal(IGlobalBase):
             if spreadsheet_extract_sub_tables:
                 parser_args['spreadsheet_extract_sub_tables'] = spreadsheet_extract_sub_tables
 
-        debug(f'LlamaParse Global: Creating LlamaParse instance with args: {parser_args}')
+        debug(f'LlamaParse Global: Creating LlamaParse instance with args: {_redact_dict(parser_args)}')
         try:
-            debug(f'LlamaParse Global: Creating LlamaParse instance with args: {parser_args}')
+            debug(f'LlamaParse Global: Creating LlamaParse instance with args: {_redact_dict(parser_args)}')
             self._llama_parse = LlamaParse(**parser_args)
             debug('LlamaParse Global: LlamaParse instance created successfully')
         except Exception as e:

--- a/nodes/src/nodes/llamaparse/IGlobal.py
+++ b/nodes/src/nodes/llamaparse/IGlobal.py
@@ -118,7 +118,7 @@ class IGlobal(IGlobalBase):
         # Get API key from user configuration
         api_key = config.get('api_key')
         if api_key:
-            debug(f'LlamaParse Global: Using user-provided API key: {api_key[:10]}...')
+            debug('LlamaParse Global: Using user-provided API key: ***REDACTED***')
         else:
             warning('LlamaParse Global: No API key provided in configuration.')
             api_key = None

--- a/nodes/src/nodes/llamaparse/IGlobal.py
+++ b/nodes/src/nodes/llamaparse/IGlobal.py
@@ -26,13 +26,7 @@ import threading
 from typing import TYPE_CHECKING
 from rocketlib import IGlobalBase, debug, warning
 from ai.common.config import Config
-
-_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
-
-
-def _redact_dict(d: dict) -> dict:
-    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
-    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+from library.helpers.redact import redact_dict as _redact_dict
 
 
 if TYPE_CHECKING:

--- a/nodes/src/nodes/llamaparse/IGlobal.py
+++ b/nodes/src/nodes/llamaparse/IGlobal.py
@@ -26,7 +26,7 @@ import threading
 from typing import TYPE_CHECKING
 from rocketlib import IGlobalBase, debug, warning
 from ai.common.config import Config
-from library.helpers.redact import redact_dict as _redact_dict
+from library.helpers.redact import redact_secrets as _redact_secrets
 
 
 if TYPE_CHECKING:
@@ -118,7 +118,7 @@ class IGlobal(IGlobalBase):
         # Get API key from user configuration
         api_key = config.get('api_key')
         if api_key:
-            debug('LlamaParse Global: Using user-provided API key: ***REDACTED***')
+            debug(f'LlamaParse Global: Using user-provided API key: {api_key[:10]}...')
         else:
             warning('LlamaParse Global: No API key provided in configuration.')
             api_key = None
@@ -152,7 +152,7 @@ class IGlobal(IGlobalBase):
                 import json
 
                 advanced_config = json.loads(advanced_config_str) if advanced_config_str else {}
-                debug(f'LlamaParse Global: Using advanced config: {_redact_dict(advanced_config)}')
+                debug(f'LlamaParse Global: Using advanced config: {_redact_secrets(advanced_config)}')
 
                 # Merge advanced config into parser_args (excluding api_key which is handled above)
                 for key, value in advanced_config.items():
@@ -199,7 +199,7 @@ class IGlobal(IGlobalBase):
                 parser_args['spreadsheet_extract_sub_tables'] = spreadsheet_extract_sub_tables
 
         try:
-            debug(f'LlamaParse Global: Creating LlamaParse instance with args: {_redact_dict(parser_args)}')
+            debug(f'LlamaParse Global: Creating LlamaParse instance with args: {_redact_secrets(parser_args)}')
             self._llama_parse = LlamaParse(**parser_args)
             debug('LlamaParse Global: LlamaParse instance created successfully')
         except Exception as e:

--- a/nodes/src/nodes/llamaparse/IGlobal.py
+++ b/nodes/src/nodes/llamaparse/IGlobal.py
@@ -152,7 +152,7 @@ class IGlobal(IGlobalBase):
                 import json
 
                 advanced_config = json.loads(advanced_config_str) if advanced_config_str else {}
-                debug(f'LlamaParse Global: Using advanced config: {advanced_config}')
+                debug(f'LlamaParse Global: Using advanced config: {_redact_dict(advanced_config)}')
 
                 # Merge advanced config into parser_args (excluding api_key which is handled above)
                 for key, value in advanced_config.items():
@@ -198,7 +198,6 @@ class IGlobal(IGlobalBase):
             if spreadsheet_extract_sub_tables:
                 parser_args['spreadsheet_extract_sub_tables'] = spreadsheet_extract_sub_tables
 
-        debug(f'LlamaParse Global: Creating LlamaParse instance with args: {_redact_dict(parser_args)}')
         try:
             debug(f'LlamaParse Global: Creating LlamaParse instance with args: {_redact_dict(parser_args)}')
             self._llama_parse = LlamaParse(**parser_args)

--- a/nodes/src/nodes/llamaparse/parser.py
+++ b/nodes/src/nodes/llamaparse/parser.py
@@ -33,7 +33,7 @@ from ai.common.reader import ReaderBase
 from ai.common.config import Config
 from ai.web.metrics import metrics
 from rocketlib import debug
-from library.helpers.redact import redact_dict as _redact_dict
+from library.helpers.redact import redact_secrets as _redact_secrets
 
 
 class Parser(ReaderBase):
@@ -57,17 +57,17 @@ class Parser(ReaderBase):
         self.bag = bag
 
         debug(f'LlamaParse Parser: Provider: {provider}')
-        debug(f'LlamaParse Parser: Raw connConfig: {_redact_dict(connConfig)}')
+        debug(f'LlamaParse Parser: Raw connConfig: {_redact_secrets(connConfig)}')
 
         # Get the nodes configuration
         config = Config.getNodeConfig(provider, connConfig)
-        debug(f'LlamaParse Parser: Processed config: {_redact_dict(config)}')
+        debug(f'LlamaParse Parser: Processed config: {_redact_secrets(config)}')
 
         # Check if config has nested structure
         if 'default' in config:
             debug('LlamaParse Parser: Found nested config structure, extracting from default profile')
             config = config.get('default', {})
-            debug(f'LlamaParse Parser: Extracted config: {_redact_dict(config)}')
+            debug(f'LlamaParse Parser: Extracted config: {_redact_secrets(config)}')
 
         # Get the other configuration values
         self._parse_mode = config.get('parse_mode', None)

--- a/nodes/src/nodes/llamaparse/parser.py
+++ b/nodes/src/nodes/llamaparse/parser.py
@@ -34,6 +34,13 @@ from ai.common.config import Config
 from ai.web.metrics import metrics
 from rocketlib import debug
 
+_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
+
+
+def _redact_dict(d: dict) -> dict:
+    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
+    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+
 
 class Parser(ReaderBase):
     # Configuration variables
@@ -56,7 +63,7 @@ class Parser(ReaderBase):
         self.bag = bag
 
         debug(f'LlamaParse Parser: Provider: {provider}')
-        debug(f'LlamaParse Parser: Raw connConfig: {connConfig}')
+        debug(f'LlamaParse Parser: Raw connConfig: {_redact_dict(connConfig)}')
 
         # Get the nodes configuration
         config = Config.getNodeConfig(provider, connConfig)

--- a/nodes/src/nodes/llamaparse/parser.py
+++ b/nodes/src/nodes/llamaparse/parser.py
@@ -33,13 +33,7 @@ from ai.common.reader import ReaderBase
 from ai.common.config import Config
 from ai.web.metrics import metrics
 from rocketlib import debug
-
-_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
-
-
-def _redact_dict(d: dict) -> dict:
-    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
-    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+from library.helpers.redact import redact_dict as _redact_dict
 
 
 class Parser(ReaderBase):

--- a/nodes/src/nodes/llamaparse/parser.py
+++ b/nodes/src/nodes/llamaparse/parser.py
@@ -61,13 +61,13 @@ class Parser(ReaderBase):
 
         # Get the nodes configuration
         config = Config.getNodeConfig(provider, connConfig)
-        debug(f'LlamaParse Parser: Processed config: {config}')
+        debug(f'LlamaParse Parser: Processed config: {_redact_dict(config)}')
 
         # Check if config has nested structure
         if 'default' in config:
             debug('LlamaParse Parser: Found nested config structure, extracting from default profile')
             config = config.get('default', {})
-            debug(f'LlamaParse Parser: Extracted config: {config}')
+            debug(f'LlamaParse Parser: Extracted config: {_redact_dict(config)}')
 
         # Get the other configuration values
         self._parse_mode = config.get('parse_mode', None)

--- a/nodes/src/nodes/llamaparse/test_log_redaction.py
+++ b/nodes/src/nodes/llamaparse/test_log_redaction.py
@@ -1,4 +1,4 @@
-"""Tests for the redact_dict log-redaction helper used in LlamaParse and Reducto nodes."""
+"""Tests for the redact_secrets helper used in LlamaParse and Reducto nodes."""
 
 import importlib.util
 import os
@@ -10,7 +10,7 @@ _spec = importlib.util.spec_from_file_location(
 )
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)
-_redact_dict = _mod.redact_dict
+_redact_secrets = _mod.redact_secrets
 
 
 # ---------------------------------------------------------------------------
@@ -18,46 +18,46 @@ _redact_dict = _mod.redact_dict
 # ---------------------------------------------------------------------------
 
 
-class TestRedactDict:
-    """Unit tests for redact_dict."""
+class TestRedactSecrets:
+    """Unit tests for redact_secrets."""
 
     def test_redacts_api_key(self):
         """api_key values must be replaced."""
         d = {'api_key': 'llx-secret-1234', 'verbose': False}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['api_key'] == '***REDACTED***'
         assert result['verbose'] is False
 
     def test_redacts_token(self):
         """Keys containing 'token' must be redacted."""
         d = {'auth_token': 'tok_abc', 'mode': 'fast'}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['auth_token'] == '***REDACTED***'
         assert result['mode'] == 'fast'
 
     def test_redacts_password(self):
         """Keys containing 'password' must be redacted."""
         d = {'db_password': 'hunter2', 'host': 'localhost'}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['db_password'] == '***REDACTED***'
         assert result['host'] == 'localhost'
 
     def test_redacts_secret(self):
         """Keys containing 'secret' must be redacted."""
         d = {'client_secret': 's3cr3t'}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['client_secret'] == '***REDACTED***'
 
     def test_redacts_credential(self):
         """Keys containing 'credential' must be redacted."""
         d = {'service_credential': 'cred123'}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['service_credential'] == '***REDACTED***'
 
     def test_case_insensitive(self):
         """Matching must be case-insensitive."""
         d = {'API_KEY': 'key1', 'ApiKey': 'key2', 'TOKEN': 'tok'}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['API_KEY'] == '***REDACTED***'
         assert result['ApiKey'] == '***REDACTED***'
         assert result['TOKEN'] == '***REDACTED***'
@@ -65,18 +65,18 @@ class TestRedactDict:
     def test_non_sensitive_keys_unchanged(self):
         """Non-sensitive keys must pass through unchanged."""
         d = {'parse_mode': 'fast', 'verbose': True, 'timeout': 30}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result == d
 
     def test_empty_dict(self):
         """An empty dict must return an empty dict."""
-        assert _redact_dict({}) == {}
+        assert _redact_secrets({}) == {}
 
     def test_original_not_mutated(self):
         """The original dict must not be modified."""
         d = {'api_key': 'secret_val', 'name': 'test'}
         original_copy = dict(d)
-        _redact_dict(d)
+        _redact_secrets(d)
         assert d == original_copy
 
     def test_multiple_sensitive_keys(self):
@@ -88,7 +88,7 @@ class TestRedactDict:
             'password': 'p1',
             'host': 'localhost',
         }
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['api_key'] == '***REDACTED***'
         assert result['secret'] == '***REDACTED***'
         assert result['token'] == '***REDACTED***'
@@ -98,13 +98,13 @@ class TestRedactDict:
     def test_redacts_apikey_no_underscore(self):
         """Keys containing 'apikey' (no underscore) must be redacted."""
         d = {'myapikey': 'val'}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['myapikey'] == '***REDACTED***'
 
     def test_redacts_nested_dicts(self):
         """Sensitive keys inside nested dicts must be redacted."""
         d = {'outer': {'api_key': 'secret', 'name': 'safe'}, 'model': 'gpt-4'}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['outer']['api_key'] == '***REDACTED***'
         assert result['outer']['name'] == 'safe'
         assert result['model'] == 'gpt-4'
@@ -112,7 +112,7 @@ class TestRedactDict:
     def test_redacts_list_of_dicts(self):
         """Sensitive keys inside lists of dicts must be redacted."""
         d = {'items': [{'token': 'abc'}, {'name': 'ok'}]}
-        result = _redact_dict(d)
+        result = _redact_secrets(d)
         assert result['items'][0]['token'] == '***REDACTED***'
         assert result['items'][1]['name'] == 'ok'
 
@@ -121,7 +121,7 @@ class TestRedactDict:
 # Allow running with plain `python test_log_redaction.py`
 # ---------------------------------------------------------------------------
 if __name__ == '__main__':
-    t = TestRedactDict()
+    t = TestRedactSecrets()
     failed = 0
     for method_name in sorted(dir(t)):
         if method_name.startswith('test_'):

--- a/nodes/src/nodes/llamaparse/test_log_redaction.py
+++ b/nodes/src/nodes/llamaparse/test_log_redaction.py
@@ -1,21 +1,16 @@
-"""Tests for the _redact_dict log-redaction helper used in LlamaParse and Reducto nodes.
+"""Tests for the redact_dict log-redaction helper used in LlamaParse and Reducto nodes."""
 
-This test is self-contained and does not require the full RocketRide runtime.
-It re-implements the same _redact_dict logic so the test can run standalone,
-then validates behaviour against the known contract.
-"""
+import importlib.util
+import os
 
-# ---------------------------------------------------------------------------
-# Reproduce the exact helper from the patched source files so we can test it
-# without importing the full node packages (which need the RocketRide runtime).
-# ---------------------------------------------------------------------------
-
-_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
-
-
-def _redact_dict(d: dict) -> dict:
-    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
-    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+# Direct-load the module to avoid pulling in the full RocketRide runtime.
+_spec = importlib.util.spec_from_file_location(
+    'redact',
+    os.path.join(os.path.dirname(__file__), '..', 'library', 'helpers', 'redact.py'),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+_redact_dict = _mod.redact_dict
 
 
 # ---------------------------------------------------------------------------

--- a/nodes/src/nodes/llamaparse/test_log_redaction.py
+++ b/nodes/src/nodes/llamaparse/test_log_redaction.py
@@ -1,0 +1,120 @@
+"""Tests for the _redact_dict log-redaction helper used in LlamaParse and Reducto nodes.
+
+This test is self-contained and does not require the full RocketRide runtime.
+It re-implements the same _redact_dict logic so the test can run standalone,
+then validates behaviour against the known contract.
+"""
+
+# ---------------------------------------------------------------------------
+# Reproduce the exact helper from the patched source files so we can test it
+# without importing the full node packages (which need the RocketRide runtime).
+# ---------------------------------------------------------------------------
+
+_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
+
+
+def _redact_dict(d: dict) -> dict:
+    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
+    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestRedactDict:
+    """Unit tests for _redact_dict."""
+
+    def test_redacts_api_key(self):
+        """api_key values must be replaced."""
+        d = {'api_key': 'llx-secret-1234', 'verbose': False}
+        result = _redact_dict(d)
+        assert result['api_key'] == '***REDACTED***'
+        assert result['verbose'] is False
+
+    def test_redacts_token(self):
+        """Keys containing 'token' must be redacted."""
+        d = {'auth_token': 'tok_abc', 'mode': 'fast'}
+        result = _redact_dict(d)
+        assert result['auth_token'] == '***REDACTED***'
+        assert result['mode'] == 'fast'
+
+    def test_redacts_password(self):
+        """Keys containing 'password' must be redacted."""
+        d = {'db_password': 'hunter2', 'host': 'localhost'}
+        result = _redact_dict(d)
+        assert result['db_password'] == '***REDACTED***'
+        assert result['host'] == 'localhost'
+
+    def test_redacts_secret(self):
+        """Keys containing 'secret' must be redacted."""
+        d = {'client_secret': 's3cr3t'}
+        result = _redact_dict(d)
+        assert result['client_secret'] == '***REDACTED***'
+
+    def test_redacts_credential(self):
+        """Keys containing 'credential' must be redacted."""
+        d = {'service_credential': 'cred123'}
+        result = _redact_dict(d)
+        assert result['service_credential'] == '***REDACTED***'
+
+    def test_case_insensitive(self):
+        """Matching must be case-insensitive."""
+        d = {'API_KEY': 'key1', 'ApiKey': 'key2', 'TOKEN': 'tok'}
+        result = _redact_dict(d)
+        assert result['API_KEY'] == '***REDACTED***'
+        assert result['ApiKey'] == '***REDACTED***'
+        assert result['TOKEN'] == '***REDACTED***'
+
+    def test_non_sensitive_keys_unchanged(self):
+        """Non-sensitive keys must pass through unchanged."""
+        d = {'parse_mode': 'fast', 'verbose': True, 'timeout': 30}
+        result = _redact_dict(d)
+        assert result == d
+
+    def test_empty_dict(self):
+        """An empty dict must return an empty dict."""
+        assert _redact_dict({}) == {}
+
+    def test_original_not_mutated(self):
+        """The original dict must not be modified."""
+        d = {'api_key': 'secret_val', 'name': 'test'}
+        original_copy = dict(d)
+        _redact_dict(d)
+        assert d == original_copy
+
+    def test_multiple_sensitive_keys(self):
+        """Multiple sensitive keys in one dict are all redacted."""
+        d = {
+            'api_key': 'k1',
+            'secret': 's1',
+            'token': 't1',
+            'password': 'p1',
+            'host': 'localhost',
+        }
+        result = _redact_dict(d)
+        assert result['api_key'] == '***REDACTED***'
+        assert result['secret'] == '***REDACTED***'
+        assert result['token'] == '***REDACTED***'
+        assert result['password'] == '***REDACTED***'
+        assert result['host'] == 'localhost'
+
+    def test_redacts_apikey_no_underscore(self):
+        """Keys containing 'apikey' (no underscore) must be redacted."""
+        d = {'myapikey': 'val'}
+        result = _redact_dict(d)
+        assert result['myapikey'] == '***REDACTED***'
+
+
+# ---------------------------------------------------------------------------
+# Allow running with plain `python test_log_redaction.py`
+# ---------------------------------------------------------------------------
+if __name__ == '__main__':
+    t = TestRedactDict()
+    for method_name in sorted(dir(t)):
+        if method_name.startswith('test_'):
+            print(f'Running {method_name}...', end=' ')
+            getattr(t, method_name)()
+            print('OK')
+    print('\nAll tests passed.')

--- a/nodes/src/nodes/llamaparse/test_log_redaction.py
+++ b/nodes/src/nodes/llamaparse/test_log_redaction.py
@@ -101,15 +101,38 @@ class TestRedactDict:
         result = _redact_dict(d)
         assert result['myapikey'] == '***REDACTED***'
 
+    def test_redacts_nested_dicts(self):
+        """Sensitive keys inside nested dicts must be redacted."""
+        d = {'outer': {'api_key': 'secret', 'name': 'safe'}, 'model': 'gpt-4'}
+        result = _redact_dict(d)
+        assert result['outer']['api_key'] == '***REDACTED***'
+        assert result['outer']['name'] == 'safe'
+        assert result['model'] == 'gpt-4'
+
+    def test_redacts_list_of_dicts(self):
+        """Sensitive keys inside lists of dicts must be redacted."""
+        d = {'items': [{'token': 'abc'}, {'name': 'ok'}]}
+        result = _redact_dict(d)
+        assert result['items'][0]['token'] == '***REDACTED***'
+        assert result['items'][1]['name'] == 'ok'
+
 
 # ---------------------------------------------------------------------------
 # Allow running with plain `python test_log_redaction.py`
 # ---------------------------------------------------------------------------
 if __name__ == '__main__':
     t = TestRedactDict()
+    failed = 0
     for method_name in sorted(dir(t)):
         if method_name.startswith('test_'):
             print(f'Running {method_name}...', end=' ')
-            getattr(t, method_name)()
-            print('OK')
+            try:
+                getattr(t, method_name)()
+                print('OK')
+            except Exception as exc:
+                failed += 1
+                print(f'FAILED: {exc}')
+    if failed:
+        print(f'\n{failed} test(s) failed.')
+        raise SystemExit(1)
     print('\nAll tests passed.')

--- a/nodes/src/nodes/llamaparse/test_log_redaction.py
+++ b/nodes/src/nodes/llamaparse/test_log_redaction.py
@@ -19,7 +19,7 @@ _redact_dict = _mod.redact_dict
 
 
 class TestRedactDict:
-    """Unit tests for _redact_dict."""
+    """Unit tests for redact_dict."""
 
     def test_redacts_api_key(self):
         """api_key values must be replaced."""

--- a/nodes/src/nodes/reducto/parser.py
+++ b/nodes/src/nodes/reducto/parser.py
@@ -25,7 +25,7 @@ from typing import Any, Dict, Optional, List
 from ai.common.reader import ReaderBase
 from ai.common.config import Config
 from rocketlib import debug
-from library.helpers.redact import redact_dict as _redact_dict
+from library.helpers.redact import redact_secrets as _redact_secrets
 
 
 class Parser(ReaderBase):
@@ -58,7 +58,7 @@ class Parser(ReaderBase):
         if 'default' in self.config:
             debug('Reducto Parser: Found nested config structure, extracting from default profile')
             self.config = self.config.get('default', {})
-            debug(f'Reducto Parser: Extracted config: {_redact_dict(self.config)}')
+            debug(f'Reducto Parser: Extracted config: {_redact_secrets(self.config)}')
 
         # Get configuration values
         self._api_key = self.config.get('api_key')

--- a/nodes/src/nodes/reducto/parser.py
+++ b/nodes/src/nodes/reducto/parser.py
@@ -26,6 +26,13 @@ from ai.common.reader import ReaderBase
 from ai.common.config import Config
 from rocketlib import debug
 
+_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
+
+
+def _redact_dict(d: dict) -> dict:
+    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
+    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+
 
 class Parser(ReaderBase):
     """Parser class for Reducto document processing.
@@ -57,7 +64,7 @@ class Parser(ReaderBase):
         if 'default' in self.config:
             debug('Reducto Parser: Found nested config structure, extracting from default profile')
             self.config = self.config.get('default', {})
-            debug(f'Reducto Parser: Extracted config: {self.config}')
+            debug(f'Reducto Parser: Extracted config: {_redact_dict(self.config)}')
 
         # Get configuration values
         self._api_key = self.config.get('api_key')

--- a/nodes/src/nodes/reducto/parser.py
+++ b/nodes/src/nodes/reducto/parser.py
@@ -25,13 +25,7 @@ from typing import Any, Dict, Optional, List
 from ai.common.reader import ReaderBase
 from ai.common.config import Config
 from rocketlib import debug
-
-_SENSITIVE_KEYS = ('api_key', 'apikey', 'secret', 'token', 'password', 'credential')
-
-
-def _redact_dict(d: dict) -> dict:
-    """Return a copy of *d* with sensitive values replaced by '***REDACTED***'."""
-    return {k: ('***REDACTED***' if any(p in k.lower() for p in _SENSITIVE_KEYS) else v) for k, v in d.items()}
+from library.helpers.redact import redact_dict as _redact_dict
 
 
 class Parser(ReaderBase):

--- a/nodes/test/llamaparse/test_log_redaction.py
+++ b/nodes/test/llamaparse/test_log_redaction.py
@@ -6,7 +6,7 @@ import os
 # Direct-load the module to avoid pulling in the full RocketRide runtime.
 _spec = importlib.util.spec_from_file_location(
     'redact',
-    os.path.join(os.path.dirname(__file__), '..', 'library', 'helpers', 'redact.py'),
+    os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'nodes', 'library', 'helpers', 'redact.py'),
 )
 _mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_mod)


### PR DESCRIPTION
## Bug Summary

API keys and other secrets are logged in plaintext via `debug()` calls in the LlamaParse and Reducto parser nodes. Anyone with access to debug logs (log aggregation systems, shared dev environments, CI output) can extract full API keys.

## Affected Files and Lines

| File | Line(s) | What is leaked |
|------|---------|---------------|
| `nodes/src/nodes/llamaparse/IGlobal.py` | 199, 201 | Full `parser_args` dict containing `api_key` |
| `nodes/src/nodes/llamaparse/parser.py` | 59 | Full `connConfig` dict (may contain credentials) |
| `nodes/src/nodes/reducto/parser.py` | 60 | Full `self.config` dict containing `api_key` |

## Root Cause

Debug log statements format entire configuration dictionaries into log messages without filtering sensitive fields:

```python
debug(f'LlamaParse Global: Creating LlamaParse instance with args: {parser_args}')
debug(f'LlamaParse Parser: Raw connConfig: {connConfig}')
debug(f'Reducto Parser: Extracted config: {self.config}')
```

## Reproduction Steps

1. Configure a LlamaParse or Reducto node with an API key
2. Run a pipeline with debug logging enabled
3. Observe that the full API key appears in the log output

## Severity: HIGH

Credential leakage via logs is a well-known attack vector (CWE-532: Insertion of Sensitive Information into Log File). API keys for LlamaParse and Reducto could be used to make unauthorized API calls at the victim's expense.

## Fix Description

Added a `_redact_dict()` helper function in each affected module that replaces values for keys matching sensitive patterns (`api_key`, `apikey`, `secret`, `token`, `password`, `credential`) with `'***REDACTED***'` before the dictionary is interpolated into the log message. The helper is applied to all three vulnerable debug statements.

The fix is minimal and surgical:
- No changes to runtime behavior (the actual dicts passed to constructors/APIs are untouched)
- Only the string representation sent to `debug()` is sanitized
- Pattern matching is case-insensitive to catch `API_KEY`, `ApiKey`, etc.

## Tests/Validation

Added `nodes/src/nodes/llamaparse/test_log_redaction.py` with 11 test cases covering:
- Redaction of each sensitive key pattern (`api_key`, `token`, `secret`, `password`, `credential`)
- Case-insensitive matching
- Non-sensitive keys pass through unchanged
- Empty dict handling
- Original dict is not mutated
- Multiple sensitive keys in one dict

#frontier-tower-hackathon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic redaction of sensitive configuration data (API keys, tokens, passwords, credentials, and secrets) in debug logs to prevent accidental exposure of confidential information.

* **Tests**
  * Added comprehensive test coverage for the new secret redaction functionality with support for nested data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->