### PR TITLE
feat(vscode): change play button to show actionable text instead of current state

### DIFF
--- a/nodes/src/nodes/anomaly_detector/IGlobal.py
+++ b/nodes/src/nodes/anomaly_detector/IGlobal.py
@@ -1,0 +1,99 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Anomaly detector node - global (shared) state.
+
+Creates and holds an ``AnomalyDetector`` instance that is shared across
+all pipeline threads so the sliding window accumulates observations from
+every invocation.
+"""
+
+from __future__ import annotations
+
+from ai.common.config import Config
+from rocketlib import IGlobalBase, OPEN_MODE, warning
+
+from .detector import AnomalyDetector, DetectorConfig, Method
+
+
+class IGlobal(IGlobalBase):
+    """Global state for anomaly_detector."""
+
+    detector: AnomalyDetector | None = None
+
+    def beginGlobal(self) -> None:
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            return
+
+        cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+
+        method_raw = str(cfg.get('method') or 'zscore').strip().lower()
+        try:
+            method = Method(method_raw)
+        except ValueError:
+            warning(f'anomaly_detector: unknown method {method_raw!r}, falling back to zscore')
+            method = Method.ZSCORE
+
+        sensitivity = _float(cfg.get('sensitivity'), 2.0, 0.1, 10.0)
+        window_size = _int(cfg.get('windowSize'), 100, 10, 10000)
+        warning_mult = _float(cfg.get('warningThreshold'), 1.5, 1.0, 5.0)
+        critical_mult = _float(cfg.get('criticalThreshold'), 2.0, 1.0, 10.0)
+
+        self.detector = AnomalyDetector(
+            config=DetectorConfig(
+                method=method,
+                sensitivity=sensitivity,
+                window_size=window_size,
+                warning_multiplier=warning_mult,
+                critical_multiplier=critical_mult,
+            )
+        )
+
+    def endGlobal(self) -> None:
+        self.detector = None
+
+
+# ======================================================================
+# Config helpers
+# ======================================================================
+
+
+def _float(raw: object, default: float, lo: float, hi: float) -> float:
+    if raw is None:
+        return default
+    try:
+        v = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(v, hi))
+
+
+def _int(raw: object, default: int, lo: int, hi: int) -> int:
+    if raw is None:
+        return default
+    try:
+        v = int(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(v, hi))

--- a/nodes/src/nodes/anomaly_detector/IInstance.py
+++ b/nodes/src/nodes/anomaly_detector/IInstance.py
@@ -1,0 +1,161 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Anomaly detector node instance.
+
+Extracts a numeric metric from each pipeline output, feeds it to the
+shared ``AnomalyDetector``, and annotates the output text with anomaly
+metadata when an anomaly is detected.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from rocketlib import IInstanceBase, warning
+
+from .detector import AnomalyResult
+from .IGlobal import IGlobal
+
+# Metric extraction strategies keyed by config name.
+_METRIC_EXTRACTORS: dict[str, Any] = {
+    'response_length': lambda text: float(len(text)),
+    'token_count': lambda text: float(len(text.split())),
+    'latency': None,  # handled separately via timing
+    'sentiment_score': None,  # requires upstream metadata
+}
+
+
+class IInstance(IInstanceBase):
+    """Per-thread instance for the anomaly detector filter."""
+
+    IGlobal: IGlobal
+
+    _metric: str = 'response_length'
+    _start_time: float = 0.0
+
+    def beginInstance(self) -> None:
+        cfg = self.instance.connConfig if hasattr(self.instance, 'connConfig') else {}
+        self._metric = str(cfg.get('metric') or 'response_length').strip()
+
+    def endInstance(self) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Filter interface — text lane
+    # ------------------------------------------------------------------
+
+    def writeTextBegin(self) -> None:
+        self._text_parts: list[str] = []
+        self._start_time = time.monotonic()
+
+    def writeText(self, text: str) -> None:
+        self._text_parts.append(text)
+
+    def writeTextEnd(self) -> str:
+        """Evaluate the accumulated text and return annotated output."""
+        full_text = ''.join(self._text_parts)
+        detector = getattr(self.IGlobal, 'detector', None)
+
+        if detector is None:
+            warning('anomaly_detector: detector not initialized, passing through')
+            return full_text
+
+        value = self._extract_metric(full_text)
+        if value is None:
+            return full_text
+
+        result: AnomalyResult = detector.observe(value)
+
+        if result.is_anomaly:
+            annotation = _build_annotation(result, self._metric)
+            return f'{full_text}\n\n<!-- ANOMALY {annotation} -->'
+
+        return full_text
+
+    # ------------------------------------------------------------------
+    # Metric extraction
+    # ------------------------------------------------------------------
+
+    def _extract_metric(self, text: str) -> float | None:
+        """Return a numeric value for the configured metric."""
+        if self._metric == 'latency':
+            return time.monotonic() - self._start_time
+
+        if self._metric == 'sentiment_score':
+            return _try_parse_sentiment(text)
+
+        extractor = _METRIC_EXTRACTORS.get(self._metric)
+        if extractor is None:
+            warning(f'anomaly_detector: unknown metric {self._metric!r}')
+            return None
+
+        try:
+            return extractor(text)
+        except Exception:
+            return None
+
+
+# ======================================================================
+# Helpers
+# ======================================================================
+
+
+def _build_annotation(result: AnomalyResult, metric: str) -> str:
+    """Build a compact JSON annotation string."""
+    payload = {
+        'metric': metric,
+        'value': round(result.value, 4),
+        'severity': result.severity.value,
+        'score': round(result.score, 4),
+        'method': result.method,
+        'baseline_mean': round(result.baseline_mean, 4),
+        'baseline_std': round(result.baseline_std, 4),
+        'message': result.message,
+    }
+    return json.dumps(payload, separators=(',', ':'))
+
+
+def _try_parse_sentiment(text: str) -> float | None:
+    """Attempt to extract a sentiment_score from structured output.
+
+    Looks for a ``"sentiment_score": <number>`` pattern in the text,
+    which would be present if an upstream LLM node emits JSON.
+    """
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict) and 'sentiment_score' in data:
+            return float(data['sentiment_score'])
+    except (json.JSONDecodeError, TypeError, ValueError):
+        pass
+
+    # Fallback: scan for the key as a substring (handles partial JSON).
+    import re
+
+    match = re.search(r'"sentiment_score"\s*:\s*([-+]?\d*\.?\d+)', text)
+    if match:
+        return float(match.group(1))
+    return None

--- a/nodes/src/nodes/anomaly_detector/__init__.py
+++ b/nodes/src/nodes/anomaly_detector/__init__.py
@@ -1,0 +1,27 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/anomaly_detector/detector.py
+++ b/nodes/src/nodes/anomaly_detector/detector.py
@@ -1,0 +1,271 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 RocketRide Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Statistical anomaly detection engine.
+
+Supports three detection methods:
+- **z-score**: flags values whose z-score exceeds the sensitivity threshold.
+- **IQR**: flags values outside ``Q1 - k*IQR .. Q3 + k*IQR``.
+- **rolling_avg**: flags values whose deviation from the rolling mean
+  exceeds ``sensitivity * rolling_std``.
+
+A sliding window of the most recent observations is maintained so the
+baseline adapts over time.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Deque, List
+
+
+class Severity(str, Enum):
+    """Anomaly severity levels."""
+
+    NONE = 'none'
+    INFO = 'info'
+    WARNING = 'warning'
+    CRITICAL = 'critical'
+
+
+class Method(str, Enum):
+    """Supported detection methods."""
+
+    ZSCORE = 'zscore'
+    IQR = 'iqr'
+    ROLLING_AVG = 'rolling_avg'
+
+
+@dataclass
+class AnomalyResult:
+    """Result of a single anomaly check."""
+
+    value: float
+    is_anomaly: bool
+    severity: Severity
+    score: float = 0.0
+    method: str = ''
+    baseline_mean: float = 0.0
+    baseline_std: float = 0.0
+    message: str = ''
+
+
+@dataclass
+class DetectorConfig:
+    """Immutable configuration for an ``AnomalyDetector``."""
+
+    method: Method = Method.ZSCORE
+    sensitivity: float = 2.0
+    window_size: int = 100
+    warning_multiplier: float = 1.5
+    critical_multiplier: float = 2.0
+
+
+@dataclass
+class AnomalyDetector:
+    """Thread-safe sliding-window anomaly detector."""
+
+    config: DetectorConfig = field(default_factory=DetectorConfig)
+    _window: Deque[float] = field(default_factory=deque, init=False, repr=False)
+    _lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+
+    def __post_init__(self) -> None:  # noqa: D105
+        self._window = deque(maxlen=self.config.window_size)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def observe(self, value: float) -> AnomalyResult:
+        """Record *value* and return an ``AnomalyResult``.
+
+        The value is always appended to the sliding window regardless of
+        whether it is anomalous.
+        """
+        with self._lock:
+            result = self._evaluate(value)
+            self._window.append(value)
+            return result
+
+    def reset(self) -> None:
+        """Clear the sliding window."""
+        with self._lock:
+            self._window.clear()
+
+    @property
+    def window_values(self) -> List[float]:
+        """Return a snapshot of the current window (mainly for testing)."""
+        with self._lock:
+            return list(self._window)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _evaluate(self, value: float) -> AnomalyResult:
+        """Evaluate *value* against the current baseline."""
+        if len(self._window) < 2:
+            return AnomalyResult(
+                value=value,
+                is_anomaly=False,
+                severity=Severity.NONE,
+                method=self.config.method.value,
+                message='insufficient data for anomaly detection',
+            )
+
+        method = self.config.method
+        if method == Method.ZSCORE:
+            return self._zscore(value)
+        if method == Method.IQR:
+            return self._iqr(value)
+        return self._rolling_avg(value)
+
+    # -- z-score -------------------------------------------------------
+
+    def _zscore(self, value: float) -> AnomalyResult:
+        mean, std = _mean_std(self._window)
+        if std == 0:
+            return self._no_variance_result(value, mean)
+
+        z = abs(value - mean) / std
+        severity = self._classify(z)
+        return AnomalyResult(
+            value=value,
+            is_anomaly=severity != Severity.NONE,
+            severity=severity,
+            score=z,
+            method='zscore',
+            baseline_mean=mean,
+            baseline_std=std,
+            message=f'z-score {z:.3f} (threshold {self.config.sensitivity})',
+        )
+
+    # -- IQR -----------------------------------------------------------
+
+    def _iqr(self, value: float) -> AnomalyResult:
+        mean, std = _mean_std(self._window)
+        sorted_vals = sorted(self._window)
+        q1 = _percentile(sorted_vals, 25)
+        q3 = _percentile(sorted_vals, 75)
+        iqr = q3 - q1
+
+        if iqr == 0:
+            return self._no_variance_result(value, mean)
+
+        lower = q1 - self.config.sensitivity * iqr
+        upper = q3 + self.config.sensitivity * iqr
+        deviation = 0.0
+        if value < lower:
+            deviation = (lower - value) / iqr
+        elif value > upper:
+            deviation = (value - upper) / iqr
+
+        severity = self._classify(deviation)
+        return AnomalyResult(
+            value=value,
+            is_anomaly=severity != Severity.NONE,
+            severity=severity,
+            score=deviation,
+            method='iqr',
+            baseline_mean=mean,
+            baseline_std=std,
+            message=f'IQR deviation {deviation:.3f} (bounds [{lower:.2f}, {upper:.2f}])',
+        )
+
+    # -- rolling average -----------------------------------------------
+
+    def _rolling_avg(self, value: float) -> AnomalyResult:
+        mean, std = _mean_std(self._window)
+        if std == 0:
+            return self._no_variance_result(value, mean)
+
+        deviation = abs(value - mean) / std
+        severity = self._classify(deviation)
+        return AnomalyResult(
+            value=value,
+            is_anomaly=severity != Severity.NONE,
+            severity=severity,
+            score=deviation,
+            method='rolling_avg',
+            baseline_mean=mean,
+            baseline_std=std,
+            message=f'rolling-avg deviation {deviation:.3f} (threshold {self.config.sensitivity})',
+        )
+
+    # -- severity classification ---------------------------------------
+
+    def _classify(self, score: float) -> Severity:
+        crit = self.config.sensitivity * self.config.critical_multiplier
+        warn = self.config.sensitivity * self.config.warning_multiplier
+        if score >= crit:
+            return Severity.CRITICAL
+        if score >= warn:
+            return Severity.WARNING
+        if score >= self.config.sensitivity:
+            return Severity.INFO
+        return Severity.NONE
+
+    def _no_variance_result(self, value: float, mean: float) -> AnomalyResult:
+        is_anomaly = value != mean
+        return AnomalyResult(
+            value=value,
+            is_anomaly=is_anomaly,
+            severity=Severity.INFO if is_anomaly else Severity.NONE,
+            method=self.config.method.value,
+            baseline_mean=mean,
+            baseline_std=0.0,
+            message='zero variance in baseline' if is_anomaly else 'no variance, value matches baseline',
+        )
+
+
+# ======================================================================
+# Pure helper functions
+# ======================================================================
+
+
+def _mean_std(data: Deque[float]) -> tuple[float, float]:
+    """Compute mean and population standard deviation."""
+    n = len(data)
+    if n == 0:
+        return 0.0, 0.0
+    mean = sum(data) / n
+    var = sum((x - mean) ** 2 for x in data) / n
+    return mean, math.sqrt(var)
+
+
+def _percentile(sorted_data: list[float], p: float) -> float:
+    """Linear-interpolation percentile on pre-sorted data."""
+    n = len(sorted_data)
+    if n == 0:
+        return 0.0
+    k = (p / 100) * (n - 1)
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return sorted_data[int(k)]
+    return sorted_data[f] * (c - k) + sorted_data[c] * (k - f)

--- a/nodes/src/nodes/anomaly_detector/requirements.txt
+++ b/nodes/src/nodes/anomaly_detector/requirements.txt
@@ -1,0 +1,1 @@
+# No external dependencies — uses only the Python standard library.

--- a/nodes/src/nodes/anomaly_detector/services.json
+++ b/nodes/src/nodes/anomaly_detector/services.json
@@ -1,0 +1,113 @@
+{
+	"title": "Anomaly Detector",
+	"protocol": "anomaly_detector://",
+	"classType": ["filter"],
+	"capabilities": [],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.anomaly_detector",
+	"prefix": "anomaly_detector",
+	"icon": "util-text.svg",
+	"description": [
+		"A filter component that monitors pipeline output values over time and ",
+		"detects statistical anomalies using z-score, IQR, or rolling average ",
+		"deviation. It maintains a sliding window of recent outputs for baseline ",
+		"computation and flags anomalous values with severity levels (info, ",
+		"warning, critical). Configurable sensitivity, window size, and detection ",
+		"method allow fine-tuned monitoring of token counts, response lengths, ",
+		"latency, and sentiment scores."
+	],
+	"lanes": {
+		"text": ["text"]
+	},
+	"input": [
+		{
+			"lane": "text",
+			"description": "Pipeline output to monitor for anomalies",
+			"min": 1,
+			"output": [
+				{
+					"lane": "text",
+					"description": "Output annotated with anomaly metadata"
+				}
+			]
+		}
+	],
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"title": "Default (z-score)",
+				"method": "zscore",
+				"sensitivity": 2.0,
+				"windowSize": 100,
+				"metric": "response_length"
+			}
+		}
+	},
+	"fields": {
+		"anomaly_detector.method": {
+			"type": "string",
+			"title": "Detection method",
+			"description": "Statistical method used to detect anomalies.",
+			"default": "zscore",
+			"enum": ["zscore", "iqr", "rolling_avg"]
+		},
+		"anomaly_detector.sensitivity": {
+			"type": "number",
+			"title": "Sensitivity threshold",
+			"description": "How many standard deviations (z-score), IQR multipliers, or rolling-average ratios before a value is flagged. Lower values flag more anomalies.",
+			"default": 2.0,
+			"minimum": 0.1,
+			"maximum": 10.0
+		},
+		"anomaly_detector.windowSize": {
+			"type": "integer",
+			"title": "Window size",
+			"description": "Number of recent observations kept for baseline computation.",
+			"default": 100,
+			"minimum": 10,
+			"maximum": 10000
+		},
+		"anomaly_detector.metric": {
+			"type": "string",
+			"title": "Metric to monitor",
+			"description": "Which numeric property of the pipeline output to track.",
+			"default": "response_length",
+			"enum": ["token_count", "response_length", "latency", "sentiment_score"]
+		},
+		"anomaly_detector.warningThreshold": {
+			"type": "number",
+			"title": "Warning threshold multiplier",
+			"description": "Multiplier applied to sensitivity to escalate from info to warning severity. Default 1.5x.",
+			"default": 1.5,
+			"minimum": 1.0,
+			"maximum": 5.0,
+			"optional": true
+		},
+		"anomaly_detector.criticalThreshold": {
+			"type": "number",
+			"title": "Critical threshold multiplier",
+			"description": "Multiplier applied to sensitivity to escalate from warning to critical severity. Default 2.0x.",
+			"default": 2.0,
+			"minimum": 1.0,
+			"maximum": 10.0,
+			"optional": true
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Anomaly Detector",
+			"properties": [
+				"type",
+				"anomaly_detector.method",
+				"anomaly_detector.sensitivity",
+				"anomaly_detector.windowSize",
+				"anomaly_detector.metric",
+				"anomaly_detector.warningThreshold",
+				"anomaly_detector.criticalThreshold"
+			]
+		}
+	]
+}

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/RunButton.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/run-button/RunButton.tsx
@@ -6,12 +6,14 @@
 /**
  * RunButton — Play/stop button that slides out from the left edge of source nodes.
  *
- * Three visual states:
- *   - **Play** (idle): accent-colored play icon; clicking saves + runs the pipeline.
+ * Four visual states:
+ *   - **Run Pipeline** (idle): accent-colored play icon; clicking saves + runs the pipeline.
  *   - **Stop** (running): red stop icon; clicking aborts the pipeline.
+ *   - **Stopping...** (stopping): disabled spinner; pipeline is shutting down.
  *   - **Pending** (transitioning): spinning icon while waiting for state change.
  *
- * On hover the button slides further left and expands to reveal its label.
+ * Button text always indicates the action that will be performed on click,
+ * never the current state. Smooth CSS transitions between all states.
  * Includes debounce guards to prevent double-clicks.
  */
 
@@ -54,10 +56,10 @@ const styles = {
 		boxShadow: '0px 2px 1px -1px rgba(0, 0, 0, 0.15), 0px 1px 1px 0px rgba(0, 0, 0, 0.1), 0px 1px 3px 0px rgba(0, 0, 0, 0.08)',
 		border: 'none',
 		outline: '1px solid var(--rr-border)',
-		transition: 'left 0.2s, width 0.2s, background-color 0.2s',
+		transition: 'left 0.2s ease, width 0.2s ease, background-color 0.2s ease, opacity 0.2s ease',
 		'&:hover': {
-			left: 'calc(-3rem - 1px)',
-			width: '3rem',
+			left: 'calc(-5rem - 1px)',
+			width: '5rem',
 			backgroundColor: 'var(--rr-accent, #007acc)',
 			'& .run-btn-label': {
 				opacity: 1,
@@ -70,6 +72,19 @@ const styles = {
 		},
 		'&.stop-button:hover': {
 			backgroundColor: 'error.main',
+			left: 'calc(-3.5rem - 1px)',
+			width: '3.5rem',
+		},
+		'&.stopping-button': {
+			cursor: 'default',
+			pointerEvents: 'none',
+			opacity: 0.6,
+			left: 'calc(-5.5rem - 1px)',
+			width: '5.5rem',
+			'& .run-btn-label': {
+				opacity: 1,
+				width: 'auto',
+			},
 		},
 	},
 	button: {
@@ -79,10 +94,11 @@ const styles = {
 	icon: {
 		width: '1rem',
 		height: '1rem',
+		transition: 'color 0.2s ease, fill 0.2s ease',
 	},
 	label: {
 		opacity: 0,
-		transition: 'width 0.2s',
+		transition: 'opacity 0.2s ease, width 0.2s ease',
 		pointerEvents: 'none',
 		whiteSpace: 'nowrap',
 		fontSize: '0.65rem',
@@ -101,13 +117,20 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 	const { currentProject, taskStatuses, onRunPipeline, onStopPipeline, isConnected } = useFlowProject();
 	const { nodes } = useFlowGraph();
 
-	// ── Running state ──────────────────────────────────────────────────────
+	// ── Running / stopping state ───────────────────────────────────────────
 	const isRunning = useMemo(() => {
 		if (!currentProject?.project_id) return false;
 		const taskStatus = taskStatuses?.[nodeId];
 		if (!taskStatus) return false;
 		const runningStates = [ITaskState.STARTING, ITaskState.INITIALIZING, ITaskState.RUNNING];
 		return runningStates.includes(taskStatus.state) && !taskStatus.completed;
+	}, [taskStatuses, currentProject, nodeId]);
+
+	const isStopping = useMemo(() => {
+		if (!currentProject?.project_id) return false;
+		const taskStatus = taskStatuses?.[nodeId];
+		if (!taskStatus) return false;
+		return taskStatus.state === ITaskState.STOPPING && !taskStatus.completed;
 	}, [taskStatuses, currentProject, nodeId]);
 
 	// ── Handlers ───────────────────────────────────────────────────────────
@@ -147,13 +170,15 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 
 	// ── Clear pending on state transitions ─────────────────────────────────
 	const prevIsRunning = useRef(isRunning);
+	const prevIsStopping = useRef(isStopping);
 	useEffect(() => {
-		if (isPending && prevIsRunning.current !== isRunning) {
+		if (isPending && (prevIsRunning.current !== isRunning || prevIsStopping.current !== isStopping)) {
 			setIsPending(false);
 			isProcessingClick.current = false;
 		}
 		prevIsRunning.current = isRunning;
-	}, [isRunning, isPending]);
+		prevIsStopping.current = isStopping;
+	}, [isRunning, isStopping, isPending]);
 
 	useEffect(() => {
 		if (!isPending) {
@@ -165,6 +190,27 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 	// Hide the button entirely when not connected — can't run or stop without a server
 	if (!isConnected) {
 		return <></>;
+	}
+
+	// Stopping state — disabled button with spinner and "Stopping..." label
+	if (isStopping) {
+		return (
+			<Box
+				sx={styles.buttonWrapper}
+				className="stopping-button"
+				onDoubleClick={(e) => {
+					e.stopPropagation();
+					e.preventDefault();
+				}}
+			>
+				<IconButton sx={styles.button} disabled>
+					<Autorenew color="warning" sx={styles.icon} className="rotate" />
+				</IconButton>
+				<Typography sx={styles.label} className="run-btn-label">
+					Stopping...
+				</Typography>
+			</Box>
+		);
 	}
 
 	if (isRunning) {
@@ -197,7 +243,7 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 		>
 			<IconButton sx={styles.button}>{isPending ? <Autorenew color="warning" sx={styles.icon} className="rotate" /> : <PlayArrow sx={{ ...styles.icon, color: 'var(--rr-accent, #007acc)' }} />}</IconButton>
 			<Typography sx={styles.label} className="run-btn-label">
-				Play
+				Run Pipeline
 			</Typography>
 		</Box>
 	);


### PR DESCRIPTION
## Summary
- Add a new `anomaly_detector` filter node that monitors pipeline output values over time and flags statistical anomalies using z-score, IQR, or rolling average deviation
- Update the `RunButton` component to show actionable text ("Run Pipeline" instead of "Play") and add a "Stopping..." disabled state with spinner

## Type
Feature + UX Enhancement

## Why this feature fits this codebase
**Anomaly detector node:** RocketRide pipelines chain LLM calls, embeddings, and transformations but have no built-in way to detect when outputs drift outside expected ranges. This node fills the observability gap by slotting into any text lane as a filter. It follows the existing `IGlobal`/`IInstance` pattern (same as `tool_python`, `webhook`, `anonymize`) and requires zero external dependencies (stdlib only: `statistics`, `threading`, `json`).

- **`IGlobal.beginGlobal()`** reads `method`, `sensitivity`, `windowSize`, `warningThreshold`, `criticalThreshold` from config via `Config.getNodeConfig()` and creates a shared `AnomalyDetector` instance
- **`IInstance.writeTextEnd()`** extracts metrics (token count, response length, latency), feeds them to the shared detector's sliding window, and annotates anomalous outputs with severity metadata
- **`detector.py`** implements three detection methods (`Method.ZSCORE`, `Method.IQR`, `Method.ROLLING_AVG`) with thread-safe sliding window via `threading.Lock`

**RunButton changes:** The button label said "Play" which describes the current state, not the action. Changed to "Run Pipeline" for clarity. Added `isStopping` state that checks `ITaskState.STOPPING` to show a disabled spinner with "Stopping..." label, matching the same stopping-state pattern added to `PageStatus`.

## What changed
| File | Change |
|------|--------|
| `nodes/src/nodes/anomaly_detector/__init__.py` | New — package init, exports `IGlobal` + `IInstance` |
| `nodes/src/nodes/anomaly_detector/IGlobal.py` | New — global state: reads config, creates shared `AnomalyDetector` with `_float()`/`_int()` clamping helpers |
| `nodes/src/nodes/anomaly_detector/IInstance.py` | New — per-thread instance: extracts metrics via `_METRIC_EXTRACTORS`, annotates anomalous outputs |
| `nodes/src/nodes/anomaly_detector/detector.py` | New — core detection engine: z-score, IQR, rolling avg with `threading.Lock`-protected sliding window |
| `nodes/src/nodes/anomaly_detector/services.json` | New — node registration with config fields for method, sensitivity, window size, severity thresholds |
| `nodes/src/nodes/anomaly_detector/requirements.txt` | New — empty (stdlib only, no pip dependencies) |
| `packages/shared-ui/src/modules/flow/components/node/node-component/run-button/RunButton.tsx` | Renamed "Play" label to "Run Pipeline"; added `isStopping` memo checking `ITaskState.STOPPING`; renders disabled spinner + "Stopping..." when stopping; widened hover width from 3rem to 5rem; added `opacity` to CSS transition |

## Validation
- `ruff check` and `ruff format` pass with zero errors on all Python files
- Anomaly detector follows the same `IGlobal`/`IInstance` pattern used by existing nodes
- Thread-safe via `threading.Lock` on the shared sliding window
- RunButton changes are backward-compatible: existing `isRunning`/`isPending` states unchanged

## How this could be extended
- Add new detection methods by extending the `Method` enum and adding a `_method_name()` evaluator in `AnomalyDetector`
- Add new metrics by registering a lambda in `_METRIC_EXTRACTORS` in `IInstance.py`
- Wire alerts to external systems (Slack, PagerDuty) by chaining a webhook node after this filter

Closes: N/A — new contribution, no pre-existing issue

#Hack-with-bay-2