### PR TITLE
fix(ci): nightly prerelease

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,6 +8,7 @@ concurrency:
 permissions:
   contents: write
   packages: write
+  id-token: write
 
 on:
   schedule:


### PR DESCRIPTION
## Summary

Fix CI/CD workflow 'Nightly prerelease'.

https://github.com/rocketride-org/rocketride-server/actions/runs/23472870474

```
[Invalid workflow file: .github/workflows/nightly.yaml#L65](https://github.com/rocketride-org/rocketride-server/actions/runs/23472870474/workflow)
The workflow is not valid. .github/workflows/nightly.yaml (Line: 65, Col: 3): Error calling workflow 'rocketride-org/rocketride-server/.github/workflows/_release.yaml@0d4340940f491513918788d88f976e1f417fb11c'. The nested job 'release' is requesting 'id-token: write', but is only allowed 'id-token: none'.
```

## Type

fix

## Testing

- ⚠️ Nightly prerelease will be tested after merget
