### PR TITLE
chore(security): add gitleaks pre-commit hook + secret scanning improvements

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -5,27 +5,26 @@
 [extend]
 useDefault = true
 
-# Custom rule: detect hardcoded API keys in .pipe JSON files
+# Custom rule: detect hardcoded API keys in .pipe pipeline files
 [[rules]]
 id = "pipe-file-api-key"
 description = "Hardcoded API key in .pipe pipeline file"
-regex = '''(?i)"(apikey|api_key|secret|token|password|auth)"\s*:\s*"([^"$]{8,})"'''
+regex = '''(?i)"(apikey|api_key|secret|token|password|auth)"\s*:\s*"([^"]{8,})"'''
 secretGroup = 2
 keywords = ["apikey", "api_key", "secret", "token", "password", "auth"]
-paths = ['''\.pipe$''', '''\.json$''']
+paths = ['''\.pipe$''']
 
     [rules.allowlist]
     regexes = [
         '''\$[A-Z_]+''',
         '''\$\{[A-Z_]+\}''',
-        '''^\s*$''',
     ]
 
 # Custom rule: detect hardcoded keys in services.json node configs
 [[rules]]
 id = "services-json-api-key"
 description = "Hardcoded API key in node services.json config"
-regex = '''(?i)"(apikey|api_key|secret_key|access_key)"\s*:\s*"([^"$]{16,})"'''
+regex = '''(?i)"(apikey|api_key|secret_key|access_key)"\s*:\s*"([^"]{16,})"'''
 secretGroup = 2
 keywords = ["apikey", "api_key", "secret_key", "access_key"]
 paths = ['''services.*\.json$''']

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -7,7 +7,7 @@ pre-commit:
         if command -v gitleaks >/dev/null 2>&1; then
           gitleaks protect --verbose --staged --config .gitleaks.toml
         else
-          echo "⚠️  gitleaks not installed — skipping secret scan (install: brew install gitleaks)"
+          echo "⚠️  gitleaks not installed — skipping secret scan (install: brew install gitleaks or go install github.com/gitleaks/gitleaks/v8@latest)"
         fi
     eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'


### PR DESCRIPTION
## Summary

Adds layered secret detection to complement #379 (`.gitignore` for `.pipe` files):

- **Gitleaks pre-commit hook** via lefthook — scans staged files for API keys before commit
- **Custom rules** for `.pipe` and `services.json` files that embed API keys in plaintext JSON
- **Env var allowlist** — allows `$VAR` / `${VAR}` references while blocking hardcoded secrets

## What changed

**lefthook.yml:**
- Added `gitleaks` command to pre-commit hooks (runs in parallel with eslint/prettier/ruff)
- Graceful skip when gitleaks is not installed (prints install instructions)

**.gitleaks.toml:**
- Extends default gitleaks rules (covers AWS, GCP, Stripe, GitHub, etc.)
- Custom `pipe-file-api-key` rule — catches `"apikey": "AIzaSy..."` in `.pipe` files
- Custom `services-json-api-key` rule — catches hardcoded keys in node configs
- Allowlist for env var patterns (`$VAR`, `${VAR}`) so teams can use references instead of raw keys
- Global path exclusions for lock files, build output, node_modules

**Secret scanning validity checks:**
- Attempted to enable via API but requires GitHub Enterprise plan
- Recommend enabling when org upgrades

## Defense in depth (how layers work together)

| Layer | Tool | What it catches | When |
|---|---|---|---|
| 1 | `.gitignore` (#379) | Entire `.pipe` files | Before `git add` |
| 2 | **Gitleaks** (this PR) | API keys inside any staged file | Before `git commit` |
| 3 | GitHub Push Protection (already active) | Known secret patterns | Before `git push` |
| 4 | GitHub Secret Scanning (already active) | Leaked keys in repo history | Continuous |

## Setup for developers

```bash
brew install gitleaks   # macOS
# or: go install github.com/gitleaks/gitleaks/v8@latest
```

No setup needed — lefthook runs it automatically. If not installed, the hook prints a warning and continues.

## Long-term: env var references in .pipe files

The `.gitleaks.toml` rules already allow `$VAR` / `${VAR}` patterns. Once the VS Code extension supports env var substitution in `.pipe` configs (e.g. `"apikey": "$GEMINI_API_KEY"`), users won't need raw keys at all. Tracked as a follow-up.

## Test plan

- [ ] Install gitleaks, stage a file with `"apikey": "sk-test-12345678901234"` — commit should be blocked
- [ ] Stage a file with `"apikey": "$GEMINI_API_KEY"` — commit should pass
- [ ] Without gitleaks installed — commit should pass with a warning

Fixes #379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated secret-detection to the dev workflow with a pre-commit scan that flags likely API/secret strings in pipeline and service config files.
  * Scan includes tuned rules to reduce false positives (ignores placeholder patterns) and a global allowlist for common lock/build/output paths.
  * Pre-commit will warn and provide installation guidance if the secret-scanning tool is not available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->