### PR TITLE
feat(engine): add OpenTelemetry tracing and Prometheus metrics

### DIFF
--- a/packages/ai/src/ai/web/endpoints/metrics_endpoint.py
+++ b/packages/ai/src/ai/web/endpoints/metrics_endpoint.py
@@ -25,8 +25,8 @@
 
 Exposes collected metrics in the Prometheus text exposition format.
 Whether the endpoint requires authentication is controlled by the
-``ROCKETRIDE_METRICS_PUBLIC`` environment variable (default: ``true``
-so Prometheus can scrape without credentials).
+``ROCKETRIDE_METRICS_PUBLIC`` environment variable (default: ``false``
+so the endpoint requires authentication by default).
 
 Integration point — register this with ``WebServer.add_route``::
 
@@ -47,21 +47,17 @@ __all__ = ['metrics_endpoint', 'is_metrics_public']
 def is_metrics_public() -> bool:
     """Return ``True`` when the /metrics endpoint should be publicly accessible.
 
-    Controlled by ``ROCKETRIDE_METRICS_PUBLIC`` (default ``true``).
-    Set to ``false`` to require authentication for scraping.
+    Controlled by ``ROCKETRIDE_METRICS_PUBLIC`` (default ``false``).
+    Set to ``true`` to allow unauthenticated scraping.
 
     Security note: when set to ``true``, the /metrics endpoint is
     unauthenticated.  In production deployments this endpoint should sit
     behind a reverse proxy (e.g. nginx, Envoy) that enforces rate
     limiting and IP allowlisting so that only the Prometheus scraper can
-    reach it.  Setting the variable to ``false`` requires the standard
-    RocketRide auth token on every scrape request.
+    reach it.  The default (``false``) requires the standard RocketRide
+    auth token on every scrape request.
     """
-    # ROCKETRIDE_METRICS_PUBLIC controls whether the /metrics endpoint is
-    # exposed without authentication.  The default (true) is convenient for
-    # development but in production you should either set this to false or
-    # put the endpoint behind a rate-limiting reverse proxy.
-    return os.environ.get('ROCKETRIDE_METRICS_PUBLIC', 'true').lower() in ('true', '1', 'yes')
+    return os.environ.get('ROCKETRIDE_METRICS_PUBLIC', 'false').lower() in ('true', '1', 'yes')
 
 
 async def metrics_endpoint() -> Response:

--- a/packages/ai/src/ai/web/endpoints/metrics_endpoint.py
+++ b/packages/ai/src/ai/web/endpoints/metrics_endpoint.py
@@ -49,12 +49,29 @@ def is_metrics_public() -> bool:
 
     Controlled by ``ROCKETRIDE_METRICS_PUBLIC`` (default ``true``).
     Set to ``false`` to require authentication for scraping.
+
+    Security note: when set to ``true``, the /metrics endpoint is
+    unauthenticated.  In production deployments this endpoint should sit
+    behind a reverse proxy (e.g. nginx, Envoy) that enforces rate
+    limiting and IP allowlisting so that only the Prometheus scraper can
+    reach it.  Setting the variable to ``false`` requires the standard
+    RocketRide auth token on every scrape request.
     """
+    # ROCKETRIDE_METRICS_PUBLIC controls whether the /metrics endpoint is
+    # exposed without authentication.  The default (true) is convenient for
+    # development but in production you should either set this to false or
+    # put the endpoint behind a rate-limiting reverse proxy.
     return os.environ.get('ROCKETRIDE_METRICS_PUBLIC', 'true').lower() in ('true', '1', 'yes')
 
 
 async def metrics_endpoint() -> Response:
     """Return current Prometheus metrics in text exposition format.
+
+    .. warning::
+
+        In production, this endpoint should be protected by rate limiting
+        at the reverse-proxy layer (or by setting ``ROCKETRIDE_METRICS_PUBLIC=false``
+        and requiring authentication) to prevent abuse.
 
     Returns:
         Response: Prometheus-formatted metrics payload.

--- a/packages/ai/src/ai/web/endpoints/metrics_endpoint.py
+++ b/packages/ai/src/ai/web/endpoints/metrics_endpoint.py
@@ -1,0 +1,68 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Prometheus /metrics endpoint for RocketRide Server.
+
+Exposes collected metrics in the Prometheus text exposition format.
+Whether the endpoint requires authentication is controlled by the
+``ROCKETRIDE_METRICS_PUBLIC`` environment variable (default: ``true``
+so Prometheus can scrape without credentials).
+
+Integration point — register this with ``WebServer.add_route``::
+
+    from ai.web.endpoints.metrics_endpoint import metrics_endpoint
+
+    server.add_route('/metrics', metrics_endpoint, ['GET'], public=is_public)
+"""
+
+import os
+
+from fastapi.responses import Response
+
+from ai.web.metrics.prometheus_metrics import generate_metrics, get_metrics_content_type
+
+__all__ = ['metrics_endpoint', 'is_metrics_public']
+
+
+def is_metrics_public() -> bool:
+    """Return ``True`` when the /metrics endpoint should be publicly accessible.
+
+    Controlled by ``ROCKETRIDE_METRICS_PUBLIC`` (default ``true``).
+    Set to ``false`` to require authentication for scraping.
+    """
+    return os.environ.get('ROCKETRIDE_METRICS_PUBLIC', 'true').lower() in ('true', '1', 'yes')
+
+
+async def metrics_endpoint() -> Response:
+    """Return current Prometheus metrics in text exposition format.
+
+    Returns:
+        Response: Prometheus-formatted metrics payload.
+
+    Responses:
+        200: Metrics returned successfully.
+    """
+    return Response(
+        content=generate_metrics(),
+        media_type=get_metrics_content_type(),
+    )

--- a/packages/ai/src/ai/web/metrics/middleware.py
+++ b/packages/ai/src/ai/web/metrics/middleware.py
@@ -26,7 +26,8 @@
 Automatically records Prometheus counters/histograms and OpenTelemetry
 span attributes for every inbound HTTP request.
 
-Usage — add *after* the auth middleware so the route path is resolved::
+Usage — add *before* the auth middleware (Starlette middleware is LIFO,
+so this will execute after auth has resolved the route path)::
 
     from ai.web.metrics.middleware import MetricsMiddleware
 
@@ -47,8 +48,8 @@ __all__ = ['MetricsMiddleware']
 
 # Patterns used to normalise dynamic path segments when route matching
 # is unavailable (e.g. catch-all or mounted sub-apps).
-_UUID_RE = re.compile(r'/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', re.IGNORECASE)
-_NUMERIC_RE = re.compile(r'/\d+')
+_UUID_RE = re.compile(r'/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}(?=/|$)', re.IGNORECASE)
+_NUMERIC_RE = re.compile(r'/\d+(?=/|$)')
 
 
 def _normalise_path(request: Request) -> str:

--- a/packages/ai/src/ai/web/metrics/middleware.py
+++ b/packages/ai/src/ai/web/metrics/middleware.py
@@ -33,15 +33,44 @@ Usage — add *after* the auth middleware so the route path is resolved::
     app.add_middleware(MetricsMiddleware)
 """
 
+import re
 import time
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
+from starlette.routing import Match
 
 from .prometheus_metrics import HTTP_REQUESTS, HTTP_REQUEST_DURATION
 from .tracing import get_tracer
 
 __all__ = ['MetricsMiddleware']
+
+# Patterns used to normalise dynamic path segments when route matching
+# is unavailable (e.g. catch-all or mounted sub-apps).
+_UUID_RE = re.compile(r'/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', re.IGNORECASE)
+_NUMERIC_RE = re.compile(r'/\d+')
+
+
+def _normalise_path(request: Request) -> str:
+    """Return the route template for *request*, falling back to regex normalisation.
+
+    Tries FastAPI/Starlette route matching first so that paths like
+    ``/pipeline/3fa85f64-…`` become ``/pipeline/{id}`` rather than a
+    unique label per request (which would cause a Prometheus cardinality
+    explosion).
+    """
+    raw_path = request.url.path
+    scope = {'type': 'http', 'method': request.method, 'path': raw_path}
+
+    for route in getattr(request.app, 'routes', []):
+        match, _ = route.matches(scope)
+        if match == Match.FULL:
+            return getattr(route, 'path', raw_path)
+
+    # Fallback: replace UUIDs and bare numeric segments with placeholders.
+    path = _UUID_RE.sub('/{id}', raw_path)
+    path = _NUMERIC_RE.sub('/{id}', path)
+    return path
 
 
 class MetricsMiddleware(BaseHTTPMiddleware):
@@ -49,7 +78,7 @@ class MetricsMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         method = request.method
-        path = request.url.path
+        path = _normalise_path(request)
         tracer = get_tracer('rocketride.http')
 
         start = time.perf_counter()

--- a/packages/ai/src/ai/web/metrics/middleware.py
+++ b/packages/ai/src/ai/web/metrics/middleware.py
@@ -1,0 +1,77 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""HTTP metrics middleware for RocketRide Server.
+
+Automatically records Prometheus counters/histograms and OpenTelemetry
+span attributes for every inbound HTTP request.
+
+Usage — add *after* the auth middleware so the route path is resolved::
+
+    from ai.web.metrics.middleware import MetricsMiddleware
+
+    app.add_middleware(MetricsMiddleware)
+"""
+
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+
+from .prometheus_metrics import HTTP_REQUESTS, HTTP_REQUEST_DURATION
+from .tracing import get_tracer
+
+__all__ = ['MetricsMiddleware']
+
+
+class MetricsMiddleware(BaseHTTPMiddleware):
+    """Record HTTP request count, duration, and status via Prometheus and OpenTelemetry."""
+
+    async def dispatch(self, request: Request, call_next):
+        method = request.method
+        path = request.url.path
+        tracer = get_tracer('rocketride.http')
+
+        start = time.perf_counter()
+        status_code = 500  # default in case of unhandled exception
+
+        with tracer.start_as_current_span(
+            f'{method} {path}',
+            attributes={
+                'http.method': method,
+                'http.url': str(request.url),
+                'http.route': path,
+            },
+        ) as span:
+            try:
+                response = await call_next(request)
+                status_code = response.status_code
+                return response
+            except Exception:
+                status_code = 500
+                raise
+            finally:
+                duration = time.perf_counter() - start
+                HTTP_REQUESTS.labels(method=method, endpoint=path, status_code=str(status_code)).inc()
+                HTTP_REQUEST_DURATION.labels(method=method, endpoint=path).observe(duration)
+                span.set_attribute('http.status_code', status_code)

--- a/packages/ai/src/ai/web/metrics/middleware.py
+++ b/packages/ai/src/ai/web/metrics/middleware.py
@@ -54,20 +54,28 @@ _NUMERIC_RE = re.compile(r'/\d+')
 def _normalise_path(request: Request) -> str:
     """Return the route template for *request*, falling back to regex normalisation.
 
-    Tries FastAPI/Starlette route matching first so that paths like
+    Prefers the resolved ``route`` object that Starlette/FastAPI places in
+    ``request.scope`` after routing completes.  Falls back to manual route
+    matching and finally regex normalisation so that paths like
     ``/pipeline/3fa85f64-…`` become ``/pipeline/{id}`` rather than a
     unique label per request (which would cause a Prometheus cardinality
     explosion).
     """
     raw_path = request.url.path
+
+    # Prefer the route already resolved by Starlette/FastAPI routing.
+    route = request.scope.get('route')
+    if route is not None and hasattr(route, 'path'):
+        return route.path
+
+    # Fallback: iterate app routes manually.
     scope = {'type': 'http', 'method': request.method, 'path': raw_path}
-
-    for route in getattr(request.app, 'routes', []):
-        match, _ = route.matches(scope)
+    for app_route in getattr(request.app, 'routes', []):
+        match, _ = app_route.matches(scope)
         if match == Match.FULL:
-            return getattr(route, 'path', raw_path)
+            return getattr(app_route, 'path', raw_path)
 
-    # Fallback: replace UUIDs and bare numeric segments with placeholders.
+    # Last resort: replace UUIDs and bare numeric segments with placeholders.
     path = _UUID_RE.sub('/{id}', raw_path)
     path = _NUMERIC_RE.sub('/{id}', path)
     return path

--- a/packages/ai/src/ai/web/metrics/prometheus_metrics.py
+++ b/packages/ai/src/ai/web/metrics/prometheus_metrics.py
@@ -28,7 +28,8 @@ engine — pipeline execution, LLM usage, vector-DB operations, and HTTP
 request instrumentation.
 """
 
-from prometheus_client import Counter, Gauge, Histogram, CollectorRegistry, generate_latest, CONTENT_TYPE_LATEST, make_asgi_app
+import prometheus_client
+from prometheus_client import Counter, Gauge, Histogram, generate_latest, CONTENT_TYPE_LATEST, make_asgi_app
 
 __all__ = [
     'PIPELINE_EXECUTIONS',
@@ -47,9 +48,10 @@ __all__ = [
 
 # ---------------------------------------------------------------------------
 # Registry — use the default global registry so instrumentation libraries
-# (e.g. opentelemetry-exporter-prometheus) can merge seamlessly.
+# (e.g. opentelemetry-exporter-prometheus) merge seamlessly and the
+# built-in process/platform collectors are included automatically.
 # ---------------------------------------------------------------------------
-REGISTRY = CollectorRegistry()
+REGISTRY = prometheus_client.REGISTRY
 
 # ---------------------------------------------------------------------------
 # Pipeline metrics
@@ -58,14 +60,12 @@ PIPELINE_EXECUTIONS = Counter(
     'rocketride_pipeline_executions_total',
     'Total number of pipeline executions',
     ['pipeline_name', 'status'],
-    registry=REGISTRY,
 )
 
 PIPELINE_DURATION = Histogram(
     'rocketride_pipeline_duration_seconds',
     'Duration of pipeline executions in seconds',
     ['pipeline_name'],
-    registry=REGISTRY,
 )
 
 # ---------------------------------------------------------------------------
@@ -75,21 +75,21 @@ LLM_REQUESTS = Counter(
     'rocketride_llm_requests_total',
     'Total number of LLM requests',
     ['provider', 'model', 'status'],
-    registry=REGISTRY,
 )
 
 LLM_TOKENS = Counter(
     'rocketride_llm_tokens_total',
     'Total number of LLM tokens consumed',
     ['provider', 'model', 'token_type'],
-    registry=REGISTRY,
 )
 
+# Custom buckets tuned for LLM calls which can take anywhere from 100ms
+# (cache hit / small model) to 120s (complex multi-turn reasoning).
 LLM_REQUEST_DURATION = Histogram(
     'rocketride_llm_request_duration_seconds',
-    'Duration of LLM requests in seconds',
+    'Duration of LLM API requests',
     ['provider', 'model'],
-    registry=REGISTRY,
+    buckets=[0.1, 0.5, 1.0, 2.0, 5.0, 10.0, 30.0, 60.0, 120.0],
 )
 
 # ---------------------------------------------------------------------------
@@ -99,7 +99,6 @@ VECTORDB_OPERATIONS = Counter(
     'rocketride_vectordb_operations_total',
     'Total number of vector DB operations',
     ['provider', 'operation'],
-    registry=REGISTRY,
 )
 
 # ---------------------------------------------------------------------------
@@ -108,7 +107,6 @@ VECTORDB_OPERATIONS = Counter(
 ACTIVE_TASKS = Gauge(
     'rocketride_active_tasks',
     'Number of currently running tasks',
-    registry=REGISTRY,
 )
 
 # ---------------------------------------------------------------------------
@@ -118,14 +116,12 @@ HTTP_REQUESTS = Counter(
     'rocketride_http_requests_total',
     'Total number of HTTP requests',
     ['method', 'endpoint', 'status_code'],
-    registry=REGISTRY,
 )
 
 HTTP_REQUEST_DURATION = Histogram(
     'rocketride_http_request_duration_seconds',
     'Duration of HTTP requests in seconds',
     ['method', 'endpoint'],
-    registry=REGISTRY,
 )
 
 

--- a/packages/ai/src/ai/web/metrics/prometheus_metrics.py
+++ b/packages/ai/src/ai/web/metrics/prometheus_metrics.py
@@ -1,0 +1,154 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Prometheus metrics definitions for RocketRide Server.
+
+Defines all Prometheus counters, histograms, and gauges used across the
+engine — pipeline execution, LLM usage, vector-DB operations, and HTTP
+request instrumentation.
+"""
+
+from prometheus_client import Counter, Gauge, Histogram, CollectorRegistry, generate_latest, CONTENT_TYPE_LATEST, make_asgi_app
+
+__all__ = [
+    'PIPELINE_EXECUTIONS',
+    'PIPELINE_DURATION',
+    'LLM_REQUESTS',
+    'LLM_TOKENS',
+    'LLM_REQUEST_DURATION',
+    'VECTORDB_OPERATIONS',
+    'ACTIVE_TASKS',
+    'HTTP_REQUESTS',
+    'HTTP_REQUEST_DURATION',
+    'REGISTRY',
+    'get_metrics_app',
+    'generate_metrics',
+]
+
+# ---------------------------------------------------------------------------
+# Registry — use the default global registry so instrumentation libraries
+# (e.g. opentelemetry-exporter-prometheus) can merge seamlessly.
+# ---------------------------------------------------------------------------
+REGISTRY = CollectorRegistry()
+
+# ---------------------------------------------------------------------------
+# Pipeline metrics
+# ---------------------------------------------------------------------------
+PIPELINE_EXECUTIONS = Counter(
+    'rocketride_pipeline_executions_total',
+    'Total number of pipeline executions',
+    ['pipeline_name', 'status'],
+    registry=REGISTRY,
+)
+
+PIPELINE_DURATION = Histogram(
+    'rocketride_pipeline_duration_seconds',
+    'Duration of pipeline executions in seconds',
+    ['pipeline_name'],
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# LLM metrics
+# ---------------------------------------------------------------------------
+LLM_REQUESTS = Counter(
+    'rocketride_llm_requests_total',
+    'Total number of LLM requests',
+    ['provider', 'model', 'status'],
+    registry=REGISTRY,
+)
+
+LLM_TOKENS = Counter(
+    'rocketride_llm_tokens_total',
+    'Total number of LLM tokens consumed',
+    ['provider', 'model', 'token_type'],
+    registry=REGISTRY,
+)
+
+LLM_REQUEST_DURATION = Histogram(
+    'rocketride_llm_request_duration_seconds',
+    'Duration of LLM requests in seconds',
+    ['provider', 'model'],
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# Vector DB metrics
+# ---------------------------------------------------------------------------
+VECTORDB_OPERATIONS = Counter(
+    'rocketride_vectordb_operations_total',
+    'Total number of vector DB operations',
+    ['provider', 'operation'],
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# Task metrics
+# ---------------------------------------------------------------------------
+ACTIVE_TASKS = Gauge(
+    'rocketride_active_tasks',
+    'Number of currently running tasks',
+    registry=REGISTRY,
+)
+
+# ---------------------------------------------------------------------------
+# HTTP metrics
+# ---------------------------------------------------------------------------
+HTTP_REQUESTS = Counter(
+    'rocketride_http_requests_total',
+    'Total number of HTTP requests',
+    ['method', 'endpoint', 'status_code'],
+    registry=REGISTRY,
+)
+
+HTTP_REQUEST_DURATION = Histogram(
+    'rocketride_http_request_duration_seconds',
+    'Duration of HTTP requests in seconds',
+    ['method', 'endpoint'],
+    registry=REGISTRY,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def generate_metrics() -> bytes:
+    """Return the current metrics in Prometheus text exposition format."""
+    return generate_latest(REGISTRY)
+
+
+def get_metrics_content_type() -> str:
+    """Return the MIME type for Prometheus text exposition format."""
+    return CONTENT_TYPE_LATEST
+
+
+def get_metrics_app():
+    """Return an ASGI app that serves the /metrics endpoint.
+
+    Suitable for mounting into a FastAPI / Starlette application:
+
+        app.mount('/metrics', get_metrics_app())
+    """
+    return make_asgi_app(registry=REGISTRY)

--- a/packages/ai/src/ai/web/metrics/requirements.txt
+++ b/packages/ai/src/ai/web/metrics/requirements.txt
@@ -1,5 +1,5 @@
-prometheus_client>=0.20.0
-opentelemetry-api>=1.24.0
-opentelemetry-sdk>=1.24.0
-opentelemetry-instrumentation-fastapi>=0.45b0
-opentelemetry-exporter-otlp>=1.24.0
+prometheus_client>=0.20.0,<1.0.0
+opentelemetry-api>=1.24.0,<2.0.0
+opentelemetry-sdk>=1.24.0,<2.0.0
+opentelemetry-instrumentation-fastapi>=0.45b0,<1.0.0
+opentelemetry-exporter-otlp>=1.24.0,<2.0.0

--- a/packages/ai/src/ai/web/metrics/requirements.txt
+++ b/packages/ai/src/ai/web/metrics/requirements.txt
@@ -1,0 +1,5 @@
+prometheus_client>=0.20.0
+opentelemetry-api>=1.24.0
+opentelemetry-sdk>=1.24.0
+opentelemetry-instrumentation-fastapi>=0.45b0
+opentelemetry-exporter-otlp>=1.24.0

--- a/packages/ai/src/ai/web/metrics/tracing.py
+++ b/packages/ai/src/ai/web/metrics/tracing.py
@@ -34,6 +34,7 @@ everything up, including automatic FastAPI instrumentation.
 """
 
 import os
+import threading
 from typing import Optional
 
 from opentelemetry import trace
@@ -49,10 +50,14 @@ __all__ = [
 
 # Module-level tracer provider reference so we can shut it down cleanly.
 _tracer_provider: Optional[TracerProvider] = None
+_setup_lock = threading.Lock()
 
 
 def setup_tracing(app=None) -> TracerProvider:
     """Initialise the OpenTelemetry TracerProvider and optionally instrument a FastAPI app.
+
+    Thread-safe: concurrent callers will block until the first caller
+    finishes initialisation, then return the already-configured provider.
 
     Args:
         app: A FastAPI application instance.  When provided the
@@ -64,25 +69,29 @@ def setup_tracing(app=None) -> TracerProvider:
     """
     global _tracer_provider
 
-    service_name = os.environ.get('OTEL_SERVICE_NAME', 'rocketride')
-    exporter_type = os.environ.get('OTEL_EXPORTER_TYPE', 'none').lower()
+    with _setup_lock:
+        if _tracer_provider is not None:
+            return _tracer_provider
 
-    resource = Resource.create({'service.name': service_name})
-    provider = TracerProvider(resource=resource)
+        service_name = os.environ.get('OTEL_SERVICE_NAME', 'rocketride')
+        exporter_type = os.environ.get('OTEL_EXPORTER_TYPE', 'none').lower()
 
-    # Attach an exporter based on configuration.
-    if exporter_type == 'otlp':
-        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+        resource = Resource.create({'service.name': service_name})
+        provider = TracerProvider(resource=resource)
 
-        endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4317')
-        exporter = OTLPSpanExporter(endpoint=endpoint)
-        provider.add_span_processor(BatchSpanProcessor(exporter))
-    elif exporter_type == 'console':
-        provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-    # else: 'none' — no exporter, tracing is effectively a no-op.
+        # Attach an exporter based on configuration.
+        if exporter_type == 'otlp':
+            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
-    trace.set_tracer_provider(provider)
-    _tracer_provider = provider
+            endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4317')
+            exporter = OTLPSpanExporter(endpoint=endpoint)
+            provider.add_span_processor(BatchSpanProcessor(exporter))
+        elif exporter_type == 'console':
+            provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+        # else: 'none' — no exporter, tracing is effectively a no-op.
+
+        trace.set_tracer_provider(provider)
+        _tracer_provider = provider
 
     # Auto-instrument FastAPI if an app is provided.
     if app is not None:

--- a/packages/ai/src/ai/web/metrics/tracing.py
+++ b/packages/ai/src/ai/web/metrics/tracing.py
@@ -58,6 +58,9 @@ def setup_tracing(app=None) -> TracerProvider:
 
     Thread-safe: concurrent callers will block until the first caller
     finishes initialisation, then return the already-configured provider.
+    Subsequent calls with an ``app`` argument will still instrument the
+    app even when the provider was already created (so callers that
+    first init without an app can later pass one).
 
     Args:
         app: A FastAPI application instance.  When provided the
@@ -70,34 +73,37 @@ def setup_tracing(app=None) -> TracerProvider:
     global _tracer_provider
 
     with _setup_lock:
-        if _tracer_provider is not None:
-            return _tracer_provider
+        if _tracer_provider is None:
+            service_name = os.environ.get('OTEL_SERVICE_NAME', 'rocketride')
+            exporter_type = os.environ.get('OTEL_EXPORTER_TYPE', 'none').lower()
 
-        service_name = os.environ.get('OTEL_SERVICE_NAME', 'rocketride')
-        exporter_type = os.environ.get('OTEL_EXPORTER_TYPE', 'none').lower()
+            resource = Resource.create({'service.name': service_name})
+            provider = TracerProvider(resource=resource)
 
-        resource = Resource.create({'service.name': service_name})
-        provider = TracerProvider(resource=resource)
+            # Attach an exporter based on configuration.
+            if exporter_type == 'otlp':
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
 
-        # Attach an exporter based on configuration.
-        if exporter_type == 'otlp':
-            from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+                endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4317')
+                exporter = OTLPSpanExporter(endpoint=endpoint)
+                provider.add_span_processor(BatchSpanProcessor(exporter))
+            elif exporter_type == 'console':
+                provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+            # else: 'none' — no exporter, tracing is effectively a no-op.
 
-            endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4317')
-            exporter = OTLPSpanExporter(endpoint=endpoint)
-            provider.add_span_processor(BatchSpanProcessor(exporter))
-        elif exporter_type == 'console':
-            provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
-        # else: 'none' — no exporter, tracing is effectively a no-op.
+            trace.set_tracer_provider(provider)
+            _tracer_provider = provider
 
-        trace.set_tracer_provider(provider)
-        _tracer_provider = provider
+        provider = _tracer_provider
 
-    # Auto-instrument FastAPI if an app is provided.
+    # Auto-instrument FastAPI if an app is provided (idempotent: skip if
+    # the app was already instrumented to avoid double-wrapping).
     if app is not None:
-        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+        if not getattr(app.state, '_otel_instrumented', False):
+            from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 
-        FastAPIInstrumentor.instrument_app(app)
+            FastAPIInstrumentor.instrument_app(app)
+            app.state._otel_instrumented = True
 
     return provider
 

--- a/packages/ai/src/ai/web/metrics/tracing.py
+++ b/packages/ai/src/ai/web/metrics/tracing.py
@@ -124,8 +124,11 @@ def shutdown_tracing() -> None:
     """Flush pending spans and shut down the tracer provider.
 
     Safe to call even if ``setup_tracing`` was never invoked.
+    Thread-safe: uses the same lock as ``setup_tracing`` to prevent
+    races between concurrent setup and shutdown calls.
     """
     global _tracer_provider
-    if _tracer_provider is not None:
-        _tracer_provider.shutdown()
-        _tracer_provider = None
+    with _setup_lock:
+        if _tracer_provider is not None:
+            _tracer_provider.shutdown()
+            _tracer_provider = None

--- a/packages/ai/src/ai/web/metrics/tracing.py
+++ b/packages/ai/src/ai/web/metrics/tracing.py
@@ -1,0 +1,116 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""OpenTelemetry tracing configuration for RocketRide Server.
+
+Provides a configurable TracerProvider driven by environment variables:
+
+  OTEL_SERVICE_NAME          — service name (default: ``rocketride``)
+  OTEL_EXPORTER_TYPE         — ``otlp``, ``console``, or ``none`` (default: ``none``)
+  OTEL_EXPORTER_OTLP_ENDPOINT — OTLP collector endpoint (default: ``http://localhost:4317``)
+
+Call ``setup_tracing(app)`` once during application startup to wire
+everything up, including automatic FastAPI instrumentation.
+"""
+
+import os
+from typing import Optional
+
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
+from opentelemetry.sdk.resources import Resource
+
+__all__ = [
+    'setup_tracing',
+    'get_tracer',
+    'shutdown_tracing',
+]
+
+# Module-level tracer provider reference so we can shut it down cleanly.
+_tracer_provider: Optional[TracerProvider] = None
+
+
+def setup_tracing(app=None) -> TracerProvider:
+    """Initialise the OpenTelemetry TracerProvider and optionally instrument a FastAPI app.
+
+    Args:
+        app: A FastAPI application instance.  When provided the
+            ``opentelemetry-instrumentation-fastapi`` instrumentor will
+            automatically create spans for every inbound request.
+
+    Returns:
+        The configured ``TracerProvider``.
+    """
+    global _tracer_provider
+
+    service_name = os.environ.get('OTEL_SERVICE_NAME', 'rocketride')
+    exporter_type = os.environ.get('OTEL_EXPORTER_TYPE', 'none').lower()
+
+    resource = Resource.create({'service.name': service_name})
+    provider = TracerProvider(resource=resource)
+
+    # Attach an exporter based on configuration.
+    if exporter_type == 'otlp':
+        from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+        endpoint = os.environ.get('OTEL_EXPORTER_OTLP_ENDPOINT', 'http://localhost:4317')
+        exporter = OTLPSpanExporter(endpoint=endpoint)
+        provider.add_span_processor(BatchSpanProcessor(exporter))
+    elif exporter_type == 'console':
+        provider.add_span_processor(BatchSpanProcessor(ConsoleSpanExporter()))
+    # else: 'none' — no exporter, tracing is effectively a no-op.
+
+    trace.set_tracer_provider(provider)
+    _tracer_provider = provider
+
+    # Auto-instrument FastAPI if an app is provided.
+    if app is not None:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        FastAPIInstrumentor.instrument_app(app)
+
+    return provider
+
+
+def get_tracer(name: str = 'rocketride') -> trace.Tracer:
+    """Return a tracer bound to the global TracerProvider.
+
+    Args:
+        name: Logical name for the tracer (usually the module or subsystem).
+
+    Returns:
+        An OpenTelemetry ``Tracer`` instance.
+    """
+    return trace.get_tracer(name)
+
+
+def shutdown_tracing() -> None:
+    """Flush pending spans and shut down the tracer provider.
+
+    Safe to call even if ``setup_tracing`` was never invoked.
+    """
+    global _tracer_provider
+    if _tracer_provider is not None:
+        _tracer_provider.shutdown()
+        _tracer_provider = None

--- a/packages/ai/src/ai/web/requirements.txt
+++ b/packages/ai/src/ai/web/requirements.txt
@@ -5,9 +5,9 @@ aiofiles
 websockets
 python_dotenv
 prometheus_client>=0.20.0
-opentelemetry-api>=1.24.0
-opentelemetry-sdk>=1.24.0
-opentelemetry-instrumentation-fastapi>=0.45b0
-opentelemetry-exporter-otlp>=1.24.0
+opentelemetry-api>=1.24.0,<2.0.0
+opentelemetry-sdk>=1.24.0,<2.0.0
+opentelemetry-instrumentation-fastapi>=0.45b0,<1.0.0
+opentelemetry-exporter-otlp>=1.24.0,<2.0.0
 
 

--- a/packages/ai/src/ai/web/requirements.txt
+++ b/packages/ai/src/ai/web/requirements.txt
@@ -4,5 +4,10 @@ python-multipart
 aiofiles
 websockets
 python_dotenv
+prometheus_client>=0.20.0
+opentelemetry-api>=1.24.0
+opentelemetry-sdk>=1.24.0
+opentelemetry-instrumentation-fastapi>=0.45b0
+opentelemetry-exporter-otlp>=1.24.0
 
 

--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -19,7 +19,10 @@ from ai.web import exception, error, Result
 from ai.account import Account, AccountInfo, Reporter
 from ai.modules import ALL as ALLOWED_MODULES
 from .middleware import AuthMiddleware
+from .metrics.middleware import MetricsMiddleware
 from .endpoints import use, ping, version, shutdown, status
+from .endpoints.metrics_endpoint import metrics_endpoint, is_metrics_public
+from .metrics.tracing import setup_tracing, shutdown_tracing
 from .denied import (
     CONST_ACCESS_DENIED_HTML,
     CONST_ACCESS_DENIED_TEXT,
@@ -128,8 +131,9 @@ class WebServer:
         self._compiled_public_paths = None
         self._compiled_private_paths = None
 
-        # Add our metrics middleware to the app
+        # Add our auth and metrics middleware to the app
         self.app.add_middleware(AuthMiddleware)
+        self.app.add_middleware(MetricsMiddleware)
 
         # Declare the port
         self._port = None
@@ -179,6 +183,7 @@ class WebServer:
         # These are always there - no way to turn them off
         self.add_route('/status', status, ['GET'])
         self.add_route('/version', version, ['GET'], public=True)
+        self.add_route('/metrics', metrics_endpoint, ['GET'], public=is_metrics_public())
 
         # Configure the Uvicorn server immediately upon initialization
         self.server = self._configure_server()
@@ -319,6 +324,9 @@ class WebServer:
         # Save the event loop in case anyone needs it
         self.eventLoop = asyncio.get_running_loop()
 
+        # Initialise OpenTelemetry tracing and auto-instrument the app
+        setup_tracing(app=self.app)
+
         # If the user has a startup function
         if self._user_startup is not None:
             await self._user_startup()
@@ -329,6 +337,9 @@ class WebServer:
 
         This method is called when the FastAPI application shuts down.
         """
+        # Flush pending spans and shut down the tracer provider
+        shutdown_tracing()
+
         if self._user_shutdown is not None:
             await self._user_shutdown()
 

--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -337,11 +337,12 @@ class WebServer:
 
         This method is called when the FastAPI application shuts down.
         """
-        # Flush pending spans and shut down the tracer provider
-        shutdown_tracing()
-
         if self._user_shutdown is not None:
             await self._user_shutdown()
+
+        # Flush pending spans and shut down the tracer provider after user
+        # callbacks so that any spans emitted during shutdown are exported.
+        shutdown_tracing()
 
     async def _authenticate_credential_inner(self, authorization: str) -> Union[AccountInfo, Tuple[int, str]]:
         """

--- a/test/nodes/test_observability.py
+++ b/test/nodes/test_observability.py
@@ -246,6 +246,14 @@ class TestMetricsEndpoint:
 class TestOpenTelemetryTracing:
     """Validate tracer initialisation and helper functions."""
 
+    @pytest.fixture(autouse=True)
+    def reset_tracing_state(self):
+        """Reset tracing module state before each test to ensure isolation."""
+        tracing._tracer_provider = None
+        yield
+        # Clean up after test
+        tracing.shutdown_tracing()
+
     def test_setup_tracing_none_exporter(self):
         """With OTEL_EXPORTER_TYPE=none, setup should succeed without network calls."""
         with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'none', 'OTEL_SERVICE_NAME': 'rocketride-test'}):
@@ -301,7 +309,30 @@ class TestOpenTelemetryTracing:
             with patch.dict(sys.modules, {'opentelemetry.exporter.otlp.proto.grpc.trace_exporter': mock_otlp_module}):
                 provider = tracing.setup_tracing()
                 assert provider is not None
+
+    def test_shutdown_tracing_is_lock_protected(self):
+        """shutdown_tracing() should acquire _setup_lock to prevent races with setup_tracing()."""
+        import threading
+
+        with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'none'}):
+            tracing.setup_tracing()
+
+        errors = []
+
+        def concurrent_shutdown():
+            try:
                 tracing.shutdown_tracing()
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=concurrent_shutdown) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f'Concurrent shutdown raised: {errors}'
+        assert tracing._tracer_provider is None
 
 
 # =========================================================================

--- a/test/nodes/test_observability.py
+++ b/test/nodes/test_observability.py
@@ -223,7 +223,7 @@ class TestMetricsEndpoint:
 
     def test_is_metrics_public_default(self):
         os.environ.pop('ROCKETRIDE_METRICS_PUBLIC', None)
-        assert metrics_endpoint.is_metrics_public() is True
+        assert metrics_endpoint.is_metrics_public() is False
 
     def test_is_metrics_public_false(self):
         with patch.dict(os.environ, {'ROCKETRIDE_METRICS_PUBLIC': 'false'}):
@@ -280,10 +280,12 @@ class TestOpenTelemetryTracing:
         """When passed a FastAPI app, auto-instrumentation should be applied."""
         with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'none'}):
             mock_app = MagicMock()
-            with patch.object(tracing, 'FastAPIInstrumentor', create=True) as mock_instrumentor_cls:
-                mock_instrumentor_cls.instrument_app = MagicMock()
+            mock_app.state = MagicMock()
+            mock_app.state._otel_instrumented = False
+            with patch('opentelemetry.instrumentation.fastapi.FastAPIInstrumentor.instrument_app') as mock_instrument_app:
                 provider = tracing.setup_tracing(app=mock_app)
                 assert provider is not None
+                mock_instrument_app.assert_called_once_with(mock_app)
                 tracing.shutdown_tracing()
 
     def test_setup_tracing_otlp_exporter(self):
@@ -318,11 +320,13 @@ class TestMetricsMiddleware:
         counter_before = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/test-mw', 'status_code': '200'}) or 0.0
         hist_count_before = REGISTRY.get_sample_value('rocketride_http_request_duration_seconds_count', {'method': 'GET', 'endpoint': '/test-mw'}) or 0.0
 
-        request = MagicMock(spec=['method', 'url', 'headers'])
+        request = MagicMock(spec=['method', 'url', 'headers', 'scope', 'app'])
         request.method = 'GET'
         request.url = MagicMock()
         request.url.path = '/test-mw'
         request.url.__str__ = lambda self: 'http://localhost:5565/test-mw'
+        request.scope = {'type': 'http'}
+        request.app = MagicMock(routes=[])
 
         mock_response = MagicMock()
         mock_response.status_code = 200
@@ -356,11 +360,13 @@ class TestMetricsMiddleware:
 
         counter_before = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'POST', 'endpoint': '/fail-mw', 'status_code': '500'}) or 0.0
 
-        request = MagicMock(spec=['method', 'url', 'headers'])
+        request = MagicMock(spec=['method', 'url', 'headers', 'scope', 'app'])
         request.method = 'POST'
         request.url = MagicMock()
         request.url.path = '/fail-mw'
         request.url.__str__ = lambda self: 'http://localhost:5565/fail-mw'
+        request.scope = {'type': 'http'}
+        request.app = MagicMock(routes=[])
 
         async def call_next(req):
             raise RuntimeError('boom')
@@ -387,11 +393,13 @@ class TestMetricsMiddleware:
 
         counter_before = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/not-found-mw', 'status_code': '404'}) or 0.0
 
-        request = MagicMock(spec=['method', 'url', 'headers'])
+        request = MagicMock(spec=['method', 'url', 'headers', 'scope', 'app'])
         request.method = 'GET'
         request.url = MagicMock()
         request.url.path = '/not-found-mw'
         request.url.__str__ = lambda self: 'http://localhost:5565/not-found-mw'
+        request.scope = {'type': 'http'}
+        request.app = MagicMock(routes=[])
 
         mock_response = MagicMock()
         mock_response.status_code = 404

--- a/test/nodes/test_observability.py
+++ b/test/nodes/test_observability.py
@@ -1,0 +1,414 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Tests for the RocketRide observability stack.
+
+Covers:
+  - Prometheus metric definitions (counters, histograms, gauges)
+  - Histogram observations
+  - /metrics endpoint Prometheus text format
+  - OpenTelemetry tracer initialisation
+  - MetricsMiddleware HTTP instrumentation
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load modules directly by file path to avoid triggering the heavy
+# ai/__init__.py and ai/web/__init__.py import chains which require
+# rocketlib, depends, and other runtime-only dependencies.
+# ---------------------------------------------------------------------------
+_WEB_METRICS_DIR = Path(__file__).resolve().parent.parent.parent / 'packages' / 'ai' / 'src' / 'ai' / 'web' / 'metrics'
+_WEB_ENDPOINTS_DIR = Path(__file__).resolve().parent.parent.parent / 'packages' / 'ai' / 'src' / 'ai' / 'web' / 'endpoints'
+
+
+def _load_module_from_file(name: str, filepath: Path):
+    """Import a Python module directly from its file path."""
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Load the modules under test by file path
+prometheus_metrics = _load_module_from_file('ai.web.metrics.prometheus_metrics', _WEB_METRICS_DIR / 'prometheus_metrics.py')
+tracing = _load_module_from_file('ai.web.metrics.tracing', _WEB_METRICS_DIR / 'tracing.py')
+
+# Middleware imports from prometheus_metrics and tracing — those are already
+# in sys.modules from the loads above, so the relative imports resolve.
+middleware = _load_module_from_file('ai.web.metrics.middleware', _WEB_METRICS_DIR / 'middleware.py')
+
+# The endpoint module imports from ai.web.metrics.prometheus_metrics which
+# is already loaded above.
+metrics_endpoint = _load_module_from_file('ai.web.endpoints.metrics_endpoint', _WEB_ENDPOINTS_DIR / 'metrics_endpoint.py')
+
+
+# =========================================================================
+# Prometheus metrics tests
+# =========================================================================
+
+
+class TestPrometheusMetrics:
+    """Validate that Prometheus metric objects are properly defined and usable."""
+
+    def test_pipeline_executions_counter_increments(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        before = REGISTRY.get_sample_value('rocketride_pipeline_executions_total', {'pipeline_name': 'test_pipe', 'status': 'success'}) or 0.0
+        prometheus_metrics.PIPELINE_EXECUTIONS.labels(pipeline_name='test_pipe', status='success').inc()
+        after = REGISTRY.get_sample_value('rocketride_pipeline_executions_total', {'pipeline_name': 'test_pipe', 'status': 'success'})
+        assert after == before + 1.0
+
+    def test_pipeline_executions_counter_error_label(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        before = REGISTRY.get_sample_value('rocketride_pipeline_executions_total', {'pipeline_name': 'err_pipe', 'status': 'error'}) or 0.0
+        prometheus_metrics.PIPELINE_EXECUTIONS.labels(pipeline_name='err_pipe', status='error').inc(3)
+        after = REGISTRY.get_sample_value('rocketride_pipeline_executions_total', {'pipeline_name': 'err_pipe', 'status': 'error'})
+        assert after == before + 3.0
+
+    def test_llm_requests_counter_increments(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        before = REGISTRY.get_sample_value('rocketride_llm_requests_total', {'provider': 'openai', 'model': 'gpt-4', 'status': 'success'}) or 0.0
+        prometheus_metrics.LLM_REQUESTS.labels(provider='openai', model='gpt-4', status='success').inc()
+        after = REGISTRY.get_sample_value('rocketride_llm_requests_total', {'provider': 'openai', 'model': 'gpt-4', 'status': 'success'})
+        assert after == before + 1.0
+
+    def test_llm_tokens_counter_by_type(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        before_in = REGISTRY.get_sample_value('rocketride_llm_tokens_total', {'provider': 'openai', 'model': 'gpt-4', 'token_type': 'input'}) or 0.0
+        before_out = REGISTRY.get_sample_value('rocketride_llm_tokens_total', {'provider': 'openai', 'model': 'gpt-4', 'token_type': 'output'}) or 0.0
+
+        prometheus_metrics.LLM_TOKENS.labels(provider='openai', model='gpt-4', token_type='input').inc(100)
+        prometheus_metrics.LLM_TOKENS.labels(provider='openai', model='gpt-4', token_type='output').inc(50)
+
+        after_in = REGISTRY.get_sample_value('rocketride_llm_tokens_total', {'provider': 'openai', 'model': 'gpt-4', 'token_type': 'input'})
+        after_out = REGISTRY.get_sample_value('rocketride_llm_tokens_total', {'provider': 'openai', 'model': 'gpt-4', 'token_type': 'output'})
+
+        assert after_in == before_in + 100.0
+        assert after_out == before_out + 50.0
+
+    def test_vectordb_operations_counter(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        before = REGISTRY.get_sample_value('rocketride_vectordb_operations_total', {'provider': 'milvus', 'operation': 'insert'}) or 0.0
+        prometheus_metrics.VECTORDB_OPERATIONS.labels(provider='milvus', operation='insert').inc()
+        after = REGISTRY.get_sample_value('rocketride_vectordb_operations_total', {'provider': 'milvus', 'operation': 'insert'})
+        assert after == before + 1.0
+
+    def test_active_tasks_gauge(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        prometheus_metrics.ACTIVE_TASKS.set(0)
+        prometheus_metrics.ACTIVE_TASKS.inc()
+        prometheus_metrics.ACTIVE_TASKS.inc()
+        val = REGISTRY.get_sample_value('rocketride_active_tasks')
+        assert val == 2.0
+
+        prometheus_metrics.ACTIVE_TASKS.dec()
+        val = REGISTRY.get_sample_value('rocketride_active_tasks')
+        assert val == 1.0
+
+    def test_http_requests_counter(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        before = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/ping', 'status_code': '200'}) or 0.0
+        prometheus_metrics.HTTP_REQUESTS.labels(method='GET', endpoint='/ping', status_code='200').inc()
+        after = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/ping', 'status_code': '200'})
+        assert after == before + 1.0
+
+
+# =========================================================================
+# Histogram observation tests
+# =========================================================================
+
+
+class TestHistogramObservations:
+    """Validate histogram .observe() works and populates bucket/sum/count."""
+
+    def test_pipeline_duration_histogram(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        count_before = REGISTRY.get_sample_value('rocketride_pipeline_duration_seconds_count', {'pipeline_name': 'hist_test'}) or 0.0
+        sum_before = REGISTRY.get_sample_value('rocketride_pipeline_duration_seconds_sum', {'pipeline_name': 'hist_test'}) or 0.0
+
+        prometheus_metrics.PIPELINE_DURATION.labels(pipeline_name='hist_test').observe(1.5)
+        prometheus_metrics.PIPELINE_DURATION.labels(pipeline_name='hist_test').observe(0.5)
+
+        count_after = REGISTRY.get_sample_value('rocketride_pipeline_duration_seconds_count', {'pipeline_name': 'hist_test'})
+        sum_after = REGISTRY.get_sample_value('rocketride_pipeline_duration_seconds_sum', {'pipeline_name': 'hist_test'})
+
+        assert count_after == count_before + 2.0
+        assert sum_after == pytest.approx(sum_before + 2.0, abs=1e-6)
+
+    def test_llm_request_duration_histogram(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        count_before = REGISTRY.get_sample_value('rocketride_llm_request_duration_seconds_count', {'provider': 'anthropic', 'model': 'claude-3'}) or 0.0
+
+        prometheus_metrics.LLM_REQUEST_DURATION.labels(provider='anthropic', model='claude-3').observe(0.42)
+
+        count_after = REGISTRY.get_sample_value('rocketride_llm_request_duration_seconds_count', {'provider': 'anthropic', 'model': 'claude-3'})
+        assert count_after == count_before + 1.0
+
+    def test_http_request_duration_histogram(self):
+        REGISTRY = prometheus_metrics.REGISTRY
+        count_before = REGISTRY.get_sample_value('rocketride_http_request_duration_seconds_count', {'method': 'POST', 'endpoint': '/use'}) or 0.0
+
+        prometheus_metrics.HTTP_REQUEST_DURATION.labels(method='POST', endpoint='/use').observe(0.123)
+
+        count_after = REGISTRY.get_sample_value('rocketride_http_request_duration_seconds_count', {'method': 'POST', 'endpoint': '/use'})
+        assert count_after == count_before + 1.0
+
+
+# =========================================================================
+# /metrics endpoint tests
+# =========================================================================
+
+
+class TestMetricsEndpoint:
+    """Validate the /metrics endpoint returns valid Prometheus text format."""
+
+    def test_generate_metrics_returns_bytes(self):
+        data = prometheus_metrics.generate_metrics()
+        assert isinstance(data, bytes)
+
+    def test_generate_metrics_contains_metric_names(self):
+        # Ensure at least one data point exists
+        prometheus_metrics.PIPELINE_EXECUTIONS.labels(pipeline_name='fmt_test', status='success').inc()
+
+        data = prometheus_metrics.generate_metrics().decode('utf-8')
+        assert 'rocketride_pipeline_executions_total' in data
+        assert 'rocketride_http_requests_total' in data
+        assert 'rocketride_active_tasks' in data
+
+    def test_generate_metrics_valid_prometheus_format(self):
+        """Each non-empty, non-comment line should match 'metric_name{labels} value' or 'metric_name value'."""
+        data = prometheus_metrics.generate_metrics().decode('utf-8')
+        for line in data.strip().split('\n'):
+            line = line.strip()
+            if not line or line.startswith('#'):
+                continue
+            # Basic shape: name{labels} value OR name value
+            parts = line.split(' ')
+            assert len(parts) >= 2, f'Malformed Prometheus line: {line}'
+
+    @pytest.mark.asyncio
+    async def test_metrics_endpoint_response(self):
+        response = await metrics_endpoint.metrics_endpoint()
+        assert response.status_code == 200
+        assert response.media_type == prometheus_metrics.get_metrics_content_type()
+        assert len(response.body) > 0
+
+    def test_is_metrics_public_default(self):
+        os.environ.pop('ROCKETRIDE_METRICS_PUBLIC', None)
+        assert metrics_endpoint.is_metrics_public() is True
+
+    def test_is_metrics_public_false(self):
+        with patch.dict(os.environ, {'ROCKETRIDE_METRICS_PUBLIC': 'false'}):
+            assert metrics_endpoint.is_metrics_public() is False
+
+    def test_get_metrics_content_type(self):
+        ct = prometheus_metrics.get_metrics_content_type()
+        assert 'text/plain' in ct or 'text/openmetrics' in ct
+
+    def test_get_metrics_app_returns_asgi(self):
+        app = prometheus_metrics.get_metrics_app()
+        assert callable(app)
+
+
+# =========================================================================
+# OpenTelemetry tracer tests
+# =========================================================================
+
+
+class TestOpenTelemetryTracing:
+    """Validate tracer initialisation and helper functions."""
+
+    def test_setup_tracing_none_exporter(self):
+        """With OTEL_EXPORTER_TYPE=none, setup should succeed without network calls."""
+        with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'none', 'OTEL_SERVICE_NAME': 'rocketride-test'}):
+            provider = tracing.setup_tracing()
+            assert provider is not None
+            tracing.shutdown_tracing()
+
+    def test_setup_tracing_console_exporter(self):
+        """Console exporter should initialise without errors."""
+        with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'console', 'OTEL_SERVICE_NAME': 'rocketride-test'}):
+            provider = tracing.setup_tracing()
+            assert provider is not None
+            tracing.shutdown_tracing()
+
+    def test_get_tracer_returns_tracer(self):
+        """get_tracer() should return a valid Tracer object."""
+        with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'none'}):
+            tracing.setup_tracing()
+            tracer = tracing.get_tracer('test-module')
+            assert tracer is not None
+            # Should be able to start a span
+            with tracer.start_as_current_span('test-span') as span:
+                assert span is not None
+            tracing.shutdown_tracing()
+
+    def test_shutdown_tracing_idempotent(self):
+        """Calling shutdown_tracing multiple times should not raise."""
+        tracing.shutdown_tracing()
+        tracing.shutdown_tracing()  # second call should be safe
+
+    def test_setup_tracing_with_fastapi_app(self):
+        """When passed a FastAPI app, auto-instrumentation should be applied."""
+        with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'none'}):
+            mock_app = MagicMock()
+            with patch.object(tracing, 'FastAPIInstrumentor', create=True) as mock_instrumentor_cls:
+                mock_instrumentor_cls.instrument_app = MagicMock()
+                provider = tracing.setup_tracing(app=mock_app)
+                assert provider is not None
+                tracing.shutdown_tracing()
+
+    def test_setup_tracing_otlp_exporter(self):
+        """OTLP exporter path should import and configure the OTLPSpanExporter."""
+        with patch.dict(os.environ, {'OTEL_EXPORTER_TYPE': 'otlp', 'OTEL_EXPORTER_OTLP_ENDPOINT': 'http://localhost:4317'}):
+            mock_exporter_cls = MagicMock()
+            mock_exporter = MagicMock()
+            mock_exporter_cls.return_value = mock_exporter
+
+            mock_otlp_module = MagicMock()
+            mock_otlp_module.OTLPSpanExporter = mock_exporter_cls
+
+            with patch.dict(sys.modules, {'opentelemetry.exporter.otlp.proto.grpc.trace_exporter': mock_otlp_module}):
+                provider = tracing.setup_tracing()
+                assert provider is not None
+                tracing.shutdown_tracing()
+
+
+# =========================================================================
+# Metrics middleware tests
+# =========================================================================
+
+
+class TestMetricsMiddleware:
+    """Validate that MetricsMiddleware records HTTP metrics for each request."""
+
+    @pytest.mark.asyncio
+    async def test_middleware_records_success(self):
+        """Middleware should increment HTTP_REQUESTS and observe duration on 200."""
+        REGISTRY = prometheus_metrics.REGISTRY
+
+        counter_before = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/test-mw', 'status_code': '200'}) or 0.0
+        hist_count_before = REGISTRY.get_sample_value('rocketride_http_request_duration_seconds_count', {'method': 'GET', 'endpoint': '/test-mw'}) or 0.0
+
+        request = MagicMock(spec=['method', 'url', 'headers'])
+        request.method = 'GET'
+        request.url = MagicMock()
+        request.url.path = '/test-mw'
+        request.url.__str__ = lambda self: 'http://localhost:5565/test-mw'
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+
+        async def call_next(req):
+            return mock_response
+
+        with patch.object(middleware, 'get_tracer') as mock_get_tracer:
+            mock_tracer = MagicMock()
+            mock_span = MagicMock()
+            mock_span.__enter__ = MagicMock(return_value=mock_span)
+            mock_span.__exit__ = MagicMock(return_value=False)
+            mock_tracer.start_as_current_span.return_value = mock_span
+            mock_get_tracer.return_value = mock_tracer
+
+            mw = middleware.MetricsMiddleware(app=MagicMock())
+            result = await mw.dispatch(request, call_next)
+
+        assert result.status_code == 200
+
+        counter_after = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/test-mw', 'status_code': '200'})
+        hist_count_after = REGISTRY.get_sample_value('rocketride_http_request_duration_seconds_count', {'method': 'GET', 'endpoint': '/test-mw'})
+
+        assert counter_after == counter_before + 1.0
+        assert hist_count_after == hist_count_before + 1.0
+
+    @pytest.mark.asyncio
+    async def test_middleware_records_error_status(self):
+        """Middleware should record 500 status when call_next raises."""
+        REGISTRY = prometheus_metrics.REGISTRY
+
+        counter_before = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'POST', 'endpoint': '/fail-mw', 'status_code': '500'}) or 0.0
+
+        request = MagicMock(spec=['method', 'url', 'headers'])
+        request.method = 'POST'
+        request.url = MagicMock()
+        request.url.path = '/fail-mw'
+        request.url.__str__ = lambda self: 'http://localhost:5565/fail-mw'
+
+        async def call_next(req):
+            raise RuntimeError('boom')
+
+        with patch.object(middleware, 'get_tracer') as mock_get_tracer:
+            mock_tracer = MagicMock()
+            mock_span = MagicMock()
+            mock_span.__enter__ = MagicMock(return_value=mock_span)
+            mock_span.__exit__ = MagicMock(return_value=False)
+            mock_tracer.start_as_current_span.return_value = mock_span
+            mock_get_tracer.return_value = mock_tracer
+
+            mw = middleware.MetricsMiddleware(app=MagicMock())
+            with pytest.raises(RuntimeError, match='boom'):
+                await mw.dispatch(request, call_next)
+
+        counter_after = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'POST', 'endpoint': '/fail-mw', 'status_code': '500'})
+        assert counter_after == counter_before + 1.0
+
+    @pytest.mark.asyncio
+    async def test_middleware_records_404(self):
+        """Middleware should record 404 status correctly."""
+        REGISTRY = prometheus_metrics.REGISTRY
+
+        counter_before = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/not-found-mw', 'status_code': '404'}) or 0.0
+
+        request = MagicMock(spec=['method', 'url', 'headers'])
+        request.method = 'GET'
+        request.url = MagicMock()
+        request.url.path = '/not-found-mw'
+        request.url.__str__ = lambda self: 'http://localhost:5565/not-found-mw'
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+
+        async def call_next(req):
+            return mock_response
+
+        with patch.object(middleware, 'get_tracer') as mock_get_tracer:
+            mock_tracer = MagicMock()
+            mock_span = MagicMock()
+            mock_span.__enter__ = MagicMock(return_value=mock_span)
+            mock_span.__exit__ = MagicMock(return_value=False)
+            mock_tracer.start_as_current_span.return_value = mock_span
+            mock_get_tracer.return_value = mock_tracer
+
+            mw = middleware.MetricsMiddleware(app=MagicMock())
+            await mw.dispatch(request, call_next)
+
+        counter_after = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/not-found-mw', 'status_code': '404'})
+        assert counter_after == counter_before + 1.0

--- a/test/nodes/test_observability.py
+++ b/test/nodes/test_observability.py
@@ -225,6 +225,10 @@ class TestMetricsEndpoint:
         os.environ.pop('ROCKETRIDE_METRICS_PUBLIC', None)
         assert metrics_endpoint.is_metrics_public() is False
 
+    def test_is_metrics_public_true(self):
+        with patch.dict(os.environ, {'ROCKETRIDE_METRICS_PUBLIC': 'true'}):
+            assert metrics_endpoint.is_metrics_public() is True
+
     def test_is_metrics_public_false(self):
         with patch.dict(os.environ, {'ROCKETRIDE_METRICS_PUBLIC': 'false'}):
             assert metrics_endpoint.is_metrics_public() is False
@@ -451,3 +455,37 @@ class TestMetricsMiddleware:
 
         counter_after = REGISTRY.get_sample_value('rocketride_http_requests_total', {'method': 'GET', 'endpoint': '/not-found-mw', 'status_code': '404'})
         assert counter_after == counter_before + 1.0
+
+
+class TestPathNormalisation:
+    """Validate regex-based path normalisation anchors to segment boundaries."""
+
+    def test_numeric_segment_replaced(self):
+        """Pure numeric segment should be replaced with {id}."""
+        path = middleware._NUMERIC_RE.sub('/{id}', '/pipeline/123/run')
+        assert path == '/pipeline/{id}/run'
+
+    def test_numeric_prefix_not_replaced(self):
+        """Numeric prefix followed by letters should NOT be replaced (partial segment)."""
+        path = middleware._NUMERIC_RE.sub('/{id}', '/pipeline/123abc/run')
+        assert path == '/pipeline/123abc/run'
+
+    def test_uuid_segment_replaced(self):
+        """UUID segment should be replaced with {id}."""
+        path = middleware._UUID_RE.sub('/{id}', '/pipeline/3fa85f64-5717-4562-b3fc-2c963f66afa6/run')
+        assert path == '/pipeline/{id}/run'
+
+    def test_uuid_prefix_not_replaced(self):
+        """UUID-like prefix followed by extra chars should NOT be replaced."""
+        path = middleware._UUID_RE.sub('/{id}', '/pipeline/3fa85f64-5717-4562-b3fc-2c963f66afa6extra/run')
+        assert path == '/pipeline/3fa85f64-5717-4562-b3fc-2c963f66afa6extra/run'
+
+    def test_numeric_at_end_of_path(self):
+        """Numeric segment at end of path (no trailing slash) should be replaced."""
+        path = middleware._NUMERIC_RE.sub('/{id}', '/pipeline/456')
+        assert path == '/pipeline/{id}'
+
+    def test_uuid_at_end_of_path(self):
+        """UUID segment at end of path (no trailing slash) should be replaced."""
+        path = middleware._UUID_RE.sub('/{id}', '/pipeline/3fa85f64-5717-4562-b3fc-2c963f66afa6')
+        assert path == '/pipeline/{id}'


### PR DESCRIPTION
#Hack-with-bay-2

## Contribution Type
**Feature** — Add OpenTelemetry distributed tracing and Prometheus metrics export

## Problem / Use Case
RocketRide Server has an internal `MetricsManager` (`packages/ai/src/ai/web/metrics/metrics.py`) that tracks per-task timers and counters, but this data is only accessible within the engine. There is no way to:
- Export metrics to external monitoring systems (Prometheus, Grafana, Datadog)
- Trace requests across pipeline stages (distributed tracing)
- Monitor LLM API costs, latency, and error rates in real-time
- Set up alerting on pipeline performance degradation

## Proposed Solution
1. **Prometheus metrics** (`prometheus_metrics.py`) — 9 metrics covering pipelines, LLM requests/tokens, vector DB ops, HTTP requests. Custom histogram buckets for LLM durations (0.1s to 120s).
2. **OpenTelemetry tracing** (`tracing.py`) — Configurable OTLP/console/none exporter with thread-safe setup via `threading.Lock`. Auto-instruments FastAPI.
3. **Metrics middleware** (`middleware.py`) — Automatic HTTP request instrumentation with URL path normalization to prevent label cardinality explosion (UUIDs and numeric IDs replaced with `/{id}`).
4. **`/metrics` endpoint** (`metrics_endpoint.py`) — Prometheus text exposition format, configurable public/private access with security documentation.
5. **27 unit tests** covering all components.

## Value Added
- **Production observability**: Prometheus scraping, Grafana dashboards, PagerDuty alerts
- **Cost tracking**: `rocketride_llm_tokens_total` by provider/model enables per-model cost analysis
- **Performance monitoring**: Pipeline duration histograms identify slow pipelines
- **Zero-config start**: `OTEL_EXPORTER_TYPE=none` (default) adds no overhead

## Why This Feature Fits This Codebase
The existing `MetricsManager` at `packages/ai/src/ai/web/metrics/metrics.py` already tracks timers and counters per-task/per-pipe (lines 96-423). This PR extends that foundation with industry-standard export formats without modifying the existing class.

The FastAPI server at `packages/ai/src/ai/web/server.py` already uses middleware (`AuthMiddleware` at line 20). The new `MetricsMiddleware` follows the identical Starlette `BaseHTTPMiddleware` pattern. URL path normalization uses Starlette's route matching (`route.matches(scope)`) to resolve paths to templates, preventing the cardinality explosion that would occur with dynamic path parameters like `/pipeline/{id}/status`.

The `/metrics` endpoint follows the same registration pattern as existing endpoints in `packages/ai/src/ai/web/endpoints/` (ping, version, status, shutdown).

## Validation
```
$ pytest test/nodes/test_observability.py -v
===== 27 passed =====
```
Tests verify: counter increments, histogram observations, gauge operations, Prometheus text format output, all 3 exporter types, middleware request recording for 200/404/500 status codes.

## How This Could Be Extended
- Instrument the circuit breaker (PR #497) to emit `rocketride_circuit_breaker_state` gauge
- Add Grafana dashboard JSON templates in `deploy/grafana/`
- Integrate with the Helm chart (PR #510) for auto-configured Prometheus ServiceMonitor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a /metrics endpoint and a metrics ASGI app; server now registers metrics middleware and route (public access configurable).
  * Automatic per-request telemetry middleware for normalized endpoint metrics and latency tracking.

* **Metrics**
  * Added counters, histograms, and gauges for pipelines, LLM requests/tokens/duration, vector DB ops, active tasks, and HTTP requests.

* **Observability**
  * Integrated OpenTelemetry tracing with configurable exporters and app instrumentation.

* **Tests**
  * Added end-to-end observability tests covering metrics, endpoint, tracing, and middleware.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->