### PR TITLE
fix(vscode): fall back to active pipeline editor for commands

### DIFF
--- a/apps/vscode/src/providers/SidebarFilesProvider.ts
+++ b/apps/vscode/src/providers/SidebarFilesProvider.ts
@@ -43,7 +43,7 @@ import { PipelineFileParser, ParsedPipelineFile, ParsedSourceComponent } from '.
 import { ConfigManager } from '../config';
 import { ConnectionManager } from '../connection/connection';
 import { GenericEvent, GenericResponse } from '../shared/types';
-import { resolvePipelineCommandUri } from './sidebarCommandContext';
+import { resolvePipelineCommandUri, resolvePipelineSourceComponentId } from './sidebarCommandContext';
 
 /** Parsed location from structured error format (ErrorType*`message`*filepath:linenumber) */
 export interface ParsedErrWarnLine {
@@ -222,7 +222,11 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 					// Get project and source identifiers
 					const parsedFile = item?.parsedFile || this.getParsedPipeline(resourceUri);
 					const projectId = parsedFile?.projectId;
-					const sourceId = item?.sourceComponent?.id || parsedFile?.pipeline?.source || '';
+					const sourceId = resolvePipelineSourceComponentId(
+						item?.sourceComponent?.id,
+						parsedFile?.pipeline?.source,
+						parsedFile?.sourceComponents
+					) || '';
 
 					// Use DAP command to execute pipeline without debugging
 					await this.connectionManager.request('execute', {
@@ -324,7 +328,21 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 	}
 
 	private resolveCommandResourceUri(item?: PipelineFileItem): vscode.Uri | undefined {
-		return resolvePipelineCommandUri(item?.resourceUri, vscode.window.activeTextEditor?.document.uri);
+		return resolvePipelineCommandUri(item?.resourceUri, vscode.window.activeTextEditor?.document.uri, this.getActivePipelineEditorUri());
+	}
+
+	private getActivePipelineEditorUri(): vscode.Uri | undefined {
+		const activeTab = vscode.window.tabGroups.activeTabGroup.activeTab;
+		if (!activeTab) {
+			return undefined;
+		}
+
+		const input = activeTab.input;
+		if (input instanceof vscode.TabInputText || input instanceof vscode.TabInputCustom) {
+			return input.uri;
+		}
+
+		return undefined;
 	}
 
 	private resolveKnownPipelineCommandContext(
@@ -343,7 +361,11 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 			return undefined;
 		}
 
-		const componentId = item?.sourceComponent?.id || parsedPipeline.pipeline?.source;
+		const componentId = resolvePipelineSourceComponentId(
+			item?.sourceComponent?.id,
+			parsedPipeline.pipeline?.source,
+			parsedPipeline.sourceComponents
+		);
 		const sourceComponent = componentId ? item?.sourceComponent || this.getSourceComponentById(resourceUri, componentId) : undefined;
 		const services = this.connectionManager.getCachedServices()?.services ?? {};
 		const providerDef = sourceComponent?.provider ? (services[sourceComponent.provider] as { title?: string } | undefined) : undefined;

--- a/apps/vscode/src/providers/sidebarCommandContext.ts
+++ b/apps/vscode/src/providers/sidebarCommandContext.ts
@@ -25,11 +25,15 @@ interface UriLike {
 	fsPath: string;
 }
 
+interface SourceComponentLike {
+	id: string;
+}
+
 function isPipelineFile(filePath: string): boolean {
 	return filePath.endsWith('.pipe') || filePath.endsWith('.pipe.json');
 }
 
-export function resolvePipelineCommandUri<T extends UriLike>(explicitUri?: T, activeEditorUri?: T): T | undefined {
+export function resolvePipelineCommandUri<T extends UriLike>(explicitUri?: T, activeEditorUri?: T, activeTabUri?: T): T | undefined {
 	if (explicitUri) {
 		return explicitUri;
 	}
@@ -38,5 +42,25 @@ export function resolvePipelineCommandUri<T extends UriLike>(explicitUri?: T, ac
 		return activeEditorUri;
 	}
 
+	if (activeTabUri && isPipelineFile(activeTabUri.fsPath)) {
+		return activeTabUri;
+	}
+
 	return undefined;
+}
+
+export function resolvePipelineSourceComponentId<T extends SourceComponentLike>(
+	explicitSourceId?: string,
+	pipelineSourceId?: string,
+	sourceComponents: T[] = []
+): string | undefined {
+	if (explicitSourceId) {
+		return explicitSourceId;
+	}
+
+	if (pipelineSourceId) {
+		return pipelineSourceId;
+	}
+
+	return sourceComponents[0]?.id;
 }

--- a/apps/vscode/src/test/sidebarCommandContext.test.ts
+++ b/apps/vscode/src/test/sidebarCommandContext.test.ts
@@ -23,7 +23,7 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { resolvePipelineCommandUri } from '../providers/sidebarCommandContext';
+import { resolvePipelineCommandUri, resolvePipelineSourceComponentId } from '../providers/sidebarCommandContext';
 
 test('prefers explicit sidebar selection when present', () => {
 	const explicitUri = { fsPath: '/tmp/selected.pipe' };
@@ -54,6 +54,38 @@ test('ignores non-pipeline active editors', () => {
 	const activeEditorUri = { fsPath: '/tmp/readme.md' };
 
 	const result = resolvePipelineCommandUri(undefined, activeEditorUri);
+
+	assert.equal(result, undefined);
+});
+
+test('falls back to active custom editor tab when there is no active text editor', () => {
+	const activeTabUri = { fsPath: '/tmp/active.pipe' };
+
+	const result = resolvePipelineCommandUri(undefined, undefined, activeTabUri);
+
+	assert.equal(result, activeTabUri);
+});
+
+test('prefers explicit source component id when available', () => {
+	const result = resolvePipelineSourceComponentId('chat_1', 'pipeline_source', [{ id: 'source_1' }]);
+
+	assert.equal(result, 'chat_1');
+});
+
+test('falls back to the pipeline source field when no explicit component id exists', () => {
+	const result = resolvePipelineSourceComponentId(undefined, 'pipeline_source', [{ id: 'source_1' }]);
+
+	assert.equal(result, 'pipeline_source');
+});
+
+test('falls back to the first parsed source component when pipeline.source is missing', () => {
+	const result = resolvePipelineSourceComponentId(undefined, undefined, [{ id: 'source_1' }, { id: 'source_2' }]);
+
+	assert.equal(result, 'source_1');
+});
+
+test('returns undefined when no source component can be resolved', () => {
+	const result = resolvePipelineSourceComponentId(undefined, undefined, []);
 
 	assert.equal(result, undefined);
 });


### PR DESCRIPTION
- Fixes a VS Code/Cursor extension bug where RocketRide pipeline commands could fail with `No pipeline file selected` or `No pipeline selected` when a valid `.pipe` file was already open in the active editor but no sidebar item was selected.
- Adds a fallback that resolves the active `.pipe` or `.pipe.json` editor when no `PipelineFileItem` is passed, and applies it to the open file, open status, and run pipeline command paths.
- Adds a focused regression test for the fallback helper so editor-driven invocation stays covered.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Local verification performed:
```bash
pnpm exec tsc apps/vscode/src/test/sidebarCommandContext.test.ts apps/vscode/src/providers/sidebarCommandContext.ts --module Node16 --moduleResolution Node16 --target ES2022 --outDir build/sidebar-context-test && node --test build/sidebar-context-test/test/sidebarCommandContext.test.js


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar commands now fail early with clearer "Invalid pipeline file or missing project_id" when a pipeline URI or context can't be resolved.
  * More reliable handling when opening or running pipeline files to prevent unexpected no-ops.

* **Improvements**
  * More consistent detection of pipeline files across editor and tabs with predictable fallbacks.
  * Unified validation across sidebar actions for steadier command behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->