### PR TITLE
fix(ci): pin all actions to immutable commit hash

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,18 +19,18 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Run Scorecard
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Mark stale
-        uses: actions/stale@v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           days-before-stale: 90
           days-before-close: 14


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in `stale.yml` and `scorecard.yml` to immutable commit SHAs
- Previously unpinned actions referenced mutable tags (`@v9`, `@v4`, `@v2.4.0`, `@v3`),
  which can be silently redirected to malicious code

## Changes

| Action | Before | After |
|---|---|---|
| `actions/stale` | `@v9` | `@5bef64f` |
| `actions/checkout` | `@v4` | `@34e114876b0b` |
| `ossf/scorecard-action` | `@v2.4.0` | `@62b2cac7` |
| `github/codeql-action/upload-sarif` | `@v3` | `@5c8a8a64` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow security by pinning dependencies to specific commit versions, improving supply chain security and reproducibility of automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->