### PR TITLE
fix(llm): clear correct _chat reference in endGlobal across all LLM nodes

### DIFF
--- a/nodes/src/nodes/llm_anthropic/IGlobal.py
+++ b/nodes/src/nodes/llm_anthropic/IGlobal.py
@@ -190,7 +190,7 @@ class IGlobal(IGlobalBase):
 
         Called when the filter is being destroyed or reset.
         """
-        self.chat = None
+        self._chat = None
 
     def _format_error(self, status, etype, emsg, fallback: str) -> str:
         """

--- a/nodes/src/nodes/llm_bedrock/IGlobal.py
+++ b/nodes/src/nodes/llm_bedrock/IGlobal.py
@@ -208,7 +208,7 @@ class IGlobal(IGlobalBase):
 
         Called when the filter is being destroyed or reset.
         """
-        self.chat = None
+        self._chat = None
 
     def _format_error(self, status, etype, emsg, fallback: str) -> str:
         """

--- a/nodes/src/nodes/llm_deepseek/IGlobal.py
+++ b/nodes/src/nodes/llm_deepseek/IGlobal.py
@@ -121,7 +121,7 @@ class IGlobal(IGlobalBase):
         self._chat = Chat(self.glb.logicalType, config, bag)
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None
 
     def _format_error(self, status, etype, emsg, fallback: str) -> str:
         """Compose a user-facing error string.

--- a/nodes/src/nodes/llm_gemini/IGlobal.py
+++ b/nodes/src/nodes/llm_gemini/IGlobal.py
@@ -175,7 +175,7 @@ class IGlobal(IGlobalBase):
 
     def endGlobal(self):
         """Clean up the global chat instance."""
-        self.chat = None
+        self._chat = None
 
     def _format_error(self, status_or_code, etype_or_status, emsg, fallback: str) -> str:
         """Compose a user-facing error string for Gemini.

--- a/nodes/src/nodes/llm_ibm_watson/IGlobal.py
+++ b/nodes/src/nodes/llm_ibm_watson/IGlobal.py
@@ -49,4 +49,4 @@ class IGlobal(IGlobalBase):
         self._chat = Chat(self.glb.logicalType, config, bag)
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None

--- a/nodes/src/nodes/llm_mistral/IGlobal.py
+++ b/nodes/src/nodes/llm_mistral/IGlobal.py
@@ -149,7 +149,7 @@ class IGlobal(IGlobalBase):
 
     def endGlobal(self):
         """Clean up the global instance when the node shuts down."""
-        self.chat = None
+        self._chat = None
 
     def _format_error(self, status_or_code, etype, emsg, fallback: str) -> str:
         parts: list[str] = []

--- a/nodes/src/nodes/llm_ollama/IGlobal.py
+++ b/nodes/src/nodes/llm_ollama/IGlobal.py
@@ -49,4 +49,4 @@ class IGlobal(IGlobalBase):
         self._chat = Chat(self.glb.logicalType, config, bag)
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None

--- a/nodes/src/nodes/llm_openai/IGlobal.py
+++ b/nodes/src/nodes/llm_openai/IGlobal.py
@@ -60,11 +60,11 @@ class IGlobal(IGlobalBase):
             # Simple API validation using provider-driven exceptions
             try:
                 client = OpenAI(api_key=apikey)
-                
+
                 # Newer models use max_completion_tokens instead of max_tokens
                 newer_models = ['gpt-5', 'gpt-5.1', 'gpt-5-mini', 'gpt-5-nano']
                 uses_max_completion_tokens = any(model.startswith(m) for m in newer_models)
-                
+
                 # Make sure model is using the correct parameters
                 if uses_max_completion_tokens:
                     client.chat.completions.create(model=model, messages=[{'role': 'user', 'content': 'Hi'}], max_completion_tokens=10)
@@ -128,4 +128,4 @@ class IGlobal(IGlobalBase):
             self._chat = Chat(self.glb.logicalType, config, bag)
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None

--- a/nodes/src/nodes/llm_perplexity/IGlobal.py
+++ b/nodes/src/nodes/llm_perplexity/IGlobal.py
@@ -141,7 +141,7 @@ class IGlobal(IGlobalBase):
 
     def endGlobal(self):
         """Clean up the global chat instance."""
-        self.chat = None
+        self._chat = None
 
     def _format_error(self, status, etype, emsg, fallback: str) -> str:
         """

--- a/nodes/src/nodes/llm_qwen/IGlobal.py
+++ b/nodes/src/nodes/llm_qwen/IGlobal.py
@@ -137,4 +137,4 @@ class IGlobal(IGlobalBase):
             self._chat = Chat(self.glb.logicalType, config, bag)
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None

--- a/nodes/src/nodes/llm_vertex/IGlobal.py
+++ b/nodes/src/nodes/llm_vertex/IGlobal.py
@@ -139,7 +139,7 @@ class IGlobal(IGlobalBase):
         self._chat = Chat(self.glb.logicalType, config, bag, self.glb.connConfig.get('parameters', {}))
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None
 
     def _read_key(self, key_formdata: str) -> str | None:
         """

--- a/nodes/src/nodes/llm_xai/IGlobal.py
+++ b/nodes/src/nodes/llm_xai/IGlobal.py
@@ -124,7 +124,7 @@ class IGlobal(IGlobalBase):
         self._chat = Chat(self.glb.logicalType, config, bag)
 
     def endGlobal(self):
-        self.chat = None
+        self._chat = None
 
     def _format_error(self, status_or_code, etype_or_status, emsg, fallback: str) -> str:
         """Compose a user-facing error string.


### PR DESCRIPTION
## Summary

All LLM node IGlobal classes assigned the Chat instance to `self._chat` in `beginGlobal`, but `endGlobal` cleared `self.chat` (no underscore) — a different attribute that was never set. This meant `endGlobal` was a no-op: the Chat object was never explicitly released when a pipeline stopped.

Fixed in 12 nodes: llm_anthropic, llm_bedrock, llm_deepseek, llm_gemini, llm_ibm_watson, llm_mistral, llm_ollama, llm_openai, llm_perplexity, llm_qwen, llm_vertex, llm_xai.

llm_vision_ollama and llm_vision_mistral were already correct.

-

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chat instance lifecycle management across all LLM providers (Anthropic, OpenAI, Gemini, Bedrock, DeepSeek, IBM Watson, Mistral, Ollama, Perplexity, Qwen, Vertex, and XAI) to ensure proper cleanup and prevent stale chat references from persisting after session termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->