### PR TITLE
feat(nodes): new node - openai compatible

### DIFF
--- a/nodes/src/nodes/llm_openai_api/IGlobal.py
+++ b/nodes/src/nodes/llm_openai_api/IGlobal.py
@@ -88,8 +88,7 @@ class IGlobal(IGlobalBase):
             from .openai_client import Chat
 
             bag = self.IEndpoint.endpoint.bag
-            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
-            self._chat = Chat(self.glb.logicalType, config, bag)
+            self._chat = Chat(self.glb.logicalType, self.glb.connConfig, bag)
 
     def endGlobal(self):
         self._chat = None

--- a/nodes/src/nodes/llm_openai_api/IGlobal.py
+++ b/nodes/src/nodes/llm_openai_api/IGlobal.py
@@ -1,4 +1,4 @@
-from rocketlib import IGlobalBase, OPEN_MODE, warning
+from rocketlib import IGlobalBase, OPEN_MODE, warning, debug
 from ai.common.config import Config
 from ai.common.chat import ChatBase
 import os
@@ -16,7 +16,7 @@ class IGlobal(IGlobalBase):
             # Load dependencies
             from depends import depends
 
-            requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+            requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
             depends(requirements)
 
             from openai import OpenAI, APIStatusError, OpenAIError, AuthenticationError, RateLimitError, APIConnectionError
@@ -29,10 +29,9 @@ class IGlobal(IGlobalBase):
             modelTotalTokens = config.get('modelTotalTokens')
 
             # Only validate tokens > 0 if provided
-            if modelTotalTokens is not None:
-                if modelTotalTokens <= 0:
-                    warning('Token limit must be greater than 0')
-                    return
+            if modelTotalTokens is not None and modelTotalTokens <= 0:
+                warning('Token limit must be greater than 0')
+                return
 
             # Simple API validation using provider-driven exceptions
             try:
@@ -63,8 +62,8 @@ class IGlobal(IGlobalBase):
                             parts.append(emsg)
                         if parts:
                             message = ' '.join(parts)
-                except Exception:
-                    pass
+                except Exception as exc:
+                    debug(f'JSON parse failed while formatting API error: {exc}')
                 message = re.sub(r'\s+', ' ', message).strip()
                 if len(message) > 500:
                     message = message[:500].rstrip() + '…'

--- a/nodes/src/nodes/llm_openai_api/IGlobal.py
+++ b/nodes/src/nodes/llm_openai_api/IGlobal.py
@@ -35,7 +35,7 @@ class IGlobal(IGlobalBase):
 
             # Simple API validation using provider-driven exceptions
             try:
-                kwargs = {'api_key': apikey}
+                kwargs = {'api_key': apikey, 'timeout': 10.0}
                 if base_url:
                     kwargs['base_url'] = base_url
 

--- a/nodes/src/nodes/llm_openai_api/IGlobal.py
+++ b/nodes/src/nodes/llm_openai_api/IGlobal.py
@@ -93,4 +93,4 @@ class IGlobal(IGlobalBase):
             self._chat = Chat(self.glb.logicalType, config, bag)
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None

--- a/nodes/src/nodes/llm_openai_api/IGlobal.py
+++ b/nodes/src/nodes/llm_openai_api/IGlobal.py
@@ -35,7 +35,7 @@ class IGlobal(IGlobalBase):
 
             # Simple API validation using provider-driven exceptions
             try:
-                kwargs = dict(api_key=apikey)
+                kwargs = {'api_key': apikey}
                 if base_url:
                     kwargs['base_url'] = base_url
 

--- a/nodes/src/nodes/llm_openai_api/IGlobal.py
+++ b/nodes/src/nodes/llm_openai_api/IGlobal.py
@@ -1,0 +1,96 @@
+from rocketlib import IGlobalBase, OPEN_MODE, warning
+from ai.common.config import Config
+from ai.common.chat import ChatBase
+import os
+import re
+
+
+class IGlobal(IGlobalBase):
+    chat: ChatBase | None = None
+
+    def validateConfig(self):
+        """
+        Validate the configuration for OpenAI-compatible API LLM node.
+        """
+        try:
+            # Load dependencies
+            from depends import depends
+
+            requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+            depends(requirements)
+
+            from openai import OpenAI, APIStatusError, OpenAIError, AuthenticationError, RateLimitError, APIConnectionError
+
+            # Get config
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            apikey = config.get('apikey')
+            model = config.get('model')
+            base_url = config.get('base_url') or None
+            modelTotalTokens = config.get('modelTotalTokens')
+
+            # Only validate tokens > 0 if provided
+            if modelTotalTokens is not None:
+                if modelTotalTokens <= 0:
+                    warning('Token limit must be greater than 0')
+                    return
+
+            # Simple API validation using provider-driven exceptions
+            try:
+                kwargs = dict(api_key=apikey)
+                if base_url:
+                    kwargs['base_url'] = base_url
+
+                client = OpenAI(**kwargs)
+                client.chat.completions.create(model=model, messages=[{'role': 'user', 'content': 'Hi'}], max_tokens=1)
+            except APIStatusError as e:
+                status = getattr(e, 'status_code', None) or getattr(e, 'status', None)
+                message = str(e)
+                try:
+                    resp = getattr(e, 'response', None)
+                    data = resp.json() if resp is not None else None
+                    if isinstance(data, dict):
+                        err = data.get('error')
+                        etype = err.get('type') if isinstance(err, dict) else None
+                        emsg = (err.get('message') if isinstance(err, dict) else None) or data.get('message')
+                        parts = []
+                        if status:
+                            parts.append(f'Error {status}:')
+                        if etype:
+                            parts.append(etype)
+                        if emsg:
+                            if etype:
+                                parts.append('-')
+                            parts.append(emsg)
+                        if parts:
+                            message = ' '.join(parts)
+                except Exception:
+                    pass
+                message = re.sub(r'\s+', ' ', message).strip()
+                if len(message) > 500:
+                    message = message[:500].rstrip() + '…'
+                warning(message)
+                return
+            except (AuthenticationError, RateLimitError, APIConnectionError, OpenAIError) as e:
+                message = re.sub(r'\s+', ' ', str(e)).strip()
+                if len(message) > 500:
+                    message = message[:500].rstrip() + '…'
+                warning(message)
+                return
+
+        except Exception as e:
+            warning(str(e))
+            return
+
+    def beginGlobal(self):
+        # Are we in config mode or some other mode?
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            pass
+        else:
+            from .openai_client import Chat
+
+            bag = self.IEndpoint.endpoint.bag
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            self._chat = Chat(self.glb.logicalType, config, bag)
+
+    def endGlobal(self):
+        self.chat = None

--- a/nodes/src/nodes/llm_openai_api/IInstance.py
+++ b/nodes/src/nodes/llm_openai_api/IInstance.py
@@ -1,0 +1,5 @@
+from nodes.llm_base import IInstanceGenericLLM
+
+
+class IInstance(IInstanceGenericLLM):
+    pass

--- a/nodes/src/nodes/llm_openai_api/__init__.py
+++ b/nodes/src/nodes/llm_openai_api/__init__.py
@@ -1,0 +1,18 @@
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+
+def getChat():
+    """
+    Get the Chat class from the module.
+    """
+    from .openai_client import Chat
+
+    return Chat
+
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+    'getChat',
+]

--- a/nodes/src/nodes/llm_openai_api/openai_client.py
+++ b/nodes/src/nodes/llm_openai_api/openai_client.py
@@ -32,12 +32,12 @@ class Chat(ChatBase):
         base_url = config.get('base_url') or None
 
         # Build kwargs for ChatOpenAI
-        kwargs = dict(
-            model=self._model,
-            api_key=apikey,
-            temperature=0,
-            max_tokens=self._modelOutputTokens,
-        )
+        kwargs = {
+            "model": self._model,
+            "api_key": apikey,
+            "temperature": 0,
+            "max_tokens": self._modelOutputTokens,
+        }
         if base_url:
             kwargs['base_url'] = base_url
 
@@ -51,16 +51,11 @@ class Chat(ChatBase):
         """
         Determine if the error is retryable.
         """
-        if isinstance(error, AuthenticationError):
+        if isinstance(error, (AuthenticationError, APIError)):
             return False
-        elif isinstance(error, APIError):
-            return False
-        elif isinstance(error, RateLimitError):
+        if isinstance(error, (RateLimitError, APIConnectionError)):
             return True
-        elif isinstance(error, APIConnectionError):
-            return True
-        else:
-            return super().is_retryable_error(error)
+        return super().is_retryable_error(error)
 
     def map_exception(self, error):
         """
@@ -68,11 +63,10 @@ class Chat(ChatBase):
         """
         if isinstance(error, AuthenticationError):
             return ValueError('Invalid API key.')
-        elif isinstance(error, APIError):
+        if isinstance(error, APIError):
             return ValueError('An error occurred with the API.')
-        elif isinstance(error, RateLimitError):
+        if isinstance(error, RateLimitError):
             return ValueError('Rate limit exceeded. Please try again later.')
-        elif isinstance(error, APIConnectionError):
+        if isinstance(error, APIConnectionError):
             return ValueError('Failed to connect to the API.')
-        else:
-            return super().map_exception(error)
+        return super().map_exception(error)

--- a/nodes/src/nodes/llm_openai_api/openai_client.py
+++ b/nodes/src/nodes/llm_openai_api/openai_client.py
@@ -1,0 +1,78 @@
+"""
+OpenAI-compatible API binding for the ChatLLM.
+Supports custom base_url for providers like Featherless, Together, Groq, Ollama, etc.
+"""
+
+from typing import Any, Dict
+from ai.common.chat import ChatBase
+from ai.common.config import Config
+from langchain_openai import ChatOpenAI
+from openai import APIError, AuthenticationError, RateLimitError, APIConnectionError
+
+
+class Chat(ChatBase):
+    """
+    Create an OpenAI-compatible API chat bot with custom base_url support.
+    """
+
+    _llm: ChatOpenAI
+
+    def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
+        """
+        Initialize the OpenAI-compatible chat bot.
+        """
+        # Init the base
+        super().__init__(provider, connConfig, bag)
+
+        # Get the nodes configuration
+        config = Config.getNodeConfig(provider, connConfig)
+
+        # Get the api key and base url
+        apikey = config.get('apikey')
+        base_url = config.get('base_url') or None
+
+        # Build kwargs for ChatOpenAI
+        kwargs = dict(
+            model=self._model,
+            api_key=apikey,
+            temperature=0,
+            max_tokens=self._modelOutputTokens,
+        )
+        if base_url:
+            kwargs['base_url'] = base_url
+
+        # Get the llm
+        self._llm = ChatOpenAI(**kwargs)
+
+        # Save our chat class into the bag
+        bag['chat'] = self
+
+    def is_retryable_error(self, error):
+        """
+        Determine if the error is retryable.
+        """
+        if isinstance(error, AuthenticationError):
+            return False
+        elif isinstance(error, APIError):
+            return False
+        elif isinstance(error, RateLimitError):
+            return True
+        elif isinstance(error, APIConnectionError):
+            return True
+        else:
+            return False
+
+    def map_exception(self, error):
+        """
+        Convert unfriendly openai exceptions to friendlier ones.
+        """
+        if isinstance(error, AuthenticationError):
+            return ValueError('Invalid API key.')
+        elif isinstance(error, APIError):
+            return ValueError('An error occurred with the API.')
+        elif isinstance(error, RateLimitError):
+            return ValueError('Rate limit exceeded. Please try again later.')
+        elif isinstance(error, APIConnectionError):
+            return ValueError('Failed to connect to the API.')
+        else:
+            return super().map_exception(error)

--- a/nodes/src/nodes/llm_openai_api/openai_client.py
+++ b/nodes/src/nodes/llm_openai_api/openai_client.py
@@ -60,7 +60,7 @@ class Chat(ChatBase):
         elif isinstance(error, APIConnectionError):
             return True
         else:
-            return False
+            return super().is_retryable_error(error)
 
     def map_exception(self, error):
         """

--- a/nodes/src/nodes/llm_openai_api/requirements.txt
+++ b/nodes/src/nodes/llm_openai_api/requirements.txt
@@ -1,0 +1,8 @@
+# Plugin OpenAI-compatible API
+openai
+langchain-openai
+tiktoken
+
+# LangChain deps
+langchain-core
+langchain

--- a/nodes/src/nodes/llm_openai_api/services.json
+++ b/nodes/src/nodes/llm_openai_api/services.json
@@ -1,0 +1,117 @@
+{
+	"title": "OpenAI-Compatible API",
+	"protocol": "llm_openai_api://",
+	"classType": [
+		"llm"
+	],
+	"capabilities": [
+		"invoke"
+	],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.llm_openai_api",
+	"prefix": "llm",
+	"description": [
+		"A component that connects to any OpenAI-compatible API endpoint for language model ",
+		"inference. Supports custom base URLs for providers like Featherless, Together, Groq, ",
+		"Ollama, LM Studio, and any other OpenAI SDK-compatible service. Configure with your ",
+		"provider's base URL, API key, and model name."
+	],
+	"icon": "openai.svg",
+	"tile": [
+		"Model: ${parameters.llm_openai_api.model}"
+	],
+	"lanes": {
+		"questions": [
+			"answers"
+		]
+	},
+	"input": [
+		{
+			"lane": "questions",
+			"output": [
+				{
+					"lane": "answers"
+				}
+			]
+		}
+	],
+	"preconfig": {
+		"default": "custom",
+		"profiles": {
+			"custom": {
+				"model": "",
+				"base_url": "",
+				"modelTotalTokens": 32768,
+				"apikey": ""
+			}
+		}
+	},
+	"fields": {
+		"model": {
+			"type": "string",
+			"title": "Model",
+			"description": "Model name (e.g. zai-org/GLM-5, meta-llama/Llama-3-70b)"
+		},
+		"base_url": {
+			"type": "string",
+			"title": "Base URL",
+			"description": "API base URL (e.g. https://api.featherless.ai/v1)"
+		},
+		"modelTotalTokens": {
+			"type": "number",
+			"title": "Tokens",
+			"description": "Total Tokens"
+		},
+		"openai_api.custom": {
+			"object": "custom",
+			"properties": [
+				"model",
+				"base_url",
+				"modelTotalTokens",
+				"llm.cloud.apikey"
+			]
+		},
+		"openai_api.profile": {
+			"title": "Configuration",
+			"description": "API configuration",
+			"type": "string",
+			"default": "custom",
+			"enum": [
+				"*>preconfig.profiles.*.title"
+			],
+			"conditional": [
+				{
+					"value": "custom",
+					"properties": [
+						"openai_api.custom"
+					]
+				}
+			]
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "OpenAI-Compatible API",
+			"properties": [
+				"openai_api.profile"
+			]
+		}
+	],
+	"test": {
+		"profiles": ["custom"],
+		"outputs": ["answers"],
+		"cases": [
+			{
+				"name": "LLM returns mock response",
+				"text": "What is 2+2?",
+				"expect": {
+					"answers": {
+						"contains": "Mock LLM response"
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Instead of having a separate node for each inference provider, just have llm_openai_api which most inference providers are compatible with anyways.

## Type

feature

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an OpenAI-compatible LLM node: configure API key, model, optional base URL, and optional total-token cap; includes credential/connectivity validation and chat-based invocation.
  * Added a lazy-access chat factory to create chat connectors on demand; improved user-facing warnings with normalized, truncated error messages for invalid settings.
* **Tests**
  * Built-in node test validating a sample prompt returns an expected mock response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->