### PR TITLE
feat(trace): interactive JSON tree viewer in trace detail panel

### DIFF
--- a/apps/vscode/src/providers/components/TraceSection/JsonTree.tsx
+++ b/apps/vscode/src/providers/components/TraceSection/JsonTree.tsx
@@ -1,0 +1,104 @@
+import React, { useState } from 'react';
+
+// ============================================================================
+// JSON TREE VIEWER
+// ============================================================================
+
+interface JsonTreeProps {
+	data: unknown;
+	defaultExpanded?: number; // auto-expand to this depth (default 1)
+}
+
+interface JsonNodeProps {
+	label?: string;
+	value: unknown;
+	depth: number;
+	defaultExpandDepth: number;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+	return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function preview(v: unknown): string {
+	if (Array.isArray(v)) return `Array(${v.length})`;
+	if (isObject(v)) {
+		const keys = Object.keys(v);
+		if (keys.length === 0) return '{}';
+		if (keys.length <= 3) return `{ ${keys.join(', ')} }`;
+		return `{ ${keys.slice(0, 3).join(', ')}, \u2026 }`;
+	}
+	return '';
+}
+
+const JsonNode: React.FC<JsonNodeProps> = ({ label, value, depth, defaultExpandDepth }) => {
+	const isExpandable = isObject(value) || (Array.isArray(value) && value.length > 0);
+	const [expanded, setExpanded] = useState(depth < defaultExpandDepth);
+
+	if (isExpandable) {
+		const entries = Array.isArray(value) ? value.map((v, i) => [String(i), v] as const) : Object.entries(value as Record<string, unknown>);
+		const bracket = Array.isArray(value) ? ['[', ']'] : ['{', '}'];
+
+		return (
+			<div className="jt-node">
+				<div className="jt-row jt-expandable" onClick={() => setExpanded(!expanded)}>
+					<span className="jt-arrow">{expanded ? '\u25BC' : '\u25B6'}</span>
+					{label !== undefined && <span className="jt-key">{label}: </span>}
+					{!expanded && <span className="jt-preview">{preview(value)}</span>}
+					{expanded && <span className="jt-bracket">{bracket[0]}</span>}
+				</div>
+				{expanded && (
+					<div className="jt-children">
+						{entries.map(([k, v]) => (
+							<JsonNode key={k} label={k} value={v} depth={depth + 1} defaultExpandDepth={defaultExpandDepth} />
+						))}
+						<div className="jt-row">
+							<span className="jt-bracket">{bracket[1]}</span>
+						</div>
+					</div>
+				)}
+			</div>
+		);
+	}
+
+	// Leaf value
+	let className = 'jt-val';
+	let display: string;
+
+	if (value === null) {
+		className += ' jt-null';
+		display = 'null';
+	} else if (typeof value === 'boolean') {
+		className += ' jt-bool';
+		display = String(value);
+	} else if (typeof value === 'number') {
+		className += ' jt-num';
+		display = String(value);
+	} else if (typeof value === 'string') {
+		className += ' jt-str';
+		display = JSON.stringify(value);
+	} else {
+		display = String(value);
+	}
+
+	return (
+		<div className="jt-node">
+			<div className="jt-row">
+				{label !== undefined && <span className="jt-key">{label}: </span>}
+				<span className={className}>{display}</span>
+			</div>
+		</div>
+	);
+};
+
+export const JsonTree: React.FC<JsonTreeProps> = ({ data, defaultExpanded = 1 }) => {
+	if (data === undefined || data === null) {
+		return <div className="jt-root jt-empty">No data</div>;
+	}
+
+	return (
+		<div className="jt-root">
+			<JsonNode value={data} depth={0} defaultExpandDepth={defaultExpanded} />
+		</div>
+	);
+};

--- a/apps/vscode/src/providers/components/TraceSection/TraceSection.tsx
+++ b/apps/vscode/src/providers/components/TraceSection/TraceSection.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useMemo, useCallback, useEffect } from 'react';
+import { JsonTree } from './JsonTree';
 
 // ============================================================================
 // TYPES
@@ -145,10 +146,7 @@ function findNodeById(nodes: TraceTreeNode[], id: number): TraceTreeNode | null 
 // HELPER: Collect all visible nodes from a tree (respecting collapsed state)
 // ============================================================================
 
-function collectVisibleNodes(
-	nodes: TraceTreeNode[],
-	expandedNodes: Set<number>
-): TraceTreeNode[] {
+function collectVisibleNodes(nodes: TraceTreeNode[], expandedNodes: Set<number>): TraceTreeNode[] {
 	const result: TraceTreeNode[] = [];
 	for (const node of nodes) {
 		result.push(node);
@@ -165,14 +163,9 @@ function collectVisibleNodes(
 
 const BATCH_SIZE = 10;
 
-type RenderItem =
-	| { type: 'node'; node: TraceTreeNode }
-	| { type: 'more'; remaining: number; groupKey: string; depth: number };
+type RenderItem = { type: 'node'; node: TraceTreeNode } | { type: 'more'; remaining: number; groupKey: string; depth: number };
 
-function buildRenderItems(
-	nodes: TraceTreeNode[],
-	moreRevealed: Map<string, number>
-): RenderItem[] {
+function buildRenderItems(nodes: TraceTreeNode[], moreRevealed: Map<string, number>): RenderItem[] {
 	const items: RenderItem[] = [];
 	let i = 0;
 
@@ -188,13 +181,7 @@ function buildRenderItems(
 
 		// Find consecutive run of identical leaf nodes (same filterName + lane + depth)
 		let runEnd = i + 1;
-		while (
-			runEnd < nodes.length &&
-			nodes[runEnd].children.length === 0 &&
-			nodes[runEnd].row.filterName === node.row.filterName &&
-			nodes[runEnd].row.lane === node.row.lane &&
-			nodes[runEnd].row.depth === node.row.depth
-		) {
+		while (runEnd < nodes.length && nodes[runEnd].children.length === 0 && nodes[runEnd].row.filterName === node.row.filterName && nodes[runEnd].row.lane === node.row.lane && nodes[runEnd].row.depth === node.row.depth) {
 			runEnd++;
 		}
 
@@ -219,7 +206,7 @@ function buildRenderItems(
 					type: 'more',
 					remaining,
 					groupKey,
-					depth: node.row.depth
+					depth: node.row.depth,
 				});
 			}
 		}
@@ -293,35 +280,31 @@ const TraceObjectRow: React.FC<{
 	onExpandAll: () => void;
 	onCollapseAll: () => void;
 }> = ({ group, expanded, onToggle, onExpandAll, onCollapseAll }) => {
-	const timeDisplay = group.hasError
-		? <span className="trace-col-time trace-time-error">ERROR</span>
-		: <span className="trace-col-time">{formatElapsed(group.totalElapsed)}</span>;
+	const timeDisplay = group.hasError ? <span className="trace-col-time trace-time-error">ERROR</span> : <span className="trace-col-time">{formatElapsed(group.totalElapsed)}</span>;
 
 	const handleClick = (e: React.MouseEvent) => {
 		if (e.shiftKey) {
-			expanded ? onCollapseAll() : onExpandAll();
+			if (expanded) {
+				onCollapseAll();
+			} else {
+				onExpandAll();
+			}
 		} else {
 			onToggle();
 		}
 	};
 
-	const chevronTitle = expanded
-		? 'Click to collapse (Shift-Click to collapse all)'
-		: 'Click to expand (Shift-Click to expand all)';
+	const chevronTitle = expanded ? 'Click to collapse (Shift-Click to collapse all)' : 'Click to expand (Shift-Click to expand all)';
 
-	const rowClass = [
-		'trace-row',
-		'trace-object-row',
-		group.inFlight ? 'trace-in-flight' : '',
-	].filter(Boolean).join(' ');
+	const rowClass = ['trace-row', 'trace-object-row', group.inFlight ? 'trace-in-flight' : ''].filter(Boolean).join(' ');
 
 	return (
 		<div className={rowClass} onClick={handleClick}>
-			<span className="trace-chev" title={chevronTitle}>{expanded ? '\u25BC' : '\u25B6'}</span>
-			<span className="trace-name trace-name-file">{group.objectName}</span>
-			<span className="trace-col-lane">
-				{group.inFlight && <span className="trace-in-flight-badge">processing</span>}
+			<span className="trace-chev" title={chevronTitle}>
+				{expanded ? '\u25BC' : '\u25B6'}
 			</span>
+			<span className="trace-name trace-name-file">{group.objectName}</span>
+			<span className="trace-col-lane">{group.inFlight && <span className="trace-in-flight-badge">processing</span>}</span>
 			{timeDisplay}
 		</div>
 	);
@@ -346,11 +329,7 @@ const TraceNodeRow: React.FC<{
 	const elapsed = getRowElapsed(row);
 	const indent = row.depth * 20 + 28;
 
-	const className = [
-		'trace-row',
-		selected ? 'selected' : '',
-		isError ? 'error' : '',
-	].filter(Boolean).join(' ');
+	const className = ['trace-row', selected ? 'selected' : '', isError ? 'error' : ''].filter(Boolean).join(' ');
 
 	const handleClick = () => {
 		onSelect();
@@ -360,40 +339,31 @@ const TraceNodeRow: React.FC<{
 		if (hasChildren) {
 			e.stopPropagation();
 			if (e.shiftKey) {
-				expanded ? onCollapseAll() : onExpandAll();
+				if (expanded) {
+					onCollapseAll();
+				} else {
+					onExpandAll();
+				}
 			} else {
 				onToggleExpand();
 			}
 		}
 	};
 
-	const chevronTitle = hasChildren
-		? (expanded
-			? 'Click to collapse (Shift-Click to collapse all)'
-			: 'Click to expand (Shift-Click to expand all)')
-		: undefined;
+	const chevronTitle = hasChildren ? (expanded ? 'Click to collapse (Shift-Click to collapse all)' : 'Click to expand (Shift-Click to expand all)') : undefined;
 
 	return (
 		<div className={className} style={{ paddingLeft: indent }} onClick={handleClick}>
-			<span
-				className="trace-chev"
-				onClick={handleChevronClick}
-				title={chevronTitle}
-			>
+			<span className="trace-chev" onClick={handleChevronClick} title={chevronTitle}>
 				{hasChildren ? (expanded ? '\u25BC' : '\u25B6') : ''}
 			</span>
 			{isError && <span className="trace-err-icon">{'\u2716'}</span>}
 			<span className="trace-dot" style={{ backgroundColor: laneColor(row.lane) }} />
-			<span className={`trace-name ${isError ? 'trace-name-error' : ''}`}>
-				{row.filterName}
-			</span>
+			<span className={`trace-name ${isError ? 'trace-name-error' : ''}`}>{row.filterName}</span>
 			<span className="trace-col-lane">
 				<span className={`trace-badge trace-badge-${row.lane}`}>{laneDisplayName(row.lane)}</span>
 			</span>
-			{isError
-				? <span className="trace-col-time trace-time-error">ERROR</span>
-				: <span className="trace-col-time">{formatElapsed(elapsed)}</span>
-			}
+			{isError ? <span className="trace-col-time trace-time-error">ERROR</span> : <span className="trace-col-time">{formatElapsed(elapsed)}</span>}
 		</div>
 	);
 };
@@ -419,9 +389,7 @@ const TraceDetailPanel: React.FC<{
 	const { row } = node;
 	const elapsed = getRowElapsed(row);
 	const parentElapsed = node.parent ? getRowElapsed(node.parent.row) : null;
-	const pctOfParent = elapsed != null && parentElapsed != null && parentElapsed > 0
-		? Math.round((elapsed / parentElapsed) * 100)
-		: null;
+	const pctOfParent = elapsed != null && parentElapsed != null && parentElapsed > 0 ? Math.round((elapsed / parentElapsed) * 100) : null;
 
 	return (
 		<div className="trace-detail-panel">
@@ -470,10 +438,7 @@ const TraceDetailPanel: React.FC<{
 					{pctOfParent != null && (
 						<>
 							<div className="trace-dp-bar">
-								<div
-									className="trace-dp-bar-fill"
-									style={{ width: `${Math.min(pctOfParent, 100)}%` }}
-								/>
+								<div className="trace-dp-bar-fill" style={{ width: `${Math.min(pctOfParent, 100)}%` }} />
 							</div>
 							<div className="trace-dp-bar-label">
 								{pctOfParent}% of parent ({node.parent!.row.filterName}.{node.parent!.row.lane}: {formatElapsed(parentElapsed)})
@@ -486,17 +451,14 @@ const TraceDetailPanel: React.FC<{
 			{/* Input Data */}
 			{row.entryData && (
 				<div className="trace-dp-sect">
-					<div
-						className="trace-dp-toggle"
-						onClick={() => setInputExpanded(!inputExpanded)}
-					>
+					<div className="trace-dp-toggle" onClick={() => setInputExpanded(!inputExpanded)}>
 						<span className="trace-dp-arr">{inputExpanded ? '\u25BC' : '\u25B6'}</span>
 						Input Data
 					</div>
 					{inputExpanded && (
-						<pre className="trace-dp-code">
-							{JSON.stringify(row.entryData, null, 2)}
-						</pre>
+						<div className="trace-dp-tree">
+							<JsonTree data={row.entryData} defaultExpanded={2} />
+						</div>
 					)}
 				</div>
 			)}
@@ -504,26 +466,16 @@ const TraceDetailPanel: React.FC<{
 			{/* Output Data */}
 			{(row.exitData || row.error) && (
 				<div className="trace-dp-sect">
-					<div
-						className="trace-dp-toggle"
-						onClick={() => setOutputExpanded(!outputExpanded)}
-					>
+					<div className="trace-dp-toggle" onClick={() => setOutputExpanded(!outputExpanded)}>
 						<span className="trace-dp-arr">{outputExpanded ? '\u25BC' : '\u25B6'}</span>
 						Output Data
 					</div>
 					{outputExpanded && (
-						<pre className="trace-dp-code">
-							{JSON.stringify(
-								row.error
-									? { error: row.error }
-									: row.exitData,
-								null, 2
-							)}
-						</pre>
+						<div className="trace-dp-tree">
+							<JsonTree data={row.error ? { error: row.error } : row.exitData} defaultExpanded={2} />
+						</div>
 					)}
-					{!outputExpanded && (
-						<div className="trace-dp-expand-hint">Click to expand</div>
-					)}
+					{!outputExpanded && <div className="trace-dp-expand-hint">Click to expand</div>}
 				</div>
 			)}
 		</div>
@@ -534,10 +486,7 @@ const TraceDetailPanel: React.FC<{
 // MAIN COMPONENT
 // ============================================================================
 
-export const TraceSection: React.FC<TraceSectionProps> = ({
-	rows,
-	onClear
-}) => {
+export const TraceSection: React.FC<TraceSectionProps> = ({ rows, onClear }) => {
 	const [expandedObjects, setExpandedObjects] = useState<Set<number>>(new Set());
 	const [expandedNodes, setExpandedNodes] = useState<Set<number>>(new Set());
 	const [selectedRowId, setSelectedRowId] = useState<number | null>(null);
@@ -549,12 +498,15 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 	const [resizeStartX, setResizeStartX] = useState(0);
 	const [resizeStartWidth, setResizeStartWidth] = useState(0);
 
-	const handleResizeStart = useCallback((e: React.MouseEvent) => {
-		e.preventDefault();
-		setIsResizing(true);
-		setResizeStartX(e.clientX);
-		setResizeStartWidth(detailWidth);
-	}, [detailWidth]);
+	const handleResizeStart = useCallback(
+		(e: React.MouseEvent) => {
+			e.preventDefault();
+			setIsResizing(true);
+			setResizeStartX(e.clientX);
+			setResizeStartWidth(detailWidth);
+		},
+		[detailWidth]
+	);
 
 	useEffect(() => {
 		if (!isResizing) return;
@@ -585,7 +537,7 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 	}, [selectedRowId, objectGroups]);
 
 	const toggleObject = useCallback((docId: number) => {
-		setExpandedObjects(prev => {
+		setExpandedObjects((prev) => {
 			const next = new Set(prev);
 			if (next.has(docId)) next.delete(docId);
 			else next.add(docId);
@@ -594,7 +546,7 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 	}, []);
 
 	const toggleNode = useCallback((id: number) => {
-		setExpandedNodes(prev => {
+		setExpandedNodes((prev) => {
 			const next = new Set(prev);
 			if (next.has(id)) next.delete(id);
 			else next.add(id);
@@ -604,12 +556,12 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 
 	const expandAllForObject = useCallback((group: TraceObjectGroup) => {
 		const allIds = collectAllParentIds(group.nodes);
-		setExpandedObjects(prev => {
+		setExpandedObjects((prev) => {
 			const next = new Set(prev);
 			next.add(group.docId);
 			return next;
 		});
-		setExpandedNodes(prev => {
+		setExpandedNodes((prev) => {
 			const next = new Set(prev);
 			for (const id of allIds) next.add(id);
 			return next;
@@ -618,7 +570,7 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 
 	const expandAllForNode = useCallback((node: TraceTreeNode) => {
 		const allIds = collectAllParentIds(node.children);
-		setExpandedNodes(prev => {
+		setExpandedNodes((prev) => {
 			const next = new Set(prev);
 			next.add(node.row.id);
 			for (const id of allIds) next.add(id);
@@ -628,12 +580,12 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 
 	const collapseAllForObject = useCallback((group: TraceObjectGroup) => {
 		const allIds = collectAllParentIds(group.nodes);
-		setExpandedObjects(prev => {
+		setExpandedObjects((prev) => {
 			const next = new Set(prev);
 			next.delete(group.docId);
 			return next;
 		});
-		setExpandedNodes(prev => {
+		setExpandedNodes((prev) => {
 			const next = new Set(prev);
 			for (const id of allIds) next.delete(id);
 			return next;
@@ -642,7 +594,7 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 
 	const collapseAllForNode = useCallback((node: TraceTreeNode) => {
 		const allIds = collectAllParentIds(node.children);
-		setExpandedNodes(prev => {
+		setExpandedNodes((prev) => {
 			const next = new Set(prev);
 			next.delete(node.row.id);
 			for (const id of allIds) next.delete(id);
@@ -651,7 +603,7 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 	}, []);
 
 	const revealMore = useCallback((groupKey: string) => {
-		setMoreRevealed(prev => {
+		setMoreRevealed((prev) => {
 			const next = new Map(prev);
 			next.set(groupKey, (next.get(groupKey) ?? 0) + 1);
 			return next;
@@ -659,7 +611,7 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 	}, []);
 
 	const selectRow = useCallback((id: number) => {
-		setSelectedRowId(prev => prev === id ? null : id);
+		setSelectedRowId((prev) => (prev === id ? null : id));
 	}, []);
 
 	return (
@@ -681,47 +633,21 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 					<div className="trace-layout">
 						<div className="trace-tree-scroll">
 							<TraceTreeHeader />
-							{objectGroups.map(group => {
+							{objectGroups.map((group) => {
 								const isExpanded = expandedObjects.has(group.docId);
-								const visibleNodes = isExpanded
-									? collectVisibleNodes(group.nodes, expandedNodes)
-									: [];
-								const renderItems = isExpanded
-									? buildRenderItems(visibleNodes, moreRevealed)
-									: [];
+								const visibleNodes = isExpanded ? collectVisibleNodes(group.nodes, expandedNodes) : [];
+								const renderItems = isExpanded ? buildRenderItems(visibleNodes, moreRevealed) : [];
 
 								return (
 									<React.Fragment key={group.docId}>
-										<TraceObjectRow
-											group={group}
-											expanded={isExpanded}
-											onToggle={() => toggleObject(group.docId)}
-											onExpandAll={() => expandAllForObject(group)}
-											onCollapseAll={() => collapseAllForObject(group)}
-										/>
-										{renderItems.map(item => {
+										<TraceObjectRow group={group} expanded={isExpanded} onToggle={() => toggleObject(group.docId)} onExpandAll={() => expandAllForObject(group)} onCollapseAll={() => collapseAllForObject(group)} />
+										{renderItems.map((item) => {
 											if (item.type === 'node') {
 												const node = item.node;
-												return (
-													<TraceNodeRow
-														key={node.row.id}
-														node={node}
-														expanded={expandedNodes.has(node.row.id)}
-														selected={selectedRowId === node.row.id}
-														onToggleExpand={() => toggleNode(node.row.id)}
-														onExpandAll={() => expandAllForNode(node)}
-														onCollapseAll={() => collapseAllForNode(node)}
-														onSelect={() => selectRow(node.row.id)}
-													/>
-												);
+												return <TraceNodeRow key={node.row.id} node={node} expanded={expandedNodes.has(node.row.id)} selected={selectedRowId === node.row.id} onToggleExpand={() => toggleNode(node.row.id)} onExpandAll={() => expandAllForNode(node)} onCollapseAll={() => collapseAllForNode(node)} onSelect={() => selectRow(node.row.id)} />;
 											}
 											return (
-												<div
-													key={`more-${item.groupKey}`}
-													className="trace-row trace-more-row"
-													style={{ paddingLeft: item.depth * 20 + 28 }}
-													onClick={() => revealMore(item.groupKey)}
-												>
+												<div key={`more-${item.groupKey}`} className="trace-row trace-more-row" style={{ paddingLeft: item.depth * 20 + 28 }} onClick={() => revealMore(item.groupKey)}>
 													<span className="trace-chev" />
 													<span className="trace-more-label">
 														{item.remaining} more... (click to show next {Math.min(BATCH_SIZE, item.remaining)})
@@ -734,11 +660,7 @@ export const TraceSection: React.FC<TraceSectionProps> = ({
 							})}
 						</div>
 						<div className="trace-detail-wrapper" style={{ width: detailWidth }}>
-							<div
-								className="trace-resize-handle"
-								onMouseDown={handleResizeStart}
-								aria-label="Resize detail panel"
-							/>
+							<div className="trace-resize-handle" onMouseDown={handleResizeStart} aria-label="Resize detail panel" />
 							<TraceDetailPanel node={selectedNode} />
 						</div>
 					</div>

--- a/apps/vscode/src/providers/views/PageStatus/styles.css
+++ b/apps/vscode/src/providers/views/PageStatus/styles.css
@@ -946,6 +946,101 @@
 	margin-top: 4px;
 }
 
+/* JSON Tree viewer */
+.trace-dp-tree {
+	max-height: 320px;
+	overflow-y: auto;
+	overflow-x: auto;
+	font-family: var(--vscode-editor-font-family, 'Cascadia Code', Consolas, monospace);
+	font-size: 11px;
+	line-height: 1.6;
+}
+
+.jt-root {
+	padding: 4px 0;
+}
+
+.jt-node {
+	/* nothing needed, just a structural wrapper */
+}
+
+.jt-row {
+	display: flex;
+	align-items: baseline;
+	white-space: nowrap;
+	padding: 0 2px;
+	border-radius: 2px;
+}
+
+.jt-row:hover {
+	background: var(--vscode-list-hoverBackground, rgba(128, 128, 128, 0.1));
+}
+
+.jt-expandable {
+	cursor: pointer;
+	user-select: none;
+}
+
+.jt-arrow {
+	width: 12px;
+	flex-shrink: 0;
+	font-size: 8px;
+	color: var(--vscode-descriptionForeground);
+	margin-right: 2px;
+}
+
+.jt-children {
+	padding-left: 16px;
+	border-left: 1px solid var(--vscode-panel-border, rgba(128, 128, 128, 0.2));
+	margin-left: 5px;
+}
+
+.jt-key {
+	color: var(--vscode-symbolIcon-propertyForeground, #9cdcfe);
+}
+
+.jt-val {
+	color: var(--vscode-foreground);
+}
+
+.jt-str {
+	color: var(--vscode-debugTokenExpression-string, #ce9178);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	max-width: 280px;
+	display: inline-block;
+	vertical-align: bottom;
+}
+
+.jt-num {
+	color: var(--vscode-debugTokenExpression-number, #b5cea8);
+}
+
+.jt-bool {
+	color: var(--vscode-debugTokenExpression-boolean, #569cd6);
+}
+
+.jt-null {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+}
+
+.jt-preview {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+	margin-left: 4px;
+}
+
+.jt-bracket {
+	color: var(--vscode-descriptionForeground);
+}
+
+.jt-empty {
+	color: var(--vscode-descriptionForeground);
+	font-style: italic;
+	padding: 4px;
+}
+
 /* ============================================================================ */
 /* "MORE..." ROW                                                                */
 /* ============================================================================ */


### PR DESCRIPTION
## Summary
- Replace raw `JSON.stringify` dumps in trace detail panel with a collapsible, syntax-highlighted JSON tree viewer
- New `JsonTree` component with expand/collapse toggles, VS Code theme-aware colors for keys, strings, numbers, booleans, and nulls
- Auto-expands to depth 2 for immediate visibility of top-level structure; indent guide lines for nesting

## Test plan
- [ ] Open a pipeline trace and click a node — verify Input/Output Data renders as an interactive tree
- [ ] Expand/collapse nested objects and arrays
- [ ] Verify colors adapt to both light and dark VS Code themes
- [ ] Check scrolling behavior with large payloads (320px max-height container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive JSON tree viewer for trace data with expandable and collapsible nodes, replacing plain text display for improved data exploration and readability.

* **Style**
  * Enhanced trace panel styling with visual theming for the JSON tree viewer component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->