### PR TITLE
fix(client-ts): preserve user-specified port in normalizeUri

### DIFF
--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -395,7 +395,17 @@ export class RocketRideClient extends DAPClient {
 		try {
 			const url = new URL(normalized);
 
-			if (!url.port && !url.hostname.includes('rocketride.ai')) {
+			// The URL API silently strips ports that are default-for-scheme
+			// (e.g. :443 on https, :80 on http), so url.port alone cannot
+			// distinguish "no port given" from "scheme-default port given".
+			// Check the raw input for an explicit `:digits` after the scheme.
+			const withoutScheme = normalized.replace(/^[a-zA-Z][a-zA-Z\d+\-.]*:\/\//, '');
+			const authority = withoutScheme.split(/[/?#]/, 1)[0] ?? '';
+			const hasExplicitPort = authority.startsWith('[')
+				? /\]:\d+$/.test(authority) // IPv6 literal with explicit port
+				: /:\d+$/.test(authority);  // hostname/IPv4 with explicit port
+
+			if (!url.port && !hasExplicitPort && !url.hostname.includes('rocketride.ai')) {
 				url.port = CONST_DEFAULT_WEB_PORT;
 			}
 


### PR DESCRIPTION
## Summary
- Fix SDK URI normalization to preserve user-specified ports instead of always overwriting with 5565

## Bug Description
**File:** `packages/client-typescript/src/client/client.ts`

The `normalizeUri` logic always sets the port to `CONST_DEFAULT_WEB_PORT` (5565) for non-cloud URIs, even when the user explicitly provides a different port. This breaks connections through:
- ngrok tunnels (port 443)
- Cloudflare tunnels (port 443)
- Custom reverse proxy deployments (any non-5565 port)

## Root Cause
The previous guard (`!url.port`) was insufficient because the URL API silently strips default-for-scheme ports (e.g. `:443` on https, `:80` on http). So `new URL("https://tunnel.example.com:443").port` is `""`, causing the code to overwrite with 5565.

## Fix
Check the raw input string for an explicit port (`:digits` pattern after stripping the scheme) before deciding whether to apply the default port. This correctly preserves any user-specified port, including scheme-default ports like 443 on HTTPS.

## Testing
- URLs without port -> default 5565 applied (existing behavior preserved)
- URLs with explicit port (e.g., :443) -> port preserved (bug fixed)
- URLs with default-for-scheme port (e.g., https://x:443) -> port preserved (bug fixed)
- Cloud URLs -> unchanged (separate code path)

Fixes #584

#frontier-tower-hackathon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected URI normalization so the client applies the default web port only when the input doesn’t include an explicit port and the host isn’t a specific domain. This prevents unintended port assignments for addresses that already specify a port or certain hostnames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->