### PR TITLE
feat(node): Expose Qdrant vector store as agent tool with keyword search

### DIFF
--- a/nodes/src/nodes/qdrant/IGlobal.py
+++ b/nodes/src/nodes/qdrant/IGlobal.py
@@ -59,6 +59,12 @@ class IGlobal(IGlobalTransform):
             # Get the configuration
             self.store = Store(self.glb.logicalType, connConfig, bag)
 
+            # Read collection description for tool use
+            from ai.common.config import Config
+
+            cfg = Config.getNodeConfig(self.glb.logicalType, connConfig)
+            self.collection_description: str = str(cfg.get('collection_description', '') or '').strip()
+
             # Get the info about our store
             collection = self.store.collection
             host = self.store.host

--- a/nodes/src/nodes/qdrant/IGlobal.py
+++ b/nodes/src/nodes/qdrant/IGlobal.py
@@ -60,8 +60,6 @@ class IGlobal(IGlobalTransform):
             self.store = Store(self.glb.logicalType, connConfig, bag)
 
             # Read collection description for tool use
-            from ai.common.config import Config
-
             cfg = Config.getNodeConfig(self.glb.logicalType, connConfig)
             self.collection_description: str = str(cfg.get('collection_description', '') or '').strip()
 

--- a/nodes/src/nodes/qdrant/IInstance.py
+++ b/nodes/src/nodes/qdrant/IInstance.py
@@ -24,15 +24,30 @@
 # ------------------------------------------------------------------------------
 # This class controls the data for each thread of the task
 # ------------------------------------------------------------------------------
+from typing import Any
+
 from rocketlib import Entry
-from typing import List
 from .IGlobal import IGlobal
+from .qdrant_driver import QdrantDriver
 from ai.common.schema import Doc, Question
 from ai.common.transform import IInstanceTransform
 
 
 class IInstance(IInstanceTransform):
     IGlobal: IGlobal
+
+    _driver: QdrantDriver | None = None
+
+    def beginInstance(self) -> None:
+        self._driver = QdrantDriver(instance=self)
+
+    def endInstance(self) -> None:
+        self._driver = None
+
+    def invoke(self, param: Any) -> Any:  # noqa: ANN401
+        if self._driver is None:
+            raise RuntimeError('qdrant: driver not initialized')
+        return self._driver.handle_invoke(param)
 
     def writeQuestions(self, question: Question):
         """
@@ -41,7 +56,7 @@ class IInstance(IInstanceTransform):
         # Dispatch to the search handler
         self.IGlobal.store.dispatchSearch(self, question)
 
-    def writeDocuments(self, documents: List[Doc]):
+    def writeDocuments(self, documents: list[Doc]):
         """
         Take a list of documents and adds them to the vector store.
 

--- a/nodes/src/nodes/qdrant/qdrant_driver.py
+++ b/nodes/src/nodes/qdrant/qdrant_driver.py
@@ -50,6 +50,8 @@ SEARCH_TOOL = {
 }
 
 _SERVER_NAME = 'qdrant'
+_DEFAULT_LIMIT = 10
+_MAX_LIMIT = 100
 
 
 class QdrantDriver(ToolsBase):
@@ -87,7 +89,11 @@ class QdrantDriver(ToolsBase):
 
         args = _normalize_input(input_obj)
         query = str(args.get('query', '')).strip()
-        limit = int(args.get('limit', 10))
+        try:
+            limit = int(args.get('limit', _DEFAULT_LIMIT))
+        except (TypeError, ValueError):
+            limit = _DEFAULT_LIMIT
+        limit = max(1, min(limit, _MAX_LIMIT))
 
         if not query:
             raise ValueError('qdrant.search requires a non-empty "query" string')
@@ -155,7 +161,7 @@ def _normalize_input(input_obj: Any) -> Dict[str, Any]:
             pass
 
     if not isinstance(input_obj, dict):
-        warning(f'qdrant.search: unexpected input type {type(input_obj).__name__}: {input_obj!r}')
+        warning(f'qdrant.search: unexpected input type {type(input_obj).__name__}')
         return {}
 
     if 'input' in input_obj and isinstance(input_obj['input'], dict):

--- a/nodes/src/nodes/qdrant/qdrant_driver.py
+++ b/nodes/src/nodes/qdrant/qdrant_driver.py
@@ -1,0 +1,167 @@
+"""
+Qdrant tool-provider driver.
+
+Exposes a `qdrant.search` tool that performs full-text keyword search against
+the configured Qdrant collection, returning matching documents with their
+content and timestamps.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from rocketlib import warning
+
+from ai.common.tools import ToolsBase
+
+# ---------------------------------------------------------------------------
+# Static tool definition
+# ---------------------------------------------------------------------------
+
+SEARCH_TOOL = {
+    'name': 'search',
+    'description': ('Search for documents in the Qdrant vector store using full-text keyword matching. Returns matching documents with their content, chunk ID, and timestamp.'),
+    'inputSchema': {
+        'type': 'object',
+        'properties': {
+            'query': {
+                'type': 'string',
+                'description': 'Text to search for in the stored documents.',
+            },
+            'limit': {
+                'type': 'integer',
+                'description': 'Maximum number of results to return (default: 10).',
+                'default': 10,
+            },
+        },
+        'required': ['query'],
+    },
+    'outputSchema': {
+        'type': 'array',
+        'items': {
+            'type': 'object',
+            'properties': {
+                'content': {'type': 'string'},
+                'chunk_id': {'type': 'integer'},
+                'time_stamp': {'type': 'number'},
+            },
+        },
+    },
+}
+
+_SERVER_NAME = 'qdrant'
+
+
+class QdrantDriver(ToolsBase):
+    """Tool provider for Qdrant keyword search."""
+
+    def __init__(self, *, instance: Any) -> None:
+        """Initialize the driver with a reference to the IInstance."""
+        self._instance = instance
+
+    @property
+    def _store(self) -> Any:
+        return self._instance.IGlobal.store
+
+    # ------------------------------------------------------------------
+    # ToolsBase hooks
+    # ------------------------------------------------------------------
+
+    def _tool_query(self) -> List[ToolsBase.ToolDescriptor]:
+        collection_desc = getattr(self._instance.IGlobal, 'collection_description', '') or ''
+        desc_prefix = f'{collection_desc} ' if collection_desc else ''
+        tool = {
+            **SEARCH_TOOL,
+            'name': f'{_SERVER_NAME}.{SEARCH_TOOL["name"]}',
+            'description': f'{desc_prefix}{SEARCH_TOOL["description"]}',
+        }
+        return [tool]
+
+    def _tool_validate(self, *, tool_name: str, input_obj: Any) -> None:
+        args = _normalize_input(input_obj)
+        if not args.get('query'):
+            raise ValueError('qdrant.search requires a non-empty "query" string')
+
+    def _tool_invoke(self, *, tool_name: str, input_obj: Any) -> Any:
+        from qdrant_client import models
+
+        args = _normalize_input(input_obj)
+        query = str(args.get('query', '')).strip()
+        limit = int(args.get('limit', 10))
+
+        if not query:
+            raise ValueError('qdrant.search requires a non-empty "query" string')
+
+        store = self._store
+        if store is None:
+            raise RuntimeError('qdrant.search: store not initialized')
+
+        results, _ = store.client.scroll(
+            collection_name=store.collection,
+            scroll_filter=models.Filter(
+                must=[
+                    models.FieldCondition(
+                        key='content',
+                        match=models.MatchText(text=query),
+                    ),
+                    models.FieldCondition(
+                        key='meta.isDeleted',
+                        match=models.MatchValue(value=False),
+                    ),
+                ]
+            ),
+            limit=limit,
+            with_payload=True,
+            with_vectors=False,
+        )
+
+        out = []
+        for point in results:
+            payload = point.payload or {}
+            meta = payload.get('meta', {}) or {}
+            out.append(
+                {
+                    'content': payload.get('content', ''),
+                    'chunk_id': meta.get('chunkId', 0),
+                    'time_stamp': meta.get('time_stamp', 0),
+                }
+            )
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _normalize_input(input_obj: Any) -> Dict[str, Any]:
+    """Normalize tool input into a plain dict."""
+    if input_obj is None:
+        return {}
+
+    if hasattr(input_obj, 'model_dump') and callable(getattr(input_obj, 'model_dump')):
+        input_obj = input_obj.model_dump()
+    elif hasattr(input_obj, 'dict') and callable(getattr(input_obj, 'dict')):
+        input_obj = input_obj.dict()
+
+    if isinstance(input_obj, str):
+        try:
+            import json as _json
+
+            parsed = _json.loads(input_obj)
+            if isinstance(parsed, dict):
+                input_obj = parsed
+        except Exception:
+            pass
+
+    if not isinstance(input_obj, dict):
+        warning(f'qdrant.search: unexpected input type {type(input_obj).__name__}: {input_obj!r}')
+        return {}
+
+    if 'input' in input_obj and isinstance(input_obj['input'], dict):
+        inner = input_obj['input']
+        extras = {k: v for k, v in input_obj.items() if k != 'input'}
+        input_obj = {**inner, **extras}
+
+    input_obj.pop('security_context', None)
+    return input_obj

--- a/nodes/src/nodes/qdrant/services.json
+++ b/nodes/src/nodes/qdrant/services.json
@@ -13,18 +13,16 @@
 	// Required:
 	//		Class type of the node - what it does
 	//
-	"classType": [
-		"store"
-	],
+	"classType": ["store", "tool"],
 	//
 	// Required:
 	//     Capabilities are flags that change the behavior of the underlying
 	//     engine
 	//
-	"capabilities": [],
+	"capabilities": ["invoke"],
 	//
 	// Optional:
-	//		Register is either filter, endpoint or ignored if not specified. If the 
+	//		Register is either filter, endpoint or ignored if not specified. If the
 	//		type is specified, a factory is registered of that given type
 	//
 	"register": "filter",
@@ -49,11 +47,7 @@
 	// Optional:
 	//		Description to of this driver
 	//
-	"description": [
-		"A vector database component for Qdrant, enabling efficient storage and ", 
-		"retrieval of vector embeddings. It supports similarity search, filtering, ",
-		"and management of vector data with high performance and advanced matching capabilities."
-	],
+	"description": ["A vector database component for Qdrant, enabling efficient storage and ", "retrieval of vector embeddings. It supports similarity search, filtering, ", "and management of vector data with high performance and advanced matching capabilities."],
 	//
 	// Optional:
 	//	  The icon is the icon to display in the UI for this node
@@ -68,10 +62,7 @@
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of
 	//      the configuration should be used to display information
-	"tile": [
-		"Host/Port: ${parameters.qdrant.${profile}.host}:${parameters.qdrant.${profile}.port}",
-		"Collection: ${parameters.qdrant.${profile}.collection}"
-	],
+	"tile": ["Host/Port: ${parameters.qdrant.${profile}.host}:${parameters.qdrant.${profile}.port}", "Collection: ${parameters.qdrant.${profile}.collection}"],
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes
@@ -87,61 +78,58 @@
 	"test": {
 		"profiles": ["local"],
 		"cases": [
-		{
-			"name": "Add document to store",
-			"documents": [
-				{
-					"page_content": "The capital of France is Paris.",
-					"metadata": {
-						"objectId": "test-doc-1",
-						"nodeId": "test-node",
-						"parent": "/test",
-						"chunkId": 0,
-						"isDeleted": false
-					},
-					"embedding": [0.1, 0.2, 0.3, 0.4, 0.5],
-					"embedding_model": "test-model"
+			{
+				"name": "Add document to store",
+				"documents": [
+					{
+						"page_content": "The capital of France is Paris.",
+						"metadata": {
+							"objectId": "test-doc-1",
+							"nodeId": "test-node",
+							"parent": "/test",
+							"chunkId": 0,
+							"isDeleted": false
+						},
+						"embedding": [0.1, 0.2, 0.3, 0.4, 0.5],
+						"embedding_model": "test-model"
+					}
+				],
+				"expect": {
+					"documents": {
+						"notEmpty": true,
+						"contains": "capital of France"
+					}
 				}
-			],
-			"expect": {
-				"documents": {
-					"notEmpty": true,
-					"contains": "capital of France"
+			},
+			{
+				"name": "Search with question",
+				"questions": {
+					"type": "semantic",
+					"questions": [
+						{
+							"text": "What is the capital of France?",
+							"embedding": [0.1, 0.2, 0.3, 0.4, 0.5],
+							"embedding_model": "test-model"
+						}
+					]
+				},
+				"expect": {
+					"documents": {
+						"notEmpty": true,
+						"contains": "Paris",
+						"property": [
+							{ "path": "[0].score", "greaterThan": 0.5 },
+							{ "path": "[0].metadata.objectId", "equals": "test-doc-1" }
+						]
+					}
 				}
 			}
-		},
-	{
-		"name": "Search with question",
-		"questions": {
-			"type": "semantic",
-			"questions": [
-				{
-					"text": "What is the capital of France?",
-					"embedding": [0.1, 0.2, 0.3, 0.4, 0.5],
-					"embedding_model": "test-model"
-				}
-			]
-		},
-		"expect": {
-			"documents": {
-				"notEmpty": true,
-				"contains": "Paris",
-				"property": [
-					{"path": "[0].score", "greaterThan": 0.5},
-					{"path": "[0].metadata.objectId", "equals": "test-doc-1"}
-				]
-			}
-		}
-	}
 		]
 	},
 	"input": [
 		{
 			"lane": "documents",
-			"description": [
-				"Stores the documents into the vector database. The documents must be ",
-				"run through an embedding model prior to this step to compute the vectors."
-			],
+			"description": ["Stores the documents into the vector database. The documents must be ", "run through an embedding model prior to this step to compute the vectors."],
 			"output": []
 		},
 		{
@@ -150,26 +138,17 @@
 			"output": [
 				{
 					"lane": "documents",
-					"description": [
-						"Produces documents that are most similar to the given question."
-					],
+					"description": ["Produces documents that are most similar to the given question."],
 					"output": []
 				},
 				{
 					"lane": "answers",
-					"description": [
-						"Produces an answer with the documents that are most similar ",
-						"to the given question."
-					],
+					"description": ["Produces an answer with the documents that are most similar ", "to the given question."],
 					"output": []
 				},
 				{
 					"lane": "questions",
-					"description": [
-						"Updates the question with documents most similar to the ",
-						"question and sets up a filter so piping this to another store ",
-						"driver will limit its answers to the given subset of documents."
-					],
+					"description": ["Updates the question with documents most similar to the ", "question and sets up a filter so piping this to another store ", "driver will limit its answers to the given subset of documents."],
 					"output": []
 				}
 			]
@@ -222,45 +201,38 @@
 		"vector.local.port": {
 			"default": 6333
 		},
+		"qdrant.collection_description": {
+			"type": "string",
+			"title": "Collection description",
+			"default": "",
+			"optional": true,
+			"description": "What is stored in this collection? Describe its content and purpose — this helps the agent search more accurately.",
+			"ui": {
+				"ui:widget": "textarea"
+			}
+		},
 		"qdrant.cloud": {
 			"object": "cloud",
-			"properties": [
-				"vector.cloud.host",
-				"vector.cloud.port",
-				"vector.apikey",
-				"vector.score",
-				"vector.collection"
-			]
+			"properties": ["vector.cloud.host", "vector.cloud.port", "vector.apikey", "vector.score", "vector.collection", "qdrant.collection_description"]
 		},
 		"qdrant.local": {
 			"object": "local",
-			"properties": [
-				"vector.local.host",
-				"vector.local.port",
-				"vector.score",
-				"vector.collection"
-			]
+			"properties": ["vector.local.host", "vector.local.port", "vector.score", "vector.collection", "qdrant.collection_description"]
 		},
 		"qdrant.profile": {
 			"title": "Type of Qdrant host",
 			"description": "Connect to...",
 			"type": "string",
 			"default": "cloud",
-			"enum": [
-				"*>preconfig.profiles.*.title"
-			],
+			"enum": ["*>preconfig.profiles.*.title"],
 			"conditional": [
 				{
 					"value": "cloud",
-					"properties": [
-						"qdrant.cloud"
-					]
+					"properties": ["qdrant.cloud"]
 				},
 				{
 					"value": "local",
-					"properties": [
-						"qdrant.local"
-					]
+					"properties": ["qdrant.local"]
 				}
 			]
 		},
@@ -271,31 +243,20 @@
 		},
 		"qdrant.qdrant": {
 			"object": "qdrant",
-			"properties": [
-				"qdrant.profile"
-			]
+			"properties": ["qdrant.profile"]
 		},
 		"qdrant.store": {
 			"object": "store",
 			"title": "Store",
-			"properties": [
-				"qdrant.provider",
-				"qdrant.qdrant"
-			]
+			"properties": ["qdrant.provider", "qdrant.qdrant"]
 		},
 		"qdrant.target.autopipe": {
 			"object": "parameters",
-			"properties": [
-				"remote",
-				"qdrant.store",
-				"all.embedding"
-			]
+			"properties": ["remote", "qdrant.store", "all.embedding"]
 		},
 		"qdrant.target.parameters": {
 			"object": "parameters",
-			"properties": [
-				"qdrant.target.autopipe"
-			]
+			"properties": ["qdrant.target.autopipe"]
 		}
 	},
 	//
@@ -307,18 +268,12 @@
 		{
 			"section": "Pipe",
 			"title": "Qdrant Vector Store",
-			"properties": [
-				"qdrant.profile"
-			]
+			"properties": ["qdrant.profile"]
 		},
 		{
 			"section": "Transform",
 			"title": "Qdrant",
-			"properties": [
-				"type",
-				"qdrant.target.parameters",
-				"target.mode"
-			]
+			"properties": ["type", "qdrant.target.parameters", "target.mode"]
 		}
 	]
 }


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->
- Exposes the Qdrant node as an agent tool (qdrant.search) using full-text keyword matching, following the same pattern as the postgres/mysql drivers                                     
 - Adds an optional collection_description field that gets prepended to the tool description so agents know what data is stored in the collection

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
feature

## Testing

- [ ] Tests added or updated
- [X] Tested locally
- [X] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Qdrant nodes now offer built-in search/invoke capability (appears as an invokable tool).
  * Search accepts a query and configurable result limit (1–100) with sane defaults.
  * Results include content, chunk identifier, and timestamp metadata.
  * Added optional "collection description" field to Qdrant node configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->