### PR TITLE
fix(connection): handle missing hostname in URI parsing

### DIFF
--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -345,7 +345,7 @@ class ConnectionMixin(DAPClient):
         parsed = urllib.parse.urlparse(uri)
 
         if not parsed.port and 'rocketride.ai' not in (parsed.hostname or ''):
-            parsed = parsed._replace(netloc=f'{parsed.hostname}:{CONST_DEFAULT_WEB_PORT}')
+            parsed = parsed._replace(netloc=f'{parsed.hostname or "localhost"}:{CONST_DEFAULT_WEB_PORT}')
 
         return parsed.geturl()
 

--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -345,7 +345,10 @@ class ConnectionMixin(DAPClient):
         parsed = urllib.parse.urlparse(uri)
 
         if not parsed.port and 'rocketride.ai' not in (parsed.hostname or ''):
-            parsed = parsed._replace(netloc=f'{parsed.hostname or "localhost"}:{CONST_DEFAULT_WEB_PORT}')
+            hostname = parsed.hostname
+            if not hostname:
+                raise ValueError(f"Invalid URI '{uri}': missing hostname")
+            parsed = parsed._replace(netloc=f'{hostname}:{CONST_DEFAULT_WEB_PORT}')
 
         return parsed.geturl()
 


### PR DESCRIPTION
## Summary

Null pointer dereference in URI parsing — packages/client-python/src/rocketride/mixins/connection.py:348
parsed.hostname can be None for malformed URIs, causing a TypeError crash
The edit adds a fallback to "localhost" when parsed.hostname is None, preventing the TypeError crash on line 348.

## Type

Fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Connection URIs now validate that a hostname is present. Missing hostnames now produce a clear error instead of creating malformed connection strings, preventing invalid connections and improving reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->