### PR TITLE
fix(security): expand sensitive field redaction patterns in VS Code logger

### DIFF
--- a/apps/vscode/src/shared/util/output.ts
+++ b/apps/vscode/src/shared/util/output.ts
@@ -45,14 +45,30 @@ import * as vscode from 'vscode';
 import { icons } from './icons';
 
 /**
+ * Case-insensitive regex matching sensitive key names.
+ */
+const SENSITIVE_KEY_PATTERN = new RegExp(
+	[
+		'auth[-_]?key',
+		'auth[-_]?token',
+		'authorization',
+		'api[-_]?key',
+		'access[-_]?token',
+		'refresh[-_]?token',
+		'private[-_]?key',
+		'token',
+		'bearer',
+		'password',
+		'secret',
+		'credential',
+	].join('|'),
+	'i'
+);
+
+/**
  * Recursively redacts sensitive fields in an object.
  * Modifies the object in place, replacing values of sensitive keys with "*****".
- * 
- * Sensitive patterns (case-insensitive substring matching):
- * - Keys containing 'auth-key' (e.g., 'auth-key', 'user-auth-key')
- * - Keys containing 'token-key' (e.g., 'token-key', 'api-token-key')
- * - Keys containing 'apikey' (e.g., 'apikey', 'apiKey', 'user-apikey')
- * 
+ *
  * @param obj The object to redact (will be modified in place)
  */
 function redactSensitiveFields(obj: unknown): void {
@@ -74,10 +90,7 @@ function redactSensitiveFields(obj: unknown): void {
 		for (const key in record) {
 			if (Object.prototype.hasOwnProperty.call(record, key)) {
 				// Check if key contains any sensitive pattern (case-insensitive)
-				const lowerKey = key.toLowerCase();
-				if (lowerKey.includes('auth-key') ||
-				    lowerKey.includes('token-key') ||
-				    lowerKey.includes('apikey')) {
+				if (SENSITIVE_KEY_PATTERN.test(key)) {
 					record[key] = '*****';
 				} else {
 					// Recursively process nested objects/arrays
@@ -93,13 +106,11 @@ function redactSensitiveFields(obj: unknown): void {
  * 
  * This function uses a lazy redaction strategy for optimal performance:
  * 1. Stringify the object first (required anyway for output)
- * 2. Quick string search for sensitive field patterns
+ * 2. Quick regex search for sensitive field patterns
  * 3. Only if found, parse, redact, and re-stringify
  * 
  * This ensures minimal overhead for the common case where no sensitive
  * data is present, while still protecting keys when they do appear.
- * 
- * Sensitive patterns searched: auth-key, token-key, apikey (case-insensitive)
  * 
  * @param obj The object to stringify
  * @returns JSON string with sensitive values redacted
@@ -108,13 +119,8 @@ export function safeJSONStringify(obj: unknown): string {
 	// Stringify first - we need to do this anyway
 	const jsonString = JSON.stringify(obj);
 
-	// Quick check: does this contain sensitive fields?
-	// Search for common patterns in lowercase for case-insensitive matching
-	// Note: No quotes around patterns so we match any key containing these substrings
-	const lowerString = jsonString.toLowerCase();
-	if (lowerString.includes('auth-key') || 
-	    lowerString.includes('token-key') || 
-	    lowerString.includes('apikey')) {
+	// Quick check: does the serialized string contain any sensitive field names?
+	if (SENSITIVE_KEY_PATTERN.test(jsonString)) {
 		// Yes - parse (creating a deep clone), redact, and re-stringify
 		const parsed = JSON.parse(jsonString);
 		redactSensitiveFields(parsed);


### PR DESCRIPTION
## Summary
- **Vulnerability**: `redactSensitiveFields` in `apps/vscode/src/shared/util/output.ts` only redacted keys containing `auth-key`, `token-key`, or `apikey`, missing many common sensitive field names
- **Fix**: Expanded pattern matching to also redact keys containing `password`, `secret`, `authorization`, `bearer`, `credential`, `token` (broader match), `access_token`, `refresh_token`, and `private_key`
- Updated both the recursive `redactSensitiveFields` function and the fast-path check in `safeJSONStringify`

## Test plan
- [ ] Verify existing redaction for `auth-key`, `apikey` fields still works
- [ ] Verify new patterns (`password`, `authorization`, `secret`, `bearer`, `credential`, `token`, `access_token`, `refresh_token`, `private_key`) are now redacted
- [ ] Verify non-sensitive fields are not affected
- [ ] Run VS Code extension and confirm logger output redacts sensitive fields

#Hack-with-bay-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sensitive data redaction with enhanced pattern detection for identifying and masking confidential fields across the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->