### PR TITLE
fix(security): don't show API keys in debug logs and tracebacks

### DIFF
--- a/packages/client-python/src/rocketride/mixins/execution.py
+++ b/packages/client-python/src/rocketride/mixins/execution.py
@@ -277,7 +277,6 @@ class ExecutionMixin(DAPClient):
 
         # Build execution request with all parameters
         arguments = {
-            'apikey': self._apikey,
             'pipeline': processed_config,  # Use processed config with variables substituted
             'args': args or [],  # Default to empty args list
         }


### PR DESCRIPTION
## Summary

Removed the redundant apikey from the execute arguments. Authentication is already handled at connection time via the 'auth' command, so including it in execute was unnecessary and a security risk when exposed in logs/tracebacks.

API key exposed in debug logs — packages/client-python/src/rocketride/mixins/execution.py:280
API key is included in request arguments dict which may be captured by logging/tracebacks

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the Python client's execution request payload structure by streamlining the data sent to the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->