### PR TITLE
ci: skip engine build on PRs when no engine files changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
               - 'builder.cmd'
               - 'scripts/lib/**'
               - '.github/workflows/_build.yaml'
+              - '.github/workflows/_init.yaml'
               - '.github/workflows/ci.yml'
 
   build:


### PR DESCRIPTION
## Summary

Skip the expensive 3-platform C++ engine build on PRs that don't touch engine-core files. Saves ~270 minutes of CI time (90min × 3 runners) for docs, Python nodes, UI, and SDK-only changes.

## How it works

Uses [dorny/paths-filter](https://github.com/dorny/paths-filter) to detect changes in engine paths:

```
packages/server/**    # C++ engine source
packages/tika/**      # Java Tika module
build/vcpkg/**        # C++ package manager
builder / builder.cmd # Build scripts
scripts/lib/**        # Build utilities
.github/workflows/_build.yaml / ci.yml
```

**On PRs:** If none of these paths changed → build job is skipped
**On push/merge_group/schedule/dispatch:** Always runs (no regression)

## Examples

| PR changes | Engine build |
|---|---|
| `nodes/src/nodes/llm_openai/...` | Skipped |
| `apps/chat-ui/src/...` | Skipped |
| `docs/...` or `CONTRIBUTING.md` | Skipped |
| `packages/server/engine-core/...` | Runs |
| `builder` or `scripts/lib/download.js` | Runs |
| Push to `develop` | Always runs |

## Test plan

- [ ] Open a PR touching only Python/docs files — build job should show as skipped
- [ ] Open a PR touching `packages/server/` — build job should run normally
- [ ] Push to `develop` — build always runs regardless of paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI skips unnecessary PR builds when only non‑relevant files change, reducing build time and resource use.
  * Added a PR-only path check to determine when a full build is required.
  * Introduced a single aggregated required check that consolidates prerequisites and fails the workflow if any prerequisite job fails, improving CI reliability and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->