### PR TITLE
fix: align client-python requires-python with monorepo py310 target

### DIFF
--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -20,11 +20,10 @@ classifiers = [
     "Topic :: System :: Networking",
     "Topic :: Internet :: WWW/HTTP",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "Typing :: Typed",
 ]
@@ -43,7 +42,7 @@ dependencies = [
     "aiofiles>=23.0.0",
     "pydantic>=2.0.0",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 license = "MIT"
 
 [project.optional-dependencies]


### PR DESCRIPTION
Fixes #434

The monorepo's root `pyproject.toml` sets `target-version = 'py310'` for ruff, indicating the project targets Python 3.10+. The client SDK's `requires-python = '>=3.8'` was inconsistent with this.

**Changes:**
- `requires-python`: `>=3.8` → `>=3.10`
- Classifiers: remove Python 3.8/3.9 entries, add Python 3.13

This ensures pip won't install the SDK into Python 3.8/3.9 environments where node code using 3.10+ features (structural pattern matching, etc.) could fail at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum Python version requirement to 3.10 (from 3.8). Dropped support for Python 3.8 and 3.9. Added support for Python 3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->