### PR TITLE
docs: add db_neo4j node usage guide with practical examples

### DIFF
--- a/docs/nodes/db-neo4j-usage.md
+++ b/docs/nodes/db-neo4j-usage.md
@@ -1,0 +1,83 @@
+# db_neo4j Node — Usage Guide
+
+The `db_neo4j` node executes Cypher queries against a Neo4j database.
+
+## Configuration
+
+```json
+{
+  "id": "query_node",
+  "type": "db_neo4j",
+  "label": "Query Neo4j",
+  "config": {
+    "uri_env": "NEO4J_URI",
+    "user_env": "NEO4J_USER",
+    "password_env": "NEO4J_PASSWORD",
+    "query": "MATCH (c:Company {name: $name}) RETURN c.industry, c.overall_severity"
+  }
+}
+```
+
+Environment variables:
+
+```
+NEO4J_URI=neo4j+s://your-instance.databases.neo4j.io
+NEO4J_USER=your_username
+NEO4J_PASSWORD=your_password
+```
+
+## Patterns
+
+### Read: fetch related nodes
+
+```cypher
+MATCH (c:Company)-[:FOUNDED_BY]->(f:Founder)
+RETURN f.name, f.email, c.name AS company
+ORDER BY c.overall_severity ASC
+```
+
+### Write: update after analysis
+
+```cypher
+MERGE (c:Company {name: $company_name})
+ON CREATE SET c.industry = $industry, c.created_at = datetime()
+SET c.overall_severity = $severity, c.analyzed_at = datetime()
+RETURN c.name
+```
+
+### Graph algorithm (Cypher-based Louvain fallback)
+
+```cypher
+MATCH (c:Company)-[r:PATTERN_MATCH]->(other:Company)
+WITH c, r.shared_signal AS signal, count(r) AS cnt
+ORDER BY cnt DESC
+WITH c, collect(signal)[0] AS dominant
+SET c.communityId = CASE dominant
+  WHEN 'MARGIN_COMPRESSION' THEN 0
+  WHEN 'CONCENTRATION_RISK' THEN 1
+  ELSE 99
+END
+RETURN count(c) AS updated
+```
+
+## Two db_neo4j Nodes in One Pipeline
+
+Neo4j appears twice in the Portfolio Brain cascade pipeline — once to read patterns,
+once to write results. This is a common pattern:
+
+```
+[Input] → [db_neo4j: Read] → [llm_openai: Analyze] → [db_neo4j: Write] → [Output]
+```
+
+The write node receives the LLM output and persists results back to the graph.
+
+## Neo4j Aura
+
+For cloud Neo4j (Aura), use the `neo4j+s://` URI scheme:
+
+```
+NEO4J_URI=neo4j+s://xxxxxxxx.databases.neo4j.io
+```
+
+Note: GDS algorithms require AuraDS or self-managed Neo4j with the GDS plugin.
+The free Aura tier supports standard Cypher but not `gds.*` procedure calls.

--- a/docs/nodes/db-neo4j-usage.md
+++ b/docs/nodes/db-neo4j-usage.md
@@ -1,48 +1,72 @@
 # db_neo4j Node — Usage Guide
 
-The `db_neo4j` node executes Cypher queries against a Neo4j database.
+The `db_neo4j` node accepts natural-language questions, uses a connected LLM to
+generate read-only Cypher queries, executes them against a Neo4j database, and
+returns results to the pipeline. Write operations (CREATE, MERGE, SET, DELETE,
+etc.) are blocked by design.
+
+## Requirements
+
+A connected LLM node is required — the db_neo4j node uses it to translate
+questions into Cypher. Connect an LLM via the node's **LLM** invoke port.
 
 ## Configuration
 
 ```json
 {
-  "id": "query_node",
-  "type": "db_neo4j",
-  "label": "Query Neo4j",
-  "config": {
-    "uri_env": "NEO4J_URI",
-    "user_env": "NEO4J_USER",
-    "password_env": "NEO4J_PASSWORD",
-    "query": "MATCH (c:Company {name: $name}) RETURN c.industry, c.overall_severity"
-  }
+	"id": "query_node",
+	"type": "db_neo4j",
+	"label": "Query Neo4j",
+	"config": {
+		"neo4jdb.uri": "neo4j+s://your-instance.databases.neo4j.io",
+		"neo4jdb.auth_method": "userpass",
+		"neo4jdb.user": "your_username",
+		"neo4jdb.password": "your_password",
+		"neo4jdb.database": "neo4j",
+		"neo4jdb.db_description": "Portfolio company graph with risk signals and founder relationships"
+	}
 }
 ```
 
-Environment variables:
+### Configuration fields
 
-```
-NEO4J_URI=neo4j+s://your-instance.databases.neo4j.io
-NEO4J_USER=your_username
-NEO4J_PASSWORD=your_password
-```
+| Field                    | Default                  | Description                                                                            |
+| ------------------------ | ------------------------ | -------------------------------------------------------------------------------------- |
+| `neo4jdb.uri`            | `neo4j://localhost:7687` | Bolt URI. Use `neo4j+s://` for TLS (e.g. Aura).                                        |
+| `neo4jdb.auth_method`    | `userpass`               | `userpass` or `token` (bearer).                                                        |
+| `neo4jdb.user`           | `neo4j`                  | Username (userpass only).                                                              |
+| `neo4jdb.password`       | —                        | Password (userpass only).                                                              |
+| `neo4jdb.token`          | —                        | Bearer token (token auth only).                                                        |
+| `neo4jdb.database`       | `neo4j`                  | Target database name.                                                                  |
+| `neo4jdb.db_description` | —                        | Plain-English description of the graph — helps the LLM generate accurate Cypher.       |
+| `neo4jdb.max_attempts`   | `5`                      | How many times to retry if the LLM generates invalid Cypher (validated via `EXPLAIN`). |
 
-## Patterns
+## How it works
 
-### Read: fetch related nodes
+1. Receives a natural-language question on the **questions** lane.
+2. Reflects the live graph schema (labels, properties, relationship types).
+3. Sends the question + schema to the connected LLM, which returns a Cypher
+   `MATCH`/`RETURN` query.
+4. Validates the query with `EXPLAIN` and retries up to `max_attempts` times if
+   Neo4j rejects it.
+5. Executes the query and emits results on the **table**, **text**, and
+   **answers** output lanes.
+
+Only read-only Cypher is permitted (`MATCH`, `OPTIONAL MATCH`, `WITH`, `WHERE`,
+`RETURN`, `ORDER BY`, `SKIP`, `LIMIT`). Write clauses are rejected before
+execution.
+
+## Example queries (natural language → Cypher)
+
+The LLM generates these — you send the natural-language form as input.
+
+### Fetch related nodes
 
 ```cypher
 MATCH (c:Company)-[:FOUNDED_BY]->(f:Founder)
 RETURN f.name, f.email, c.name AS company
 ORDER BY c.overall_severity ASC
-```
-
-### Write: update after analysis
-
-```cypher
-MERGE (c:Company {name: $company_name})
-ON CREATE SET c.industry = $industry, c.created_at = datetime()
-SET c.overall_severity = $severity, c.analyzed_at = datetime()
-RETURN c.name
+LIMIT 250
 ```
 
 ### Graph algorithm (Cypher-based Louvain fallback)
@@ -52,31 +76,16 @@ MATCH (c:Company)-[r:PATTERN_MATCH]->(other:Company)
 WITH c, r.shared_signal AS signal, count(r) AS cnt
 ORDER BY cnt DESC
 WITH c, collect(signal)[0] AS dominant
-SET c.communityId = CASE dominant
-  WHEN 'MARGIN_COMPRESSION' THEN 0
-  WHEN 'CONCENTRATION_RISK' THEN 1
-  ELSE 99
-END
-RETURN count(c) AS updated
+RETURN c.name, dominant
+LIMIT 250
 ```
-
-## Two db_neo4j Nodes in One Pipeline
-
-Neo4j appears twice in the Portfolio Brain cascade pipeline — once to read patterns,
-once to write results. This is a common pattern:
-
-```
-[Input] → [db_neo4j: Read] → [llm_openai: Analyze] → [db_neo4j: Write] → [Output]
-```
-
-The write node receives the LLM output and persists results back to the graph.
 
 ## Neo4j Aura
 
-For cloud Neo4j (Aura), use the `neo4j+s://` URI scheme:
+For cloud Neo4j (Aura), use the `neo4j+s://` URI scheme in `neo4jdb.uri`:
 
-```
-NEO4J_URI=neo4j+s://xxxxxxxx.databases.neo4j.io
+```text
+neo4j+s://xxxxxxxx.databases.neo4j.io
 ```
 
 Note: GDS algorithms require AuraDS or self-managed Neo4j with the GDS plugin.


### PR DESCRIPTION
Adds `docs/nodes/db-neo4j-usage.md` with usage patterns discovered while building Portfolio Brain at HackwithBay 2.0.

Covers:
- Configuration reference (uri_env, user_env, password_env)
- Read, write, and graph algorithm Cypher patterns
- The 'read-then-write' two-node pipeline pattern (common pattern not documented)
- Neo4j Aura connection notes (neo4j+s:// scheme, GDS availability)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive usage guide for the Neo4j node: flow, required configuration fields, and example JSON.
  * Describes how to ask natural-language questions, how the node reflects the live graph schema, and that generated Cypher is read-only and validated before execution.
  * Details output lanes (table, text, answers), Neo4j Aura TLS usage, and free-tier limitations (no gds.* procedures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->