### PR TITLE
ci: skip build for docs-only PRs, let builder handle engine download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
               - 'scripts/**'
               - 'builder'
               - 'builder.cmd'
-              - 'build/vcpkg/**'
               - '.github/workflows/**'
 
   build:


### PR DESCRIPTION
## Summary

Simplifies the CI path filter per Stepan's feedback. Builder already handles engine download-vs-compile internally via hash comparison with nightly builds — no need for engine/code tier splitting in CI.

## How it works now

| PR changes | What happens |
|---|---|
| **Docs only** (.md, images, non-code) | Build skipped entirely |
| **Any code** (Python, TS, C++, scripts, workflows) | Full build runs — builder decides internally whether to download prebuilt engine or compile from source |
| **Push/schedule/dispatch** | Always full build |

## What changed

- **Simplified** path filter: single `code` filter instead of `engine`+`code` tiers
- **Removed** `skip_engine_compile` input from `_build.yaml` (not needed)
- **Kept** gatekeeper `ci-ok` job for docs-only PRs
- Builder's `server:download` step handles engine hash comparison with nightly — if engine source unchanged, downloads prebuilt binary automatically

## Why this approach

Stepan explained the builder already has this logic in `server:download` → `computeHash`:
- Compares local engine source hash with nightly build hash
- If match → downloads prebuilt engine (fast)
- If mismatch → compiles from source
- CI doesn't need to duplicate this decision

Fixes #390

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow path detection to distinguish between code and documentation changes, enabling documentation-only pull requests to skip unnecessary build steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->