### PR TITLE
fix(vscode): hide run/stop button when not connected to server

### DIFF
--- a/apps/vscode/src/providers/PageEditorProvider.ts
+++ b/apps/vscode/src/providers/PageEditorProvider.ts
@@ -37,7 +37,7 @@
  */
 
 import * as vscode from 'vscode';
-import { TaskStatus, GenericEvent, GenericResponse } from '../shared/types';
+import { TaskStatus, GenericEvent, GenericResponse, ConnectionState } from '../shared/types';
 import { ConnectionManager } from '../connection/connection';
 import { ConfigManager } from '../config';
 import { getLogger } from '../shared/util/output';
@@ -101,12 +101,14 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 		// Listen for connection state changes to start monitoring when connected
 		const connectionStateListener = this.connectionManager.on('connectionStateChanged', async (connectionStatus) => {
 			try {
-				if (connectionStatus.state === 2) {
-					// ConnectionState.CONNECTED
+				if (connectionStatus.state === ConnectionState.CONNECTED) {
 					await this.startMonitoringForAllEditors();
 				} else {
 					await this.stopMonitoringForAllEditors();
 				}
+
+				// Broadcast connection state to all open editor webviews
+				this.broadcastConnectionState(this.connectionManager.isConnected());
 			} catch (error) {
 				this.logger.error(`Handling connection state change: ${error}`);
 			}
@@ -136,6 +138,19 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 					.then(undefined, (err: unknown) => {
 						this.logger.error(`Failed to post servicesUpdate to webview: ${err}`);
 					});
+			}
+		}
+	}
+
+	/**
+	 * Broadcasts connection state to all open page editor webviews.
+	 */
+	private broadcastConnectionState(isConnected: boolean): void {
+		for (const editorState of this.editorStates.values()) {
+			if (editorState.isReady && !editorState.isDisposed && editorState.webviewPanel.webview) {
+				editorState.webviewPanel.webview.postMessage({ type: 'connectionState', isConnected }).then(undefined, (err: unknown) => {
+					this.logger.error(`Failed to post connectionState to webview: ${err}`);
+				});
 			}
 		}
 	}
@@ -431,6 +446,11 @@ export class PageEditorProvider implements vscode.CustomTextEditorProvider {
 							});
 						}
 					}
+
+					// Send initial connection state
+					webview.postMessage({ type: 'connectionState', isConnected: this.connectionManager.isConnected() }).then(undefined, (err: unknown) => {
+						this.logger.error(`Failed to post connectionState to webview: ${err}`);
+					});
 
 					// Now start monitoring for future updates (if not already monitoring)
 					if (!editorState.isMonitoring) {

--- a/apps/vscode/src/providers/views/PageEditor/PageEditor.tsx
+++ b/apps/vscode/src/providers/views/PageEditor/PageEditor.tsx
@@ -63,6 +63,10 @@ export type PageEditorIncomingMessage =
 			type: 'validateResponse';
 			result: unknown;
 			error?: string;
+	  }
+	| {
+			type: 'connectionState';
+			isConnected: boolean;
 	  };
 
 export type PageEditorOutgoingMessage =
@@ -139,6 +143,8 @@ export const PageEditor: React.FC = () => {
 	const [preferences, setPreferences] = useState<Record<string, unknown>>({});
 	// Server host URL for {host} placeholder replacement in endpoint URLs
 	const [serverHost, setServerHost] = useState<string>('');
+	// Whether the extension is connected to the RocketRide server
+	const [isConnected, setIsConnected] = useState<boolean>(false);
 
 	const contentChangedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const pendingContentRef = useRef<string | null>(null);
@@ -231,6 +237,9 @@ export const PageEditor: React.FC = () => {
 						pendingValidate.current?.resolve(message.result as IValidateResponse);
 					}
 					pendingValidate.current = null;
+					break;
+				case 'connectionState':
+					setIsConnected(message.isConnected);
 					break;
 			}
 		},
@@ -333,7 +342,7 @@ export const PageEditor: React.FC = () => {
 
 	return (
 		<div className="pipeline-editor-container">
-			<Canvas oauth2RootUrl={oauth2RootUrl} project={content} servicesJson={servicesJson} handleValidatePipeline={handleValidatePipeline} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} />
+			<Canvas oauth2RootUrl={oauth2RootUrl} project={content} servicesJson={servicesJson} handleValidatePipeline={handleValidatePipeline} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} />
 		</div>
 	);
 };

--- a/packages/shared-ui/src/modules/flow/Flow.tsx
+++ b/packages/shared-ui/src/modules/flow/Flow.tsx
@@ -105,13 +105,16 @@ export interface IFlowProps {
 
 	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
 	serverHost?: string;
+
+	/** Whether the host is connected to the server. Controls run/stop button availability. */
+	isConnected?: boolean;
 }
 
 // =============================================================================
 // Component
 // =============================================================================
 
-export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, getPreference, setPreference, onContentChanged, onUndo, onRedo, onRunPipeline, onStopPipeline, onOpenStatus, serverHost }: IFlowProps) {
+export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, getPreference, setPreference, onContentChanged, onUndo, onRedo, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected }: IFlowProps) {
 	// --- Build inventory from service catalog --------------------------------
 	const inventory = buildInventory(servicesJson);
 
@@ -170,6 +173,7 @@ export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuse
 					onStopPipeline={onStopPipeline}
 					onOpenStatus={onOpenStatus}
 					serverHost={serverHost}
+					isConnected={isConnected}
 					features={{
 						addNode: true,
 						addAnnotation: true,

--- a/packages/shared-ui/src/modules/flow/components/FlowContainer.tsx
+++ b/packages/shared-ui/src/modules/flow/components/FlowContainer.tsx
@@ -117,6 +117,9 @@ export interface IFlowContainerProps {
 	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
 	serverHost?: string;
 
+	/** Whether the host is connected to the server. Controls run/stop button availability. */
+	isConnected?: boolean;
+
 	/** Child components (typically the Canvas grid). */
 	children?: ReactNode;
 }
@@ -131,12 +134,12 @@ export interface IFlowContainerProps {
  * Uses `key` on the outer Box to force a clean re-mount when the project
  * ID changes, ensuring no stale graph state leaks between projects.
  */
-export default function FlowContainer({ project, oauth2RootUrl, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, onOpenLink, getPreference, setPreference, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, children }: IFlowContainerProps): ReactElement {
+export default function FlowContainer({ project, oauth2RootUrl, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, onOpenLink, getPreference, setPreference, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, children }: IFlowContainerProps): ReactElement {
 	return (
 		<ReactFlowProvider>
 			{/* Re-key on project ID to force clean re-mount between projects */}
 			<Box sx={{ position: 'relative', width: '100%', height: '100%' }} key={`${project.project_id ?? 'new'}-${project.name}`}>
-				<FlowProvider project={project} projectId={project.project_id ?? ''} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost}>
+				<FlowProvider project={project} projectId={project.project_id ?? ''} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected}>
 					{children}
 				</FlowProvider>
 			</Box>

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/RunButton.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/RunButton.tsx
@@ -98,7 +98,7 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 	const [isPending, setIsPending] = useState(false);
 	const isProcessingClick = useRef(false);
 
-	const { currentProject, taskStatuses, onRunPipeline, onStopPipeline } = useFlowProject();
+	const { currentProject, taskStatuses, onRunPipeline, onStopPipeline, isConnected } = useFlowProject();
 	const { nodes } = useFlowGraph();
 
 	// ── Running state ──────────────────────────────────────────────────────
@@ -162,6 +162,11 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 	}, [isPending]);
 
 	// ── Render ─────────────────────────────────────────────────────────────
+	// Hide the button entirely when not connected — can't run or stop without a server
+	if (!isConnected) {
+		return <></>;
+	}
+
 	if (isRunning) {
 		return (
 			<Box

--- a/packages/shared-ui/src/modules/flow/context/FlowProjectContext.tsx
+++ b/packages/shared-ui/src/modules/flow/context/FlowProjectContext.tsx
@@ -138,6 +138,9 @@ export interface IFlowProjectContext {
 
 	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
 	serverHost?: string;
+
+	/** Whether the host is connected to the server. Controls run/stop button availability. */
+	isConnected?: boolean;
 }
 
 const FlowProjectContext = createContext<IFlowProjectContext | null>(null);
@@ -183,6 +186,7 @@ export interface IFlowProjectProviderProps {
 	onStopPipeline?: (source: string) => void;
 	onOpenStatus?: (source: string) => void;
 	serverHost?: string;
+	isConnected?: boolean;
 }
 
 // ============================================================================
@@ -196,7 +200,7 @@ export interface IFlowProjectProviderProps {
  * The host application passes props that are tunneled through this context
  * so deeply nested components can access them without prop drilling.
  */
-export function FlowProjectProvider({ children, project: currentProject, features = DEFAULT_FLOW_FEATURES, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost }: IFlowProjectProviderProps): ReactElement {
+export function FlowProjectProvider({ children, project: currentProject, features = DEFAULT_FLOW_FEATURES, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected }: IFlowProjectProviderProps): ReactElement {
 	// --- Toolchain state ---------------------------------------------------
 
 	const [toolchainState, setToolchainState] = useState<IToolchainState>(DEFAULT_TOOLCHAIN_STATE);
@@ -245,6 +249,7 @@ export function FlowProjectProvider({ children, project: currentProject, feature
 		onStopPipeline,
 		onOpenStatus,
 		serverHost,
+		isConnected,
 	};
 
 	return <FlowProjectContext.Provider value={value}>{children}</FlowProjectContext.Provider>;

--- a/packages/shared-ui/src/modules/flow/context/FlowProvider.tsx
+++ b/packages/shared-ui/src/modules/flow/context/FlowProvider.tsx
@@ -102,6 +102,9 @@ export interface IFlowProviderProps {
 	onOpenStatus?: (source: string) => void;
 	/** Server host URL for replacing {host} placeholders in endpoint URLs. */
 	serverHost?: string;
+
+	/** Whether the host is connected to the server. */
+	isConnected?: boolean;
 }
 
 // ============================================================================
@@ -120,10 +123,10 @@ export interface IFlowProviderProps {
  * </ReactFlowProvider>
  * ```
  */
-export function FlowProvider({ children, project, projectId, getPreference, setPreference, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost }: IFlowProviderProps): ReactElement {
+export function FlowProvider({ children, project, projectId, getPreference, setPreference, features, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected }: IFlowProviderProps): ReactElement {
 	return (
 		<FlowPreferencesProvider projectId={projectId} getPreference={getPreference} setPreference={setPreference}>
-			<FlowProjectProvider project={project} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost}>
+			<FlowProjectProvider project={project} features={features} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected}>
 				<FlowGraphProvider>{children}</FlowGraphProvider>
 			</FlowProjectProvider>
 		</FlowPreferencesProvider>


### PR DESCRIPTION
## Summary
- Clicking Play on a source node while disconnected caused the RunButton to spin forever — `connectionManager.request()` silently returned `undefined`, so no task status transition ever arrived to clear the pending state
- Threads `isConnected` from the extension host through to the RunButton via `connectionState` webview messages and FlowProjectContext
- RunButton now hides itself entirely when disconnected — no play or stop button is shown
- Follows the same pattern PageStatus already uses to gate its UI on connection state

## Changes
| File | What |
|------|------|
| `PageEditorProvider.ts` | Broadcasts `connectionState` on connect/disconnect + sends initial state on `ready` |
| `PageEditor.tsx` | Handles `connectionState` message, tracks `isConnected`, passes to Canvas |
| `Flow.tsx` / `FlowContainer.tsx` / `FlowProvider.tsx` / `FlowProjectContext.tsx` | Thread `isConnected` prop through to context |
| `RunButton.tsx` | Returns empty fragment when `!isConnected` |

## Test plan
- [ ] Open a pipeline editor while **disconnected** — verify no play button appears on source nodes
- [ ] Connect to the server — verify the play button appears
- [ ] Click Play while connected — verify it runs normally
- [ ] Disconnect while a pipeline is idle — verify the play button disappears
- [ ] Disconnect while a pipeline is running — verify the stop button disappears (pipeline continues server-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection state monitoring: host connectivity is tracked and communicated to editor views; editors receive initial state when ready.
  * Run/Stop button availability now reflects host connectivity—controls are hidden when disconnected.

* **Bug Fixes / Reliability**
  * Improved messaging robustness: failed connection-state messages are now logged for easier diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->