### PR TITLE
fix(ci): remove main from scorecard push trigger

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '22 5 * * 1'  # Weekly Monday 5:22 UTC
   push:
-    branches: [develop, main]
+    branches: [develop]
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
## Summary
- Remove `main` from the OpenSSF Scorecard push trigger
- Scorecard only supports the default branch (`develop`) and always fails on main with `only default branch is supported`

## Test plan
- [ ] No more Scorecard failures on push to main