### PR TITLE
feat(vscode): improve stop button feedback in Pipeline Observability screen

### DIFF
--- a/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
+++ b/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
@@ -350,6 +350,9 @@ export const PageStatus: React.FC = () => {
 		const state = taskStatus?.state ?? TASK_STATE.NONE;
 		const runLabel = tracingEnabled ? 'Run & Trace' : 'Run';
 
+		if (state === TASK_STATE.STOPPING) {
+			return { label: 'Stopping...', action: 'stop' as const, disabled: true, className: 'action-btn stopping-btn disabled' };
+		}
 		if (state === TASK_STATE.RUNNING || state === TASK_STATE.INITIALIZING) {
 			return { label: 'Stop', action: 'stop' as const, disabled: false, className: 'action-btn stop-btn' };
 		}

--- a/apps/vscode/src/providers/views/PageStatus/styles.css
+++ b/apps/vscode/src/providers/views/PageStatus/styles.css
@@ -306,6 +306,12 @@
 	background: var(--vscode-errorForeground);
 }
 
+.action-btn.stopping-btn {
+	background: var(--vscode-charts-orange);
+	color: white;
+	cursor: not-allowed;
+}
+
 .action-btn.run-btn {
 	background: var(--vscode-charts-green);
 	color: white;


### PR DESCRIPTION
## Summary
- Stop button now immediately shows "Stopping..." with disabled state when pipeline is shutting down
- Distinct orange styling differentiates the stopping state from stop (red) and run (green)
- Button is disabled during stopping to prevent duplicate clicks

## Type
Enhancement

## Why this feature fits this codebase
The codebase already defines `TASK_STATE.STOPPING` (value 4) in the task state enum and the `StatusHeader` component already renders a "Stopping" label with an orange indicator dot for this state. However, the control button in `getControlButton()` did not handle `TASK_STATE.STOPPING` — it fell through to the default case, showing a disabled "Run" button. This change aligns the button behavior with the existing state machine and visual language already established in the codebase (orange = stopping, as seen in `.status-indicator.stopping` and the deploy page's stopping state).

## What changed
- **`apps/vscode/src/providers/views/PageStatus/PageStatus.tsx`**: Added a `TASK_STATE.STOPPING` check in `getControlButton()` that returns a disabled "Stopping..." button with the `stopping-btn` CSS class, placed before the RUNNING/INITIALIZING check so the stopping state takes priority.
- **`apps/vscode/src/providers/views/PageStatus/styles.css`**: Added `.action-btn.stopping-btn` style with `--vscode-charts-orange` background and `cursor: not-allowed`, consistent with the existing `.status-indicator.stopping` orange color and the `.action-btn.disabled` pattern.

## Validation
- The `TASK_STATE.STOPPING` state (value 4) is already emitted by the engine during pipeline shutdown — no backend changes needed
- Button state transitions: **Stop** (red, clickable) -> **Stopping...** (orange, disabled) -> **Run** (green, clickable)
- The existing `.action-btn.disabled` rule (`opacity: 0.4; cursor: not-allowed`) applies alongside `.stopping-btn` for consistent disabled UX
- The `StatusHeader` already displays "Stopping" with an orange dot for this state, so the button now matches the header indicator

## How this can be extended
- A timeout could be added: if the pipeline stays in STOPPING state for more than N seconds, show an error toast or re-enable a "Force Stop" button
- An animated spinner icon could be added inside the button label for additional visual feedback
- The `handlePipelineAction` in `PageStatusProvider.ts` could send intermediate status messages back to the webview for more granular progress

Closes #404

#Hack-with-bay-2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated visual feedback for stopping operations. When an action is being stopped, users see a "Stopping..." button state with disabled interaction, providing clear status indication throughout the process.

* **Style**
  * Introduced distinctive styling for the stopping button state, featuring an orange background and not-allowed cursor to clearly differentiate it from other action button states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->