### PR TITLE
Fix: SDK connect error callback type

### DIFF
--- a/apps/chat-ui/src/hooks/clientSingleton.ts
+++ b/apps/chat-ui/src/hooks/clientSingleton.ts
@@ -27,7 +27,7 @@
  *
  * Manages a single, shared WebSocket connection to RocketRide services across
  * the entire application. This singleton pattern ensures:
- * 
+ *
  * Benefits:
  * - Only one WebSocket connection exists (no duplicate connections)
  * - Connection persists across component mount/unmount cycles
@@ -35,24 +35,24 @@
  * - Multiple components can share the same connection
  * - Automatic reconnection handling
  * - Centralized event broadcasting
- * 
+ *
  * Architecture:
  * - Singleton instance stored outside React lifecycle
  * - Pub/sub pattern for event distribution
  * - Promise-based connection management
- * 
+ *
  * Event Types:
  * - Connection events: broadcast when WebSocket connects
  * - Disconnection events: broadcast when WebSocket disconnects
  * - Message events: broadcast for all incoming RocketRide messages
  * - Status events: broadcast for UI status updates
- * 
+ *
  * Authentication: Token is obtained by App and passed to startClient().
- * 
+ *
  * @module clientSingleton
  */
 
-import { RocketRideClient, RocketRideClientConfig } from 'rocketride';
+import { RocketRideClient, RocketRideClientConfig, ConnectionException } from 'rocketride';
 import { API_CONFIG } from '../config/apiConfig';
 
 // ============================================================================
@@ -106,12 +106,12 @@ let lastConnectionError: { reason: string; hasError: boolean } | null = null;
 
 /**
  * Broadcasts incoming RocketRide events to all subscribed listeners
- * 
+ *
  * Error Handling:
  * - Individual subscriber errors are caught and logged
  * - One failing subscriber doesn't affect others
  * - Ensures all subscribers receive the event
- * 
+ *
  * @param message - Event message from RocketRide client
  */
 async function handleEvent(message: any): Promise<void> {
@@ -126,12 +126,12 @@ async function handleEvent(message: any): Promise<void> {
 
 /**
  * Broadcasts connection event to all subscribed listeners
- * 
+ *
  * Flow:
  * 1. Clears any status messages (connection successful)
  * 2. Notifies all connection subscribers
  * 3. Allows subscribers to perform setup (e.g., initialize pipelines)
- * 
+ *
  * @param client - The connected RocketRideClient instance
  */
 async function handleConnected(client: RocketRideClient): Promise<void> {
@@ -158,17 +158,17 @@ async function handleConnected(client: RocketRideClient): Promise<void> {
 
 /**
  * Broadcasts disconnection event to all subscribed listeners
- * 
+ *
  * Flow:
  * 1. Shows descriptive error message from server
  * 2. Notifies all disconnection subscribers
  * 3. SDK will automatically attempt reconnection
- * 
+ *
  * Server Error Messages:
  * - HTTP 400: Pipeline not running
  * - HTTP 401: Authentication error
  * - Other: Connection lost or network errors
- * 
+ *
  * @param reason - Reason for disconnection (from server or network)
  * @param hasError - Whether disconnection was due to an error
  */
@@ -235,19 +235,19 @@ async function handleDisconnected(reason: string, hasError: boolean): Promise<vo
 
 /**
  * Starts the RocketRide client singleton with persistent connection
- * 
+ *
  * This function initializes the client once and enables automatic reconnection.
  * If the client is already started, this function does nothing (idempotent).
- * 
+ *
  * Connection Flow:
  * - Creates RocketRideClient with persist: true
  * - Attempts initial connection (may fail if pipeline not running)
  * - SDK automatically retries connection every 1 second
  * - onConnected/onDisconnected callbacks notify subscribers
- * 
+ *
  * @param authToken - Authentication token (obtained by App from URL, session storage, or config)
  * @throws Error if authentication token is missing
- * 
+ *
  * @example
  * ```typescript
  * // In App.tsx
@@ -261,7 +261,7 @@ export async function startClient(authToken: string): Promise<void> {
 	}
 
 	if (!authToken) {
-		throw new Error('Sorry, I couldn\'t get you authenticated. Please contact your system admin.');
+		throw new Error("Sorry, I couldn't get you authenticated. Please contact your system admin.");
 	}
 
 	const config: RocketRideClientConfig = {
@@ -275,9 +275,8 @@ export async function startClient(authToken: string): Promise<void> {
 		onDisconnected: async (reason?: string, hasError?: boolean) => {
 			await handleDisconnected(reason || 'Connection lost', hasError || false);
 		},
-		onConnectError: (message: string) =>
-			handleDisconnected(message, true).catch((e) => console.error('handleDisconnected:', e)),
-		env: API_CONFIG
+		onConnectError: (error: ConnectionException) => handleDisconnected(error.message, true).catch((e) => console.error('handleDisconnected:', e)),
+		env: API_CONFIG,
 	};
 
 	const client = new RocketRideClient(config);
@@ -308,10 +307,10 @@ export function getClient(): RocketRideClient | null {
 
 /**
  * Stops the RocketRide client and disables persistent connection
- * 
+ *
  * Disconnects from the server and clears the singleton instance.
  * After calling this, you must call startClient() again to reconnect.
- * 
+ *
  * @example
  * ```typescript
  * await stopClient();
@@ -330,18 +329,18 @@ export async function stopClient(): Promise<void> {
 
 /**
  * Subscribes to client events with automatic cleanup
- * 
+ *
  * Subscription Pattern:
  * - Register callbacks for events, connection, disconnection, status
  * - Returns unsubscribe function for cleanup
  * - Safe to call during component unmount
- * 
+ *
  * Callback Types:
  * - onEvent: Called for each RocketRide message
  * - onConnected: Called once when connection established
  * - onDisconnected: Called when connection lost
  * - onStatusChange: Called for UI status updates
- * 
+ *
  * Usage Pattern:
  * ```typescript
  * useEffect(() => {
@@ -350,20 +349,15 @@ export async function stopClient(): Promise<void> {
  *     onConnected: (client) => console.log('Connected'),
  *     onDisconnected: (reason) => console.log('Disconnected:', reason)
  *   });
- *   
+ *
  *   return () => unsubscribe(); // Cleanup on unmount
  * }, []);
  * ```
- * 
+ *
  * @param callbacks - Object containing optional callback functions
  * @returns Unsubscribe function to remove all callbacks
  */
-export function subscribeToClient(callbacks: {
-	onEvent?: EventSubscriber;
-	onConnected?: ConnectionSubscriber;
-	onDisconnected?: DisconnectionSubscriber;
-	onStatusChange?: StatusSubscriber;
-}): () => void {
+export function subscribeToClient(callbacks: { onEvent?: EventSubscriber; onConnected?: ConnectionSubscriber; onDisconnected?: DisconnectionSubscriber; onStatusChange?: StatusSubscriber }): () => void {
 	const { onEvent, onConnected, onDisconnected, onStatusChange } = callbacks;
 
 	// Add callbacks to subscriber sets
@@ -388,4 +382,3 @@ export function subscribeToClient(callbacks: {
 		if (onStatusChange) statusSubscribers.delete(onStatusChange);
 	};
 }
-

--- a/apps/chat-ui/src/hooks/clientSingleton.ts
+++ b/apps/chat-ui/src/hooks/clientSingleton.ts
@@ -27,7 +27,7 @@
  *
  * Manages a single, shared WebSocket connection to RocketRide services across
  * the entire application. This singleton pattern ensures:
- *
+ * 
  * Benefits:
  * - Only one WebSocket connection exists (no duplicate connections)
  * - Connection persists across component mount/unmount cycles
@@ -35,20 +35,20 @@
  * - Multiple components can share the same connection
  * - Automatic reconnection handling
  * - Centralized event broadcasting
- *
+ * 
  * Architecture:
  * - Singleton instance stored outside React lifecycle
  * - Pub/sub pattern for event distribution
  * - Promise-based connection management
- *
+ * 
  * Event Types:
  * - Connection events: broadcast when WebSocket connects
  * - Disconnection events: broadcast when WebSocket disconnects
  * - Message events: broadcast for all incoming RocketRide messages
  * - Status events: broadcast for UI status updates
- *
+ * 
  * Authentication: Token is obtained by App and passed to startClient().
- *
+ * 
  * @module clientSingleton
  */
 
@@ -106,12 +106,12 @@ let lastConnectionError: { reason: string; hasError: boolean } | null = null;
 
 /**
  * Broadcasts incoming RocketRide events to all subscribed listeners
- *
+ * 
  * Error Handling:
  * - Individual subscriber errors are caught and logged
  * - One failing subscriber doesn't affect others
  * - Ensures all subscribers receive the event
- *
+ * 
  * @param message - Event message from RocketRide client
  */
 async function handleEvent(message: any): Promise<void> {
@@ -126,12 +126,12 @@ async function handleEvent(message: any): Promise<void> {
 
 /**
  * Broadcasts connection event to all subscribed listeners
- *
+ * 
  * Flow:
  * 1. Clears any status messages (connection successful)
  * 2. Notifies all connection subscribers
  * 3. Allows subscribers to perform setup (e.g., initialize pipelines)
- *
+ * 
  * @param client - The connected RocketRideClient instance
  */
 async function handleConnected(client: RocketRideClient): Promise<void> {
@@ -158,17 +158,17 @@ async function handleConnected(client: RocketRideClient): Promise<void> {
 
 /**
  * Broadcasts disconnection event to all subscribed listeners
- *
+ * 
  * Flow:
  * 1. Shows descriptive error message from server
  * 2. Notifies all disconnection subscribers
  * 3. SDK will automatically attempt reconnection
- *
+ * 
  * Server Error Messages:
  * - HTTP 400: Pipeline not running
  * - HTTP 401: Authentication error
  * - Other: Connection lost or network errors
- *
+ * 
  * @param reason - Reason for disconnection (from server or network)
  * @param hasError - Whether disconnection was due to an error
  */
@@ -235,19 +235,19 @@ async function handleDisconnected(reason: string, hasError: boolean): Promise<vo
 
 /**
  * Starts the RocketRide client singleton with persistent connection
- *
+ * 
  * This function initializes the client once and enables automatic reconnection.
  * If the client is already started, this function does nothing (idempotent).
- *
+ * 
  * Connection Flow:
  * - Creates RocketRideClient with persist: true
  * - Attempts initial connection (may fail if pipeline not running)
  * - SDK automatically retries connection every 1 second
  * - onConnected/onDisconnected callbacks notify subscribers
- *
+ * 
  * @param authToken - Authentication token (obtained by App from URL, session storage, or config)
  * @throws Error if authentication token is missing
- *
+ * 
  * @example
  * ```typescript
  * // In App.tsx
@@ -275,7 +275,8 @@ export async function startClient(authToken: string): Promise<void> {
 		onDisconnected: async (reason?: string, hasError?: boolean) => {
 			await handleDisconnected(reason || 'Connection lost', hasError || false);
 		},
-		onConnectError: (error: ConnectionException) => handleDisconnected(error.message, true).catch((e) => console.error('handleDisconnected:', e)),
+		onConnectError: (error: ConnectionException) =>
+			handleDisconnected(error.message, true).catch((e) => console.error('handleDisconnected:', e)),
 		env: API_CONFIG,
 	};
 
@@ -307,10 +308,10 @@ export function getClient(): RocketRideClient | null {
 
 /**
  * Stops the RocketRide client and disables persistent connection
- *
+ * 
  * Disconnects from the server and clears the singleton instance.
  * After calling this, you must call startClient() again to reconnect.
- *
+ * 
  * @example
  * ```typescript
  * await stopClient();
@@ -329,18 +330,18 @@ export async function stopClient(): Promise<void> {
 
 /**
  * Subscribes to client events with automatic cleanup
- *
+ * 
  * Subscription Pattern:
  * - Register callbacks for events, connection, disconnection, status
  * - Returns unsubscribe function for cleanup
  * - Safe to call during component unmount
- *
+ * 
  * Callback Types:
  * - onEvent: Called for each RocketRide message
  * - onConnected: Called once when connection established
  * - onDisconnected: Called when connection lost
  * - onStatusChange: Called for UI status updates
- *
+ * 
  * Usage Pattern:
  * ```typescript
  * useEffect(() => {
@@ -349,15 +350,20 @@ export async function stopClient(): Promise<void> {
  *     onConnected: (client) => console.log('Connected'),
  *     onDisconnected: (reason) => console.log('Disconnected:', reason)
  *   });
- *
+ *   
  *   return () => unsubscribe(); // Cleanup on unmount
  * }, []);
  * ```
- *
+ * 
  * @param callbacks - Object containing optional callback functions
  * @returns Unsubscribe function to remove all callbacks
  */
-export function subscribeToClient(callbacks: { onEvent?: EventSubscriber; onConnected?: ConnectionSubscriber; onDisconnected?: DisconnectionSubscriber; onStatusChange?: StatusSubscriber }): () => void {
+export function subscribeToClient(callbacks: {
+	onEvent?: EventSubscriber;
+	onConnected?: ConnectionSubscriber;
+	onDisconnected?: DisconnectionSubscriber;
+	onStatusChange?: StatusSubscriber;
+}): () => void {
 	const { onEvent, onConnected, onDisconnected, onStatusChange } = callbacks;
 
 	// Add callbacks to subscriber sets

--- a/apps/dropper-ui/src/hooks/clientSingleton.ts
+++ b/apps/dropper-ui/src/hooks/clientSingleton.ts
@@ -6,10 +6,10 @@
 
 /**
  * RocketRide Client Singleton Module
- *
+ * 
  * Manages a single, shared WebSocket connection to RocketRideservices across
  * the entire application. This singleton pattern ensures:
- *
+ * 
  * Benefits:
  * - Only one WebSocket connection exists (no duplicate connections)
  * - Connection persists across component mount/unmount cycles
@@ -17,25 +17,25 @@
  * - Multiple components can share the same connection
  * - Automatic reconnection handling
  * - Centralized event broadcasting
- *
+ * 
  * Architecture:
  * - Singleton instance stored outside React lifecycle
  * - Pub/sub pattern for event distribution
  * - Promise-based connection management
  * - Session-based authentication caching
- *
+ * 
  * Event Types:
  * - Connection events: broadcast when WebSocket connects
  * - Disconnection events: broadcast when WebSocket disconnects
  * - Message events: broadcast for all incoming RocketRidemessages
  * - Status events: broadcast for UI status updates
- *
+ * 
  * Authentication Flow:
  * 1. Check session storage for cached token
  * 2. In dev mode: use API key from config
  * 3. In production: check URL params or fetch from /api/auth
  * 4. Cache token in session storage for reuse
- *
+ * 
  * @module clientSingleton
  */
 
@@ -93,23 +93,23 @@ let lastConnectionError: { reason: string; hasError: boolean } | null = null;
 
 /**
  * Retrieves authentication token from various sources
- *
+ * 
  * Token Priority:
  * 1. Session storage (cached from previous retrieval)
  * 2. Dev mode: API key from configuration
  * 3. Production: URL parameter or /api/auth endpoint
- *
+ * 
  * Caching:
  * - Tokens are cached in sessionStorage for reuse
  * - Reduces authentication requests
  * - Cleared on browser tab close
- *
+ * 
  * URL Cleanup:
  * - Removes token from URL bar after extraction (security)
  * - Uses history.replaceState to avoid adding to browser history
- *
+ * 
  * @returns Authentication token string or null if unavailable
- *
+ * 
  * @example
  * ```typescript
  * const token = await getAuthToken();
@@ -144,7 +144,7 @@ async function getAuthToken(): Promise<string | null> {
 		} else {
 			// Token found in URL - clean up URL bar for security
 			if (window.location.search.includes('token=')) {
-				window.history.replaceState({}, '', window.location.pathname);
+				window.history.replaceState({}, "", window.location.pathname);
 			}
 		}
 	}
@@ -160,12 +160,12 @@ async function getAuthToken(): Promise<string | null> {
 
 /**
  * Broadcasts incoming RocketRideevents to all subscribed listeners
- *
+ * 
  * Error Handling:
  * - Individual subscriber errors are caught and logged
  * - One failing subscriber doesn't affect others
  * - Ensures all subscribers receive the event
- *
+ * 
  * @param message - Event message from RocketRideclient
  */
 async function handleEvent(message: any): Promise<void> {
@@ -180,12 +180,12 @@ async function handleEvent(message: any): Promise<void> {
 
 /**
  * Broadcasts connection event to all subscribed listeners
- *
+ * 
  * Flow:
  * 1. Clears any status messages (connection successful)
  * 2. Notifies all connection subscribers
  * 3. Allows subscribers to perform setup (e.g., initialize pipelines)
- *
+ * 
  * @param client - The connected RocketRideClient instance
  */
 async function handleConnected(client: RocketRideClient): Promise<void> {
@@ -212,17 +212,17 @@ async function handleConnected(client: RocketRideClient): Promise<void> {
 
 /**
  * Broadcasts disconnection event to all subscribed listeners
- *
+ * 
  * Flow:
  * 1. Shows descriptive error message from server
  * 2. Notifies all disconnection subscribers
  * 3. SDK will automatically attempt reconnection
- *
+ * 
  * Server Error Messages:
  * - HTTP 400: Pipeline not running
  * - HTTP 401: Authentication error
  * - Other: Connection lost or network errors
- *
+ * 
  * @param reason - Reason for disconnection (from server or network)
  * @param hasError - Whether disconnection was due to an error
  */
@@ -253,14 +253,14 @@ async function handleDisconnected(reason: string, hasError: boolean): Promise<vo
 
 /**
  * Starts the RocketRideclient singleton with persistent connection
- *
+ * 
  * This function initializes the client once and enables automatic reconnection.
  * If the client is already started, this function does nothing (idempotent).
  * With persist, the client retries from initial failure and calls onConnectError.
- *
+ * 
  * @param authToken - Optional authentication token. If not provided, calls getAuthToken()
  * @throws Error if authentication token cannot be obtained
- *
+ * 
  * @example
  * ```typescript
  * // In App.tsx
@@ -274,16 +274,15 @@ export async function startClient(authToken?: string): Promise<void> {
 	}
 
 	// Get authentication token
-	const token = authToken || (await getAuthToken());
-
+	const token = authToken || await getAuthToken();
+	
 	if (!token) {
 		throw new Error("Sorry, I couldn't get you authenticated. Please contact your system admin.");
 	}
 
 	// Create client first (before config) so we can reference it in callbacks
-	// eslint-disable-next-line prefer-const
 	let client: RocketRideClient;
-
+	
 	const config: RocketRideClientConfig = {
 		auth: token,
 		uri: API_CONFIG.ROCKETRIDE_URI || (typeof window !== 'undefined' ? window.location.origin : ''),
@@ -295,7 +294,8 @@ export async function startClient(authToken?: string): Promise<void> {
 		onDisconnected: async (reason?: string, hasError?: boolean) => {
 			await handleDisconnected(reason || 'Connection lost', hasError || false);
 		},
-		onConnectError: (error: ConnectionException) => handleDisconnected(error.message, true).catch((e) => console.error('handleDisconnected:', e)),
+		onConnectError: (error: ConnectionException) =>
+			handleDisconnected(error.message, true).catch((e) => console.error('handleDisconnected:', e)),
 		env: API_CONFIG,
 	};
 
@@ -306,12 +306,12 @@ export async function startClient(authToken?: string): Promise<void> {
 
 /**
  * Gets the current RocketRideclient instance
- *
+ * 
  * Returns the singleton client instance if started, null otherwise.
  * Does not create or start the client - use startClient() first.
- *
+ * 
  * @returns The RocketRideClient instance or null if not started
- *
+ * 
  * @example
  * ```typescript
  * const client = getClient();
@@ -326,10 +326,10 @@ export function getClient(): RocketRideClient | null {
 
 /**
  * Stops the RocketRideclient and disables persistent connection
- *
+ * 
  * Disconnects from the server and clears the singleton instance.
  * After calling this, you must call startClient() again to reconnect.
- *
+ * 
  * @example
  * ```typescript
  * await stopClient();
@@ -348,18 +348,18 @@ export async function stopClient(): Promise<void> {
 
 /**
  * Subscribes to client events with automatic cleanup
- *
+ * 
  * Subscription Pattern:
  * - Register callbacks for events, connection, disconnection, status
  * - Returns unsubscribe function for cleanup
  * - Safe to call during component unmount
- *
+ * 
  * Callback Types:
  * - onEvent: Called for each RocketRidemessage
  * - onConnected: Called once when connection established
  * - onDisconnected: Called when connection lost
  * - onStatusChange: Called for UI status updates
- *
+ * 
  * Usage Pattern:
  * ```typescript
  * useEffect(() => {
@@ -368,15 +368,20 @@ export async function stopClient(): Promise<void> {
  *     onConnected: (client) => console.log('Connected'),
  *     onDisconnected: (reason) => console.log('Disconnected:', reason)
  *   });
- *
+ *   
  *   return () => unsubscribe(); // Cleanup on unmount
  * }, []);
  * ```
- *
+ * 
  * @param callbacks - Object containing optional callback functions
  * @returns Unsubscribe function to remove all callbacks
  */
-export function subscribeToClient(callbacks: { onEvent?: EventSubscriber; onConnected?: ConnectionSubscriber; onDisconnected?: DisconnectionSubscriber; onStatusChange?: StatusSubscriber }): () => void {
+export function subscribeToClient(callbacks: {
+	onEvent?: EventSubscriber;
+	onConnected?: ConnectionSubscriber;
+	onDisconnected?: DisconnectionSubscriber;
+	onStatusChange?: StatusSubscriber;
+}): () => void {
 	const { onEvent, onConnected, onDisconnected, onStatusChange } = callbacks;
 
 	// Add callbacks to subscriber sets

--- a/apps/dropper-ui/src/hooks/clientSingleton.ts
+++ b/apps/dropper-ui/src/hooks/clientSingleton.ts
@@ -6,10 +6,10 @@
 
 /**
  * RocketRide Client Singleton Module
- * 
+ *
  * Manages a single, shared WebSocket connection to RocketRideservices across
  * the entire application. This singleton pattern ensures:
- * 
+ *
  * Benefits:
  * - Only one WebSocket connection exists (no duplicate connections)
  * - Connection persists across component mount/unmount cycles
@@ -17,29 +17,29 @@
  * - Multiple components can share the same connection
  * - Automatic reconnection handling
  * - Centralized event broadcasting
- * 
+ *
  * Architecture:
  * - Singleton instance stored outside React lifecycle
  * - Pub/sub pattern for event distribution
  * - Promise-based connection management
  * - Session-based authentication caching
- * 
+ *
  * Event Types:
  * - Connection events: broadcast when WebSocket connects
  * - Disconnection events: broadcast when WebSocket disconnects
  * - Message events: broadcast for all incoming RocketRidemessages
  * - Status events: broadcast for UI status updates
- * 
+ *
  * Authentication Flow:
  * 1. Check session storage for cached token
  * 2. In dev mode: use API key from config
  * 3. In production: check URL params or fetch from /api/auth
  * 4. Cache token in session storage for reuse
- * 
+ *
  * @module clientSingleton
  */
 
-import { RocketRideClient, RocketRideClientConfig } from 'rocketride';
+import { RocketRideClient, RocketRideClientConfig, ConnectionException } from 'rocketride';
 import { API_CONFIG } from '../config/apiConfig';
 
 // ============================================================================
@@ -93,23 +93,23 @@ let lastConnectionError: { reason: string; hasError: boolean } | null = null;
 
 /**
  * Retrieves authentication token from various sources
- * 
+ *
  * Token Priority:
  * 1. Session storage (cached from previous retrieval)
  * 2. Dev mode: API key from configuration
  * 3. Production: URL parameter or /api/auth endpoint
- * 
+ *
  * Caching:
  * - Tokens are cached in sessionStorage for reuse
  * - Reduces authentication requests
  * - Cleared on browser tab close
- * 
+ *
  * URL Cleanup:
  * - Removes token from URL bar after extraction (security)
  * - Uses history.replaceState to avoid adding to browser history
- * 
+ *
  * @returns Authentication token string or null if unavailable
- * 
+ *
  * @example
  * ```typescript
  * const token = await getAuthToken();
@@ -144,7 +144,7 @@ async function getAuthToken(): Promise<string | null> {
 		} else {
 			// Token found in URL - clean up URL bar for security
 			if (window.location.search.includes('token=')) {
-				window.history.replaceState({}, "", window.location.pathname);
+				window.history.replaceState({}, '', window.location.pathname);
 			}
 		}
 	}
@@ -160,12 +160,12 @@ async function getAuthToken(): Promise<string | null> {
 
 /**
  * Broadcasts incoming RocketRideevents to all subscribed listeners
- * 
+ *
  * Error Handling:
  * - Individual subscriber errors are caught and logged
  * - One failing subscriber doesn't affect others
  * - Ensures all subscribers receive the event
- * 
+ *
  * @param message - Event message from RocketRideclient
  */
 async function handleEvent(message: any): Promise<void> {
@@ -180,12 +180,12 @@ async function handleEvent(message: any): Promise<void> {
 
 /**
  * Broadcasts connection event to all subscribed listeners
- * 
+ *
  * Flow:
  * 1. Clears any status messages (connection successful)
  * 2. Notifies all connection subscribers
  * 3. Allows subscribers to perform setup (e.g., initialize pipelines)
- * 
+ *
  * @param client - The connected RocketRideClient instance
  */
 async function handleConnected(client: RocketRideClient): Promise<void> {
@@ -212,17 +212,17 @@ async function handleConnected(client: RocketRideClient): Promise<void> {
 
 /**
  * Broadcasts disconnection event to all subscribed listeners
- * 
+ *
  * Flow:
  * 1. Shows descriptive error message from server
  * 2. Notifies all disconnection subscribers
  * 3. SDK will automatically attempt reconnection
- * 
+ *
  * Server Error Messages:
  * - HTTP 400: Pipeline not running
  * - HTTP 401: Authentication error
  * - Other: Connection lost or network errors
- * 
+ *
  * @param reason - Reason for disconnection (from server or network)
  * @param hasError - Whether disconnection was due to an error
  */
@@ -253,14 +253,14 @@ async function handleDisconnected(reason: string, hasError: boolean): Promise<vo
 
 /**
  * Starts the RocketRideclient singleton with persistent connection
- * 
+ *
  * This function initializes the client once and enables automatic reconnection.
  * If the client is already started, this function does nothing (idempotent).
  * With persist, the client retries from initial failure and calls onConnectError.
- * 
+ *
  * @param authToken - Optional authentication token. If not provided, calls getAuthToken()
  * @throws Error if authentication token cannot be obtained
- * 
+ *
  * @example
  * ```typescript
  * // In App.tsx
@@ -274,15 +274,16 @@ export async function startClient(authToken?: string): Promise<void> {
 	}
 
 	// Get authentication token
-	const token = authToken || await getAuthToken();
-	
+	const token = authToken || (await getAuthToken());
+
 	if (!token) {
-		throw new Error('Sorry, I couldn\'t get you authenticated. Please contact your system admin.');
+		throw new Error("Sorry, I couldn't get you authenticated. Please contact your system admin.");
 	}
 
 	// Create client first (before config) so we can reference it in callbacks
+	// eslint-disable-next-line prefer-const
 	let client: RocketRideClient;
-	
+
 	const config: RocketRideClientConfig = {
 		auth: token,
 		uri: API_CONFIG.ROCKETRIDE_URI || (typeof window !== 'undefined' ? window.location.origin : ''),
@@ -294,9 +295,8 @@ export async function startClient(authToken?: string): Promise<void> {
 		onDisconnected: async (reason?: string, hasError?: boolean) => {
 			await handleDisconnected(reason || 'Connection lost', hasError || false);
 		},
-		onConnectError: (message: string) =>
-			handleDisconnected(message, true).catch((e) => console.error('handleDisconnected:', e)),
-		env: API_CONFIG
+		onConnectError: (error: ConnectionException) => handleDisconnected(error.message, true).catch((e) => console.error('handleDisconnected:', e)),
+		env: API_CONFIG,
 	};
 
 	client = new RocketRideClient(config);
@@ -306,12 +306,12 @@ export async function startClient(authToken?: string): Promise<void> {
 
 /**
  * Gets the current RocketRideclient instance
- * 
+ *
  * Returns the singleton client instance if started, null otherwise.
  * Does not create or start the client - use startClient() first.
- * 
+ *
  * @returns The RocketRideClient instance or null if not started
- * 
+ *
  * @example
  * ```typescript
  * const client = getClient();
@@ -326,10 +326,10 @@ export function getClient(): RocketRideClient | null {
 
 /**
  * Stops the RocketRideclient and disables persistent connection
- * 
+ *
  * Disconnects from the server and clears the singleton instance.
  * After calling this, you must call startClient() again to reconnect.
- * 
+ *
  * @example
  * ```typescript
  * await stopClient();
@@ -348,18 +348,18 @@ export async function stopClient(): Promise<void> {
 
 /**
  * Subscribes to client events with automatic cleanup
- * 
+ *
  * Subscription Pattern:
  * - Register callbacks for events, connection, disconnection, status
  * - Returns unsubscribe function for cleanup
  * - Safe to call during component unmount
- * 
+ *
  * Callback Types:
  * - onEvent: Called for each RocketRidemessage
  * - onConnected: Called once when connection established
  * - onDisconnected: Called when connection lost
  * - onStatusChange: Called for UI status updates
- * 
+ *
  * Usage Pattern:
  * ```typescript
  * useEffect(() => {
@@ -368,20 +368,15 @@ export async function stopClient(): Promise<void> {
  *     onConnected: (client) => console.log('Connected'),
  *     onDisconnected: (reason) => console.log('Disconnected:', reason)
  *   });
- *   
+ *
  *   return () => unsubscribe(); // Cleanup on unmount
  * }, []);
  * ```
- * 
+ *
  * @param callbacks - Object containing optional callback functions
  * @returns Unsubscribe function to remove all callbacks
  */
-export function subscribeToClient(callbacks: {
-	onEvent?: EventSubscriber;
-	onConnected?: ConnectionSubscriber;
-	onDisconnected?: DisconnectionSubscriber;
-	onStatusChange?: StatusSubscriber;
-}): () => void {
+export function subscribeToClient(callbacks: { onEvent?: EventSubscriber; onConnected?: ConnectionSubscriber; onDisconnected?: DisconnectionSubscriber; onStatusChange?: StatusSubscriber }): () => void {
 	const { onEvent, onConnected, onDisconnected, onStatusChange } = callbacks;
 
 	// Add callbacks to subscriber sets

--- a/apps/vscode/src/debugger/session.ts
+++ b/apps/vscode/src/debugger/session.ts
@@ -37,7 +37,10 @@ import { icons } from '../shared/util/icons';
 import { ConfigManager } from '../config';
 import { GenericEvent, GenericResponse, GenericRequest } from '../shared/types/protocol';
 
-import { LaunchRequest, AttachRequest } from '../shared/types/protocol';
+import {
+	LaunchRequest,
+	AttachRequest
+} from '../shared/types/protocol';
 
 /**
  * Debug Adapter with individual RocketRideClient connection
@@ -98,7 +101,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 				this.emitEvent({
 					type: 'event',
 					event: 'terminated',
-					body: {},
+					body: {}
 				});
 			},
 			onConnectError: async (error: ConnectionException) => {
@@ -116,7 +119,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 				this.emitEvent({
 					type: 'event',
 					event: 'terminated',
-					body: {},
+					body: {}
 				});
 			},
 		});
@@ -125,14 +128,14 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 	private emitResponse(message: GenericResponse): void {
 		this.messageEmitter.fire({
 			...message,
-			seq: this.getNextSeq(),
+			seq: this.getNextSeq()
 		});
 	}
 
 	private emitEvent(message: GenericEvent): void {
 		this.messageEmitter.fire({
 			...message,
-			seq: this.getNextSeq(),
+			seq: this.getNextSeq()
 		});
 	}
 
@@ -257,6 +260,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			if (this.isLaunchRequest(message)) {
 				message.arguments.pipeline = this.pipeline;
 				message.arguments.args = this.configManager.getEffectiveEngineArgs();
+
 			} else if (this.isAttachRequest(message)) {
 				this.token = message.arguments?.token;
 			}
@@ -264,7 +268,11 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			// Include token in the request
 			message.token = this.token;
 
-			const response = await this.client.dapRequest(message.command, message.arguments, message.token);
+			const response = await this.client.dapRequest(
+				message.command,
+				message.arguments,
+				message.token
+			);
 
 			// Cast DAPMessage to GenericResponse
 			const genericResponse = response as unknown as GenericResponse;
@@ -278,13 +286,14 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			}
 
 			this.emitResponse(genericResponse);
+
 		} catch (error) {
 			this.emitResponse({
 				type: 'response',
 				request_seq: message.seq,
 				command: message.command,
 				success: false,
-				message: error instanceof Error ? error.message : String(error),
+				message: error instanceof Error ? error.message : String(error)
 			});
 		}
 	}

--- a/apps/vscode/src/debugger/session.ts
+++ b/apps/vscode/src/debugger/session.ts
@@ -31,16 +31,13 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { RocketRideClient, DAPMessage } from 'rocketride';
+import { RocketRideClient, DAPMessage, ConnectionException } from 'rocketride';
 import { getLogger } from '../shared/util/output';
 import { icons } from '../shared/util/icons';
 import { ConfigManager } from '../config';
 import { GenericEvent, GenericResponse, GenericRequest } from '../shared/types/protocol';
 
-import {
-	LaunchRequest,
-	AttachRequest
-} from '../shared/types/protocol';
+import { LaunchRequest, AttachRequest } from '../shared/types/protocol';
 
 /**
  * Debug Adapter with individual RocketRideClient connection
@@ -101,25 +98,25 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 				this.emitEvent({
 					type: 'event',
 					event: 'terminated',
-					body: {}
+					body: {},
 				});
 			},
-			onConnectError: async (errorMessage: string) => {
-				this.logger.output(`${icons.error} ${errorMessage}`);
+			onConnectError: async (error: ConnectionException) => {
+				this.logger.output(`${icons.error} ${error.message}`);
 
 				this.emitEvent({
 					type: 'event',
 					event: 'output',
 					body: {
 						category: 'stderr',
-						output: `Connection error: ${errorMessage}\n`
-					}
+						output: `Connection error: ${error.message}\n`,
+					},
 				});
 
 				this.emitEvent({
 					type: 'event',
 					event: 'terminated',
-					body: {}
+					body: {},
 				});
 			},
 		});
@@ -128,14 +125,14 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 	private emitResponse(message: GenericResponse): void {
 		this.messageEmitter.fire({
 			...message,
-			seq: this.getNextSeq()
+			seq: this.getNextSeq(),
 		});
 	}
 
 	private emitEvent(message: GenericEvent): void {
 		this.messageEmitter.fire({
 			...message,
-			seq: this.getNextSeq()
+			seq: this.getNextSeq(),
 		});
 	}
 
@@ -260,7 +257,6 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			if (this.isLaunchRequest(message)) {
 				message.arguments.pipeline = this.pipeline;
 				message.arguments.args = this.configManager.getEffectiveEngineArgs();
-
 			} else if (this.isAttachRequest(message)) {
 				this.token = message.arguments?.token;
 			}
@@ -268,11 +264,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			// Include token in the request
 			message.token = this.token;
 
-			const response = await this.client.dapRequest(
-				message.command,
-				message.arguments,
-				message.token
-			);
+			const response = await this.client.dapRequest(message.command, message.arguments, message.token);
 
 			// Cast DAPMessage to GenericResponse
 			const genericResponse = response as unknown as GenericResponse;
@@ -286,14 +278,13 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			}
 
 			this.emitResponse(genericResponse);
-
 		} catch (error) {
 			this.emitResponse({
 				type: 'response',
 				request_seq: message.seq,
 				command: message.command,
 				success: false,
-				message: error instanceof Error ? error.message : String(error)
+				message: error instanceof Error ? error.message : String(error),
 			});
 		}
 	}

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2026 Aparavi Software AG
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,24 +28,24 @@ import { DAPMessage, EventCallback, RocketRideClientConfig, ConnectCallback, Dis
 import { TASK_STATUS, UPLOAD_RESULT, PIPELINE_RESULT, PipelineConfig } from './types/index.js';
 import { CONST_DEFAULT_WEB_CLOUD, CONST_DEFAULT_WEB_PROTOCOL, CONST_DEFAULT_WEB_PORT } from './constants.js';
 import { Question } from './schema/Question.js';
-import { AuthenticationException } from './exceptions/index.js';
+import { AuthenticationException, ConnectionException } from './exceptions/index.js';
 
 // Global counter for generating unique client IDs
 let clientId = 0;
 
 /**
  * Streaming data pipe for sending large datasets to RocketRide pipelines.
- * 
+ *
  * DataPipe provides a stream-like interface for uploading data to an RocketRide
  * pipeline. It handles the low-level protocol details of opening, writing to,
  * and closing data pipes on the server.
- * 
+ *
  * Usage pattern:
  * 1. Create pipe using client.pipe()
  * 2. Call open() to establish the pipe
  * 3. Call write() multiple times with data chunks
  * 4. Call close() to finalize and get results
- * 
+ *
  * @example
  * ```typescript
  * const pipe = await client.pipe(token, { filename: 'data.json' }, 'application/json');
@@ -76,14 +76,7 @@ export class DataPipe {
 	 * @param onSSE - Optional async callback invoked for each SSE event emitted by
 	 *                the pipeline node for this specific pipe
 	 */
-	constructor(
-		client: RocketRideClient,
-		token: string,
-		objinfo: Record<string, unknown> = {},
-		mimeType = 'application/octet-stream',
-		provider?: string,
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
-	) {
+	constructor(client: RocketRideClient, token: string, objinfo: Record<string, unknown> = {}, mimeType = 'application/octet-stream', provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>) {
 		this._client = client;
 		this._token = token;
 		this._objinfo = objinfo;
@@ -94,7 +87,7 @@ export class DataPipe {
 
 	/**
 	 * Check if the pipe is currently open for writing.
-	 * 
+	 *
 	 * @returns true if the pipe has been opened and not yet closed
 	 */
 	get isOpened(): boolean {
@@ -103,10 +96,10 @@ export class DataPipe {
 
 	/**
 	 * Get the unique ID assigned to this pipe by the server.
-	 * 
+	 *
 	 * This ID is assigned when the pipe is opened and is used for subsequent
 	 * write operations. It remains undefined until open() is called successfully.
-	 * 
+	 *
 	 * @returns The server-assigned pipe ID, or undefined if not yet opened
 	 */
 	get pipeId(): number | undefined {
@@ -115,11 +108,11 @@ export class DataPipe {
 
 	/**
 	 * Open the pipe for data transmission.
-	 * 
+	 *
 	 * Establishes a data pipe on the server for streaming data to the pipeline.
 	 * Must be called before any write() operations. The server will assign a
 	 * unique pipe ID that is used for subsequent operations.
-	 * 
+	 *
 	 * @returns This DataPipe instance (for method chaining)
 	 * @throws Error if the pipe is already opened or if the pipeline is not running
 	 */
@@ -158,10 +151,10 @@ export class DataPipe {
 
 	/**
 	 * Write data to the pipe.
-	 * 
+	 *
 	 * Sends a chunk of data through the pipe to the server pipeline. Can be called
 	 * multiple times to stream large datasets. The pipe must be opened first.
-	 * 
+	 *
 	 * @param buffer - Data to write, must be a Uint8Array
 	 * @throws Error if the pipe is not opened, buffer is invalid, or write fails
 	 */
@@ -192,11 +185,11 @@ export class DataPipe {
 
 	/**
 	 * Close the pipe and get the processing results.
-	 * 
+	 *
 	 * Finalizes the data stream and signals the server that no more data will be sent.
 	 * The server processes any buffered data and returns the final result. After closing,
 	 * the pipe cannot be reopened or written to again.
-	 * 
+	 *
 	 * @returns The processing result from the server, or undefined if already closed
 	 * @throws Error if closing the pipe fails
 	 */
@@ -239,11 +232,11 @@ export class DataPipe {
 
 /**
  * Main RocketRide client for connecting to RocketRide servers and services.
- * 
+ *
  * This client provides a comprehensive API for interacting with RocketRide services,
  * including connection management, pipeline execution, data operations, AI chat,
  * event handling, and server connectivity testing.
- * 
+ *
  * Key features:
  * - Single shared WebSocket connection for all operations
  * - Connection management (connect/disconnect) with optional persistence
@@ -282,13 +275,13 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Creates a new RocketRideClient instance.
-	 * 
+	 *
 	 * Configuration priority (highest to lowest):
 	 * 1. Values passed in config parameter (auth, uri)
 	 * 2. Values from env parameter (if provided)
 	 * 3. Values from .env file (Node.js only)
 	 * 4. Default values
-	 * 
+	 *
 	 * @param config - Configuration options for the client
 	 * @param config.auth - API key for authentication (required)
 	 * @param config.uri - Server URI (default: CONST_DEFAULT_SERVICE)
@@ -300,9 +293,9 @@ export class RocketRideClient extends DAPClient {
 	 * @param config.requestTimeout - Default timeout in ms for individual requests
 	 * @param config.maxRetryTime - Max total time in ms to keep retrying connections
 	 * @param config.module - Optional module name for client identification
-	 * 
+	 *
 	 * @throws Error if auth is not provided via config, env, or .env file
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Using explicit auth and URI
@@ -312,7 +305,7 @@ export class RocketRideClient extends DAPClient {
 	 *   persist: true,
 	 *   onEvent: (event) => console.log('Event:', event)
 	 * });
-	 * 
+	 *
 	 * // Using custom env dictionary
 	 * const client = new RocketRideClient({
 	 *   env: {
@@ -343,17 +336,7 @@ export class RocketRideClient extends DAPClient {
 			}
 		}
 
-		const {
-			auth = config.auth || clientEnv.ROCKETRIDE_APIKEY,
-			uri = config.uri || clientEnv.ROCKETRIDE_URI || CONST_DEFAULT_WEB_CLOUD,
-			onEvent,
-			onConnected,
-			onDisconnected,
-			onConnectError,
-			persist,
-			maxRetryTime,
-			module,
-		} = config;
+		const { auth = config.auth || clientEnv.ROCKETRIDE_APIKEY, uri = config.uri || clientEnv.ROCKETRIDE_URI || CONST_DEFAULT_WEB_CLOUD, onEvent, onConnected, onDisconnected, onConnectError, persist, maxRetryTime, module } = config;
 
 		// Create unique client identifier
 		const clientName = module || `CLIENT-${clientId++}`;
@@ -636,7 +619,7 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Test connectivity to the RocketRide server.
-	 * 
+	 *
 	 * Sends a lightweight ping request to the server to verify it's responding
 	 * and reachable. This is useful for connectivity testing, health checks,
 	 * and measuring response times.
@@ -686,7 +669,7 @@ export class RocketRideClient extends DAPClient {
 			return this.substituteEnvVars(obj);
 		} else if (Array.isArray(obj)) {
 			// If it's an array, process each element
-			return obj.map(item => this.processEnvSubstitution(item));
+			return obj.map((item) => this.processEnvSubstitution(item));
 		} else if (obj !== null && typeof obj === 'object') {
 			// If it's an object, process each property
 			const result: Record<string, unknown> = {};
@@ -768,17 +751,14 @@ export class RocketRideClient extends DAPClient {
 	 * }
 	 * ```
 	 */
-	async validate(options: {
-		pipeline: PipelineConfig | Record<string, unknown>;
-		source?: string;
-	}): Promise<Record<string, unknown>> {
+	async validate(options: { pipeline: PipelineConfig | Record<string, unknown>; source?: string }): Promise<Record<string, unknown>> {
 		const { pipeline, source } = options;
 		const arguments_: Record<string, unknown> = { pipeline };
 		if (source !== undefined) {
 			arguments_.source = source;
 		}
 		const request = this.buildRequest('rrext_validate', {
-			arguments: arguments_
+			arguments: arguments_,
 		});
 		const response = await this.request(request);
 		if (this.didFail(response)) {
@@ -835,29 +815,21 @@ export class RocketRideClient extends DAPClient {
 	 * const result = await client.use({ filepath: './chat.pipe', useExisting: true });
 	 * ```
 	 */
-	async use(options: {
-		token?: string;
-		filepath?: string;
-		pipeline?: PipelineConfig;
-		source?: string;
-		threads?: number;
-		useExisting?: boolean;
-		args?: string[];
-		ttl?: number;
-		/** Pipeline trace level. When set, captures every lane write and invoke call in the response under '_trace'. */
-		pipelineTraceLevel?: 'none' | 'metadata' | 'summary' | 'full';
-	} = {}): Promise<Record<string, unknown> & { token: string }> {
-		const {
-			token,
-			filepath,
-			pipeline,
-			source,
-			threads,
-			useExisting,
-			args,
-			ttl,
-			pipelineTraceLevel
-		} = options;
+	async use(
+		options: {
+			token?: string;
+			filepath?: string;
+			pipeline?: PipelineConfig;
+			source?: string;
+			threads?: number;
+			useExisting?: boolean;
+			args?: string[];
+			ttl?: number;
+			/** Pipeline trace level. When set, captures every lane write and invoke call in the response under '_trace'. */
+			pipelineTraceLevel?: 'none' | 'metadata' | 'summary' | 'full';
+		} = {}
+	): Promise<Record<string, unknown> & { token: string }> {
+		const { token, filepath, pipeline, source, threads, useExisting, args, ttl, pipelineTraceLevel } = options;
 
 		// Validate required parameters
 		if (!pipeline && !filepath) {
@@ -991,26 +963,14 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Create a data pipe for streaming operations.
 	 */
-	async pipe(
-		token: string,
-		objinfo: Record<string, unknown> = {},
-		mimeType?: string,
-		provider?: string,
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
-	): Promise<DataPipe> {
+	async pipe(token: string, objinfo: Record<string, unknown> = {}, mimeType?: string, provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<DataPipe> {
 		return new DataPipe(this, token, objinfo, mimeType, provider, onSSE);
 	}
 
 	/**
 	 * Send data to a running pipeline.
 	 */
-	async send(
-		token: string,
-		data: string | Uint8Array,
-		objinfo: Record<string, unknown> = {},
-		mimetype?: string,
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
-	): Promise<PIPELINE_RESULT | undefined> {
+	async send(token: string, data: string | Uint8Array, objinfo: Record<string, unknown> = {}, mimetype?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<PIPELINE_RESULT | undefined> {
 		// Convert string to bytes if needed
 		let buffer: Uint8Array;
 		if (typeof data === 'string') {
@@ -1043,27 +1003,27 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Upload multiple files to a pipeline with progress tracking and parallel execution.
-	 * 
+	 *
 	 * This method efficiently uploads files in parallel with configurable concurrency control.
 	 * Each file is streamed through a data pipe, and progress events are emitted through the
 	 * event system for all subscribers. The order of results matches the input file order.
-	 * 
+	 *
 	 * Progress events are sent through the event system as 'apaevt_status_upload' events
 	 * (matching Python client behavior) rather than through a callback parameter.
-	 * 
+	 *
 	 * @param files - Array of file objects with optional metadata and MIME types
 	 * @param token - Pipeline task token to receive the uploads
 	 * @param maxConcurrent - Maximum number of concurrent uploads (default: 5)
-	 * 
+	 *
 	 * @returns Promise resolving to array of UPLOAD_RESULT objects in the same order as input
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Subscribe to upload events
 	 * client.on('apaevt_status_upload', (event) => {
 	 *   console.log(`${event.body.filepath}: ${event.body.bytes_sent}/${event.body.file_size}`);
 	 * });
-	 * 
+	 *
 	 * // Upload files
 	 * const results = await client.sendFiles(
 	 *   [
@@ -1094,7 +1054,7 @@ export class RocketRideClient extends DAPClient {
 				event: 'apaevt_status_upload',
 				body: body as unknown as Record<string, unknown>,
 				seq: 0,
-				type: 'event'
+				type: 'event',
 			};
 			this.onEvent(eventMessage);
 		};
@@ -1106,10 +1066,7 @@ export class RocketRideClient extends DAPClient {
 		 * 3. Close pipe
 		 * 4. Send status update
 		 */
-		const uploadFile = async (
-			fileData: { file: File; objinfo?: Record<string, unknown>; mimetype?: string },
-			index: number
-		): Promise<void> => {
+		const uploadFile = async (fileData: { file: File; objinfo?: Record<string, unknown>; mimetype?: string }, index: number): Promise<void> => {
 			const { file, objinfo = {}, mimetype } = fileData;
 			const startTime = Date.now();
 			let bytesUploaded = 0;
@@ -1177,7 +1134,6 @@ export class RocketRideClient extends DAPClient {
 				});
 
 				result = await pipe.close();
-
 			} catch (err) {
 				error = err instanceof Error ? err.message : String(err);
 			}
@@ -1199,8 +1155,8 @@ export class RocketRideClient extends DAPClient {
 		};
 
 		// Create a promise for every file - let server handle queuing
-		const uploadPromises = files.map((fileData, index) => 
-			uploadFile(fileData, index).catch(err => {
+		const uploadPromises = files.map((fileData, index) =>
+			uploadFile(fileData, index).catch((err) => {
 				// Ensure errors don't kill the whole batch
 				console.error(`Upload failed for ${fileData.file.name}:`, err);
 			})
@@ -1219,11 +1175,7 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Ask a question to RocketRide's AI and get an intelligent response.
 	 */
-	async chat(options: {
-		token: string;
-		question: Question;
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
-	}): Promise<PIPELINE_RESULT> {
+	async chat(options: { token: string; question: Question; onSSE?: (type: string, data: Record<string, unknown>) => Promise<void> }): Promise<PIPELINE_RESULT> {
 		const { token, question, onSSE } = options;
 
 		try {
@@ -1258,7 +1210,6 @@ export class RocketRideClient extends DAPClient {
 
 				// Return success response in standard format
 				return result;
-
 			} finally {
 				// Ensure the pipe is properly closed even if errors occur
 				if (pipe.isOpened) {
@@ -1269,7 +1220,6 @@ export class RocketRideClient extends DAPClient {
 					}
 				}
 			}
-
 		} catch (error) {
 			// Return error response in standard format
 			throw new Error(error instanceof Error ? error.message : String(error));
@@ -1360,7 +1310,8 @@ export class RocketRideClient extends DAPClient {
 	async onConnectError(error: Error): Promise<void> {
 		if (this._callerOnConnectError) {
 			try {
-				await this._callerOnConnectError(error instanceof Error ? error.message : String(error));
+				const connectionError = error instanceof ConnectionException ? error : new ConnectionException({ message: String(error) });
+				await this._callerOnConnectError(connectionError);
 			} catch (e) {
 				this.debugMessage(`Error in user onConnectError handler: ${e}`);
 			}
@@ -1447,18 +1398,18 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Save or update a project pipeline.
-	 * 
+	 *
 	 * Stores a project pipeline configuration on the server. If the project
 	 * already exists, it will be updated. Use expectedVersion to ensure
 	 * you're updating the version you expect (prevents conflicts).
-	 * 
+	 *
 	 * @param options - Save project options
 	 * @param options.projectId - Unique identifier for the project
 	 * @param options.pipeline - Pipeline configuration object
 	 * @param options.expectedVersion - Expected current version for atomic updates (optional)
 	 * @returns Promise resolving to save result with success status, projectId, and new version
 	 * @throws Error if save fails due to version mismatch, storage error, or invalid input
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Save a new project
@@ -1471,7 +1422,7 @@ export class RocketRideClient extends DAPClient {
 	 *   }
 	 * });
 	 * console.log(`Saved version: ${result.version}`);
-	 * 
+	 *
 	 * // Update existing project with version check
 	 * const existing = await client.getProject({ projectId: 'proj-123' });
 	 * existing.name = 'Updated Name';
@@ -1482,11 +1433,7 @@ export class RocketRideClient extends DAPClient {
 	 * });
 	 * ```
 	 */
-	async saveProject(options: {
-		projectId: string;
-		pipeline: Record<string, any>;
-		expectedVersion?: string;
-	}): Promise<{
+	async saveProject(options: { projectId: string; pipeline: Record<string, any>; expectedVersion?: string }): Promise<{
 		success: boolean;
 		project_id: string;
 		version: string;
@@ -1531,16 +1478,16 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve a project by its ID.
-	 * 
+	 *
 	 * Fetches the complete pipeline configuration and current version for
 	 * the specified project. Use this before updating to get the current
 	 * version for atomic updates.
-	 * 
+	 *
 	 * @param options - Get project options
 	 * @param options.projectId - Unique identifier of the project to retrieve
 	 * @returns Promise resolving to project data with success status, pipeline, and version
 	 * @throws Error if project doesn't exist or retrieval fails
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Get a project
@@ -1553,7 +1500,7 @@ export class RocketRideClient extends DAPClient {
 	 *     console.log("Project doesn't exist");
 	 *   }
 	 * }
-	 * 
+	 *
 	 * // Before updating - get current version
 	 * const project = await client.getProject({ projectId: 'proj-123' });
 	 * project.name = 'Updated';
@@ -1564,9 +1511,7 @@ export class RocketRideClient extends DAPClient {
 	 * });
 	 * ```
 	 */
-	async getProject(options: {
-		projectId: string;
-	}): Promise<{
+	async getProject(options: { projectId: string }): Promise<{
 		success: boolean;
 		pipeline: Record<string, any>;
 		version: string;
@@ -1602,17 +1547,17 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Delete a project by its ID.
-	 * 
+	 *
 	 * Permanently removes a project from storage. Optionally verify the
 	 * version before deletion to ensure you're deleting the version you
 	 * expect (prevents accidental deletion of modified projects).
-	 * 
+	 *
 	 * @param options - Delete project options
 	 * @param options.projectId - Unique identifier of the project to delete
 	 * @param options.expectedVersion - Expected current version for atomic deletion (required)
 	 * @returns Promise resolving to deletion result with success status and message
 	 * @throws Error if project doesn't exist, version mismatch, or deletion fails
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Safe deletion with version check
@@ -1630,10 +1575,7 @@ export class RocketRideClient extends DAPClient {
 	 * }
 	 * ```
 	 */
-	async deleteProject(options: {
-		projectId: string;
-		expectedVersion?: string;
-	}): Promise<{
+	async deleteProject(options: { projectId: string; expectedVersion?: string }): Promise<{
 		success: boolean;
 		message: string;
 	}> {
@@ -1673,13 +1615,13 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * List all projects for the current user.
-	 * 
+	 *
 	 * Retrieves a summary of all projects stored for the authenticated user.
 	 * Each project summary includes the ID, name, list of data sources, and total component count.
-	 * 
+	 *
 	 * @returns Promise resolving to list result with success status, projects array, and count
 	 * @throws Error if retrieval fails
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // List all projects
@@ -1691,7 +1633,7 @@ export class RocketRideClient extends DAPClient {
 	 *     console.log(`  * ${source.name} (${source.provider})`);
 	 *   }
 	 * }
-	 * 
+	 *
 	 * // Find specific project
 	 * const result = await client.getAllProjects();
 	 * const myProject = result.projects.find(p => p.id === 'proj-123');
@@ -1739,11 +1681,11 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Save or update a template pipeline.
-	 * 
+	 *
 	 * Stores a template pipeline configuration on the server. Templates are system-wide
 	 * and accessible to all users. If the template already exists, it will be updated.
 	 * Use expectedVersion to ensure you're updating the version you expect.
-	 * 
+	 *
 	 * @param options - Save template options
 	 * @param options.templateId - Unique identifier for the template
 	 * @param options.pipeline - Pipeline configuration object
@@ -1751,11 +1693,7 @@ export class RocketRideClient extends DAPClient {
 	 * @returns Promise resolving to save result with success status, templateId, and new version
 	 * @throws Error if save fails due to version mismatch, storage error, or invalid input
 	 */
-	async saveTemplate(options: {
-		templateId: string;
-		pipeline: Record<string, any>;
-		expectedVersion?: string;
-	}): Promise<{
+	async saveTemplate(options: { templateId: string; pipeline: Record<string, any>; expectedVersion?: string }): Promise<{
 		success: boolean;
 		template_id: string;
 		version: string;
@@ -1801,9 +1739,7 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Retrieve a template by its ID.
 	 */
-	async getTemplate(options: {
-		templateId: string;
-	}): Promise<{
+	async getTemplate(options: { templateId: string }): Promise<{
 		success: boolean;
 		pipeline: Record<string, any>;
 		version: string;
@@ -1840,10 +1776,7 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Delete a template by its ID.
 	 */
-	async deleteTemplate(options: {
-		templateId: string;
-		expectedVersion?: string;
-	}): Promise<{
+	async deleteTemplate(options: { templateId: string; expectedVersion?: string }): Promise<{
 		success: boolean;
 		message: string;
 	}> {
@@ -1927,11 +1860,7 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Save a log file for a source run.
 	 */
-	async saveLog(options: {
-		projectId: string;
-		source: string;
-		contents: Record<string, any>;
-	}): Promise<{
+	async saveLog(options: { projectId: string; source: string; contents: Record<string, any> }): Promise<{
 		success: boolean;
 		filename: string;
 	}> {
@@ -1975,11 +1904,7 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Get a log file by source name and start time.
 	 */
-	async getLog(options: {
-		projectId: string;
-		source: string;
-		startTime: number;
-	}): Promise<{
+	async getLog(options: { projectId: string; source: string; startTime: number }): Promise<{
 		success: boolean;
 		contents: Record<string, any>;
 	}> {
@@ -2023,11 +1948,7 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * List log files for a project.
 	 */
-	async listLogs(options: {
-		projectId: string;
-		source?: string;
-		page?: number;
-	}): Promise<{
+	async listLogs(options: { projectId: string; source?: string; page?: number }): Promise<{
 		success: boolean;
 		logs: string[];
 		count: number;
@@ -2090,12 +2011,7 @@ export class RocketRideClient extends DAPClient {
 	 * @param timeout - Optional per-request timeout in ms
 	 * @returns The response DAPMessage from the server
 	 */
-	async dapRequest(
-		command: string,
-		args?: Record<string, unknown>,
-		token?: string,
-		timeout?: number
-	): Promise<DAPMessage> {
+	async dapRequest(command: string, args?: Record<string, unknown>, token?: string, timeout?: number): Promise<DAPMessage> {
 		const message = this.buildRequest(command, {
 			arguments: args,
 			token,
@@ -2119,10 +2035,7 @@ export class RocketRideClient extends DAPClient {
 	 * Static factory method for automatic connection management.
 	 * Equivalent to Python's async with pattern
 	 */
-	static async withConnection<T>(
-		config: RocketRideClientConfig,
-		callback: (client: RocketRideClient) => Promise<T>
-	): Promise<T> {
+	static async withConnection<T>(config: RocketRideClientConfig, callback: (client: RocketRideClient) => Promise<T>): Promise<T> {
 		const client = new RocketRideClient(config);
 		try {
 			await client.connect();
@@ -2138,24 +2051,24 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve all available service definitions from the server.
-	 * 
+	 *
 	 * Returns a dictionary containing all service definitions available on
 	 * the connected RocketRide server. Each service definition includes schemas,
 	 * UI schemas, and configuration metadata.
-	 * 
+	 *
 	 * @returns Promise resolving to object mapping service names to their definitions
 	 * @throws Error if the request fails or server returns an error
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Get all available services
 	 * const services = await client.getServices();
-	 * 
+	 *
 	 * // List available service names
 	 * for (const name of Object.keys(services)) {
 	 *   console.log(`Available service: ${name}`);
 	 * }
-	 * 
+	 *
 	 * // Access a specific service's schema
 	 * if (services['ocr']) {
 	 *   console.log('OCR schema:', services['ocr'].schema);
@@ -2181,14 +2094,14 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve a specific service definition from the server.
-	 * 
+	 *
 	 * Returns the definition for a specific service (connector) by name.
 	 * The definition includes schemas, UI schemas, and configuration metadata.
-	 * 
+	 *
 	 * @param service - Name of the service to retrieve (e.g., 'ocr', 'embed', 'chat')
 	 * @returns Promise resolving to service definition or undefined if not found
 	 * @throws Error if the request fails or server returns an error
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Get OCR service definition
@@ -2208,7 +2121,7 @@ export class RocketRideClient extends DAPClient {
 
 		// Build services request with specific service name
 		const request = this.buildRequest('rrext_services', {
-			arguments: { service }
+			arguments: { service },
 		});
 
 		// Send to server and wait for response

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -1,18 +1,18 @@
 /**
  * MIT License
- *
+ * 
  * Copyright (c) 2026 Aparavi Software AG
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,17 +35,17 @@ let clientId = 0;
 
 /**
  * Streaming data pipe for sending large datasets to RocketRide pipelines.
- *
+ * 
  * DataPipe provides a stream-like interface for uploading data to an RocketRide
  * pipeline. It handles the low-level protocol details of opening, writing to,
  * and closing data pipes on the server.
- *
+ * 
  * Usage pattern:
  * 1. Create pipe using client.pipe()
  * 2. Call open() to establish the pipe
  * 3. Call write() multiple times with data chunks
  * 4. Call close() to finalize and get results
- *
+ * 
  * @example
  * ```typescript
  * const pipe = await client.pipe(token, { filename: 'data.json' }, 'application/json');
@@ -76,7 +76,14 @@ export class DataPipe {
 	 * @param onSSE - Optional async callback invoked for each SSE event emitted by
 	 *                the pipeline node for this specific pipe
 	 */
-	constructor(client: RocketRideClient, token: string, objinfo: Record<string, unknown> = {}, mimeType = 'application/octet-stream', provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>) {
+	constructor(
+		client: RocketRideClient,
+		token: string,
+		objinfo: Record<string, unknown> = {},
+		mimeType = 'application/octet-stream',
+		provider?: string,
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
+	) {
 		this._client = client;
 		this._token = token;
 		this._objinfo = objinfo;
@@ -87,7 +94,7 @@ export class DataPipe {
 
 	/**
 	 * Check if the pipe is currently open for writing.
-	 *
+	 * 
 	 * @returns true if the pipe has been opened and not yet closed
 	 */
 	get isOpened(): boolean {
@@ -96,10 +103,10 @@ export class DataPipe {
 
 	/**
 	 * Get the unique ID assigned to this pipe by the server.
-	 *
+	 * 
 	 * This ID is assigned when the pipe is opened and is used for subsequent
 	 * write operations. It remains undefined until open() is called successfully.
-	 *
+	 * 
 	 * @returns The server-assigned pipe ID, or undefined if not yet opened
 	 */
 	get pipeId(): number | undefined {
@@ -108,11 +115,11 @@ export class DataPipe {
 
 	/**
 	 * Open the pipe for data transmission.
-	 *
+	 * 
 	 * Establishes a data pipe on the server for streaming data to the pipeline.
 	 * Must be called before any write() operations. The server will assign a
 	 * unique pipe ID that is used for subsequent operations.
-	 *
+	 * 
 	 * @returns This DataPipe instance (for method chaining)
 	 * @throws Error if the pipe is already opened or if the pipeline is not running
 	 */
@@ -151,10 +158,10 @@ export class DataPipe {
 
 	/**
 	 * Write data to the pipe.
-	 *
+	 * 
 	 * Sends a chunk of data through the pipe to the server pipeline. Can be called
 	 * multiple times to stream large datasets. The pipe must be opened first.
-	 *
+	 * 
 	 * @param buffer - Data to write, must be a Uint8Array
 	 * @throws Error if the pipe is not opened, buffer is invalid, or write fails
 	 */
@@ -185,11 +192,11 @@ export class DataPipe {
 
 	/**
 	 * Close the pipe and get the processing results.
-	 *
+	 * 
 	 * Finalizes the data stream and signals the server that no more data will be sent.
 	 * The server processes any buffered data and returns the final result. After closing,
 	 * the pipe cannot be reopened or written to again.
-	 *
+	 * 
 	 * @returns The processing result from the server, or undefined if already closed
 	 * @throws Error if closing the pipe fails
 	 */
@@ -232,11 +239,11 @@ export class DataPipe {
 
 /**
  * Main RocketRide client for connecting to RocketRide servers and services.
- *
+ * 
  * This client provides a comprehensive API for interacting with RocketRide services,
  * including connection management, pipeline execution, data operations, AI chat,
  * event handling, and server connectivity testing.
- *
+ * 
  * Key features:
  * - Single shared WebSocket connection for all operations
  * - Connection management (connect/disconnect) with optional persistence
@@ -275,13 +282,13 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Creates a new RocketRideClient instance.
-	 *
+	 * 
 	 * Configuration priority (highest to lowest):
 	 * 1. Values passed in config parameter (auth, uri)
 	 * 2. Values from env parameter (if provided)
 	 * 3. Values from .env file (Node.js only)
 	 * 4. Default values
-	 *
+	 * 
 	 * @param config - Configuration options for the client
 	 * @param config.auth - API key for authentication (required)
 	 * @param config.uri - Server URI (default: CONST_DEFAULT_SERVICE)
@@ -293,9 +300,9 @@ export class RocketRideClient extends DAPClient {
 	 * @param config.requestTimeout - Default timeout in ms for individual requests
 	 * @param config.maxRetryTime - Max total time in ms to keep retrying connections
 	 * @param config.module - Optional module name for client identification
-	 *
+	 * 
 	 * @throws Error if auth is not provided via config, env, or .env file
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // Using explicit auth and URI
@@ -305,7 +312,7 @@ export class RocketRideClient extends DAPClient {
 	 *   persist: true,
 	 *   onEvent: (event) => console.log('Event:', event)
 	 * });
-	 *
+	 * 
 	 * // Using custom env dictionary
 	 * const client = new RocketRideClient({
 	 *   env: {
@@ -336,7 +343,17 @@ export class RocketRideClient extends DAPClient {
 			}
 		}
 
-		const { auth = config.auth || clientEnv.ROCKETRIDE_APIKEY, uri = config.uri || clientEnv.ROCKETRIDE_URI || CONST_DEFAULT_WEB_CLOUD, onEvent, onConnected, onDisconnected, onConnectError, persist, maxRetryTime, module } = config;
+		const {
+			auth = config.auth || clientEnv.ROCKETRIDE_APIKEY,
+			uri = config.uri || clientEnv.ROCKETRIDE_URI || CONST_DEFAULT_WEB_CLOUD,
+			onEvent,
+			onConnected,
+			onDisconnected,
+			onConnectError,
+			persist,
+			maxRetryTime,
+			module,
+		} = config;
 
 		// Create unique client identifier
 		const clientName = module || `CLIENT-${clientId++}`;
@@ -619,7 +636,7 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Test connectivity to the RocketRide server.
-	 *
+	 * 
 	 * Sends a lightweight ping request to the server to verify it's responding
 	 * and reachable. This is useful for connectivity testing, health checks,
 	 * and measuring response times.
@@ -669,7 +686,7 @@ export class RocketRideClient extends DAPClient {
 			return this.substituteEnvVars(obj);
 		} else if (Array.isArray(obj)) {
 			// If it's an array, process each element
-			return obj.map((item) => this.processEnvSubstitution(item));
+			return obj.map(item => this.processEnvSubstitution(item));
 		} else if (obj !== null && typeof obj === 'object') {
 			// If it's an object, process each property
 			const result: Record<string, unknown> = {};
@@ -751,14 +768,17 @@ export class RocketRideClient extends DAPClient {
 	 * }
 	 * ```
 	 */
-	async validate(options: { pipeline: PipelineConfig | Record<string, unknown>; source?: string }): Promise<Record<string, unknown>> {
+	async validate(options: {
+		pipeline: PipelineConfig | Record<string, unknown>;
+		source?: string;
+	}): Promise<Record<string, unknown>> {
 		const { pipeline, source } = options;
 		const arguments_: Record<string, unknown> = { pipeline };
 		if (source !== undefined) {
 			arguments_.source = source;
 		}
 		const request = this.buildRequest('rrext_validate', {
-			arguments: arguments_,
+			arguments: arguments_
 		});
 		const response = await this.request(request);
 		if (this.didFail(response)) {
@@ -815,21 +835,29 @@ export class RocketRideClient extends DAPClient {
 	 * const result = await client.use({ filepath: './chat.pipe', useExisting: true });
 	 * ```
 	 */
-	async use(
-		options: {
-			token?: string;
-			filepath?: string;
-			pipeline?: PipelineConfig;
-			source?: string;
-			threads?: number;
-			useExisting?: boolean;
-			args?: string[];
-			ttl?: number;
-			/** Pipeline trace level. When set, captures every lane write and invoke call in the response under '_trace'. */
-			pipelineTraceLevel?: 'none' | 'metadata' | 'summary' | 'full';
-		} = {}
-	): Promise<Record<string, unknown> & { token: string }> {
-		const { token, filepath, pipeline, source, threads, useExisting, args, ttl, pipelineTraceLevel } = options;
+	async use(options: {
+		token?: string;
+		filepath?: string;
+		pipeline?: PipelineConfig;
+		source?: string;
+		threads?: number;
+		useExisting?: boolean;
+		args?: string[];
+		ttl?: number;
+		/** Pipeline trace level. When set, captures every lane write and invoke call in the response under '_trace'. */
+		pipelineTraceLevel?: 'none' | 'metadata' | 'summary' | 'full';
+	} = {}): Promise<Record<string, unknown> & { token: string }> {
+		const {
+			token,
+			filepath,
+			pipeline,
+			source,
+			threads,
+			useExisting,
+			args,
+			ttl,
+			pipelineTraceLevel
+		} = options;
 
 		// Validate required parameters
 		if (!pipeline && !filepath) {
@@ -963,14 +991,26 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Create a data pipe for streaming operations.
 	 */
-	async pipe(token: string, objinfo: Record<string, unknown> = {}, mimeType?: string, provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<DataPipe> {
+	async pipe(
+		token: string,
+		objinfo: Record<string, unknown> = {},
+		mimeType?: string,
+		provider?: string,
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
+	): Promise<DataPipe> {
 		return new DataPipe(this, token, objinfo, mimeType, provider, onSSE);
 	}
 
 	/**
 	 * Send data to a running pipeline.
 	 */
-	async send(token: string, data: string | Uint8Array, objinfo: Record<string, unknown> = {}, mimetype?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<PIPELINE_RESULT | undefined> {
+	async send(
+		token: string,
+		data: string | Uint8Array,
+		objinfo: Record<string, unknown> = {},
+		mimetype?: string,
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
+	): Promise<PIPELINE_RESULT | undefined> {
 		// Convert string to bytes if needed
 		let buffer: Uint8Array;
 		if (typeof data === 'string') {
@@ -1003,27 +1043,27 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Upload multiple files to a pipeline with progress tracking and parallel execution.
-	 *
+	 * 
 	 * This method efficiently uploads files in parallel with configurable concurrency control.
 	 * Each file is streamed through a data pipe, and progress events are emitted through the
 	 * event system for all subscribers. The order of results matches the input file order.
-	 *
+	 * 
 	 * Progress events are sent through the event system as 'apaevt_status_upload' events
 	 * (matching Python client behavior) rather than through a callback parameter.
-	 *
+	 * 
 	 * @param files - Array of file objects with optional metadata and MIME types
 	 * @param token - Pipeline task token to receive the uploads
 	 * @param maxConcurrent - Maximum number of concurrent uploads (default: 5)
-	 *
+	 * 
 	 * @returns Promise resolving to array of UPLOAD_RESULT objects in the same order as input
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // Subscribe to upload events
 	 * client.on('apaevt_status_upload', (event) => {
 	 *   console.log(`${event.body.filepath}: ${event.body.bytes_sent}/${event.body.file_size}`);
 	 * });
-	 *
+	 * 
 	 * // Upload files
 	 * const results = await client.sendFiles(
 	 *   [
@@ -1054,7 +1094,7 @@ export class RocketRideClient extends DAPClient {
 				event: 'apaevt_status_upload',
 				body: body as unknown as Record<string, unknown>,
 				seq: 0,
-				type: 'event',
+				type: 'event'
 			};
 			this.onEvent(eventMessage);
 		};
@@ -1066,7 +1106,10 @@ export class RocketRideClient extends DAPClient {
 		 * 3. Close pipe
 		 * 4. Send status update
 		 */
-		const uploadFile = async (fileData: { file: File; objinfo?: Record<string, unknown>; mimetype?: string }, index: number): Promise<void> => {
+		const uploadFile = async (
+			fileData: { file: File; objinfo?: Record<string, unknown>; mimetype?: string },
+			index: number
+		): Promise<void> => {
 			const { file, objinfo = {}, mimetype } = fileData;
 			const startTime = Date.now();
 			let bytesUploaded = 0;
@@ -1134,6 +1177,7 @@ export class RocketRideClient extends DAPClient {
 				});
 
 				result = await pipe.close();
+
 			} catch (err) {
 				error = err instanceof Error ? err.message : String(err);
 			}
@@ -1155,8 +1199,8 @@ export class RocketRideClient extends DAPClient {
 		};
 
 		// Create a promise for every file - let server handle queuing
-		const uploadPromises = files.map((fileData, index) =>
-			uploadFile(fileData, index).catch((err) => {
+		const uploadPromises = files.map((fileData, index) => 
+			uploadFile(fileData, index).catch(err => {
 				// Ensure errors don't kill the whole batch
 				console.error(`Upload failed for ${fileData.file.name}:`, err);
 			})
@@ -1175,7 +1219,11 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Ask a question to RocketRide's AI and get an intelligent response.
 	 */
-	async chat(options: { token: string; question: Question; onSSE?: (type: string, data: Record<string, unknown>) => Promise<void> }): Promise<PIPELINE_RESULT> {
+	async chat(options: {
+		token: string;
+		question: Question;
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
+	}): Promise<PIPELINE_RESULT> {
 		const { token, question, onSSE } = options;
 
 		try {
@@ -1210,6 +1258,7 @@ export class RocketRideClient extends DAPClient {
 
 				// Return success response in standard format
 				return result;
+
 			} finally {
 				// Ensure the pipe is properly closed even if errors occur
 				if (pipe.isOpened) {
@@ -1220,6 +1269,7 @@ export class RocketRideClient extends DAPClient {
 					}
 				}
 			}
+
 		} catch (error) {
 			// Return error response in standard format
 			throw new Error(error instanceof Error ? error.message : String(error));
@@ -1398,18 +1448,18 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Save or update a project pipeline.
-	 *
+	 * 
 	 * Stores a project pipeline configuration on the server. If the project
 	 * already exists, it will be updated. Use expectedVersion to ensure
 	 * you're updating the version you expect (prevents conflicts).
-	 *
+	 * 
 	 * @param options - Save project options
 	 * @param options.projectId - Unique identifier for the project
 	 * @param options.pipeline - Pipeline configuration object
 	 * @param options.expectedVersion - Expected current version for atomic updates (optional)
 	 * @returns Promise resolving to save result with success status, projectId, and new version
 	 * @throws Error if save fails due to version mismatch, storage error, or invalid input
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // Save a new project
@@ -1422,7 +1472,7 @@ export class RocketRideClient extends DAPClient {
 	 *   }
 	 * });
 	 * console.log(`Saved version: ${result.version}`);
-	 *
+	 * 
 	 * // Update existing project with version check
 	 * const existing = await client.getProject({ projectId: 'proj-123' });
 	 * existing.name = 'Updated Name';
@@ -1433,7 +1483,11 @@ export class RocketRideClient extends DAPClient {
 	 * });
 	 * ```
 	 */
-	async saveProject(options: { projectId: string; pipeline: Record<string, any>; expectedVersion?: string }): Promise<{
+	async saveProject(options: {
+		projectId: string;
+		pipeline: Record<string, any>;
+		expectedVersion?: string;
+	}): Promise<{
 		success: boolean;
 		project_id: string;
 		version: string;
@@ -1478,16 +1532,16 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve a project by its ID.
-	 *
+	 * 
 	 * Fetches the complete pipeline configuration and current version for
 	 * the specified project. Use this before updating to get the current
 	 * version for atomic updates.
-	 *
+	 * 
 	 * @param options - Get project options
 	 * @param options.projectId - Unique identifier of the project to retrieve
 	 * @returns Promise resolving to project data with success status, pipeline, and version
 	 * @throws Error if project doesn't exist or retrieval fails
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // Get a project
@@ -1500,7 +1554,7 @@ export class RocketRideClient extends DAPClient {
 	 *     console.log("Project doesn't exist");
 	 *   }
 	 * }
-	 *
+	 * 
 	 * // Before updating - get current version
 	 * const project = await client.getProject({ projectId: 'proj-123' });
 	 * project.name = 'Updated';
@@ -1511,7 +1565,9 @@ export class RocketRideClient extends DAPClient {
 	 * });
 	 * ```
 	 */
-	async getProject(options: { projectId: string }): Promise<{
+	async getProject(options: {
+		projectId: string;
+	}): Promise<{
 		success: boolean;
 		pipeline: Record<string, any>;
 		version: string;
@@ -1547,17 +1603,17 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Delete a project by its ID.
-	 *
+	 * 
 	 * Permanently removes a project from storage. Optionally verify the
 	 * version before deletion to ensure you're deleting the version you
 	 * expect (prevents accidental deletion of modified projects).
-	 *
+	 * 
 	 * @param options - Delete project options
 	 * @param options.projectId - Unique identifier of the project to delete
 	 * @param options.expectedVersion - Expected current version for atomic deletion (required)
 	 * @returns Promise resolving to deletion result with success status and message
 	 * @throws Error if project doesn't exist, version mismatch, or deletion fails
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // Safe deletion with version check
@@ -1575,7 +1631,10 @@ export class RocketRideClient extends DAPClient {
 	 * }
 	 * ```
 	 */
-	async deleteProject(options: { projectId: string; expectedVersion?: string }): Promise<{
+	async deleteProject(options: {
+		projectId: string;
+		expectedVersion?: string;
+	}): Promise<{
 		success: boolean;
 		message: string;
 	}> {
@@ -1615,13 +1674,13 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * List all projects for the current user.
-	 *
+	 * 
 	 * Retrieves a summary of all projects stored for the authenticated user.
 	 * Each project summary includes the ID, name, list of data sources, and total component count.
-	 *
+	 * 
 	 * @returns Promise resolving to list result with success status, projects array, and count
 	 * @throws Error if retrieval fails
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // List all projects
@@ -1633,7 +1692,7 @@ export class RocketRideClient extends DAPClient {
 	 *     console.log(`  * ${source.name} (${source.provider})`);
 	 *   }
 	 * }
-	 *
+	 * 
 	 * // Find specific project
 	 * const result = await client.getAllProjects();
 	 * const myProject = result.projects.find(p => p.id === 'proj-123');
@@ -1681,11 +1740,11 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Save or update a template pipeline.
-	 *
+	 * 
 	 * Stores a template pipeline configuration on the server. Templates are system-wide
 	 * and accessible to all users. If the template already exists, it will be updated.
 	 * Use expectedVersion to ensure you're updating the version you expect.
-	 *
+	 * 
 	 * @param options - Save template options
 	 * @param options.templateId - Unique identifier for the template
 	 * @param options.pipeline - Pipeline configuration object
@@ -1693,7 +1752,11 @@ export class RocketRideClient extends DAPClient {
 	 * @returns Promise resolving to save result with success status, templateId, and new version
 	 * @throws Error if save fails due to version mismatch, storage error, or invalid input
 	 */
-	async saveTemplate(options: { templateId: string; pipeline: Record<string, any>; expectedVersion?: string }): Promise<{
+	async saveTemplate(options: {
+		templateId: string;
+		pipeline: Record<string, any>;
+		expectedVersion?: string;
+	}): Promise<{
 		success: boolean;
 		template_id: string;
 		version: string;
@@ -1739,7 +1802,9 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Retrieve a template by its ID.
 	 */
-	async getTemplate(options: { templateId: string }): Promise<{
+	async getTemplate(options: {
+		templateId: string;
+	}): Promise<{
 		success: boolean;
 		pipeline: Record<string, any>;
 		version: string;
@@ -1776,7 +1841,10 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Delete a template by its ID.
 	 */
-	async deleteTemplate(options: { templateId: string; expectedVersion?: string }): Promise<{
+	async deleteTemplate(options: {
+		templateId: string;
+		expectedVersion?: string;
+	}): Promise<{
 		success: boolean;
 		message: string;
 	}> {
@@ -1860,7 +1928,11 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Save a log file for a source run.
 	 */
-	async saveLog(options: { projectId: string; source: string; contents: Record<string, any> }): Promise<{
+	async saveLog(options: {
+		projectId: string;
+		source: string;
+		contents: Record<string, any>;
+	}): Promise<{
 		success: boolean;
 		filename: string;
 	}> {
@@ -1904,7 +1976,11 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Get a log file by source name and start time.
 	 */
-	async getLog(options: { projectId: string; source: string; startTime: number }): Promise<{
+	async getLog(options: {
+		projectId: string;
+		source: string;
+		startTime: number;
+	}): Promise<{
 		success: boolean;
 		contents: Record<string, any>;
 	}> {
@@ -1948,7 +2024,11 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * List log files for a project.
 	 */
-	async listLogs(options: { projectId: string; source?: string; page?: number }): Promise<{
+	async listLogs(options: {
+		projectId: string;
+		source?: string;
+		page?: number;
+	}): Promise<{
 		success: boolean;
 		logs: string[];
 		count: number;
@@ -2011,7 +2091,12 @@ export class RocketRideClient extends DAPClient {
 	 * @param timeout - Optional per-request timeout in ms
 	 * @returns The response DAPMessage from the server
 	 */
-	async dapRequest(command: string, args?: Record<string, unknown>, token?: string, timeout?: number): Promise<DAPMessage> {
+	async dapRequest(
+		command: string,
+		args?: Record<string, unknown>,
+		token?: string,
+		timeout?: number
+	): Promise<DAPMessage> {
 		const message = this.buildRequest(command, {
 			arguments: args,
 			token,
@@ -2035,7 +2120,10 @@ export class RocketRideClient extends DAPClient {
 	 * Static factory method for automatic connection management.
 	 * Equivalent to Python's async with pattern
 	 */
-	static async withConnection<T>(config: RocketRideClientConfig, callback: (client: RocketRideClient) => Promise<T>): Promise<T> {
+	static async withConnection<T>(
+		config: RocketRideClientConfig,
+		callback: (client: RocketRideClient) => Promise<T>
+	): Promise<T> {
 		const client = new RocketRideClient(config);
 		try {
 			await client.connect();
@@ -2051,24 +2139,24 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve all available service definitions from the server.
-	 *
+	 * 
 	 * Returns a dictionary containing all service definitions available on
 	 * the connected RocketRide server. Each service definition includes schemas,
 	 * UI schemas, and configuration metadata.
-	 *
+	 * 
 	 * @returns Promise resolving to object mapping service names to their definitions
 	 * @throws Error if the request fails or server returns an error
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // Get all available services
 	 * const services = await client.getServices();
-	 *
+	 * 
 	 * // List available service names
 	 * for (const name of Object.keys(services)) {
 	 *   console.log(`Available service: ${name}`);
 	 * }
-	 *
+	 * 
 	 * // Access a specific service's schema
 	 * if (services['ocr']) {
 	 *   console.log('OCR schema:', services['ocr'].schema);
@@ -2094,14 +2182,14 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve a specific service definition from the server.
-	 *
+	 * 
 	 * Returns the definition for a specific service (connector) by name.
 	 * The definition includes schemas, UI schemas, and configuration metadata.
-	 *
+	 * 
 	 * @param service - Name of the service to retrieve (e.g., 'ocr', 'embed', 'chat')
 	 * @returns Promise resolving to service definition or undefined if not found
 	 * @throws Error if the request fails or server returns an error
-	 *
+	 * 
 	 * @example
 	 * ```typescript
 	 * // Get OCR service definition
@@ -2121,7 +2209,7 @@ export class RocketRideClient extends DAPClient {
 
 		// Build services request with specific service name
 		const request = this.buildRequest('rrext_services', {
-			arguments: { service },
+			arguments: { service }
 		});
 
 		// Send to server and wait for response

--- a/packages/client-typescript/src/client/types/client.ts
+++ b/packages/client-typescript/src/client/types/client.ts
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2026 Aparavi Software AG
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,7 +24,7 @@
 
 /**
  * Type definitions for RocketRide client configuration and DAP communication.
- * 
+ *
  * This module defines the core types used for client-server communication
  * including DAP messages, callbacks, configuration options, and transport interfaces.
  */
@@ -80,7 +80,7 @@ export interface DAPMessage {
 
 /**
  * Callback functions for transport layer events and debugging.
- * 
+ *
  * These callbacks provide hooks for monitoring transport activity,
  * debugging protocol messages, and handling connection lifecycle events.
  */
@@ -114,7 +114,7 @@ export interface ConnectionInfo {
 
 /**
  * Callback function for handling real-time events from the server.
- * 
+ *
  * Events include pipeline status updates, processing progress,
  * error notifications, and system alerts.
  */
@@ -134,11 +134,11 @@ export type DisconnectCallback = (reason?: string, hasError?: boolean) => Promis
  * Callback when a connection attempt fails (e.g. auth or pipeline not ready).
  * Used in persist mode to inform the UI while the client keeps retrying.
  */
-export type ConnectErrorCallback = (message: string) => Promise<void>;
+export type ConnectErrorCallback = (error: Error | string) => void | Promise<void>;
 
 /**
  * Configuration options for creating an RocketRideClient instance.
- * 
+ *
  * Provides connection settings, authentication, and event handling
  * configuration for establishing and managing server connections.
  */
@@ -149,7 +149,7 @@ export interface RocketRideClientConfig {
 	/** Server URI (will be converted to WebSocket URI automatically) */
 	uri?: string;
 
-	/** 
+	/**
 	 * Environment variables dictionary for configuration and variable substitution.
 	 * If not provided, will load from .env file (Node.js only), then fall back to process.env
 	 */
@@ -185,5 +185,3 @@ export interface RocketRideClientConfig {
 	/** Client module name for debugging and identification */
 	module?: string;
 }
-
-

--- a/packages/client-typescript/src/client/types/client.ts
+++ b/packages/client-typescript/src/client/types/client.ts
@@ -29,6 +29,8 @@
  * including DAP messages, callbacks, configuration options, and transport interfaces.
  */
 
+import { ConnectionException } from '../exceptions/index.js';
+
 /**
  * Stack trace information for errors.
  */
@@ -134,7 +136,7 @@ export type DisconnectCallback = (reason?: string, hasError?: boolean) => Promis
  * Callback when a connection attempt fails (e.g. auth or pipeline not ready).
  * Used in persist mode to inform the UI while the client keeps retrying.
  */
-export type ConnectErrorCallback = (error: Error | string) => void | Promise<void>;
+export type ConnectErrorCallback = (error: ConnectionException) => void | Promise<void>;
 
 /**
  * Configuration options for creating an RocketRideClient instance.

--- a/packages/client-typescript/src/client/types/client.ts
+++ b/packages/client-typescript/src/client/types/client.ts
@@ -1,18 +1,18 @@
 /**
  * MIT License
- *
+ * 
  * Copyright (c) 2026 Aparavi Software AG
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -24,7 +24,7 @@
 
 /**
  * Type definitions for RocketRide client configuration and DAP communication.
- *
+ * 
  * This module defines the core types used for client-server communication
  * including DAP messages, callbacks, configuration options, and transport interfaces.
  */
@@ -82,7 +82,7 @@ export interface DAPMessage {
 
 /**
  * Callback functions for transport layer events and debugging.
- *
+ * 
  * These callbacks provide hooks for monitoring transport activity,
  * debugging protocol messages, and handling connection lifecycle events.
  */
@@ -116,7 +116,7 @@ export interface ConnectionInfo {
 
 /**
  * Callback function for handling real-time events from the server.
- *
+ * 
  * Events include pipeline status updates, processing progress,
  * error notifications, and system alerts.
  */
@@ -140,7 +140,7 @@ export type ConnectErrorCallback = (error: ConnectionException) => void | Promis
 
 /**
  * Configuration options for creating an RocketRideClient instance.
- *
+ * 
  * Provides connection settings, authentication, and event handling
  * configuration for establishing and managing server connections.
  */
@@ -151,7 +151,7 @@ export interface RocketRideClientConfig {
 	/** Server URI (will be converted to WebSocket URI automatically) */
 	uri?: string;
 
-	/**
+	/** 
 	 * Environment variables dictionary for configuration and variable substitution.
 	 * If not provided, will load from .env file (Node.js only), then fall back to process.env
 	 */


### PR DESCRIPTION
## Summary

- Change ConnectErrorCallback type from (message: string) => Promise<void> to (error: ConnectionException) =>
void | Promise<void> for richer error context in persist-mode retry callbacks
- Migrate all three consumer call sites (vscode debugger, chat-ui, dropper-ui) to accept ConnectionException and
 extract .message where a string is needed
- Apply code style fixes (prettier formatting, eslint prefer-const suppression) across touched files

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Connection error callbacks now receive a structured exception object (use error.message) and may return synchronously or a promise — update handlers accordingly.

* **Improvements**
  * Connection error handling unified across clients for more consistent reporting and debugging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->