### PR TITLE
fix(engine): dap_base typo for default value

### DIFF
--- a/packages/client-python/src/rocketride/core/dap_base.py
+++ b/packages/client-python/src/rocketride/core/dap_base.py
@@ -101,7 +101,7 @@ class DAPBase:
         _seq_counter (int): Counter for generating unique sequence numbers.
     """
 
-    def __init__(self, module: str = 'UNKOWN', **kwargs) -> None:
+    def __init__(self, module: str = 'UNKNOWN', **kwargs) -> None:
         """
         Initialize the DAP base class with configuration and module identification.
 


### PR DESCRIPTION
## Summary

Typo in default parameter — packages/client-python/src/rocketride/core/dap_base.py:104
Default value is 'UNKOWN' instead of 'UNKNOWN', causing inconsistent log output

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected a spelling error in a default configuration value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->