### PR TITLE
feat(store): handle-based streaming I/O for file store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -222,3 +222,4 @@ downloads/maven-3.9.6.tar.gz
 
 # One of the python modules keeps installing this
 include/python3.12/greenlet/greenlet.h
+.rocketride/

--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -1,0 +1,425 @@
+"""
+FileStore - General-purpose binary file system interface for RocketRide.
+
+Provides directory-like semantics (read, write, delete, list_dir, mkdir, stat)
+over the flat key-value IStore backends (Filesystem, S3, Azure). Each FileStore
+instance is scoped to a single account via client_id.
+
+Supports handle-based I/O for streaming reads and writes:
+    handle = await fs.open_write(path, connection_id)
+    await fs.write_chunk(handle, chunk1)
+    await fs.write_chunk(handle, chunk2)
+    await fs.close_write(handle)
+
+Usage:
+    from ai.account.store import Store
+
+    store = Store.create()
+    fs = store.get_file_store(client_id='user-123')
+
+    await fs.write('data/input.csv', b'col1,col2\\n1,2\\n', connection_id=1)
+    data = await fs.read('data/input.csv', connection_id=1)
+    entries = await fs.list_dir('data/')
+"""
+
+import uuid
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import PurePosixPath
+from typing import Any
+
+from .store import IStore, StorageError
+
+# Sentinel file used to represent empty directories on object stores
+DIR_MARKER = '.dirmarker'
+
+
+class FileHandleMode(Enum):
+    """Mode for an open file handle."""
+
+    READ = 'r'
+    WRITE = 'w'
+
+
+@dataclass
+class FileHandle:
+    """Tracks an open file handle and its backend-specific context."""
+
+    handle_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    path: str = ''
+    mode: FileHandleMode = FileHandleMode.READ
+    connection_id: int = 0
+    context: Any = None
+    offset: int = 0
+    bytes_written: int = 0
+    closed: bool = False
+
+
+class FileStore:
+    """
+    General-purpose binary file system interface built on top of IStore.
+
+    All paths are scoped to ``users/<client_id>/files/`` within the storage
+    backend, providing per-account isolation. All I/O is raw bytes.
+
+    Handle-based operations (open_write/read, write_chunk/read_chunk, close)
+    allow streaming large files without buffering everything in memory.
+    Each handle is tagged with a connection_id so it can be cleaned up when
+    the owning connection terminates.
+    """
+
+    def __init__(self, store: IStore, client_id: str):
+        """Initialize FileStore scoped to a specific account."""
+        if not client_id:
+            raise ValueError('client_id is required')
+        self._store = store
+        self._client_id = client_id
+        self._handles: dict[str, FileHandle] = {}
+        self._write_locks: set[str] = set()
+
+    # =========================================================================
+    # Handle-Based Write Operations
+    # =========================================================================
+
+    async def open_write(self, path: str, connection_id: int) -> str:
+        """
+        Open a file for writing.
+
+        Args:
+            path: Relative path within the account store.
+            connection_id: ID of the owning connection (for cleanup on disconnect).
+
+        Returns:
+            Handle ID string.
+
+        Raises:
+            StorageError: If the path is already open for writing.
+        """
+        full_path = self._full_path(path)
+        if full_path in self._write_locks:
+            raise StorageError(f'File already open for writing: {path}')
+
+        result = await self._store.open_write(full_path)
+        handle = FileHandle(
+            path=full_path,
+            mode=FileHandleMode.WRITE,
+            connection_id=connection_id,
+            context=result['context'],
+        )
+        self._handles[handle.handle_id] = handle
+        self._write_locks.add(full_path)
+        return handle.handle_id
+
+    async def write_chunk(self, handle_id: str, data: bytes) -> int:
+        """
+        Write data to an open write handle.
+
+        Args:
+            handle_id: Handle returned by open_write.
+            data: Bytes to append.
+
+        Returns:
+            Number of bytes written.
+        """
+        handle = self._get_handle(handle_id, FileHandleMode.WRITE)
+        written = await self._store.write_chunk(handle.path, handle.context, data)
+        handle.bytes_written += written
+        return written
+
+    async def close_write(self, handle_id: str) -> None:
+        """Close a write handle, committing the data."""
+        handle = self._get_handle(handle_id, FileHandleMode.WRITE)
+        try:
+            await self._store.close_write(handle.path, handle.context)
+        finally:
+            self._release_handle(handle)
+
+    # =========================================================================
+    # Handle-Based Read Operations
+    # =========================================================================
+
+    async def open_read(self, path: str, connection_id: int, offset: int = 0) -> dict:
+        """
+        Open a file for reading.
+
+        Args:
+            path: Relative path within the account store.
+            connection_id: ID of the owning connection (for cleanup on disconnect).
+            offset: Initial byte offset.
+
+        Returns:
+            Dict with 'handle' (str) and 'size' (int).
+        """
+        full_path = self._full_path(path)
+        result = await self._store.open_read(full_path)
+        handle = FileHandle(
+            path=full_path,
+            mode=FileHandleMode.READ,
+            connection_id=connection_id,
+            context=result['context'],
+            offset=offset,
+        )
+        self._handles[handle.handle_id] = handle
+        return {'handle': handle.handle_id, 'size': result['size']}
+
+    async def read_chunk(self, handle_id: str, length: int = 4_194_304) -> bytes:
+        """
+        Read data from an open read handle.
+
+        Args:
+            handle_id: Handle returned by open_read.
+            length: Max bytes to read (default 4 MB).
+
+        Returns:
+            Bytes read. Empty bytes indicates EOF.
+        """
+        handle = self._get_handle(handle_id, FileHandleMode.READ)
+        data = await self._store.read_chunk(handle.path, handle.context, handle.offset, length)
+        handle.offset += len(data)
+        return data
+
+    async def close_read(self, handle_id: str) -> None:
+        """Close a read handle."""
+        handle = self._get_handle(handle_id, FileHandleMode.READ)
+        try:
+            await self._store.close_read(handle.path, handle.context)
+        finally:
+            self._release_handle(handle)
+
+    # =========================================================================
+    # Connection Cleanup
+    # =========================================================================
+
+    async def close_all_handles(self, connection_id: int) -> None:
+        """
+        Force-close all handles owned by the given connection.
+
+        Called when a connection terminates to prevent resource leaks.
+        Write handles are committed with whatever data has been written.
+        """
+        handles_to_close = [h for h in self._handles.values() if h.connection_id == connection_id]
+        for handle in handles_to_close:
+            await self._force_close_handle(handle.handle_id)
+
+    # =========================================================================
+    # Convenience Methods (fire-and-forget, use handles internally)
+    # =========================================================================
+
+    async def read(self, path: str, connection_id: int = 0) -> bytes:
+        """
+        Read file contents as raw bytes.
+
+        Args:
+            path: Relative path within the account store.
+            connection_id: Owning connection ID.
+
+        Returns:
+            Raw bytes of the file.
+
+        Raises:
+            StorageError: If the file does not exist or read fails.
+        """
+        info = await self.open_read(path, connection_id)
+        try:
+            chunks = []
+            while True:
+                chunk = await self.read_chunk(info['handle'])
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return b''.join(chunks)
+        finally:
+            await self.close_read(info['handle'])
+
+    async def write(self, path: str, data: bytes, connection_id: int = 0) -> None:
+        """
+        Write raw bytes to a file.
+
+        Args:
+            path: Relative path within the account store.
+            data: Raw bytes to write.
+            connection_id: Owning connection ID.
+
+        Raises:
+            StorageError: If write fails.
+        """
+        handle_id = await self.open_write(path, connection_id)
+        try:
+            await self.write_chunk(handle_id, data)
+            await self.close_write(handle_id)
+        except Exception:
+            await self._force_close_handle(handle_id)
+            raise
+
+    async def delete(self, path: str) -> None:
+        """
+        Delete a file.
+
+        Args:
+            path: Relative path within the account store.
+
+        Raises:
+            StorageError: If file does not exist or delete fails.
+        """
+        full_path = self._full_path(path)
+        await self._store.delete_file(full_path)
+
+    async def list_dir(self, path: str = '') -> dict:
+        """
+        List immediate children of a directory.
+
+        Args:
+            path: Relative directory path (default: account root).
+
+        Returns:
+            Dict with keys: entries (list of {name, type, modified?}), count.
+            File entries include a modified epoch timestamp.
+        """
+        prefix = self._full_path(path)
+        if not prefix.endswith('/'):
+            prefix += '/'
+
+        all_files = await self._store.list_files(prefix)
+
+        # Track entries; for files, keep the full path for mtime lookup
+        entries_map: dict[str, dict] = {}
+        for file_path in all_files:
+            relative = file_path[len(prefix) :]
+            if not relative:
+                continue
+
+            parts = relative.split('/')
+            name = parts[0]
+
+            if name == DIR_MARKER:
+                continue
+
+            if len(parts) == 1:
+                if name not in entries_map:
+                    entries_map[name] = {'type': 'file', 'full_path': file_path}
+            else:
+                entries_map[name] = {'type': 'dir'}
+
+        entries = []
+        for name in sorted(entries_map):
+            info = entries_map[name]
+            entry: dict = {'name': name, 'type': info['type']}
+            if info['type'] == 'file':
+                try:
+                    entry['modified'] = await self._store.get_modified_time(info['full_path'])
+                except StorageError:
+                    pass
+            entries.append(entry)
+
+        return {'entries': entries, 'count': len(entries)}
+
+    async def mkdir(self, path: str) -> None:
+        """
+        Create a directory.
+
+        Writes a zero-length .dirmarker sentinel file for object store
+        compatibility.
+
+        Args:
+            path: Relative directory path.
+        """
+        marker_path = self._full_path(path.rstrip('/') + '/' + DIR_MARKER)
+        await self._store.write_bytes(marker_path, b'')
+
+    async def stat(self, path: str) -> dict:
+        """
+        Get file or directory metadata.
+
+        Args:
+            path: Relative path within the account store.
+
+        Returns:
+            Dict with keys: exists, type (file|dir), modified (epoch timestamp, files only).
+        """
+        full_path = self._full_path(path)
+
+        # Try as directory first (check for children under path/)
+        dir_prefix = full_path.rstrip('/') + '/'
+        files = await self._store.list_files(dir_prefix)
+        # Only count as directory if there are files strictly inside the prefix
+        if any(f != full_path and f.startswith(dir_prefix) for f in files):
+            return {'exists': True, 'type': 'dir'}
+
+        # Try as file
+        try:
+            modified = await self._store.get_modified_time(full_path)
+            return {'exists': True, 'type': 'file', 'modified': modified}
+        except StorageError:
+            pass
+
+        return {'exists': False}
+
+    # =========================================================================
+    # Private Methods
+    # =========================================================================
+
+    def _get_handle(self, handle_id: str, expected_mode: FileHandleMode) -> FileHandle:
+        """Look up a handle and validate its state."""
+        handle = self._handles.get(handle_id)
+        if handle is None:
+            raise StorageError(f'Invalid handle: {handle_id}')
+        if handle.closed:
+            raise StorageError(f'Handle already closed: {handle_id}')
+        if handle.mode != expected_mode:
+            raise StorageError(f'Wrong handle mode: expected {expected_mode.value}, got {handle.mode.value}')
+        return handle
+
+    def _release_handle(self, handle: FileHandle) -> None:
+        """Remove a handle from the registry and release any write lock."""
+        handle.closed = True
+        self._handles.pop(handle.handle_id, None)
+        if handle.mode == FileHandleMode.WRITE:
+            self._write_locks.discard(handle.path)
+
+    async def _force_close_handle(self, handle_id: str) -> None:
+        """Force-close a handle, committing any written data. Best-effort."""
+        handle = self._handles.get(handle_id)
+        if handle is None or handle.closed:
+            return
+        try:
+            if handle.mode == FileHandleMode.WRITE:
+                await self._store.close_write(handle.path, handle.context)
+            else:
+                await self._store.close_read(handle.path, handle.context)
+        except Exception:
+            pass
+        finally:
+            self._release_handle(handle)
+
+    @staticmethod
+    def _validate_path(path: str) -> str:
+        """Validate and normalize a user-provided path."""
+        path = path.replace('\\', '/')
+
+        if path.startswith('/'):
+            path = path.lstrip('/')
+
+        parts = path.split('/')
+        if '..' in parts:
+            raise ValueError(f'Path traversal not allowed: {path}')
+
+        normalized = str(PurePosixPath(path)) if path else ''
+        if normalized == '.':
+            normalized = ''
+
+        return normalized
+
+    def _full_path(self, path: str) -> str:
+        """Build the full storage path: users/<client_id>/files/<path>."""
+        validated = self._validate_path(path)
+        if validated:
+            return f'users/{self._client_id}/files/{validated}'
+        return f'users/{self._client_id}/files'
+
+
+__all__ = [
+    'FileStore',
+    'FileHandle',
+    'FileHandleMode',
+    'DIR_MARKER',
+]

--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -125,25 +125,26 @@ class FileStore:
         self._handles[handle.handle_id] = handle
         return handle.handle_id
 
-    async def write_chunk(self, handle_id: str, data: bytes) -> int:
+    async def write_chunk(self, handle_id: str, data: bytes, connection_id: int = 0) -> int:
         """
         Write data to an open write handle.
 
         Args:
             handle_id: Handle returned by open_write.
             data: Bytes to append.
+            connection_id: Caller's connection ID for ownership check.
 
         Returns:
             Number of bytes written.
         """
-        handle = self._get_handle(handle_id, FileHandleMode.WRITE)
+        handle = self._get_handle(handle_id, FileHandleMode.WRITE, connection_id)
         written = await self._store.write_chunk(handle.path, handle.context, data)
         handle.bytes_written += written
         return written
 
-    async def close_write(self, handle_id: str) -> None:
+    async def close_write(self, handle_id: str, connection_id: int = 0) -> None:
         """Close a write handle, committing the data."""
-        handle = self._get_handle(handle_id, FileHandleMode.WRITE)
+        handle = self._get_handle(handle_id, FileHandleMode.WRITE, connection_id)
         try:
             await self._store.close_write(handle.path, handle.context)
         finally:
@@ -175,7 +176,7 @@ class FileStore:
         self._handles[handle.handle_id] = handle
         return {'handle': handle.handle_id, 'size': result['size']}
 
-    async def read_chunk(self, handle_id: str, offset: int, length: int = MAX_CHUNK_SIZE) -> bytes:
+    async def read_chunk(self, handle_id: str, offset: int, length: int = MAX_CHUNK_SIZE, connection_id: int = 0) -> bytes:
         """
         Read data from an open read handle.
 
@@ -192,12 +193,12 @@ class FileStore:
         if length <= 0:
             raise StorageError(f'Read length must be positive, got {length}')
         length = min(length, MAX_CHUNK_SIZE)
-        handle = self._get_handle(handle_id, FileHandleMode.READ)
+        handle = self._get_handle(handle_id, FileHandleMode.READ, connection_id)
         return await self._store.read_chunk(handle.path, handle.context, offset, length)
 
-    async def close_read(self, handle_id: str) -> None:
+    async def close_read(self, handle_id: str, connection_id: int = 0) -> None:
         """Close a read handle."""
-        handle = self._get_handle(handle_id, FileHandleMode.READ)
+        handle = self._get_handle(handle_id, FileHandleMode.READ, connection_id)
         try:
             await self._store.close_read(handle.path, handle.context)
         finally:
@@ -382,8 +383,8 @@ class FileStore:
     # Private Methods
     # =========================================================================
 
-    def _get_handle(self, handle_id: str, expected_mode: FileHandleMode) -> FileHandle:
-        """Look up a handle and validate its state."""
+    def _get_handle(self, handle_id: str, expected_mode: FileHandleMode, connection_id: int = 0) -> FileHandle:
+        """Look up a handle and validate its state and ownership."""
         handle = self._handles.get(handle_id)
         if handle is None:
             raise StorageError(f'Invalid handle: {handle_id}')
@@ -391,6 +392,8 @@ class FileStore:
             raise StorageError(f'Handle already closed: {handle_id}')
         if handle.mode != expected_mode:
             raise StorageError(f'Wrong handle mode: expected {expected_mode.value}, got {handle.mode.value}')
+        if connection_id and handle.connection_id and handle.connection_id != connection_id:
+            raise StorageError('Handle belongs to another connection')
         return handle
 
     def _release_handle(self, handle: FileHandle) -> None:

--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -33,6 +33,12 @@ from .store import IStore, StorageError
 # Sentinel file used to represent empty directories on object stores
 DIR_MARKER = '.dirmarker'
 
+# Maximum bytes a single read_chunk call may return
+MAX_CHUNK_SIZE = 4_194_304  # 4 MB
+
+# Characters forbidden inside any single path segment
+_INVALID_SEGMENT_CHARS = frozenset('*?<>|"\x00')
+
 
 class FileHandleMode(Enum):
     """Mode for an open file handle."""
@@ -50,7 +56,6 @@ class FileHandle:
     mode: FileHandleMode = FileHandleMode.READ
     connection_id: int = 0
     context: Any = None
-    offset: int = 0
     bytes_written: int = 0
     closed: bool = False
 
@@ -72,6 +77,10 @@ class FileStore:
         """Initialize FileStore scoped to a specific account."""
         if not client_id:
             raise ValueError('client_id is required')
+        if '/' in client_id or '\\' in client_id:
+            raise ValueError('client_id must not contain path separators')
+        if client_id in ('.', '..'):
+            raise ValueError('client_id must not be "." or ".."')
         self._store = store
         self._client_id = client_id
         self._handles: dict[str, FileHandle] = {}
@@ -99,7 +108,14 @@ class FileStore:
         if full_path in self._write_locks:
             raise StorageError(f'File already open for writing: {path}')
 
-        result = await self._store.open_write(full_path)
+        # Acquire lock before awaiting to prevent races at suspension points
+        self._write_locks.add(full_path)
+        try:
+            result = await self._store.open_write(full_path)
+        except Exception:
+            self._write_locks.discard(full_path)
+            raise
+
         handle = FileHandle(
             path=full_path,
             mode=FileHandleMode.WRITE,
@@ -107,7 +123,6 @@ class FileStore:
             context=result['context'],
         )
         self._handles[handle.handle_id] = handle
-        self._write_locks.add(full_path)
         return handle.handle_id
 
     async def write_chunk(self, handle_id: str, data: bytes) -> int:
@@ -138,14 +153,13 @@ class FileStore:
     # Handle-Based Read Operations
     # =========================================================================
 
-    async def open_read(self, path: str, connection_id: int, offset: int = 0) -> dict:
+    async def open_read(self, path: str, connection_id: int) -> dict:
         """
         Open a file for reading.
 
         Args:
             path: Relative path within the account store.
             connection_id: ID of the owning connection (for cleanup on disconnect).
-            offset: Initial byte offset.
 
         Returns:
             Dict with 'handle' (str) and 'size' (int).
@@ -157,26 +171,29 @@ class FileStore:
             mode=FileHandleMode.READ,
             connection_id=connection_id,
             context=result['context'],
-            offset=offset,
         )
         self._handles[handle.handle_id] = handle
         return {'handle': handle.handle_id, 'size': result['size']}
 
-    async def read_chunk(self, handle_id: str, length: int = 4_194_304) -> bytes:
+    async def read_chunk(self, handle_id: str, offset: int, length: int = MAX_CHUNK_SIZE) -> bytes:
         """
         Read data from an open read handle.
 
         Args:
             handle_id: Handle returned by open_read.
-            length: Max bytes to read (default 4 MB).
+            offset: Byte offset to read from.
+            length: Max bytes to read (default 4 MB, capped at MAX_CHUNK_SIZE).
 
         Returns:
             Bytes read. Empty bytes indicates EOF.
         """
+        if offset < 0:
+            raise StorageError(f'Offset must be non-negative, got {offset}')
+        if length <= 0:
+            raise StorageError(f'Read length must be positive, got {length}')
+        length = min(length, MAX_CHUNK_SIZE)
         handle = self._get_handle(handle_id, FileHandleMode.READ)
-        data = await self._store.read_chunk(handle.path, handle.context, handle.offset, length)
-        handle.offset += len(data)
-        return data
+        return await self._store.read_chunk(handle.path, handle.context, offset, length)
 
     async def close_read(self, handle_id: str) -> None:
         """Close a read handle."""
@@ -222,11 +239,13 @@ class FileStore:
         info = await self.open_read(path, connection_id)
         try:
             chunks = []
+            offset = 0
             while True:
-                chunk = await self.read_chunk(info['handle'])
+                chunk = await self.read_chunk(info['handle'], offset)
                 if not chunk:
                     break
                 chunks.append(chunk)
+                offset += len(chunk)
             return b''.join(chunks)
         finally:
             await self.close_read(info['handle'])
@@ -259,9 +278,11 @@ class FileStore:
             path: Relative path within the account store.
 
         Raises:
-            StorageError: If file does not exist or delete fails.
+            StorageError: If file does not exist, delete fails, or file is open for writing.
         """
         full_path = self._full_path(path)
+        if full_path in self._write_locks:
+            raise StorageError(f'Cannot delete file while it is open for writing: {path}')
         await self._store.delete_file(full_path)
 
     async def list_dir(self, path: str = '') -> dict:
@@ -272,8 +293,8 @@ class FileStore:
             path: Relative directory path (default: account root).
 
         Returns:
-            Dict with keys: entries (list of {name, type, modified?}), count.
-            File entries include a modified epoch timestamp.
+            Dict with keys: entries (list of {name, type, size?, modified?}), count.
+            File entries include size (bytes) and modified (epoch timestamp).
         """
         prefix = self._full_path(path)
         if not prefix.endswith('/'):
@@ -302,11 +323,13 @@ class FileStore:
 
         entries = []
         for name in sorted(entries_map):
-            info = entries_map[name]
-            entry: dict = {'name': name, 'type': info['type']}
-            if info['type'] == 'file':
+            meta = entries_map[name]
+            entry: dict = {'name': name, 'type': meta['type']}
+            if meta['type'] == 'file':
                 try:
-                    entry['modified'] = await self._store.get_modified_time(info['full_path'])
+                    file_info = await self._store.get_file_info(meta['full_path'])
+                    entry['size'] = file_info['size']
+                    entry['modified'] = file_info['modified']
                 except StorageError:
                     pass
             entries.append(entry)
@@ -334,7 +357,8 @@ class FileStore:
             path: Relative path within the account store.
 
         Returns:
-            Dict with keys: exists, type (file|dir), modified (epoch timestamp, files only).
+            Dict with keys: exists, type (file|dir), size (bytes, files only),
+            modified (epoch timestamp, files only).
         """
         full_path = self._full_path(path)
 
@@ -347,8 +371,8 @@ class FileStore:
 
         # Try as file
         try:
-            modified = await self._store.get_modified_time(full_path)
-            return {'exists': True, 'type': 'file', 'modified': modified}
+            file_info = await self._store.get_file_info(full_path)
+            return {'exists': True, 'type': 'file', 'size': file_info['size'], 'modified': file_info['modified']}
         except StorageError:
             pass
 
@@ -403,6 +427,10 @@ class FileStore:
         if '..' in parts:
             raise ValueError(f'Path traversal not allowed: {path}')
 
+        for part in parts:
+            if part and any(c in _INVALID_SEGMENT_CHARS or ord(c) < 0x20 for c in part):
+                raise ValueError(f'Path contains invalid characters: {path}')
+
         normalized = str(PurePosixPath(path)) if path else ''
         if normalized == '.':
             normalized = ''
@@ -421,5 +449,6 @@ __all__ = [
     'FileStore',
     'FileHandle',
     'FileHandleMode',
+    'MAX_CHUNK_SIZE',
     'DIR_MARKER',
 ]

--- a/packages/ai/src/ai/account/store.py
+++ b/packages/ai/src/ai/account/store.py
@@ -11,15 +11,16 @@ Defaults to filesystem://~/.rocketlib/dtc if not set (user home directory).
 Falls back to temp directory if home directory cannot be determined.
 """
 
+import io
 import os
 import re
-import json
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Any, Optional
 
-from .account import AccountInfo
+if TYPE_CHECKING:
+    from .file_store import FileStore
 
 
 # Retry configuration for cloud storage operations
@@ -164,6 +165,132 @@ class IStore(ABC):
         """
         pass
 
+    async def get_modified_time(self, filename: str) -> float:
+        """
+        Get the last modified time of a file as an epoch timestamp.
+
+        Default implementation reads the file to confirm existence, then
+        returns current time. Backends should override with native metadata.
+
+        Args:
+            filename: Relative path to file
+
+        Returns:
+            float: Last modified time as Unix epoch timestamp
+
+        Raises:
+            StorageError: If file doesn't exist
+        """
+        import time
+
+        # Default: confirm file exists, return current time
+        await self.read_file(filename)
+        return time.time()
+
+    async def write_bytes(self, filename: str, data: bytes) -> None:
+        """
+        Write binary data to file.
+
+        Default implementation encodes to string via latin-1.
+        Backends should override for proper binary I/O.
+
+        Args:
+            filename: Relative path to file
+            data: Binary data to write
+
+        Raises:
+            StorageError: If write operation fails
+        """
+        await self.write_file(filename, data.decode('latin-1'))
+
+    async def read_bytes(self, filename: str) -> bytes:
+        """
+        Read binary data from file.
+
+        Default implementation decodes from string via latin-1.
+        Backends should override for proper binary I/O.
+
+        Args:
+            filename: Relative path to file
+
+        Returns:
+            File contents as bytes
+
+        Raises:
+            StorageError: If file doesn't exist or read fails
+        """
+        content = await self.read_file(filename)
+        return content.encode('latin-1')
+
+    # =========================================================================
+    # Handle-Based I/O — open / read / write / close
+    # =========================================================================
+    #
+    # Default implementations buffer everything in memory and delegate to
+    # read_bytes/write_bytes on close.  Backends should override with native
+    # streaming (S3 multipart, Azure staged blocks, filesystem fd).
+
+    async def open_write(self, filename: str) -> dict:
+        """
+        Begin a write session for the given file.
+
+        Returns:
+            dict with backend-specific context. Must include key 'context'.
+        """
+        return {'context': {'buffer': bytearray(), 'filename': filename}}
+
+    async def write_chunk(self, filename: str, context: Any, data: bytes) -> int:
+        """
+        Append a chunk of data to an open write session.
+
+        Returns:
+            Number of bytes written.
+        """
+        context['buffer'].extend(data)
+        return len(data)
+
+    async def close_write(self, filename: str, context: Any) -> None:
+        """Finalize and commit the write session."""
+        await self.write_bytes(filename, bytes(context['buffer']))
+
+    async def abort_write(self, filename: str, context: Any) -> None:
+        """Close a write session, committing whatever data has been written."""
+        await self.close_write(filename, context)
+
+    async def open_read(self, filename: str) -> dict:
+        """
+        Begin a read session for the given file.
+
+        Returns:
+            dict with 'context' (opaque) and 'size' (total bytes).
+        """
+        data = await self.read_bytes(filename)
+        buf = io.BytesIO(data)
+        return {'context': {'buf': buf}, 'size': len(data)}
+
+    async def read_chunk(self, filename: str, context: Any, offset: int, length: int = 4_194_304) -> bytes:
+        """
+        Read a chunk of data from an open read session.
+
+        Args:
+            filename: The file being read.
+            context: Opaque context from open_read.
+            offset: Byte offset to read from.
+            length: Number of bytes to read (default 4 MB).
+
+        Returns:
+            The requested bytes. Empty bytes indicates EOF.
+        """
+        buf: io.BytesIO = context['buf']
+        buf.seek(offset)
+        return buf.read(length)
+
+    async def close_read(self, filename: str, context: Any) -> None:
+        """Close a read session and release resources."""
+        buf = context.get('buf')
+        if buf:
+            buf.close()
+
     @abstractmethod
     async def list_files(self, prefix: str = '') -> list:  # noqa: D102
         """
@@ -257,6 +384,7 @@ class Store:
             store: Backend storage implementation (FilesystemStore, S3Store, AzureBlobStore)
         """
         self._store = store
+        self._file_stores: dict = {}
 
     # =========================================================================
     # Public Static Methods
@@ -325,422 +453,24 @@ class Store:
         # Wrap backend in Store instance
         return Store(backend)
 
-    # =========================================================================
-    # Public Methods - Proxy (Direct pass-through to IStore)
-    # =========================================================================
-
-    async def read_file(self, path: str) -> str:
+    def get_file_store(self, client_id: str) -> 'FileStore':
         """
-        Read file contents from storage.
+        Get a FileStore instance scoped to a specific account.
+
+        FileStore instances are cached per client_id to avoid repeated
+        instantiation for the same account.
 
         Args:
-            path: Relative path to file within storage root
+            client_id: Account identifier for path scoping.
 
         Returns:
-            str: File contents as string
-
-        Raises:
-            StorageError: If file doesn't exist or read fails
+            FileStore instance scoped to the given account.
         """
-        return await self._store.read_file(path)
-
-    async def write_file(self, path: str, content: str) -> None:
-        """
-        Write file to storage (non-atomic, overwrites existing).
-
-        For atomic writes with version checking, use write_file_atomic() instead.
-
-        Args:
-            path: Relative path to file within storage root
-            content: File contents to write
-
-        Raises:
-            StorageError: If write fails
-        """
-        return await self._store.write_file(path, content)
-
-    async def read_file_with_metadata(self, path: str):
-        """
-        Read file contents along with version metadata.
-
-        Returns version information (hash/ETag) for use in atomic operations.
-
-        Args:
-            path: Relative path to file within storage root
-
-        Returns:
-            tuple: (content: str, version: str) where version is hash or ETag
-
-        Raises:
-            StorageError: If file doesn't exist or read fails
-        """
-        return await self._store.read_file_with_metadata(path)
-
-    async def write_file_atomic(self, path: str, content: str, expected_version: Optional[str] = None) -> str:
-        """
-        Write file atomically with optimistic locking.
-
-        For updates/deletes of existing files, expected_version MUST be provided.
-        For new file creation, expected_version should be None.
-
-        Implementation varies by backend:
-        - Filesystem: Uses OS-level file locking (fcntl/msvcrt)
-        - S3: Uses conditional PutObject with IfMatch ETag
-        - Azure: Uses conditional upload_blob with match_condition
-
-        Args:
-            path: Relative path to file within storage root
-            content: File contents to write
-            expected_version: Expected current version (hash/ETag) for conflict detection
-
-        Returns:
-            str: New version identifier (hash/ETag) after write
-
-        Raises:
-            StorageError: If write fails or version mismatch (conflict)
-        """
-        return await self._store.write_file_atomic(path, content, expected_version)
-
-    async def delete_file(self, path: str, expected_version: Optional[str] = None) -> None:
-        """
-        Delete file atomically with optimistic locking.
-
-        For deleting existing files, expected_version MUST be provided to prevent
-        accidental deletion if file was modified by another process.
-
-        Args:
-            path: Relative path to file within storage root
-            expected_version: Expected current version (hash/ETag) for conflict detection
-
-        Raises:
-            StorageError: If file doesn't exist, delete fails, or version mismatch
-        """
-        return await self._store.delete_file(path, expected_version)
-
-    async def list_files(self, prefix: str = '') -> list:
-        """
-        List all files under a given path prefix.
-
-        Args:
-            prefix: Path prefix to filter files (e.g., 'user-123/.projects/')
-                   Empty string lists all files
-
-        Returns:
-            list[str]: List of relative file paths matching the prefix
-        """
-        return await self._store.list_files(prefix)
-
-    # =========================================================================
-    # Public Methods - Project Operations (User-Scoped)
-    # =========================================================================
-
-    async def save_project(self, account_info, project_id: str, pipeline: dict, expected_version: Optional[str] = None) -> dict:
-        """
-        Save a project for a user.
-
-        Args:
-            account_info: AccountInfo object containing clientid
-            project_id: Project ID (used for filename)
-            pipeline: Pipeline configuration dictionary
-            expected_version: Expected current version for atomic update (optional)
-
-        Returns:
-            dict: Result with success status, project_id, and new version
-
-        Raises:
-            ValueError: If parameters are invalid
-            StorageError: If storage operation fails or version mismatch
-        """
-        if not isinstance(account_info, AccountInfo):
-            raise ValueError('account_info must be an AccountInfo instance')
-        if not project_id:
-            raise ValueError('project_id is required')
-        if not pipeline:
-            raise ValueError('pipeline is required')
-
-        file_path = Store._construct_store_path(account_info.clientid, project_id)
-        return await self._save_item(file_path, project_id, 'project_id', pipeline, expected_version)
-
-    async def get_project(self, account_info, project_id: str) -> dict:
-        """
-        Get a project by ID.
-
-        Args:
-            account_info: AccountInfo object containing clientid
-            project_id: Project ID to retrieve
-
-        Returns:
-            dict: Result with success status, project data, and version
-
-        Raises:
-            StorageError: If project not found or read fails
-        """
-        if not isinstance(account_info, AccountInfo):
-            raise ValueError('account_info must be an AccountInfo instance')
-
-        file_path = Store._construct_store_path(account_info.clientid, project_id)
-        return await self._get_item(file_path)
-
-    async def delete_project(self, account_info, project_id: str, expected_version: Optional[str] = None) -> dict:
-        """
-        Delete a project by ID.
-
-        Args:
-            account_info: AccountInfo object containing clientid
-            project_id: Project ID to delete
-            expected_version: Expected current version for atomic delete (optional)
-
-        Returns:
-            dict: Result with success status
-
-        Raises:
-            StorageError: If project not found, delete fails, or version mismatch
-        """
-        if not isinstance(account_info, AccountInfo):
-            raise ValueError('account_info must be an AccountInfo instance')
-
-        file_path = Store._construct_store_path(account_info.clientid, project_id)
-        return await self._delete_item(file_path, project_id, 'project_id', expected_version)
-
-    async def get_all_projects(self, account_info) -> dict:
-        """
-        Get all projects for a user.
-
-        Args:
-            account_info: AccountInfo object containing clientid
-
-        Returns:
-            dict: Result with success status, projects array, and count
-        """
-        if not isinstance(account_info, AccountInfo):
-            raise ValueError('account_info must be an AccountInfo instance')
-
-        prefix = Store._construct_store_path(account_info.clientid)
-        return await self._get_all_items(prefix, 'id', 'projects')
-
-    # =========================================================================
-    # Public Methods - Template Operations (System-Wide)
-    # =========================================================================
-
-    async def save_template(self, template_id: str, pipeline: dict, expected_version: Optional[str] = None) -> dict:
-        """
-        Save a template (system-wide, accessible to all users).
-
-        Args:
-            template_id: Template ID (used for filename)
-            pipeline: Pipeline configuration dictionary
-            expected_version: Expected current version for atomic update (optional)
-
-        Returns:
-            dict: Result with success status, template_id, and new version
-
-        Raises:
-            ValueError: If parameters are invalid
-            StorageError: If storage operation fails or version mismatch
-        """
-        if not template_id:
-            raise ValueError('template_id is required')
-        if not pipeline:
-            raise ValueError('pipeline is required')
-
-        file_path = Store._construct_template_path(template_id)
-        return await self._save_item(file_path, template_id, 'template_id', pipeline, expected_version)
-
-    async def get_template(self, template_id: str) -> dict:
-        """
-        Get a template by ID.
-
-        Args:
-            template_id: Template ID to retrieve
-
-        Returns:
-            dict: Result with success status, template data, and version
-
-        Raises:
-            StorageError: If template not found or read fails
-        """
-        if not template_id:
-            raise ValueError('template_id is required')
-
-        file_path = Store._construct_template_path(template_id)
-        return await self._get_item(file_path)
-
-    async def delete_template(self, template_id: str, expected_version: Optional[str] = None) -> dict:
-        """
-        Delete a template by ID.
-
-        Args:
-            template_id: Template ID to delete
-            expected_version: Expected current version for atomic delete (optional)
-
-        Returns:
-            dict: Result with success status
-
-        Raises:
-            StorageError: If template not found, delete fails, or version mismatch
-        """
-        if not template_id:
-            raise ValueError('template_id is required')
-
-        file_path = Store._construct_template_path(template_id)
-        return await self._delete_item(file_path, template_id, 'template_id', expected_version)
-
-    async def get_all_templates(self) -> dict:
-        """
-        Get all templates (system-wide).
-
-        Returns:
-            dict: Result with success status, templates array, and count
-        """
-        prefix = Store._construct_template_path()
-        return await self._get_all_items(prefix, 'id', 'templates')
-
-    # =========================================================================
-    # Public Methods - Log Operations (User-Scoped, Per-Project)
-    # =========================================================================
-
-    async def save_log(self, account_info, project_id: str, source: str, contents: dict) -> dict:
-        """
-        Save a log file for a source run.
-
-        Creates or overwrites a log file in the users/<client-id>/.logs/<project_id>/ directory.
-        The filename is constructed as <source>-<start_time>.log where start_time
-        is extracted from contents['body']['startTime'].
-
-        Args:
-            account_info: AccountInfo object containing clientid
-            project_id: Project ID
-            source: Name of the source
-            contents: Log contents dictionary containing body.startTime
-
-        Returns:
-            dict: Result with success status and filename
-
-        Raises:
-            ValueError: If parameters are invalid
-            StorageError: If storage operation fails
-        """
-        if not isinstance(account_info, AccountInfo):
-            raise ValueError('account_info must be an AccountInfo instance')
-        if not project_id:
-            raise ValueError('project_id is required')
-        if not source:
-            raise ValueError('source is required')
-        if not contents:
-            raise ValueError('contents is required')
-
-        # Extract start_time from contents
-        start_time = contents.get('body', {}).get('startTime')
-        if start_time is None:
-            raise ValueError('contents must contain body.startTime')
-
-        # Construct filename: source-<start_time>.log
-        filename = f'{source}-{start_time}.log'
-        file_path = Store._construct_log_path(account_info.clientid, project_id, filename)
-
-        # Serialize contents to JSON
-        contents_json = json.dumps(contents, indent=2)
-
-        # Save file (overwrite if exists)
-        await self._store.write_file(file_path, contents_json)
-
-        return {'success': True, 'filename': filename}
-
-    async def get_log(self, account_info, project_id: str, source: str, start_time: float) -> dict:
-        """
-        Get a log file by source name and start time.
-
-        Args:
-            account_info: AccountInfo object containing clientid
-            project_id: Project ID
-            source: Name of the source
-            start_time: Start time of the run
-
-        Returns:
-            dict: Result with success status and log contents
-
-        Raises:
-            ValueError: If parameters are invalid
-            StorageError: If log not found or read fails
-        """
-        if not isinstance(account_info, AccountInfo):
-            raise ValueError('account_info must be an AccountInfo instance')
-        if not project_id:
-            raise ValueError('project_id is required')
-        if not source:
-            raise ValueError('source is required')
-        if start_time is None:
-            raise ValueError('start_time is required')
-
-        # Construct filename: source-<start_time>.log
-        filename = f'{source}-{start_time}.log'
-        file_path = Store._construct_log_path(account_info.clientid, project_id, filename)
-
-        # Read log file
-        contents_json = await self._store.read_file(file_path)
-        contents = json.loads(contents_json)
-
-        return {'success': True, 'contents': contents}
-
-    async def list_logs(self, account_info, project_id: str, source: Optional[str] = None, page: Optional[int] = None) -> dict:
-        """
-        List log files for a project.
-
-        Args:
-            account_info: AccountInfo object containing clientid
-            project_id: Project ID
-            source: Optional source name to filter logs (filters files starting with '<source>-')
-            page: Page number (0-indexed). If negative or None, defaults to 0.
-                  Page size is LOG_PAGE_SIZE (100).
-
-        Returns:
-            dict: Result with success status, logs array, count, total_count, page, and total_pages
-        """
-        if not isinstance(account_info, AccountInfo):
-            raise ValueError('account_info must be an AccountInfo instance')
-        if not project_id:
-            raise ValueError('project_id is required')
-
-        # Normalize page number
-        if page is None or page < 0:
-            page = 0
-
-        # Get directory prefix
-        prefix = Store._construct_log_path(account_info.clientid, project_id)
-
-        # List all files in directory
-        file_paths = await self._store.list_files(prefix)
-
-        # Filter to only .log files
-        log_files = [f for f in file_paths if f.endswith('.log')]
-
-        # If source provided, filter files starting with source-
-        if source:
-            log_files = [f for f in log_files if Path(f).name.startswith(f'{source}-')]
-
-        # Sort files
-        log_files.sort()
-
-        # Calculate pagination
-        total_count = len(log_files)
-        total_pages = (total_count + LOG_PAGE_SIZE - 1) // LOG_PAGE_SIZE if total_count > 0 else 1
-        start_idx = page * LOG_PAGE_SIZE
-        end_idx = start_idx + LOG_PAGE_SIZE
-
-        # Get page of files
-        page_files = log_files[start_idx:end_idx]
-
-        # Extract just filenames from paths
-        logs = [Path(f).name for f in page_files]
-
-        return {
-            'success': True,
-            'logs': logs,
-            'count': len(logs),
-            'total_count': total_count,
-            'page': page,
-            'total_pages': total_pages,
-        }
+        if client_id not in self._file_stores:
+            from .file_store import FileStore
+
+            self._file_stores[client_id] = FileStore(self._store, client_id)
+        return self._file_stores[client_id]
 
     # =========================================================================
     # Private Static Methods
@@ -761,7 +491,7 @@ class Store:
         try:
             # Try to get user's home directory (works on Windows/Linux/Mac)
             home = Path.home()
-            storage_path = home / '.rocketlib' / 'dtc'
+            storage_path = home / '.rocketlib' / 'store'
         except Exception:
             # Fallback to temp directory if home cannot be determined
             storage_path = Path(tempfile.gettempdir()) / '.rocketlib' / 'dtc'
@@ -794,203 +524,6 @@ class Store:
                 url = f'{scheme}://{expanded_path}'
 
         return url
-
-    @staticmethod
-    def _construct_path(components: list, item_id: Optional[str] = None) -> str:
-        """
-        Construct storage path for items (projects or templates).
-
-        Args:
-            components: List of path components (e.g., ['users', client_id, '.projects'])
-            item_id: Item ID (optional)
-
-        Returns:
-            str: File path if item_id provided, directory path otherwise
-        """
-        # Use Path for cross-platform path construction, convert to POSIX-style string
-        # (forward slashes) for storage consistency across platforms
-        base_path = Path(*components)
-
-        if item_id:
-            file_path = base_path / f'{item_id}.json'
-            return file_path.as_posix()
-        else:
-            # Return directory path with trailing slash
-            return base_path.as_posix() + '/'
-
-    @staticmethod
-    def _construct_store_path(client_id: str, project_id: Optional[str] = None) -> str:
-        """
-        Construct storage path for projects.
-
-        Args:
-            client_id: Client/user ID
-            project_id: Project ID (optional)
-
-        Returns:
-            str: File path if project_id provided, directory path otherwise
-                - With project_id: "users/<client_id>/.projects/<project_id>.json"
-                - Without project_id: "users/<client_id>/.projects/"
-        """
-        return Store._construct_path(['users', client_id, '.projects'], project_id)
-
-    @staticmethod
-    def _construct_template_path(template_id: Optional[str] = None) -> str:
-        """
-        Construct storage path for templates.
-
-        Templates are stored in a system-wide location accessible to all users.
-
-        Args:
-            template_id: Template ID (optional)
-
-        Returns:
-            str: File path if template_id provided, directory path otherwise
-                - With template_id: "system/.templates/<template_id>.json"
-                - Without template_id: "system/.templates/"
-        """
-        return Store._construct_path(['system', '.templates'], template_id)
-
-    @staticmethod
-    def _construct_log_path(client_id: str, project_id: str, filename: Optional[str] = None) -> str:
-        """
-        Construct storage path for log files.
-
-        Args:
-            client_id: Client/user ID
-            project_id: Project ID
-            filename: Log filename (optional)
-
-        Returns:
-            str: File path if filename provided, directory path otherwise
-                - With filename: "users/<client_id>/.logs/<project_id>/<filename>"
-                - Without filename: "users/<client_id>/.logs/<project_id>/"
-        """
-        base_path = Path('users', client_id, '.logs', project_id)
-        if filename:
-            file_path = base_path / filename
-            return file_path.as_posix()
-        else:
-            return base_path.as_posix() + '/'
-
-    # =========================================================================
-    # Private Methods
-    # =========================================================================
-
-    async def _save_item(self, file_path: str, item_id: str, id_key: str, pipeline: dict, expected_version: Optional[str] = None) -> dict:
-        """
-        Save an item (project or template).
-
-        Args:
-            file_path: Storage path for the item
-            item_id: Item ID
-            id_key: Key name for ID in response (e.g., 'project_id' or 'template_id')
-            pipeline: Pipeline configuration dictionary
-            expected_version: Expected current version for atomic update (optional)
-
-        Returns:
-            dict: Result with success status, item ID, and new version
-        """
-        # Serialize pipeline to JSON
-        pipeline_json = json.dumps(pipeline, indent=2)
-
-        # Save atomically using the wrapped store
-        new_version = await self._store.write_file_atomic(file_path, pipeline_json, expected_version)
-
-        return {'success': True, id_key: item_id, 'version': new_version}
-
-    async def _get_item(self, file_path: str) -> dict:
-        """
-        Get an item (project or template) by path.
-
-        Args:
-            file_path: Storage path for the item
-
-        Returns:
-            dict: Result with success status, pipeline data, and version
-        """
-        # Read pipeline with version using the wrapped store
-        pipeline_json, version = await self._store.read_file_with_metadata(file_path)
-        pipeline = json.loads(pipeline_json)
-
-        return {'success': True, 'pipeline': pipeline, 'version': version}
-
-    async def _delete_item(self, file_path: str, item_id: str, id_key: str, expected_version: Optional[str] = None) -> dict:
-        """
-        Delete an item (project or template).
-
-        Args:
-            file_path: Storage path for the item
-            item_id: Item ID
-            id_key: Key name for ID in response (e.g., 'project_id' or 'template_id')
-            expected_version: Expected current version for atomic delete (optional)
-
-        Returns:
-            dict: Result with success status
-        """
-        # Delete atomically using the wrapped store
-        await self._store.delete_file(file_path, expected_version)
-
-        return {'success': True, id_key: item_id}
-
-    async def _get_all_items(self, prefix: str, id_key: str, list_key: str) -> dict:
-        """
-        Get all items (projects or templates) from a directory.
-
-        Args:
-            prefix: Directory prefix to list
-            id_key: Key name for ID in summaries (e.g., 'id')
-            list_key: Key name for the list in response (e.g., 'projects' or 'templates')
-
-        Returns:
-            dict: Result with success status, items array, and count
-        """
-        # List all files in directory using the wrapped store
-        file_paths = await self._store.list_files(prefix)
-
-        # Filter to only .json files
-        item_files = [f for f in file_paths if f.endswith('.json')]
-
-        # Read each item and extract summary
-        items = []
-        for file_path in item_files:
-            try:
-                # Extract item_id from filename
-                item_id = Path(file_path).stem  # Gets filename without extension
-
-                # Read pipeline data
-                pipeline_json = await self._store.read_file(file_path)
-                pipeline = json.loads(pipeline_json)
-
-                # Extract name (from pipeline.name or source component name)
-                pipeline_name = pipeline.get('name', 'Untitled')
-                pipeline_desc = pipeline.get('description', '')
-
-                # Extract sources (all components where config.mode == 'Source')
-                sources = []
-                pipeline_components = pipeline.get('components', [])
-                for component in pipeline_components:
-                    config = component.get('config', {})
-                    if config.get('mode') == 'Source':
-                        sources.append({
-                            'id': component.get('id'),
-                            'provider': component.get('provider'),
-                            'name': config.get('name', component.get('id'))
-                        })
-
-                summary = {
-                    id_key: item_id,
-                    'name': pipeline_name,
-                    'description': pipeline_desc,
-                    'sources': sources,
-                    'totalComponents': len(pipeline_components)
-                }
-                items.append(summary)
-            except Exception:
-                # Skip files that can't be read or parsed
-                continue
-
-        return {'success': True, list_key: items, 'count': len(items)}
 
 
 __all__ = [

--- a/packages/ai/src/ai/account/store.py
+++ b/packages/ai/src/ai/account/store.py
@@ -169,8 +169,7 @@ class IStore(ABC):
         """
         Get the last modified time of a file as an epoch timestamp.
 
-        Default implementation reads the file to confirm existence, then
-        returns current time. Backends should override with native metadata.
+        Default implementation delegates to get_file_info.
 
         Args:
             filename: Relative path to file
@@ -181,11 +180,30 @@ class IStore(ABC):
         Raises:
             StorageError: If file doesn't exist
         """
+        info = await self.get_file_info(filename)
+        return info['modified']
+
+    async def get_file_info(self, filename: str) -> dict:
+        """
+        Get file metadata: size and modification time.
+
+        Default implementation reads the file to confirm existence and
+        returns approximate values. Backends should override with native
+        metadata (stat, head_object, get_blob_properties).
+
+        Args:
+            filename: Relative path to file
+
+        Returns:
+            dict with 'size' (int, bytes) and 'modified' (float, epoch timestamp)
+
+        Raises:
+            StorageError: If file doesn't exist
+        """
         import time
 
-        # Default: confirm file exists, return current time
-        await self.read_file(filename)
-        return time.time()
+        data = await self.read_bytes(filename)
+        return {'size': len(data), 'modified': time.time()}
 
     async def write_bytes(self, filename: str, data: bytes) -> None:
         """
@@ -494,7 +512,7 @@ class Store:
             storage_path = home / '.rocketlib' / 'store'
         except Exception:
             # Fallback to temp directory if home cannot be determined
-            storage_path = Path(tempfile.gettempdir()) / '.rocketlib' / 'dtc'
+            storage_path = Path(tempfile.gettempdir()) / '.rocketlib' / 'store'
 
         return f'filesystem://{storage_path.as_posix()}'
 

--- a/packages/ai/src/ai/account/store.py
+++ b/packages/ai/src/ai/account/store.py
@@ -271,10 +271,6 @@ class IStore(ABC):
         """Finalize and commit the write session."""
         await self.write_bytes(filename, bytes(context['buffer']))
 
-    async def abort_write(self, filename: str, context: Any) -> None:
-        """Close a write session, committing whatever data has been written."""
-        await self.close_write(filename, context)
-
     async def open_read(self, filename: str) -> dict:
         """
         Begin a read session for the given file.

--- a/packages/ai/src/ai/account/store_providers/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure.py
@@ -308,6 +308,119 @@ class AzureBlobStore(IStore):
             raise StorageError(f'Failed to list files with prefix {prefix} from Azure: {e}') from e
 
     # =========================================================================
+    # Handle-Based I/O
+    # =========================================================================
+
+    # Azure recommended block size (4 MB)
+    _AZURE_BLOCK_SIZE = 4 * 1024 * 1024
+
+    async def open_write(self, filename: str) -> dict:
+        """Prepare a staged block upload session."""
+        blob_name = self._get_blob_name(filename)
+        return {
+            'context': {
+                'blob_name': blob_name,
+                'block_ids': [],
+                'block_counter': 0,
+                'buffer': bytearray(),
+            },
+        }
+
+    async def write_chunk(self, filename: str, context, data: bytes) -> int:
+        """Buffer data and stage blocks when buffer reaches 4 MB."""
+        try:
+            context['buffer'].extend(data)
+            written = len(data)
+
+            while len(context['buffer']) >= self._AZURE_BLOCK_SIZE:
+                chunk = bytes(context['buffer'][: self._AZURE_BLOCK_SIZE])
+                del context['buffer'][: self._AZURE_BLOCK_SIZE]
+                self._stage_block(context, chunk)
+
+            return written
+        except Exception as e:
+            raise StorageError(f'Failed to write chunk to {filename}: {e}') from e
+
+    async def close_write(self, filename: str, context) -> None:
+        """Commit staged blocks or do a simple upload for small files."""
+        try:
+            client = self._get_client()
+            blob_client = client.get_blob_client(
+                container=self._container,
+                blob=context['blob_name'],
+            )
+            remaining = bytes(context['buffer'])
+            context['buffer'].clear()
+
+            if not context['block_ids']:
+                # Small file — no blocks were staged, simple upload
+                blob_client.upload_blob(remaining, overwrite=True)
+            else:
+                # Flush remaining buffer as the final block
+                if remaining:
+                    self._stage_block(context, remaining)
+
+                blob_client.commit_block_list(context['block_ids'])
+
+        except Exception as e:
+            raise StorageError(f'Failed to finalize upload for {filename}: {e}') from e
+
+    async def abort_write(self, filename: str, context) -> None:
+        """Close the upload, committing whatever has been written."""
+        await self.close_write(filename, context)
+
+    async def open_read(self, filename: str) -> dict:
+        """Get blob properties for ranged reads."""
+        try:
+            client = self._get_client()
+            blob_name = self._get_blob_name(filename)
+            blob_client = client.get_blob_client(
+                container=self._container,
+                blob=blob_name,
+            )
+            properties = blob_client.get_blob_properties()
+            size = properties.size
+            return {'context': {'blob_name': blob_name}, 'size': size}
+        except Exception as e:
+            if 'BlobNotFound' in str(e) or 'ResourceNotFound' in str(e):
+                raise StorageError(f'File not found: {filename}')
+            raise StorageError(f'Failed to open {filename} for reading: {e}') from e
+
+    async def read_chunk(self, filename: str, context, offset: int, length: int = 4_194_304) -> bytes:
+        """Read a range of bytes from Azure Blob."""
+        try:
+            client = self._get_client()
+            blob_client = client.get_blob_client(
+                container=self._container,
+                blob=context['blob_name'],
+            )
+            download_stream = blob_client.download_blob(offset=offset, length=length)
+            return download_stream.readall()
+        except Exception as e:
+            error_str = str(e)
+            if 'InvalidRange' in error_str or '416' in error_str:
+                return b''
+            raise StorageError(f'Failed to read chunk from {filename}: {e}') from e
+
+    async def close_read(self, filename: str, context) -> None:
+        """No-op — Azure reads are stateless."""
+        pass
+
+    def _stage_block(self, context: dict, data: bytes) -> None:
+        """Stage a single block and record its ID."""
+        import base64
+
+        client = self._get_client()
+        blob_client = client.get_blob_client(
+            container=self._container,
+            blob=context['blob_name'],
+        )
+        block_id = base64.b64encode(f'block-{context["block_counter"]:06d}'.encode()).decode()
+        blob_client.stage_block(block_id=block_id, data=data)
+        context['block_ids'].append(block_id)
+        context['block_counter'] += 1
+
+    # =========================================================================
     # Private Methods
     # =========================================================================
 

--- a/packages/ai/src/ai/account/store_providers/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure.py
@@ -1,5 +1,6 @@
 """Azure Blob Storage implementation."""
 
+import asyncio
 import json
 from typing import Optional
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
@@ -73,7 +74,7 @@ class AzureBlobStore(IStore):
                 container=self._container,
                 blob=blob_name,
             )
-            blob_client.upload_blob(data.encode('utf-8'), overwrite=True)
+            await asyncio.to_thread(blob_client.upload_blob, data.encode('utf-8'), overwrite=True)
 
         except (ConnectionError, TimeoutError):
             # Let these bubble up for retry
@@ -101,8 +102,7 @@ class AzureBlobStore(IStore):
                 container=self._container,
                 blob=blob_name,
             )
-            download_stream = blob_client.download_blob()
-            data = download_stream.readall()
+            data = await asyncio.to_thread(lambda: blob_client.download_blob().readall())
             return data.decode('utf-8')
 
         except (ConnectionError, TimeoutError):
@@ -133,12 +133,11 @@ class AzureBlobStore(IStore):
                 container=self._container,
                 blob=blob_name,
             )
-            download_stream = blob_client.download_blob()
-            data = download_stream.readall()
+            data = await asyncio.to_thread(lambda: blob_client.download_blob().readall())
             content = data.decode('utf-8')
 
             # Get properties to retrieve ETag
-            properties = blob_client.get_blob_properties()
+            properties = await asyncio.to_thread(blob_client.get_blob_properties)
             etag = properties.etag.strip('"')
 
             return (content, etag)
@@ -174,7 +173,7 @@ class AzureBlobStore(IStore):
             # Check if blob exists - expected_version is REQUIRED for updates
             file_exists = False
             try:
-                file_exists = blob_client.exists()
+                file_exists = await asyncio.to_thread(blob_client.exists)
             except Exception:
                 # If we can't check existence, continue (will fail later if needed)
                 pass
@@ -190,10 +189,10 @@ class AzureBlobStore(IStore):
                 upload_kwargs['etag'] = expected_version
                 upload_kwargs['match_condition'] = 'IfMatch'
 
-            blob_client.upload_blob(**upload_kwargs)
+            await asyncio.to_thread(lambda: blob_client.upload_blob(**upload_kwargs))
 
             # Get new ETag
-            properties = blob_client.get_blob_properties()
+            properties = await asyncio.to_thread(blob_client.get_blob_properties)
             new_etag = properties.etag.strip('"')
             return new_etag
 
@@ -230,7 +229,7 @@ class AzureBlobStore(IStore):
 
             # Check if blob exists and get current ETag if needed
             try:
-                properties = blob_client.get_blob_properties()
+                properties = await asyncio.to_thread(blob_client.get_blob_properties)
                 current_etag = properties.etag.strip('"')
 
                 # expected_version is REQUIRED for delete operations
@@ -256,7 +255,7 @@ class AzureBlobStore(IStore):
                 delete_kwargs['etag'] = expected_version
                 delete_kwargs['match_condition'] = 'IfMatch'
 
-            blob_client.delete_blob(**delete_kwargs)
+            await asyncio.to_thread(lambda: blob_client.delete_blob(**delete_kwargs))
 
         except (ConnectionError, TimeoutError):
             raise
@@ -287,7 +286,7 @@ class AzureBlobStore(IStore):
             blob_prefix = self._get_blob_name(prefix) if prefix else self._prefix
 
             files = []
-            blob_list = container_client.list_blobs(name_starts_with=blob_prefix)
+            blob_list = await asyncio.to_thread(container_client.list_blobs, name_starts_with=blob_prefix)
 
             for blob in blob_list:
                 blob_name = blob.name
@@ -334,7 +333,7 @@ class AzureBlobStore(IStore):
 
             while len(context['buffer']) >= self._AZURE_BLOCK_SIZE:
                 chunk = bytes(context['buffer'][: self._AZURE_BLOCK_SIZE])
-                self._stage_block(context, chunk)
+                await self._stage_block(context, chunk)
                 # Only discard from buffer after successful staging
                 del context['buffer'][: self._AZURE_BLOCK_SIZE]
 
@@ -354,13 +353,13 @@ class AzureBlobStore(IStore):
 
             if not context['block_ids']:
                 # Small file — no blocks were staged, simple upload
-                blob_client.upload_blob(remaining, overwrite=True)
+                await asyncio.to_thread(blob_client.upload_blob, remaining, overwrite=True)
             else:
                 # Flush remaining buffer as the final block
                 if remaining:
-                    self._stage_block(context, remaining)
+                    await self._stage_block(context, remaining)
 
-                blob_client.commit_block_list(context['block_ids'])
+                await asyncio.to_thread(blob_client.commit_block_list, context['block_ids'])
 
             # Only clear buffer after successful commit
             context['buffer'].clear()
@@ -381,7 +380,7 @@ class AzureBlobStore(IStore):
                 container=self._container,
                 blob=blob_name,
             )
-            properties = blob_client.get_blob_properties()
+            properties = await asyncio.to_thread(blob_client.get_blob_properties)
             size = properties.size
             return {'context': {'blob_name': blob_name}, 'size': size}
         except Exception as e:
@@ -397,8 +396,8 @@ class AzureBlobStore(IStore):
                 container=self._container,
                 blob=context['blob_name'],
             )
-            download_stream = blob_client.download_blob(offset=offset, length=length)
-            return download_stream.readall()
+            data = await asyncio.to_thread(lambda: blob_client.download_blob(offset=offset, length=length).readall())
+            return data
         except Exception as e:
             error_str = str(e)
             if 'InvalidRange' in error_str or '416' in error_str:
@@ -418,7 +417,7 @@ class AzureBlobStore(IStore):
                 container=self._container,
                 blob=blob_name,
             )
-            properties = blob_client.get_blob_properties()
+            properties = await asyncio.to_thread(blob_client.get_blob_properties)
             return {
                 'size': properties.size,
                 'modified': properties.last_modified.timestamp(),
@@ -428,7 +427,7 @@ class AzureBlobStore(IStore):
                 raise StorageError(f'File not found: {filename}')
             raise StorageError(f'Failed to get file info for {filename}: {e}') from e
 
-    def _stage_block(self, context: dict, data: bytes) -> None:
+    async def _stage_block(self, context: dict, data: bytes) -> None:
         """Stage a single block and record its ID."""
         import base64
 
@@ -438,7 +437,7 @@ class AzureBlobStore(IStore):
             blob=context['blob_name'],
         )
         block_id = base64.b64encode(f'block-{context["block_counter"]:06d}'.encode()).decode()
-        blob_client.stage_block(block_id=block_id, data=data)
+        await asyncio.to_thread(blob_client.stage_block, block_id=block_id, data=data)
         context['block_ids'].append(block_id)
         context['block_counter'] += 1
 

--- a/packages/ai/src/ai/account/store_providers/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure.py
@@ -334,8 +334,9 @@ class AzureBlobStore(IStore):
 
             while len(context['buffer']) >= self._AZURE_BLOCK_SIZE:
                 chunk = bytes(context['buffer'][: self._AZURE_BLOCK_SIZE])
-                del context['buffer'][: self._AZURE_BLOCK_SIZE]
                 self._stage_block(context, chunk)
+                # Only discard from buffer after successful staging
+                del context['buffer'][: self._AZURE_BLOCK_SIZE]
 
             return written
         except Exception as e:
@@ -350,7 +351,6 @@ class AzureBlobStore(IStore):
                 blob=context['blob_name'],
             )
             remaining = bytes(context['buffer'])
-            context['buffer'].clear()
 
             if not context['block_ids']:
                 # Small file — no blocks were staged, simple upload
@@ -361,6 +361,9 @@ class AzureBlobStore(IStore):
                     self._stage_block(context, remaining)
 
                 blob_client.commit_block_list(context['block_ids'])
+
+            # Only clear buffer after successful commit
+            context['buffer'].clear()
 
         except Exception as e:
             raise StorageError(f'Failed to finalize upload for {filename}: {e}') from e
@@ -405,6 +408,25 @@ class AzureBlobStore(IStore):
     async def close_read(self, filename: str, context) -> None:
         """No-op — Azure reads are stateless."""
         pass
+
+    async def get_file_info(self, filename: str) -> dict:
+        """Get file size and modification time via get_blob_properties."""
+        try:
+            client = self._get_client()
+            blob_name = self._get_blob_name(filename)
+            blob_client = client.get_blob_client(
+                container=self._container,
+                blob=blob_name,
+            )
+            properties = blob_client.get_blob_properties()
+            return {
+                'size': properties.size,
+                'modified': properties.last_modified.timestamp(),
+            }
+        except Exception as e:
+            if 'BlobNotFound' in str(e) or 'ResourceNotFound' in str(e):
+                raise StorageError(f'File not found: {filename}')
+            raise StorageError(f'Failed to get file info for {filename}: {e}') from e
 
     def _stage_block(self, context: dict, data: bytes) -> None:
         """Stage a single block and record its ID."""

--- a/packages/ai/src/ai/account/store_providers/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure.py
@@ -367,10 +367,6 @@ class AzureBlobStore(IStore):
         except Exception as e:
             raise StorageError(f'Failed to finalize upload for {filename}: {e}') from e
 
-    async def abort_write(self, filename: str, context) -> None:
-        """Close the upload, committing whatever has been written."""
-        await self.close_write(filename, context)
-
     async def open_read(self, filename: str) -> dict:
         """Get blob properties for ranged reads."""
         try:

--- a/packages/ai/src/ai/account/store_providers/filesystem.py
+++ b/packages/ai/src/ai/account/store_providers/filesystem.py
@@ -251,11 +251,17 @@ class FilesystemStore(IStore):
 
     async def get_modified_time(self, filename: str) -> float:
         """Get the last modified time of a file as an epoch timestamp."""
+        info = await self.get_file_info(filename)
+        return info['modified']
+
+    async def get_file_info(self, filename: str) -> dict:
+        """Get file size and modification time in a single stat call."""
         try:
             full_path = self._get_full_path(filename)
             if not full_path.exists():
                 raise StorageError(f'File not found: {filename}')
-            return full_path.stat().st_mtime
+            st = full_path.stat()
+            return {'size': st.st_size, 'modified': st.st_mtime}
         except StorageError:
             raise
         except Exception as e:

--- a/packages/ai/src/ai/account/store_providers/filesystem.py
+++ b/packages/ai/src/ai/account/store_providers/filesystem.py
@@ -3,7 +3,6 @@
 import aiofiles
 import aiofiles.os
 import asyncio
-import hashlib
 import os
 import sys
 from pathlib import Path
@@ -127,9 +126,9 @@ class FilesystemStore(IStore):
                 async with aiofiles.open(full_path, 'r', encoding='utf-8') as f:
                     content = await f.read()
 
-                # Calculate version
-                version = hashlib.sha256(content.encode('utf-8')).hexdigest()
-                return (content, version)
+                # Use modification time as version identifier
+                mtime = full_path.stat().st_mtime
+                return (content, str(mtime))
 
             finally:
                 # Release lock
@@ -166,31 +165,22 @@ class FilesystemStore(IStore):
                 await self._acquire_lock(lock_fd, shared=False)
 
                 # Now we have exclusive access - check version
-                if full_path.exists():
-                    # File exists - expected_version is REQUIRED for updates
-                    if expected_version is None:
-                        raise StorageError(f'Expected version is required when updating existing file: {filename}')
-
-                    # Read current content and verify version
-                    async with aiofiles.open(full_path, 'r', encoding='utf-8') as f:
-                        current_content = await f.read()
-                    current_version = hashlib.sha256(current_content.encode('utf-8')).hexdigest()
-
-                    if current_version != expected_version:
+                if full_path.exists() and expected_version is not None:
+                    # Verify modification time matches expected version
+                    current_mtime = str(full_path.stat().st_mtime)
+                    if current_mtime != expected_version:
                         raise VersionMismatchError(
                             filename=filename,
                             expected_version=expected_version,
-                            actual_version=current_version,
+                            actual_version=current_mtime,
                         )
 
                 # Write file while holding lock
                 async with aiofiles.open(full_path, 'w', encoding='utf-8') as f:
                     await f.write(data)
 
-                # Calculate new version
-                new_version = hashlib.sha256(data.encode('utf-8')).hexdigest()
-
-                return new_version
+                # Return new modification time as version
+                return str(full_path.stat().st_mtime)
 
             finally:
                 # Release lock and close file descriptor
@@ -229,21 +219,15 @@ class FilesystemStore(IStore):
                 if not full_path.exists():
                     raise StorageError(f'File not found: {filename}')
 
-                # expected_version is REQUIRED for delete operations
-                if expected_version is None:
-                    raise StorageError(f'Expected version is required when deleting file: {filename}')
-
-                # Verify version matches
-                async with aiofiles.open(full_path, 'r', encoding='utf-8') as f:
-                    current_content = await f.read()
-                current_version = hashlib.sha256(current_content.encode('utf-8')).hexdigest()
-
-                if current_version != expected_version:
-                    raise VersionMismatchError(
-                        filename=filename,
-                        expected_version=expected_version,
-                        actual_version=current_version,
-                    )
+                # If expected_version provided, verify modification time matches
+                if expected_version is not None:
+                    current_mtime = str(full_path.stat().st_mtime)
+                    if current_mtime != expected_version:
+                        raise VersionMismatchError(
+                            filename=filename,
+                            expected_version=expected_version,
+                            actual_version=current_mtime,
+                        )
 
                 # Delete file while holding lock
                 full_path.unlink()
@@ -264,6 +248,41 @@ class FilesystemStore(IStore):
             raise
         except Exception as e:
             raise StorageError(f'Failed to delete file {filename}: {e}') from e
+
+    async def get_modified_time(self, filename: str) -> float:
+        """Get the last modified time of a file as an epoch timestamp."""
+        try:
+            full_path = self._get_full_path(filename)
+            if not full_path.exists():
+                raise StorageError(f'File not found: {filename}')
+            return full_path.stat().st_mtime
+        except StorageError:
+            raise
+        except Exception as e:
+            raise StorageError(f'Failed to stat file {filename}: {e}') from e
+
+    async def write_bytes(self, filename: str, data: bytes) -> None:
+        """Write binary data to file."""
+        try:
+            full_path = self._get_full_path(filename)
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            async with aiofiles.open(full_path, 'wb') as f:
+                await f.write(data)
+        except Exception as e:
+            raise StorageError(f'Failed to write file {filename}: {e}') from e
+
+    async def read_bytes(self, filename: str) -> bytes:
+        """Read binary data from file."""
+        try:
+            full_path = self._get_full_path(filename)
+            if not full_path.exists():
+                raise StorageError(f'File not found: {filename}')
+            async with aiofiles.open(full_path, 'rb') as f:
+                return await f.read()
+        except StorageError:
+            raise
+        except Exception as e:
+            raise StorageError(f'Failed to read file {filename}: {e}') from e
 
     async def list_files(self, prefix: str = '') -> list:
         """List all files with given prefix."""
@@ -291,6 +310,72 @@ class FilesystemStore(IStore):
 
         except Exception as e:
             raise StorageError(f'Failed to list files with prefix {prefix}: {e}') from e
+
+    # =========================================================================
+    # Handle-Based I/O
+    # =========================================================================
+
+    async def open_write(self, filename: str) -> dict:
+        """Open a file for writing. Returns context with aiofiles handle."""
+        try:
+            full_path = self._get_full_path(filename)
+            full_path.parent.mkdir(parents=True, exist_ok=True)
+            f = await aiofiles.open(full_path, 'wb')
+            return {'context': {'file': f, 'path': full_path}}
+        except Exception as e:
+            raise StorageError(f'Failed to open file {filename} for writing: {e}') from e
+
+    async def write_chunk(self, filename: str, context, data: bytes) -> int:
+        """Write a chunk to the open file handle."""
+        try:
+            f = context['file']
+            await f.write(data)
+            return len(data)
+        except Exception as e:
+            raise StorageError(f'Failed to write chunk to {filename}: {e}') from e
+
+    async def close_write(self, filename: str, context) -> None:
+        """Close the file handle, committing the data."""
+        try:
+            f = context['file']
+            await f.close()
+        except Exception as e:
+            raise StorageError(f'Failed to close file {filename}: {e}') from e
+
+    async def abort_write(self, filename: str, context) -> None:
+        """Close the file, committing whatever has been written."""
+        await self.close_write(filename, context)
+
+    async def open_read(self, filename: str) -> dict:
+        """Open a file for reading. Returns context with aiofiles handle and file size."""
+        try:
+            full_path = self._get_full_path(filename)
+            if not full_path.exists():
+                raise StorageError(f'File not found: {filename}')
+            size = full_path.stat().st_size
+            f = await aiofiles.open(full_path, 'rb')
+            return {'context': {'file': f, 'path': full_path}, 'size': size}
+        except StorageError:
+            raise
+        except Exception as e:
+            raise StorageError(f'Failed to open file {filename} for reading: {e}') from e
+
+    async def read_chunk(self, filename: str, context, offset: int, length: int = 4_194_304) -> bytes:
+        """Read a chunk from the open file handle at the given offset."""
+        try:
+            f = context['file']
+            await f.seek(offset)
+            return await f.read(length)
+        except Exception as e:
+            raise StorageError(f'Failed to read chunk from {filename}: {e}') from e
+
+    async def close_read(self, filename: str, context) -> None:
+        """Close the read file handle."""
+        try:
+            f = context['file']
+            await f.close()
+        except Exception as e:
+            raise StorageError(f'Failed to close file {filename}: {e}') from e
 
     # =========================================================================
     # Private Methods

--- a/packages/ai/src/ai/account/store_providers/filesystem.py
+++ b/packages/ai/src/ai/account/store_providers/filesystem.py
@@ -348,10 +348,6 @@ class FilesystemStore(IStore):
         except Exception as e:
             raise StorageError(f'Failed to close file {filename}: {e}') from e
 
-    async def abort_write(self, filename: str, context) -> None:
-        """Close the file, committing whatever has been written."""
-        await self.close_write(filename, context)
-
     async def open_read(self, filename: str) -> dict:
         """Open a file for reading. Returns context with aiofiles handle and file size."""
         try:

--- a/packages/ai/src/ai/account/store_providers/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3.py
@@ -316,23 +316,20 @@ class S3Store(IStore):
     _S3_MIN_PART_SIZE = 5 * 1024 * 1024
 
     async def open_write(self, filename: str) -> dict:
-        """Begin a multipart upload session."""
+        """Prepare a write session. Multipart upload is deferred until needed."""
         try:
-            client = self._get_client()
             key = self._get_key(filename)
-            response = client.create_multipart_upload(Bucket=self._bucket, Key=key)
-            upload_id = response['UploadId']
             return {
                 'context': {
                     'key': key,
-                    'upload_id': upload_id,
+                    'upload_id': None,
                     'parts': [],
                     'part_number': 1,
                     'buffer': bytearray(),
                 },
             }
         except Exception as e:
-            raise StorageError(f'Failed to start multipart upload for {filename}: {e}') from e
+            raise StorageError(f'Failed to prepare upload for {filename}: {e}') from e
 
     async def write_chunk(self, filename: str, context, data: bytes) -> int:
         """Buffer data and flush as S3 parts when buffer reaches 5 MB."""
@@ -342,9 +339,15 @@ class S3Store(IStore):
 
             # Flush parts while buffer is large enough
             while len(context['buffer']) >= self._S3_MIN_PART_SIZE:
+                # Lazily create multipart upload on first flush
+                if context['upload_id'] is None:
+                    client = self._get_client()
+                    response = client.create_multipart_upload(Bucket=self._bucket, Key=context['key'])
+                    context['upload_id'] = response['UploadId']
+
                 chunk = bytes(context['buffer'][: self._S3_MIN_PART_SIZE])
-                del context['buffer'][: self._S3_MIN_PART_SIZE]
                 self._upload_part(context, chunk)
+                del context['buffer'][: self._S3_MIN_PART_SIZE]
 
             return written
         except Exception as e:
@@ -357,13 +360,8 @@ class S3Store(IStore):
             remaining = bytes(context['buffer'])
             context['buffer'].clear()
 
-            if not context['parts']:
-                # Total data < 5 MB: skip multipart, use simple put_object
-                client.abort_multipart_upload(
-                    Bucket=self._bucket,
-                    Key=context['key'],
-                    UploadId=context['upload_id'],
-                )
+            if context['upload_id'] is None:
+                # No multipart was started — simple put_object
                 client.put_object(
                     Bucket=self._bucket,
                     Key=context['key'],
@@ -381,15 +379,16 @@ class S3Store(IStore):
                     MultipartUpload={'Parts': context['parts']},
                 )
         except Exception as e:
-            # Best-effort abort on failure
-            try:
-                self._get_client().abort_multipart_upload(
-                    Bucket=self._bucket,
-                    Key=context['key'],
-                    UploadId=context['upload_id'],
-                )
-            except Exception:
-                pass
+            # Best-effort abort on failure (only if multipart was started)
+            if context.get('upload_id'):
+                try:
+                    self._get_client().abort_multipart_upload(
+                        Bucket=self._bucket,
+                        Key=context['key'],
+                        UploadId=context['upload_id'],
+                    )
+                except Exception:
+                    pass
             raise StorageError(f'Failed to finalize upload for {filename}: {e}') from e
 
     async def abort_write(self, filename: str, context) -> None:
@@ -430,6 +429,21 @@ class S3Store(IStore):
     async def close_read(self, filename: str, context) -> None:
         """No-op — S3 reads are stateless."""
         pass
+
+    async def get_file_info(self, filename: str) -> dict:
+        """Get file size and modification time via head_object."""
+        try:
+            client = self._get_client()
+            key = self._get_key(filename)
+            response = client.head_object(Bucket=self._bucket, Key=key)
+            return {
+                'size': response['ContentLength'],
+                'modified': response['LastModified'].timestamp(),
+            }
+        except Exception as e:
+            if self._is_no_such_key_error(e):
+                raise StorageError(f'File not found: {filename}')
+            raise StorageError(f'Failed to get file info for {filename}: {e}') from e
 
     def _upload_part(self, context: dict, data: bytes) -> None:
         """Upload a single part and record its ETag."""

--- a/packages/ai/src/ai/account/store_providers/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3.py
@@ -1,5 +1,6 @@
 """AWS S3 storage implementation."""
 
+import asyncio
 import json
 from typing import Optional
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
@@ -74,11 +75,7 @@ class S3Store(IStore):
             client = self._get_client()
             key = self._get_key(filename)
 
-            client.put_object(
-                Bucket=self._bucket,
-                Key=key,
-                Body=data.encode('utf-8'),
-            )
+            await asyncio.to_thread(client.put_object, Bucket=self._bucket, Key=key, Body=data.encode('utf-8'))
 
         except (ConnectionError, TimeoutError):
             # Let these bubble up for retry
@@ -102,8 +99,11 @@ class S3Store(IStore):
             client = self._get_client()
             key = self._get_key(filename)
 
-            response = client.get_object(Bucket=self._bucket, Key=key)
-            data = response['Body'].read()
+            def _read():
+                response = client.get_object(Bucket=self._bucket, Key=key)
+                return response['Body'].read()
+
+            data = await asyncio.to_thread(_read)
             return data.decode('utf-8')
 
         except (ConnectionError, TimeoutError):
@@ -131,12 +131,13 @@ class S3Store(IStore):
             client = self._get_client()
             key = self._get_key(filename)
 
-            response = client.get_object(Bucket=self._bucket, Key=key)
-            data = response['Body'].read()
-            content = data.decode('utf-8')
-            etag = response.get('ETag', '').strip('"')  # Remove quotes from ETag
+            def _read():
+                response = client.get_object(Bucket=self._bucket, Key=key)
+                data = response['Body'].read()
+                return data, response.get('ETag', '').strip('"')
 
-            return (content, etag)
+            data, etag = await asyncio.to_thread(_read)
+            return (data.decode('utf-8'), etag)
 
         except (ConnectionError, TimeoutError):
             raise
@@ -169,7 +170,7 @@ class S3Store(IStore):
             # Check if file exists - expected_version is REQUIRED for updates
             file_exists = False
             try:
-                client.head_object(Bucket=self._bucket, Key=key)
+                await asyncio.to_thread(client.head_object, Bucket=self._bucket, Key=key)
                 file_exists = True
             except Exception as e:
                 # Check if it's a NoSuchKey error (file doesn't exist)
@@ -193,7 +194,7 @@ class S3Store(IStore):
                 put_kwargs['IfMatch'] = expected_version
 
             try:
-                response = client.put_object(**put_kwargs)
+                response = await asyncio.to_thread(lambda: client.put_object(**put_kwargs))
             except Exception as put_error:
                 # Handle race condition: file was deleted between head_object and put_object
                 # When IfMatch is used but key doesn't exist, S3 returns NoSuchKey
@@ -236,7 +237,7 @@ class S3Store(IStore):
 
             # Verify file exists first
             try:
-                head_response = client.head_object(Bucket=self._bucket, Key=key)
+                head_response = await asyncio.to_thread(client.head_object, Bucket=self._bucket, Key=key)
                 current_etag = head_response.get('ETag', '').strip('"')
 
                 # expected_version is REQUIRED for delete operations
@@ -258,7 +259,7 @@ class S3Store(IStore):
                 raise
 
             # Delete the file
-            client.delete_object(Bucket=self._bucket, Key=key)
+            await asyncio.to_thread(client.delete_object, Bucket=self._bucket, Key=key)
 
         except (ConnectionError, TimeoutError):
             raise
@@ -281,27 +282,26 @@ class S3Store(IStore):
             client = self._get_client()
             key_prefix = self._get_key(prefix) if prefix else self._prefix
 
-            files = []
-            paginator = client.get_paginator('list_objects_v2')
+            def _list():
+                result = []
+                paginator = client.get_paginator('list_objects_v2')
+                page_kwargs = {'Bucket': self._bucket}
+                if key_prefix:
+                    page_kwargs['Prefix'] = key_prefix
+                for page in paginator.paginate(**page_kwargs):
+                    if 'Contents' in page:
+                        for obj in page['Contents']:
+                            k = obj['Key']
+                            if self._prefix and k.startswith(self._prefix + '/'):
+                                relative_key = k[len(self._prefix) + 1 :]
+                            elif self._prefix and k.startswith(self._prefix):
+                                relative_key = k[len(self._prefix) :]
+                            else:
+                                relative_key = k
+                            result.append(relative_key)
+                return sorted(result)
 
-            page_kwargs = {'Bucket': self._bucket}
-            if key_prefix:
-                page_kwargs['Prefix'] = key_prefix
-
-            for page in paginator.paginate(**page_kwargs):
-                if 'Contents' in page:
-                    for obj in page['Contents']:
-                        key = obj['Key']
-                        # Remove prefix to get relative path
-                        if self._prefix and key.startswith(self._prefix + '/'):
-                            relative_key = key[len(self._prefix) + 1 :]
-                        elif self._prefix and key.startswith(self._prefix):
-                            relative_key = key[len(self._prefix) :]
-                        else:
-                            relative_key = key
-                        files.append(relative_key)
-
-            return sorted(files)
+            return await asyncio.to_thread(_list)
 
         except (ConnectionError, TimeoutError):
             raise
@@ -342,11 +342,11 @@ class S3Store(IStore):
                 # Lazily create multipart upload on first flush
                 if context['upload_id'] is None:
                     client = self._get_client()
-                    response = client.create_multipart_upload(Bucket=self._bucket, Key=context['key'])
+                    response = await asyncio.to_thread(client.create_multipart_upload, Bucket=self._bucket, Key=context['key'])
                     context['upload_id'] = response['UploadId']
 
                 chunk = bytes(context['buffer'][: self._S3_MIN_PART_SIZE])
-                self._upload_part(context, chunk)
+                await self._upload_part(context, chunk)
                 del context['buffer'][: self._S3_MIN_PART_SIZE]
 
             return written
@@ -362,17 +362,14 @@ class S3Store(IStore):
 
             if context['upload_id'] is None:
                 # No multipart was started — simple put_object
-                client.put_object(
-                    Bucket=self._bucket,
-                    Key=context['key'],
-                    Body=remaining,
-                )
+                await asyncio.to_thread(client.put_object, Bucket=self._bucket, Key=context['key'], Body=remaining)
             else:
                 # Flush remaining buffer as the final part (can be < 5 MB)
                 if remaining:
-                    self._upload_part(context, remaining)
+                    await self._upload_part(context, remaining)
 
-                client.complete_multipart_upload(
+                await asyncio.to_thread(
+                    client.complete_multipart_upload,
                     Bucket=self._bucket,
                     Key=context['key'],
                     UploadId=context['upload_id'],
@@ -382,7 +379,8 @@ class S3Store(IStore):
             # Best-effort abort on failure (only if multipart was started)
             if context.get('upload_id'):
                 try:
-                    self._get_client().abort_multipart_upload(
+                    await asyncio.to_thread(
+                        self._get_client().abort_multipart_upload,
                         Bucket=self._bucket,
                         Key=context['key'],
                         UploadId=context['upload_id'],
@@ -400,7 +398,7 @@ class S3Store(IStore):
         try:
             client = self._get_client()
             key = self._get_key(filename)
-            response = client.head_object(Bucket=self._bucket, Key=key)
+            response = await asyncio.to_thread(client.head_object, Bucket=self._bucket, Key=key)
             size = response['ContentLength']
             return {'context': {'key': key}, 'size': size}
         except Exception as e:
@@ -413,12 +411,12 @@ class S3Store(IStore):
         try:
             client = self._get_client()
             end = offset + length - 1
-            response = client.get_object(
-                Bucket=self._bucket,
-                Key=context['key'],
-                Range=f'bytes={offset}-{end}',
-            )
-            return response['Body'].read()
+
+            def _read_range():
+                response = client.get_object(Bucket=self._bucket, Key=context['key'], Range=f'bytes={offset}-{end}')
+                return response['Body'].read()
+
+            return await asyncio.to_thread(_read_range)
         except Exception as e:
             # Empty response at EOF
             error_str = str(e)
@@ -435,7 +433,7 @@ class S3Store(IStore):
         try:
             client = self._get_client()
             key = self._get_key(filename)
-            response = client.head_object(Bucket=self._bucket, Key=key)
+            response = await asyncio.to_thread(client.head_object, Bucket=self._bucket, Key=key)
             return {
                 'size': response['ContentLength'],
                 'modified': response['LastModified'].timestamp(),
@@ -445,10 +443,11 @@ class S3Store(IStore):
                 raise StorageError(f'File not found: {filename}')
             raise StorageError(f'Failed to get file info for {filename}: {e}') from e
 
-    def _upload_part(self, context: dict, data: bytes) -> None:
+    async def _upload_part(self, context: dict, data: bytes) -> None:
         """Upload a single part and record its ETag."""
         client = self._get_client()
-        response = client.upload_part(
+        response = await asyncio.to_thread(
+            client.upload_part,
             Bucket=self._bucket,
             Key=context['key'],
             UploadId=context['upload_id'],

--- a/packages/ai/src/ai/account/store_providers/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3.py
@@ -389,10 +389,6 @@ class S3Store(IStore):
                     pass
             raise StorageError(f'Failed to finalize upload for {filename}: {e}') from e
 
-    async def abort_write(self, filename: str, context) -> None:
-        """Close the upload, committing whatever has been written."""
-        await self.close_write(filename, context)
-
     async def open_read(self, filename: str) -> dict:
         """Get file size via head_object for ranged reads."""
         try:

--- a/packages/ai/src/ai/account/store_providers/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3.py
@@ -309,6 +309,147 @@ class S3Store(IStore):
             raise StorageError(f'Failed to list files with prefix {prefix} from S3: {e}') from e
 
     # =========================================================================
+    # Handle-Based I/O
+    # =========================================================================
+
+    # S3 minimum part size (5 MB) — all parts except the last must be >= this
+    _S3_MIN_PART_SIZE = 5 * 1024 * 1024
+
+    async def open_write(self, filename: str) -> dict:
+        """Begin a multipart upload session."""
+        try:
+            client = self._get_client()
+            key = self._get_key(filename)
+            response = client.create_multipart_upload(Bucket=self._bucket, Key=key)
+            upload_id = response['UploadId']
+            return {
+                'context': {
+                    'key': key,
+                    'upload_id': upload_id,
+                    'parts': [],
+                    'part_number': 1,
+                    'buffer': bytearray(),
+                },
+            }
+        except Exception as e:
+            raise StorageError(f'Failed to start multipart upload for {filename}: {e}') from e
+
+    async def write_chunk(self, filename: str, context, data: bytes) -> int:
+        """Buffer data and flush as S3 parts when buffer reaches 5 MB."""
+        try:
+            context['buffer'].extend(data)
+            written = len(data)
+
+            # Flush parts while buffer is large enough
+            while len(context['buffer']) >= self._S3_MIN_PART_SIZE:
+                chunk = bytes(context['buffer'][: self._S3_MIN_PART_SIZE])
+                del context['buffer'][: self._S3_MIN_PART_SIZE]
+                self._upload_part(context, chunk)
+
+            return written
+        except Exception as e:
+            raise StorageError(f'Failed to write chunk to {filename}: {e}') from e
+
+    async def close_write(self, filename: str, context) -> None:
+        """Finalize the upload — single put_object if small, complete multipart otherwise."""
+        try:
+            client = self._get_client()
+            remaining = bytes(context['buffer'])
+            context['buffer'].clear()
+
+            if not context['parts']:
+                # Total data < 5 MB: skip multipart, use simple put_object
+                client.abort_multipart_upload(
+                    Bucket=self._bucket,
+                    Key=context['key'],
+                    UploadId=context['upload_id'],
+                )
+                client.put_object(
+                    Bucket=self._bucket,
+                    Key=context['key'],
+                    Body=remaining,
+                )
+            else:
+                # Flush remaining buffer as the final part (can be < 5 MB)
+                if remaining:
+                    self._upload_part(context, remaining)
+
+                client.complete_multipart_upload(
+                    Bucket=self._bucket,
+                    Key=context['key'],
+                    UploadId=context['upload_id'],
+                    MultipartUpload={'Parts': context['parts']},
+                )
+        except Exception as e:
+            # Best-effort abort on failure
+            try:
+                self._get_client().abort_multipart_upload(
+                    Bucket=self._bucket,
+                    Key=context['key'],
+                    UploadId=context['upload_id'],
+                )
+            except Exception:
+                pass
+            raise StorageError(f'Failed to finalize upload for {filename}: {e}') from e
+
+    async def abort_write(self, filename: str, context) -> None:
+        """Close the upload, committing whatever has been written."""
+        await self.close_write(filename, context)
+
+    async def open_read(self, filename: str) -> dict:
+        """Get file size via head_object for ranged reads."""
+        try:
+            client = self._get_client()
+            key = self._get_key(filename)
+            response = client.head_object(Bucket=self._bucket, Key=key)
+            size = response['ContentLength']
+            return {'context': {'key': key}, 'size': size}
+        except Exception as e:
+            if self._is_no_such_key_error(e):
+                raise StorageError(f'File not found: {filename}')
+            raise StorageError(f'Failed to open {filename} for reading: {e}') from e
+
+    async def read_chunk(self, filename: str, context, offset: int, length: int = 4_194_304) -> bytes:
+        """Read a range of bytes from S3."""
+        try:
+            client = self._get_client()
+            end = offset + length - 1
+            response = client.get_object(
+                Bucket=self._bucket,
+                Key=context['key'],
+                Range=f'bytes={offset}-{end}',
+            )
+            return response['Body'].read()
+        except Exception as e:
+            # Empty response at EOF
+            error_str = str(e)
+            if 'InvalidRange' in error_str or '416' in error_str:
+                return b''
+            raise StorageError(f'Failed to read chunk from {filename}: {e}') from e
+
+    async def close_read(self, filename: str, context) -> None:
+        """No-op — S3 reads are stateless."""
+        pass
+
+    def _upload_part(self, context: dict, data: bytes) -> None:
+        """Upload a single part and record its ETag."""
+        client = self._get_client()
+        response = client.upload_part(
+            Bucket=self._bucket,
+            Key=context['key'],
+            UploadId=context['upload_id'],
+            PartNumber=context['part_number'],
+            Body=data,
+        )
+        context['parts'].append(
+            {
+                'PartNumber': context['part_number'],
+                'ETag': response['ETag'],
+            }
+        )
+        context['part_number'] += 1
+
+    # =========================================================================
     # Private Static Methods
     # =========================================================================
 

--- a/packages/ai/src/ai/modules/task/commands/cmd_debug.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_debug.py
@@ -194,6 +194,7 @@ class DebugCommands(DAPConn):
                 request,
                 self,
                 attach_debugger=True,
+                client_id=self._account_info.clientid,
             )
 
             # Save the debug token and the event id

--- a/packages/ai/src/ai/modules/task/commands/cmd_task.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_task.py
@@ -30,7 +30,6 @@ The actual task execution and management is delegated to the TaskServer.
 
 from typing import TYPE_CHECKING, Dict, Any
 from ai.common.dap import DAPConn, TransportBase
-from ai.account.store import StorageError
 
 # Only import for type checking to avoid circular import errors
 if TYPE_CHECKING:
@@ -81,17 +80,14 @@ class TaskCommands(DAPConn):
         """
         # Map of store subcommand names to handler methods
         self._store_subcommand_handlers = {
-            'save_project': self._store_save_project,
-            'get_project': self._store_get_project,
-            'delete_project': self._store_delete_project,
-            'get_all_projects': self._store_get_all_projects,
-            'save_template': self._store_save_template,
-            'get_template': self._store_get_template,
-            'delete_template': self._store_delete_template,
-            'get_all_templates': self._store_get_all_templates,
-            'save_log': self._store_save_log,
-            'get_log': self._store_get_log,
-            'list_logs': self._store_list_logs,
+            'fs_open': self._store_fs_open,
+            'fs_read': self._store_fs_read,
+            'fs_write': self._store_fs_write,
+            'fs_close': self._store_fs_close,
+            'fs_delete': self._store_fs_delete,
+            'fs_list_dir': self._store_fs_list_dir,
+            'fs_mkdir': self._store_fs_mkdir,
+            'fs_stat': self._store_fs_stat,
         }
 
     async def on_execute(self, request: Dict[str, Any]) -> Dict[str, Any]:
@@ -128,6 +124,7 @@ class TaskCommands(DAPConn):
                 request,
                 self,
                 wait_for_running=True,
+                client_id=self._account_info.clientid,
             )
 
             # Confirm successful task execution startup
@@ -369,160 +366,76 @@ class TaskCommands(DAPConn):
             self.debug_message(f'Store operation failed: {str(e)}')
             raise
 
-    async def _store_save_project(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Save project subcommand handler."""
-        try:
-            # Save project using authenticated account (validation done in store)
-            result = await self._server.store.save_project(self._account_info, args.get('projectId'), args.get('pipeline'), args.get('expectedVersion'))
+    def _get_file_store(self):
+        """Get a FileStore scoped to the authenticated user."""
+        return self._server.store.get_file_store(self._account_info.clientid)
 
-            # Return success response
+    # =========================================================================
+    # Generic File Store Handlers
+    # =========================================================================
+
+    async def _store_fs_open(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Open a file handle for reading or writing."""
+        fs = self._get_file_store()
+        path = args.get('path')
+        mode = args.get('mode', 'r')
+
+        if mode == 'w':
+            handle_id = await fs.open_write(path, self._connection_id)
+            return self.build_response(request, body={'handle': handle_id})
+        else:
+            offset = args.get('offset', 0)
+            result = await fs.open_read(path, self._connection_id, offset=offset)
             return self.build_response(request, body=result)
 
-        except StorageError as e:
-            self.debug_message(f'Storage error saving project: {str(e)}')
-            raise
+    async def _store_fs_read(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Read data from an open read handle."""
+        fs = self._get_file_store()
+        handle = args.get('handle')
+        length = args.get('length', 4_194_304)
+        data = await fs.read_chunk(handle, length)
+        response = self.build_response(request, body={'size': len(data)})
+        response['arguments'] = {'data': data}
+        return response
 
-    async def _store_get_project(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Get project subcommand handler."""
-        try:
-            # Get project using authenticated account (validation done in store)
-            result = await self._server.store.get_project(self._account_info, args.get('projectId'))
+    async def _store_fs_write(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Write data to an open write handle."""
+        fs = self._get_file_store()
+        handle = args.get('handle')
+        data = args.get('data', b'')
+        if isinstance(data, str):
+            data = data.encode('utf-8')
+        written = await fs.write_chunk(handle, data)
+        return self.build_response(request, body={'bytesWritten': written})
 
-            # Return success response
-            return self.build_response(request, body=result)
+    async def _store_fs_close(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Close a file handle."""
+        fs = self._get_file_store()
+        handle = args.get('handle')
+        mode = args.get('mode', 'r')
 
-        except StorageError as e:
-            self.debug_message(f'Storage error getting project: {str(e)}')
-            raise
+        if mode == 'w':
+            await fs.close_write(handle)
+        else:
+            await fs.close_read(handle)
+        return self.build_response(request)
 
-    async def _store_delete_project(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Delete project subcommand handler."""
-        try:
-            # Delete project using authenticated account (validation done in store)
-            result = await self._server.store.delete_project(self._account_info, args.get('projectId'), args.get('expectedVersion'))
+    async def _store_fs_delete(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Delete file from file store."""
+        await self._get_file_store().delete(args.get('path'))
+        return self.build_response(request)
 
-            # Return success response
-            return self.build_response(request, body=result)
+    async def _store_fs_list_dir(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """List directory contents."""
+        result = await self._get_file_store().list_dir(args.get('path', ''))
+        return self.build_response(request, body=result)
 
-        except StorageError as e:
-            self.debug_message(f'Storage error deleting project: {str(e)}')
-            raise
+    async def _store_fs_mkdir(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Create directory."""
+        await self._get_file_store().mkdir(args.get('path'))
+        return self.build_response(request)
 
-    async def _store_get_all_projects(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Get all projects subcommand handler."""
-        try:
-            # Get all projects for authenticated account (no parameters needed from args)
-            result = await self._server.store.get_all_projects(self._account_info)
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error listing projects: {str(e)}')
-            raise
-
-    async def _store_save_template(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Save template subcommand handler."""
-        try:
-            # Save template (system-wide, validation done in store)
-            result = await self._server.store.save_template(args.get('templateId'), args.get('pipeline'), args.get('expectedVersion'))
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error saving template: {str(e)}')
-            raise
-
-    async def _store_get_template(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Get template subcommand handler."""
-        try:
-            # Get template (validation done in store)
-            result = await self._server.store.get_template(args.get('templateId'))
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error getting template: {str(e)}')
-            raise
-
-    async def _store_delete_template(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Delete template subcommand handler."""
-        try:
-            # Delete template (validation done in store)
-            result = await self._server.store.delete_template(args.get('templateId'), args.get('expectedVersion'))
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error deleting template: {str(e)}')
-            raise
-
-    async def _store_get_all_templates(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Get all templates subcommand handler."""
-        try:
-            # Get all templates (system-wide, no parameters needed from args)
-            result = await self._server.store.get_all_templates()
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error listing templates: {str(e)}')
-            raise
-
-    async def _store_save_log(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Save log subcommand handler."""
-        try:
-            # Save log using authenticated account
-            result = await self._server.store.save_log(
-                self._account_info,
-                args.get('projectId'),
-                args.get('source'),
-                args.get('contents'),
-            )
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error saving log: {str(e)}')
-            raise
-
-    async def _store_get_log(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """Get log subcommand handler."""
-        try:
-            # Get log using authenticated account
-            result = await self._server.store.get_log(
-                self._account_info,
-                args.get('projectId'),
-                args.get('source'),
-                args.get('startTime'),
-            )
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error getting log: {str(e)}')
-            raise
-
-    async def _store_list_logs(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
-        """List logs subcommand handler."""
-        try:
-            # List logs using authenticated account
-            result = await self._server.store.list_logs(
-                self._account_info,
-                args.get('projectId'),
-                args.get('source'),
-                args.get('page'),
-            )
-
-            # Return success response
-            return self.build_response(request, body=result)
-
-        except StorageError as e:
-            self.debug_message(f'Storage error listing logs: {str(e)}')
-            raise
+    async def _store_fs_stat(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """Get file/directory metadata."""
+        result = await self._get_file_store().stat(args.get('path'))
+        return self.build_response(request, body=result)

--- a/packages/ai/src/ai/modules/task/commands/cmd_task.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_task.py
@@ -384,16 +384,24 @@ class TaskCommands(DAPConn):
             handle_id = await fs.open_write(path, self._connection_id)
             return self.build_response(request, body={'handle': handle_id})
         else:
-            offset = args.get('offset', 0)
-            result = await fs.open_read(path, self._connection_id, offset=offset)
+            result = await fs.open_read(path, self._connection_id)
             return self.build_response(request, body=result)
 
     async def _store_fs_read(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
         """Read data from an open read handle."""
         fs = self._get_file_store()
         handle = args.get('handle')
+        offset = args.get('offset', 0)
         length = args.get('length', 4_194_304)
-        data = await fs.read_chunk(handle, length)
+
+        # Clamp client-supplied values
+        if not isinstance(offset, int) or offset < 0:
+            offset = 0
+        if not isinstance(length, int) or length <= 0:
+            length = 4_194_304
+        length = min(length, 4_194_304)
+
+        data = await fs.read_chunk(handle, offset, length)
         response = self.build_response(request, body={'size': len(data)})
         response['arguments'] = {'data': data}
         return response

--- a/packages/ai/src/ai/modules/task/commands/cmd_task.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_task.py
@@ -401,7 +401,7 @@ class TaskCommands(DAPConn):
             length = 4_194_304
         length = min(length, 4_194_304)
 
-        data = await fs.read_chunk(handle, offset, length)
+        data = await fs.read_chunk(handle, offset, length, connection_id=self._connection_id)
         response = self.build_response(request, body={'size': len(data)})
         response['arguments'] = {'data': data}
         return response
@@ -413,7 +413,7 @@ class TaskCommands(DAPConn):
         data = args.get('data', b'')
         if isinstance(data, str):
             data = data.encode('utf-8')
-        written = await fs.write_chunk(handle, data)
+        written = await fs.write_chunk(handle, data, connection_id=self._connection_id)
         return self.build_response(request, body={'bytesWritten': written})
 
     async def _store_fs_close(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
@@ -423,9 +423,9 @@ class TaskCommands(DAPConn):
         mode = args.get('mode', 'r')
 
         if mode == 'w':
-            await fs.close_write(handle)
+            await fs.close_write(handle, connection_id=self._connection_id)
         else:
-            await fs.close_read(handle)
+            await fs.close_read(handle, connection_id=self._connection_id)
         return self.build_response(request)
 
     async def _store_fs_delete(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -194,6 +194,7 @@ class Task(DAPBase):
         launch_type: LAUNCH_TYPE = LAUNCH_TYPE.LAUNCH,
         provider: str = None,
         ttl: int = 900,
+        client_id: str = '',
         **kwargs,
     ) -> None:
         """
@@ -206,6 +207,7 @@ class Task(DAPBase):
             launch_args: Launch configuration parameters
             launch_type: Task creation mode (launch/attach)
             ttl: Time-to-live in seconds for idle tasks (default: 900 = 15 minutes; 0 = no timeout)
+            client_id: Account identifier for store access scoping
             **kwargs: Additional DAP configuration
         """
         # Store authentication
@@ -214,6 +216,7 @@ class Task(DAPBase):
         self.source = source
         self.token = token
         self.public_auth = public_auth
+        self.client_id = client_id
 
         # TTL management - count-up timer approach
         self._ttl = ttl  # Maximum idle time in seconds
@@ -1508,7 +1511,10 @@ class Task(DAPBase):
 
             await self._send_status_update()
 
-            # Launch subprocess - explicitly pass environment to inherit ROCKETRIDE_MOCK for testing
+            # Launch subprocess - pass environment with account context for store access
+            subprocess_env = os.environ.copy()
+            subprocess_env['ROCKETRIDE_CLIENT_ID'] = self.client_id
+
             self._engine_process = await asyncio.create_subprocess_exec(
                 exec_path,
                 *child_args,
@@ -1517,7 +1523,7 @@ class Task(DAPBase):
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 limit=CONST_SUBPROCESS_BUFFER_LIMIT,
-                env=os.environ.copy(),
+                env=subprocess_env,
             )
 
             # Initialize stdio interface

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -47,7 +47,7 @@ import time
 import asyncio
 import uuid
 from typing import List
-from fastapi import WebSocket, HTTPException
+from fastapi import WebSocket
 from dataclasses import dataclass
 from typing import Dict, Any, Optional
 from ai.constants import CONST_CLEANUP_DELAY_TIME, CONST_CLEANUP_SLEEP_TIME, CONST_DEFAULT_TTL, CONST_TTL_CHECK
@@ -80,8 +80,9 @@ class TASK_CONTROL:
     # Short of the pipe -  used for display and events
     id: str = ''
 
-    # These are the mapped apikey and the token for the task
+    # These are the mapped apikey, client_id, and the token for the task
     apikey: str = ''
+    client_id: str = ''
     token: str = ''
 
     # Public token - used in as alt auth
@@ -418,6 +419,14 @@ class TaskServer(DAPBase):
             except Exception as e:
                 # Log cleanup errors but continue processing other tasks
                 self.debug_message(f'Error during disconnection cleanup for task "{control.id}": {e}')
+
+        # Close any open file store handles for this connection
+        if hasattr(conn, '_account_info') and conn._account_info:
+            try:
+                fs = self.store.get_file_store(conn._account_info.clientid)
+                await fs.close_all_handles(connection_id)
+            except Exception as e:
+                self.debug_message(f'Error closing file handles for connection {connection_id}: {e}')
 
         # Log successful disconnection cleanup
         self.debug_message(f'Connection {connection_id} disconnected and cleaned up.')
@@ -804,6 +813,7 @@ class TaskServer(DAPBase):
         *,
         attach_debugger=False,
         wait_for_running=False,
+        client_id: str = '',
     ) -> str:
         """
         Create and start a new computational task with full lifecycle management.
@@ -880,6 +890,7 @@ class TaskServer(DAPBase):
 
         # Parse task configuration from request arguments
         control.apikey = apikey
+        control.client_id = client_id
         control.token = args.get('token', None)
         control.pipeline = args.get('pipeline', None)
         control.source = args.get('source', None)
@@ -1016,6 +1027,7 @@ class TaskServer(DAPBase):
                 launch_type=control.launch_type,
                 provider=control.provider,
                 ttl=ttl,
+                client_id=control.client_id,
             )
 
             # Register task in central registry

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -423,8 +423,9 @@ class TaskServer(DAPBase):
         # Close any open file store handles for this connection
         if hasattr(conn, '_account_info') and conn._account_info:
             try:
-                fs = self.store.get_file_store(conn._account_info.clientid)
-                await fs.close_all_handles(connection_id)
+                client_id = conn._account_info.clientid
+                if client_id in self.store._file_stores:
+                    await self.store._file_stores[client_id].close_all_handles(connection_id)
             except Exception as e:
                 self.debug_message(f'Error closing file handles for connection {connection_id}: {e}')
 

--- a/packages/ai/tests/ai/account/test_file_store.py
+++ b/packages/ai/tests/ai/account/test_file_store.py
@@ -1,0 +1,447 @@
+"""
+Unit tests for FileStore interface.
+
+Tests cover:
+- Generic file operations (read, write, delete, list_dir, mkdir, stat)
+- Path validation and traversal prevention
+- Directory listing with file/dir type detection
+- Domain convenience methods (projects, templates, logs)
+- User isolation between different client_ids
+"""
+
+import pytest
+import tempfile
+import shutil
+
+from ai.account.store import Store, StorageError
+from ai.account.file_store import FileStore, DIR_MARKER
+from ai.account.store_providers.filesystem import FilesystemStore
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def temp_dir():
+    """Create temporary directory for tests."""
+    temp_path = tempfile.mkdtemp()
+    yield temp_path
+    shutil.rmtree(temp_path, ignore_errors=True)
+
+
+@pytest.fixture
+def istore(temp_dir):
+    """Create filesystem IStore backend."""
+    url = f'filesystem://{temp_dir}'
+    return FilesystemStore(url)
+
+
+@pytest.fixture
+def fs(istore):
+    """Create a FileStore for test-user-1."""
+    return FileStore(istore, 'test-user-1')
+
+
+@pytest.fixture
+def fs2(istore):
+    """Create a FileStore for test-user-2 (isolation tests)."""
+    return FileStore(istore, 'test-user-2')
+
+
+@pytest.fixture
+def store(istore):
+    """Create a Store wrapper (for get_file_store tests)."""
+    return Store(istore)
+
+
+# ============================================================================
+# FileStore Construction
+# ============================================================================
+
+
+class TestFileStoreInit:
+    """Test FileStore initialization."""
+
+    def test_requires_client_id(self, istore):
+        """FileStore requires a non-empty client_id."""
+        with pytest.raises(ValueError, match='client_id is required'):
+            FileStore(istore, '')
+
+    def test_creates_with_valid_client_id(self, istore):
+        """FileStore creates successfully with a valid client_id."""
+        fs = FileStore(istore, 'user-123')
+        assert fs._client_id == 'user-123'
+
+
+# ============================================================================
+# Store.get_file_store Factory
+# ============================================================================
+
+
+class TestGetFileStore:
+    """Test Store.get_file_store() factory method."""
+
+    def test_returns_file_store(self, store):
+        """get_file_store returns a FileStore instance."""
+        fs = store.get_file_store('user-123')
+        assert isinstance(fs, FileStore)
+
+    def test_caches_per_client_id(self, store):
+        """get_file_store returns the same instance for the same client_id."""
+        fs1 = store.get_file_store('user-123')
+        fs2 = store.get_file_store('user-123')
+        assert fs1 is fs2
+
+    def test_different_client_ids(self, store):
+        """get_file_store returns different instances for different client_ids."""
+        fs1 = store.get_file_store('user-1')
+        fs2 = store.get_file_store('user-2')
+        assert fs1 is not fs2
+
+
+# ============================================================================
+# Path Validation
+# ============================================================================
+
+
+class TestPathValidation:
+    """Test path validation and normalization."""
+
+    def test_rejects_traversal(self):
+        """Paths with .. are rejected."""
+        with pytest.raises(ValueError, match='Path traversal'):
+            FileStore._validate_path('../escape')
+
+    def test_rejects_embedded_traversal(self):
+        """Paths with embedded .. are rejected."""
+        with pytest.raises(ValueError, match='Path traversal'):
+            FileStore._validate_path('a/../../escape')
+
+    def test_strips_leading_slash(self):
+        """Leading slashes are stripped."""
+        assert FileStore._validate_path('/foo/bar') == 'foo/bar'
+
+    def test_normalizes_backslash(self):
+        """Backslashes are converted to forward slashes."""
+        assert FileStore._validate_path('foo\\bar') == 'foo/bar'
+
+    def test_empty_path(self):
+        """Empty path normalizes to empty string."""
+        assert FileStore._validate_path('') == ''
+
+    def test_normal_path(self):
+        """Normal paths pass through unchanged."""
+        assert FileStore._validate_path('data/input.csv') == 'data/input.csv'
+
+
+# ============================================================================
+# Generic File Operations
+# ============================================================================
+
+
+class TestReadWrite:
+    """Test read and write operations."""
+
+    @pytest.mark.asyncio
+    async def test_write_and_read(self, fs):
+        """Write then read returns the same content."""
+        await fs.write('test.txt', b'Hello, World!')
+        data = await fs.read('test.txt')
+        assert data == b'Hello, World!'
+
+    @pytest.mark.asyncio
+    async def test_write_creates_nested_dirs(self, fs):
+        """Writing to a nested path creates intermediate directories."""
+        await fs.write('a/b/c/deep.txt', b'deep content')
+        data = await fs.read('a/b/c/deep.txt')
+        assert data == b'deep content'
+
+    @pytest.mark.asyncio
+    async def test_overwrite(self, fs):
+        """Overwriting a file replaces its content."""
+        await fs.write('file.txt', b'v1')
+        await fs.write('file.txt', b'v2')
+        data = await fs.read('file.txt')
+        assert data == b'v2'
+
+    @pytest.mark.asyncio
+    async def test_read_nonexistent(self, fs):
+        """Reading a nonexistent file raises StorageError."""
+        with pytest.raises(StorageError):
+            await fs.read('does-not-exist.txt')
+
+
+class TestDelete:
+    """Test delete operations."""
+
+    @pytest.mark.asyncio
+    async def test_delete_file(self, fs):
+        """Delete removes the file."""
+        await fs.write('to-delete.txt', b'temp')
+        await fs.delete('to-delete.txt')
+
+        with pytest.raises(StorageError):
+            await fs.read('to-delete.txt')
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent(self, fs):
+        """Deleting a nonexistent file raises StorageError."""
+        with pytest.raises(StorageError):
+            await fs.delete('ghost.txt')
+
+
+# ============================================================================
+# Directory Operations
+# ============================================================================
+
+
+class TestListDir:
+    """Test list_dir operation."""
+
+    @pytest.mark.asyncio
+    async def test_list_files_only(self, fs):
+        """list_dir shows files in the directory."""
+        await fs.write('root1.txt', b'a')
+        await fs.write('root2.txt', b'b')
+
+        result = await fs.list_dir('')
+        assert result['count'] == 2
+        names = {e['name'] for e in result['entries']}
+        assert names == {'root1.txt', 'root2.txt'}
+        assert all(e['type'] == 'file' for e in result['entries'])
+
+    @pytest.mark.asyncio
+    async def test_list_files_have_modified(self, fs):
+        """list_dir returns modified timestamps for file entries."""
+        await fs.write('timestamped.txt', b'data')
+
+        result = await fs.list_dir('')
+        file_entry = next(e for e in result['entries'] if e['name'] == 'timestamped.txt')
+        assert 'modified' in file_entry
+        assert isinstance(file_entry['modified'], float)
+
+    @pytest.mark.asyncio
+    async def test_list_mixed(self, fs):
+        """list_dir shows both files and directories."""
+        await fs.write('file.txt', b'a')
+        await fs.write('subdir/nested.txt', b'b')
+
+        result = await fs.list_dir('')
+        entries = {e['name']: e['type'] for e in result['entries']}
+        assert entries == {'file.txt': 'file', 'subdir': 'dir'}
+
+    @pytest.mark.asyncio
+    async def test_list_dirs_no_modified(self, fs):
+        """list_dir does not include modified for directory entries."""
+        await fs.write('subdir/nested.txt', b'a')
+
+        result = await fs.list_dir('')
+        dir_entry = next(e for e in result['entries'] if e['type'] == 'dir')
+        assert 'modified' not in dir_entry
+
+    @pytest.mark.asyncio
+    async def test_list_empty(self, fs):
+        """list_dir on empty/nonexistent dir returns empty entries."""
+        result = await fs.list_dir('empty')
+        assert result['count'] == 0
+        assert result['entries'] == []
+
+    @pytest.mark.asyncio
+    async def test_list_nested(self, fs):
+        """list_dir shows only immediate children, not grandchildren."""
+        await fs.write('parent/child1.txt', b'a')
+        await fs.write('parent/child2.txt', b'b')
+        await fs.write('parent/grandchild/deep.txt', b'c')
+
+        result = await fs.list_dir('parent')
+        entries = {e['name']: e['type'] for e in result['entries']}
+        assert entries == {'child1.txt': 'file', 'child2.txt': 'file', 'grandchild': 'dir'}
+
+    @pytest.mark.asyncio
+    async def test_list_filters_dirmarker(self, fs):
+        """list_dir filters out .dirmarker sentinel files."""
+        await fs.mkdir('mydir')
+        result = await fs.list_dir('mydir')
+
+        names = {e['name'] for e in result['entries']}
+        assert DIR_MARKER not in names
+
+
+class TestMkdir:
+    """Test mkdir operation."""
+
+    @pytest.mark.asyncio
+    async def test_mkdir_creates_directory(self, fs):
+        """Mkdir creates a directory that shows up in stat."""
+        await fs.mkdir('newdir')
+        result = await fs.stat('newdir')
+
+        assert result['exists'] is True
+        assert result['type'] == 'dir'
+
+    @pytest.mark.asyncio
+    async def test_mkdir_nested(self, fs):
+        """Mkdir creates nested directory."""
+        await fs.mkdir('a/b/c')
+        result = await fs.stat('a/b/c')
+        assert result['exists'] is True
+
+
+class TestStat:
+    """Test stat operation."""
+
+    @pytest.mark.asyncio
+    async def test_stat_file(self, fs):
+        """Stat returns file metadata with modified timestamp."""
+        await fs.write('hello.txt', b'world')
+        result = await fs.stat('hello.txt')
+
+        assert result['exists'] is True
+        assert result['type'] == 'file'
+        assert 'modified' in result
+        assert isinstance(result['modified'], float)
+
+    @pytest.mark.asyncio
+    async def test_stat_dir(self, fs):
+        """Stat returns directory metadata."""
+        await fs.write('mydir/file.txt', b'content')
+        result = await fs.stat('mydir')
+
+        assert result['exists'] is True
+        assert result['type'] == 'dir'
+
+    @pytest.mark.asyncio
+    async def test_stat_nonexistent(self, fs):
+        """Stat returns exists=False for missing paths."""
+        result = await fs.stat('nope')
+
+        assert result['exists'] is False
+
+
+# ============================================================================
+# User Isolation
+# ============================================================================
+
+
+class TestUserIsolation:
+    """Test that different client_ids are isolated."""
+
+    @pytest.mark.asyncio
+    async def test_files_isolated(self, fs, fs2):
+        """Files written by one user are not visible to another."""
+        await fs.write('secret.txt', b'user1 data')
+
+        with pytest.raises(StorageError):
+            await fs2.read('secret.txt')
+
+    @pytest.mark.asyncio
+    async def test_list_isolated(self, fs, fs2):
+        """list_dir only shows files for the scoped user."""
+        await fs.write('file1.txt', b'a')
+        await fs2.write('file2.txt', b'b')
+
+        result1 = await fs.list_dir('')
+        result2 = await fs2.list_dir('')
+
+        names1 = {e['name'] for e in result1['entries']}
+        names2 = {e['name'] for e in result2['entries']}
+
+        assert 'file1.txt' in names1
+        assert 'file2.txt' not in names1
+        assert 'file2.txt' in names2
+        assert 'file1.txt' not in names2
+
+
+# ============================================================================
+# Handle-Based I/O
+# ============================================================================
+
+
+class TestHandleIO:
+    """Test handle-based read and write operations."""
+
+    @pytest.mark.asyncio
+    async def test_write_chunks_and_read(self, fs):
+        """Write multiple chunks via handle, then read back."""
+        handle_id = await fs.open_write('chunked.bin', connection_id=1)
+        await fs.write_chunk(handle_id, b'part-1-')
+        await fs.write_chunk(handle_id, b'part-2-')
+        await fs.write_chunk(handle_id, b'part-3')
+        await fs.close_write(handle_id)
+
+        data = await fs.read('chunked.bin')
+        assert data == b'part-1-part-2-part-3'
+
+    @pytest.mark.asyncio
+    async def test_read_chunks(self, fs):
+        """Read a file in chunks via handle."""
+        await fs.write('big.bin', b'A' * 100)
+
+        info = await fs.open_read('big.bin', connection_id=1)
+        assert info['size'] == 100
+
+        chunk = await fs.read_chunk(info['handle'], length=40)
+        assert len(chunk) == 40
+
+        chunk2 = await fs.read_chunk(info['handle'], length=40)
+        assert len(chunk2) == 40
+
+        chunk3 = await fs.read_chunk(info['handle'], length=40)
+        assert len(chunk3) == 20  # Only 20 bytes left
+
+        chunk4 = await fs.read_chunk(info['handle'])
+        assert chunk4 == b''  # EOF
+
+        await fs.close_read(info['handle'])
+
+    @pytest.mark.asyncio
+    async def test_write_lock(self, fs):
+        """Cannot open the same file for writing twice."""
+        handle_id = await fs.open_write('locked.bin', connection_id=1)
+
+        with pytest.raises(StorageError, match='already open for writing'):
+            await fs.open_write('locked.bin', connection_id=2)
+
+        await fs.close_write(handle_id)
+
+        # After close, can open again
+        handle_id2 = await fs.open_write('locked.bin', connection_id=2)
+        await fs.close_write(handle_id2)
+
+    @pytest.mark.asyncio
+    async def test_close_all_handles(self, fs):
+        """close_all_handles commits data and releases locks."""
+        handle_id = await fs.open_write('orphan.bin', connection_id=99)
+        await fs.write_chunk(handle_id, b'orphan-data')
+
+        await fs.close_all_handles(connection_id=99)
+
+        # Data should be committed
+        data = await fs.read('orphan.bin')
+        assert data == b'orphan-data'
+
+        # Lock should be released
+        handle_id2 = await fs.open_write('orphan.bin', connection_id=1)
+        await fs.close_write(handle_id2)
+
+    @pytest.mark.asyncio
+    async def test_invalid_handle(self, fs):
+        """Operations on invalid handles raise StorageError."""
+        with pytest.raises(StorageError, match='Invalid handle'):
+            await fs.write_chunk('nonexistent-handle', b'data')
+
+        with pytest.raises(StorageError, match='Invalid handle'):
+            await fs.read_chunk('nonexistent-handle')
+
+    @pytest.mark.asyncio
+    async def test_wrong_mode(self, fs):
+        """Using a read handle for writing (or vice versa) raises StorageError."""
+        await fs.write('mode-test.bin', b'data')
+        info = await fs.open_read('mode-test.bin', connection_id=1)
+
+        with pytest.raises(StorageError, match='Wrong handle mode'):
+            await fs.write_chunk(info['handle'], b'nope')
+
+        await fs.close_read(info['handle'])

--- a/packages/ai/tests/ai/account/test_file_store.py
+++ b/packages/ai/tests/ai/account/test_file_store.py
@@ -5,7 +5,7 @@ Tests cover:
 - Generic file operations (read, write, delete, list_dir, mkdir, stat)
 - Path validation and traversal prevention
 - Directory listing with file/dir type detection
-- Domain convenience methods (projects, templates, logs)
+- Handle-based I/O (open/close/read/write handles)
 - User isolation between different client_ids
 """
 
@@ -74,6 +74,16 @@ class TestFileStoreInit:
         fs = FileStore(istore, 'user-123')
         assert fs._client_id == 'user-123'
 
+    def test_rejects_client_id_with_slash(self, istore):
+        """client_id with path separators is rejected."""
+        with pytest.raises(ValueError, match='path separators'):
+            FileStore(istore, 'user/evil')
+
+    def test_rejects_client_id_dotdot(self, istore):
+        """client_id of '..' is rejected."""
+        with pytest.raises(ValueError, match=r'\.\.'):
+            FileStore(istore, '..')
+
 
 # ============================================================================
 # Store.get_file_store Factory
@@ -134,6 +144,21 @@ class TestPathValidation:
     def test_normal_path(self):
         """Normal paths pass through unchanged."""
         assert FileStore._validate_path('data/input.csv') == 'data/input.csv'
+
+    def test_rejects_glob_chars(self):
+        """Paths with glob/wildcard characters are rejected."""
+        with pytest.raises(ValueError, match='invalid characters'):
+            FileStore._validate_path('data/file*.txt')
+
+    def test_rejects_question_mark(self):
+        """Paths with ? are rejected."""
+        with pytest.raises(ValueError, match='invalid characters'):
+            FileStore._validate_path('data/file?.txt')
+
+    def test_rejects_angle_brackets(self):
+        """Paths with < or > are rejected."""
+        with pytest.raises(ValueError, match='invalid characters'):
+            FileStore._validate_path('data/<bad>.txt')
 
 
 # ============================================================================
@@ -213,13 +238,13 @@ class TestListDir:
         assert all(e['type'] == 'file' for e in result['entries'])
 
     @pytest.mark.asyncio
-    async def test_list_files_have_modified(self, fs):
-        """list_dir returns modified timestamps for file entries."""
+    async def test_list_files_have_size_and_modified(self, fs):
+        """list_dir returns size and modified timestamps for file entries."""
         await fs.write('timestamped.txt', b'data')
 
         result = await fs.list_dir('')
         file_entry = next(e for e in result['entries'] if e['name'] == 'timestamped.txt')
-        assert 'modified' in file_entry
+        assert file_entry['size'] == 4
         assert isinstance(file_entry['modified'], float)
 
     @pytest.mark.asyncio
@@ -233,12 +258,13 @@ class TestListDir:
         assert entries == {'file.txt': 'file', 'subdir': 'dir'}
 
     @pytest.mark.asyncio
-    async def test_list_dirs_no_modified(self, fs):
-        """list_dir does not include modified for directory entries."""
+    async def test_list_dirs_no_size_or_modified(self, fs):
+        """list_dir does not include size or modified for directory entries."""
         await fs.write('subdir/nested.txt', b'a')
 
         result = await fs.list_dir('')
         dir_entry = next(e for e in result['entries'] if e['type'] == 'dir')
+        assert 'size' not in dir_entry
         assert 'modified' not in dir_entry
 
     @pytest.mark.asyncio
@@ -294,13 +320,13 @@ class TestStat:
 
     @pytest.mark.asyncio
     async def test_stat_file(self, fs):
-        """Stat returns file metadata with modified timestamp."""
+        """Stat returns file metadata with size and modified timestamp."""
         await fs.write('hello.txt', b'world')
         result = await fs.stat('hello.txt')
 
         assert result['exists'] is True
         assert result['type'] == 'file'
-        assert 'modified' in result
+        assert result['size'] == 5
         assert isinstance(result['modified'], float)
 
     @pytest.mark.asyncio
@@ -376,22 +402,22 @@ class TestHandleIO:
 
     @pytest.mark.asyncio
     async def test_read_chunks(self, fs):
-        """Read a file in chunks via handle."""
+        """Read a file in chunks via handle with explicit offsets."""
         await fs.write('big.bin', b'A' * 100)
 
         info = await fs.open_read('big.bin', connection_id=1)
         assert info['size'] == 100
 
-        chunk = await fs.read_chunk(info['handle'], length=40)
+        chunk = await fs.read_chunk(info['handle'], offset=0, length=40)
         assert len(chunk) == 40
 
-        chunk2 = await fs.read_chunk(info['handle'], length=40)
+        chunk2 = await fs.read_chunk(info['handle'], offset=40, length=40)
         assert len(chunk2) == 40
 
-        chunk3 = await fs.read_chunk(info['handle'], length=40)
+        chunk3 = await fs.read_chunk(info['handle'], offset=80, length=40)
         assert len(chunk3) == 20  # Only 20 bytes left
 
-        chunk4 = await fs.read_chunk(info['handle'])
+        chunk4 = await fs.read_chunk(info['handle'], offset=100)
         assert chunk4 == b''  # EOF
 
         await fs.close_read(info['handle'])
@@ -433,7 +459,7 @@ class TestHandleIO:
             await fs.write_chunk('nonexistent-handle', b'data')
 
         with pytest.raises(StorageError, match='Invalid handle'):
-            await fs.read_chunk('nonexistent-handle')
+            await fs.read_chunk('nonexistent-handle', offset=0)
 
     @pytest.mark.asyncio
     async def test_wrong_mode(self, fs):

--- a/packages/ai/tests/ai/account/test_store.py
+++ b/packages/ai/tests/ai/account/test_store.py
@@ -363,9 +363,7 @@ class TestS3Store:
         content = await store.read_file(filename)
 
         assert content == 'Test data'
-        mock_s3_client.get_object.assert_called_once_with(
-            Bucket='test-bucket', Key='prefix/test/file.txt'
-        )
+        mock_s3_client.get_object.assert_called_once_with(Bucket='test-bucket', Key='prefix/test/file.txt')
 
     @pytest.mark.asyncio
     async def test_read_nonexistent_file(self, store, mock_s3_client):
@@ -470,9 +468,7 @@ class TestS3Store:
         mock_s3_client.put_object.return_value = {'ETag': '"new-etag-456"'}
 
         # Call with expected_version but file doesn't exist
-        new_version = await store.write_file_atomic(
-            filename, data, expected_version=stale_version
-        )
+        new_version = await store.write_file_atomic(filename, data, expected_version=stale_version)
 
         # Should succeed and return new version
         assert new_version == 'new-etag-456'
@@ -483,9 +479,7 @@ class TestS3Store:
         assert 'IfMatch' not in call_kwargs  # No conditional header
 
     @pytest.mark.asyncio
-    async def test_write_atomic_race_condition_file_deleted_between_check_and_write(
-        self, store, mock_s3_client
-    ):
+    async def test_write_atomic_race_condition_file_deleted_between_check_and_write(self, store, mock_s3_client):
         """Test atomic write handles race condition: file deleted between head_object and put_object.
 
         Scenario:
@@ -515,9 +509,7 @@ class TestS3Store:
             {'ETag': '"recreated-etag"'},  # Second attempt without IfMatch succeeds
         ]
 
-        new_version = await store.write_file_atomic(
-            filename, data, expected_version=expected_version
-        )
+        new_version = await store.write_file_atomic(filename, data, expected_version=expected_version)
 
         # Should succeed with new version
         assert new_version == 'recreated-etag'
@@ -537,9 +529,7 @@ class TestS3Store:
         assert 'IfMatch' not in second_call_kwargs
 
     @pytest.mark.asyncio
-    async def test_write_atomic_race_condition_retries_exhausted(
-        self, store, mock_s3_client, monkeypatch
-    ):
+    async def test_write_atomic_race_condition_retries_exhausted(self, store, mock_s3_client, monkeypatch):
         """Test atomic write fails after max retries on persistent race condition.
 
         Scenario: File keeps getting deleted between check and write, exhausting all retries.
@@ -568,9 +558,7 @@ class TestS3Store:
 
         # Should fail after STORE_MAX_RETRY_ATTEMPTS
         with pytest.raises(S3Store._RaceConditionError):
-            await store.write_file_atomic(
-                filename, data, expected_version=expected_version
-            )
+            await store.write_file_atomic(filename, data, expected_version=expected_version)
 
         # Verify put_object was called STORE_MAX_RETRY_ATTEMPTS times
         assert mock_s3_client.put_object.call_count == STORE_MAX_RETRY_ATTEMPTS
@@ -863,46 +851,12 @@ class TestAzureBlobStore:
 
 
 # ============================================================================
-# Project Operations Tests
+# Store.get_file_store Tests
 # ============================================================================
 
 
-class TestStorePathConstruction:
-    """Test Store path construction for projects and templates."""
-
-    def test_construct_path_with_item_id(self):
-        """Test generic path construction with item ID."""
-        path = Store._construct_path(['some', 'base', 'path'], 'item-123')
-        assert path == 'some/base/path/item-123.json'
-
-    def test_construct_path_without_item_id(self):
-        """Test generic path construction without item ID (directory)."""
-        path = Store._construct_path(['some', 'base', 'path'])
-        assert path == 'some/base/path/'
-
-    def test_construct_store_path_with_project_id(self):
-        """Test project path includes users/ prefix."""
-        path = Store._construct_store_path('client-123', 'proj-456')
-        assert path == 'users/client-123/.projects/proj-456.json'
-
-    def test_construct_store_path_without_project_id(self):
-        """Test project directory path includes users/ prefix."""
-        path = Store._construct_store_path('client-123')
-        assert path == 'users/client-123/.projects/'
-
-    def test_construct_template_path_with_template_id(self):
-        """Test template path uses system/.templates."""
-        path = Store._construct_template_path('tmpl-123')
-        assert path == 'system/.templates/tmpl-123.json'
-
-    def test_construct_template_path_without_template_id(self):
-        """Test template directory path uses system/.templates."""
-        path = Store._construct_template_path()
-        assert path == 'system/.templates/'
-
-
-class TestStoreProjects:
-    """Test Store project operations (get_all_projects)."""
+class TestStoreFileStore:
+    """Test Store.get_file_store returns a working FileStore."""
 
     @pytest.fixture
     def temp_dir(self):
@@ -917,666 +871,47 @@ class TestStoreProjects:
         url = f'filesystem://{temp_dir}'
         return Store.create(url=url)
 
-    @pytest.fixture
-    def account_info(self):
-        """Create mock AccountInfo."""
-        from ai.account import AccountInfo
+    def test_get_file_store_returns_file_store(self, store):
+        """Test that get_file_store returns a FileStore instance."""
+        from ai.account.file_store import FileStore
 
-        return AccountInfo(clientid='test-user-123')
+        fs = store.get_file_store('test-user')
+        assert isinstance(fs, FileStore)
 
-    @pytest.mark.asyncio
-    async def test_get_all_projects_with_nested_pipeline_structure(self, store, account_info):
-        """Test that get_all_projects correctly extracts sources from pipeline components."""
-        project_id = 'test-proj-001'
-        pipeline_data = {
-            'source': 'source_1',
-            'name': 'Test Pipeline',
-            'components': [
-                {
-                    'id': 'source_1',
-                    'provider': 'filesystem',
-                    'config': {
-                        'mode': 'Source',
-                        'name': 'Filesystem Source',
-                        'path': '/data/input',
-                    },
-                },
-                {
-                    'id': 'source_2',
-                    'provider': 's3',
-                    'config': {'mode': 'Source', 'name': 'S3 Source', 'bucket': 'my-bucket'},
-                },
-                {
-                    'id': 'processor_1',
-                    'provider': 'transform',
-                    'config': {'mode': 'Transform', 'name': 'Data Processor'},
-                },
-            ],
-        }
+    def test_get_file_store_caches_by_client_id(self, store):
+        """Test that the same FileStore is returned for the same client_id."""
+        fs1 = store.get_file_store('user-1')
+        fs2 = store.get_file_store('user-1')
+        fs3 = store.get_file_store('user-2')
 
-        # Save the project
-        result = await store.save_project(account_info, project_id, pipeline_data)
-        assert result['success'] is True
-
-        # Get all projects and verify sources are extracted correctly
-        all_projects = await store.get_all_projects(account_info)
-
-        assert all_projects['success'] is True
-        assert all_projects['count'] == 1
-
-        project = all_projects['projects'][0]
-        assert project['id'] == project_id
-        assert project['name'] == 'Test Pipeline'
-        assert project['totalComponents'] == 3  # 2 sources + 1 processor
-
-        # Verify only Source components are included in sources array
-        assert len(project['sources']) == 2
-
-        source_ids = [s['id'] for s in project['sources']]
-        assert 'source_1' in source_ids
-        assert 'source_2' in source_ids
-        assert 'processor_1' not in source_ids  # Transform should not be included
-
-        # Verify source details
-        fs_source = next(s for s in project['sources'] if s['id'] == 'source_1')
-        assert fs_source['provider'] == 'filesystem'
-        assert fs_source['name'] == 'Filesystem Source'
-
-        s3_source = next(s for s in project['sources'] if s['id'] == 'source_2')
-        assert s3_source['provider'] == 's3'
-        assert s3_source['name'] == 'S3 Source'
+        assert fs1 is fs2
+        assert fs1 is not fs3
 
     @pytest.mark.asyncio
-    async def test_get_all_projects_with_empty_pipeline(self, store, account_info):
-        """Test get_all_projects with empty components list."""
-        project_id = 'empty-proj'
-        pipeline_data = {
-            'source': 'source_1',
-            'name': 'Empty Pipeline',
-            'components': [],
-        }
+    async def test_file_store_write_and_read(self, store):
+        """Test writing and reading via FileStore."""
+        fs = store.get_file_store('test-user')
 
-        await store.save_project(account_info, project_id, pipeline_data)
+        await fs.write('test.txt', b'Hello, World!')
+        data = await fs.read('test.txt')
 
-        all_projects = await store.get_all_projects(account_info)
-
-        assert all_projects['success'] is True
-        assert all_projects['count'] == 1
-
-        project = all_projects['projects'][0]
-        assert project['name'] == 'Empty Pipeline'
-        assert project['sources'] == []
-        assert project['totalComponents'] == 0
+        assert data == b'Hello, World!'
 
     @pytest.mark.asyncio
-    async def test_get_all_projects_with_missing_name(self, store, account_info):
-        """Test get_all_projects defaults to 'Untitled' when project has no name."""
-        project_id = 'no-name-proj'
-        pipeline_data = {
-            'source': 'source_1',
-            'components': [
-                {
-                    'id': 'source_1',
-                    'provider': 'filesystem',
-                    'config': {'mode': 'Source', 'name': 'Legacy Source'},
-                }
-            ],
-        }
-
-        await store.save_project(account_info, project_id, pipeline_data)
-
-        all_projects = await store.get_all_projects(account_info)
-
-        assert all_projects['success'] is True
-        assert all_projects['count'] == 1
-
-        project = all_projects['projects'][0]
-        assert project['name'] == 'Untitled'
-        assert len(project['sources']) == 1
-        assert project['totalComponents'] == 1
-
-
-# ============================================================================
-# Template Operations Tests
-# ============================================================================
-
-
-class TestStoreTemplates:
-    """Test Store template operations (system-wide templates)."""
-
-    @pytest.fixture
-    def temp_dir(self):
-        """Create temporary directory for tests."""
-        temp_path = tempfile.mkdtemp()
-        yield temp_path
-        shutil.rmtree(temp_path, ignore_errors=True)
-
-    @pytest.fixture
-    def store(self, temp_dir):
-        """Create store instance."""
-        url = f'filesystem://{temp_dir}'
-        return Store.create(url=url)
-
-    @pytest.mark.asyncio
-    async def test_save_and_get_template(self, store):
-        """Test saving and retrieving a template."""
-        template_id = 'tmpl-001'
-        pipeline_data = {
-            'name': 'Test Template',
-            'source': 'source_1',
-            'components': [
-                {
-                    'id': 'source_1',
-                    'provider': 'filesystem',
-                    'config': {
-                        'mode': 'Source',
-                        'name': 'Template Source',
-                        'path': '/data/template',
-                    },
-                }
-            ],
-        }
-
-        # Save template
-        save_result = await store.save_template(template_id, pipeline_data)
-        assert save_result['success'] is True
-        assert save_result['template_id'] == template_id
-        assert 'version' in save_result
-
-        # Get template
-        get_result = await store.get_template(template_id)
-        assert get_result['success'] is True
-        assert get_result['pipeline']['name'] == 'Test Template'
-        assert 'version' in get_result
-
-    @pytest.mark.asyncio
-    async def test_update_template_with_version(self, store):
-        """Test updating a template with version check."""
-        template_id = 'tmpl-002'
-        pipeline_data = {
-            'name': 'Original Template',
-            'source': 'source_1',
-            'components': [],
-        }
-
-        # Save initial template
-        save_result = await store.save_template(template_id, pipeline_data)
-        version = save_result['version']
-
-        # Update with correct version
-        updated_pipeline = {
-            'name': 'Updated Template',
-            'source': 'source_1',
-            'components': [],
-        }
-        update_result = await store.save_template(
-            template_id, updated_pipeline, expected_version=version
-        )
-        assert update_result['success'] is True
-        assert update_result['version'] != version  # Version should change
-
-        # Verify update
-        get_result = await store.get_template(template_id)
-        assert get_result['pipeline']['name'] == 'Updated Template'
-
-    @pytest.mark.asyncio
-    async def test_delete_template(self, store):
-        """Test deleting a template."""
-        template_id = 'tmpl-003'
-        pipeline_data = {
-            'name': 'Delete Me Template',
-            'source': 'source_1',
-            'components': [],
-        }
-
-        # Save template
-        save_result = await store.save_template(template_id, pipeline_data)
-        version = save_result['version']
-
-        # Delete template
-        delete_result = await store.delete_template(template_id, expected_version=version)
-        assert delete_result['success'] is True
-        assert delete_result['template_id'] == template_id
-
-        # Verify deletion
-        with pytest.raises(StorageError):
-            await store.get_template(template_id)
-
-    @pytest.mark.asyncio
-    async def test_get_all_templates(self, store):
-        """Test listing all templates."""
-        # Save multiple templates
-        for i in range(3):
-            pipeline_data = {
-                'source': 'source_1',
-                'name': f'Template {i}',
-                'components': [
-                    {
-                        'id': 'source_1',
-                        'provider': 'filesystem',
-                        'config': {'mode': 'Source', 'name': f'Source {i}'},
-                    }
-                ],
-            }
-            await store.save_template(f'tmpl-{i:03d}', pipeline_data)
-
-        # Get all templates
-        all_templates = await store.get_all_templates()
-
-        assert all_templates['success'] is True
-        assert all_templates['count'] == 3
-
-        template_ids = [t['id'] for t in all_templates['templates']]
-        assert 'tmpl-000' in template_ids
-        assert 'tmpl-001' in template_ids
-        assert 'tmpl-002' in template_ids
-
-        # Verify each template has correct structure
-        for template in all_templates['templates']:
-            assert 'name' in template
-            assert 'sources' in template
-            assert 'totalComponents' in template
-            assert template['totalComponents'] == 1  # Each has 1 component
-
-    @pytest.mark.asyncio
-    async def test_get_all_templates_empty(self, store):
-        """Test listing templates when none exist."""
-        all_templates = await store.get_all_templates()
-
-        assert all_templates['success'] is True
-        assert all_templates['count'] == 0
-        assert all_templates['templates'] == []
-
-    @pytest.mark.asyncio
-    async def test_template_validation_errors(self, store):
-        """Test validation errors for template operations."""
-        # Empty template_id
-        with pytest.raises(ValueError) as exc_info:
-            await store.save_template('', {'name': 'Test'})
-        assert 'template_id is required' in str(exc_info.value)
-
-        # Empty pipeline
-        with pytest.raises(ValueError) as exc_info:
-            await store.save_template('tmpl-test', None)
-        assert 'pipeline is required' in str(exc_info.value)
-
-        # Empty template_id for get
-        with pytest.raises(ValueError) as exc_info:
-            await store.get_template('')
-        assert 'template_id is required' in str(exc_info.value)
-
-        # Empty template_id for delete
-        with pytest.raises(ValueError) as exc_info:
-            await store.delete_template('')
-        assert 'template_id is required' in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_template_not_found(self, store):
-        """Test getting a non-existent template."""
-        with pytest.raises(StorageError) as exc_info:
-            await store.get_template('nonexistent-template')
-        assert 'not found' in str(exc_info.value).lower()
-
-
-# ============================================================================
-# Integration Tests
-# ============================================================================
-
-
-# ============================================================================
-# Log Operations Tests
-# ============================================================================
-
-
-class TestStoreLogPathConstruction:
-    """Test Store path construction for log files."""
-
-    def test_construct_log_path_with_filename(self):
-        """Test log path construction with filename."""
-        path = Store._construct_log_path(
-            'client-123', 'proj-456', 'source_1-1234567890.123.log'
-        )
-        assert path == 'users/client-123/.logs/proj-456/source_1-1234567890.123.log'
-
-    def test_construct_log_path_without_filename(self):
-        """Test log path construction without filename (directory)."""
-        path = Store._construct_log_path('client-123', 'proj-456')
-        assert path == 'users/client-123/.logs/proj-456/'
-
-
-class TestStoreLogs:
-    """Test Store log operations (save_log, get_log, list_logs)."""
-
-    @pytest.fixture
-    def temp_dir(self):
-        """Create temporary directory for tests."""
-        temp_path = tempfile.mkdtemp()
-        yield temp_path
-        shutil.rmtree(temp_path, ignore_errors=True)
-
-    @pytest.fixture
-    def store(self, temp_dir):
-        """Create store instance."""
-        url = f'filesystem://{temp_dir}'
-        return Store.create(url=url)
-
-    @pytest.fixture
-    def account_info(self):
-        """Create mock AccountInfo."""
-        from ai.account import AccountInfo
-
-        return AccountInfo(clientid='test-user-123')
-
-    @pytest.fixture
-    def sample_log_contents(self):
-        """Sample log contents matching the status update event format."""
-        return {
-            'type': 'event',
-            'seq': 79,
-            'event': 'apaevt_status_update',
-            'body': {
-                'name': 'atl-confluence_1',
-                'project_id': '851018af-1616-4d24-a544-9009339a8542',
-                'source': 'atl-confluence_1',
-                'completed': True,
-                'state': 5,
-                'startTime': 1764337626.6564875,
-                'endTime': 1764337716.5507987,
-                'debuggerAttached': False,
-                'status': 'Completed',
-                'warnings': [],
-                'errors': [],
-                'currentObject': '',
-                'currentSize': 0,
-                'notes': [],
-                'totalSize': 810034,
-                'totalCount': 15,
-                'completedSize': 810034,
-                'completedCount': 15,
-                'failedSize': 0,
-                'failedCount': 0,
-                'wordsSize': 0,
-                'wordsCount': 0,
-                'rateSize': 975944,
-                'rateCount': 18,
-                'serviceUp': False,
-                'exitCode': 0,
-                'exitMessage': '',
-                'pipeflow': {'totalPipes': 3, 'byPipe': {'0': [], '1': [], '2': []}},
-                'metrics': {
-                    'cpu_percent': 0.0,
-                    'cpu_memory_mb': 0.0,
-                    'gpu_memory_mb': 0.0,
-                    'peak_cpu_percent': 0.0,
-                    'peak_cpu_memory_mb': 0.0,
-                    'peak_gpu_memory_mb': 0.0,
-                    'avg_cpu_percent': 0.0,
-                    'avg_cpu_memory_mb': 0.0,
-                    'avg_gpu_memory_mb': 0.0,
-                },
-                'tokens': {
-                    'cpu_utilization': 6.0,
-                    'cpu_memory': 0.7,
-                    'gpu_memory': 0.0,
-                    'total': 6.7,
-                },
-                '__id': 'e6e29a87.atl-confluence_1',
-            },
-        }
-
-    @pytest.mark.asyncio
-    async def test_save_and_get_log(self, store, account_info, sample_log_contents):
-        """Test saving and retrieving a log file."""
-        project_id = 'proj-001'
-        source = 'source_1'
-
-        # Save log
-        save_result = await store.save_log(
-            account_info, project_id, source, sample_log_contents
-        )
-        assert save_result['success'] is True
-        assert 'filename' in save_result
-        expected_filename = f'{source}-{sample_log_contents["body"]["startTime"]}.log'
-        assert save_result['filename'] == expected_filename
-
-        # Get log
-        start_time = sample_log_contents['body']['startTime']
-        get_result = await store.get_log(account_info, project_id, source, start_time)
-        assert get_result['success'] is True
-        assert get_result['contents'] == sample_log_contents
-
-    @pytest.mark.asyncio
-    async def test_save_log_overwrites_existing(
-        self, store, account_info, sample_log_contents
-    ):
-        """Test that save_log overwrites existing log file."""
-        project_id = 'proj-001'
-        source = 'source_1'
-
-        # Save initial log
-        await store.save_log(account_info, project_id, source, sample_log_contents)
-
-        # Modify contents and save again (same source and startTime)
-        modified_contents = sample_log_contents.copy()
-        modified_contents['body'] = sample_log_contents['body'].copy()
-        modified_contents['body']['status'] = 'Updated'
-        modified_contents['body']['completedCount'] = 20
-
-        await store.save_log(account_info, project_id, source, modified_contents)
-
-        # Verify the file was overwritten
-        start_time = sample_log_contents['body']['startTime']
-        get_result = await store.get_log(account_info, project_id, source, start_time)
-        assert get_result['contents']['body']['status'] == 'Updated'
-        assert get_result['contents']['body']['completedCount'] == 20
-
-    @pytest.mark.asyncio
-    async def test_list_logs_empty(self, store, account_info):
-        """Test listing logs when none exist."""
-        result = await store.list_logs(account_info, 'nonexistent-proj')
-
-        assert result['success'] is True
-        assert result['logs'] == []
-        assert result['count'] == 0
-        assert result['total_count'] == 0
-        assert result['page'] == 0
-        assert result['total_pages'] == 1
-
-    @pytest.mark.asyncio
-    async def test_list_logs_all(self, store, account_info, sample_log_contents):
-        """Test listing all logs for a project."""
-        project_id = 'proj-001'
-
-        # Save multiple logs with different sources and start times
-        sources = ['source_1', 'source_2', 'source_1']
-        start_times = [1000000.0, 2000000.0, 3000000.0]
-
-        for source, start_time in zip(sources, start_times):
-            contents = sample_log_contents.copy()
-            contents['body'] = sample_log_contents['body'].copy()
-            contents['body']['startTime'] = start_time
-            contents['body']['source'] = source
-            await store.save_log(account_info, project_id, source, contents)
-
-        # List all logs
-        result = await store.list_logs(account_info, project_id)
-
-        assert result['success'] is True
-        assert result['count'] == 3
-        assert result['total_count'] == 3
-        assert len(result['logs']) == 3
-
-    @pytest.mark.asyncio
-    async def test_list_logs_filter_by_source(
-        self, store, account_info, sample_log_contents
-    ):
-        """Test filtering logs by source name."""
-        project_id = 'proj-001'
-
-        # Save logs for different sources
-        for source, start_time in [
-            ('source_1', 1000000.0),
-            ('source_2', 2000000.0),
-            ('source_1', 3000000.0),
-        ]:
-            contents = sample_log_contents.copy()
-            contents['body'] = sample_log_contents['body'].copy()
-            contents['body']['startTime'] = start_time
-            contents['body']['source'] = source
-            await store.save_log(account_info, project_id, source, contents)
-
-        # List only source_1 logs
-        result = await store.list_logs(account_info, project_id, source='source_1')
-
-        assert result['success'] is True
-        assert result['count'] == 2
-        assert result['total_count'] == 2
-        for log in result['logs']:
-            assert log.startswith('source_1-')
-
-    @pytest.mark.asyncio
-    async def test_list_logs_pagination(self, store, account_info, sample_log_contents):
-        """Test log listing pagination."""
-        from ai.account.store import LOG_PAGE_SIZE
-
-        project_id = 'proj-001'
-        source = 'source_1'
-
-        # Create more logs than one page
-        num_logs = LOG_PAGE_SIZE + 10
-        for i in range(num_logs):
-            contents = sample_log_contents.copy()
-            contents['body'] = sample_log_contents['body'].copy()
-            contents['body']['startTime'] = float(1000000 + i)
-            await store.save_log(account_info, project_id, source, contents)
-
-        # Get first page
-        result_page0 = await store.list_logs(account_info, project_id, page=0)
-        assert result_page0['success'] is True
-        assert result_page0['count'] == LOG_PAGE_SIZE
-        assert result_page0['total_count'] == num_logs
-        assert result_page0['page'] == 0
-        assert result_page0['total_pages'] == 2
-
-        # Get second page
-        result_page1 = await store.list_logs(account_info, project_id, page=1)
-        assert result_page1['success'] is True
-        assert result_page1['count'] == 10
-        assert result_page1['total_count'] == num_logs
-        assert result_page1['page'] == 1
-
-        # Verify no overlap between pages
-        page0_logs = set(result_page0['logs'])
-        page1_logs = set(result_page1['logs'])
-        assert page0_logs.isdisjoint(page1_logs)
-
-    @pytest.mark.asyncio
-    async def test_list_logs_negative_page(
-        self, store, account_info, sample_log_contents
-    ):
-        """Test that negative page numbers default to 0."""
-        project_id = 'proj-001'
-
-        contents = sample_log_contents.copy()
-        contents['body'] = sample_log_contents['body'].copy()
-        await store.save_log(account_info, project_id, 'source_1', contents)
-
-        result = await store.list_logs(account_info, project_id, page=-5)
-        assert result['page'] == 0
-
-    @pytest.mark.asyncio
-    async def test_list_logs_none_page(self, store, account_info, sample_log_contents):
-        """Test that None page defaults to 0."""
-        project_id = 'proj-001'
-
-        contents = sample_log_contents.copy()
-        contents['body'] = sample_log_contents['body'].copy()
-        await store.save_log(account_info, project_id, 'source_1', contents)
-
-        result = await store.list_logs(account_info, project_id, page=None)
-        assert result['page'] == 0
-
-    @pytest.mark.asyncio
-    async def test_get_log_not_found(self, store, account_info):
-        """Test getting a non-existent log file."""
-        with pytest.raises(StorageError) as exc_info:
-            await store.get_log(account_info, 'proj-001', 'source_1', 9999999.0)
-        assert 'not found' in str(exc_info.value).lower()
-
-    @pytest.mark.asyncio
-    async def test_save_log_validation_errors(
-        self, store, account_info, sample_log_contents
-    ):
-        """Test validation errors for save_log."""
-        # Missing project_id
-        with pytest.raises(ValueError) as exc_info:
-            await store.save_log(account_info, '', 'source_1', sample_log_contents)
-        assert 'project_id is required' in str(exc_info.value)
-
-        # Missing source
-        with pytest.raises(ValueError) as exc_info:
-            await store.save_log(account_info, 'proj-001', '', sample_log_contents)
-        assert 'source is required' in str(exc_info.value)
-
-        # Missing contents
-        with pytest.raises(ValueError) as exc_info:
-            await store.save_log(account_info, 'proj-001', 'source_1', None)
-        assert 'contents is required' in str(exc_info.value)
-
-        # Missing startTime in contents
-        with pytest.raises(ValueError) as exc_info:
-            await store.save_log(account_info, 'proj-001', 'source_1', {'body': {}})
-        assert 'body.startTime' in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_get_log_validation_errors(self, store, account_info):
-        """Test validation errors for get_log."""
-        # Missing project_id
-        with pytest.raises(ValueError) as exc_info:
-            await store.get_log(account_info, '', 'source_1', 1234567.0)
-        assert 'project_id is required' in str(exc_info.value)
-
-        # Missing source
-        with pytest.raises(ValueError) as exc_info:
-            await store.get_log(account_info, 'proj-001', '', 1234567.0)
-        assert 'source is required' in str(exc_info.value)
-
-        # Missing start_time
-        with pytest.raises(ValueError) as exc_info:
-            await store.get_log(account_info, 'proj-001', 'source_1', None)
-        assert 'start_time is required' in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_list_logs_validation_errors(self, store, account_info):
-        """Test validation errors for list_logs."""
-        # Missing project_id
-        with pytest.raises(ValueError) as exc_info:
-            await store.list_logs(account_info, '')
-        assert 'project_id is required' in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_log_files_sorted(self, store, account_info, sample_log_contents):
-        """Test that log files are returned in sorted order."""
-        project_id = 'proj-001'
-        source = 'source_1'
-
-        # Save logs in random order
-        start_times = [3000000.0, 1000000.0, 2000000.0]
-        for start_time in start_times:
-            contents = sample_log_contents.copy()
-            contents['body'] = sample_log_contents['body'].copy()
-            contents['body']['startTime'] = start_time
-            await store.save_log(account_info, project_id, source, contents)
-
-        # List logs and verify sorted order
-        result = await store.list_logs(account_info, project_id)
-        logs = result['logs']
-
-        assert logs == sorted(logs)
+    async def test_file_store_isolation(self, store):
+        """Test that different client_ids have isolated storage."""
+        fs1 = store.get_file_store('user-1')
+        fs2 = store.get_file_store('user-2')
+
+        await fs1.write('shared-name.txt', b'user-1 data')
+        await fs2.write('shared-name.txt', b'user-2 data')
+
+        assert await fs1.read('shared-name.txt') == b'user-1 data'
+        assert await fs2.read('shared-name.txt') == b'user-2 data'
 
 
 class TestStoreIntegration:
-    """Integration tests using real filesystem."""
+    """Integration tests using real filesystem via Store + FileStore."""
 
     @pytest.fixture
     def temp_dir(self):
@@ -1587,22 +922,22 @@ class TestStoreIntegration:
 
     @pytest.mark.asyncio
     async def test_end_to_end_workflow(self, temp_dir):
-        """Test complete workflow: create store, write, read."""
-        # Create store via factory
+        """Test complete workflow: create store, get FileStore, write, read."""
         url = f'filesystem://{temp_dir}'
         store = Store.create(url=url)
+        fs = store.get_file_store('test-user')
 
         # Write multiple files
-        await store.write_file('logs/app.log', 'Application started\n')
-        await store.write_file('logs/app.log', 'Processing data\n')  # Overwrite
-        await store.write_file('data/config.json', '{"key": "value"}')
+        await fs.write('logs/app.log', b'Application started\n')
+        await fs.write('logs/app.log', b'Processing data\n')  # Overwrite
+        await fs.write('data/config.json', b'{"key": "value"}')
 
         # Read files
-        log_content = await store.read_file('logs/app.log')
-        config_content = await store.read_file('data/config.json')
+        log_content = await fs.read('logs/app.log')
+        config_content = await fs.read('data/config.json')
 
-        assert log_content == 'Processing data\n'
-        assert config_content == '{"key": "value"}'
+        assert log_content == b'Processing data\n'
+        assert config_content == b'{"key": "value"}'
 
     @pytest.mark.asyncio
     async def test_concurrent_operations(self, temp_dir):
@@ -1611,20 +946,75 @@ class TestStoreIntegration:
 
         url = f'filesystem://{temp_dir}'
         store = Store.create(url=url)
+        fs = store.get_file_store('test-user')
 
         # Write multiple files concurrently
-        tasks = [
-            store.write_file(f'file{i}.txt', f'Content {i}') for i in range(10)
-        ]
+        tasks = [fs.write(f'file{i}.txt', f'Content {i}'.encode()) for i in range(10)]
         await asyncio.gather(*tasks)
 
         # Read files concurrently
-        tasks = [store.read_file(f'file{i}.txt') for i in range(10)]
+        tasks = [fs.read(f'file{i}.txt') for i in range(10)]
         results = await asyncio.gather(*tasks)
 
         # Verify all files were written correctly
         for i, content in enumerate(results):
-            assert content == f'Content {i}'
+            assert content == f'Content {i}'.encode()
+
+    @pytest.mark.asyncio
+    async def test_handle_based_write_and_read(self, temp_dir):
+        """Test handle-based streaming write and read."""
+        url = f'filesystem://{temp_dir}'
+        store = Store.create(url=url)
+        fs = store.get_file_store('test-user')
+
+        # Write in chunks via handles
+        handle_id = await fs.open_write('chunked.bin', connection_id=1)
+        await fs.write_chunk(handle_id, b'chunk-1-')
+        await fs.write_chunk(handle_id, b'chunk-2-')
+        await fs.write_chunk(handle_id, b'chunk-3')
+        await fs.close_write(handle_id)
+
+        # Read back via handles
+        info = await fs.open_read('chunked.bin', connection_id=1)
+        assert info['size'] == 23  # len('chunk-1-chunk-2-chunk-3')
+        data = await fs.read_chunk(info['handle'])
+        await fs.close_read(info['handle'])
+
+        assert data == b'chunk-1-chunk-2-chunk-3'
+
+    @pytest.mark.asyncio
+    async def test_close_all_handles_on_disconnect(self, temp_dir):
+        """Test that close_all_handles commits and cleans up."""
+        url = f'filesystem://{temp_dir}'
+        store = Store.create(url=url)
+        fs = store.get_file_store('test-user')
+
+        # Open a write handle and write some data
+        handle_id = await fs.open_write('disconnect.bin', connection_id=42)
+        await fs.write_chunk(handle_id, b'partial-data')
+
+        # Simulate disconnect — should commit what was written
+        await fs.close_all_handles(connection_id=42)
+
+        # Data should be committed and readable
+        data = await fs.read('disconnect.bin')
+        assert data == b'partial-data'
+
+    @pytest.mark.asyncio
+    async def test_write_lock_prevents_double_open(self, temp_dir):
+        """Test that opening the same file for writing twice raises an error."""
+        url = f'filesystem://{temp_dir}'
+        store = Store.create(url=url)
+        fs = store.get_file_store('test-user')
+
+        handle_id = await fs.open_write('locked.bin', connection_id=1)
+
+        with pytest.raises(StorageError) as exc_info:
+            await fs.open_write('locked.bin', connection_id=2)
+        assert 'already open for writing' in str(exc_info.value)
+
+        # Clean up
+        await fs.close_write(handle_id)
 
 
 if __name__ == '__main__':

--- a/packages/ai/tests/ai/account/test_store.py
+++ b/packages/ai/tests/ai/account/test_store.py
@@ -977,7 +977,7 @@ class TestStoreIntegration:
         # Read back via handles
         info = await fs.open_read('chunked.bin', connection_id=1)
         assert info['size'] == 23  # len('chunk-1-chunk-2-chunk-3')
-        data = await fs.read_chunk(info['handle'])
+        data = await fs.read_chunk(info['handle'], offset=0)
         await fs.close_read(info['handle'])
 
         assert data == b'chunk-1-chunk-2-chunk-3'
@@ -999,6 +999,10 @@ class TestStoreIntegration:
         # Data should be committed and readable
         data = await fs.read('disconnect.bin')
         assert data == b'partial-data'
+
+        # Write lock should be released — a new write must succeed
+        handle_id2 = await fs.open_write('disconnect.bin', connection_id=43)
+        await fs.close_write(handle_id2)
 
     @pytest.mark.asyncio
     async def test_write_lock_prevents_double_open(self, temp_dir):

--- a/packages/client-python/src/rocketride/cli/commands/store.py
+++ b/packages/client-python/src/rocketride/cli/commands/store.py
@@ -23,36 +23,17 @@
 """
 RocketRide CLI Store Command Implementation.
 
-This module provides the StoreCommand class for managing project and template storage
-through the RocketRide CLI. It uses the StoreMixin methods from the client
-to perform storage operations on the server.
+File system-style commands for managing the account file store.
 
-The store command supports atomic operations to prevent concurrent modification
-conflicts using version/ETag checking.
-
-Key Features:
-    - Save projects with atomic write operations
-    - Retrieve projects by ID
-    - Delete projects with version checking
-    - List all projects for authenticated user
-    - Save, retrieve, delete, and list templates (system-wide)
-    - Server-side storage with proper authentication
-
-Usage:
-    rocketride rrext_store save_project --project-id <id> --project-file <file> --apikey <key>
-    rocketride rrext_store get_project --project-id <id> --apikey <key>
-    rocketride rrext_store delete_project --project-id <id> --apikey <key>
-    rocketride rrext_store get_all_projects --apikey <key>
-    rocketride rrext_store save_template --template-id <id> --template-file <file> --apikey <key>
-    rocketride rrext_store get_template --template-id <id> --apikey <key>
-    rocketride rrext_store delete_template --template-id <id> --apikey <key>
-    rocketride rrext_store get_all_templates --apikey <key>
-
-Components:
-    StoreCommand: Main command implementation for project and template storage operations
+Commands:
+    rocketride store dir [path]                          - list directory
+    rocketride store type <path>                         - display file contents
+    rocketride store write <path> --file/--content       - write file
+    rocketride store rm <path>                           - delete file
+    rocketride store mkdir <path>                        - create directory
+    rocketride store stat <path>                         - file/dir metadata
 """
 
-import json
 from typing import TYPE_CHECKING
 from .base import BaseCommand
 
@@ -61,393 +42,104 @@ if TYPE_CHECKING:
 
 
 class StoreCommand(BaseCommand):
-    """
-    Command implementation for project storage operations.
-
-    Uses the client's StoreMixin methods to perform storage operations
-    with proper authentication and atomic conflict detection.
-
-    Example:
-        ```python
-        # Initialize and execute store command
-        command = StoreCommand(cli, args)
-        exit_code = await command.execute(client)
-        ```
-
-    Key Features:
-        - Server-side storage with authentication
-        - Atomic operations with version checking
-        - Uses client mixin methods for clean interface
-        - Proper error handling and user feedback
-    """
+    """Command implementation for file store operations."""
 
     def __init__(self, cli, args):
-        """
-        Initialize StoreCommand with CLI context and parsed arguments.
-
-        Args:
-            cli: CLI instance providing cancellation state and event handling
-            args: Parsed command line arguments containing subcommand and options
-        """
+        """Initialize StoreCommand."""
         super().__init__(cli, args)
 
-        # Map of subcommand names to handler methods
         self._subcommand_handlers = {
-            'save_project': self._save_project,
-            'get_project': self._get_project,
-            'delete_project': self._delete_project,
-            'get_all_projects': self._get_all_projects,
-            'save_template': self._save_template,
-            'get_template': self._get_template,
-            'delete_template': self._delete_template,
-            'get_all_templates': self._get_all_templates,
-            'save_log': self._save_log,
-            'get_log': self._get_log,
-            'list_logs': self._list_logs,
+            'dir': self._cmd_dir,
+            'type': self._cmd_type,
+            'write': self._cmd_write,
+            'rm': self._cmd_rm,
+            'mkdir': self._cmd_mkdir,
+            'stat': self._cmd_stat,
         }
 
-    def _load_pipeline_from_args(self, file_attr: str, json_attr: str) -> dict:
-        """
-        Load pipeline JSON from file or string argument.
-
-        Args:
-            file_attr: Name of the file argument attribute (e.g., 'project_file')
-            json_attr: Name of the JSON string argument attribute (e.g., 'project_json')
-
-        Returns:
-            dict: Parsed pipeline configuration
-
-        Raises:
-            ValueError: If arguments are invalid or missing
-            FileNotFoundError: If specified file doesn't exist
-            json.JSONDecodeError: If JSON is invalid
-        """
-        file_path = getattr(self.args, file_attr, None)
-        json_str = getattr(self.args, json_attr, None)
-
-        if file_path:
-            with open(file_path, 'r', encoding='utf-8') as f:
-                content = f.read().strip()
-                if not content:
-                    raise ValueError(f'Pipeline file is empty: {file_path}')
-                pipeline = json.loads(content)
-        elif json_str:
-            if not isinstance(json_str, str):
-                raise ValueError(f'Invalid JSON value (expected string, got {type(json_str).__name__})')
-            json_str_stripped = json_str.strip()
-            if not json_str_stripped:
-                raise ValueError('Pipeline JSON string is empty or contains only whitespace')
-            pipeline = json.loads(json_str_stripped)
-        else:
-            raise ValueError(f'Either --{file_attr.replace("_", "-")} or --{json_attr.replace("_", "-")} is required')
-
-        if not pipeline:
-            raise ValueError('Pipeline data cannot be empty')
-        if not isinstance(pipeline, dict):
-            raise ValueError('Pipeline must be a JSON object')
-
-        return pipeline
-
     async def execute(self, client: 'RocketRideClient') -> int:
-        """
-        Execute the store command based on subcommand.
-
-        Routes to the appropriate subcommand handler which uses the
-        client's mixin methods for storage operations.
-
-        Args:
-            client: Connected RocketRideClient instance for server communication
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
+        """Execute the store command based on subcommand."""
         try:
-            # Connect to server if not already connected
             if not self.cli.client.is_connected():
                 await self.cli.connect()
 
-            # Route to appropriate subcommand handler
             if handler := self._subcommand_handlers.get(self.args.store_subcommand):
                 return await handler(client)
             else:
                 raise ValueError(f'Unknown store subcommand: {self.args.store_subcommand}')
 
         except Exception as e:  # noqa: BLE001
-            print(f'Error executing store command: {e}')
+            print(f'Error: {e}')
             return 1
 
-    async def _save_project(self, client: 'RocketRideClient') -> int:
-        """
-        Save a project using the client's save_project method.
+    async def _cmd_dir(self, client: 'RocketRideClient') -> int:
+        """List directory contents."""
+        path = getattr(self.args, 'path', '') or ''
+        result = await client.fs_list_dir(path)
 
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        project_id = self.args.project_id
-        if not project_id:
-            raise ValueError('Project ID is required')
+        entries = result.get('entries', [])
+        if not entries:
+            print('(empty directory)')
+            return 0
+        for entry in entries:
+            type_indicator = 'DIR ' if entry['type'] == 'dir' else 'FILE'
+            print(f'  {type_indicator}  {entry["name"]}')
+        print(f'\n  {result["count"]} item(s)')
 
-        # Load pipeline JSON
-        pipeline = self._load_pipeline_from_args('project_file', 'project_json')
-
-        # Get expected version (from args or auto-fetch)
-        expected_version = getattr(self.args, 'expected_version', None)
-        if not expected_version:
-            # Auto-fetch current version if updating existing project
-            try:
-                existing = await client.get_project(project_id)
-                expected_version = existing.get('version')
-            except RuntimeError:
-                # Project doesn't exist yet - no version to check
-                pass
-
-        # Call client mixin method
-        result = await client.save_project(project_id=project_id, pipeline=pipeline, expected_version=expected_version)
-
-        # Display success
-        print(json.dumps(result, indent=2))
         return 0
 
-    async def _get_project(self, client: 'RocketRideClient') -> int:
-        """
-        Get a project using the client's get_project method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        project_id = self.args.project_id
-        if not project_id:
-            raise ValueError('Project ID is required')
-
-        # Call client mixin method
-        result = await client.get_project(project_id)
-
-        # Display result
-        print(json.dumps(result, indent=2))
+    async def _cmd_type(self, client: 'RocketRideClient') -> int:
+        """Display file contents."""
+        path = self.args.path
+        text = await client.fs_read_string(path)
+        print(text, end='')
         return 0
 
-    async def _delete_project(self, client: 'RocketRideClient') -> int:
-        """
-        Delete a project using the client's delete_project method.
+    async def _cmd_write(self, client: 'RocketRideClient') -> int:
+        """Write file from local file or inline content."""
+        path = self.args.path
+        file_path = getattr(self.args, 'file', None)
+        content = getattr(self.args, 'content', None)
 
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        project_id = self.args.project_id
-        if not project_id:
-            raise ValueError('Project ID is required')
+        if file_path:
+            with open(file_path, 'rb') as f:
+                data = f.read()
+            await client.fs_write(path, data)
+        elif content is not None:
+            await client.fs_write_string(path, content)
+        else:
+            raise ValueError('Either --file or --content is required')
 
-        # Get expected version if provided
-        expected_version = getattr(self.args, 'expected_version', None)
-
-        # Call client mixin method
-        result = await client.delete_project(project_id=project_id, expected_version=expected_version)
-
-        # Display success
-        print(f'Project {project_id} deleted successfully')
-        if result.get('message'):
-            print(result['message'])
+        print(f'Written: {path}')
         return 0
 
-    async def _get_all_projects(self, client: 'RocketRideClient') -> int:
-        """
-        List all projects using the client's get_all_projects method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        # Call client mixin method
-        result = await client.get_all_projects()
-
-        # Display results
-        print(json.dumps(result, indent=2))
+    async def _cmd_rm(self, client: 'RocketRideClient') -> int:
+        """Delete a file."""
+        await client.fs_delete(self.args.path)
+        print(f'Deleted: {self.args.path}')
         return 0
 
-    # =========================================================================
-    # Template Operations (system-wide templates accessible to all users)
-    # =========================================================================
-
-    async def _save_template(self, client: 'RocketRideClient') -> int:
-        """
-        Save a template using the client's save_template method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        template_id = self.args.template_id
-        if not template_id:
-            raise ValueError('Template ID is required')
-
-        # Load pipeline JSON
-        pipeline = self._load_pipeline_from_args('template_file', 'template_json')
-
-        # Get expected version (from args or auto-fetch)
-        expected_version = getattr(self.args, 'expected_version', None)
-        if not expected_version:
-            # Auto-fetch current version if updating existing template
-            try:
-                existing = await client.get_template(template_id)
-                expected_version = existing.get('version')
-            except RuntimeError:
-                # Template doesn't exist yet - no version to check
-                pass
-
-        # Call client mixin method
-        result = await client.save_template(template_id=template_id, pipeline=pipeline, expected_version=expected_version)
-
-        # Display success
-        print(json.dumps(result, indent=2))
+    async def _cmd_mkdir(self, client: 'RocketRideClient') -> int:
+        """Create a directory."""
+        await client.fs_mkdir(self.args.path)
+        print(f'Created: {self.args.path}/')
         return 0
 
-    async def _get_template(self, client: 'RocketRideClient') -> int:
-        """
-        Get a template using the client's get_template method.
+    async def _cmd_stat(self, client: 'RocketRideClient') -> int:
+        """Get file/directory metadata."""
+        path = self.args.path
+        result = await client.fs_stat(path)
 
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        template_id = self.args.template_id
-        if not template_id:
-            raise ValueError('Template ID is required')
+        if not result.get('exists'):
+            print(f'{path}: not found')
+        else:
+            entry_type = result.get('type', 'unknown')
+            modified = result.get('modified')
+            if modified:
+                from datetime import datetime, timezone
 
-        # Call client mixin method
-        result = await client.get_template(template_id)
-
-        # Display result
-        print(json.dumps(result, indent=2))
-        return 0
-
-    async def _delete_template(self, client: 'RocketRideClient') -> int:
-        """
-        Delete a template using the client's delete_template method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        template_id = self.args.template_id
-        if not template_id:
-            raise ValueError('Template ID is required')
-
-        # Get expected version if provided
-        expected_version = getattr(self.args, 'expected_version', None)
-
-        # Call client mixin method
-        result = await client.delete_template(template_id=template_id, expected_version=expected_version)
-
-        # Display success
-        print(f'Template {template_id} deleted successfully')
-        if result.get('message'):
-            print(result['message'])
-        return 0
-
-    async def _get_all_templates(self, client: 'RocketRideClient') -> int:
-        """
-        List all templates using the client's get_all_templates method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        # Call client mixin method
-        result = await client.get_all_templates()
-
-        # Display results
-        print(json.dumps(result, indent=2))
-        return 0
-
-    # =========================================================================
-    # Log Operations (per-project log files for historical tracking)
-    # =========================================================================
-
-    async def _save_log(self, client: 'RocketRideClient') -> int:
-        """
-        Save a log file using the client's save_log method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        project_id = self.args.project_id
-        if not project_id:
-            raise ValueError('Project ID is required')
-
-        source = self.args.source
-        if not source:
-            raise ValueError('Source is required')
-
-        # Load contents JSON
-        contents_json = getattr(self.args, 'contents_json', None)
-        if not contents_json:
-            raise ValueError('--contents-json is required')
-
-        contents = json.loads(contents_json)
-
-        # Call client mixin method
-        result = await client.save_log(
-            project_id=project_id,
-            source=source,
-            contents=contents,
-        )
-
-        # Display success
-        print(json.dumps(result, indent=2))
-        return 0
-
-    async def _get_log(self, client: 'RocketRideClient') -> int:
-        """
-        Get a log file using the client's get_log method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        project_id = self.args.project_id
-        if not project_id:
-            raise ValueError('Project ID is required')
-
-        source = self.args.source
-        if not source:
-            raise ValueError('Source is required')
-
-        start_time = getattr(self.args, 'start_time', None)
-        if start_time is None:
-            raise ValueError('Start time is required')
-
-        # Convert to float
-        start_time = float(start_time)
-
-        # Call client mixin method
-        result = await client.get_log(
-            project_id=project_id,
-            source=source,
-            start_time=start_time,
-        )
-
-        # Display result
-        print(json.dumps(result, indent=2))
-        return 0
-
-    async def _list_logs(self, client: 'RocketRideClient') -> int:
-        """
-        List log files using the client's list_logs method.
-
-        Returns:
-            Exit code: 0 for success, 1 for errors
-        """
-        project_id = self.args.project_id
-        if not project_id:
-            raise ValueError('Project ID is required')
-
-        # Get optional parameters
-        source = getattr(self.args, 'source', None)
-        page = getattr(self.args, 'page', None)
-        if page is not None:
-            page = int(page)
-
-        # Call client mixin method
-        result = await client.list_logs(
-            project_id=project_id,
-            source=source,
-            page=page,
-        )
-
-        # Display results
-        print(json.dumps(result, indent=2))
+                ts = datetime.fromtimestamp(modified, tz=timezone.utc).isoformat()
+                print(f'{path}: {entry_type} (modified: {ts})')
+            else:
+                print(f'{path}: {entry_type}')
         return 0

--- a/packages/client-python/src/rocketride/cli/commands/store.py
+++ b/packages/client-python/src/rocketride/cli/commands/store.py
@@ -74,17 +74,37 @@ class StoreCommand(BaseCommand):
 
     async def _cmd_dir(self, client: 'RocketRideClient') -> int:
         """List directory contents."""
+        from datetime import datetime, timezone
+
         path = getattr(self.args, 'path', '') or ''
         result = await client.fs_list_dir(path)
 
         entries = result.get('entries', [])
         if not entries:
-            print('(empty directory)')
+            print('File Not Found')
             return 0
+
+        total_size = 0
+        file_count = 0
+        dir_count = 0
         for entry in entries:
-            type_indicator = 'DIR ' if entry['type'] == 'dir' else 'FILE'
-            print(f'  {type_indicator}  {entry["name"]}')
-        print(f'\n  {result["count"]} item(s)')
+            modified = entry.get('modified')
+            if modified:
+                dt = datetime.fromtimestamp(modified, tz=timezone.utc)
+                date_str = dt.strftime('%m/%d/%Y  %I:%M %p')
+            else:
+                date_str = '                   '
+            if entry['type'] == 'dir':
+                print(f'{date_str}    <DIR>          {entry["name"]}')
+                dir_count += 1
+            else:
+                size = entry.get('size', 0)
+                total_size += size
+                print(f'{date_str}    {size:>14,} {entry["name"]}')
+                file_count += 1
+
+        print(f'    {file_count:>8,} File(s)  {total_size:>14,} bytes')
+        print(f'    {dir_count:>8,} Dir(s)')
 
         return 0
 
@@ -102,9 +122,22 @@ class StoreCommand(BaseCommand):
         content = getattr(self.args, 'content', None)
 
         if file_path:
-            with open(file_path, 'rb') as f:
-                data = f.read()
-            await client.fs_write(path, data)
+            info = await client.fs_open(path, 'w')
+            handle = info['handle']
+            try:
+                with open(file_path, 'rb') as f:
+                    while True:
+                        chunk = f.read(65536)
+                        if not chunk:
+                            break
+                        await client.fs_write(handle, chunk)
+                await client.fs_close(handle, 'w')
+            except Exception:
+                try:
+                    await client.fs_close(handle, 'w')
+                except Exception:
+                    pass
+                raise
         elif content is not None:
             await client.fs_write_string(path, content)
         else:
@@ -134,12 +167,15 @@ class StoreCommand(BaseCommand):
             print(f'{path}: not found')
         else:
             entry_type = result.get('type', 'unknown')
+            details = []
+            size = result.get('size')
+            if size is not None:
+                details.append(f'size: {size:,}')
             modified = result.get('modified')
             if modified:
                 from datetime import datetime, timezone
 
-                ts = datetime.fromtimestamp(modified, tz=timezone.utc).isoformat()
-                print(f'{path}: {entry_type} (modified: {ts})')
-            else:
-                print(f'{path}: {entry_type}')
+                details.append(f'modified: {datetime.fromtimestamp(modified, tz=timezone.utc).isoformat()}')
+            suffix = f' ({", ".join(details)})' if details else ''
+            print(f'{path}: {entry_type}{suffix}')
         return 0

--- a/packages/client-python/src/rocketride/cli/commands/store.py
+++ b/packages/client-python/src/rocketride/cli/commands/store.py
@@ -81,6 +81,11 @@ class StoreCommand(BaseCommand):
 
         entries = result.get('entries', [])
         if not entries:
+            stat = await client.fs_stat(path) if path else {'exists': True, 'type': 'dir'}
+            if stat.get('exists') and stat.get('type') == 'dir':
+                print(f'    {0:>8,} File(s)  {0:>14,} bytes')
+                print(f'    {0:>8,} Dir(s)')
+                return 0
             print('File Not Found')
             return 0
 

--- a/packages/client-python/src/rocketride/cli/main.py
+++ b/packages/client-python/src/rocketride/cli/main.py
@@ -463,213 +463,48 @@ class RocketRideCLI:
             help='Output results in JSON format',
         )
 
-        # Store command - manages project storage
-        # Create a parent parser with common args that will be inherited by subcommands
+        # Store command - file store and domain storage operations
         store_common_parser = argparse.ArgumentParser(add_help=False)
         add_common_args(store_common_parser)
 
-        store_parser = subparsers.add_parser('rrext_store', help='Manage project storage', parents=[store_common_parser])
+        store_parser = subparsers.add_parser('store', help='File store operations', parents=[store_common_parser])
 
-        # Create subparser for store subcommands
         store_subparsers = store_parser.add_subparsers(
             dest='store_subcommand',
-            help='Storage operations',
-            metavar='STORE_COMMAND',
-        )
-
-        # save_project subcommand (inherits common args from parent)
-        save_project_parser = store_subparsers.add_parser(
-            'save_project',
-            help='Save a project to storage',
-            parents=[store_common_parser],
-        )
-        save_project_parser.add_argument(
-            '--project-id',
-            required=True,
-            help='Project ID',
-        )
-        save_project_parser.add_argument(
-            '--expected-version',
-            help='Expected version for atomic update (optional)',
-        )
-        save_project_group = save_project_parser.add_mutually_exclusive_group(required=True)
-        save_project_group.add_argument(
-            '--project-file',
-            help='Path to pipeline JSON file',
-        )
-        save_project_group.add_argument(
-            '--project-json',
-            help='Pipeline JSON as string',
-        )
-
-        # get_project subcommand (inherits common args from parent)
-        get_project_parser = store_subparsers.add_parser(
-            'get_project',
-            help='Get a project from storage',
-            parents=[store_common_parser],
-        )
-        get_project_parser.add_argument(
-            '--project-id',
-            required=True,
-            help='Project ID to retrieve',
-        )
-
-        # delete_project subcommand (inherits common args from parent)
-        delete_project_parser = store_subparsers.add_parser(
-            'delete_project',
-            help='Delete a project from storage',
-            parents=[store_common_parser],
-        )
-        delete_project_parser.add_argument(
-            '--project-id',
-            required=True,
-            help='Project ID to delete',
-        )
-        delete_project_parser.add_argument(
-            '--expected-version',
-            help='Expected version for atomic delete (required)',
-        )
-
-        # get_all_projects subcommand (inherits common args from parent)
-        store_subparsers.add_parser(
-            'get_all_projects',
-            help='List all projects for authenticated user',
-            parents=[store_common_parser],
+            help='Store commands',
+            metavar='COMMAND',
         )
 
         # =====================================================================
-        # Template subcommands (system-wide templates accessible to all users)
+        # File system commands
         # =====================================================================
 
-        # save_template subcommand (inherits common args from parent)
-        save_template_parser = store_subparsers.add_parser(
-            'save_template',
-            help='Save a template to storage (system-wide)',
-            parents=[store_common_parser],
-        )
-        save_template_parser.add_argument(
-            '--template-id',
-            required=True,
-            help='Template ID',
-        )
-        save_template_parser.add_argument(
-            '--expected-version',
-            help='Expected version for atomic update (optional)',
-        )
-        save_template_group = save_template_parser.add_mutually_exclusive_group(required=True)
-        save_template_group.add_argument(
-            '--template-file',
-            help='Path to pipeline JSON file',
-        )
-        save_template_group.add_argument(
-            '--template-json',
-            help='Pipeline JSON as string',
-        )
+        # dir - list directory
+        dir_parser = store_subparsers.add_parser('dir', help='List directory contents', parents=[store_common_parser])
+        dir_parser.add_argument('path', nargs='?', default='', help='Directory path (default: root)')
 
-        # get_template subcommand (inherits common args from parent)
-        get_template_parser = store_subparsers.add_parser(
-            'get_template',
-            help='Get a template from storage',
-            parents=[store_common_parser],
-        )
-        get_template_parser.add_argument(
-            '--template-id',
-            required=True,
-            help='Template ID to retrieve',
-        )
+        # type - display file contents
+        type_parser = store_subparsers.add_parser('type', help='Display file contents', parents=[store_common_parser])
+        type_parser.add_argument('path', help='File path')
 
-        # delete_template subcommand (inherits common args from parent)
-        delete_template_parser = store_subparsers.add_parser(
-            'delete_template',
-            help='Delete a template from storage',
-            parents=[store_common_parser],
-        )
-        delete_template_parser.add_argument(
-            '--template-id',
-            required=True,
-            help='Template ID to delete',
-        )
-        delete_template_parser.add_argument(
-            '--expected-version',
-            help='Expected version for atomic delete (optional)',
-        )
+        # write - write file
+        write_parser = store_subparsers.add_parser('write', help='Write a file', parents=[store_common_parser])
+        write_parser.add_argument('path', help='File path')
+        write_group = write_parser.add_mutually_exclusive_group(required=True)
+        write_group.add_argument('--file', help='Local file to upload')
+        write_group.add_argument('--content', help='Inline text content')
 
-        # get_all_templates subcommand (inherits common args from parent)
-        store_subparsers.add_parser(
-            'get_all_templates',
-            help='List all templates (system-wide)',
-            parents=[store_common_parser],
-        )
+        # rm - delete file
+        rm_parser = store_subparsers.add_parser('rm', help='Delete a file', parents=[store_common_parser])
+        rm_parser.add_argument('path', help='File path')
 
-        # =====================================================================
-        # Log subcommands (per-project log files for historical tracking)
-        # =====================================================================
+        # mkdir - create directory
+        mkdir_parser = store_subparsers.add_parser('mkdir', help='Create a directory', parents=[store_common_parser])
+        mkdir_parser.add_argument('path', help='Directory path')
 
-        # save_log subcommand (inherits common args from parent)
-        save_log_parser = store_subparsers.add_parser(
-            'save_log',
-            help='Save a log file for a source run',
-            parents=[store_common_parser],
-        )
-        save_log_parser.add_argument(
-            '--project-id',
-            required=True,
-            help='Project ID',
-        )
-        save_log_parser.add_argument(
-            '--source',
-            required=True,
-            help='Source name',
-        )
-        save_log_parser.add_argument(
-            '--contents-json',
-            required=True,
-            help='Log contents JSON as string (must contain body.startTime)',
-        )
-
-        # get_log subcommand (inherits common args from parent)
-        get_log_parser = store_subparsers.add_parser(
-            'get_log',
-            help='Get a log file by source and start time',
-            parents=[store_common_parser],
-        )
-        get_log_parser.add_argument(
-            '--project-id',
-            required=True,
-            help='Project ID',
-        )
-        get_log_parser.add_argument(
-            '--source',
-            required=True,
-            help='Source name',
-        )
-        get_log_parser.add_argument(
-            '--start-time',
-            required=True,
-            type=float,
-            help='Start time of the run (float)',
-        )
-
-        # list_logs subcommand (inherits common args from parent)
-        list_logs_parser = store_subparsers.add_parser(
-            'list_logs',
-            help='List log files for a project',
-            parents=[store_common_parser],
-        )
-        list_logs_parser.add_argument(
-            '--project-id',
-            required=True,
-            help='Project ID',
-        )
-        list_logs_parser.add_argument(
-            '--source',
-            help='Optional source name to filter logs',
-        )
-        list_logs_parser.add_argument(
-            '--page',
-            type=int,
-            help='Page number (0-indexed, page size is 100)',
-        )
+        # stat - file/directory metadata
+        stat_parser = store_subparsers.add_parser('stat', help='Get file/directory metadata', parents=[store_common_parser])
+        stat_parser.add_argument('path', help='File or directory path')
 
         return parser
 
@@ -720,7 +555,7 @@ class RocketRideCLI:
             # List command doesn't require token (lists all user's tasks)
             pass
 
-        elif self.args.command == 'rrext_store':
+        elif self.args.command == 'store':
             # Store command requires store_subcommand
             if not hasattr(self.args, 'store_subcommand') or not self.args.store_subcommand:
                 print('Error: Store subcommand is required (save_project, get_project, delete_project, get_all_projects, save_template, get_template, delete_template, get_all_templates, save_log, get_log, list_logs)')
@@ -768,7 +603,7 @@ class RocketRideCLI:
                 'stop': StopCommand,
                 'events': EventsCommand,
                 'list': ListCommand,
-                'rrext_store': StoreCommand,
+                'store': StoreCommand,
             }
 
             if self.args.command in command_map:

--- a/packages/client-python/src/rocketride/cli/main.py
+++ b/packages/client-python/src/rocketride/cli/main.py
@@ -558,7 +558,7 @@ class RocketRideCLI:
         elif self.args.command == 'store':
             # Store command requires store_subcommand
             if not hasattr(self.args, 'store_subcommand') or not self.args.store_subcommand:
-                print('Error: Store subcommand is required (save_project, get_project, delete_project, get_all_projects, save_template, get_template, delete_template, get_all_templates, save_log, get_log, list_logs)')
+                print('Error: Store subcommand is required (dir, type, write, rm, mkdir, stat)')
                 return 1
 
         elif self.args.command == 'upload' and not self.args.pipeline_path and not self.args.token:

--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -48,6 +48,7 @@ from .mixins.chat import ChatMixin
 from .mixins.events import EventMixin
 from .mixins.ping import PingMixin
 from .mixins.services import ServicesMixin
+from .mixins.store import StoreMixin
 
 client_id = 0
 
@@ -65,6 +66,7 @@ class RocketRideClient(
     EventMixin,
     PingMixin,
     ServicesMixin,
+    StoreMixin,
     DAPClient,
 ):
     """
@@ -117,8 +119,8 @@ class RocketRideClient(
 
     def __init__(
         self,
-        uri: str = "",
-        auth: str = "",
+        uri: str = '',
+        auth: str = '',
         **kwargs,
     ):
         """
@@ -147,7 +149,7 @@ class RocketRideClient(
         if env is None:
             # Start with process environment so ROCKETRIDE_* vars work out of the box.
             self._env = dict(os.environ)
-            
+
             # Try to load .env file
             try:
                 env_path = os.path.join(os.getcwd(), '.env')
@@ -164,8 +166,7 @@ class RocketRideClient(
                                 key = key.strip()
                                 value = value.strip()
                                 # Remove quotes if present
-                                if (value.startswith('"') and value.endswith('"')) or \
-                                   (value.startswith("'") and value.endswith("'")):
+                                if (value.startswith('"') and value.endswith('"')) or (value.startswith("'") and value.endswith("'")):
                                     value = value[1:-1]
                                 # Preserve already-defined process env values.
                                 self._env.setdefault(key, value)
@@ -186,6 +187,7 @@ class RocketRideClient(
 
         # Normalize the URI into a fully-formed WebSocket address
         from .mixins.connection import ConnectionMixin
+
         self._uri = ConnectionMixin._get_websocket_uri(uri)
         self._apikey = auth
 

--- a/packages/client-python/src/rocketride/mixins/store.py
+++ b/packages/client-python/src/rocketride/mixins/store.py
@@ -21,711 +21,267 @@
 # SOFTWARE.
 
 """
-Project Storage Management for RocketRide Client.
+Storage Management for RocketRide Client.
 
-This module provides project storage capabilities including saving, retrieving,
-and managing project pipelines. Projects are stored securely with version control
-and atomic operations to prevent conflicts.
-
-Key Features:
-- Save and update project pipelines with version control
-- Retrieve projects by ID with version metadata
-- Delete projects with optional version checking
-- List all user projects with summaries
-- Atomic operations to prevent race conditions
-
-Usage:
-    # Save a new project
-    result = await client.save_project(
-        project_id="my-project",
-        pipeline={"name": "My Pipeline", "components": [...]}
-    )
-
-    # Get a project
-    project = await client.get_project(project_id="my-project")
-    print(f"Version: {project['version']}")
-
-    # Update with version check
-    result = await client.save_project(
-        project_id="my-project",
-        pipeline=updated_pipeline,
-        expected_version=project['version']
-    )
-
-    # Delete a project
-    await client.delete_project(
-        project_id="my-project",
-        expected_version=project['version']
-    )
-
-    # List all projects
-    projects = await client.get_all_projects()
-    for proj in projects['projects']:
-        print(f"{proj['id']}: {proj['name']}")
+Handle-based I/O: use fs_open/fs_read/fs_write/fs_close for streaming.
+Convenience wrappers (fs_read_string, fs_write_json, etc.) handle
+open/close internally.
 """
 
+import json
 from typing import Dict, Any, Optional
 from ..core import DAPClient
 
 
 class StoreMixin(DAPClient):
     """
-    Provides project storage capabilities for the RocketRide client.
+    Provides handle-based file store and domain storage capabilities.
 
-    This mixin adds the ability to save, retrieve, delete, and list project
-    pipelines stored on the RocketRide server. All operations are atomic and
-    support version control to prevent conflicts when multiple users or
-    processes modify the same project.
-
-    Storage operations work with project IDs and pipeline configurations:
-    - Projects are stored per-user (automatically isolated by API key)
-    - Each save operation returns a version hash
-    - Updates require matching version to prevent conflicts
-    - Deletions can optionally verify version before removing
-
-    This is automatically included when you use RocketRideClient, so you can
-    call methods like client.save_project() and client.get_project() directly.
+    Core methods (fs_open, fs_read, fs_write, fs_close) use handles for
+    streaming I/O. Convenience wrappers handle open/close internally.
+    Domain methods (save_project, get_template, etc.) are client-side
+    wrappers that call the convenience methods with well-known paths.
     """
 
     def __init__(self, **kwargs):
-        """Initialize project storage capabilities."""
+        """Initialize storage capabilities."""
         super().__init__(**kwargs)
 
-    async def save_project(
-        self,
-        project_id: str,
-        pipeline: Dict[str, Any],
-        expected_version: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Save or update a project pipeline.
+    # =========================================================================
+    # Handle-Based I/O
+    # =========================================================================
 
-        Stores a project pipeline configuration on the server. If the project
-        already exists, it will be updated. Use expected_version to ensure
-        you're updating the version you expect (prevents conflicts).
+    async def fs_open(self, path: str, mode: str = 'r', offset: int = 0) -> Dict[str, Any]:
+        """
+        Open a file handle for reading or writing.
 
         Args:
-            project_id: Unique identifier for the project
-            pipeline: Pipeline configuration as a dictionary
-            expected_version: Expected current version for atomic updates (optional)
-                If provided and doesn't match current version, save fails with CONFLICT error.
-                For updates, recommended to auto-fetch or specify explicitly.
-                For new projects, omit this parameter.
+            path: Relative path within the account store.
+            mode: 'r' for read, 'w' for write.
+            offset: Initial byte offset (read mode only).
 
         Returns:
-            Dict containing:
-            - success: True if saved successfully (bool)
-            - project_id: The project ID that was saved (str)
-            - version: New version hash after save (str)
-
-        Raises:
-            ValueError: If project_id or pipeline is missing/invalid
-            RuntimeError: If save fails due to:
-                - CONFLICT: Version mismatch (someone else modified it)
-                - STORAGE_ERROR: Server storage problem
-                - Other server errors
-
-        Example:
-            # Save a new project
-            pipeline = {
-                "name": "Data Processor",
-                "source": "source_1",
-                "components": [
-                    {"id": "source_1", "provider": "filesystem", "config": {...}}
-                ]
-            }
-            result = await client.save_project("proj-123", pipeline)
-            print(f"Saved version: {result['version']}")
-
-            # Update existing project with version check
-            existing = await client.get_project("proj-123")
-            updated_pipeline = existing['pipeline']
-            updated_pipeline['name'] = "Updated Name"
-
-            result = await client.save_project(
-                "proj-123",
-                updated_pipeline,
-                expected_version=existing['version']  # Ensures atomic update
-            )
-
-            # Save/overwrite without version check (not recommended for updates)
-            result = await client.save_project("proj-123", pipeline)
-
-        Version Control:
-            - For NEW projects: Don't provide expected_version
-            - For UPDATES: Provide expected_version to prevent conflicts
-            - If version mismatch occurs, fetch latest and retry:
-                try:
-                    await client.save_project(id, pipeline, version)
-                except RuntimeError as e:
-                    if 'CONFLICT' in str(e):
-                        # Fetch latest version and merge changes
-                        latest = await client.get_project(id)
-                        # ... resolve conflicts ...
-                        await client.save_project(id, merged, latest['version'])
+            Dict with 'handle' (str). Read mode also includes 'size' (int).
         """
-        # Validate inputs
+        args: Dict[str, Any] = {'subcommand': 'fs_open', 'path': path, 'mode': mode}
+        if mode == 'r' and offset > 0:
+            args['offset'] = offset
+        request = self.build_request(command='rrext_store', arguments=args)
+        response = await self.request(request)
+        self._check_response(response)
+        return response.get('body', {})
+
+    async def fs_read(self, handle: str, length: int = 4_194_304) -> bytes:
+        """
+        Read data from an open read handle.
+
+        Args:
+            handle: Handle ID returned by fs_open.
+            length: Max bytes to read (default 4 MB).
+
+        Returns:
+            Bytes read. Empty bytes indicates EOF.
+        """
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_read', 'handle': handle, 'length': length})
+        response = await self.request(request)
+        self._check_response(response)
+        return response.get('arguments', {}).get('data', b'')
+
+    async def fs_write(self, handle: str, data: bytes) -> int:
+        """
+        Write data to an open write handle.
+
+        Args:
+            handle: Handle ID returned by fs_open.
+            data: Raw bytes to write.
+
+        Returns:
+            Number of bytes written.
+        """
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_write', 'handle': handle, 'data': data})
+        response = await self.request(request)
+        self._check_response(response)
+        return response.get('body', {}).get('bytesWritten', 0)
+
+    async def fs_close(self, handle: str, mode: str = 'r') -> None:
+        """
+        Close a file handle.
+
+        Args:
+            handle: Handle ID returned by fs_open.
+            mode: 'r' or 'w' (must match the mode used in fs_open).
+        """
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_close', 'handle': handle, 'mode': mode})
+        response = await self.request(request)
+        self._check_response(response)
+
+    # =========================================================================
+    # Other File Operations
+    # =========================================================================
+
+    async def fs_delete(self, path: str) -> None:
+        """
+        Delete a file.
+
+        Args:
+            path: Relative path within the account store.
+        """
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_delete', 'path': path})
+        response = await self.request(request)
+        self._check_response(response)
+
+    async def fs_list_dir(self, path: str = '') -> Dict[str, Any]:
+        """
+        List immediate children of a directory.
+
+        Args:
+            path: Relative directory path (default: account root).
+
+        Returns:
+            Dict with keys: entries (list of {name, type, modified?}), count.
+            File entries include a modified epoch timestamp.
+        """
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_list_dir', 'path': path})
+        response = await self.request(request)
+        self._check_response(response)
+        return response.get('body', {})
+
+    async def fs_mkdir(self, path: str) -> None:
+        """
+        Create a directory.
+
+        Args:
+            path: Relative directory path.
+        """
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_mkdir', 'path': path})
+        response = await self.request(request)
+        self._check_response(response)
+
+    async def fs_stat(self, path: str) -> Dict[str, Any]:
+        """
+        Get file or directory metadata.
+
+        Args:
+            path: Relative path within the account store.
+
+        Returns:
+            Dict with keys: exists, type (file|dir), modified (epoch timestamp, files only).
+        """
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_stat', 'path': path})
+        response = await self.request(request)
+        self._check_response(response)
+        return response.get('body', {})
+
+    # =========================================================================
+    # Convenience Wrappers (text/JSON over binary)
+    # =========================================================================
+
+    async def fs_read_string(self, path: str, encoding: str = 'utf-8') -> str:
+        """Read a file as a decoded string."""
+        info = await self.fs_open(path, 'r')
+        handle = info['handle']
+        try:
+            chunks = []
+            while True:
+                chunk = await self.fs_read(handle)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            return b''.join(chunks).decode(encoding)
+        finally:
+            await self.fs_close(handle, 'r')
+
+    async def fs_write_string(self, path: str, text: str, encoding: str = 'utf-8') -> None:
+        """Write a string to a file."""
+        info = await self.fs_open(path, 'w')
+        handle = info['handle']
+        try:
+            await self.fs_write(handle, text.encode(encoding))
+            await self.fs_close(handle, 'w')
+        except Exception:
+            try:
+                await self.fs_close(handle, 'w')
+            except Exception:
+                pass
+            raise
+
+    async def fs_read_json(self, path: str) -> Any:
+        """Read a JSON file. Returns the parsed object."""
+        text = await self.fs_read_string(path)
+        return json.loads(text)
+
+    async def fs_write_json(self, path: str, obj: Any) -> None:
+        """Write an object as JSON."""
+        await self.fs_write_string(path, json.dumps(obj, indent=2))
+
+    # =========================================================================
+    # Domain Convenience - Projects
+    # =========================================================================
+
+    async def save_project(self, project_id: str, pipeline: Dict[str, Any]) -> None:
+        """Save a project pipeline to .projects/<project_id>.json."""
         if not project_id:
             raise ValueError('project_id is required')
-
         if not pipeline or not isinstance(pipeline, dict):
             raise ValueError('pipeline must be a non-empty dictionary')
 
-        # Build request arguments
-        arguments = {
-            'subcommand': 'save_project',
-            'projectId': project_id,
-            'pipeline': pipeline,
-        }
-
-        # Add optional version for atomic updates
-        if expected_version is not None:
-            arguments['expectedVersion'] = expected_version
-
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error saving project')
-            self.debug_message(f'Project save failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Project saved successfully: {project_id}, version: {response_body.get("version")}')
-        return response_body
+        await self.fs_write_json(f'.projects/{project_id}.json', pipeline)
 
     async def get_project(self, project_id: str) -> Dict[str, Any]:
-        """
-        Retrieve a project by its ID.
-
-        Fetches the complete pipeline configuration and current version for
-        the specified project. Use this before updating to get the current
-        version for atomic updates.
-
-        Args:
-            project_id: Unique identifier of the project to retrieve
-
-        Returns:
-            Dict containing:
-            - success: True if retrieved successfully (bool)
-            - pipeline: Complete pipeline configuration (dict)
-            - version: Current version hash (str)
-
-        Raises:
-            ValueError: If project_id is missing
-            RuntimeError: If retrieval fails due to:
-                - NOT_FOUND: Project doesn't exist
-                - STORAGE_ERROR: Server storage problem
-                - Other server errors
-
-        Example:
-            # Get a project
-            try:
-                project = await client.get_project("proj-123")
-                print(f"Project: {project['pipeline']['name']}")
-                print(f"Version: {project['version']}")
-
-                # Access pipeline components
-                for component in project['pipeline']['components']:
-                    print(f"  - {component['id']}: {component['provider']}")
-
-            except RuntimeError as e:
-                if 'NOT_FOUND' in str(e):
-                    print("Project doesn't exist")
-                else:
-                    print(f"Error: {e}")
-
-        Use Cases:
-            # Before updating - get current version
-            project = await client.get_project("proj-123")
-            pipeline = project['pipeline']
-            pipeline['name'] = "Updated"
-            await client.save_project("proj-123", pipeline, project['version'])
-
-            # Check if project exists
-            try:
-                await client.get_project("proj-123")
-                print("Project exists")
-            except RuntimeError:
-                print("Project doesn't exist")
-        """
-        # Validate inputs
+        """Get a project by ID from .projects/<project_id>.json."""
         if not project_id:
             raise ValueError('project_id is required')
 
-        # Build request
-        arguments = {
-            'subcommand': 'get_project',
-            'projectId': project_id,
-        }
+        return await self.fs_read_json(f'.projects/{project_id}.json')
 
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error retrieving project')
-            self.debug_message(f'Project retrieval failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Project retrieved successfully: {project_id}')
-        return response_body
-
-    async def delete_project(
-        self,
-        project_id: str,
-        expected_version: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Delete a project by its ID.
-
-        Permanently removes a project from storage. Optionally verify the
-        version before deletion to ensure you're deleting the version you
-        expect (prevents accidental deletion of modified projects).
-
-        Args:
-            project_id: Unique identifier of the project to delete
-            expected_version: Expected current version for atomic deletion (required)
-                If provided and doesn't match, deletion fails with CONFLICT error.
-                Recommended to fetch current version before deleting.
-
-        Returns:
-            Dict containing:
-            - success: True if deleted successfully (bool)
-            - message: Confirmation message (str)
-
-        Raises:
-            ValueError: If project_id is missing
-            RuntimeError: If deletion fails due to:
-                - NOT_FOUND: Project doesn't exist
-                - CONFLICT: Version mismatch
-                - STORAGE_ERROR: Server storage problem
-                - Other server errors
-
-        Example:
-            # Safe deletion with version check
-            project = await client.get_project("proj-123")
-            try:
-                result = await client.delete_project(
-                    "proj-123",
-                    expected_version=project['version']
-                )
-                print("Project deleted successfully")
-            except RuntimeError as e:
-                if 'CONFLICT' in str(e):
-                    print("Project was modified, deletion cancelled")
-                elif 'NOT_FOUND' in str(e):
-                    print("Project doesn't exist")
-                else:
-                    print(f"Error: {e}")
-
-            # Delete without version check (not recommended)
-            # Note: Server may still require version for existing projects
-            result = await client.delete_project("proj-123")
-
-        Warning:
-            Deletion is permanent and cannot be undone. Always verify the
-            project_id and consider backing up important projects before deletion.
-
-        Version Check:
-            - Always provide expected_version for safe deletion
-            - If version mismatch occurs, project was modified - verify before retrying
-            - If project doesn't exist, deletion fails with NOT_FOUND
-        """
-        # Validate inputs
+    async def delete_project(self, project_id: str) -> None:
+        """Delete a project by ID."""
         if not project_id:
             raise ValueError('project_id is required')
 
-        # Build request
-        arguments = {
-            'subcommand': 'delete_project',
-            'projectId': project_id,
-        }
-
-        # Add optional version for atomic deletion
-        if expected_version is not None:
-            arguments['expectedVersion'] = expected_version
-
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error deleting project')
-            self.debug_message(f'Project deletion failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Project deleted successfully: {project_id}')
-        return response_body
+        await self.fs_delete(f'.projects/{project_id}.json')
 
     async def get_all_projects(self) -> Dict[str, Any]:
-        r"""
-        List all projects for the current user.
-
-        Retrieves a summary of all projects stored for the authenticated user.
-        Each project summary includes the ID, name, and list of data sources.
-
-        Returns:
-            Dict containing:
-            - success: True if retrieved successfully (bool)
-            - projects: List of project summaries (list of dict)
-                Each project contains:
-                - id: Project identifier (str)
-                - name: Project name from pipeline (str)
-                - sources: List of source components (list of dict)
-                    Each source contains:
-                    - id: Component ID (str)
-                    - provider: Provider type (e.g., "filesystem", "s3") (str)
-                    - name: Component name (str)
-            - count: Total number of projects (int)
-
-        Raises:
-            RuntimeError: If retrieval fails due to server errors
-
-        Example:
-            # List all projects
-            result = await client.get_all_projects()
-
-            print(f"Found {result['count']} projects:")
-            for project in result['projects']:
-                print(f"\nProject: {project['id']}")
-                print(f"  Name: {project['name']}")
-                print(f"  Sources:")
-                for source in project['sources']:
-                    print(f"    - {source['name']} ({source['provider']})")
-
-            # Find specific project
-            result = await client.get_all_projects()
-            my_project = next(
-                (p for p in result['projects'] if p['id'] == 'proj-123'),
-                None
-            )
-            if my_project:
-                print(f"Found: {my_project['name']}")
-
-            # Check if user has any projects
-            result = await client.get_all_projects()
-            if result['count'] == 0:
-                print("No projects found")
-            else:
-                print(f"User has {result['count']} projects")
-
-        Use Cases:
-            # Display project list in UI
-            projects = await client.get_all_projects()
-            for proj in projects['projects']:
-                show_in_list(proj['id'], proj['name'])
-
-            # Search for projects by name
-            all_projects = await client.get_all_projects()
-            matches = [p for p in all_projects['projects']
-                      if 'test' in p['name'].lower()]
-
-            # Get project IDs for batch operations
-            result = await client.get_all_projects()
-            project_ids = [p['id'] for p in result['projects']]
-        """
-        # Build request
-        arguments = {
-            'subcommand': 'get_all_projects',
-        }
-
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error listing projects')
-            self.debug_message(f'Project list retrieval failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        project_count = response_body.get('count', 0)
-        self.debug_message(f'Projects retrieved successfully: {project_count} projects')
-        return response_body
+        """List all projects with summaries."""
+        return await self._get_all_items('.projects', 'id', 'projects')
 
     # =========================================================================
-    # Template Operations (system-wide templates accessible to all users)
+    # Domain Convenience - Templates
     # =========================================================================
 
-    async def save_template(
-        self,
-        template_id: str,
-        pipeline: Dict[str, Any],
-        expected_version: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Save or update a template pipeline (system-wide).
-
-        Templates are stored in a system-wide location accessible to all users.
-        They can be used as starting points for creating new projects.
-
-        Args:
-            template_id: Unique identifier for the template
-            pipeline: Pipeline configuration as a dictionary
-            expected_version: Expected current version for atomic updates (optional)
-
-        Returns:
-            Dict containing:
-            - success: True if saved successfully (bool)
-            - template_id: The template ID that was saved (str)
-            - version: New version hash after save (str)
-
-        Raises:
-            ValueError: If template_id or pipeline is missing/invalid
-            RuntimeError: If save fails
-
-        Example:
-            # Save a new template
-            pipeline = {
-                "name": "Data Processing Template",
-                "source": "source_1",
-                "components": [...]
-            }
-            result = await client.save_template("tmpl-123", pipeline)
-            print(f"Saved version: {result['version']}")
-        """
-        # Validate inputs
+    async def save_template(self, template_id: str, pipeline: Dict[str, Any]) -> None:
+        """Save a template pipeline to .templates/<template_id>.json."""
         if not template_id:
             raise ValueError('template_id is required')
-
         if not pipeline or not isinstance(pipeline, dict):
             raise ValueError('pipeline must be a non-empty dictionary')
 
-        # Build request arguments
-        arguments = {
-            'subcommand': 'save_template',
-            'templateId': template_id,
-            'pipeline': pipeline,
-        }
-
-        # Add optional version for atomic updates
-        if expected_version is not None:
-            arguments['expectedVersion'] = expected_version
-
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error saving template')
-            self.debug_message(f'Template save failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Template saved successfully: {template_id}, version: {response_body.get("version")}')
-        return response_body
+        await self.fs_write_json(f'.templates/{template_id}.json', pipeline)
 
     async def get_template(self, template_id: str) -> Dict[str, Any]:
-        """
-        Retrieve a template by its ID.
-
-        Args:
-            template_id: Unique identifier of the template to retrieve
-
-        Returns:
-            Dict containing:
-            - success: True if retrieved successfully (bool)
-            - pipeline: Complete pipeline configuration (dict)
-            - version: Current version hash (str)
-
-        Raises:
-            ValueError: If template_id is missing
-            RuntimeError: If retrieval fails (NOT_FOUND, etc.)
-
-        Example:
-            template = await client.get_template("tmpl-123")
-            print(f"Template: {template['pipeline']['name']}")
-        """
-        # Validate inputs
+        """Get a template by ID from .templates/<template_id>.json."""
         if not template_id:
             raise ValueError('template_id is required')
 
-        # Build request
-        arguments = {
-            'subcommand': 'get_template',
-            'templateId': template_id,
-        }
+        return await self.fs_read_json(f'.templates/{template_id}.json')
 
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error retrieving template')
-            self.debug_message(f'Template retrieval failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Template retrieved successfully: {template_id}')
-        return response_body
-
-    async def delete_template(
-        self,
-        template_id: str,
-        expected_version: Optional[str] = None,
-    ) -> Dict[str, Any]:
-        """
-        Delete a template by its ID.
-
-        Args:
-            template_id: Unique identifier of the template to delete
-            expected_version: Expected current version for atomic deletion (optional)
-
-        Returns:
-            Dict containing:
-            - success: True if deleted successfully (bool)
-            - template_id: The deleted template ID (str)
-
-        Raises:
-            ValueError: If template_id is missing
-            RuntimeError: If deletion fails (NOT_FOUND, CONFLICT, etc.)
-
-        Example:
-            template = await client.get_template("tmpl-123")
-            result = await client.delete_template(
-                "tmpl-123",
-                expected_version=template['version']
-            )
-        """
-        # Validate inputs
+    async def delete_template(self, template_id: str) -> None:
+        """Delete a template by ID."""
         if not template_id:
             raise ValueError('template_id is required')
 
-        # Build request
-        arguments = {
-            'subcommand': 'delete_template',
-            'templateId': template_id,
-        }
-
-        # Add optional version for atomic deletion
-        if expected_version is not None:
-            arguments['expectedVersion'] = expected_version
-
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error deleting template')
-            self.debug_message(f'Template deletion failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Template deleted successfully: {template_id}')
-        return response_body
+        await self.fs_delete(f'.templates/{template_id}.json')
 
     async def get_all_templates(self) -> Dict[str, Any]:
-        """
-        List all templates (system-wide).
-
-        Retrieves a summary of all templates available in the system.
-        Each template summary includes the ID, name, and list of data sources.
-
-        Returns:
-            Dict containing:
-            - success: True if retrieved successfully (bool)
-            - templates: List of template summaries (list of dict)
-                Each template contains:
-                - id: Template identifier (str)
-                - name: Template name from pipeline (str)
-                - sources: List of source components (list of dict)
-            - count: Total number of templates (int)
-
-        Raises:
-            RuntimeError: If retrieval fails due to server errors
-
-        Example:
-            result = await client.get_all_templates()
-            print(f"Found {result['count']} templates:")
-            for tmpl in result['templates']:
-                print(f"  - {tmpl['id']}: {tmpl['name']}")
-        """
-        # Build request
-        arguments = {
-            'subcommand': 'get_all_templates',
-        }
-
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error listing templates')
-            self.debug_message(f'Template list retrieval failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        template_count = response_body.get('count', 0)
-        self.debug_message(f'Templates retrieved successfully: {template_count} templates')
-        return response_body
+        """List all templates with summaries."""
+        return await self._get_all_items('.templates', 'id', 'templates')
 
     # =========================================================================
-    # Log Operations (per-project log files for historical tracking)
+    # Domain Convenience - Logs
     # =========================================================================
 
-    async def save_log(
-        self,
-        project_id: str,
-        source: str,
-        contents: Dict[str, Any],
-    ) -> Dict[str, Any]:
-        """
-        Save a log file for a source run.
-
-        Creates or overwrites a log file in the project's log directory.
-        The filename is constructed as <source>-<startTime>.log where startTime
-        is extracted from contents['body']['startTime'].
-
-        Args:
-            project_id: Project ID
-            source: Name of the source
-            contents: Log contents dictionary containing body.startTime
-
-        Returns:
-            Dict containing:
-            - success: True if saved successfully (bool)
-            - filename: The log filename that was saved (str)
-
-        Raises:
-            ValueError: If parameters are invalid
-            RuntimeError: If save fails
-
-        Example:
-            log_contents = {
-                "type": "event",
-                "event": "apaevt_status_update",
-                "body": {
-                    "source": "source_1",
-                    "startTime": 1764337626.6564875,
-                    "status": "Completed",
-                    "completed": True,
-                    ...
-                }
-            }
-            result = await client.save_log("proj-123", "source_1", log_contents)
-            print(f"Saved: {result['filename']}")
-        """
-        # Validate inputs
+    async def save_log(self, project_id: str, source: str, contents: Dict[str, Any]) -> str:
+        """Save a log file to .logs/<project_id>/<source>-<start_time>.log. Returns filename."""
         if not project_id:
             raise ValueError('project_id is required')
         if not source:
@@ -733,57 +289,16 @@ class StoreMixin(DAPClient):
         if not contents or not isinstance(contents, dict):
             raise ValueError('contents must be a non-empty dictionary')
 
-        # Build request arguments
-        arguments = {
-            'subcommand': 'save_log',
-            'projectId': project_id,
-            'source': source,
-            'contents': contents,
-        }
+        start_time = contents.get('body', {}).get('startTime')
+        if start_time is None:
+            raise ValueError('contents must contain body.startTime')
 
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
+        filename = f'{source}-{start_time}.log'
+        await self.fs_write_json(f'.logs/{project_id}/{filename}', contents)
+        return filename
 
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error saving log')
-            self.debug_message(f'Log save failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Log saved successfully: {response_body.get("filename")}')
-        return response_body
-
-    async def get_log(
-        self,
-        project_id: str,
-        source: str,
-        start_time: float,
-    ) -> Dict[str, Any]:
-        """
-        Get a log file by source name and start time.
-
-        Args:
-            project_id: Project ID
-            source: Name of the source
-            start_time: Start time of the run
-
-        Returns:
-            Dict containing:
-            - success: True if retrieved successfully (bool)
-            - contents: The log contents (dict)
-
-        Raises:
-            ValueError: If parameters are invalid
-            RuntimeError: If log not found or retrieval fails
-
-        Example:
-            log = await client.get_log("proj-123", "source_1", 1764337626.6564875)
-            print(f"Status: {log['contents']['body']['status']}")
-        """
-        # Validate inputs
+    async def get_log(self, project_id: str, source: str, start_time: float) -> Dict[str, Any]:
+        """Get a log file by source name and start time."""
         if not project_id:
             raise ValueError('project_id is required')
         if not source:
@@ -791,98 +306,49 @@ class StoreMixin(DAPClient):
         if start_time is None:
             raise ValueError('start_time is required')
 
-        # Build request
-        arguments = {
-            'subcommand': 'get_log',
-            'projectId': project_id,
-            'source': source,
-            'startTime': start_time,
-        }
+        filename = f'{source}-{start_time}.log'
+        return await self.fs_read_json(f'.logs/{project_id}/{filename}')
 
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
-
-        # Check for errors
-        if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error retrieving log')
-            self.debug_message(f'Log retrieval failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        self.debug_message(f'Log retrieved successfully: {project_id}/{source}')
-        return response_body
-
-    async def list_logs(
-        self,
-        project_id: str,
-        source: Optional[str] = None,
-        page: Optional[int] = None,
-    ) -> Dict[str, Any]:
-        """
-        List log files for a project.
-
-        Args:
-            project_id: Project ID
-            source: Optional source name to filter logs (filters files starting with '<source>-')
-            page: Page number (0-indexed). If negative or None, defaults to 0.
-                  Page size is 100.
-
-        Returns:
-            Dict containing:
-            - success: True if retrieved successfully (bool)
-            - logs: List of log filenames (list of str)
-            - count: Number of logs in this page (int)
-            - total_count: Total number of logs (int)
-            - page: Current page number (int)
-            - total_pages: Total number of pages (int)
-
-        Raises:
-            ValueError: If project_id is missing
-            RuntimeError: If retrieval fails
-
-        Example:
-            # List all logs
-            result = await client.list_logs("proj-123")
-            print(f"Found {result['total_count']} logs")
-            for log in result['logs']:
-                print(f"  - {log}")
-
-            # Filter by source
-            result = await client.list_logs("proj-123", source="source_1")
-
-            # With pagination
-            result = await client.list_logs("proj-123", page=1)
-        """
-        # Validate inputs
+    async def list_logs(self, project_id: str, source: Optional[str] = None) -> Dict[str, Any]:
+        """List log files for a project."""
         if not project_id:
             raise ValueError('project_id is required')
 
-        # Build request
-        arguments: Dict[str, Any] = {
-            'subcommand': 'list_logs',
-            'projectId': project_id,
-        }
+        dir_result = await self.fs_list_dir(f'.logs/{project_id}')
+        logs = [e['name'] for e in dir_result.get('entries', []) if e['type'] == 'file' and e['name'].endswith('.log')]
 
-        # Add optional parameters
-        if source is not None:
-            arguments['source'] = source
-        if page is not None:
-            arguments['page'] = page
+        if source:
+            logs = [f for f in logs if f.startswith(f'{source}-')]
 
-        # Send request to server
-        request = self.build_request(command='rrext_store', arguments=arguments)
-        response = await self.request(request)
+        logs.sort()
+        return {'success': True, 'logs': logs, 'count': len(logs)}
 
-        # Check for errors
+    # =========================================================================
+    # Private
+    # =========================================================================
+
+    async def _get_all_items(self, directory: str, id_key: str, list_key: str) -> Dict[str, Any]:
+        """List all items in a domain directory with pipeline summaries."""
+        dir_result = await self.fs_list_dir(directory)
+        json_entries = [e for e in dir_result.get('entries', []) if e['type'] == 'file' and e['name'].endswith('.json')]
+
+        items = []
+        for entry in json_entries:
+            try:
+                item_id = entry['name'][:-5]
+                pipeline = await self.fs_read_json(f'{directory}/{entry["name"]}')
+                sources = []
+                for component in pipeline.get('components', []):
+                    config = component.get('config', {})
+                    if config.get('mode') == 'Source':
+                        sources.append({'id': component.get('id'), 'provider': component.get('provider'), 'name': config.get('name', component.get('id'))})
+                items.append({id_key: item_id, 'name': pipeline.get('name', 'Untitled'), 'description': pipeline.get('description', ''), 'sources': sources, 'totalComponents': len(pipeline.get('components', []))})
+            except Exception:
+                continue
+
+        return {list_key: items, 'count': len(items)}
+
+    def _check_response(self, response: Dict[str, Any]) -> None:
+        """Raise RuntimeError if the response indicates failure."""
         if self.did_fail(response):
-            error_msg = response.get('message', 'Unknown error listing logs')
-            self.debug_message(f'Log list retrieval failed: {error_msg}')
-            raise RuntimeError(error_msg)
-
-        # Extract and return response
-        response_body = response.get('body', {})
-        log_count = response_body.get('total_count', 0)
-        self.debug_message(f'Logs retrieved successfully: {log_count} logs')
-        return response_body
+            raise RuntimeError(response.get('message', 'Unknown storage error'))

--- a/packages/client-python/src/rocketride/mixins/store.py
+++ b/packages/client-python/src/rocketride/mixins/store.py
@@ -43,6 +43,8 @@ class StoreMixin(DAPClient):
     wrappers that call the convenience methods with well-known paths.
     """
 
+    _INVALID_PATH_CHARS = frozenset('*?<>|"\x00')
+
     def __init__(self, **kwargs):
         """Initialize storage capabilities."""
         super().__init__(**kwargs)
@@ -51,38 +53,37 @@ class StoreMixin(DAPClient):
     # Handle-Based I/O
     # =========================================================================
 
-    async def fs_open(self, path: str, mode: str = 'r', offset: int = 0) -> Dict[str, Any]:
+    async def fs_open(self, path: str, mode: str = 'r') -> Dict[str, Any]:
         """
         Open a file handle for reading or writing.
 
         Args:
             path: Relative path within the account store.
             mode: 'r' for read, 'w' for write.
-            offset: Initial byte offset (read mode only).
 
         Returns:
             Dict with 'handle' (str). Read mode also includes 'size' (int).
         """
+        self._validate_store_path(path)
         args: Dict[str, Any] = {'subcommand': 'fs_open', 'path': path, 'mode': mode}
-        if mode == 'r' and offset > 0:
-            args['offset'] = offset
         request = self.build_request(command='rrext_store', arguments=args)
         response = await self.request(request)
         self._check_response(response)
         return response.get('body', {})
 
-    async def fs_read(self, handle: str, length: int = 4_194_304) -> bytes:
+    async def fs_read(self, handle: str, offset: int = 0, length: int = 4_194_304) -> bytes:
         """
         Read data from an open read handle.
 
         Args:
             handle: Handle ID returned by fs_open.
+            offset: Byte offset to read from.
             length: Max bytes to read (default 4 MB).
 
         Returns:
             Bytes read. Empty bytes indicates EOF.
         """
-        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_read', 'handle': handle, 'length': length})
+        request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_read', 'handle': handle, 'offset': offset, 'length': length})
         response = await self.request(request)
         self._check_response(response)
         return response.get('arguments', {}).get('data', b'')
@@ -126,6 +127,7 @@ class StoreMixin(DAPClient):
         Args:
             path: Relative path within the account store.
         """
+        self._validate_store_path(path)
         request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_delete', 'path': path})
         response = await self.request(request)
         self._check_response(response)
@@ -138,9 +140,11 @@ class StoreMixin(DAPClient):
             path: Relative directory path (default: account root).
 
         Returns:
-            Dict with keys: entries (list of {name, type, modified?}), count.
-            File entries include a modified epoch timestamp.
+            Dict with keys: entries (list of {name, type, size?, modified?}), count.
+            File entries include size (bytes) and modified (epoch timestamp).
         """
+        if path:
+            self._validate_store_path(path)
         request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_list_dir', 'path': path})
         response = await self.request(request)
         self._check_response(response)
@@ -153,6 +157,7 @@ class StoreMixin(DAPClient):
         Args:
             path: Relative directory path.
         """
+        self._validate_store_path(path)
         request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_mkdir', 'path': path})
         response = await self.request(request)
         self._check_response(response)
@@ -165,8 +170,10 @@ class StoreMixin(DAPClient):
             path: Relative path within the account store.
 
         Returns:
-            Dict with keys: exists, type (file|dir), modified (epoch timestamp, files only).
+            Dict with keys: exists, type (file|dir), size (bytes, files only),
+            modified (epoch timestamp, files only).
         """
+        self._validate_store_path(path)
         request = self.build_request(command='rrext_store', arguments={'subcommand': 'fs_stat', 'path': path})
         response = await self.request(request)
         self._check_response(response)
@@ -182,11 +189,13 @@ class StoreMixin(DAPClient):
         handle = info['handle']
         try:
             chunks = []
+            offset = 0
             while True:
-                chunk = await self.fs_read(handle)
+                chunk = await self.fs_read(handle, offset)
                 if not chunk:
                     break
                 chunks.append(chunk)
+                offset += len(chunk)
             return b''.join(chunks).decode(encoding)
         finally:
             await self.fs_close(handle, 'r')
@@ -220,8 +229,7 @@ class StoreMixin(DAPClient):
 
     async def save_project(self, project_id: str, pipeline: Dict[str, Any]) -> None:
         """Save a project pipeline to .projects/<project_id>.json."""
-        if not project_id:
-            raise ValueError('project_id is required')
+        self._validate_id(project_id, 'project_id')
         if not pipeline or not isinstance(pipeline, dict):
             raise ValueError('pipeline must be a non-empty dictionary')
 
@@ -229,15 +237,13 @@ class StoreMixin(DAPClient):
 
     async def get_project(self, project_id: str) -> Dict[str, Any]:
         """Get a project by ID from .projects/<project_id>.json."""
-        if not project_id:
-            raise ValueError('project_id is required')
+        self._validate_id(project_id, 'project_id')
 
         return await self.fs_read_json(f'.projects/{project_id}.json')
 
     async def delete_project(self, project_id: str) -> None:
         """Delete a project by ID."""
-        if not project_id:
-            raise ValueError('project_id is required')
+        self._validate_id(project_id, 'project_id')
 
         await self.fs_delete(f'.projects/{project_id}.json')
 
@@ -251,8 +257,7 @@ class StoreMixin(DAPClient):
 
     async def save_template(self, template_id: str, pipeline: Dict[str, Any]) -> None:
         """Save a template pipeline to .templates/<template_id>.json."""
-        if not template_id:
-            raise ValueError('template_id is required')
+        self._validate_id(template_id, 'template_id')
         if not pipeline or not isinstance(pipeline, dict):
             raise ValueError('pipeline must be a non-empty dictionary')
 
@@ -260,15 +265,13 @@ class StoreMixin(DAPClient):
 
     async def get_template(self, template_id: str) -> Dict[str, Any]:
         """Get a template by ID from .templates/<template_id>.json."""
-        if not template_id:
-            raise ValueError('template_id is required')
+        self._validate_id(template_id, 'template_id')
 
         return await self.fs_read_json(f'.templates/{template_id}.json')
 
     async def delete_template(self, template_id: str) -> None:
         """Delete a template by ID."""
-        if not template_id:
-            raise ValueError('template_id is required')
+        self._validate_id(template_id, 'template_id')
 
         await self.fs_delete(f'.templates/{template_id}.json')
 
@@ -282,10 +285,8 @@ class StoreMixin(DAPClient):
 
     async def save_log(self, project_id: str, source: str, contents: Dict[str, Any]) -> str:
         """Save a log file to .logs/<project_id>/<source>-<start_time>.log. Returns filename."""
-        if not project_id:
-            raise ValueError('project_id is required')
-        if not source:
-            raise ValueError('source is required')
+        self._validate_id(project_id, 'project_id')
+        self._validate_id(source, 'source')
         if not contents or not isinstance(contents, dict):
             raise ValueError('contents must be a non-empty dictionary')
 
@@ -299,10 +300,8 @@ class StoreMixin(DAPClient):
 
     async def get_log(self, project_id: str, source: str, start_time: float) -> Dict[str, Any]:
         """Get a log file by source name and start time."""
-        if not project_id:
-            raise ValueError('project_id is required')
-        if not source:
-            raise ValueError('source is required')
+        self._validate_id(project_id, 'project_id')
+        self._validate_id(source, 'source')
         if start_time is None:
             raise ValueError('start_time is required')
 
@@ -311,8 +310,9 @@ class StoreMixin(DAPClient):
 
     async def list_logs(self, project_id: str, source: Optional[str] = None) -> Dict[str, Any]:
         """List log files for a project."""
-        if not project_id:
-            raise ValueError('project_id is required')
+        self._validate_id(project_id, 'project_id')
+        if source:
+            self._validate_id(source, 'source')
 
         dir_result = await self.fs_list_dir(f'.logs/{project_id}')
         logs = [e['name'] for e in dir_result.get('entries', []) if e['type'] == 'file' and e['name'].endswith('.log')]
@@ -347,6 +347,25 @@ class StoreMixin(DAPClient):
                 continue
 
         return {list_key: items, 'count': len(items)}
+
+    @staticmethod
+    def _validate_store_path(path: str) -> None:
+        """Validate a store path before sending to the server."""
+        for segment in path.replace('\\', '/').split('/'):
+            if segment == '..':
+                raise ValueError(f'Path traversal not allowed: {path}')
+            if segment and any(c in StoreMixin._INVALID_PATH_CHARS or ord(c) < 0x20 for c in segment):
+                raise ValueError(f'Path contains invalid characters: {path}')
+
+    @staticmethod
+    def _validate_id(value: str, name: str) -> None:
+        """Validate that a domain identifier is a safe single path segment."""
+        if not value:
+            raise ValueError(f'{name} is required')
+        if '/' in value or '\\' in value:
+            raise ValueError(f'{name} must not contain path separators')
+        if any(c in StoreMixin._INVALID_PATH_CHARS or ord(c) < 0x20 for c in value):
+            raise ValueError(f'{name} contains invalid characters: {value}')
 
     def _check_response(self, response: Dict[str, Any]) -> None:
         """Raise RuntimeError if the response indicates failure."""

--- a/packages/client-python/src/rocketride/mixins/store.py
+++ b/packages/client-python/src/rocketride/mixins/store.py
@@ -343,7 +343,10 @@ class StoreMixin(DAPClient):
                     if config.get('mode') == 'Source':
                         sources.append({'id': component.get('id'), 'provider': component.get('provider'), 'name': config.get('name', component.get('id'))})
                 items.append({id_key: item_id, 'name': pipeline.get('name', 'Untitled'), 'description': pipeline.get('description', ''), 'sources': sources, 'totalComponents': len(pipeline.get('components', []))})
-            except Exception:
+            except Exception as e:
+                import logging
+
+                logging.getLogger(__name__).debug('Failed to read %s/%s: %s', directory, entry['name'], e)
                 continue
 
         return {list_key: items, 'count': len(items)}

--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -2240,6 +2240,152 @@ def test_get_websocket_uri_normalization(input_uri: str, expected_uri: str) -> N
     assert ConnectionMixin._get_websocket_uri(input_uri) == expected_uri
 
 
+# ============================================================================
+# File Store Operations
+# ============================================================================
+
+
+class TestFileStoreOperations:
+    """Test handle-based file store operations against a live server."""
+
+    def _unique_path(self, prefix: str = 'test') -> str:
+        return f'.test-store/{prefix}-{"".join(random.choices(string.ascii_lowercase, k=8))}'
+
+    @pytest.mark.asyncio
+    async def test_handle_write_and_read(self):
+        """Write via handle, read back via handle."""
+        client = RocketRideClient(auth=TEST_CONFIG['auth'], uri=TEST_CONFIG['uri'])
+        try:
+            await client.connect()
+            path = self._unique_path('hw')
+
+            info = await client.fs_open(path, 'w')
+            written = await client.fs_write(info['handle'], b'hello world')
+            assert written == 11
+            await client.fs_close(info['handle'], 'w')
+
+            info = await client.fs_open(path, 'r')
+            assert info['size'] == 11
+            data = await client.fs_read(info['handle'])
+            assert data == b'hello world'
+            await client.fs_close(info['handle'], 'r')
+
+            await client.fs_delete(path)
+        finally:
+            if client.is_connected():
+                await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_multiple_write_chunks(self):
+        """Write multiple chunks then read back."""
+        client = RocketRideClient(auth=TEST_CONFIG['auth'], uri=TEST_CONFIG['uri'])
+        try:
+            await client.connect()
+            path = self._unique_path('chunks')
+
+            info = await client.fs_open(path, 'w')
+            for i in range(5):
+                await client.fs_write(info['handle'], f'chunk-{i}-'.encode())
+            await client.fs_close(info['handle'], 'w')
+
+            content = await client.fs_read_string(path)
+            assert content == 'chunk-0-chunk-1-chunk-2-chunk-3-chunk-4-'
+
+            await client.fs_delete(path)
+        finally:
+            if client.is_connected():
+                await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_read_in_chunks(self):
+        """Read a file in multiple chunks via handle."""
+        client = RocketRideClient(auth=TEST_CONFIG['auth'], uri=TEST_CONFIG['uri'])
+        try:
+            await client.connect()
+            path = self._unique_path('rc')
+            data = b'X' * 1000
+
+            info = await client.fs_open(path, 'w')
+            await client.fs_write(info['handle'], data)
+            await client.fs_close(info['handle'], 'w')
+
+            info = await client.fs_open(path, 'r')
+            chunks = []
+            while True:
+                chunk = await client.fs_read(info['handle'], length=300)
+                if not chunk:
+                    break
+                chunks.append(chunk)
+            await client.fs_close(info['handle'], 'r')
+
+            assert b''.join(chunks) == data
+            assert len(chunks) == 4  # 300 + 300 + 300 + 100
+
+            await client.fs_delete(path)
+        finally:
+            if client.is_connected():
+                await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_convenience_string_roundtrip(self):
+        """fs_write_string / fs_read_string round-trip."""
+        client = RocketRideClient(auth=TEST_CONFIG['auth'], uri=TEST_CONFIG['uri'])
+        try:
+            await client.connect()
+            path = self._unique_path('str')
+
+            await client.fs_write_string(path, 'Hello \u2603 \U0001f680')
+            result = await client.fs_read_string(path)
+            assert result == 'Hello \u2603 \U0001f680'
+
+            await client.fs_delete(path)
+        finally:
+            if client.is_connected():
+                await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_convenience_json_roundtrip(self):
+        """fs_write_json / fs_read_json round-trip."""
+        client = RocketRideClient(auth=TEST_CONFIG['auth'], uri=TEST_CONFIG['uri'])
+        try:
+            await client.connect()
+            path = self._unique_path('json')
+            obj = {'name': 'Test', 'values': [1, 2, 3], 'nested': {'ok': True}}
+
+            await client.fs_write_json(path, obj)
+            result = await client.fs_read_json(path)
+            assert result == obj
+
+            await client.fs_delete(path)
+        finally:
+            if client.is_connected():
+                await client.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_stat_and_delete(self):
+        """Write a file, stat it, delete it, stat again."""
+        client = RocketRideClient(auth=TEST_CONFIG['auth'], uri=TEST_CONFIG['uri'])
+        try:
+            await client.connect()
+            path = self._unique_path('stat')
+
+            info = await client.fs_open(path, 'w')
+            await client.fs_write(info['handle'], b'data')
+            await client.fs_close(info['handle'], 'w')
+
+            result = await client.fs_stat(path)
+            assert result['exists'] is True
+            assert result['type'] == 'file'
+
+            await client.fs_delete(path)
+
+            result = await client.fs_stat(path)
+            assert result['exists'] is False
+        finally:
+            if client.is_connected():
+                await client.disconnect()
+
+
 # Pytest configuration
 pytest_plugins = ['pytest_asyncio']
 

--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -2248,8 +2248,8 @@ def test_get_websocket_uri_normalization(input_uri: str, expected_uri: str) -> N
 class TestFileStoreOperations:
     """Test handle-based file store operations against a live server."""
 
-    def _unique_path(self, prefix: str = 'test') -> str:
-        return f'.test-store/{prefix}-{"".join(random.choices(string.ascii_lowercase, k=8))}'
+    def _unique_path(self, name: str = 'test') -> str:
+        return f'.test-store/py-{name}-{"".join(random.choices(string.ascii_lowercase, k=8))}'
 
     @pytest.mark.asyncio
     async def test_handle_write_and_read(self):
@@ -2266,7 +2266,7 @@ class TestFileStoreOperations:
 
             info = await client.fs_open(path, 'r')
             assert info['size'] == 11
-            data = await client.fs_read(info['handle'])
+            data = await client.fs_read(info['handle'], offset=0)
             assert data == b'hello world'
             await client.fs_close(info['handle'], 'r')
 
@@ -2311,11 +2311,13 @@ class TestFileStoreOperations:
 
             info = await client.fs_open(path, 'r')
             chunks = []
+            offset = 0
             while True:
-                chunk = await client.fs_read(info['handle'], length=300)
+                chunk = await client.fs_read(info['handle'], offset=offset, length=300)
                 if not chunk:
                     break
                 chunks.append(chunk)
+                offset += len(chunk)
             await client.fs_close(info['handle'], 'r')
 
             assert b''.join(chunks) == data

--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -978,7 +978,13 @@ export class RocketRideCLI {
 					const result = await client.fsListDir(path || '');
 					const entries = result.entries || [];
 					if (entries.length === 0) {
-						console.log('File Not Found');
+						const stat = path ? await client.fsStat(path) : { exists: true, type: 'dir' as const };
+						if (stat.exists && stat.type === 'dir') {
+							console.log(`    ${(0).toLocaleString().padStart(8)} File(s)  ${(0).toLocaleString().padStart(14)} bytes`);
+							console.log(`    ${(0).toLocaleString().padStart(8)} Dir(s)`);
+						} else {
+							console.log('File Not Found');
+						}
 					} else {
 						let totalSize = 0;
 						let fileCount = 0;

--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -982,6 +982,123 @@ export class RocketRideCLI {
 
 		addCommonOptions(stopCmd);
 
+		// Store command with file system subcommands
+		const storeCmd = program
+			.command('store')
+			.description('File store operations');
+
+		// store dir
+		const storeDirCmd = storeCmd
+			.command('dir [path]')
+			.description('List directory contents')
+			.action(async (path, options) => {
+				this.args = { command: 'store', subcommand: 'dir', path: path || '', ...options };
+				this.uri = options.uri;
+				try {
+					const client = await this.createAndConnectClient();
+					const result = await client.fsListDir(path || '');
+					const entries = result.entries || [];
+					if (entries.length === 0) { console.log('(empty directory)'); }
+					else {
+						for (const e of entries) { console.log(`  ${e.type === 'dir' ? 'DIR ' : 'FILE'}  ${e.name}`); }
+						console.log(`\n  ${result.count} item(s)`);
+					}
+					process.exit(0);
+				} finally { this.cancel(); await this.cleanupClient(); }
+			});
+		addCommonOptions(storeDirCmd);
+
+		// store type
+		const storeTypeCmd = storeCmd
+			.command('type <path>')
+			.description('Display file contents')
+			.action(async (path, options) => {
+				this.args = { command: 'store', subcommand: 'type', path, ...options };
+				this.uri = options.uri;
+				try {
+					const client = await this.createAndConnectClient();
+					const text = await client.fsReadString(path);
+					process.stdout.write(text);
+					process.exit(0);
+				} finally { this.cancel(); await this.cleanupClient(); }
+			});
+		addCommonOptions(storeTypeCmd);
+
+		// store write
+		const storeWriteCmd = storeCmd
+			.command('write <path>')
+			.description('Write a file')
+			.option('--file <localFile>', 'Local file to upload')
+			.option('--content <text>', 'Inline text content')
+			.action(async (path, options) => {
+				this.args = { command: 'store', subcommand: 'write', path, ...options };
+				this.uri = options.uri;
+				try {
+					const client = await this.createAndConnectClient();
+					if (options.file) {
+						const fs = await import('fs');
+						const data = fs.readFileSync(options.file);
+						await client.fsWrite(path, data);
+					} else if (options.content !== undefined) {
+						await client.fsWriteString(path, options.content);
+					} else {
+						console.error('Error: Either --file or --content is required'); process.exit(1);
+					}
+					console.log(`Written: ${path}`);
+					process.exit(0);
+				} finally { this.cancel(); await this.cleanupClient(); }
+			});
+		addCommonOptions(storeWriteCmd);
+
+		// store rm
+		const storeRmCmd = storeCmd
+			.command('rm <path>')
+			.description('Delete a file')
+			.action(async (path, options) => {
+				this.args = { command: 'store', subcommand: 'rm', path, ...options };
+				this.uri = options.uri;
+				try {
+					const client = await this.createAndConnectClient();
+					await client.fsDelete(path);
+					console.log(`Deleted: ${path}`);
+					process.exit(0);
+				} finally { this.cancel(); await this.cleanupClient(); }
+			});
+		addCommonOptions(storeRmCmd);
+
+		// store mkdir
+		const storeMkdirCmd = storeCmd
+			.command('mkdir <path>')
+			.description('Create a directory')
+			.action(async (path, options) => {
+				this.args = { command: 'store', subcommand: 'mkdir', path, ...options };
+				this.uri = options.uri;
+				try {
+					const client = await this.createAndConnectClient();
+					await client.fsMkdir(path);
+					console.log(`Created: ${path}/`);
+					process.exit(0);
+				} finally { this.cancel(); await this.cleanupClient(); }
+			});
+		addCommonOptions(storeMkdirCmd);
+
+		// store stat
+		const storeStatCmd = storeCmd
+			.command('stat <path>')
+			.description('Get file/directory metadata')
+			.action(async (path, options) => {
+				this.args = { command: 'store', subcommand: 'stat', path, ...options };
+				this.uri = options.uri;
+				try {
+					const client = await this.createAndConnectClient();
+					const result = await client.fsStat(path);
+					if (!result.exists) { console.log(`${path}: not found`); }
+					else { console.log(`${path}: ${result.type}${result.modified ? ` (modified: ${new Date(result.modified * 1000).toISOString()})` : ''}`); }
+					process.exit(0);
+				} finally { this.cancel(); await this.cleanupClient(); }
+			});
+		addCommonOptions(storeStatCmd);
+
 		return program;
 	}
 

--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -2,19 +2,19 @@
 
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2026 Aparavi Software AG
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -30,27 +30,27 @@
  * This module provides a comprehensive command-line interface for managing RocketRide pipelines,
  * uploading files, monitoring task status, and controlling pipeline execution using the
  * Debug Adapter Protocol (DAP).
- * 
+ *
  * Features:
  * - Start and manage RocketRide data processing pipelines
  * - Upload files with parallel processing and progress tracking
  * - Monitor real-time pipeline status and metrics
  * - Stop running pipelines gracefully
  * - Environment-based configuration via .env files
- * 
+ *
  * Configuration:
  * The client supports configuration via .env file with the following variables:
  * - ROCKETRIDE_APIKEY: Your RocketRide API key (required for authentication)
  * - ROCKETRIDE_URI: The RocketRide server URI (defaults to wss://cloud.rocketride.ai)
  * - ROCKETRIDE_PIPELINE: Path to your default pipeline configuration file
  * - ROCKETRIDE_TOKEN: Task token for existing pipelines
- * 
+ *
  * Commands:
  * - start: Start a new pipeline from configuration file
  * - upload: Upload files to a pipeline (with --pipeline or --token)
  * - status: Monitor real-time status of a running pipeline
  * - stop: Terminate a running pipeline gracefully
- * 
+ *
  * @example
  * ```bash
  * # Start a pipeline
@@ -119,7 +119,7 @@ class Box {
 
 	private boxTop(): string {
 		const titlePart = ` ${this.title} `;
-		const remainingWidth = (this.width - 3) - titlePart.length;
+		const remainingWidth = this.width - 3 - titlePart.length;
 		return CHR_TL + CHR_HORIZ + titlePart + CHR_HORIZ.repeat(Math.max(0, remainingWidth)) + CHR_TR;
 	}
 
@@ -348,29 +348,18 @@ class StatusMonitor extends BoxMonitor {
 			3: ['Online', ANSI_GREEN],
 			4: ['Stopping', ANSI_YELLOW],
 			5: ['Offline', ANSI_GRAY],
-			6: ['Offline', ANSI_GRAY]
+			6: ['Offline', ANSI_GRAY],
 		};
 		return stateMap[state] || ['Unknown', ANSI_RESET];
 	}
 
 	private hasCountData(status: Record<string, unknown>): boolean {
-		return (
-			(Number(status.totalSize) || 0) > 0 ||
-			(Number(status.totalCount) || 0) > 0 ||
-			(Number(status.completedSize) || 0) > 0 ||
-			(Number(status.completedCount) || 0) > 0 ||
-			(Number(status.failedSize) || 0) > 0 ||
-			(Number(status.failedCount) || 0) > 0 ||
-			(Number(status.rateSize) || 0) > 0 ||
-			(Number(status.rateCount) || 0) > 0
-		);
+		return (Number(status.totalSize) || 0) > 0 || (Number(status.totalCount) || 0) > 0 || (Number(status.completedSize) || 0) > 0 || (Number(status.completedCount) || 0) > 0 || (Number(status.failedSize) || 0) > 0 || (Number(status.failedCount) || 0) > 0 || (Number(status.rateSize) || 0) > 0 || (Number(status.rateCount) || 0) > 0;
 	}
 
 	private hasMetricsData(status: Record<string, unknown>): boolean {
 		const metrics = (status.metrics || {}) as Record<string, unknown>;
-		return Object.values(metrics).some(value =>
-			typeof value === 'number' && value > 0
-		);
+		return Object.values(metrics).some((value) => typeof value === 'number' && value > 0);
 	}
 
 	onEvent(message: DAPMessage): void {
@@ -431,7 +420,7 @@ class StatusMonitor extends BoxMonitor {
 			const startStr = new Date(startTime * 1000).toLocaleString();
 			lines.push(`Started: ${startStr}`);
 
-			const endTime = status.completed ? (Number(status.endTime) || 0) : undefined;
+			const endTime = status.completed ? Number(status.endTime) || 0 : undefined;
 			const duration = this.formatDuration(startTime, endTime);
 			lines.push(`Elapsed: ${duration}`);
 		}
@@ -441,7 +430,7 @@ class StatusMonitor extends BoxMonitor {
 			const dataTypes = [
 				['total', 'Total'],
 				['completed', 'Completed'],
-				['failed', 'Failed']
+				['failed', 'Failed'],
 			];
 
 			for (const [keyBase, label] of dataTypes) {
@@ -472,7 +461,7 @@ class StatusMonitor extends BoxMonitor {
 
 		for (const [key, value] of Object.entries(metrics)) {
 			if (typeof value === 'number' && value > 0) {
-				const label = key.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
+				const label = key.replace(/_/g, ' ').replace(/\b\w/g, (l) => l.toUpperCase());
 				lines.push(`${label}: ${value}`);
 			}
 		}
@@ -494,8 +483,7 @@ class StatusMonitor extends BoxMonitor {
 				const errType = parts[0].trim();
 				const message = parts[1].replace(/`/g, '').trim();
 				const fileInfo = parts[2].trim();
-				const filename = fileInfo.includes('\\') || fileInfo.includes('/') ?
-					path.basename(fileInfo) : fileInfo;
+				const filename = fileInfo.includes('\\') || fileInfo.includes('/') ? path.basename(fileInfo) : fileInfo;
 
 				lines.push(`${color}${errType}${ANSI_RESET}: ${message}`);
 				if (filename) {
@@ -514,7 +502,7 @@ class StatusMonitor extends BoxMonitor {
 			return [];
 		}
 
-		return items.slice(-5).map(item => `• ${item}`);
+		return items.slice(-5).map((item) => `• ${item}`);
 	}
 
 	displayConnecting(url: string, attempt: number): void {
@@ -541,7 +529,7 @@ class UploadProgressMonitor extends BoxMonitor {
 	}
 
 	private createProgressBar(percent: number, width: number = 30): string {
-		const filledLength = Math.floor(width * percent / 100);
+		const filledLength = Math.floor((width * percent) / 100);
 		const bar = CHR_BLOCK.repeat(filledLength) + CHR_LIGHT_BLOCK.repeat(width - filledLength);
 		return `[${bar}] ${percent.toFixed(1).padStart(5)}%`;
 	}
@@ -582,7 +570,7 @@ class UploadProgressMonitor extends BoxMonitor {
 				filepath,
 				action,
 				bytes_sent: bytesSent,
-				file_size: fileSize
+				file_size: fileSize,
 			});
 		} else if (action === 'close') {
 			const existing = this.activeUploads.get(filename);
@@ -591,7 +579,7 @@ class UploadProgressMonitor extends BoxMonitor {
 					...existing,
 					action,
 					bytes_sent: bytesSent,
-					file_size: fileSize
+					file_size: fileSize,
 				});
 			}
 		} else if (action === 'complete') {
@@ -599,7 +587,7 @@ class UploadProgressMonitor extends BoxMonitor {
 			this.completedUploads.set(filename, {
 				filepath,
 				action,
-				file_size: fileSize
+				file_size: fileSize,
 			});
 		} else if (action === 'error') {
 			this.activeUploads.delete(filename);
@@ -608,7 +596,7 @@ class UploadProgressMonitor extends BoxMonitor {
 				filepath,
 				action,
 				file_size: fileSize,
-				error: errorMessage
+				error: errorMessage,
 			});
 		}
 
@@ -637,7 +625,7 @@ class UploadProgressMonitor extends BoxMonitor {
 				filepath,
 				action,
 				bytes_sent: bytesSent,
-				file_size: fileSize
+				file_size: fileSize,
 			});
 		} else if (action === 'close') {
 			const existing = this.activeUploads.get(filename);
@@ -646,7 +634,7 @@ class UploadProgressMonitor extends BoxMonitor {
 					...existing,
 					action,
 					bytes_sent: bytesSent,
-					file_size: fileSize
+					file_size: fileSize,
 				});
 			}
 		} else if (action === 'complete') {
@@ -654,7 +642,7 @@ class UploadProgressMonitor extends BoxMonitor {
 			this.completedUploads.set(filename, {
 				filepath,
 				action,
-				file_size: fileSize
+				file_size: fileSize,
 			});
 		} else if (action === 'error') {
 			this.activeUploads.delete(filename);
@@ -663,7 +651,7 @@ class UploadProgressMonitor extends BoxMonitor {
 				filepath,
 				action,
 				file_size: fileSize,
-				error: errorMessage
+				error: errorMessage,
 			});
 		}
 
@@ -696,7 +684,7 @@ class UploadProgressMonitor extends BoxMonitor {
 
 				const bytesSent = Number(data.bytes_sent) || 0;
 				const fileSize = Number(data.file_size) || 1;
-				const percent = fileSize > 0 ? (bytesSent / fileSize * 100) : 0;
+				const percent = fileSize > 0 ? (bytesSent / fileSize) * 100 : 0;
 
 				const progressBar = this.createProgressBar(percent, 12);
 				const sizeInfo = `${this.formatSize(bytesSent)}/${this.formatSize(fileSize)}`;
@@ -722,8 +710,7 @@ class UploadProgressMonitor extends BoxMonitor {
 				summaryLines.push(`Failed: ${this.failedUploads.size} files`);
 			}
 
-			const totalBytes = Array.from(this.completedUploads.values())
-				.reduce((sum, data) => sum + (Number(data.file_size) || 0), 0);
+			const totalBytes = Array.from(this.completedUploads.values()).reduce((sum, data) => sum + (Number(data.file_size) || 0), 0);
 			summaryLines.push(`Total size: ${this.formatSize(totalBytes)}`);
 
 			this.addBox('Upload Summary', summaryLines);
@@ -739,8 +726,7 @@ class UploadProgressMonitor extends BoxMonitor {
 			for (const [filename, data] of failedEntries.slice(-displayCount)) {
 				const displayName = this.truncateFilename(filename, 25);
 				const errorStr = String(data.error || '');
-				const errorMsg = errorStr.length > 30 ?
-					`${errorStr.substring(0, 30)}...` : errorStr;
+				const errorMsg = errorStr.length > 30 ? `${errorStr.substring(0, 30)}...` : errorStr;
 				failedLines.push(`${ANSI_RED}${CHR_CROSS}${ANSI_RESET} ${displayName} - ${errorMsg}`);
 			}
 
@@ -808,7 +794,7 @@ export class RocketRideCLI {
 		total_bytes: 0,
 		successful_uploads: 0,
 		failed_uploads: 0,
-		upload_times: []
+		upload_times: [],
 	};
 	private uri: string = '';
 	private monitor?: BoxMonitor;
@@ -840,16 +826,11 @@ export class RocketRideCLI {
 	private createProgram(): Command {
 		const program = new Command();
 
-		program
-			.name('rocketride')
-			.description('RocketRide Unified Pipeline and File Management CLI')
-			.version('1.3.0');
+		program.name('rocketride').description('RocketRide Unified Pipeline and File Management CLI').version('1.3.0');
 
 		// Common options
 		const addCommonOptions = (cmd: Command) => {
-			return cmd
-				.option('--uri <uri>', 'RocketRide server URI (can use ROCKETRIDE_URI env var)', process.env.ROCKETRIDE_URI || CONST_DEFAULT_WEB_LOCAL)
-				.option('--apikey <key>', 'API key for RocketRide server authentication (can use ROCKETRIDE_APIKEY in .env or env var)', process.env.ROCKETRIDE_APIKEY);
+			return cmd.option('--uri <uri>', 'RocketRide server URI (can use ROCKETRIDE_URI env var)', process.env.ROCKETRIDE_URI || CONST_DEFAULT_WEB_LOCAL).option('--apikey <key>', 'API key for RocketRide server authentication (can use ROCKETRIDE_APIKEY in .env or env var)', process.env.ROCKETRIDE_APIKEY);
 		};
 
 		// Start command
@@ -871,7 +852,7 @@ export class RocketRideCLI {
 					command: 'start',
 					...options,
 					pipeline: options.pipeline,
-					threads: parseInt(options.threads)
+					threads: parseInt(options.threads),
 				};
 				this.uri = options.uri;
 
@@ -909,7 +890,7 @@ export class RocketRideCLI {
 					files,
 					threads: parseInt(options.threads),
 					max_concurrent: parseInt(options.maxConcurrent || '5'),
-					pipeline_args: options.args
+					pipeline_args: options.args,
 				};
 				this.uri = options.uri;
 
@@ -983,9 +964,7 @@ export class RocketRideCLI {
 		addCommonOptions(stopCmd);
 
 		// Store command with file system subcommands
-		const storeCmd = program
-			.command('store')
-			.description('File store operations');
+		const storeCmd = program.command('store').description('File store operations');
 
 		// store dir
 		const storeDirCmd = storeCmd
@@ -998,13 +977,43 @@ export class RocketRideCLI {
 					const client = await this.createAndConnectClient();
 					const result = await client.fsListDir(path || '');
 					const entries = result.entries || [];
-					if (entries.length === 0) { console.log('(empty directory)'); }
-					else {
-						for (const e of entries) { console.log(`  ${e.type === 'dir' ? 'DIR ' : 'FILE'}  ${e.name}`); }
-						console.log(`\n  ${result.count} item(s)`);
+					if (entries.length === 0) {
+						console.log('File Not Found');
+					} else {
+						let totalSize = 0;
+						let fileCount = 0;
+						let dirCount = 0;
+						for (const e of entries) {
+							let dateStr = '                   ';
+							if (e.modified) {
+								const d = new Date(e.modified * 1000);
+								const mm = String(d.getUTCMonth() + 1).padStart(2, '0');
+								const dd = String(d.getUTCDate()).padStart(2, '0');
+								const yyyy = d.getUTCFullYear();
+								let hh = d.getUTCHours();
+								const min = String(d.getUTCMinutes()).padStart(2, '0');
+								const ampm = hh >= 12 ? 'PM' : 'AM';
+								hh = hh % 12 || 12;
+								dateStr = `${mm}/${dd}/${yyyy}  ${String(hh).padStart(2, '0')}:${min} ${ampm}`;
+							}
+							if (e.type === 'dir') {
+								console.log(`${dateStr}    <DIR>          ${e.name}`);
+								dirCount++;
+							} else {
+								const size = e.size ?? 0;
+								totalSize += size;
+								console.log(`${dateStr}    ${size.toLocaleString().padStart(14)} ${e.name}`);
+								fileCount++;
+							}
+						}
+						console.log(`    ${fileCount.toLocaleString().padStart(8)} File(s)  ${totalSize.toLocaleString().padStart(14)} bytes`);
+						console.log(`    ${dirCount.toLocaleString().padStart(8)} Dir(s)`);
 					}
 					process.exit(0);
-				} finally { this.cancel(); await this.cleanupClient(); }
+				} finally {
+					this.cancel();
+					await this.cleanupClient();
+				}
 			});
 		addCommonOptions(storeDirCmd);
 
@@ -1020,7 +1029,10 @@ export class RocketRideCLI {
 					const text = await client.fsReadString(path);
 					process.stdout.write(text);
 					process.exit(0);
-				} finally { this.cancel(); await this.cleanupClient(); }
+				} finally {
+					this.cancel();
+					await this.cleanupClient();
+				}
 			});
 		addCommonOptions(storeTypeCmd);
 
@@ -1036,17 +1048,34 @@ export class RocketRideCLI {
 				try {
 					const client = await this.createAndConnectClient();
 					if (options.file) {
-						const fs = await import('fs');
-						const data = fs.readFileSync(options.file);
-						await client.fsWrite(path, data);
+						const nodeFs = await import('fs');
+						const { handle } = await client.fsOpen(path, 'w');
+						try {
+							const stream = nodeFs.createReadStream(options.file);
+							for await (const chunk of stream) {
+								await client.fsWrite(handle, chunk as Uint8Array);
+							}
+							await client.fsClose(handle, 'w');
+						} catch (err) {
+							try {
+								await client.fsClose(handle, 'w');
+							} catch {
+								/* best-effort */
+							}
+							throw err;
+						}
 					} else if (options.content !== undefined) {
 						await client.fsWriteString(path, options.content);
 					} else {
-						console.error('Error: Either --file or --content is required'); process.exit(1);
+						console.error('Error: Either --file or --content is required');
+						process.exit(1);
 					}
 					console.log(`Written: ${path}`);
 					process.exit(0);
-				} finally { this.cancel(); await this.cleanupClient(); }
+				} finally {
+					this.cancel();
+					await this.cleanupClient();
+				}
 			});
 		addCommonOptions(storeWriteCmd);
 
@@ -1062,7 +1091,10 @@ export class RocketRideCLI {
 					await client.fsDelete(path);
 					console.log(`Deleted: ${path}`);
 					process.exit(0);
-				} finally { this.cancel(); await this.cleanupClient(); }
+				} finally {
+					this.cancel();
+					await this.cleanupClient();
+				}
 			});
 		addCommonOptions(storeRmCmd);
 
@@ -1078,7 +1110,10 @@ export class RocketRideCLI {
 					await client.fsMkdir(path);
 					console.log(`Created: ${path}/`);
 					process.exit(0);
-				} finally { this.cancel(); await this.cleanupClient(); }
+				} finally {
+					this.cancel();
+					await this.cleanupClient();
+				}
 			});
 		addCommonOptions(storeMkdirCmd);
 
@@ -1092,10 +1127,19 @@ export class RocketRideCLI {
 				try {
 					const client = await this.createAndConnectClient();
 					const result = await client.fsStat(path);
-					if (!result.exists) { console.log(`${path}: not found`); }
-					else { console.log(`${path}: ${result.type}${result.modified ? ` (modified: ${new Date(result.modified * 1000).toISOString()})` : ''}`); }
+					if (!result.exists) {
+						console.log(`${path}: not found`);
+					} else {
+						const details: string[] = [];
+						if (result.size !== undefined) details.push(`size: ${result.size.toLocaleString()}`);
+						if (result.modified) details.push(`modified: ${new Date(result.modified * 1000).toISOString()}`);
+						console.log(`${path}: ${result.type}${details.length ? ` (${details.join(', ')})` : ''}`);
+					}
 					process.exit(0);
-				} finally { this.cancel(); await this.cleanupClient(); }
+				} finally {
+					this.cancel();
+					await this.cleanupClient();
+				}
 			});
 		addCommonOptions(storeStatCmd);
 
@@ -1108,16 +1152,13 @@ export class RocketRideCLI {
 		}
 	}
 
-	private async createAndConnectClient(
-		onConnected?: (connectionInfo?: string) => Promise<void>,
-		onDisconnected?: (reason?: string, hasError?: boolean) => Promise<void>
-	): Promise<RocketRideClient> {
+	private async createAndConnectClient(onConnected?: (connectionInfo?: string) => Promise<void>, onDisconnected?: (reason?: string, hasError?: boolean) => Promise<void>): Promise<RocketRideClient> {
 		this.client = new RocketRideClient({
 			uri: this.uri,
 			auth: this.args.apikey,
 			onEvent: this.handleEvent.bind(this),
 			onConnected,
-			onDisconnected
+			onDisconnected,
 		});
 
 		await this.client.connect();
@@ -1131,7 +1172,7 @@ export class RocketRideCLI {
 			const arguments_ = { subscribe };
 			const monitorRequest = this.client.buildRequest('rrext_monitor', {
 				token,
-				arguments: arguments_
+				arguments: arguments_,
 			});
 			const monitorResponse = await this.client.request(monitorRequest);
 
@@ -1196,16 +1237,10 @@ export class RocketRideCLI {
 				pipeline: pipelineData,
 				threads: this.args.threads,
 				token: this.args.token,
-				args: this.args.pipeline_args || []
+				args: this.args.pipeline_args || [],
 			});
 
-			const executionLines = [
-				'Pipeline execution started successfully',
-				`Task token: ${taskToken}`,
-				'',
-				'Use the following command to monitor status:',
-				`rocketride status --token ${taskToken} --apikey ${this.args.apikey}`
-			];
+			const executionLines = ['Pipeline execution started successfully', `Task token: ${taskToken}`, '', 'Use the following command to monitor status:', `rocketride status --token ${taskToken} --apikey ${this.args.apikey}`];
 
 			this.monitor.setCommandStatus(executionLines);
 			this.monitor.draw();
@@ -1238,7 +1273,7 @@ export class RocketRideCLI {
 				total_bytes: 0,
 				successful_uploads: 0,
 				failed_uploads: 0,
-				upload_times: []
+				upload_times: [],
 			};
 
 			let pipelineConfig: PipelineConfig | undefined;
@@ -1296,7 +1331,7 @@ export class RocketRideCLI {
 				this.monitor.draw();
 
 				// Wait briefly to show errors
-				await new Promise(resolve => setTimeout(resolve, 3000));
+				await new Promise((resolve) => setTimeout(resolve, 3000));
 			}
 
 			if (validFiles.length === 0) {
@@ -1320,7 +1355,7 @@ export class RocketRideCLI {
 					pipeline: pipelineConfig,
 					threads: this.args.threads,
 					token: 'UPLOAD_TASK',
-					args: this.args.pipeline_args || []
+					args: this.args.pipeline_args || [],
 				});
 
 				taskToken = result.token;
@@ -1333,28 +1368,25 @@ export class RocketRideCLI {
 			const startTime = Date.now();
 
 			// Convert file paths to File objects for sendFiles
-			const fileObjects = validFiles.map(filePath => {
+			const fileObjects = validFiles.map((filePath) => {
 				const stats = fs.statSync(filePath);
 				const content = fs.readFileSync(filePath);
 
 				return {
 					file: new File([content], path.basename(filePath), {
 						type: 'application/octet-stream',
-						lastModified: stats.mtimeMs
+						lastModified: stats.mtimeMs,
 					}),
 					objinfo: {
 						filepath: filePath,
-						size: stats.size
-					}
+						size: stats.size,
+					},
 				};
 			});
 
-		// Upload files - progress events come through event subscription
-		// Server handles concurrency automatically
-		const results = await this.client!.sendFiles(
-			fileObjects,
-			taskToken!
-		);
+			// Upload files - progress events come through event subscription
+			// Server handles concurrency automatically
+			const results = await this.client!.sendFiles(fileObjects, taskToken!);
 
 			const endTime = Date.now();
 
@@ -1364,11 +1396,7 @@ export class RocketRideCLI {
 			// Cleanup pipeline if we created it
 			if (shouldManagePipeline && taskToken) {
 				try {
-					this.monitor.setCommandStatus([
-						'Upload completed successfully',
-						'Cleaning up...',
-						'Terminating pipeline...'
-					]);
+					this.monitor.setCommandStatus(['Upload completed successfully', 'Cleaning up...', 'Terminating pipeline...']);
 					this.monitor.draw();
 
 					await this.client!.terminate(taskToken);
@@ -1402,8 +1430,6 @@ export class RocketRideCLI {
 		}
 	}
 
-
-
 	private findFiles(patterns: string[]): string[] {
 		const files: string[] = [];
 
@@ -1416,12 +1442,12 @@ export class RocketRideCLI {
 					files.push(fullPath);
 				} else if (stat.isDirectory()) {
 					const dirFiles = glob.sync(path.join(fullPath, '**/*'), { nodir: true });
-					files.push(...dirFiles.map(f => path.resolve(f)));
+					files.push(...dirFiles.map((f) => path.resolve(f)));
 				}
 			} catch {
 				// Try glob pattern
 				const matches = glob.sync(pattern, { nodir: true });
-				files.push(...matches.map(f => path.resolve(f)));
+				files.push(...matches.map((f) => path.resolve(f)));
 			}
 		}
 
@@ -1456,8 +1482,8 @@ export class RocketRideCLI {
 
 		this.monitor.clear();
 
-		const successfulFiles: Array<{ name: string, size: number, time: number }> = [];
-		const failedFiles: Array<{ name: string, error: string }> = [];
+		const successfulFiles: Array<{ name: string; size: number; time: number }> = [];
+		const failedFiles: Array<{ name: string; error: string }> = [];
 
 		for (const result of results) {
 			const filename = path.basename(result.filepath || '');
@@ -1470,12 +1496,12 @@ export class RocketRideCLI {
 				successfulFiles.push({
 					name: filename,
 					size: result.file_size || 0,
-					time: result.upload_time || 0
+					time: result.upload_time || 0,
 				});
 			} else {
 				failedFiles.push({
 					name: filename,
-					error: result.error || 'Unknown error'
+					error: result.error || 'Unknown error',
 				});
 				this.uploadStats.failed_uploads++;
 			}
@@ -1487,10 +1513,7 @@ export class RocketRideCLI {
 		const failed = this.uploadStats.failed_uploads;
 		const totalBytes = this.uploadStats.total_bytes;
 
-		const summaryLines = [
-			`Total files processed: ${successful + failed}`,
-			`Successful uploads: ${ANSI_GREEN}${successful}${ANSI_RESET}`
-		];
+		const summaryLines = [`Total files processed: ${successful + failed}`, `Successful uploads: ${ANSI_GREEN}${successful}${ANSI_RESET}`];
 
 		if (failed > 0) {
 			summaryLines.push(`Failed uploads: ${ANSI_RED}${failed}${ANSI_RESET}`);
@@ -1531,10 +1554,8 @@ export class RocketRideCLI {
 			const failureLines: string[] = [];
 
 			for (const failedFile of failedFiles.slice(0, 10)) {
-				const filename = failedFile.name.length > 25 ?
-					`${failedFile.name.substring(0, 25)}...` : failedFile.name;
-				const errorMsg = failedFile.error.length > 40 ?
-					`${failedFile.error.substring(0, 40)}...` : failedFile.error;
+				const filename = failedFile.name.length > 25 ? `${failedFile.name.substring(0, 25)}...` : failedFile.name;
+				const errorMsg = failedFile.error.length > 40 ? `${failedFile.error.substring(0, 40)}...` : failedFile.error;
 
 				failureLines.push(`${ANSI_RED}${CHR_CROSS}${ANSI_RESET} ${filename} - ${errorMsg}`);
 			}
@@ -1551,8 +1572,7 @@ export class RocketRideCLI {
 			const successLines: string[] = [];
 
 			for (const successFile of successfulFiles.slice(-5)) {
-				const truncatedName = successFile.name.length > 35 ?
-					`${successFile.name.substring(0, 35)}...` : successFile.name;
+				const truncatedName = successFile.name.length > 35 ? `${successFile.name.substring(0, 35)}...` : successFile.name;
 				const sizeStr = this.monitor.formatSize(successFile.size);
 				const timeStr = `${successFile.time.toFixed(1)}s`;
 
@@ -1598,11 +1618,11 @@ export class RocketRideCLI {
 						await this.createAndConnectClient(onConnected, onDisconnected);
 					} catch {
 						this.attempt++;
-						await new Promise(resolve => setTimeout(resolve, 5000));
+						await new Promise((resolve) => setTimeout(resolve, 5000));
 						continue;
 					}
 				}
-				await new Promise(resolve => setTimeout(resolve, 1000));
+				await new Promise((resolve) => setTimeout(resolve, 1000));
 			}
 
 			return 0;
@@ -1641,11 +1661,7 @@ export class RocketRideCLI {
 
 			await this.client!.terminate(this.args.token);
 
-			const stopLines = [
-				`Task ${this.args.token} terminated successfully`,
-				'',
-				'The task has been stopped and resources cleaned up.'
-			];
+			const stopLines = [`Task ${this.args.token} terminated successfully`, '', 'The task has been stopped and resources cleaned up.'];
 
 			this.monitor.setCommandStatus(stopLines);
 			this.monitor.draw();
@@ -1715,7 +1731,7 @@ export async function main(): Promise<void> {
 
 // Entry point when script is run directly
 if (require.main === module) {
-	main().catch(error => {
+	main().catch((error) => {
 		console.error('Fatal error:', error);
 		process.exit(1);
 	});

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -1434,20 +1434,20 @@ export class RocketRideClient extends DAPClient {
 	 * ```
 	 */
 	async saveProject(options: { projectId: string; pipeline: Record<string, any> }): Promise<void> {
-		if (!options.projectId) throw new Error('projectId is required');
+		this.validateId(options.projectId, 'projectId');
 		if (!options.pipeline || typeof options.pipeline !== 'object') throw new Error('pipeline must be a non-empty object');
 
 		await this.fsWriteJson(`.projects/${options.projectId}.json`, options.pipeline);
 	}
 
 	async getProject(options: { projectId: string }): Promise<Record<string, any>> {
-		if (!options.projectId) throw new Error('projectId is required');
+		this.validateId(options.projectId, 'projectId');
 
 		return this.fsReadJson(`.projects/${options.projectId}.json`);
 	}
 
 	async deleteProject(options: { projectId: string }): Promise<void> {
-		if (!options.projectId) throw new Error('projectId is required');
+		this.validateId(options.projectId, 'projectId');
 
 		await this.fsDelete(`.projects/${options.projectId}.json`);
 	}
@@ -1476,20 +1476,20 @@ export class RocketRideClient extends DAPClient {
 	// ============================================================================
 
 	async saveTemplate(options: { templateId: string; pipeline: Record<string, any> }): Promise<void> {
-		if (!options.templateId) throw new Error('templateId is required');
+		this.validateId(options.templateId, 'templateId');
 		if (!options.pipeline || typeof options.pipeline !== 'object') throw new Error('pipeline must be a non-empty object');
 
 		await this.fsWriteJson(`.templates/${options.templateId}.json`, options.pipeline);
 	}
 
 	async getTemplate(options: { templateId: string }): Promise<Record<string, any>> {
-		if (!options.templateId) throw new Error('templateId is required');
+		this.validateId(options.templateId, 'templateId');
 
 		return this.fsReadJson(`.templates/${options.templateId}.json`);
 	}
 
 	async deleteTemplate(options: { templateId: string }): Promise<void> {
-		if (!options.templateId) throw new Error('templateId is required');
+		this.validateId(options.templateId, 'templateId');
 
 		await this.fsDelete(`.templates/${options.templateId}.json`);
 	}
@@ -1518,8 +1518,8 @@ export class RocketRideClient extends DAPClient {
 	// ============================================================================
 
 	async saveLog(options: { projectId: string; source: string; contents: Record<string, any> }): Promise<string> {
-		if (!options.projectId) throw new Error('projectId is required');
-		if (!options.source) throw new Error('source is required');
+		this.validateId(options.projectId, 'projectId');
+		this.validateId(options.source, 'source');
 		if (!options.contents || typeof options.contents !== 'object') throw new Error('contents must be a non-empty object');
 
 		const startTime = options.contents?.body?.startTime;
@@ -1531,8 +1531,8 @@ export class RocketRideClient extends DAPClient {
 	}
 
 	async getLog(options: { projectId: string; source: string; startTime: number }): Promise<Record<string, any>> {
-		if (!options.projectId) throw new Error('projectId is required');
-		if (!options.source) throw new Error('source is required');
+		this.validateId(options.projectId, 'projectId');
+		this.validateId(options.source, 'source');
 		if (options.startTime === undefined || options.startTime === null) throw new Error('startTime is required');
 
 		const filename = `${options.source}-${options.startTime}.log`;
@@ -1540,7 +1540,8 @@ export class RocketRideClient extends DAPClient {
 	}
 
 	async listLogs(options: { projectId: string; source?: string }): Promise<string[]> {
-		if (!options.projectId) throw new Error('projectId is required');
+		this.validateId(options.projectId, 'projectId');
+		if (options.source) this.validateId(options.source, 'source');
 
 		const dir = await this.fsListDir(`.logs/${options.projectId}`);
 		let logs = dir.entries.filter((e) => e.type === 'file' && e.name.endsWith('.log')).map((e) => e.name);
@@ -1565,11 +1566,9 @@ export class RocketRideClient extends DAPClient {
 	 * @param offset - Initial byte offset (read mode only)
 	 * @returns Object with 'handle' (string). Read mode also includes 'size' (number).
 	 */
-	async fsOpen(path: string, mode: 'r' | 'w' = 'r', offset?: number): Promise<{ handle: string; size?: number }> {
+	async fsOpen(path: string, mode: 'r' | 'w' = 'r'): Promise<{ handle: string; size?: number }> {
+		this.validateStorePath(path);
 		const args: Record<string, unknown> = { subcommand: 'fs_open', path, mode };
-		if (mode === 'r' && offset !== undefined && offset > 0) {
-			args.offset = offset;
-		}
 		const request = this.buildRequest('rrext_store', { arguments: args });
 		const response = await this.request(request);
 		if (this.didFail(response)) throw new Error(response.message || 'Failed to open file');
@@ -1580,11 +1579,12 @@ export class RocketRideClient extends DAPClient {
 	 * Read data from an open read handle.
 	 *
 	 * @param handle - Handle ID returned by fsOpen
+	 * @param offset - Byte offset to read from
 	 * @param length - Max bytes to read (default 4 MB). Empty Uint8Array indicates EOF.
 	 * @returns The bytes read
 	 */
-	async fsRead(handle: string, length: number = 4_194_304): Promise<Uint8Array> {
-		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_read', handle, length } });
+	async fsRead(handle: string, offset: number = 0, length: number = 4_194_304): Promise<Uint8Array> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_read', handle, offset, length } });
 		const response = await this.request(request);
 		if (this.didFail(response)) throw new Error(response.message || 'Failed to read from handle');
 		return ((response.arguments as any)?.data as Uint8Array) || new Uint8Array(0);
@@ -1623,6 +1623,7 @@ export class RocketRideClient extends DAPClient {
 	 * @throws Error if file does not exist or delete fails
 	 */
 	async fsDelete(path: string): Promise<void> {
+		this.validateStorePath(path);
 		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_delete', path } });
 		const response = await this.request(request);
 		if (this.didFail(response)) throw new Error(response.message || 'Failed to delete file');
@@ -1634,7 +1635,8 @@ export class RocketRideClient extends DAPClient {
 	 * @param path - Relative directory path (default: account root)
 	 * @returns Directory entries with name and type (file or dir)
 	 */
-	async fsListDir(path: string = ''): Promise<{ entries: Array<{ name: string; type: 'file' | 'dir'; modified?: number }>; count: number }> {
+	async fsListDir(path: string = ''): Promise<{ entries: Array<{ name: string; type: 'file' | 'dir'; size?: number; modified?: number }>; count: number }> {
+		if (path) this.validateStorePath(path);
 		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_list_dir', path } });
 		const response = await this.request(request);
 		if (this.didFail(response)) throw new Error(response.message || 'Failed to list directory');
@@ -1647,6 +1649,7 @@ export class RocketRideClient extends DAPClient {
 	 * @param path - Relative directory path
 	 */
 	async fsMkdir(path: string): Promise<void> {
+		this.validateStorePath(path);
 		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_mkdir', path } });
 		const response = await this.request(request);
 		if (this.didFail(response)) throw new Error(response.message || 'Failed to create directory');
@@ -1656,9 +1659,10 @@ export class RocketRideClient extends DAPClient {
 	 * Get file or directory metadata.
 	 *
 	 * @param path - Relative path within the account store
-	 * @returns Metadata including existence, type, and modified epoch timestamp (for files)
+	 * @returns Metadata including existence, type, size (bytes), and modified epoch timestamp (for files)
 	 */
-	async fsStat(path: string): Promise<{ exists: boolean; type?: 'file' | 'dir'; modified?: number }> {
+	async fsStat(path: string): Promise<{ exists: boolean; type?: 'file' | 'dir'; size?: number; modified?: number }> {
+		this.validateStorePath(path);
 		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_stat', path } });
 		const response = await this.request(request);
 		if (this.didFail(response)) throw new Error(response.message || 'Failed to stat path');
@@ -1674,16 +1678,18 @@ export class RocketRideClient extends DAPClient {
 		const { handle } = await this.fsOpen(path, 'r');
 		try {
 			const chunks: Uint8Array[] = [];
+			let offset = 0;
 			while (true) {
-				const chunk = await this.fsRead(handle);
+				const chunk = await this.fsRead(handle, offset);
 				if (chunk.length === 0) break;
 				chunks.push(chunk);
-			}
-			const total = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
-			let offset = 0;
-			for (const chunk of chunks) {
-				total.set(chunk, offset);
 				offset += chunk.length;
+			}
+			const total = new Uint8Array(offset);
+			let pos = 0;
+			for (const chunk of chunks) {
+				total.set(chunk, pos);
+				pos += chunk.length;
 			}
 			return new TextDecoder().decode(total);
 		} finally {
@@ -1716,6 +1722,35 @@ export class RocketRideClient extends DAPClient {
 	/** Write an object as JSON. */
 	async fsWriteJson(path: string, obj: any): Promise<void> {
 		await this.fsWriteString(path, JSON.stringify(obj, null, 2));
+	}
+
+	// ============================================================================
+	// PATH AND ID VALIDATION
+	// ============================================================================
+
+	private static readonly INVALID_PATH_CHARS = new Set(['*', '?', '<', '>', '|', '"', '\x00']);
+
+	private validateStorePath(path: string): void {
+		for (const segment of path.replace(/\\/g, '/').split('/')) {
+			if (segment === '..') throw new Error(`Path traversal not allowed: ${path}`);
+			if (segment) {
+				for (const ch of segment) {
+					if (RocketRideClient.INVALID_PATH_CHARS.has(ch) || ch.charCodeAt(0) < 0x20) {
+						throw new Error(`Path contains invalid characters: ${path}`);
+					}
+				}
+			}
+		}
+	}
+
+	private validateId(value: string, name: string): void {
+		if (!value) throw new Error(`${name} is required`);
+		if (value.includes('/') || value.includes('\\')) throw new Error(`${name} must not contain path separators`);
+		for (const ch of value) {
+			if (RocketRideClient.INVALID_PATH_CHARS.has(ch) || ch.charCodeAt(0) < 0x20) {
+				throw new Error(`${name} contains invalid characters: ${value}`);
+			}
+		}
 	}
 
 	// ============================================================================

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -1,18 +1,18 @@
 /**
  * MIT License
- * 
+ *
  * Copyright (c) 2026 Aparavi Software AG
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in all
  * copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -35,17 +35,17 @@ let clientId = 0;
 
 /**
  * Streaming data pipe for sending large datasets to RocketRide pipelines.
- * 
+ *
  * DataPipe provides a stream-like interface for uploading data to an RocketRide
  * pipeline. It handles the low-level protocol details of opening, writing to,
  * and closing data pipes on the server.
- * 
+ *
  * Usage pattern:
  * 1. Create pipe using client.pipe()
  * 2. Call open() to establish the pipe
  * 3. Call write() multiple times with data chunks
  * 4. Call close() to finalize and get results
- * 
+ *
  * @example
  * ```typescript
  * const pipe = await client.pipe(token, { filename: 'data.json' }, 'application/json');
@@ -76,14 +76,7 @@ export class DataPipe {
 	 * @param onSSE - Optional async callback invoked for each SSE event emitted by
 	 *                the pipeline node for this specific pipe
 	 */
-	constructor(
-		client: RocketRideClient,
-		token: string,
-		objinfo: Record<string, unknown> = {},
-		mimeType = 'application/octet-stream',
-		provider?: string,
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
-	) {
+	constructor(client: RocketRideClient, token: string, objinfo: Record<string, unknown> = {}, mimeType = 'application/octet-stream', provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>) {
 		this._client = client;
 		this._token = token;
 		this._objinfo = objinfo;
@@ -94,7 +87,7 @@ export class DataPipe {
 
 	/**
 	 * Check if the pipe is currently open for writing.
-	 * 
+	 *
 	 * @returns true if the pipe has been opened and not yet closed
 	 */
 	get isOpened(): boolean {
@@ -103,10 +96,10 @@ export class DataPipe {
 
 	/**
 	 * Get the unique ID assigned to this pipe by the server.
-	 * 
+	 *
 	 * This ID is assigned when the pipe is opened and is used for subsequent
 	 * write operations. It remains undefined until open() is called successfully.
-	 * 
+	 *
 	 * @returns The server-assigned pipe ID, or undefined if not yet opened
 	 */
 	get pipeId(): number | undefined {
@@ -115,11 +108,11 @@ export class DataPipe {
 
 	/**
 	 * Open the pipe for data transmission.
-	 * 
+	 *
 	 * Establishes a data pipe on the server for streaming data to the pipeline.
 	 * Must be called before any write() operations. The server will assign a
 	 * unique pipe ID that is used for subsequent operations.
-	 * 
+	 *
 	 * @returns This DataPipe instance (for method chaining)
 	 * @throws Error if the pipe is already opened or if the pipeline is not running
 	 */
@@ -158,10 +151,10 @@ export class DataPipe {
 
 	/**
 	 * Write data to the pipe.
-	 * 
+	 *
 	 * Sends a chunk of data through the pipe to the server pipeline. Can be called
 	 * multiple times to stream large datasets. The pipe must be opened first.
-	 * 
+	 *
 	 * @param buffer - Data to write, must be a Uint8Array
 	 * @throws Error if the pipe is not opened, buffer is invalid, or write fails
 	 */
@@ -192,11 +185,11 @@ export class DataPipe {
 
 	/**
 	 * Close the pipe and get the processing results.
-	 * 
+	 *
 	 * Finalizes the data stream and signals the server that no more data will be sent.
 	 * The server processes any buffered data and returns the final result. After closing,
 	 * the pipe cannot be reopened or written to again.
-	 * 
+	 *
 	 * @returns The processing result from the server, or undefined if already closed
 	 * @throws Error if closing the pipe fails
 	 */
@@ -239,11 +232,11 @@ export class DataPipe {
 
 /**
  * Main RocketRide client for connecting to RocketRide servers and services.
- * 
+ *
  * This client provides a comprehensive API for interacting with RocketRide services,
  * including connection management, pipeline execution, data operations, AI chat,
  * event handling, and server connectivity testing.
- * 
+ *
  * Key features:
  * - Single shared WebSocket connection for all operations
  * - Connection management (connect/disconnect) with optional persistence
@@ -282,13 +275,13 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Creates a new RocketRideClient instance.
-	 * 
+	 *
 	 * Configuration priority (highest to lowest):
 	 * 1. Values passed in config parameter (auth, uri)
 	 * 2. Values from env parameter (if provided)
 	 * 3. Values from .env file (Node.js only)
 	 * 4. Default values
-	 * 
+	 *
 	 * @param config - Configuration options for the client
 	 * @param config.auth - API key for authentication (required)
 	 * @param config.uri - Server URI (default: CONST_DEFAULT_SERVICE)
@@ -300,9 +293,9 @@ export class RocketRideClient extends DAPClient {
 	 * @param config.requestTimeout - Default timeout in ms for individual requests
 	 * @param config.maxRetryTime - Max total time in ms to keep retrying connections
 	 * @param config.module - Optional module name for client identification
-	 * 
+	 *
 	 * @throws Error if auth is not provided via config, env, or .env file
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Using explicit auth and URI
@@ -312,7 +305,7 @@ export class RocketRideClient extends DAPClient {
 	 *   persist: true,
 	 *   onEvent: (event) => console.log('Event:', event)
 	 * });
-	 * 
+	 *
 	 * // Using custom env dictionary
 	 * const client = new RocketRideClient({
 	 *   env: {
@@ -343,17 +336,7 @@ export class RocketRideClient extends DAPClient {
 			}
 		}
 
-		const {
-			auth = config.auth || clientEnv.ROCKETRIDE_APIKEY,
-			uri = config.uri || clientEnv.ROCKETRIDE_URI || CONST_DEFAULT_WEB_CLOUD,
-			onEvent,
-			onConnected,
-			onDisconnected,
-			onConnectError,
-			persist,
-			maxRetryTime,
-			module,
-		} = config;
+		const { auth = config.auth || clientEnv.ROCKETRIDE_APIKEY, uri = config.uri || clientEnv.ROCKETRIDE_URI || CONST_DEFAULT_WEB_CLOUD, onEvent, onConnected, onDisconnected, onConnectError, persist, maxRetryTime, module } = config;
 
 		// Create unique client identifier
 		const clientName = module || `CLIENT-${clientId++}`;
@@ -403,7 +386,7 @@ export class RocketRideClient extends DAPClient {
 			const authority = withoutScheme.split(/[/?#]/, 1)[0] ?? '';
 			const hasExplicitPort = authority.startsWith('[')
 				? /\]:\d+$/.test(authority) // IPv6 literal with explicit port
-				: /:\d+$/.test(authority);  // hostname/IPv4 with explicit port
+				: /:\d+$/.test(authority); // hostname/IPv4 with explicit port
 
 			if (!url.port && !hasExplicitPort && !url.hostname.includes('rocketride.ai')) {
 				url.port = CONST_DEFAULT_WEB_PORT;
@@ -424,7 +407,7 @@ export class RocketRideClient extends DAPClient {
 
 		try {
 			const url = new URL(httpUrl);
-			const wsScheme = (url.protocol === 'https:' || url.protocol === 'wss:') ? 'wss:' : 'ws:';
+			const wsScheme = url.protocol === 'https:' || url.protocol === 'wss:' ? 'wss:' : 'ws:';
 			return `${wsScheme}//${url.host}/task/service`;
 		} catch {
 			return `${httpUrl}/task/service`;
@@ -646,7 +629,7 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Test connectivity to the RocketRide server.
-	 * 
+	 *
 	 * Sends a lightweight ping request to the server to verify it's responding
 	 * and reachable. This is useful for connectivity testing, health checks,
 	 * and measuring response times.
@@ -696,7 +679,7 @@ export class RocketRideClient extends DAPClient {
 			return this.substituteEnvVars(obj);
 		} else if (Array.isArray(obj)) {
 			// If it's an array, process each element
-			return obj.map(item => this.processEnvSubstitution(item));
+			return obj.map((item) => this.processEnvSubstitution(item));
 		} else if (obj !== null && typeof obj === 'object') {
 			// If it's an object, process each property
 			const result: Record<string, unknown> = {};
@@ -778,17 +761,14 @@ export class RocketRideClient extends DAPClient {
 	 * }
 	 * ```
 	 */
-	async validate(options: {
-		pipeline: PipelineConfig | Record<string, unknown>;
-		source?: string;
-	}): Promise<Record<string, unknown>> {
+	async validate(options: { pipeline: PipelineConfig | Record<string, unknown>; source?: string }): Promise<Record<string, unknown>> {
 		const { pipeline, source } = options;
 		const arguments_: Record<string, unknown> = { pipeline };
 		if (source !== undefined) {
 			arguments_.source = source;
 		}
 		const request = this.buildRequest('rrext_validate', {
-			arguments: arguments_
+			arguments: arguments_,
 		});
 		const response = await this.request(request);
 		if (this.didFail(response)) {
@@ -845,29 +825,21 @@ export class RocketRideClient extends DAPClient {
 	 * const result = await client.use({ filepath: './chat.pipe', useExisting: true });
 	 * ```
 	 */
-	async use(options: {
-		token?: string;
-		filepath?: string;
-		pipeline?: PipelineConfig;
-		source?: string;
-		threads?: number;
-		useExisting?: boolean;
-		args?: string[];
-		ttl?: number;
-		/** Pipeline trace level. When set, captures every lane write and invoke call in the response under '_trace'. */
-		pipelineTraceLevel?: 'none' | 'metadata' | 'summary' | 'full';
-	} = {}): Promise<Record<string, unknown> & { token: string }> {
-		const {
-			token,
-			filepath,
-			pipeline,
-			source,
-			threads,
-			useExisting,
-			args,
-			ttl,
-			pipelineTraceLevel
-		} = options;
+	async use(
+		options: {
+			token?: string;
+			filepath?: string;
+			pipeline?: PipelineConfig;
+			source?: string;
+			threads?: number;
+			useExisting?: boolean;
+			args?: string[];
+			ttl?: number;
+			/** Pipeline trace level. When set, captures every lane write and invoke call in the response under '_trace'. */
+			pipelineTraceLevel?: 'none' | 'metadata' | 'summary' | 'full';
+		} = {}
+	): Promise<Record<string, unknown> & { token: string }> {
+		const { token, filepath, pipeline, source, threads, useExisting, args, ttl, pipelineTraceLevel } = options;
 
 		// Validate required parameters
 		if (!pipeline && !filepath) {
@@ -1001,26 +973,14 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Create a data pipe for streaming operations.
 	 */
-	async pipe(
-		token: string,
-		objinfo: Record<string, unknown> = {},
-		mimeType?: string,
-		provider?: string,
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
-	): Promise<DataPipe> {
+	async pipe(token: string, objinfo: Record<string, unknown> = {}, mimeType?: string, provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<DataPipe> {
 		return new DataPipe(this, token, objinfo, mimeType, provider, onSSE);
 	}
 
 	/**
 	 * Send data to a running pipeline.
 	 */
-	async send(
-		token: string,
-		data: string | Uint8Array,
-		objinfo: Record<string, unknown> = {},
-		mimetype?: string,
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
-	): Promise<PIPELINE_RESULT | undefined> {
+	async send(token: string, data: string | Uint8Array, objinfo: Record<string, unknown> = {}, mimetype?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<PIPELINE_RESULT | undefined> {
 		// Convert string to bytes if needed
 		let buffer: Uint8Array;
 		if (typeof data === 'string') {
@@ -1053,27 +1013,27 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Upload multiple files to a pipeline with progress tracking and parallel execution.
-	 * 
+	 *
 	 * This method efficiently uploads files in parallel with configurable concurrency control.
 	 * Each file is streamed through a data pipe, and progress events are emitted through the
 	 * event system for all subscribers. The order of results matches the input file order.
-	 * 
+	 *
 	 * Progress events are sent through the event system as 'apaevt_status_upload' events
 	 * (matching Python client behavior) rather than through a callback parameter.
-	 * 
+	 *
 	 * @param files - Array of file objects with optional metadata and MIME types
 	 * @param token - Pipeline task token to receive the uploads
 	 * @param maxConcurrent - Maximum number of concurrent uploads (default: 5)
-	 * 
+	 *
 	 * @returns Promise resolving to array of UPLOAD_RESULT objects in the same order as input
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Subscribe to upload events
 	 * client.on('apaevt_status_upload', (event) => {
 	 *   console.log(`${event.body.filepath}: ${event.body.bytes_sent}/${event.body.file_size}`);
 	 * });
-	 * 
+	 *
 	 * // Upload files
 	 * const results = await client.sendFiles(
 	 *   [
@@ -1104,7 +1064,7 @@ export class RocketRideClient extends DAPClient {
 				event: 'apaevt_status_upload',
 				body: body as unknown as Record<string, unknown>,
 				seq: 0,
-				type: 'event'
+				type: 'event',
 			};
 			this.onEvent(eventMessage);
 		};
@@ -1116,10 +1076,7 @@ export class RocketRideClient extends DAPClient {
 		 * 3. Close pipe
 		 * 4. Send status update
 		 */
-		const uploadFile = async (
-			fileData: { file: File; objinfo?: Record<string, unknown>; mimetype?: string },
-			index: number
-		): Promise<void> => {
+		const uploadFile = async (fileData: { file: File; objinfo?: Record<string, unknown>; mimetype?: string }, index: number): Promise<void> => {
 			const { file, objinfo = {}, mimetype } = fileData;
 			const startTime = Date.now();
 			let bytesUploaded = 0;
@@ -1187,7 +1144,6 @@ export class RocketRideClient extends DAPClient {
 				});
 
 				result = await pipe.close();
-
 			} catch (err) {
 				error = err instanceof Error ? err.message : String(err);
 			}
@@ -1209,8 +1165,8 @@ export class RocketRideClient extends DAPClient {
 		};
 
 		// Create a promise for every file - let server handle queuing
-		const uploadPromises = files.map((fileData, index) => 
-			uploadFile(fileData, index).catch(err => {
+		const uploadPromises = files.map((fileData, index) =>
+			uploadFile(fileData, index).catch((err) => {
 				// Ensure errors don't kill the whole batch
 				console.error(`Upload failed for ${fileData.file.name}:`, err);
 			})
@@ -1229,11 +1185,7 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Ask a question to RocketRide's AI and get an intelligent response.
 	 */
-	async chat(options: {
-		token: string;
-		question: Question;
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
-	}): Promise<PIPELINE_RESULT> {
+	async chat(options: { token: string; question: Question; onSSE?: (type: string, data: Record<string, unknown>) => Promise<void> }): Promise<PIPELINE_RESULT> {
 		const { token, question, onSSE } = options;
 
 		try {
@@ -1268,7 +1220,6 @@ export class RocketRideClient extends DAPClient {
 
 				// Return success response in standard format
 				return result;
-
 			} finally {
 				// Ensure the pipe is properly closed even if errors occur
 				if (pipe.isOpened) {
@@ -1279,7 +1230,6 @@ export class RocketRideClient extends DAPClient {
 					}
 				}
 			}
-
 		} catch (error) {
 			// Return error response in standard format
 			throw new Error(error instanceof Error ? error.message : String(error));
@@ -1458,18 +1408,18 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Save or update a project pipeline.
-	 * 
+	 *
 	 * Stores a project pipeline configuration on the server. If the project
 	 * already exists, it will be updated. Use expectedVersion to ensure
 	 * you're updating the version you expect (prevents conflicts).
-	 * 
+	 *
 	 * @param options - Save project options
 	 * @param options.projectId - Unique identifier for the project
 	 * @param options.pipeline - Pipeline configuration object
 	 * @param options.expectedVersion - Expected current version for atomic updates (optional)
 	 * @returns Promise resolving to save result with success status, projectId, and new version
 	 * @throws Error if save fails due to version mismatch, storage error, or invalid input
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Save a new project
@@ -1481,607 +1431,291 @@ export class RocketRideClient extends DAPClient {
 	 *     components: [...]
 	 *   }
 	 * });
-	 * console.log(`Saved version: ${result.version}`);
-	 * 
-	 * // Update existing project with version check
-	 * const existing = await client.getProject({ projectId: 'proj-123' });
-	 * existing.name = 'Updated Name';
-	 * const updated = await client.saveProject({
-	 *   projectId: 'proj-123',
-	 *   pipeline: existing,
-	 *   expectedVersion: existing.version
-	 * });
 	 * ```
 	 */
-	async saveProject(options: {
-		projectId: string;
-		pipeline: Record<string, any>;
-		expectedVersion?: string;
-	}): Promise<{
-		success: boolean;
-		project_id: string;
-		version: string;
-	}> {
-		const { projectId, pipeline, expectedVersion } = options;
+	async saveProject(options: { projectId: string; pipeline: Record<string, any> }): Promise<void> {
+		if (!options.projectId) throw new Error('projectId is required');
+		if (!options.pipeline || typeof options.pipeline !== 'object') throw new Error('pipeline must be a non-empty object');
 
-		// Validate inputs
-		if (!projectId) {
-			throw new Error('projectId is required');
+		await this.fsWriteJson(`.projects/${options.projectId}.json`, options.pipeline);
+	}
+
+	async getProject(options: { projectId: string }): Promise<Record<string, any>> {
+		if (!options.projectId) throw new Error('projectId is required');
+
+		return this.fsReadJson(`.projects/${options.projectId}.json`);
+	}
+
+	async deleteProject(options: { projectId: string }): Promise<void> {
+		if (!options.projectId) throw new Error('projectId is required');
+
+		await this.fsDelete(`.projects/${options.projectId}.json`);
+	}
+
+	async getAllProjects(): Promise<Array<{ id: string; name: string; sources: any[]; totalComponents: number }>> {
+		const dir = await this.fsListDir('.projects');
+		const projects: Array<{ id: string; name: string; sources: any[]; totalComponents: number }> = [];
+
+		for (const entry of dir.entries) {
+			if (entry.type !== 'file' || !entry.name.endsWith('.json')) continue;
+			try {
+				const id = entry.name.slice(0, -5);
+				const pipeline = await this.fsReadJson(`.projects/${entry.name}`);
+				const sources = (pipeline.components || []).filter((c: any) => c.config?.mode === 'Source').map((c: any) => ({ id: c.id, provider: c.provider, name: c.config?.name || c.id }));
+				projects.push({ id, name: pipeline.name || 'Untitled', sources, totalComponents: (pipeline.components || []).length });
+			} catch {
+				continue;
+			}
 		}
-		if (!pipeline || typeof pipeline !== 'object') {
-			throw new Error('pipeline must be a non-empty object');
+
+		return projects;
+	}
+
+	// ============================================================================
+	// TEMPLATE STORAGE MANAGEMENT (convenience wrappers using fsReadJson/fsWriteJson)
+	// ============================================================================
+
+	async saveTemplate(options: { templateId: string; pipeline: Record<string, any> }): Promise<void> {
+		if (!options.templateId) throw new Error('templateId is required');
+		if (!options.pipeline || typeof options.pipeline !== 'object') throw new Error('pipeline must be a non-empty object');
+
+		await this.fsWriteJson(`.templates/${options.templateId}.json`, options.pipeline);
+	}
+
+	async getTemplate(options: { templateId: string }): Promise<Record<string, any>> {
+		if (!options.templateId) throw new Error('templateId is required');
+
+		return this.fsReadJson(`.templates/${options.templateId}.json`);
+	}
+
+	async deleteTemplate(options: { templateId: string }): Promise<void> {
+		if (!options.templateId) throw new Error('templateId is required');
+
+		await this.fsDelete(`.templates/${options.templateId}.json`);
+	}
+
+	async getAllTemplates(): Promise<Array<{ id: string; name: string; sources: any[]; totalComponents: number }>> {
+		const dir = await this.fsListDir('.templates');
+		const templates: Array<{ id: string; name: string; sources: any[]; totalComponents: number }> = [];
+
+		for (const entry of dir.entries) {
+			if (entry.type !== 'file' || !entry.name.endsWith('.json')) continue;
+			try {
+				const id = entry.name.slice(0, -5);
+				const pipeline = await this.fsReadJson(`.templates/${entry.name}`);
+				const sources = (pipeline.components || []).filter((c: any) => c.config?.mode === 'Source').map((c: any) => ({ id: c.id, provider: c.provider, name: c.config?.name || c.id }));
+				templates.push({ id, name: pipeline.name || 'Untitled', sources, totalComponents: (pipeline.components || []).length });
+			} catch {
+				continue;
+			}
 		}
 
-		// Build request arguments
-		const args: any = {
-			subcommand: 'save_project',
-			projectId,
-			pipeline,
-		};
+		return templates;
+	}
 
-		// Add optional version for atomic updates
-		if (expectedVersion !== undefined) {
-			args.expectedVersion = expectedVersion;
+	// ============================================================================
+	// LOG STORAGE MANAGEMENT (convenience wrappers using fsReadJson/fsWriteJson)
+	// ============================================================================
+
+	async saveLog(options: { projectId: string; source: string; contents: Record<string, any> }): Promise<string> {
+		if (!options.projectId) throw new Error('projectId is required');
+		if (!options.source) throw new Error('source is required');
+		if (!options.contents || typeof options.contents !== 'object') throw new Error('contents must be a non-empty object');
+
+		const startTime = options.contents?.body?.startTime;
+		if (startTime === undefined) throw new Error('contents must contain body.startTime');
+
+		const filename = `${options.source}-${startTime}.log`;
+		await this.fsWriteJson(`.logs/${options.projectId}/${filename}`, options.contents);
+		return filename;
+	}
+
+	async getLog(options: { projectId: string; source: string; startTime: number }): Promise<Record<string, any>> {
+		if (!options.projectId) throw new Error('projectId is required');
+		if (!options.source) throw new Error('source is required');
+		if (options.startTime === undefined || options.startTime === null) throw new Error('startTime is required');
+
+		const filename = `${options.source}-${options.startTime}.log`;
+		return this.fsReadJson(`.logs/${options.projectId}/${filename}`);
+	}
+
+	async listLogs(options: { projectId: string; source?: string }): Promise<string[]> {
+		if (!options.projectId) throw new Error('projectId is required');
+
+		const dir = await this.fsListDir(`.logs/${options.projectId}`);
+		let logs = dir.entries.filter((e) => e.type === 'file' && e.name.endsWith('.log')).map((e) => e.name);
+
+		if (options.source) {
+			logs = logs.filter((f) => f.startsWith(`${options.source}-`));
 		}
 
-		// Send request to server
+		logs.sort();
+		return logs;
+	}
+
+	// ============================================================================
+	// HANDLE-BASED FILE STORE OPERATIONS
+	// ============================================================================
+
+	/**
+	 * Open a file handle for reading or writing.
+	 *
+	 * @param path - Relative path within the account store
+	 * @param mode - 'r' for read, 'w' for write (default: 'r')
+	 * @param offset - Initial byte offset (read mode only)
+	 * @returns Object with 'handle' (string). Read mode also includes 'size' (number).
+	 */
+	async fsOpen(path: string, mode: 'r' | 'w' = 'r', offset?: number): Promise<{ handle: string; size?: number }> {
+		const args: Record<string, unknown> = { subcommand: 'fs_open', path, mode };
+		if (mode === 'r' && offset !== undefined && offset > 0) {
+			args.offset = offset;
+		}
 		const request = this.buildRequest('rrext_store', { arguments: args });
 		const response = await this.request(request);
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to open file');
+		return response.body as { handle: string; size?: number };
+	}
 
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error saving project';
-			this.debugMessage(`Project save failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
+	/**
+	 * Read data from an open read handle.
+	 *
+	 * @param handle - Handle ID returned by fsOpen
+	 * @param length - Max bytes to read (default 4 MB). Empty Uint8Array indicates EOF.
+	 * @returns The bytes read
+	 */
+	async fsRead(handle: string, length: number = 4_194_304): Promise<Uint8Array> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_read', handle, length } });
+		const response = await this.request(request);
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to read from handle');
+		return ((response.arguments as any)?.data as Uint8Array) || new Uint8Array(0);
+	}
 
-		// Extract and return response
-		this.debugMessage(`Project saved successfully: ${projectId}, version: ${response.body?.version}`);
+	/**
+	 * Write data to an open write handle.
+	 *
+	 * @param handle - Handle ID returned by fsOpen
+	 * @param data - Raw bytes to write
+	 * @returns Number of bytes written
+	 */
+	async fsWrite(handle: string, data: Uint8Array): Promise<number> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_write', handle, data } });
+		const response = await this.request(request);
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to write to handle');
+		return (response.body as any)?.bytesWritten ?? 0;
+	}
+
+	/**
+	 * Close a file handle.
+	 *
+	 * @param handle - Handle ID returned by fsOpen
+	 * @param mode - 'r' or 'w' (must match the mode used in fsOpen)
+	 */
+	async fsClose(handle: string, mode: 'r' | 'w'): Promise<void> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_close', handle, mode } });
+		const response = await this.request(request);
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to close handle');
+	}
+
+	/**
+	 * Delete a file.
+	 *
+	 * @param path - Relative path within the account store
+	 * @throws Error if file does not exist or delete fails
+	 */
+	async fsDelete(path: string): Promise<void> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_delete', path } });
+		const response = await this.request(request);
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to delete file');
+	}
+
+	/**
+	 * List immediate children of a directory.
+	 *
+	 * @param path - Relative directory path (default: account root)
+	 * @returns Directory entries with name and type (file or dir)
+	 */
+	async fsListDir(path: string = ''): Promise<{ entries: Array<{ name: string; type: 'file' | 'dir'; modified?: number }>; count: number }> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_list_dir', path } });
+		const response = await this.request(request);
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to list directory');
 		return response.body as any;
 	}
 
 	/**
-	 * Retrieve a project by its ID.
-	 * 
-	 * Fetches the complete pipeline configuration and current version for
-	 * the specified project. Use this before updating to get the current
-	 * version for atomic updates.
-	 * 
-	 * @param options - Get project options
-	 * @param options.projectId - Unique identifier of the project to retrieve
-	 * @returns Promise resolving to project data with success status, pipeline, and version
-	 * @throws Error if project doesn't exist or retrieval fails
-	 * 
-	 * @example
-	 * ```typescript
-	 * // Get a project
-	 * try {
-	 *   const project = await client.getProject({ projectId: 'proj-123' });
-	 *   console.log(`Project: ${project.name}`);
-	 *   console.log(`Version: ${project.version}`);
-	 * } catch (error) {
-	 *   if (error.message.includes('NOT_FOUND')) {
-	 *     console.log("Project doesn't exist");
-	 *   }
-	 * }
-	 * 
-	 * // Before updating - get current version
-	 * const project = await client.getProject({ projectId: 'proj-123' });
-	 * project.name = 'Updated';
-	 * await client.saveProject({
-	 *   projectId: 'proj-123',
-	 *   pipeline: project,
-	 *   expectedVersion: project.version
-	 * });
-	 * ```
+	 * Create a directory.
+	 *
+	 * @param path - Relative directory path
 	 */
-	async getProject(options: {
-		projectId: string;
-	}): Promise<{
-		success: boolean;
-		pipeline: Record<string, any>;
-		version: string;
-	}> {
-		const { projectId } = options;
-
-		// Validate inputs
-		if (!projectId) {
-			throw new Error('projectId is required');
-		}
-
-		// Build request
-		const args = {
-			subcommand: 'get_project',
-			projectId,
-		};
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
+	async fsMkdir(path: string): Promise<void> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_mkdir', path } });
 		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error retrieving project';
-			this.debugMessage(`Project retrieval failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		this.debugMessage(`Project retrieved successfully: ${projectId}`);
-		return response.body as any;
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to create directory');
 	}
 
 	/**
-	 * Delete a project by its ID.
-	 * 
-	 * Permanently removes a project from storage. Optionally verify the
-	 * version before deletion to ensure you're deleting the version you
-	 * expect (prevents accidental deletion of modified projects).
-	 * 
-	 * @param options - Delete project options
-	 * @param options.projectId - Unique identifier of the project to delete
-	 * @param options.expectedVersion - Expected current version for atomic deletion (required)
-	 * @returns Promise resolving to deletion result with success status and message
-	 * @throws Error if project doesn't exist, version mismatch, or deletion fails
-	 * 
-	 * @example
-	 * ```typescript
-	 * // Safe deletion with version check
-	 * const project = await client.getProject({ projectId: 'proj-123' });
-	 * try {
-	 *   const result = await client.deleteProject({
-	 *     projectId: 'proj-123',
-	 *     expectedVersion: project.version
-	 *   });
-	 *   console.log('Project deleted successfully');
-	 * } catch (error) {
-	 *   if (error.message.includes('CONFLICT')) {
-	 *     console.log('Project was modified, deletion cancelled');
-	 *   }
-	 * }
-	 * ```
+	 * Get file or directory metadata.
+	 *
+	 * @param path - Relative path within the account store
+	 * @returns Metadata including existence, type, and modified epoch timestamp (for files)
 	 */
-	async deleteProject(options: {
-		projectId: string;
-		expectedVersion?: string;
-	}): Promise<{
-		success: boolean;
-		message: string;
-	}> {
-		const { projectId, expectedVersion } = options;
-
-		// Validate inputs
-		if (!projectId) {
-			throw new Error('projectId is required');
-		}
-
-		// Build request
-		const args: any = {
-			subcommand: 'delete_project',
-			projectId,
-		};
-
-		// Add optional version for atomic deletion
-		if (expectedVersion !== undefined) {
-			args.expectedVersion = expectedVersion;
-		}
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
+	async fsStat(path: string): Promise<{ exists: boolean; type?: 'file' | 'dir'; modified?: number }> {
+		const request = this.buildRequest('rrext_store', { arguments: { subcommand: 'fs_stat', path } });
 		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error deleting project';
-			this.debugMessage(`Project deletion failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		this.debugMessage(`Project deleted successfully: ${projectId}`);
-		return response.body as any;
-	}
-
-	/**
-	 * List all projects for the current user.
-	 * 
-	 * Retrieves a summary of all projects stored for the authenticated user.
-	 * Each project summary includes the ID, name, list of data sources, and total component count.
-	 * 
-	 * @returns Promise resolving to list result with success status, projects array, and count
-	 * @throws Error if retrieval fails
-	 * 
-	 * @example
-	 * ```typescript
-	 * // List all projects
-	 * const result = await client.getAllProjects();
-	 * console.log(`Found ${result.count} projects:`);
-	 * for (const project of result.projects) {
-	 *   console.log(`- ${project.id}: ${project.name} (${project.totalComponents} components)`);
-	 *   for (const source of project.sources) {
-	 *     console.log(`  * ${source.name} (${source.provider})`);
-	 *   }
-	 * }
-	 * 
-	 * // Find specific project
-	 * const result = await client.getAllProjects();
-	 * const myProject = result.projects.find(p => p.id === 'proj-123');
-	 * ```
-	 */
-	async getAllProjects(): Promise<{
-		success: boolean;
-		projects: Array<{
-			id: string;
-			name: string;
-			sources: Array<{
-				id: string;
-				provider: string;
-				name: string;
-			}>;
-			totalComponents: number;
-		}>;
-		count: number;
-	}> {
-		// Build request
-		const args = {
-			subcommand: 'get_all_projects',
-		};
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error listing projects';
-			this.debugMessage(`Project list retrieval failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		const projectCount = response.body?.count || 0;
-		this.debugMessage(`Projects retrieved successfully: ${projectCount} projects`);
+		if (this.didFail(response)) throw new Error(response.message || 'Failed to stat path');
 		return response.body as any;
 	}
 
 	// ============================================================================
-	// TEMPLATE STORAGE MANAGEMENT (System-wide templates)
+	// CONVENIENCE WRAPPERS (text/JSON over binary, handle open/close internally)
 	// ============================================================================
 
-	/**
-	 * Save or update a template pipeline.
-	 * 
-	 * Stores a template pipeline configuration on the server. Templates are system-wide
-	 * and accessible to all users. If the template already exists, it will be updated.
-	 * Use expectedVersion to ensure you're updating the version you expect.
-	 * 
-	 * @param options - Save template options
-	 * @param options.templateId - Unique identifier for the template
-	 * @param options.pipeline - Pipeline configuration object
-	 * @param options.expectedVersion - Expected current version for atomic updates (optional)
-	 * @returns Promise resolving to save result with success status, templateId, and new version
-	 * @throws Error if save fails due to version mismatch, storage error, or invalid input
-	 */
-	async saveTemplate(options: {
-		templateId: string;
-		pipeline: Record<string, any>;
-		expectedVersion?: string;
-	}): Promise<{
-		success: boolean;
-		template_id: string;
-		version: string;
-	}> {
-		const { templateId, pipeline, expectedVersion } = options;
-
-		// Validate inputs
-		if (!templateId) {
-			throw new Error('templateId is required');
+	/** Read a file as a UTF-8 string. */
+	async fsReadString(path: string): Promise<string> {
+		const { handle } = await this.fsOpen(path, 'r');
+		try {
+			const chunks: Uint8Array[] = [];
+			while (true) {
+				const chunk = await this.fsRead(handle);
+				if (chunk.length === 0) break;
+				chunks.push(chunk);
+			}
+			const total = new Uint8Array(chunks.reduce((n, c) => n + c.length, 0));
+			let offset = 0;
+			for (const chunk of chunks) {
+				total.set(chunk, offset);
+				offset += chunk.length;
+			}
+			return new TextDecoder().decode(total);
+		} finally {
+			await this.fsClose(handle, 'r');
 		}
-		if (!pipeline || typeof pipeline !== 'object') {
-			throw new Error('pipeline must be a non-empty object');
-		}
-
-		// Build request arguments
-		const args: any = {
-			subcommand: 'save_template',
-			templateId,
-			pipeline,
-		};
-
-		// Add optional version for atomic updates
-		if (expectedVersion !== undefined) {
-			args.expectedVersion = expectedVersion;
-		}
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error saving template';
-			this.debugMessage(`Template save failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		this.debugMessage(`Template saved successfully: ${templateId}, version: ${response.body?.version}`);
-		return response.body as any;
 	}
 
-	/**
-	 * Retrieve a template by its ID.
-	 */
-	async getTemplate(options: {
-		templateId: string;
-	}): Promise<{
-		success: boolean;
-		pipeline: Record<string, any>;
-		version: string;
-	}> {
-		const { templateId } = options;
-
-		// Validate inputs
-		if (!templateId) {
-			throw new Error('templateId is required');
+	/** Write a UTF-8 string to a file. */
+	async fsWriteString(path: string, text: string): Promise<void> {
+		const { handle } = await this.fsOpen(path, 'w');
+		try {
+			await this.fsWrite(handle, new TextEncoder().encode(text));
+			await this.fsClose(handle, 'w');
+		} catch (err) {
+			try {
+				await this.fsClose(handle, 'w');
+			} catch {
+				/* best-effort */
+			}
+			throw err;
 		}
-
-		// Build request
-		const args = {
-			subcommand: 'get_template',
-			templateId,
-		};
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error retrieving template';
-			this.debugMessage(`Template retrieval failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		this.debugMessage(`Template retrieved successfully: ${templateId}`);
-		return response.body as any;
 	}
 
-	/**
-	 * Delete a template by its ID.
-	 */
-	async deleteTemplate(options: {
-		templateId: string;
-		expectedVersion?: string;
-	}): Promise<{
-		success: boolean;
-		message: string;
-	}> {
-		const { templateId, expectedVersion } = options;
-
-		// Validate inputs
-		if (!templateId) {
-			throw new Error('templateId is required');
-		}
-
-		// Build request
-		const args: any = {
-			subcommand: 'delete_template',
-			templateId,
-		};
-
-		// Add optional version for atomic deletion
-		if (expectedVersion !== undefined) {
-			args.expectedVersion = expectedVersion;
-		}
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error deleting template';
-			this.debugMessage(`Template deletion failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		this.debugMessage(`Template deleted successfully: ${templateId}`);
-		return response.body as any;
+	/** Read a JSON file. */
+	async fsReadJson<T = any>(path: string): Promise<T> {
+		const text = await this.fsReadString(path);
+		return JSON.parse(text);
 	}
 
-	/**
-	 * List all templates.
-	 */
-	async getAllTemplates(): Promise<{
-		success: boolean;
-		templates: Array<{
-			id: string;
-			name: string;
-			sources: Array<{
-				id: string;
-				provider: string;
-				name: string;
-			}>;
-			totalComponents: number;
-		}>;
-		count: number;
-	}> {
-		// Build request
-		const args = {
-			subcommand: 'get_all_templates',
-		};
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error listing templates';
-			this.debugMessage(`Template list retrieval failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		const templateCount = response.body?.count || 0;
-		this.debugMessage(`Templates retrieved successfully: ${templateCount} templates`);
-		return response.body as any;
-	}
-
-	// ============================================================================
-	// LOG STORAGE MANAGEMENT (Per-project log files for historical tracking)
-	// ============================================================================
-
-	/**
-	 * Save a log file for a source run.
-	 */
-	async saveLog(options: {
-		projectId: string;
-		source: string;
-		contents: Record<string, any>;
-	}): Promise<{
-		success: boolean;
-		filename: string;
-	}> {
-		const { projectId, source, contents } = options;
-
-		// Validate inputs
-		if (!projectId) {
-			throw new Error('projectId is required');
-		}
-		if (!source) {
-			throw new Error('source is required');
-		}
-		if (!contents || typeof contents !== 'object') {
-			throw new Error('contents must be a non-empty object');
-		}
-
-		// Build request arguments
-		const args = {
-			subcommand: 'save_log',
-			projectId,
-			source,
-			contents,
-		};
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error saving log';
-			this.debugMessage(`Log save failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		this.debugMessage(`Log saved successfully: ${response.body?.filename}`);
-		return response.body as any;
-	}
-
-	/**
-	 * Get a log file by source name and start time.
-	 */
-	async getLog(options: {
-		projectId: string;
-		source: string;
-		startTime: number;
-	}): Promise<{
-		success: boolean;
-		contents: Record<string, any>;
-	}> {
-		const { projectId, source, startTime } = options;
-
-		// Validate inputs
-		if (!projectId) {
-			throw new Error('projectId is required');
-		}
-		if (!source) {
-			throw new Error('source is required');
-		}
-		if (startTime === undefined || startTime === null) {
-			throw new Error('startTime is required');
-		}
-
-		// Build request
-		const args = {
-			subcommand: 'get_log',
-			projectId,
-			source,
-			startTime,
-		};
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error retrieving log';
-			this.debugMessage(`Log retrieval failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		this.debugMessage(`Log retrieved successfully: ${projectId}/${source}`);
-		return response.body as any;
-	}
-
-	/**
-	 * List log files for a project.
-	 */
-	async listLogs(options: {
-		projectId: string;
-		source?: string;
-		page?: number;
-	}): Promise<{
-		success: boolean;
-		logs: string[];
-		count: number;
-		total_count: number;
-		page: number;
-		total_pages: number;
-	}> {
-		const { projectId, source, page } = options;
-
-		// Validate inputs
-		if (!projectId) {
-			throw new Error('projectId is required');
-		}
-
-		// Build request
-		const args: any = {
-			subcommand: 'list_logs',
-			projectId,
-		};
-
-		// Add optional parameters
-		if (source !== undefined) {
-			args.source = source;
-		}
-		if (page !== undefined) {
-			args.page = page;
-		}
-
-		// Send request to server
-		const request = this.buildRequest('rrext_store', { arguments: args });
-		const response = await this.request(request);
-
-		// Check for errors
-		if (this.didFail(response)) {
-			const errorMsg = response.message || 'Unknown error listing logs';
-			this.debugMessage(`Log list retrieval failed: ${errorMsg}`);
-			throw new Error(errorMsg);
-		}
-
-		// Extract and return response
-		const logCount = response.body?.total_count || 0;
-		this.debugMessage(`Logs retrieved successfully: ${logCount} logs`);
-		return response.body as any;
+	/** Write an object as JSON. */
+	async fsWriteJson(path: string, obj: any): Promise<void> {
+		await this.fsWriteString(path, JSON.stringify(obj, null, 2));
 	}
 
 	// ============================================================================
@@ -2101,12 +1735,7 @@ export class RocketRideClient extends DAPClient {
 	 * @param timeout - Optional per-request timeout in ms
 	 * @returns The response DAPMessage from the server
 	 */
-	async dapRequest(
-		command: string,
-		args?: Record<string, unknown>,
-		token?: string,
-		timeout?: number
-	): Promise<DAPMessage> {
+	async dapRequest(command: string, args?: Record<string, unknown>, token?: string, timeout?: number): Promise<DAPMessage> {
 		const message = this.buildRequest(command, {
 			arguments: args,
 			token,
@@ -2130,10 +1759,7 @@ export class RocketRideClient extends DAPClient {
 	 * Static factory method for automatic connection management.
 	 * Equivalent to Python's async with pattern
 	 */
-	static async withConnection<T>(
-		config: RocketRideClientConfig,
-		callback: (client: RocketRideClient) => Promise<T>
-	): Promise<T> {
+	static async withConnection<T>(config: RocketRideClientConfig, callback: (client: RocketRideClient) => Promise<T>): Promise<T> {
 		const client = new RocketRideClient(config);
 		try {
 			await client.connect();
@@ -2149,24 +1775,24 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve all available service definitions from the server.
-	 * 
+	 *
 	 * Returns a dictionary containing all service definitions available on
 	 * the connected RocketRide server. Each service definition includes schemas,
 	 * UI schemas, and configuration metadata.
-	 * 
+	 *
 	 * @returns Promise resolving to object mapping service names to their definitions
 	 * @throws Error if the request fails or server returns an error
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Get all available services
 	 * const services = await client.getServices();
-	 * 
+	 *
 	 * // List available service names
 	 * for (const name of Object.keys(services)) {
 	 *   console.log(`Available service: ${name}`);
 	 * }
-	 * 
+	 *
 	 * // Access a specific service's schema
 	 * if (services['ocr']) {
 	 *   console.log('OCR schema:', services['ocr'].schema);
@@ -2192,14 +1818,14 @@ export class RocketRideClient extends DAPClient {
 
 	/**
 	 * Retrieve a specific service definition from the server.
-	 * 
+	 *
 	 * Returns the definition for a specific service (connector) by name.
 	 * The definition includes schemas, UI schemas, and configuration metadata.
-	 * 
+	 *
 	 * @param service - Name of the service to retrieve (e.g., 'ocr', 'embed', 'chat')
 	 * @returns Promise resolving to service definition or undefined if not found
 	 * @throws Error if the request fails or server returns an error
-	 * 
+	 *
 	 * @example
 	 * ```typescript
 	 * // Get OCR service definition
@@ -2219,7 +1845,7 @@ export class RocketRideClient extends DAPClient {
 
 		// Build services request with specific service name
 		const request = this.buildRequest('rrext_services', {
-			arguments: { service }
+			arguments: { service },
 		});
 
 		// Send to server and wait for response

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -1463,7 +1463,8 @@ export class RocketRideClient extends DAPClient {
 				const pipeline = await this.fsReadJson(`.projects/${entry.name}`);
 				const sources = (pipeline.components || []).filter((c: any) => c.config?.mode === 'Source').map((c: any) => ({ id: c.id, provider: c.provider, name: c.config?.name || c.id }));
 				projects.push({ id, name: pipeline.name || 'Untitled', sources, totalComponents: (pipeline.components || []).length });
-			} catch {
+			} catch (err) {
+				console.debug(`[RocketRideClient] Failed to read .projects/${entry.name}:`, err);
 				continue;
 			}
 		}
@@ -1505,7 +1506,8 @@ export class RocketRideClient extends DAPClient {
 				const pipeline = await this.fsReadJson(`.templates/${entry.name}`);
 				const sources = (pipeline.components || []).filter((c: any) => c.config?.mode === 'Source').map((c: any) => ({ id: c.id, provider: c.provider, name: c.config?.name || c.id }));
 				templates.push({ id, name: pipeline.name || 'Untitled', sources, totalComponents: (pipeline.components || []).length });
-			} catch {
+			} catch (err) {
+				console.debug(`[RocketRideClient] Failed to read .templates/${entry.name}:`, err);
 				continue;
 			}
 		}

--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -24,27 +24,22 @@
 
 import { RocketRideClient, Question, TASK_STATE, UPLOAD_RESULT, PIPELINE_RESULT, DAPMessage } from '../src/client';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, jest } from '@jest/globals';
-import { getEchoPipeline } from './echo.pipeline'
+import { getEchoPipeline } from './echo.pipeline';
 import { getChatPipeline } from './chat.pipeline';
 // Skip chat tests when no LLM API key is available (must match env vars used by chat.pipeline.ts)
-const hasLLMKey = !!(
-	process.env.ROCKETRIDE_APIKEY_OPENAI
-	|| process.env.ROCKETRIDE_APIKEY_ANTHROPIC
-	|| process.env.ROCKETRIDE_APIKEY_GEMINI
-	|| process.env.ROCKETRIDE_HOST_OLLAMA
-);
+const hasLLMKey = !!(process.env.ROCKETRIDE_APIKEY_OPENAI || process.env.ROCKETRIDE_APIKEY_ANTHROPIC || process.env.ROCKETRIDE_APIKEY_GEMINI || process.env.ROCKETRIDE_HOST_OLLAMA);
 const describeIfLLM = hasLLMKey ? describe : describe.skip;
 const itIfLLM = hasLLMKey ? it : it.skip;
 
 /**
  * Environment Variables:
- * 
+ *
  * 	ROCKETRIDE_APIKEY - General API key for RocketRide server
  * 	ROCKETRIDE_APIKEY_OPENAI - API key for OpenAI (GPT-4)
  * 	ROCKETRIDE_APIKEY_ANTHROPIC - API key for Anthropic (Claude-3 Sonnet)
  * 	ROCKETRIDE_APIKEY_GEMINI - API key for Gemini (Gemini Pro model)
  * 	ROCKETRIDE_HOST_OLLAMA - Host URL for local Ollama server
- * 
+ *
  *  Note: Only one of the LLM settings needs to be set for chat pipeline tests.
  */
 
@@ -54,7 +49,6 @@ const TEST_CONFIG = {
 	auth: process.env.ROCKETRIDE_APIKEY || 'MYAPIKEY',
 	timeout: 120000, // 120 second timeout for integration tests (CI runners can be slow)
 };
-
 
 async function ensureCleanPipeline(client: RocketRideClient, token: string): Promise<void> {
 	try {
@@ -81,36 +75,49 @@ describe('RocketRideClient Integration Tests', () => {
 	});
 
 	describe('Server Connection', () => {
-		it('should connect to live server', async () => {
-			await client.connect();
-			expect(client.isConnected()).toBe(true);
-		}, TEST_CONFIG.timeout);
+		it(
+			'should connect to live server',
+			async () => {
+				await client.connect();
+				expect(client.isConnected()).toBe(true);
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should disconnect from server', async () => {
-			await client.connect();
-			expect(client.isConnected()).toBe(true);
+		it(
+			'should disconnect from server',
+			async () => {
+				await client.connect();
+				expect(client.isConnected()).toBe(true);
 
-			await client.disconnect();
-			expect(client.isConnected()).toBe(false);
-		}, TEST_CONFIG.timeout);
+				await client.disconnect();
+				expect(client.isConnected()).toBe(false);
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should ping server successfully', async () => {
-			await client.connect();
-			await expect(client.ping()).resolves.not.toThrow();
-		}, TEST_CONFIG.timeout);
+		it(
+			'should ping server successfully',
+			async () => {
+				await client.connect();
+				await expect(client.ping()).resolves.not.toThrow();
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle connection with context manager', async () => {
-			const result = await RocketRideClient.withConnection(
-				TEST_CONFIG,
-				async (connectedClient) => {
+		it(
+			'should handle connection with context manager',
+			async () => {
+				const result = await RocketRideClient.withConnection(TEST_CONFIG, async (connectedClient) => {
 					expect(connectedClient.isConnected()).toBe(true);
 					await connectedClient.ping();
 					return 'success';
-				}
-			);
+				});
 
-			expect(result).toBe('success');
-		}, TEST_CONFIG.timeout);
+				expect(result).toBe('success');
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Pipeline Operations', () => {
@@ -125,18 +132,22 @@ describe('RocketRideClient Integration Tests', () => {
 			await ensureCleanPipeline(client, PIPELINE_TOKEN);
 		});
 
-		it('should start a pipeline', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: PIPELINE_TOKEN,
-			});
+		it(
+			'should start a pipeline',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: PIPELINE_TOKEN,
+				});
 
-			expect(result).toHaveProperty('token');
-			expect(typeof result.token).toBe('string');
-			expect(result.token.length).toBeGreaterThan(0);
+				expect(result).toHaveProperty('token');
+				expect(typeof result.token).toBe('string');
+				expect(result.token.length).toBeGreaterThan(0);
 
-			await client.terminate(result.token);
-		}, TEST_CONFIG.timeout);
+				await client.terminate(result.token);
+			},
+			TEST_CONFIG.timeout
+		);
 
 		it('should get pipeline status', async () => {
 			const result = await client.use({
@@ -164,14 +175,18 @@ describe('RocketRideClient Integration Tests', () => {
 			await client.terminate(result.token);
 		}, 90000);
 
-		it('should terminate a pipeline', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: PIPELINE_TOKEN,
-			});
+		it(
+			'should terminate a pipeline',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: PIPELINE_TOKEN,
+				});
 
-			await expect(client.terminate(result.token)).resolves.not.toThrow();
-		}, TEST_CONFIG.timeout);
+				await expect(client.terminate(result.token)).resolves.not.toThrow();
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Data Operations', () => {
@@ -200,33 +215,36 @@ describe('RocketRideClient Integration Tests', () => {
 			}
 		});
 
-		it('should send text data - no mime type', async () => {
-			const testData = 'Hello from integration test!';
+		it(
+			'should send text data - no mime type',
+			async () => {
+				const testData = 'Hello from integration test!';
 
-			const result = await client.send(pipelineToken, testData);
+				const result = await client.send(pipelineToken, testData);
 
-			expect(result).toBeDefined();
-			expect(typeof result).toBe('object');
+				expect(result).toBeDefined();
+				expect(typeof result).toBe('object');
 
-			if (!result)
-				throw new Error('Result is undefined');
+				if (!result) throw new Error('Result is undefined');
 
-			// Validate basic response structure
-			expect(result.name).toBeDefined();
-			expect(typeof result.name).toBe('string');
-			expect(result.name).toMatch(/^[0-9a-f-]{36}$/); // UUID format
+				// Validate basic response structure
+				expect(result.name).toBeDefined();
+				expect(typeof result.name).toBe('string');
+				expect(result.name).toMatch(/^[0-9a-f-]{36}$/); // UUID format
 
-			expect(result.path).toBeDefined();
-			expect(typeof result.path).toBe('string');
-			expect(result.path).toBe(''); // Should be empty for direct sends
+				expect(result.path).toBeDefined();
+				expect(typeof result.path).toBe('string');
+				expect(result.path).toBe(''); // Should be empty for direct sends
 
-			expect(result.objectId).toBeDefined();
-			expect(typeof result.objectId).toBe('string');
-			expect(result.objectId).toMatch(/^[0-9a-f-]{36}$/); // UUID format
+				expect(result.objectId).toBeDefined();
+				expect(typeof result.objectId).toBe('string');
+				expect(result.objectId).toMatch(/^[0-9a-f-]{36}$/); // UUID format
 
-			// Without MIME type, should not have processed content
-			expect(result.result_types).toBeUndefined();
-		}, TEST_CONFIG.timeout);
+				// Without MIME type, should not have processed content
+				expect(result.result_types).toBeUndefined();
+			},
+			TEST_CONFIG.timeout
+		);
 
 		it('should send text data - with mime type', async () => {
 			const testData = 'Hello from integration test!';
@@ -236,8 +254,7 @@ describe('RocketRideClient Integration Tests', () => {
 			expect(result).toBeDefined();
 			expect(typeof result).toBe('object');
 
-			if (!result)
-				throw new Error('Result is undefined');
+			if (!result) throw new Error('Result is undefined');
 
 			// Validate basic response structure
 			expect(result.name).toBeDefined();
@@ -264,189 +281,193 @@ describe('RocketRideClient Integration Tests', () => {
 			expect(result.text[0]).toContain('Hello from integration test!');
 		}, 90000); // Longer timeout for Windows/CI where send can be slow
 
-		it('should send binary data', async () => {
-			const binaryData = new Uint8Array([72, 101, 108, 108, 111]); // "Hello" in bytes
+		it(
+			'should send binary data',
+			async () => {
+				const binaryData = new Uint8Array([72, 101, 108, 108, 111]); // "Hello" in bytes
 
-			const result = await client.send(pipelineToken, binaryData);
-
-			expect(result).toBeDefined();
-			expect(typeof result).toBe('object');
-
-			if (!result)
-				throw new Error('Result is undefined');
-
-			// Validate basic response structure
-			expect(result.name).toBeDefined();
-			expect(typeof result.name).toBe('string');
-			expect(result.name).toMatch(/^[0-9a-f-]{36}$/);
-
-			expect(result.path).toBeDefined();
-			expect(typeof result.path).toBe('string');
-			expect(result.path).toBe('');
-
-			expect(result.objectId).toBeDefined();
-			expect(typeof result.objectId).toBe('string');
-			expect(result.objectId).toMatch(/^[0-9a-f-]{36}$/);
-
-			// Binary data without MIME type should not have processed content
-			expect(result.result_types).toBeUndefined();
-		}, TEST_CONFIG.timeout);
-
-		it('should use data pipe for streaming', async () => {
-			const pipe = await client.pipe(
-				pipelineToken,
-				{ name: 'test-stream.txt' },
-				'text/plain'
-			);
-
-			await pipe.open();
-
-			const chunks = ['Hello ', 'from ', 'streaming ', 'test!'];
-			for (const chunk of chunks) {
-				await pipe.write(new TextEncoder().encode(chunk));
-			}
-
-			const result = await pipe.close();
-
-			expect(result).toBeDefined();
-			expect(typeof result).toBe('object');
-
-			if (!result)
-				throw new Error('Result is undefined');
-
-			// Should use the provided name instead of UUID for streaming
-			expect(result.name).toBe('test-stream.txt');
-
-			expect(result.path).toBeDefined();
-			expect(typeof result.path).toBe('string');
-			expect(result.path).toBe('');
-
-			expect(result.objectId).toBeDefined();
-			expect(typeof result.objectId).toBe('string');
-			expect(result.objectId).toMatch(/^[0-9a-f-]{36}$/);
-
-			// Streaming with MIME type should have processed content
-			expect(result.result_types).toBeDefined();
-			expect(result.result_types!.text).toBe('text');
-
-			expect(result.text).toBeDefined();
-			expect(Array.isArray(result.text)).toBe(true);
-			expect(result.text.length).toBeGreaterThan(0);
-			expect(result.text[0]).toBe(chunks.join('\n\n') + '\n\n');
-		}, TEST_CONFIG.timeout);
-
-		it('should handle file uploads', async () => {
-			const testContent = 'Test file content for upload';
-			const testFile = new File([testContent], 'test.txt', {
-				type: 'text/plain',
-			});
-
-			const uploadResults: UPLOAD_RESULT[] = await client.sendFiles(
-				[{ file: testFile }],
-				pipelineToken
-			);
-
-			expect(uploadResults).toBeDefined();
-			expect(Array.isArray(uploadResults)).toBe(true);
-			expect(uploadResults).toHaveLength(1);
-
-			const uploadResult = uploadResults[0];
-
-			// Validate UPLOAD_RESULT structure
-			expect(uploadResult.action).toBe('complete');
-			expect(uploadResult.filepath).toBe('test.txt');
-			expect(uploadResult.bytes_sent).toBe(testContent.length);
-			expect(uploadResult.file_size).toBe(testContent.length);
-			expect(typeof uploadResult.upload_time).toBe('number');
-			expect(uploadResult.upload_time).toBeGreaterThan(0);
-			expect(uploadResult.error).toBeUndefined();
-
-			// Validate processing result
-			expect(uploadResult.result).toBeDefined();
-			const processingResult = uploadResult.result!;
-
-			// Should use original filename
-			expect(processingResult.name).toBe('test.txt');
-			expect(processingResult.path).toBe('');
-			expect(processingResult.objectId).toMatch(/^[0-9a-f-]{36}$/);
-
-			// File uploads should have processed content
-			expect(processingResult.result_types).toBeDefined();
-			expect(processingResult.result_types!.text).toBe('text');
-
-			expect(processingResult.text).toBeDefined();
-			expect(Array.isArray(processingResult.text)).toBe(true);
-			expect(processingResult.text).toContain(testContent + '\n\n');
-		}, TEST_CONFIG.timeout);
-
-		it('should handle different result_types field mappings', async () => {
-			const testData = 'Multi-field result type test';
-
-			const result = await client.send(pipelineToken, testData, {}, 'text/plain');
-
-			if (!result)
-				throw new Error('Result is undefined');
-
-			if (result.result_types) {
-				// Check each field exists and has the right type
-				for (const [fieldName, fieldType] of Object.entries(result.result_types)) {
-					expect(result[fieldName]).toBeDefined();
-
-					// For text type fields, should be string arrays
-					if (fieldType === 'text') {
-						expect(Array.isArray(result[fieldName])).toBe(true);
-					}
-				}
-			}
-		}, TEST_CONFIG.timeout);
-
-		it('should handle various MIME types and result structures', async () => {
-			const testCases = [
-				{
-					data: 'Plain text content',
-					mimeType: 'text/plain',
-					description: 'plain text'
-				},
-				{
-					data: JSON.stringify({ message: 'Hello', value: 42 }),
-					mimeType: 'application/json',
-					description: 'JSON data'
-				}
-			];
-
-			for (const testCase of testCases) {
-				const result = await client.send(
-					pipelineToken,
-					testCase.data,
-					{},
-					testCase.mimeType
-				);
+				const result = await client.send(pipelineToken, binaryData);
 
 				expect(result).toBeDefined();
+				expect(typeof result).toBe('object');
 
-				if (!result)
-					throw new Error('Result is undefined');
+				if (!result) throw new Error('Result is undefined');
 
-				// All results should have basic fields
+				// Validate basic response structure
 				expect(result.name).toBeDefined();
+				expect(typeof result.name).toBe('string');
+				expect(result.name).toMatch(/^[0-9a-f-]{36}$/);
+
+				expect(result.path).toBeDefined();
+				expect(typeof result.path).toBe('string');
+				expect(result.path).toBe('');
+
 				expect(result.objectId).toBeDefined();
+				expect(typeof result.objectId).toBe('string');
+				expect(result.objectId).toMatch(/^[0-9a-f-]{36}$/);
+
+				// Binary data without MIME type should not have processed content
+				expect(result.result_types).toBeUndefined();
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should use data pipe for streaming',
+			async () => {
+				const pipe = await client.pipe(pipelineToken, { name: 'test-stream.txt' }, 'text/plain');
+
+				await pipe.open();
+
+				const chunks = ['Hello ', 'from ', 'streaming ', 'test!'];
+				for (const chunk of chunks) {
+					await pipe.write(new TextEncoder().encode(chunk));
+				}
+
+				const result = await pipe.close();
+
+				expect(result).toBeDefined();
+				expect(typeof result).toBe('object');
+
+				if (!result) throw new Error('Result is undefined');
+
+				// Should use the provided name instead of UUID for streaming
+				expect(result.name).toBe('test-stream.txt');
+
+				expect(result.path).toBeDefined();
+				expect(typeof result.path).toBe('string');
+				expect(result.path).toBe('');
+
+				expect(result.objectId).toBeDefined();
+				expect(typeof result.objectId).toBe('string');
+				expect(result.objectId).toMatch(/^[0-9a-f-]{36}$/);
+
+				// Streaming with MIME type should have processed content
+				expect(result.result_types).toBeDefined();
+				expect(result.result_types!.text).toBe('text');
+
+				expect(result.text).toBeDefined();
+				expect(Array.isArray(result.text)).toBe(true);
+				expect(result.text.length).toBeGreaterThan(0);
+				expect(result.text[0]).toBe(chunks.join('\n\n') + '\n\n');
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should handle file uploads',
+			async () => {
+				const testContent = 'Test file content for upload';
+				const testFile = new File([testContent], 'test.txt', {
+					type: 'text/plain',
+				});
+
+				const uploadResults: UPLOAD_RESULT[] = await client.sendFiles([{ file: testFile }], pipelineToken);
+
+				expect(uploadResults).toBeDefined();
+				expect(Array.isArray(uploadResults)).toBe(true);
+				expect(uploadResults).toHaveLength(1);
+
+				const uploadResult = uploadResults[0];
+
+				// Validate UPLOAD_RESULT structure
+				expect(uploadResult.action).toBe('complete');
+				expect(uploadResult.filepath).toBe('test.txt');
+				expect(uploadResult.bytes_sent).toBe(testContent.length);
+				expect(uploadResult.file_size).toBe(testContent.length);
+				expect(typeof uploadResult.upload_time).toBe('number');
+				expect(uploadResult.upload_time).toBeGreaterThan(0);
+				expect(uploadResult.error).toBeUndefined();
+
+				// Validate processing result
+				expect(uploadResult.result).toBeDefined();
+				const processingResult = uploadResult.result!;
+
+				// Should use original filename
+				expect(processingResult.name).toBe('test.txt');
+				expect(processingResult.path).toBe('');
+				expect(processingResult.objectId).toMatch(/^[0-9a-f-]{36}$/);
+
+				// File uploads should have processed content
+				expect(processingResult.result_types).toBeDefined();
+				expect(processingResult.result_types!.text).toBe('text');
+
+				expect(processingResult.text).toBeDefined();
+				expect(Array.isArray(processingResult.text)).toBe(true);
+				expect(processingResult.text).toContain(testContent + '\n\n');
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should handle different result_types field mappings',
+			async () => {
+				const testData = 'Multi-field result type test';
+
+				const result = await client.send(pipelineToken, testData, {}, 'text/plain');
+
+				if (!result) throw new Error('Result is undefined');
 
 				if (result.result_types) {
-					// Check result_types structure
-					expect(typeof result.result_types).toBe('object');
-
-					// Verify fields referenced in result_types actually exist
+					// Check each field exists and has the right type
 					for (const [fieldName, fieldType] of Object.entries(result.result_types)) {
 						expect(result[fieldName]).toBeDefined();
 
-						// Basic type checking
+						// For text type fields, should be string arrays
 						if (fieldType === 'text') {
 							expect(Array.isArray(result[fieldName])).toBe(true);
 						}
 					}
 				}
-			}
-		}, TEST_CONFIG.timeout);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should handle various MIME types and result structures',
+			async () => {
+				const testCases = [
+					{
+						data: 'Plain text content',
+						mimeType: 'text/plain',
+						description: 'plain text',
+					},
+					{
+						data: JSON.stringify({ message: 'Hello', value: 42 }),
+						mimeType: 'application/json',
+						description: 'JSON data',
+					},
+				];
+
+				for (const testCase of testCases) {
+					const result = await client.send(pipelineToken, testCase.data, {}, testCase.mimeType);
+
+					expect(result).toBeDefined();
+
+					if (!result) throw new Error('Result is undefined');
+
+					// All results should have basic fields
+					expect(result.name).toBeDefined();
+					expect(result.objectId).toBeDefined();
+
+					if (result.result_types) {
+						// Check result_types structure
+						expect(typeof result.result_types).toBe('object');
+
+						// Verify fields referenced in result_types actually exist
+						for (const [fieldName, fieldType] of Object.entries(result.result_types)) {
+							expect(result[fieldName]).toBeDefined();
+
+							// Basic type checking
+							if (fieldType === 'text') {
+								expect(Array.isArray(result[fieldName])).toBe(true);
+							}
+						}
+					}
+				}
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describeIfLLM('Chat Operations', () => {
@@ -475,227 +496,250 @@ describe('RocketRideClient Integration Tests', () => {
 			}
 		});
 
-		it('should send simple chat question', async () => {
-			const question = new Question();
-			question.addQuestion('What is 2 + 2?');
+		it(
+			'should send simple chat question',
+			async () => {
+				const question = new Question();
+				question.addQuestion('What is 2 + 2?');
 
-			const response: PIPELINE_RESULT = await client.chat({
-				token: chatToken,
-				question,
-			});
+				const response: PIPELINE_RESULT = await client.chat({
+					token: chatToken,
+					question,
+				});
 
-			expect(response).toBeDefined();
-			expect(typeof response).toBe('object');
+				expect(response).toBeDefined();
+				expect(typeof response).toBe('object');
 
-			// Validate basic response structure
-			expect(response.name).toBeDefined();
-			expect(typeof response.name).toBe('string');
-			expect(response.path).toBeDefined();
-			expect(response.objectId).toBeDefined();
-			expect(response.objectId).toMatch(/^[0-9a-f-]{36}$/);
+				// Validate basic response structure
+				expect(response.name).toBeDefined();
+				expect(typeof response.name).toBe('string');
+				expect(response.path).toBeDefined();
+				expect(response.objectId).toBeDefined();
+				expect(response.objectId).toMatch(/^[0-9a-f-]{36}$/);
 
-			// Chat should have processed content with answers
-			expect(response.result_types).toBeDefined();
-			expect(response.result_types!.answers).toBe('answers');
+				// Chat should have processed content with answers
+				expect(response.result_types).toBeDefined();
+				expect(response.result_types!.answers).toBe('answers');
 
-			// Validate the answers field
-			expect(response.answers).toBeDefined();
-			expect(Array.isArray(response.answers)).toBe(true);
-			expect(response.answers.length).toBeGreaterThan(0);
+				// Validate the answers field
+				expect(response.answers).toBeDefined();
+				expect(Array.isArray(response.answers)).toBe(true);
+				expect(response.answers.length).toBeGreaterThan(0);
 
-			// Check that we got a meaningful answer
-			const answer = response.answers[0];
-			expect(typeof answer).toBe('string');
-			expect(answer.length).toBeGreaterThan(0);
-		}, TEST_CONFIG.timeout);
+				// Check that we got a meaningful answer
+				const answer = response.answers[0];
+				expect(typeof answer).toBe('string');
+				expect(answer.length).toBeGreaterThan(0);
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle JSON response questions', async () => {
-			const question = new Question({ expectJson: true });
-			question.addQuestion('Site the first paragraph of the constitution of the United States');
-			question.addExample('greeting request', { text: 'Hello, world!' });
+		it(
+			'should handle JSON response questions',
+			async () => {
+				const question = new Question({ expectJson: true });
+				question.addQuestion('Site the first paragraph of the constitution of the United States');
+				question.addExample('greeting request', { text: 'Hello, world!' });
 
-			const response: PIPELINE_RESULT = await client.chat({
-				token: chatToken,
-				question,
-			});
+				const response: PIPELINE_RESULT = await client.chat({
+					token: chatToken,
+					question,
+				});
 
-			expect(response).toBeDefined();
-			expect(typeof response).toBe('object');
+				expect(response).toBeDefined();
+				expect(typeof response).toBe('object');
 
-			// Validate basic response structure
-			expect(response.name).toBeDefined();
-			expect(response.path).toBeDefined();
-			expect(response.objectId).toBeDefined();
+				// Validate basic response structure
+				expect(response.name).toBeDefined();
+				expect(response.path).toBeDefined();
+				expect(response.objectId).toBeDefined();
 
-			// Should have answers field
-			expect(response.result_types).toBeDefined();
-			expect(response.result_types!.answers).toBe('answers');
-			expect(response.answers).toBeDefined();
-			expect(Array.isArray(response.answers)).toBe(true);
-			expect(response.answers.length).toBeGreaterThan(0);
+				// Should have answers field
+				expect(response.result_types).toBeDefined();
+				expect(response.result_types!.answers).toBe('answers');
+				expect(response.answers).toBeDefined();
+				expect(Array.isArray(response.answers)).toBe(true);
+				expect(response.answers.length).toBeGreaterThan(0);
 
-			// Validate answer content
-			const answer = response.answers[0];
-			expect(typeof answer).toBe('object');
-			expect(answer).toHaveProperty('text');
-			expect(answer.text.length).toBeGreaterThan(0);
-			expect(answer.text).toContain('We the People');
+				// Validate answer content
+				const answer = response.answers[0];
+				expect(typeof answer).toBe('object');
+				expect(answer).toHaveProperty('text');
+				expect(answer.text.length).toBeGreaterThan(0);
+				expect(answer.text).toContain('We the People');
+			},
+			TEST_CONFIG.timeout
+		);
 
-		}, TEST_CONFIG.timeout);
+		it(
+			'should handle questions with instructions',
+			async () => {
+				const question = new Question();
+				question.addQuestion('Tell me about machine learning');
+				question.addInstruction('Format', 'Keep the response under 100 words');
+				question.addInstruction('Tone', 'Use simple, beginner-friendly language and talk like yoda');
 
-		it('should handle questions with instructions', async () => {
-			const question = new Question();
-			question.addQuestion('Tell me about machine learning');
-			question.addInstruction('Format', 'Keep the response under 100 words');
-			question.addInstruction('Tone', 'Use simple, beginner-friendly language and talk like yoda');
+				const response: PIPELINE_RESULT = await client.chat({
+					token: chatToken,
+					question,
+				});
 
-			const response: PIPELINE_RESULT = await client.chat({
-				token: chatToken,
-				question,
-			});
+				expect(response).toBeDefined();
+				expect(typeof response).toBe('object');
 
-			expect(response).toBeDefined();
-			expect(typeof response).toBe('object');
+				// Validate basic response structure
+				expect(response.name).toBeDefined();
+				expect(response.path).toBeDefined();
+				expect(response.objectId).toBeDefined();
 
-			// Validate basic response structure
-			expect(response.name).toBeDefined();
-			expect(response.path).toBeDefined();
-			expect(response.objectId).toBeDefined();
+				// Should have answers field
+				expect(response.result_types).toBeDefined();
+				expect(response.result_types!.answers).toBe('answers');
+				expect(response.answers).toBeDefined();
+				expect(Array.isArray(response.answers)).toBe(true);
+				expect(response.answers.length).toBeGreaterThan(0);
 
-			// Should have answers field
-			expect(response.result_types).toBeDefined();
-			expect(response.result_types!.answers).toBe('answers');
-			expect(response.answers).toBeDefined();
-			expect(Array.isArray(response.answers)).toBe(true);
-			expect(response.answers.length).toBeGreaterThan(0);
+				// Check that we got a meaningful answer
+				const answer = response.answers[0];
+				expect(typeof answer).toBe('string');
+				expect(answer.length).toBeGreaterThan(0);
+			},
+			TEST_CONFIG.timeout
+		);
 
-			// Check that we got a meaningful answer
-			const answer = response.answers[0];
-			expect(typeof answer).toBe('string');
-			expect(answer.length).toBeGreaterThan(0);
-		}, TEST_CONFIG.timeout);
+		it(
+			'should handle questions with context',
+			async () => {
+				const question = new Question();
+				question.addContext('This is a test environment');
+				question.addContext('The user is learning about the RocketRide SDK');
+				question.addQuestion('Explain what just happened in this interaction');
 
-		it('should handle questions with context', async () => {
-			const question = new Question();
-			question.addContext('This is a test environment');
-			question.addContext('The user is learning about the RocketRide SDK');
-			question.addQuestion('Explain what just happened in this interaction');
+				const response: PIPELINE_RESULT = await client.chat({
+					token: chatToken,
+					question,
+				});
 
-			const response: PIPELINE_RESULT = await client.chat({
-				token: chatToken,
-				question,
-			});
+				expect(response).toBeDefined();
+				expect(typeof response).toBe('object');
 
-			expect(response).toBeDefined();
-			expect(typeof response).toBe('object');
+				// Validate basic response structure
+				expect(response.name).toBeDefined();
+				expect(response.path).toBeDefined();
+				expect(response.objectId).toBeDefined();
 
-			// Validate basic response structure
-			expect(response.name).toBeDefined();
-			expect(response.path).toBeDefined();
-			expect(response.objectId).toBeDefined();
+				// Should have answers field
+				expect(response.result_types).toBeDefined();
+				expect(response.result_types!.answers).toBe('answers');
+				expect(response.answers).toBeDefined();
+				expect(Array.isArray(response.answers)).toBe(true);
+				expect(response.answers.length).toBeGreaterThan(0);
 
-			// Should have answers field
-			expect(response.result_types).toBeDefined();
-			expect(response.result_types!.answers).toBe('answers');
-			expect(response.answers).toBeDefined();
-			expect(Array.isArray(response.answers)).toBe(true);
-			expect(response.answers.length).toBeGreaterThan(0);
+				// Check that we got a response
+				const answer = response.answers[0];
+				expect(typeof answer).toBe('string');
+				expect(answer.length).toBeGreaterThan(0);
+			},
+			TEST_CONFIG.timeout
+		);
 
-			// Check that we got a response
-			const answer = response.answers[0];
-			expect(typeof answer).toBe('string');
-			expect(answer.length).toBeGreaterThan(0);
-		}, TEST_CONFIG.timeout);
+		it(
+			'should validate chat response structure matches PIPELINE_RESULT',
+			async () => {
+				const question = new Question();
+				question.addQuestion('What is the weather like today?');
 
-		it('should validate chat response structure matches PIPELINE_RESULT', async () => {
-			const question = new Question();
-			question.addQuestion('What is the weather like today?');
+				const response: PIPELINE_RESULT = await client.chat({
+					token: chatToken,
+					question,
+				});
 
-			const response: PIPELINE_RESULT = await client.chat({
-				token: chatToken,
-				question,
-			});
+				// Verify it's a standard PIPELINE_RESULT
+				expect(response.name).toBeDefined();
+				expect(response.path).toBeDefined();
+				expect(response.objectId).toBeDefined();
 
-			// Verify it's a standard PIPELINE_RESULT
-			expect(response.name).toBeDefined();
-			expect(response.path).toBeDefined();
-			expect(response.objectId).toBeDefined();
+				// Check result_types specifically for chat responses
+				if (response.result_types) {
+					for (const [fieldName, fieldType] of Object.entries(response.result_types)) {
+						expect(response[fieldName]).toBeDefined();
 
-			// Check result_types specifically for chat responses
-			if (response.result_types) {
-				for (const [fieldName, fieldType] of Object.entries(response.result_types)) {
-					expect(response[fieldName]).toBeDefined();
-
-					// For answers type fields, should be string arrays
-					if (fieldType === 'answers') {
-						expect(Array.isArray(response[fieldName])).toBe(true);
-						if (response[fieldName].length > 0) {
-							expect(typeof response[fieldName][0]).toBe('string');
+						// For answers type fields, should be string arrays
+						if (fieldType === 'answers') {
+							expect(Array.isArray(response[fieldName])).toBe(true);
+							if (response[fieldName].length > 0) {
+								expect(typeof response[fieldName][0]).toBe('string');
+							}
 						}
 					}
 				}
-			}
-		}, TEST_CONFIG.timeout);
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Connection Events', () => {
-		it('should call onConnected/onDisconnected callbacks', async () => {
-			const connectedSpy = jest.fn(async (_connectionInfo?: string) => { });
-			const disconnectedSpy = jest.fn(async (_reason?: string, _hasError?: boolean) => { });
+		it(
+			'should call onConnected/onDisconnected callbacks',
+			async () => {
+				const connectedSpy = jest.fn(async (_connectionInfo?: string) => {});
+				const disconnectedSpy = jest.fn(async (_reason?: string, _hasError?: boolean) => {});
 
-			const client = new RocketRideClient({
-				auth: TEST_CONFIG.auth,
-				uri: TEST_CONFIG.uri,
-				onConnected: connectedSpy,
-				onDisconnected: disconnectedSpy,
-			});
+				const client = new RocketRideClient({
+					auth: TEST_CONFIG.auth,
+					uri: TEST_CONFIG.uri,
+					onConnected: connectedSpy,
+					onDisconnected: disconnectedSpy,
+				});
 
+				expect(client.isConnected()).toBe(false);
 
-			expect(client.isConnected()).toBe(false);
-
-			await client.connect();
-			expect(client.isConnected()).toBe(true);
-
-			expect(connectedSpy).toHaveBeenCalledTimes(1);
-			expect(connectedSpy).toHaveBeenCalledWith(expect.any(String));
-			expect(disconnectedSpy).not.toHaveBeenCalled();
-
-			await client.disconnect();
-
-			expect(client.isConnected()).toBe(false);
-
-			expect(disconnectedSpy).toHaveBeenCalledTimes(1);
-			expect(disconnectedSpy).toHaveBeenCalledWith(
-				expect.any(String),
-				false
-			);
-		}, TEST_CONFIG.timeout);
-
-		it('should call onDisconnected with error flag on connection failure', async () => {
-			const connectedSpy = jest.fn(async (_connectionInfo?: string) => { });
-			const disconnectedSpy = jest.fn(async (_reason?: string, _hasError?: boolean) => { });
-
-			// Use an invalid URI that will definitely fail to connect
-			const client = new RocketRideClient({
-				auth: 'INVALID_KEY',
-				uri: 'http://localhost:59999',  // Non-existent server
-				onConnected: connectedSpy,
-				onDisconnected: disconnectedSpy,
-			});
-
-			try {
 				await client.connect();
-			} catch {
-				// Expected to fail
-			}
+				expect(client.isConnected()).toBe(true);
 
-			expect(connectedSpy).not.toHaveBeenCalled();
+				expect(connectedSpy).toHaveBeenCalledTimes(1);
+				expect(connectedSpy).toHaveBeenCalledWith(expect.any(String));
+				expect(disconnectedSpy).not.toHaveBeenCalled();
 
-			if (disconnectedSpy.mock.calls.length > 0) {
-				const [_, hasError] = disconnectedSpy.mock.calls[0];
-				expect(hasError).toBe(true);
-			}
-		}, TEST_CONFIG.timeout);
+				await client.disconnect();
+
+				expect(client.isConnected()).toBe(false);
+
+				expect(disconnectedSpy).toHaveBeenCalledTimes(1);
+				expect(disconnectedSpy).toHaveBeenCalledWith(expect.any(String), false);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should call onDisconnected with error flag on connection failure',
+			async () => {
+				const connectedSpy = jest.fn(async (_connectionInfo?: string) => {});
+				const disconnectedSpy = jest.fn(async (_reason?: string, _hasError?: boolean) => {});
+
+				// Use an invalid URI that will definitely fail to connect
+				const client = new RocketRideClient({
+					auth: 'INVALID_KEY',
+					uri: 'http://localhost:59999', // Non-existent server
+					onConnected: connectedSpy,
+					onDisconnected: disconnectedSpy,
+				});
+
+				try {
+					await client.connect();
+				} catch {
+					// Expected to fail
+				}
+
+				expect(connectedSpy).not.toHaveBeenCalled();
+
+				if (disconnectedSpy.mock.calls.length > 0) {
+					const [_, hasError] = disconnectedSpy.mock.calls[0];
+					expect(hasError).toBe(true);
+				}
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Event Handling', () => {
@@ -735,288 +779,292 @@ describe('RocketRideClient Integration Tests', () => {
 			}
 		});
 
-		it('should subscribe to events and receive them', async () => {
-			await client.setEvents(eventToken, [
-				'summary'
-			]);
+		it(
+			'should subscribe to events and receive them',
+			async () => {
+				await client.setEvents(eventToken, ['summary']);
 
-			await client.send(eventToken, 'Test data for events');
+				await client.send(eventToken, 'Test data for events');
 
-			// Wait with timeout for events
-			const timeout = 10000;
-			const start = Date.now();
+				// Wait with timeout for events
+				const timeout = 10000;
+				const start = Date.now();
 
-			while (receivedEvents.length === 0 && (Date.now() - start) < timeout) {
-				await new Promise(resolve => setTimeout(resolve, 250));
-			}
-
-			// Verify we got events
-			expect(receivedEvents.length).toBeGreaterThanOrEqual(0);
-
-			// If we got events, verify their structure
-			if (receivedEvents.length > 0) {
-				const event = receivedEvents[0];
-				expect(event).toHaveProperty('event');
-				expect(event).toHaveProperty('body');
-				expect(typeof event.event).toBe('string');
-			}
-		}, TEST_CONFIG.timeout);
-
-		it('should receive EVENT_STATUS_UPDATE events with proper structure', async () => {
-			// Subscribe to status update events
-			await client.setEvents(eventToken, ['summary']);
-
-			// Trigger an event by sending data
-			await client.send(eventToken, 'Test data for status updates');
-
-			// Wait for status update events
-			const timeout = 10000;
-			const start = Date.now();
-
-			while (receivedEvents.length === 0 && (Date.now() - start) < timeout) {
-				await new Promise(resolve => setTimeout(resolve, 250));
-			}
-
-			// Find status update events
-			const statusEvents = receivedEvents.filter(event =>
-				event.event === 'apaevt_status_update'
-			);
-
-			if (statusEvents.length > 0) {
-				const statusEvent = statusEvents[0];
-
-				// Verify EVENT_STATUS_UPDATE structure
-				expect(statusEvent.type).toBe('event');
-				expect(statusEvent.event).toBe('apaevt_status_update');
-				expect(statusEvent.body).toBeDefined();
-
-				// Verify TASK_STATUS structure in body
-				const taskStatus = statusEvent.body;
-				expect(taskStatus).toHaveProperty('name');
-				expect(taskStatus).toHaveProperty('project_id');
-				expect(taskStatus).toHaveProperty('source');
-				expect(taskStatus).toHaveProperty('completed');
-				expect(taskStatus).toHaveProperty('state');
-				expect(taskStatus).toHaveProperty('startTime');
-				expect(taskStatus).toHaveProperty('endTime');
-
-				// Verify statistics fields
-				expect(taskStatus).toHaveProperty('totalSize');
-				expect(taskStatus).toHaveProperty('totalCount');
-				expect(taskStatus).toHaveProperty('completedSize');
-				expect(taskStatus).toHaveProperty('completedCount');
-
-				// Verify arrays
-				expect(Array.isArray(taskStatus.warnings)).toBe(true);
-				expect(Array.isArray(taskStatus.errors)).toBe(true);
-				expect(Array.isArray(taskStatus.notes)).toBe(true);
-
-				// Verify pipeline flow structure
-				expect(taskStatus.pipeflow).toBeDefined();
-				expect(taskStatus.pipeflow).toHaveProperty('totalPipes');
-				expect(taskStatus.pipeflow).toHaveProperty('byPipe');
-			}
-		}, TEST_CONFIG.timeout);
-
-		it('should receive EVENT_TASK events with proper structure', async () => {
-			// Subscribe to task lifecycle events  
-			await client.setEvents(eventToken, ['task']);
-
-			// Wait for task events (begin/end events should be sent during pipeline lifecycle)
-			const timeout = 15000;
-			const start = Date.now();
-
-			// Trigger pipeline operations to generate task events
-			await client.send(eventToken, 'Test data for task events');
-
-			while (receivedEvents.length === 0 && (Date.now() - start) < timeout) {
-				await new Promise(resolve => setTimeout(resolve, 250));
-			}
-
-			// Find task events
-			const taskEvents = receivedEvents.filter(event =>
-				event.event === 'apaevt_task'
-			);
-
-			if (taskEvents.length > 0) {
-				const taskEvent = taskEvents[0];
-
-				// Verify basic EVENT_TASK structure
-				expect(taskEvent.type).toBe('event');
-				expect(taskEvent.event).toBe('apaevt_task');
-				expect(taskEvent.body).toBeDefined();
-				expect(taskEvent.body.action).toBeDefined();
-
-				const action = taskEvent.body.action;
-				expect(['running', 'begin', 'end']).toContain(action);
-
-				if (action === 'running') {
-					// Verify 'running' action structure
-					expect(taskEvent.body.tasks).toBeDefined();
-					expect(Array.isArray(taskEvent.body.tasks)).toBe(true);
-
-					if (taskEvent.body.tasks.length > 0) {
-						const taskInfo = taskEvent.body.tasks[0];
-						expect(taskInfo).toHaveProperty('id');
-						expect(taskInfo).toHaveProperty('projectId');
-						expect(taskInfo).toHaveProperty('source');
-						expect(typeof taskInfo.id).toBe('string');
-						expect(typeof taskInfo.projectId).toBe('string');
-						expect(typeof taskInfo.source).toBe('string');
-					}
-				} else if (action === 'begin' || action === 'end') {
-					// Verify 'begin'/'end' action structure
-					expect(taskEvent.id).toBeDefined();
-					expect(typeof taskEvent.id).toBe('string');
-					expect(taskEvent.body.projectId).toBeDefined();
-					expect(taskEvent.body.source).toBeDefined();
-					expect(typeof taskEvent.body.projectId).toBe('string');
-					expect(typeof taskEvent.body.source).toBe('string');
-				}
-			}
-		}, TEST_CONFIG.timeout);
-
-		it('should handle EVENT_TYPE flag combinations correctly', async () => {
-			// Test subscribing to multiple event types using flag combinations
-			// This would require extending the client API to support EVENT_TYPE flags
-			// For now, we test the concept with string arrays
-
-			const eventTypes = [
-				'apaevt_status_update',
-				'apaevt_task'
-			];
-
-			// Setup to receive both event categories
-			await client.setEvents(eventToken, ['summary', 'task']);
-
-			// Trigger various events
-			await client.send(eventToken, 'Test data for multiple event types');
-
-			const timeout = 10000;
-			const start = Date.now();
-
-			while (receivedEvents.length === 0 && (Date.now() - start) < timeout) {
-				await new Promise(resolve => setTimeout(resolve, 250));
-			}
-
-			// Verify we can receive different types of events
-			const eventTypesSeen = new Set(receivedEvents.map(event => event.event));
-
-			// Should have received at least one of the subscribed event types
-			const expectedEvents = new Set(eventTypes);
-			const intersection = new Set([...eventTypesSeen].filter(x => expectedEvents.has(x)));
-
-			expect(intersection.size).toBeGreaterThan(0);
-		}, TEST_CONFIG.timeout);
-
-		it('should validate event structure matches TypeScript definitions', async () => {
-			// Subscribe to all relevant event types
-			await client.setEvents(eventToken, [
-				'summary',
-				'task'
-			]);
-
-			// Trigger events
-			await client.send(eventToken, 'Validation test data');
-
-			const timeout = 10000;
-			const start = Date.now();
-
-			while (receivedEvents.length === 0 && (Date.now() - start) < timeout) {
-				await new Promise(resolve => setTimeout(resolve, 250));
-			}
-
-			// Validate each received event matches our type definitions
-			for (const event of receivedEvents) {
-				// All events should have basic DAP structure
-				expect(event).toHaveProperty('type', 'event');
-				expect(event).toHaveProperty('event');
-				expect(typeof event.event).toBe('string');
-
-				if (event.event === 'apaevt_status_update') {
-					// Validate EVENT_STATUS_UPDATE structure
-					expect(event.body).toBeDefined();
-
-					// Key TASK_STATUS fields that should always be present
-					const requiredFields = [
-						'name', 'project_id', 'source', 'completed', 'state',
-						'startTime', 'endTime', 'debuggerAttached', 'status',
-						'warnings', 'errors', 'currentObject', 'currentSize',
-						'notes', 'totalSize', 'totalCount', 'completedSize',
-						'completedCount', 'failedSize', 'failedCount',
-						'wordsSize', 'wordsCount', 'rateSize', 'rateCount',
-						'serviceUp', 'exitCode', 'exitMessage', 'pipeflow'
-					];
-
-					for (const field of requiredFields) {
-						expect(event.body).toHaveProperty(field);
-					}
-
-					// Validate types for critical fields
-					expect(typeof event.body.name).toBe('string');
-					expect(typeof event.body.project_id).toBe('string');
-					expect(typeof event.body.source).toBe('string');
-					expect(typeof event.body.completed).toBe('boolean');
-					expect(typeof event.body.state).toBe('number');
-					expect(Array.isArray(event.body.warnings)).toBe(true);
-					expect(Array.isArray(event.body.errors)).toBe(true);
-					expect(Array.isArray(event.body.notes)).toBe(true);
+				while (receivedEvents.length === 0 && Date.now() - start < timeout) {
+					await new Promise((resolve) => setTimeout(resolve, 250));
 				}
 
-				if (event.event === 'apaevt_task') {
-					// Validate EVENT_TASK structure
-					expect(event.body).toBeDefined();
-					expect(event.body.action).toBeDefined();
-					expect(['running', 'begin', 'end']).toContain(event.body.action);
+				// Verify we got events
+				expect(receivedEvents.length).toBeGreaterThanOrEqual(0);
 
-					if (event.body.action === 'running') {
-						expect(event.body.tasks).toBeDefined();
-						expect(Array.isArray(event.body.tasks)).toBe(true);
-					} else {
-						expect(event.id).toBeDefined();
-						expect(typeof event.id).toBe('string');
-						expect(event.body.projectId).toBeDefined();
-						expect(event.body.source).toBeDefined();
+				// If we got events, verify their structure
+				if (receivedEvents.length > 0) {
+					const event = receivedEvents[0];
+					expect(event).toHaveProperty('event');
+					expect(event).toHaveProperty('body');
+					expect(typeof event.event).toBe('string');
+				}
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should receive EVENT_STATUS_UPDATE events with proper structure',
+			async () => {
+				// Subscribe to status update events
+				await client.setEvents(eventToken, ['summary']);
+
+				// Trigger an event by sending data
+				await client.send(eventToken, 'Test data for status updates');
+
+				// Wait for status update events
+				const timeout = 10000;
+				const start = Date.now();
+
+				while (receivedEvents.length === 0 && Date.now() - start < timeout) {
+					await new Promise((resolve) => setTimeout(resolve, 250));
+				}
+
+				// Find status update events
+				const statusEvents = receivedEvents.filter((event) => event.event === 'apaevt_status_update');
+
+				if (statusEvents.length > 0) {
+					const statusEvent = statusEvents[0];
+
+					// Verify EVENT_STATUS_UPDATE structure
+					expect(statusEvent.type).toBe('event');
+					expect(statusEvent.event).toBe('apaevt_status_update');
+					expect(statusEvent.body).toBeDefined();
+
+					// Verify TASK_STATUS structure in body
+					const taskStatus = statusEvent.body;
+					expect(taskStatus).toHaveProperty('name');
+					expect(taskStatus).toHaveProperty('project_id');
+					expect(taskStatus).toHaveProperty('source');
+					expect(taskStatus).toHaveProperty('completed');
+					expect(taskStatus).toHaveProperty('state');
+					expect(taskStatus).toHaveProperty('startTime');
+					expect(taskStatus).toHaveProperty('endTime');
+
+					// Verify statistics fields
+					expect(taskStatus).toHaveProperty('totalSize');
+					expect(taskStatus).toHaveProperty('totalCount');
+					expect(taskStatus).toHaveProperty('completedSize');
+					expect(taskStatus).toHaveProperty('completedCount');
+
+					// Verify arrays
+					expect(Array.isArray(taskStatus.warnings)).toBe(true);
+					expect(Array.isArray(taskStatus.errors)).toBe(true);
+					expect(Array.isArray(taskStatus.notes)).toBe(true);
+
+					// Verify pipeline flow structure
+					expect(taskStatus.pipeflow).toBeDefined();
+					expect(taskStatus.pipeflow).toHaveProperty('totalPipes');
+					expect(taskStatus.pipeflow).toHaveProperty('byPipe');
+				}
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should receive EVENT_TASK events with proper structure',
+			async () => {
+				// Subscribe to task lifecycle events
+				await client.setEvents(eventToken, ['task']);
+
+				// Wait for task events (begin/end events should be sent during pipeline lifecycle)
+				const timeout = 15000;
+				const start = Date.now();
+
+				// Trigger pipeline operations to generate task events
+				await client.send(eventToken, 'Test data for task events');
+
+				while (receivedEvents.length === 0 && Date.now() - start < timeout) {
+					await new Promise((resolve) => setTimeout(resolve, 250));
+				}
+
+				// Find task events
+				const taskEvents = receivedEvents.filter((event) => event.event === 'apaevt_task');
+
+				if (taskEvents.length > 0) {
+					const taskEvent = taskEvents[0];
+
+					// Verify basic EVENT_TASK structure
+					expect(taskEvent.type).toBe('event');
+					expect(taskEvent.event).toBe('apaevt_task');
+					expect(taskEvent.body).toBeDefined();
+					expect(taskEvent.body.action).toBeDefined();
+
+					const action = taskEvent.body.action;
+					expect(['running', 'begin', 'end']).toContain(action);
+
+					if (action === 'running') {
+						// Verify 'running' action structure
+						expect(taskEvent.body.tasks).toBeDefined();
+						expect(Array.isArray(taskEvent.body.tasks)).toBe(true);
+
+						if (taskEvent.body.tasks.length > 0) {
+							const taskInfo = taskEvent.body.tasks[0];
+							expect(taskInfo).toHaveProperty('id');
+							expect(taskInfo).toHaveProperty('projectId');
+							expect(taskInfo).toHaveProperty('source');
+							expect(typeof taskInfo.id).toBe('string');
+							expect(typeof taskInfo.projectId).toBe('string');
+							expect(typeof taskInfo.source).toBe('string');
+						}
+					} else if (action === 'begin' || action === 'end') {
+						// Verify 'begin'/'end' action structure
+						expect(taskEvent.id).toBeDefined();
+						expect(typeof taskEvent.id).toBe('string');
+						expect(taskEvent.body.projectId).toBeDefined();
+						expect(taskEvent.body.source).toBeDefined();
+						expect(typeof taskEvent.body.projectId).toBe('string');
+						expect(typeof taskEvent.body.source).toBe('string');
 					}
 				}
-			}
-		}, TEST_CONFIG.timeout);
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle event filtering based on subscription', async () => {
-			// Test that we only receive events we subscribed to
-			await client.setEvents(eventToken, ['summary']);
+		it(
+			'should handle EVENT_TYPE flag combinations correctly',
+			async () => {
+				// Test subscribing to multiple event types using flag combinations
+				// This would require extending the client API to support EVENT_TYPE flags
+				// For now, we test the concept with string arrays
 
-			// Trigger events
-			await client.send(eventToken, 'Filtering test data');
+				const eventTypes = ['apaevt_status_update', 'apaevt_task'];
 
-			const timeout = 10000;
-			const start = Date.now();
+				// Setup to receive both event categories
+				await client.setEvents(eventToken, ['summary', 'task']);
 
-			while (receivedEvents.length === 0 && (Date.now() - start) < timeout) {
-				await new Promise(resolve => setTimeout(resolve, 250));
-			}
+				// Trigger various events
+				await client.send(eventToken, 'Test data for multiple event types');
 
-			// Should have received at least one status_update event
-			const statusEvents = receivedEvents.filter(e => e.event === 'apaevt_status_update');
-			expect(statusEvents.length).toBeGreaterThan(0);
+				const timeout = 10000;
+				const start = Date.now();
 
-			// Clear events and change subscription
-			receivedEvents = [];
-			await client.setEvents(eventToken, ['task']);
+				while (receivedEvents.length === 0 && Date.now() - start < timeout) {
+					await new Promise((resolve) => setTimeout(resolve, 250));
+				}
 
-			// Trigger more events
-			await client.send(eventToken, 'Second filtering test');
+				// Verify we can receive different types of events
+				const eventTypesSeen = new Set(receivedEvents.map((event) => event.event));
 
-			// Wait for task events (filter out unsolicited events from other server activity)
-			const start2 = Date.now();
-			while (!receivedEvents.some(e => e.event === 'apaevt_task') && (Date.now() - start2) < timeout) {
-				await new Promise(resolve => setTimeout(resolve, 250));
-			}
+				// Should have received at least one of the subscribed event types
+				const expectedEvents = new Set(eventTypes);
+				const intersection = new Set([...eventTypesSeen].filter((x) => expectedEvents.has(x)));
 
-			// Should have received at least one task event
-			const taskEvents = receivedEvents.filter(e => e.event === 'apaevt_task');
-			expect(taskEvents.length).toBeGreaterThan(0);
-		}, TEST_CONFIG.timeout);
+				expect(intersection.size).toBeGreaterThan(0);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should validate event structure matches TypeScript definitions',
+			async () => {
+				// Subscribe to all relevant event types
+				await client.setEvents(eventToken, ['summary', 'task']);
+
+				// Trigger events
+				await client.send(eventToken, 'Validation test data');
+
+				const timeout = 10000;
+				const start = Date.now();
+
+				while (receivedEvents.length === 0 && Date.now() - start < timeout) {
+					await new Promise((resolve) => setTimeout(resolve, 250));
+				}
+
+				// Validate each received event matches our type definitions
+				for (const event of receivedEvents) {
+					// All events should have basic DAP structure
+					expect(event).toHaveProperty('type', 'event');
+					expect(event).toHaveProperty('event');
+					expect(typeof event.event).toBe('string');
+
+					if (event.event === 'apaevt_status_update') {
+						// Validate EVENT_STATUS_UPDATE structure
+						expect(event.body).toBeDefined();
+
+						// Key TASK_STATUS fields that should always be present
+						const requiredFields = ['name', 'project_id', 'source', 'completed', 'state', 'startTime', 'endTime', 'debuggerAttached', 'status', 'warnings', 'errors', 'currentObject', 'currentSize', 'notes', 'totalSize', 'totalCount', 'completedSize', 'completedCount', 'failedSize', 'failedCount', 'wordsSize', 'wordsCount', 'rateSize', 'rateCount', 'serviceUp', 'exitCode', 'exitMessage', 'pipeflow'];
+
+						for (const field of requiredFields) {
+							expect(event.body).toHaveProperty(field);
+						}
+
+						// Validate types for critical fields
+						expect(typeof event.body.name).toBe('string');
+						expect(typeof event.body.project_id).toBe('string');
+						expect(typeof event.body.source).toBe('string');
+						expect(typeof event.body.completed).toBe('boolean');
+						expect(typeof event.body.state).toBe('number');
+						expect(Array.isArray(event.body.warnings)).toBe(true);
+						expect(Array.isArray(event.body.errors)).toBe(true);
+						expect(Array.isArray(event.body.notes)).toBe(true);
+					}
+
+					if (event.event === 'apaevt_task') {
+						// Validate EVENT_TASK structure
+						expect(event.body).toBeDefined();
+						expect(event.body.action).toBeDefined();
+						expect(['running', 'begin', 'end']).toContain(event.body.action);
+
+						if (event.body.action === 'running') {
+							expect(event.body.tasks).toBeDefined();
+							expect(Array.isArray(event.body.tasks)).toBe(true);
+						} else {
+							expect(event.id).toBeDefined();
+							expect(typeof event.id).toBe('string');
+							expect(event.body.projectId).toBeDefined();
+							expect(event.body.source).toBeDefined();
+						}
+					}
+				}
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should handle event filtering based on subscription',
+			async () => {
+				// Test that we only receive events we subscribed to
+				await client.setEvents(eventToken, ['summary']);
+
+				// Trigger events
+				await client.send(eventToken, 'Filtering test data');
+
+				const timeout = 10000;
+				const start = Date.now();
+
+				while (receivedEvents.length === 0 && Date.now() - start < timeout) {
+					await new Promise((resolve) => setTimeout(resolve, 250));
+				}
+
+				// Should have received at least one status_update event
+				const statusEvents = receivedEvents.filter((e) => e.event === 'apaevt_status_update');
+				expect(statusEvents.length).toBeGreaterThan(0);
+
+				// Clear events and change subscription
+				receivedEvents = [];
+				await client.setEvents(eventToken, ['task']);
+
+				// Trigger more events
+				await client.send(eventToken, 'Second filtering test');
+
+				// Wait for task events (filter out unsolicited events from other server activity)
+				const start2 = Date.now();
+				while (!receivedEvents.some((e) => e.event === 'apaevt_task') && Date.now() - start2 < timeout) {
+					await new Promise((resolve) => setTimeout(resolve, 250));
+				}
+
+				// Should have received at least one task event
+				const taskEvents = receivedEvents.filter((e) => e.event === 'apaevt_task');
+				expect(taskEvents.length).toBeGreaterThan(0);
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Validation Operations', () => {
@@ -1024,70 +1072,86 @@ describe('RocketRideClient Integration Tests', () => {
 			await client.connect();
 		});
 
-		it('should validate echo pipeline with source in config', async () => {
-			const pipeline = getEchoPipeline();
-			const result = await client.validate({ pipeline });
+		it(
+			'should validate echo pipeline with source in config',
+			async () => {
+				const pipeline = getEchoPipeline();
+				const result = await client.validate({ pipeline });
 
-			expect(result).toBeDefined();
-			expect(result).toHaveProperty('pipeline');
-		}, TEST_CONFIG.timeout);
+				expect(result).toBeDefined();
+				expect(result).toHaveProperty('pipeline');
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should validate echo pipeline with explicit source override', async () => {
-			const pipeline = getEchoPipeline();
-			const result = await client.validate({
-				pipeline,
-				source: 'webhook_1',
-			});
+		it(
+			'should validate echo pipeline with explicit source override',
+			async () => {
+				const pipeline = getEchoPipeline();
+				const result = await client.validate({
+					pipeline,
+					source: 'webhook_1',
+				});
 
-			expect(result).toBeDefined();
-			expect(result).toHaveProperty('pipeline');
-		}, TEST_CONFIG.timeout);
+				expect(result).toBeDefined();
+				expect(result).toHaveProperty('pipeline');
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should validate pipeline with implied source from component mode', async () => {
-			// Pipeline with no explicit source field — webhook_1 has config.mode == 'Source'
-			const pipeline = {
-				components: [
-					{
-						id: "webhook_1",
-						provider: "webhook",
-						config: { hideForm: true, mode: "Source", type: "webhook" },
-					},
-					{
-						id: "response_1",
-						provider: "response",
-						config: { lanes: [] },
-						input: [{ lane: "text", from: "webhook_1" }],
-					},
-				],
-				project_id: "e612b741-748c-4b35-a8b7-186797a8ea42",
-			};
+		it(
+			'should validate pipeline with implied source from component mode',
+			async () => {
+				// Pipeline with no explicit source field — webhook_1 has config.mode == 'Source'
+				const pipeline = {
+					components: [
+						{
+							id: 'webhook_1',
+							provider: 'webhook',
+							config: { hideForm: true, mode: 'Source', type: 'webhook' },
+						},
+						{
+							id: 'response_1',
+							provider: 'response',
+							config: { lanes: [] },
+							input: [{ lane: 'text', from: 'webhook_1' }],
+						},
+					],
+					project_id: 'e612b741-748c-4b35-a8b7-186797a8ea42',
+				};
 
-			const result = await client.validate({ pipeline });
+				const result = await client.validate({ pipeline });
 
-			expect(result).toBeDefined();
-			expect(result).toHaveProperty('pipeline');
-		}, TEST_CONFIG.timeout);
+				expect(result).toBeDefined();
+				expect(result).toHaveProperty('pipeline');
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should return errors for invalid pipeline configuration', async () => {
-			const invalidPipeline = {
-				components: [
-					{
-						id: "invalid_1",
-						provider: "nonexistent_provider",
-						config: {},
-					},
-				],
-				source: "invalid_1",
-				project_id: "e612b741-748c-4b35-a8b7-186797a8ea42",
-			};
+		it(
+			'should return errors for invalid pipeline configuration',
+			async () => {
+				const invalidPipeline = {
+					components: [
+						{
+							id: 'invalid_1',
+							provider: 'nonexistent_provider',
+							config: {},
+						},
+					],
+					source: 'invalid_1',
+					project_id: 'e612b741-748c-4b35-a8b7-186797a8ea42',
+				};
 
-			const result = await client.validate({ pipeline: invalidPipeline });
+				const result = await client.validate({ pipeline: invalidPipeline });
 
-			expect(result).toBeDefined();
-			expect(result.errors).toBeDefined();
-			expect(Array.isArray(result.errors)).toBe(true);
-			expect((result.errors as unknown[]).length).toBeGreaterThan(0);
-		}, TEST_CONFIG.timeout);
+				expect(result).toBeDefined();
+				expect(result.errors).toBeDefined();
+				expect(Array.isArray(result.errors)).toBe(true);
+				expect((result.errors as unknown[]).length).toBeGreaterThan(0);
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Error Handling', () => {
@@ -1102,42 +1166,50 @@ describe('RocketRideClient Integration Tests', () => {
 			await ensureCleanPipeline(client, ERROR_TOKEN);
 		});
 
-		it('should handle invalid pipeline configuration', async () => {
-			const invalidPipeline = {
-				components: [
-					{
-						id: "invalid_1",
-						provider: "nonexistent_provider",
-						config: {}
-					}
-				],
-				source: "invalid_1",
-				project_id: "e612b741-748c-4b35-a8b7-186797a8ea42"
-			};
+		it(
+			'should handle invalid pipeline configuration',
+			async () => {
+				const invalidPipeline = {
+					components: [
+						{
+							id: 'invalid_1',
+							provider: 'nonexistent_provider',
+							config: {},
+						},
+					],
+					source: 'invalid_1',
+					project_id: 'e612b741-748c-4b35-a8b7-186797a8ea42',
+				};
 
-			await expect(
-				client.use({ pipeline: invalidPipeline, token: ERROR_TOKEN })
-			).rejects.toThrow();
-		}, TEST_CONFIG.timeout);
+				await expect(client.use({ pipeline: invalidPipeline, token: ERROR_TOKEN })).rejects.toThrow();
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle operations on terminated pipeline', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: ERROR_TOKEN,
-			});
+		it(
+			'should handle operations on terminated pipeline',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: ERROR_TOKEN,
+				});
 
-			await client.terminate(result.token);
+				await client.terminate(result.token);
 
-			await expect(
-				client.send(result.token, 'data')
-			).rejects.toThrow();
-		}, TEST_CONFIG.timeout);
+				await expect(client.send(result.token, 'data')).rejects.toThrow();
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle network disconnection gracefully', async () => {
-			await client.disconnect();
+		it(
+			'should handle network disconnection gracefully',
+			async () => {
+				await client.disconnect();
 
-			await expect(client.ping()).rejects.toThrow();
-		}, TEST_CONFIG.timeout);
+				await expect(client.ping()).rejects.toThrow();
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('End-to-End Workflow', () => {
@@ -1166,344 +1238,351 @@ describe('RocketRideClient Integration Tests', () => {
 			await ensureCleanPipeline(client, `${E2E_TOKEN}-large`);
 		});
 
-		it('should complete full data processing workflow', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: E2E_TOKEN
-			});
-			const token = result.token;
+		it(
+			'should complete full data processing workflow',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: E2E_TOKEN,
+				});
+				const token = result.token;
 
-			await client.setEvents(token, [
-				'summary',
-				'task',
-			]);
+				await client.setEvents(token, ['summary', 'task']);
 
-			const testData = 'hello world from e2e test';
-			const processResult: PIPELINE_RESULT | undefined = await client.send(token, testData, {}, 'text/plain');
+				const testData = 'hello world from e2e test';
+				const processResult: PIPELINE_RESULT | undefined = await client.send(token, testData, {}, 'text/plain');
 
-			const status = await client.getTaskStatus(token);
+				const status = await client.getTaskStatus(token);
 
-			await client.terminate(token);
+				await client.terminate(token);
 
-			// Enhanced validation
-			expect(processResult).toBeDefined();
-			if (!processResult)
-				throw new Error('Process result is undefined');
+				// Enhanced validation
+				expect(processResult).toBeDefined();
+				if (!processResult) throw new Error('Process result is undefined');
 
-			expect(processResult.name).toBeDefined();
-			expect(processResult.objectId).toBeDefined();
-			expect(processResult.result_types).toBeDefined();
-			expect(processResult.text).toBeDefined();
-			expect(processResult.text[0]).toContain(testData);
+				expect(processResult.name).toBeDefined();
+				expect(processResult.objectId).toBeDefined();
+				expect(processResult.result_types).toBeDefined();
+				expect(processResult.text).toBeDefined();
+				expect(processResult.text[0]).toContain(testData);
 
-			expect(status).toHaveProperty('state');
-			expect(Object.values(TASK_STATE)).toContain(status.state);
-			expect(result.token).toBeTruthy();
-		}, TEST_CONFIG.timeout);
+				expect(status).toHaveProperty('state');
+				expect(Object.values(TASK_STATE)).toContain(status.state);
+				expect(result.token).toBeTruthy();
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle complete file upload and processing workflow', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: `${E2E_TOKEN}-file`
-			});
-			const token = result.token;
+		it(
+			'should handle complete file upload and processing workflow',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: `${E2E_TOKEN}-file`,
+				});
+				const token = result.token;
 
-			// Set up event monitoring
-			await client.setEvents(token, [
-				'summary',
-				'task'
-			]);
+				// Set up event monitoring
+				await client.setEvents(token, ['summary', 'task']);
 
-			// Create test file
-			const testContent = `End-to-end file processing test
+				// Create test file
+				const testContent = `End-to-end file processing test
 Line 2: timestamp ${Date.now()}
 Line 3: random data ${Math.random().toString(36).substring(2)}`;
 
-			const testFile = new File([testContent], 'e2e-test.txt', {
-				type: 'text/plain',
-			});
+				const testFile = new File([testContent], 'e2e-test.txt', {
+					type: 'text/plain',
+				});
 
-			// Upload and process file
-			const uploadResults: UPLOAD_RESULT[] = await client.sendFiles(
-				[{ file: testFile }],
-				token
-			);
+				// Upload and process file
+				const uploadResults: UPLOAD_RESULT[] = await client.sendFiles([{ file: testFile }], token);
 
-			// Get final task status
-			const finalStatus = await client.getTaskStatus(token);
+				// Get final task status
+				const finalStatus = await client.getTaskStatus(token);
 
-			await client.terminate(token);
+				await client.terminate(token);
 
-			// Validate complete workflow
-			expect(uploadResults).toHaveLength(1);
-			expect(uploadResults[0].action).toBe('complete');
-			expect(uploadResults[0].result).toBeDefined();
+				// Validate complete workflow
+				expect(uploadResults).toHaveLength(1);
+				expect(uploadResults[0].action).toBe('complete');
+				expect(uploadResults[0].result).toBeDefined();
 
-			const processingResult = uploadResults[0].result!;
-			expect(processingResult.name).toBe('e2e-test.txt');
-			expect(processingResult.result_types!.text).toBe('text');
-			expect(processingResult.text).toBeDefined();
-			expect(processingResult.text[0]).toContain('End-to-end file processing test');
+				const processingResult = uploadResults[0].result!;
+				expect(processingResult.name).toBe('e2e-test.txt');
+				expect(processingResult.result_types!.text).toBe('text');
+				expect(processingResult.text).toBeDefined();
+				expect(processingResult.text[0]).toContain('End-to-end file processing test');
 
-			expect(finalStatus).toHaveProperty('state');
-			expect(finalStatus.completed).toBeDefined();
-		}, TEST_CONFIG.timeout);
+				expect(finalStatus).toHaveProperty('state');
+				expect(finalStatus.completed).toBeDefined();
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle multi-step data processing workflow', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: `${E2E_TOKEN}-multi`
-			});
-			const token = result.token;
+		it(
+			'should handle multi-step data processing workflow',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: `${E2E_TOKEN}-multi`,
+				});
+				const token = result.token;
 
-			await client.setEvents(token, ['summary']);
+				await client.setEvents(token, ['summary']);
 
-			// Step 1: Send initial data
-			const step1Data = 'Step 1: Initial data';
-			const step1Result: PIPELINE_RESULT | undefined = await client.send(token, step1Data, {}, 'text/plain');
+				// Step 1: Send initial data
+				const step1Data = 'Step 1: Initial data';
+				const step1Result: PIPELINE_RESULT | undefined = await client.send(token, step1Data, {}, 'text/plain');
 
-			// Verify step 1
-			if (!step1Result)
-				throw new Error('Step 1 result is undefined');
+				// Verify step 1
+				if (!step1Result) throw new Error('Step 1 result is undefined');
 
-			expect(step1Result.text[0]).toContain(step1Data);
+				expect(step1Result.text[0]).toContain(step1Data);
 
-			// Step 2: Send follow-up data
-			const step2Data = 'Step 2: Follow-up processing';
-			const step2Result: PIPELINE_RESULT | undefined = await client.send(token, step2Data, {}, 'text/plain');
+				// Step 2: Send follow-up data
+				const step2Data = 'Step 2: Follow-up processing';
+				const step2Result: PIPELINE_RESULT | undefined = await client.send(token, step2Data, {}, 'text/plain');
 
-			// Verify step 2
-			if (!step2Result)
-				throw new Error('Step 2 result is undefined');
+				// Verify step 2
+				if (!step2Result) throw new Error('Step 2 result is undefined');
 
-			expect(step2Result.text[0]).toContain(step2Data);
+				expect(step2Result.text[0]).toContain(step2Data);
 
-			// Step 3: Streaming data
-			const pipe = await client.pipe(token, { name: 'step3-stream.txt' }, 'text/plain');
-			await pipe.open();
-			await pipe.write(new TextEncoder().encode('Step 3: Streaming data'));
-			const step3Result: PIPELINE_RESULT | undefined = await pipe.close();
+				// Step 3: Streaming data
+				const pipe = await client.pipe(token, { name: 'step3-stream.txt' }, 'text/plain');
+				await pipe.open();
+				await pipe.write(new TextEncoder().encode('Step 3: Streaming data'));
+				const step3Result: PIPELINE_RESULT | undefined = await pipe.close();
 
-			// Verify step 3
-			if (!step3Result)
-				throw new Error('Step 3 result is undefined');
+				// Verify step 3
+				if (!step3Result) throw new Error('Step 3 result is undefined');
 
-			expect(step3Result.name).toBe('step3-stream.txt');
-			expect(step3Result.text[0]).toContain('Step 3: Streaming data');
+				expect(step3Result.name).toBe('step3-stream.txt');
+				expect(step3Result.text[0]).toContain('Step 3: Streaming data');
 
-			// Verify all three operations produced valid results
-			expect(step1Result.objectId).toMatch(/^[0-9a-f-]{36}$/);
-			expect(step2Result.objectId).toMatch(/^[0-9a-f-]{36}$/);
-			expect(step3Result.objectId).toMatch(/^[0-9a-f-]{36}$/);
+				// Verify all three operations produced valid results
+				expect(step1Result.objectId).toMatch(/^[0-9a-f-]{36}$/);
+				expect(step2Result.objectId).toMatch(/^[0-9a-f-]{36}$/);
+				expect(step3Result.objectId).toMatch(/^[0-9a-f-]{36}$/);
 
-			// Ensure all results are unique
-			const objectIds = [step1Result.objectId, step2Result.objectId, step3Result.objectId];
-			const uniqueIds = new Set(objectIds);
-			expect(uniqueIds.size).toBe(3);
+				// Ensure all results are unique
+				const objectIds = [step1Result.objectId, step2Result.objectId, step3Result.objectId];
+				const uniqueIds = new Set(objectIds);
+				expect(uniqueIds.size).toBe(3);
 
-			await client.terminate(token);
-		}, TEST_CONFIG.timeout);
+				await client.terminate(token);
+			},
+			TEST_CONFIG.timeout
+		);
 
-		itIfLLM('should handle chat workflow with multiple interactions', async () => {
-			const result = await client.use({
-				pipeline: getChatPipeline(),
-				token: `${E2E_TOKEN}-chat`
-			});
-			const token = result.token;
+		itIfLLM(
+			'should handle chat workflow with multiple interactions',
+			async () => {
+				const result = await client.use({
+					pipeline: getChatPipeline(),
+					token: `${E2E_TOKEN}-chat`,
+				});
+				const token = result.token;
 
-			await client.setEvents(token, ['summary', 'task']);
+				await client.setEvents(token, ['summary', 'task']);
 
-			// First chat interaction
-			const question1 = new Question();
-			question1.addQuestion('What is 5 + 3?');
-			const response1: PIPELINE_RESULT = await client.chat({ token, question: question1 });
+				// First chat interaction
+				const question1 = new Question();
+				question1.addQuestion('What is 5 + 3?');
+				const response1: PIPELINE_RESULT = await client.chat({ token, question: question1 });
 
-			expect(response1.result_types!.answers).toBe('answers');
-			expect(response1.answers).toBeDefined();
-			expect(response1.answers[0]).toContain('8');
+				expect(response1.result_types!.answers).toBe('answers');
+				expect(response1.answers).toBeDefined();
+				expect(response1.answers[0]).toContain('8');
 
-			// Second chat interaction with context
-			const question2 = new Question();
-			question2.addContext('We just solved a math problem');
-			question2.addQuestion('What was the previous answer?');
-			const response2: PIPELINE_RESULT = await client.chat({ token, question: question2 });
+				// Second chat interaction with context
+				const question2 = new Question();
+				question2.addContext('We just solved a math problem');
+				question2.addQuestion('What was the previous answer?');
+				const response2: PIPELINE_RESULT = await client.chat({ token, question: question2 });
 
-			expect(response2.answers).toBeDefined();
-			expect(response2.answers.length).toBeGreaterThan(0);
+				expect(response2.answers).toBeDefined();
+				expect(response2.answers.length).toBeGreaterThan(0);
 
-			// Third interaction with JSON expectation
-			const question3 = new Question({ expectJson: true });
-			question3.addQuestion('Return the result of 10 * 2 as JSON');
-			question3.addExample('math result', { result: 20, operation: 'multiplication' });
-			const response3: PIPELINE_RESULT = await client.chat({ token, question: question3 });
+				// Third interaction with JSON expectation
+				const question3 = new Question({ expectJson: true });
+				question3.addQuestion('Return the result of 10 * 2 as JSON');
+				question3.addExample('math result', { result: 20, operation: 'multiplication' });
+				const response3: PIPELINE_RESULT = await client.chat({ token, question: question3 });
 
-			expect(response3.answers).toBeDefined();
-			const answer3 = response3.answers[0];
-			expect(typeof answer3).toBe('object');
-			expect(answer3).toHaveProperty('result');
+				expect(response3.answers).toBeDefined();
+				const answer3 = response3.answers[0];
+				expect(typeof answer3).toBe('object');
+				expect(answer3).toHaveProperty('result');
 
-			// Verify all three chat interactions produced valid results
-			expect(response1.objectId).toMatch(/^[0-9a-f-]{36}$/);
-			expect(response2.objectId).toMatch(/^[0-9a-f-]{36}$/);
-			expect(response3.objectId).toMatch(/^[0-9a-f-]{36}$/);
+				// Verify all three chat interactions produced valid results
+				expect(response1.objectId).toMatch(/^[0-9a-f-]{36}$/);
+				expect(response2.objectId).toMatch(/^[0-9a-f-]{36}$/);
+				expect(response3.objectId).toMatch(/^[0-9a-f-]{36}$/);
 
-			await client.terminate(token);
-		}, TEST_CONFIG.timeout);
+				await client.terminate(token);
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should handle mixed operation workflow with events', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: `${E2E_TOKEN}-mixed`
-			});
-			const token = result.token;
+		it(
+			'should handle mixed operation workflow with events',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: `${E2E_TOKEN}-mixed`,
+				});
+				const token = result.token;
 
-			// Set up comprehensive event monitoring
-			const receivedEvents: any[] = [];
-			const originalClient = client;
+				// Set up comprehensive event monitoring
+				const receivedEvents: any[] = [];
+				const originalClient = client;
 
-			client = new RocketRideClient({
-				auth: TEST_CONFIG.auth,
-				uri: TEST_CONFIG.uri,
-				onEvent: jest.fn(async (event: DAPMessage) => {
-					receivedEvents.push(event);
-				}),
-			});
+				client = new RocketRideClient({
+					auth: TEST_CONFIG.auth,
+					uri: TEST_CONFIG.uri,
+					onEvent: jest.fn(async (event: DAPMessage) => {
+						receivedEvents.push(event);
+					}),
+				});
 
-			await client.connect();
+				await client.connect();
 
-			// Use the same token with new client
-			await client.setEvents(token, [
-				'summary', 'task'
-			]);
+				// Use the same token with new client
+				await client.setEvents(token, ['summary', 'task']);
 
-			// Mixed operations
-			const operations = [
-				// Direct send
-				() => client.send(token, 'Mixed operation 1', {}, 'text/plain'),
+				// Mixed operations
+				const operations = [
+					// Direct send
+					() => client.send(token, 'Mixed operation 1', {}, 'text/plain'),
 
-				// File upload  
-				() => {
-					const file = new File(['Mixed file content'], 'mixed.txt', { type: 'text/plain' });
-					return client.sendFiles([{ file }], token);
-				},
+					// File upload
+					() => {
+						const file = new File(['Mixed file content'], 'mixed.txt', { type: 'text/plain' });
+						return client.sendFiles([{ file }], token);
+					},
 
-				// Streaming
-				async () => {
-					const pipe = await client.pipe(token, { name: 'mixed-stream.txt' }, 'text/plain');
-					await pipe.open();
-					await pipe.write(new TextEncoder().encode('Mixed streaming content'));
-					return await pipe.close();
+					// Streaming
+					async () => {
+						const pipe = await client.pipe(token, { name: 'mixed-stream.txt' }, 'text/plain');
+						await pipe.open();
+						await pipe.write(new TextEncoder().encode('Mixed streaming content'));
+						return await pipe.close();
+					},
+				];
+
+				// Execute operations in sequence
+				const results = [];
+				for (let i = 0; i < operations.length; i++) {
+					const result = await operations[i]();
+					results.push(result);
+
+					// Small delay to ensure events are processed
+					await new Promise((resolve) => setTimeout(resolve, 100));
 				}
-			];
 
-			// Execute operations in sequence
-			const results = [];
-			for (let i = 0; i < operations.length; i++) {
-				const result = await operations[i]();
-				results.push(result);
+				// Wait for events to be received
+				await new Promise((resolve) => setTimeout(resolve, 500));
 
-				// Small delay to ensure events are processed
-				await new Promise(resolve => setTimeout(resolve, 100));
-			}
+				// Validate results
+				expect(results).toHaveLength(3);
 
-			// Wait for events to be received
-			await new Promise(resolve => setTimeout(resolve, 500));
+				// Direct send result
+				const sendResult = results[0] as PIPELINE_RESULT;
+				expect(sendResult.text[0]).toContain('Mixed operation 1');
 
-			// Validate results
-			expect(results).toHaveLength(3);
+				// File upload result
+				const uploadResult = results[1] as UPLOAD_RESULT[];
+				expect(uploadResult[0].result!.text[0]).toContain('Mixed file content');
 
-			// Direct send result
-			const sendResult = results[0] as PIPELINE_RESULT;
-			expect(sendResult.text[0]).toContain('Mixed operation 1');
+				// Stream result
+				const streamResult = results[2] as PIPELINE_RESULT;
+				expect(streamResult.text[0]).toContain('Mixed streaming content');
 
-			// File upload result
-			const uploadResult = results[1] as UPLOAD_RESULT[];
-			expect(uploadResult[0].result!.text[0]).toContain('Mixed file content');
+				// Check that we received events
+				expect(receivedEvents.length).toBeGreaterThan(0);
 
-			// Stream result  
-			const streamResult = results[2] as PIPELINE_RESULT;
-			expect(streamResult.text[0]).toContain('Mixed streaming content');
+				// Verify event types
+				const eventTypes = new Set(receivedEvents.map((e) => e.event));
+				expect(eventTypes.has('apaevt_status_update') || eventTypes.has('apaevt_task')).toBe(true);
 
-			// Check that we received events
-			expect(receivedEvents.length).toBeGreaterThan(0);
+				await client.terminate(token);
+				await client.disconnect();
 
-			// Verify event types
-			const eventTypes = new Set(receivedEvents.map(e => e.event));
-			expect(eventTypes.has('apaevt_status_update') || eventTypes.has('apaevt_task')).toBe(true);
+				// Restore original client
+				client = originalClient;
+			},
+			TEST_CONFIG.timeout
+		);
 
-			await client.terminate(token);
-			await client.disconnect();
+		it(
+			'should handle error recovery workflow',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: `${E2E_TOKEN}-error`,
+				});
+				const token = result.token;
 
-			// Restore original client
-			client = originalClient;
-		}, TEST_CONFIG.timeout);
+				// Send valid data first
+				const validResult: PIPELINE_RESULT | undefined = await client.send(token, 'Valid data before error', {}, 'text/plain');
+				if (!validResult) throw new Error('Process result is undefined');
 
-		it('should handle error recovery workflow', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: `${E2E_TOKEN}-error`
-			});
-			const token = result.token;
+				expect(validResult.text[0]).toContain('Valid data before error');
 
-			// Send valid data first
-			const validResult: PIPELINE_RESULT | undefined = await client.send(token, 'Valid data before error', {}, 'text/plain');
-			if (!validResult)
-				throw new Error('Process result is undefined');
+				// Check status after valid operation
+				const statusAfterValid = await client.getTaskStatus(token);
+				expect(statusAfterValid.errors).toHaveLength(0);
 
-			expect(validResult.text[0]).toContain('Valid data before error');
+				// Try to send data after termination (should fail)
+				await client.terminate(token);
 
-			// Check status after valid operation
-			const statusAfterValid = await client.getTaskStatus(token);
-			expect(statusAfterValid.errors).toHaveLength(0);
+				await expect(client.send(token, 'Data after termination', {}, 'text/plain')).rejects.toThrow();
 
-			// Try to send data after termination (should fail)
-			await client.terminate(token);
+				// Verify the valid operation completed successfully despite later error
+				expect(validResult).toBeDefined();
+				expect(validResult.text[0]).toContain('Valid data before error');
+			},
+			TEST_CONFIG.timeout
+		);
 
-			await expect(
-				client.send(token, 'Data after termination', {}, 'text/plain')
-			).rejects.toThrow();
+		it(
+			'should handle large data workflow',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: `${E2E_TOKEN}-large`,
+				});
+				const token = result.token;
 
-			// Verify the valid operation completed successfully despite later error
-			expect(validResult).toBeDefined();
-			expect(validResult.text[0]).toContain('Valid data before error');
-		}, TEST_CONFIG.timeout);
+				// Generate large text content (10KB)
+				const largeText = Array.from({ length: 1000 }, (_, i) => `Line ${i + 1}: This is a test line with some content to make it longer. Random: ${Math.random()}`).join('\n');
 
-		it('should handle large data workflow', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: `${E2E_TOKEN}-large`
-			});
-			const token = result.token;
+				expect(largeText.length).toBeGreaterThan(10000);
 
-			// Generate large text content (10KB)
-			const largeText = Array.from({ length: 1000 }, (_, i) =>
-				`Line ${i + 1}: This is a test line with some content to make it longer. Random: ${Math.random()}`
-			).join('\n');
+				const startTime = Date.now();
+				const largeResult: PIPELINE_RESULT | undefined = await client.send(token, largeText, {}, 'text/plain');
+				const endTime = Date.now();
 
-			expect(largeText.length).toBeGreaterThan(10000);
+				// Validate large data processing
+				if (!largeResult) throw new Error('Process result is undefined');
 
-			const startTime = Date.now();
-			const largeResult: PIPELINE_RESULT | undefined = await client.send(token, largeText, {}, 'text/plain');
-			const endTime = Date.now();
+				expect(largeResult.text[0]).toContain('Line 1:');
+				expect(largeResult.text[0]).toContain('Line 1000:');
+				expect(largeResult.text[0].length).toBeGreaterThan(10000);
 
-			// Validate large data processing
-			if (!largeResult)
-				throw new Error('Process result is undefined');
+				// Check processing time (should complete reasonably quickly)
+				const processingTime = endTime - startTime;
+				expect(processingTime).toBeLessThan(10000); // Less than 10 seconds
 
-			expect(largeResult.text[0]).toContain('Line 1:');
-			expect(largeResult.text[0]).toContain('Line 1000:');
-			expect(largeResult.text[0].length).toBeGreaterThan(10000);
+				// Get final status to verify task completed
+				const finalStatus = await client.getTaskStatus(token);
+				expect(finalStatus).toHaveProperty('state');
 
-			// Check processing time (should complete reasonably quickly)
-			const processingTime = endTime - startTime;
-			expect(processingTime).toBeLessThan(10000); // Less than 10 seconds
-
-			// Get final status to verify task completed
-			const finalStatus = await client.getTaskStatus(token);
-			expect(finalStatus).toHaveProperty('state');
-
-			await client.terminate(token);
-		}, TEST_CONFIG.timeout);
+				await client.terminate(token);
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Services Operations', () => {
@@ -1511,41 +1590,57 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 			await client.connect();
 		});
 
-		it('should get all services', async () => {
-			const result = await client.getServices();
+		it(
+			'should get all services',
+			async () => {
+				const result = await client.getServices();
 
-			expect(typeof result).toBe('object');
-			expect(result).toHaveProperty('services');
-			expect(typeof result.services).toBe('object');
-			if ('version' in result) {
-				expect(['number', 'string']).toContain(typeof result.version);
-			}
-		}, TEST_CONFIG.timeout);
+				expect(typeof result).toBe('object');
+				expect(result).toHaveProperty('services');
+				expect(typeof result.services).toBe('object');
+				if ('version' in result) {
+					expect(['number', 'string']).toContain(typeof result.version);
+				}
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should get a single service', async () => {
-			const all = await client.getServices();
-			const servicesDict = (all.services as Record<string, unknown>) ?? all;
-			const serviceNames = Object.keys(servicesDict);
-			if (serviceNames.length === 0) {
-				return; // skip if no services available
-			}
+		it(
+			'should get a single service',
+			async () => {
+				const all = await client.getServices();
+				const servicesDict = (all.services as Record<string, unknown>) ?? all;
+				const serviceNames = Object.keys(servicesDict);
+				if (serviceNames.length === 0) {
+					return; // skip if no services available
+				}
 
-			const serviceName = serviceNames[0];
-			const single = await client.getService(serviceName);
+				const serviceName = serviceNames[0];
+				const single = await client.getService(serviceName);
 
-			expect(single).toBeDefined();
-			expect(typeof single).toBe('object');
-			const hasExpectedKey = 'title' in single! || 'protocol' in single! || 'prefix' in single!;
-			expect(hasExpectedKey).toBe(true);
-		}, TEST_CONFIG.timeout);
+				expect(single).toBeDefined();
+				expect(typeof single).toBe('object');
+				const hasExpectedKey = 'title' in single! || 'protocol' in single! || 'prefix' in single!;
+				expect(hasExpectedKey).toBe(true);
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should throw for an unknown service', async () => {
-			await expect(client.getService('nonexistent_service_xyz')).rejects.toThrow();
-		}, TEST_CONFIG.timeout);
+		it(
+			'should throw for an unknown service',
+			async () => {
+				await expect(client.getService('nonexistent_service_xyz')).rejects.toThrow();
+			},
+			TEST_CONFIG.timeout
+		);
 
-		it('should throw when service name is empty', async () => {
-			await expect(client.getService('')).rejects.toThrow(/required/i);
-		}, TEST_CONFIG.timeout);
+		it(
+			'should throw when service name is empty',
+			async () => {
+				await expect(client.getService('')).rejects.toThrow(/required/i);
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 
 	describe('Concurrent Pipeline Operations', () => {
@@ -1587,32 +1682,27 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					return { index, token: result.token };
 				})
 			);
-			pipelineTokens = pipelines.map(p => p.token);
+			pipelineTokens = pipelines.map((p) => p.token);
 
 			// Generate unique test data for each pipeline
 			const testData = pipelines.map((pipeline, index) => ({
 				pipelineIndex: index,
 				token: pipeline.token,
 				text: `Pipeline-${index} unique test data: ${Math.random().toString(36).substring(2)} timestamp-${Date.now()}-${index}`,
-				expectedId: `pipeline-${index}-response`
+				expectedId: `pipeline-${index}-response`,
 			}));
 
 			// Send data to all pipelines concurrently with random delays
 			const sendPromises = testData.map(async (data, _index) => {
 				// Add random delay (0-100ms) to simulate real-world timing variations
-				await new Promise(resolve => setTimeout(resolve, Math.random() * 100));
+				await new Promise((resolve) => setTimeout(resolve, Math.random() * 100));
 
-				const result: PIPELINE_RESULT | undefined = await client.send(
-					data.token,
-					data.text,
-					{},
-					'text/plain'
-				);
+				const result: PIPELINE_RESULT | undefined = await client.send(data.token, data.text, {}, 'text/plain');
 
 				return {
 					pipelineIndex: data.pipelineIndex,
 					originalText: data.text,
-					response: result
+					response: result,
 				};
 			});
 
@@ -1629,8 +1719,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 				// Validate basic response structure
 				expect(response).toBeDefined();
 
-				if (!response)
-					throw new Error('Response is undefined');
+				if (!response) throw new Error('Response is undefined');
 
 				expect(typeof response).toBe('object');
 				expect(response.name).toBeDefined();
@@ -1653,11 +1742,11 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 			}
 
 			// Verify no cross-contamination between pipelines
-			const uniqueTexts = new Set(results.map(r => r.response!.text[0]));
+			const uniqueTexts = new Set(results.map((r) => r.response!.text[0]));
 			expect(uniqueTexts.size).toBe(PIPELINE_COUNT); // All responses should be unique
 
 			// Verify all pipeline indices are represented
-			const pipelineIndices = results.map(r => r.pipelineIndex).sort((a, b) => a - b);
+			const pipelineIndices = results.map((r) => r.pipelineIndex).sort((a, b) => a - b);
 			const expectedIndices = Array.from({ length: PIPELINE_COUNT }, (_, i) => i);
 			expect(pipelineIndices).toEqual(expectedIndices);
 		}, 30000);
@@ -1681,19 +1770,14 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 			// Send all data concurrently to the same pipeline
 			const sendPromises = testData.map(async (data, _index) => {
 				// Add small random delay to simulate real conditions
-				await new Promise(resolve => setTimeout(resolve, Math.random() * 50));
+				await new Promise((resolve) => setTimeout(resolve, Math.random() * 50));
 
-				const response: PIPELINE_RESULT | undefined = await client.send(
-					result.token,
-					data.text,
-					{},
-					'text/plain'
-				);
+				const response: PIPELINE_RESULT | undefined = await client.send(result.token, data.text, {}, 'text/plain');
 
 				return {
 					sendIndex: data.index,
 					originalText: data.text,
-					response
+					response,
 				};
 			});
 
@@ -1707,8 +1791,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 				// Validate basic structure
 				expect(response).toBeDefined();
 
-				if (!response)
-					throw new Error('Response is undefined');
+				if (!response) throw new Error('Response is undefined');
 
 				expect(response.result_types!.text).toBe('text');
 				expect(response.text).toBeDefined();
@@ -1721,7 +1804,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 			}
 
 			// Verify all responses are unique (no cross-contamination)
-			const responseTexts = responses.map(r => r.response!.text[0]);
+			const responseTexts = responses.map((r) => r.response!.text[0]);
 			const uniqueResponseTexts = new Set(responseTexts);
 			expect(uniqueResponseTexts.size).toBe(SEND_COUNT);
 		});
@@ -1741,15 +1824,15 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					return { index, token: result.token };
 				})
 			);
-			pipelineTokens = pipelines.map(p => p.token);
+			pipelineTokens = pipelines.map((p) => p.token);
 
 			// Generate test data for multiple sends per pipeline
-			const allSendPromises = pipelines.flatMap(pipeline =>
+			const allSendPromises = pipelines.flatMap((pipeline) =>
 				Array.from({ length: SENDS_PER_PIPELINE }, (_, sendIndex) => ({
 					pipelineIndex: pipeline.index,
 					sendIndex,
 					token: pipeline.token,
-					text: `Mixed-P${pipeline.index}-S${sendIndex}: ${Math.random().toString(36).substring(2)} time-${Date.now()}-${pipeline.index}-${sendIndex}`
+					text: `Mixed-P${pipeline.index}-S${sendIndex}: ${Math.random().toString(36).substring(2)} time-${Date.now()}-${pipeline.index}-${sendIndex}`,
 				}))
 			);
 
@@ -1757,20 +1840,15 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 			const sendResults = await Promise.all(
 				allSendPromises.map(async (data) => {
 					// Random delay to simulate realistic timing
-					await new Promise(resolve => setTimeout(resolve, Math.random() * 200));
+					await new Promise((resolve) => setTimeout(resolve, Math.random() * 200));
 
-					const response: PIPELINE_RESULT | undefined = await client.send(
-						data.token,
-						data.text,
-						{},
-						'text/plain'
-					);
+					const response: PIPELINE_RESULT | undefined = await client.send(data.token, data.text, {}, 'text/plain');
 
 					return {
 						pipelineIndex: data.pipelineIndex,
 						sendIndex: data.sendIndex,
 						originalText: data.text,
-						response
+						response,
 					};
 				})
 			);
@@ -1780,13 +1858,16 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 			expect(sendResults).toHaveLength(totalExpectedSends);
 
 			// Group results by pipeline to verify separation
-			const resultsByPipeline = sendResults.reduce((acc, result) => {
-				if (!acc[result.pipelineIndex]) {
-					acc[result.pipelineIndex] = [];
-				}
-				acc[result.pipelineIndex].push(result);
-				return acc;
-			}, {} as Record<number, typeof sendResults>);
+			const resultsByPipeline = sendResults.reduce(
+				(acc, result) => {
+					if (!acc[result.pipelineIndex]) {
+						acc[result.pipelineIndex] = [];
+					}
+					acc[result.pipelineIndex].push(result);
+					return acc;
+				},
+				{} as Record<number, typeof sendResults>
+			);
 
 			// Verify each pipeline received exactly the right number of sends
 			for (let i = 0; i < PIPELINE_COUNT; i++) {
@@ -1801,7 +1882,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 			}
 
 			// Verify no cross-contamination - all responses should be unique
-			const allResponseTexts = sendResults.map(r => r.response!.text[0]);
+			const allResponseTexts = sendResults.map((r) => r.response!.text[0]);
 			const uniqueResponseTexts = new Set(allResponseTexts);
 			expect(uniqueResponseTexts.size).toBe(totalExpectedSends);
 		}, 30000);
@@ -1812,7 +1893,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 
 			// Create 4 independent subprocesses concurrently
 			const tokens = Array.from({ length: SUBPROCESS_COUNT }, (_, i) => `${CONCURRENT_TOKEN}-stress-${i}`);
-			await Promise.all(tokens.map(token => client.use({ pipeline: getEchoPipeline(), token })));
+			await Promise.all(tokens.map((token) => client.use({ pipeline: getEchoPipeline(), token })));
 			pipelineTokens.push(...tokens);
 
 			// Each pipeline independently cycles 32 send/recv — all 4 run in parallel
@@ -1828,17 +1909,149 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 				return results;
 			}
 
-			const allResults = await Promise.all(
-				tokens.map((token, i) => runPipeline(token, i))
-			);
+			const allResults = await Promise.all(tokens.map((token, i) => runPipeline(token, i)));
 
 			// All 128 results present
 			expect(allResults.flat()).toHaveLength(SUBPROCESS_COUNT * CYCLES_PER_PIPELINE);
 
 			// All responses unique across all pipelines and cycles
-			const unique = new Set(allResults.flat().map(r => r.response));
+			const unique = new Set(allResults.flat().map((r) => r.response));
 			expect(unique.size).toBe(SUBPROCESS_COUNT * CYCLES_PER_PIPELINE);
 		}, 30000);
+	});
+
+	// ============================================================================
+	// FILE STORE OPERATIONS
+	// ============================================================================
+
+	describe('File Store Operations', () => {
+		const storePrefix = `.test-store/ts-${Date.now()}`;
+
+		function uniquePath(name: string): string {
+			return `${storePrefix}/${name}-${Math.random().toString(36).slice(2, 10)}`;
+		}
+
+		beforeEach(async () => {
+			await client.connect();
+		});
+
+		it(
+			'should write and read via handles',
+			async () => {
+				const path = uniquePath('hw');
+
+				const wInfo = await client.fsOpen(path, 'w');
+				const written = await client.fsWrite(wInfo.handle, new TextEncoder().encode('hello world'));
+				expect(written).toBe(11);
+				await client.fsClose(wInfo.handle, 'w');
+
+				const rInfo = await client.fsOpen(path, 'r');
+				expect(rInfo.size).toBe(11);
+				const data = await client.fsRead(rInfo.handle);
+				expect(new TextDecoder().decode(data)).toBe('hello world');
+				await client.fsClose(rInfo.handle, 'r');
+
+				await client.fsDelete(path);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should write multiple chunks',
+			async () => {
+				const path = uniquePath('chunks');
+
+				const { handle } = await client.fsOpen(path, 'w');
+				for (let i = 0; i < 5; i++) {
+					await client.fsWrite(handle, new TextEncoder().encode(`chunk-${i}-`));
+				}
+				await client.fsClose(handle, 'w');
+
+				const content = await client.fsReadString(path);
+				expect(content).toBe('chunk-0-chunk-1-chunk-2-chunk-3-chunk-4-');
+
+				await client.fsDelete(path);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should read in chunks',
+			async () => {
+				const path = uniquePath('rc');
+				const data = new Uint8Array(1000).fill(88); // 1000 'X' bytes
+
+				const wInfo = await client.fsOpen(path, 'w');
+				await client.fsWrite(wInfo.handle, data);
+				await client.fsClose(wInfo.handle, 'w');
+
+				const rInfo = await client.fsOpen(path, 'r');
+				const chunks: Uint8Array[] = [];
+				while (true) {
+					const chunk = await client.fsRead(rInfo.handle, 300);
+					if (chunk.length === 0) break;
+					chunks.push(chunk);
+				}
+				await client.fsClose(rInfo.handle, 'r');
+
+				const total = chunks.reduce((n, c) => n + c.length, 0);
+				expect(total).toBe(1000);
+				expect(chunks.length).toBe(4); // 300 + 300 + 300 + 100
+
+				await client.fsDelete(path);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should round-trip strings via convenience wrappers',
+			async () => {
+				const path = uniquePath('str');
+
+				await client.fsWriteString(path, 'Hello \u2603 \uD83D\uDE80');
+				const result = await client.fsReadString(path);
+				expect(result).toBe('Hello \u2603 \uD83D\uDE80');
+
+				await client.fsDelete(path);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should round-trip JSON via convenience wrappers',
+			async () => {
+				const path = uniquePath('json');
+				const obj = { name: 'Test', values: [1, 2, 3], nested: { ok: true } };
+
+				await client.fsWriteJson(path, obj);
+				const result = await client.fsReadJson(path);
+				expect(result).toEqual(obj);
+
+				await client.fsDelete(path);
+			},
+			TEST_CONFIG.timeout
+		);
+
+		it(
+			'should stat and delete a file',
+			async () => {
+				const path = uniquePath('stat');
+
+				const { handle } = await client.fsOpen(path, 'w');
+				await client.fsWrite(handle, new TextEncoder().encode('data'));
+				await client.fsClose(handle, 'w');
+
+				const stat1 = await client.fsStat(path);
+				expect(stat1.exists).toBe(true);
+				expect(stat1.type).toBe('file');
+
+				await client.fsDelete(path);
+
+				const stat2 = await client.fsStat(path);
+				expect(stat2.exists).toBe(false);
+			},
+			TEST_CONFIG.timeout
+		);
 	});
 });
 

--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -1925,10 +1925,8 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 	// ============================================================================
 
 	describe('File Store Operations', () => {
-		const storePrefix = `.test-store/ts-${Date.now()}`;
-
 		function uniquePath(name: string): string {
-			return `${storePrefix}/${name}-${Math.random().toString(36).slice(2, 10)}`;
+			return `.test-store/ts-${name}-${Math.random().toString(36).slice(2, 10)}`;
 		}
 
 		beforeEach(async () => {
@@ -1947,7 +1945,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 
 				const rInfo = await client.fsOpen(path, 'r');
 				expect(rInfo.size).toBe(11);
-				const data = await client.fsRead(rInfo.handle);
+				const data = await client.fsRead(rInfo.handle, 0);
 				expect(new TextDecoder().decode(data)).toBe('hello world');
 				await client.fsClose(rInfo.handle, 'r');
 
@@ -1987,10 +1985,12 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 
 				const rInfo = await client.fsOpen(path, 'r');
 				const chunks: Uint8Array[] = [];
+				let offset = 0;
 				while (true) {
-					const chunk = await client.fsRead(rInfo.handle, 300);
+					const chunk = await client.fsRead(rInfo.handle, offset, 300);
 					if (chunk.length === 0) break;
 					chunks.push(chunk);
+					offset += chunk.length;
 				}
 				await client.fsClose(rInfo.handle, 'r');
 


### PR DESCRIPTION
## Summary

- Replaces the monolithic Store class with a generic filesystem-style interface (open/read/write/close) on FileStore, enabling streaming large files without buffering everything in memory
- Each backend uses its native chunked upload API: S3 multipart upload (5 MB buffer), Azure staged blocks (4 MB buffer), filesystem file descriptors
- Domain methods (save_project, get_template, save_log, etc.) become thin client-side convenience wrappers over the generic file operations — the server no longer needs domain-specific subcommands
- Handles are connection-scoped and force-closed on disconnect, committing whatever data has been written

## Test plan

- [x] `builder ai:test` — all 164 passed (server-side store + file_store tests)
- [x] `builder client-python:test` — TestFileStoreOperations passed (live server integration)
- [x] `builder client-typescript:test` — File Store Operations passed (live server integration)
- [ ] Verify S3 multipart threshold with files > 5 MB
- [ ] Verify Azure staged blocks with files > 4 MB
- [ ] Configure S3 lifecycle rule to abort incomplete multipart uploads (infrastructure safety net)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account-scoped file storage: create/read/write/delete files, list directories, mkdir, and view metadata.
  * Streaming handle-based read/write with exclusive write locks and text/JSON helpers.
  * CLI/SDK store commands: dir/type/write/rm/mkdir/stat and handle-based fs APIs.

* **Refactor**
  * Server and client storage moved to per-account file-store model; task/runtime now propagates account context.

* **Tests**
  * New end-to-end and unit tests covering file-store behavior, locks, handles, and client integrations.

* **Chores**
  * Default local storage path changed to ~/.rocketlib/store; added .rocketride/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->