### PR TITLE
feat(flow): add Run/Stop buttons and additional node stats

### DIFF
--- a/apps/vscode/src/providers/PageEditorProvider.ts
+++ b/apps/vscode/src/providers/PageEditorProvider.ts
@@ -174,6 +174,7 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 						type: 'taskStatusUpdate',
 						source: source,
 						taskStatus: taskStatus,
+						host: this.connectionManager.getHttpUrl(),
 					});
 				}
 				break;
@@ -283,6 +284,7 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 							type: 'taskStatusUpdate',
 							source,
 							taskStatus,
+							host: this.connectionManager.getHttpUrl(),
 						});
 					}
 				}
@@ -425,6 +427,7 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 								type: 'taskStatusUpdate',
 								source: source,
 								taskStatus: taskStatus,
+								host: this.connectionManager.getHttpUrl(),
 							});
 						}
 					}
@@ -461,9 +464,54 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 					break;
 				}
 
+				case 'run': {
+					// Save to disk then execute the pipeline.
+					// The file watcher fires asynchronously after the disk write and checks
+					// handlePipelineRestart. We flag savesForRun so it skips the restart
+					// prompt, and clear the flag after a delay to cover the async watcher.
+					if (typeof data.content === 'string' && typeof data.source === 'string') {
+						const uriKey = document.uri.toString();
+						this.savesForRun.add(uriKey);
+						try {
+							await this.saveDocument(document, data.content);
+							const parsed = JSON.parse(document.getText());
+							await this.runPipeline({ pipeline: { ...parsed, source: data.source } });
+						} catch (error: unknown) {
+							const message = error instanceof Error ? error.message : String(error);
+							vscode.window.showErrorMessage(`Failed to run pipeline: ${message}`);
+						}
+						// Clear after a delay so the async file watcher has time to check the flag
+						setTimeout(() => this.savesForRun.delete(uriKey), 2000);
+					}
+					break;
+				}
+
+				case 'stop': {
+					// Stop a running pipeline for the given source node
+					if (typeof data.source === 'string') {
+						await this.stopPipeline(data.source, document);
+					}
+					break;
+				}
+
+				case 'openStatus': {
+					// Open the status page for a source node
+					if (typeof data.source === 'string') {
+						try {
+							const parsed = JSON.parse(document.getText());
+							const projectId = parsed.project_id ?? '';
+							const displayName = data.source;
+							await vscode.commands.executeCommand('rocketride.page.status.open', displayName, document.uri, projectId, data.source);
+						} catch (error: unknown) {
+							this.logger.error(`[PageEditorProvider] Failed to open status page: ${error}`);
+						}
+					}
+					break;
+				}
+
 				case 'openExternal':
 					if (data.url) {
-						vscode.env.openExternal(vscode.Uri.parse(data.url));
+						this.openLink(data.url, data.displayName);
 					}
 					break;
 
@@ -628,11 +676,13 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 			const projectId = project.project_id;
 			const source = project.source;
 
-			// Use DAP command to execute pipeline
+			// Use DAP command to execute pipeline (always trace from canvas)
 			await this.connectionManager.request('execute', {
 				projectId: projectId,
 				source: source,
 				pipeline: projectTransformed,
+				pipelineTraceLevel: 'full',
+				args: ConfigManager.getInstance().getEffectiveEngineArgs(),
 			});
 		} catch (error: unknown) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -675,6 +725,223 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 			const message = error instanceof Error ? error.message : String(error);
 			vscode.window.showErrorMessage(`Failed to stop pipeline: ${message}`);
 		}
+	}
+
+	/**
+	 * Opens a URL in an embedded VS Code WebviewPanel with an iframe.
+	 *
+	 * Mirrors PageStatusProvider.openLink — bridges drag-and-drop, clipboard,
+	 * theme colors, and env variables to the iframe.
+	 */
+	private openLink(url: string, displayName?: string): void {
+		const panel = vscode.window.createWebviewPanel('externalContent', displayName || 'Pipeline', vscode.ViewColumn.One, {
+			enableScripts: true,
+			retainContextWhenHidden: true,
+		});
+
+		const env: Record<string, string | boolean> = ConfigManager.getInstance().getEnv();
+		env['devMode'] = true;
+
+		panel.webview.html = `
+			<!DOCTYPE html>
+			<html>
+			<head>
+				<meta charset="UTF-8">
+				<meta name="viewport" content="width=device-width, initial-scale=1.0">
+				<style>
+					body { margin: 0; padding: 0; }
+					iframe { width: 100%; height: 100vh; border: none; }
+				</style>
+			</head>
+			<body>
+				<iframe id="app-iframe" src="${url}${url.includes('?') ? '&' : '?'}_t=${Date.now()}" allow="clipboard-read; clipboard-write"></iframe>
+				<script>
+					(function() {
+						const vscode = acquireVsCodeApi();
+						const iframe = document.getElementById('app-iframe');
+						const envVars = ${JSON.stringify(env)};
+						let iframeOrigin = '*';
+						try { iframeOrigin = new URL(iframe.src).origin; } catch(e) {}
+
+						['dragenter', 'dragover'].forEach(eventName => {
+							document.addEventListener(eventName, (e) => {
+								e.preventDefault();
+								e.stopPropagation();
+								try { iframe.contentWindow.postMessage({ type: 'dragHover', x: e.clientX, y: e.clientY }, iframeOrigin); } catch(err) {}
+							});
+						});
+						document.addEventListener('dragleave', (e) => {
+							if (e.relatedTarget === null) {
+								try { iframe.contentWindow.postMessage({ type: 'dragLeave' }, iframeOrigin); } catch(err) {}
+							}
+						});
+
+						document.addEventListener('drop', async (e) => {
+							e.preventDefault();
+							e.stopPropagation();
+							const files = e.dataTransfer && e.dataTransfer.files;
+							if (!files || files.length === 0) return;
+
+							const fileDataArray = [];
+							for (let i = 0; i < files.length; i++) {
+								const file = files[i];
+								const buffer = await file.arrayBuffer();
+								fileDataArray.push({
+									name: file.name,
+									type: file.type || 'application/octet-stream',
+									size: file.size,
+									lastModified: file.lastModified,
+									buffer: buffer
+								});
+							}
+
+							try {
+								iframe.contentWindow.postMessage({
+									type: 'bridgedFileDrop',
+									files: fileDataArray
+								}, iframeOrigin, fileDataArray.map(f => f.buffer));
+								iframe.contentWindow.postMessage({ type: 'dragLeave' }, iframeOrigin);
+							} catch (err) {
+								console.error('[Parent] Error bridging file drop to iframe:', err);
+							}
+						});
+
+						function getVSCodeThemeColors() {
+							const style = getComputedStyle(document.body);
+							const getColor = (varName, fallback = '') => {
+								const value = style.getPropertyValue(varName).trim();
+								return value || fallback;
+							};
+							return {
+								'--bg-primary': getColor('--vscode-editor-background'),
+								'--bg-secondary': getColor('--vscode-sideBar-background'),
+								'--bg-tertiary': getColor('--vscode-editorWidget-background'),
+								'--bg-hover': getColor('--vscode-list-hoverBackground'),
+								'--text-primary': getColor('--vscode-editor-foreground'),
+								'--text-secondary': getColor('--vscode-descriptionForeground'),
+								'--text-muted': getColor('--vscode-disabledForeground'),
+								'--border-color': getColor('--vscode-panel-border'),
+								'--border-hover': getColor('--vscode-focusBorder'),
+								'--accent-primary': getColor('--vscode-focusBorder'),
+								'--accent-secondary': getColor('--vscode-button-background'),
+								'--accent-hover': getColor('--vscode-button-hoverBackground'),
+								'--success-color': getColor('--vscode-terminal-ansiGreen'),
+								'--error-color': getColor('--vscode-errorForeground'),
+								'--warning-color': getColor('--vscode-editorWarning-foreground'),
+								'--info-color': getColor('--vscode-editorInfo-foreground'),
+								'--code-bg': getColor('--vscode-textCodeBlock-background'),
+								'--input-bg': getColor('--vscode-input-background'),
+								'--input-border': getColor('--vscode-input-border'),
+								'--shadow-sm': getColor('--vscode-widget-shadow'),
+								'--shadow-md': getColor('--vscode-widget-shadow'),
+								'--shadow-lg': getColor('--vscode-widget-shadow')
+							};
+						}
+
+						function sendDataToIframe() {
+							const colors = getVSCodeThemeColors();
+							try {
+								iframe.contentWindow.postMessage({
+									type: 'vscodeData',
+									env: envVars,
+									theme: colors
+								}, iframeOrigin);
+							} catch (error) {
+								console.error('[Parent] Error sending data to iframe:', error);
+							}
+						}
+
+						window.addEventListener('message', (event) => {
+							if (event.source === iframe.contentWindow) {
+								if (event.data.type === 'ready') {
+									sendDataToIframe();
+								}
+								if (event.data.type === 'requestPaste') {
+									vscode.postMessage({ type: 'requestPaste' });
+								}
+								if (event.data.type === 'copyText' && event.data.text) {
+									vscode.postMessage({ type: 'copyText', text: event.data.text });
+								}
+								if (event.data.type === 'requestFileDialog') {
+									vscode.postMessage({ type: 'requestFileDialog' });
+								}
+							}
+						});
+
+						window.addEventListener('message', (event) => {
+							const msg = event.data;
+							if (msg.type === 'themeChanged') {
+								setTimeout(() => {
+									sendDataToIframe();
+								}, 50);
+							}
+							if (msg.type === 'pasteContent' && msg.text && iframe.contentWindow) {
+								iframe.contentWindow.postMessage({
+									type: 'paste',
+									text: msg.text
+								}, iframeOrigin);
+							}
+							if (msg.type === 'nativeFilesSelected' && iframe.contentWindow) {
+								iframe.contentWindow.postMessage({
+									type: 'nativeFilesSelected',
+									files: msg.files
+								}, iframeOrigin);
+							}
+						});
+					})();
+				</script>
+			</body>
+			</html>
+		`;
+
+		const messageDisposable = panel.webview.onDidReceiveMessage(async (msg: { type: string; text?: string }) => {
+			if (msg.type === 'requestPaste') {
+				const text = await vscode.env.clipboard.readText();
+				if (text) {
+					panel.webview.postMessage({ type: 'pasteContent', text });
+				}
+			}
+			if (msg.type === 'copyText' && msg.text) {
+				await vscode.env.clipboard.writeText(msg.text);
+			}
+			if (msg.type === 'requestFileDialog') {
+				const uris = await vscode.window.showOpenDialog({
+					canSelectMany: true,
+					canSelectFiles: true,
+					canSelectFolders: false,
+					title: 'Select files to upload',
+				});
+				if (uris && uris.length > 0) {
+					const path = require('path');
+					const fileDataArray: { name: string; type: string; size: number; lastModified: number; buffer: number[] }[] = [];
+					for (const uri of uris) {
+						const bytes = await vscode.workspace.fs.readFile(uri);
+						fileDataArray.push({
+							name: path.basename(uri.fsPath),
+							type: 'application/octet-stream',
+							size: bytes.length,
+							lastModified: Date.now(),
+							buffer: Array.from(bytes),
+						});
+					}
+					panel.webview.postMessage({
+						type: 'nativeFilesSelected',
+						files: fileDataArray,
+					});
+				}
+			}
+		});
+
+		const themeChangeDisposable = vscode.window.onDidChangeActiveColorTheme(() => {
+			panel.webview.postMessage({
+				type: 'themeChanged',
+			});
+		});
+
+		panel.onDidDispose(() => {
+			messageDisposable.dispose();
+			themeChangeDisposable.dispose();
+		});
 	}
 
 	/**

--- a/apps/vscode/src/providers/SidebarFilesProvider.ts
+++ b/apps/vscode/src/providers/SidebarFilesProvider.ts
@@ -551,9 +551,9 @@ export class SidebarFilesProvider implements vscode.TreeDataProvider<PipelineFil
 
 				const message = runningComponents.length === 1 ? `Pipeline component "${componentNames}" in ${fileName} is running. Restart it?` : `${runningComponents.length} components (${componentNames}) in ${fileName} are running. Restart them?`;
 
-				const choice = await vscode.window.showInformationMessage(message, { modal: true }, 'Restart');
+				const choice = await vscode.window.showInformationMessage(message, { modal: true }, 'Yes', 'No');
 
-				if (choice === 'Restart') {
+				if (choice === 'Yes') {
 					for (const component of runningComponents) {
 						await this.restartPipe(parsedFile.projectId!, component.id, uri);
 					}

--- a/apps/vscode/src/providers/views/PageEditor/PageEditor.tsx
+++ b/apps/vscode/src/providers/views/PageEditor/PageEditor.tsx
@@ -45,6 +45,7 @@ export type PageEditorIncomingMessage =
 			type: 'taskStatusUpdate';
 			source: string; // Component ID
 			taskStatus: TaskStatus; // Single TaskStatus update from backend
+			host: string; // Server host URL for {host} placeholder replacement
 	  }
 	| {
 			type: 'servicesUpdate';
@@ -75,6 +76,7 @@ export type PageEditorOutgoingMessage =
 	| {
 			type: 'openExternal';
 			url: string;
+			displayName?: string;
 	  }
 	| {
 			type: 'setPreference';
@@ -86,6 +88,19 @@ export type PageEditorOutgoingMessage =
 	| {
 			type: 'validate';
 			pipeline: IProject;
+	  }
+	| {
+			type: 'run';
+			source: string;
+			content: string;
+	  }
+	| {
+			type: 'stop';
+			source: string;
+	  }
+	| {
+			type: 'openStatus';
+			source: string;
 	  };
 
 // ============================================================================
@@ -122,6 +137,8 @@ export const PageEditor: React.FC = () => {
 	const [oauth2RootUrl, setOauth2RootUrl] = useState<string>('https://oauth2.rocketride.ai');
 	// Canvas preferences (synced from extension on ready, persisted via setPreference)
 	const [preferences, setPreferences] = useState<Record<string, unknown>>({});
+	// Server host URL for {host} placeholder replacement in endpoint URLs
+	const [serverHost, setServerHost] = useState<string>('');
 
 	const contentChangedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const pendingContentRef = useRef<string | null>(null);
@@ -144,7 +161,8 @@ export const PageEditor: React.FC = () => {
 				case 'taskStatusUpdate': {
 					// Drive canvas node state from status_update: merge this source's status
 					// so the node with id === source (e.g. chat_2) re-renders with run/Processing/offline.
-					const { source, taskStatus } = message;
+					const { source, taskStatus, host } = message;
+					if (host) setServerHost(host);
 					setTaskStatuses((prev) => ({
 						...prev,
 						[source]: taskStatus,
@@ -236,8 +254,8 @@ export const PageEditor: React.FC = () => {
 	};
 
 	const onOpenLink = useCallback(
-		(url: string) => {
-			sendMessage({ type: 'openExternal', url });
+		(url: string, displayName?: string) => {
+			sendMessage({ type: 'openExternal', url, displayName });
 		},
 		[sendMessage]
 	);
@@ -255,6 +273,28 @@ export const PageEditor: React.FC = () => {
 	// are handled natively by VS Code's custom editor framework.
 	const onUndo = useCallback(() => sendMessage({ type: 'requestUndo' }), [sendMessage]);
 	const onRedo = useCallback(() => sendMessage({ type: 'requestRedo' }), [sendMessage]);
+
+	// Pipeline execution callbacks — save-to-disk + run is atomic on the host side
+	const onRunPipeline = useCallback(
+		(source: string, project: IProject) => {
+			sendMessage({ type: 'run', source, content: JSON.stringify(project) });
+		},
+		[sendMessage]
+	);
+
+	const onStopPipeline = useCallback(
+		(source: string) => {
+			sendMessage({ type: 'stop', source });
+		},
+		[sendMessage]
+	);
+
+	const onOpenStatus = useCallback(
+		(source: string) => {
+			sendMessage({ type: 'openStatus', source });
+		},
+		[sendMessage]
+	);
 
 	const onContentChanged = useCallback(
 		(project: object) => {
@@ -293,7 +333,7 @@ export const PageEditor: React.FC = () => {
 
 	return (
 		<div className="pipeline-editor-container">
-			<Canvas oauth2RootUrl={oauth2RootUrl} project={content} servicesJson={servicesJson} handleValidatePipeline={handleValidatePipeline} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} />
+			<Canvas oauth2RootUrl={oauth2RootUrl} project={content} servicesJson={servicesJson} handleValidatePipeline={handleValidatePipeline} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} />
 		</div>
 	);
 };

--- a/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
+++ b/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
@@ -31,7 +31,6 @@ import { TokenSection } from '../../components/TokenSection';
 import { TabPanel } from '../../components/TabPanel';
 import { TraceSection, TraceRow } from '../../components/TraceSection';
 import { EndpointInfoModal, EndpointInfo } from '../../components/EndpointInfoModal';
-import { WarningIcon } from '../../components/icons/WarningIcon';
 
 // Import the styles
 import '../../styles/vscode.css';
@@ -400,15 +399,26 @@ export const PageStatus: React.FC = () => {
 
 	const endpointInfo = getEndpointInfo();
 	const controlButton = getControlButton();
-	const errorCount = (taskStatus?.errors?.length ?? 0) + (taskStatus?.warnings?.length ?? 0);
+	const errCount = taskStatus?.errors?.length ?? 0;
+	const warnCount = taskStatus?.warnings?.length ?? 0;
 
-	// Build tab list (Errors tab always visible, badge shown when count > 0)
+	// Build tab list (Errors tab always visible, badges shown when count > 0)
+	const errorsBadge = (() => {
+		if (errCount === 0 && warnCount === 0) return undefined;
+		return (
+			<span style={{ display: 'inline-flex', gap: '3px', marginLeft: '4px' }}>
+				{errCount > 0 && <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: '16px', height: '16px', borderRadius: '8px', backgroundColor: 'var(--vscode-errorForeground, #f14c4c)', color: '#fff', fontSize: '10px', fontWeight: 600, padding: '0 4px' }}>{errCount}</span>}
+				{warnCount > 0 && <span style={{ display: 'inline-flex', alignItems: 'center', justifyContent: 'center', minWidth: '16px', height: '16px', borderRadius: '8px', backgroundColor: 'var(--vscode-editorWarning-foreground, #cca700)', color: '#fff', fontSize: '10px', fontWeight: 600, padding: '0 4px' }}>{warnCount}</span>}
+			</span>
+		);
+	})();
+
 	const tabs = [
 		{ id: 'status', label: 'Status' },
 		{ id: 'tokens', label: 'Tokens' },
 		{ id: 'flow', label: 'Flow' },
 		{ id: 'trace', label: 'Trace' },
-		{ id: 'errors', label: 'Errors', badge: errorCount > 0 ? <WarningIcon size={14} /> : undefined },
+		{ id: 'errors', label: 'Errors', badge: errorsBadge },
 	];
 
 	return (

--- a/packages/ai/src/ai/modules/task/commands/cmd_monitor.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_monitor.py
@@ -151,12 +151,18 @@ class MonitorCommands(DAPConn):
                 subscriber_preference = self._monitors[pipe_key]
                 await _send_event(subscriber_preference)
 
-        # Project-scoped check
+        # Project-scoped check (exact source match)
         if project_key in self._monitors:
             subscriber_preference = self._monitors[project_key]
             await _send_event(subscriber_preference)
 
-        # Wildcard check
+        # Project-wildcard check (all sources within a project: p.{projectId}.*)
+        project_wildcard_key = f'p.{control.project_id}.*'
+        if project_wildcard_key != project_key and project_wildcard_key in self._monitors:
+            subscriber_preference = self._monitors[project_wildcard_key]
+            await _send_event(subscriber_preference)
+
+        # Global wildcard check (all tasks)
         if '*' in self._monitors:
             subscriber_preference = self._monitors['*']
             await _send_event(subscriber_preference)

--- a/packages/shared-ui/src/components/pipeline-actions/EndpointInfoModal.tsx
+++ b/packages/shared-ui/src/components/pipeline-actions/EndpointInfoModal.tsx
@@ -1,0 +1,175 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+/**
+ * EndpointInfoModal — Plain React modal showing endpoint configuration details.
+ *
+ * Displays the endpoint URL, auth key, and optional private token with
+ * copy-to-clipboard and show/hide functionality. Mirrors the behavior of
+ * the PageStatus EndpointInfoModal.
+ *
+ * Plain React + inline styles using --rr-* theme tokens. No MUI.
+ */
+
+import React, { ReactElement, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { IEndpointInfo } from './PipelineActions';
+import { modalStyles as styles } from './index.style';
+
+// =============================================================================
+// Props
+// =============================================================================
+
+interface IEndpointInfoModalProps {
+	/** Endpoint configuration data. */
+	endpointInfo: IEndpointInfo | null;
+	/** Whether the modal is open. */
+	isOpen: boolean;
+	/** Handler to close the modal. */
+	onClose: () => void;
+	/** Handler to open external URLs. */
+	onOpenLink?: (url: string, displayName?: string) => void;
+	/** Display name for the source node (used as the tab title when opening links). */
+	displayName?: string;
+	/** Host to replace {host} placeholders in all values. */
+	host?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Replaces {host} placeholders in all string values of the endpoint info. */
+function processEndpointInfo(info: IEndpointInfo, host?: string): IEndpointInfo {
+	if (!host) return info;
+	const processed = { ...info };
+	for (const key of Object.keys(processed) as (keyof IEndpointInfo)[]) {
+		const value = processed[key];
+		if (typeof value === 'string') {
+			(processed[key] as string) = value.replace(/{host}/g, host);
+		}
+	}
+	return processed;
+}
+
+const MASKED_VALUE = '•••••••••••••••••••';
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export default function EndpointInfoModal({ endpointInfo, isOpen, onClose, onOpenLink, displayName, host }: IEndpointInfoModalProps): ReactElement | null {
+	const [isKeyVisible, setIsKeyVisible] = useState(false);
+	const [isTokenVisible, setIsTokenVisible] = useState(false);
+	const [copyFeedback, setCopyFeedback] = useState<string | null>(null);
+
+	const onCloseRef = React.useRef(onClose);
+	onCloseRef.current = onClose;
+
+	if (!endpointInfo || !isOpen) return null;
+
+	const processed = processEndpointInfo(endpointInfo, host);
+
+	const handleCopy = (text: string, label: string) => {
+		navigator.clipboard
+			.writeText(text)
+			.then(() => {
+				setCopyFeedback(label);
+				setTimeout(() => setCopyFeedback(null), 1500);
+			})
+			.catch(() => {
+				// Clipboard not available
+			});
+	};
+
+	const handleBackdropClick = (e: React.MouseEvent<HTMLDivElement>) => {
+		if (e.target === e.currentTarget) {
+			onCloseRef.current();
+		}
+	};
+
+	const iconBtn = (label: string): React.CSSProperties => ({
+		...styles.iconBtn,
+		...(copyFeedback === label ? styles.iconBtnSuccess : {}),
+	});
+
+	return createPortal(
+		<div style={styles.overlay} onClick={handleBackdropClick}>
+			<div style={styles.modal} onClick={(e) => e.stopPropagation()}>
+				{/* Header */}
+				<div style={styles.header}>
+					<div style={styles.title}>Endpoint Configuration</div>
+					<button style={styles.closeBtn} onClick={() => onCloseRef.current()}>
+						×
+					</button>
+				</div>
+
+				{/* Body */}
+				<div style={styles.body}>
+					{/* URL Section */}
+					<div style={styles.configItem}>
+						<div style={styles.configLabel}>{processed['url-text']}</div>
+						<div style={styles.configValueRow}>
+							<div style={styles.configValueLink}>
+								<a
+									href="#"
+									style={styles.link}
+									onClick={(e) => {
+										e.preventDefault();
+										onOpenLink?.(processed['url-link'], displayName);
+									}}
+								>
+									{processed['url-link']}
+								</a>
+							</div>
+							<button style={iconBtn('url')} onClick={() => handleCopy(processed['url-link'], 'url')}>
+								{copyFeedback === 'url' ? 'Copied!' : 'Copy'}
+							</button>
+							<button style={styles.iconBtn} onClick={() => onOpenLink?.(processed['url-link'], displayName)}>
+								Open
+							</button>
+						</div>
+					</div>
+
+					{/* Auth Key Section */}
+					<div style={styles.configItem}>
+						<div style={styles.configLabel}>{processed['auth-text']}</div>
+						<div style={styles.configValueRow}>
+							<div style={isKeyVisible ? styles.configValue : styles.configValueMasked}>{isKeyVisible ? processed['auth-key'] : MASKED_VALUE}</div>
+							<button style={iconBtn('key')} onClick={() => handleCopy(processed['auth-key'], 'key')}>
+								{copyFeedback === 'key' ? 'Copied!' : 'Copy'}
+							</button>
+							<button style={styles.iconBtn} onClick={() => setIsKeyVisible(!isKeyVisible)}>
+								{isKeyVisible ? 'Hide' : 'Show'}
+							</button>
+						</div>
+					</div>
+
+					{/* Token Section (if available) */}
+					{processed['token-key'] && processed['token-text'] && (
+						<div style={styles.configItem}>
+							<div style={styles.configLabel}>{processed['token-text']}</div>
+							<div style={styles.configValueRow}>
+								<div style={isTokenVisible ? styles.configValue : styles.configValueMasked}>{isTokenVisible ? processed['token-key'] : MASKED_VALUE}</div>
+								<button style={iconBtn('token')} onClick={() => handleCopy(processed['token-key']!, 'token')}>
+									{copyFeedback === 'token' ? 'Copied!' : 'Copy'}
+								</button>
+								<button style={styles.iconBtn} onClick={() => setIsTokenVisible(!isTokenVisible)}>
+									{isTokenVisible ? 'Hide' : 'Show'}
+								</button>
+							</div>
+						</div>
+					)}
+
+					{/* Security Note */}
+					<div style={styles.securityNote}>
+						<strong>Security:</strong> Keep your authentication credentials secure. Do not share them publicly or commit them to version control.
+					</div>
+				</div>
+			</div>
+		</div>,
+		document.body
+	);
+}

--- a/packages/shared-ui/src/components/pipeline-actions/PipelineActions.tsx
+++ b/packages/shared-ui/src/components/pipeline-actions/PipelineActions.tsx
@@ -1,0 +1,122 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+/**
+ * PipelineActions — Renders action buttons derived from a running pipeline's
+ * endpoint info (e.g. "Chat now", "Endpoint Info").
+ *
+ * The endpoint info comes from `taskStatus.notes[0]` when the server reports
+ * that a service is ready. This component extracts the button metadata and
+ * renders compact action buttons.
+ *
+ * Used on canvas source nodes and the status page header.
+ *
+ * Plain React + inline styles using --rr-* theme tokens. No MUI.
+ */
+
+import React, { ReactElement, useMemo, useState } from 'react';
+import EndpointInfoModal from './EndpointInfoModal';
+import { actionsStyles as styles } from './index.style';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Endpoint info structure embedded in `taskStatus.notes[0]` by the server
+ * when a pipeline service exposes an external endpoint (chat UI, webhook, etc.).
+ */
+export interface IEndpointInfo {
+	/** Label for the primary action button (e.g. "Chat now", "Open Dropper"). */
+	'button-text'?: string;
+	/** URL the primary button opens. May contain `{host}` placeholders. */
+	'button-link'?: string;
+	/** Label for the endpoint URL row (e.g. "Chat interface URL"). */
+	'url-text': string;
+	/** The actual endpoint URL. */
+	'url-link': string;
+	/** Label for the auth key row (e.g. "Public Authorization Key"). */
+	'auth-text': string;
+	/** The actual auth key value. */
+	'auth-key': string;
+	/** Label for an optional private token row. */
+	'token-text'?: string;
+	/** The actual private token value. */
+	'token-key'?: string;
+}
+
+export interface IPipelineActionsProps {
+	/** The notes array from taskStatus. Endpoint info is extracted from notes[0]. */
+	notes?: (string | Record<string, unknown>)[];
+	/** Host address used to replace `{host}` placeholders in URLs. */
+	host?: string;
+	/** Called when a URL needs to be opened externally. */
+	onOpenLink?: (url: string, displayName?: string) => void;
+	/** Display name for the source node (used as the tab title when opening links). */
+	displayName?: string;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/** Type guard: checks whether an unknown value is IEndpointInfo. */
+function isEndpointInfo(value: unknown): value is IEndpointInfo {
+	return value != null && typeof value === 'object' && 'url-text' in value && 'url-link' in value && 'auth-text' in value && 'auth-key' in value;
+}
+
+function getEndpointInfo(notes?: (string | Record<string, unknown>)[]): IEndpointInfo | null {
+	if (!notes || notes.length === 0) return null;
+	const first = notes[0];
+	return isEndpointInfo(first) ? first : null;
+}
+
+/** Replaces {host} placeholders in a URL. */
+function processLink(link: string | undefined, host?: string): string | undefined {
+	if (!link || !host) return link;
+	return link.replace(/{host}/g, host);
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+export default function PipelineActions({ notes, host, onOpenLink, displayName }: IPipelineActionsProps): ReactElement | null {
+	const endpointInfo = useMemo(() => getEndpointInfo(notes), [notes]);
+	const [isModalOpen, setIsModalOpen] = useState(false);
+
+	if (!endpointInfo) return null;
+
+	const buttonLink = processLink(endpointInfo['button-link'], host);
+	const hasButton = endpointInfo['button-text'] && buttonLink;
+
+	return (
+		<>
+			<div style={styles.container}>
+				{hasButton && (
+					<button
+						style={styles.primaryBtn}
+						onClick={(e: React.MouseEvent) => {
+							e.stopPropagation();
+							onOpenLink?.(buttonLink, displayName);
+						}}
+					>
+						{endpointInfo['button-text']}
+					</button>
+				)}
+				<button
+					style={styles.secondaryBtn}
+					onClick={(e: React.MouseEvent) => {
+						e.stopPropagation();
+						setIsModalOpen(true);
+					}}
+				>
+					Endpoint Info
+				</button>
+			</div>
+			<EndpointInfoModal endpointInfo={endpointInfo} isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} onOpenLink={onOpenLink} displayName={displayName} host={host} />
+		</>
+	);
+}

--- a/packages/shared-ui/src/components/pipeline-actions/index.style.ts
+++ b/packages/shared-ui/src/components/pipeline-actions/index.style.ts
@@ -1,0 +1,197 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+/**
+ * Style definitions for PipelineActions and EndpointInfoModal.
+ *
+ * All visual properties reference --rr-* CSS custom properties defined
+ * in the rocketride theme (rocketride-web.css / rocketride-vscode.css).
+ */
+
+import type { CSSProperties } from 'react';
+
+// =============================================================================
+// PipelineActions
+// =============================================================================
+
+const btnSmBase: CSSProperties = {
+	display: 'inline-flex',
+	alignItems: 'center',
+	justifyContent: 'center',
+	height: 'var(--rr-btn-sm-height, 16px)',
+	padding: 'var(--rr-btn-sm-padding, 0 6px)',
+	borderRadius: 'var(--rr-btn-sm-radius, 3px)',
+	cursor: 'pointer',
+	fontSize: 'var(--rr-btn-sm-font-size, 9px)',
+	fontWeight: 500,
+	lineHeight: 1,
+	whiteSpace: 'nowrap',
+};
+
+export const actionsStyles: Record<string, CSSProperties> = {
+	container: {
+		display: 'flex',
+		gap: '4px',
+		marginTop: '4px',
+		width: '100%',
+	},
+
+	primaryBtn: {
+		...btnSmBase,
+		flex: 1,
+		border: 'none',
+		backgroundColor: 'var(--rr-accent, #007acc)',
+		color: 'var(--rr-fg-button, #fff)',
+	},
+
+	secondaryBtn: {
+		...btnSmBase,
+		flex: 1,
+		border: '1px solid var(--rr-border, #dcdcdc)',
+		backgroundColor: 'var(--rr-bg-paper, #fff)',
+		color: 'var(--rr-text-secondary, #666)',
+	},
+};
+
+// =============================================================================
+// EndpointInfoModal
+// =============================================================================
+
+export const modalStyles: Record<string, CSSProperties> = {
+	overlay: {
+		position: 'fixed',
+		inset: 0,
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: 'rgba(0, 0, 0, 0.5)',
+		zIndex: 10000,
+	},
+
+	modal: {
+		backgroundColor: 'var(--rr-bg-paper, #1e1e1e)',
+		border: '1px solid var(--rr-border, #dcdcdc)',
+		borderRadius: '8px',
+		width: '100%',
+		maxWidth: '500px',
+		boxShadow: '0 8px 32px rgba(0, 0, 0, 0.3)',
+	},
+
+	header: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		padding: '14px 18px',
+		borderBottom: '1px solid var(--rr-border, #dcdcdc)',
+		backgroundColor: 'var(--rr-bg-widget-header, rgba(0,0,0,0.08))',
+		borderRadius: '8px 8px 0 0',
+	},
+
+	title: {
+		fontSize: '14px',
+		fontWeight: 600,
+		color: 'var(--rr-text-primary, inherit)',
+	},
+
+	closeBtn: {
+		background: 'none',
+		border: 'none',
+		color: 'var(--rr-text-secondary, #666)',
+		fontSize: '18px',
+		cursor: 'pointer',
+		padding: '4px 8px',
+		borderRadius: '4px',
+	},
+
+	body: {
+		padding: '20px',
+	},
+
+	configItem: {
+		marginBottom: '16px',
+	},
+
+	configLabel: {
+		fontSize: '11px',
+		fontWeight: 600,
+		color: 'var(--rr-text-secondary, #666)',
+		textTransform: 'uppercase',
+		letterSpacing: '0.5px',
+		marginBottom: '6px',
+	},
+
+	configValueRow: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: '8px',
+		backgroundColor: 'var(--rr-bg-surface-alt, var(--rr-bg-paper))',
+		border: '1px solid var(--rr-border, #dcdcdc)',
+		borderRadius: '4px',
+		padding: '10px',
+	},
+
+	configValueLink: {
+		flex: 1,
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap',
+	},
+
+	link: {
+		color: 'var(--rr-text-link, #007acc)',
+		textDecoration: 'none',
+		fontSize: '12px',
+	},
+
+	configValue: {
+		flex: 1,
+		fontSize: '12px',
+		color: 'var(--rr-text-primary, inherit)',
+		fontFamily: 'monospace',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap',
+	},
+
+	configValueMasked: {
+		flex: 1,
+		fontSize: '12px',
+		color: 'var(--rr-text-disabled, #666)',
+		fontFamily: 'monospace',
+		letterSpacing: '2px',
+	},
+
+	iconBtn: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: '4px 8px',
+		borderRadius: '3px',
+		border: '1px solid var(--rr-border, #dcdcdc)',
+		cursor: 'pointer',
+		backgroundColor: 'transparent',
+		color: 'var(--rr-text-secondary, #666)',
+		fontSize: '11px',
+		fontWeight: 500,
+		whiteSpace: 'nowrap',
+	},
+
+	iconBtnSuccess: {
+		backgroundColor: 'var(--rr-accent, #007acc)',
+		borderColor: 'var(--rr-accent, #007acc)',
+		color: 'var(--rr-fg-button, #fff)',
+	},
+
+	securityNote: {
+		marginTop: '16px',
+		padding: '10px 12px',
+		background: 'rgba(255, 152, 0, 0.1)',
+		borderLeft: '3px solid var(--rr-color-warning, #e8b931)',
+		borderRadius: '4px',
+		fontSize: '11px',
+		color: 'var(--rr-text-secondary, #666)',
+		lineHeight: 1.5,
+	},
+};

--- a/packages/shared-ui/src/components/pipeline-actions/index.tsx
+++ b/packages/shared-ui/src/components/pipeline-actions/index.tsx
@@ -1,0 +1,3 @@
+export { default as PipelineActions } from './PipelineActions';
+export { default as EndpointInfoModal } from './EndpointInfoModal';
+export type { IEndpointInfo, IPipelineActionsProps } from './PipelineActions';

--- a/packages/shared-ui/src/modules/flow/Flow.tsx
+++ b/packages/shared-ui/src/modules/flow/Flow.tsx
@@ -77,7 +77,7 @@ export interface IFlowProps {
 	handleValidatePipeline: (pipeline: IProject) => Promise<IValidateResponse>;
 
 	/** Opens a URL in the host browser. */
-	onOpenLink?: (url: string) => void;
+	onOpenLink?: (url: string, displayName?: string) => void;
 
 	/** Host-provided preference reader. */
 	getPreference?: (key: string) => unknown;
@@ -93,13 +93,25 @@ export interface IFlowProps {
 
 	/** Host-provided redo callback. */
 	onRedo?: () => void;
+
+	/** Runs a pipeline: host saves to disk then executes. */
+	onRunPipeline?: (source: string, project: IProject) => void;
+
+	/** Stops a running pipeline for the given source node. */
+	onStopPipeline?: (source: string) => void;
+
+	/** Opens the status page for a source node. */
+	onOpenStatus?: (source: string) => void;
+
+	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
+	serverHost?: string;
 }
 
 // =============================================================================
 // Component
 // =============================================================================
 
-export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, getPreference, setPreference, onContentChanged, onUndo, onRedo }: IFlowProps) {
+export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, getPreference, setPreference, onContentChanged, onUndo, onRedo, onRunPipeline, onStopPipeline, onOpenStatus, serverHost }: IFlowProps) {
 	// --- Build inventory from service catalog --------------------------------
 	const inventory = buildInventory(servicesJson);
 
@@ -154,6 +166,10 @@ export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuse
 					onContentChanged={onContentChanged}
 					onUndo={onUndo}
 					onRedo={onRedo}
+					onRunPipeline={onRunPipeline}
+					onStopPipeline={onStopPipeline}
+					onOpenStatus={onOpenStatus}
+					serverHost={serverHost}
 					features={{
 						addNode: true,
 						addAnnotation: true,

--- a/packages/shared-ui/src/modules/flow/components/FlowContainer.tsx
+++ b/packages/shared-ui/src/modules/flow/components/FlowContainer.tsx
@@ -88,7 +88,7 @@ export interface IFlowContainerProps {
 	onRedo?: () => void;
 
 	/** Opens a URL in the host browser. */
-	onOpenLink?: (url: string) => void;
+	onOpenLink?: (url: string, displayName?: string) => void;
 
 	/** Host-provided preference reader. */
 	getPreference?: (key: string) => unknown;
@@ -105,6 +105,18 @@ export interface IFlowContainerProps {
 	/** Google Picker client ID. */
 	googlePickerClientId?: string;
 
+	/** Runs a pipeline: host saves to disk then executes. */
+	onRunPipeline?: (source: string, project: IProject) => void;
+
+	/** Stops a running pipeline for the given source node. */
+	onStopPipeline?: (source: string) => void;
+
+	/** Opens the status page for a source node. */
+	onOpenStatus?: (source: string) => void;
+
+	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
+	serverHost?: string;
+
 	/** Child components (typically the Canvas grid). */
 	children?: ReactNode;
 }
@@ -119,12 +131,12 @@ export interface IFlowContainerProps {
  * Uses `key` on the outer Box to force a clean re-mount when the project
  * ID changes, ensuring no stale graph state leaks between projects.
  */
-export default function FlowContainer({ project, oauth2RootUrl, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, onOpenLink, getPreference, setPreference, googlePickerDeveloperKey, googlePickerClientId, children }: IFlowContainerProps): ReactElement {
+export default function FlowContainer({ project, oauth2RootUrl, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, onOpenLink, getPreference, setPreference, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, children }: IFlowContainerProps): ReactElement {
 	return (
 		<ReactFlowProvider>
 			{/* Re-key on project ID to force clean re-mount between projects */}
 			<Box sx={{ position: 'relative', width: '100%', height: '100%' }} key={`${project.project_id ?? 'new'}-${project.name}`}>
-				<FlowProvider project={project} projectId={project.project_id ?? ''} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId}>
+				<FlowProvider project={project} projectId={project.project_id ?? ''} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost}>
 					{children}
 				</FlowProvider>
 			</Box>

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/NodeComponent.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/NodeComponent.tsx
@@ -54,6 +54,7 @@ import { Edge, Position } from '@xyflow/react';
 
 import { useFlow } from '../../../hooks';
 import { useFlowGraph } from '../../../context/FlowGraphContext';
+import { useFlowProject } from '../../../context/FlowProjectContext';
 import { getIconPath } from '../../../util/get-icon-path';
 import ConditionalRender from '../../ConditionalRender';
 import { INodeData, IService, IServiceCatalog, IServiceLane, INodeLayout, IServiceCapabilities, ITaskState } from '../../../types';
@@ -62,6 +63,7 @@ import NodeTop from './top';
 import NodeHeader from './header';
 import NodeLanes from './lanes';
 import NodeStatus from './status';
+import RunButton from './run-button';
 import { InvokeHandle } from '../../handles';
 
 // =============================================================================
@@ -116,6 +118,7 @@ export default function NodeComponent({ id, data, type, parentId, children, layo
 	// Pull shared canvas state from the flow context
 	const { nodes, taskStatuses, componentPipeCounts, totalPipes, servicesJson, edges } = useFlow();
 	const { setQuickAddState } = useFlowGraph();
+	const { onOpenStatus, onOpenLink, serverHost } = useFlowProject();
 
 	// =========================================================================
 	// Service lookup — all service metadata comes from here, not from data
@@ -175,6 +178,18 @@ export default function NodeComponent({ id, data, type, parentId, children, layo
 	/** Task status for this node from DAP events. */
 	const taskStatus = taskStatuses?.[id];
 
+	/** Error count for the source node badge (from failedCount or errors array). */
+	const errorCount = useMemo(() => {
+		if (!isSourceNode || !taskStatus) return 0;
+		return Math.max(taskStatus.failedCount || 0, taskStatus.errors?.length || 0);
+	}, [isSourceNode, taskStatus]);
+
+	/** Warning count for the source node badge. */
+	const warningCount = useMemo(() => {
+		if (!isSourceNode || !taskStatus) return 0;
+		return taskStatus.warnings?.length || 0;
+	}, [isSourceNode, taskStatus]);
+
 	// =========================================================================
 	// Section visibility flags — drive the bottom cap background color
 	// =========================================================================
@@ -182,8 +197,8 @@ export default function NodeComponent({ id, data, type, parentId, children, layo
 	/** Any lane key (including _ prefixed hidden lanes) means lanes render. */
 	const hasLanes = Object.keys(lanes ?? {}).length > 0;
 
-	/** Status section is visible when the pipeline is actively running. */
-	const hasStatus = isSourceNode ? !!(taskStatus && !taskStatus.completed && [ITaskState.STARTING, ITaskState.INITIALIZING, ITaskState.RUNNING].includes(taskStatus.state)) : !!(componentPipeCounts && id in componentPipeCounts && (totalPipes ?? 0) > 0);
+	/** Status section is visible when running OR when completed status should persist. */
+	const hasStatus = isSourceNode ? !!(taskStatus && taskStatus.state !== ITaskState.NONE) : !!(componentPipeCounts && id in componentPipeCounts && (totalPipes ?? 0) > 0);
 
 	// Bottom cap color:
 	//   - If the node has lanes, status, OR invoke source diamonds, use canvas bg
@@ -196,11 +211,14 @@ export default function NodeComponent({ id, data, type, parentId, children, layo
 
 	return (
 		<>
+			{/* Play/stop button on source nodes — slides out from the left edge */}
+			{isSourceNode && <RunButton nodeId={id} />}
+
 			{/* Top cap + optional invoke target diamond */}
 			<NodeTop id={id} edges={edges} isInvocable={isInvocable} setQuickAddState={setQuickAddState} />
 
-			{/* Header — icon, title, class type, gear, overflow menu */}
-			<NodeHeader id={id} icon={icon} title={displayTitle} handleClick={handleClick} nodeType={type} hideEdit={false} formDataValid={data.formDataValid} description={displayDescription} documentation={documentation} parentId={mostRecentParentId} classType={classType} />
+			{/* Header — icon, title, class type, gear, overflow menu, error badge */}
+			<NodeHeader id={id} icon={icon} title={displayTitle} handleClick={handleClick} nodeType={type} hideEdit={false} formDataValid={data.formDataValid} description={displayDescription} documentation={documentation} parentId={mostRecentParentId} classType={classType} errorCount={isSourceNode ? errorCount : undefined} warningCount={isSourceNode ? warningCount : undefined} onBadgeClick={isSourceNode && onOpenStatus ? () => onOpenStatus(id) : undefined} />
 			{children}
 
 			{/* Data lanes — input/output handles */}
@@ -208,9 +226,9 @@ export default function NodeComponent({ id, data, type, parentId, children, layo
 				<NodeLanes nodeId={id} lanes={lanes!} layout={layout} data={data} />
 			</ConditionalRender>
 
-			{/* Pipeline execution status (only during active runs) */}
+			{/* Pipeline execution status — persists after completion for source nodes */}
 			<ConditionalRender condition={hasStatus}>
-				<NodeStatus componentProvider={id} isSourceNode={isSourceNode} taskStatus={taskStatus} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} />
+				<NodeStatus componentProvider={id} isSourceNode={isSourceNode} taskStatus={taskStatus} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} onOpenStatus={onOpenStatus} onOpenLink={onOpenLink} serverHost={serverHost} displayName={displayTitle} />
 			</ConditionalRender>
 
 			{/* Spacer to reserve vertical space for invoke source labels */}

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/header/NodeHeader.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/header/NodeHeader.tsx
@@ -78,6 +78,12 @@ interface INodeHeaderProps {
 	handleClick?: () => void;
 	/** Class type tags for the node (e.g. ["llm"]), shown as a subtitle. */
 	classType?: string[];
+	/** Number of pipeline errors to display as a red badge on the title. */
+	errorCount?: number;
+	/** Number of pipeline warnings to display as an orange badge on the title. */
+	warningCount?: number;
+	/** Callback when error/warning badge is clicked (opens status page). */
+	onBadgeClick?: () => void;
 }
 
 /**
@@ -86,7 +92,7 @@ interface INodeHeaderProps {
  * @param props - Node identity, metadata, and an optional click handler.
  * @returns The fully rendered header bar element.
  */
-export default function NodeHeader({ id, hideEdit = false, nodeType, icon, title, description, documentation, formDataValid, parentId: _parentId, handleClick, classType }: INodeHeaderProps): ReactElement {
+export default function NodeHeader({ id, hideEdit = false, nodeType, icon, title, description, documentation, formDataValid, parentId: _parentId, handleClick, classType, errorCount, warningCount, onBadgeClick }: INodeHeaderProps): ReactElement {
 	// ========================================================================
 	// FlowContext state and actions
 	// ========================================================================
@@ -161,7 +167,33 @@ export default function NodeHeader({ id, hideEdit = false, nodeType, icon, title
 	// Title element — reused in both the tooltip and non-tooltip render paths
 	const titleElement = (
 		<Box>
-			<Typography sx={{ ...styles.title, ...nodeStyles.label }}>{displayTitle}</Typography>
+			<Typography sx={{ ...styles.title, ...nodeStyles.label }}>
+				{displayTitle}
+				{errorCount != null && errorCount > 0 && (
+					<Box
+						component="span"
+						sx={styles.errorBadge}
+						onClick={(e: React.MouseEvent) => {
+							e.stopPropagation();
+							onBadgeClick?.();
+						}}
+					>
+						{errorCount}
+					</Box>
+				)}
+				{warningCount != null && warningCount > 0 && (
+					<Box
+						component="span"
+						sx={styles.warningBadge}
+						onClick={(e: React.MouseEvent) => {
+							e.stopPropagation();
+							onBadgeClick?.();
+						}}
+					>
+						{warningCount}
+					</Box>
+				)}
+			</Typography>
 			<ConditionalRender condition={subtitleText}>
 				<Typography sx={styles.subtitle}>{subtitleText}</Typography>
 			</ConditionalRender>
@@ -326,5 +358,42 @@ const styles = {
 		height: '1rem',
 		width: 'auto',
 		fill: 'var(--rr-text-secondary)',
+	},
+
+	/** Red error count badge next to the title. */
+	errorBadge: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: 'var(--rr-error, #f14c4c)',
+		color: '#fff',
+		fontSize: '8px',
+		fontWeight: 600,
+		minWidth: '14px',
+		height: '14px',
+		borderRadius: '7px',
+		padding: '0 3px',
+		marginLeft: '4px',
+		lineHeight: 1,
+		cursor: 'pointer',
+		verticalAlign: 'middle',
+	},
+	/** Orange warning count badge next to the title. */
+	warningBadge: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		backgroundColor: 'var(--rr-warning, #cca700)',
+		color: '#fff',
+		fontSize: '8px',
+		fontWeight: 600,
+		minWidth: '14px',
+		height: '14px',
+		borderRadius: '7px',
+		padding: '0 3px',
+		marginLeft: '4px',
+		lineHeight: 1,
+		cursor: 'pointer',
+		verticalAlign: 'middle',
 	},
 };

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/RunButton.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/RunButton.tsx
@@ -1,0 +1,199 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+/**
+ * RunButton — Play/stop button that slides out from the left edge of source nodes.
+ *
+ * Three visual states:
+ *   - **Play** (idle): accent-colored play icon; clicking saves + runs the pipeline.
+ *   - **Stop** (running): red stop icon; clicking aborts the pipeline.
+ *   - **Pending** (transitioning): spinning icon while waiting for state change.
+ *
+ * On hover the button slides further left and expands to reveal its label.
+ * Includes debounce guards to prevent double-clicks.
+ */
+
+import { ReactElement, useMemo, useState, useEffect, useRef, useCallback } from 'react';
+import { Box, IconButton, Typography } from '@mui/material';
+import { PlayArrow, StopCircle, Autorenew } from '@mui/icons-material';
+import { useFlowProject } from '../../../../context/FlowProjectContext';
+import { useFlowGraph } from '../../../../context/FlowGraphContext';
+import { ITaskState, IProject, INode, PIPELINE_SCHEMA_VERSION } from '../../../../types';
+import { getProjectComponents } from '../../../../util/graph';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface IRunButtonProps {
+	/** ID of the source node whose pipeline this button controls. */
+	nodeId: string;
+}
+
+// ============================================================================
+// Styles
+// ============================================================================
+
+const styles = {
+	buttonWrapper: {
+		zIndex: -1,
+		position: 'absolute',
+		backgroundColor: 'var(--rr-bg-paper)',
+		left: 'calc(-2rem - 1px)',
+		top: '0.75rem',
+		margin: 'auto',
+		width: '2rem',
+		height: '1.75rem',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		cursor: 'pointer',
+		borderRadius: '1rem 0 0 1rem',
+		boxShadow: '0px 2px 1px -1px rgba(0, 0, 0, 0.15), 0px 1px 1px 0px rgba(0, 0, 0, 0.1), 0px 1px 3px 0px rgba(0, 0, 0, 0.08)',
+		border: 'none',
+		outline: '1px solid var(--rr-border)',
+		transition: 'left 0.2s, width 0.2s, background-color 0.2s',
+		'&:hover': {
+			left: 'calc(-3rem - 1px)',
+			width: '3rem',
+			backgroundColor: 'var(--rr-accent, #007acc)',
+			'& .run-btn-label': {
+				opacity: 1,
+				color: '#fff',
+				width: 'auto',
+			},
+			'& svg': {
+				fill: '#fff',
+			},
+		},
+		'&.stop-button:hover': {
+			backgroundColor: 'error.main',
+		},
+	},
+	button: {
+		padding: '0.13rem',
+		pointerEvents: 'none',
+	},
+	icon: {
+		width: '1rem',
+		height: '1rem',
+	},
+	label: {
+		opacity: 0,
+		transition: 'width 0.2s',
+		pointerEvents: 'none',
+		whiteSpace: 'nowrap',
+		fontSize: '0.65rem',
+		width: '0',
+	},
+};
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
+	const [isPending, setIsPending] = useState(false);
+	const isProcessingClick = useRef(false);
+
+	const { currentProject, taskStatuses, onRunPipeline, onStopPipeline } = useFlowProject();
+	const { nodes } = useFlowGraph();
+
+	// ── Running state ──────────────────────────────────────────────────────
+	const isRunning = useMemo(() => {
+		if (!currentProject?.project_id) return false;
+		const taskStatus = taskStatuses?.[nodeId];
+		if (!taskStatus) return false;
+		const runningStates = [ITaskState.STARTING, ITaskState.INITIALIZING, ITaskState.RUNNING];
+		return runningStates.includes(taskStatus.state) && !taskStatus.completed;
+	}, [taskStatuses, currentProject, nodeId]);
+
+	// ── Handlers ───────────────────────────────────────────────────────────
+	const handleRun = useCallback(
+		(e?: React.MouseEvent) => {
+			e?.stopPropagation();
+			if (isPending || isProcessingClick.current || isRunning || !onRunPipeline) return;
+
+			isProcessingClick.current = true;
+			setIsPending(true);
+
+			// Serialize the current graph into an IProject for the host
+			const components = getProjectComponents(nodes as INode[]);
+			const project: IProject = {
+				...currentProject,
+				components,
+				version: PIPELINE_SCHEMA_VERSION,
+				source: nodeId,
+			};
+
+			onRunPipeline(nodeId, project);
+		},
+		[isPending, isRunning, onRunPipeline, nodeId, nodes, currentProject]
+	);
+
+	const handleStop = useCallback(
+		(e?: React.MouseEvent) => {
+			e?.stopPropagation();
+			if (isPending || isProcessingClick.current || !onStopPipeline) return;
+
+			isProcessingClick.current = true;
+			setIsPending(true);
+			onStopPipeline(nodeId);
+		},
+		[isPending, onStopPipeline, nodeId]
+	);
+
+	// ── Clear pending on state transitions ─────────────────────────────────
+	const prevIsRunning = useRef(isRunning);
+	useEffect(() => {
+		if (isPending && prevIsRunning.current !== isRunning) {
+			setIsPending(false);
+			isProcessingClick.current = false;
+		}
+		prevIsRunning.current = isRunning;
+	}, [isRunning, isPending]);
+
+	useEffect(() => {
+		if (!isPending) {
+			isProcessingClick.current = false;
+		}
+	}, [isPending]);
+
+	// ── Render ─────────────────────────────────────────────────────────────
+	if (isRunning) {
+		return (
+			<Box
+				sx={styles.buttonWrapper}
+				className="stop-button"
+				onClick={handleStop}
+				onDoubleClick={(e) => {
+					e.stopPropagation();
+					e.preventDefault();
+				}}
+			>
+				<IconButton sx={styles.button}>{isPending ? <Autorenew color="warning" sx={styles.icon} className="rotate" /> : <StopCircle color="error" sx={styles.icon} />}</IconButton>
+				<Typography sx={styles.label} className="run-btn-label">
+					Stop
+				</Typography>
+			</Box>
+		);
+	}
+
+	return (
+		<Box
+			sx={styles.buttonWrapper}
+			onClick={handleRun}
+			onDoubleClick={(e) => {
+				e.stopPropagation();
+				e.preventDefault();
+			}}
+		>
+			<IconButton sx={styles.button}>{isPending ? <Autorenew color="warning" sx={styles.icon} className="rotate" /> : <PlayArrow sx={{ ...styles.icon, color: 'var(--rr-accent, #007acc)' }} />}</IconButton>
+			<Typography sx={styles.label} className="run-btn-label">
+				Play
+			</Typography>
+		</Box>
+	);
+}

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/index.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './RunButton';

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/status/NodeStatus.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/status/NodeStatus.tsx
@@ -1,75 +1,39 @@
 // =============================================================================
 // MIT License
 // Copyright (c) 2026 Aparavi Software AG Inc.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
 // =============================================================================
 
 /**
  * NodeStatus — Real-time pipeline execution status displayed on canvas nodes.
  *
- * Renders runtime status information at the bottom of a canvas node:
+ * For **source nodes**, shows a persistent mini dashboard:
+ *   - Starting: "Initializing..." + status message + indeterminate progress bar
+ *   - Running: "X done · Ys" + progress bar + "Status ↗" link
+ *   - Running with errors: adds error count, orange progress bar
+ *   - Completed (success): "✓ X done · Ys" + green accent bar — persists
+ *   - Completed (errors): counts + orange accent bar + persists
+ *   - Startup error: "✕ Failed to start" + error message inline + red accent bar
  *
- *   - **Source nodes**: Shows "X done / Y failed" with an expandable detail
- *     panel containing the current status string and elapsed time since start.
- *     Only visible while the pipeline is actively running (STARTING, INITIALIZING,
- *     or RUNNING states). Hidden when idle or completed.
- *
- *   - **Non-source nodes**: Shows a "Pipes X/Y" progress bar indicating how
- *     many data pipes have reached this component out of the pipeline total.
- *     Only visible when pipe count data is available.
- *
- * Returns null when the pipeline is idle — the node shows no status chrome.
+ * For **non-source nodes**, shows a "Pipes X/Y" progress bar during execution.
  */
 
-import { ReactElement, useState } from 'react';
-import { Box, Typography, LinearProgress, Collapse, IconButton } from '@mui/material';
-import { ExpandMore as ExpandMoreIcon } from '@mui/icons-material';
+import { ReactElement } from 'react';
+import { Box, Typography, LinearProgress } from '@mui/material';
 import { ITaskStatus, ITaskState } from '../../../../types';
+import { PipelineActions } from '../../../../../../components/pipeline-actions';
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
-/**
- * Formats a duration in seconds into a compact, human-readable string.
- *
- * Produces the same format used on the pipeline status page so that elapsed
- * times are displayed consistently across the application.
- *
- * @param seconds - The elapsed time in seconds to format.
- * @returns A formatted string such as "45s", "3m 12s", or "1h 5m 30s".
- */
 const formatElapsedTime = (seconds: number): string => {
 	const totalSeconds = Math.floor(seconds);
-
-	// Sub-minute: just seconds
 	if (totalSeconds < 60) return `${totalSeconds}s`;
-
-	// Sub-hour: minutes and seconds
 	if (totalSeconds < 3600) {
 		const minutes = Math.floor(totalSeconds / 60);
 		const remainingSeconds = totalSeconds % 60;
 		return `${minutes}m ${remainingSeconds}s`;
 	}
-
-	// Hours, minutes, and seconds
 	const hours = Math.floor(totalSeconds / 3600);
 	const minutes = Math.floor((totalSeconds % 3600) / 60);
 	const remainingSeconds = totalSeconds % 60;
@@ -80,9 +44,6 @@ const formatElapsedTime = (seconds: number): string => {
 // Component
 // ============================================================================
 
-/**
- * Props for the NodeStatus component.
- */
 interface INodeStatusProps {
 	/** Node ID used to look up this component's pipe count in the flow data. */
 	componentProvider: string;
@@ -94,85 +55,168 @@ interface INodeStatusProps {
 	componentPipeCounts?: Record<string, number>;
 	/** Total number of pipes in the running pipeline (denominator for progress). */
 	totalPipes?: number;
+	/** Callback to open the status page for this source node. */
+	onOpenStatus?: (nodeId: string) => void;
+	/** Callback to open a URL externally (for pipeline action buttons). */
+	onOpenLink?: (url: string, displayName?: string) => void;
+	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
+	serverHost?: string;
+	/** Display name for the source node (used as the tab title when opening links). */
+	displayName?: string;
 }
 
-/**
- * Renders pipeline execution status inside a canvas node.
- *
- * @param props - Pipeline status data and node identity.
- * @returns Status UI for the active pipeline, or null when idle.
- */
-export default function NodeStatus({ componentProvider, isSourceNode, taskStatus, componentPipeCounts, totalPipes }: INodeStatusProps): ReactElement | null {
-	/** Whether the expandable details section is open (source nodes only). */
-	const [expanded, setExpanded] = useState(false);
-
+export default function NodeStatus({ componentProvider, isSourceNode, taskStatus, componentPipeCounts, totalPipes, onOpenStatus, onOpenLink, serverHost, displayName }: INodeStatusProps): ReactElement | null {
 	// ========================================================================
-	// Source node: Completed/Errors summary with expandable details
+	// Source node: persistent mini dashboard
 	// ========================================================================
 	if (isSourceNode && taskStatus) {
-		// Only show status during active execution states
-		const isRunning = [ITaskState.STARTING, ITaskState.INITIALIZING, ITaskState.RUNNING].includes(taskStatus.state) && !taskStatus.completed;
+		const runningStates = [ITaskState.STARTING, ITaskState.INITIALIZING, ITaskState.RUNNING];
+		const isRunning = runningStates.includes(taskStatus.state) && !taskStatus.completed;
+		const isCompleted = taskStatus.completed || taskStatus.state === ITaskState.COMPLETED || taskStatus.state === ITaskState.CANCELLED;
 
-		// Hide entirely when the pipeline is idle or has completed
-		if (!isRunning) return null;
-
-		// Default counters to zero when the task hasn't reported counts yet
 		const completedCount = taskStatus.completedCount || 0;
 		const failedCount = taskStatus.failedCount || 0;
+		const hasErrors = failedCount > 0 || (taskStatus.errors && taskStatus.errors.length > 0);
 
-		// Compute wall-clock elapsed time from the task's start timestamp
 		const currentTimeSeconds = Math.floor(Date.now() / 1000);
 		const elapsed = taskStatus.startTime > 0 ? Math.max(0, currentTimeSeconds - taskStatus.startTime) : 0;
 
-		// Include failure count only when there are actual failures
-		const statusText = failedCount > 0 ? `${completedCount} done / ${failedCount} failed` : `${completedCount} done`;
+		const statusLink = onOpenStatus ? (
+			<Typography
+				component="a"
+				onClick={(e: React.MouseEvent) => {
+					e.stopPropagation();
+					onOpenStatus(componentProvider);
+				}}
+				sx={styles.statusLink}
+			>
+				Status ↗
+			</Typography>
+		) : null;
 
-		return (
-			<Box sx={styles.footer}>
-				{/* Main status line with expand toggle */}
-				<Box sx={styles.sourceFooterMain}>
-					<Typography sx={styles.footerText}>{statusText}</Typography>
-					<IconButton
-						size="small"
-						onClick={() => setExpanded(!expanded)}
-						sx={{
-							...styles.expandButton,
-							transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
-						}}
-					>
-						<ExpandMoreIcon fontSize="small" />
-					</IconButton>
-				</Box>
+		const pipelineActions = <PipelineActions notes={taskStatus.notes} host={serverHost} onOpenLink={onOpenLink} displayName={displayName} />;
 
-				{/* Expandable details panel */}
-				<Collapse in={expanded}>
-					<Box sx={styles.expandedDetails}>
-						<Box sx={styles.detailRow}>
-							<Typography sx={styles.detailLabel}>Status:</Typography>
-							<Typography sx={styles.detailValue}>{taskStatus.status}</Typography>
-						</Box>
-						<Box sx={styles.detailRow}>
-							<Typography sx={styles.detailLabel}>Started</Typography>
-							<Typography sx={styles.detailValue}>{formatElapsedTime(elapsed)} ago</Typography>
-						</Box>
+		// ── Starting / Initializing ──────────────────────────────────────
+		if (isRunning && (taskStatus.state === ITaskState.STARTING || taskStatus.state === ITaskState.INITIALIZING)) {
+			return (
+				<Box sx={styles.footer}>
+					<Box sx={styles.sourceFooterMain}>
+						<Typography sx={{ ...styles.footerText, color: 'var(--rr-text-disabled)' }}>Initializing...</Typography>
+						{statusLink}
 					</Box>
-				</Collapse>
-			</Box>
-		);
+					{taskStatus.status && (
+						<Typography sx={styles.statusMessage} title={taskStatus.status}>
+							{taskStatus.status}
+						</Typography>
+					)}
+					{pipelineActions}
+					<LinearProgress sx={styles.indeterminateBar} />
+				</Box>
+			);
+		}
+
+		// ── Running ──────────────────────────────────────────────────────
+		if (isRunning) {
+			return (
+				<Box sx={styles.footer}>
+					<Box sx={styles.sourceFooterMain}>
+						<Typography sx={styles.footerText}>
+							<Box component="span" sx={{ color: 'var(--rr-success, #4ec9b0)' }}>
+								{completedCount} done
+							</Box>
+							{failedCount > 0 && (
+								<>
+									{' · '}
+									<Box component="span" sx={{ color: 'var(--rr-error, #f14c4c)' }}>
+										{failedCount} errors
+									</Box>
+								</>
+							)}
+							<Box component="span" sx={{ color: 'var(--rr-text-disabled)', ml: '2px' }}>
+								{' '}
+								· {formatElapsedTime(elapsed)}
+							</Box>
+						</Typography>
+						{statusLink}
+					</Box>
+					{taskStatus.status && (
+						<Typography sx={styles.statusMessage} title={taskStatus.status}>
+							{taskStatus.status}
+						</Typography>
+					)}
+					{pipelineActions}
+				</Box>
+			);
+		}
+
+		// ── Completed / Stopped ──────────────────────────────────────────
+		if (isCompleted) {
+			// Check for startup error: completed with errors but zero completions
+			const isStartupError = completedCount === 0 && hasErrors;
+			const firstError = taskStatus.errors?.[0];
+
+			const elapsedFinal = taskStatus.endTime > 0 && taskStatus.startTime > 0 ? Math.max(0, taskStatus.endTime - taskStatus.startTime) : elapsed;
+
+			if (isStartupError) {
+				return (
+					<Box sx={styles.footer}>
+						<Box sx={styles.sourceFooterMain}>
+							<Typography sx={styles.footerText}>
+								<Box component="span" sx={{ color: 'var(--rr-error, #f14c4c)' }}>
+									✕ Failed to start
+								</Box>
+							</Typography>
+							{statusLink}
+						</Box>
+						{firstError && <Typography sx={styles.errorMessage}>{firstError}</Typography>}
+						<Box sx={styles.accentBarError} />
+					</Box>
+				);
+			}
+
+			return (
+				<Box sx={styles.footer}>
+					<Box sx={styles.sourceFooterMain}>
+						<Typography sx={styles.footerText}>
+							{!hasErrors && (
+								<Box component="span" sx={{ color: 'var(--rr-success, #4ec9b0)' }}>
+									✓{' '}
+								</Box>
+							)}
+							<Box component="span" sx={{ color: 'var(--rr-success, #4ec9b0)' }}>
+								{completedCount} done
+							</Box>
+							{failedCount > 0 && (
+								<>
+									{' · '}
+									<Box component="span" sx={{ color: 'var(--rr-error, #f14c4c)' }}>
+										{failedCount} errors
+									</Box>
+								</>
+							)}
+							<Box component="span" sx={{ color: 'var(--rr-text-disabled)', ml: '2px' }}>
+								{' '}
+								· {formatElapsedTime(elapsedFinal)}
+							</Box>
+						</Typography>
+						{statusLink}
+					</Box>
+					{pipelineActions}
+				</Box>
+			);
+		}
+
+		// No status to show (NONE state, no data yet)
+		return null;
 	}
 
 	// ========================================================================
 	// Non-source node: Pipes progress bar
 	// ========================================================================
-
-	// Only render when this component has reported pipe flow data
 	if (!componentPipeCounts || !(componentProvider in componentPipeCounts)) return null;
 	const pipesInComponent = componentPipeCounts[componentProvider];
-
-	// Cannot render a meaningful progress bar without a total
 	if (!totalPipes || totalPipes === 0) return null;
 
-	// Calculate what percentage of total pipes have reached this component
 	const progressPercentage = totalPipes > 0 ? (pipesInComponent / totalPipes) * 100 : 0;
 
 	return (
@@ -180,7 +224,7 @@ export default function NodeStatus({ componentProvider, isSourceNode, taskStatus
 			<Box sx={styles.pipesFooter}>
 				<Typography sx={styles.pipesLabel}>Pipes</Typography>
 				<Box sx={styles.progressBarContainer}>
-					<LinearProgress variant="determinate" value={progressPercentage} sx={styles.progressBar} />
+					<LinearProgress variant="determinate" value={progressPercentage} sx={styles.progressBarGreen} />
 				</Box>
 				<Typography sx={styles.pipesCount}>
 					{pipesInComponent}/{totalPipes}
@@ -194,14 +238,7 @@ export default function NodeStatus({ componentProvider, isSourceNode, taskStatus
 // Styles
 // ============================================================================
 
-/**
- * MUI sx-compatible style definitions for the NodeStatus component.
- *
- * Covers both the source-node footer (completion summary with expandable
- * details) and the non-source-node footer (pipe progress bar).
- */
 const styles = {
-	/** Shared footer container — sits below the lanes with a top border. */
 	footer: {
 		borderTop: '1px solid',
 		borderColor: 'var(--rr-border)',
@@ -210,100 +247,116 @@ const styles = {
 		fontSize: 'var(--rr-font-size-xs)',
 		borderRadius: 0,
 	},
-
-	/** Source node: horizontal layout for status text and expand button. */
 	sourceFooterMain: {
 		display: 'flex',
 		alignItems: 'center',
 		justifyContent: 'space-between',
 		gap: '0.5rem',
 	},
-
-	/** Status text (e.g. "3 done / 1 failed"). */
 	footerText: {
 		fontSize: 'var(--rr-font-size-xs)',
 		color: 'var(--rr-text-secondary)',
 		fontWeight: 500,
+		whiteSpace: 'nowrap',
+	},
+	statusLink: {
+		fontSize: '9px',
+		color: 'var(--rr-accent, #007acc)',
+		cursor: 'pointer',
+		whiteSpace: 'nowrap',
+		textDecoration: 'none',
+		flexShrink: 0,
+		'&:hover': { textDecoration: 'underline' },
+	},
+	statusMessage: {
+		fontSize: '9px',
+		color: 'var(--rr-text-disabled)',
+		marginTop: '3px',
+		whiteSpace: 'nowrap',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+	},
+	errorMessage: {
+		fontSize: '9px',
+		color: 'var(--rr-error, #f14c4c)',
+		marginTop: '3px',
+		whiteSpace: 'nowrap',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		opacity: 0.85,
 	},
 
-	/** Expand/collapse chevron button. */
-	expandButton: {
-		padding: '0.2rem',
-		transition: 'transform 0.2s',
-		color: 'var(--rr-text-secondary)',
+	// Progress bars
+	indeterminateBar: {
+		height: '3px',
+		borderRadius: '2px',
+		marginTop: '5px',
+		backgroundColor: 'action.hover',
+		'& .MuiLinearProgress-bar': {
+			backgroundColor: 'var(--rr-accent, #007acc)',
+			borderRadius: '2px',
+		},
+	},
+	progressBarGreen: {
+		height: '3px',
+		borderRadius: '2px',
+		marginTop: '5px',
+		backgroundColor: 'action.hover',
+		'& .MuiLinearProgress-bar': {
+			backgroundColor: 'var(--rr-success, #4ec9b0)',
+			borderRadius: '2px',
+			transition: 'transform 0.1s ease-in-out !important',
+		},
+	},
+	progressBarOrange: {
+		height: '3px',
+		borderRadius: '2px',
+		marginTop: '5px',
+		backgroundColor: 'action.hover',
+		'& .MuiLinearProgress-bar': {
+			backgroundColor: 'var(--rr-warning, #cca700)',
+			borderRadius: '2px',
+			transition: 'transform 0.1s ease-in-out !important',
+		},
 	},
 
-	/** Container for the expanded detail rows. */
-	expandedDetails: {
-		paddingTop: '0.5rem',
-		paddingLeft: '0.2rem',
-		display: 'flex',
-		flexDirection: 'column',
-		gap: '0.3rem',
-		borderTop: '1px solid',
-		borderColor: 'var(--rr-border)',
-		marginTop: '0.5rem',
+	// Accent bars (thin 2px bar at bottom of completed status)
+	accentBarSuccess: {
+		height: '2px',
+		marginTop: '5px',
+		borderRadius: '1px',
+		backgroundColor: 'var(--rr-success, #4ec9b0)',
+	},
+	accentBarWarning: {
+		height: '2px',
+		marginTop: '5px',
+		borderRadius: '1px',
+		backgroundColor: 'var(--rr-warning, #cca700)',
+	},
+	accentBarError: {
+		height: '2px',
+		marginTop: '5px',
+		borderRadius: '1px',
+		backgroundColor: 'var(--rr-error, #f14c4c)',
 	},
 
-	/** Single detail row (label + value side by side). */
-	detailRow: {
-		display: 'flex',
-		alignItems: 'center',
-		gap: '0.3rem',
-		lineHeight: 1.4,
-	},
-
-	/** Detail label text (e.g. "Status:"). */
-	detailLabel: {
-		fontSize: '0.45rem',
-		color: 'var(--rr-text-secondary)',
-		fontWeight: 400,
-		textAlign: 'left',
-	},
-
-	/** Detail value text (e.g. "Processing file 3 of 10"). */
-	detailValue: {
-		fontSize: '0.45rem',
-		color: 'var(--rr-text-primary)',
-		fontWeight: 500,
-		textAlign: 'left',
-	},
-
-	/** Non-source node: horizontal layout for label, bar, and count. */
+	// Non-source node pipes footer
 	pipesFooter: {
 		display: 'flex',
 		alignItems: 'center',
 		gap: '0.5rem',
 		width: '100%',
 	},
-
-	/** "Pipes" label to the left of the progress bar. */
 	pipesLabel: {
 		fontSize: 'var(--rr-font-size-xs)',
 		color: 'var(--rr-text-secondary)',
 		fontWeight: 400,
 		minWidth: 'fit-content',
 	},
-
-	/** Flex container for the progress bar. */
 	progressBarContainer: {
 		flex: 1,
 		minWidth: '60px',
 	},
-
-	/** MUI LinearProgress overrides for the green progress bar. */
-	progressBar: {
-		height: '6px',
-		borderRadius: '3px',
-		backgroundColor: 'action.hover',
-		'& .MuiLinearProgress-bar': {
-			backgroundColor: 'success.main',
-			borderRadius: '3px',
-			transition: 'transform 0.1s ease-in-out !important',
-		},
-	},
-
-	/** Pipe count text to the right of the progress bar (e.g. "3/10"). */
 	pipesCount: {
 		fontSize: 'var(--rr-font-size-xs)',
 		color: 'var(--rr-text-primary)',

--- a/packages/shared-ui/src/modules/flow/components/panels/node-config/NodeConfigPanel.tsx
+++ b/packages/shared-ui/src/modules/flow/components/panels/node-config/NodeConfigPanel.tsx
@@ -51,7 +51,7 @@ import { getSecuredFormData, removeRequired, setUiSchemaProperty } from '../../.
 import { useFlowGraph } from '../../../context/FlowGraphContext';
 import { useFlowProject } from '../../../context/FlowProjectContext';
 import { useFlowPreferences } from '../../../context/FlowPreferencesContext';
-import { INode, IService, IServiceCatalog, IProject } from '../../../types';
+import { INode, IService, IServiceCatalog, IProject, PIPELINE_SCHEMA_VERSION } from '../../../types';
 import { getComponentFromNode, getChildComponents } from '../../../util/graph';
 
 import { IAuthTokensRef, persistTokensFromFormData, mergeAuthTokensIntoFormData, persistOAuthTokensAndSave } from './authTokenHelpers';
@@ -193,7 +193,7 @@ export default function NodeConfigPanel({ node, onClose }: INodeConfigPanelProps
 
 	// --- Context ------------------------------------------------------------
 	const { updateNode, onToolchainUpdated, nodes } = useFlowGraph();
-	const { servicesJson, handleValidatePipeline, currentProject, googlePickerDeveloperKey, googlePickerClientId } = useFlowProject();
+	const { servicesJson, handleValidatePipeline, currentProject: _currentProject, googlePickerDeveloperKey, googlePickerClientId } = useFlowProject();
 	const { getPreference, setPreference } = useFlowPreferences();
 
 	// --- Service lookup -----------------------------------------------------
@@ -317,7 +317,7 @@ export default function NodeConfigPanel({ node, onClose }: INodeConfigPanelProps
 					// Get sibling components at the same level (same parentId)
 					const siblingComponents = getChildComponents(nodes as INode[], node.parentId);
 					const payload = {
-						version: currentProject?.version ?? 1,
+						version: PIPELINE_SCHEMA_VERSION,
 						component,
 						components: siblingComponents,
 					} as unknown as IProject;
@@ -355,7 +355,7 @@ export default function NodeConfigPanel({ node, onClose }: INodeConfigPanelProps
 				setIsSubmitting(false);
 			}
 		},
-		[node.id, node.data.config, node.parentId, nodes, name, updateNode, handleValidatePipeline, currentProject?.version, clearSecureParamsFromUrl, onToolchainUpdated, onClose]
+		[node.id, node.data.config, node.parentId, nodes, name, updateNode, handleValidatePipeline, clearSecureParamsFromUrl, onToolchainUpdated, onClose]
 	);
 
 	// --- Resize logic -------------------------------------------------------

--- a/packages/shared-ui/src/modules/flow/context/FlowGraphContext.tsx
+++ b/packages/shared-ui/src/modules/flow/context/FlowGraphContext.tsx
@@ -50,7 +50,7 @@ import { createContext, ReactElement, ReactNode, useCallback, useContext, useEff
 
 import { Connection, Edge, EdgeChange, Node, NodeChange, useEdgesState, useNodesState, useReactFlow, getConnectedEdges } from '@xyflow/react';
 
-import { INode, INodeData, IInputConnection, IControlConnection, IProject, INodeType } from '../types';
+import { INode, INodeData, IInputConnection, IControlConnection, IProject, INodeType, PIPELINE_SCHEMA_VERSION } from '../types';
 
 /** ReactFlow Node with strongly-typed data. Used throughout this context. */
 type FlowNode = Node<INodeData>;
@@ -268,7 +268,7 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 	/** True while loadData is replacing all nodes/edges. Prevents onNodesChange from notifying the host. */
 	const isLoadingRef = useRef(false);
 
-	/** The last version number we sent to the host. -1 ensures initial load always runs. */
+	/** The last docRevision number we sent to the host. -1 ensures initial load always runs. */
 	const lastSentVersion = useRef(-1);
 
 	// --- Derived state -----------------------------------------------------
@@ -318,7 +318,8 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 				...currentProjectRef.current,
 				components,
 				viewport,
-				version: nextVersion,
+				version: PIPELINE_SCHEMA_VERSION,
+				docRevision: nextVersion,
 			};
 			lastSentVersion.current = nextVersion;
 			onContentChanged(project);
@@ -818,13 +819,13 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		[setNodes, setEdges]
 	);
 
-	// --- Load project on mount / when host sends a new version --------------
+	// --- Load project on mount / when host sends a new docRevision ----------
 	// Reloads the canvas whenever the host sends a project with a different
-	// version than what we last sent. Our own changes increment version before
-	// sending, so echoed updates match lastSentVersion and are skipped.
-	// Undo/redo sends an older version, which triggers a reload.
+	// docRevision than what we last sent. Our own changes increment docRevision
+	// before sending, so echoed updates match lastSentVersion and are skipped.
+	// Undo/redo sends an older docRevision, which triggers a reload.
 
-	const incomingVersion = currentProject?.version ?? 0;
+	const incomingVersion = currentProject?.docRevision ?? 0;
 
 	useEffect(() => {
 		if (!currentProject) return;

--- a/packages/shared-ui/src/modules/flow/context/FlowProjectContext.tsx
+++ b/packages/shared-ui/src/modules/flow/context/FlowProjectContext.tsx
@@ -117,13 +117,27 @@ export interface IFlowProjectContext {
 	oauth2RootUrl: string;
 
 	/** Opens an external URL in the host's default browser. */
-	onOpenLink?: (url: string) => void;
+	onOpenLink?: (url: string, displayName?: string) => void;
 
 	/** Google Picker developer key (for Google Drive integration). */
 	googlePickerDeveloperKey?: string;
 
 	/** Google Picker client ID (for Google Drive integration). */
 	googlePickerClientId?: string;
+
+	// --- Pipeline execution callbacks --------------------------------------
+
+	/** Runs a pipeline: host saves to disk then executes. */
+	onRunPipeline?: (source: string, project: IProject) => void;
+
+	/** Stops a running pipeline for the given source node. */
+	onStopPipeline?: (source: string) => void;
+
+	/** Opens the status page for a source node. */
+	onOpenStatus?: (source: string) => void;
+
+	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
+	serverHost?: string;
 }
 
 const FlowProjectContext = createContext<IFlowProjectContext | null>(null);
@@ -160,9 +174,15 @@ export interface IFlowProjectProviderProps {
 	onUndo?: () => void;
 	onRedo?: () => void;
 	oauth2RootUrl: string;
-	onOpenLink?: (url: string) => void;
+	onOpenLink?: (url: string, displayName?: string) => void;
 	googlePickerDeveloperKey?: string;
 	googlePickerClientId?: string;
+
+	// --- Pipeline execution callbacks --------------------------------------
+	onRunPipeline?: (source: string, project: IProject) => void;
+	onStopPipeline?: (source: string) => void;
+	onOpenStatus?: (source: string) => void;
+	serverHost?: string;
 }
 
 // ============================================================================
@@ -176,7 +196,7 @@ export interface IFlowProjectProviderProps {
  * The host application passes props that are tunneled through this context
  * so deeply nested components can access them without prop drilling.
  */
-export function FlowProjectProvider({ children, project: currentProject, features = DEFAULT_FLOW_FEATURES, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId }: IFlowProjectProviderProps): ReactElement {
+export function FlowProjectProvider({ children, project: currentProject, features = DEFAULT_FLOW_FEATURES, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost }: IFlowProjectProviderProps): ReactElement {
 	// --- Toolchain state ---------------------------------------------------
 
 	const [toolchainState, setToolchainState] = useState<IToolchainState>(DEFAULT_TOOLCHAIN_STATE);
@@ -221,6 +241,10 @@ export function FlowProjectProvider({ children, project: currentProject, feature
 		onOpenLink,
 		googlePickerDeveloperKey,
 		googlePickerClientId,
+		onRunPipeline,
+		onStopPipeline,
+		onOpenStatus,
+		serverHost,
 	};
 
 	return <FlowProjectContext.Provider value={value}>{children}</FlowProjectContext.Provider>;

--- a/packages/shared-ui/src/modules/flow/context/FlowProvider.tsx
+++ b/packages/shared-ui/src/modules/flow/context/FlowProvider.tsx
@@ -89,9 +89,19 @@ export interface IFlowProviderProps {
 	onUndo?: () => void;
 	onRedo?: () => void;
 	oauth2RootUrl: string;
-	onOpenLink?: (url: string) => void;
+	onOpenLink?: (url: string, displayName?: string) => void;
 	googlePickerDeveloperKey?: string;
 	googlePickerClientId?: string;
+
+	// --- Pipeline execution callbacks --------------------------------------
+	/** Runs a pipeline: host saves to disk then executes. */
+	onRunPipeline?: (source: string, project: IProject) => void;
+	/** Stops a running pipeline for the given source node. */
+	onStopPipeline?: (source: string) => void;
+	/** Opens the status page for a source node. */
+	onOpenStatus?: (source: string) => void;
+	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
+	serverHost?: string;
 }
 
 // ============================================================================
@@ -110,10 +120,10 @@ export interface IFlowProviderProps {
  * </ReactFlowProvider>
  * ```
  */
-export function FlowProvider({ children, project, projectId, getPreference, setPreference, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId }: IFlowProviderProps): ReactElement {
+export function FlowProvider({ children, project, projectId, getPreference, setPreference, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost }: IFlowProviderProps): ReactElement {
 	return (
 		<FlowPreferencesProvider projectId={projectId} getPreference={getPreference} setPreference={setPreference}>
-			<FlowProjectProvider project={project} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId}>
+			<FlowProjectProvider project={project} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost}>
 				<FlowGraphProvider>{children}</FlowGraphProvider>
 			</FlowProjectProvider>
 		</FlowPreferencesProvider>

--- a/packages/shared-ui/src/modules/flow/types.ts
+++ b/packages/shared-ui/src/modules/flow/types.ts
@@ -41,6 +41,9 @@ export type { IProject, IProjectComponent, IComponentUI, IControlConnection, IIn
 
 export { IServiceCapabilities, ITaskState, DEFAULT_TOOLCHAIN_STATE } from '../../types/project';
 
+/** Pipeline schema version. Must match the server's IServices::VERSION (engine-lib). */
+export const PIPELINE_SCHEMA_VERSION = 1;
+
 // ============================================================================
 // Node Type Discriminator
 // ============================================================================

--- a/packages/shared-ui/src/themes/rocketride-vscode.css
+++ b/packages/shared-ui/src/themes/rocketride-vscode.css
@@ -104,6 +104,11 @@
 	--rr-bg-button: var(--vscode-button-background);
 	--rr-fg-button: var(--vscode-button-foreground);
 
+	--rr-btn-sm-height: 16px;
+	--rr-btn-sm-padding: 0 6px;
+	--rr-btn-sm-font-size: 9px;
+	--rr-btn-sm-radius: 3px;
+
 	/* ================================================================== */
 	/* Inputs                                                              */
 	/* ================================================================== */

--- a/packages/shared-ui/src/themes/rocketride-web.css
+++ b/packages/shared-ui/src/themes/rocketride-web.css
@@ -181,6 +181,18 @@
 	/** Primary button foreground. */
 	--rr-fg-button: #ffffff;
 
+	/** Small button height (compact actions on nodes, toolbars). */
+	--rr-btn-sm-height: 16px;
+
+	/** Small button horizontal padding. */
+	--rr-btn-sm-padding: 0 6px;
+
+	/** Small button font size. */
+	--rr-btn-sm-font-size: 9px;
+
+	/** Small button border radius. */
+	--rr-btn-sm-radius: 3px;
+
 	/* ================================================================== */
 	/* Inputs                                                              */
 	/* ================================================================== */

--- a/packages/shared-ui/src/types/project.ts
+++ b/packages/shared-ui/src/types/project.ts
@@ -278,7 +278,10 @@ export interface IProjectComponent extends Omit<PipelineComponent, 'ui'> {
  * Top-level project entity persisted to the .pipe file.
  * Extends the SDK's PipelineConfig.
  */
-export interface IProject extends PipelineConfig {}
+export interface IProject extends PipelineConfig {
+	/** Editor document revision counter for change tracking (undo/redo, echo detection). Not a schema version. */
+	docRevision?: number;
+}
 
 // ============================================================================
 // Validation


### PR DESCRIPTION
Adds play/stop pipeline execution directly from source nodes on the flow canvas, with persistent real-time status, endpoint action buttons, and several supporting bug fixes.

- Play/stop button slides out from the left edge of source nodes
- Three visual states: play (idle), stop (running), spinner (pending)
- Serializes the graph and sends a single 'run' message to the host, which saves to disk then executes — atomic save+run avoids the old canvas's two-step race condition
- Always enables tracing (pipelineTraceLevel: 'full') and passes engine args, matching PageStatus behavior

- Persistent status that remains visible after pipeline completion instead of vanishing
- States: initializing (indeterminate progress bar), running (counts + elapsed time), completed (checkmark + final counts), startup error (inline error message + red accent bar)
- "Status ↗" link opens the full status page
- Status message shows native tooltip on hover for truncated text
- Removed progress bar from running state (only shows during init)
- Removed accent bar from completed state

- Renders "Chat now" and "Endpoint Info" buttons from taskStatus.notes[0] endpoint metadata
- Plain React + inline styles using --rr-* theme tokens — no MUI dependency, reusable by both canvas and PageStatus
- EndpointInfoModal: full endpoint config dialog (URL, auth key, private token) with copy-to-clipboard, show/hide masking, and security warning
- Portals to document.body to avoid node DOM width constraints
- Styles extracted to index.style.ts following project conventions

- Red badge for error count, orange badge for warning count
- Clickable — opens the status page for the source node

- Renamed editor's revision counter from 'version' to 'docRevision' to avoid collision with the pipeline schema version field
- Added PIPELINE_SCHEMA_VERSION = 1 constant; flow always sets version to this value, preventing server rejection of inflated version numbers

- forward_event in cmd_monitor.py now checks for project-wildcard monitor keys (p.{projectId}.*), fixing the bug where canvas nodes registered with source='*' never received status_update events until the status page was opened

- Added 'run', 'stop', 'openStatus' message handlers
- 'run' handler: flags savesForRun to suppress filesystem watcher's restart prompt during save-before-run, clears after 2s delay
- 'openExternal' handler: creates embedded VS Code WebviewPanel with iframe (matching PageStatusProvider.openLink) instead of vscode.env.openExternal — bridges drag-and-drop, clipboard, theme colors, and env variables
- Threaded serverHost, onOpenLink (with displayName), onRunPipeline, onStopPipeline, onOpenStatus through the full provider hierarchy: PageEditor → Flow → FlowContainer → FlowProvider → FlowProjectContext → NodeComponent → NodeStatus → PipelineActions

- Added --rr-btn-sm-height, --rr-btn-sm-padding, --rr-btn-sm-font-size, --rr-btn-sm-radius to both rocketride-web.css and rocketride-vscode.css

- Errors tab badge: replaced yellow triangle icon with red/orange circle count badges matching the node header style
- Restart dialog labels changed from 'Restart' to 'Yes'/'No'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added pipeline run and stop controls directly from the editor interface.
  * Added pipeline status viewer with endpoint configuration details modal.
  * Added error and warning count badges displayed on pipeline nodes.
  * Enhanced link handling with clipboard and file drag-and-drop support.

* **Improvements**
  * Refined pipeline restart confirmation dialog with explicit Yes/No options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->