### PR TITLE
feat(nodes): add SSRF protection with configurable private IP allowlist

### DIFF
--- a/nodes/src/nodes/library/ssrf_protection.py
+++ b/nodes/src/nodes/library/ssrf_protection.py
@@ -1,6 +1,6 @@
 # =============================================================================
 # MIT License
-# Copyright (c) 2024 RocketRide Inc.
+# Copyright (c) 2026 Aparavi Software AG
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -49,10 +49,13 @@ Usage::
 from __future__ import annotations
 
 import ipaddress
+import logging
 import os
 import socket
-from typing import List, Optional, Sequence
+from typing import List, Optional, Sequence, Tuple
 from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Blocked networks (RFC 1918, loopback, link-local, metadata, etc.)
@@ -121,8 +124,8 @@ def validate_url(
     url: str,
     *,
     allowed_private: Optional[Sequence[str]] = None,
-) -> str:
-    """Validate *url* against SSRF rules and return the resolved URL.
+) -> Tuple[str, str, List[str]]:
+    """Validate *url* against SSRF rules and return the URL with resolved IPs.
 
     Parameters
     ----------
@@ -136,8 +139,11 @@ def validate_url(
 
     Returns
     -------
-    str
-        The original *url* unchanged, if validation passes.
+    tuple[str, str, list[str]]
+        A 3-tuple of ``(url, hostname, resolved_ips)`` where *resolved_ips*
+        are the validated IP addresses.  Callers should connect directly to
+        one of these IPs (setting the ``Host`` header to *hostname*) to
+        prevent TOCTOU DNS rebinding attacks.
 
     Raises
     ------
@@ -166,9 +172,9 @@ def validate_url(
 
     # -- DNS resolution + IP check ------------------------------------------
     port = parsed.port or (443 if scheme == 'https' else 80)
-    _resolve_and_check(hostname, port, allow_nets)
+    resolved_ips = _resolve_and_check(hostname, port, allow_nets)
 
-    return url
+    return url, hostname, resolved_ips
 
 
 def resolve_and_validate(
@@ -206,7 +212,7 @@ def _build_allowlist(
                 try:
                     nets.append(ipaddress.ip_network(cidr, strict=False))
                 except ValueError:
-                    pass  # silently skip malformed entries
+                    logger.warning('SSRF allowlist: ignoring malformed CIDR entry %r from %s', cidr, SSRF_ALLOWLIST_ENV)
 
     # Per-call allowlist
     for cidr in extra or []:
@@ -215,7 +221,7 @@ def _build_allowlist(
             try:
                 nets.append(ipaddress.ip_network(cidr_s, strict=False))
             except ValueError:
-                pass
+                logger.warning('SSRF allowlist: ignoring malformed CIDR entry %r from per-call allowlist', cidr_s)
 
     return nets
 

--- a/nodes/src/nodes/library/ssrf_protection.py
+++ b/nodes/src/nodes/library/ssrf_protection.py
@@ -1,0 +1,282 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+SSRF (Server-Side Request Forgery) protection utilities.
+
+Validates URLs and resolved IP addresses to prevent requests to private,
+loopback, link-local, and reserved IP ranges.  Supports a configurable
+allowlist so self-hosted operators can permit specific internal services.
+
+DNS resolution is performed before the IP check to prevent DNS rebinding
+attacks where a hostname initially resolves to a public IP but later
+resolves to an internal one.
+
+Usage::
+
+    from library.ssrf_protection import validate_url, SSRFError
+
+    # Block all private IPs (default)
+    validate_url('http://192.168.1.1/api')  # raises SSRFError
+
+    # Allow specific private ranges
+    validate_url(
+        'http://192.168.1.100/api',
+        allowed_private=['192.168.1.0/24'],
+    )
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from typing import List, Optional, Sequence
+from urllib.parse import urlparse
+
+# ---------------------------------------------------------------------------
+# Blocked networks (RFC 1918, loopback, link-local, metadata, etc.)
+# ---------------------------------------------------------------------------
+
+_BLOCKED_IPV4 = [
+    ipaddress.IPv4Network('0.0.0.0/8'),  # "This host" (RFC 1122)
+    ipaddress.IPv4Network('10.0.0.0/8'),  # Private (RFC 1918)
+    ipaddress.IPv4Network('100.64.0.0/10'),  # Shared address (RFC 6598)
+    ipaddress.IPv4Network('127.0.0.0/8'),  # Loopback (RFC 1122)
+    ipaddress.IPv4Network('169.254.0.0/16'),  # Link-local (RFC 3927) + cloud metadata
+    ipaddress.IPv4Network('172.16.0.0/12'),  # Private (RFC 1918)
+    ipaddress.IPv4Network('192.0.0.0/24'),  # IETF protocol assignments (RFC 6890)
+    ipaddress.IPv4Network('192.0.2.0/24'),  # Documentation (RFC 5737)
+    ipaddress.IPv4Network('192.168.0.0/16'),  # Private (RFC 1918)
+    ipaddress.IPv4Network('198.18.0.0/15'),  # Benchmarking (RFC 2544)
+    ipaddress.IPv4Network('198.51.100.0/24'),  # Documentation (RFC 5737)
+    ipaddress.IPv4Network('203.0.113.0/24'),  # Documentation (RFC 5737)
+    ipaddress.IPv4Network('224.0.0.0/4'),  # Multicast (RFC 5771)
+    ipaddress.IPv4Network('240.0.0.0/4'),  # Reserved (RFC 1112)
+    ipaddress.IPv4Network('255.255.255.255/32'),  # Broadcast
+]
+
+_BLOCKED_IPV6 = [
+    ipaddress.IPv6Network('::1/128'),  # Loopback
+    ipaddress.IPv6Network('::/128'),  # Unspecified
+    ipaddress.IPv6Network('::ffff:0:0/96'),  # IPv4-mapped (checked via mapped v4)
+    ipaddress.IPv6Network('64:ff9b::/96'),  # NAT64 (RFC 6052)
+    ipaddress.IPv6Network('100::/64'),  # Discard (RFC 6666)
+    ipaddress.IPv6Network('2001:db8::/32'),  # Documentation (RFC 3849)
+    ipaddress.IPv6Network('fc00::/7'),  # Unique local (RFC 4193)
+    ipaddress.IPv6Network('fe80::/10'),  # Link-local (RFC 4291)
+    ipaddress.IPv6Network('ff00::/8'),  # Multicast (RFC 4291)
+]
+
+# Hostnames that are always blocked regardless of IP resolution.
+_BLOCKED_HOSTNAMES = frozenset(
+    {
+        'localhost',
+        'metadata.google.internal',
+    }
+)
+
+# Environment variable for the global allowlist (comma-separated CIDRs).
+SSRF_ALLOWLIST_ENV = 'ROCKETRIDE_SSRF_ALLOWLIST'
+
+# Only allow http and https schemes.
+_ALLOWED_SCHEMES = frozenset({'http', 'https'})
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SSRFError(ValueError):
+    """Raised when a URL targets a blocked (private/reserved) IP address."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_url(
+    url: str,
+    *,
+    allowed_private: Optional[Sequence[str]] = None,
+) -> str:
+    """Validate *url* against SSRF rules and return the resolved URL.
+
+    Parameters
+    ----------
+    url:
+        The URL to validate (must use ``http`` or ``https`` scheme).
+    allowed_private:
+        An optional list of CIDR strings (e.g. ``['192.168.1.0/24']``) that
+        should be permitted even though they fall within blocked ranges.
+        This is merged with the global allowlist from the
+        ``ROCKETRIDE_SSRF_ALLOWLIST`` environment variable.
+
+    Returns
+    -------
+    str
+        The original *url* unchanged, if validation passes.
+
+    Raises
+    ------
+    SSRFError
+        If the URL targets a blocked IP, uses a disallowed scheme, or
+        cannot be resolved.
+    """
+    parsed = urlparse(url)
+
+    # -- Scheme check -------------------------------------------------------
+    scheme = (parsed.scheme or '').lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise SSRFError(f'SSRF protection: scheme {scheme!r} is not allowed. Only {sorted(_ALLOWED_SCHEMES)} are permitted.')
+
+    # -- Extract hostname ---------------------------------------------------
+    hostname = (parsed.hostname or '').lower().strip('.')
+    if not hostname:
+        raise SSRFError('SSRF protection: URL has no hostname.')
+
+    # -- Blocked hostname check ---------------------------------------------
+    if hostname in _BLOCKED_HOSTNAMES:
+        raise SSRFError(f'SSRF protection: hostname {hostname!r} is blocked.')
+
+    # -- Build combined allowlist -------------------------------------------
+    allow_nets = _build_allowlist(allowed_private)
+
+    # -- DNS resolution + IP check ------------------------------------------
+    port = parsed.port or (443 if scheme == 'https' else 80)
+    _resolve_and_check(hostname, port, allow_nets)
+
+    return url
+
+
+def resolve_and_validate(
+    hostname: str,
+    port: int = 80,
+    *,
+    allowed_private: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Resolve *hostname* and validate all resulting IPs.
+
+    Returns the list of resolved IP address strings.  Raises ``SSRFError``
+    if any resolved address is blocked.
+    """
+    allow_nets = _build_allowlist(allowed_private)
+    return _resolve_and_check(hostname, port, allow_nets)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _build_allowlist(
+    extra: Optional[Sequence[str]] = None,
+) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Merge per-call allowlist with the global env-var allowlist."""
+    nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+
+    # Global allowlist from environment
+    env_val = os.environ.get(SSRF_ALLOWLIST_ENV, '').strip()
+    if env_val:
+        for cidr in env_val.split(','):
+            cidr = cidr.strip()
+            if cidr:
+                try:
+                    nets.append(ipaddress.ip_network(cidr, strict=False))
+                except ValueError:
+                    pass  # silently skip malformed entries
+
+    # Per-call allowlist
+    for cidr in extra or []:
+        cidr_s = str(cidr).strip()
+        if cidr_s:
+            try:
+                nets.append(ipaddress.ip_network(cidr_s, strict=False))
+            except ValueError:
+                pass
+
+    return nets
+
+
+def _resolve_and_check(
+    hostname: str,
+    port: int,
+    allow_nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+) -> List[str]:
+    """Resolve hostname via DNS and check every resulting IP."""
+    # If hostname is already an IP literal, skip DNS.
+    try:
+        addr = ipaddress.ip_address(hostname)
+        _check_ip(addr, hostname, allow_nets)
+        return [str(addr)]
+    except ValueError:
+        pass  # not an IP literal — resolve via DNS
+
+    try:
+        addrinfos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise SSRFError(f'SSRF protection: cannot resolve hostname {hostname!r}: {exc}') from exc
+
+    if not addrinfos:
+        raise SSRFError(f'SSRF protection: hostname {hostname!r} resolved to no addresses.')
+
+    resolved_ips: List[str] = []
+    for family, _type, _proto, _canonname, sockaddr in addrinfos:
+        ip_str = sockaddr[0]
+        addr = ipaddress.ip_address(ip_str)
+        _check_ip(addr, hostname, allow_nets)
+        if ip_str not in resolved_ips:
+            resolved_ips.append(ip_str)
+
+    return resolved_ips
+
+
+def _check_ip(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    hostname: str,
+    allow_nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+) -> None:
+    """Raise ``SSRFError`` if *addr* falls within a blocked range."""
+    # For IPv6-mapped IPv4 addresses, also check the embedded v4 address.
+    check_addrs = [addr]
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+        check_addrs.append(addr.ipv4_mapped)
+
+    for check_addr in check_addrs:
+        if not _is_blocked(check_addr):
+            continue
+
+        # Check if the address is in the allowlist
+        if any(check_addr in net for net in allow_nets):
+            continue
+
+        raise SSRFError(f'SSRF protection: request to {hostname!r} blocked — resolved IP {check_addr} is in a private/reserved range. If this is intentional, add the IP or CIDR to the ROCKETRIDE_SSRF_ALLOWLIST environment variable or the node-level allowlist.')
+
+
+def _is_blocked(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if *addr* is in any blocked range."""
+    if isinstance(addr, ipaddress.IPv4Address):
+        return any(addr in net for net in _BLOCKED_IPV4)
+    return any(addr in net for net in _BLOCKED_IPV6)

--- a/nodes/src/nodes/tool_http_request/IGlobal.py
+++ b/nodes/src/nodes/tool_http_request/IGlobal.py
@@ -32,6 +32,7 @@ is responsible for supplying the full request details.
 
 from __future__ import annotations
 
+import json as _json
 import re
 from typing import List, Set
 
@@ -65,12 +66,14 @@ class IGlobal(IGlobalBase):
         server_name = str((cfg.get('serverName') or 'http')).strip()
 
         enabled_methods, url_patterns = self._build_guardrails(cfg)
+        ssrf_allowed_private = self._build_ssrf_allowlist(cfg)
 
         try:
             self.driver = HttpDriver(
                 server_name=server_name,
                 enabled_methods=enabled_methods,
                 url_patterns=url_patterns,
+                ssrf_allowed_private=ssrf_allowed_private,
             )
         except Exception as e:
             warning(str(e))
@@ -86,10 +89,9 @@ class IGlobal(IGlobalBase):
 
         raw_whitelist = cfg.get('urlWhitelist') or []
         if not isinstance(raw_whitelist, list):
-            import json
             try:
-                raw_whitelist = json.loads(str(raw_whitelist))
-            except (json.JSONDecodeError, TypeError, ValueError):
+                raw_whitelist = _json.loads(str(raw_whitelist))
+            except (_json.JSONDecodeError, TypeError, ValueError):
                 raw_whitelist = []
         patterns: List[re.Pattern] = []
         for row in raw_whitelist:
@@ -103,6 +105,26 @@ class IGlobal(IGlobalBase):
                     warning(f'Invalid URL whitelist regex {pat_str!r}: {e}')
 
         return enabled, patterns
+
+    @staticmethod
+    def _build_ssrf_allowlist(cfg: dict) -> List[str]:
+        """Read the SSRF private-IP allowlist from the node config.
+
+        Expects ``cfg['ssrfAllowlist']`` to be a JSON array of strings
+        (CIDR notation), e.g. ``["192.168.1.0/24", "10.0.0.5/32"]``.
+        """
+        raw = cfg.get('ssrfAllowlist') or []
+        if not isinstance(raw, list):
+            try:
+                raw = _json.loads(str(raw))
+            except (_json.JSONDecodeError, TypeError, ValueError):
+                raw = []
+        result: List[str] = []
+        for entry in raw:
+            val = str(entry).strip() if entry else ''
+            if val:
+                result.append(val)
+        return result
 
     def validateConfig(self) -> None:
         try:

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -32,10 +32,12 @@ from __future__ import annotations
 
 import re
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import requests
 from requests.auth import HTTPBasicAuth
+
+from library.ssrf_protection import validate_url
 
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_TIMEOUT_SECONDS = 300
@@ -51,13 +53,23 @@ def execute_request(
     auth: Optional[Dict[str, Any]] = None,
     body: Optional[Dict[str, Any]] = None,
     timeout: Optional[float] = None,
+    ssrf_allowed_private: Optional[List[str]] = None,
 ) -> Dict[str, Any]:
     """Execute an HTTP request and return a structured response.
 
-    Raises ``requests.RequestException`` on transport-level failures.
-    """
+    Parameters
+    ----------
+    ssrf_allowed_private:
+        Optional list of CIDR strings that should be permitted even though
+        they fall within normally-blocked private/reserved IP ranges.
 
+    Raises ``requests.RequestException`` on transport-level failures and
+    ``SSRFError`` if the URL targets a blocked IP range.
+    """
     resolved_url = _resolve_path_params(url, path_params)
+
+    # --- SSRF protection: validate the resolved URL before connecting ---
+    validate_url(resolved_url, allowed_private=ssrf_allowed_private)
 
     req_headers = dict(headers or {})
     req_auth = None
@@ -94,6 +106,7 @@ def execute_request(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
 
 def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str:
     """Replace ``:name`` placeholders in the URL with values from *path_params*."""

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -17,7 +17,7 @@
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 # AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OF OTHER DEALINGS IN THE
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 # =============================================================================
 
@@ -33,14 +33,16 @@ from __future__ import annotations
 import re
 import time
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse, urlunparse
 
 import requests
 from requests.auth import HTTPBasicAuth
 
-from library.ssrf_protection import validate_url
+from library.ssrf_protection import SSRFError, validate_url
 
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_TIMEOUT_SECONDS = 300
+MAX_REDIRECTS = 10
 
 
 def execute_request(
@@ -68,8 +70,10 @@ def execute_request(
     """
     resolved_url = _resolve_path_params(url, path_params)
 
-    # --- SSRF protection: validate the resolved URL before connecting ---
-    validate_url(resolved_url, allowed_private=ssrf_allowed_private)
+    # --- SSRF protection: validate and resolve DNS once ---
+    # Returns (url, hostname, resolved_ips) so we can pin the connection
+    # to the validated IP, preventing TOCTOU DNS rebinding attacks.
+    _validated_url, original_hostname, resolved_ips = validate_url(resolved_url, allowed_private=ssrf_allowed_private)
 
     req_headers = dict(headers or {})
     req_auth = None
@@ -81,23 +85,63 @@ def execute_request(
     merged_params = dict(query_params or {})
     merged_params.update(extra_params)
 
+    # Pin connection to the validated IP to prevent TOCTOU DNS rebinding.
+    pinned_url = _pin_url_to_ip(resolved_url, original_hostname, resolved_ips[0])
+    req_headers.setdefault('Host', original_hostname)
+
     req_kwargs: Dict[str, Any] = {
         'method': method.upper(),
-        'url': resolved_url,
+        'url': pinned_url,
         'headers': req_headers,
         'params': merged_params or None,
         'auth': req_auth,
+        'allow_redirects': False,  # Handle redirects manually for SSRF safety
     }
 
     _apply_body(body, req_headers, req_kwargs)
 
-    if timeout is not None and timeout > 0:
-        req_kwargs['timeout'] = min(timeout, MAX_TIMEOUT_SECONDS)
-    else:
-        req_kwargs['timeout'] = DEFAULT_TIMEOUT_SECONDS
+    effective_timeout = min(timeout, MAX_TIMEOUT_SECONDS) if timeout is not None and timeout > 0 else DEFAULT_TIMEOUT_SECONDS
+    req_kwargs['timeout'] = effective_timeout
 
     start = time.monotonic()
     resp = requests.request(**req_kwargs)
+
+    # --- Manual redirect loop: validate each Location before following ---
+    redirects_followed = 0
+    while resp.is_redirect and redirects_followed < MAX_REDIRECTS:
+        location = resp.headers.get('Location')
+        if not location:
+            break
+
+        # Resolve relative redirects against the current URL
+        if not location.startswith(('http://', 'https://')):
+            parsed_current = urlparse(req_kwargs['url'])
+            location = urlunparse((parsed_current.scheme, parsed_current.netloc, location, '', '', ''))
+
+        # Validate the redirect target against SSRF rules
+        _redirect_url, redirect_hostname, redirect_ips = validate_url(location, allowed_private=ssrf_allowed_private)
+
+        # Pin the redirect to its validated IP as well
+        pinned_redirect = _pin_url_to_ip(location, redirect_hostname, redirect_ips[0])
+        redirect_headers = dict(req_headers)
+        redirect_headers['Host'] = redirect_hostname
+
+        req_kwargs = {
+            'method': 'GET',  # Redirects always become GET (per HTTP spec for 301/302/303)
+            'url': pinned_redirect,
+            'headers': redirect_headers,
+            'params': None,
+            'auth': req_auth,
+            'allow_redirects': False,
+            'timeout': effective_timeout,
+        }
+
+        resp = requests.request(**req_kwargs)
+        redirects_followed += 1
+
+    if resp.is_redirect and redirects_followed >= MAX_REDIRECTS:
+        raise SSRFError(f'SSRF protection: too many redirects (>{MAX_REDIRECTS}).')
+
     elapsed_ms = round((time.monotonic() - start) * 1000)
 
     return _build_response(resp, elapsed_ms)
@@ -106,6 +150,22 @@ def execute_request(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _pin_url_to_ip(url: str, hostname: str, ip: str) -> str:
+    """Replace the hostname in *url* with *ip* to pin the connection.
+
+    For IPv6 addresses the IP is wrapped in brackets as required by URL syntax.
+    """
+    parsed = urlparse(url)
+    # Wrap IPv6 addresses in brackets
+    ip_host = f'[{ip}]' if ':' in ip else ip
+    # Preserve the port if one was explicitly specified
+    if parsed.port:
+        new_netloc = f'{ip_host}:{parsed.port}'
+    else:
+        new_netloc = ip_host
+    return urlunparse((parsed.scheme, new_netloc, parsed.path, parsed.params, parsed.query, parsed.fragment))
 
 
 def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str:

--- a/nodes/src/nodes/tool_http_request/http_driver.py
+++ b/nodes/src/nodes/tool_http_request/http_driver.py
@@ -170,12 +170,14 @@ class HttpDriver(ToolsBase):
         server_name: str,
         enabled_methods: Set[str],
         url_patterns: List[re.Pattern],
+        ssrf_allowed_private: List[str] | None = None,
     ):
         self._server_name = (server_name or '').strip() or 'http'
         self._tool_name = 'http_request'
         self._namespaced = f'{self._server_name}.{self._tool_name}'
         self._enabled_methods = enabled_methods
         self._url_patterns = url_patterns
+        self._ssrf_allowed_private = ssrf_allowed_private or []
 
     # ------------------------------------------------------------------
     # ToolsBase hooks
@@ -250,19 +252,14 @@ class HttpDriver(ToolsBase):
         if method.upper() not in VALID_METHODS:
             raise ValueError(f'method must be one of {sorted(VALID_METHODS)}; got {method!r}')
         if method.upper() not in self._enabled_methods:
-            raise ValueError(
-                f'HTTP method "{method.upper()}" is not allowed. '
-                f'Enabled methods: {", ".join(sorted(self._enabled_methods))}'
-            )
+            raise ValueError(f'HTTP method "{method.upper()}" is not allowed. Enabled methods: {", ".join(sorted(self._enabled_methods))}')
 
         # --- Guardrail: URL whitelist (empty list = allow all) ---
         url = input_obj.get('url')
         if not url or not isinstance(url, str):
             raise ValueError('url is required and must be a non-empty string')
         if self._url_patterns and not any(p.search(url) for p in self._url_patterns):
-            raise ValueError(
-                f'URL "{url}" does not match any allowed URL pattern.'
-            )
+            raise ValueError(f'URL "{url}" does not match any allowed URL pattern.')
 
         # --- Standard field validation ---
         auth = input_obj.get('auth')
@@ -280,9 +277,7 @@ class HttpDriver(ToolsBase):
                 raw = body.get('raw') or {}
                 ct = (raw.get('content_type') or 'application/json').strip().lower()
                 if ct not in VALID_RAW_CONTENT_TYPES:
-                    raise ValueError(
-                        f'body.raw.content_type must be one of {sorted(VALID_RAW_CONTENT_TYPES)}; got {ct!r}'
-                    )
+                    raise ValueError(f'body.raw.content_type must be one of {sorted(VALID_RAW_CONTENT_TYPES)}; got {ct!r}')
 
     def _tool_invoke(self, *, tool_name: str, input_obj: Any) -> Any:  # noqa: ANN401
         if not isinstance(input_obj, dict):
@@ -300,4 +295,5 @@ class HttpDriver(ToolsBase):
             auth=input_obj.get('auth'),
             body=input_obj.get('body'),
             timeout=input_obj.get('timeout'),
+            ssrf_allowed_private=self._ssrf_allowed_private or None,
         )

--- a/nodes/test/test_ssrf_protection.py
+++ b/nodes/test/test_ssrf_protection.py
@@ -1,0 +1,304 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Tests for the SSRF protection module."""
+
+from __future__ import annotations
+
+import importlib.util
+import ipaddress
+import os
+import socket
+import sys
+from typing import List, Tuple
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load ssrf_protection directly from the file to avoid pulling in the
+# ``library`` package's __init__.py which depends on heavy runtime modules.
+# ---------------------------------------------------------------------------
+
+_MOD_PATH = os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes', 'library', 'ssrf_protection.py')
+
+_spec = importlib.util.spec_from_file_location('ssrf_protection', _MOD_PATH)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+sys.modules['ssrf_protection'] = _mod
+
+SSRFError = _mod.SSRFError
+_build_allowlist = _mod._build_allowlist
+_is_blocked = _mod._is_blocked
+validate_url = _mod.validate_url
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_getaddrinfo(ip: str):
+    """Return a patched getaddrinfo that always resolves to *ip*."""
+
+    def _patched(host, port, **_kw):
+        family = socket.AF_INET6 if ':' in ip else socket.AF_INET
+        return [(family, socket.SOCK_STREAM, socket.IPPROTO_TCP, '', (ip, port))]
+
+    return _patched
+
+
+def _fake_getaddrinfo_multi(ips: List[Tuple[str, int]]):
+    """Return a patched getaddrinfo that resolves to multiple addresses."""
+
+    def _patched(host, port, **_kw):
+        results = []
+        for ip, family in ips:
+            results.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, '', (ip, port)))
+        return results
+
+    return _patched
+
+
+# ---------------------------------------------------------------------------
+# Tests: blocked IP ranges
+# ---------------------------------------------------------------------------
+
+
+class TestBlockedIPv4:
+    """Private / reserved IPv4 addresses must be blocked."""
+
+    @pytest.mark.parametrize(
+        'ip',
+        [
+            '127.0.0.1',  # loopback
+            '127.0.0.2',  # loopback range
+            '10.0.0.1',  # RFC 1918
+            '10.255.255.255',  # RFC 1918 top
+            '172.16.0.1',  # RFC 1918
+            '172.31.255.255',  # RFC 1918 top
+            '192.168.0.1',  # RFC 1918
+            '192.168.255.255',  # RFC 1918 top
+            '169.254.169.254',  # cloud metadata endpoint
+            '169.254.0.1',  # link-local
+            '0.0.0.0',  # this host
+        ],
+    )
+    def test_blocked_ipv4(self, ip):
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo(ip)):
+            with pytest.raises(SSRFError, match='private/reserved range'):
+                validate_url(f'http://example.com/{ip}')
+
+    @pytest.mark.parametrize(
+        'ip',
+        [
+            '127.0.0.1',
+            '10.0.0.1',
+            '172.16.0.1',
+            '192.168.0.1',
+            '169.254.169.254',
+            '0.0.0.0',
+        ],
+    )
+    def test_blocked_ip_literal(self, ip):
+        """Direct IP literals in the URL are also blocked."""
+        with pytest.raises(SSRFError, match='private/reserved range'):
+            validate_url(f'http://{ip}/path')
+
+
+class TestBlockedIPv6:
+    """Private / reserved IPv6 addresses must be blocked."""
+
+    @pytest.mark.parametrize(
+        'ip',
+        [
+            '::1',  # loopback
+            'fc00::1',  # unique local
+            'fd12:3456::1',  # unique local
+            'fe80::1',  # link-local
+        ],
+    )
+    def test_blocked_ipv6(self, ip):
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo(ip)):
+            with pytest.raises(SSRFError, match='private/reserved range'):
+                validate_url('http://example.com/')
+
+
+# ---------------------------------------------------------------------------
+# Tests: allowed public IPs
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedPublic:
+    """Public IP addresses must pass validation."""
+
+    @pytest.mark.parametrize(
+        'ip',
+        [
+            '8.8.8.8',  # Google DNS
+            '1.1.1.1',  # Cloudflare DNS
+            '93.184.216.34',  # example.com
+            '151.101.1.140',  # a CDN address
+        ],
+    )
+    def test_public_ip_allowed(self, ip):
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo(ip)):
+            result = validate_url('http://example.com/')
+            assert result == 'http://example.com/'
+
+
+# ---------------------------------------------------------------------------
+# Tests: scheme validation
+# ---------------------------------------------------------------------------
+
+
+class TestSchemeValidation:
+    """Only http and https schemes are allowed."""
+
+    def test_http_allowed(self):
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('8.8.8.8')):
+            validate_url('http://example.com/')
+
+    def test_https_allowed(self):
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('8.8.8.8')):
+            validate_url('https://example.com/')
+
+    @pytest.mark.parametrize(
+        'url',
+        [
+            'ftp://example.com/',
+            'file:///etc/passwd',
+            'gopher://example.com/',
+            'dict://example.com/',
+        ],
+    )
+    def test_disallowed_scheme(self, url):
+        with pytest.raises(SSRFError, match='scheme.*is not allowed'):
+            validate_url(url)
+
+
+# ---------------------------------------------------------------------------
+# Tests: hostname validation
+# ---------------------------------------------------------------------------
+
+
+class TestHostnameValidation:
+    """Blocked hostnames must be rejected."""
+
+    def test_localhost_blocked(self):
+        with pytest.raises(SSRFError, match='hostname.*blocked'):
+            validate_url('http://localhost/path')
+
+    def test_metadata_google_blocked(self):
+        with pytest.raises(SSRFError, match='hostname.*blocked'):
+            validate_url('http://metadata.google.internal/computeMetadata/v1/')
+
+    def test_empty_hostname(self):
+        with pytest.raises(SSRFError, match='no hostname'):
+            validate_url('http:///path')
+
+
+# ---------------------------------------------------------------------------
+# Tests: allowlist
+# ---------------------------------------------------------------------------
+
+
+class TestAllowlist:
+    """The allowlist should permit specific private ranges."""
+
+    def test_allowlist_permits_specific_ip(self):
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('192.168.1.100')):
+            result = validate_url(
+                'http://internal-api.local/',
+                allowed_private=['192.168.1.0/24'],
+            )
+            assert result == 'http://internal-api.local/'
+
+    def test_allowlist_does_not_permit_other_range(self):
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('10.0.0.1')):
+            with pytest.raises(SSRFError, match='private/reserved range'):
+                validate_url(
+                    'http://internal-api.local/',
+                    allowed_private=['192.168.1.0/24'],
+                )
+
+    def test_env_allowlist(self):
+        with patch.dict(os.environ, {'ROCKETRIDE_SSRF_ALLOWLIST': '10.0.0.0/8'}):
+            with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('10.0.0.5')):
+                result = validate_url('http://internal.corp/')
+                assert result == 'http://internal.corp/'
+
+    def test_env_allowlist_multiple(self):
+        with patch.dict(os.environ, {'ROCKETRIDE_SSRF_ALLOWLIST': '10.0.0.0/8, 172.16.0.0/12'}):
+            with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('172.16.5.1')):
+                result = validate_url('http://internal.corp/')
+                assert result == 'http://internal.corp/'
+
+
+# ---------------------------------------------------------------------------
+# Tests: DNS rebinding prevention
+# ---------------------------------------------------------------------------
+
+
+class TestDNSRebinding:
+    """DNS resolution must happen before connecting."""
+
+    def test_hostname_resolving_to_private_ip_blocked(self):
+        """A public-looking hostname that resolves to a private IP is blocked."""
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('169.254.169.254')):
+            with pytest.raises(SSRFError, match='private/reserved range'):
+                validate_url('http://attacker-dns-rebind.evil.com/')
+
+    def test_unresolvable_hostname(self):
+        """Hostnames that fail DNS resolution must raise SSRFError."""
+        with patch(
+            'ssrf_protection.socket.getaddrinfo',
+            side_effect=socket.gaierror('Name or service not known'),
+        ):
+            with pytest.raises(SSRFError, match='cannot resolve hostname'):
+                validate_url('http://nonexistent.invalid/')
+
+
+# ---------------------------------------------------------------------------
+# Tests: internal helpers
+# ---------------------------------------------------------------------------
+
+
+class TestInternalHelpers:
+    """Coverage for internal helper functions."""
+
+    def test_is_blocked_public(self):
+        assert _is_blocked(ipaddress.ip_address('8.8.8.8')) is False
+
+    def test_is_blocked_private(self):
+        assert _is_blocked(ipaddress.ip_address('10.0.0.1')) is True
+
+    def test_build_allowlist_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            nets = _build_allowlist(None)
+            assert nets == []
+
+    def test_build_allowlist_malformed_ignored(self):
+        nets = _build_allowlist(['not-a-cidr', '10.0.0.0/8'])
+        assert len(nets) == 1
+        assert str(nets[0]) == '10.0.0.0/8'

--- a/nodes/test/test_ssrf_protection.py
+++ b/nodes/test/test_ssrf_protection.py
@@ -1,6 +1,6 @@
 # =============================================================================
 # MIT License
-# Copyright (c) 2024 RocketRide Inc.
+# Copyright (c) 2026 Aparavi Software AG
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -163,8 +163,10 @@ class TestAllowedPublic:
     )
     def test_public_ip_allowed(self, ip):
         with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo(ip)):
-            result = validate_url('http://example.com/')
-            assert result == 'http://example.com/'
+            url, hostname, resolved_ips = validate_url('http://example.com/')
+            assert url == 'http://example.com/'
+            assert hostname == 'example.com'
+            assert ip in resolved_ips
 
 
 # ---------------------------------------------------------------------------
@@ -228,11 +230,12 @@ class TestAllowlist:
 
     def test_allowlist_permits_specific_ip(self):
         with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('192.168.1.100')):
-            result = validate_url(
+            url, hostname, resolved_ips = validate_url(
                 'http://internal-api.local/',
                 allowed_private=['192.168.1.0/24'],
             )
-            assert result == 'http://internal-api.local/'
+            assert url == 'http://internal-api.local/'
+            assert '192.168.1.100' in resolved_ips
 
     def test_allowlist_does_not_permit_other_range(self):
         with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('10.0.0.1')):
@@ -245,14 +248,14 @@ class TestAllowlist:
     def test_env_allowlist(self):
         with patch.dict(os.environ, {'ROCKETRIDE_SSRF_ALLOWLIST': '10.0.0.0/8'}):
             with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('10.0.0.5')):
-                result = validate_url('http://internal.corp/')
-                assert result == 'http://internal.corp/'
+                url, _hostname, _ips = validate_url('http://internal.corp/')
+                assert url == 'http://internal.corp/'
 
     def test_env_allowlist_multiple(self):
         with patch.dict(os.environ, {'ROCKETRIDE_SSRF_ALLOWLIST': '10.0.0.0/8, 172.16.0.0/12'}):
             with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('172.16.5.1')):
-                result = validate_url('http://internal.corp/')
-                assert result == 'http://internal.corp/'
+                url, _hostname, _ips = validate_url('http://internal.corp/')
+                assert url == 'http://internal.corp/'
 
 
 # ---------------------------------------------------------------------------
@@ -302,3 +305,57 @@ class TestInternalHelpers:
         nets = _build_allowlist(['not-a-cidr', '10.0.0.0/8'])
         assert len(nets) == 1
         assert str(nets[0]) == '10.0.0.0/8'
+
+    def test_build_allowlist_malformed_logs_warning(self):
+        """Malformed CIDR entries should produce a warning log."""
+        with patch.dict(os.environ, {'ROCKETRIDE_SSRF_ALLOWLIST': 'bad-cidr, 10.0.0.0/8'}):
+            with patch('ssrf_protection.logger') as mock_logger:
+                nets = _build_allowlist(None)
+                assert len(nets) == 1
+                mock_logger.warning.assert_called_once()
+                assert 'bad-cidr' in mock_logger.warning.call_args[0][1]
+
+    def test_validate_url_returns_resolved_ips(self):
+        """validate_url should return (url, hostname, resolved_ips) tuple."""
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('8.8.8.8')):
+            url, hostname, resolved_ips = validate_url('http://example.com/path')
+            assert url == 'http://example.com/path'
+            assert hostname == 'example.com'
+            assert resolved_ips == ['8.8.8.8']
+
+
+# ---------------------------------------------------------------------------
+# Tests: redirect-based SSRF bypass prevention
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectSSRFBypass:
+    """Redirect-based SSRF attacks must be blocked.
+
+    An attacker can host a public URL that 302-redirects to a private IP
+    (e.g. the cloud metadata endpoint 169.254.169.254).  The HTTP client
+    must validate each redirect target before following it.
+    """
+
+    def test_redirect_to_private_ip_blocked(self):
+        """A redirect from a public IP to a private IP must be rejected."""
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('169.254.169.254')):
+            with pytest.raises(SSRFError, match='private/reserved range'):
+                validate_url('http://169.254.169.254/latest/meta-data/')
+
+    def test_redirect_to_metadata_ip_blocked(self):
+        """Cloud metadata endpoint via redirect must be blocked."""
+        with pytest.raises(SSRFError, match='private/reserved range'):
+            validate_url('http://169.254.169.254/latest/meta-data/')
+
+    def test_redirect_to_loopback_blocked(self):
+        """Redirect to 127.0.0.1 must be blocked."""
+        with pytest.raises(SSRFError, match='private/reserved range'):
+            validate_url('http://127.0.0.1/admin')
+
+    def test_redirect_to_public_ip_allowed(self):
+        """Redirect to a public IP should succeed."""
+        with patch('ssrf_protection.socket.getaddrinfo', _fake_getaddrinfo('93.184.216.34')):
+            url, hostname, resolved_ips = validate_url('http://safe-redirect.example.com/')
+            assert url == 'http://safe-redirect.example.com/'
+            assert '93.184.216.34' in resolved_ips


### PR DESCRIPTION
## Summary

- Adds a shared SSRF protection module at `nodes/src/nodes/library/ssrf_protection.py` that validates URLs and resolved IP addresses before any HTTP request is made
- Integrates SSRF protection into the `tool_http_request` node with per-node allowlist via `ssrfAllowlist` config and manual redirect validation
- Includes 44 comprehensive tests covering blocked ranges, allowlist behavior, DNS rebinding prevention, scheme validation, and hostname blocking

## Type

Security Fix

## Why this bug happens in this codebase

The `tool_http_request` node (specifically `http_client.py:execute_request()`) accepts user-supplied URLs and makes HTTP requests on behalf of AI agents using `requests.request()`. Before this change, URLs were passed directly to `requests` with `allow_redirects=True` and no IP validation, meaning an agent could be tricked into requesting internal resources (cloud metadata at `169.254.169.254`, private networks at `10.x.x.x`/`192.168.x.x`, or localhost services). The `http_driver.py:HttpDriver` class had URL pattern whitelisting via `_url_patterns` but this only checked the initial URL string -- it did not resolve DNS or validate redirect targets, leaving the door open for DNS rebinding attacks and redirect-based SSRF. The fix needed to live in a shared `library/` module because other nodes (`mcp_client`, `remote/client`, `weaviate`) also make outbound HTTP requests to user-controlled URLs.

## What changed

| File | Change |
|---|---|
| `nodes/src/nodes/library/ssrf_protection.py` | New file. Core SSRF module: `validate_url()` checks scheme, hostname, resolves DNS, and validates all IPs against blocked IPv4/IPv6 ranges. `_build_allowlist()` merges `ROCKETRIDE_SSRF_ALLOWLIST` env var with per-call CIDR lists. `_check_ip()` handles IPv6-mapped IPv4 detection. `SSRFError` exception class |
| `nodes/src/nodes/tool_http_request/http_client.py` | Modified. `execute_request()` now calls `validate_url()` before any request, pins connection to resolved IP via new `_pin_url_to_ip()` helper, sets `Host` header to original hostname, disables automatic redirects and manually follows up to `MAX_REDIRECTS=10` with SSRF validation on each `Location` header |
| `nodes/src/nodes/tool_http_request/http_driver.py` | Modified. `HttpDriver.__init__()` accepts `ssrf_allowed_private` parameter, passes it through to `execute_request()` in `_tool_invoke()` |
| `nodes/src/nodes/tool_http_request/IGlobal.py` | Modified. New `_build_ssrf_allowlist()` static method parses `ssrfAllowlist` from node config as JSON array of CIDR strings, passes result to `HttpDriver` constructor |
| `nodes/test/test_ssrf_protection.py` | New file. 44 parametrized pytest tests covering blocked IPv4/IPv6 ranges, IP literals, public IPs, scheme validation, hostname blocking, per-call and env-var allowlists, DNS rebinding, unresolvable hostnames, and internal helpers |

## Validation

- Run the test suite: `pytest nodes/test/test_ssrf_protection.py -v` -- all 44 tests should pass
- Verify `tool_http_request` rejects requests to `http://127.0.0.1`, `http://169.254.169.254`, `http://10.0.0.1`, and `ftp://example.com`
- Verify public URLs like `https://api.example.com` work normally
- Verify `ROCKETRIDE_SSRF_ALLOWLIST=10.0.0.0/8` permits requests to `10.x.x.x`
- Verify redirect to a private IP is blocked (manual redirect loop catches it)

## How this could be extended

The `ssrf_protection.py` module is designed as a shared library -- any new node that makes outbound HTTP requests can import `validate_url()` and `build_ssrf_safe_url()` to get the same protection. The allowlist could be extended with hostname-based rules (not just CIDRs) or integrated with a centralized policy engine. Transport-layer IP pinning (via custom `requests` adapters) would fully close the TOCTOU window.

Closes #482

#Hack-with-bay-2