### PR TITLE
fix(vscode): validate pipe connections and handle invalid pipeline data gracefully

### DIFF
--- a/apps/vscode/src/providers/views/PageEditor/PageEditor.tsx
+++ b/apps/vscode/src/providers/views/PageEditor/PageEditor.tsx
@@ -167,8 +167,13 @@ export const PageEditor: React.FC = () => {
 			switch (message.type) {
 				case 'update':
 					if (message.content && message.content !== '') {
-						setFileErrors(null);
-						setContent(JSON.parse(message.content));
+						try {
+							const parsed = JSON.parse(message.content);
+							setFileErrors(null);
+							setContent(parsed);
+						} catch (e) {
+							setFileErrors([`Failed to parse pipeline JSON: ${e instanceof Error ? e.message : 'Unknown error'}`]);
+						}
 					}
 					break;
 				case 'fileInvalid':

--- a/apps/vscode/src/shared/util/pipelineParser.ts
+++ b/apps/vscode/src/shared/util/pipelineParser.ts
@@ -184,6 +184,40 @@ export class PipelineFileParser {
 			if (duplicates.length > 0) {
 				errors.push(`Duplicate component IDs found: ${(duplicates as string[]).join(', ')}`);
 			}
+
+			// Validate connection references on each component
+			const idSet = new Set(componentIds as string[]);
+			record.components.forEach((component: unknown, index: number) => {
+				const comp = component as Record<string, unknown>;
+				const compId = (comp.id as string) || `index ${index}`;
+
+				// Validate input connections
+				if (Array.isArray(comp.input)) {
+					comp.input.forEach((conn: unknown, connIdx: number) => {
+						const c = conn as Record<string, unknown>;
+						if (!c.from || typeof c.from !== 'string') {
+							errors.push(`Component "${compId}" input connection at index ${connIdx} is missing a valid "from" field`);
+						} else if (!idSet.has(c.from)) {
+							errors.push(`Component "${compId}" input connection references non-existent component "${c.from}"`);
+						}
+						if (!c.lane || typeof c.lane !== 'string') {
+							errors.push(`Component "${compId}" input connection at index ${connIdx} is missing a valid "lane" field`);
+						}
+					});
+				}
+
+				// Validate control connections
+				if (Array.isArray(comp.control)) {
+					comp.control.forEach((conn: unknown, connIdx: number) => {
+						const c = conn as Record<string, unknown>;
+						if (!c.from || typeof c.from !== 'string') {
+							errors.push(`Component "${compId}" control connection at index ${connIdx} is missing a valid "from" field`);
+						} else if (!idSet.has(c.from)) {
+							errors.push(`Component "${compId}" control connection references non-existent component "${c.from}"`);
+						}
+					});
+				}
+			});
 		}
 
 		return {

--- a/packages/shared-ui/src/modules/flow/context/FlowGraphContext.tsx
+++ b/packages/shared-ui/src/modules/flow/context/FlowGraphContext.tsx
@@ -807,12 +807,20 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		(project: IProject) => {
 			isLoadingRef.current = true;
 
-			const newNodes = getNodesFromProject(project);
-			const sortedNodes = sortNodesParentFirst(newNodes as FlowNode[]);
-			const newEdges = getEdgesFromNodes(sortedNodes);
+			try {
+				const newNodes = getNodesFromProject(project);
+				const sortedNodes = sortNodesParentFirst(newNodes as FlowNode[]);
+				const newEdges = getEdgesFromNodes(sortedNodes);
 
-			setNodes(sortedNodes);
-			setEdges(newEdges);
+				setNodes(sortedNodes);
+				setEdges(newEdges);
+			} catch (error) {
+				// Prevent malformed pipeline data from crashing the canvas.
+				// Clear nodes/edges so the user sees an empty canvas rather than a crash.
+				console.error('[FlowGraphContext] Failed to load project data:', error);
+				setNodes([]);
+				setEdges([]);
+			}
 
 			isLoadingRef.current = false;
 		},

--- a/packages/shared-ui/src/modules/flow/util/graph.ts
+++ b/packages/shared-ui/src/modules/flow/util/graph.ts
@@ -242,15 +242,20 @@ export const getNodesFromProject = (project: IProject): INode[] => {
 export const getEdgesFromNodes = (nodes: INodeLike[]): Edge[] => {
 	const edges: Edge[] = [];
 
+	// Build a set of valid node IDs for reference validation
+	const nodeIdSet = new Set(nodes.map((n) => n.id));
+
 	for (const node of nodes) {
 		const { data } = node;
 
 		// -----------------------------------------------------------------
 		// Build invoke-type edges from control connections (trigger/control flow).
 		// These connect diamond-shaped handles between nodes.
+		// Skip malformed entries to prevent canvas crashes from invalid pipe data.
 		// -----------------------------------------------------------------
 		if (data.control?.length) {
 			data.control.forEach((control: IControlConnection) => {
+				if (!control.from || !nodeIdSet.has(control.from)) return;
 				edges.push({
 					...DEFAULT_EDGE,
 					id: uuid(),
@@ -265,9 +270,11 @@ export const getEdgesFromNodes = (nodes: INodeLike[]): Edge[] => {
 		// -----------------------------------------------------------------
 		// Build lane-type edges from input connections (data flow).
 		// These connect circular handles between nodes.
+		// Skip malformed entries to prevent canvas crashes from invalid pipe data.
 		// -----------------------------------------------------------------
 		if (data.input?.length) {
 			data.input.forEach((input: IInputConnection) => {
+				if (!input.from || !nodeIdSet.has(input.from) || !input.lane) return;
 				edges.push({
 					...DEFAULT_EDGE,
 					id: uuid(),


### PR DESCRIPTION
## Summary
- Adds connection-level validation to the pipeline file parser so `.pipe` files with broken `input`/`control` references are rejected with clear, actionable error messages before reaching the canvas
- Adds defensive guards in the graph edge builder to silently skip malformed connection entries, preventing React Flow from receiving edges with `undefined` source/target
- Wraps the canvas `loadData` path and the webview JSON parse in try/catch so unexpected data shapes show an error overlay instead of crashing the UI

## Type
Bug fix

## Why this bug happens in this codebase
The pipeline file parser (`PipelineFileParser.validatePipelineStructure`) only validated that components have `id` and `provider` fields, but never checked the `input` and `control` connection arrays. When a `.pipe` file contained connections with a missing `from` field, a missing `lane` field, or a `from` value referencing a component ID that doesn't exist in the file, the data passed validation and was sent to the canvas. The graph builder (`getEdgesFromNodes`) then created React Flow edges with `undefined` source or target handles, which caused React Flow to throw an unrecoverable error, crashing the entire canvas UI with a cryptic "invalid pipe" message and no recovery path.

## What changed

| File | Change |
|------|--------|
| `apps/vscode/src/shared/util/pipelineParser.ts` | Added validation of `input[].from`, `input[].lane`, and `control[].from` fields on each component, including cross-reference checks against the component ID set |
| `packages/shared-ui/src/modules/flow/util/graph.ts` | `getEdgesFromNodes` now builds a node ID set and skips any connection entry where `from` is missing or references a non-existent node |
| `apps/vscode/src/providers/views/PageEditor/PageEditor.tsx` | Wrapped `JSON.parse` in the `'update'` message handler with try/catch, routing parse failures to the file-invalid error overlay |
| `packages/shared-ui/src/modules/flow/context/FlowGraphContext.tsx` | Wrapped `loadData` in try/catch so any unexpected error clears the canvas instead of crashing it |

## Validation
- [x] Malformed `.pipe` file with missing `from` in input connection shows clear error in the editor overlay
- [x] `.pipe` file referencing a non-existent component ID shows specific error message naming the bad reference
- [x] Valid `.pipe` files continue to load and render normally
- [x] Canvas does not crash on unexpected data shapes — falls back to empty canvas with console error

## How this could be extended
- Add a "Repair pipeline" button to the error overlay that strips invalid connections and reloads
- Surface connection validation warnings (not just errors) for connections that reference valid but disconnected components
- Add schema-level validation (JSON Schema) for `.pipe` files as a pre-parse step
- Integrate the same validation into the headless pipeline execution path so the engine rejects invalid pipes before attempting to run them

Closes #395

#Hack-with-bay-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added error handling with detailed validation messages for data parsing in the page editor
  * Enhanced validation of pipeline component connections and reference integrity
  * Added protective error handling when loading project data to prevent canvas crashes
  * Improved validation of flow graph connections to filter and handle invalid references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->