### PR TITLE
feat(nodes): add anomaly detection node for pipeline output monitoring

### DIFF
--- a/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
+++ b/apps/vscode/src/providers/views/PageStatus/PageStatus.tsx
@@ -350,6 +350,9 @@ export const PageStatus: React.FC = () => {
 		const state = taskStatus?.state ?? TASK_STATE.NONE;
 		const runLabel = tracingEnabled ? 'Run & Trace' : 'Run';
 
+		if (state === TASK_STATE.STOPPING) {
+			return { label: 'Stopping...', action: 'stop' as const, disabled: true, className: 'action-btn stopping-btn disabled' };
+		}
 		if (state === TASK_STATE.RUNNING || state === TASK_STATE.INITIALIZING) {
 			return { label: 'Stop', action: 'stop' as const, disabled: false, className: 'action-btn stop-btn' };
 		}

--- a/apps/vscode/src/providers/views/PageStatus/styles.css
+++ b/apps/vscode/src/providers/views/PageStatus/styles.css
@@ -306,6 +306,12 @@
 	background: var(--vscode-errorForeground);
 }
 
+.action-btn.stopping-btn {
+	background: var(--vscode-charts-orange);
+	color: white;
+	cursor: not-allowed;
+}
+
 .action-btn.run-btn {
 	background: var(--vscode-charts-green);
 	color: white;


### PR DESCRIPTION
## Summary
- Add `TASK_STATE.STOPPING` handling to the pipeline status control button in the VS Code extension
- Display a disabled "Stopping..." button styled in orange when a pipeline is shutting down
- Prevent user interaction during the stopping transition

## Type
Bug Fix (UX)

## Why this bug happens in this codebase
The `getControlButton()` function in `PageStatus.tsx` handles `TASK_STATE.RUNNING` and `TASK_STATE.INITIALIZING` but did not handle `TASK_STATE.STOPPING`. When a pipeline entered the stopping state, the button fell through to the default case and showed a disabled "Run" button — confusing because it gave no indication that a stop was in progress.

The codebase already defines `TASK_STATE.STOPPING` in its state enum and the `StatusHeader` component already renders an orange "Stopping" indicator dot for this state, but the control button was not aligned.

## What changed
| File | Change |
|------|--------|
| `apps/vscode/src/providers/views/PageStatus/PageStatus.tsx` | Added `TASK_STATE.STOPPING` case in `getControlButton()` returning `{ label: 'Stopping...', disabled: true, className: 'action-btn stopping-btn disabled' }` |
| `apps/vscode/src/providers/views/PageStatus/styles.css` | Added `.action-btn.stopping-btn` style: orange background (`--vscode-charts-orange`), white text, `cursor: not-allowed` |

## Validation
- Change is purely additive — existing `RUNNING`/`INITIALIZING`/default cases are untouched
- Uses the same `--vscode-charts-orange` CSS variable already used for stopping indicators elsewhere in the codebase
- Button is disabled so no click handler fires during the transition

## How this could be extended
- Add a timeout: if the pipeline stays in STOPPING for more than N seconds, show an error toast or re-enable a "Force Stop" button
- Add a progress indicator showing which pipeline step is still draining

Closes: N/A — this is a duplicate of the change in PR #549; only one should be merged

#Hack-with-bay-2