### PR TITLE
docs(contributing): require green CI checks before review

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,7 +106,18 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
    - Testing performed
    - Breaking changes (if any)
 
-5. Wait for code review and address feedback
+5. **Ensure all CI checks pass** before requesting a review. If you see unexpected failures (compilation errors, test failures unrelated to your changes), your branch is likely out of date with `develop`. Rebase before pushing:
+
+   ```bash
+   git fetch origin
+   git rebase origin/develop
+   ```
+
+   PRs with failing checks will not be reviewed until the checks are green.
+
+   If compilation still fails after rebasing and there is no open issue tracking it, and the code compiles cleanly on your machine — you've found a bug in CI or the build itself. Please open an issue and feel free to follow up with a PR to fix it.
+
+6. Wait for code review and address feedback
 
 ## Code Style Guidelines
 


### PR DESCRIPTION

## Summary

Adds a step to the PR process making it explicit that all CI checks must pass before requesting a review.

Includes guidance on the most common cause of spurious failures (branch out of date with `develop`) and a rebase command to fix it. Also notes that persistent unexplained failures after rebasing are issue candidates and contributions to fix them are welcome.


## Type

docs

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution workflow instructions with clarified CI check requirements before requesting review and added troubleshooting guidance for branches experiencing unexpected CI failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->