### PR TITLE
chore: run ruff format across nodes/src/nodes/ for consistent baseline

### DIFF
--- a/nodes/src/nodes/accessibility_describe/accessibility_vision.py
+++ b/nodes/src/nodes/accessibility_describe/accessibility_vision.py
@@ -67,7 +67,7 @@ HAZARD_PROMPTS = {
 
 # Spatial format prompt modifiers
 SPATIAL_PROMPTS = {
-    'clock': '\n\nUse clock positions for spatial references (12 o\'clock = straight ahead).',
+    'clock': "\n\nUse clock positions for spatial references (12 o'clock = straight ahead).",
     'relative': '\n\nUse relative directions (left, right, ahead, behind) for spatial references.',
     'both': '\n\nUse both clock positions and relative directions for spatial references.',
 }
@@ -98,31 +98,18 @@ class Chat(ChatBase):
         spatial_format = config.get('accessibility.spatialFormat', 'clock')
 
         # Build system prompt with config modifiers
-        self._system_prompt = (
-            config.get('accessibility.systemPrompt')
-            or config.get('systemPrompt')
-            or DEFAULT_SYSTEM_PROMPT
-        )
+        self._system_prompt = config.get('accessibility.systemPrompt') or config.get('systemPrompt') or DEFAULT_SYSTEM_PROMPT
         self._system_prompt += HAZARD_PROMPTS.get(hazard_priority, '')
         self._system_prompt += SPATIAL_PROMPTS.get(spatial_format, '')
 
-        self._prompt = (
-            config.get('accessibility.prompt')
-            or config.get('prompt')
-            or DEFAULT_PROMPT
-        )
+        self._prompt = config.get('accessibility.prompt') or config.get('prompt') or DEFAULT_PROMPT
 
         if not api_key:
-            raise ValueError(
-                'Missing Google AI API key. Get one at https://aistudio.google.com/apikey'
-            )
+            raise ValueError('Missing Google AI API key. Get one at https://aistudio.google.com/apikey')
 
         # Validate the API key format
         if api_key.startswith('sk-'):
-            raise ValueError(
-                'Invalid API key format. This appears to be an OpenAI key. '
-                'Please provide a Google AI API key.'
-            )
+            raise ValueError('Invalid API key format. This appears to be an OpenAI key. Please provide a Google AI API key.')
 
         try:
             self._client = genai.Client(api_key=api_key)
@@ -157,7 +144,7 @@ class Chat(ChatBase):
         if any(phrase in error_lower for phrase in ['invalid input', 'bad request', '400']):
             return 'Invalid input. Please check your image format and prompt.'
         if any(phrase in error_lower for phrase in ['model not found', 'unavailable', 'not supported']):
-            return f'Model \'{self._model}\' is currently unavailable. Please try a different model.'
+            return f"Model '{self._model}' is currently unavailable. Please try a different model."
         if any(phrase in error_lower for phrase in ['timeout', 'timed out']):
             return 'Request timed out. Please try again.'
         if any(phrase in error_lower for phrase in ['content policy', 'safety', 'blocked']):
@@ -199,9 +186,7 @@ class Chat(ChatBase):
             mime_type = header.split(':')[1].split(';')[0]
             image_bytes = base64.b64decode(b64_data)
         except (ValueError, IndexError, base64.binascii.Error) as e:
-            raise ValueError(
-                'Malformed image data URL. Expected format: data:<mime>;base64,<data>'
-            ) from e
+            raise ValueError('Malformed image data URL. Expected format: data:<mime>;base64,<data>') from e
 
         # Build request contents once (deterministic, no need to rebuild per retry)
         contents = [
@@ -233,7 +218,7 @@ class Chat(ChatBase):
             except Exception as e:
                 last_error = e
                 if attempt < max_retries and self._shouldRetry(e):
-                    delay = base_delay * (2 ** attempt)
+                    delay = base_delay * (2**attempt)
                     time.sleep(delay)
                     continue
                 break

--- a/nodes/src/nodes/agent_crewai/crewai.py
+++ b/nodes/src/nodes/agent_crewai/crewai.py
@@ -198,12 +198,7 @@ class CrewDriver(AgentBase):
         agent_obj = Agent(
             role='Assistant',
             goal='Solve the user request using available tools when helpful.',
-            backstory=(
-                'You are an agent node in a tool-invocation hierarchy. '
-                'You may call tools wired to you via the host tools interface. '
-                'When a tool is needed, call it; otherwise respond directly. '
-                'Follow any additional instructions exactly.'
-            ),
+            backstory=('You are an agent node in a tool-invocation hierarchy. You may call tools wired to you via the host tools interface. When a tool is needed, call it; otherwise respond directly. Follow any additional instructions exactly.'),
             tools=tools_for_agent,
             llm=llm,
             verbose=False,

--- a/nodes/src/nodes/agent_langchain/IInstance.py
+++ b/nodes/src/nodes/agent_langchain/IInstance.py
@@ -46,4 +46,3 @@ class IInstance(IInstanceBase):
         if isinstance(op, str) and op.startswith('tool.'):
             return self.IGlobal.agent.handle_invoke(self, param)
         return super().invoke(param)
-

--- a/nodes/src/nodes/agent_langchain/langchain.py
+++ b/nodes/src/nodes/agent_langchain/langchain.py
@@ -67,7 +67,7 @@ class LangChainDriver(AgentBase):
             def _identifying_params(self) -> Dict[str, Any]:
                 return {'framework': 'rocketride', 'adapter': 'tool_calling_json'}
 
-            def bind_tools(self, tools: Any, **kwargs: Any) -> "RocketRideToolCallingChatModel":
+            def bind_tools(self, tools: Any, **kwargs: Any) -> 'RocketRideToolCallingChatModel':
                 try:
                     self._bound_tools = _normalize_bound_tools(tools)
                 except Exception:
@@ -448,4 +448,3 @@ def _safe_str(v: Any) -> str:
         return '' if v is None else str(v)
     except Exception:
         return ''
-

--- a/nodes/src/nodes/agent_rocketride/IGlobal.py
+++ b/nodes/src/nodes/agent_rocketride/IGlobal.py
@@ -42,6 +42,7 @@ class IGlobal(IGlobalBase):
         config handling is needed here.
         """
         from .rocketride_agent import RocketRideDriver
+
         self.agent = RocketRideDriver(self)
 
     def endGlobal(self) -> None:

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -81,6 +81,7 @@ _REF_PATTERN = re.compile(r'\{\{memory\.ref:([^}:]+)(?::([^}:]+))?(?::([^}]+))?\
 # Structural summary (_describe)
 # ---------------------------------------------------------------------------
 
+
 def _describe(value: Any, depth: int = 0) -> str:
     """Return a compact structural summary of *value* for LLM context.
 
@@ -118,9 +119,7 @@ def _describe(value: Any, depth: int = 0) -> str:
         if isinstance(first, dict):
             # Collect field names from up to 5 rows to handle sparse rows
             # where early rows may be missing fields that appear later.
-            keys = list(dict.fromkeys(
-                k for row in value[:5] if isinstance(row, dict) for k in row
-            ))
+            keys = list(dict.fromkeys(k for row in value[:5] if isinstance(row, dict) for k in row))
             lines = [f'{n} items, fields: {keys}']
             # Show first 2 rows as sample data so the LLM can see real values
             for i, row in enumerate(value[:2]):
@@ -151,6 +150,7 @@ def _describe_dict(d: dict, depth: int) -> str:
 # ---------------------------------------------------------------------------
 # Template resolution
 # ---------------------------------------------------------------------------
+
 
 def _memory_get(key: str, host: AgentHost) -> Any:
     """Fetch a raw value from the memory store.
@@ -298,6 +298,7 @@ def resolve_answer_refs(answer: str, host: AgentHost) -> str:
 # Wave result storage
 # ---------------------------------------------------------------------------
 
+
 def _auto_key(wave_name: str, idx: int) -> str:
     """Generate a memory key scoped to a wave and call index.
 
@@ -335,6 +336,7 @@ def _store_and_preview(tool: str, key: str, result: Any, host: AgentHost) -> Dic
 # Wave executor
 # ---------------------------------------------------------------------------
 
+
 def _execute_wave_calls(
     wave: List[Dict[str, Any]],
     *,
@@ -356,10 +358,7 @@ def _execute_wave_calls(
 
     # Tag each call with its auto-generated memory key before parallelism so
     # the key assignment is deterministic and order-preserving.
-    tagged: List[Dict[str, Any]] = [
-        {**call, '_key': _auto_key(wave_name, i)}
-        for i, call in enumerate(wave)
-    ]
+    tagged: List[Dict[str, Any]] = [{**call, '_key': _auto_key(wave_name, i)} for i, call in enumerate(wave)]
 
     def _run_one(call: Dict[str, Any]) -> Dict[str, Any]:
         """Execute a single tool call and return a result dict."""
@@ -411,8 +410,11 @@ def _execute_wave_calls(
                         total_items = len(value)
                         preview = json.dumps(value[:_PEEK_MAX_ARRAY_ITEMS], ensure_ascii=False)
                         return {
-                            'tool': tool, 'key': key, 'path': path,
-                            'preview': preview, 'truncated': True,
+                            'tool': tool,
+                            'key': key,
+                            'path': path,
+                            'preview': preview,
+                            'truncated': True,
                             'returned_items': _PEEK_MAX_ARRAY_ITEMS,
                             'total_items': total_items,
                         }
@@ -426,10 +428,14 @@ def _execute_wave_calls(
                     value = json.dumps(value, ensure_ascii=False, indent=2)
                 offset = int(args.get('offset', 0))
                 length = int(args.get('length', _PEEK_DEFAULT_LENGTH))
-                chunk = value[offset:offset + length]
+                chunk = value[offset : offset + length]
                 return {
-                    'tool': tool, 'key': key, 'preview': chunk,
-                    'offset': offset, 'length': len(chunk), 'total_chars': len(value),
+                    'tool': tool,
+                    'key': key,
+                    'preview': chunk,
+                    'offset': offset,
+                    'length': len(chunk),
+                    'total_chars': len(value),
                 }
 
             # Regular tool — route through the host's tool pipeline which

--- a/nodes/src/nodes/agent_rocketride/rocketride_agent.py
+++ b/nodes/src/nodes/agent_rocketride/rocketride_agent.py
@@ -46,6 +46,7 @@ from .executor import execute_wave, resolve_answer_refs
 # Can be overridden via the ``max_waves`` node configuration field.
 _DEFAULT_MAX_WAVES = 10
 
+
 class RocketRideDriver(AgentBase):
     """
     RocketRide Wave framework driver.

--- a/nodes/src/nodes/anonymize/IInstance.py
+++ b/nodes/src/nodes/anonymize/IInstance.py
@@ -27,15 +27,10 @@ from .IGlobal import IGlobal
 
 class IInstance(IInstanceBase):
     IGlobal: IGlobal  # Reference to a global context providing recognizer functionality
-    
+
     # Default PII labels for zero-shot NER when no classifications provided
-    DEFAULT_PII_LABELS = [
-        'person', 'name', 'email', 'phone number', 'address',
-        'social security number', 'credit card number', 'date of birth',
-        'organization', 'company', 'location', 'ip address',
-        'bank account', 'passport number', 'driver license'
-    ]
-    
+    DEFAULT_PII_LABELS = ['person', 'name', 'email', 'phone number', 'address', 'social security number', 'credit card number', 'date of birth', 'organization', 'company', 'location', 'ip address', 'bank account', 'passport number', 'driver license']
+
     #
     # Current object context properties
     #
@@ -59,7 +54,7 @@ class IInstance(IInstanceBase):
         if not self.has_classifications:
             # No classifications received - anonymize with default PII labels
             self.target_object_text = self.IGlobal.recognizer.process(self.target_object_text, self.DEFAULT_PII_LABELS)
-        
+
         # Resume the writeText lane
         self.instance.writeText(self.target_object_text)
 

--- a/nodes/src/nodes/anonymize/anonymize.py
+++ b/nodes/src/nodes/anonymize/anonymize.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 # =============================================================================
 
+
 def anonymize(text: str, matches, anonymize_char: str = '*') -> str:
     """Replace specified segments with a sequence of anonymization characters.
 

--- a/nodes/src/nodes/anonymize/glinerRecognizer.py
+++ b/nodes/src/nodes/anonymize/glinerRecognizer.py
@@ -36,7 +36,7 @@ class GliNERRecognizer:
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
         """
         Initialize the GLiNER Recognizer.
-        
+
         Uses ai.common.models.GLiNER which automatically routes to model server
         if --modelserver flag is present, otherwise runs locally.
         """
@@ -50,7 +50,7 @@ class GliNERRecognizer:
         enginePath = expand('%execPath%')
         rule_file_path = os.path.join(enginePath, 'nucleuz', 'rulePack.dat')
         self.ruleParser = RuleParser(rule_file_path)
-        
+
         # Use ai.common.models.GLiNER - auto-detects local vs model server mode
         self.model = GLiNER(self.model_name)
 
@@ -182,34 +182,34 @@ class GliNERRecognizer:
     def process(self, text: str, labels: list, existing_matches: list = None) -> str:
         """
         Core anonymization method - detects entities using GLiNER and masks them.
-        
+
         Args:
             text: The text to anonymize
             labels: Entity labels to detect
             existing_matches: Optional list of (offset, length) tuples from classifications
-            
+
         Returns:
             Anonymized text with detected entities replaced by anonymize_char
         """
         if not text:
             return text
-        
+
         # Run NER prediction
         ner_results = self.predict(text, labels)
         ner_matches = self.convert_ner_results_to_matches(ner_results)
-        
+
         debug(f'Anonymize: Detected {len(ner_results)} entities')
-        
+
         # Combine with existing matches (from classifications)
         all_matches = list(existing_matches or []) + ner_matches
-        
+
         if not all_matches:
             debug('Anonymize: No entities to mask')
             return text
-        
+
         # Sort by offset and apply masking
         all_matches_sorted = sorted(all_matches, key=lambda x: x[0])
-        
+
         return _anonymize(text, all_matches_sorted, self.anonymize_char)
 
     def handleClassifications(self, classifications: dict, target_object_text: str, classificationPolicy: any, classificationRules: any):
@@ -234,9 +234,6 @@ class GliNERRecognizer:
         labels = self.ruleParser.get_rules_names(unique_id_refs) + rules
 
         # Extract existing matches from classifications (offset, length tuples)
-        existing_matches = list(
-            (m['offset'], m['length']) 
-            for m in ((m.get('location', {}).get('inChars') or m) for m in text_matches)
-        )
+        existing_matches = list((m['offset'], m['length']) for m in ((m.get('location', {}).get('inChars') or m) for m in text_matches))
 
         return self.process(target_object_text, labels, existing_matches)

--- a/nodes/src/nodes/audio_transcribe/IGlobal.py
+++ b/nodes/src/nodes/audio_transcribe/IGlobal.py
@@ -66,10 +66,7 @@ class IGlobal(IGlobalBase):
             )
 
         segments = result.get('$segments') or []
-        return [
-            SimpleNamespace(text=s.get('text', ''), start=s.get('start', 0.0), end=s.get('end', 0.0))
-            for s in segments
-        ]
+        return [SimpleNamespace(text=s.get('text', ''), start=s.get('start', 0.0), end=s.get('end', 0.0)) for s in segments]
 
     def _audio_to_pcm_bytes(self, audio: Any) -> bytes:
         """Convert audio (bytes or float32 numpy) to PCM int16 bytes (16 kHz mono)."""

--- a/nodes/src/nodes/autopipe/IGlobal.py
+++ b/nodes/src/nodes/autopipe/IGlobal.py
@@ -168,7 +168,6 @@ class IGlobal(IGlobalBase):
                 providerStore, configStore = Config.getMultiProviderConfig('store', autopipeConfig)
                 pushLocal(getFilter('vector_1', providerStore, configStore))
 
-
             pass
 
         # Now, add all the filters we figured out

--- a/nodes/src/nodes/chart_chartjs/IInstance.py
+++ b/nodes/src/nodes/chart_chartjs/IInstance.py
@@ -70,9 +70,7 @@ class IInstance(IInstanceBase):
         if driver._llm_invoke is None:
             llm_invoker = _make_llm_invoker(self.instance)
             if llm_invoker is None:
-                raise RuntimeError(
-                    'Chart generator requires an LLM node connected to the pipeline.'
-                )
+                raise RuntimeError('Chart generator requires an LLM node connected to the pipeline.')
             driver.set_llm_invoker(llm_invoker)
 
         return driver.handle_invoke(param)

--- a/nodes/src/nodes/chart_chartjs/chartjs_driver.py
+++ b/nodes/src/nodes/chart_chartjs/chartjs_driver.py
@@ -40,8 +40,14 @@ from ai.common.tools import ToolsBase
 MAX_DATA_ROWS = 200
 
 VALID_CHART_TYPES = [
-    'bar', 'line', 'pie', 'doughnut', 'radar',
-    'polarArea', 'scatter', 'bubble',
+    'bar',
+    'line',
+    'pie',
+    'doughnut',
+    'radar',
+    'polarArea',
+    'scatter',
+    'bubble',
 ]
 
 INPUT_SCHEMA: Dict[str, Any] = {
@@ -52,10 +58,7 @@ INPUT_SCHEMA: Dict[str, Any] = {
             # Accept both array and object forms — LLMs may produce either.
             # chart_type is optional; the renderer defaults to Bar when omitted or unknown.
             'oneOf': [{'type': 'array'}, {'type': 'object'}],
-            'description': (
-                'The raw data to chart. Can be an array of objects, '
-                'key-value pairs, or any structured data.'
-            ),
+            'description': ('The raw data to chart. Can be an array of objects, key-value pairs, or any structured data.'),
         },
         'chart_type': {
             'type': 'string',
@@ -134,16 +137,11 @@ class ChartjsDriver(ToolsBase):
 
         chart_type = input_obj.get('chart_type')
         if chart_type and chart_type not in VALID_CHART_TYPES:
-            raise ValueError(
-                f'"chart_type" must be one of {VALID_CHART_TYPES}; got {chart_type!r}'
-            )
+            raise ValueError(f'"chart_type" must be one of {VALID_CHART_TYPES}; got {chart_type!r}')
 
     def _tool_invoke(self, *, tool_name: str, input_obj: Any) -> Any:  # noqa: ANN401
         if self._llm_invoke is None:
-            raise RuntimeError(
-                'Chart generator requires an LLM node connected to the pipeline. '
-                'No LLM invoker was bound.'
-            )
+            raise RuntimeError('Chart generator requires an LLM node connected to the pipeline. No LLM invoker was bound.')
 
         self._tool_validate(tool_name=tool_name, input_obj=input_obj)
 
@@ -159,20 +157,17 @@ class ChartjsDriver(ToolsBase):
 
         q.addInstruction(
             'Output format',
-            'Produce ONLY a valid Chart.js v4 JSON configuration object. '
-            'No markdown fences, no explanation — just the raw JSON object.',
+            'Produce ONLY a valid Chart.js v4 JSON configuration object. No markdown fences, no explanation — just the raw JSON object.',
         )
 
         q.addInstruction(
             'Required fields',
-            'The JSON must include "type", "data" (with "labels" and "datasets"), and "options". '
-            'Set responsive to true and maintainAspectRatio to true in options.',
+            'The JSON must include "type", "data" (with "labels" and "datasets"), and "options". Set responsive to true and maintainAspectRatio to true in options.',
         )
 
         q.addInstruction(
             'Styling',
-            'Use readable colors with good contrast. '
-            'Include a legend if there are multiple datasets.',
+            'Use readable colors with good contrast. Include a legend if there are multiple datasets.',
         )
 
         q.addInstruction(
@@ -193,14 +188,11 @@ class ChartjsDriver(ToolsBase):
             q.addContext(f'Description: {description}')
 
         q.addGoal(
-            'Generate a Chart.js v4 configuration for the provided data'
-            + (f' as a {chart_type} chart' if chart_type else '')
-            + '.',
+            'Generate a Chart.js v4 configuration for the provided data' + (f' as a {chart_type} chart' if chart_type else '') + '.',
         )
 
         q.addQuestion(
-            'Generate the Chart.js configuration JSON for the data above.'
-            if not description else description,
+            'Generate the Chart.js configuration JSON for the data above.' if not description else description,
         )
 
         response_text = self._llm_invoke(q)

--- a/nodes/src/nodes/db_mysql/IGlobal.py
+++ b/nodes/src/nodes/db_mysql/IGlobal.py
@@ -40,11 +40,11 @@ class IGlobal(DatabaseGlobalBase):
         # Config.getNodeConfig() strips the node namespace prefix before returning;
         # keys are unprefixed here by design (e.g. 'host', not 'mysql.host').
         return {
-            'host':     config.get('host', 'localhost').strip(),
-            'user':     config.get('user', 'root').strip(),
+            'host': config.get('host', 'localhost').strip(),
+            'user': config.get('user', 'root').strip(),
             'password': config.get('password', ''),  # Do not strip — whitespace is valid in passwords
             'database': config.get('database', 'database').strip(),
-            'table':    config.get('table', 'table').strip(),
+            'table': config.get('table', 'table').strip(),
         }
 
     def _build_connection_url(self, params: Dict[str, str]) -> str:

--- a/nodes/src/nodes/db_postgres/IGlobal.py
+++ b/nodes/src/nodes/db_postgres/IGlobal.py
@@ -40,11 +40,11 @@ class IGlobal(DatabaseGlobalBase):
         # Config.getNodeConfig() strips the node namespace prefix before returning;
         # keys are unprefixed here by design (e.g. 'host', not 'postgresdb.host').
         return {
-            'host':     config.get('host', 'localhost').strip(),
-            'user':     config.get('user', 'postgres').strip(),
+            'host': config.get('host', 'localhost').strip(),
+            'user': config.get('user', 'postgres').strip(),
             'password': config.get('password', ''),  # Do not strip — whitespace is valid in passwords
             'database': config.get('database', 'postgres').strip(),
-            'table':    config.get('table', 'table').strip(),
+            'table': config.get('table', 'table').strip(),
         }
 
     def _build_connection_url(self, params: Dict[str, str]) -> str:

--- a/nodes/src/nodes/index_search/IEndpoint.py
+++ b/nodes/src/nodes/index_search/IEndpoint.py
@@ -27,9 +27,9 @@ Endpoint transform for the index_search node.
 Defines the pipeline endpoint; configuration and lifecycle are handled by
 IGlobal and IInstance.
 """
+
 from ai.common.transform import IEndpointTransform
 
 
 class IEndpoint(IEndpointTransform):
     """Endpoint for index_search (Elasticsearch and OpenSearch). No extra config."""
-

--- a/nodes/src/nodes/index_search/IGlobal.py
+++ b/nodes/src/nodes/index_search/IGlobal.py
@@ -72,9 +72,9 @@ def _normalize_opensearch_host(host: str, use_auth: bool) -> str:
 def _parse_mode_opensearch(mode_raw: str) -> str:
     """Parse OpenSearch mode config into MODE_INDEX or MODE_VSTORE."""
     mode = (str(mode_raw or '').strip()).lower()
-    if mode in ("false", "index", ""):
+    if mode in ('false', 'index', ''):
         return MODE_INDEX
-    if mode in ("true", "vstore"):
+    if mode in ('true', 'vstore'):
         return MODE_VSTORE
     raise ValueError(f'Invalid mode: {mode_raw}')
 
@@ -84,9 +84,9 @@ def _parse_mode_elasticsearch(mode_raw: Any) -> str:
     if isinstance(mode_raw, bool):
         return MODE_VSTORE if mode_raw else MODE_INDEX
     mode = str(mode_raw).strip().lower()
-    if mode in ("false", "index", ""):
+    if mode in ('false', 'index', ''):
         return MODE_INDEX
-    if mode in ("true", "vstore", "vector_database"):
+    if mode in ('true', 'vstore', 'vector_database'):
         return MODE_VSTORE
     return MODE_VSTORE
 
@@ -162,7 +162,7 @@ class IGlobal(IGlobalTransform):
         username = (auth_cfg.get('username') or connConfig.get('username') or '').strip()
         password = auth_cfg.get('password') or connConfig.get('password') or ''
 
-        use_auth = auth_cfg.get("enabled")
+        use_auth = auth_cfg.get('enabled')
         if use_auth is None:
             use_auth = bool(username or password)
 
@@ -211,9 +211,7 @@ class IGlobal(IGlobalTransform):
             mode = config.get('mode', 'self-managed')
 
             if not INDEX_NAME_RE.fullmatch(index):
-                warning(
-                    'Index name is invalid. Use 1-255 lowercase chars: letters, digits, \'_\', \'-\', \'.\'; no \'/\' or spaces'
-                )
+                warning("Index name is invalid. Use 1-255 lowercase chars: letters, digits, '_', '-', '.'; no '/' or spaces")
                 return
             if port == 0:
                 warning('Port cannot be 0')
@@ -259,9 +257,7 @@ class IGlobal(IGlobalTransform):
                 warning('Host is required for OpenSearch')
                 return
             if collection and not INDEX_NAME_RE.fullmatch(collection):
-                warning(
-                    'Collection name is invalid. Use 1-255 chars: letters, digits, \'_\', \'-\', \'.\'; no \'/\' or spaces'
-                )
+                warning("Collection name is invalid. Use 1-255 chars: letters, digits, '_', '-', '.'; no '/' or spaces")
                 return
             if use_auth:
                 if not username:
@@ -331,9 +327,7 @@ class IGlobal(IGlobalTransform):
         """Load search options from config (match operator, slop, highlight, fragment size)."""
         from .constants import VALID_MATCH_OPERATORS
 
-        match_operator_raw = (
-            (connConfig.get('matchOperator') or connConfig.get('match_operator') or '').strip().lower()
-        )
+        match_operator_raw = (connConfig.get('matchOperator') or connConfig.get('match_operator') or '').strip().lower()
         if match_operator_raw not in (*VALID_MATCH_OPERATORS, ''):
             warning(f"matchOperator must be 'and', 'or', or 'exact'; got: {match_operator_raw}")
             match_operator_raw = ''
@@ -341,22 +335,14 @@ class IGlobal(IGlobalTransform):
 
         try:
             slop_val = connConfig.get('slop')
-            self.search_exact_slop = (
-                int(slop_val or 0) if self.search_match_operator == 'exact' else 0
-            )
+            self.search_exact_slop = int(slop_val or 0) if self.search_match_operator == 'exact' else 0
         except Exception:
             self.search_exact_slop = 0
 
         self.search_highlight_enabled = bool(connConfig.get('highlight', False))
         if self.search_highlight_enabled:
-            self.search_highlight_fragment_size = int(
-                connConfig.get('fragment_size') or DEFAULT_HIGHLIGHT_FRAGMENT_SIZE
-            )
-        debug(
-            f'Search options: enabled={self.search_enabled} matchOperator={self.search_match_operator} '
-            f'slop={self.search_exact_slop} highlight={self.search_highlight_enabled} '
-            f'fragment_size={self.search_highlight_fragment_size}'
-        )
+            self.search_highlight_fragment_size = int(connConfig.get('fragment_size') or DEFAULT_HIGHLIGHT_FRAGMENT_SIZE)
+        debug(f'Search options: enabled={self.search_enabled} matchOperator={self.search_match_operator} slop={self.search_exact_slop} highlight={self.search_highlight_enabled} fragment_size={self.search_highlight_fragment_size}')
 
 
 def _format_error(e: Exception) -> str:
@@ -379,4 +365,3 @@ def _format_error(e: Exception) -> str:
             pass
 
     return error_str
-

--- a/nodes/src/nodes/index_search/IInstance.py
+++ b/nodes/src/nodes/index_search/IInstance.py
@@ -233,9 +233,7 @@ class IInstance(IInstanceTransform):
             return
         expected_dim = self._os_get_vector_dim()
         if expected_dim and len(q_embedding) != expected_dim:
-            debug(
-                f'writeQuestions vector mode: embedding dim mismatch len={len(q_embedding)} expected={expected_dim}; skipping'
-            )
+            debug(f'writeQuestions vector mode: embedding dim mismatch len={len(q_embedding)} expected={expected_dim}; skipping')
             return
         debug(f'writeQuestions vector search index={index} dim={len(q_embedding)}')
         resp = client.search_vector(index=index, vector=q_embedding, k=10)
@@ -366,6 +364,7 @@ class IInstance(IInstanceTransform):
 
     def renderObject(self, object: Entry) -> None:
         """Stream document text to the writeText lane (Elasticsearch only; uses DocumentStoreBase)."""
+
         def callback(text: str) -> None:
             self.instance.sendText(text)
 
@@ -377,4 +376,3 @@ class IInstance(IInstanceTransform):
             return
         self.IGlobal.store.render(objectId=object.objectId, callback=callback)
         self.preventDefault()
-

--- a/nodes/src/nodes/index_search/__init__.py
+++ b/nodes/src/nodes/index_search/__init__.py
@@ -27,6 +27,7 @@ index_search node: Elasticsearch and OpenSearch.
 Exposes IEndpoint, IGlobal, IInstance for the pipeline and getStore() for
 direct access to the Elasticsearch Store class when the backend is Elasticsearch.
 """
+
 from .IEndpoint import IEndpoint
 from .IGlobal import IGlobal
 from .IInstance import IInstance
@@ -45,4 +46,3 @@ __all__ = [
     'IInstance',
     'getStore',
 ]
-

--- a/nodes/src/nodes/index_search/constants.py
+++ b/nodes/src/nodes/index_search/constants.py
@@ -52,5 +52,5 @@ MODE_VSTORE = 'vstore'
 # -----------------------------------------------------------------------------
 # Validation
 # -----------------------------------------------------------------------------
-VALID_MATCH_OPERATORS = ("and", "or", "exact")
+VALID_MATCH_OPERATORS = ('and', 'or', 'exact')
 """Allowed values for text search match operator (and/or/exact phrase)."""

--- a/nodes/src/nodes/index_search/elasticsearch_store.py
+++ b/nodes/src/nodes/index_search/elasticsearch_store.py
@@ -103,9 +103,7 @@ class Store(DocumentStoreBase):
 
         similarity = config.get('similarity', 'cosine')
         if similarity not in ('cosine', 'l2_norm', 'dot_product'):
-            raise Exception(
-                'Similarity must be one of: cosine, l2_norm, dot_product'
-            )
+            raise Exception('Similarity must be one of: cosine, l2_norm, dot_product')
         self.similarity = similarity
 
         # Use explicit scheme from host if present; else derive from mode (self-managed -> http)
@@ -539,9 +537,7 @@ class Store(DocumentStoreBase):
                     err = op.get('error', {})
                     reason = err.get('reason') or err.get('type') or str(err) or str(e)
                     doc_id = op.get('_id', '?')
-                    raise Exception(
-                        f'Elasticsearch index failed (id={doc_id}): {reason}'
-                    ) from e
+                    raise Exception(f'Elasticsearch index failed (id={doc_id}): {reason}') from e
                 raise
 
         # For each document
@@ -798,9 +794,7 @@ class Store(DocumentStoreBase):
             op = 'or'
         slop = max(int(match_operator_slop or 0), 0)
         if op == 'exact':
-            base_query: Dict[str, Any] = {
-                'match_phrase': {CONTENT_FIELD: {'query': query, 'slop': slop}}
-            }
+            base_query: Dict[str, Any] = {'match_phrase': {CONTENT_FIELD: {'query': query, 'slop': slop}}}
         elif op == 'and':
             base_query = {'match': {CONTENT_FIELD: {'query': query, 'operator': 'and'}}}
         elif op == 'or':
@@ -818,4 +812,3 @@ class Store(DocumentStoreBase):
             frag_size = max(int(highlight_fragment_size or 0), 0) or DEFAULT_HIGHLIGHT_FRAGMENT_SIZE
             body['highlight'] = _build_highlight_config(CONTENT_FIELD, frag_size)
         return body
-

--- a/nodes/src/nodes/index_search/opensearch_client.py
+++ b/nodes/src/nodes/index_search/opensearch_client.py
@@ -44,7 +44,7 @@ from .constants import (
 )
 
 # OpenSearch-specific default (config overrides at runtime)
-DEFAULT_HOST = "http://localhost:9200"
+DEFAULT_HOST = 'http://localhost:9200'
 
 
 def _build_highlight_config(field: str, fragment_size: int) -> Dict[str, Any]:
@@ -344,9 +344,7 @@ class OpenSearchClient:
             op = 'or'
         slop = max(int(match_operator_slop or 0), 0)
         if op == 'exact':
-            base_query: Dict[str, Any] = {
-                'match_phrase': {CONTENT_FIELD: {'query': query, 'slop': slop}}
-            }
+            base_query: Dict[str, Any] = {'match_phrase': {CONTENT_FIELD: {'query': query, 'slop': slop}}}
         elif op == 'and':
             base_query = {'match': {CONTENT_FIELD: {'query': query, 'operator': 'and'}}}
         elif op == 'or':
@@ -367,4 +365,3 @@ class OpenSearchClient:
             frag_size = max(int(highlight_fragment_size or 0), 0) or DEFAULT_HIGHLIGHT_FRAGMENT_SIZE
             body['highlight'] = _build_highlight_config(CONTENT_FIELD, frag_size)
         return body
-

--- a/nodes/src/nodes/library/msgraph/application_permissions.py
+++ b/nodes/src/nodes/library/msgraph/application_permissions.py
@@ -51,11 +51,7 @@ class ApplicationPermissions:
         '5b567255-7703-4780-807c-7be8301ae99b': {
             'roleName': 'Group.Read.All',
             'Display Name': 'Read all groups',
-            'Description': (
-                'Allows the app to create groups, read all group properties and memberships, update group properties '
-                'and memberships, and delete groups. Also allows the app to read and write conversations. '
-                'All of these operations can be performed by the app without a signed-in user.'
-            ),
+            'Description': ('Allows the app to create groups, read all group properties and memberships, update group properties and memberships, and delete groups. Also allows the app to read and write conversations. All of these operations can be performed by the app without a signed-in user.'),
         },
         '62a82d76-70ea-41e2-9197-370581804d09': {'roleName': 'Group.ReadWrite.All', 'Display Name': 'Read and write all groups', 'Description': 'Allows the app to read and update user profiles without a signed in user.'},
         '332a536c-c7ef-4017-ab91-336970924f0d': {

--- a/nodes/src/nodes/library/permissions/utils.py
+++ b/nodes/src/nodes/library/permissions/utils.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 # =============================================================================
 
+
 def is_permission_scan_enabled(service_config: dict) -> bool:
     """
     Check if the permissions are enabled for the endpoint.

--- a/nodes/src/nodes/llamaparse/IInstance.py
+++ b/nodes/src/nodes/llamaparse/IInstance.py
@@ -278,19 +278,9 @@ class IInstance(IInstanceBase):
             if not text or len(text.strip()) == 0:
                 debug('LlamaParse Instance: No text content extracted, creating fallback message')
                 if mime_type.startswith('image/'):
-                    text = (
-                        f'# Image Processing Result\n\n'
-                        f'This image was processed by LlamaParse but no text content was extracted.\n\n'
-                        f'**File Type:** {mime_type}\n**File Size:** {len(document_data)} bytes\n\n'
-                        f'*Note: This may indicate that the image contains no readable text or the OCR processing was unsuccessful.*'
-                    )
+                    text = f'# Image Processing Result\n\nThis image was processed by LlamaParse but no text content was extracted.\n\n**File Type:** {mime_type}\n**File Size:** {len(document_data)} bytes\n\n*Note: This may indicate that the image contains no readable text or the OCR processing was unsuccessful.*'
                 else:
-                    text = (
-                        f'# Document Processing Result\n\n'
-                        f'This document was processed by LlamaParse but no text content was extracted.\n\n'
-                        f'**File Type:** {mime_type}\n**File Size:** {len(document_data)} bytes\n\n'
-                        f'*Note: This may indicate that the document is empty or the parsing was unsuccessful.*'
-                    )
+                    text = f'# Document Processing Result\n\nThis document was processed by LlamaParse but no text content was extracted.\n\n**File Type:** {mime_type}\n**File Size:** {len(document_data)} bytes\n\n*Note: This may indicate that the document is empty or the parsing was unsuccessful.*'
 
             # Extract tables from the parsed text and structured data
             self.extract_tables_from_text(text)
@@ -329,12 +319,7 @@ class IInstance(IInstanceBase):
             debug(f'LlamaParse Instance: Full traceback: {traceback.format_exc()}')
 
             # Create error message as markdown
-            error_text = (
-                f'# LlamaParse Processing Error\n\n'
-                f'**Error Type:** {type(e).__name__}\n**Error Message:** {str(e)}\n\n'
-                f'**File Type:** {mime_type}\n**File Size:** {len(document_data)} bytes\n\n'
-                f'*The document could not be processed due to an error in the LlamaParse service.*'
-            )
+            error_text = f'# LlamaParse Processing Error\n\n**Error Type:** {type(e).__name__}\n**Error Message:** {str(e)}\n\n**File Type:** {mime_type}\n**File Size:** {len(document_data)} bytes\n\n*The document could not be processed due to an error in the LlamaParse service.*'
 
             # Write error message to text lane
             if self.instance.hasListener('text'):

--- a/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
+++ b/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
@@ -31,10 +31,20 @@ from ibm_watsonx_ai.foundation_models.schema import TextChatParameters
 
 
 # Known IBM Cloud regions for Watson services
-_VALID_LOCATIONS = frozenset({
-    'us-south', 'us-east', 'eu-gb', 'eu-de', 'eu-es',
-    'jp-tok', 'jp-osa', 'au-syd', 'ca-tor', 'br-sao',
-})
+_VALID_LOCATIONS = frozenset(
+    {
+        'us-south',
+        'us-east',
+        'eu-gb',
+        'eu-de',
+        'eu-es',
+        'jp-tok',
+        'jp-osa',
+        'au-syd',
+        'ca-tor',
+        'br-sao',
+    }
+)
 
 _LOCATION_RE = re.compile(r'^[a-z0-9]([a-z0-9-]*[a-z0-9])?$')
 
@@ -58,10 +68,7 @@ def _validate_location(location):
     if not _LOCATION_RE.match(location):
         raise ValueError(f'Invalid location format: {location!r}')
     if location not in _VALID_LOCATIONS:
-        raise ValueError(
-            f'Unknown IBM Cloud location: {location!r}. '
-            f'Valid locations: {", ".join(sorted(_VALID_LOCATIONS))}'
-        )
+        raise ValueError(f'Unknown IBM Cloud location: {location!r}. Valid locations: {", ".join(sorted(_VALID_LOCATIONS))}')
     return f'https://{location}.ml.cloud.ibm.com'
 
 

--- a/nodes/src/nodes/llm_openai/IGlobal.py
+++ b/nodes/src/nodes/llm_openai/IGlobal.py
@@ -60,11 +60,11 @@ class IGlobal(IGlobalBase):
             # Simple API validation using provider-driven exceptions
             try:
                 client = OpenAI(api_key=apikey)
-                
+
                 # Newer models use max_completion_tokens instead of max_tokens
                 newer_models = ['gpt-5', 'gpt-5.1', 'gpt-5-mini', 'gpt-5-nano']
                 uses_max_completion_tokens = any(model.startswith(m) for m in newer_models)
-                
+
                 # Make sure model is using the correct parameters
                 if uses_max_completion_tokens:
                     client.chat.completions.create(model=model, messages=[{'role': 'user', 'content': 'Hi'}], max_completion_tokens=10)

--- a/nodes/src/nodes/mcp_client/IGlobal.py
+++ b/nodes/src/nodes/mcp_client/IGlobal.py
@@ -138,10 +138,7 @@ class IGlobal(IGlobalBase):
                     self._client = McpStreamableHttpClient(endpoint=endpoint, headers=headers)
 
             else:
-                raise Exception(
-                    f'mcp_client transport {self.transport!r} not supported '
-                    '(use stdio, streamable-http, or sse)'
-                )
+                raise Exception(f'mcp_client transport {self.transport!r} not supported (use stdio, streamable-http, or sse)')
 
             self._client.start()
             tools = self._client.list_tools()
@@ -248,10 +245,7 @@ class IGlobal(IGlobalBase):
 
     def call_tool(self, *, server_name: str, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
         if server_name != self.serverName:
-            raise Exception(
-                f'Unknown MCP serverName {server_name!r} (this node configured as {self.serverName!r})'
-            )
+            raise Exception(f'Unknown MCP serverName {server_name!r} (this node configured as {self.serverName!r})')
         if self._client is None:
             raise Exception('MCP client is not connected')
         return self._client.call_tool(name=tool_name, arguments=arguments or {})
-

--- a/nodes/src/nodes/mcp_client/IInstance.py
+++ b/nodes/src/nodes/mcp_client/IInstance.py
@@ -48,4 +48,3 @@ class IInstance(IInstanceBase):
         if driver is None:
             raise RuntimeError('mcp_client: driver not initialized')
         return driver.handle_invoke(param)
-

--- a/nodes/src/nodes/mcp_client/__init__.py
+++ b/nodes/src/nodes/mcp_client/__init__.py
@@ -27,4 +27,3 @@ from .IGlobal import IGlobal
 from .IInstance import IInstance
 
 __all__ = ['IGlobal', 'IInstance']
-

--- a/nodes/src/nodes/mcp_client/mcp_driver.py
+++ b/nodes/src/nodes/mcp_client/mcp_driver.py
@@ -74,4 +74,3 @@ class McpDriver(ToolsBase):
             raise ValueError('Tool input must be a JSON object (dict)')
 
         return self._call_tool(server_name, bare_tool, arguments)
-

--- a/nodes/src/nodes/mcp_client/mcp_sse_client.py
+++ b/nodes/src/nodes/mcp_client/mcp_sse_client.py
@@ -89,7 +89,7 @@ class McpSseClient:
 
         self._reader_thread: threading.Thread | None = None
         self._stop = threading.Event()
-        self._incoming: "queue.Queue[dict]" = queue.Queue()
+        self._incoming: 'queue.Queue[dict]' = queue.Queue()
         self._endpoint_url: str | None = None
         self._resp = None
 
@@ -313,11 +313,7 @@ class McpSseClient:
             # Validate the resolved URL stays on the same origin to prevent
             # auth-token theft via malicious absolute-URL redirects.
             if self._origin(resolved) != base:
-                raise McpProtocolError(
-                    f'MCP endpoint redirect rejected: '
-                    f'resolved origin {self._origin(resolved)!r} '
-                    f'does not match SSE origin {base!r}'
-                )
+                raise McpProtocolError(f'MCP endpoint redirect rejected: resolved origin {self._origin(resolved)!r} does not match SSE origin {base!r}')
             self._endpoint_url = resolved
             return
 
@@ -352,4 +348,3 @@ class McpSseClient:
         elif scheme == 'http' and netloc.endswith(':80'):
             netloc = netloc[:-3]
         return f'{scheme}://{netloc}'
-

--- a/nodes/src/nodes/mcp_client/mcp_stdio_client.py
+++ b/nodes/src/nodes/mcp_client/mcp_stdio_client.py
@@ -256,4 +256,3 @@ class McpStdioClient:
                 message = msg['error'].get('message')
                 raise McpProtocolError(f'MCP error (id={req_id}) code={code} message={message}')
             return msg.get('result')
-

--- a/nodes/src/nodes/mcp_client/mcp_streamable_http_client.py
+++ b/nodes/src/nodes/mcp_client/mcp_streamable_http_client.py
@@ -357,4 +357,3 @@ def _match_jsonrpc_id(msg: dict, *, req_id: int) -> Any | None:  # noqa: ANN401
         message = msg['error'].get('message')
         raise McpProtocolError(f'MCP error (id={req_id}) code={code} message={message}')
     return msg.get('result')
-

--- a/nodes/src/nodes/memory_internal/memory.py
+++ b/nodes/src/nodes/memory_internal/memory.py
@@ -100,8 +100,6 @@ TOOL_DESCRIPTORS: List[Dict[str, Any]] = [
 ]
 
 
-
-
 class MemoryStore:
     """Run-scoped keyed memory for the RocketRide planning agent."""
 
@@ -156,7 +154,7 @@ class MemoryStore:
             args = {}
 
         # Strip the "memory." prefix to get the operation name
-        op = tool_name[len(_MEMORY_PREFIX):]
+        op = tool_name[len(_MEMORY_PREFIX) :]
         if op == 'put':
             return self.put(args.get('key', ''), args.get('value'))
         if op == 'get':

--- a/nodes/src/nodes/ner/IGlobal.py
+++ b/nodes/src/nodes/ner/IGlobal.py
@@ -28,13 +28,13 @@ from ai.common.config import Config
 class IGlobal(IGlobalBase):
     """
     Global context for NER node.
-    
+
     Initializes the NER recognizer once per pipeline execution and shares
     it across all instances.
     """
-    
+
     recognizer = None
-    
+
     def beginGlobal(self):
         """Initialize the NER recognizer when the pipeline starts."""
         if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
@@ -49,13 +49,12 @@ class IGlobal(IGlobalBase):
 
             # Get this node's config
             config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
-            
+
             # Initialize the NER recognizer
             debug(f'    Loading NER model: {config.get("model", "default")}')
             self.recognizer = NERRecognizer(self.glb.logicalType, config, bag)
             debug('    NER model loaded successfully')
-    
+
     def endGlobal(self):
         """Clean up the NER recognizer when the pipeline ends."""
         self.recognizer = None
-

--- a/nodes/src/nodes/ner/IInstance.py
+++ b/nodes/src/nodes/ner/IInstance.py
@@ -30,60 +30,60 @@ from .IGlobal import IGlobal
 class IInstance(IInstanceBase):
     """
     Instance handler for NER node.
-    
+
     Processes individual documents and text, extracting named entities
     and adding them to document metadata.
     """
-    
+
     IGlobal: IGlobal  # Reference to global context with NER recognizer
-    
+
     # Current object context
     current_text: str = ''
     current_entities: List[dict] = []
-    
+
     def open(self, obj: Entry):
         """Initialize instance for a new object."""
         self.current_text = ''
         self.current_entities = []
-    
+
     def writeText(self, text: str):
         """
         Process text and extract named entities.
-        
+
         Args:
             text: Text to process
         """
         # Store the text
         self.current_text += text
-        
+
         # Extract entities from the text
         entities = self.IGlobal.recognizer.extract_entities(text)
         self.current_entities.extend(entities)
-        
+
         # Pass through the original text
         self.instance.writeText(text)
-    
+
     def writeDocuments(self, documents: List[Doc]):
         """
         Process documents and extract named entities.
-        
+
         Args:
             documents: List of documents to process
         """
         enriched_docs = []
-        
+
         for doc in documents:
             # Extract entities from document content
             entities = self.IGlobal.recognizer.extract_entities(doc.page_content)
-            
+
             # Create a copy to avoid modifying the original
             enriched_doc = doc.model_copy()
-            
+
             # Store entities in metadata if configured
             if self.IGlobal.recognizer.store_in_metadata:
                 if enriched_doc.metadata is None:
                     enriched_doc.metadata = {}
-                
+
                 # Group entities by type
                 entities_by_type = {}
                 for entity in entities:
@@ -91,26 +91,25 @@ class IInstance(IInstanceBase):
                     if entity_type not in entities_by_type:
                         entities_by_type[entity_type] = []
                     entities_by_type[entity_type].append(entity['word'])
-                
+
                 # Add to metadata (deduplicate and sort)
                 for entity_type, words in entities_by_type.items():
                     unique_words = sorted(list(set(words)))
                     enriched_doc.metadata[f'entities_{entity_type.lower()}'] = unique_words
-                
+
                 # Also store total count
                 enriched_doc.metadata['entities_count'] = len(entities)
-            
+
             enriched_docs.append(enriched_doc)
-        
+
         # Write enriched documents
         self.instance.writeDocuments(enriched_docs)
-    
+
     def closing(self):
         """Called before close, finalize any pending operations."""
         pass
-    
+
     def close(self):
         """Clean up instance state."""
         self.current_text = ''
         self.current_entities = []
-

--- a/nodes/src/nodes/ocr/IGlobal.py
+++ b/nodes/src/nodes/ocr/IGlobal.py
@@ -29,6 +29,7 @@ from rocketlib import IGlobalBase, debug
 from ai.common.config import Config
 
 from depends import depends
+
 requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
 depends(requirements)
 
@@ -45,19 +46,19 @@ from img2table.ocr.base import OCRInstance
 class ModelServerOCR(OCRInstance):
     """
     Custom OCR adapter that routes img2table OCR requests to the model server.
-    
+
     This implements the img2table OCRInstance interface, which requires:
     - content(document: Document) -> list of OCR results per page
     - to_ocr_dataframe(content) -> OCRDataframe
-    
+
     This keeps img2table (OpenCV table detection) on the node while
     offloading the heavy OCR inference to the model server (or local fallback).
     """
-    
+
     def __init__(self, engine: str = 'doctr', languages: List[str] = None):
         """
         Initialize the adapter with a model server OCR engine.
-        
+
         Args:
             engine: OCR engine to use - 'doctr', 'easyocr', or 'surya'
             languages: List of language codes (e.g., ['en', 'fr'])
@@ -65,91 +66,96 @@ class ModelServerOCR(OCRInstance):
         self.engine = engine.lower()
         self.languages = languages or ['en']
         self._ocr = None
-    
+
     @property
     def ocr(self):
         """Lazy-load the OCR engine from model server (or local fallback)."""
         if self._ocr is None:
             if self.engine == 'doctr':
                 from ai.common.models import DocTR
+
                 self._ocr = DocTR()
             elif self.engine == 'easyocr':
                 from ai.common.models import EasyOCR
+
                 self._ocr = EasyOCR(languages=self.languages)
             elif self.engine == 'surya':
                 from ai.common.models import Surya
+
                 self._ocr = Surya()
             else:
                 raise ValueError(f'Unknown OCR engine: {self.engine}')
             debug(f'ModelServerOCR: Initialized {self.engine} engine')
         return self._ocr
-    
+
     def content(self, document) -> List[List[Tuple]]:
         """
         Perform OCR on all images in the document.
-        
+
         This is called by img2table's OCRInstance.of() method.
-        
+
         Args:
             document: img2table Document object with .images property
-            
+
         Returns:
             List of pages, each page is a list of (bbox, text, confidence) tuples
             Format matches EasyOCR: [[[x1,y1],[x2,y1],[x2,y2],[x1,y2]], text, confidence]
         """
+
         def _diag(msg):
             pass
 
         _diag(f'[DIAG] ModelServerOCR.content() called, document type: {type(document)}')
         _diag(f'[DIAG] document.images count: {len(document.images) if hasattr(document, "images") else "N/A"}')
-        
+
         all_results = []
-        
+
         try:
             for idx, image in enumerate(document.images):
                 _diag(f'[DIAG] Processing image {idx}, shape: {image.shape}')
-                
+
                 # Convert numpy array to bytes for model server
                 image_bytes = self._to_bytes(image)
                 _diag(f'[DIAG] Converted to {len(image_bytes)} bytes')
-                
+
                 # Call model server OCR (or local fallback)
                 _diag(f'[DIAG] Calling self.ocr.read() with engine={self.engine}')
                 result = self.ocr.read(image_bytes)
                 _diag(f'[DIAG] OCR result: {result}')
-                
+
                 # Convert to EasyOCR-compatible format
                 page_results = self._format_to_easyocr(result, image.shape)
                 _diag(f'[DIAG] Page {idx} results: {len(page_results)} items')
                 all_results.append(page_results)
-                
+
         except Exception as e:
             import traceback
+
             _diag(f'[DIAG] ModelServerOCR.content() EXCEPTION: {e}')
             _diag(f'[DIAG] Traceback: {traceback.format_exc()}')
-        
+
         return all_results
-    
+
     def to_ocr_dataframe(self, content: List[List]) -> Any:
         """
         Convert OCR content to OCRDataframe.
-        
+
         Args:
             content: List of pages, each page has list of (bbox, text, confidence) tuples
-            
+
         Returns:
             OCRDataframe object
         """
         from img2table.ocr.data import OCRDataframe
         import polars as pl
-        
+
         def _diag(msg):
             pass
-        
+
         _diag(f'[DIAG] to_ocr_dataframe called, content pages: {len(content)}')
-        
+
         list_elements = []
-        
+
         for page, ocr_result in enumerate(content):
             for idx, word in enumerate(ocr_result):
                 # word format: [bbox_points, text, confidence]
@@ -157,61 +163,61 @@ class ModelServerOCR(OCRInstance):
                 bbox = word[0]
                 text = word[1]
                 confidence = word[2] if len(word) > 2 else 1.0
-                
+
                 # Extract x1, y1, x2, y2 from bbox points
                 x_coords = [p[0] for p in bbox]
                 y_coords = [p[1] for p in bbox]
                 x1, x2 = min(x_coords), max(x_coords)
                 y1, y2 = min(y_coords), max(y_coords)
-                
+
                 dict_word = {
-                    "page": page,
-                    "class": "ocrx_word",
-                    "id": f"word_{page + 1}_{idx + 1}",
-                    "parent": f"word_{page + 1}_{idx + 1}",
-                    "value": text,
-                    "confidence": round(100 * confidence),
-                    "x1": int(x1),
-                    "y1": int(y1),
-                    "x2": int(x2),
-                    "y2": int(y2),
+                    'page': page,
+                    'class': 'ocrx_word',
+                    'id': f'word_{page + 1}_{idx + 1}',
+                    'parent': f'word_{page + 1}_{idx + 1}',
+                    'value': text,
+                    'confidence': round(100 * confidence),
+                    'x1': int(x1),
+                    'y1': int(y1),
+                    'x2': int(x2),
+                    'y2': int(y2),
                 }
                 list_elements.append(dict_word)
-        
+
         _diag(f'[DIAG] Created {len(list_elements)} OCR elements')
-        
+
         if list_elements:
             df = pl.DataFrame(list_elements, schema=self.pl_schema)
         else:
             df = pl.DataFrame(schema=self.pl_schema)
-        
+
         return OCRDataframe(df=df)
-    
+
     def _to_bytes(self, image: np.ndarray) -> bytes:
         """Convert numpy array to PNG bytes."""
         pil_image = Image.fromarray(image)
         buffer = io.BytesIO()
         pil_image.save(buffer, format='PNG')
         return buffer.getvalue()
-    
+
     def _format_to_easyocr(self, result: dict, image_shape: tuple) -> List[Tuple]:
         """
         Convert model server result to EasyOCR-compatible format.
-        
+
         EasyOCR format: [[[x1,y1],[x2,y1],[x2,y2],[x1,y2]], text, confidence]
-        
+
         Args:
             result: OCR result from model server {'text': '...', 'boxes': [...]}
             image_shape: Shape of the input image for default bbox
-            
+
         Returns:
             List of (bbox_points, text, confidence) tuples
         """
         formatted = []
-        
+
         text = result.get('text', '')
         boxes = result.get('boxes', [])
-        
+
         if boxes and isinstance(boxes, list) and len(boxes) > 0:
             for box_info in boxes:
                 if isinstance(box_info, dict):
@@ -220,18 +226,18 @@ class ModelServerOCR(OCRInstance):
                     confidence = box_info.get('confidence', 1.0)
                 else:
                     continue
-                
+
                 # Convert [x1, y1, x2, y2] to [[x1,y1],[x2,y1],[x2,y2],[x1,y2]]
                 x1, y1, x2, y2 = bbox[0], bbox[1], bbox[2], bbox[3]
                 bbox_points = [[x1, y1], [x2, y1], [x2, y2], [x1, y2]]
-                
+
                 formatted.append([bbox_points, box_text, confidence])
         elif text:
             # No boxes but we have text - use full image as bbox
             h, w = image_shape[:2]
             bbox_points = [[0, 0], [w, 0], [w, h], [0, h]]
             formatted.append([bbox_points, text, 1.0])
-        
+
         return formatted
 
 
@@ -255,14 +261,15 @@ class IGlobal(IGlobalBase):
 
         self.io = io
         self.Img2TableImage = Img2TableImage
-        
+
         # Get table OCR settings
         # script_family determines languages for EasyOCR, table_engine selects OCR backend
         script_family = config.get('script_family', 'latin')
         table_engine = config.get('table_engine', 'doctr').lower()
-        
+
         # Import script families from ocr module
         from .ocr import SCRIPT_FAMILIES
+
         languages = SCRIPT_FAMILIES.get(script_family, ['en'])
 
         # Use ModelServerOCR adapter - routes to model server or local fallback

--- a/nodes/src/nodes/ocr/IInstance.py
+++ b/nodes/src/nodes/ocr/IInstance.py
@@ -44,12 +44,13 @@ class IInstance(IInstanceBase):
         :param image_data: Image in bytes
         :param table_callback: Function to call with each extracted Markdown table
         """
+
         # Write diagnostics to a file since print() goes to DAP
         def _diag(msg):
             pass
-        
+
         _diag(f'[DIAG] extract_tables_from_image called, image size: {len(image_data)} bytes')
-        
+
         if not hasattr(self.IGlobal, 'table_ocr'):
             _diag('[DIAG] Table OCR not initialized - SKIPPING')
             return
@@ -118,6 +119,7 @@ class IInstance(IInstanceBase):
 
         except Exception as e:
             import traceback
+
             _diag(f'[DIAG] Table extraction EXCEPTION: {str(e)}')
             _diag(f'[DIAG] Traceback: {traceback.format_exc()}')
 

--- a/nodes/src/nodes/tool_firecrawl/firecrawl_driver.py
+++ b/nodes/src/nodes/tool_firecrawl/firecrawl_driver.py
@@ -92,7 +92,7 @@ class FirecrawlDriver(ToolsBase):
     def _bare_name(self, tool_name: str) -> str:
         """Strip server prefix, accepting both bare and namespaced tool names."""
         prefix = f'{self._server_name}.'
-        return tool_name[len(prefix):] if tool_name.startswith(prefix) else tool_name
+        return tool_name[len(prefix) :] if tool_name.startswith(prefix) else tool_name
 
     # ------------------------------------------------------------------
     # ToolsBase hooks
@@ -102,10 +102,7 @@ class FirecrawlDriver(ToolsBase):
         # Return namespaced descriptors (<server>.<tool>) so multiple Firecrawl nodes
         # do not produce colliding tool names. _tool_validate and _tool_invoke use
         # _bare_name() to strip the prefix when looking up _TOOLS_BY_BARE_NAME.
-        return [
-            {**tool, 'name': f'{self._server_name}.{tool["name"]}'}
-            for tool in _TOOLS_BY_BARE_NAME.values()
-        ]
+        return [{**tool, 'name': f'{self._server_name}.{tool["name"]}'} for tool in _TOOLS_BY_BARE_NAME.values()]
 
     def _tool_validate(self, *, tool_name: str, input_obj: Any) -> None:  # noqa: ANN401
         tool = _TOOLS_BY_BARE_NAME.get(self._bare_name(tool_name))
@@ -145,9 +142,7 @@ class FirecrawlDriver(ToolsBase):
         # v2 SDK: app.scrape(url) returns a Document Pydantic model
         result = firecrawl_wrapper(lambda: self._app.scrape(url))
 
-        content = getattr(result, 'markdown', None) \
-            or getattr(result, 'html', None) \
-            or ''
+        content = getattr(result, 'markdown', None) or getattr(result, 'html', None) or ''
         if not isinstance(content, str):
             content = json.dumps(content)
 
@@ -212,6 +207,7 @@ def _normalize_tool_input(input_obj: Any) -> Dict[str, Any]:
     if isinstance(input_obj, str):
         try:
             import json as _json
+
             parsed = _json.loads(input_obj)
             if isinstance(parsed, dict):
                 input_obj = parsed

--- a/nodes/src/nodes/tool_http_request/IGlobal.py
+++ b/nodes/src/nodes/tool_http_request/IGlobal.py
@@ -87,6 +87,7 @@ class IGlobal(IGlobalBase):
         raw_whitelist = cfg.get('urlWhitelist') or []
         if not isinstance(raw_whitelist, list):
             import json
+
             try:
                 raw_whitelist = json.loads(str(raw_whitelist))
             except (json.JSONDecodeError, TypeError, ValueError):

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -95,6 +95,7 @@ def execute_request(
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+
 def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str:
     """Replace ``:name`` placeholders in the URL with values from *path_params*."""
     if not path_params:

--- a/nodes/src/nodes/tool_http_request/http_driver.py
+++ b/nodes/src/nodes/tool_http_request/http_driver.py
@@ -250,19 +250,14 @@ class HttpDriver(ToolsBase):
         if method.upper() not in VALID_METHODS:
             raise ValueError(f'method must be one of {sorted(VALID_METHODS)}; got {method!r}')
         if method.upper() not in self._enabled_methods:
-            raise ValueError(
-                f'HTTP method "{method.upper()}" is not allowed. '
-                f'Enabled methods: {", ".join(sorted(self._enabled_methods))}'
-            )
+            raise ValueError(f'HTTP method "{method.upper()}" is not allowed. Enabled methods: {", ".join(sorted(self._enabled_methods))}')
 
         # --- Guardrail: URL whitelist (empty list = allow all) ---
         url = input_obj.get('url')
         if not url or not isinstance(url, str):
             raise ValueError('url is required and must be a non-empty string')
         if self._url_patterns and not any(p.search(url) for p in self._url_patterns):
-            raise ValueError(
-                f'URL "{url}" does not match any allowed URL pattern.'
-            )
+            raise ValueError(f'URL "{url}" does not match any allowed URL pattern.')
 
         # --- Standard field validation ---
         auth = input_obj.get('auth')
@@ -280,9 +275,7 @@ class HttpDriver(ToolsBase):
                 raw = body.get('raw') or {}
                 ct = (raw.get('content_type') or 'application/json').strip().lower()
                 if ct not in VALID_RAW_CONTENT_TYPES:
-                    raise ValueError(
-                        f'body.raw.content_type must be one of {sorted(VALID_RAW_CONTENT_TYPES)}; got {ct!r}'
-                    )
+                    raise ValueError(f'body.raw.content_type must be one of {sorted(VALID_RAW_CONTENT_TYPES)}; got {ct!r}')
 
     def _tool_invoke(self, *, tool_name: str, input_obj: Any) -> Any:  # noqa: ANN401
         if not isinstance(input_obj, dict):

--- a/nodes/src/nodes/vectordb_postgres/vectordb_postgres.py
+++ b/nodes/src/nodes/vectordb_postgres/vectordb_postgres.py
@@ -51,23 +51,7 @@ MIN_SIMILARITY_SCORE = 0.20
 SQL_QUERIES = {
     'check_collection_exists': "SELECT EXISTS (SELECT FROM pg_tables WHERE schemaname = 'public' AND tablename = %s)",
     # fmt: off
-    'create_collection': (
-        'CREATE TABLE IF NOT EXISTS {collection} ('
-        'id bigserial PRIMARY KEY, '
-        'content text, '
-        'objectId text, '
-        'nodeId text, '
-        'parent text, '
-        'permissionId int, '
-        'isDeleted boolean, '
-        'chunkId int, '
-        'isTable boolean, '
-        'tableId int, '
-        'vectorSize int, '
-        'modelName text, '
-        'embedding vector({vector_size})'
-        ');'
-    ),
+    'create_collection': ('CREATE TABLE IF NOT EXISTS {collection} (id bigserial PRIMARY KEY, content text, objectId text, nodeId text, parent text, permissionId int, isDeleted boolean, chunkId int, isTable boolean, tableId int, vectorSize int, modelName text, embedding vector({vector_size}));'),
     # fmt: on
     'count_documents': 'SELECT COUNT(*) FROM {collection}',
     'search_keyword': 'SELECT * FROM {collection} WHERE content LIKE %s {where_clause} LIMIT %s',


### PR DESCRIPTION
Fixes #432

Run `ruff format` across `nodes/src/nodes/` Python files to establish a consistent formatting baseline.

**Changes:**
- 45 files reformatted with ruff
- No logic changes — formatting only

This is the one-time pass referenced in the issue before CI enforcement is added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Code formatting and consistency improvements throughout the codebase, including string literal standardization, consolidated multi-line expressions, and whitespace normalization. No changes to functionality or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->