### PR TITLE
ci: build nightly prereleases from stage branch

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -3,6 +3,11 @@ name: Build
 on:
   workflow_call:
     inputs:
+      ref:
+        description: Git ref to check out (branch, tag, or sha). Empty uses the default.
+        required: false
+        type: string
+        default: ''
       full_version:
         description: Full build version (e.g. 1.2.3.456)
         required: true
@@ -72,6 +77,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.ref }}
           submodules: recursive
       - name: Set up pnpm
         uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4

--- a/.github/workflows/_docker.yaml
+++ b/.github/workflows/_docker.yaml
@@ -3,6 +3,11 @@ name: Docker
 on:
   workflow_call:
     inputs:
+      ref:
+        description: Git ref to check out (branch, tag, or sha). Empty uses the default.
+        required: false
+        type: string
+        default: ''
       server_version:
         required: true
         type: string
@@ -21,6 +26,8 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Download server artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4

--- a/.github/workflows/_init.yaml
+++ b/.github/workflows/_init.yaml
@@ -3,6 +3,11 @@ name: Initialize
 on:
   workflow_call:
     inputs:
+      ref:
+        description: Git ref to check out (branch, tag, or sha). Empty uses the default.
+        required: false
+        type: string
+        default: ''
       check_server_tag:
         description: Check whether the server release tag already exists
         required: false
@@ -49,6 +54,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: ${{ inputs.check_server_tag && '0' || '1' }}
       - name: Extract versions
         id: vars

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -3,6 +3,11 @@ name: Release
 on:
   workflow_call:
     inputs:
+      ref:
+        description: Git ref to check out (branch, tag, or sha). Empty uses the default.
+        required: false
+        type: string
+        default: ''
       prerelease:
         description: Create a prerelease (skips registry publishing, force-pushes tags)
         required: false
@@ -70,6 +75,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: ${{ inputs.ref }}
           fetch-depth: ${{ inputs.prerelease && 1 || 0 }}
 
       - name: Check if tag exists

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,9 @@ concurrency:
 
 on:
   push:
-    branches: [develop, main, 'release/**']
+    branches: [develop, stage, main, 'release/**']
   pull_request:
-    branches: [develop, main, 'release/**']
+    branches: [develop, stage, main, 'release/**']
   merge_group:
     types: [checks_requested]
   schedule:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,11 +19,14 @@ jobs:
   init:
     name: Initialize
     uses: ./.github/workflows/_init.yaml
+    with:
+      ref: stage
   build:
     name: Build
     needs: init
     uses: ./.github/workflows/_build.yaml
     with:
+      ref: stage
       full_version: ${{ needs.init.outputs.full_server_version }}
       build_hash: ${{ needs.init.outputs.build_hash }}
       build_stamp: ${{ needs.init.outputs.build_stamp }}
@@ -40,6 +43,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          ref: stage
           fetch-depth: 0
 
       - name: Delete existing prerelease tags and releases
@@ -69,6 +73,7 @@ jobs:
     needs: [init, build, cleanup-prereleases]
     uses: ./.github/workflows/_release.yaml
     with:
+      ref: stage
       prerelease: true
       server_version: ${{ needs.init.outputs.server_version }}
       vscode_version: ${{ needs.init.outputs.vscode_version }}
@@ -82,6 +87,7 @@ jobs:
     needs: [init, build]
     uses: ./.github/workflows/_docker.yaml
     with:
+      ref: stage
       server_version: ${{ needs.init.outputs.server_version }}
       prerelease: true
     secrets: inherit

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -21,7 +21,7 @@ The release pipeline consists of two workflows:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| **Nightly** (`.github/workflows/nightly.yaml`) | Daily at 02:00 UTC or manual dispatch | Build and publish prereleases from `develop` |
+| **Nightly** (`.github/workflows/nightly.yaml`) | Daily at 02:00 UTC or manual dispatch | Build and publish prereleases from `stage` |
 | **Release** (`.github/workflows/release.yaml`) | Push to `main` | Build, publish to registries, and create stable GitHub Releases |
 
 Both workflows build the full project across three platforms (Linux, Windows, macOS), run tests, and package artifacts. The key difference is that nightly creates prereleases on GitHub only, while the release workflow publishes to external registries (npm, PyPI, VS Code Marketplace) and creates stable GitHub Releases.
@@ -69,15 +69,16 @@ Each package produces specific artifacts during the build:
 
 ```
 feature/* ──┐
-bugfix/*  ──┼──> develop ──────────────> main
-hotfix/*  ──┘        │                    │
-                     │                    │
-              Nightly builds        Stable releases
-              (prereleases)      (registry + GitHub)
+bugfix/*  ──┼──> develop ──> stage ──> main
+hotfix/*  ──┘                  │         │
+                               │         │
+                        Nightly builds   Stable releases
+                        (prereleases)  (registry + GitHub)
 ```
 
-- **`develop`** — Integration branch. All feature and bugfix branches merge here. Nightly prereleases are built from this branch.
-- **`main`** — Stable release branch. When `develop` is merged into `main`, the release workflow triggers automatically.
+- **`develop`** — Integration branch. All feature and bugfix branches merge here. No prereleases are built from this branch.
+- **`stage`** — Prerelease stabilization branch. Changes are promoted from `develop` to `stage` once they are ready to be validated. Nightly prereleases are built from this branch, so a broken commit on `develop` cannot leak into a prerelease.
+- **`main`** — Stable release branch. When `stage` is merged into `main`, the release workflow triggers automatically.
 - **`feature/*`**, **`bugfix/*`**, **`hotfix/*`** — Short-lived branches that merge into `develop` via pull request.
 
 ## Nightly Prereleases
@@ -114,13 +115,13 @@ hotfix/*  ──┘        │                    │
 
 ### Downloading nightly builds
 
-Visit the [Releases page](https://github.com/rocketride-org/rocketride-server/releases) and look for releases tagged with `-prerelease`. These contain the latest development builds from the `develop` branch.
+Visit the [Releases page](https://github.com/rocketride-org/rocketride-server/releases) and look for releases tagged with `-prerelease`. These contain the latest builds from the `stage` branch.
 
 ## Stable Releases
 
 **Workflow:** `.github/workflows/release.yaml`
 
-**Trigger:** Automatically runs when commits are pushed to the `main` branch (typically via a merge from `develop`).
+**Trigger:** Automatically runs when commits are pushed to the `main` branch (typically via a merge from `stage`).
 
 ### What happens
 
@@ -173,12 +174,18 @@ Each package is published independently:
 ### How to release a new version
 
 1. **Bump the version** in the appropriate file(s) on the `develop` branch.
-2. **Commit and push** to `develop`. The next nightly build will create a prerelease with the new version.
+2. **Commit and push** to `develop`, then **merge `develop` into `stage`** once the change is ready to be validated:
+   ```bash
+   git checkout stage
+   git merge develop
+   git push origin stage
+   ```
+   The next nightly build will create a prerelease with the new version from `stage`.
 3. **Verify the prerelease** by downloading artifacts from the GitHub Releases page.
-4. **Merge `develop` into `main`**:
+4. **Merge `stage` into `main`**:
    ```bash
    git checkout main
-   git merge develop
+   git merge stage
    git push origin main
    ```
 5. The release workflow triggers automatically and publishes all packages with new versions.


### PR DESCRIPTION
## Summary
- Nightly workflow now builds from a new `stage` branch instead of `develop`, so a broken commit on `develop` can no longer leak into a prerelease.
- Added a `ref` input to `_init`, `_build`, `_release`, and `_docker` reusable workflows and plumbed it into each \`actions/checkout\` (scheduled triggers always resolve workflow files from the default branch, so the caller must pin the ref explicitly).
- Added \`stage\` to CI push/PR branch filters.
- Updated \`RELEASE.md\` branching diagram and release flow to \`develop → stage → main\`.

## Action items before merging
- Create the \`stage\` branch on the remote (e.g. \`git branch stage main && git push origin stage\`) — the nightly checkout will fail until it exists.
- This must land on \`develop\` (the default branch) before the next scheduled nightly picks it up.
- Recommended: add a branch protection rule on \`stage\` requiring CI to pass.

## Test plan
- [ ] \`stage\` branch created on the remote
- [ ] Manually dispatch the Nightly workflow and confirm it checks out \`stage\` in every job
- [ ] Confirm prerelease artifacts/tags are produced as before
- [ ] Open a PR targeting \`stage\` and confirm CI runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Discord notifications now sent for new discussions, issues, and pull requests

* **Documentation**
  * Updated release documentation to reflect the new branching strategy with the `stage` branch in the CI/CD pipeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->