### PR TITLE
fix: resolve three crash-causing bugs in response, remote, and audio_player nodes

### DIFF
--- a/nodes/src/nodes/audio_player/player.py
+++ b/nodes/src/nodes/audio_player/player.py
@@ -123,7 +123,7 @@ class Player(AudioReader):
         del buf[:required_bytes]
 
         # Save the new buffer
-        self.play_callback_buffer = buf
+        self._play_callback_buffer = buf
 
     def start(self):
         """

--- a/nodes/src/nodes/remote/client/IGlobal.py
+++ b/nodes/src/nodes/remote/client/IGlobal.py
@@ -85,7 +85,7 @@ class IGlobal(IGlobalBase):
 
         # Check for success
         if response.status_code != 200:
-            raise Exception(f'Unable to destroy pipe on {self.urlControl}: {response.txt}')
+            raise Exception(f'Unable to destroy pipe on {self.urlControl}: {response.text}')
 
     def isLaneRemote(self, lane: str) -> bool:
         return lane in self.inputLanes

--- a/nodes/src/nodes/response/IGlobal.py
+++ b/nodes/src/nodes/response/IGlobal.py
@@ -30,7 +30,7 @@ class IGlobal(IGlobalBase):
 
     def beginGlobal(self):
         # This will create a local copy
-        self.lanes = None
+        self.lanes = {}
         self.laneName = None
 
         # Get this nodes config


### PR DESCRIPTION
## Summary

- Fix three independent bugs across pipeline nodes that cause runtime crashes, masked errors, and data corruption
- Each bug is a single-character or single-word typo with clear, provable impact

## Bug 1: Response node crashes with TypeError on lane configuration

**File:** `nodes/src/nodes/response/IGlobal.py` (line 33)  
**Severity:** Critical — runtime crash

```python
# Line 33: lanes initialized as None
self.lanes = None

# Line 57: later attempts dict assignment
self.lanes[laneId] = laneName  # TypeError: 'NoneType' object does not support item assignment
```

**Impact:** Any pipeline using the response node with lane configuration crashes immediately with `TypeError`. The class-level default `lanes: Dict[str, str] = {}` at line 29 is overridden by `None` at instance level.

**Proof:** Line 80 in the same file correctly uses it as a dict (`self.lanes.get(lane, lane)`), confirming it was always intended to be a dict.

**Fix:** Change `self.lanes = None` to `self.lanes = {}` (line 33)

---

## Bug 2: Remote client masks cleanup errors with AttributeError

**File:** `nodes/src/nodes/remote/client/IGlobal.py` (line 88)  
**Severity:** High — error masking

```python
# Line 80 (correct):
raise Exception(f'... {response.text}')

# Line 88 (bug — typo):
raise Exception(f'... {response.txt}')
#                                ^^^^ should be .text
```

**Impact:** When remote pipe cleanup fails (`DELETE` request returns non-200), the code tries to access `response.txt` which doesn't exist on `requests.Response`. This raises `AttributeError: 'Response' object has no attribute 'txt'` instead of the actual server error message, making debugging impossible.

**Proof:** Line 80 (6 lines above!) correctly uses `response.text` for the same pattern.

**Fix:** Change `response.txt` to `response.text` (line 88)

---

## Bug 3: Audio player loses buffer data due to missing underscore

**File:** `nodes/src/nodes/audio_player/player.py` (line 126)  
**Severity:** High — data corruption

```python
# Line 56: buffer initialized with underscore prefix (private)
self._play_callback_buffer = bytearray()

# Line 126: writes to WRONG attribute (no underscore)
self.play_callback_buffer = buf  # Creates new attribute, doesn't update the real one!
```

**Impact:** After audio data is processed in the playback callback, the updated buffer is assigned to a new, unused attribute (`play_callback_buffer`) instead of the actual private buffer (`_play_callback_buffer`). The real buffer is never updated, causing:
- Audio playback corruption (stale data replayed)
- Memory leak (old buffer data never freed, new attribute accumulates)

**Proof:** Line 56 defines `self._play_callback_buffer` and line 107 reads from `self._play_callback_buffer` — line 126 is the only reference without the underscore prefix.

**Fix:** Change `self.play_callback_buffer` to `self._play_callback_buffer` (line 126)

---

## Root Cause

All three bugs are classic copy-paste / typo errors:
1. `None` instead of `{}` — wrong initialization value
2. `.txt` instead of `.text` — missing character
3. Missing `_` prefix — private attribute naming inconsistency

## Verification

- [x] `ruff check` passes on all 3 files
- [x] `ruff format` passes on all 3 files
- [x] All pre-commit hooks pass
- [x] Each bug has a correct reference in the same file proving the intended behavior

| Bug | Wrong | Correct | Proof (same file) |
|-----|-------|---------|-------------------|
| Response lanes | `self.lanes = None` | `self.lanes = {}` | Line 29: `lanes: Dict[str, str] = {}` |
| Remote text | `response.txt` | `response.text` | Line 80: `response.text` |
| Audio buffer | `self.play_callback_buffer` | `self._play_callback_buffer` | Lines 56, 107: `self._play_callback_buffer` |

#frontier-tower-hackathon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting by fixing response message handling to properly display error details.
  * Fixed initialization logic to prevent potential type-related issues during runtime operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->