### PR TITLE
feat(nodes): add llm_vision_ollama node for open-source image-to-text

### DIFF
--- a/nodes/src/nodes/llm_vision_ollama/IGlobal.py
+++ b/nodes/src/nodes/llm_vision_ollama/IGlobal.py
@@ -1,0 +1,48 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+from rocketlib import IGlobalBase
+from ai.common.chat import ChatBase
+
+
+class IGlobal(IGlobalBase):
+    """Global lifecycle handler for the Ollama Vision node."""
+
+    _chat: ChatBase | None = None
+
+    def beginGlobal(self):
+        from depends import depends  # type: ignore
+
+        requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
+        depends(requirements)
+
+        from .ollama_vision import Chat
+
+        # Shared runtime state
+        bag = self.IEndpoint.endpoint.bag
+        # Get a chat to interface
+        self._chat = Chat(self.glb.logicalType, self.glb.connConfig, bag)
+
+    def endGlobal(self):
+        self._chat = None

--- a/nodes/src/nodes/llm_vision_ollama/IInstance.py
+++ b/nodes/src/nodes/llm_vision_ollama/IInstance.py
@@ -1,0 +1,81 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from nodes.llm_base import IInstanceGenericLLM
+from rocketlib import AVI_ACTION
+
+
+class IInstance(IInstanceGenericLLM):
+    """Instance handler for the Ollama Vision node."""
+
+    IGlobal: IGlobal
+
+    # Raw image data accumulated across AVI chunks
+    image_data: bytearray | None = None
+
+    def writeImage(self, action: int, mimeType: str, buffer: bytes):
+        # Handle AVI_BEGIN action
+        if action == AVI_ACTION.BEGIN:
+            self.image_data = bytearray()
+            return self.preventDefault()
+
+        # Handle AVI_WRITE action (appending chunks of the image)
+        elif action == AVI_ACTION.WRITE:
+            if self.image_data is None:
+                raise RuntimeError('AVI protocol error: WRITE received before BEGIN')
+            self.image_data += buffer
+            return self.preventDefault()
+
+        # Handle AVI_END action (finalizing the image processing)
+        elif action == AVI_ACTION.END:
+            if self.image_data is None:
+                raise RuntimeError('AVI protocol error: END received while there is no data')
+
+            from ai.common.schema import Question
+
+            question = Question()
+
+            # Convert image bytes to base64 data URL and add as context
+            import base64
+
+            image_base64 = base64.b64encode(bytes(self.image_data)).decode('utf-8')
+            image_data_url = f'data:{mimeType};base64,{image_base64}'
+
+            # Add the image as context
+            question.addContext(image_data_url)
+
+            # Add the configured prompt as a question
+            question.addQuestion(self.IGlobal._chat._prompt)
+
+            # Call the vision model and emit text output
+            answer = self.IGlobal._chat.chat(question)
+            self.instance.writeText(answer.getText())
+
+            # Clear the buffer
+            self.image_data = None
+            return self.preventDefault()
+
+        # Handle unknown actions
+        else:
+            raise RuntimeError(f'AVI protocol error: Unknown action {action}')

--- a/nodes/src/nodes/llm_vision_ollama/__init__.py
+++ b/nodes/src/nodes/llm_vision_ollama/__init__.py
@@ -1,0 +1,39 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+
+def getChat():
+    """Get the Chat class from the module."""
+    from .ollama_vision import Chat
+
+    return Chat
+
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+    'getChat',
+]

--- a/nodes/src/nodes/llm_vision_ollama/ollama_vision.py
+++ b/nodes/src/nodes/llm_vision_ollama/ollama_vision.py
@@ -1,0 +1,133 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import time
+from typing import Any, Dict
+from langchain_openai import ChatOpenAI
+from ai.common.schema import Answer, Question
+from ai.common.chat import ChatBase
+from ai.common.config import Config
+
+
+class Chat(ChatBase):
+    """Ollama Vision chat bot using open-source multimodal models."""
+
+    _llm: ChatOpenAI
+    _system_prompt: str = ''
+    _prompt: str = ''
+    _serverbase: str = ''
+
+    def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
+        """Initialize the Ollama Vision chat instance."""
+        super().__init__(provider, connConfig, bag)
+
+        config = Config.getNodeConfig(provider, connConfig)
+
+        serverbase = config.get('serverbase', 'http://localhost:11434/v1')
+        # Normalize serverbase to end with /v1
+        if not serverbase.rstrip('/').endswith('/v1'):
+            serverbase = serverbase.rstrip('/') + '/v1'
+        self._serverbase = serverbase
+
+        self._system_prompt = config.get('vision.systemPrompt') or config.get('systemPrompt') or ''
+        self._prompt = config.get('vision.prompt') or config.get('prompt') or ''
+
+        self._llm = ChatOpenAI(
+            model=self._model,
+            base_url=self._serverbase,
+            api_key='ollama',
+            temperature=0,
+            max_tokens=self._modelOutputTokens,
+        )
+
+        bag['chat'] = self
+
+    def _format_user_error(self, error_msg: str) -> str:
+        """Convert API error messages to user-friendly format."""
+        error_lower = error_msg.lower()
+        if any(p in error_lower for p in ['connection refused', 'connection error', 'failed to connect', 'cannot connect']):
+            return f'Cannot connect to Ollama server. Is Ollama running? (tried: {self._serverbase})'
+        if any(p in error_lower for p in ['model not found', 'no such model', '404']):
+            return f"Model '{self._model}' is not loaded in Ollama. Run: ollama pull {self._model}"
+        if any(p in error_lower for p in ['rate limit', 'too many requests', '429']):
+            return 'Too many requests to Ollama. Please wait a moment and try again.'
+        if any(p in error_lower for p in ['internal server error', '500', 'service unavailable']):
+            return 'Ollama returned a server error. Please check the Ollama logs.'
+        if any(p in error_lower for p in ['timeout', 'timed out']):
+            return f"Vision request timed out. The model '{self._model}' may need more time — please try again."
+        if any(p in error_lower for p in ['image', 'vision', 'multimodal']):
+            return 'Image processing error. Please check that your image is in a supported format (JPEG, PNG, GIF, WEBP).'
+        return f'Ollama Vision error: {error_msg}'
+
+    def chat(self, question: Question) -> Answer:
+        """Send a vision request to Ollama and get the response."""
+        from langchain_core.messages import HumanMessage, SystemMessage
+
+        # Extract image data URL from context
+        image_data = None
+        for ctx in question.context:
+            if ctx.startswith(('data:image/', 'data:application/')):
+                image_data = ctx
+                break
+
+        if not image_data:
+            raise ValueError('No image data found in question context.')
+
+        # Use configured prompt, or fall back to question text
+        prompt_text = self._prompt or (question.questions[0].text if question.questions else None)
+        if not prompt_text:
+            prompt_text = 'Describe this image.'
+
+        # Build multimodal messages
+        messages = []
+        if self._system_prompt:
+            messages.append(SystemMessage(content=self._system_prompt))
+        messages.append(
+            HumanMessage(
+                content=[
+                    {'type': 'text', 'text': prompt_text},
+                    {'type': 'image_url', 'image_url': {'url': image_data}},
+                ]
+            )
+        )
+
+        # Retry loop with exponential backoff
+        max_retries = 3
+        base_delay = 1.0
+        last_error = None
+
+        for attempt in range(max_retries + 1):
+            try:
+                response = self._llm.invoke(messages)
+                answer = Answer(expectJson=question.expectJson)
+                answer.setAnswer(response.content)
+                return answer
+            except Exception as e:
+                last_error = e
+                if attempt < max_retries and self.is_retryable_error(e):
+                    delay = base_delay * (2**attempt)
+                    time.sleep(delay)
+                    continue
+                break
+
+        raise Exception(self._format_user_error(str(last_error)))

--- a/nodes/src/nodes/llm_vision_ollama/requirements.txt
+++ b/nodes/src/nodes/llm_vision_ollama/requirements.txt
@@ -1,0 +1,9 @@
+# LangChain OpenAI-compatible client (used to talk to Ollama's /v1 endpoint)
+langchain-openai
+
+# Token counting
+tokenizers
+
+# LangChain deps
+langchain-core
+langchain

--- a/nodes/src/nodes/llm_vision_ollama/services.json
+++ b/nodes/src/nodes/llm_vision_ollama/services.json
@@ -1,0 +1,390 @@
+{
+	//
+	// Required:
+	//		The displayable name of this node
+	//
+	"title": "Ollama Vision",
+	//
+	// Required:
+	//		The protocol is the endpoint protocol
+	//
+	"protocol": "image_vision_ollama://",
+	//
+	// Required:
+	//		Class type of the node - what it does
+	//
+	"classType": [
+		"image"
+	],
+	//
+	// Required:
+	//		Capabilities are flags that change the behavior of the underlying
+	//		engine
+	//
+	"capabilities": [
+		"invoke"
+	],
+	//
+	// Optional:
+	//		Register is either filter, endpoint or ignored if not specified. If the
+	//		type is specified, a factory is registered of that given type
+	//
+	"register": "filter",
+	//
+	// Optional:
+	//		The node is the actual physical node to instantiate - if
+	//		not specified, the protocol will be used
+	//
+	"node": "python",
+	//
+	// Optional:
+	//		The path is the executable/script code - it is node dependent
+	// 		and is optional for most node
+	//
+	"path": "nodes.llm_vision_ollama",
+	//
+	// Required:
+	//		The prefix map when added/removed when converting URLs <=> paths
+	//
+	"prefix": "image_vision_ollama",
+	//
+	// Optional:
+	//		Description to of this driver
+	//
+	"description": [
+		"A component that connects to locally-hosted open-source vision models through Ollama ",
+		"for image analysis, description, and visual understanding tasks. Supports Llama 3.2 Vision, ",
+		"LLaVA, Moondream, MiniCPM-V, and other multimodal models. Runs entirely on-premise with no ",
+		"external API keys required — ideal for privacy-sensitive applications."
+	],
+	//
+	// Optional:
+	//	  The icon is the icon to display in the UI for this node
+	//
+	"icon": "ollama.svg",
+	//
+	// Optional:
+	//	  Documentation link for this driver
+	//
+	"documentation": "https://bit.ly/3JFO3zk",
+	//
+	//  Optional:
+	//      Rendering hints to the UI which indicate which fields of
+	//      the configuration should be used to display information
+	//
+	"tile": [
+		"Model: ${parameters.image_vision_ollama.profile}"
+	],
+	//
+	//	Optional:
+	//		As a pipe component, define what this pipe component takes
+	//		and what it produces
+	//
+	"lanes": {
+		"image": [
+			"text"
+		]
+	},
+	"input": [
+		{
+			"lane": "image",
+			"description": "Image to analyze with a local Ollama vision model",
+			"output": [
+				{
+					"lane": "text",
+					"description": "Text analysis of the image content"
+				}
+			]
+		}
+	],
+	//
+	//	Optional:
+	//		Profile section are configuration options used by the driver
+	//		itself
+	//
+	"preconfig": {
+		// Define the values that will be merged into any profile configuration
+		// specified, unless the profile is 'absolute'
+		"default": "llama3_2-vision-11b",
+		// Defines profiles used with the "profile": key
+		"profiles": {
+			"custom": {
+				"title": "Custom",
+				"model": "",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 16385
+			},
+			"llama3_2-vision-11b": {
+				"title": "Llama 3.2 Vision 11B",
+				"model": "llama3.2-vision:11b",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 128000
+			},
+			"llama3_2-vision-90b": {
+				"title": "Llama 3.2 Vision 90B",
+				"model": "llama3.2-vision:90b",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 128000
+			},
+			"llava-7b": {
+				"title": "LLaVA 7B",
+				"model": "llava:7b",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 32768
+			},
+			"llava-13b": {
+				"title": "LLaVA 13B",
+				"model": "llava:13b",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 4096
+			},
+			"llava-34b": {
+				"title": "LLaVA 34B",
+				"model": "llava:34b",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 4096
+			},
+			"moondream": {
+				"title": "Moondream 2",
+				"model": "moondream",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 2048
+			},
+			"minicpm-v": {
+				"title": "MiniCPM-V",
+				"model": "minicpm-v",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 8192
+			},
+			"qwen2_5vl-3b": {
+				"title": "Qwen 2.5 VL 3B",
+				"model": "qwen2.5vl:3b",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 128000
+			},
+			"qwen2_5vl-7b": {
+				"title": "Qwen 2.5 VL 7B",
+				"model": "qwen2.5vl:7b",
+				"serverbase": "http://localhost:11434/v1",
+				"modelTotalTokens": 128000
+			}
+		}
+	},
+	//
+	// Optional:
+	//		Local fields definitions - these define fields only for the
+	//		current service. You may specify them here, or directly
+	//		in the shape
+	//
+	"fields": {
+		"model": {
+			"type": "string",
+			"title": "Model",
+			"description": "Ollama vision model name"
+		},
+		"modelTotalTokens": {
+			"type": "number",
+			"title": "Tokens",
+			"description": "Total Tokens"
+		},
+		"vision.systemPrompt": {
+			"type": "string",
+			"format": "textarea",
+			"title": "System Instructions",
+			"description": "Define the model's role and behavior for image analysis"
+		},
+		"vision.prompt": {
+			"type": "string",
+			"format": "textarea",
+			"title": "Analysis Prompt",
+			"description": "Describe what you want to analyze or extract from the image"
+		},
+		"image_vision_ollama.custom": {
+			"object": "custom",
+			"properties": [
+				"model",
+				"modelTotalTokens",
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.llama3_2-vision-11b": {
+			"object": "llama3_2-vision-11b",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.llama3_2-vision-90b": {
+			"object": "llama3_2-vision-90b",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.llava-7b": {
+			"object": "llava-7b",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.llava-13b": {
+			"object": "llava-13b",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.llava-34b": {
+			"object": "llava-34b",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.moondream": {
+			"object": "moondream",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.minicpm-v": {
+			"object": "minicpm-v",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.qwen2_5vl-3b": {
+			"object": "qwen2_5vl-3b",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.qwen2_5vl-7b": {
+			"object": "qwen2_5vl-7b",
+			"properties": [
+				"llm.local.serverbase",
+				"vision.systemPrompt",
+				"vision.prompt"
+			]
+		},
+		"image_vision_ollama.profile": {
+			"title": "Vision Model",
+			"description": "Select the Ollama vision model to use",
+			"type": "string",
+			"default": "llama3_2-vision-11b",
+			"enum": [
+				"*>preconfig.profiles.*.title"
+			],
+			"conditional": [
+				{
+					"value": "custom",
+					"properties": [
+						"image_vision_ollama.custom"
+					]
+				},
+				{
+					"value": "llama3_2-vision-11b",
+					"properties": [
+						"image_vision_ollama.llama3_2-vision-11b"
+					]
+				},
+				{
+					"value": "llama3_2-vision-90b",
+					"properties": [
+						"image_vision_ollama.llama3_2-vision-90b"
+					]
+				},
+				{
+					"value": "llava-7b",
+					"properties": [
+						"image_vision_ollama.llava-7b"
+					]
+				},
+				{
+					"value": "llava-13b",
+					"properties": [
+						"image_vision_ollama.llava-13b"
+					]
+				},
+				{
+					"value": "llava-34b",
+					"properties": [
+						"image_vision_ollama.llava-34b"
+					]
+				},
+				{
+					"value": "moondream",
+					"properties": [
+						"image_vision_ollama.moondream"
+					]
+				},
+				{
+					"value": "minicpm-v",
+					"properties": [
+						"image_vision_ollama.minicpm-v"
+					]
+				},
+				{
+					"value": "qwen2_5vl-3b",
+					"properties": [
+						"image_vision_ollama.qwen2_5vl-3b"
+					]
+				},
+				{
+					"value": "qwen2_5vl-7b",
+					"properties": [
+						"image_vision_ollama.qwen2_5vl-7b"
+					]
+				}
+			]
+		}
+	},
+	//
+	// Required:
+	//		Defines the fields (shape) of the service. Either source or target
+	//		map be specified, or both, but at least one is required
+	//
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Ollama Vision",
+			"properties": [
+				"image_vision_ollama.profile"
+			]
+		}
+	],
+	"test": {
+		"profiles": [
+			"llama3_2-vision-11b"
+		],
+		"outputs": [
+			"text"
+		],
+		"timeout": 30,
+		"cases": [
+			{
+				"name": "Vision node returns mock response for image input",
+				"image": "images/ocr_test_text.png",
+				"expect": {
+					"text": {
+						"contains": "Mock LLM response"
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Implements a new vision node that uses locally-hosted open-source multimodal models via Ollama as an alternative to proprietary vision APIs. Supports LLaVA, Llama 3.2 Vision, Moondream, MiniCPM-V, and Qwen 2.5 VL models (10 pre-configured profiles). No API key required — runs fully on-premise.

## Type

feat

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #393


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ollama Vision node for image-to-text analysis using local vision-capable models.
  * Supports chunked image uploads, automatic image encoding, and streaming image handling.
  * Many pre-configured model profiles plus a customizable profile.

* **Improvements**
  * UI exposes vision system/prompt editing, model selection, and local server settings.
  * More robust LLM calls with retries and clearer, user-friendly error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->