### PR TITLE
fix(ci): add permissions to release and docker jobs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,6 +40,9 @@ jobs:
     name: Release
     needs: [init, build]
     uses: ./.github/workflows/_release.yaml
+    permissions:
+      contents: write
+      id-token: write
     with:
       environment: release
       server_version: ${{ needs.init.outputs.server_version }}
@@ -54,6 +57,9 @@ jobs:
     needs: [init, release]
     if: needs.init.outputs.server_tag_exists == 'false'
     uses: ./.github/workflows/_docker.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       server_version: ${{ needs.init.outputs.server_version }}
     secrets: inherit


### PR DESCRIPTION
## Summary
- Add `permissions: contents: write, id-token: write` to the `release` job
- Add `permissions: contents: read, packages: write` to the `docker` job
- Fixes `startup_failure` on the Release workflow after main was reset to develop

## Root cause
The release.yaml refactor (splitting into reusable workflows) set top-level `permissions: contents: read`. The `_release.yaml` reusable workflow needs `contents: write` for creating tags/releases, but reusable workflows can't escalate beyond the caller's ceiling.

## Test plan
- [ ] Release workflow no longer fails with startup_failure
- [ ] Tags and GitHub releases are created successfully