### PR TITLE
fix(vscode): restore marketplace extension name in vsix staging

### DIFF
--- a/apps/vscode/scripts/tasks.js
+++ b/apps/vscode/scripts/tasks.js
@@ -151,6 +151,10 @@ function makeStageFilesAction() {
 			task.output = 'Staging manifest and assets to build/vscode...';
 			const pkgPath = path.join(APP_ROOT, 'package.json');
 			const pkg = JSON.parse(await readFile(pkgPath));
+			// Restore marketplace extension ID — source uses 'rocketride-vscode' for pnpm
+			// workspace resolution (avoids collision with client-typescript), but the
+			// VS Code Marketplace listing is rocketride.rocketride
+			pkg.name = 'rocketride';
 			pkg.main = './rocketride.js';
 			pkg.icon = 'rocketride-dark-icon.png';
 			pkg.files = ['rocketride.js', 'rocketride.js.map', 'webview/**', 'rocketride-dark-icon.png', 'rocketride-light-icon.png', 'docker.svg', 'onprem.svg', 'package.json', 'LICENSE', 'README.md'];


### PR DESCRIPTION
## Summary
- PR #330 renamed the package to `rocketride-vscode` for pnpm workspace resolution, but this changed the marketplace extension ID from `rocketride.rocketride` to `rocketride.rocketride-vscode`
- Override `pkg.name` back to `rocketride` in the build staging step so the vsix matches the existing marketplace listing
- Root cause of every "display name is taken" publish failure since #330

## Test plan
- [ ] CI build produces vsix named `rocketride-1.0.5.vsix` (not `rocketride-vscode-`)
- [ ] Release publish step succeeds for VS Code Marketplace