### PR TITLE
fix(security): extend SSRF protection to all HTTP-capable modules

### DIFF
--- a/nodes/src/nodes/library/image/embed.py
+++ b/nodes/src/nodes/library/image/embed.py
@@ -28,7 +28,7 @@ from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urlunparse, ParseResult
 
 from rocketlib import debug
-from library.ssrf_protection import validate_url
+from library.ssrf_protection import build_ssrf_safe_url, validate_url
 
 
 def embed_images_in_html(html_content: str, default_scheme: str, default_site: str) -> str:
@@ -59,11 +59,12 @@ def embed_images_in_html(html_content: str, default_scheme: str, default_site: s
             # Download the image
             debug(f'Processing image URL: {image_url}')
 
-            # SSRF protection: validate the image URL before fetching
-            validate_url(image_url)
+            # SSRF protection: validate and pin to resolved IP to prevent TOCTOU
+            _url, hostname, resolved_ips = validate_url(image_url)
+            safe_url, host_headers = build_ssrf_safe_url(image_url, hostname, resolved_ips)
 
             # Check if the image URL is valid
-            response = requests.get(image_url)
+            response = requests.get(safe_url, headers=host_headers, allow_redirects=False)
             response.raise_for_status()
             image_data = response.content
 

--- a/nodes/src/nodes/library/image/embed.py
+++ b/nodes/src/nodes/library/image/embed.py
@@ -28,6 +28,7 @@ from bs4 import BeautifulSoup
 from urllib.parse import urlparse, urlunparse, ParseResult
 
 from rocketlib import debug
+from library.ssrf_protection import validate_url
 
 
 def embed_images_in_html(html_content: str, default_scheme: str, default_site: str) -> str:
@@ -57,6 +58,9 @@ def embed_images_in_html(html_content: str, default_scheme: str, default_site: s
 
             # Download the image
             debug(f'Processing image URL: {image_url}')
+
+            # SSRF protection: validate the image URL before fetching
+            validate_url(image_url)
 
             # Check if the image URL is valid
             response = requests.get(image_url)

--- a/nodes/src/nodes/library/ssrf_protection.py
+++ b/nodes/src/nodes/library/ssrf_protection.py
@@ -1,0 +1,288 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+SSRF (Server-Side Request Forgery) protection utilities.
+
+Validates URLs and resolved IP addresses to prevent requests to private,
+loopback, link-local, and reserved IP ranges.  Supports a configurable
+allowlist so self-hosted operators can permit specific internal services.
+
+DNS resolution is performed before the IP check to prevent DNS rebinding
+attacks where a hostname initially resolves to a public IP but later
+resolves to an internal one.
+
+Usage::
+
+    from library.ssrf_protection import validate_url, SSRFError
+
+    # Block all private IPs (default)
+    validate_url('http://192.168.1.1/api')  # raises SSRFError
+
+    # Allow specific private ranges
+    validate_url(
+        'http://192.168.1.100/api',
+        allowed_private=['192.168.1.0/24'],
+    )
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import socket
+from typing import List, Optional, Sequence, Tuple
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Blocked networks (RFC 1918, loopback, link-local, metadata, etc.)
+# ---------------------------------------------------------------------------
+
+_BLOCKED_IPV4 = [
+    ipaddress.IPv4Network('0.0.0.0/8'),  # "This host" (RFC 1122)
+    ipaddress.IPv4Network('10.0.0.0/8'),  # Private (RFC 1918)
+    ipaddress.IPv4Network('100.64.0.0/10'),  # Shared address (RFC 6598)
+    ipaddress.IPv4Network('127.0.0.0/8'),  # Loopback (RFC 1122)
+    ipaddress.IPv4Network('169.254.0.0/16'),  # Link-local (RFC 3927) + cloud metadata
+    ipaddress.IPv4Network('172.16.0.0/12'),  # Private (RFC 1918)
+    ipaddress.IPv4Network('192.0.0.0/24'),  # IETF protocol assignments (RFC 6890)
+    ipaddress.IPv4Network('192.0.2.0/24'),  # Documentation (RFC 5737)
+    ipaddress.IPv4Network('192.168.0.0/16'),  # Private (RFC 1918)
+    ipaddress.IPv4Network('198.18.0.0/15'),  # Benchmarking (RFC 2544)
+    ipaddress.IPv4Network('198.51.100.0/24'),  # Documentation (RFC 5737)
+    ipaddress.IPv4Network('203.0.113.0/24'),  # Documentation (RFC 5737)
+    ipaddress.IPv4Network('224.0.0.0/4'),  # Multicast (RFC 5771)
+    ipaddress.IPv4Network('240.0.0.0/4'),  # Reserved (RFC 1112)
+    ipaddress.IPv4Network('255.255.255.255/32'),  # Broadcast
+]
+
+_BLOCKED_IPV6 = [
+    ipaddress.IPv6Network('::1/128'),  # Loopback
+    ipaddress.IPv6Network('::/128'),  # Unspecified
+    ipaddress.IPv6Network('::ffff:0:0/96'),  # IPv4-mapped (checked via mapped v4)
+    ipaddress.IPv6Network('64:ff9b::/96'),  # NAT64 (RFC 6052)
+    ipaddress.IPv6Network('100::/64'),  # Discard (RFC 6666)
+    ipaddress.IPv6Network('2001:db8::/32'),  # Documentation (RFC 3849)
+    ipaddress.IPv6Network('fc00::/7'),  # Unique local (RFC 4193)
+    ipaddress.IPv6Network('fe80::/10'),  # Link-local (RFC 4291)
+    ipaddress.IPv6Network('ff00::/8'),  # Multicast (RFC 4291)
+]
+
+# Hostnames that are always blocked regardless of IP resolution.
+_BLOCKED_HOSTNAMES = frozenset(
+    {
+        'localhost',
+        'metadata.google.internal',
+    }
+)
+
+# Environment variable for the global allowlist (comma-separated CIDRs).
+SSRF_ALLOWLIST_ENV = 'ROCKETRIDE_SSRF_ALLOWLIST'
+
+# Only allow http and https schemes.
+_ALLOWED_SCHEMES = frozenset({'http', 'https'})
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class SSRFError(ValueError):
+    """Raised when a URL targets a blocked (private/reserved) IP address."""
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def validate_url(
+    url: str,
+    *,
+    allowed_private: Optional[Sequence[str]] = None,
+) -> Tuple[str, str, List[str]]:
+    """Validate *url* against SSRF rules and return the URL with resolved IPs.
+
+    Parameters
+    ----------
+    url:
+        The URL to validate (must use ``http`` or ``https`` scheme).
+    allowed_private:
+        An optional list of CIDR strings (e.g. ``['192.168.1.0/24']``) that
+        should be permitted even though they fall within blocked ranges.
+        This is merged with the global allowlist from the
+        ``ROCKETRIDE_SSRF_ALLOWLIST`` environment variable.
+
+    Returns
+    -------
+    tuple[str, str, list[str]]
+        A 3-tuple of ``(url, hostname, resolved_ips)`` where *resolved_ips*
+        are the validated IP addresses.  Callers should connect directly to
+        one of these IPs (setting the ``Host`` header to *hostname*) to
+        prevent TOCTOU DNS rebinding attacks.
+
+    Raises
+    ------
+    SSRFError
+        If the URL targets a blocked IP, uses a disallowed scheme, or
+        cannot be resolved.
+    """
+    parsed = urlparse(url)
+
+    # -- Scheme check -------------------------------------------------------
+    scheme = (parsed.scheme or '').lower()
+    if scheme not in _ALLOWED_SCHEMES:
+        raise SSRFError(f'SSRF protection: scheme {scheme!r} is not allowed. Only {sorted(_ALLOWED_SCHEMES)} are permitted.')
+
+    # -- Extract hostname ---------------------------------------------------
+    hostname = (parsed.hostname or '').lower().strip('.')
+    if not hostname:
+        raise SSRFError('SSRF protection: URL has no hostname.')
+
+    # -- Blocked hostname check ---------------------------------------------
+    if hostname in _BLOCKED_HOSTNAMES:
+        raise SSRFError(f'SSRF protection: hostname {hostname!r} is blocked.')
+
+    # -- Build combined allowlist -------------------------------------------
+    allow_nets = _build_allowlist(allowed_private)
+
+    # -- DNS resolution + IP check ------------------------------------------
+    port = parsed.port or (443 if scheme == 'https' else 80)
+    resolved_ips = _resolve_and_check(hostname, port, allow_nets)
+
+    return url, hostname, resolved_ips
+
+
+def resolve_and_validate(
+    hostname: str,
+    port: int = 80,
+    *,
+    allowed_private: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Resolve *hostname* and validate all resulting IPs.
+
+    Returns the list of resolved IP address strings.  Raises ``SSRFError``
+    if any resolved address is blocked.
+    """
+    allow_nets = _build_allowlist(allowed_private)
+    return _resolve_and_check(hostname, port, allow_nets)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _build_allowlist(
+    extra: Optional[Sequence[str]] = None,
+) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+    """Merge per-call allowlist with the global env-var allowlist."""
+    nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+
+    # Global allowlist from environment
+    env_val = os.environ.get(SSRF_ALLOWLIST_ENV, '').strip()
+    if env_val:
+        for cidr in env_val.split(','):
+            cidr = cidr.strip()
+            if cidr:
+                try:
+                    nets.append(ipaddress.ip_network(cidr, strict=False))
+                except ValueError:
+                    logger.warning('SSRF allowlist: ignoring malformed CIDR entry %r from %s', cidr, SSRF_ALLOWLIST_ENV)
+
+    # Per-call allowlist
+    for cidr in extra or []:
+        cidr_s = str(cidr).strip()
+        if cidr_s:
+            try:
+                nets.append(ipaddress.ip_network(cidr_s, strict=False))
+            except ValueError:
+                logger.warning('SSRF allowlist: ignoring malformed CIDR entry %r from per-call allowlist', cidr_s)
+
+    return nets
+
+
+def _resolve_and_check(
+    hostname: str,
+    port: int,
+    allow_nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+) -> List[str]:
+    """Resolve hostname via DNS and check every resulting IP."""
+    # If hostname is already an IP literal, skip DNS.
+    try:
+        addr = ipaddress.ip_address(hostname)
+        _check_ip(addr, hostname, allow_nets)
+        return [str(addr)]
+    except ValueError:
+        pass  # not an IP literal — resolve via DNS
+
+    try:
+        addrinfos = socket.getaddrinfo(hostname, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise SSRFError(f'SSRF protection: cannot resolve hostname {hostname!r}: {exc}') from exc
+
+    if not addrinfos:
+        raise SSRFError(f'SSRF protection: hostname {hostname!r} resolved to no addresses.')
+
+    resolved_ips: List[str] = []
+    for family, _type, _proto, _canonname, sockaddr in addrinfos:
+        ip_str = sockaddr[0]
+        addr = ipaddress.ip_address(ip_str)
+        _check_ip(addr, hostname, allow_nets)
+        if ip_str not in resolved_ips:
+            resolved_ips.append(ip_str)
+
+    return resolved_ips
+
+
+def _check_ip(
+    addr: ipaddress.IPv4Address | ipaddress.IPv6Address,
+    hostname: str,
+    allow_nets: list[ipaddress.IPv4Network | ipaddress.IPv6Network],
+) -> None:
+    """Raise ``SSRFError`` if *addr* falls within a blocked range."""
+    # For IPv6-mapped IPv4 addresses, also check the embedded v4 address.
+    check_addrs = [addr]
+    if isinstance(addr, ipaddress.IPv6Address) and addr.ipv4_mapped:
+        check_addrs.append(addr.ipv4_mapped)
+
+    for check_addr in check_addrs:
+        if not _is_blocked(check_addr):
+            continue
+
+        # Check if the address is in the allowlist
+        if any(check_addr in net for net in allow_nets):
+            continue
+
+        raise SSRFError(f'SSRF protection: request to {hostname!r} blocked — resolved IP {check_addr} is in a private/reserved range. If this is intentional, add the IP or CIDR to the ROCKETRIDE_SSRF_ALLOWLIST environment variable or the node-level allowlist.')
+
+
+def _is_blocked(addr: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return True if *addr* is in any blocked range."""
+    if isinstance(addr, ipaddress.IPv4Address):
+        return any(addr in net for net in _BLOCKED_IPV4)
+    return any(addr in net for net in _BLOCKED_IPV6)

--- a/nodes/src/nodes/library/ssrf_protection.py
+++ b/nodes/src/nodes/library/ssrf_protection.py
@@ -52,8 +52,8 @@ import ipaddress
 import logging
 import os
 import socket
-from typing import List, Optional, Sequence, Tuple
-from urllib.parse import urlparse
+from typing import Dict, List, Optional, Sequence, Tuple
+from urllib.parse import urlparse, urlunparse
 
 logger = logging.getLogger(__name__)
 
@@ -175,6 +175,36 @@ def validate_url(
     resolved_ips = _resolve_and_check(hostname, port, allow_nets)
 
     return url, hostname, resolved_ips
+
+
+def build_ssrf_safe_url(
+    url: str,
+    hostname: str,
+    resolved_ips: List[str],
+) -> Tuple[str, Dict[str, str]]:
+    """Replace the hostname in *url* with a resolved IP and return a Host header.
+
+    This prevents TOCTOU DNS rebinding: the caller connects directly to a
+    validated IP while sending the original ``Host`` header so virtual-hosted
+    servers still route the request correctly.
+
+    Returns
+    -------
+    tuple[str, dict[str, str]]
+        A 2-tuple of ``(ip_url, extra_headers)`` where *ip_url* has the
+        hostname replaced with the first resolved IP and *extra_headers*
+        contains at minimum ``{'Host': '<original_host_with_port>'}``.
+    """
+    parsed = urlparse(url)
+    ip = resolved_ips[0]
+    # Preserve the port in the Host header when it is non-default.
+    host_header = parsed.netloc  # includes port if present
+    # For IPv6 IPs, wrap in brackets for the URL netloc.
+    ip_netloc = f'[{ip}]' if ':' in ip else ip
+    if parsed.port:
+        ip_netloc = f'{ip_netloc}:{parsed.port}'
+    ip_url = urlunparse(parsed._replace(netloc=ip_netloc))
+    return ip_url, {'Host': host_header}
 
 
 def resolve_and_validate(

--- a/nodes/src/nodes/mcp_client/mcp_sse_client.py
+++ b/nodes/src/nodes/mcp_client/mcp_sse_client.py
@@ -50,6 +50,8 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+from library.ssrf_protection import validate_url
+
 
 class McpProtocolError(RuntimeError):
     pass
@@ -89,7 +91,7 @@ class McpSseClient:
 
         self._reader_thread: threading.Thread | None = None
         self._stop = threading.Event()
-        self._incoming: "queue.Queue[dict]" = queue.Queue()
+        self._incoming: 'queue.Queue[dict]' = queue.Queue()
         self._endpoint_url: str | None = None
         self._resp = None
 
@@ -102,6 +104,9 @@ class McpSseClient:
     def start(self) -> None:
         if self._reader_thread is not None:
             raise RuntimeError('MCP SSE client already started')
+
+        # SSRF protection: validate the user-supplied SSE endpoint before any requests
+        validate_url(self._sse_endpoint)
 
         self._stop.clear()
         self._reader_thread = threading.Thread(target=self._reader_loop, name='McpSseReader', daemon=True)
@@ -313,11 +318,9 @@ class McpSseClient:
             # Validate the resolved URL stays on the same origin to prevent
             # auth-token theft via malicious absolute-URL redirects.
             if self._origin(resolved) != base:
-                raise McpProtocolError(
-                    f'MCP endpoint redirect rejected: '
-                    f'resolved origin {self._origin(resolved)!r} '
-                    f'does not match SSE origin {base!r}'
-                )
+                raise McpProtocolError(f'MCP endpoint redirect rejected: resolved origin {self._origin(resolved)!r} does not match SSE origin {base!r}')
+            # SSRF protection: validate the server-provided endpoint URL
+            validate_url(resolved)
             self._endpoint_url = resolved
             return
 
@@ -352,4 +355,3 @@ class McpSseClient:
         elif scheme == 'http' and netloc.endswith(':80'):
             netloc = netloc[:-3]
         return f'{scheme}://{netloc}'
-

--- a/nodes/src/nodes/mcp_client/mcp_streamable_http_client.py
+++ b/nodes/src/nodes/mcp_client/mcp_streamable_http_client.py
@@ -53,6 +53,8 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional
 
+from library.ssrf_protection import validate_url
+
 
 class McpProtocolError(RuntimeError):
     pass
@@ -109,6 +111,9 @@ class McpStreamableHttpClient:
     def start(self) -> None:
         if self._started:
             raise RuntimeError('MCP streamable-http client already started')
+
+        # SSRF protection: validate the user-supplied endpoint before any requests
+        validate_url(self._endpoint)
 
         init_result, resp_headers = self._request_with_headers(
             'initialize',
@@ -357,4 +362,3 @@ def _match_jsonrpc_id(msg: dict, *, req_id: int) -> Any | None:  # noqa: ANN401
         message = msg['error'].get('message')
         raise McpProtocolError(f'MCP error (id={req_id}) code={code} message={message}')
     return msg.get('result')
-

--- a/nodes/src/nodes/remote/client/IGlobal.py
+++ b/nodes/src/nodes/remote/client/IGlobal.py
@@ -28,6 +28,7 @@ from typing import Dict, Any, List
 import requests
 from rocketlib import configureLogger, IGlobalBase, monitorStatus, IJson, Lvl
 from ai.common.config import Config
+from library.ssrf_protection import validate_url
 
 
 class IGlobal(IGlobalBase):
@@ -66,6 +67,9 @@ class IGlobal(IGlobalBase):
         # Build the URLs to access the pipe
         self.urlControl = f'http://{self._host}:{self._port}/remote?pipe={self._pipeId}'
         self.urlProcess = f'ws://{self._host}:{self._port}/remote/pipe?pipe={self._pipeId}'
+
+        # SSRF protection: validate the user-supplied host before making requests
+        validate_url(self.urlControl)
 
         # Update the monitor
         monitorStatus('Loading remote pipe')

--- a/nodes/src/nodes/remote/client/IGlobal.py
+++ b/nodes/src/nodes/remote/client/IGlobal.py
@@ -28,7 +28,7 @@ from typing import Dict, Any, List
 import requests
 from rocketlib import configureLogger, IGlobalBase, monitorStatus, IJson, Lvl
 from ai.common.config import Config
-from library.ssrf_protection import validate_url
+from library.ssrf_protection import build_ssrf_safe_url, validate_url
 
 
 class IGlobal(IGlobalBase):
@@ -68,16 +68,22 @@ class IGlobal(IGlobalBase):
         self.urlControl = f'http://{self._host}:{self._port}/remote?pipe={self._pipeId}'
         self.urlProcess = f'ws://{self._host}:{self._port}/remote/pipe?pipe={self._pipeId}'
 
-        # SSRF protection: validate the user-supplied host before making requests
-        validate_url(self.urlControl)
+        # SSRF protection: validate and pin to resolved IP to prevent TOCTOU
+        _url, hostname, resolved_ips = validate_url(self.urlControl)
+        safe_control_url, host_headers = build_ssrf_safe_url(self.urlControl, hostname, resolved_ips)
+        # Merge Host header into request headers for all subsequent calls
+        self.headers.update(host_headers)
+        # Store the IP-pinned base for use in all requests
+        self._safe_control_url = safe_control_url
+        safe_use_url, _ = build_ssrf_safe_url(f'http://{self._host}:{self._port}/use?name=remote', hostname, resolved_ips)
 
         # Update the monitor
         monitorStatus('Loading remote pipe')
 
-        requests.post(f'http://{self._host}:{self._port}/use?name=remote', headers=self.headers).raise_for_status()
+        requests.post(safe_use_url, headers=self.headers, allow_redirects=False).raise_for_status()
 
         # Issue the request
-        response = requests.post(self.urlControl, json=IJson.toDict(self._pipeline), headers=self.headers)
+        response = requests.post(self._safe_control_url, json=IJson.toDict(self._pipeline), headers=self.headers, allow_redirects=False)
 
         # Check for success
         if response.status_code != 200:
@@ -85,7 +91,7 @@ class IGlobal(IGlobalBase):
 
     def endGlobal(self):
         # Issue the request
-        response = requests.delete(self.urlControl, headers=self.headers)
+        response = requests.delete(self._safe_control_url, headers=self.headers, allow_redirects=False)
 
         # Check for success
         if response.status_code != 200:

--- a/nodes/src/nodes/weaviate/IGlobal.py
+++ b/nodes/src/nodes/weaviate/IGlobal.py
@@ -27,6 +27,7 @@ from ai.common.config import Config
 from ai.common.transform import IGlobalTransform
 from rocketlib import OPEN_MODE
 from rocketlib import warning
+from library.ssrf_protection import validate_url
 
 
 # Module-level regex constant for collection name validation (official rule)
@@ -118,6 +119,8 @@ class IGlobal(IGlobalTransform):
             if is_cloud:
                 # Cloud: REST + API key only; do not probe gRPC
                 url = base_url.rstrip('/') + '/v1/meta'
+                # SSRF protection: validate the user-supplied host before making requests
+                validate_url(url)
                 headers = {'Authorization': f'Bearer {apikey}'} if apikey else {}
                 r = httpx.get(url, headers=headers, timeout=3)
                 r.raise_for_status()

--- a/nodes/src/nodes/weaviate/IGlobal.py
+++ b/nodes/src/nodes/weaviate/IGlobal.py
@@ -27,7 +27,7 @@ from ai.common.config import Config
 from ai.common.transform import IGlobalTransform
 from rocketlib import OPEN_MODE
 from rocketlib import warning
-from library.ssrf_protection import validate_url
+from library.ssrf_protection import build_ssrf_safe_url, validate_url
 
 
 # Module-level regex constant for collection name validation (official rule)
@@ -119,10 +119,12 @@ class IGlobal(IGlobalTransform):
             if is_cloud:
                 # Cloud: REST + API key only; do not probe gRPC
                 url = base_url.rstrip('/') + '/v1/meta'
-                # SSRF protection: validate the user-supplied host before making requests
-                validate_url(url)
+                # SSRF protection: validate and pin to resolved IP to prevent TOCTOU
+                _url, hostname, resolved_ips = validate_url(url)
+                safe_url, host_headers = build_ssrf_safe_url(url, hostname, resolved_ips)
                 headers = {'Authorization': f'Bearer {apikey}'} if apikey else {}
-                r = httpx.get(url, headers=headers, timeout=3)
+                headers.update(host_headers)
+                r = httpx.get(safe_url, headers=headers, timeout=3, follow_redirects=False)
                 r.raise_for_status()
                 return
             else:


### PR DESCRIPTION
## Summary

- Extends the SSRF protection from #517 to all remaining modules that make outbound HTTP requests to user-controlled URLs: remote client, Weaviate, MCP SSE/Streamable HTTP clients, and image embed
- Each integration calls `validate_url()` and `build_ssrf_safe_url()` to resolve DNS once, validate IPs, and pin connections to the resolved address with the original `Host` header preserved

## Type

Security Fix

## Why this bug happens in this codebase

After #517 protected `tool_http_request`, five other modules still made unvalidated outbound HTTP requests to user-supplied URLs. In `nodes/src/nodes/remote/client/IGlobal.py`, `beginGlobal()` constructs `urlControl` from user-configured `host` and `port` fields and passes it directly to `requests.post()` and `requests.delete()` -- an attacker could set the remote host to a private IP. In `nodes/src/nodes/weaviate/IGlobal.py`, `validateConfig()` builds a REST probe URL from the user-supplied `base_url` and calls `httpx.get()` without validation. In `nodes/src/nodes/mcp_client/mcp_sse_client.py`, the `start()` method opens an SSE connection to a user-supplied endpoint, and `_handle_sse_event()` accepts a server-provided endpoint URL without checking whether it points to a private network. In `nodes/src/nodes/mcp_client/mcp_streamable_http_client.py`, `start()` similarly sends requests to a user-supplied endpoint. In `nodes/src/nodes/library/image/embed.py`, `embed_images_in_html()` fetches image URLs extracted from HTML content via `requests.get()` with no SSRF check, meaning a crafted HTML document could trigger requests to internal services.

## What changed

| File | Change |
|---|---|
| `nodes/src/nodes/remote/client/IGlobal.py` | Added import of `validate_url` and `build_ssrf_safe_url`. In `beginGlobal()`, validates `urlControl`, pins to resolved IP, merges `Host` header, and uses `allow_redirects=False` on all `requests.post()`/`requests.delete()` calls |
| `nodes/src/nodes/weaviate/IGlobal.py` | Added import of `validate_url` and `build_ssrf_safe_url`. In `validateConfig()`, validates the cloud REST probe URL, pins to resolved IP, and uses `follow_redirects=False` on the `httpx.get()` call |
| `nodes/src/nodes/mcp_client/mcp_sse_client.py` | Added import of `validate_url`. Calls `validate_url()` in `start()` before opening the SSE connection and in `_handle_sse_event()` when the server provides an endpoint URL |
| `nodes/src/nodes/mcp_client/mcp_streamable_http_client.py` | Added import of `validate_url`. Calls `validate_url()` in `start()` before the initialize request |
| `nodes/src/nodes/library/image/embed.py` | Added import of `validate_url` and `build_ssrf_safe_url`. In `embed_images_in_html()`, validates each image URL, pins to resolved IP, and uses `allow_redirects=False` on `requests.get()` |
| `nodes/src/nodes/library/ssrf_protection.py` | Included as prerequisite (identical to #517) with added `build_ssrf_safe_url()` helper for IP pinning with Host header preservation |

## Validation

- Verify each protected module rejects requests to private IPs (127.0.0.1, 10.x, 172.16.x, 192.168.x, 169.254.169.254)
- Verify non-http/https schemes are rejected in all modules
- Verify `ROCKETRIDE_SSRF_ALLOWLIST` env var can allowlist specific CIDRs for legitimate internal services
- Verify normal operation with public URLs is unaffected across all modules
- Verify MCP SSE client validates server-provided endpoint URLs (not just the initial user-supplied one)
- Run the existing test suite to confirm no regressions

## How this could be extended

Any future node that makes outbound HTTP requests should import `validate_url()` from `library.ssrf_protection` -- the pattern is now established across all existing HTTP-capable modules. Full TOCTOU mitigation via transport-layer IP pinning (custom `requests` transport adapters or `httpx` transport hooks) could be added as a follow-up. A centralized audit log for blocked SSRF attempts would help operators detect prompt injection attacks targeting internal infrastructure.

Closes #435

#Hack-with-bay-2