### PR TITLE
feat(discord): add live CI check status and PR state tracking to embed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,3 +214,17 @@ jobs:
           fi
           echo "✅ All CI checks passed (or were correctly skipped)."
           echo "Results: init=${{ needs.init.result }}, changes=${{ needs.changes.result }}, build=${{ needs.build.result }}"
+
+  # ---------------------------------------------------------------------------
+  #  Discord — update PR embed with final check counts after CI completes.
+  # ---------------------------------------------------------------------------
+  discord-notify:
+    needs: [ci-ok]
+    if: always() && github.event_name == 'pull_request'
+    uses: ./.github/workflows/discord-pr.yml
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: read
+    secrets: inherit

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -94,60 +94,59 @@ jobs:
           fi
 
           # ── Fetch check runs + commit statuses for this commit ────────────
-          # On pull_request events, CI checks haven't been created yet (timing
-          # gap), so show a placeholder. The workflow_run trigger fires after
-          # CI completes and will update the embed with accurate counts.
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            CHECKS_FIELD="⏳ Waiting for CI..."
+          # GitHub's PR checks page merges both APIs, so we must too.
+          # Deduplicate check runs by name (keep latest), filter out
+          # unexpanded matrix placeholders.
+          MATRIX_MARKER=$(printf '\044\173\173')
+          # Exclude own check run ("notify") since it's always in-progress
+          # at query time; add it back as success below.
+          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+            --paginate --jq '[.check_runs[]]' 2>/dev/null \
+            | jq -s --arg marker "$MATRIX_MARKER" 'add // []
+              | map(select((.name | contains($marker) | not) and .name != "notify"))
+              | group_by(.name)
+              | map(sort_by(.started_at) | last)
+              | map({name: .name, state: (
+                  if .status != "completed" then "pending"
+                  elif .conclusion == "success" then "success"
+                  elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
+                  else "failure" end
+                )})
+              + [{name: "notify", state: "success"}]')
+
+          # Fetch commit statuses (used by CodeRabbit, external CI, etc.)
+          COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
+            --jq '[.statuses[] | {name: .context, state: (
+                if .state == "success" then "success"
+                elif .state == "pending" then "pending"
+                elif .state == "failure" or .state == "error" then "failure"
+                else "skipped" end
+              )}]' 2>/dev/null || echo '[]')
+
+          # Merge both sources, dedup by name (check runs take priority)
+          ALL_CHECKS=$(echo "$CHECK_RUNS"$'\n'"$COMMIT_STATUSES" \
+            | jq -s 'add // [] | group_by(.name) | map(.[0])')
+
+          TOTAL=$(echo "$ALL_CHECKS" | jq 'length')
+
+          if [ "$TOTAL" = "0" ]; then
+            CHECKS_FIELD="⏳ Pending"
           else
-            # GitHub's PR checks page merges both APIs, so we must too.
-            # Deduplicate check runs by name (keep latest), filter out
-            # unexpanded matrix placeholders.
-            MATRIX_MARKER=$(printf '\044\173\173')
-            # Exclude own check run ("notify") since it's always in-progress
-            # at query time; add it back as success below.
-            CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-              --paginate --jq '[.check_runs[]]' 2>/dev/null \
-              | jq -s --arg marker "$MATRIX_MARKER" 'add // []
-                | map(select((.name | contains($marker) | not) and .name != "notify"))
-                | group_by(.name)
-                | map(sort_by(.started_at) | last)
-                | map({name: .name, state: (
-                    if .status != "completed" then "pending"
-                    elif .conclusion == "success" then "success"
-                    elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
-                    else "failure" end
-                  )})
-                + [{name: "notify", state: "success"}]')
+            PASSING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="success")] | length')
+            FAILING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="failure")] | length')
+            PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
+            SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
 
-            # Fetch commit statuses (used by CodeRabbit, external CI, etc.)
-            COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
-              --jq '[.statuses[] | {name: .context, state: (
-                  if .state == "success" then "success"
-                  elif .state == "pending" then "pending"
-                  elif .state == "failure" or .state == "error" then "failure"
-                  else "skipped" end
-                )}]' 2>/dev/null || echo '[]')
+            # Always show passed and failed; only show running/skipped if > 0
+            CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
+            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · 🔄 $PENDING running"
+            [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
+          fi
 
-            # Merge both sources, dedup by name (check runs take priority)
-            ALL_CHECKS=$(echo "$CHECK_RUNS"$'\n'"$COMMIT_STATUSES" \
-              | jq -s 'add // [] | group_by(.name) | map(.[0])')
-
-            TOTAL=$(echo "$ALL_CHECKS" | jq 'length')
-
-            if [ "$TOTAL" = "0" ]; then
-              CHECKS_FIELD="⏳ Pending"
-            else
-              PASSING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="success")] | length')
-              FAILING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="failure")] | length')
-              PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
-              SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
-
-              # Always show passed and failed; only show running/skipped if > 0
-              CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
-              [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · 🔄 $PENDING running"
-              [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
-            fi
+          # On pull_request events, CI checks may not exist yet (timing gap).
+          # The workflow_run trigger updates the embed after CI completes.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            CHECKS_FIELD="${CHECKS_FIELD} · ⏳ CI starting..."
           fi
 
           # ── Truncate + repair body ───────────────────────────────────────

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -122,7 +122,7 @@ jobs:
           CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
             --paginate --jq '[.check_runs[]]' 2>/dev/null \
             | jq -s --arg marker "$MATRIX_MARKER" 'add // []
-              | map(select((.name | contains($marker) | not) and .name != "notify"))
+              | map(select((.name | contains($marker) | not) and (.name | test("^(notify|discord-notify|Discord PR Notification)") | not)))
               | group_by(.name)
               | map(sort_by(.started_at) | last)
               | map({name: .name, state: (
@@ -131,7 +131,7 @@ jobs:
                   elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
                   else "failure" end
                 )})
-              + [{name: "notify", state: "success"}]')
+              + [{name: "notify", state: "success"}, {name: "discord-notify", state: "success"}]')
 
           COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
             --jq '[.statuses[] | {name: .context, state: (

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -164,10 +164,13 @@ jobs:
               fields: [
                 {name: "Status",    value: $status,    inline: true},
                 {name: "Branch",    value: $branch,    inline: true},
-                {name: "Repo",      value: $repo,      inline: true},
+                {name: "\u200b",    value: "\u200b",   inline: false},
                 {name: "Labels",    value: $labels,    inline: true},
+                {name: "Repo",      value: $repo,      inline: true},
+                {name: "\u200b",    value: "\u200b",   inline: false},
                 {name: "Assignees", value: $assignees, inline: true},
                 {name: "Reviewers", value: $reviewers, inline: true},
+                {name: "\u200b",    value: "\u200b",   inline: false},
                 {name: "Checks",    value: $checks,    inline: false}
               ]
             }]}')

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -139,6 +139,8 @@ jobs:
           BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\n?//gs')
           # Remove all empty lines
           BODY=$(echo "$BODY" | sed '/^\s*$/d')
+          # Add trailing blank line to separate description from fields
+          BODY="${BODY}"$'\n'
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -94,53 +94,60 @@ jobs:
           fi
 
           # ── Fetch check runs + commit statuses for this commit ────────────
-          # GitHub's PR checks page merges both APIs, so we must too.
-          # Deduplicate check runs by name (keep latest), filter out
-          # unexpanded matrix placeholders.
-          MATRIX_MARKER=$(printf '\044\173\173')
-          # Exclude own check run ("notify") since it's always in-progress
-          # at query time; add it back as success below.
-          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
-            --paginate --jq '[.check_runs[]]' 2>/dev/null \
-            | jq -s --arg marker "$MATRIX_MARKER" 'add // []
-              | map(select((.name | contains($marker) | not) and .name != "notify"))
-              | group_by(.name)
-              | map(sort_by(.started_at) | last)
-              | map({name: .name, state: (
-                  if .status != "completed" then "pending"
-                  elif .conclusion == "success" then "success"
-                  elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
-                  else "failure" end
-                )})
-              + [{name: "notify", state: "success"}]')
-
-          # Fetch commit statuses (used by CodeRabbit, external CI, etc.)
-          COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
-            --jq '[.statuses[] | {name: .context, state: (
-                if .state == "success" then "success"
-                elif .state == "pending" then "pending"
-                elif .state == "failure" or .state == "error" then "failure"
-                else "skipped" end
-              )}]' 2>/dev/null || echo '[]')
-
-          # Merge both sources, dedup by name (check runs take priority)
-          ALL_CHECKS=$(echo "$CHECK_RUNS"$'\n'"$COMMIT_STATUSES" \
-            | jq -s 'add // [] | group_by(.name) | map(.[0])')
-
-          TOTAL=$(echo "$ALL_CHECKS" | jq 'length')
-
-          if [ "$TOTAL" = "0" ]; then
-            CHECKS_FIELD="⏳ Pending"
+          # On pull_request events, CI checks haven't been created yet (timing
+          # gap), so show a placeholder. The workflow_run trigger fires after
+          # CI completes and will update the embed with accurate counts.
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            CHECKS_FIELD="⏳ Waiting for CI..."
           else
-            PASSING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="success")] | length')
-            FAILING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="failure")] | length')
-            PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
-            SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
+            # GitHub's PR checks page merges both APIs, so we must too.
+            # Deduplicate check runs by name (keep latest), filter out
+            # unexpanded matrix placeholders.
+            MATRIX_MARKER=$(printf '\044\173\173')
+            # Exclude own check run ("notify") since it's always in-progress
+            # at query time; add it back as success below.
+            CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+              --paginate --jq '[.check_runs[]]' 2>/dev/null \
+              | jq -s --arg marker "$MATRIX_MARKER" 'add // []
+                | map(select((.name | contains($marker) | not) and .name != "notify"))
+                | group_by(.name)
+                | map(sort_by(.started_at) | last)
+                | map({name: .name, state: (
+                    if .status != "completed" then "pending"
+                    elif .conclusion == "success" then "success"
+                    elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
+                    else "failure" end
+                  )})
+                + [{name: "notify", state: "success"}]')
 
-            # Always show passed and failed; only show running/skipped if > 0
-            CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
-            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · 🔄 $PENDING running"
-            [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
+            # Fetch commit statuses (used by CodeRabbit, external CI, etc.)
+            COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
+              --jq '[.statuses[] | {name: .context, state: (
+                  if .state == "success" then "success"
+                  elif .state == "pending" then "pending"
+                  elif .state == "failure" or .state == "error" then "failure"
+                  else "skipped" end
+                )}]' 2>/dev/null || echo '[]')
+
+            # Merge both sources, dedup by name (check runs take priority)
+            ALL_CHECKS=$(echo "$CHECK_RUNS"$'\n'"$COMMIT_STATUSES" \
+              | jq -s 'add // [] | group_by(.name) | map(.[0])')
+
+            TOTAL=$(echo "$ALL_CHECKS" | jq 'length')
+
+            if [ "$TOTAL" = "0" ]; then
+              CHECKS_FIELD="⏳ Pending"
+            else
+              PASSING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="success")] | length')
+              FAILING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="failure")] | length')
+              PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
+              SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
+
+              # Always show passed and failed; only show running/skipped if > 0
+              CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
+              [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · 🔄 $PENDING running"
+              [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
+            fi
           fi
 
           # ── Truncate + repair body ───────────────────────────────────────

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -131,14 +131,14 @@ jobs:
           fi
 
           # ── Clean body for Discord ───────────────────────────────────────
-          # Strip HTML comments
-          BODY=$(echo "$BODY" | sed 's/<!--[^>]*-->//g')
+          # Strip HTML comments (perl handles multi-line spans)
+          BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->//gs')
           # Collapse consecutive blank lines left by stripped comments
           BODY=$(echo "$BODY" | awk 'NF || prev { print } { prev = NF }')
           # Convert GH markdown checkboxes to unicode
           BODY=$(echo "$BODY" | sed 's/- \[ \]/☐/g; s/- \[x\]/☑/g; s/- \[X\]/☑/g')
           # Convert ## headings to Discord bold
-          BODY=$(echo "$BODY" | sed 's/^#{1,6} \(.*\)$/\n**\1**/g')
+          BODY=$(echo "$BODY" | sed -E 's/^#{1,6} (.*)$/\n**\1**/g')
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -141,10 +141,8 @@ jobs:
           BODY=$(echo "$BODY" | sed 's/- \[ \]/☐/g; s/- \[x\]/☑/g; s/- \[X\]/☑/g')
           # Convert ## headings to Discord bold
           BODY=$(echo "$BODY" | sed -E 's/^#{1,6} (.*)$/**\1**/g')
-          # Collapse all double newlines to single (Discord renders \n as line breaks)
-          BODY=$(echo "$BODY" | perl -0pe 's/\n{2,}/\n/g')
-          # Trim leading/trailing whitespace
-          BODY=$(echo "$BODY" | sed '/./,$!d' | sed -e :a -e '/^\s*$/d;N;ba')
+          # Collapse all double newlines to single and trim leading/trailing whitespace
+          BODY=$(echo "$BODY" | perl -0pe 's/\n{2,}/\n/g; s/^\s+//; s/\s+$//')
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -165,13 +165,10 @@ jobs:
               fields: [
                 {name: "Status",    value: $status,    inline: true},
                 {name: "Branch",    value: $branch,    inline: true},
-                {name: "\u200b",    value: "\u200b",   inline: false},
-                {name: "Labels",    value: $labels,    inline: true},
                 {name: "Repo",      value: $repo,      inline: true},
-                {name: "\u200b",    value: "\u200b",   inline: false},
+                {name: "Labels",    value: $labels,    inline: true},
                 {name: "Assignees", value: $assignees, inline: true},
                 {name: "Reviewers", value: $reviewers, inline: true},
-                {name: "\u200b",    value: "\u200b",   inline: false},
                 {name: "Checks",    value: $checks,    inline: false}
               ]
             }]}')

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -93,28 +93,46 @@ jobs:
           else                                   COLOR=3066993;  STATUS="🟢 Open"
           fi
 
-          # ── Fetch check runs for this commit ─────────────────────────────
-          # --paginate handles repos with >30 checks
-          # Deduplicate by name, keeping only the latest run per check
-          # (mirrors what GitHub's UI shows). Also filters out unexpanded
-          # matrix placeholders like "matrix.label".
+          # ── Fetch check runs + commit statuses for this commit ────────────
+          # GitHub's PR checks page merges both APIs, so we must too.
+          # Deduplicate check runs by name (keep latest), filter out
+          # unexpanded matrix placeholders.
           MATRIX_MARKER=$(printf '\044\173\173')
-          CHECKS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
+          CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
             --paginate --jq '[.check_runs[]]' 2>/dev/null \
             | jq -s --arg marker "$MATRIX_MARKER" 'add // []
               | map(select(.name | contains($marker) | not))
               | group_by(.name)
-              | map(sort_by(.started_at) | last)')
+              | map(sort_by(.started_at) | last)
+              | map({name: .name, state: (
+                  if .status != "completed" then "pending"
+                  elif .conclusion == "success" then "success"
+                  elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
+                  else "failure" end
+                )})')
 
-          TOTAL=$(echo "$CHECKS" | jq 'length')
+          # Fetch commit statuses (used by CodeRabbit, external CI, etc.)
+          COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
+            --jq '[.statuses[] | {name: .context, state: (
+                if .state == "success" then "success"
+                elif .state == "pending" then "pending"
+                elif .state == "failure" or .state == "error" then "failure"
+                else "skipped" end
+              )}]' 2>/dev/null || echo '[]')
+
+          # Merge both sources, dedup by name (check runs take priority)
+          ALL_CHECKS=$(echo "$CHECK_RUNS"$'\n'"$COMMIT_STATUSES" \
+            | jq -s 'add // [] | group_by(.name) | map(.[0])')
+
+          TOTAL=$(echo "$ALL_CHECKS" | jq 'length')
 
           if [ "$TOTAL" = "0" ]; then
             CHECKS_FIELD="⏳ Pending"
           else
-            PASSING=$(echo "$CHECKS" | jq '[.[] | select(.conclusion=="success")] | length')
-            FAILING=$(echo "$CHECKS" | jq '[.[] | select(.conclusion | . == "failure" or . == "timed_out")] | length')
-            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
-            SKIPPED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion | . == "skipped" or . == "cancelled")] | length')
+            PASSING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="success")] | length')
+            FAILING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="failure")] | length')
+            PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
+            SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
 
             CHECKS_FIELD=""
             [ "$PASSING" -gt 0 ] && CHECKS_FIELD="✅ $PASSING passed"

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -20,6 +20,7 @@ on:
   workflow_run:
     workflows: ['CI', 'PR checks']
     types: [completed]
+  workflow_call:
 
 permissions:
   contents: read
@@ -49,7 +50,7 @@ jobs:
           fi
 
           # ── Resolve PR number ────────────────────────────────────────────
-          if [ "$EVENT_NAME" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
           elif [ "$EVENT_NAME" = "check_run" ]; then
             HEAD_SHA="${{ github.event.check_run.head_sha }}"

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -27,7 +27,7 @@ permissions:
 
 concurrency:
   group: discord-pr-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   notify:
@@ -119,7 +119,7 @@ jobs:
             [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }⏭️ $SKIPPED skipped"
 
             # If everything passed, make it obvious
-            if [ "$FAILING" = "0" ] && [ "$PENDING" = "0" ] && [ "$PASSING" -gt 0 ]; then
+            if [ "$FAILING" = "0" ] && [ "$PENDING" = "0" ] && [ "$SKIPPED" = "0" ] && [ "$PASSING" -gt 0 ]; then
               CHECKS_FIELD="✅ All $PASSING passed"
             fi
           fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -136,13 +136,13 @@ jobs:
 
           # ── Clean body for Discord ───────────────────────────────────────
           # Strip HTML comments (perl handles multi-line spans)
-          BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->//gs')
-          # Collapse consecutive blank lines left by stripped comments
-          BODY=$(echo "$BODY" | awk 'NF || prev { print } { prev = NF }')
+          BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\s*//gs')
+          # Collapse runs of 3+ newlines down to 2 (one blank line)
+          BODY=$(echo "$BODY" | perl -0pe 's/\n{3,}/\n\n/g')
           # Convert GH markdown checkboxes to unicode
           BODY=$(echo "$BODY" | sed 's/- \[ \]/☐/g; s/- \[x\]/☑/g; s/- \[X\]/☑/g')
           # Convert ## headings to Discord bold
-          BODY=$(echo "$BODY" | sed -E 's/^#{1,6} (.*)$/\n**\1**/g')
+          BODY=$(echo "$BODY" | sed -E 's/^#{1,6} (.*)$/**\1**/g')
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -135,14 +135,8 @@ jobs:
           fi
 
           # ── Clean body for Discord ───────────────────────────────────────
-          # Strip HTML comments (perl handles multi-line spans)
-          BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\s*//gs')
-          # Convert GH markdown checkboxes to unicode
-          BODY=$(echo "$BODY" | sed 's/- \[ \]/☐/g; s/- \[x\]/☑/g; s/- \[X\]/☑/g')
-          # Convert ## headings to Discord bold
-          BODY=$(echo "$BODY" | sed -E 's/^#{1,6} (.*)$/**\1**/g')
-          # Collapse all double newlines to single and trim leading/trailing whitespace
-          BODY=$(echo "$BODY" | perl -0pe 's/\n{2,}/\n/g; s/^\s+//; s/\s+$//')
+          # Strip HTML comments and the blank line following them
+          BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\n?//gs')
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -72,7 +72,6 @@ jobs:
 
           PR_TITLE=$(echo  "$PR" | jq -r '.title')
           PR_URL=$(echo    "$PR" | jq -r '.html_url')
-          PR_BODY=$(echo   "$PR" | jq -r '.body // ""')
           PR_AUTHOR=$(echo "$PR" | jq -r '.user.login')
           PR_AVATAR=$(echo "$PR" | jq -r '.user.avatar_url')
           HEAD_REF=$(echo  "$PR" | jq -r '.head.ref')
@@ -149,27 +148,10 @@ jobs:
             CHECKS_FIELD="${CHECKS_FIELD} · ⏳ CI starting..."
           fi
 
-          # ── Truncate + repair body ───────────────────────────────────────
-          BODY="${PR_BODY:0:1200}"
-          if (( $(echo "$BODY" | grep -o '```' | wc -l) % 2 != 0 )); then
-            BODY="${BODY}..."$'\n```'
-          fi
-
-          # ── Clean body for Discord ───────────────────────────────────────
-          # Strip HTML comments and the blank line following them
-          BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\n?//gs')
-          # Convert markdown checkboxes to unicode
-          BODY=$(echo "$BODY" | sed 's/- \[x\]/☑/g; s/- \[X\]/☑/g; s/- \[ \]/☐/g')
-          # Remove all empty lines
-          BODY=$(echo "$BODY" | sed '/^\s*$/d')
-          # Add trailing spacer to separate description from fields
-          BODY="${BODY}"$'\n\u200b'
-
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \
             --arg  title     "#$PR_NUMBER $PR_TITLE" \
             --arg  url       "$PR_URL" \
-            --arg  desc      "$BODY" \
             --arg  author    "$PR_AUTHOR" \
             --arg  avatar    "$PR_AVATAR" \
             --arg  branch    "$HEAD_REF → $BASE_REF" \
@@ -181,7 +163,7 @@ jobs:
             --arg  checks    "$CHECKS_FIELD" \
             --argjson color  "$COLOR" \
             '{embeds: [{
-              title: $title, url: $url, description: $desc, color: $color,
+              title: $title, url: $url, color: $color,
               author: {name: $author, url: ("https://github.com/" + $author), icon_url: $avatar},
               fields: [
                 {name: "Status",    value: $status,    inline: true},

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -1,49 +1,168 @@
 name: Discord PR Notification
-
 on:
   pull_request:
-    types: [opened]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - labeled
+      - unlabeled
+      - assigned
+      - unassigned
+      - review_requested
+      - review_request_removed
+      - ready_for_review
+      - converted_to_draft
+      - closed
+      - reopened
+  check_run:
+    types: [completed]
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   notify:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_WEBHOOK_URL }}
+      REPO: ${{ github.repository }}
+      EVENT_NAME: ${{ github.event_name }}
     steps:
-      - name: Post to Discord
-        env:
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_PR_WEBHOOK_URL }}
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
-          PR_AVATAR: ${{ github.event.pull_request.user.avatar_url }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+      - name: Resolve PR, build embed, post or patch Discord
         run: |
-          # Truncate body to 1500 chars (leave room for embed fields).
-          # Close any unclosed code blocks to prevent broken formatting.
-          BODY="${PR_BODY:0:1500}"
-          BACKTICK_COUNT=$(echo "$BODY" | grep -o '```' | wc -l)
-          if (( BACKTICK_COUNT % 2 != 0 )); then
-            BODY="${BODY}..."$'\n'"$BODY"'```'
-            BODY="${PR_BODY:0:1500}..."$'\n```'
+          # ── Resolve PR number ────────────────────────────────────────────
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+          else
+            HEAD_SHA="${{ github.event.check_run.head_sha }}"
+            # check_run.pull_requests is populated for same-repo PRs; fall back to API for forks
+            PR_NUMBER=$(echo '${{ toJson(github.event.check_run.pull_requests) }}' \
+              | jq -r '.[0].number // empty')
+            if [ -z "$PR_NUMBER" ]; then
+              PR_NUMBER=$(gh api "/repos/$REPO/commits/$HEAD_SHA/pulls" \
+                --jq '.[0].number // empty' 2>/dev/null)
+            fi
+            if [ -z "$PR_NUMBER" ]; then
+              echo "No open PR for $HEAD_SHA — skipping"
+              exit 0
+            fi
           fi
 
+          # ── Fetch current PR state (always fresh, not from stale event payload) ──
+          PR=$(gh api "/repos/$REPO/pulls/$PR_NUMBER")
+
+          PR_TITLE=$(echo  "$PR" | jq -r '.title')
+          PR_URL=$(echo    "$PR" | jq -r '.html_url')
+          PR_BODY=$(echo   "$PR" | jq -r '.body // ""')
+          PR_AUTHOR=$(echo "$PR" | jq -r '.user.login')
+          PR_AVATAR=$(echo "$PR" | jq -r '.user.avatar_url')
+          HEAD_REF=$(echo  "$PR" | jq -r '.head.ref')
+          BASE_REF=$(echo  "$PR" | jq -r '.base.ref')
+          HEAD_SHA=$(echo  "$PR" | jq -r '.head.sha')
+          PR_STATE=$(echo  "$PR" | jq -r '.state')
+          PR_DRAFT=$(echo  "$PR" | jq -r '.draft')
+          PR_MERGED=$(echo "$PR" | jq -r '.merged')
+
+          LABELS=$(echo    "$PR" | jq -r '[.labels[].name]           | if length==0 then "None"       else join(", ") end')
+          ASSIGNEES=$(echo "$PR" | jq -r '[.assignees[].login]       | if length==0 then "Unassigned" else join(", ") end')
+          REVIEWERS=$(echo "$PR" | jq -r '[.requested_reviewers[].login] | if length==0 then "None"  else join(", ") end')
+
+          # ── Status + color ───────────────────────────────────────────────
+          if   [ "$PR_MERGED" = "true"  ]; then COLOR=7419530;  STATUS="🟣 Merged"
+          elif [ "$PR_STATE"  = "closed" ]; then COLOR=15158332; STATUS="🔴 Closed"
+          elif [ "$PR_DRAFT"  = "true"  ]; then COLOR=9807270;  STATUS="⚫ Draft"
+          else                                   COLOR=5814783;  STATUS="🟢 Open"
+          fi
+
+          # ── Fetch all check runs for this commit ─────────────────────────
+          # --paginate handles repos with >30 checks
+          CHECKS=$(gh api "/repos/$REPO/commits/$HEAD_SHA/check-runs" \
+            --paginate --jq '[.check_runs[]]' 2>/dev/null \
+            | jq -s 'add // []')
+
+          TOTAL=$(echo "$CHECKS" | jq 'length')
+
+          if [ "$TOTAL" = "0" ]; then
+            CHECKS_FIELD="⏳ Pending"
+          else
+            PASSING=$(echo "$CHECKS" | jq '[.[] | select(.conclusion=="success")] | length')
+            FAILING=$(echo "$CHECKS" | jq '[.[] | select(.conclusion | . == "failure" or . == "timed_out" or . == "cancelled")] | length')
+            PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
+            SKIPPED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion=="skipped")] | length')
+
+            CHECKS_FIELD=""
+            [ "$PASSING" -gt 0 ] && CHECKS_FIELD="✅ $PASSING passed"
+            [ "$FAILING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }❌ $FAILING failed"
+            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }⏳ $PENDING running"
+            [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }⏭️ $SKIPPED skipped"
+
+            # If everything passed, make it obvious
+            if [ "$FAILING" = "0" ] && [ "$PENDING" = "0" ]; then
+              CHECKS_FIELD="✅ All $PASSING passed"
+            fi
+          fi
+
+          # ── Truncate + repair body ───────────────────────────────────────
+          BODY="${PR_BODY:0:1200}"
+          if (( $(echo "$BODY" | grep -o '```' | wc -l) % 2 != 0 )); then
+            BODY="${BODY}..."$'\n```'
+          fi
+
+          # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \
-            --arg title "#$PR_NUMBER $PR_TITLE" \
-            --arg url "$PR_URL" \
-            --arg desc "$BODY" \
-            --arg author "$PR_AUTHOR" \
-            --arg avatar "$PR_AVATAR" \
-            --arg branch "$HEAD_REF → $BASE_REF" \
-            --arg repo "$GITHUB_REPOSITORY" \
-            '{embeds: [{title: $title, url: $url, description: $desc, color: 5814783,
-               author: {name: $author, url: ("https://github.com/" + $author), icon_url: $avatar},
-               fields: [
-                 {name: "Branch", value: $branch, inline: true},
-                 {name: "Repo", value: $repo, inline: true}
-               ]}]}')
-          curl -sS -f -H "Content-Type: application/json" -d "$PAYLOAD" "$DISCORD_WEBHOOK_URL"
+            --arg  title     "#$PR_NUMBER $PR_TITLE" \
+            --arg  url       "$PR_URL" \
+            --arg  desc      "$BODY" \
+            --arg  author    "$PR_AUTHOR" \
+            --arg  avatar    "$PR_AVATAR" \
+            --arg  branch    "$HEAD_REF → $BASE_REF" \
+            --arg  repo      "$REPO" \
+            --arg  status    "$STATUS" \
+            --arg  labels    "$LABELS" \
+            --arg  assignees "$ASSIGNEES" \
+            --arg  reviewers "$REVIEWERS" \
+            --arg  checks    "$CHECKS_FIELD" \
+            --argjson color  "$COLOR" \
+            '{embeds: [{
+              title: $title, url: $url, description: $desc, color: $color,
+              author: {name: $author, url: ("https://github.com/" + $author), icon_url: $avatar},
+              fields: [
+                {name: "Status",    value: $status,    inline: true},
+                {name: "Branch",    value: $branch,    inline: true},
+                {name: "Repo",      value: $repo,      inline: true},
+                {name: "Labels",    value: $labels,    inline: true},
+                {name: "Assignees", value: $assignees, inline: true},
+                {name: "Reviewers", value: $reviewers, inline: true},
+                {name: "Checks",    value: $checks,    inline: false}
+              ]
+            }]}')
+
+          # ── Look up stored message ID ────────────────────────────────────
+          COMMENTS=$(gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | {id: .id, body: .body}]')
+
+          DISCORD_MSG_ID=$(echo "$COMMENTS" | \
+            jq -r '.[] | select(.body | contains("discord-msg-id:")) | .body' | \
+            grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2 | head -1)
+
+          WEBHOOK_ID=$(echo    "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $(NF-1)}')
+          WEBHOOK_TOKEN=$(echo "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $NF}')
+
+          if [ -n "$DISCORD_MSG_ID" ]; then
+            curl -sS -f -X PATCH \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID"
+          else
+            RESPONSE=$(curl -sS -f \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              "${DISCORD_WEBHOOK_URL}?wait=true")
+            DISCORD_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
+            gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
+              -X POST \
+              -f body="<!-- discord-msg-id:${DISCORD_MSG_ID} -->"
+          fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -136,7 +136,7 @@ jobs:
 
             # Always show passed and failed; only show running/skipped if > 0
             CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
-            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏳ $PENDING running"
+            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · 🔄 $PENDING running"
             [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
           fi
 

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -15,6 +15,8 @@ on:
       - converted_to_draft
       - closed
       - reopened
+  check_run:
+    types: [completed]
   workflow_run:
     workflows: ['CI', 'PR checks']
     types: [completed]
@@ -26,7 +28,7 @@ permissions:
   checks: read
 
 concurrency:
-  group: discord-pr-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  group: discord-pr-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -49,9 +51,20 @@ jobs:
           # ── Resolve PR number ────────────────────────────────────────────
           if [ "$EVENT_NAME" = "pull_request" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
+          elif [ "$EVENT_NAME" = "check_run" ]; then
+            HEAD_SHA="${{ github.event.check_run.head_sha }}"
+            PR_NUMBER=$(echo '${{ toJson(github.event.check_run.pull_requests) }}' \
+              | jq -r '.[0].number // empty')
+            if [ -z "$PR_NUMBER" ]; then
+              PR_NUMBER=$(gh api "/repos/$REPO/commits/$HEAD_SHA/pulls" \
+                --jq '.[0].number // empty' 2>/dev/null)
+            fi
+            if [ -z "$PR_NUMBER" ]; then
+              echo "No open PR for $HEAD_SHA — skipping"
+              exit 0
+            fi
           else
             HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-            # workflow_run.pull_requests is populated for same-repo PRs; fall back to API for forks
             PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' \
               | jq -r '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
@@ -143,7 +156,7 @@ jobs:
           fi
 
           # On pull_request events, CI checks may not exist yet (timing gap).
-          # The workflow_run trigger updates the embed after CI completes.
+          # check_run and workflow_run triggers update the embed as checks complete.
           if [ "$EVENT_NAME" = "pull_request" ]; then
             CHECKS_FIELD="${CHECKS_FIELD} · ⏳ CI starting..."
           fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -15,11 +15,6 @@ on:
       - converted_to_draft
       - closed
       - reopened
-  check_run:
-    types: [completed]
-  workflow_run:
-    workflows: ['CI', 'PR checks']
-    types: [completed]
   workflow_call:
 
 permissions:
@@ -29,7 +24,7 @@ permissions:
   checks: read
 
 concurrency:
-  group: discord-pr-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
+  group: discord-pr-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -52,39 +47,11 @@ jobs:
           # ── Resolve PR number ────────────────────────────────────────────
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
-          elif [ "$EVENT_NAME" = "check_run" ]; then
-            HEAD_SHA="${{ github.event.check_run.head_sha }}"
-
-            # Try payload first
-            PR_NUMBER=$(echo '${{ toJson(github.event.check_run.pull_requests) }}' \
-              | jq -r '.[0].number // empty')
-            echo "check_run: sha=$HEAD_SHA pr_from_payload=$PR_NUMBER"
-
-            # Fallback: search open PRs by head SHA directly
-            if [ -z "$PR_NUMBER" ]; then
-              PR_NUMBER=$(gh api "/repos/$REPO/pulls" \
-                -f state=open \
-                --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
-                2>/dev/null | head -1)
-              echo "check_run: pr_from_api=$PR_NUMBER"
-            fi
-
-            if [ -z "$PR_NUMBER" ]; then
-              echo "No open PR for $HEAD_SHA — skipping"
-              exit 0
-            fi
           else
-            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
-            PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' \
-              | jq -r '.[0].number // empty')
+            # workflow_call — inherits caller's event context
+            PR_NUMBER="${{ github.event.pull_request.number }}"
             if [ -z "$PR_NUMBER" ]; then
-              PR_NUMBER=$(gh api "/repos/$REPO/pulls" \
-                -f state=open \
-                --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
-                2>/dev/null | head -1)
-            fi
-            if [ -z "$PR_NUMBER" ]; then
-              echo "No open PR for $HEAD_SHA — skipping"
+              echo "Could not resolve PR number — skipping"
               exit 0
             fi
           fi
@@ -131,7 +98,7 @@ jobs:
                   elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
                   else "failure" end
                 )})
-              + [{name: "notify", state: "success"}, {name: "discord-notify", state: "success"}]')
+              ')
 
           COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
             --jq '[.statuses[] | {name: .context, state: (
@@ -228,8 +195,23 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "${DISCORD_WEBHOOK_URL}?wait=true")
-            DISCORD_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
-            gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
-              -X POST \
-              -f body="<!-- discord-msg-id:${DISCORD_MSG_ID} -->"
+            NEW_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
+
+            # ── Race guard: re-check for a comment created by a concurrent run ──
+            EXISTING=$(gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$")))] | first // empty' 2>/dev/null)
+
+            if [ -n "$EXISTING" ]; then
+              # Another run won the race — delete our duplicate message, use theirs
+              curl -sS -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" || true
+              DISCORD_MSG_ID=$(echo "$EXISTING" | jq -r '.body' | grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2)
+              # Patch the existing message with our payload
+              curl -sS -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
+                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null
+            else
+              DISCORD_MSG_ID="$NEW_MSG_ID"
+              gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
+                -X POST \
+                -f body="<!-- discord-msg-id:${DISCORD_MSG_ID} -->"
+            fi
           fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -134,16 +134,10 @@ jobs:
             PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
             SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
 
-            CHECKS_FIELD=""
-            [ "$PASSING" -gt 0 ] && CHECKS_FIELD="✅ $PASSING passed"
-            [ "$FAILING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }❌ $FAILING failed"
-            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }⏳ $PENDING running"
-            [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }⏭️ $SKIPPED skipped"
-
-            # If everything passed, make it obvious
-            if [ "$FAILING" = "0" ] && [ "$PENDING" = "0" ] && [ "$SKIPPED" = "0" ] && [ "$PASSING" -gt 0 ]; then
-              CHECKS_FIELD="✅ All $PASSING passed"
-            fi
+            # Always show passed and failed; only show running/skipped if > 0
+            CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
+            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏳ $PENDING running"
+            [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
           fi
 
           # ── Truncate + repair body ───────────────────────────────────────

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -26,7 +26,7 @@ permissions:
   checks: read
 
 concurrency:
-  group: discord-pr-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
+  group: discord-pr-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
@@ -65,7 +65,10 @@ jobs:
           fi
 
           # ── Fetch current PR state (always fresh, not from stale event payload) ──
-          PR=$(gh api "/repos/$REPO/pulls/$PR_NUMBER")
+          if ! PR=$(gh api "/repos/$REPO/pulls/$PR_NUMBER") || [ -z "$PR" ]; then
+            echo "Failed to fetch PR #$PR_NUMBER — skipping"
+            exit 0
+          fi
 
           PR_TITLE=$(echo  "$PR" | jq -r '.title')
           PR_URL=$(echo    "$PR" | jq -r '.html_url')

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -21,6 +21,11 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  issues: write
+
+concurrency:
+  group: discord-pr-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number }}
+  cancel-in-progress: true
 
 jobs:
   notify:

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -98,10 +98,12 @@ jobs:
           # Deduplicate check runs by name (keep latest), filter out
           # unexpanded matrix placeholders.
           MATRIX_MARKER=$(printf '\044\173\173')
+          # Exclude own check run ("notify") since it's always in-progress
+          # at query time; add it back as success below.
           CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
             --paginate --jq '[.check_runs[]]' 2>/dev/null \
             | jq -s --arg marker "$MATRIX_MARKER" 'add // []
-              | map(select(.name | contains($marker) | not))
+              | map(select((.name | contains($marker) | not) and .name != "notify"))
               | group_by(.name)
               | map(sort_by(.started_at) | last)
               | map({name: .name, state: (
@@ -109,7 +111,8 @@ jobs:
                   elif .conclusion == "success" then "success"
                   elif .conclusion == "skipped" or .conclusion == "cancelled" then "skipped"
                   else "failure" end
-                )})')
+                )})
+              + [{name: "notify", state: "success"}]')
 
           # Fetch commit statuses (used by CodeRabbit, external CI, etc.)
           COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -38,6 +38,12 @@ jobs:
     steps:
       - name: Resolve PR, build embed, post or patch Discord
         run: |
+          # ── Guard: bail if webhook is not configured ─────────────────────
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_PR_WEBHOOK_URL secret is not set — skipping"
+            exit 0
+          fi
+
           # ── Resolve PR number ────────────────────────────────────────────
           if [ "$EVENT_NAME" = "pull_request" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -111,7 +117,7 @@ jobs:
             [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }⏭️ $SKIPPED skipped"
 
             # If everything passed, make it obvious
-            if [ "$FAILING" = "0" ] && [ "$PENDING" = "0" ]; then
+            if [ "$FAILING" = "0" ] && [ "$PENDING" = "0" ] && [ "$PASSING" -gt 0 ]; then
               CHECKS_FIELD="✅ All $PASSING passed"
             fi
           fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -97,11 +97,12 @@ jobs:
           # --paginate handles repos with >30 checks
           # Deduplicate by name, keeping only the latest run per check
           # (mirrors what GitHub's UI shows). Also filters out unexpanded
-          # matrix placeholders like "${{ matrix.label }}".
+          # matrix placeholders like "matrix.label".
+          MATRIX_MARKER='${{'
           CHECKS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
             --paginate --jq '[.check_runs[]]' 2>/dev/null \
-            | jq -s 'add // []
-              | map(select(.name | contains("${{") | not))
+            | jq -s --arg marker "$MATRIX_MARKER" 'add // []
+              | map(select(.name | contains($marker) | not))
               | group_by(.name)
               | map(sort_by(.started_at) | last)')
 

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -137,13 +137,14 @@ jobs:
           # ── Clean body for Discord ───────────────────────────────────────
           # Strip HTML comments (perl handles multi-line spans)
           BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\s*//gs')
-          # Collapse runs of 3+ newlines down to 2 (one blank line)
-          BODY=$(echo "$BODY" | perl -0pe 's/\n{3,}/\n\n/g')
           # Convert GH markdown checkboxes to unicode
           BODY=$(echo "$BODY" | sed 's/- \[ \]/☐/g; s/- \[x\]/☑/g; s/- \[X\]/☑/g')
-          # Convert ## headings to Discord bold and remove the blank line after them
+          # Convert ## headings to Discord bold
           BODY=$(echo "$BODY" | sed -E 's/^#{1,6} (.*)$/**\1**/g')
-          BODY=$(echo "$BODY" | perl -0pe 's/(\*\*[^*]+\*\*)\n\n/\1\n/g')
+          # Collapse all double newlines to single (Discord renders \n as line breaks)
+          BODY=$(echo "$BODY" | perl -0pe 's/\n{2,}/\n/g')
+          # Trim leading/trailing whitespace
+          BODY=$(echo "$BODY" | sed '/./,$!d' | sed -e :a -e '/^\s*$/d;N;ba')
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -98,7 +98,7 @@ jobs:
           # Deduplicate by name, keeping only the latest run per check
           # (mirrors what GitHub's UI shows). Also filters out unexpanded
           # matrix placeholders like "matrix.label".
-          MATRIX_MARKER='${{'
+          MATRIX_MARKER=$(printf '\044\173\173')
           CHECKS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
             --paginate --jq '[.check_runs[]]' 2>/dev/null \
             | jq -s --arg marker "$MATRIX_MARKER" 'add // []

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -137,6 +137,8 @@ jobs:
           # ── Clean body for Discord ───────────────────────────────────────
           # Strip HTML comments and the blank line following them
           BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\n?//gs')
+          # Convert markdown checkboxes to unicode
+          BODY=$(echo "$BODY" | sed 's/- \[x\]/☑/g; s/- \[X\]/☑/g; s/- \[ \]/☐/g')
           # Remove all empty lines
           BODY=$(echo "$BODY" | sed '/^\s*$/d')
           # Add trailing spacer to separate description from fields

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -111,6 +111,16 @@ jobs:
             BODY="${BODY}..."$'\n```'
           fi
 
+          # ── Clean body for Discord ───────────────────────────────────────
+          # Strip HTML comments
+          BODY=$(echo "$BODY" | sed 's/<!--[^>]*-->//g')
+          # Collapse consecutive blank lines left by stripped comments
+          BODY=$(echo "$BODY" | awk 'NF || prev { print } { prev = NF }')
+          # Convert GH markdown checkboxes to unicode
+          BODY=$(echo "$BODY" | sed 's/- \[ \]/☐/g; s/- \[x\]/☑/g; s/- \[X\]/☑/g')
+          # Convert ## headings to Discord bold
+          BODY=$(echo "$BODY" | sed 's/^#{1,6} \(.*\)$/\n**\1**/g')
+
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \
             --arg  title     "#$PR_NUMBER $PR_TITLE" \
@@ -151,12 +161,22 @@ jobs:
           WEBHOOK_ID=$(echo    "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $(NF-1)}')
           WEBHOOK_TOKEN=$(echo "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $NF}')
 
+          # ── Post or patch ────────────────────────────────────────────────
           if [ -n "$DISCORD_MSG_ID" ]; then
-            curl -sS -f -X PATCH \
+            PATCH_STATUS=$(curl -sS -o /dev/null -w "%{http_code}" -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID"
-          else
+              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID")
+
+            if [ "$PATCH_STATUS" = "404" ]; then
+              STALE_COMMENT_ID=$(echo "$COMMENTS" | \
+                jq -r '.[] | select(.body | contains("discord-msg-id:")) | .id' | head -1)
+              gh api -X DELETE "/repos/$REPO/issues/comments/$STALE_COMMENT_ID"
+              DISCORD_MSG_ID=""
+            fi
+          fi
+
+          if [ -z "$DISCORD_MSG_ID" ]; then
             RESPONSE=$(curl -sS -f \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -74,7 +74,7 @@ jobs:
           if   [ "$PR_MERGED" = "true"  ]; then COLOR=7419530;  STATUS="🟣 Merged"
           elif [ "$PR_STATE"  = "closed" ]; then COLOR=15158332; STATUS="🔴 Closed"
           elif [ "$PR_DRAFT"  = "true"  ]; then COLOR=9807270;  STATUS="⚫ Draft"
-          else                                   COLOR=5814783;  STATUS="🟢 Open"
+          else                                   COLOR=3066993;  STATUS="🟢 Open"
           fi
 
           # ── Fetch all check runs for this commit ─────────────────────────

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -82,11 +82,17 @@ jobs:
           else                                   COLOR=3066993;  STATUS="🟢 Open"
           fi
 
-          # ── Fetch all check runs for this commit ─────────────────────────
+          # ── Fetch check runs for this commit ─────────────────────────────
           # --paginate handles repos with >30 checks
-          CHECKS=$(gh api "/repos/$REPO/commits/$HEAD_SHA/check-runs" \
+          # Deduplicate by name, keeping only the latest run per check
+          # (mirrors what GitHub's UI shows). Also filters out unexpanded
+          # matrix placeholders like "${{ matrix.label }}".
+          CHECKS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
             --paginate --jq '[.check_runs[]]' 2>/dev/null \
-            | jq -s 'add // []')
+            | jq -s 'add // []
+              | map(select(.name | contains("${{") | not))
+              | group_by(.name)
+              | map(sort_by(.started_at) | last)')
 
           TOTAL=$(echo "$CHECKS" | jq 'length')
 
@@ -94,9 +100,9 @@ jobs:
             CHECKS_FIELD="⏳ Pending"
           else
             PASSING=$(echo "$CHECKS" | jq '[.[] | select(.conclusion=="success")] | length')
-            FAILING=$(echo "$CHECKS" | jq '[.[] | select(.conclusion | . == "failure" or . == "timed_out" or . == "cancelled")] | length')
+            FAILING=$(echo "$CHECKS" | jq '[.[] | select(.conclusion | . == "failure" or . == "timed_out")] | length')
             PENDING=$(echo "$CHECKS" | jq '[.[] | select(.status == "in_progress" or .status == "queued")] | length')
-            SKIPPED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion=="skipped")] | length')
+            SKIPPED=$(echo "$CHECKS" | jq '[.[] | select(.conclusion | . == "skipped" or . == "cancelled")] | length')
 
             CHECKS_FIELD=""
             [ "$PASSING" -gt 0 ] && CHECKS_FIELD="✅ $PASSING passed"

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -137,6 +137,8 @@ jobs:
           # ── Clean body for Discord ───────────────────────────────────────
           # Strip HTML comments and the blank line following them
           BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\n?//gs')
+          # Remove all empty lines
+          BODY=$(echo "$BODY" | sed '/^\s*$/d')
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -139,8 +139,8 @@ jobs:
           BODY=$(echo "$BODY" | perl -0pe 's/<!--.*?-->\n?//gs')
           # Remove all empty lines
           BODY=$(echo "$BODY" | sed '/^\s*$/d')
-          # Add trailing blank line to separate description from fields
-          BODY="${BODY}"$'\n'
+          # Add trailing spacer to separate description from fields
+          BODY="${BODY}"$'\n\u200b'
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -153,9 +153,12 @@ jobs:
             PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
             SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
 
-            CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
-            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · 🔄 $PENDING running"
-            [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
+            CHECKS_FIELD=""
+            [ "$PASSING" -gt 0 ] && CHECKS_FIELD="✅ $PASSING passed"
+            [ "$FAILING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }❌ $FAILING failed"
+            [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }🔄 $PENDING running"
+            [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD:+$CHECKS_FIELD · }⏭️ $SKIPPED skipped"
+            [ -z "$CHECKS_FIELD" ] && CHECKS_FIELD="⏳ Pending"
           fi
 
           # ── Build payload ────────────────────────────────────────────────

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -53,12 +53,21 @@ jobs:
             PR_NUMBER="${{ github.event.pull_request.number }}"
           elif [ "$EVENT_NAME" = "check_run" ]; then
             HEAD_SHA="${{ github.event.check_run.head_sha }}"
+
+            # Try payload first
             PR_NUMBER=$(echo '${{ toJson(github.event.check_run.pull_requests) }}' \
               | jq -r '.[0].number // empty')
+            echo "check_run: sha=$HEAD_SHA pr_from_payload=$PR_NUMBER"
+
+            # Fallback: search open PRs by head SHA directly
             if [ -z "$PR_NUMBER" ]; then
-              PR_NUMBER=$(gh api "/repos/$REPO/commits/$HEAD_SHA/pulls" \
-                --jq '.[0].number // empty' 2>/dev/null)
+              PR_NUMBER=$(gh api "/repos/$REPO/pulls" \
+                -f state=open \
+                --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
+                2>/dev/null | head -1)
+              echo "check_run: pr_from_api=$PR_NUMBER"
             fi
+
             if [ -z "$PR_NUMBER" ]; then
               echo "No open PR for $HEAD_SHA — skipping"
               exit 0
@@ -68,8 +77,10 @@ jobs:
             PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' \
               | jq -r '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
-              PR_NUMBER=$(gh api "/repos/$REPO/commits/$HEAD_SHA/pulls" \
-                --jq '.[0].number // empty' 2>/dev/null)
+              PR_NUMBER=$(gh api "/repos/$REPO/pulls" \
+                -f state=open \
+                --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" \
+                2>/dev/null | head -1)
             fi
             if [ -z "$PR_NUMBER" ]; then
               echo "No open PR for $HEAD_SHA — skipping"
@@ -106,12 +117,7 @@ jobs:
           fi
 
           # ── Fetch check runs + commit statuses for this commit ────────────
-          # GitHub's PR checks page merges both APIs, so we must too.
-          # Deduplicate check runs by name (keep latest), filter out
-          # unexpanded matrix placeholders.
           MATRIX_MARKER=$(printf '\044\173\173')
-          # Exclude own check run ("notify") since it's always in-progress
-          # at query time; add it back as success below.
           CHECK_RUNS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" \
             --paginate --jq '[.check_runs[]]' 2>/dev/null \
             | jq -s --arg marker "$MATRIX_MARKER" 'add // []
@@ -126,7 +132,6 @@ jobs:
                 )})
               + [{name: "notify", state: "success"}]')
 
-          # Fetch commit statuses (used by CodeRabbit, external CI, etc.)
           COMMIT_STATUSES=$(gh api "repos/$REPO/commits/$HEAD_SHA/status" \
             --jq '[.statuses[] | {name: .context, state: (
                 if .state == "success" then "success"
@@ -135,7 +140,6 @@ jobs:
                 else "skipped" end
               )}]' 2>/dev/null || echo '[]')
 
-          # Merge both sources, dedup by name (check runs take priority)
           ALL_CHECKS=$(echo "$CHECK_RUNS"$'\n'"$COMMIT_STATUSES" \
             | jq -s 'add // [] | group_by(.name) | map(.[0])')
 
@@ -149,7 +153,6 @@ jobs:
             PENDING=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="pending")] | length')
             SKIPPED=$(echo "$ALL_CHECKS" | jq '[.[] | select(.state=="skipped")] | length')
 
-            # Always show passed and failed; only show running/skipped if > 0
             CHECKS_FIELD="✅ $PASSING passed · ❌ $FAILING failed"
             [ "$PENDING" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · 🔄 $PENDING running"
             [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
@@ -184,7 +187,6 @@ jobs:
             }]}')
 
           # ── Look up stored message ID ────────────────────────────────────
-          # Only match bot-authored hidden markers to avoid spoofing
           COMMENTS=$(gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq '[.[] | {id: .id, body: .body, author: .user.login}]')
 
@@ -197,16 +199,23 @@ jobs:
 
           # ── Post or patch ────────────────────────────────────────────────
           if [ -n "$DISCORD_MSG_ID" ]; then
-            PATCH_STATUS=$(curl -sS -o /dev/null -w "%{http_code}" -X PATCH \
+            PATCH_RESPONSE=$(curl -sS -w "\n%{http_code}" -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID")
+
+            PATCH_BODY=$(echo "$PATCH_RESPONSE" | head -n -1)
+            PATCH_STATUS=$(echo "$PATCH_RESPONSE" | tail -n 1)
+            echo "PATCH status: $PATCH_STATUS"
 
             if [ "$PATCH_STATUS" = "404" ]; then
               STALE_COMMENT_ID=$(echo "$COMMENTS" | \
                 jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$"))) | .id' | head -1)
               gh api -X DELETE "/repos/$REPO/issues/comments/$STALE_COMMENT_ID"
               DISCORD_MSG_ID=""
+            elif [ "$PATCH_STATUS" != "200" ]; then
+              echo "PATCH failed ($PATCH_STATUS): $PATCH_BODY"
+              exit 1
             fi
           fi
 

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -141,8 +141,9 @@ jobs:
           BODY=$(echo "$BODY" | perl -0pe 's/\n{3,}/\n\n/g')
           # Convert GH markdown checkboxes to unicode
           BODY=$(echo "$BODY" | sed 's/- \[ \]/☐/g; s/- \[x\]/☑/g; s/- \[X\]/☑/g')
-          # Convert ## headings to Discord bold
+          # Convert ## headings to Discord bold and remove the blank line after them
           BODY=$(echo "$BODY" | sed -E 's/^#{1,6} (.*)$/**\1**/g')
+          BODY=$(echo "$BODY" | perl -0pe 's/(\*\*[^*]+\*\*)\n\n/\1\n/g')
 
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -15,16 +15,18 @@ on:
       - converted_to_draft
       - closed
       - reopened
-  check_run:
+  workflow_run:
+    workflows: ['CI', 'PR checks']
     types: [completed]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  checks: read
 
 concurrency:
-  group: discord-pr-${{ github.event.pull_request.number || github.event.check_run.pull_requests[0].number }}
+  group: discord-pr-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number }}
   cancel-in-progress: true
 
 jobs:
@@ -48,9 +50,9 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
           else
-            HEAD_SHA="${{ github.event.check_run.head_sha }}"
-            # check_run.pull_requests is populated for same-repo PRs; fall back to API for forks
-            PR_NUMBER=$(echo '${{ toJson(github.event.check_run.pull_requests) }}' \
+            HEAD_SHA="${{ github.event.workflow_run.head_sha }}"
+            # workflow_run.pull_requests is populated for same-repo PRs; fall back to API for forks
+            PR_NUMBER=$(echo '${{ toJson(github.event.workflow_run.pull_requests) }}' \
               | jq -r '.[0].number // empty')
             if [ -z "$PR_NUMBER" ]; then
               PR_NUMBER=$(gh api "/repos/$REPO/commits/$HEAD_SHA/pulls" \
@@ -168,11 +170,12 @@ jobs:
             }]}')
 
           # ── Look up stored message ID ────────────────────────────────────
+          # Only match bot-authored hidden markers to avoid spoofing
           COMMENTS=$(gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
-            --jq '[.[] | {id: .id, body: .body}]')
+            --jq '[.[] | {id: .id, body: .body, author: .user.login}]')
 
           DISCORD_MSG_ID=$(echo "$COMMENTS" | \
-            jq -r '.[] | select(.body | contains("discord-msg-id:")) | .body' | \
+            jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$"))) | .body' | \
             grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2 | head -1)
 
           WEBHOOK_ID=$(echo    "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $(NF-1)}')
@@ -187,7 +190,7 @@ jobs:
 
             if [ "$PATCH_STATUS" = "404" ]; then
               STALE_COMMENT_ID=$(echo "$COMMENTS" | \
-                jq -r '.[] | select(.body | contains("discord-msg-id:")) | .id' | head -1)
+                jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$"))) | .id' | head -1)
               gh api -X DELETE "/repos/$REPO/issues/comments/$STALE_COMMENT_ID"
               DISCORD_MSG_ID=""
             fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -155,12 +155,6 @@ jobs:
             [ "$SKIPPED" -gt 0 ] && CHECKS_FIELD="${CHECKS_FIELD} · ⏭️ $SKIPPED skipped"
           fi
 
-          # On pull_request events, CI checks may not exist yet (timing gap).
-          # check_run and workflow_run triggers update the embed as checks complete.
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            CHECKS_FIELD="${CHECKS_FIELD} · ⏳ CI starting..."
-          fi
-
           # ── Build payload ────────────────────────────────────────────────
           PAYLOAD=$(jq -n \
             --arg  title     "#$PR_NUMBER $PR_TITLE" \

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -22,3 +22,14 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           sync-labels: true
+
+  discord-notify:
+    needs: [label]
+    if: always()
+    uses: ./.github/workflows/discord-pr.yml
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      checks: read
+    secrets: inherit


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

Enhance the Discord PR notification workflow to update a single embed message throughout the PR lifecycle instead of posting once on open. Tracks PR state (open/draft/closed/merged), labels, assignees, reviewers, and live CI check results by reacting to pull_request and check_run events. Uses a hidden PR comment to store the Discord message ID for subsequent PATCH updates.

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

Chore

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

https://github.com/rocketride-org/rocketride-server/issues/613

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->