### PR TITLE
chore: bump rocketride-mcp to 1.0.7 for PyPI banner

### DIFF
--- a/packages/client-mcp/pyproject.toml
+++ b/packages/client-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride-mcp"
-version = "1.0.6"
+version = "1.0.7"
 description = "RocketRide MCP stdio server that streams local files to RocketRide EaaS"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
MCP 1.0.6 was published with SVG banner. PyPI doesn't allow re-upload. Bump to 1.0.7.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.0.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->