### PR TITLE
feat(llm): add GMI Cloud LLM connector

### DIFF
--- a/nodes/src/nodes/llm_gmi_cloud/IGlobal.py
+++ b/nodes/src/nodes/llm_gmi_cloud/IGlobal.py
@@ -1,0 +1,192 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+import re
+from urllib.parse import urlparse
+from typing import Optional
+from rocketlib import IGlobalBase, warning
+from ai.common.config import Config
+from ai.common.chat import ChatBase
+
+
+class IGlobal(IGlobalBase):
+    """Global handler for the GMI Cloud LLM node."""
+
+    _chat: Optional[ChatBase] = None
+
+    _VALIDATION_PROMPT = 'Hi'
+    _GMI_CLOUD_BASE_URL = 'https://api.gmi-serving.com/v1'
+    _ALLOWED_DOMAIN = 'gmi-serving.com'
+    # Substrings that indicate a vision/multimodal model (case-insensitive).
+    # Used to warn the user when a custom model name looks like a vision model.
+    _VISION_HINTS = ('vl', 'vision', 'visual', 'multimodal')
+
+    def _validate_serverbase(self, url: str) -> Optional[str]:
+        """Return an error message if url is not a valid GMI Cloud endpoint, else None.
+
+        Enforces HTTPS and restricts the hostname to *.gmi-serving.com to
+        prevent SSRF via user-supplied endpoint URLs.
+        """
+        parsed = urlparse(url)
+        if parsed.scheme != 'https':
+            return 'Endpoint URL must use HTTPS.'
+        host = parsed.hostname or ''
+        if host != self._ALLOWED_DOMAIN and not host.endswith('.' + self._ALLOWED_DOMAIN):
+            return f'Endpoint URL must be a {self._ALLOWED_DOMAIN} address.'
+        return None
+
+    def validateConfig(self):
+        """Validate GMI Cloud models at save time.
+
+        For named profiles the model ID is pre-verified. For the custom
+        profile the user-entered model name is checked: vision/multimodal
+        model names trigger a warning and skip the API probe; all other
+        non-empty names are probed with a 1-token request to confirm both
+        the API key and model existence.
+        """
+        from depends import depends  # type: ignore
+
+        requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
+        depends(requirements)
+
+        try:
+            from openai import OpenAI
+            from openai import APIStatusError, OpenAIError, AuthenticationError, RateLimitError, APIConnectionError
+
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            apikey = config.get('apikey')
+            model = config.get('model')
+            serverbase = config.get('serverbase') or self._GMI_CLOUD_BASE_URL
+
+            # Nothing to validate if model or API key is not set yet.
+            if not model or not apikey:
+                return
+
+            # Deploy-on-demand profiles (Llama, Qwen) require the user to supply
+            # their deployment endpoint URL. Skip the probe if it has not been set yet.
+            if not config.get('serverbase'):
+                return
+
+            err = self._validate_serverbase(serverbase)
+            if err:
+                warning(err)
+                return
+
+            # Vision heuristic: warn and skip probe if model looks like a vision model
+            model_lower = model.lower()
+            if any(hint in model_lower for hint in self._VISION_HINTS):
+                warning('This model appears to be a vision/multimodal model. For image input, use a vision node instead.')
+                # Skip the probe — vision models may reject text-only requests,
+                # which would produce a misleading error on top of this warning.
+                return
+
+            # Probe with a 1-token request to validate key + model existence
+            try:
+                client = OpenAI(api_key=apikey, base_url=serverbase)
+                client.chat.completions.create(
+                    model=model,
+                    messages=[{'role': 'user', 'content': self._VALIDATION_PROMPT}],
+                    max_tokens=1,
+                )
+            except RateLimitError:
+                # 429 during validation means the API key is accepted — the probe
+                # just hit the rate limit. Treat as valid; no warning needed.
+                return
+            except APIStatusError as e:
+                status = getattr(e, 'status_code', None) or getattr(e, 'status', None)
+                # 429 via APIStatusError: same as RateLimitError — key is valid.
+                if status == 429:
+                    return
+                try:
+                    resp = getattr(e, 'response', None)
+                    data = resp.json() if resp is not None else None
+                    if isinstance(data, dict):
+                        api_err = data.get('error')
+                        if isinstance(api_err, dict):
+                            etype = api_err.get('type')
+                            emsg = api_err.get('message') or data.get('message')
+                        else:
+                            etype = None
+                            emsg = data.get('message')
+                        message = self._format_error(status, etype, emsg, str(e))
+                    else:
+                        message = self._format_error(status, None, None, str(e))
+                except Exception:
+                    message = self._format_error(status, None, None, str(e))
+                warning(message)
+                return
+            except (AuthenticationError, APIConnectionError, OpenAIError) as e:
+                message = self._format_error(None, None, None, str(e))
+                warning(message)
+                return
+
+        except Exception as e:
+            warning(str(e))
+
+    def beginGlobal(self):
+        """Initialize the GMI Cloud chat client."""
+        from depends import depends  # type: ignore
+
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        from .gmi_cloud import Chat
+
+        bag = self.IEndpoint.endpoint.bag
+        config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+        if not config.get('apikey'):
+            raise ValueError('GMI Cloud API key is required.')
+        serverbase = config.get('serverbase') or self._GMI_CLOUD_BASE_URL
+        err = self._validate_serverbase(serverbase)
+        if err:
+            raise ValueError(err)
+        self._chat = Chat(self.glb.logicalType, config, bag)
+
+    def endGlobal(self):
+        """Release the chat client."""
+        self._chat = None
+
+    def _format_error(self, status, etype, emsg, fallback: str) -> str:
+        """Compose a user-facing error string.
+
+        If a numeric HTTP status is available, prefix it as 'Error <status>:'.
+        Then include provider error type and message when present.
+        If no structured fields are available, return the fallback message as-is.
+        Whitespace is normalized to a single line.
+        """
+        parts: list[str] = []
+        if status is not None:
+            parts.append(f'Error {status}:')
+        if etype:
+            parts.append(str(etype))
+        if emsg:
+            if etype:
+                parts.append('-')
+            parts.append(str(emsg))
+        # If we only have a status code with no detail, append the raw fallback
+        # so the user sees the full provider message rather than "Error 404:" alone.
+        if parts and not etype and not emsg and fallback:
+            parts.append(fallback)
+        message = ' '.join(parts) if parts else fallback
+        return re.sub(r'\s+', ' ', message).strip()

--- a/nodes/src/nodes/llm_gmi_cloud/IInstance.py
+++ b/nodes/src/nodes/llm_gmi_cloud/IInstance.py
@@ -1,0 +1,28 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from nodes.llm_base import IInstanceGenericLLM
+
+
+class IInstance(IInstanceGenericLLM):
+    pass

--- a/nodes/src/nodes/llm_gmi_cloud/__init__.py
+++ b/nodes/src/nodes/llm_gmi_cloud/__init__.py
@@ -1,0 +1,39 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+
+def getChat():
+    """Get the Chat class from the module."""
+    from .gmi_cloud import Chat
+
+    return Chat
+
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+    'getChat',
+]

--- a/nodes/src/nodes/llm_gmi_cloud/gmi_cloud.py
+++ b/nodes/src/nodes/llm_gmi_cloud/gmi_cloud.py
@@ -1,0 +1,88 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""GMI Cloud binding for the ChatLLM."""
+
+from typing import Any, Dict
+from openai import AuthenticationError, APIError, RateLimitError, APIConnectionError
+from ai.common.chat import ChatBase
+from ai.common.config import Config
+from langchain_openai import ChatOpenAI
+
+
+class Chat(ChatBase):
+    """Creates a GMI Cloud chat bot."""
+
+    _llm: ChatOpenAI
+
+    def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
+        """Initialize the GMI Cloud chat bot.
+
+        Args:
+            provider (str): Provider name
+            connConfig (Dict[str, Any]): Node configuration
+            bag (Dict[str, Any]): Bag to store data
+        """
+        super().__init__(provider, connConfig, bag)
+
+        config = Config.getNodeConfig(provider, connConfig)
+
+        serverbase = config.get('serverbase')
+        if not serverbase:
+            raise ValueError('GMI Cloud serverbase is required.')
+
+        # Use a dummy key placeholder so the LLM client initialises without
+        # crashing when the user has not yet saved a valid API key.
+        apikey = config.get('apikey') or 'sk-dummy'
+
+        self._llm = ChatOpenAI(
+            model=self._model,
+            base_url=serverbase,
+            api_key=apikey,
+            temperature=0,
+            max_tokens=self._modelOutputTokens,
+        )
+
+        bag['chat'] = self
+
+    def is_retryable_error(self, error):
+        """Determine if the error is retryable."""
+        if isinstance(error, RateLimitError):
+            return True
+        elif isinstance(error, APIConnectionError):
+            return True
+        else:
+            return False
+
+    def map_exception(self, error):
+        """Convert GMI Cloud API exceptions to friendlier messages."""
+        if isinstance(error, AuthenticationError):
+            return ValueError('Invalid API key.')
+        elif isinstance(error, RateLimitError):
+            return ValueError(f'GMI Cloud rate limit: {error}')
+        elif isinstance(error, APIConnectionError):
+            return ValueError('Failed to connect to the GMI Cloud API.')
+        elif isinstance(error, APIError):
+            return ValueError(f'GMI Cloud API error: {error}')
+        else:
+            return super().map_exception(error)

--- a/nodes/src/nodes/llm_gmi_cloud/requirements.txt
+++ b/nodes/src/nodes/llm_gmi_cloud/requirements.txt
@@ -1,0 +1,7 @@
+# Plugin GMI Cloud core
+openai
+langchain-openai
+
+# LangChain deps
+langchain-core
+langchain

--- a/nodes/src/nodes/llm_gmi_cloud/services.json
+++ b/nodes/src/nodes/llm_gmi_cloud/services.json
@@ -1,0 +1,594 @@
+{
+	//
+	// Required:
+	//		The displayable name of this node
+	//
+	"title": "GMI Cloud",
+	//
+	// Required:
+	//		The protocol is the endpoint protocol
+	//
+	"protocol": "llm_gmi_cloud://",
+	//
+	// Required:
+	//		Class type of the node - what it does
+	//
+	"classType": [
+		"llm"
+	],
+	//
+	// Required:
+	//		Capabilities are flags that change the behavior of the underlying
+	//		engine
+	//
+	"capabilities": [
+		"invoke"
+	],
+	//
+	// Optional:
+	//		Register is either filter, endpoint or ignored if not specified. If the
+	//		type is specified, a factory is registered of that given type
+	//
+	"register": "filter",
+	//
+	// Optional:
+	//		The node is the actual physical node to instantiate - if
+	//		not specified, the protocol will be used
+	//
+	"node": "python",
+	//
+	// Optional:
+	//		The path is the executable/script code - it is node dependent
+	// 		and is optional for most node
+	//
+	"path": "nodes.llm_gmi_cloud",
+	//
+	// Required:
+	//		The prefix map when added/removed when converting URLs <=> paths
+	//
+	"prefix": "llm",
+	//
+	// Optional:
+	//		Description of this driver
+	//
+	"description": [
+		"A component that connects to GMI Cloud's large language models for advanced ",
+		"natural language processing. GMI Cloud hosts 100+ OpenAI-compatible models ",
+		"including Llama 4, Qwen3, DeepSeek, GPT, Claude, and Gemini on owned H100/H200 ",
+		"GPU infrastructure. It enables capabilities like text generation, summarization, ",
+		"reasoning, and code understanding across a wide range of open-weight and ",
+		"proprietary models through a unified OpenAI-compatible API."
+	],
+	//
+	// Optional:
+	//		The icon is the icon to display in the UI for this node
+	//
+	"icon": "gmi_cloud.svg",
+	//
+	// Optional:
+	//		Documentation link for this driver
+	//
+	"documentation": "https://docs.gmicloud.ai/inference-engine/api-reference",
+	//
+	// Optional:
+	//		Rendering hints to the UI which indicate which fields of
+	//		the configuration should be used to display information
+	//		on the tile box
+	//
+	"tile": [
+		"Model: ${parameters.llm_gmi_cloud.profile}"
+	],
+	//
+	// Optional:
+	//		As a pipe component, define what this pipe component takes
+	//		and what it produces
+	//
+	"lanes": {
+		"questions": [
+			"answers"
+		]
+	},
+	"input": [
+		{
+			"lane": "questions",
+			"output": [
+				{
+					"lane": "answers"
+				}
+			]
+		}
+	],
+	//
+	// Optional:
+	//		Profile section are configuration options used by the driver
+	//		itself
+	//
+	// Notes:
+	// GMI Cloud has two model tiers:
+	//   Shared (always-on): DeepSeek, GPT, Claude, Gemini — available immediately at the
+	//   shared endpoint; only an API key is required.
+	//   Deploy-on-demand: Llama, Qwen — must be deployed first in the GMI Cloud console
+	//   (console.gmicloud.ai), after which a unique endpoint URL is provided. Enter that
+	//   URL in the "Endpoint URL" field that appears for these profiles.
+	"preconfig": {
+		// Define the values that will be merged into any profile configuration
+		// specified, unless the profile is 'absolute'
+		"default": "deepseek-v3",
+		// Defines profiles used with the "profile": key
+		"profiles": {
+			"custom": {
+				"model": "",
+				"modelTotalTokens": 16384,
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": ""
+			},
+			"llama-4-scout": {
+				"title": "Llama 4 Scout",
+				"model": "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 1048576
+			},
+			"llama-4-maverick": {
+				"title": "Llama 4 Maverick",
+				"model": "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 1048576
+			},
+			"qwen3-235b": {
+				"title": "Qwen3 235B",
+				"model": "Qwen/Qwen3-235B-A22B-FP8",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"qwen3-32b": {
+				"title": "Qwen3 32B",
+				"model": "Qwen/Qwen3-32B-FP8",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"qwen3-30b": {
+				"title": "Qwen3 30B",
+				"model": "Qwen/Qwen3-30B-A3B",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"qwen3-coder-480b": {
+				"title": "Qwen3 Coder 480B",
+				"model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"deepseek-v3-2": {
+				"title": "DeepSeek V3.2",
+				"model": "deepseek-ai/DeepSeek-V3.2",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 163840
+			},
+			"deepseek-v3": {
+				"title": "DeepSeek V3",
+				"model": "deepseek-ai/DeepSeek-V3-0324",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 163840
+			},
+			"deepseek-r1": {
+				"title": "DeepSeek R1",
+				"model": "deepseek-ai/DeepSeek-R1",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"deepseek-r1-distill-32b": {
+				"title": "DeepSeek R1 Distill 32B",
+				"model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-32B",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"deepseek-r1-distill-1-5b": {
+				"title": "DeepSeek R1 Distill 1.5B",
+				"model": "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B",
+				"serverbase": "",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"deepseek-prover-v2": {
+				"title": "DeepSeek Prover V2",
+				"model": "deepseek-ai/DeepSeek-Prover-V2-671B",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 131072
+			},
+			"gpt-5-2": {
+				"title": "GPT-5.2",
+				"model": "openai/gpt-5.2",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 128000
+			},
+			"gpt-5-1": {
+				"title": "GPT-5.1",
+				"model": "openai/gpt-5.1",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 128000
+			},
+			"gpt-5": {
+				"title": "GPT-5",
+				"model": "openai/gpt-5",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 128000
+			},
+			"gpt-4o": {
+				"title": "GPT-4o",
+				"model": "openai/gpt-4o",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 128000
+			},
+			"claude-opus-4-5": {
+				"title": "Claude Opus 4.5",
+				"model": "anthropic/claude-opus-4.5",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 200000
+			},
+			"claude-sonnet-4-5": {
+				"title": "Claude Sonnet 4.5",
+				"model": "anthropic/claude-sonnet-4.5",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 200000
+			},
+			"gemini-3-pro": {
+				"title": "Gemini 3 Pro",
+				"model": "google/gemini-3-pro-preview",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 128000
+			},
+			"gemini-3-flash": {
+				"title": "Gemini 3 Flash",
+				"model": "google/gemini-3-flash-preview",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 128000
+			}
+		}
+	},
+	//
+	// Optional:
+	//		Local fields definitions - these define fields only for the
+	//		current service. You may specify them here, or directly
+	//		in the shape
+	//
+	"fields": {
+		"model": {
+			"type": "string",
+			"title": "Model",
+			"description": "GMI Cloud model identifier. Use org/model-name for open-weight models (e.g. deepseek-ai/DeepSeek-R1, Qwen/Qwen3-32B-FP8) or provider/model-name for proxied models (e.g. openai/gpt-4o, anthropic/claude-sonnet-4.5, google/gemini-3-flash-preview). Full list: https://www.gmicloud.ai/models"
+		},
+		"modelTotalTokens": {
+			"type": "number",
+			"title": "Tokens",
+			"description": "Total Tokens"
+		},
+		"gmi_cloud.serverbase": {
+			"type": "string",
+			"title": "Endpoint URL",
+			"description": "Your GMI Cloud deployment endpoint URL. Deploy the model at console.gmicloud.ai, then paste the provided endpoint URL here.",
+			"optional": false
+		},
+		"gmi_cloud.custom": {
+			"object": "custom",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"model",
+				"modelTotalTokens",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.llama-4-scout": {
+			"object": "llama-4-scout",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.llama-4-maverick": {
+			"object": "llama-4-maverick",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.qwen3-235b": {
+			"object": "qwen3-235b",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.qwen3-32b": {
+			"object": "qwen3-32b",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.qwen3-30b": {
+			"object": "qwen3-30b",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.qwen3-coder-480b": {
+			"object": "qwen3-coder-480b",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.deepseek-v3-2": {
+			"object": "deepseek-v3-2",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.deepseek-v3": {
+			"object": "deepseek-v3",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.deepseek-r1": {
+			"object": "deepseek-r1",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.deepseek-r1-distill-32b": {
+			"object": "deepseek-r1-distill-32b",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.deepseek-r1-distill-1-5b": {
+			"object": "deepseek-r1-distill-1-5b",
+			"properties": [
+				"gmi_cloud.serverbase",
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.deepseek-prover-v2": {
+			"object": "deepseek-prover-v2",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.gpt-5-2": {
+			"object": "gpt-5-2",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.gpt-5-1": {
+			"object": "gpt-5-1",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.gpt-5": {
+			"object": "gpt-5",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.gpt-4o": {
+			"object": "gpt-4o",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.claude-opus-4-5": {
+			"object": "claude-opus-4-5",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.claude-sonnet-4-5": {
+			"object": "claude-sonnet-4-5",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.gemini-3-pro": {
+			"object": "gemini-3-pro",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.gemini-3-flash": {
+			"object": "gemini-3-flash",
+			"properties": [
+				"llm.cloud.apikey"
+			]
+		},
+		"gmi_cloud.profile": {
+			"title": "Model",
+			"description": "GMI Cloud LLM model",
+			"type": "string",
+			"default": "deepseek-v3",
+			"enum": [
+				"*>preconfig.profiles.*.title"
+			],
+			"conditional": [
+				{
+					"value": "custom",
+					"properties": [
+						"gmi_cloud.custom"
+					]
+				},
+				{
+					"value": "llama-4-scout",
+					"properties": [
+						"gmi_cloud.llama-4-scout"
+					]
+				},
+				{
+					"value": "llama-4-maverick",
+					"properties": [
+						"gmi_cloud.llama-4-maverick"
+					]
+				},
+				{
+					"value": "qwen3-235b",
+					"properties": [
+						"gmi_cloud.qwen3-235b"
+					]
+				},
+				{
+					"value": "qwen3-32b",
+					"properties": [
+						"gmi_cloud.qwen3-32b"
+					]
+				},
+				{
+					"value": "qwen3-30b",
+					"properties": [
+						"gmi_cloud.qwen3-30b"
+					]
+				},
+				{
+					"value": "qwen3-coder-480b",
+					"properties": [
+						"gmi_cloud.qwen3-coder-480b"
+					]
+				},
+				{
+					"value": "deepseek-v3-2",
+					"properties": [
+						"gmi_cloud.deepseek-v3-2"
+					]
+				},
+				{
+					"value": "deepseek-v3",
+					"properties": [
+						"gmi_cloud.deepseek-v3"
+					]
+				},
+				{
+					"value": "deepseek-r1",
+					"properties": [
+						"gmi_cloud.deepseek-r1"
+					]
+				},
+				{
+					"value": "deepseek-r1-distill-32b",
+					"properties": [
+						"gmi_cloud.deepseek-r1-distill-32b"
+					]
+				},
+				{
+					"value": "deepseek-r1-distill-1-5b",
+					"properties": [
+						"gmi_cloud.deepseek-r1-distill-1-5b"
+					]
+				},
+				{
+					"value": "deepseek-prover-v2",
+					"properties": [
+						"gmi_cloud.deepseek-prover-v2"
+					]
+				},
+				{
+					"value": "gpt-5-2",
+					"properties": [
+						"gmi_cloud.gpt-5-2"
+					]
+				},
+				{
+					"value": "gpt-5-1",
+					"properties": [
+						"gmi_cloud.gpt-5-1"
+					]
+				},
+				{
+					"value": "gpt-5",
+					"properties": [
+						"gmi_cloud.gpt-5"
+					]
+				},
+				{
+					"value": "gpt-4o",
+					"properties": [
+						"gmi_cloud.gpt-4o"
+					]
+				},
+				{
+					"value": "claude-opus-4-5",
+					"properties": [
+						"gmi_cloud.claude-opus-4-5"
+					]
+				},
+				{
+					"value": "claude-sonnet-4-5",
+					"properties": [
+						"gmi_cloud.claude-sonnet-4-5"
+					]
+				},
+				{
+					"value": "gemini-3-pro",
+					"properties": [
+						"gmi_cloud.gemini-3-pro"
+					]
+				},
+				{
+					"value": "gemini-3-flash",
+					"properties": [
+						"gmi_cloud.gemini-3-flash"
+					]
+				}
+			]
+		}
+	},
+	//
+	// Required:
+	//		Defines the fields (shape) of the service. Either source or target
+	//		may be specified, or both, but at least one is required
+	//
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "GMI Cloud",
+			"properties": [
+				"gmi_cloud.profile"
+			]
+		}
+	],
+	"test": {
+		"profiles": ["deepseek-v3"],
+		"outputs": ["answers"],
+		"cases": [
+			{
+				"name": "LLM returns mock response",
+				"text": "What is 2+2?",
+				"expect": {
+					"answers": {
+						"contains": "Mock LLM response"
+					}
+				}
+			}
+		]
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new LLM node for GMI Cloud (api.gmi-serving.com), an OpenAI-compatible inference platform hosting 100+ models including DeepSeek, GPT, Claude, Gemini, Llama 4, and Qwen3 on owned H100/H200 GPU infrastructure.

### Profiles

Two model tiers are supported:

Shared (always-on) — API key only required:
DeepSeek V3.2, V3, R1, R1 Distill 32B & 1.5B, Prover V2 GPT-5.2, 5.1, 5, 4o
Claude Opus 4.5, Sonnet 4.5
Gemini 3 Pro, Gemini 3 Flash

Deploy-on-demand — endpoint URL + API key required (deploy first at console.gmicloud.ai, then paste the provided endpoint URL): Llama 4 Scout, Llama 4 Maverick
Qwen3 235B, 32B, 30B, Coder 480B

A custom profile allows specifying any model name and endpoint URL manually.


## Type

feat

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->
Fixes #538 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added GMI Cloud LLM integration node for pipeline workflows
* Supports multiple pre-configured models including DeepSeek, Llama, Qwen, and standard provider models (OpenAI, Anthropic, Google)
* Configurable API endpoints and authentication keys for custom deployments
* Integrated pipeline support with question-to-answer processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->