### PR TITLE
ci: add daily Actions storage cleanup workflow

### DIFF
--- a/.github/workflows/storage-cleanup.yml
+++ b/.github/workflows/storage-cleanup.yml
@@ -77,13 +77,13 @@ jobs:
           while read -r id created size name; do
             CREATED_EPOCH=$(date -u -d "${created}" +%s)
             if [ "${CREATED_EPOCH}" -lt "${CUTOFF}" ]; then
-              if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" >/dev/null 2>&1; then
+              if err=$(gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" 2>&1 >/dev/null); then
                 DELETED=$((DELETED + 1))
                 BYTES=$((BYTES + size))
                 echo "  deleted #${id} (${name}, ${size} bytes, ${created})"
               else
                 FAILED=$((FAILED + 1))
-                echo "  failed to delete #${id}" >&2
+                echo "  failed to delete #${id}: ${err}" >&2
               fi
             fi
           done < "${ARTIFACTS_FILE}"
@@ -126,13 +126,13 @@ jobs:
           while read -r id last_used size key; do
             ACCESSED_EPOCH=$(date -u -d "${last_used}" +%s)
             if [ "${ACCESSED_EPOCH}" -lt "${CUTOFF}" ]; then
-              if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/caches/${id}" >/dev/null 2>&1; then
+              if err=$(gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/caches/${id}" 2>&1 >/dev/null); then
                 DELETED=$((DELETED + 1))
                 BYTES=$((BYTES + size))
                 echo "  deleted cache #${id} (${key}, ${size} bytes, accessed ${last_used})"
               else
                 FAILED=$((FAILED + 1))
-                echo "  failed to delete cache #${id}" >&2
+                echo "  failed to delete cache #${id}: ${err}" >&2
               fi
             fi
           done < "${CACHES_FILE}"

--- a/.github/workflows/storage-cleanup.yml
+++ b/.github/workflows/storage-cleanup.yml
@@ -17,12 +17,12 @@ on:
   workflow_dispatch:
     inputs:
       artifact_max_age_days:
-        description: Delete artifacts older than this many days
+        description: Delete artifacts older than this many days (minimum 1)
         required: false
         type: string
-        default: '2'
+        default: '3'
       cache_max_age_days:
-        description: Delete caches older than this many days
+        description: Delete caches older than this many days (minimum 1)
         required: false
         type: string
         default: '7'
@@ -44,11 +44,32 @@ jobs:
       - name: Delete old artifacts
         env:
           GH_TOKEN: ${{ github.token }}
-          MAX_AGE_DAYS: ${{ inputs.artifact_max_age_days || '2' }}
+          MAX_AGE_DAYS: ${{ inputs.artifact_max_age_days || '3' }}
         run: |
           set -euo pipefail
+
+          # Reject 0 / non-positive: a 0-day window resolves to "now" and would
+          # delete every artifact created before the script started, including
+          # ones uploaded seconds earlier. Aligns with the nightly's
+          # retention_days: 3 default.
+          if ! [[ "${MAX_AGE_DAYS}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::artifact_max_age_days must be a positive integer (got '${MAX_AGE_DAYS}')"
+            exit 1
+          fi
+
           CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
           echo "Deleting artifacts created before $(date -u -d @${CUTOFF} -Iseconds)"
+
+          # Materialize the API output to a file so producer failures surface
+          # via set -e. Process substitution (`< <(gh api ...)`) is async and
+          # its exit code is not visible to the surrounding command, so a
+          # failed `gh api --paginate` would be silently treated as an empty
+          # list and the job would report "0 deleted" instead of failing.
+          ARTIFACTS_FILE=$(mktemp)
+          trap 'rm -f "${ARTIFACTS_FILE}"' EXIT
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts" \
+            --jq '.artifacts[] | "\(.id) \(.created_at) \(.size_in_bytes) \(.name)"' \
+            > "${ARTIFACTS_FILE}"
 
           DELETED=0
           BYTES=0
@@ -63,8 +84,7 @@ jobs:
                 echo "  failed to delete #${id}" >&2
               fi
             fi
-          done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts" \
-                    --jq '.artifacts[] | "\(.id) \(.created_at) \(.size_in_bytes) \(.name)"')
+          done < "${ARTIFACTS_FILE}"
 
           MB=$((BYTES / 1024 / 1024))
           echo "Artifact cleanup complete: ${DELETED} artifacts, ${MB} MiB freed"
@@ -78,8 +98,20 @@ jobs:
           MAX_AGE_DAYS: ${{ inputs.cache_max_age_days || '7' }}
         run: |
           set -euo pipefail
+
+          if ! [[ "${MAX_AGE_DAYS}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::cache_max_age_days must be a positive integer (got '${MAX_AGE_DAYS}')"
+            exit 1
+          fi
+
           CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
           echo "Deleting caches last accessed before $(date -u -d @${CUTOFF} -Iseconds)"
+
+          CACHES_FILE=$(mktemp)
+          trap 'rm -f "${CACHES_FILE}"' EXIT
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/caches" \
+            --jq '.actions_caches[] | "\(.id) \(.last_accessed_at) \(.size_in_bytes) \(.key)"' \
+            > "${CACHES_FILE}"
 
           DELETED=0
           BYTES=0
@@ -94,8 +126,7 @@ jobs:
                 echo "  failed to delete cache #${id}" >&2
               fi
             fi
-          done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/caches" \
-                    --jq '.actions_caches[] | "\(.id) \(.last_accessed_at) \(.size_in_bytes) \(.key)"')
+          done < "${CACHES_FILE}"
 
           MB=$((BYTES / 1024 / 1024))
           echo "Cache cleanup complete: ${DELETED} caches, ${MB} MiB freed"

--- a/.github/workflows/storage-cleanup.yml
+++ b/.github/workflows/storage-cleanup.yml
@@ -1,0 +1,121 @@
+name: Actions storage cleanup
+run-name: Cleanup ${{ github.event_name == 'workflow_dispatch' && '(manual)' || '(scheduled)' }}
+
+# Why this workflow exists:
+#   GitHub Actions storage (artifacts + caches) is org-wide and counts against
+#   the included quota for the rocketride-org account. This monorepo's nightly
+#   build matrix uploads ~30 platform/client artifact bundles per run, which
+#   accumulates well beyond the 0.5 GB free tier even with retention_days: 3.
+#
+#   Storage usage is averaged over the billing cycle, so deleting old artifacts
+#   doesn't retroactively reduce the bill — but it lowers the rate of growth and
+#   prevents the next cycle from starting in the red. This job runs daily.
+
+on:
+  schedule:
+    - cron: '0 6 * * *' # Daily 06:00 UTC, 4h after the nightly build
+  workflow_dispatch:
+    inputs:
+      artifact_max_age_days:
+        description: Delete artifacts older than this many days
+        required: false
+        type: string
+        default: '2'
+      cache_max_age_days:
+        description: Delete caches older than this many days
+        required: false
+        type: string
+        default: '7'
+
+permissions:
+  actions: write
+  contents: read
+
+concurrency:
+  group: storage-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete old artifacts and caches
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Delete old artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_AGE_DAYS: ${{ inputs.artifact_max_age_days || '2' }}
+        run: |
+          set -euo pipefail
+          CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
+          echo "Deleting artifacts created before $(date -u -d @${CUTOFF} -Iseconds)"
+
+          DELETED=0
+          BYTES=0
+          while read -r id created size name; do
+            CREATED_EPOCH=$(date -u -d "${created}" +%s)
+            if [ "${CREATED_EPOCH}" -lt "${CUTOFF}" ]; then
+              if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/artifacts/${id}" >/dev/null 2>&1; then
+                DELETED=$((DELETED + 1))
+                BYTES=$((BYTES + size))
+                echo "  deleted #${id} (${name}, ${size} bytes, ${created})"
+              else
+                echo "  failed to delete #${id}" >&2
+              fi
+            fi
+          done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/artifacts" \
+                    --jq '.artifacts[] | "\(.id) \(.created_at) \(.size_in_bytes) \(.name)"')
+
+          MB=$((BYTES / 1024 / 1024))
+          echo "Artifact cleanup complete: ${DELETED} artifacts, ${MB} MiB freed"
+          echo "## Artifacts cleaned" >> $GITHUB_STEP_SUMMARY
+          echo "- Deleted: ${DELETED}" >> $GITHUB_STEP_SUMMARY
+          echo "- Freed: ${MB} MiB" >> $GITHUB_STEP_SUMMARY
+
+      - name: Delete old caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          MAX_AGE_DAYS: ${{ inputs.cache_max_age_days || '7' }}
+        run: |
+          set -euo pipefail
+          CUTOFF=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
+          echo "Deleting caches last accessed before $(date -u -d @${CUTOFF} -Iseconds)"
+
+          DELETED=0
+          BYTES=0
+          while read -r id last_used size key; do
+            ACCESSED_EPOCH=$(date -u -d "${last_used}" +%s)
+            if [ "${ACCESSED_EPOCH}" -lt "${CUTOFF}" ]; then
+              if gh api -X DELETE "repos/${GITHUB_REPOSITORY}/actions/caches/${id}" >/dev/null 2>&1; then
+                DELETED=$((DELETED + 1))
+                BYTES=$((BYTES + size))
+                echo "  deleted cache #${id} (${key}, ${size} bytes, accessed ${last_used})"
+              else
+                echo "  failed to delete cache #${id}" >&2
+              fi
+            fi
+          done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/actions/caches" \
+                    --jq '.actions_caches[] | "\(.id) \(.last_accessed_at) \(.size_in_bytes) \(.key)"')
+
+          MB=$((BYTES / 1024 / 1024))
+          echo "Cache cleanup complete: ${DELETED} caches, ${MB} MiB freed"
+          echo "## Caches cleaned" >> $GITHUB_STEP_SUMMARY
+          echo "- Deleted: ${DELETED}" >> $GITHUB_STEP_SUMMARY
+          echo "- Freed: ${MB} MiB" >> $GITHUB_STEP_SUMMARY
+
+      - name: Report current usage
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          ARTIFACT_COUNT=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts" --jq '.total_count')
+          CACHE_INFO=$(gh api "repos/${GITHUB_REPOSITORY}/actions/cache/usage")
+          CACHE_COUNT=$(echo "${CACHE_INFO}" | jq -r '.active_caches_count')
+          CACHE_BYTES=$(echo "${CACHE_INFO}" | jq -r '.active_caches_size_in_bytes')
+          CACHE_MB=$((CACHE_BYTES / 1024 / 1024))
+
+          echo "## Current storage" >> $GITHUB_STEP_SUMMARY
+          echo "- Artifacts remaining: ${ARTIFACT_COUNT}" >> $GITHUB_STEP_SUMMARY
+          echo "- Active caches: ${CACHE_COUNT} (${CACHE_MB} MiB)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "_Note: cache usage counter recalculates every 6–12h, so values here may lag actual deletions._" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/storage-cleanup.yml
+++ b/.github/workflows/storage-cleanup.yml
@@ -73,6 +73,7 @@ jobs:
 
           DELETED=0
           BYTES=0
+          FAILED=0
           while read -r id created size name; do
             CREATED_EPOCH=$(date -u -d "${created}" +%s)
             if [ "${CREATED_EPOCH}" -lt "${CUTOFF}" ]; then
@@ -81,6 +82,7 @@ jobs:
                 BYTES=$((BYTES + size))
                 echo "  deleted #${id} (${name}, ${size} bytes, ${created})"
               else
+                FAILED=$((FAILED + 1))
                 echo "  failed to delete #${id}" >&2
               fi
             fi
@@ -91,6 +93,11 @@ jobs:
           echo "## Artifacts cleaned" >> $GITHUB_STEP_SUMMARY
           echo "- Deleted: ${DELETED}" >> $GITHUB_STEP_SUMMARY
           echo "- Freed: ${MB} MiB" >> $GITHUB_STEP_SUMMARY
+          if [ "${FAILED}" -gt 0 ]; then
+            echo "- Failed: ${FAILED}" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Artifact cleanup had ${FAILED} failed deletions"
+            exit 1
+          fi
 
       - name: Delete old caches
         env:
@@ -115,6 +122,7 @@ jobs:
 
           DELETED=0
           BYTES=0
+          FAILED=0
           while read -r id last_used size key; do
             ACCESSED_EPOCH=$(date -u -d "${last_used}" +%s)
             if [ "${ACCESSED_EPOCH}" -lt "${CUTOFF}" ]; then
@@ -123,6 +131,7 @@ jobs:
                 BYTES=$((BYTES + size))
                 echo "  deleted cache #${id} (${key}, ${size} bytes, accessed ${last_used})"
               else
+                FAILED=$((FAILED + 1))
                 echo "  failed to delete cache #${id}" >&2
               fi
             fi
@@ -133,6 +142,11 @@ jobs:
           echo "## Caches cleaned" >> $GITHUB_STEP_SUMMARY
           echo "- Deleted: ${DELETED}" >> $GITHUB_STEP_SUMMARY
           echo "- Freed: ${MB} MiB" >> $GITHUB_STEP_SUMMARY
+          if [ "${FAILED}" -gt 0 ]; then
+            echo "- Failed: ${FAILED}" >> $GITHUB_STEP_SUMMARY
+            echo "::error::Cache cleanup had ${FAILED} failed deletions"
+            exit 1
+          fi
 
       - name: Report current usage
         env:


### PR DESCRIPTION
## Summary
- New \`.github/workflows/storage-cleanup.yml\` runs daily at 06:00 UTC (4h after the nightly).
- Deletes artifacts older than 2 days and caches older than 7 days. Both ages are configurable on \`workflow_dispatch\`.
- Reports counts and freed bytes via \`\$GITHUB_STEP_SUMMARY\` so it's easy to spot regressions.

## Why
The org's free Actions storage quota (0.5 GB included) was sitting at 100%. This repo alone had **29.7 GB across 480 artifacts** plus 705 MB of caches, accumulated despite the nightly's \`retention_days: 3\` because the build matrix uploads ~30 bundles per run. I manually wiped the backlog today; this workflow keeps the meter near zero going forward.

Storage usage is **averaged over the billing cycle**, so daily deletion lowers the *rate* of growth — it doesn't retroactively reduce the current bill (per the GitHub community discussion on storage management). Combined with a small spending limit it's enough to keep nightlies running through the May 1 reset.

## Action items not in this PR (UI-only, can't be set via API)
- [ ] Set org-wide artifact retention default to **7 days** (currently 90): Settings → Actions → General → Artifact and log retention. Defense-in-depth alongside this workflow.
- [ ] Set an Actions spending limit of \`\$5/mo\` so a runaway upload doesn't fail nightlies before this workflow has a chance to clean up: Settings → Billing → Spending limits → Actions.

## Test plan
- [ ] After merge, manually dispatch with \`artifact_max_age_days: 0\` once to confirm the script handles an empty artifact list (it should report \`Deleted: 0\`)
- [ ] After tomorrow's nightly, manually dispatch and confirm the post-nightly artifacts survive (they're <24h old, threshold is 2 days)
- [ ] After 3 days, confirm the scheduled run is removing the now-stale nightly artifacts via the step summary

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to regularly clean up repository storage by removing old artifacts and caches; runs daily and can be triggered manually, with configurable age thresholds (defaults: artifacts 3 days, caches 7 days).
  * Workflow now summarizes each run with deletion counts, freed space, and current storage usage for visibility; run fails if any deletions cannot be completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->