### PR TITLE
docs(client-python): update stale Python 3.8 references to 3.10

### DIFF
--- a/docs/agents/ROCKETRIDE_python_API.md
+++ b/docs/agents/ROCKETRIDE_python_API.md
@@ -957,7 +957,7 @@ Common error scenarios:
 
 ## Requirements
 
-- Python 3.8 or higher
+- Python 3.10 or higher
 - WebSocket connection to RocketRide DAP server
 - Valid API key for authentication
 

--- a/packages/client-python/src/rocketride/types/client.py
+++ b/packages/client-python/src/rocketride/types/client.py
@@ -38,7 +38,7 @@ Types Defined:
     DisconnectCallback: Type alias for disconnection callbacks
     TraceInfo: Stack trace information for debugging errors
 
-These types are compatible with Python 3.8+ using native typing without extensions.
+These types are compatible with Python 3.10+ using native typing without extensions.
 
 Usage:
     from rocketride.types import RocketRideClientConfig, EventCallback


### PR DESCRIPTION
## Summary
- Updates `ROCKETRIDE_python_API.md` requirement from "Python 3.8 or higher" to "Python 3.10 or higher"
- Updates `client.py` docstring from "Python 3.8+" to "Python 3.10+"
- Follow-up to #491 which bumped `requires-python` to `>=3.10` in `pyproject.toml` but didn't update these doc references
- Closes #434 (supersedes #564)

## Type
docs

## Test plan
- [x] Verified no other stale Python 3.8 references remain in the repo (`grep` returns empty)
- [x] Diff is exactly 2 files, 2 lines — no unrelated changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated minimum Python runtime requirement from 3.8+ to 3.10+ across API documentation and client package module specifications

<!-- end of auto-generated comment: release notes by coderabbit.ai -->