### PR TITLE
fix(client-mcp): bump to v1.0.5 — fix broken pip install

### DIFF
--- a/packages/client-mcp/pyproject.toml
+++ b/packages/client-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride-mcp"
-version = "1.0.4"
+version = "1.0.5"
 description = "RocketRide MCP stdio server that streams local files to RocketRide EaaS"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

`pip install rocketride-mcp` is broken. Published v1.0.4 on PyPI depends on `rocketride-client>=1.1.0` which doesn't exist. The correct package name is `rocketride`.

The dependency fix is already in `pyproject.toml` (`rocketride>=1.1.0`) but was never published because the version wasn't bumped.

## Changes

- Bump `rocketride-mcp` version `1.0.4` → `1.0.5` in `pyproject.toml`

## After merge

Trigger the release workflow to publish v1.0.5 to PyPI with the corrected dependency.

Fixes #321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 1.0.5

<!-- end of auto-generated comment: release notes by coderabbit.ai -->