### PR TITLE
docs: fix broken image links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
 
 <a href="https://rocketride.org">
-  <img src="./images/banner-root.png" alt="RocketRide" width="100%">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/banner-root.png" alt="RocketRide" width="100%">
 </a>
 
 <p>
@@ -14,9 +14,9 @@
 </p>
 
 <p>
-  <img src="./images/icon-cpp.png" height="28" alt="C++" />&nbsp;&nbsp;
-  <img src="./images/icon-python.png" height="28" alt="Python" />&nbsp;&nbsp;
-  <img src="./images/icon-typescript.png" height="28" alt="TypeScript" />
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-cpp.png" height="28" alt="C++" />&nbsp;&nbsp;
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-python.png" height="28" alt="Python" />&nbsp;&nbsp;
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-typescript.png" height="28" alt="TypeScript" />
 </p>
 
 <p>
@@ -36,11 +36,11 @@
 
 </div>
 
-<img src="./images/screenshot-ide.png" alt="Build and run AI pipelines inside your IDE" width="100%">
+<img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/screenshot-ide.png" alt="Build and run AI pipelines inside your IDE" width="100%">
 
 _Design, test, and ship complex AI workflows from a visual canvas, right where you write code._
 
-<img src="./images/screenshot-sdk.png" alt="Integrate real AI solutions using a simple SDK" width="100%">
+<img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/screenshot-sdk.png" alt="Integrate real AI solutions using a simple SDK" width="100%">
 
 _Drop pipelines into any Python or TypeScript app with a few lines of code, no infrastructure glue required._
 
@@ -60,7 +60,7 @@ _Drop pipelines into any Python or TypeScript app with a few lines of code, no i
 1. Install the extension for your IDE. Search for RocketRide in the extension marketplace:
 
    <p align="center">
-     <img src="./images/install.png" alt="Install RocketRide extension">
+     <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/install.png" alt="Install RocketRide extension">
    </p>
 
    <sub>[Not seeing your IDE? Open an issue](https://github.com/rocketride-org/rocketride-server/issues/new) · [Download directly](https://open-vsx.org/extension/RocketRide/rocketride)</sub>
@@ -81,7 +81,7 @@ _Drop pipelines into any Python or TypeScript app with a few lines of code, no i
 3. Connect input lanes and output lanes by type to properly wire your pipeline. Some nodes like agents or LLMs can be invoked as tools for use by a parent node as shown below:
 
 <p align="center">
-  <img src="./images/first_pipe.gif" alt="Pipeline canvas example" width="100%">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/first_pipe.gif" alt="Pipeline canvas example" width="100%">
 </p>
 
 4. You can run a pipeline from the canvas by pressing the ▶️ button on the source node or from the `Connection Manager` directly.
@@ -104,7 +104,7 @@ _Drop pipelines into any Python or TypeScript app with a few lines of code, no i
 Selecting running pipelines allows for in-depth analytics. Trace call trees, token usage, memory consumption, and more to optimize your pipelines before scaling and deploying. Find the models, agents, and tools best fit for your task.
 
 <p align="center">
-  <img src="./images/tracing.gif" alt="Pipeline observability and tracing">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/tracing.gif" alt="Pipeline observability and tracing">
 </p>
 
 ## Contributors

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 </p>
 
 <p>
- RocketRide is an open-source data pipeline builder and runtime built for AI and ML workloads. With 50+ pipeline nodes spanning 13 LLM providers, 8 vector databases, OCR, NER, and more — pipelines are defined as portable JSON, built visually in VS Code, and executed by a multithreaded C++ runtime. From real-time data processing to multimodal AI search, RocketRide runs entirely on your own infrastructure.
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-cpp.png" alt="C++" />&nbsp;&nbsp;
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-python.png" alt="Python" />&nbsp;&nbsp;
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-typescript.png" alt="TypeScript" />
 </p>
 
 <p>
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-cpp.png" height="28" alt="C++" />&nbsp;&nbsp;
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-python.png" height="28" alt="Python" />&nbsp;&nbsp;
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/icon-typescript.png" height="28" alt="TypeScript" />
+ RocketRide is an open-source data pipeline builder and runtime built for AI and ML workloads. With 50+ pipeline nodes spanning 13 LLM providers, 8 vector databases, OCR, NER, and more — pipelines are defined as portable JSON, built visually in VS Code, and executed by a multithreaded C++ runtime. From real-time data processing to multimodal AI search, RocketRide runs entirely on your own infrastructure.
 </p>
 
 <p>
@@ -34,8 +34,6 @@
   <a href="https://github.com/rocketride-org/rocketride-server/blob/develop/LICENSE"><img src="https://img.shields.io/badge/license-MIT-41b6e6" alt="MIT License"></a>
 </p>
 
-</div>
-
 <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/screenshot-ide.png" alt="Build and run AI pipelines inside your IDE" width="100%">
 
 _Design, test, and ship complex AI workflows from a visual canvas, right where you write code._
@@ -43,6 +41,8 @@ _Design, test, and ship complex AI workflows from a visual canvas, right where y
 <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/screenshot-sdk.png" alt="Integrate real AI solutions using a simple SDK" width="100%">
 
 _Drop pipelines into any Python or TypeScript app with a few lines of code, no infrastructure glue required._
+
+</div>
 
 ## Features
 

--- a/docs/README-mcp-client.md
+++ b/docs/README-mcp-client.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/main/images/banner-mcp.png" alt="RocketRide MCP Server" width="900">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/banner-mcp.png" alt="RocketRide MCP Server" width="900">
 </p>
 
 <p align="center">

--- a/docs/README-python-client.md
+++ b/docs/README-python-client.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/main/images/banner-python.png" alt="RocketRide Python SDK" width="900">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/banner-python.png" alt="RocketRide Python SDK" width="900">
 </p>
 
 <p align="center">
@@ -37,7 +37,7 @@ asyncio.run(main())
 Don't have a pipeline yet? Visit [RocketRide on GitHub](https://github.com/rocketride-org/rocketride-server) or download the extension directly in your IDE.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/main/images/install.png" alt="Install RocketRide extension" width="600">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/install.png" alt="Install RocketRide extension" width="600">
 </p>
 
 ## What is RocketRide?

--- a/docs/README-typescript-client.md
+++ b/docs/README-typescript-client.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/main/images/banner-typescript.png" alt="RocketRide TypeScript SDK" width="900">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/banner-typescript.png" alt="RocketRide TypeScript SDK" width="900">
 </p>
 
 <p align="center">
@@ -42,7 +42,7 @@ await client.disconnect();
 Don't have a pipeline yet? Visit [RocketRide on GitHub](https://github.com/rocketride-org/rocketride-server) or download the extension directly in your IDE.
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/main/images/install.png" alt="Install RocketRide extension" width="600">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/install.png" alt="Install RocketRide extension" width="600">
 </p>
 
 ## What is RocketRide?

--- a/docs/README-vscode.md
+++ b/docs/README-vscode.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/main/images/banner-vscode.png" alt="RocketRide for VS Code" width="900">
+  <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/banner-vscode.png" alt="RocketRide for VS Code" width="900">
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

- Replace all 9 relative image paths (`./images/...`) in `README.md` with absolute `raw.githubusercontent.com` URLs so images render on GitHub, npm, PyPI, and external platforms
- Fix branch references in `docs/README-mcp-client.md`, `docs/README-python-client.md`, `docs/README-typescript-client.md`, and `docs/README-vscode.md` from `main` to `develop`
- Reorder the hero section markup in `README.md` so language icons appear above the description paragraph

## Type
Bug Fix

## Why this bug happens in this codebase
The root `README.md` uses relative image paths like `./images/banner-root.png` for all 9 embedded images (banner, language icons, screenshots, and GIFs). These relative paths work when browsing the repo on GitHub directly, but break when the README is consumed externally — for example on the npm or PyPI package pages, or in any context where the base URL differs from the repository root. Additionally, the four documentation READMEs under `docs/` (`README-mcp-client.md`, `README-python-client.md`, `README-typescript-client.md`, `README-vscode.md`) point their banner and install images at the `main` branch via `raw.githubusercontent.com/rocketride-org/rocketride-server/main/images/...`, but this repository's default branch is `develop`, meaning those images 404 whenever `main` is out of sync. The fix converts all relative paths to absolute `raw.githubusercontent.com/...develop/...` URLs and updates the stale `main` references to `develop`.

## What changed
- **`README.md`** — Replaced 9 relative `./images/...` `<img>` src attributes with absolute `https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/images/...` URLs; moved the language-icon `<p>` block above the description paragraph; moved the closing `</div>` tag after the SDK screenshot so both hero screenshots are inside the centered div
- **`docs/README-mcp-client.md`** — Changed banner image URL branch from `main` to `develop`
- **`docs/README-python-client.md`** — Changed banner and install image URLs branch from `main` to `develop`
- **`docs/README-typescript-client.md`** — Changed banner and install image URLs branch from `main` to `develop`
- **`docs/README-vscode.md`** — Changed banner image URL branch from `main` to `develop`

## Validation
- Open the PR "Files changed" tab on GitHub and confirm all 9 images in `README.md` render in the diff preview
- View the raw README from the repository root on GitHub and confirm every image loads
- Check `docs/README-python-client.md` and `docs/README-typescript-client.md` to confirm the install images now load (previously 404'd on `main`)
- Verify no other image references were missed (badge shields already use absolute URLs)

## How this could be extended
The same pattern applies to any future documentation files or sub-package READMEs that embed images. A CI lint step (e.g., a markdown link checker) could catch broken relative paths and stale branch references automatically before they reach users on package registries.

Closes #495

#Hack-with-bay-2