### PR TITLE
fix(nodes): openai - add latest openai models

### DIFF
--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -303,7 +303,7 @@
 		}
 	],
 	"test": {
-		"profiles": ["openai-5-4-mini"],
+		"profiles": ["openai-5-4", "openai-5-4-pro", "openai-5-4-mini", "openai-5-4-nano"],
 		"outputs": ["answers"],
 		"cases": [
 			{

--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -13,26 +13,22 @@
 	// Required:
 	//		Class type of the node - what it does
 	//
-	"classType": [
-		"llm"
-	],
+	"classType": ["llm"],
 	//
 	// Required:
 	//		Capabilities are flags that change the behavior of the underlying
 	//		engine
 	//
-	"capabilities": [
-		"invoke"
-	],
+	"capabilities": ["invoke"],
 	//
 	// Optional:
-	//		Register is either filter, endpoint or ignored if not specified. If the 
+	//		Register is either filter, endpoint or ignored if not specified. If the
 	//		type is specified, a factory is registered of that given type
 	//
 	"register": "filter",
 	//
 	// Optional:
-	//		The node is the actual pyhsical node to instantiate - if 
+	//		The node is the actual pyhsical node to instantiate - if
 	//		not specified, the protocol will be used
 	//
 	"node": "python",
@@ -51,15 +47,7 @@
 	// Optional:
 	//		Description to of this driver
 	//
-	"description": [
-		"A component that connects to OpenAI's latest GPT models for advanced natural language ",
-		"processing. It supports tasks such as text generation, summarization, question ",
-		"answering, and chat-based interactions. With access to state-of-the-art language ",
-		"models like GPT-5, GPT-4o, GPT-4o-mini, and GPT-4 Turbo, this component enables ",
-		"high-quality, context-aware responses and creative text generation. Configurable with ",
-		"API keys and deployment options, it allows seamless integration into AI-driven ",
-		"workflows with scalable performance and enhanced multimodal capabilities."
-	],
+	"description": ["A component that connects to OpenAI's latest GPT models for advanced natural language ", "processing. It supports tasks such as text generation, summarization, question ", "answering, and chat-based interactions. With access to state-of-the-art language ", "models like GPT-5.4, GPT-5, GPT-4o, and GPT-4o-mini, this component enables ", "high-quality, context-aware responses and creative text generation. Configurable with ", "API keys and deployment options, it allows seamless integration into AI-driven ", "workflows with scalable performance and enhanced multimodal capabilities."],
 	//
 	// Optional:
 	//	  The icon is the icon to display in the UI for this node
@@ -75,18 +63,14 @@
 	//      Rendering hints to the UI which indicate which fields of
 	//      the configuration should be used to display information
 	//
-	"tile": [
-		"Model: ${parameters.llm_openai.profile}"
-	],
+	"tile": ["Model: ${parameters.llm_openai.profile}"],
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes
 	//		and what it produces
 	//
 	"lanes": {
-		"questions": [
-			"answers"
-		]
+		"questions": ["answers"]
 	},
 	"input": [
 		{
@@ -106,7 +90,7 @@
 	"preconfig": {
 		// Define the values that will be merged into any profile configuration
 		// specified, unless the profile is 'absolute'
-		"default": "openai-5-2",
+		"default": "openai-5-4",
 		// Defines profiles used with the "profile": key
 		"profiles": {
 			"custom": {
@@ -114,24 +98,48 @@
 				"modelTotalTokens": 16384,
 				"apikey": ""
 			},
-		"openai-4o": {
+			"openai-5-4": {
+				"title": "GPT-5.4",
+				"model": "gpt-5.4",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"openai-5-4-pro": {
+				"title": "GPT-5.4 Pro",
+				"model": "gpt-5.4-pro",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"openai-5-4-mini": {
+				"title": "GPT-5.4-mini",
+				"model": "gpt-5.4-mini",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"openai-5-4-nano": {
+				"title": "GPT-5.4-nano",
+				"model": "gpt-5.4-nano",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"openai-4o": {
 				"title": "GPT-4o",
-			"model": "gpt-4o",
-			"modelTotalTokens": 128000,
-			"apikey": ""
-		},
-		"openai-4o-mini": {
+				"model": "gpt-4o",
+				"modelTotalTokens": 128000,
+				"apikey": ""
+			},
+			"openai-4o-mini": {
 				"title": "GPT-4o-mini",
-			"model": "gpt-4o-mini",
-			"modelTotalTokens": 128000,
-			"apikey": ""
-		},
+				"model": "gpt-4o-mini",
+				"modelTotalTokens": 128000,
+				"apikey": ""
+			},
 			"openai-5": {
 				"title": "GPT-5",
 				"model": "gpt-5",
-			"modelTotalTokens": 128000,
-			"apikey": ""
-		},
+				"modelTotalTokens": 128000,
+				"apikey": ""
+			},
 			"openai-5-1": {
 				"title": "GPT-5.1",
 				"model": "gpt-5.1",
@@ -153,9 +161,9 @@
 			"openai-5-nano": {
 				"title": "GPT-5-nano",
 				"model": "gpt-5-nano",
-			"modelTotalTokens": 128000,
-			"apikey": ""
-		}
+				"modelTotalTokens": 128000,
+				"apikey": ""
+			}
 		}
 	},
 	//
@@ -177,13 +185,33 @@
 		},
 		"openai.custom": {
 			"object": "custom",
+			"properties": ["model", "modelTotalTokens", "llm.cloud.apikey"]
+		},
+
+		"openai.openai-5-4": {
+			"object": "openai-5-4",
 			"properties": [
-				"model",
-				"modelTotalTokens",
 				"llm.cloud.apikey"
 			]
 		},
-		
+		"openai.openai-5-4-pro": {
+			"object": "openai-5-4-pro",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"openai.openai-5-4-mini": {
+			"object": "openai-5-4-mini",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"openai.openai-5-4-nano": {
+			"object": "openai-5-4-nano",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
 		"openai.openai-4o": {
 			"object": "openai-4o",
 			"properties": [
@@ -209,9 +237,9 @@
 			]
 		},
 		"openai.openai-5-2": {
-      		"object": "openai-5-2",
-      		"properties": [
-        		"llm.cloud.apikey"
+			"object": "openai-5-2",
+			"properties": [
+				"llm.cloud.apikey"
 			]
 		},
 		"openai.openai-5-mini": {
@@ -230,7 +258,7 @@
 			"title": "Model",
 			"description": "LLM model",
 			"type": "string",
-			"default": "openai-5-2",
+			"default": "openai-5-4",
 			"enum": [
 				"*>preconfig.profiles.*.title"
 			],
@@ -239,6 +267,30 @@
 					"value": "custom",
 					"properties": [
 						"openai.custom"
+					]
+				},
+				{
+					"value": "openai-5-4",
+					"properties": [
+						"openai.openai-5-4"
+					]
+				},
+				{
+					"value": "openai-5-4-pro",
+					"properties": [
+						"openai.openai-5-4-pro"
+					]
+				},
+				{
+					"value": "openai-5-4-mini",
+					"properties": [
+						"openai.openai-5-4-mini"
+					]
+				},
+				{
+					"value": "openai-5-4-nano",
+					"properties": [
+						"openai.openai-5-4-nano"
 					]
 				},
 				{
@@ -268,7 +320,7 @@
 				{
 					"value": "openai-5-2",
 					"properties": [
-					  "openai.openai-5-2"
+						"openai.openai-5-2"
 					]
 				},
 				{
@@ -285,6 +337,8 @@
 				}
 			]
 		}
+			]
+		}
 	},
 	//
 	// Required:
@@ -295,13 +349,11 @@
 		{
 			"section": "Pipe",
 			"title": "OpenAI",
-			"properties": [
-				"openai.profile"
-			]
+			"properties": ["openai.profile"]
 		}
 	],
 	"test": {
-		"profiles": ["openai-5-mini"],
+		"profiles": ["openai-5-4-mini"],
 		"outputs": ["answers"],
 		"cases": [
 			{

--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -137,31 +137,31 @@
 			"openai-5": {
 				"title": "GPT-5",
 				"model": "gpt-5",
-				"modelTotalTokens": 128000,
+				"modelTotalTokens": 400000,
 				"apikey": ""
 			},
 			"openai-5-1": {
 				"title": "GPT-5.1",
 				"model": "gpt-5.1",
-				"modelTotalTokens": 128000,
+				"modelTotalTokens": 400000,
 				"apikey": ""
 			},
 			"openai-5-2": {
 				"title": "GPT-5.2",
 				"model": "gpt-5.2",
-				"modelTotalTokens": 128000,
+				"modelTotalTokens": 400000,
 				"apikey": ""
 			},
 			"openai-5-mini": {
 				"title": "GPT-5-mini",
 				"model": "gpt-5-mini",
-				"modelTotalTokens": 128000,
+				"modelTotalTokens": 400000,
 				"apikey": ""
 			},
 			"openai-5-nano": {
 				"title": "GPT-5-nano",
 				"model": "gpt-5-nano",
-				"modelTotalTokens": 128000,
+				"modelTotalTokens": 400000,
 				"apikey": ""
 			}
 		}
@@ -303,7 +303,7 @@
 		}
 	],
 	"test": {
-		"profiles": ["openai-5-4", "openai-5-4-pro", "openai-5-4-mini", "openai-5-4-nano"],
+		"profiles": ["openai-5-2", "openai-5-4", "openai-5-4-pro", "openai-5-4-mini", "openai-5-4-nano"],
 		"outputs": ["answers"],
 		"cases": [
 			{

--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -90,7 +90,7 @@
 	"preconfig": {
 		// Define the values that will be merged into any profile configuration
 		// specified, unless the profile is 'absolute'
-		"default": "openai-5-4",
+		"default": "openai-5-2",
 		// Defines profiles used with the "profile": key
 		"profiles": {
 			"custom": {
@@ -236,7 +236,7 @@
 			"title": "Model",
 			"description": "LLM model",
 			"type": "string",
-			"default": "openai-5-4",
+			"default": "openai-5-2",
 			"enum": ["*>preconfig.profiles.*.title"],
 			"conditional": [
 				{

--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -101,25 +101,25 @@
 			"openai-5-4": {
 				"title": "GPT-5.4",
 				"model": "gpt-5.4",
-				"modelTotalTokens": 1048576,
+				"modelTotalTokens": 1050000,
 				"apikey": ""
 			},
 			"openai-5-4-pro": {
 				"title": "GPT-5.4 Pro",
 				"model": "gpt-5.4-pro",
-				"modelTotalTokens": 1048576,
+				"modelTotalTokens": 1050000,
 				"apikey": ""
 			},
 			"openai-5-4-mini": {
 				"title": "GPT-5.4-mini",
 				"model": "gpt-5.4-mini",
-				"modelTotalTokens": 1048576,
+				"modelTotalTokens": 400000,
 				"apikey": ""
 			},
 			"openai-5-4-nano": {
 				"title": "GPT-5.4-nano",
 				"model": "gpt-5.4-nano",
-				"modelTotalTokens": 1048576,
+				"modelTotalTokens": 400000,
 				"apikey": ""
 			},
 			"openai-4o": {
@@ -190,153 +190,103 @@
 
 		"openai.openai-5-4": {
 			"object": "openai-5-4",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5-4-pro": {
 			"object": "openai-5-4-pro",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5-4-mini": {
 			"object": "openai-5-4-mini",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5-4-nano": {
 			"object": "openai-5-4-nano",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-4o": {
 			"object": "openai-4o",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-4o-mini": {
 			"object": "openai-4o-mini",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5": {
 			"object": "openai-5",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5-1": {
 			"object": "openai-5-1",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5-2": {
 			"object": "openai-5-2",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5-mini": {
 			"object": "openai-5-mini",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.openai-5-nano": {
 			"object": "openai-5-nano",
-			"properties": [
-				"llm.cloud.apikey"
-			]
+			"properties": ["llm.cloud.apikey"]
 		},
 		"openai.profile": {
 			"title": "Model",
 			"description": "LLM model",
 			"type": "string",
 			"default": "openai-5-4",
-			"enum": [
-				"*>preconfig.profiles.*.title"
-			],
+			"enum": ["*>preconfig.profiles.*.title"],
 			"conditional": [
 				{
 					"value": "custom",
-					"properties": [
-						"openai.custom"
-					]
+					"properties": ["openai.custom"]
 				},
 				{
 					"value": "openai-5-4",
-					"properties": [
-						"openai.openai-5-4"
-					]
+					"properties": ["openai.openai-5-4"]
 				},
 				{
 					"value": "openai-5-4-pro",
-					"properties": [
-						"openai.openai-5-4-pro"
-					]
+					"properties": ["openai.openai-5-4-pro"]
 				},
 				{
 					"value": "openai-5-4-mini",
-					"properties": [
-						"openai.openai-5-4-mini"
-					]
+					"properties": ["openai.openai-5-4-mini"]
 				},
 				{
 					"value": "openai-5-4-nano",
-					"properties": [
-						"openai.openai-5-4-nano"
-					]
+					"properties": ["openai.openai-5-4-nano"]
 				},
 				{
 					"value": "openai-4o",
-					"properties": [
-						"openai.openai-4o"
-					]
+					"properties": ["openai.openai-4o"]
 				},
 				{
 					"value": "openai-4o-mini",
-					"properties": [
-						"openai.openai-4o-mini"
-					]
+					"properties": ["openai.openai-4o-mini"]
 				},
 				{
 					"value": "openai-5",
-					"properties": [
-						"openai.openai-5"
-					]
+					"properties": ["openai.openai-5"]
 				},
 				{
 					"value": "openai-5-1",
-					"properties": [
-						"openai.openai-5-1"
-					]
+					"properties": ["openai.openai-5-1"]
 				},
 				{
 					"value": "openai-5-2",
-					"properties": [
-						"openai.openai-5-2"
-					]
+					"properties": ["openai.openai-5-2"]
 				},
 				{
 					"value": "openai-5-mini",
-					"properties": [
-						"openai.openai-5-mini"
-					]
+					"properties": ["openai.openai-5-mini"]
 				},
 				{
 					"value": "openai-5-nano",
-					"properties": [
-						"openai.openai-5-nano"
-					]
+					"properties": ["openai.openai-5-nano"]
 				}
-			]
-		}
 			]
 		}
 	},

--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -28,7 +28,7 @@
 	"register": "filter",
 	//
 	// Optional:
-	//		The node is the actual pyhsical node to instantiate - if
+	//		The node is the actual physical node to instantiate - if
 	//		not specified, the protocol will be used
 	//
 	"node": "python",


### PR DESCRIPTION
## Summary

- Updated Gemini LLM node to use current model lineup
- Added gpt-5.4 (new default, 1M context), gpt-5.4-pro, gpt-5.4-mini, gpt-5.4-nano
- Updated default to gpt-5.4

## Type

Fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GPT-5.4 preconfigured profiles: GPT-5.4, GPT-5.4 Pro, GPT-5.4-mini, GPT-5.4-nano.
  * Service descriptions updated to reference GPT-5.4.
  * Selecting any GPT-5.4 profile exposes its corresponding API key configuration field.
  * Test profiles updated to include all four GPT-5.4 variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->