### PR TITLE
fix(vscode): use @vscode/vsce for vsix packaging

### DIFF
--- a/apps/vscode/scripts/tasks.js
+++ b/apps/vscode/scripts/tasks.js
@@ -197,7 +197,7 @@ function makePackageVsixAction() {
 
 			await mkdir(VSCODE_DIST_DIR);
 			const vsceOut = path.relative(BUILD_DIR, VSCODE_DIST_DIR);
-			await execCommand('npx', ['vsce', 'package', '--no-dependencies', '-o', vsceOut], { task, cwd: BUILD_DIR });
+			await execCommand('npx', ['@vscode/vsce', 'package', '--no-dependencies', '-o', vsceOut], { task, cwd: BUILD_DIR });
 
 			task.output = `Package created in ${VSCODE_DIST_DIR}`;
 		},


### PR DESCRIPTION
## Summary
- Replace deprecated `vsce` with `@vscode/vsce` in the vsix packaging step
- `npx vsce` resolves to `vsce@2.15.0` (deprecated) when run from `build/vscode/` which is outside the pnpm workspace, mangling the extension name (`rocketride` → `rocketride-vscode`) and version (`1.0.4` → `1.0.5`)
- This caused the marketplace publish to fail: `This extension display name is taken`

## Test plan
- [ ] CI build produces vsix named `rocketride-{version}.vsix` (not `rocketride-vscode-`)
- [ ] Release publish step succeeds for VS Code Marketplace