### PR TITLE
chore: pin pnpm version via packageManager field

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
-          version: 10
+          version: 10.33.0
       - name: Set up vcpkg
         run: ${{ matrix.builder_cmd }} vcpkg:submodule-build
       - name: Set up vcpkg nuget / Linux/macOS

--- a/package.json
+++ b/package.json
@@ -34,9 +34,10 @@
 	"scripts": {
 		"prepare": "lefthook install --force"
 	},
+	"packageManager": "pnpm@10.33.0",
 	"engines": {
 		"node": ">=18.0.0",
-		"pnpm": ">=8.0.0"
+		"pnpm": ">=10.0.0"
 	},
 	"pnpm": {
 		"peerDependencyRules": {


### PR DESCRIPTION
## Summary

Recurrence-prevention follow-up to #621 / #622.

Adds `"packageManager": "pnpm@10.33.0"` to root `package.json` so contributors using corepack get the same pnpm version as CI (`.github/workflows/_build.yaml` uses `pnpm/action-setup@v4` with `version: 10`). Also bumps `engines.pnpm` from `>=8.0.0` to `>=10.0.0` for consistency.

## Why

The previous loose constraint (`>=8.0.0`) allowed contributors to regenerate `pnpm-lock.yaml` with pnpm 8 or 9, which strips lockfile-v9+ fields like `libc` from native package entries. That's exactly what happened in #621 and required #622 as a follow-up cleanup.

With this change:
- `corepack enable && pnpm install` (or just running `pnpm` in a corepack-enabled environment) automatically uses pnpm 10.33.0
- Lockfile regenerations match CI's pnpm version every time
- The libc / Alpine regression class can't recur

## Test plan
- [ ] CI builds pass on this PR (Ubuntu, Windows, macOS)
- [ ] `pnpm install --frozen-lockfile` validates against the existing lockfile (verified locally)

## Notes

If anyone has a pinned pnpm version locally that's different from 10.33.0, corepack will warn and prompt to use the pinned version. Bump the patch as needed in future PRs when CI's pnpm version moves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration: package manager set to pnpm@10.33.0 and minimum pnpm requirement raised to >=10.0.0 (Node requirement unchanged).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->