### PR TITLE
feat: add MiniMax as 14th LLM provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ RocketRide is a high-performance data processing engine built on a C++ core with
 - **Stay in your IDE** — Build, debug, test, and scale heavy AI and data workloads with an intuitive visual builder in the environment you're used to. Stop using your browser.
 - **High-performance C++ engine** — Native multithreading. No bottleneck. Purpose-built for throughput, not prototypes.
 - **Multi-agent workflows** — Orchestrate and scale agents with built-in support for CrewAI and LangChain.
-- **50+ pipeline nodes** — Python-extensible, with 13 LLM providers, 8 vector databases, OCR, NER, PII anonymization, and more.
+- **50+ pipeline nodes** — Python-extensible, with 14 LLM providers (OpenAI, Anthropic, DeepSeek, Gemini, Mistral, Qwen, xAI, Perplexity, MiniMax, Ollama, IBM Watson, AWS Bedrock, Google Vertex, and more), 8 vector databases, OCR, NER, PII anonymization, and more.
 - **TypeScript, Python & MCP SDKs** — Integrate pipelines into native applications or expose them as tools for AI assistants.
 - **One-click deploy** — Run on Docker, on-prem, or RocketRide Cloud (👀*coming soon*). Our architecture is made for production, not demos.
 

--- a/nodes/src/nodes/llm_minimax/IGlobal.py
+++ b/nodes/src/nodes/llm_minimax/IGlobal.py
@@ -1,0 +1,136 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+import re
+from typing import Optional
+from rocketlib import IGlobalBase, warning
+from ai.common.config import Config
+from ai.common.chat import ChatBase
+
+
+VALIDATION_PROMPT = 'Hi'
+MINIMAX_BASE_URL = 'https://api.minimax.io/v1'
+
+
+class IGlobal(IGlobalBase):
+    """Global handler for the MiniMax LLM node."""
+
+    chat: Optional[ChatBase] = None
+
+    def validateConfig(self):
+        """Validate MiniMax cloud models at save time using a minimal probe."""
+        # Load dependencies first
+        from depends import depends  # type: ignore
+
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        try:
+            # Import OpenAI SDK (MiniMax is OpenAI-compatible)
+            from openai import OpenAI
+
+            # Prefer provider-driven exception types over string parsing
+            from openai import APIStatusError, OpenAIError, AuthenticationError, RateLimitError, APIConnectionError
+
+            # Get config
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            apikey = config.get('apikey')
+            model = config.get('model')
+
+            # Minimal probe; UI handles missing key prompts
+            try:
+                # Create client and make a 1-token probe
+                client = OpenAI(api_key=apikey, base_url=MINIMAX_BASE_URL)
+                client.chat.completions.create(model=model, messages=[{'role': 'user', 'content': VALIDATION_PROMPT}], max_tokens=1)
+            except APIStatusError as e:
+                # HTTP error with structured body; pull code/type/message
+                status = getattr(e, 'status_code', None) or getattr(e, 'status', None)
+                try:
+                    resp = getattr(e, 'response', None)
+                    data = resp.json() if resp is not None else None
+                    if isinstance(data, dict):
+                        err = data.get('error')
+                        if isinstance(err, dict):
+                            etype = err.get('type')
+                            emsg = err.get('message') or data.get('message')
+                        else:
+                            etype = None
+                            emsg = data.get('message')
+                        message = self._format_error(status, etype, emsg, str(e))
+                    else:
+                        message = self._format_error(status, None, None, str(e))
+                except Exception:
+                    message = self._format_error(status, None, None, str(e))
+                warning(message)
+                return
+            except (AuthenticationError, RateLimitError, APIConnectionError, OpenAIError) as e:
+                # Other OpenAI exceptions; format consistently
+                message = self._format_error(None, None, None, str(e))
+                warning(message)
+                return
+
+        except Exception as e:
+            # Generic fallback - do not alter provider message
+            warning(str(e))
+
+    def beginGlobal(self):
+        from depends import depends  # type: ignore
+
+        # Load the requirements
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        from .minimax import Chat
+
+        # Get our bag
+        bag = self.IEndpoint.endpoint.bag
+
+        # Get this nodes config
+        config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+
+        # Get a chat to interface
+        self._chat = Chat(self.glb.logicalType, config, bag)
+
+    def endGlobal(self):
+        self.chat = None
+
+    def _format_error(self, status, etype, emsg, fallback: str) -> str:
+        """Compose a user-facing error string.
+
+        - If a numeric HTTP status/code is available, prefix it as "Error <status>:".
+        - Then include provider error type and message when present.
+        - If no structured fields are available, return the fallback message as-is.
+        - Whitespace is normalized to a single line; content is not truncated.
+        """
+        parts: list[str] = []
+        if status is not None:
+            parts.append(f'Error {status}:')
+        if etype:
+            parts.append(str(etype))
+        if emsg:
+            if etype:
+                parts.append('-')
+            parts.append(str(emsg))
+        message = ' '.join(parts) if parts else fallback
+        return re.sub(r'\s+', ' ', message).strip()

--- a/nodes/src/nodes/llm_minimax/IInstance.py
+++ b/nodes/src/nodes/llm_minimax/IInstance.py
@@ -1,0 +1,28 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from nodes.llm_base import IInstanceGenericLLM
+
+
+class IInstance(IInstanceGenericLLM):
+    pass

--- a/nodes/src/nodes/llm_minimax/__init__.py
+++ b/nodes/src/nodes/llm_minimax/__init__.py
@@ -1,0 +1,41 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+
+def getChat():
+    """
+    Get the Chat class from the module.
+    """
+    from .minimax import Chat
+
+    return Chat
+
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+    'getChat',
+]

--- a/nodes/src/nodes/llm_minimax/minimax.py
+++ b/nodes/src/nodes/llm_minimax/minimax.py
@@ -1,0 +1,77 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+MiniMax binding for the ChatLLM.
+"""
+
+from typing import Any, Dict
+from ai.common.chat import ChatBase
+from ai.common.config import Config
+from langchain_openai import ChatOpenAI
+
+
+MINIMAX_BASE_URL = 'https://api.minimax.io/v1'
+
+
+class Chat(ChatBase):
+    """
+    Creates a MiniMax chat bot.
+    """
+
+    _llm: ChatOpenAI
+
+    def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
+        """Initialize the MiniMax chat bot.
+
+        Args:
+            provider (str): Provider name
+            connConfig (Dict[str, Any]): Node configuration
+            bag (Dict[str, Any]): Bag to store data
+        """
+        # Init the base
+        super().__init__(provider, connConfig, bag)
+
+        # Get the nodes configuration
+        config = Config.getNodeConfig(provider, connConfig)
+
+        # Get the api key
+        apikey = config.get('apikey')
+        if not apikey:
+            raise ValueError('MiniMax API key is required.')
+
+        # MiniMax temperature must be strictly greater than 0
+        # Clamp temperature=0 to a small positive value
+        temperature = max(config.get('temperature', 0.01), 0.01)
+
+        # Get the llm via OpenAI-compatible API
+        self._llm = ChatOpenAI(
+            model=self._model,
+            base_url=MINIMAX_BASE_URL,
+            api_key=apikey,
+            temperature=temperature,
+            max_tokens=self._modelOutputTokens,
+        )
+
+        # Save our chat class into the bag
+        bag['chat'] = self

--- a/nodes/src/nodes/llm_minimax/requirements.txt
+++ b/nodes/src/nodes/llm_minimax/requirements.txt
@@ -1,0 +1,18 @@
+# Plugin MiniMax core
+openai
+langchain-openai
+transformers
+tokenizers
+
+# Transformers deps
+accelerate
+huggingface-hub
+pyyaml
+filelock
+regex
+tqdm
+safetensors
+
+# LangChain deps
+langchain-core
+langchain

--- a/nodes/src/nodes/llm_minimax/services.json
+++ b/nodes/src/nodes/llm_minimax/services.json
@@ -1,0 +1,267 @@
+{
+	//
+	// Required:
+	//		The displayable name of this node
+	//
+	"title": "MiniMax",
+	//
+	// Required:
+	//		The protocol is the endpoint protocol
+	//
+	"protocol": "llm_minimax://",
+	//
+	// Required:
+	//		Class type of the node - what it does
+	//
+	"classType": [
+		"llm"
+	],
+	//
+	// Required:
+	//		Capabilities are flags that change the behavior of the underlying
+	//		engine
+	//
+	"capabilities": [
+		"invoke"
+	],
+	//
+	// Optional:
+	//		Register is either filter, endpoint or ignored if not specified. If the
+	//		type is specified, a factory is registered of that given type
+	//
+	"register": "filter",
+	//
+	// Optional:
+	//		The node is the actual pyhsical node to instantiate - if
+	//		not specified, the protocol will be used
+	//
+	"node": "python",
+	//
+	// Optional:
+	//		The path is the executable/script code - it is node dependent
+	// 		and is optional for most node
+	//
+	"path": "nodes.llm_minimax",
+	//
+	// Required:
+	//		The prefix map when added/removed when convertting URLs <=> paths
+	//
+	"prefix": "llm",
+	//
+	// Optional:
+	//		Description to of this driver
+	//
+	"description": [
+		"A component that connects to MiniMax's large language models for advanced ",
+		"natural language processing. MiniMax offers high-performance models with up to ",
+		"1M token context windows, optimized for text generation, summarization, and ",
+		"conversational AI. The component supports the latest MiniMax-M2.7 and ",
+		"MiniMax-M2.5 model families via an OpenAI-compatible API, enabling seamless ",
+		"integration into existing pipelines."
+	],
+	//
+	// Optional:
+	//	  The icon is the icon to display in the UI for this node
+	//
+	"icon": "minimax.svg",
+	//
+	// Optional:
+	//	  Documentation link for this driver
+	//
+	"documentation": "https://platform.minimaxi.com/document/introduction",
+	//
+	//  Optional:
+	//      Rendering hints to the UI which indicate which fields of
+	//      the configuration should be used to display information
+	//
+	"tile": [
+		"Model: ${parameters.llm_minimax.profile}"
+	],
+	//
+	//	Optional:
+	//		As a pipe component, define what this pipe component takes
+	//		and what it produces
+	//
+	"lanes": {
+		"questions": [
+			"answers"
+		]
+	},
+	"input": [
+		{
+			"lane": "questions",
+			"output": [
+				{
+					"lane": "answers"
+				}
+			]
+		}
+	],
+	//
+	//	Optional:
+	//		Profile section are configuration optoins used by the driver
+	//		itself
+	//
+	"preconfig": {
+		// Define the values that will be merged into any profile configuration
+		// specified, unless the profile is 'absolute'
+		"default": "minimax-m2_7",
+		// Defines profiles used with the "profile": key
+		"profiles": {
+			"minimax-m2_7": {
+				"model": "MiniMax-M2.7",
+				"title": "MiniMax-M2.7",
+				"apikey": "",
+				"modelTotalTokens": 1000000
+			},
+			"minimax-m2_7-highspeed": {
+				"model": "MiniMax-M2.7-highspeed",
+				"title": "MiniMax-M2.7 Highspeed",
+				"apikey": "",
+				"modelTotalTokens": 1000000
+			},
+			"minimax-m2_5": {
+				"model": "MiniMax-M2.5",
+				"title": "MiniMax-M2.5",
+				"apikey": "",
+				"modelTotalTokens": 204000
+			},
+			"minimax-m2_5-highspeed": {
+				"model": "MiniMax-M2.5-highspeed",
+				"title": "MiniMax-M2.5 Highspeed",
+				"apikey": "",
+				"modelTotalTokens": 204000
+			},
+			"custom": {
+				"title": "Custom Model",
+				"model": "",
+				"modelTotalTokens": 128000,
+				"apikey": ""
+			}
+		}
+	},
+	//
+	// Optional:
+	//		Local fields defintions - these define fields only for the
+	//		current service. You may specify them here, or directly
+	//		in the shape
+	//
+	"fields": {
+		"model": {
+			"type": "string",
+			"title": "Model",
+			"description": "MiniMax model"
+		},
+		"modelTotalTokens": {
+			"type": "number",
+			"title": "Tokens",
+			"description": "Total Tokens"
+		},
+		"minimax.custom": {
+			"object": "custom",
+			"properties": [
+				"model",
+				"modelTotalTokens",
+				"llm.cloud.apikey"
+			]
+		},
+		"minimax.minimax-m2_7": {
+			"object": "minimax-m2_7",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"minimax.minimax-m2_7-highspeed": {
+			"object": "minimax-m2_7-highspeed",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"minimax.minimax-m2_5": {
+			"object": "minimax-m2_5",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"minimax.minimax-m2_5-highspeed": {
+			"object": "minimax-m2_5-highspeed",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"minimax.profile": {
+			"title": "Model",
+			"description": "MiniMax LLM model",
+			"type": "string",
+			"default": "minimax-m2_7",
+			"enum": [
+				["custom", "Custom Model"],
+				["minimax-m2_7", "MiniMax-M2.7"],
+				["minimax-m2_7-highspeed", "MiniMax-M2.7 Highspeed"],
+				["minimax-m2_5", "MiniMax-M2.5"],
+				["minimax-m2_5-highspeed", "MiniMax-M2.5 Highspeed"]
+			],
+			"conditional": [
+				{
+					"value": "custom",
+					"properties": [
+						"minimax.custom"
+					]
+				},
+				{
+					"value": "minimax-m2_7",
+					"properties": [
+						"minimax.minimax-m2_7"
+					]
+				},
+				{
+					"value": "minimax-m2_7-highspeed",
+					"properties": [
+						"minimax.minimax-m2_7-highspeed"
+					]
+				},
+				{
+					"value": "minimax-m2_5",
+					"properties": [
+						"minimax.minimax-m2_5"
+					]
+				},
+				{
+					"value": "minimax-m2_5-highspeed",
+					"properties": [
+						"minimax.minimax-m2_5-highspeed"
+					]
+				}
+			]
+		}
+	},
+	//
+	// Required:
+	//		Defines the fields (shape) of the service. Either source or target
+	//		map be specified, or both, but at least one is required
+	//
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "MiniMax",
+			"properties": [
+				"minimax.profile"
+			]
+		}
+	],
+	"test": {
+		"profiles": ["minimax-m2_7"],
+		"outputs": ["answers"],
+		"cases": [
+			{
+				"name": "LLM returns mock response",
+				"text": "What is 2+2?",
+				"expect": {
+					"answers": {
+						"contains": "Mock LLM response"
+					}
+				}
+			}
+		]
+	}
+}

--- a/nodes/test/llm_minimax/test_minimax.py
+++ b/nodes/test/llm_minimax/test_minimax.py
@@ -1,0 +1,421 @@
+"""
+Tests for MiniMax LLM provider.
+
+Validates the MiniMax Chat class initialization, temperature clamping,
+API key validation, and services.json configuration without requiring
+a real API connection.
+"""
+
+import importlib
+import importlib.util
+import json
+import json5
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path setup
+# ---------------------------------------------------------------------------
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_SRC_NODES = os.path.join(_HERE, '..', '..', 'src', 'nodes')
+_MINIMAX_DIR = os.path.join(_SRC_NODES, 'llm_minimax')
+_MINIMAX_MOD = os.path.join(_MINIMAX_DIR, 'minimax.py')
+_SERVICES_JSON = os.path.join(_MINIMAX_DIR, 'services.json')
+_IGLOBAL_MOD = os.path.join(_MINIMAX_DIR, 'IGlobal.py')
+
+# Expected base URL for MiniMax API
+MINIMAX_BASE_URL = 'https://api.minimax.io/v1'
+
+
+# ---------------------------------------------------------------------------
+# Helpers: load module with stubbed runtime deps
+# ---------------------------------------------------------------------------
+
+def _stub_modules():
+    """Stub out heavy runtime dependencies so we can import the Chat class."""
+    stub_names = [
+        'ai', 'ai.common', 'ai.common.chat', 'ai.common.config',
+        'langchain_openai', 'rocketlib',
+    ]
+    saved = {}
+    for name in stub_names:
+        saved[name] = sys.modules.get(name)
+        stub = types.ModuleType(name)
+        if name == 'ai.common.chat':
+            # Provide a minimal ChatBase for subclassing
+            class FakeChatBase:
+                def __init__(self, provider, connConfig, bag):
+                    self._model = 'MiniMax-M2.7'
+                    self._modelTotalTokens = 1000000
+                    self._modelOutputTokens = 4096
+            stub.ChatBase = FakeChatBase
+        if name == 'ai.common.config':
+            class FakeConfig:
+                @staticmethod
+                def getNodeConfig(provider, connConfig):
+                    return connConfig
+            stub.Config = FakeConfig
+        if name == 'langchain_openai':
+            class FakeChatOpenAI:
+                def __init__(self, **kwargs):
+                    self.model = kwargs.get('model')
+                    self.base_url = kwargs.get('base_url')
+                    self.api_key = kwargs.get('api_key')
+                    self.temperature = kwargs.get('temperature')
+                    self.max_tokens = kwargs.get('max_tokens')
+            stub.ChatOpenAI = FakeChatOpenAI
+        if name == 'rocketlib':
+            stub.IGlobalBase = type('IGlobalBase', (), {})
+            stub.warning = lambda msg: None
+        sys.modules[name] = stub
+    return saved, stub_names
+
+
+def _restore_modules(saved, stub_names):
+    """Restore original sys.modules state."""
+    for name in stub_names:
+        if saved[name] is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = saved[name]
+
+
+def _load_chat_class():
+    """Load the Chat class from minimax.py with stubbed deps."""
+    saved, stub_names = _stub_modules()
+    try:
+        spec = importlib.util.spec_from_file_location('_minimax', _MINIMAX_MOD)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.Chat, mod.MINIMAX_BASE_URL
+    finally:
+        _restore_modules(saved, stub_names)
+
+
+Chat, LOADED_BASE_URL = _load_chat_class()
+
+
+# ---- Tests for services.json configuration --------------------------------
+
+class TestServicesJson:
+    """Validate that services.json is well-formed and complete."""
+
+    @pytest.fixture(autouse=True)
+    def load_services(self):
+        with open(_SERVICES_JSON, 'r') as f:
+            self.services = json5.load(f)
+
+    def test_title(self):
+        assert self.services['title'] == 'MiniMax'
+
+    def test_protocol(self):
+        assert self.services['protocol'] == 'llm_minimax://'
+
+    def test_class_type(self):
+        assert self.services['classType'] == ['llm']
+
+    def test_capabilities(self):
+        assert 'invoke' in self.services['capabilities']
+
+    def test_register(self):
+        assert self.services['register'] == 'filter'
+
+    def test_node_type(self):
+        assert self.services['node'] == 'python'
+
+    def test_path(self):
+        assert self.services['path'] == 'nodes.llm_minimax'
+
+    def test_prefix(self):
+        assert self.services['prefix'] == 'llm'
+
+    def test_has_description(self):
+        desc = self.services.get('description', [])
+        assert len(desc) > 0
+        full = ''.join(desc)
+        assert 'MiniMax' in full
+
+    def test_has_documentation(self):
+        assert 'documentation' in self.services
+
+    def test_has_tile(self):
+        tile = self.services.get('tile', [])
+        assert len(tile) > 0
+        assert 'llm_minimax' in tile[0]
+
+    def test_lanes(self):
+        assert self.services['lanes'] == {'questions': ['answers']}
+
+    def test_input_output(self):
+        inputs = self.services['input']
+        assert len(inputs) == 1
+        assert inputs[0]['lane'] == 'questions'
+        assert inputs[0]['output'][0]['lane'] == 'answers'
+
+
+class TestServicesJsonProfiles:
+    """Validate that model profiles are correctly defined."""
+
+    @pytest.fixture(autouse=True)
+    def load_services(self):
+        with open(_SERVICES_JSON, 'r') as f:
+            self.services = json5.load(f)
+        self.profiles = self.services['preconfig']['profiles']
+
+    def test_default_profile_exists(self):
+        default = self.services['preconfig']['default']
+        assert default in self.profiles
+
+    def test_m2_7_profile(self):
+        p = self.profiles['minimax-m2_7']
+        assert p['model'] == 'MiniMax-M2.7'
+        assert p['modelTotalTokens'] == 1000000
+
+    def test_m2_7_highspeed_profile(self):
+        p = self.profiles['minimax-m2_7-highspeed']
+        assert p['model'] == 'MiniMax-M2.7-highspeed'
+        assert p['modelTotalTokens'] == 1000000
+
+    def test_m2_5_profile(self):
+        p = self.profiles['minimax-m2_5']
+        assert p['model'] == 'MiniMax-M2.5'
+        assert p['modelTotalTokens'] == 204000
+
+    def test_m2_5_highspeed_profile(self):
+        p = self.profiles['minimax-m2_5-highspeed']
+        assert p['model'] == 'MiniMax-M2.5-highspeed'
+        assert p['modelTotalTokens'] == 204000
+
+    def test_custom_profile(self):
+        p = self.profiles['custom']
+        assert p['model'] == ''
+        assert p['title'] == 'Custom Model'
+
+    def test_all_cloud_profiles_have_apikey(self):
+        for name, p in self.profiles.items():
+            assert 'apikey' in p, f"Profile {name} missing apikey field"
+
+    def test_profile_count(self):
+        assert len(self.profiles) == 5
+
+
+class TestServicesJsonFields:
+    """Validate that UI field definitions are correct."""
+
+    @pytest.fixture(autouse=True)
+    def load_services(self):
+        with open(_SERVICES_JSON, 'r') as f:
+            self.services = json5.load(f)
+        self.fields = self.services['fields']
+
+    def test_profile_field_exists(self):
+        assert 'minimax.profile' in self.fields
+
+    def test_profile_field_default(self):
+        assert self.fields['minimax.profile']['default'] == 'minimax-m2_7'
+
+    def test_profile_field_enum_count(self):
+        enum = self.fields['minimax.profile']['enum']
+        assert len(enum) == 5  # custom + 4 models
+
+    def test_profile_conditional_count(self):
+        conds = self.fields['minimax.profile']['conditional']
+        assert len(conds) == 5
+
+    def test_custom_field_has_model_and_tokens(self):
+        custom = self.fields['minimax.custom']
+        props = custom['properties']
+        assert 'model' in props
+        assert 'modelTotalTokens' in props
+        assert 'llm.cloud.apikey' in props
+
+    def test_non_custom_fields_have_apikey(self):
+        for key in ['minimax.minimax-m2_7', 'minimax.minimax-m2_7-highspeed',
+                     'minimax.minimax-m2_5', 'minimax.minimax-m2_5-highspeed']:
+            assert 'llm.cloud.apikey' in self.fields[key]['properties']
+
+
+class TestServicesJsonTest:
+    """Validate the test configuration in services.json."""
+
+    @pytest.fixture(autouse=True)
+    def load_services(self):
+        with open(_SERVICES_JSON, 'r') as f:
+            self.services = json5.load(f)
+        self.test_config = self.services['test']
+
+    def test_has_profiles(self):
+        assert len(self.test_config['profiles']) > 0
+
+    def test_has_outputs(self):
+        assert 'answers' in self.test_config['outputs']
+
+    def test_has_cases(self):
+        assert len(self.test_config['cases']) > 0
+
+    def test_first_case_has_expect(self):
+        case = self.test_config['cases'][0]
+        assert 'expect' in case
+        assert 'answers' in case['expect']
+
+
+# ---- Tests for Chat class initialization -----------------------------------
+
+class TestChatInit:
+    """Validate Chat class initialization and configuration."""
+
+    def test_basic_init(self):
+        config = {
+            'model': 'MiniMax-M2.7',
+            'apikey': 'test-key-123',
+            'modelTotalTokens': 1000000,
+            'modelOutputTokens': 4096,
+        }
+        bag = {}
+        chat = Chat('llm_minimax', config, bag)
+        assert bag['chat'] is chat
+        assert chat._llm.api_key == 'test-key-123'
+        assert chat._llm.base_url == MINIMAX_BASE_URL
+
+    def test_missing_apikey_raises(self):
+        config = {
+            'model': 'MiniMax-M2.7',
+            'apikey': '',
+            'modelTotalTokens': 1000000,
+            'modelOutputTokens': 4096,
+        }
+        with pytest.raises(ValueError, match='API key is required'):
+            Chat('llm_minimax', config, {})
+
+    def test_none_apikey_raises(self):
+        config = {
+            'model': 'MiniMax-M2.7',
+            'apikey': None,
+            'modelTotalTokens': 1000000,
+            'modelOutputTokens': 4096,
+        }
+        with pytest.raises(ValueError, match='API key is required'):
+            Chat('llm_minimax', config, {})
+
+
+class TestTemperatureClamping:
+    """Validate that temperature is properly clamped for MiniMax."""
+
+    def _make_chat(self, temperature=None):
+        config = {
+            'model': 'MiniMax-M2.7',
+            'apikey': 'test-key-123',
+            'modelTotalTokens': 1000000,
+            'modelOutputTokens': 4096,
+        }
+        if temperature is not None:
+            config['temperature'] = temperature
+        return Chat('llm_minimax', config, {})
+
+    def test_zero_temperature_clamped(self):
+        chat = self._make_chat(temperature=0)
+        assert chat._llm.temperature >= 0.01
+
+    def test_negative_temperature_clamped(self):
+        chat = self._make_chat(temperature=-1)
+        assert chat._llm.temperature >= 0.01
+
+    def test_normal_temperature_preserved(self):
+        chat = self._make_chat(temperature=0.7)
+        assert chat._llm.temperature == 0.7
+
+    def test_default_temperature_clamped(self):
+        chat = self._make_chat()
+        assert chat._llm.temperature >= 0.01
+
+    def test_small_positive_temperature_preserved(self):
+        chat = self._make_chat(temperature=0.5)
+        assert chat._llm.temperature == 0.5
+
+
+class TestBaseUrl:
+    """Validate that the MiniMax base URL is correctly set."""
+
+    def test_base_url_constant(self):
+        assert LOADED_BASE_URL == MINIMAX_BASE_URL
+
+    def test_chat_uses_correct_base_url(self):
+        config = {
+            'model': 'MiniMax-M2.7',
+            'apikey': 'test-key-123',
+            'modelTotalTokens': 1000000,
+            'modelOutputTokens': 4096,
+        }
+        chat = Chat('llm_minimax', config, {})
+        assert chat._llm.base_url == 'https://api.minimax.io/v1'
+
+
+# ---- Tests for IGlobal error formatting -----------------------------------
+
+class TestIGlobalErrorFormat:
+    """Validate IGlobal._format_error helper."""
+
+    @pytest.fixture(autouse=True)
+    def load_iglobal(self):
+        saved, stub_names = _stub_modules()
+        try:
+            spec = importlib.util.spec_from_file_location('_iglobal', _IGLOBAL_MOD)
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            self.IGlobal = mod.IGlobal
+        finally:
+            _restore_modules(saved, stub_names)
+
+    def _format(self, status, etype, emsg, fallback):
+        inst = object.__new__(self.IGlobal)
+        return inst._format_error(status, etype, emsg, fallback)
+
+    def test_format_with_status_and_message(self):
+        result = self._format(401, 'AuthError', 'Invalid API key', 'fallback')
+        assert 'Error 401:' in result
+        assert 'Invalid API key' in result
+
+    def test_format_fallback_when_no_fields(self):
+        result = self._format(None, None, None, 'some raw error')
+        assert result == 'some raw error'
+
+    def test_format_normalizes_whitespace(self):
+        result = self._format(500, None, 'multi\n  line\t error', 'fallback')
+        assert '\n' not in result
+        assert '\t' not in result
+
+    def test_format_status_only(self):
+        result = self._format(429, None, None, 'fallback')
+        assert result == 'Error 429:'
+
+
+# ---- Tests for module exports ---------------------------------------------
+
+class TestModuleExports:
+    """Validate that __init__.py exports the expected symbols."""
+
+    def test_init_exports(self):
+        init_path = os.path.join(_MINIMAX_DIR, '__init__.py')
+        with open(init_path, 'r') as f:
+            content = f.read()
+        assert 'IGlobal' in content
+        assert 'IInstance' in content
+        assert 'getChat' in content
+
+    def test_iinstance_inherits_base(self):
+        iinstance_path = os.path.join(_MINIMAX_DIR, 'IInstance.py')
+        with open(iinstance_path, 'r') as f:
+            content = f.read()
+        assert 'IInstanceGenericLLM' in content
+
+    def test_requirements_has_openai(self):
+        req_path = os.path.join(_MINIMAX_DIR, 'requirements.txt')
+        with open(req_path, 'r') as f:
+            content = f.read()
+        assert 'openai' in content
+        assert 'langchain-openai' in content


### PR DESCRIPTION
## Summary

Add **MiniMax AI** as the 14th LLM provider in RocketRide, enabling users to connect pipelines to MiniMax's high-performance language models via the OpenAI-compatible API.

### What's included

- **Full provider implementation** (`nodes/src/nodes/llm_minimax/`):
  - `services.json` — service registration with 5 model profiles (M2.7, M2.7-highspeed, M2.5, M2.5-highspeed, Custom) and UI field definitions
  - `minimax.py` — Chat class extending `ChatBase`, using `ChatOpenAI` with MiniMax's `https://api.minimax.io/v1` base URL
  - `IGlobal.py` — save-time validation via 1-token probe, structured error formatting
  - `IInstance.py` — standard `IInstanceGenericLLM` inheritance
  - `requirements.txt` — OpenAI + LangChain dependencies
  - `__init__.py` — module exports with lazy `getChat()` factory

- **Temperature clamping** — MiniMax requires temperature ∈ (0, 1], so `temperature=0` is clamped to `0.01`

- **48 unit tests** (`nodes/test/llm_minimax/test_minimax.py`):
  - `services.json` schema validation (title, protocol, profiles, fields, test config)
  - Chat initialization, API key validation, temperature clamping
  - `IGlobal._format_error` helper
  - Module export and dependency checks

- **README** updated: provider count 13 → 14

### Model profiles

| Profile | Model | Context Window |
|---------|-------|---------------|
| MiniMax-M2.7 (default) | `MiniMax-M2.7` | 1M tokens |
| MiniMax-M2.7 Highspeed | `MiniMax-M2.7-highspeed` | 1M tokens |
| MiniMax-M2.5 | `MiniMax-M2.5` | 204K tokens |
| MiniMax-M2.5 Highspeed | `MiniMax-M2.5-highspeed` | 204K tokens |
| Custom | User-defined | Configurable |

## Test plan

- [x] All 48 unit tests pass (`pytest nodes/test/llm_minimax/test_minimax.py -v`)
- [ ] Dynamic test framework discovers `llm_minimax` via `services.json` test config
- [ ] Integration test with MiniMax API key (set `MINIMAX_API_KEY` env var)
