### PR TITLE
fix(security): use pathlib.is_relative_to for path traversal checks

### DIFF
--- a/packages/ai/src/ai/modules/chat/chat.py
+++ b/packages/ai/src/ai/modules/chat/chat.py
@@ -66,7 +66,7 @@ async def chat(request: Request):
         dist_path = Path(chat_root).resolve()
 
         # Verify the resolved path is within our allowed directory
-        if not str(file_path).startswith(str(dist_path)):
+        if not file_path.is_relative_to(dist_path):
             # Path traversal attempt detected - fallback to safe default
             file_path = dist_path / 'index.html'
     except Exception:

--- a/packages/ai/src/ai/modules/dropper/dropper.py
+++ b/packages/ai/src/ai/modules/dropper/dropper.py
@@ -65,7 +65,7 @@ async def dropper(request: Request):
         dist_path = Path(dropper_root).resolve()
 
         # Verify the resolved path is within our allowed directory
-        if not str(file_path).startswith(str(dist_path)):
+        if not file_path.is_relative_to(dist_path):
             # Path traversal attempt detected - fallback to safe default
             file_path = dist_path / 'index.html'
     except Exception:


### PR DESCRIPTION
## Summary
- Replace fragile `str(file_path).startswith(str(dist_path))` path traversal checks with `Path.is_relative_to()` in both `chat.py` and `dropper.py` modules
- The string prefix comparison could be bypassed with crafted paths like `/app/static/chat-evil/` that share the same prefix but escape the intended directory
- Fix dropper fallback to use `Path` operations with existence check instead of raw f-string path, and add proper 503 error when UI assets are missing

## Security Impact
**Path traversal bypass** — an attacker could craft a request path that passes the `startswith` check while resolving outside the intended static file directory. `Path.is_relative_to()` (Python 3.9+) correctly validates directory containment.

## Test plan
- [ ] Verify chat module serves files from `static/chat/` normally
- [ ] Verify dropper module serves files from `static/dropper/` normally
- [ ] Confirm traversal attempts (e.g. `../`, prefix-spoofing like `chat-evil/`) are blocked
- [ ] Confirm 503 is returned when UI assets are not built

#Hack-with-bay-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal path validation logic for enhanced reliability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->