### PR TITLE
docs: add .env.example to Python client package

### DIFF
--- a/packages/client-python/.env.example
+++ b/packages/client-python/.env.example
@@ -1,0 +1,46 @@
+# RocketRide Python Client — Environment Variables
+#
+# Copy this file to .env and fill in the values for your setup.
+# The SDK auto-loads .env from the working directory if python-dotenv is installed.
+#
+# Usage: cp .env.example .env
+
+# ─── Engine Connection ───────────────────────────────────────────────────────
+
+# URI of the RocketRide engine (WebSocket server)
+# Default: http://localhost:5565 (VS Code extension auto-starts on this port)
+# Docker: docker run -p 5565:5565 ghcr.io/rocketride-org/rocketride-engine:latest
+ROCKETRIDE_URI=http://localhost:5565
+
+# API key for authenticated cloud or on-prem deployments
+# Leave empty for local development (no auth required by default)
+ROCKETRIDE_APIKEY=
+
+# ─── LLM Provider Keys (used by pipeline nodes) ──────────────────────────────
+
+# OpenAI
+ROCKETRIDE_APIKEY_OPENAI=
+
+# Anthropic
+ROCKETRIDE_APIKEY_ANTHROPIC=
+
+# Google Gemini
+ROCKETRIDE_APIKEY_GEMINI=
+
+# Ollama (local — set to host:port, not an API key)
+ROCKETRIDE_HOST_OLLAMA=http://localhost:11434
+
+# ─── GMI Cloud (OpenAI-compatible, 40+ models) ───────────────────────────────
+# Sign up at https://console.gmicloud.ai
+# Works with any llm_openai node via base_url_env + api_key_env config
+
+GMI_API_KEY=
+GMI_BASE=https://api.gmi-serving.com/v1/chat/completions
+
+# ─── Neo4j (db_neo4j node) ───────────────────────────────────────────────────
+# Cloud: neo4j+s://your-instance.databases.neo4j.io
+# Local: bolt://localhost:7687
+
+NEO4J_URI=
+NEO4J_USER=neo4j
+NEO4J_PASSWORD=


### PR DESCRIPTION
Adds `packages/client-python/.env.example` with all environment variables used by the SDK and common pipeline nodes.

Covers:
- Engine connection (`ROCKETRIDE_URI`, `ROCKETRIDE_APIKEY`)
- LLM provider keys (OpenAI, Anthropic, Gemini, Ollama)
- GMI Cloud env vars (`GMI_API_KEY`, `GMI_BASE`) for `llm_openai` node
- Neo4j env vars (`NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD`) for `db_neo4j` node

New contributors and hackathon participants currently have to read through multiple docs files to find what env vars they need. A single .env.example makes onboarding significantly faster.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `.env.example` configuration file for the Python client, providing example environment variable templates for setup and configuration.

* **Chores**
  * Included example credentials and connection settings for external services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->