### PR TITLE
fix(mixins): error handling for missing pipeline configuration files

### DIFF
--- a/packages/client-python/src/rocketride/mixins/execution.py
+++ b/packages/client-python/src/rocketride/mixins/execution.py
@@ -53,6 +53,7 @@ Usage:
     await client.terminate(token)
 """
 
+import asyncio
 import json
 import re
 import copy
@@ -254,17 +255,16 @@ class ExecutionMixin(DAPClient):
 
         # Load pipeline configuration from file if needed
         if not pipeline:
+
+            def _load_pipeline_config(path: str):
+                with open(path, 'r', encoding='utf-8') as file:
+                    parsed = json5.load(file) if json5 else json.load(file)
+                return parsed.get('pipeline', parsed) if isinstance(parsed, dict) else parsed
+
             try:
-                with open(filepath, 'r', encoding='utf-8') as file:
-                    # Prefer JSON5 for better developer experience (comments, trailing commas)
-                    if json5:
-                        parsed = json5.load(file)
-                    else:
-                        parsed = json.load(file)
-                    # .pipe files wrap the config in { "pipeline": { ... } } — unwrap if present
-                    pipeline_config = parsed.get('pipeline', parsed) if isinstance(parsed, dict) else parsed
-            except FileNotFoundError:
-                raise FileNotFoundError(f"Pipeline file not found: '{filepath}'. Please provide a valid file path or use inline pipeline configuration.")
+                pipeline_config = await asyncio.to_thread(_load_pipeline_config, filepath)
+            except FileNotFoundError as err:
+                raise FileNotFoundError(f"Pipeline file not found: '{filepath}'. Please provide a valid file path or use inline pipeline configuration.") from err
         else:
             pipeline_config = pipeline
 

--- a/packages/client-python/src/rocketride/mixins/execution.py
+++ b/packages/client-python/src/rocketride/mixins/execution.py
@@ -262,7 +262,11 @@ class ExecutionMixin(DAPClient):
                 return parsed.get('pipeline', parsed) if isinstance(parsed, dict) else parsed
 
             try:
-                pipeline_config = await asyncio.to_thread(_load_pipeline_config, filepath)
+                if hasattr(asyncio, 'to_thread'):
+                    pipeline_config = await asyncio.to_thread(_load_pipeline_config, filepath)
+                else:
+                    loop = asyncio.get_running_loop()
+                    pipeline_config = await loop.run_in_executor(None, _load_pipeline_config, filepath)
             except FileNotFoundError as err:
                 raise FileNotFoundError(f"Pipeline file not found: '{filepath}'. Please provide a valid file path or use inline pipeline configuration.") from err
         else:

--- a/packages/client-python/src/rocketride/mixins/execution.py
+++ b/packages/client-python/src/rocketride/mixins/execution.py
@@ -270,7 +270,8 @@ class ExecutionMixin(DAPClient):
             except FileNotFoundError as err:
                 raise FileNotFoundError(f"Pipeline file not found: '{filepath}'. Please provide a valid file path or use inline pipeline configuration.") from err
         else:
-            pipeline_config = pipeline
+            # Keep behavior consistent with filepath-based loading
+            pipeline_config = pipeline.get('pipeline', pipeline) if isinstance(pipeline, dict) else pipeline
 
         # Create a deep copy to avoid modifying the original
         processed_config = copy.deepcopy(pipeline_config)

--- a/packages/client-python/src/rocketride/mixins/execution.py
+++ b/packages/client-python/src/rocketride/mixins/execution.py
@@ -254,14 +254,17 @@ class ExecutionMixin(DAPClient):
 
         # Load pipeline configuration from file if needed
         if not pipeline:
-            with open(filepath, 'r', encoding='utf-8') as file:
-                # Prefer JSON5 for better developer experience (comments, trailing commas)
-                if json5:
-                    parsed = json5.load(file)
-                else:
-                    parsed = json.load(file)
-                # .pipe files wrap the config in { "pipeline": { ... } } — unwrap if present
-                pipeline_config = parsed.get('pipeline', parsed) if isinstance(parsed, dict) else parsed
+            try:
+                with open(filepath, 'r', encoding='utf-8') as file:
+                    # Prefer JSON5 for better developer experience (comments, trailing commas)
+                    if json5:
+                        parsed = json5.load(file)
+                    else:
+                        parsed = json.load(file)
+                    # .pipe files wrap the config in { "pipeline": { ... } } — unwrap if present
+                    pipeline_config = parsed.get('pipeline', parsed) if isinstance(parsed, dict) else parsed
+            except FileNotFoundError:
+                raise FileNotFoundError(f"Pipeline file not found: '{filepath}'. Please provide a valid file path or use inline pipeline configuration.")
         else:
             pipeline_config = pipeline
 


### PR DESCRIPTION
## Summary

FileNotFoundError not handled gracefully — packages/client-python/src/rocketride/mixins/execution.py:257
File opened without existence check or user-friendly error handling.

Added try/except around the file open operation to catch FileNotFoundError and re-raise with a user-friendly message explaining the issue and how to fix it.

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Pipeline configuration loading is now non-blocking, improving responsiveness when reading local configs.
  * Format detection and support for wrapped config objects are preserved.

* **Bug Fixes**
  * Missing pipeline files now raise a clearer FileNotFoundError that includes the provided filepath to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->