### PR TITLE
fix(ci): add build passthrough for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,28 @@ jobs:
     secrets: inherit
 
   # ---------------------------------------------------------------------------
+  #  Build passthrough — when build is skipped (docs-only PRs), report success
+  #  under the same check names so branch protection required checks pass.
+  # ---------------------------------------------------------------------------
+  build-skip:
+    name: Build / ${{ matrix.label }}
+    needs: [init, changes]
+    if: >-
+      always() &&
+      needs.init.result == 'success' &&
+      github.event_name == 'pull_request' &&
+      needs.changes.outputs.code != 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - label: Ubuntu 22.04
+          - label: Windows Server 2022
+          - label: macOS (ARM64)
+    steps:
+      - run: echo "Build skipped — no code changes detected"
+
+  # ---------------------------------------------------------------------------
   #  CodeQL — scheduled + push only (not on PRs to avoid blocking releases)
   # ---------------------------------------------------------------------------
   codeql:


### PR DESCRIPTION
## Summary
- Docs-only PRs hang forever because branch protection requires `Build / Ubuntu 22.04`, `Build / macOS (ARM64)`, and `Build / Windows Server 2022` checks, but the CI correctly skips builds when no code changes are detected
- Adds a `build-skip` job that reports success under the same check names when the build is skipped, satisfying branch protection without running actual builds
- Fixes #594 and any future docs-only PR being blocked

## Test plan
- [x] Verify `build-skip` job names match required status check names exactly
- [ ] Merge this PR, then confirm PR #594 checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline to skip unnecessary builds for documentation-only changes, providing faster feedback on non-code updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->