### PR TITLE
feat(nodes): add questions lane to webhook source node

### DIFF
--- a/nodes/src/nodes/webhook/services.webhook.json
+++ b/nodes/src/nodes/webhook/services.webhook.json
@@ -66,8 +66,19 @@
 	//		and what it produces
 	//
 	"lanes": {
-		"_source": ["tags", "text", "audio", "video", "image"]
+		"_source": ["tags", "text", "audio", "video", "image", "questions"]
 	},
+	"input": [
+		{
+			"lane": "_source",
+			"output": [
+				{
+					"lane": "questions",
+					"description": "Produces questions to be answered by the pipeline."
+				}
+			]
+		}
+	],
 	//
 	//	Optional:
 	//		Profile section are configuration options used by the driver

--- a/nodes/src/nodes/webhook/services.webhook.json
+++ b/nodes/src/nodes/webhook/services.webhook.json
@@ -73,6 +73,21 @@
 			"lane": "_source",
 			"output": [
 				{
+					"lane": "tags"
+				},
+				{
+					"lane": "text"
+				},
+				{
+					"lane": "audio"
+				},
+				{
+					"lane": "video"
+				},
+				{
+					"lane": "image"
+				},
+				{
 					"lane": "questions",
 					"description": "Produces questions to be answered by the pipeline."
 				}


### PR DESCRIPTION
## Summary
- Add `questions` to the webhook source node's `lanes._source` array and `input` descriptor
- Enables developers to send `application/rocketride-question` payloads to the webhook endpoint and have them route directly to downstream LLM/agent nodes
- No Python code changes needed — `_determine_lane()` already handles the MIME routing

## Type
feature

## Why this feature fits this codebase
The webhook is the correct source node for programmatic question delivery because the developer controls the payload MIME type. Unlike the Dropper (where browser-native MIMEs like `application/pdf` or `image/png` will never match `application/rocketride-question`), webhook consumers can set any MIME type they need.

This aligns with the existing source node separation:
- **Chat** → end-user question UI → `questions` lane
- **Dropper** → end-user file uploads → `raw`/`text`/`image` lanes
- **Webhook** → programmatic/API integration → all lanes including `questions` (this PR)

The `_determine_lane()` function in `data_conn.py` already routes `application/rocketride-question` to the `questions` lane when a listener exists. This PR simply declares the lane in the service descriptor so the VS Code canvas shows the output port and validates connections.

## What changed

| File | Change |
|------|--------|
| `nodes/src/nodes/webhook/services.webhook.json` | Added `questions` to `lanes._source` and added `input` descriptor for the questions output |

## Validation
- [ ] Webhook node shows "questions" output port in VS Code canvas
- [ ] Connection from Webhook → LLM/agent node is valid in the visual builder
- [ ] Sending `application/rocketride-question` payload to webhook endpoint routes to questions lane
- [ ] Existing webhook pipelines using data lanes are unaffected (backward compatible)

## How this could be extended
- Configurable field mapping (e.g. `payload.message` → question lane) could be added in a follow-up to IEndpoint.py
- The same pattern could be applied to add questions lanes to other programmatic source nodes

Closes #402

#Hack-with-bay-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Webhook service can now emit a new "questions" output, enabling pipelines to produce and process question-based content alongside tags, text, audio, video, and images.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->