### PR TITLE
fix(ui): resolve dark mode icon and edge visibility in flow builder (…

### DIFF
--- a/packages/shared-ui/src/modules/flow/Flow.tsx
+++ b/packages/shared-ui/src/modules/flow/Flow.tsx
@@ -139,6 +139,14 @@ export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuse
 	// Rebuild MUI theme from --rr-* CSS custom properties
 	const currentTheme = useMemo(() => getMuiTheme(), [themeVersion]); // eslint-disable-line react-hooks/exhaustive-deps
 
+	// Sync --icon-filter on <body> whenever the theme changes.
+	// Kept as a side effect here (not inside getMuiTheme) so the theme
+	// function stays pure and safe to call from useMemo.
+	useEffect(() => {
+		const iconFilter = currentTheme.palette.mode === 'dark' ? 'brightness(0) invert(1)' : 'none';
+		document.body.style.setProperty('--icon-filter', iconFilter);
+	}, [currentTheme]);
+
 	// --- Render --------------------------------------------------------------
 
 	return (

--- a/packages/shared-ui/src/modules/flow/components/edge/FlowEdge.tsx
+++ b/packages/shared-ui/src/modules/flow/components/edge/FlowEdge.tsx
@@ -88,6 +88,7 @@ export default function FlowEdge({ id, sourceX, sourceY, targetX, targetY, sourc
 						style={{
 							position: 'absolute',
 							transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+							pointerEvents: 'all',
 						}}
 						className="nopan"
 					>

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/header/NodeHeader.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/header/NodeHeader.tsx
@@ -286,8 +286,8 @@ export default function NodeHeader({ id, hideEdit = false, nodeType, icon, title
 							size={16}
 							style={{
 								...styles.editIcon,
-								// Red gear when form data is invalid
-								color: formDataValid === false ? 'var(--rr-color-error)' : undefined,
+								// Red gear when form data is invalid; otherwise let editIcon.color stand.
+								...(formDataValid === false ? { color: 'var(--rr-color-error)' } : {}),
 							}}
 						/>
 					</button>

--- a/packages/shared-ui/src/modules/flow/components/node/node-component/header/more-menu/MoreMenu.tsx
+++ b/packages/shared-ui/src/modules/flow/components/node/node-component/header/more-menu/MoreMenu.tsx
@@ -75,7 +75,7 @@ export default function MoreMenu({ options, isDisabled, buttonSx }: IMoreMenuPro
 	return (
 		<>
 			<button aria-label="More options" onMouseDown={(event) => event.stopPropagation()} onClick={handleMenuClick} disabled={isDisabled} style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 0, display: 'inline-flex', alignItems: 'center', ...(typeof buttonSx === 'object' && !Array.isArray(buttonSx) ? (buttonSx as React.CSSProperties) : {}) }}>
-				<MoreVertical size={18} />
+				<MoreVertical size={18} style={{ color: 'var(--rr-text-secondary)' }} />
 			</button>
 
 			<Menu

--- a/packages/shared-ui/src/modules/flow/components/panels/create-node/CreateNodePanel.tsx
+++ b/packages/shared-ui/src/modules/flow/components/panels/create-node/CreateNodePanel.tsx
@@ -439,7 +439,7 @@ export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): Rea
 												(e.currentTarget as HTMLElement).style.backgroundColor = '';
 											}}
 										>
-											{service.icon && <img src={service.icon} alt="" style={styles.itemIcon} />}
+											{service.icon && <img src={service.icon} alt="" style={{ ...styles.itemIcon, filter: service.icon?.includes('#td') ? 'var(--icon-filter)' : undefined }} />}
 											<span style={styles.itemTitle}>{service.title ?? key}</span>
 											{Array.isArray(service.classType) && service.classType.includes('tool') && <span style={styles.badge}>Tool</span>}
 											{!!(service.capabilities && IServiceCapabilities.Experimental & service.capabilities) && <span style={styles.experimentalBadge}>Experimental</span>}

--- a/packages/shared-ui/src/modules/flow/components/reactflow-overrides.css
+++ b/packages/shared-ui/src/modules/flow/components/reactflow-overrides.css
@@ -11,6 +11,10 @@
 	--xy-node-border: none;
 	--xy-node-boxshadow-hover: var(--rr-shadow-hover);
 	--xy-node-boxshadow-selected: var(--rr-shadow-selected);
+
+	/* Edge stroke colour — visible on both light and dark backgrounds */
+	--xy-edge-stroke: var(--rr-text-disabled, #b1b1b7);
+	--xy-edge-stroke-selected: var(--rr-accent, #0078d4);
 }
 
 /* Suppress native focus ring — our box-shadow is the indicator */

--- a/packages/shared-ui/src/modules/flow/util/get-icon-path.ts
+++ b/packages/shared-ui/src/modules/flow/util/get-icon-path.ts
@@ -210,6 +210,7 @@ const THEME_DYNAMIC_ICONS: ReadonlySet<string> = new Set([
 	'webhook',
 	// Embeddings
 	'embedding-image',
+	'embedding-openai',
 	'embedding-text',
 	// LLMs
 	'anthropic',
@@ -243,6 +244,7 @@ const THEME_DYNAMIC_ICONS: ReadonlySet<string> = new Set([
 	'summaries',
 	'classification',
 	// Audio
+	'audio-player',
 	'audio-transcribe',
 	// Data
 	'hash',
@@ -252,6 +254,8 @@ const THEME_DYNAMIC_ICONS: ReadonlySet<string> = new Set([
 	// Infrastructure
 	'util-infrastructure',
 	'text-output',
+	// Accessibility
+	'accessibility-describe',
 ]);
 
 /**

--- a/packages/shared-ui/src/themes/dark.json
+++ b/packages/shared-ui/src/themes/dark.json
@@ -3,6 +3,7 @@
 	"--rr-palette-mode": "dark",
 	"--rr-bg-default": "#1e1e1e",
 	"--rr-bg-paper": "#252526",
+	"--rr-bg-surface": "#2a2a2a",
 	"--rr-bg-surface-alt": "#2d2d2d",
 	"--rr-fg-titleBar-active": "#cccccc",
 	"--rr-fg-titleBar-inactive": "#999999",

--- a/packages/shared-ui/src/themes/getMuiTheme.ts
+++ b/packages/shared-ui/src/themes/getMuiTheme.ts
@@ -141,14 +141,6 @@ export function getMuiTheme(): Theme {
 	const effectiveBg = vscodeEditorBg || bgDefault;
 	const isDark = isVsCodeDark || declaredMode === 'dark' || (declaredMode !== 'light' && isColorDark(effectiveBg));
 
-	// Set --icon-filter on <body> so it doesn't conflict with the CSS rules
-	// in rocketride-vscode.css (which also target body). For the web fallback
-	// and non-VS Code hosts, this ensures the variable is always defined.
-	const iconFilter = isDark ? 'brightness(0) invert(1)' : 'none';
-	if (typeof document !== 'undefined') {
-		document.body.style.setProperty('--icon-filter', iconFilter);
-	}
-
 	// Body-level font size in px (used for htmlFontSize and component sizing)
 	const bodyFontSizePx = fontSizeBody !== 'inherit' ? parseFloat(fontSizeBody) || 16 : 16;
 

--- a/packages/shared-ui/src/themes/getMuiTheme.ts
+++ b/packages/shared-ui/src/themes/getMuiTheme.ts
@@ -114,7 +114,6 @@ export function getMuiTheme(): Theme {
 	const fontWeightButton = parseInt(rr('--rr-font-weight-button', '600'), 10) || 600;
 
 	const paperBorder = rr('--rr-border-paper', '2px solid #eee');
-	const iconFilter = rr('--rr-icon-filter', 'none');
 
 	const scrollbarThumb = rr('--rr-bg-scrollbar-thumb', 'rgba(121,121,121,0.4)');
 
@@ -123,10 +122,32 @@ export function getMuiTheme(): Theme {
 
 	// --- Derived values -----------------------------------------------------
 
-	// Determine palette mode from the declared token, falling back to
-	// luminance-based detection from the background colour.
+	// Determine palette mode.
+	//
+	// Priority order:
+	//   1. VS Code's body attribute (data-vscode-theme-kind) — most reliable
+	//      signal when running inside a webview.
+	//   2. Explicit --rr-palette-mode CSS token (set by the web defaults).
+	//   3. Luminance-based detection from the effective background colour.
+	//
+	// The web CSS (rocketride-web.css) declares --rr-palette-mode: light, which
+	// is never overridden by the VS Code CSS because the theme kind is dynamic.
+	// Reading the body attribute bypasses that static declaration.
+	const vscodeThemeKind = typeof document !== 'undefined' ? document.body.getAttribute('data-vscode-theme-kind') || '' : '';
+	const isVsCodeDark = vscodeThemeKind === 'vscode-dark' || vscodeThemeKind === 'vscode-high-contrast';
+
 	const declaredMode = rr('--rr-palette-mode', '');
-	const isDark = declaredMode === 'dark' || (declaredMode !== 'light' && isColorDark(bgDefault));
+	const vscodeEditorBg = typeof document !== 'undefined' ? getComputedStyle(document.body).getPropertyValue('--vscode-editor-background').trim() : '';
+	const effectiveBg = vscodeEditorBg || bgDefault;
+	const isDark = isVsCodeDark || declaredMode === 'dark' || (declaredMode !== 'light' && isColorDark(effectiveBg));
+
+	// Set --icon-filter on <body> so it doesn't conflict with the CSS rules
+	// in rocketride-vscode.css (which also target body). For the web fallback
+	// and non-VS Code hosts, this ensures the variable is always defined.
+	const iconFilter = isDark ? 'brightness(0) invert(1)' : 'none';
+	if (typeof document !== 'undefined') {
+		document.body.style.setProperty('--icon-filter', iconFilter);
+	}
 
 	// Body-level font size in px (used for htmlFontSize and component sizing)
 	const bodyFontSizePx = fontSizeBody !== 'inherit' ? parseFloat(fontSizeBody) || 16 : 16;
@@ -168,9 +189,6 @@ export function getMuiTheme(): Theme {
 		components: {
 			MuiCssBaseline: {
 				styleOverrides: {
-					':root': {
-						'--icon-filter': iconFilter,
-					},
 					'@global': {
 						'.add-node-list-scroll': {
 							scrollbarWidth: 'thin' as const,

--- a/packages/shared-ui/src/themes/light.json
+++ b/packages/shared-ui/src/themes/light.json
@@ -3,6 +3,7 @@
 	"--rr-palette-mode": "light",
 	"--rr-bg-default": "#ffffff",
 	"--rr-bg-paper": "#ffffff",
+	"--rr-bg-surface": "#ffffff",
 	"--rr-bg-surface-alt": "#fafafa",
 	"--rr-fg-titleBar-active": "#1a1a1a",
 	"--rr-fg-titleBar-inactive": "#666666",

--- a/packages/shared-ui/src/themes/rocketride-default.css
+++ b/packages/shared-ui/src/themes/rocketride-default.css
@@ -62,6 +62,9 @@
 	/** Alternate surface for visually distinct sections (e.g. lanes). */
 	--rr-bg-surface-alt: #fafafa;
 
+	/** Generic surface — used for floating UI elements (e.g. edge delete button). */
+	--rr-bg-surface: #ffffff;
+
 	/* ================================================================== */
 	/* Title bar                                                           */
 	/* ================================================================== */

--- a/packages/shared-ui/src/themes/rocketride-vscode.css
+++ b/packages/shared-ui/src/themes/rocketride-vscode.css
@@ -26,9 +26,7 @@
 	/* Palette mode                                                        */
 	/* ================================================================== */
 
-	/* --rr-palette-mode and --rr-icon-filter are NOT overridden here
-	   because they depend on the active VS Code theme (light vs dark).
-	   getMuiTheme() computes them at runtime from --rr-bg-default. */
+	/* --rr-palette-mode is computed at runtime by getMuiTheme(). */
 
 	/* ================================================================== */
 	/* Backgrounds                                                         */
@@ -36,6 +34,7 @@
 
 	--rr-bg-default: var(--vscode-editor-background, #ffffff);
 	--rr-bg-paper: var(--vscode-editor-background, #ffffff);
+	--rr-bg-surface: var(--vscode-editor-background);
 	--rr-bg-surface-alt: var(--vscode-editor-background, #fafafa);
 
 	/* ================================================================== */
@@ -166,4 +165,25 @@
 
 	--rr-font-weight-h5: 700;
 	--rr-font-weight-button: 400;
+}
+
+/* ======================================================================
+ * Dark / High-Contrast theme overrides
+ *
+ * VS Code sets data-vscode-theme-kind on <body> to one of:
+ *   vscode-light | vscode-dark | vscode-high-contrast | vscode-high-contrast-light
+ *
+ * We use this to set --icon-filter in pure CSS — no JS required.
+ * This is the most reliable approach because it works even before
+ * getMuiTheme() runs and survives theme switches without a re-render.
+ * ====================================================================== */
+
+body[data-vscode-theme-kind='vscode-dark'],
+body[data-vscode-theme-kind='vscode-high-contrast'] {
+	--icon-filter: brightness(0) invert(1);
+}
+
+body[data-vscode-theme-kind='vscode-light'],
+body[data-vscode-theme-kind='vscode-high-contrast-light'] {
+	--icon-filter: none;
 }

--- a/packages/shared-ui/src/themes/tokens.ts
+++ b/packages/shared-ui/src/themes/tokens.ts
@@ -11,6 +11,7 @@ export type ThemeTokens = {
 	'--rr-palette-mode': string;
 	'--rr-bg-default': string;
 	'--rr-bg-paper': string;
+	'--rr-bg-surface': string;
 	'--rr-bg-surface-alt': string;
 	'--rr-fg-titleBar-active': string;
 	'--rr-fg-titleBar-inactive': string;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -491,6 +491,9 @@ importers:
       lodash:
         specifier: ~4.17.21
         version: 4.17.23
+      lucide-react:
+        specifier: ^0.540.0
+        version: 0.540.0(react@18.3.1)
       markdown-to-jsx:
         specifier: ~7.7.16
         version: 7.7.17(react@18.3.1)


### PR DESCRIPTION
## Summary

- Fix dark mode icon, edge, and button visibility in the `.pipe` flow builder when using VS Code dark themes
- Detect VS Code theme via `data-vscode-theme-kind` body attribute instead of relying on a static CSS variable
- Apply theme-aware fills and filters to icons, gear/menu buttons, and ReactFlow edges

## Type

fix

## Issue Description

When using any VS Code dark theme (Dark+, One Dark Pro, etc.), the flow builder renders dark icons on a dark background, making them invisible. The settings gear (⚙️), three-dots menu (⋮), and connection edges between nodes are also invisible or extremely faint.

### Steps to Reproduce

1. Install the RocketRide VS Code extension
2. Set VS Code to a dark theme (e.g., "Dark+")
3. Open any `.pipe` file
4. Observe the canvas: node icons, sidebar icons, gear button, three-dots menu, and edges are invisible

### Expected vs Actual Behavior

**Before the fix (actual):**
- Node icons in the canvas and sidebar are dark-on-dark (invisible)
- Settings gear icon is invisible (empty string fill overrides the base style)
- Three-dots menu icon is invisible (inherits default MUI colour, not theme-aware)
- Connection edges are barely visible (default `#b1b1b7` on dark background)

**After the fix (expected and verified):**
- All node icons are white-on-dark (properly inverted via `--icon-filter`)
- Settings gear is visible using `var(--rr-text-secondary)` fill
- Three-dots menu uses explicit theme-aware fill
- Edges use `var(--rr-text-disabled)` for visibility on both light and dark

## Why this bug happens in this codebase

The theme system has two CSS layers:

1. **`rocketride-web.css`** declares `--rr-palette-mode: light` as a static default for the web app.
2. **`rocketride-vscode.css`** maps `--rr-*` tokens to `--vscode-*` equivalents but **never overrides `--rr-palette-mode`** because VS Code's theme is dynamic — it's set at runtime via the `data-vscode-theme-kind` attribute on `<body>`, not as a CSS variable.

In **`getMuiTheme.ts`**, the function reads `--rr-palette-mode` to determine `isDark`. Since this is always `'light'` (from the web defaults, never overridden by VS Code CSS), the MUI palette stays in light mode. Consequently, `--icon-filter` is never set to `brightness(0) invert(1)`, so dark SVG icons remain dark.

Additionally:
- **`NodeHeader.tsx`** sets `fill: formDataValid === false ? red[500] : ''`. The empty string `''` becomes an inline style that **overrides** the base `editIcon` style's `fill: 'var(--rr-text-secondary)'`, blanking the gear icon.
- **`MoreMenu.tsx`** renders `<MoreVert>` without an explicit `fill`, so it inherits a default colour invisible on dark panels.
- **`reactflow-overrides.css`** sets custom node styling but does not override `--xy-edge-stroke`, leaving edges at the library default.

## Fix Details

| File | Change | Why |
|------|--------|-----|
| `getMuiTheme.ts` | Read `data-vscode-theme-kind` body attribute as priority-1 dark mode signal; set `--icon-filter` on body | Bypasses the static CSS variable never overridden in VS Code |
| `rocketride-vscode.css` | Add `body[data-vscode-theme-kind='vscode-dark']` CSS rules for `--icon-filter`; add `--rr-bg-surface` | Pure-CSS fallback before JS runs |
| `rocketride-web.css` | Add `--rr-bg-surface` token | Web parity for the new token |
| `NodeHeader.tsx` | Replace `fill: ''` with conditional spread preserving base style | Preserves `var(--rr-text-secondary)` fill when valid |
| `MoreMenu.tsx` | Add `fill: 'var(--rr-text-secondary)'` to MoreVert | Explicit theme-aware fill |
| `CreateNodePanel.tsx` | Apply `var(--icon-filter)` to `#td`-tagged sidebar icons | Sidebar icons invert in dark mode |
| `reactflow-overrides.css` | Set `--xy-edge-stroke` and `--xy-edge-stroke-selected` | Theme-aware edge colours |
| `get-icon-path.ts` | Add missing icons to `THEME_DYNAMIC_ICONS` | Missing icons now get `#td` tag for inversion |

## Validation

- Tested locally with VS Code Dark+ and One Dark Pro themes
- All node icons visible (white on dark background)
- Settings gear and three-dots menu visible on node headers
- Connection edges clearly visible
- Switched to light theme — all icons remain correct (dark on light)
- Pre-commit hooks pass: prettier ✔️, eslint ✔️

## Optional Extension

This fix pattern (reading `data-vscode-theme-kind` and setting CSS filter variables) can be extended to:
- Any future icon sets added to the flow builder
- Other VS Code webview panels that may have similar visibility issues
- High-contrast theme support (the CSS rules already handle `vscode-high-contrast`)

## Testing

- [x] Tested locally
- [] Tests added or updated
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #596

#Hack-with-bay-2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved theme detection tied to editor theme; icon filter synced on theme changes
  * More icons now automatically adapt to your theme
  * Added edge styling variables for flow diagrams

* **Bug Fixes**
  * Delete button on flow edges is now reliably interactive

* **Style**
  * Refined icon colors across the flow editor
  * Validation gear icon only highlights on invalid state
  * Menu trigger and node list icons display updated color/filter behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->