### PR TITLE
fix(ci): handle Open VSX 'already published' error

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -184,7 +184,7 @@ jobs:
           VSIX=$(find release-assets -name '*.vsix' | head -n1)
           echo "Publishing ${VSIX}"
           OUTPUT=$(ovsx publish "${VSIX}" -p "$OVSX_PAT" 2>&1) && exit 0
-          if echo "$OUTPUT" | grep -qi "already exists"; then
+          if echo "$OUTPUT" | grep -qiE "already exists|already published"; then
             echo "Version already exists on Open VSX — skipping"
           else
             echo "$OUTPUT"


### PR DESCRIPTION
Open VSX returns 'already published' not 'already exists'. Adds regex match for both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow to more robustly handle Open VSX publishing scenarios where extension versions are already published, improving overall release process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->