### PR TITLE
chore: add Discord notifications for PRs, issues, and discussions

### DIFF
--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -1,0 +1,46 @@
+name: Discord Discussion Notification
+
+on:
+  discussion:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK_URL }}
+          DISCUSSION_TITLE: ${{ github.event.discussion.title }}
+          DISCUSSION_URL: ${{ github.event.discussion.html_url }}
+          DISCUSSION_BODY: ${{ github.event.discussion.body }}
+          DISCUSSION_AUTHOR: ${{ github.event.discussion.user.login }}
+          DISCUSSION_AVATAR: ${{ github.event.discussion.user.avatar_url }}
+          DISCUSSION_NUMBER: ${{ github.event.discussion.number }}
+          DISCUSSION_CATEGORY: ${{ github.event.discussion.category.name }}
+        run: |
+          # Truncate body and close unclosed code blocks
+          BODY="${DISCUSSION_BODY:0:1500}"
+          BACKTICK_COUNT=$(echo "$BODY" | grep -o '```' | wc -l)
+          if (( BACKTICK_COUNT % 2 != 0 )); then
+            BODY="${DISCUSSION_BODY:0:1500}..."$'\n```'
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg title "#$DISCUSSION_NUMBER $DISCUSSION_TITLE" \
+            --arg url "$DISCUSSION_URL" \
+            --arg desc "$BODY" \
+            --arg author "$DISCUSSION_AUTHOR" \
+            --arg avatar "$DISCUSSION_AVATAR" \
+            --arg category "$DISCUSSION_CATEGORY" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            '{embeds: [{title: $title, url: $url, description: $desc, color: 10181046,
+               author: {name: $author, url: ("https://github.com/" + $author), icon_url: $avatar},
+               fields: [
+                 {name: "Category", value: $category, inline: true},
+                 {name: "Repo", value: $repo, inline: true}
+               ]}]}')
+          curl -sS -f -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -1,0 +1,43 @@
+name: Discord Issue Notification
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_ISSUES_WEBHOOK_URL }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_AVATAR: ${{ github.event.issue.user.avatar_url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          # Truncate body and close unclosed code blocks
+          BODY="${ISSUE_BODY:0:1500}"
+          BACKTICK_COUNT=$(echo "$BODY" | grep -o '```' | wc -l)
+          if (( BACKTICK_COUNT % 2 != 0 )); then
+            BODY="${ISSUE_BODY:0:1500}..."$'\n```'
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg title "#$ISSUE_NUMBER $ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            --arg desc "$BODY" \
+            --arg author "$ISSUE_AUTHOR" \
+            --arg avatar "$ISSUE_AVATAR" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            '{embeds: [{title: $title, url: $url, description: $desc, color: 15548997,
+               author: {name: $author, url: ("https://github.com/" + $author), icon_url: $avatar},
+               fields: [
+                 {name: "Repo", value: $repo, inline: true}
+               ]}]}')
+          curl -sS -f -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -1,0 +1,49 @@
+name: Discord PR Notification
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          # Truncate body to 1500 chars (leave room for embed fields).
+          # Close any unclosed code blocks to prevent broken formatting.
+          BODY="${PR_BODY:0:1500}"
+          BACKTICK_COUNT=$(echo "$BODY" | grep -o '```' | wc -l)
+          if (( BACKTICK_COUNT % 2 != 0 )); then
+            BODY="${BODY}..."$'\n'"$BODY"'```'
+            BODY="${PR_BODY:0:1500}..."$'\n```'
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg title "#$PR_NUMBER $PR_TITLE" \
+            --arg url "$PR_URL" \
+            --arg desc "$BODY" \
+            --arg author "$PR_AUTHOR" \
+            --arg avatar "$PR_AVATAR" \
+            --arg branch "$HEAD_REF → $BASE_REF" \
+            --arg repo "$GITHUB_REPOSITORY" \
+            '{embeds: [{title: $title, url: $url, description: $desc, color: 5814783,
+               author: {name: $author, url: ("https://github.com/" + $author), icon_url: $avatar},
+               fields: [
+                 {name: "Branch", value: $branch, inline: true},
+                 {name: "Repo", value: $repo, inline: true}
+               ]}]}')
+          curl -sS -f -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## Summary
- Adds 3 GitHub Actions workflows posting to separate Discord channels via webhooks
- **PRs** → `#pr-reviews` (blue embed)
- **Issues** → `#issues` (red embed)  
- **Discussions** → `#discussions` (purple embed)
- Uses `jq` for safe JSON construction (avoids shell escaping issues per Reddit best practices)
- Truncates body to 1500 chars with unclosed code block detection (prevents broken Discord formatting)
- Webhook URLs stored as GitHub Secrets (already configured)

Closes #610

## Test plan
- [ ] Open a test PR → verify Discord `#pr-reviews` embed
- [ ] Open a test issue → verify Discord `#issues` embed
- [ ] Create a test discussion → verify Discord `#discussions` embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Discord notifications for newly created GitHub discussions
  * Integrated Discord notifications for newly opened GitHub issues
  * Integrated Discord notifications for newly opened pull requests
  * Discord messages include relevant details and author information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->