### PR TITLE
feat(sdk): add programmatic pipeline creation API

### DIFF
--- a/packages/client-python/src/rocketride/__init__.py
+++ b/packages/client-python/src/rocketride/__init__.py
@@ -37,15 +37,15 @@ The RocketRide Client SDK enables you to:
 
 Quick Start:
     from rocketride import RocketRideClient, Question
-    
+
     # Connect and process data
     async with RocketRideClient(auth='your_api_key') as client:
         # Start a pipeline
         result = await client.use(filepath='pipeline.json')
-        
+
         # Send data for processing
         response = await client.send(result['token'], 'your data')
-        
+
         # Chat with AI
         question = Question()
         question.addQuestion('What are the key findings?')
@@ -98,6 +98,7 @@ from .types import (
 
 from .client import RocketRideClient, RocketRideException
 from .core.exceptions import AuthenticationException
+from .pipeline import Pipeline, PipelineValidationError
 
 from .core.constants import (
     CONST_DEFAULT_SERVICE,
@@ -155,4 +156,7 @@ __all__ = [
     'TraceInfo',
     'TransportCallbacks',
     'UPLOAD_RESULT',
+    # Pipeline builder
+    'Pipeline',
+    'PipelineValidationError',
 ]

--- a/packages/client-python/src/rocketride/pipeline.py
+++ b/packages/client-python/src/rocketride/pipeline.py
@@ -1,0 +1,538 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Programmatic Pipeline Builder for RocketRide.
+
+This module provides a fluent API for constructing RocketRide pipelines
+without manually editing JSON. Pipelines built with this API produce valid
+.pipe JSON that the RocketRide engine can execute.
+
+Quick Start::
+
+    from rocketride import Pipeline
+
+    pipeline = Pipeline()
+    pipeline.add_node('webhook_1', 'webhook', source=True)
+    pipeline.add_node('parse_1', 'parse')
+    pipeline.connect('webhook_1', 'parse_1', lane='tags')
+    pipeline.add_node('response_1', 'response_text', config={'laneName': 'text'})
+    pipeline.connect('parse_1', 'response_1', lane='text')
+
+    # Export to .pipe JSON
+    json_str = pipeline.to_json()
+
+    # Save to file
+    pipeline.to_file('my_pipeline.pipe')
+
+    # Load from existing file
+    loaded = Pipeline.from_file('existing.pipe')
+
+Fluent chaining::
+
+    pipeline = (
+        Pipeline()
+        .add_node('chat_1', 'chat', source=True)
+        .add_node(
+            'llm_1',
+            'llm_openai',
+            config={
+                'profile': 'openai-5',
+                'openai-5': {'apikey': '${ROCKETRIDE_OPENAI_KEY}'},
+            },
+        )
+        .connect('chat_1', 'llm_1', lane='questions')
+        .add_node('response_1', 'response_answers', config={'laneName': 'answers'})
+        .connect('llm_1', 'response_1', lane='answers')
+    )
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections import deque
+from typing import Any, Optional
+
+
+# Source component providers that require special config
+_SOURCE_PROVIDERS = frozenset(
+    {
+        'webhook',
+        'chat',
+        'dropper',
+    }
+)
+
+
+class PipelineValidationError(Exception):
+    """Raised when pipeline validation fails."""
+
+
+class Pipeline:
+    """Fluent builder for constructing RocketRide .pipe pipeline definitions.
+
+    A Pipeline manages a directed graph of components (nodes) connected by
+    typed data lanes. It can export to the .pipe JSON format consumed by
+    the RocketRide engine and validate the graph for common errors.
+
+    Attributes:
+        project_id: Unique GUID identifying this pipeline.
+    """
+
+    def __init__(self, *, project_id: Optional[str] = None) -> None:
+        """Create a new empty pipeline.
+
+        Args:
+            project_id: Optional UUID for the pipeline. If not provided,
+                a new UUID is generated automatically.
+        """
+        self.project_id: str = project_id or str(uuid.uuid4())
+        self._nodes: dict[str, dict[str, Any]] = {}
+        self._node_order: list[str] = []
+        self._source_id: Optional[str] = None
+        self._viewport: dict[str, Any] = {'x': 0, 'y': 0, 'zoom': 1}
+
+    # ------------------------------------------------------------------
+    # Node management
+    # ------------------------------------------------------------------
+
+    def add_node(
+        self,
+        node_id: str,
+        provider: str,
+        *,
+        config: Optional[dict[str, Any]] = None,
+        source: bool = False,
+    ) -> 'Pipeline':
+        """Add a component node to the pipeline.
+
+        Args:
+            node_id: Unique identifier for this node (e.g. ``"llm_1"``).
+            provider: Component provider type (e.g. ``"llm_openai"``, ``"parse"``).
+            config: Provider-specific configuration dict. For source nodes with
+                providers in (webhook, chat, dropper) the required source fields
+                are added automatically if missing.
+            source: If True, marks this node as the pipeline entry point.
+
+        Returns:
+            self, for fluent chaining.
+
+        Raises:
+            ValueError: If ``node_id`` already exists or a second source is added.
+        """
+        if node_id in self._nodes:
+            raise ValueError(f"Node '{node_id}' already exists in the pipeline")
+
+        if source and self._source_id is not None:
+            raise ValueError(f"Pipeline already has a source node '{self._source_id}'. Cannot add '{node_id}' as a second source.")
+
+        node_config = dict(config) if config else {}
+
+        # Auto-populate required source config fields
+        if source or provider in _SOURCE_PROVIDERS:
+            node_config.setdefault('hideForm', True)
+            node_config.setdefault('mode', 'Source')
+            node_config.setdefault('parameters', {})
+            node_config.setdefault('type', provider)
+            self._source_id = node_id
+
+        component: dict[str, Any] = {
+            'id': node_id,
+            'provider': provider,
+            'config': node_config,
+        }
+
+        self._nodes[node_id] = component
+        self._node_order.append(node_id)
+        return self
+
+    def configure_node(self, node_id: str, config: dict[str, Any]) -> 'Pipeline':
+        """Update configuration of an existing node (shallow merge).
+
+        Args:
+            node_id: ID of the node to configure.
+            config: Configuration dict to merge into the existing config.
+
+        Returns:
+            self, for fluent chaining.
+
+        Raises:
+            KeyError: If the node does not exist.
+        """
+        if node_id not in self._nodes:
+            raise KeyError(f"Node '{node_id}' not found in the pipeline")
+
+        self._nodes[node_id]['config'].update(config)
+        return self
+
+    def remove_node(self, node_id: str) -> 'Pipeline':
+        """Remove a node and all its connections from the pipeline.
+
+        Args:
+            node_id: ID of the node to remove.
+
+        Returns:
+            self, for fluent chaining.
+
+        Raises:
+            KeyError: If the node does not exist.
+        """
+        if node_id not in self._nodes:
+            raise KeyError(f"Node '{node_id}' not found in the pipeline")
+
+        del self._nodes[node_id]
+        self._node_order.remove(node_id)
+
+        if self._source_id == node_id:
+            self._source_id = None
+
+        # Remove connections referencing this node
+        for component in self._nodes.values():
+            if 'input' in component:
+                component['input'] = [inp for inp in component['input'] if inp['from'] != node_id]
+                if not component['input']:
+                    del component['input']
+
+            if 'control' in component:
+                component['control'] = [ctrl for ctrl in component['control'] if ctrl['from'] != node_id]
+                if not component['control']:
+                    del component['control']
+
+        return self
+
+    # ------------------------------------------------------------------
+    # Connection management
+    # ------------------------------------------------------------------
+
+    def connect(
+        self,
+        source_id: str,
+        target_id: str,
+        *,
+        lane: str = 'text',
+    ) -> 'Pipeline':
+        """Connect two nodes with a data lane.
+
+        Args:
+            source_id: ID of the upstream node that produces data.
+            target_id: ID of the downstream node that consumes data.
+            lane: Data lane type (e.g. ``"text"``, ``"tags"``, ``"questions"``,
+                ``"answers"``, ``"documents"``, ``"image"``).
+
+        Returns:
+            self, for fluent chaining.
+
+        Raises:
+            KeyError: If either node does not exist.
+        """
+        if source_id not in self._nodes:
+            raise KeyError(f"Source node '{source_id}' not found in the pipeline")
+        if target_id not in self._nodes:
+            raise KeyError(f"Target node '{target_id}' not found in the pipeline")
+
+        target = self._nodes[target_id]
+        if 'input' not in target:
+            target['input'] = []
+
+        target['input'].append({'lane': lane, 'from': source_id})
+        return self
+
+    def connect_control(
+        self,
+        source_id: str,
+        target_id: str,
+        *,
+        class_type: str = 'llm',
+    ) -> 'Pipeline':
+        """Add a control-flow connection between two nodes.
+
+        Args:
+            source_id: ID of the upstream node.
+            target_id: ID of the downstream node.
+            class_type: Control channel type (e.g. ``"llm"``, ``"tool"``, ``"memory"``).
+
+        Returns:
+            self, for fluent chaining.
+
+        Raises:
+            KeyError: If either node does not exist.
+        """
+        if source_id not in self._nodes:
+            raise KeyError(f"Source node '{source_id}' not found in the pipeline")
+        if target_id not in self._nodes:
+            raise KeyError(f"Target node '{target_id}' not found in the pipeline")
+
+        target = self._nodes[target_id]
+        if 'control' not in target:
+            target['control'] = []
+
+        target['control'].append({'classType': class_type, 'from': source_id})
+        return self
+
+    def disconnect(
+        self,
+        source_id: str,
+        target_id: str,
+        *,
+        lane: Optional[str] = None,
+    ) -> 'Pipeline':
+        """Remove data-lane connections from *source_id* to *target_id*.
+
+        Args:
+            source_id: Upstream node ID.
+            target_id: Downstream node ID.
+            lane: If provided, only remove connections on this lane.
+                If None, remove all connections from source to target.
+
+        Returns:
+            self, for fluent chaining.
+        """
+        if target_id not in self._nodes:
+            return self
+
+        target = self._nodes[target_id]
+        if 'input' not in target:
+            return self
+
+        target['input'] = [inp for inp in target['input'] if not (inp['from'] == source_id and (lane is None or inp['lane'] == lane))]
+
+        if not target['input']:
+            del target['input']
+
+        return self
+
+    # ------------------------------------------------------------------
+    # Serialization
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the pipeline as an ordered dict matching .pipe JSON format.
+
+        The ``components`` key always appears first, followed by ``project_id``,
+        ``viewport``, and ``version`` at the bottom, as required by the RocketRide
+        engine.
+        """
+        components = [self._nodes[nid] for nid in self._node_order]
+        result: dict[str, Any] = {'components': components}
+        if self._source_id:
+            result['source'] = self._source_id
+        result['project_id'] = self.project_id
+        result['viewport'] = dict(self._viewport)
+        result['version'] = 1
+        return result
+
+    def to_json(self, *, indent: int = 2) -> str:
+        """Serialize the pipeline to a .pipe-compatible JSON string.
+
+        Args:
+            indent: JSON indentation level (default 2).
+
+        Returns:
+            A JSON string that can be written to a ``.pipe`` file.
+        """
+        return json.dumps(self.to_dict(), indent=indent)
+
+    def to_file(self, path: str, *, indent: int = 2) -> None:
+        """Write the pipeline to a ``.pipe`` file.
+
+        Args:
+            path: File path (should end with ``.pipe``).
+            indent: JSON indentation level.
+        """
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(self.to_json(indent=indent))
+            f.write('\n')
+
+    # ------------------------------------------------------------------
+    # Deserialization
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> 'Pipeline':
+        """Create a Pipeline from a dict (parsed .pipe JSON).
+
+        Args:
+            data: Dictionary with ``components``, ``project_id``, etc.
+
+        Returns:
+            A new Pipeline instance populated from the dict.
+        """
+        pipeline = cls(project_id=data.get('project_id', str(uuid.uuid4())))
+        pipeline._viewport = data.get('viewport', {'x': 0, 'y': 0, 'zoom': 1})
+        pipeline._source_id = data.get('source')
+
+        for comp in data.get('components', []):
+            node_id = comp['id']
+            component = dict(comp)
+            pipeline._nodes[node_id] = component
+            pipeline._node_order.append(node_id)
+
+            # Detect source node from config
+            if component.get('config', {}).get('mode') == 'Source':
+                pipeline._source_id = pipeline._source_id or node_id
+
+        return pipeline
+
+    @classmethod
+    def from_json(cls, json_str: str) -> 'Pipeline':
+        """Create a Pipeline from a JSON string.
+
+        Args:
+            json_str: A .pipe-format JSON string.
+
+        Returns:
+            A new Pipeline instance.
+        """
+        return cls.from_dict(json.loads(json_str))
+
+    @classmethod
+    def from_file(cls, path: str) -> 'Pipeline':
+        """Load a Pipeline from a ``.pipe`` file.
+
+        Args:
+            path: Path to the ``.pipe`` file.
+
+        Returns:
+            A new Pipeline instance populated from the file.
+        """
+        with open(path, encoding='utf-8') as f:
+            return cls.from_dict(json.load(f))
+
+    # ------------------------------------------------------------------
+    # Validation
+    # ------------------------------------------------------------------
+
+    def validate(self) -> list[str]:
+        """Validate the pipeline graph and return a list of error messages.
+
+        Checks performed:
+        - At least one component exists
+        - Exactly one source node is defined
+        - All input/control ``from`` references point to existing nodes
+        - The graph contains no cycles
+        - ``project_id`` is present and looks like a UUID
+
+        Returns:
+            A list of error strings. An empty list means the pipeline is valid.
+        """
+        errors: list[str] = []
+
+        if not self._nodes:
+            errors.append('Pipeline has no components')
+            return errors
+
+        # Check project_id
+        if not self.project_id:
+            errors.append('Pipeline is missing a project_id')
+        else:
+            try:
+                uuid.UUID(self.project_id)
+            except ValueError:
+                errors.append(f"project_id '{self.project_id}' is not a valid UUID")
+
+        # Check source node
+        source_nodes = [nid for nid, comp in self._nodes.items() if comp.get('config', {}).get('mode') == 'Source']
+        if not source_nodes and self._source_id is None:
+            errors.append('Pipeline has no source node')
+        elif len(source_nodes) > 1:
+            errors.append(f'Pipeline has multiple source nodes: {source_nodes}')
+
+        # Check references
+        for nid, comp in self._nodes.items():
+            for inp in comp.get('input', []):
+                if inp['from'] not in self._nodes:
+                    errors.append(f"Node '{nid}' references unknown input node '{inp['from']}'")
+            for ctrl in comp.get('control', []):
+                if ctrl['from'] not in self._nodes:
+                    errors.append(f"Node '{nid}' references unknown control node '{ctrl['from']}'")
+
+        # Cycle detection (BFS/Kahn's algorithm)
+        in_degree: dict[str, int] = {nid: 0 for nid in self._nodes}
+        adjacency: dict[str, list[str]] = {nid: [] for nid in self._nodes}
+
+        for nid, comp in self._nodes.items():
+            for inp in comp.get('input', []):
+                src = inp['from']
+                if src in self._nodes:
+                    adjacency[src].append(nid)
+                    in_degree[nid] += 1
+            for ctrl in comp.get('control', []):
+                src = ctrl['from']
+                if src in self._nodes:
+                    adjacency[src].append(nid)
+                    in_degree[nid] += 1
+
+        queue: deque[str] = deque(nid for nid, deg in in_degree.items() if deg == 0)
+        visited = 0
+        while queue:
+            node = queue.popleft()
+            visited += 1
+            for neighbour in adjacency[node]:
+                in_degree[neighbour] -= 1
+                if in_degree[neighbour] == 0:
+                    queue.append(neighbour)
+
+        if visited != len(self._nodes):
+            errors.append('Pipeline graph contains a cycle')
+
+        return errors
+
+    def validate_or_raise(self) -> None:
+        """Validate the pipeline and raise if there are errors.
+
+        Raises:
+            PipelineValidationError: With all validation error messages joined.
+        """
+        errors = self.validate()
+        if errors:
+            raise PipelineValidationError('Pipeline validation failed:\n' + '\n'.join(f'  - {e}' for e in errors))
+
+    # ------------------------------------------------------------------
+    # Introspection helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def node_ids(self) -> list[str]:
+        """Return all node IDs in insertion order."""
+        return list(self._node_order)
+
+    def get_node(self, node_id: str) -> dict[str, Any]:
+        """Return the raw component dict for a node.
+
+        Args:
+            node_id: ID of the node.
+
+        Raises:
+            KeyError: If the node does not exist.
+        """
+        if node_id not in self._nodes:
+            raise KeyError(f"Node '{node_id}' not found in the pipeline")
+        return dict(self._nodes[node_id])
+
+    def __len__(self) -> int:
+        """Return the number of nodes in the pipeline."""
+        return len(self._nodes)
+
+    def __repr__(self) -> str:
+        """Return a developer-friendly string representation."""
+        return f"Pipeline(project_id='{self.project_id}', nodes={len(self._nodes)}, source='{self._source_id}')"

--- a/packages/client-typescript/src/client/index.ts
+++ b/packages/client-typescript/src/client/index.ts
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2026 Aparavi Software AG
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,10 +24,10 @@
 
 /**
  * RocketRide Client TypeScript SDK
- * 
+ *
  * Main entry point for the RocketRide TypeScript client library.
  * Exports all public APIs, types, exceptions, and schema definitions.
- * 
+ *
  * @packageDocumentation
  */
 
@@ -42,3 +42,7 @@ export * from './types/index.js';
 
 // Export the main client and utilities
 export * from './client.js';
+
+// Export the pipeline builder
+export { Pipeline, PipelineValidationError } from './pipeline.js';
+export type { AddNodeOptions, ConnectOptions, ConnectControlOptions } from './pipeline.js';

--- a/packages/client-typescript/src/client/pipeline.ts
+++ b/packages/client-typescript/src/client/pipeline.ts
@@ -1,0 +1,509 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Programmatic Pipeline Builder for RocketRide.
+ *
+ * Provides a fluent API for constructing RocketRide pipelines without manually
+ * editing JSON. Pipelines built with this API produce valid .pipe JSON that
+ * the RocketRide engine can execute.
+ *
+ * @example Basic usage
+ * ```typescript
+ * import { Pipeline } from 'rocketride';
+ *
+ * const pipeline = new Pipeline()
+ *   .addNode('webhook_1', 'webhook', { source: true })
+ *   .addNode('parse_1', 'parse')
+ *   .connect('webhook_1', 'parse_1', { lane: 'tags' })
+ *   .addNode('response_1', 'response_text', { config: { laneName: 'text' } })
+ *   .connect('parse_1', 'response_1', { lane: 'text' });
+ *
+ * // Export to .pipe JSON
+ * const json = pipeline.toJSON();
+ *
+ * // Save to file (Node.js)
+ * pipeline.toFile('my_pipeline.pipe');
+ *
+ * // Load from existing file
+ * const loaded = Pipeline.fromFile('existing.pipe');
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync, writeFileSync } from 'fs';
+import type { PipelineComponent, PipelineConfig } from './types/pipeline.js';
+
+/** Source provider types that receive automatic source config. */
+const SOURCE_PROVIDERS = new Set(['webhook', 'chat', 'dropper']);
+
+/** UUID v4 regex for validation. */
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Error thrown when pipeline validation fails.
+ */
+export class PipelineValidationError extends Error {
+	/** Individual validation error messages. */
+	public readonly errors: string[];
+
+	constructor(errors: string[]) {
+		super('Pipeline validation failed:\n' + errors.map((e) => `  - ${e}`).join('\n'));
+		this.name = 'PipelineValidationError';
+		this.errors = errors;
+	}
+}
+
+/** Options for {@link Pipeline.addNode}. */
+export interface AddNodeOptions {
+	/** Provider-specific configuration. */
+	config?: Record<string, unknown>;
+	/** Mark this node as the pipeline source/entry point. */
+	source?: boolean;
+}
+
+/** Options for {@link Pipeline.connect}. */
+export interface ConnectOptions {
+	/** Data lane type (default: `"text"`). */
+	lane?: string;
+}
+
+/** Options for {@link Pipeline.connectControl}. */
+export interface ConnectControlOptions {
+	/** Control channel class type (default: `"llm"`). */
+	classType?: string;
+}
+
+/**
+ * Fluent builder for constructing RocketRide `.pipe` pipeline definitions.
+ *
+ * A `Pipeline` manages a directed graph of components (nodes) connected by
+ * typed data lanes. It can export to the `.pipe` JSON format consumed by
+ * the RocketRide engine and validate the graph for common errors.
+ */
+export class Pipeline {
+	/** Unique GUID identifying this pipeline. */
+	public projectId: string;
+
+	private _nodes: Map<string, PipelineComponent> = new Map();
+	private _nodeOrder: string[] = [];
+	private _sourceId: string | null = null;
+	private _viewport = { x: 0, y: 0, zoom: 1 };
+
+	/**
+	 * Create a new empty pipeline.
+	 *
+	 * @param projectId - Optional UUID for the pipeline. A new one is
+	 *   generated automatically if omitted.
+	 */
+	constructor(projectId?: string) {
+		this.projectId = projectId ?? crypto.randomUUID();
+	}
+
+	// ------------------------------------------------------------------
+	// Node management
+	// ------------------------------------------------------------------
+
+	/**
+	 * Add a component node to the pipeline.
+	 *
+	 * @param nodeId - Unique identifier (e.g. `"llm_1"`).
+	 * @param provider - Component provider type (e.g. `"llm_openai"`).
+	 * @param options - Optional config and source flag.
+	 * @returns `this` for fluent chaining.
+	 */
+	addNode(nodeId: string, provider: string, options: AddNodeOptions = {}): this {
+		if (this._nodes.has(nodeId)) {
+			throw new Error(`Node '${nodeId}' already exists in the pipeline`);
+		}
+		if (options.source && this._sourceId !== null) {
+			throw new Error(`Pipeline already has a source node '${this._sourceId}'. ` + `Cannot add '${nodeId}' as a second source.`);
+		}
+
+		const config: Record<string, unknown> = { ...(options.config ?? {}) };
+
+		// Auto-populate required source config fields
+		if (options.source || SOURCE_PROVIDERS.has(provider)) {
+			config.hideForm ??= true;
+			config.mode ??= 'Source';
+			config.parameters ??= {};
+			config.type ??= provider;
+			this._sourceId = nodeId;
+		}
+
+		const component: PipelineComponent = {
+			id: nodeId,
+			provider,
+			config,
+		};
+
+		this._nodes.set(nodeId, component);
+		this._nodeOrder.push(nodeId);
+		return this;
+	}
+
+	/**
+	 * Update configuration of an existing node (shallow merge).
+	 *
+	 * @param nodeId - ID of the node to configure.
+	 * @param config - Configuration to merge.
+	 * @returns `this` for fluent chaining.
+	 */
+	configureNode(nodeId: string, config: Record<string, unknown>): this {
+		const node = this._getNode(nodeId);
+		Object.assign(node.config, config);
+		return this;
+	}
+
+	/**
+	 * Remove a node and all its connections from the pipeline.
+	 *
+	 * @param nodeId - ID of the node to remove.
+	 * @returns `this` for fluent chaining.
+	 */
+	removeNode(nodeId: string): this {
+		if (!this._nodes.has(nodeId)) {
+			throw new Error(`Node '${nodeId}' not found in the pipeline`);
+		}
+
+		this._nodes.delete(nodeId);
+		this._nodeOrder = this._nodeOrder.filter((id) => id !== nodeId);
+
+		if (this._sourceId === nodeId) {
+			this._sourceId = null;
+		}
+
+		// Remove connections referencing this node
+		for (const component of this._nodes.values()) {
+			if (component.input) {
+				component.input = component.input.filter((inp) => inp.from !== nodeId);
+				if (component.input.length === 0) {
+					delete component.input;
+				}
+			}
+			if (component.control) {
+				component.control = component.control.filter((ctrl) => ctrl.from !== nodeId);
+				if (component.control.length === 0) {
+					delete component.control;
+				}
+			}
+		}
+
+		return this;
+	}
+
+	// ------------------------------------------------------------------
+	// Connection management
+	// ------------------------------------------------------------------
+
+	/**
+	 * Connect two nodes with a data lane.
+	 *
+	 * @param sourceId - Upstream node producing data.
+	 * @param targetId - Downstream node consuming data.
+	 * @param options - Lane type (default: `"text"`).
+	 * @returns `this` for fluent chaining.
+	 */
+	connect(sourceId: string, targetId: string, options: ConnectOptions = {}): this {
+		this._getNode(sourceId);
+		const target = this._getNode(targetId);
+		const lane = options.lane ?? 'text';
+
+		if (!target.input) {
+			target.input = [];
+		}
+		target.input.push({ lane, from: sourceId });
+		return this;
+	}
+
+	/**
+	 * Add a control-flow connection between two nodes.
+	 *
+	 * @param sourceId - Upstream node.
+	 * @param targetId - Downstream node.
+	 * @param options - Class type (default: `"llm"`).
+	 * @returns `this` for fluent chaining.
+	 */
+	connectControl(sourceId: string, targetId: string, options: ConnectControlOptions = {}): this {
+		this._getNode(sourceId);
+		const target = this._getNode(targetId);
+		const classType = options.classType ?? 'llm';
+
+		if (!target.control) {
+			target.control = [];
+		}
+		target.control.push({ classType, from: sourceId });
+		return this;
+	}
+
+	/**
+	 * Remove data-lane connections from `sourceId` to `targetId`.
+	 *
+	 * @param sourceId - Upstream node ID.
+	 * @param targetId - Downstream node ID.
+	 * @param lane - If provided, only remove connections on this lane.
+	 * @returns `this` for fluent chaining.
+	 */
+	disconnect(sourceId: string, targetId: string, lane?: string): this {
+		const target = this._nodes.get(targetId);
+		if (!target?.input) return this;
+
+		target.input = target.input.filter((inp) => !(inp.from === sourceId && (lane === undefined || inp.lane === lane)));
+		if (target.input.length === 0) {
+			delete target.input;
+		}
+		return this;
+	}
+
+	// ------------------------------------------------------------------
+	// Serialization
+	// ------------------------------------------------------------------
+
+	/**
+	 * Return the pipeline as a plain object matching .pipe JSON format.
+	 */
+	toDict(): PipelineConfig {
+		const components = this._nodeOrder.map((id) => this._nodes.get(id)!);
+		const result: PipelineConfig = {
+			components,
+			project_id: this.projectId,
+			viewport: { ...this._viewport },
+			version: 1,
+		};
+		if (this._sourceId) {
+			result.source = this._sourceId;
+		}
+		return result;
+	}
+
+	/**
+	 * Serialize the pipeline to a .pipe-compatible JSON string.
+	 *
+	 * @param indent - Indentation (default: 2 spaces).
+	 */
+	toJSON(indent: number = 2): string {
+		return JSON.stringify(this.toDict(), null, indent);
+	}
+
+	/**
+	 * Write the pipeline to a `.pipe` file (Node.js only).
+	 *
+	 * @param path - File path (should end with `.pipe`).
+	 * @param indent - JSON indentation level.
+	 */
+	toFile(path: string, indent: number = 2): void {
+		writeFileSync(path, this.toJSON(indent) + '\n', 'utf-8');
+	}
+
+	// ------------------------------------------------------------------
+	// Deserialization
+	// ------------------------------------------------------------------
+
+	/**
+	 * Create a Pipeline from a plain object (parsed .pipe JSON).
+	 */
+	static fromDict(data: PipelineConfig): Pipeline {
+		const pipeline = new Pipeline(data.project_id ?? crypto.randomUUID());
+		pipeline._viewport = data.viewport ?? { x: 0, y: 0, zoom: 1 };
+		pipeline._sourceId = data.source ?? null;
+
+		for (const comp of data.components ?? []) {
+			const component: PipelineComponent = { ...comp };
+			pipeline._nodes.set(comp.id, component);
+			pipeline._nodeOrder.push(comp.id);
+
+			// Detect source from config
+			if ((component.config as Record<string, unknown>)?.mode === 'Source') {
+				pipeline._sourceId = pipeline._sourceId ?? comp.id;
+			}
+		}
+
+		return pipeline;
+	}
+
+	/**
+	 * Create a Pipeline from a JSON string.
+	 */
+	static fromJSON(jsonStr: string): Pipeline {
+		return Pipeline.fromDict(JSON.parse(jsonStr));
+	}
+
+	/**
+	 * Load a Pipeline from a `.pipe` file (Node.js only).
+	 */
+	static fromFile(path: string): Pipeline {
+		const content = readFileSync(path, 'utf-8');
+		return Pipeline.fromJSON(content);
+	}
+
+	// ------------------------------------------------------------------
+	// Validation
+	// ------------------------------------------------------------------
+
+	/**
+	 * Validate the pipeline graph and return an array of error messages.
+	 *
+	 * Checks:
+	 * - At least one component exists
+	 * - Exactly one source node is defined
+	 * - All input/control references point to existing nodes
+	 * - The graph contains no cycles
+	 * - `projectId` looks like a UUID
+	 *
+	 * @returns An array of error strings. Empty means valid.
+	 */
+	validate(): string[] {
+		const errors: string[] = [];
+
+		if (this._nodes.size === 0) {
+			errors.push('Pipeline has no components');
+			return errors;
+		}
+
+		// Check project_id
+		if (!this.projectId) {
+			errors.push('Pipeline is missing a project_id');
+		} else if (!UUID_RE.test(this.projectId)) {
+			errors.push(`project_id '${this.projectId}' is not a valid UUID`);
+		}
+
+		// Check source node
+		const sourceNodes: string[] = [];
+		for (const [id, comp] of this._nodes) {
+			if ((comp.config as Record<string, unknown>)?.mode === 'Source') {
+				sourceNodes.push(id);
+			}
+		}
+		if (sourceNodes.length === 0 && this._sourceId === null) {
+			errors.push('Pipeline has no source node');
+		} else if (sourceNodes.length > 1) {
+			errors.push(`Pipeline has multiple source nodes: ${sourceNodes.join(', ')}`);
+		}
+
+		// Check references
+		for (const [id, comp] of this._nodes) {
+			for (const inp of comp.input ?? []) {
+				if (!this._nodes.has(inp.from)) {
+					errors.push(`Node '${id}' references unknown input node '${inp.from}'`);
+				}
+			}
+			for (const ctrl of comp.control ?? []) {
+				if (!this._nodes.has(ctrl.from)) {
+					errors.push(`Node '${id}' references unknown control node '${ctrl.from}'`);
+				}
+			}
+		}
+
+		// Cycle detection (Kahn's algorithm)
+		const inDegree = new Map<string, number>();
+		const adjacency = new Map<string, string[]>();
+		for (const id of this._nodes.keys()) {
+			inDegree.set(id, 0);
+			adjacency.set(id, []);
+		}
+
+		for (const [id, comp] of this._nodes) {
+			for (const inp of comp.input ?? []) {
+				if (this._nodes.has(inp.from)) {
+					adjacency.get(inp.from)!.push(id);
+					inDegree.set(id, inDegree.get(id)! + 1);
+				}
+			}
+			for (const ctrl of comp.control ?? []) {
+				if (this._nodes.has(ctrl.from)) {
+					adjacency.get(ctrl.from)!.push(id);
+					inDegree.set(id, inDegree.get(id)! + 1);
+				}
+			}
+		}
+
+		const queue: string[] = [];
+		for (const [id, deg] of inDegree) {
+			if (deg === 0) queue.push(id);
+		}
+
+		let visited = 0;
+		while (queue.length > 0) {
+			const node = queue.shift()!;
+			visited++;
+			for (const neighbour of adjacency.get(node)!) {
+				const newDeg = inDegree.get(neighbour)! - 1;
+				inDegree.set(neighbour, newDeg);
+				if (newDeg === 0) queue.push(neighbour);
+			}
+		}
+
+		if (visited !== this._nodes.size) {
+			errors.push('Pipeline graph contains a cycle');
+		}
+
+		return errors;
+	}
+
+	/**
+	 * Validate the pipeline and throw if there are errors.
+	 *
+	 * @throws PipelineValidationError
+	 */
+	validateOrThrow(): void {
+		const errors = this.validate();
+		if (errors.length > 0) {
+			throw new PipelineValidationError(errors);
+		}
+	}
+
+	// ------------------------------------------------------------------
+	// Introspection helpers
+	// ------------------------------------------------------------------
+
+	/** All node IDs in insertion order. */
+	get nodeIds(): string[] {
+		return [...this._nodeOrder];
+	}
+
+	/** Number of nodes in the pipeline. */
+	get size(): number {
+		return this._nodes.size;
+	}
+
+	/**
+	 * Return a copy of the raw component object for a node.
+	 */
+	getNode(nodeId: string): PipelineComponent {
+		return { ...this._getNode(nodeId) };
+	}
+
+	// ------------------------------------------------------------------
+	// Private helpers
+	// ------------------------------------------------------------------
+
+	private _getNode(nodeId: string): PipelineComponent {
+		const node = this._nodes.get(nodeId);
+		if (!node) {
+			throw new Error(`Node '${nodeId}' not found in the pipeline`);
+		}
+		return node;
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `Pipeline` builder class to both the Python and TypeScript SDKs for programmatic construction of `.pipe` pipeline definitions
- Supports fluent chaining, graph validation (cycle detection via Kahn's algorithm, dangling reference checks, source-node enforcement), and round-trip serialization to/from `.pipe` JSON
- Auto-populates required source-node config fields (`hideForm`, `mode`, `parameters`, `type`) for `webhook`, `chat`, and `dropper` providers

## Type
Feature

## Why this feature fits this codebase
RocketRide pipelines are defined as `.pipe` JSON files containing an array of components with `id`, `provider`, `config`, `input`, and `control` fields, plus top-level `project_id`, `viewport`, and `version` keys. Currently, users must hand-edit this JSON or use the visual editor -- there is no programmatic API. The Python SDK at `packages/client-python/src/rocketride/` already provides `RocketRideClient` with `client.use(filepath='pipeline.json')` for executing pipelines, and the TypeScript SDK at `packages/client-ts/src/` mirrors this. This PR adds `Pipeline` classes that produce the same `.pipe` JSON structure, enabling CI/CD pipeline generation, testing, and templating. The Python `Pipeline` in `packages/client-python/src/rocketride/pipeline.py` is exported from `__init__.py` alongside `RocketRideClient`, and the TypeScript `Pipeline` in `packages/client-ts/src/pipeline.ts` is exported from `index.ts`. Both implement identical graph operations (`add_node`/`addNode`, `connect`, `validate`, `to_json`/`toJSON`) and validation logic (Kahn's algorithm for cycle detection, reference integrity checks, single-source enforcement). The `_SOURCE_PROVIDERS` set ensures `webhook`, `chat`, and `dropper` nodes get the required config fields that the engine expects for source components.

## What changed
- `packages/client-python/src/rocketride/pipeline.py` -- New 538-line `Pipeline` class with `add_node()`, `connect()`, `connect_control()`, `configure_node()`, `remove_node()`, `disconnect()`, `validate()`, `validate_or_raise()`, `to_json()`, `to_file()`, `to_dict()`, `from_file()`, `from_json()`, `from_dict()` class methods; `PipelineValidationError` exception; cycle detection via Kahn's algorithm
- `packages/client-python/src/rocketride/__init__.py` -- Exports `Pipeline` and `PipelineValidationError` from the package
- `packages/client-ts/src/pipeline.ts` -- New TypeScript `Pipeline` class with equivalent API (`addNode`, `connect`, `connectControl`, `configureNode`, `removeNode`, `disconnect`, `validate`, `validateOrThrow`, `toJSON`, `toFile`, `toDict`, `fromFile`, `fromJSON`, `fromDict`)
- `packages/client-ts/src/index.ts` -- Exports `Pipeline` and `PipelineValidationError` from the package

## Validation
- Python: Build a pipeline with `add_node` and `connect`, call `validate()`, verify empty error list
- Python: Introduce a cycle (A -> B -> A), verify `validate()` returns a cycle error
- Python: `to_json()` then `Pipeline.from_json()` round-trip preserves all nodes and connections
- Python: `to_file()` then `Pipeline.from_file()` round-trip works
- TypeScript: Same validation tests as Python
- Both: Verify output JSON matches the `.pipe` schema (components array, `project_id`, `viewport`, `version` at top level)
- Both: Programmatically built pipeline executes via `client.use(pipeline=pipeline.to_dict())`

## How this could be extended
The `Pipeline` builder could be extended with a `from_template()` factory method that accepts a high-level description (e.g., "RAG with Qdrant and OpenAI") and produces a pre-wired pipeline skeleton. It could also support pipeline diff/merge operations for version-controlled pipeline definitions in CI/CD workflows.

Closes #408

#Hack-with-bay-2