### PR TITLE
chore: release 1.0.6 — banner fix

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "rocketride",
 	"displayName": "RocketRide",
 	"description": "RocketRide extension for Visual Studio Code",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"publisher": "rocketride",
 	"repository": {
 		"type": "git",

--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride"
-version = "1.0.5"
+version = "1.0.6"
 description = "RocketRide Pipeline Python Client SDK"
 readme = "README.md"
 authors = [

--- a/packages/client-typescript/package.json
+++ b/packages/client-typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride",
-	"version": "1.0.5",
+	"version": "1.0.6",
 	"author": "RocketRide, Inc.",
 	"license": "MIT",
 	"description": "TypeScript client for RocketRide data processing and AI services",


### PR DESCRIPTION
Bumps to 1.0.6 with PNG banners + absolute URLs.