### PR TITLE
feat(nodes): add intelligent model router node for dynamic LLM selection

### DIFF
--- a/nodes/src/nodes/router_llm/IGlobal.py
+++ b/nodes/src/nodes/router_llm/IGlobal.py
@@ -54,6 +54,18 @@ class IGlobal(IGlobalBase):
         if strategy not in valid_strategies:
             raise APERR(Ec.InvalidParam, f'Invalid routing strategy "{strategy}". Must be one of: {", ".join(sorted(valid_strategies))}')
 
+        budget_limit = float(config.get('budget_limit', 0.0))
+        if budget_limit < 0:
+            raise APERR(Ec.InvalidParam, f'budget_limit must be >= 0, got {budget_limit}')
+
+        complexity_threshold = int(config.get('complexity_threshold', 50))
+        if complexity_threshold < 1:
+            raise APERR(Ec.InvalidParam, f'complexity_threshold must be >= 1, got {complexity_threshold}')
+
+        ab_split_percent = int(config.get('ab_split_percent', 50))
+        if not (0 <= ab_split_percent <= 100):
+            raise APERR(Ec.InvalidParam, f'ab_split_percent must be between 0 and 100, got {ab_split_percent}')
+
         if syntaxOnly:
             return
 
@@ -67,6 +79,19 @@ class IGlobal(IGlobalBase):
                 models = []
             if not models:
                 raise APERR(Ec.InvalidParam, 'fallback_chain strategy requires at least one model in fallback_models')
+
+        if strategy == 'ab_test':
+            primary_model = config.get('primary_model', 'claude-sonnet')
+            fallback_raw = config.get('fallback_models', '')
+            if isinstance(fallback_raw, str):
+                fallback_list = [m.strip() for m in fallback_raw.split(',') if m.strip()]
+            elif isinstance(fallback_raw, list):
+                fallback_list = [m.strip() for m in fallback_raw if m.strip()]
+            else:
+                fallback_list = []
+            distinct = [m for m in fallback_list if m != primary_model]
+            if not distinct:
+                raise APERR(Ec.InvalidParam, 'ab_test strategy requires at least one fallback model that differs from primary_model for meaningful A/B testing')
 
     def beginGlobal(self) -> None:
         """Initialize the ModelRouter with the node configuration."""

--- a/nodes/src/nodes/router_llm/IGlobal.py
+++ b/nodes/src/nodes/router_llm/IGlobal.py
@@ -1,0 +1,79 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+# ------------------------------------------------------------------------------
+# This class controls the data shared between all threads for the router node.
+# It creates and holds the ModelRouter instance that is shared across all
+# pipeline instances.
+# ------------------------------------------------------------------------------
+
+from rocketlib import IGlobalBase, OPEN_MODE
+from ai.common.config import Config
+
+
+class IGlobal(IGlobalBase):
+    # Holds the shared ModelRouter instance
+    router = None
+
+    def validateConfig(self, syntaxOnly: bool) -> None:
+        """Validate the routing configuration.
+
+        Checks that the strategy is one of the known routing strategies
+        and that fallback_chain strategy has at least one fallback model.
+        """
+        config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+        strategy = config.get('strategy', 'complexity')
+
+        valid_strategies = {'complexity', 'cost_aware', 'latency', 'fallback_chain', 'ab_test'}
+        if strategy not in valid_strategies:
+            from rocketlib.error import APERR, Ec
+
+            raise APERR(Ec.InvalidParam, f'Invalid routing strategy "{strategy}". Must be one of: {", ".join(sorted(valid_strategies))}')
+
+        if strategy == 'fallback_chain':
+            fallback_raw = config.get('fallback_models', '')
+            if isinstance(fallback_raw, str):
+                models = [m.strip() for m in fallback_raw.split(',') if m.strip()]
+            elif isinstance(fallback_raw, list):
+                models = [m.strip() for m in fallback_raw if m.strip()]
+            else:
+                models = []
+            if not models:
+                from rocketlib.error import APERR, Ec
+
+                raise APERR(Ec.InvalidParam, 'fallback_chain strategy requires at least one model in fallback_models')
+
+    def beginGlobal(self) -> None:
+        """Initialize the ModelRouter with the node configuration."""
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            # Configuration mode - no need to create the router
+            pass
+        else:
+            from .router import ModelRouter
+
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            self.router = ModelRouter(config)
+
+    def endGlobal(self) -> None:
+        """Release the router instance."""
+        self.router = None

--- a/nodes/src/nodes/router_llm/IGlobal.py
+++ b/nodes/src/nodes/router_llm/IGlobal.py
@@ -38,17 +38,24 @@ class IGlobal(IGlobalBase):
     def validateConfig(self, syntaxOnly: bool) -> None:
         """Validate the routing configuration.
 
+        When syntaxOnly is True, only lightweight checks are performed
+        (e.g. verifying the strategy name). Expensive validation such as
+        parsing fallback model lists is skipped.
+
         Checks that the strategy is one of the known routing strategies
         and that fallback_chain strategy has at least one fallback model.
         """
+        from rocketlib.error import APERR, Ec
+
         config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
         strategy = config.get('strategy', 'complexity')
 
         valid_strategies = {'complexity', 'cost_aware', 'latency', 'fallback_chain', 'ab_test'}
         if strategy not in valid_strategies:
-            from rocketlib.error import APERR, Ec
-
             raise APERR(Ec.InvalidParam, f'Invalid routing strategy "{strategy}". Must be one of: {", ".join(sorted(valid_strategies))}')
+
+        if syntaxOnly:
+            return
 
         if strategy == 'fallback_chain':
             fallback_raw = config.get('fallback_models', '')
@@ -59,8 +66,6 @@ class IGlobal(IGlobalBase):
             else:
                 models = []
             if not models:
-                from rocketlib.error import APERR, Ec
-
                 raise APERR(Ec.InvalidParam, 'fallback_chain strategy requires at least one model in fallback_models')
 
     def beginGlobal(self) -> None:

--- a/nodes/src/nodes/router_llm/IInstance.py
+++ b/nodes/src/nodes/router_llm/IInstance.py
@@ -38,7 +38,7 @@ from .IGlobal import IGlobal
 class IInstance(IInstanceBase):
     IGlobal: IGlobal
 
-    def open(self, object: Entry):
+    def open(self, obj: Entry):
         """Initialize state for a new object."""
         pass
 
@@ -54,7 +54,11 @@ class IInstance(IInstanceBase):
         # Extract the question text for routing analysis
         question_text = ''
         if hasattr(routed_question, 'questions') and routed_question.questions:
-            question_text = routed_question.questions[0].text if hasattr(routed_question.questions[0], 'text') else str(routed_question.questions[0])
+            first = routed_question.questions[0]
+            if hasattr(first, 'text'):
+                question_text = first.text
+            else:
+                question_text = str(first)
         elif hasattr(routed_question, 'getPrompt'):
             question_text = routed_question.getPrompt()
 

--- a/nodes/src/nodes/router_llm/IInstance.py
+++ b/nodes/src/nodes/router_llm/IInstance.py
@@ -1,0 +1,70 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+# ------------------------------------------------------------------------------
+# This class controls the data for each thread of the router node.
+# It receives incoming questions, runs them through the ModelRouter to
+# determine optimal model selection, attaches routing metadata, and
+# forwards the question downstream.
+# ------------------------------------------------------------------------------
+
+import copy
+
+from rocketlib import IInstanceBase, Entry
+from ai.common.schema import Question
+from .IGlobal import IGlobal
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    def open(self, object: Entry):
+        """Initialize state for a new object."""
+        pass
+
+    def writeQuestions(self, question: Question):
+        """Route an incoming question through the model router.
+
+        Deep copies the question to avoid mutating the original, attaches
+        routing metadata, then forwards the annotated question downstream.
+        """
+        # Deep copy to prevent mutation of the original question object
+        routed_question = copy.deepcopy(question)
+
+        # Extract the question text for routing analysis
+        question_text = ''
+        if hasattr(routed_question, 'questions') and routed_question.questions:
+            question_text = routed_question.questions[0].text if hasattr(routed_question.questions[0], 'text') else str(routed_question.questions[0])
+        elif hasattr(routed_question, 'getPrompt'):
+            question_text = routed_question.getPrompt()
+
+        # Run the router to select the optimal model
+        routing_decision = self.IGlobal.router.select_model(question_text)
+
+        # Attach routing metadata to the question
+        if not hasattr(routed_question, 'metadata') or routed_question.metadata is None:
+            routed_question.metadata = {}
+        routed_question.metadata['routing'] = routing_decision
+
+        # Forward the annotated question downstream
+        self.instance.writeQuestions(routed_question)

--- a/nodes/src/nodes/router_llm/__init__.py
+++ b/nodes/src/nodes/router_llm/__init__.py
@@ -1,0 +1,29 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+# ------------------------------------------------------------------------------
+# Main module
+# ------------------------------------------------------------------------------
+
+from .IGlobal import IGlobal as IGlobal
+from .IInstance import IInstance as IInstance

--- a/nodes/src/nodes/router_llm/requirements.txt
+++ b/nodes/src/nodes/router_llm/requirements.txt
@@ -1,0 +1,3 @@
+#
+# No external requirements - the model router uses only Python stdlib.
+#

--- a/nodes/src/nodes/router_llm/router.py
+++ b/nodes/src/nodes/router_llm/router.py
@@ -137,8 +137,16 @@ class ModelRouter:
             self.fallback_models = []
 
         self.budget_limit: float = float(config.get('budget_limit', 0.0))
+        if self.budget_limit < 0:
+            raise ValueError(f'budget_limit must be >= 0, got {self.budget_limit}')
+
         self.ab_split_percent: int = int(config.get('ab_split_percent', 50))
+        if not (0 <= self.ab_split_percent <= 100):
+            raise ValueError(f'ab_split_percent must be between 0 and 100, got {self.ab_split_percent}')
+
         self.complexity_threshold: int = int(config.get('complexity_threshold', 50))
+        if self.complexity_threshold < 1:
+            raise ValueError(f'complexity_threshold must be >= 1, got {self.complexity_threshold}')
 
         # Runtime state — guarded by _lock for thread safety across pipeline threads
         self._lock = threading.Lock()
@@ -202,24 +210,33 @@ class ModelRouter:
         with self._lock:
             self._request_count += 1
 
+        primary_info = _get_model_info(self.primary_model)
+
         if score >= self.complexity_threshold:
             # Complex query -> tier 1 (powerful)
-            info = _get_model_info(self.primary_model) if _get_model_info(self.primary_model)['tier'] == 1 else _get_model_info('claude-opus')
+            info = primary_info if primary_info['tier'] == 1 else _get_model_info('claude-opus')
             info['reason'] = f'complexity score {score} >= threshold {self.complexity_threshold}, routed to powerful model'
         elif score >= self.complexity_threshold // 2:
             # Medium complexity -> tier 2 (balanced)
-            info = _get_model_info(self.primary_model) if _get_model_info(self.primary_model)['tier'] == 2 else _get_model_info('claude-sonnet')
+            info = primary_info if primary_info['tier'] == 2 else _get_model_info('claude-sonnet')
             info['reason'] = f'complexity score {score}, routed to balanced model'
         else:
             # Simple query -> tier 3 (fast/cheap)
-            info = _get_model_info('claude-haiku')
+            info = primary_info if primary_info['tier'] == 3 else _get_model_info('claude-haiku')
             info['reason'] = f'complexity score {score} < {self.complexity_threshold // 2}, routed to fast model'
 
         info['complexity_score'] = score
         return info
 
     def _route_cost_aware(self, text: str) -> Dict[str, Any]:
-        """Route based on cumulative cost against budget."""
+        """Route based on cumulative cost against budget.
+
+        Note: This strategy requires downstream nodes to call
+        ``router.record_cost(amount)`` after each LLM invocation so that
+        cumulative spend is tracked.  Without that integration the budget
+        will never be consumed and the router will always use the primary
+        model.
+        """
         with self._lock:
             self._request_count += 1
             current_cost = self._cumulative_cost
@@ -280,6 +297,11 @@ class ModelRouter:
         with self._lock:
             self._request_count += 1
 
+        # Determine group-B model, ensuring it differs from primary
+        fallback = self.fallback_models[0] if self.fallback_models else self.primary_model
+        if fallback == self.primary_model and len(self.fallback_models) > 1:
+            fallback = self.fallback_models[1]
+
         # Deterministic bucket via hash
         digest = hashlib.sha256(text.encode('utf-8')).hexdigest()
         bucket = int(digest[:8], 16) % 100  # 0-99
@@ -289,10 +311,13 @@ class ModelRouter:
             info['reason'] = f'A/B test bucket {bucket} < {self.ab_split_percent}%, assigned to group A (primary)'
             info['ab_group'] = 'A'
         else:
-            fallback = self.fallback_models[0] if self.fallback_models else self.primary_model
             info = _get_model_info(fallback)
             info['reason'] = f'A/B test bucket {bucket} >= {self.ab_split_percent}%, assigned to group B (fallback)'
             info['ab_group'] = 'B'
+
+        # Warn if A/B test is effectively a no-op (both groups use same model)
+        if fallback == self.primary_model:
+            info['ab_warning'] = 'group A and group B use the same model; configure a distinct fallback_models entry for meaningful A/B testing'
 
         info['ab_bucket'] = bucket
         return info

--- a/nodes/src/nodes/router_llm/router.py
+++ b/nodes/src/nodes/router_llm/router.py
@@ -84,6 +84,14 @@ def _get_model_info(model_name: str) -> Dict[str, Any]:
     return {'provider': 'unknown', 'model': model_name, 'tier': 2}
 
 
+def _get_default_model_for_tier(tier: int) -> Dict[str, Any]:
+    """Return the first model in MODEL_TIERS that matches the given tier."""
+    for entry in MODEL_TIERS.values():
+        if entry['tier'] == tier:
+            return dict(entry)
+    return _get_model_info('claude-sonnet')
+
+
 def _estimate_complexity(text: Optional[str], threshold: int = 50) -> int:
     """Return a complexity score for the given text.
 
@@ -214,15 +222,15 @@ class ModelRouter:
 
         if score >= self.complexity_threshold:
             # Complex query -> tier 1 (powerful)
-            info = primary_info if primary_info['tier'] == 1 else _get_model_info('claude-opus')
+            info = primary_info if primary_info['tier'] == 1 else _get_default_model_for_tier(1)
             info['reason'] = f'complexity score {score} >= threshold {self.complexity_threshold}, routed to powerful model'
         elif score >= self.complexity_threshold // 2:
             # Medium complexity -> tier 2 (balanced)
-            info = primary_info if primary_info['tier'] == 2 else _get_model_info('claude-sonnet')
+            info = primary_info if primary_info['tier'] == 2 else _get_default_model_for_tier(2)
             info['reason'] = f'complexity score {score}, routed to balanced model'
         else:
             # Simple query -> tier 3 (fast/cheap)
-            info = primary_info if primary_info['tier'] == 3 else _get_model_info('claude-haiku')
+            info = primary_info if primary_info['tier'] == 3 else _get_default_model_for_tier(3)
             info['reason'] = f'complexity score {score} < {self.complexity_threshold // 2}, routed to fast model'
 
         info['complexity_score'] = score
@@ -231,32 +239,34 @@ class ModelRouter:
     def _route_cost_aware(self, text: str) -> Dict[str, Any]:
         """Route based on cumulative cost against budget.
 
-        Note: This strategy requires downstream nodes to call
-        ``router.record_cost(amount)`` after each LLM invocation so that
-        cumulative spend is tracked.  Without that integration the budget
-        will never be consumed and the router will always use the primary
-        model.
-
-        TODO: Wire up cost recording in the pipeline flow — either by
-        having downstream nodes call ``record_cost()`` after each LLM
-        invocation, or by estimating cost from token counts.
+        Each call records an estimated cost based on the selected model's
+        tier so that the budget is consumed even without downstream cost
+        reporting.  Downstream nodes may still call ``record_cost()`` to
+        refine the running total with actual spend.
         """
         with self._lock:
             self._request_count += 1
             current_cost = self._cumulative_cost
 
+        # Estimated cost per tier (USD) for budget tracking when actual
+        # costs are not reported by downstream nodes.
+        _tier_estimated_cost = {1: 0.03, 2: 0.01, 3: 0.002}
+
         if self.budget_limit > 0 and current_cost >= self.budget_limit:
             info = _get_model_info('gemini-flash')
             info['reason'] = f'budget exhausted (spent ${current_cost:.4f} of ${self.budget_limit:.4f}), routed to cheapest model'
+            self.record_cost(_tier_estimated_cost.get(info['tier'], 0.01))
             return info
 
         if self.budget_limit > 0 and current_cost >= self.budget_limit * 0.8:
             info = _get_model_info('claude-sonnet')
             info['reason'] = f'approaching budget limit (spent ${current_cost:.4f} of ${self.budget_limit:.4f}), routed to balanced model'
+            self.record_cost(_tier_estimated_cost.get(info['tier'], 0.01))
             return info
 
         info = _get_model_info(self.primary_model)
         info['reason'] = f'within budget (spent ${current_cost:.4f} of ${self.budget_limit:.4f}), using primary model'
+        self.record_cost(_tier_estimated_cost.get(info['tier'], 0.01))
         return info
 
     def _route_latency(self, text: str) -> Dict[str, Any]:

--- a/nodes/src/nodes/router_llm/router.py
+++ b/nodes/src/nodes/router_llm/router.py
@@ -156,6 +156,10 @@ class ModelRouter:
         if self.complexity_threshold < 1:
             raise ValueError(f'complexity_threshold must be >= 1, got {self.complexity_threshold}')
 
+        if self.strategy == 'ab_test':
+            if not any(model != self.primary_model for model in self.fallback_models):
+                raise ValueError('ab_test strategy requires at least one fallback model that differs from primary_model for meaningful A/B testing')
+
         # Runtime state — guarded by _lock for thread safety across pipeline threads
         self._lock = threading.Lock()
         self._cumulative_cost: float = 0.0
@@ -287,7 +291,7 @@ class ModelRouter:
         with self._lock:
             self._request_count += 1
 
-        chain = [self.primary_model] + self.fallback_models
+        chain = [self.primary_model, *self.fallback_models]
         # Deduplicate while preserving order
         seen = set()
         unique_chain: List[str] = []

--- a/nodes/src/nodes/router_llm/router.py
+++ b/nodes/src/nodes/router_llm/router.py
@@ -1,0 +1,290 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+# ------------------------------------------------------------------------------
+# ModelRouter - Intelligent LLM model routing engine.
+#
+# Selects the optimal provider/model based on configurable strategies:
+# complexity, cost awareness, latency preference, fallback chains, and A/B
+# testing splits.
+# ------------------------------------------------------------------------------
+
+import hashlib
+from typing import Any, Dict, List, Optional
+
+# Built-in model tier classification
+MODEL_TIERS: Dict[str, Dict[str, Any]] = {
+    # Tier 1 - Powerful: best accuracy, highest cost, slower
+    'gpt-5': {'provider': 'openai', 'model': 'gpt-5', 'tier': 1},
+    'claude-opus': {'provider': 'anthropic', 'model': 'claude-opus', 'tier': 1},
+    'gemini-ultra': {'provider': 'google', 'model': 'gemini-ultra', 'tier': 1},
+    # Tier 2 - Balanced: good accuracy, moderate cost
+    'gpt-5-mini': {'provider': 'openai', 'model': 'gpt-5-mini', 'tier': 2},
+    'claude-sonnet': {'provider': 'anthropic', 'model': 'claude-sonnet', 'tier': 2},
+    'gemini-pro': {'provider': 'google', 'model': 'gemini-pro', 'tier': 2},
+    # Tier 3 - Fast/Cheap: fastest response, lowest cost
+    'gpt-5-nano': {'provider': 'openai', 'model': 'gpt-5-nano', 'tier': 3},
+    'claude-haiku': {'provider': 'anthropic', 'model': 'claude-haiku', 'tier': 3},
+    'gemini-flash': {'provider': 'google', 'model': 'gemini-flash', 'tier': 3},
+}
+
+# Keywords that suggest a complex query requiring a powerful model
+COMPLEXITY_KEYWORDS = [
+    'explain',
+    'analyze',
+    'compare',
+    'evaluate',
+    'synthesize',
+    'contrast',
+    'elaborate',
+    'critique',
+    'justify',
+    'derive',
+    'prove',
+    'debate',
+    'summarize in detail',
+    'multi-step',
+    'trade-off',
+    'implications',
+    'comprehensive',
+    'nuanced',
+    'in-depth',
+]
+
+
+def _get_model_info(model_name: str) -> Dict[str, Any]:
+    """Resolve a model name to its provider/model/tier dict.
+
+    If the model is not in MODEL_TIERS, return a best-effort dict with
+    tier 2 (balanced) as the default.
+    """
+    if model_name in MODEL_TIERS:
+        return dict(MODEL_TIERS[model_name])
+    return {'provider': 'unknown', 'model': model_name, 'tier': 2}
+
+
+def _estimate_complexity(text: str, threshold: int = 50) -> int:
+    """Return a complexity score for the given text.
+
+    Scoring heuristic:
+      - Base score from text length (1 point per 20 chars, capped at 50).
+      - +10 for each complexity keyword found.
+      - +5 for each question-mark (multiple questions => harder).
+
+    Args:
+        text: The query text to evaluate.
+        threshold: Not used in scoring; kept for forward-compat.
+
+    Returns:
+        An integer complexity score (higher = more complex).
+    """
+    if not text:
+        return 0
+
+    score = 0
+
+    # Length contribution (longer queries tend to be more complex)
+    score += min(len(text) // 20, 50)
+
+    # Keyword contribution
+    lower = text.lower()
+    for keyword in COMPLEXITY_KEYWORDS:
+        if keyword in lower:
+            score += 10
+
+    # Question-mark contribution
+    score += text.count('?') * 5
+
+    return score
+
+
+class ModelRouter:
+    """Intelligent model router that picks the best LLM for each request."""
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        """Initialize the router with the given configuration dict."""
+        self.strategy: str = config.get('strategy', 'complexity')
+        self.primary_model: str = config.get('primary_model', 'claude-sonnet')
+
+        # Parse fallback models from comma-separated string or list
+        fallback_raw = config.get('fallback_models', '')
+        if isinstance(fallback_raw, list):
+            self.fallback_models: List[str] = [m.strip() for m in fallback_raw if m.strip()]
+        elif isinstance(fallback_raw, str) and fallback_raw.strip():
+            self.fallback_models = [m.strip() for m in fallback_raw.split(',') if m.strip()]
+        else:
+            self.fallback_models = []
+
+        self.budget_limit: float = float(config.get('budget_limit', 0.0))
+        self.ab_split_percent: int = int(config.get('ab_split_percent', 50))
+        self.complexity_threshold: int = int(config.get('complexity_threshold', 50))
+
+        # Runtime state
+        self._cumulative_cost: float = 0.0
+        self._request_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def select_model(self, question: Optional[str]) -> Dict[str, Any]:
+        """Evaluate routing rules and return the selected model config.
+
+        Args:
+            question: The user query text. May be None or empty.
+
+        Returns:
+            A dict with keys: provider, model, tier, reason.
+        """
+        text = question if question else ''
+
+        strategy = self.strategy
+        if strategy == 'complexity':
+            return self._route_complexity(text)
+        elif strategy == 'cost_aware':
+            return self._route_cost_aware(text)
+        elif strategy == 'latency':
+            return self._route_latency(text)
+        elif strategy == 'fallback_chain':
+            return self._route_fallback_chain(text)
+        elif strategy == 'ab_test':
+            return self._route_ab_test(text)
+        else:
+            # Unknown strategy falls back to primary model
+            info = _get_model_info(self.primary_model)
+            info['reason'] = f'unknown strategy "{strategy}", using primary model'
+            return info
+
+    def record_cost(self, amount: float) -> None:
+        """Record a cost incurred by a model call (used by cost_aware strategy)."""
+        self._cumulative_cost += amount
+
+    @property
+    def cumulative_cost(self) -> float:
+        return self._cumulative_cost
+
+    @property
+    def request_count(self) -> int:
+        return self._request_count
+
+    # ------------------------------------------------------------------
+    # Strategy implementations
+    # ------------------------------------------------------------------
+
+    def _route_complexity(self, text: str) -> Dict[str, Any]:
+        """Route based on estimated query complexity."""
+        score = _estimate_complexity(text, self.complexity_threshold)
+        self._request_count += 1
+
+        if score >= self.complexity_threshold:
+            # Complex query -> tier 1 (powerful)
+            info = _get_model_info(self.primary_model) if _get_model_info(self.primary_model)['tier'] == 1 else _get_model_info('claude-opus')
+            info['reason'] = f'complexity score {score} >= threshold {self.complexity_threshold}, routed to powerful model'
+        elif score >= self.complexity_threshold // 2:
+            # Medium complexity -> tier 2 (balanced)
+            info = _get_model_info(self.primary_model) if _get_model_info(self.primary_model)['tier'] == 2 else _get_model_info('claude-sonnet')
+            info['reason'] = f'complexity score {score}, routed to balanced model'
+        else:
+            # Simple query -> tier 3 (fast/cheap)
+            info = _get_model_info('claude-haiku')
+            info['reason'] = f'complexity score {score} < {self.complexity_threshold // 2}, routed to fast model'
+
+        info['complexity_score'] = score
+        return info
+
+    def _route_cost_aware(self, text: str) -> Dict[str, Any]:
+        """Route based on cumulative cost against budget."""
+        self._request_count += 1
+
+        if self.budget_limit > 0 and self._cumulative_cost >= self.budget_limit:
+            # Budget exhausted -> cheapest model
+            info = _get_model_info('gemini-flash')
+            info['reason'] = f'budget exhausted (spent ${self._cumulative_cost:.4f} of ${self.budget_limit:.4f}), routed to cheapest model'
+            return info
+
+        if self.budget_limit > 0 and self._cumulative_cost >= self.budget_limit * 0.8:
+            # Nearing budget -> balanced model
+            info = _get_model_info('claude-sonnet')
+            info['reason'] = f'approaching budget limit (spent ${self._cumulative_cost:.4f} of ${self.budget_limit:.4f}), routed to balanced model'
+            return info
+
+        # Under budget -> use primary model
+        info = _get_model_info(self.primary_model)
+        info['reason'] = f'within budget (spent ${self._cumulative_cost:.4f} of ${self.budget_limit:.4f}), using primary model'
+        return info
+
+    def _route_latency(self, text: str) -> Dict[str, Any]:
+        """Route to the fastest (lowest-tier) model for real-time use."""
+        self._request_count += 1
+        info = _get_model_info('gemini-flash')
+        info['reason'] = 'latency strategy selected fastest model'
+        return info
+
+    def _route_fallback_chain(self, text: str) -> Dict[str, Any]:
+        """Return the first model in the fallback chain.
+
+        In a real deployment the caller would iterate through the chain
+        on failure.  Here we return the primary model with the full
+        chain attached so downstream code can retry.
+        """
+        self._request_count += 1
+
+        chain = [self.primary_model] + self.fallback_models
+        # Deduplicate while preserving order
+        seen = set()
+        unique_chain: List[str] = []
+        for m in chain:
+            if m not in seen:
+                seen.add(m)
+                unique_chain.append(m)
+
+        info = _get_model_info(unique_chain[0])
+        info['reason'] = f'fallback chain: {" -> ".join(unique_chain)}'
+        info['fallback_chain'] = unique_chain
+        return info
+
+    def _route_ab_test(self, text: str) -> Dict[str, Any]:
+        """Deterministically split traffic between primary and first fallback.
+
+        Uses a hash of the query text so the same question always goes
+        to the same bucket (deterministic per session/query, not random
+        per request).
+        """
+        self._request_count += 1
+
+        # Deterministic bucket via hash
+        digest = hashlib.sha256(text.encode('utf-8')).hexdigest()
+        bucket = int(digest[:8], 16) % 100  # 0-99
+
+        if bucket < self.ab_split_percent:
+            info = _get_model_info(self.primary_model)
+            info['reason'] = f'A/B test bucket {bucket} < {self.ab_split_percent}%, assigned to group A (primary)'
+            info['ab_group'] = 'A'
+        else:
+            fallback = self.fallback_models[0] if self.fallback_models else self.primary_model
+            info = _get_model_info(fallback)
+            info['reason'] = f'A/B test bucket {bucket} >= {self.ab_split_percent}%, assigned to group B (fallback)'
+            info['ab_group'] = 'B'
+
+        info['ab_bucket'] = bucket
+        return info

--- a/nodes/src/nodes/router_llm/router.py
+++ b/nodes/src/nodes/router_llm/router.py
@@ -30,6 +30,7 @@
 # ------------------------------------------------------------------------------
 
 import hashlib
+import threading
 from typing import Any, Dict, List, Optional
 
 # Built-in model tier classification
@@ -139,7 +140,8 @@ class ModelRouter:
         self.ab_split_percent: int = int(config.get('ab_split_percent', 50))
         self.complexity_threshold: int = int(config.get('complexity_threshold', 50))
 
-        # Runtime state
+        # Runtime state — guarded by _lock for thread safety across pipeline threads
+        self._lock = threading.Lock()
         self._cumulative_cost: float = 0.0
         self._request_count: int = 0
 
@@ -177,15 +179,18 @@ class ModelRouter:
 
     def record_cost(self, amount: float) -> None:
         """Record a cost incurred by a model call (used by cost_aware strategy)."""
-        self._cumulative_cost += amount
+        with self._lock:
+            self._cumulative_cost += amount
 
     @property
     def cumulative_cost(self) -> float:
-        return self._cumulative_cost
+        with self._lock:
+            return self._cumulative_cost
 
     @property
     def request_count(self) -> int:
-        return self._request_count
+        with self._lock:
+            return self._request_count
 
     # ------------------------------------------------------------------
     # Strategy implementations
@@ -194,7 +199,8 @@ class ModelRouter:
     def _route_complexity(self, text: str) -> Dict[str, Any]:
         """Route based on estimated query complexity."""
         score = _estimate_complexity(text, self.complexity_threshold)
-        self._request_count += 1
+        with self._lock:
+            self._request_count += 1
 
         if score >= self.complexity_threshold:
             # Complex query -> tier 1 (powerful)
@@ -214,28 +220,28 @@ class ModelRouter:
 
     def _route_cost_aware(self, text: str) -> Dict[str, Any]:
         """Route based on cumulative cost against budget."""
-        self._request_count += 1
+        with self._lock:
+            self._request_count += 1
+            current_cost = self._cumulative_cost
 
-        if self.budget_limit > 0 and self._cumulative_cost >= self.budget_limit:
-            # Budget exhausted -> cheapest model
+        if self.budget_limit > 0 and current_cost >= self.budget_limit:
             info = _get_model_info('gemini-flash')
-            info['reason'] = f'budget exhausted (spent ${self._cumulative_cost:.4f} of ${self.budget_limit:.4f}), routed to cheapest model'
+            info['reason'] = f'budget exhausted (spent ${current_cost:.4f} of ${self.budget_limit:.4f}), routed to cheapest model'
             return info
 
-        if self.budget_limit > 0 and self._cumulative_cost >= self.budget_limit * 0.8:
-            # Nearing budget -> balanced model
+        if self.budget_limit > 0 and current_cost >= self.budget_limit * 0.8:
             info = _get_model_info('claude-sonnet')
-            info['reason'] = f'approaching budget limit (spent ${self._cumulative_cost:.4f} of ${self.budget_limit:.4f}), routed to balanced model'
+            info['reason'] = f'approaching budget limit (spent ${current_cost:.4f} of ${self.budget_limit:.4f}), routed to balanced model'
             return info
 
-        # Under budget -> use primary model
         info = _get_model_info(self.primary_model)
-        info['reason'] = f'within budget (spent ${self._cumulative_cost:.4f} of ${self.budget_limit:.4f}), using primary model'
+        info['reason'] = f'within budget (spent ${current_cost:.4f} of ${self.budget_limit:.4f}), using primary model'
         return info
 
     def _route_latency(self, text: str) -> Dict[str, Any]:
         """Route to the fastest (lowest-tier) model for real-time use."""
-        self._request_count += 1
+        with self._lock:
+            self._request_count += 1
         info = _get_model_info('gemini-flash')
         info['reason'] = 'latency strategy selected fastest model'
         return info
@@ -247,7 +253,8 @@ class ModelRouter:
         on failure.  Here we return the primary model with the full
         chain attached so downstream code can retry.
         """
-        self._request_count += 1
+        with self._lock:
+            self._request_count += 1
 
         chain = [self.primary_model] + self.fallback_models
         # Deduplicate while preserving order
@@ -270,7 +277,8 @@ class ModelRouter:
         to the same bucket (deterministic per session/query, not random
         per request).
         """
-        self._request_count += 1
+        with self._lock:
+            self._request_count += 1
 
         # Deterministic bucket via hash
         digest = hashlib.sha256(text.encode('utf-8')).hexdigest()

--- a/nodes/src/nodes/router_llm/router.py
+++ b/nodes/src/nodes/router_llm/router.py
@@ -84,7 +84,7 @@ def _get_model_info(model_name: str) -> Dict[str, Any]:
     return {'provider': 'unknown', 'model': model_name, 'tier': 2}
 
 
-def _estimate_complexity(text: str, threshold: int = 50) -> int:
+def _estimate_complexity(text: Optional[str], threshold: int = 50) -> int:
     """Return a complexity score for the given text.
 
     Scoring heuristic:
@@ -236,6 +236,10 @@ class ModelRouter:
         cumulative spend is tracked.  Without that integration the budget
         will never be consumed and the router will always use the primary
         model.
+
+        TODO: Wire up cost recording in the pipeline flow — either by
+        having downstream nodes call ``record_cost()`` after each LLM
+        invocation, or by estimating cost from token counts.
         """
         with self._lock:
             self._request_count += 1

--- a/nodes/src/nodes/router_llm/services.json
+++ b/nodes/src/nodes/router_llm/services.json
@@ -1,27 +1,16 @@
 {
 	"title": "Model Router",
 	"protocol": "router_llm://",
-	"classType": [
-		"router"
-	],
+	"classType": ["router"],
 	"capabilities": [],
 	"register": "filter",
 	"node": "python",
 	"path": "nodes.router_llm",
 	"prefix": "router_llm",
-	"description": [
-		"An intelligent LLM model router that selects the optimal provider and model ",
-		"based on configurable routing strategies. Supports complexity-based routing ",
-		"(simple queries to cheap models, complex to powerful ones), cost-aware routing ",
-		"(switches to cheaper models when budget threshold is hit), latency-optimized ",
-		"routing, ordered fallback chains, and random A/B traffic splitting for model ",
-		"comparison experiments."
-	],
+	"description": ["An intelligent LLM model router that selects the optimal provider and model ", "based on configurable routing strategies. Supports complexity-based routing ", "(simple queries to cheap models, complex to powerful ones), cost-aware routing ", "(switches to cheaper models when budget threshold is hit), latency-optimized ", "routing, ordered fallback chains, and deterministic A/B traffic splitting for model ", "comparison experiments."],
 	"icon": "util-infrastructure.svg",
 	"lanes": {
-		"questions": [
-			"questions"
-		]
+		"questions": ["questions"]
 	},
 	"input": [
 		{
@@ -137,24 +126,14 @@
 			"description": "Routing profile",
 			"type": "string",
 			"default": "complexity",
-			"enum": [
-				"*>preconfig.profiles.*.title"
-			]
+			"enum": ["*>preconfig.profiles.*.title"]
 		}
 	},
 	"shape": [
 		{
 			"section": "Pipe",
 			"title": "Model Router",
-			"properties": [
-				"router.profile",
-				"router.strategy",
-				"router.primary_model",
-				"router.fallback_models",
-				"router.budget_limit",
-				"router.ab_split_percent",
-				"router.complexity_threshold"
-			]
+			"properties": ["router.profile", "router.strategy", "router.primary_model", "router.fallback_models", "router.budget_limit", "router.ab_split_percent", "router.complexity_threshold"]
 		}
 	]
 }

--- a/nodes/src/nodes/router_llm/services.json
+++ b/nodes/src/nodes/router_llm/services.json
@@ -1,0 +1,160 @@
+{
+	"title": "Model Router",
+	"protocol": "router_llm://",
+	"classType": [
+		"router"
+	],
+	"capabilities": [],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.router_llm",
+	"prefix": "router_llm",
+	"description": [
+		"An intelligent LLM model router that selects the optimal provider and model ",
+		"based on configurable routing strategies. Supports complexity-based routing ",
+		"(simple queries to cheap models, complex to powerful ones), cost-aware routing ",
+		"(switches to cheaper models when budget threshold is hit), latency-optimized ",
+		"routing, ordered fallback chains, and random A/B traffic splitting for model ",
+		"comparison experiments."
+	],
+	"icon": "util-infrastructure.svg",
+	"lanes": {
+		"questions": [
+			"questions"
+		]
+	},
+	"input": [
+		{
+			"lane": "questions",
+			"description": "Incoming questions to be routed to the optimal model",
+			"output": [
+				{
+					"lane": "questions",
+					"description": "Questions annotated with routing metadata (provider, model, tier, reason)"
+				}
+			]
+		}
+	],
+	"preconfig": {
+		"default": "complexity",
+		"profiles": {
+			"complexity": {
+				"title": "Complexity-based routing",
+				"strategy": "complexity",
+				"primary_model": "claude-opus",
+				"fallback_models": "",
+				"budget_limit": 0,
+				"ab_split_percent": 50,
+				"complexity_threshold": 50
+			},
+			"cost_aware": {
+				"title": "Cost-aware routing",
+				"strategy": "cost_aware",
+				"primary_model": "claude-sonnet",
+				"fallback_models": "",
+				"budget_limit": 10.0,
+				"ab_split_percent": 50,
+				"complexity_threshold": 50
+			},
+			"latency": {
+				"title": "Latency-optimized routing",
+				"strategy": "latency",
+				"primary_model": "gemini-flash",
+				"fallback_models": "",
+				"budget_limit": 0,
+				"ab_split_percent": 50,
+				"complexity_threshold": 50
+			},
+			"fallback_chain": {
+				"title": "Fallback chain routing",
+				"strategy": "fallback_chain",
+				"primary_model": "claude-opus",
+				"fallback_models": "claude-sonnet,claude-haiku",
+				"budget_limit": 0,
+				"ab_split_percent": 50,
+				"complexity_threshold": 50
+			},
+			"ab_test": {
+				"title": "A/B test routing",
+				"strategy": "ab_test",
+				"primary_model": "claude-sonnet",
+				"fallback_models": "gpt-5-mini",
+				"budget_limit": 0,
+				"ab_split_percent": 50,
+				"complexity_threshold": 50
+			}
+		}
+	},
+	"fields": {
+		"router.strategy": {
+			"type": "string",
+			"title": "Routing strategy",
+			"description": "The routing strategy to use for model selection",
+			"default": "complexity",
+			"enum": [
+				["complexity", "Complexity-based"],
+				["cost_aware", "Cost-aware"],
+				["latency", "Latency-optimized"],
+				["fallback_chain", "Fallback chain"],
+				["ab_test", "A/B test"]
+			]
+		},
+		"router.primary_model": {
+			"type": "string",
+			"title": "Primary model",
+			"description": "The primary model to route to (e.g. claude-sonnet, gpt-5, gemini-pro)",
+			"default": "claude-sonnet"
+		},
+		"router.fallback_models": {
+			"type": "string",
+			"title": "Fallback models",
+			"description": "Comma-separated list of fallback models (e.g. claude-haiku,gpt-5-nano)",
+			"default": ""
+		},
+		"router.budget_limit": {
+			"type": "number",
+			"title": "Budget limit ($)",
+			"description": "Maximum cumulative cost before switching to cheaper models (0 = unlimited)",
+			"default": 0
+		},
+		"router.ab_split_percent": {
+			"type": "number",
+			"title": "A/B split percentage",
+			"description": "Percentage of traffic routed to group A (primary model). Remainder goes to group B (first fallback).",
+			"default": 50,
+			"minimum": 0,
+			"maximum": 100
+		},
+		"router.complexity_threshold": {
+			"type": "number",
+			"title": "Complexity threshold",
+			"description": "Score threshold above which queries are considered complex and routed to powerful models",
+			"default": 50,
+			"minimum": 1
+		},
+		"router.profile": {
+			"title": "Profile",
+			"description": "Routing profile",
+			"type": "string",
+			"default": "complexity",
+			"enum": [
+				"*>preconfig.profiles.*.title"
+			]
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Model Router",
+			"properties": [
+				"router.profile",
+				"router.strategy",
+				"router.primary_model",
+				"router.fallback_models",
+				"router.budget_limit",
+				"router.ab_split_percent",
+				"router.complexity_threshold"
+			]
+		}
+	]
+}

--- a/test/nodes/test_router_llm.py
+++ b/test/nodes/test_router_llm.py
@@ -136,7 +136,8 @@ class TestComplexityEstimation:
         assert _estimate_complexity('') == 0
 
     def test_none_returns_zero(self):
-        assert _estimate_complexity(None) == 0
+        # Implementation handles None gracefully despite Optional[str] type hint
+        assert _estimate_complexity(None) == 0  # type: ignore[arg-type]
 
     def test_short_simple_query(self):
         score = _estimate_complexity('Hi')
@@ -618,6 +619,8 @@ class TestIGlobalLifecycle:
             config = {'strategy': strategy}
             if strategy == 'fallback_chain':
                 config['fallback_models'] = 'claude-haiku'
+            if strategy == 'ab_test':
+                config['fallback_models'] = 'gpt-5-mini'
             with patch.object(MockConfig, 'getNodeConfig', return_value=config):
                 iglobal.validateConfig(False)  # should not raise
 
@@ -626,6 +629,41 @@ class TestIGlobalLifecycle:
         with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'fallback_chain', 'fallback_models': ''}):
             with pytest.raises(Exception, match='requires at least one model'):
                 iglobal.validateConfig(False)
+
+    def test_validate_rejects_negative_budget_limit(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'complexity', 'budget_limit': -1}):
+            with pytest.raises(Exception, match='budget_limit must be >= 0'):
+                iglobal.validateConfig(False)
+
+    def test_validate_rejects_invalid_complexity_threshold(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'complexity', 'complexity_threshold': 0}):
+            with pytest.raises(Exception, match='complexity_threshold must be >= 1'):
+                iglobal.validateConfig(False)
+
+    def test_validate_rejects_invalid_ab_split_percent(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'complexity', 'ab_split_percent': 101}):
+            with pytest.raises(Exception, match='ab_split_percent must be between 0 and 100'):
+                iglobal.validateConfig(False)
+
+    def test_validate_ab_test_rejects_same_model(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'claude-sonnet'}):
+            with pytest.raises(Exception, match='ab_test strategy requires at least one fallback model that differs'):
+                iglobal.validateConfig(False)
+
+    def test_validate_ab_test_rejects_empty_fallback(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': ''}):
+            with pytest.raises(Exception, match='ab_test strategy requires at least one fallback model that differs'):
+                iglobal.validateConfig(False)
+
+    def test_validate_syntax_only_skips_full_validation(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'fallback_chain', 'fallback_models': ''}):
+            iglobal.validateConfig(True)  # should not raise, skips full validation
 
     def test_begin_global_creates_router(self):
         iglobal = self._make_iglobal({})

--- a/test/nodes/test_router_llm.py
+++ b/test/nodes/test_router_llm.py
@@ -203,7 +203,7 @@ class TestModelTiers:
         assert len(MODEL_TIERS) == 9
 
     def test_each_entry_has_required_keys(self):
-        for name, entry in MODEL_TIERS.items():
+        for entry in MODEL_TIERS.values():
             assert 'provider' in entry
             assert 'model' in entry
             assert 'tier' in entry
@@ -397,6 +397,103 @@ class TestABTestRouting:
         result = router.select_model('Hello')
         assert 'ab_bucket' in result
         assert 0 <= result['ab_bucket'] <= 99
+
+
+# ===========================================================================
+# Test: Initialization Validation
+# ===========================================================================
+
+
+class TestInitValidation:
+    """Tests for range validation on router configuration."""
+
+    def test_negative_budget_limit_rejected(self):
+        with pytest.raises(ValueError, match='budget_limit must be >= 0'):
+            ModelRouter({'strategy': 'complexity', 'budget_limit': -1.0})
+
+    def test_zero_budget_limit_accepted(self):
+        router = ModelRouter({'strategy': 'complexity', 'budget_limit': 0})
+        assert router.budget_limit == 0.0
+
+    def test_ab_split_below_zero_rejected(self):
+        with pytest.raises(ValueError, match='ab_split_percent must be between 0 and 100'):
+            ModelRouter({'strategy': 'ab_test', 'ab_split_percent': -1})
+
+    def test_ab_split_above_100_rejected(self):
+        with pytest.raises(ValueError, match='ab_split_percent must be between 0 and 100'):
+            ModelRouter({'strategy': 'ab_test', 'ab_split_percent': 101})
+
+    def test_ab_split_boundary_values_accepted(self):
+        r0 = ModelRouter({'strategy': 'ab_test', 'ab_split_percent': 0})
+        assert r0.ab_split_percent == 0
+        r100 = ModelRouter({'strategy': 'ab_test', 'ab_split_percent': 100})
+        assert r100.ab_split_percent == 100
+
+    def test_complexity_threshold_zero_rejected(self):
+        with pytest.raises(ValueError, match='complexity_threshold must be >= 1'):
+            ModelRouter({'strategy': 'complexity', 'complexity_threshold': 0})
+
+    def test_complexity_threshold_negative_rejected(self):
+        with pytest.raises(ValueError, match='complexity_threshold must be >= 1'):
+            ModelRouter({'strategy': 'complexity', 'complexity_threshold': -5})
+
+    def test_complexity_threshold_one_accepted(self):
+        router = ModelRouter({'strategy': 'complexity', 'complexity_threshold': 1})
+        assert router.complexity_threshold == 1
+
+
+# ===========================================================================
+# Test: Complexity Routing Honors Tier-3 Primary Model
+# ===========================================================================
+
+
+class TestComplexityRoutingTier3Primary:
+    """Verify that simple queries use the configured primary_model when it is tier 3."""
+
+    def test_tier3_primary_used_for_simple_queries(self):
+        router = ModelRouter({'strategy': 'complexity', 'primary_model': 'gpt-5-nano', 'complexity_threshold': 50})
+        result = router.select_model('Hi')
+        assert result['model'] == 'gpt-5-nano'
+        assert result['tier'] == 3
+
+    def test_tier3_primary_not_used_for_complex_queries(self):
+        router = ModelRouter({'strategy': 'complexity', 'primary_model': 'gpt-5-nano', 'complexity_threshold': 50})
+        complex_q = 'Please explain and analyze the comprehensive implications of this nuanced trade-off in detail?'
+        result = router.select_model(complex_q)
+        # Tier-3 primary should not be used for complex queries; should fall back to tier-1
+        assert result['tier'] == 1
+
+
+# ===========================================================================
+# Test: A/B Test Warning for Same Model
+# ===========================================================================
+
+
+class TestABTestWarning:
+    """Verify that A/B test warns when both groups use the same model."""
+
+    def test_warning_when_no_fallback(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': '', 'ab_split_percent': 50})
+        result = router.select_model('Hello')
+        assert 'ab_warning' in result
+
+    def test_warning_when_fallback_matches_primary(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'claude-sonnet', 'ab_split_percent': 50})
+        result = router.select_model('Hello')
+        assert 'ab_warning' in result
+
+    def test_no_warning_when_fallback_differs(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 50})
+        result = router.select_model('Hello')
+        assert 'ab_warning' not in result
+
+    def test_distinct_second_fallback_used_when_first_matches_primary(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'claude-sonnet,gpt-5-mini', 'ab_split_percent': 0})
+        result = router.select_model('Hello')
+        # Should pick gpt-5-mini since claude-sonnet matches primary
+        assert result['model'] == 'gpt-5-mini'
+        assert result['ab_group'] == 'B'
+        assert 'ab_warning' not in result
 
 
 # ===========================================================================

--- a/test/nodes/test_router_llm.py
+++ b/test/nodes/test_router_llm.py
@@ -1,0 +1,604 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Tests for the Model Router pipeline node (router_llm).
+
+Covers complexity estimation, model tier classification, all five routing
+strategies, metadata attachment, deep copy isolation, and IGlobal/IInstance
+lifecycle mocking.
+"""
+
+import copy
+import sys
+import types
+from collections import Counter
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Bootstrap mock modules so the node code can be imported without the full
+# RocketRide engine runtime.
+# ---------------------------------------------------------------------------
+
+# Mock engLib (C++ bridge)
+mock_englib = types.ModuleType('engLib')
+mock_englib.Entry = type('Entry', (), {})
+mock_englib.Filters = type('Filters', (), {})
+sys.modules['engLib'] = mock_englib
+
+# Mock rocketlib
+mock_rocketlib = types.ModuleType('rocketlib')
+mock_rocketlib.IGlobalBase = type('IGlobalBase', (), {'IEndpoint': None, 'glb': None, 'preventDefault': lambda self: None})
+mock_rocketlib.IInstanceBase = type('IInstanceBase', (), {'IEndpoint': None, 'IGlobal': None, 'instance': None, 'preventDefault': lambda self: None})
+mock_rocketlib.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config', 'NORMAL': 'normal'})()
+mock_rocketlib.Entry = mock_englib.Entry
+mock_rocketlib.debug = lambda *a, **kw: None
+sys.modules['rocketlib'] = mock_rocketlib
+
+# Mock rocketlib.error
+mock_rocketlib_error = types.ModuleType('rocketlib.error')
+mock_rocketlib_error.APERR = type('APERR', (Exception,), {'__init__': lambda self, ec, msg: Exception.__init__(self, msg)})
+mock_rocketlib_error.Ec = type('Ec', (), {'PreventDefault': 'PreventDefault', 'InvalidParam': 'InvalidParam'})()
+sys.modules['rocketlib.error'] = mock_rocketlib_error
+
+# Mock rocketlib.types
+mock_rocketlib_types = types.ModuleType('rocketlib.types')
+sys.modules['rocketlib.types'] = mock_rocketlib_types
+
+# Mock ai.common.config
+mock_ai = types.ModuleType('ai')
+mock_ai_common = types.ModuleType('ai.common')
+mock_ai_common_config = types.ModuleType('ai.common.config')
+mock_ai_common_schema = types.ModuleType('ai.common.schema')
+
+sys.modules['ai'] = mock_ai
+sys.modules['ai.common'] = mock_ai_common
+sys.modules['ai.common.config'] = mock_ai_common_config
+sys.modules['ai.common.schema'] = mock_ai_common_schema
+
+mock_ai.common = mock_ai_common
+mock_ai_common.config = mock_ai_common_config
+mock_ai_common.schema = mock_ai_common_schema
+
+
+class MockConfig:
+    @staticmethod
+    def getNodeConfig(_logical_type, _conn_config):
+        return {}
+
+
+mock_ai_common_config.Config = MockConfig
+
+
+# Minimal Question mock
+class MockQuestionText:
+    def __init__(self, text=''):  # noqa: D107
+        self.text = text
+
+
+class MockQuestion:
+    def __init__(self, text=''):  # noqa: D107
+        self.questions = [MockQuestionText(text)] if text else []
+        self.metadata = {}
+
+    def getPrompt(self):
+        return self.questions[0].text if self.questions else ''
+
+
+mock_ai_common_schema.Question = MockQuestion
+
+# Mock depends
+mock_depends = types.ModuleType('depends')
+mock_depends.depends = lambda *a, **kw: None
+sys.modules['depends'] = mock_depends
+
+# ---------------------------------------------------------------------------
+# Now import the router module under test
+# ---------------------------------------------------------------------------
+
+from nodes.src.nodes.router_llm.router import (
+    MODEL_TIERS,
+    ModelRouter,
+    _estimate_complexity,
+    _get_model_info,
+)
+
+# ===========================================================================
+# Test: Complexity Estimation
+# ===========================================================================
+
+
+class TestComplexityEstimation:
+    """Tests for the _estimate_complexity helper."""
+
+    def test_empty_string_returns_zero(self):
+        assert _estimate_complexity('') == 0
+
+    def test_none_returns_zero(self):
+        assert _estimate_complexity(None) == 0
+
+    def test_short_simple_query(self):
+        score = _estimate_complexity('Hi')
+        assert score < 10
+
+    def test_long_query_gets_length_bonus(self):
+        long_text = 'a' * 1000
+        score = _estimate_complexity(long_text)
+        assert score >= 50  # capped length contribution
+
+    def test_keyword_increases_score(self):
+        base = _estimate_complexity('Tell me about dogs')
+        with_keyword = _estimate_complexity('Explain the concept of dogs in detail')
+        assert with_keyword > base
+
+    def test_multiple_keywords_stack(self):
+        one = _estimate_complexity('Explain this')
+        two = _estimate_complexity('Explain and analyze this')
+        assert two > one
+
+    def test_question_marks_increase_score(self):
+        no_q = _estimate_complexity('Tell me about X')
+        one_q = _estimate_complexity('What is X?')
+        many_q = _estimate_complexity('What is X? Why is Y? How does Z?')
+        assert one_q > no_q
+        assert many_q > one_q
+
+    def test_case_insensitive_keywords(self):
+        lower = _estimate_complexity('analyze this data')
+        upper = _estimate_complexity('ANALYZE THIS DATA')
+        assert lower == upper
+
+
+# ===========================================================================
+# Test: Model Tier Classification
+# ===========================================================================
+
+
+class TestModelTiers:
+    """Tests for MODEL_TIERS and _get_model_info."""
+
+    def test_all_tier1_models(self):
+        for name in ['gpt-5', 'claude-opus', 'gemini-ultra']:
+            info = _get_model_info(name)
+            assert info['tier'] == 1, f'{name} should be tier 1'
+
+    def test_all_tier2_models(self):
+        for name in ['gpt-5-mini', 'claude-sonnet', 'gemini-pro']:
+            info = _get_model_info(name)
+            assert info['tier'] == 2, f'{name} should be tier 2'
+
+    def test_all_tier3_models(self):
+        for name in ['gpt-5-nano', 'claude-haiku', 'gemini-flash']:
+            info = _get_model_info(name)
+            assert info['tier'] == 3, f'{name} should be tier 3'
+
+    def test_unknown_model_defaults_to_tier2(self):
+        info = _get_model_info('some-custom-model')
+        assert info['tier'] == 2
+        assert info['provider'] == 'unknown'
+        assert info['model'] == 'some-custom-model'
+
+    def test_model_tiers_has_nine_entries(self):
+        assert len(MODEL_TIERS) == 9
+
+    def test_each_entry_has_required_keys(self):
+        for name, entry in MODEL_TIERS.items():
+            assert 'provider' in entry
+            assert 'model' in entry
+            assert 'tier' in entry
+
+
+# ===========================================================================
+# Test: Complexity Routing Strategy
+# ===========================================================================
+
+
+class TestComplexityRouting:
+    """Tests for the 'complexity' routing strategy."""
+
+    def test_simple_query_routes_to_fast_model(self):
+        router = ModelRouter({'strategy': 'complexity', 'complexity_threshold': 50})
+        result = router.select_model('Hi')
+        assert result['tier'] == 3
+        assert 'fast model' in result['reason']
+
+    def test_complex_query_routes_to_powerful_model(self):
+        router = ModelRouter({'strategy': 'complexity', 'primary_model': 'claude-opus', 'complexity_threshold': 50})
+        complex_q = 'Please explain and analyze the comprehensive implications of this nuanced trade-off in detail?'
+        result = router.select_model(complex_q)
+        assert result['tier'] == 1
+        assert 'powerful model' in result['reason']
+
+    def test_medium_query_routes_to_balanced_model(self):
+        router = ModelRouter({'strategy': 'complexity', 'primary_model': 'claude-sonnet', 'complexity_threshold': 50})
+        # Score should land between threshold//2 and threshold
+        medium_q = 'What are the main differences? Can you compare them?'
+        result = router.select_model(medium_q)
+        assert result['tier'] in (2, 3)  # depends on exact score
+
+    def test_includes_complexity_score_in_result(self):
+        router = ModelRouter({'strategy': 'complexity'})
+        result = router.select_model('Hello')
+        assert 'complexity_score' in result
+
+
+# ===========================================================================
+# Test: Cost-Aware Routing Strategy
+# ===========================================================================
+
+
+class TestCostAwareRouting:
+    """Tests for the 'cost_aware' routing strategy."""
+
+    def test_under_budget_uses_primary(self):
+        router = ModelRouter({'strategy': 'cost_aware', 'primary_model': 'claude-sonnet', 'budget_limit': 10.0})
+        result = router.select_model('Any question')
+        assert result['model'] == 'claude-sonnet'
+        assert 'within budget' in result['reason']
+
+    def test_over_budget_routes_to_cheapest(self):
+        router = ModelRouter({'strategy': 'cost_aware', 'primary_model': 'claude-opus', 'budget_limit': 5.0})
+        router.record_cost(5.0)
+        result = router.select_model('Any question')
+        assert result['tier'] == 3
+        assert 'budget exhausted' in result['reason']
+
+    def test_near_budget_routes_to_balanced(self):
+        router = ModelRouter({'strategy': 'cost_aware', 'primary_model': 'claude-opus', 'budget_limit': 10.0})
+        router.record_cost(8.5)  # 85% of budget
+        result = router.select_model('Any question')
+        assert result['tier'] == 2
+        assert 'approaching budget' in result['reason']
+
+    def test_zero_budget_always_uses_primary(self):
+        router = ModelRouter({'strategy': 'cost_aware', 'primary_model': 'gpt-5', 'budget_limit': 0})
+        router.record_cost(1000.0)
+        result = router.select_model('Any question')
+        assert result['model'] == 'gpt-5'
+
+    def test_cumulative_cost_tracking(self):
+        router = ModelRouter({'strategy': 'cost_aware', 'budget_limit': 10.0})
+        router.record_cost(3.0)
+        router.record_cost(2.5)
+        assert router.cumulative_cost == 5.5
+
+
+# ===========================================================================
+# Test: Latency Routing Strategy
+# ===========================================================================
+
+
+class TestLatencyRouting:
+    """Tests for the 'latency' routing strategy."""
+
+    def test_always_selects_fastest_model(self):
+        router = ModelRouter({'strategy': 'latency'})
+        result = router.select_model('Any question at all')
+        assert result['tier'] == 3
+        assert result['model'] == 'gemini-flash'
+
+    def test_reason_mentions_latency(self):
+        router = ModelRouter({'strategy': 'latency'})
+        result = router.select_model('Hello')
+        assert 'latency' in result['reason'].lower()
+
+
+# ===========================================================================
+# Test: Fallback Chain Routing Strategy
+# ===========================================================================
+
+
+class TestFallbackChainRouting:
+    """Tests for the 'fallback_chain' routing strategy."""
+
+    def test_returns_primary_as_first(self):
+        router = ModelRouter({'strategy': 'fallback_chain', 'primary_model': 'claude-opus', 'fallback_models': 'claude-sonnet,claude-haiku'})
+        result = router.select_model('Hello')
+        assert result['model'] == 'claude-opus'
+
+    def test_chain_includes_all_models(self):
+        router = ModelRouter({'strategy': 'fallback_chain', 'primary_model': 'claude-opus', 'fallback_models': 'claude-sonnet,claude-haiku'})
+        result = router.select_model('Hello')
+        assert result['fallback_chain'] == ['claude-opus', 'claude-sonnet', 'claude-haiku']
+
+    def test_chain_deduplicates(self):
+        router = ModelRouter({'strategy': 'fallback_chain', 'primary_model': 'claude-opus', 'fallback_models': 'claude-opus,claude-haiku'})
+        result = router.select_model('Hello')
+        assert result['fallback_chain'] == ['claude-opus', 'claude-haiku']
+
+    def test_chain_with_list_input(self):
+        router = ModelRouter({'strategy': 'fallback_chain', 'primary_model': 'gpt-5', 'fallback_models': ['gpt-5-mini', 'gpt-5-nano']})
+        result = router.select_model('Hello')
+        assert result['fallback_chain'] == ['gpt-5', 'gpt-5-mini', 'gpt-5-nano']
+
+    def test_no_infinite_loop_with_single_model(self):
+        """Ensure a single-model chain does not loop."""
+        router = ModelRouter({'strategy': 'fallback_chain', 'primary_model': 'claude-opus', 'fallback_models': ''})
+        result = router.select_model('Hello')
+        assert result['fallback_chain'] == ['claude-opus']
+
+
+# ===========================================================================
+# Test: A/B Test Routing Strategy
+# ===========================================================================
+
+
+class TestABTestRouting:
+    """Tests for the 'ab_test' routing strategy."""
+
+    def test_deterministic_for_same_query(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 50})
+        result1 = router.select_model('What is 2+2?')
+        result2 = router.select_model('What is 2+2?')
+        assert result1['ab_group'] == result2['ab_group']
+        assert result1['model'] == result2['model']
+
+    def test_different_queries_can_differ(self):
+        """Not every query lands in the same bucket."""
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 50})
+        groups = set()
+        for i in range(100):
+            result = router.select_model(f'Query number {i}')
+            groups.add(result['ab_group'])
+        # With 100 queries and a 50/50 split, we should see both groups
+        assert len(groups) == 2
+
+    def test_ab_split_statistical_distribution(self):
+        """Validate that traffic split approximately matches the configured percentage."""
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 70})
+        counts = Counter()
+        n = 1000
+        for i in range(n):
+            result = router.select_model(f'Unique query text number {i}')
+            counts[result['ab_group']] += 1
+        # 70% split should yield roughly 700 in A, allow +/- 10%
+        a_pct = counts['A'] / n * 100
+        assert 55 < a_pct < 85, f'Expected ~70% in group A, got {a_pct:.1f}%'
+
+    def test_zero_percent_routes_all_to_b(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 0})
+        result = router.select_model('Any query')
+        assert result['ab_group'] == 'B'
+
+    def test_hundred_percent_routes_all_to_a(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 100})
+        result = router.select_model('Any query')
+        assert result['ab_group'] == 'A'
+
+    def test_no_fallback_uses_primary_for_both(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': '', 'ab_split_percent': 50})
+        result = router.select_model('Hello')
+        # Both groups should map to primary when no fallback
+        assert result['model'] == 'claude-sonnet'
+
+    def test_result_includes_ab_bucket(self):
+        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini'})
+        result = router.select_model('Hello')
+        assert 'ab_bucket' in result
+        assert 0 <= result['ab_bucket'] <= 99
+
+
+# ===========================================================================
+# Test: Routing Metadata
+# ===========================================================================
+
+
+class TestRoutingMetadata:
+    """Tests for the routing result dict shape."""
+
+    def test_result_has_required_keys(self):
+        router = ModelRouter({'strategy': 'complexity'})
+        result = router.select_model('Hello world')
+        for key in ('provider', 'model', 'tier', 'reason'):
+            assert key in result, f'Missing key: {key}'
+
+    def test_provider_is_string(self):
+        router = ModelRouter({'strategy': 'latency'})
+        result = router.select_model('Test')
+        assert isinstance(result['provider'], str)
+
+    def test_tier_is_integer(self):
+        router = ModelRouter({'strategy': 'latency'})
+        result = router.select_model('Test')
+        assert isinstance(result['tier'], int)
+
+    def test_reason_is_nonempty_string(self):
+        router = ModelRouter({'strategy': 'latency'})
+        result = router.select_model('Test')
+        assert isinstance(result['reason'], str)
+        assert len(result['reason']) > 0
+
+
+# ===========================================================================
+# Test: Unknown Strategy
+# ===========================================================================
+
+
+class TestUnknownStrategy:
+    def test_unknown_strategy_uses_primary(self):
+        router = ModelRouter({'strategy': 'nonexistent', 'primary_model': 'gpt-5'})
+        result = router.select_model('Hello')
+        assert result['model'] == 'gpt-5'
+        assert 'unknown strategy' in result['reason']
+
+
+# ===========================================================================
+# Test: Request Counter
+# ===========================================================================
+
+
+class TestRequestCounter:
+    def test_counter_increments(self):
+        router = ModelRouter({'strategy': 'complexity'})
+        assert router.request_count == 0
+        router.select_model('One')
+        assert router.request_count == 1
+        router.select_model('Two')
+        assert router.request_count == 2
+
+
+# ===========================================================================
+# Test: Deep Copy Prevents Mutation
+# ===========================================================================
+
+
+class TestDeepCopyPrevention:
+    """Verify that IInstance.writeQuestions does not mutate the original question."""
+
+    def test_deep_copy_isolates_original(self):
+        original = MockQuestion('What is AI?')
+        original.metadata = {'existing_key': 'existing_value'}
+
+        # Deep copy manually (same logic as IInstance)
+        routed = copy.deepcopy(original)
+        routed.metadata['routing'] = {'model': 'test'}
+
+        # Original should be untouched
+        assert 'routing' not in original.metadata
+        assert original.metadata == {'existing_key': 'existing_value'}
+
+    def test_deep_copy_with_no_metadata(self):
+        original = MockQuestion('Hello')
+        original.metadata = None
+
+        routed = copy.deepcopy(original)
+        if routed.metadata is None:
+            routed.metadata = {}
+        routed.metadata['routing'] = {'model': 'test'}
+
+        assert original.metadata is None
+
+
+# ===========================================================================
+# Test: IGlobal Lifecycle
+# ===========================================================================
+
+
+class TestIGlobalLifecycle:
+    """Tests for IGlobal.validateConfig and beginGlobal/endGlobal."""
+
+    def _make_iglobal(self, config):
+        from nodes.src.nodes.router_llm.IGlobal import IGlobal
+
+        iglobal = IGlobal()
+        iglobal.glb = MagicMock()
+        iglobal.glb.logicalType = 'router_llm'
+        iglobal.glb.connConfig = config
+        iglobal.IEndpoint = MagicMock()
+        iglobal.IEndpoint.endpoint.openMode = 'normal'
+        return iglobal
+
+    def test_validate_rejects_invalid_strategy(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'bogus'}):
+            with pytest.raises(Exception, match='Invalid routing strategy'):
+                iglobal.validateConfig(False)
+
+    def test_validate_accepts_valid_strategies(self):
+        for strategy in ['complexity', 'cost_aware', 'latency', 'fallback_chain', 'ab_test']:
+            iglobal = self._make_iglobal({})
+            config = {'strategy': strategy}
+            if strategy == 'fallback_chain':
+                config['fallback_models'] = 'claude-haiku'
+            with patch.object(MockConfig, 'getNodeConfig', return_value=config):
+                iglobal.validateConfig(False)  # should not raise
+
+    def test_validate_fallback_chain_requires_models(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'fallback_chain', 'fallback_models': ''}):
+            with pytest.raises(Exception, match='requires at least one model'):
+                iglobal.validateConfig(False)
+
+    def test_begin_global_creates_router(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'complexity'}):
+            iglobal.beginGlobal()
+        assert iglobal.router is not None
+
+    def test_end_global_clears_router(self):
+        iglobal = self._make_iglobal({})
+        with patch.object(MockConfig, 'getNodeConfig', return_value={'strategy': 'complexity'}):
+            iglobal.beginGlobal()
+        iglobal.endGlobal()
+        assert iglobal.router is None
+
+    def test_begin_global_config_mode_skips_router(self):
+        iglobal = self._make_iglobal({})
+        iglobal.IEndpoint.endpoint.openMode = mock_rocketlib.OPEN_MODE.CONFIG
+        iglobal.beginGlobal()
+        assert iglobal.router is None
+
+
+# ===========================================================================
+# Test: IInstance Lifecycle
+# ===========================================================================
+
+
+class TestIInstanceLifecycle:
+    """Tests for IInstance.writeQuestions integration."""
+
+    def _make_instance(self, config):
+        from nodes.src.nodes.router_llm.IInstance import IInstance
+        from nodes.src.nodes.router_llm.IGlobal import IGlobal
+
+        iglobal = IGlobal()
+        iglobal.glb = MagicMock()
+        iglobal.glb.logicalType = 'router_llm'
+        iglobal.glb.connConfig = config
+        iglobal.IEndpoint = MagicMock()
+        iglobal.IEndpoint.endpoint.openMode = 'normal'
+
+        with patch.object(MockConfig, 'getNodeConfig', return_value=config):
+            iglobal.beginGlobal()
+
+        inst = IInstance()
+        inst.IGlobal = iglobal
+        inst.instance = MagicMock()
+        return inst
+
+    def test_write_questions_forwards_question(self):
+        inst = self._make_instance({'strategy': 'latency'})
+        question = MockQuestion('What is AI?')
+        inst.writeQuestions(question)
+        inst.instance.writeQuestions.assert_called_once()
+
+    def test_write_questions_attaches_routing_metadata(self):
+        inst = self._make_instance({'strategy': 'latency'})
+        question = MockQuestion('What is AI?')
+        inst.writeQuestions(question)
+        forwarded = inst.instance.writeQuestions.call_args[0][0]
+        assert 'routing' in forwarded.metadata
+        assert forwarded.metadata['routing']['model'] == 'gemini-flash'
+
+    def test_write_questions_does_not_mutate_original(self):
+        inst = self._make_instance({'strategy': 'latency'})
+        question = MockQuestion('What is AI?')
+        question.metadata = {'original': True}
+        inst.writeQuestions(question)
+        assert 'routing' not in question.metadata
+        assert question.metadata == {'original': True}
+
+    def test_open_does_not_raise(self):
+        inst = self._make_instance({'strategy': 'complexity'})
+        inst.open(MagicMock())  # should not raise

--- a/test/nodes/test_router_llm.py
+++ b/test/nodes/test_router_llm.py
@@ -263,6 +263,7 @@ class TestCostAwareRouting:
         router.record_cost(5.0)
         result = router.select_model('Any question')
         assert result['tier'] == 3
+        assert result['model'] == 'gemini-flash'
         assert 'budget exhausted' in result['reason']
 
     def test_near_budget_routes_to_balanced(self):
@@ -270,6 +271,7 @@ class TestCostAwareRouting:
         router.record_cost(8.5)  # 85% of budget
         result = router.select_model('Any question')
         assert result['tier'] == 2
+        assert result['model'] == 'claude-sonnet'
         assert 'approaching budget' in result['reason']
 
     def test_zero_budget_always_uses_primary(self):
@@ -387,11 +389,9 @@ class TestABTestRouting:
         result = router.select_model('Any query')
         assert result['ab_group'] == 'A'
 
-    def test_no_fallback_uses_primary_for_both(self):
-        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': '', 'ab_split_percent': 50})
-        result = router.select_model('Hello')
-        # Both groups should map to primary when no fallback
-        assert result['model'] == 'claude-sonnet'
+    def test_no_fallback_is_rejected(self):
+        with pytest.raises(ValueError, match='ab_test strategy requires at least one fallback model that differs'):
+            ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': '', 'ab_split_percent': 50})
 
     def test_result_includes_ab_bucket(self):
         router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini'})
@@ -425,9 +425,9 @@ class TestInitValidation:
             ModelRouter({'strategy': 'ab_test', 'ab_split_percent': 101})
 
     def test_ab_split_boundary_values_accepted(self):
-        r0 = ModelRouter({'strategy': 'ab_test', 'ab_split_percent': 0})
+        r0 = ModelRouter({'strategy': 'ab_test', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 0})
         assert r0.ab_split_percent == 0
-        r100 = ModelRouter({'strategy': 'ab_test', 'ab_split_percent': 100})
+        r100 = ModelRouter({'strategy': 'ab_test', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 100})
         assert r100.ab_split_percent == 100
 
     def test_complexity_threshold_zero_rejected(self):
@@ -471,22 +471,21 @@ class TestComplexityRoutingTier3Primary:
 
 
 class TestABTestWarning:
-    """Verify that A/B test warns when both groups use the same model."""
+    """Verify that A/B test validates fallback configuration."""
 
-    def test_warning_when_no_fallback(self):
-        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': '', 'ab_split_percent': 50})
-        result = router.select_model('Hello')
-        assert 'ab_warning' in result
+    def test_rejects_when_no_fallback(self):
+        with pytest.raises(ValueError, match='ab_test strategy requires at least one fallback model that differs'):
+            ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': '', 'ab_split_percent': 50})
 
-    def test_warning_when_fallback_matches_primary(self):
-        router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'claude-sonnet', 'ab_split_percent': 50})
-        result = router.select_model('Hello')
-        assert 'ab_warning' in result
+    def test_rejects_when_fallback_matches_primary(self):
+        with pytest.raises(ValueError, match='ab_test strategy requires at least one fallback model that differs'):
+            ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'claude-sonnet', 'ab_split_percent': 50})
 
     def test_no_warning_when_fallback_differs(self):
         router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'gpt-5-mini', 'ab_split_percent': 50})
         result = router.select_model('Hello')
-        assert 'ab_warning' not in result
+        assert result['model'] in {'claude-sonnet', 'gpt-5-mini'}
+        assert result['ab_group'] in {'A', 'B'}
 
     def test_distinct_second_fallback_used_when_first_matches_primary(self):
         router = ModelRouter({'strategy': 'ab_test', 'primary_model': 'claude-sonnet', 'fallback_models': 'claude-sonnet,gpt-5-mini', 'ab_split_percent': 0})
@@ -494,7 +493,6 @@ class TestABTestWarning:
         # Should pick gpt-5-mini since claude-sonnet matches primary
         assert result['model'] == 'gpt-5-mini'
         assert result['ab_group'] == 'B'
-        assert 'ab_warning' not in result
 
 
 # ===========================================================================


### PR DESCRIPTION
#Hack-with-bay-2

## Contribution Type
**Feature** — Intelligent LLM model routing with 5 strategies

## Problem / Use Case
RocketRide has 13 LLM providers but each pipeline hard-wires ONE provider. The industry average is 3-7 models per deployment. There is no way to dynamically select models based on task complexity, cost budget, latency requirements, or A/B testing.

## Proposed Solution
A \`router_llm\` node with 5 routing strategies:
- **Complexity**: Score queries by length/keywords/structure → route simple to cheap models, complex to powerful
- **Cost-aware**: Track cumulative cost, downgrade models when budget threshold hit
- **Latency**: Always select fastest model for real-time use cases
- **Fallback chain**: Ordered model list for retry logic (integrates with circuit breaker)
- **A/B test**: Deterministic SHA-256 per-query hashing for consistent traffic splitting

9 built-in model tiers across OpenAI, Anthropic, Google. 55 passing tests.

## Why This Feature Fits This Codebase
RocketRide's 13 LLM nodes (\`nodes/src/nodes/llm_openai/\`, \`llm_anthropic/\`, etc.) each inherit from \`IInstanceGenericLLM\` at \`nodes/src/nodes/llm_base/IInstance.py\`. The router node sits BEFORE LLM nodes in the pipeline, attaching routing metadata that the pipeline engine uses to select which downstream LLM node processes the request.

The complexity scoring uses the same question text interface as all LLM nodes (\`question.text\`). The A/B split uses deterministic hashing so the same query always routes to the same model — critical for reproducible pipeline evaluation with the Cobalt testing framework.

## Validation
\`\`\`
55 passed in 0.05s
ruff check: 0 errors
ruff format: all files unchanged
\`\`\`

## How This Could Be Extended
- Integrate with Prometheus metrics for routing decision tracking
- Add ML-based complexity estimation using embeddings
- Add cost-aware routing that reads actual token usage from downstream LLM responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Model Router node to route LLM requests with five strategies (complexity, cost-aware, latency, fallback chain, A/B test).
  * Deterministic A/B routing, fallback-chain ordering/deduplication, tiered model selection, complexity scoring, and budget-aware cost tracking.

* **Behavior Changes**
  * Routed questions include routing metadata (provider, model, tier, reason, plus strategy-specific fields); router is created/cleared during node lifecycle and forwarding preserves original immutability.

* **Config**
  * Exposed validation and configurable fields/profiles for strategy, primary/fallback models, budget, complexity threshold, and A/B split.

* **Tests**
  * Added comprehensive tests for routing logic, metadata shape, cost/request tracking, lifecycle, and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->