### PR TITLE
fix(endpoint): remove redundant Open button and reorder Copy to last

### DIFF
--- a/packages/shared-ui/src/components/pipeline-actions/EndpointInfoModal.tsx
+++ b/packages/shared-ui/src/components/pipeline-actions/EndpointInfoModal.tsx
@@ -154,9 +154,6 @@ export default function EndpointInfoModal({ endpointInfo, isOpen, onClose, onOpe
 							<button style={iconBtn('url')} onClick={() => handleCopy(endpointUrl, 'url')}>
 								{copyFeedback === 'url' ? 'Copied!' : 'Copy'}
 							</button>
-							<button style={styles.iconBtn} onClick={() => onOpenLink?.(endpointUrl, displayName)}>
-								Open
-							</button>
 						</div>
 					</div>
 
@@ -177,11 +174,11 @@ export default function EndpointInfoModal({ endpointInfo, isOpen, onClose, onOpe
 									{urlWithAuth}
 								</a>
 							</div>
-							<button style={iconBtn('urlAuth')} onClick={() => handleCopy(urlWithAuth, 'urlAuth')}>
-								{copyFeedback === 'urlAuth' ? 'Copied!' : 'Copy'}
-							</button>
 							<button style={styles.iconBtn} onClick={() => onOpenLink?.(urlWithAuth, displayName)}>
 								Open
+							</button>
+							<button style={iconBtn('urlAuth')} onClick={() => handleCopy(urlWithAuth, 'urlAuth')}>
+								{copyFeedback === 'urlAuth' ? 'Copied!' : 'Copy'}
 							</button>
 						</div>
 					</div>
@@ -203,11 +200,11 @@ export default function EndpointInfoModal({ endpointInfo, isOpen, onClose, onOpe
 							<div style={styles.configLabel}>{processed['token-text']}</div>
 							<div style={styles.configValueRow}>
 								<div style={isTokenVisible ? styles.configValue : styles.configValueMasked}>{isTokenVisible ? processed['token-key'] : MASKED_VALUE}</div>
-								<button style={iconBtn('token')} onClick={() => handleCopy(processed['token-key']!, 'token')}>
-									{copyFeedback === 'token' ? 'Copied!' : 'Copy'}
-								</button>
 								<button style={styles.iconBtn} onClick={() => setIsTokenVisible(!isTokenVisible)}>
 									{isTokenVisible ? 'Hide' : 'Show'}
+								</button>
+								<button style={iconBtn('token')} onClick={() => handleCopy(processed['token-key']!, 'token')}>
+									{copyFeedback === 'token' ? 'Copied!' : 'Copy'}
 								</button>
 							</div>
 						</div>


### PR DESCRIPTION
## Summary

- Remove Open button from base URL row (no auth key, won't work for external access)
- Reorder buttons so Copy is consistently last when multiple actions are present
  - URL with Auth: Open | Copy
  - Private Token: Show | Copy

## Test plan

- [ ] Open endpoint config modal from canvas or status page
- [ ] Verify base URL row has only Copy (no Open)
- [ ] Verify URL with Auth row shows: Open | Copy
- [ ] Verify Token row shows: Show | Copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Endpoint Info modal by removing an unnecessary "Open" action button and reordering controls in other sections for improved layout and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->