### PR TITLE
feat(nodes): add cost tracker node for LLM spend monitoring and budget enforcement

### DIFF
--- a/nodes/src/nodes/cost_tracker/IGlobal.py
+++ b/nodes/src/nodes/cost_tracker/IGlobal.py
@@ -1,0 +1,51 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from rocketlib import IGlobalBase, OPEN_MODE
+from ai.common.config import Config
+
+from .tracker import CostTracker
+
+
+class IGlobal(IGlobalBase):
+    """Global state for the Cost Tracker node.
+
+    Holds a single :class:`CostTracker` instance that is shared across
+    all pipeline threads for this node.
+    """
+
+    tracker: CostTracker = None
+
+    def beginGlobal(self):
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            # Config-only mode -- nothing to initialise
+            return
+
+        # Load node configuration from the services preconfig / connConfig
+        config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+
+        # Create the shared tracker
+        self.tracker = CostTracker(config)
+
+    def endGlobal(self):
+        self.tracker = None

--- a/nodes/src/nodes/cost_tracker/IInstance.py
+++ b/nodes/src/nodes/cost_tracker/IInstance.py
@@ -1,0 +1,110 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import copy
+
+from rocketlib import IInstanceBase, debug
+from ai.common.schema import Answer
+from .IGlobal import IGlobal
+
+
+class IInstance(IInstanceBase):
+    """Per-thread instance for the Cost Tracker node.
+
+    Intercepts the ``answers`` lane, calculates LLM cost from the
+    answer's token-usage metadata, tracks cumulative spend, and
+    either warns or blocks when the configured budget is exceeded.
+    """
+
+    IGlobal: IGlobal
+
+    def writeAnswers(self, answer: Answer):
+        """Process an incoming answer, attach cost metadata, and enforce budget.
+
+        Token usage is read from ``answer.metadata`` (keys
+        ``input_tokens``, ``output_tokens``, ``model``).  If the
+        metadata is absent the answer is forwarded unchanged.
+        """
+        tracker = self.IGlobal.tracker
+        if tracker is None:
+            # Tracker not initialised (e.g. CONFIG mode) -- pass through
+            return
+
+        # Deep-copy so downstream mutations never corrupt our accounting
+        answer = copy.deepcopy(answer)
+
+        # ----------------------------------------------------------------
+        # Extract token-usage metadata from the answer
+        # ----------------------------------------------------------------
+        metadata = getattr(answer, 'metadata', None) or {}
+        if isinstance(metadata, dict):
+            input_tokens = metadata.get('input_tokens', 0)
+            output_tokens = metadata.get('output_tokens', 0)
+            model = metadata.get('model', 'unknown')
+        else:
+            input_tokens = getattr(metadata, 'input_tokens', 0)
+            output_tokens = getattr(metadata, 'output_tokens', 0)
+            model = getattr(metadata, 'model', 'unknown')
+
+        # Ensure integers
+        try:
+            input_tokens = int(input_tokens)
+        except (TypeError, ValueError):
+            input_tokens = 0
+        try:
+            output_tokens = int(output_tokens)
+        except (TypeError, ValueError):
+            output_tokens = 0
+
+        # ----------------------------------------------------------------
+        # Calculate and track
+        # ----------------------------------------------------------------
+        cost_entry = tracker.calculate_cost(model, input_tokens, output_tokens)
+        tracker.track(cost_entry)
+
+        # Attach cost metadata onto the answer for downstream consumers
+        if not hasattr(answer, 'metadata') or answer.metadata is None:
+            answer.metadata = {}
+        if isinstance(answer.metadata, dict):
+            answer.metadata['cost_usd'] = cost_entry['cost_usd']
+            answer.metadata['cumulative_cost_usd'] = tracker.get_total()
+
+        # ----------------------------------------------------------------
+        # Budget enforcement
+        # ----------------------------------------------------------------
+        budget_status = tracker.check_budget()
+
+        if budget_status.get('alert_threshold_reached') and budget_status.get('within_budget'):
+            debug(f'Cost Tracker: alert threshold reached -- {budget_status["percent_used"]:.1f}% of budget used (${budget_status["used"]:.6f} / ${budget_status["used"] + budget_status["remaining"]:.6f})')
+
+        if not budget_status.get('within_budget', True):
+            if tracker.policy == 'block':
+                debug(f'Cost Tracker: BLOCKING answer -- budget exceeded (${budget_status["used"]:.6f} spent, limit ${budget_status["used"] - budget_status["remaining"]:.6f})')
+                # Prevent the answer from propagating downstream
+                self.preventDefault()
+                return
+            else:
+                debug(f'Cost Tracker: WARNING -- budget exceeded (${budget_status["used"]:.6f} spent)')
+
+        # Forward the (annotated) answer downstream
+        self.instance.writeAnswers(answer)

--- a/nodes/src/nodes/cost_tracker/IInstance.py
+++ b/nodes/src/nodes/cost_tracker/IInstance.py
@@ -104,7 +104,7 @@ class IInstance(IInstanceBase):
                 # Prevent the answer from propagating downstream
                 self.preventDefault()
                 return
-            debug(f'Cost Tracker: WARNING -- budget exceeded (${budget_status["used"]:.6f} spent)')
+            debug(f'Cost Tracker: WARNING -- budget exceeded (${budget_status["used"]:.6f} spent, limit ${budget_status["limit"]:.6f})')
 
         # Forward the (annotated) answer downstream
         self.instance.writeAnswers(answer)

--- a/nodes/src/nodes/cost_tracker/IInstance.py
+++ b/nodes/src/nodes/cost_tracker/IInstance.py
@@ -48,6 +48,7 @@ class IInstance(IInstanceBase):
         tracker = self.IGlobal.tracker
         if tracker is None:
             # Tracker not initialised (e.g. CONFIG mode) -- pass through
+            self.instance.writeAnswers(answer)
             return
 
         # Deep-copy so downstream mutations never corrupt our accounting
@@ -95,16 +96,15 @@ class IInstance(IInstanceBase):
         budget_status = tracker.check_budget()
 
         if budget_status.get('alert_threshold_reached') and budget_status.get('within_budget'):
-            debug(f'Cost Tracker: alert threshold reached -- {budget_status["percent_used"]:.1f}% of budget used (${budget_status["used"]:.6f} / ${budget_status["used"] + budget_status["remaining"]:.6f})')
+            debug(f'Cost Tracker: alert threshold reached -- {budget_status["percent_used"]:.1f}% of budget used (${budget_status["used"]:.6f} / ${budget_status["limit"]:.6f})')
 
         if not budget_status.get('within_budget', True):
             if tracker.policy == 'block':
-                debug(f'Cost Tracker: BLOCKING answer -- budget exceeded (${budget_status["used"]:.6f} spent, limit ${budget_status["used"] - budget_status["remaining"]:.6f})')
+                debug(f'Cost Tracker: BLOCKING answer -- budget exceeded (${budget_status["used"]:.6f} spent, limit ${budget_status["limit"]:.6f})')
                 # Prevent the answer from propagating downstream
                 self.preventDefault()
                 return
-            else:
-                debug(f'Cost Tracker: WARNING -- budget exceeded (${budget_status["used"]:.6f} spent)')
+            debug(f'Cost Tracker: WARNING -- budget exceeded (${budget_status["used"]:.6f} spent)')
 
         # Forward the (annotated) answer downstream
         self.instance.writeAnswers(answer)

--- a/nodes/src/nodes/cost_tracker/__init__.py
+++ b/nodes/src/nodes/cost_tracker/__init__.py
@@ -1,0 +1,30 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+]

--- a/nodes/src/nodes/cost_tracker/pricing.py
+++ b/nodes/src/nodes/cost_tracker/pricing.py
@@ -1,0 +1,123 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""LLM pricing data and cost calculation utilities.
+
+Prices are per 1 million tokens, sourced from provider pricing pages as of
+March 2026.  Custom pricing can be supplied at runtime to override these
+defaults.
+"""
+
+from typing import Dict, Optional
+
+# ---------------------------------------------------------------------------
+# Default pricing table (USD per 1 M tokens)
+# ---------------------------------------------------------------------------
+PRICING: Dict[str, Dict[str, float]] = {
+    'gpt-5': {'input': 2.00, 'output': 8.00},
+    'gpt-5.1': {'input': 2.00, 'output': 8.00},
+    'gpt-5.2': {'input': 2.00, 'output': 8.00},
+    'gpt-5-mini': {'input': 0.40, 'output': 1.60},
+    'gpt-5-nano': {'input': 0.10, 'output': 0.40},
+    'gpt-4o': {'input': 2.50, 'output': 10.00},
+    'gpt-4o-mini': {'input': 0.15, 'output': 0.60},
+    'claude-opus': {'input': 15.00, 'output': 75.00},
+    'claude-sonnet': {'input': 3.00, 'output': 15.00},
+    'claude-haiku': {'input': 0.25, 'output': 1.25},
+    'gemini-pro': {'input': 1.25, 'output': 5.00},
+    'gemini-flash': {'input': 0.075, 'output': 0.30},
+    'mistral-large': {'input': 2.00, 'output': 6.00},
+    'mistral-small': {'input': 0.20, 'output': 0.60},
+    'deepseek-chat': {'input': 0.14, 'output': 0.28},
+    'deepseek-reasoner': {'input': 0.55, 'output': 2.19},
+    'perplexity-sonar': {'input': 1.00, 'output': 1.00},
+    'ollama': {'input': 0.00, 'output': 0.00},
+}
+
+
+def find_model_pricing(model_name: str, custom_pricing: Optional[Dict[str, Dict[str, float]]] = None) -> Optional[Dict[str, float]]:
+    """Return the pricing entry for *model_name* using fuzzy matching.
+
+    Resolution order:
+    1. Exact match in *custom_pricing* (if provided).
+    2. Exact match in the default ``PRICING`` table.
+    3. Prefix / substring match against both tables (custom first).
+       For example ``gpt-5.2-preview`` matches ``gpt-5.2``.
+    4. ``None`` if nothing matches.
+    """
+    if not model_name:
+        return None
+
+    normalized = model_name.strip().lower()
+
+    # Build merged lookup: custom overrides default
+    merged: Dict[str, Dict[str, float]] = dict(PRICING)
+    if custom_pricing:
+        merged.update(custom_pricing)
+
+    # 1. Exact match
+    if normalized in merged:
+        return merged[normalized]
+
+    # 2. The model name starts with a known key (longest match wins)
+    best_key: Optional[str] = None
+    for key in merged:
+        if normalized.startswith(key) and (best_key is None or len(key) > len(best_key)):
+            best_key = key
+    if best_key is not None:
+        return merged[best_key]
+
+    # 3. A known key is a substring of the model name (longest match wins)
+    best_key = None
+    for key in merged:
+        if key in normalized and (best_key is None or len(key) > len(best_key)):
+            best_key = key
+    if best_key is not None:
+        return merged[best_key]
+
+    return None
+
+
+def get_price(model: str, input_tokens: int, output_tokens: int, custom_pricing: Optional[Dict[str, Dict[str, float]]] = None) -> float:
+    """Calculate the cost in USD for a single LLM request.
+
+    Args:
+        model: Model identifier (e.g. ``'gpt-5'``).
+        input_tokens: Number of prompt / input tokens.
+        output_tokens: Number of completion / output tokens.
+        custom_pricing: Optional per-model overrides.
+
+    Returns:
+        Cost in USD.  Returns ``0.0`` when the model is unknown.
+    """
+    pricing = find_model_pricing(model, custom_pricing)
+    if pricing is None:
+        return 0.0
+
+    # Clamp negative token counts to zero
+    input_tokens = max(0, input_tokens)
+    output_tokens = max(0, output_tokens)
+
+    input_cost = (input_tokens / 1_000_000) * pricing['input']
+    output_cost = (output_tokens / 1_000_000) * pricing['output']
+    return input_cost + output_cost

--- a/nodes/src/nodes/cost_tracker/pricing.py
+++ b/nodes/src/nodes/cost_tracker/pricing.py
@@ -28,12 +28,12 @@ March 2026.  Custom pricing can be supplied at runtime to override these
 defaults.
 """
 
-from typing import Dict, Optional
+from typing import Optional
 
 # ---------------------------------------------------------------------------
 # Default pricing table (USD per 1 M tokens)
 # ---------------------------------------------------------------------------
-PRICING: Dict[str, Dict[str, float]] = {
+PRICING: dict[str, dict[str, float]] = {
     'gpt-5': {'input': 2.00, 'output': 8.00},
     'gpt-5.1': {'input': 2.00, 'output': 8.00},
     'gpt-5.2': {'input': 2.00, 'output': 8.00},
@@ -55,7 +55,7 @@ PRICING: Dict[str, Dict[str, float]] = {
 }
 
 
-def find_model_pricing(model_name: str, custom_pricing: Optional[Dict[str, Dict[str, float]]] = None) -> Optional[Dict[str, float]]:
+def find_model_pricing(model_name: str, custom_pricing: Optional[dict[str, dict[str, float]]] = None) -> Optional[dict[str, float]]:
     """Return the pricing entry for *model_name* using fuzzy matching.
 
     Resolution order:
@@ -71,7 +71,7 @@ def find_model_pricing(model_name: str, custom_pricing: Optional[Dict[str, Dict[
     normalized = model_name.strip().lower()
 
     # Build merged lookup: custom overrides default (normalize keys to lowercase)
-    merged: Dict[str, Dict[str, float]] = dict(PRICING)
+    merged: dict[str, dict[str, float]] = dict(PRICING)
     if custom_pricing:
         merged.update({k.strip().lower(): v for k, v in custom_pricing.items()})
 
@@ -98,7 +98,7 @@ def find_model_pricing(model_name: str, custom_pricing: Optional[Dict[str, Dict[
     return None
 
 
-def get_price(model: str, input_tokens: int, output_tokens: int, custom_pricing: Optional[Dict[str, Dict[str, float]]] = None) -> float:
+def get_price(model: str, input_tokens: int, output_tokens: int, custom_pricing: Optional[dict[str, dict[str, float]]] = None) -> float:
     """Calculate the cost in USD for a single LLM request.
 
     Args:

--- a/nodes/src/nodes/cost_tracker/pricing.py
+++ b/nodes/src/nodes/cost_tracker/pricing.py
@@ -70,10 +70,10 @@ def find_model_pricing(model_name: str, custom_pricing: Optional[Dict[str, Dict[
 
     normalized = model_name.strip().lower()
 
-    # Build merged lookup: custom overrides default
+    # Build merged lookup: custom overrides default (normalize keys to lowercase)
     merged: Dict[str, Dict[str, float]] = dict(PRICING)
     if custom_pricing:
-        merged.update(custom_pricing)
+        merged.update({k.strip().lower(): v for k, v in custom_pricing.items()})
 
     # 1. Exact match
     if normalized in merged:

--- a/nodes/src/nodes/cost_tracker/requirements.txt
+++ b/nodes/src/nodes/cost_tracker/requirements.txt
@@ -1,0 +1,1 @@
+# Cost Tracker — no external dependencies

--- a/nodes/src/nodes/cost_tracker/services.json
+++ b/nodes/src/nodes/cost_tracker/services.json
@@ -1,0 +1,243 @@
+{
+	//
+	// Required:
+	//		The displayable name of this node
+	//
+	"title": "Cost Tracker",
+	//
+	// Required:
+	//		The protocol is the endpoint protocol
+	//
+	"protocol": "cost_tracker://",
+	//
+	// Required:
+	//		Class type of the node - what it does
+	//
+	"classType": [
+		"tracker"
+	],
+	//
+	// Required:
+	//		Capabilities are flags that change the behavior of the underlying
+	//		engine
+	//
+	"capabilities": [],
+	//
+	// Optional:
+	//		Register is either filter, endpoint or ignored if not specified. If the
+	//		type is specified, a factory is registered of that given type
+	//
+	"register": "filter",
+	//
+	// Optional:
+	//		The node is the actual physical node to instantiate - if
+	//		not specified, the protocol will be used
+	//
+	"node": "python",
+	//
+	// Optional:
+	//		The path is the executable/script code - it is node dependent
+	//		and is optional for most nodes
+	//
+	"path": "nodes.cost_tracker",
+	//
+	// Required:
+	//		The prefix map when added/removed when converting URLs <=> paths
+	//
+	"prefix": "cost_tracker",
+	//
+	// Optional:
+	//		Description of this driver
+	//
+	"description": [
+		"A filter component that calculates and tracks per-request LLM costs with ",
+		"budget enforcement. Place it after any LLM node in a pipeline to monitor ",
+		"token usage and spending. Supports all 13 built-in LLM providers, custom ",
+		"pricing overrides, configurable budget limits, and alert thresholds. ",
+		"When the budget is exceeded the node can either warn (log and continue) ",
+		"or block (prevent the answer from propagating downstream)."
+	],
+	//
+	// Optional:
+	//		The icon is the icon to display in the UI for this node
+	//
+	"icon": "util-infrastructure.svg",
+	//
+	//  Optional:
+	//      Rendering hints to the UI which indicate which fields of
+	//      the configuration should be used to display information
+	//
+	"tile": [
+		"Policy: ${parameters.cost_tracker.profile}"
+	],
+	//
+	//	Optional:
+	//		As a pipe component, define what this pipe component takes
+	//		and what it produces
+	//
+	"lanes": {
+		"answers": [
+			"answers"
+		]
+	},
+	"input": [
+		{
+			"lane": "answers",
+			"description": "LLM answers with token-usage metadata",
+			"output": [
+				{
+					"lane": "answers",
+					"description": "Answers annotated with cost metadata"
+				}
+			]
+		}
+	],
+	//
+	//	Optional:
+	//		Profile section are configuration options used by the driver
+	//		itself
+	//
+	"preconfig": {
+		"default": "monitor",
+		"profiles": {
+			"monitor": {
+				"title": "Monitor",
+				"budget_limit_usd": null,
+				"alert_threshold_pct": 80,
+				"policy": "warn",
+				"custom_pricing_json": ""
+			},
+			"budget": {
+				"title": "Budget",
+				"budget_limit_usd": 10.00,
+				"alert_threshold_pct": 80,
+				"policy": "block",
+				"custom_pricing_json": ""
+			},
+			"custom": {
+				"title": "Custom",
+				"budget_limit_usd": null,
+				"alert_threshold_pct": 80,
+				"policy": "warn",
+				"custom_pricing_json": ""
+			}
+		}
+	},
+	//
+	// Optional:
+	//		Local field definitions - these define fields only for the
+	//		current service. You may specify them here, or directly
+	//		in the shape
+	//
+	"fields": {
+		"budget_limit_usd": {
+			"type": "number",
+			"title": "Budget Limit (USD)",
+			"description": "Maximum spend in USD. Leave empty for unlimited."
+		},
+		"alert_threshold_pct": {
+			"type": "number",
+			"title": "Alert Threshold (%)",
+			"description": "Log a warning when this percentage of the budget is consumed.",
+			"default": 80
+		},
+		"policy": {
+			"type": "string",
+			"title": "Over-budget Policy",
+			"description": "Action when budget is exceeded: warn (log and continue) or block (drop answer).",
+			"enum": [
+				["warn", "Warn"],
+				["block", "Block"]
+			],
+			"default": "warn"
+		},
+		"custom_pricing_json": {
+			"type": "string",
+			"title": "Custom Pricing (JSON)",
+			"description": "Optional JSON object mapping model names to {input, output} prices per 1M tokens."
+		},
+		"cost_tracker.monitor": {
+			"object": "monitor",
+			"properties": [
+				"alert_threshold_pct",
+				"custom_pricing_json"
+			]
+		},
+		"cost_tracker.budget": {
+			"object": "budget",
+			"properties": [
+				"budget_limit_usd",
+				"alert_threshold_pct",
+				"policy",
+				"custom_pricing_json"
+			]
+		},
+		"cost_tracker.custom": {
+			"object": "custom",
+			"properties": [
+				"budget_limit_usd",
+				"alert_threshold_pct",
+				"policy",
+				"custom_pricing_json"
+			]
+		},
+		"cost_tracker.profile": {
+			"title": "Mode",
+			"description": "Cost tracking mode",
+			"type": "string",
+			"default": "monitor",
+			"enum": [
+				"*>preconfig.profiles.*.title"
+			],
+			"conditional": [
+				{
+					"value": "monitor",
+					"properties": [
+						"cost_tracker.monitor"
+					]
+				},
+				{
+					"value": "budget",
+					"properties": [
+						"cost_tracker.budget"
+					]
+				},
+				{
+					"value": "custom",
+					"properties": [
+						"cost_tracker.custom"
+					]
+				}
+			]
+		}
+	},
+	//
+	// Required:
+	//		Defines the fields (shape) of the service. Either source or target
+	//		may be specified, or both, but at least one is required
+	//
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Cost Tracker",
+			"properties": [
+				"cost_tracker.profile"
+			]
+		}
+	],
+	"test": {
+		"profiles": ["monitor"],
+		"outputs": ["answers"],
+		"cases": [
+			{
+				"name": "Cost tracker passes answers through",
+				"text": "What is 2+2?",
+				"expect": {
+					"answers": {
+						"contains": "Mock LLM response"
+					}
+				}
+			}
+		]
+	}
+}

--- a/nodes/src/nodes/cost_tracker/tracker.py
+++ b/nodes/src/nodes/cost_tracker/tracker.py
@@ -1,0 +1,184 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Thread-safe cost tracker with budget enforcement."""
+
+import json
+import threading
+from typing import Any, Dict, List, Optional
+
+from .pricing import get_price
+
+
+class CostTracker:
+    """Accumulates per-request LLM costs and enforces budget limits.
+
+    All public methods that mutate state are protected by a
+    ``threading.Lock`` so the tracker is safe to use from multiple
+    pipeline threads concurrently.
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        """Initialise the tracker from a node configuration dict."""
+        self._lock = threading.Lock()
+
+        # Budget configuration
+        self._budget_limit: Optional[float] = config.get('budget_limit_usd')
+        if self._budget_limit is not None:
+            self._budget_limit = float(self._budget_limit)
+
+        self._alert_threshold_pct: float = float(config.get('alert_threshold_pct', 80))
+        self._policy: str = config.get('policy', 'warn')  # 'warn' | 'block'
+
+        # Custom pricing override (JSON string or dict)
+        custom_pricing_raw = config.get('custom_pricing_json')
+        self._custom_pricing: Optional[Dict[str, Dict[str, float]]] = None
+        if custom_pricing_raw:
+            if isinstance(custom_pricing_raw, str):
+                self._custom_pricing = json.loads(custom_pricing_raw)
+            elif isinstance(custom_pricing_raw, dict):
+                self._custom_pricing = custom_pricing_raw
+
+        # Accumulation state
+        self._total_cost: float = 0.0
+        self._entries: List[Dict[str, Any]] = []
+        self._per_model: Dict[str, Dict[str, Any]] = {}
+
+    # ------------------------------------------------------------------
+    # Cost calculation
+    # ------------------------------------------------------------------
+
+    def calculate_cost(self, model: str, input_tokens: int, output_tokens: int) -> Dict[str, Any]:
+        """Calculate cost for a single request without tracking it.
+
+        Returns:
+            A dict with keys ``cost_usd``, ``model``, ``input_tokens``,
+            ``output_tokens``.
+        """
+        cost = get_price(model, input_tokens, output_tokens, self._custom_pricing)
+        return {
+            'cost_usd': cost,
+            'model': model,
+            'input_tokens': max(0, input_tokens),
+            'output_tokens': max(0, output_tokens),
+        }
+
+    # ------------------------------------------------------------------
+    # Tracking
+    # ------------------------------------------------------------------
+
+    def track(self, cost_entry: Dict[str, Any]) -> None:
+        """Record a cost entry and accumulate totals.
+
+        ``cost_entry`` should be a dict as returned by
+        :meth:`calculate_cost`.
+        """
+        cost = cost_entry.get('cost_usd', 0.0)
+        model = cost_entry.get('model', 'unknown')
+
+        with self._lock:
+            self._total_cost += cost
+            self._entries.append(cost_entry)
+
+            if model not in self._per_model:
+                self._per_model[model] = {
+                    'total_cost': 0.0,
+                    'total_input_tokens': 0,
+                    'total_output_tokens': 0,
+                    'request_count': 0,
+                }
+            summary = self._per_model[model]
+            summary['total_cost'] += cost
+            summary['total_input_tokens'] += cost_entry.get('input_tokens', 0)
+            summary['total_output_tokens'] += cost_entry.get('output_tokens', 0)
+            summary['request_count'] += 1
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    def get_total(self) -> float:
+        """Return the cumulative cost tracked so far (USD)."""
+        with self._lock:
+            return self._total_cost
+
+    def check_budget(self, budget_limit: Optional[float] = None) -> Dict[str, Any]:
+        """Check spending against a budget limit.
+
+        Args:
+            budget_limit: Optional override; falls back to the limit
+                configured at init time.
+
+        Returns:
+            A dict with ``within_budget``, ``used``, ``remaining``,
+            ``percent_used``, and ``alert_threshold_reached``.
+        """
+        limit = budget_limit if budget_limit is not None else self._budget_limit
+
+        with self._lock:
+            used = self._total_cost
+
+        if limit is None or limit <= 0:
+            return {
+                'within_budget': True,
+                'used': used,
+                'remaining': float('inf'),
+                'percent_used': 0.0,
+                'alert_threshold_reached': False,
+            }
+
+        remaining = limit - used
+        percent_used = (used / limit) * 100.0 if limit > 0 else 0.0
+
+        return {
+            'within_budget': used <= limit,
+            'used': used,
+            'remaining': max(0.0, remaining),
+            'percent_used': percent_used,
+            'alert_threshold_reached': percent_used >= self._alert_threshold_pct,
+        }
+
+    def get_summary(self) -> Dict[str, Any]:
+        """Return a per-model cost breakdown plus the overall total."""
+        with self._lock:
+            return {
+                'total_cost': self._total_cost,
+                'per_model': {k: dict(v) for k, v in self._per_model.items()},
+                'request_count': len(self._entries),
+            }
+
+    # ------------------------------------------------------------------
+    # Policy helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def policy(self) -> str:
+        """Return the configured over-budget policy (``'warn'`` or ``'block'``)."""
+        return self._policy
+
+    def is_over_budget(self) -> bool:
+        """Return ``True`` when spending has exceeded the configured budget."""
+        if self._budget_limit is None:
+            return False
+        with self._lock:
+            return self._total_cost > self._budget_limit

--- a/nodes/src/nodes/cost_tracker/tracker.py
+++ b/nodes/src/nodes/cost_tracker/tracker.py
@@ -25,7 +25,7 @@
 
 import json
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from .pricing import get_price
 
@@ -38,7 +38,7 @@ class CostTracker:
     pipeline threads concurrently.
     """
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: dict[str, Any]):
         """Initialise the tracker from a node configuration dict."""
         self._lock = threading.Lock()
 
@@ -52,7 +52,7 @@ class CostTracker:
 
         # Custom pricing override (JSON string or dict)
         custom_pricing_raw = config.get('custom_pricing_json')
-        self._custom_pricing: Optional[Dict[str, Dict[str, float]]] = None
+        self._custom_pricing: Optional[dict[str, dict[str, float]]] = None
         if custom_pricing_raw:
             if isinstance(custom_pricing_raw, str):
                 self._custom_pricing = json.loads(custom_pricing_raw)
@@ -61,14 +61,14 @@ class CostTracker:
 
         # Accumulation state
         self._total_cost: float = 0.0
-        self._entries: List[Dict[str, Any]] = []
-        self._per_model: Dict[str, Dict[str, Any]] = {}
+        self._entries: list[dict[str, Any]] = []
+        self._per_model: dict[str, dict[str, Any]] = {}
 
     # ------------------------------------------------------------------
     # Cost calculation
     # ------------------------------------------------------------------
 
-    def calculate_cost(self, model: str, input_tokens: int, output_tokens: int) -> Dict[str, Any]:
+    def calculate_cost(self, model: str, input_tokens: int, output_tokens: int) -> dict[str, Any]:
         """Calculate cost for a single request without tracking it.
 
         Returns:
@@ -87,7 +87,7 @@ class CostTracker:
     # Tracking
     # ------------------------------------------------------------------
 
-    def track(self, cost_entry: Dict[str, Any]) -> None:
+    def track(self, cost_entry: dict[str, Any]) -> None:
         """Record a cost entry and accumulate totals.
 
         ``cost_entry`` should be a dict as returned by
@@ -122,7 +122,7 @@ class CostTracker:
         with self._lock:
             return self._total_cost
 
-    def check_budget(self, budget_limit: Optional[float] = None) -> Dict[str, Any]:
+    def check_budget(self, budget_limit: Optional[float] = None) -> dict[str, Any]:
         """Check spending against a budget limit.
 
         Args:
@@ -160,7 +160,7 @@ class CostTracker:
             'alert_threshold_reached': percent_used >= self._alert_threshold_pct,
         }
 
-    def get_summary(self) -> Dict[str, Any]:
+    def get_summary(self) -> dict[str, Any]:
         """Return a per-model cost breakdown plus the overall total."""
         with self._lock:
             return {

--- a/nodes/src/nodes/cost_tracker/tracker.py
+++ b/nodes/src/nodes/cost_tracker/tracker.py
@@ -142,6 +142,7 @@ class CostTracker:
             return {
                 'within_budget': True,
                 'used': used,
+                'limit': None,
                 'remaining': float('inf'),
                 'percent_used': 0.0,
                 'alert_threshold_reached': False,
@@ -153,6 +154,7 @@ class CostTracker:
         return {
             'within_budget': used <= limit,
             'used': used,
+            'limit': limit,
             'remaining': max(0.0, remaining),
             'percent_used': percent_used,
             'alert_threshold_reached': percent_used >= self._alert_threshold_pct,

--- a/test/nodes/test_cost_tracker.py
+++ b/test/nodes/test_cost_tracker.py
@@ -1,0 +1,568 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Tests for the cost_tracker pipeline node.
+
+Covers pricing lookup, cost calculation, budget enforcement, thread safety,
+custom pricing, edge cases, policy enforcement, and the IGlobal / IInstance
+lifecycle.
+"""
+
+import copy
+import json
+import math
+import threading
+from unittest.mock import MagicMock
+
+# ---------------------------------------------------------------------------
+# We import pricing.py and tracker.py directly (via importlib) to avoid
+# triggering cost_tracker/__init__.py which pulls in rocketlib / the full
+# engine runtime that is not available in a plain pytest environment.
+# ---------------------------------------------------------------------------
+import importlib.util
+import sys
+import os
+
+_nodes_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'nodes', 'src', 'nodes'))
+
+
+def _load_module(name: str, filepath: str):
+    """Load a single .py file as a module without executing __init__.py."""
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# Register the sub-modules so relative imports inside tracker.py resolve
+_pricing_mod = _load_module('cost_tracker.pricing', os.path.join(_nodes_dir, 'cost_tracker', 'pricing.py'))
+_tracker_mod = _load_module('cost_tracker.tracker', os.path.join(_nodes_dir, 'cost_tracker', 'tracker.py'))
+
+PRICING = _pricing_mod.PRICING
+find_model_pricing = _pricing_mod.find_model_pricing
+get_price = _pricing_mod.get_price
+CostTracker = _tracker_mod.CostTracker
+
+
+# ===================================================================
+# Pricing lookup tests
+# ===================================================================
+
+
+class TestFindModelPricing:
+    """Tests for find_model_pricing fuzzy matching."""
+
+    def test_exact_match(self):
+        """Exact model name returns correct pricing."""
+        result = find_model_pricing('gpt-5')
+        assert result == {'input': 2.00, 'output': 8.00}
+
+    def test_exact_match_claude_opus(self):
+        """Exact match for claude-opus."""
+        result = find_model_pricing('claude-opus')
+        assert result == {'input': 15.00, 'output': 75.00}
+
+    def test_exact_match_ollama(self):
+        """Ollama is free."""
+        result = find_model_pricing('ollama')
+        assert result == {'input': 0.00, 'output': 0.00}
+
+    def test_prefix_match(self):
+        """Model name starting with a known key matches (e.g. gpt-5.2-preview)."""
+        result = find_model_pricing('gpt-5.2-preview')
+        assert result is not None
+        assert result['input'] == 2.00
+
+    def test_prefix_match_longest_wins(self):
+        """Longer prefix wins when multiple keys match.
+
+        'gpt-5-mini-latest' should match 'gpt-5-mini' (len 9) not 'gpt-5' (len 5).
+        """
+        result = find_model_pricing('gpt-5-mini-latest')
+        assert result is not None
+        assert result['input'] == 0.40  # gpt-5-mini pricing
+
+    def test_substring_match(self):
+        """Substring matching as last resort."""
+        # 'deepseek-chat' is a key; 'my-deepseek-chat-v2' contains it
+        result = find_model_pricing('my-deepseek-chat-v2')
+        assert result is not None
+        assert result['input'] == 0.14
+
+    def test_unknown_model_returns_none(self):
+        """Completely unknown model returns None."""
+        result = find_model_pricing('totally-unknown-model-xyz')
+        assert result is None
+
+    def test_empty_string_returns_none(self):
+        """Empty model name returns None."""
+        assert find_model_pricing('') is None
+
+    def test_none_returns_none(self):
+        """None model name returns None."""
+        assert find_model_pricing(None) is None
+
+    def test_case_insensitive(self):
+        """Lookup is case-insensitive."""
+        result = find_model_pricing('GPT-5')
+        assert result is not None
+        assert result['input'] == 2.00
+
+    def test_whitespace_stripped(self):
+        """Leading/trailing whitespace is stripped."""
+        result = find_model_pricing('  gpt-5  ')
+        assert result is not None
+
+    def test_custom_pricing_exact_override(self):
+        """Custom pricing overrides the default table."""
+        custom = {'gpt-5': {'input': 99.0, 'output': 99.0}}
+        result = find_model_pricing('gpt-5', custom_pricing=custom)
+        assert result['input'] == 99.0
+
+    def test_custom_pricing_new_model(self):
+        """Custom pricing can introduce entirely new models."""
+        custom = {'my-custom-llm': {'input': 1.0, 'output': 2.0}}
+        result = find_model_pricing('my-custom-llm', custom_pricing=custom)
+        assert result == {'input': 1.0, 'output': 2.0}
+
+
+# ===================================================================
+# Cost calculation accuracy tests
+# ===================================================================
+
+
+class TestGetPrice:
+    """Tests for get_price."""
+
+    def test_basic_cost_gpt5(self):
+        """GPT-5: 1000 input + 500 output tokens."""
+        cost = get_price('gpt-5', 1000, 500)
+        expected = (1000 / 1_000_000) * 2.00 + (500 / 1_000_000) * 8.00
+        assert math.isclose(cost, expected, rel_tol=1e-9)
+
+    def test_basic_cost_claude_opus(self):
+        """Claude Opus: expensive model."""
+        cost = get_price('claude-opus', 1_000_000, 1_000_000)
+        expected = 15.00 + 75.00
+        assert math.isclose(cost, expected, rel_tol=1e-9)
+
+    def test_zero_tokens(self):
+        """Zero tokens should yield zero cost."""
+        assert get_price('gpt-5', 0, 0) == 0.0
+
+    def test_negative_tokens_clamped(self):
+        """Negative token counts are clamped to zero."""
+        assert get_price('gpt-5', -100, -200) == 0.0
+
+    def test_very_large_tokens(self):
+        """Very large token count produces a proportional cost."""
+        cost = get_price('gpt-5', 100_000_000, 100_000_000)
+        expected = (100_000_000 / 1_000_000) * 2.00 + (100_000_000 / 1_000_000) * 8.00
+        assert math.isclose(cost, expected, rel_tol=1e-9)
+
+    def test_unknown_model_zero_cost(self):
+        """Unknown model returns 0.0 cost."""
+        assert get_price('nonexistent-model', 1000, 1000) == 0.0
+
+    def test_ollama_free(self):
+        """Ollama is free regardless of token count."""
+        assert get_price('ollama', 1_000_000, 1_000_000) == 0.0
+
+    def test_custom_pricing_used(self):
+        """Custom pricing is respected in get_price."""
+        custom = {'my-model': {'input': 10.0, 'output': 20.0}}
+        cost = get_price('my-model', 1_000_000, 1_000_000, custom_pricing=custom)
+        assert math.isclose(cost, 30.0, rel_tol=1e-9)
+
+    def test_gemini_flash_small_cost(self):
+        """Gemini Flash has very low pricing."""
+        cost = get_price('gemini-flash', 1_000_000, 1_000_000)
+        expected = 0.075 + 0.30
+        assert math.isclose(cost, expected, rel_tol=1e-9)
+
+
+# ===================================================================
+# CostTracker tests
+# ===================================================================
+
+
+class TestCostTracker:
+    """Tests for the CostTracker class."""
+
+    def _make_tracker(self, **overrides):
+        config = {
+            'budget_limit_usd': 1.0,
+            'alert_threshold_pct': 80,
+            'policy': 'warn',
+        }
+        config.update(overrides)
+        return CostTracker(config)
+
+    # ---------------------------------------------------------------
+    # Basic tracking
+    # ---------------------------------------------------------------
+
+    def test_initial_total_is_zero(self):
+        tracker = self._make_tracker()
+        assert tracker.get_total() == 0.0
+
+    def test_track_single_entry(self):
+        tracker = self._make_tracker()
+        entry = tracker.calculate_cost('gpt-5', 1000, 500)
+        tracker.track(entry)
+        assert tracker.get_total() > 0
+
+    def test_track_accumulates(self):
+        tracker = self._make_tracker()
+        e1 = tracker.calculate_cost('gpt-5', 1000, 500)
+        e2 = tracker.calculate_cost('gpt-5', 2000, 1000)
+        tracker.track(e1)
+        tracker.track(e2)
+        assert math.isclose(tracker.get_total(), e1['cost_usd'] + e2['cost_usd'], rel_tol=1e-9)
+
+    # ---------------------------------------------------------------
+    # Budget enforcement
+    # ---------------------------------------------------------------
+
+    def test_within_budget(self):
+        tracker = self._make_tracker(budget_limit_usd=100.0)
+        entry = tracker.calculate_cost('gpt-5', 1000, 500)
+        tracker.track(entry)
+        status = tracker.check_budget()
+        assert status['within_budget'] is True
+        assert status['remaining'] > 0
+
+    def test_over_budget(self):
+        tracker = self._make_tracker(budget_limit_usd=0.000001)
+        entry = tracker.calculate_cost('claude-opus', 1_000_000, 1_000_000)
+        tracker.track(entry)
+        status = tracker.check_budget()
+        assert status['within_budget'] is False
+        assert status['remaining'] == 0.0
+
+    def test_alert_threshold_reached(self):
+        tracker = self._make_tracker(budget_limit_usd=1.0, alert_threshold_pct=50)
+        # Spend just over 50%
+        entry = tracker.calculate_cost('claude-opus', 100_000, 0)
+        # claude-opus input: 15.00/1M => 100k = $1.50 which is > 50% of $1.0
+        tracker.track(entry)
+        status = tracker.check_budget()
+        assert status['alert_threshold_reached'] is True
+
+    def test_no_budget_limit(self):
+        tracker = self._make_tracker(budget_limit_usd=None)
+        entry = tracker.calculate_cost('claude-opus', 10_000_000, 10_000_000)
+        tracker.track(entry)
+        status = tracker.check_budget()
+        assert status['within_budget'] is True
+        assert status['remaining'] == float('inf')
+
+    def test_check_budget_override(self):
+        """budget_limit argument overrides the configured limit."""
+        tracker = self._make_tracker(budget_limit_usd=100.0)
+        entry = tracker.calculate_cost('gpt-5', 1_000_000, 1_000_000)
+        tracker.track(entry)
+        # With the configured limit ($100) we should be within budget
+        assert tracker.check_budget()['within_budget'] is True
+        # With a tiny override we should be over
+        assert tracker.check_budget(budget_limit=0.001)['within_budget'] is False
+
+    # ---------------------------------------------------------------
+    # Per-model summary
+    # ---------------------------------------------------------------
+
+    def test_summary_single_model(self):
+        tracker = self._make_tracker()
+        entry = tracker.calculate_cost('gpt-5', 1000, 500)
+        tracker.track(entry)
+        summary = tracker.get_summary()
+        assert 'gpt-5' in summary['per_model']
+        assert summary['per_model']['gpt-5']['request_count'] == 1
+        assert summary['request_count'] == 1
+
+    def test_summary_multiple_models(self):
+        tracker = self._make_tracker()
+        tracker.track(tracker.calculate_cost('gpt-5', 1000, 500))
+        tracker.track(tracker.calculate_cost('claude-opus', 2000, 1000))
+        summary = tracker.get_summary()
+        assert len(summary['per_model']) == 2
+        assert summary['request_count'] == 2
+
+    def test_summary_tokens_accumulate(self):
+        tracker = self._make_tracker()
+        tracker.track(tracker.calculate_cost('gpt-5', 1000, 500))
+        tracker.track(tracker.calculate_cost('gpt-5', 3000, 1500))
+        model_summary = tracker.get_summary()['per_model']['gpt-5']
+        assert model_summary['total_input_tokens'] == 4000
+        assert model_summary['total_output_tokens'] == 2000
+        assert model_summary['request_count'] == 2
+
+    # ---------------------------------------------------------------
+    # Thread safety
+    # ---------------------------------------------------------------
+
+    def test_thread_safe_concurrent_tracking(self):
+        """Multiple threads tracking concurrently should not lose entries."""
+        tracker = self._make_tracker(budget_limit_usd=None)
+        n_threads = 10
+        n_per_thread = 100
+
+        def worker():
+            for _ in range(n_per_thread):
+                entry = tracker.calculate_cost('gpt-5', 1000, 500)
+                tracker.track(entry)
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        summary = tracker.get_summary()
+        assert summary['request_count'] == n_threads * n_per_thread
+
+    # ---------------------------------------------------------------
+    # Custom pricing
+    # ---------------------------------------------------------------
+
+    def test_custom_pricing_via_json_string(self):
+        custom = json.dumps({'my-llm': {'input': 5.0, 'output': 10.0}})
+        tracker = CostTracker({'custom_pricing_json': custom})
+        entry = tracker.calculate_cost('my-llm', 1_000_000, 1_000_000)
+        assert math.isclose(entry['cost_usd'], 15.0, rel_tol=1e-9)
+
+    def test_custom_pricing_via_dict(self):
+        tracker = CostTracker({'custom_pricing_json': {'my-llm': {'input': 5.0, 'output': 10.0}}})
+        entry = tracker.calculate_cost('my-llm', 1_000_000, 1_000_000)
+        assert math.isclose(entry['cost_usd'], 15.0, rel_tol=1e-9)
+
+    # ---------------------------------------------------------------
+    # Policy
+    # ---------------------------------------------------------------
+
+    def test_policy_default_warn(self):
+        tracker = self._make_tracker()
+        assert tracker.policy == 'warn'
+
+    def test_policy_block(self):
+        tracker = CostTracker({'policy': 'block'})
+        assert tracker.policy == 'block'
+
+    def test_is_over_budget_false_when_no_limit(self):
+        tracker = self._make_tracker(budget_limit_usd=None)
+        assert tracker.is_over_budget() is False
+
+    def test_is_over_budget_true(self):
+        tracker = self._make_tracker(budget_limit_usd=0.0001)
+        tracker.track(tracker.calculate_cost('gpt-5', 1_000_000, 1_000_000))
+        assert tracker.is_over_budget() is True
+
+    # ---------------------------------------------------------------
+    # calculate_cost shape
+    # ---------------------------------------------------------------
+
+    def test_calculate_cost_shape(self):
+        tracker = self._make_tracker()
+        entry = tracker.calculate_cost('gpt-5', 1000, 500)
+        assert 'cost_usd' in entry
+        assert 'model' in entry
+        assert 'input_tokens' in entry
+        assert 'output_tokens' in entry
+        assert entry['model'] == 'gpt-5'
+        assert entry['input_tokens'] == 1000
+        assert entry['output_tokens'] == 500
+
+    def test_calculate_cost_negative_tokens_clamped(self):
+        tracker = self._make_tracker()
+        entry = tracker.calculate_cost('gpt-5', -10, -20)
+        assert entry['input_tokens'] == 0
+        assert entry['output_tokens'] == 0
+        assert entry['cost_usd'] == 0.0
+
+
+# ===================================================================
+# IInstance / IGlobal lifecycle mocks
+# ===================================================================
+
+
+class TestIInstanceLifecycle:
+    """Test the IInstance writeAnswers flow with mocked engine objects."""
+
+    def _build_instance(self, budget_limit_usd=None, policy='warn'):
+        """Build a minimal mock of IGlobal + IInstance wiring."""
+        # We import here to avoid needing the full rocketlib at module level
+        # Instead we mock the dependencies
+        tracker = CostTracker(
+            {
+                'budget_limit_usd': budget_limit_usd,
+                'alert_threshold_pct': 80,
+                'policy': policy,
+            }
+        )
+
+        # Build a mock answer
+        answer = MagicMock()
+        answer.metadata = {
+            'input_tokens': 5000,
+            'output_tokens': 2000,
+            'model': 'gpt-5',
+        }
+        answer.answer = 'The answer is 4.'
+
+        return tracker, answer
+
+    def test_cost_attached_to_metadata(self):
+        """After writeAnswers the answer metadata should contain cost_usd."""
+        tracker, answer = self._build_instance()
+
+        # Simulate what IInstance.writeAnswers does (minus engine calls)
+        metadata = answer.metadata
+        entry = tracker.calculate_cost(
+            metadata['model'],
+            metadata['input_tokens'],
+            metadata['output_tokens'],
+        )
+        tracker.track(entry)
+        answer.metadata['cost_usd'] = entry['cost_usd']
+        answer.metadata['cumulative_cost_usd'] = tracker.get_total()
+
+        assert 'cost_usd' in answer.metadata
+        assert answer.metadata['cost_usd'] > 0
+        assert answer.metadata['cumulative_cost_usd'] > 0
+
+    def test_deep_copy_prevents_mutation(self):
+        """Deep copying the answer prevents upstream mutation."""
+        tracker, answer = self._build_instance()
+
+        original_metadata = dict(answer.metadata)
+        answer_copy = copy.deepcopy(answer)
+        answer_copy.metadata['cost_usd'] = 999.0
+
+        # Original should be unaffected
+        assert 'cost_usd' not in original_metadata
+
+    def test_block_policy_prevents_forwarding(self):
+        """With policy=block and over budget, the answer should NOT be forwarded."""
+        tracker, answer = self._build_instance(budget_limit_usd=0.0000001, policy='block')
+
+        metadata = answer.metadata
+        entry = tracker.calculate_cost(
+            metadata['model'],
+            metadata['input_tokens'],
+            metadata['output_tokens'],
+        )
+        tracker.track(entry)
+
+        # Check that we're over budget
+        assert tracker.is_over_budget() is True
+        assert tracker.policy == 'block'
+
+    def test_warn_policy_allows_forwarding(self):
+        """With policy=warn and over budget, the answer IS still forwarded."""
+        tracker, answer = self._build_instance(budget_limit_usd=0.0000001, policy='warn')
+
+        metadata = answer.metadata
+        entry = tracker.calculate_cost(
+            metadata['model'],
+            metadata['input_tokens'],
+            metadata['output_tokens'],
+        )
+        tracker.track(entry)
+
+        # Over budget but policy is warn -- forwarding should proceed
+        assert tracker.is_over_budget() is True
+        assert tracker.policy == 'warn'
+        # In the real IInstance, writeAnswers would still call self.instance.writeAnswers(answer)
+
+    def test_missing_metadata_defaults(self):
+        """When answer has no metadata, defaults to 0 tokens / unknown model."""
+        tracker = CostTracker({})
+        # Simulate missing metadata
+        entry = tracker.calculate_cost('unknown', 0, 0)
+        tracker.track(entry)
+        assert tracker.get_total() == 0.0
+
+
+# ===================================================================
+# Edge cases
+# ===================================================================
+
+
+class TestEdgeCases:
+    """Miscellaneous edge-case tests."""
+
+    def test_pricing_table_has_all_expected_models(self):
+        """Ensure the default table covers all documented models."""
+        expected = [
+            'gpt-5',
+            'gpt-5.1',
+            'gpt-5.2',
+            'gpt-5-mini',
+            'gpt-5-nano',
+            'gpt-4o',
+            'gpt-4o-mini',
+            'claude-opus',
+            'claude-sonnet',
+            'claude-haiku',
+            'gemini-pro',
+            'gemini-flash',
+            'mistral-large',
+            'mistral-small',
+            'deepseek-chat',
+            'deepseek-reasoner',
+            'perplexity-sonar',
+            'ollama',
+        ]
+        for model in expected:
+            assert model in PRICING, f'{model} missing from PRICING table'
+
+    def test_all_pricing_entries_have_input_output(self):
+        """Every entry must have 'input' and 'output' keys."""
+        for model, prices in PRICING.items():
+            assert 'input' in prices, f'{model} missing input price'
+            assert 'output' in prices, f'{model} missing output price'
+
+    def test_all_prices_non_negative(self):
+        """Prices must be >= 0."""
+        for model, prices in PRICING.items():
+            assert prices['input'] >= 0, f'{model} has negative input price'
+            assert prices['output'] >= 0, f'{model} has negative output price'
+
+    def test_tracker_with_empty_config(self):
+        """Tracker should work with a completely empty config."""
+        tracker = CostTracker({})
+        entry = tracker.calculate_cost('gpt-5', 1000, 500)
+        tracker.track(entry)
+        assert tracker.get_total() > 0
+
+    def test_percent_used_at_exact_limit(self):
+        """When exactly at the budget limit, percent_used should be 100."""
+        tracker = CostTracker({'budget_limit_usd': 10.0})
+        # GPT-5: input $2/1M, output $8/1M => 1M in + 1M out = $10.00
+        entry = tracker.calculate_cost('gpt-5', 1_000_000, 1_000_000)
+        tracker.track(entry)
+        status = tracker.check_budget()
+        assert math.isclose(status['percent_used'], 100.0, rel_tol=1e-6)
+        # At exactly the limit, within_budget should still be True (<=)
+        assert status['within_budget'] is True

--- a/test/nodes/test_cost_tracker.py
+++ b/test/nodes/test_cost_tracker.py
@@ -453,7 +453,7 @@ class TestIInstanceLifecycle:
 
     def test_deep_copy_prevents_mutation(self):
         """Deep copying the answer prevents upstream mutation."""
-        tracker, answer = self._build_instance()
+        _tracker, answer = self._build_instance()
 
         original_metadata = dict(answer.metadata)
         answer_copy = copy.deepcopy(answer)


### PR DESCRIPTION
#Hack-with-bay-2

## Contribution Type
**Feature** — Per-request LLM cost tracking with budget enforcement

## Problem / Use Case
RocketRide pipelines chain multiple LLM calls but have no visibility into costs. When pipelines use expensive models (Claude Opus at \$75/M output tokens), costs can spike unexpectedly. There's no way to set budgets, track per-model spending, or alert on cost thresholds.

## Proposed Solution
A \`cost_tracker\` node with:
- **Pricing table** for all 13 providers (18 models) with fuzzy model-name matching (prefix → substring → exact)
- **Thread-safe tracking** via \`threading.Lock\` with per-model breakdown
- **Budget enforcement**: warn (log + continue) or block (\`preventDefault()\` stops answer propagation)
- **Custom pricing** override via JSON config
- **Cost metadata** attached to every answer (\`cost_usd\`, \`cumulative_cost_usd\`)

## Why This Feature Fits This Codebase
The node sits after LLM nodes in the pipeline and reads token usage from answer metadata — the same metadata structure populated by \`IInstanceGenericLLM\` at \`nodes/src/nodes/llm_base/IInstance.py\`. The \`preventDefault()\` method for budget blocking uses the existing \`IInstanceBase\` control flow mechanism.

Fuzzy model matching handles the model naming variations across RocketRide's 13 LLM providers (e.g., \`gpt-5.2-preview\` matches the \`gpt-5.2\` pricing entry via longest-prefix-wins).

## Validation
52 tests passing including thread safety (10 threads × 100 entries). ruff check + format clean.

## How This Could Be Extended
- Integrate with Prometheus metrics for cost dashboards
- Add daily/weekly/monthly budget periods (not just cumulative)
- Auto-downgrade model tier when approaching budget (pairs with Model Router)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Cost Tracker node for monitoring and managing LLM request costs.
  * Automatically calculates per-request and cumulative costs from token usage, with per-model summaries.
  * Annotates responses with cost and cumulative cost metadata and enforces budgets (warn or block).
  * Supports configurable budgets, alert thresholds, custom pricing, and three operating modes (monitor, budget, custom).
* **Tests**
  * End-to-end unit tests covering pricing resolution, cost accumulation, budget enforcement, concurrency, and policy behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->