### PR TITLE
fix(scripts): accept installed ca-certificates without update-ca-certificates on PATH

### DIFF
--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -348,6 +348,16 @@ check_linux_dependencies() {
                     echo "✓ gnupg: gpg available"
                 fi
                 ;;
+            ca-certificates)
+                # update-ca-certificates may be root-only on PATH while the package is installed (#370)
+                if dpkg -l ca-certificates 2>/dev/null | grep -q "^ii" || command_exists update-ca-certificates; then
+                    echo "✓ ca-certificates"
+                else
+                    echo "✗ ca-certificates: package not installed and update-ca-certificates not on PATH"
+                    COMMANDS+=("    # Install package ca-certificates")
+                    COMMANDS+=("    sudo apt install -y ca-certificates")
+                fi
+                ;;
             libncurses-dev)
                 # Ubuntu 24.04+ uses libncurses-dev, older systems use libncurses5-dev/libncursesw5-dev
                 if ! dpkg -l "libncurses-dev" 2>/dev/null | grep -q "^ii" && \
@@ -374,7 +384,6 @@ check_linux_dependencies() {
                     ninja-build) cmd_name="ninja" ;;
                     libtool) cmd_name="libtoolize" ;;
                     dos2unix) cmd_name="dos2unix" ;;
-                    ca-certificates) cmd_name="update-ca-certificates" ;;
                     python3-pip) cmd_name="pip3" ;;
                     python3-venv) cmd_name="python3" ;;
                     autoconf-archive | lsb-release)


### PR DESCRIPTION
## Summary

Fix false-negative Linux prerequisite detection for `ca-certificates` when the package is installed but `update-ca-certificates` is not on the user PATH (reported on Devuan and similar). Aligns with existing `dpkg`-based checks in the same script.

## Bug

- **Issue:** [#370](https://github.com/rocketride-org/rocketride-server/issues/370)
- **Symptom:** `./builder build` / `./scripts/compiler-unix.sh` fails with `ca-certificates: update-ca-certificates not available` even when the `ca-certificates` package is installed.

## Steps to Reproduce

1. Use a Linux environment where `ca-certificates` is installed per `dpkg` but `update-ca-certificates` is not available on the invoking user PATH (see issue #370).
2. From repo root: `./scripts/compiler-unix.sh` or `./builder build`.
3. Observe false failure on `ca-certificates`.

## Root Cause

`ca-certificates` was validated only indirectly by requiring the `update-ca-certificates` command to be on PATH, unlike other packages that use `dpkg -l ... ^ii` in this same function.

## Fix

- Add an explicit `ca-certificates` case: pass if `dpkg -l ca-certificates` shows `^ii` **or** `update-ca-certificates` exists on PATH.
- Remove the inner `ca-certificates` → `update-ca-certificates` command mapping.

## Why This Works

The script already uses `dpkg -l` with `^ii` for `*-dev` and special-cases like `libncurses-dev`. Treating `ca-certificates` the same way matches established intent: verify the **installed package**, not only a helper binary location.

## Testing / Validation

- `bash -n scripts/compiler-unix.sh` (pass)
- `./builder test --verbose` **blocked** locally: CMake 4.3.0 rejected by macOS prerequisite check (environment issue, not caused by this diff). CI / another machine with supported CMake should run the full pipeline.

## Type

- [x] Bug fix

## Checklist

- [ ] Tests added/updated — **N/A**: no shell test harness in repo; logic mirrors existing `dpkg` checks in the same file (`libncurses-dev`, `*-dev`).
- [x] Tested locally (`bash -n` + manual review of branch logic)
- [ ] `./builder test` pass status — **blocked** on this host (CMake version gate); no regression expected (Linux-only code path; macOS uses `check_mac_dependencies`)
- [x] Conventional commit usage
- [x] No secrets/credentials
- [ ] Wiki updated (if applicable) — N/A
- [ ] Breaking changes documented — None

## Related Issues

Fixes #370
