### PR TITLE
Feat: deepagent subagents

### DIFF
--- a/nodes/src/nodes/agent_deepagent/IGlobal.py
+++ b/nodes/src/nodes/agent_deepagent/IGlobal.py
@@ -65,9 +65,14 @@ class IGlobal(IGlobalBase):
         requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
         depends(requirements)
 
-        from .deepagent import DeepAgentDriver
+        if self.glb.logicalType == 'agent_deepagent_subagent':
+            from .deepagent import DeepAgentSubagentDriver
 
-        self.agent = DeepAgentDriver(self)
+            self.agent = DeepAgentSubagentDriver(self)
+        else:
+            from .deepagent import DeepAgentDriver
+
+            self.agent = DeepAgentDriver(self)
 
     def endGlobal(self) -> None:
         """

--- a/nodes/src/nodes/agent_deepagent/IInstance.py
+++ b/nodes/src/nodes/agent_deepagent/IInstance.py
@@ -102,22 +102,15 @@ class IInstance(IInstanceBase):
         from rocketlib.types import IInvokeDeepagent
 
         driver = self.IGlobal.agent
-
         pipe_type = self.instance.pipeType
         node_id = str(pipe_type.get('id') if isinstance(pipe_type, dict) else getattr(pipe_type, 'id', '')) or ''
 
-        # Use driver attributes resolved at init time
-        name = node_id or str(self.IGlobal.glb.logicalType)
-        description = getattr(driver, '_description', '') or ''
-        system_prompt = getattr(driver, '_system_prompt', '') or ''
-        instructions = list(getattr(driver, '_instructions', []) or [])
-
         param.agents.append(
             IInvokeDeepagent.DescribeResponse(
-                name=name,
-                description=description,
-                system_prompt=system_prompt,
-                instructions=instructions,
+                name=node_id or str(self.IGlobal.glb.logicalType),
+                description=driver._description,
+                system_prompt=driver._system_prompt,
+                instructions=list(driver._instructions or []),
                 node_id=node_id,
                 invoke=self,
             )

--- a/nodes/src/nodes/agent_deepagent/IInstance.py
+++ b/nodes/src/nodes/agent_deepagent/IInstance.py
@@ -64,7 +64,9 @@ class IInstance(IInstanceBase):
         Handle a control-plane invocation on this node instance.
 
         Intercepts ``tool.*`` operations so the node can be composed as a tool inside
-        a parent agent.  All other operations are forwarded to the base-class handler.
+        a parent agent.  Intercepts ``deepagent.describe`` so this node can register
+        itself as a sub-agent with a DeepAgent orchestrator.  All other operations are
+        forwarded to the base-class handler.
 
         Args:
             param: Invocation parameter dict (with an ``op`` key) or an object with
@@ -77,4 +79,46 @@ class IInstance(IInstanceBase):
         op = param.get('op') if isinstance(param, dict) else getattr(param, 'op', None)
         if isinstance(op, str) and op.startswith('tool.'):
             return self.IGlobal.agent.handle_invoke(self, param)
+        if isinstance(op, str) and op == 'deepagent.describe':
+            self._handle_deepagent_describe(param)
+            return
         return super().invoke(param)
+
+    def _handle_deepagent_describe(self, param: Any) -> None:
+        """
+        Respond to a ``deepagent.describe`` fan-out from an orchestrator.
+
+        Reads resolved config from the driver (set at init time) and appends a
+        ``DescribeResponse`` to ``param.agents`` so the orchestrator can build a
+        ``SubAgent`` entry.
+
+        Args:
+            param: An ``IInvokeDeepagent.Describe`` instance whose ``agents`` list
+                is populated in-place.
+
+        Returns:
+            None
+        """
+        from rocketlib.types import IInvokeDeepagent
+
+        driver = self.IGlobal.agent
+
+        pipe_type = self.instance.pipeType
+        node_id = str(pipe_type.get('id') if isinstance(pipe_type, dict) else getattr(pipe_type, 'id', '')) or ''
+
+        # Use driver attributes resolved at init time
+        name = node_id or str(self.IGlobal.glb.logicalType)
+        description = getattr(driver, '_description', '') or ''
+        system_prompt = getattr(driver, '_system_prompt', '') or ''
+        instructions = list(getattr(driver, '_instructions', []) or [])
+
+        param.agents.append(
+            IInvokeDeepagent.DescribeResponse(
+                name=name,
+                description=description,
+                system_prompt=system_prompt,
+                instructions=instructions,
+                node_id=node_id,
+                invoke=self,
+            )
+        )

--- a/nodes/src/nodes/agent_deepagent/deepagent.py
+++ b/nodes/src/nodes/agent_deepagent/deepagent.py
@@ -31,7 +31,7 @@ from typing import Any, Callable
 
 from ai.common.agent import AgentBase
 from ai.common.agent.types import AgentHost, AgentInput, AgentRunResult
-from rocketlib import ToolDescriptor
+from rocketlib import ToolDescriptor, debug, error
 
 
 class DeepAgentDriver(AgentBase):
@@ -167,33 +167,25 @@ class DeepAgentDriver(AgentBase):
                     A ``ChatResult`` wrapping either a tool-call ``AIMessage`` or a plain
                     ``AIMessage`` with the raw LLM text as its content.
                 """
-                from rocketlib import debug as _debug
-
                 transcript = _langchain_messages_to_transcript(messages)
                 tool_hint = _tool_call_protocol_prompt(self._bound_tools)
                 prompt = (tool_hint + '\n\n' + transcript).strip()
 
-                _debug(f'deepagent _generate bound_tools={[t.get("name") for t in self._bound_tools]} prompt_len={len(prompt)}')
-
                 # Stop generation at the first newline-then-brace, which is the
                 # LLM's common failure mode of emitting a second JSON object after
                 # the intended one (either a duplicate call or a hallucinated final).
-                stop_list = list(stop) if isinstance(stop, list) else ([stop] if isinstance(stop, str) else [])
-                if '\n{' not in stop_list:
-                    stop_list = stop_list + ['\n{']
+                stop_list = _merge_stop_words(stop, '\n{')
 
                 raw = ''
                 for attempt in range(3):
                     raw = _safe_str(call_llm(prompt, stop_words=stop_list)).strip()
-                    _debug(f'deepagent _generate attempt={attempt} raw_len={len(raw)} raw_head={raw[:400]!r}')
                     msg = _parse_tool_call_envelope(raw)
                     if msg is not None:
-                        _debug(f'deepagent _generate parsed envelope tool_calls={getattr(msg, "tool_calls", None)}')
                         return ChatResult(generations=[ChatGeneration(message=msg)])
                     if attempt < 2:
                         prompt = prompt + '\n\nsystem: Your last output was invalid. Output ONLY a single JSON object per the schema.'
 
-                _debug('deepagent _generate parse FAILED after 3 attempts; falling back to plain AIMessage')
+                debug('deepagent _generate parse failed after 3 attempts; falling back to plain text')
                 return ChatResult(generations=[ChatGeneration(message=AIMessage(content=raw))])
 
         return RocketRideToolCallingChatModel()
@@ -576,8 +568,6 @@ class DeepAgentDriver(AgentBase):
             Returns:
                 None
             """
-            from rocketlib import debug
-
             debug(f'deep agent tool call tool={tool_name} input_len={len(_safe_str(input))} output_len={len(_safe_str(output))}')
 
         llm = self._bind_framework_llm(host=host, call_llm=_call_llm, ctx=ctx)
@@ -589,28 +579,18 @@ class DeepAgentDriver(AgentBase):
             ctx=ctx,
         )
 
-        from ai.common.config import Config
-
-        _config = Config.getNodeConfig(self._iGlobal.glb.logicalType, self._iGlobal.glb.connConfig)
-        system_prompt = (_config.get('system_prompt', '') or '').strip()
-        if not system_prompt:
-            system_prompt = 'You are an agent node in a tool-invocation hierarchy.\nUse the provided tools when needed.'
+        system_prompt = _compose_system_prompt(
+            base=self._system_prompt,
+            instructions=self._instructions,
+            fallback='You are an agent node in a tool-invocation hierarchy.\nUse the provided tools when needed.',
+        )
 
         # Fan out deepagent.describe to any connected sub-agent nodes
         subagents_list = self._collect_subagents(host=host, ctx=ctx, log_tool_call=_log_tool_call)
         if subagents_list:
             self.sendSSE('thinking', message=f'Collected {len(subagents_list)} sub-agent(s)')
 
-        from rocketlib import debug as _debug
-
-        _debug(f'deep agent create system_prompt_len={len(system_prompt)} tools={len(tools_for_agent)} subagents={len(subagents_list)}')
-        for _sa in subagents_list:
-            _sa_name = _sa.get('name', '') if isinstance(_sa, dict) else getattr(_sa, 'name', '')
-            _sa_desc = _sa.get('description', '') if isinstance(_sa, dict) else getattr(_sa, 'description', '')
-            _sa_sp = _sa.get('system_prompt', '') if isinstance(_sa, dict) else getattr(_sa, 'system_prompt', '')
-            _sa_tools = _sa.get('tools', []) if isinstance(_sa, dict) else getattr(_sa, 'tools', [])
-            _sa_tool_names = [getattr(t, 'name', '') for t in (_sa_tools or [])]
-            _debug(f'  subagent name={_sa_name!r} description={_sa_desc!r} system_prompt={_sa_sp!r} tools={_sa_tool_names}')
+        debug(f'deep agent create system_prompt_len={len(system_prompt)} tools={len(tools_for_agent)} subagents={len(subagents_list)}')
 
         self.sendSSE('thinking', message='Starting Deep Agent...')
         stage = 'create_deep_agent'
@@ -720,27 +700,21 @@ class DeepAgentDriver(AgentBase):
                         ctx=ctx,
                     )
 
-                    # Merge system_prompt + instructions
-                    sp = (d.system_prompt or '').strip()
-                    for inst in d.instructions or []:
-                        if inst.strip():
-                            sp += f'\n{inst.strip()}'
-                    if not sp:
-                        sp = 'You are a helpful sub-agent. Use your tools to complete the assigned task.'
-
                     subagents.append(
                         _SubAgent(
                             name=d.name,
                             description=d.description or d.name,
-                            system_prompt=sp,
+                            system_prompt=_compose_system_prompt(
+                                base=d.system_prompt,
+                                instructions=d.instructions,
+                                fallback='You are a helpful sub-agent. Use your tools to complete the assigned task.',
+                            ),
                             tools=sa_tools,
                             model=sa_llm,
                         )
                     )
                 except Exception as e:
-                    from rocketlib import error as _error
-
-                    _error(f'deep agent collect_subagents failed for node={node_id}: {type(e).__name__}: {_safe_str(e)}')
+                    error(f'deep agent collect_subagents failed for node={node_id}: {type(e).__name__}: {_safe_str(e)}')
 
         return subagents
 
@@ -809,45 +783,54 @@ def _normalize_bound_tools(tools: Any) -> list[dict[str, Any]]:
     Returns:
         A list of ``dict`` objects suitable for use with ``_tool_call_protocol_prompt``.
     """
-    out: list[dict[str, Any]] = []
     if not tools:
-        return out
+        return []
     if not isinstance(tools, list):
         tools = [tools]
-    for t in tools:
-        name = _safe_str(getattr(t, 'name', ''))
-        desc = _safe_str(getattr(t, 'description', ''))
-        schema: Any = None
-        input_schema: Any = None
-        try:
-            schema = getattr(t, 'args_schema', None)
-        except Exception:
-            schema = None
-        try:
-            input_schema = getattr(t, '_rr_input_schema', None)
-        except Exception:
-            input_schema = None
 
-        # Prefer a structured JSON-Schema over the opaque str(schema). Pydantic v2
-        # models expose `.model_json_schema()`; fall back gracefully otherwise.
-        args_schema_json: Any = None
-        try:
-            if schema is not None and hasattr(schema, 'model_json_schema'):
-                args_schema_json = schema.model_json_schema()
-            elif schema is not None and hasattr(schema, 'schema'):
-                args_schema_json = schema.schema()
-        except Exception:
-            args_schema_json = None
+    out: list[dict[str, Any]] = []
+    for t in tools:
+        schema = getattr(t, 'args_schema', None)
+        input_schema = getattr(t, '_rr_input_schema', None)
 
         entry: dict[str, Any] = {
-            'name': name,
-            'description': desc,
-            'args_schema': args_schema_json if isinstance(args_schema_json, dict) else _safe_str(schema),
+            'name': _safe_str(getattr(t, 'name', '')),
+            'description': _safe_str(getattr(t, 'description', '')),
+            'args_schema': _tool_args_schema(schema),
         }
         if isinstance(input_schema, dict):
             entry['input_schema'] = input_schema
         out.append(entry)
     return out
+
+
+def _tool_args_schema(schema: Any) -> Any:
+    """
+    Return a JSON-Schema dict for a tool's ``args_schema``, or a string fallback.
+
+    Pydantic v2 models expose ``model_json_schema()``; older models expose ``schema()``.
+    When neither works, falls back to ``str(schema)`` so the LLM still sees *something*
+    identifying the expected shape.
+
+    Args:
+        schema: The ``args_schema`` attribute from a LangChain tool — typically a
+            pydantic model class, or ``None``.
+
+    Returns:
+        A JSON-Schema ``dict`` when extractable, otherwise the string representation.
+    """
+    if schema is None:
+        return ''
+    for attr in ('model_json_schema', 'schema'):
+        fn = getattr(schema, attr, None)
+        if callable(fn):
+            try:
+                result = fn()
+                if isinstance(result, dict):
+                    return result
+            except Exception:
+                continue
+    return _safe_str(schema)
 
 
 def _langchain_messages_to_transcript(messages: Any) -> str:
@@ -951,39 +934,80 @@ def _parse_tool_call_envelope(raw: str) -> Any:
     if not isinstance(obj, dict):
         return None
 
+    try:
+        from langchain_core.messages import AIMessage
+    except Exception:
+        return None
+
     msg_type = obj.get('type')
     if msg_type == 'final':
-        content = _safe_str(obj.get('content', ''))
-        try:
-            from langchain_core.messages import AIMessage
-
-            return AIMessage(content=content)
-        except Exception:
-            return None
+        return AIMessage(content=_safe_str(obj.get('content', '')))
 
     if msg_type == 'tool_call':
         name = _safe_str(obj.get('name', '')).strip()
         if not name:
             return None
-        args = obj.get('args')
-        if args is None:
-            args = {}
+        args = obj.get('args') or {}
         if not isinstance(args, dict):
             args = {'input': args}
 
         tool_call = {'id': f'call_{uuid.uuid4().hex[:12]}', 'type': 'tool_call', 'name': name, 'args': args}
-
-        try:
-            from langchain_core.messages import AIMessage
-
-            try:
-                return AIMessage(content='', tool_calls=[tool_call])
-            except Exception:
-                return AIMessage(content='', additional_kwargs={'tool_calls': [tool_call]})
-        except Exception:
-            return None
+        return AIMessage(content='', tool_calls=[tool_call])
 
     return None
+
+
+def _compose_system_prompt(*, base: str | None, instructions: list[str] | None, fallback: str) -> str:
+    """
+    Combine a base system prompt with trailing instruction lines.
+
+    Used by both the manager (``DeepAgentDriver._run``) and the sub-agent collector
+    (``_collect_subagents``) so the two paths produce prompts in an identical shape:
+
+    * Start with *base* (stripped); fall back to *fallback* when *base* is empty.
+    * Append each non-empty instruction on its own line.
+
+    Args:
+        base: The primary system prompt string, or ``None``/empty for the fallback.
+        instructions: Optional list of instruction lines to append.
+        fallback: Default prompt text used when *base* is empty after stripping.
+
+    Returns:
+        A single system-prompt string ready to hand to ``create_deep_agent``.
+    """
+    prompt = (base or '').strip() or fallback
+    for inst in instructions or []:
+        inst = inst.strip()
+        if inst:
+            prompt = f'{prompt}\n{inst}'
+    return prompt
+
+
+def _merge_stop_words(existing: Any, extra: str) -> list[str]:
+    """
+    Merge *extra* into an existing stop-word value (list, string, or ``None``).
+
+    Used by the tool-call protocol adapter to append a guard sequence (e.g. ``'\\n{'``)
+    that halts generation at the first sign of a second JSON object, without
+    clobbering any stop words the caller (LangChain/LangGraph) already supplied.
+
+    Args:
+        existing: The ``stop`` value passed in by LangChain — a list, a single
+            string, or ``None``.
+        extra: A stop string to append if not already present.
+
+    Returns:
+        A list of stop strings with *extra* appended exactly once.
+    """
+    if isinstance(existing, str):
+        stops = [existing]
+    elif existing:
+        stops = list(existing)
+    else:
+        stops = []
+    if extra not in stops:
+        stops.append(extra)
+    return stops
 
 
 def _extract_first_json_object(raw: str) -> Any:

--- a/nodes/src/nodes/agent_deepagent/deepagent.py
+++ b/nodes/src/nodes/agent_deepagent/deepagent.py
@@ -60,6 +60,13 @@ class DeepAgentDriver(AgentBase):
             None
         """
         super().__init__(iGlobal)
+        # Read system_prompt at init time alongside agent_description/_instructions
+        # (resolved by AgentBase.__init__ via Config.getNodeConfig)
+        from ai.common.config import Config
+
+        _config = Config.getNodeConfig(self._iGlobal.glb.logicalType, self._iGlobal.glb.connConfig)
+        self._system_prompt: str = (_config.get('system_prompt', '') or '').strip()
+        self._description: str = (_config.get('description', '') or '').strip()
 
     # ------------------------------------------------------------------
     # Bindings — identical to the LangChain driver since deepagents is
@@ -160,19 +167,33 @@ class DeepAgentDriver(AgentBase):
                     A ``ChatResult`` wrapping either a tool-call ``AIMessage`` or a plain
                     ``AIMessage`` with the raw LLM text as its content.
                 """
+                from rocketlib import debug as _debug
+
                 transcript = _langchain_messages_to_transcript(messages)
                 tool_hint = _tool_call_protocol_prompt(self._bound_tools)
                 prompt = (tool_hint + '\n\n' + transcript).strip()
 
+                _debug(f'deepagent _generate bound_tools={[t.get("name") for t in self._bound_tools]} prompt_len={len(prompt)}')
+
+                # Stop generation at the first newline-then-brace, which is the
+                # LLM's common failure mode of emitting a second JSON object after
+                # the intended one (either a duplicate call or a hallucinated final).
+                stop_list = list(stop) if isinstance(stop, list) else ([stop] if isinstance(stop, str) else [])
+                if '\n{' not in stop_list:
+                    stop_list = stop_list + ['\n{']
+
                 raw = ''
                 for attempt in range(3):
-                    raw = _safe_str(call_llm(prompt, stop_words=stop)).strip()
+                    raw = _safe_str(call_llm(prompt, stop_words=stop_list)).strip()
+                    _debug(f'deepagent _generate attempt={attempt} raw_len={len(raw)} raw_head={raw[:400]!r}')
                     msg = _parse_tool_call_envelope(raw)
                     if msg is not None:
+                        _debug(f'deepagent _generate parsed envelope tool_calls={getattr(msg, "tool_calls", None)}')
                         return ChatResult(generations=[ChatGeneration(message=msg)])
                     if attempt < 2:
                         prompt = prompt + '\n\nsystem: Your last output was invalid. Output ONLY a single JSON object per the schema.'
 
+                _debug('deepagent _generate parse FAILED after 3 attempts; falling back to plain AIMessage')
                 return ChatResult(generations=[ChatGeneration(message=AIMessage(content=raw))])
 
         return RocketRideToolCallingChatModel()
@@ -508,6 +529,9 @@ class DeepAgentDriver(AgentBase):
 
         tool_descriptors = self.discover_tools(host=host)
         self.sendSSE('thinking', message=f'Discovered {len(tool_descriptors)} host tool(s)')
+        from rocketlib import debug as _debug
+
+        _debug(f'deepagent _run discovered {len(tool_descriptors)} tools: {[td.get("name") if hasattr(td, "get") else str(td) for td in tool_descriptors]}')
 
         def _call_llm(messages: Any, stop_words: Any = None) -> str:
             """
@@ -565,12 +589,38 @@ class DeepAgentDriver(AgentBase):
             ctx=ctx,
         )
 
-        system_prompt = 'You are an agent node in a tool-invocation hierarchy.\nUse the provided tools when needed.'
+        from ai.common.config import Config
+
+        _config = Config.getNodeConfig(self._iGlobal.glb.logicalType, self._iGlobal.glb.connConfig)
+        system_prompt = (_config.get('system_prompt', '') or '').strip()
+        if not system_prompt:
+            system_prompt = 'You are an agent node in a tool-invocation hierarchy.\nUse the provided tools when needed.'
+
+        # Fan out deepagent.describe to any connected sub-agent nodes
+        subagents_list = self._collect_subagents(host=host, ctx=ctx, log_tool_call=_log_tool_call)
+        if subagents_list:
+            self.sendSSE('thinking', message=f'Collected {len(subagents_list)} sub-agent(s)')
+
+        from rocketlib import debug as _debug
+
+        _debug(f'deep agent create system_prompt_len={len(system_prompt)} tools={len(tools_for_agent)} subagents={len(subagents_list)}')
+        for _sa in subagents_list:
+            _sa_name = _sa.get('name', '') if isinstance(_sa, dict) else getattr(_sa, 'name', '')
+            _sa_desc = _sa.get('description', '') if isinstance(_sa, dict) else getattr(_sa, 'description', '')
+            _sa_sp = _sa.get('system_prompt', '') if isinstance(_sa, dict) else getattr(_sa, 'system_prompt', '')
+            _sa_tools = _sa.get('tools', []) if isinstance(_sa, dict) else getattr(_sa, 'tools', [])
+            _sa_tool_names = [getattr(t, 'name', '') for t in (_sa_tools or [])]
+            _debug(f'  subagent name={_sa_name!r} description={_sa_desc!r} system_prompt={_sa_sp!r} tools={_sa_tool_names}')
 
         self.sendSSE('thinking', message='Starting Deep Agent...')
         stage = 'create_deep_agent'
         try:
-            agent = create_deep_agent(model=llm, tools=tools_for_agent, system_prompt=system_prompt)
+            agent = create_deep_agent(
+                model=llm,
+                tools=tools_for_agent,
+                system_prompt=system_prompt,
+                subagents=subagents_list if subagents_list else None,
+            )
             stage = 'invoke'
             state = agent.invoke(
                 {'messages': [HumanMessage(content=_safe_str(agent_input.question.getPrompt() or ''))]},
@@ -594,6 +644,120 @@ class DeepAgentDriver(AgentBase):
             final_text = _safe_str(state)
 
         return _safe_str(final_text), state
+
+    def _collect_subagents(
+        self,
+        *,
+        host: AgentHost,
+        ctx: dict[str, Any],
+        log_tool_call: Any,
+    ) -> list[Any]:
+        """
+        Fan out ``deepagent.describe`` to all nodes on the ``deepagent`` invoke channel
+        and return a list of ``SubAgent`` TypedDicts ready for ``create_deep_agent``.
+
+        For each responding sub-agent, an ``AgentHostServices`` is created from the
+        sub-agent's own ``pSelf`` so its LLM and tools are routed through its own
+        engine channels independently of the orchestrator's.
+
+        Args:
+            host: The orchestrator's host services (unused here but kept for consistency).
+            ctx: Run-context dict forwarded from ``_run``.
+            log_tool_call: Debug logging callable forwarded to ``_bind_framework_tools``.
+
+        Returns:
+            A (possibly empty) list of ``deepagents.middleware.subagents.SubAgent`` dicts.
+        """
+        from rocketlib.types import IInvokeDeepagent
+        from ai.common.agent._internal.host import AgentHostServices
+
+        if not self._invoker:
+            return []
+
+        try:
+            deepagent_node_ids = self._invoker.instance.getControllerNodeIds('deepagent')
+        except Exception:
+            return []
+
+        if not deepagent_node_ids:
+            return []
+
+        from deepagents.middleware.subagents import SubAgent as _SubAgent  # noqa: PLC0415
+
+        subagents: list[Any] = []
+        for node_id in deepagent_node_ids:
+            req = IInvokeDeepagent.Describe()
+            try:
+                self._invoker.instance.invoke('deepagent', req, nodeId=node_id)
+            except Exception:
+                pass
+
+            for d in req.agents:
+                if d is None:
+                    continue
+                try:
+                    sa_host = AgentHostServices(d.invoke)
+
+                    def _sa_call_llm(messages: Any, stop_words: Any = None, _h: Any = sa_host) -> str:
+                        return self.call_host_llm(
+                            host=_h,
+                            messages=messages,
+                            question_role='You are a helpful assistant.',
+                            stop_words=stop_words,
+                        )
+
+                    sa_llm = self._bind_framework_llm(host=sa_host, call_llm=_sa_call_llm, ctx=ctx)
+                    sa_tool_descriptors = sa_host.tools.query()
+
+                    def _sa_invoke_tool(tool_name: str, input: Any = None, kwargs: Any = None, _h: Any = sa_host) -> Any:  # noqa: A002
+                        return self.invoke_host_tool(host=_h, tool_name=tool_name, input=input, kwargs=kwargs)
+
+                    sa_tools = self._bind_framework_tools(
+                        host=sa_host,
+                        tool_descriptors=sa_tool_descriptors,
+                        invoke_tool=_sa_invoke_tool,
+                        log_tool_call=log_tool_call,
+                        ctx=ctx,
+                    )
+
+                    # Merge system_prompt + instructions
+                    sp = (d.system_prompt or '').strip()
+                    for inst in d.instructions or []:
+                        if inst.strip():
+                            sp += f'\n{inst.strip()}'
+                    if not sp:
+                        sp = 'You are a helpful sub-agent. Use your tools to complete the assigned task.'
+
+                    subagents.append(
+                        _SubAgent(
+                            name=d.name,
+                            description=d.description or d.name,
+                            system_prompt=sp,
+                            tools=sa_tools,
+                            model=sa_llm,
+                        )
+                    )
+                except Exception as e:
+                    from rocketlib import error as _error
+
+                    _error(f'deep agent collect_subagents failed for node={node_id}: {type(e).__name__}: {_safe_str(e)}')
+
+        return subagents
+
+
+class DeepAgentSubagentDriver(DeepAgentDriver):
+    """
+    Sub-agent node driver for ``agent_deepagent_subagent``.
+
+    Behaviorally identical to ``DeepAgentDriver`` — runs a single ``create_deep_agent``
+    invocation with its own LLM and tools.  Registered under the
+    ``agent_deepagent_subagent`` logical type so it can be wired on an orchestrator's
+    ``deepagent`` invoke channel.
+
+    Does not fan out on a ``deepagent`` channel (no such channel on this node type).
+    """
+
+    FRAMEWORK = 'deepagent_subagent'
 
 
 # ------------------------------------------------------------------
@@ -664,7 +828,22 @@ def _normalize_bound_tools(tools: Any) -> list[dict[str, Any]]:
         except Exception:
             input_schema = None
 
-        entry: dict[str, Any] = {'name': name, 'description': desc, 'args_schema': _safe_str(schema)}
+        # Prefer a structured JSON-Schema over the opaque str(schema). Pydantic v2
+        # models expose `.model_json_schema()`; fall back gracefully otherwise.
+        args_schema_json: Any = None
+        try:
+            if schema is not None and hasattr(schema, 'model_json_schema'):
+                args_schema_json = schema.model_json_schema()
+            elif schema is not None and hasattr(schema, 'schema'):
+                args_schema_json = schema.schema()
+        except Exception:
+            args_schema_json = None
+
+        entry: dict[str, Any] = {
+            'name': name,
+            'description': desc,
+            'args_schema': args_schema_json if isinstance(args_schema_json, dict) else _safe_str(schema),
+        }
         if isinstance(input_schema, dict):
             entry['input_schema'] = input_schema
         out.append(entry)
@@ -768,10 +947,7 @@ def _parse_tool_call_envelope(raw: str) -> Any:
         A LangChain ``AIMessage`` on success, or ``None`` when *raw* is not valid JSON,
         has an unrecognised ``type`` value, or the required fields are absent.
     """
-    try:
-        obj = json.loads(raw)
-    except Exception:
-        return None
+    obj = _extract_first_json_object(raw)
     if not isinstance(obj, dict):
         return None
 
@@ -807,6 +983,76 @@ def _parse_tool_call_envelope(raw: str) -> Any:
         except Exception:
             return None
 
+    return None
+
+
+def _extract_first_json_object(raw: str) -> Any:
+    """
+    Best-effort extraction of the first balanced JSON object from a raw LLM response.
+
+    Complements the stop-word defence in the protocol adapter: if the model still
+    manages to emit trailing text or a second object after the first one closes
+    (e.g. ``{...}\\n{...}`` or ``{...}`` + commentary), this parser returns only
+    the first object rather than failing the whole envelope.
+
+    Tolerates:
+      * Leading/trailing whitespace or prose
+      * Markdown code fences (```json ... ```)
+      * Trailing content after the first closing brace
+      * Multiple concatenated JSON objects (returns only the first)
+
+    Args:
+        raw: The raw string returned by the LLM.
+
+    Returns:
+        The decoded first JSON object, or ``None`` if none can be parsed.
+    """
+    if not isinstance(raw, str) or not raw:
+        return None
+
+    s = raw.strip()
+    if s.startswith('```'):
+        s = s.split('\n', 1)[1] if '\n' in s else s[3:]
+        if '```' in s:
+            s = s.rsplit('```', 1)[0]
+        s = s.strip()
+
+    # Fast path: valid JSON as-is
+    try:
+        return json.loads(s)
+    except Exception:
+        pass
+
+    # Walk from the first '{' to its matching '}', honouring string escapes
+    start = s.find('{')
+    if start < 0:
+        return None
+
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(s)):
+        ch = s[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif ch == '\\':
+                esc = True
+            elif ch == '"':
+                in_str = False
+            continue
+        if ch == '"':
+            in_str = True
+        elif ch == '{':
+            depth += 1
+        elif ch == '}':
+            depth -= 1
+            if depth == 0:
+                candidate = s[start : i + 1]
+                try:
+                    return json.loads(candidate)
+                except Exception:
+                    return None
     return None
 
 

--- a/nodes/src/nodes/agent_deepagent/deepagent.py
+++ b/nodes/src/nodes/agent_deepagent/deepagent.py
@@ -171,14 +171,9 @@ class DeepAgentDriver(AgentBase):
                 tool_hint = _tool_call_protocol_prompt(self._bound_tools)
                 prompt = (tool_hint + '\n\n' + transcript).strip()
 
-                # Stop generation at the first newline-then-brace, which is the
-                # LLM's common failure mode of emitting a second JSON object after
-                # the intended one (either a duplicate call or a hallucinated final).
-                stop_list = _merge_stop_words(stop, '\n{')
-
                 raw = ''
                 for attempt in range(3):
-                    raw = _safe_str(call_llm(prompt, stop_words=stop_list)).strip()
+                    raw = _safe_str(call_llm(prompt, stop_words=stop)).strip()
                     msg = _parse_tool_call_envelope(raw)
                     if msg is not None:
                         return ChatResult(generations=[ChatGeneration(message=msg)])
@@ -983,41 +978,15 @@ def _compose_system_prompt(*, base: str | None, instructions: list[str] | None, 
     return prompt
 
 
-def _merge_stop_words(existing: Any, extra: str) -> list[str]:
-    """
-    Merge *extra* into an existing stop-word value (list, string, or ``None``).
-
-    Used by the tool-call protocol adapter to append a guard sequence (e.g. ``'\\n{'``)
-    that halts generation at the first sign of a second JSON object, without
-    clobbering any stop words the caller (LangChain/LangGraph) already supplied.
-
-    Args:
-        existing: The ``stop`` value passed in by LangChain — a list, a single
-            string, or ``None``.
-        extra: A stop string to append if not already present.
-
-    Returns:
-        A list of stop strings with *extra* appended exactly once.
-    """
-    if isinstance(existing, str):
-        stops = [existing]
-    elif existing:
-        stops = list(existing)
-    else:
-        stops = []
-    if extra not in stops:
-        stops.append(extra)
-    return stops
-
-
 def _extract_first_json_object(raw: str) -> Any:
     """
-    Best-effort extraction of the first balanced JSON object from a raw LLM response.
+    Extract the first balanced JSON object from a raw LLM response.
 
-    Complements the stop-word defence in the protocol adapter: if the model still
-    manages to emit trailing text or a second object after the first one closes
-    (e.g. ``{...}\\n{...}`` or ``{...}`` + commentary), this parser returns only
-    the first object rather than failing the whole envelope.
+    Handles the common failure modes we've seen from host LLMs producing the
+    tool-call envelope — extra prose, markdown fences, or a second JSON object
+    appended after the first one closes (e.g. a duplicate tool call or a
+    hallucinated final answer). Returns just the first object so the parser
+    can build a valid ``AIMessage`` instead of failing the whole envelope.
 
     Tolerates:
       * Leading/trailing whitespace or prose

--- a/nodes/src/nodes/agent_deepagent/services.json
+++ b/nodes/src/nodes/agent_deepagent/services.json
@@ -16,6 +16,10 @@
 		"tool": {
 			"description": "Tools available to the agent (via control-plane invoke)",
 			"min": 0
+		},
+		"deepagent": {
+			"description": "DeepAgent sub-agent nodes for hierarchical orchestration",
+			"min": 0
 		}
 	},
 	"lanes": {
@@ -36,7 +40,8 @@
 		"profiles": {
 			"default": {
 				"agent_description": "",
-				"instructions": []
+				"instructions": [],
+				"system_prompt": ""
 			}
 		}
 	},
@@ -47,6 +52,16 @@
 			"default": "",
 			"optional": true,
 			"description": "What does this agent do? Describe its purpose and capabilities \u2014 this helps parent agents select and invoke it correctly.",
+			"ui": {
+				"ui:widget": "textarea"
+			}
+		},
+		"system_prompt": {
+			"type": "string",
+			"title": "System prompt",
+			"default": "",
+			"optional": true,
+			"description": "Instructions that define this agent's role and behaviour. Leave blank to use the default.",
 			"ui": {
 				"ui:widget": "textarea"
 			}
@@ -62,7 +77,7 @@
 		},
 		"agent_deepagent.default": {
 			"object": "default",
-			"properties": ["agent_description", "instructions"]
+			"properties": ["agent_description", "system_prompt", "instructions"]
 		},
 		"agent_deepagent.profile": {
 			"title": "Profile",
@@ -81,7 +96,7 @@
 		{
 			"section": "Pipe",
 			"title": "Deep Agent",
-			"properties": ["agent_description", "instructions"]
+			"properties": ["agent_description", "system_prompt", "instructions"]
 		}
 	],
 	"icon": "deepagent.svg",

--- a/nodes/src/nodes/agent_deepagent/services.json
+++ b/nodes/src/nodes/agent_deepagent/services.json
@@ -39,8 +39,9 @@
 		"default": "default",
 		"profiles": {
 			"default": {
-				"agent_description": "",
+				"advanced_mode": false,
 				"instructions": [],
+				"agent_description": "",
 				"system_prompt": ""
 			}
 		}
@@ -69,34 +70,42 @@
 		"instructions": {
 			"type": "array",
 			"title": "Instructions",
-			"description": "Additional instructions to guide the agent.",
+			"description": "Additional instructions to guide the agent. Each line is appended to the system prompt.",
 			"items": {
 				"type": "string",
 				"format": "textarea"
 			}
 		},
-		"agent_deepagent.default": {
-			"object": "default",
-			"properties": ["agent_description", "system_prompt", "instructions"]
-		},
-		"agent_deepagent.profile": {
-			"title": "Profile",
-			"type": "string",
-			"default": "default",
-			"enum": [["default", "Default"]],
+		"advanced_mode": {
+			"type": "boolean",
+			"title": "Advanced Mode",
+			"description": "When enabled, replace the Instructions list with direct Agent Description and System Prompt fields for full control.",
+			"default": false,
+			"enum": [
+				[false, "Off"],
+				[true, "On"]
+			],
 			"conditional": [
 				{
-					"value": "default",
-					"properties": ["agent_deepagent.default"]
+					"value": false,
+					"properties": ["instructions"]
+				},
+				{
+					"value": true,
+					"properties": ["agent_description", "system_prompt"]
 				}
 			]
+		},
+		"agent_deepagent.default": {
+			"object": "default",
+			"properties": ["advanced_mode"]
 		}
 	},
 	"shape": [
 		{
 			"section": "Pipe",
 			"title": "Deep Agent",
-			"properties": ["agent_description", "system_prompt", "instructions"]
+			"properties": ["agent_deepagent.default"]
 		}
 	],
 	"icon": "deepagent.svg",

--- a/nodes/src/nodes/agent_deepagent/services.subagent.json
+++ b/nodes/src/nodes/agent_deepagent/services.subagent.json
@@ -1,13 +1,13 @@
 {
 	"title": "DeepAgent - Subagent",
 	"protocol": "agent_deepagent_subagent://",
-	"classType": ["agent", "tool", "deepagent"],
+	"classType": ["deepagent"],
 	"capabilities": ["invoke"],
 	"register": "filter",
 	"node": "python",
 	"path": "nodes.agent_deepagent",
 	"prefix": "agent",
-	"description": ["Sub-agent node for use within a DeepAgent orchestrator.", "Connect to a Deep Agent node via the 'deepagent' invoke channel.", "Can also be invoked as a standalone agent or as a tool (`<nodeId>.run_agent`)."],
+	"description": ["Sub-agent node for use within a DeepAgent orchestrator.", "Connect to a Deep Agent node via the 'deepagent' invoke channel. This node is invoke-only and cannot be used as a top-level pipeline agent."],
 	"invoke": {
 		"llm": {
 			"description": "LLM used by this sub-agent",
@@ -18,23 +18,11 @@
 			"min": 0
 		}
 	},
-	"lanes": {
-		"questions": ["answers"]
-	},
-	"input": [
-		{
-			"lane": "questions",
-			"output": [
-				{
-					"lane": "answers"
-				}
-			]
-		}
-	],
 	"preconfig": {
 		"default": "default",
 		"profiles": {
 			"default": {
+				"advanced_mode": false,
 				"description": "",
 				"instructions": [],
 				"system_prompt": ""
@@ -47,7 +35,7 @@
 			"title": "Description",
 			"default": "",
 			"optional": true,
-			"description": "A concise explanation of what this sub-agent does. The orchestrator reads this to decide when to delegate to this agent.",
+			"description": "The orchestrator reads this description to decide when to delegate to this sub-agent. Keep it specific and action-oriented \u2014 this is the only signal the orchestrator uses to pick a sub-agent.",
 			"ui": {
 				"ui:widget": "textarea"
 			}
@@ -65,34 +53,42 @@
 		"instructions": {
 			"type": "array",
 			"title": "Instructions",
-			"description": "Additional instructions to guide this sub-agent.",
+			"description": "Additional instructions to guide this sub-agent. Each line is appended to the system prompt.",
 			"items": {
 				"type": "string",
 				"format": "textarea"
 			}
 		},
-		"agent_deepagent_subagent.default": {
-			"object": "default",
-			"properties": ["description", "system_prompt", "instructions"]
-		},
-		"agent_deepagent_subagent.profile": {
-			"title": "Profile",
-			"type": "string",
-			"default": "default",
-			"enum": [["default", "Default"]],
+		"advanced_mode": {
+			"type": "boolean",
+			"title": "Advanced Mode",
+			"description": "When enabled, replace the Instructions list with a direct System Prompt field for full control.",
+			"default": false,
+			"enum": [
+				[false, "Off"],
+				[true, "On"]
+			],
 			"conditional": [
 				{
-					"value": "default",
-					"properties": ["agent_deepagent_subagent.default"]
+					"value": false,
+					"properties": ["instructions"]
+				},
+				{
+					"value": true,
+					"properties": ["system_prompt"]
 				}
 			]
+		},
+		"agent_deepagent_subagent.default": {
+			"object": "default",
+			"properties": ["description", "advanced_mode"]
 		}
 	},
 	"shape": [
 		{
 			"section": "Pipe",
 			"title": "DeepAgent - Subagent",
-			"properties": ["description", "system_prompt", "instructions"]
+			"properties": ["agent_deepagent_subagent.default"]
 		}
 	],
 	"icon": "deepagent.svg",

--- a/nodes/src/nodes/agent_deepagent/services.subagent.json
+++ b/nodes/src/nodes/agent_deepagent/services.subagent.json
@@ -1,0 +1,100 @@
+{
+	"title": "DeepAgent - Subagent",
+	"protocol": "agent_deepagent_subagent://",
+	"classType": ["agent", "tool", "deepagent"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.agent_deepagent",
+	"prefix": "agent",
+	"description": ["Sub-agent node for use within a DeepAgent orchestrator.", "Connect to a Deep Agent node via the 'deepagent' invoke channel.", "Can also be invoked as a standalone agent or as a tool (`<nodeId>.run_agent`)."],
+	"invoke": {
+		"llm": {
+			"description": "LLM used by this sub-agent",
+			"min": 1
+		},
+		"tool": {
+			"description": "Tools available to this sub-agent (via control-plane invoke)",
+			"min": 0
+		}
+	},
+	"lanes": {
+		"questions": ["answers"]
+	},
+	"input": [
+		{
+			"lane": "questions",
+			"output": [
+				{
+					"lane": "answers"
+				}
+			]
+		}
+	],
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"description": "",
+				"instructions": [],
+				"system_prompt": ""
+			}
+		}
+	},
+	"fields": {
+		"description": {
+			"type": "string",
+			"title": "Description",
+			"default": "",
+			"optional": true,
+			"description": "A concise explanation of what this sub-agent does. The orchestrator reads this to decide when to delegate to this agent.",
+			"ui": {
+				"ui:widget": "textarea"
+			}
+		},
+		"system_prompt": {
+			"type": "string",
+			"title": "System prompt",
+			"default": "",
+			"optional": true,
+			"description": "Instructions that define this sub-agent's role and behaviour. Leave blank to use the default.",
+			"ui": {
+				"ui:widget": "textarea"
+			}
+		},
+		"instructions": {
+			"type": "array",
+			"title": "Instructions",
+			"description": "Additional instructions to guide this sub-agent.",
+			"items": {
+				"type": "string",
+				"format": "textarea"
+			}
+		},
+		"agent_deepagent_subagent.default": {
+			"object": "default",
+			"properties": ["description", "system_prompt", "instructions"]
+		},
+		"agent_deepagent_subagent.profile": {
+			"title": "Profile",
+			"type": "string",
+			"default": "default",
+			"enum": [["default", "Default"]],
+			"conditional": [
+				{
+					"value": "default",
+					"properties": ["agent_deepagent_subagent.default"]
+				}
+			]
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "DeepAgent - Subagent",
+			"properties": ["description", "system_prompt", "instructions"]
+		}
+	],
+	"icon": "deepagent.svg",
+	"documentation": "https://docs.rocketride.org"
+}

--- a/packages/server/engine-lib/rocketlib-python/lib/rocketlib/__init__.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/rocketlib/__init__.py
@@ -73,6 +73,7 @@ from .types import IInvoke
 from .types import IInvokeLLM
 from .types import IInvokeTool
 from .types import IInvokeCrew
+from .types import IInvokeDeepagent
 from .types import IJson
 from .types import OPEN_MODE
 from .types import PROTOCOL_CAPS
@@ -112,6 +113,7 @@ __all__ = [
     'IInvokeLLM',
     'IInvokeTool',
     'IInvokeCrew',
+    'IInvokeDeepagent',
     'IJson',
     'ILoader',
     'isAppMonitor',

--- a/packages/server/engine-lib/rocketlib-python/lib/rocketlib/types.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/rocketlib/types.py
@@ -294,6 +294,37 @@ class IInvokeCrew(IInvoke):
         model_config = ConfigDict(extra='allow')
 
 
+class IInvokeDeepagent(IInvoke):
+    """
+    Control-plane type for DeepAgent sub-agent discovery (deepagent.describe fan-out).
+
+    Each sub-agent connected on the 'deepagent' channel appends a DescribeResponse
+    to Describe.agents when the orchestrator fans out a Describe request.
+    """
+
+    op: str = 'deepagent.describe'
+    model_config = ConfigDict(extra='allow')
+
+    class Describe(BaseModel):
+        """Fan-out request: each connected sub-agent appends its descriptor."""
+
+        op: str = Field(default='deepagent.describe', frozen=True)
+        agents: List[Any] = Field(default_factory=list)
+        model_config = ConfigDict(extra='allow')
+
+    class DescribeResponse(BaseModel):
+        """Sub-agent descriptor returned in response to deepagent.describe."""
+
+        op: str = Field(default='deepagent.describe', frozen=True)
+        name: str  # agent_description or logicalType
+        description: str = ''
+        system_prompt: str = ''
+        instructions: List[str] = Field(default_factory=list)
+        node_id: str = ''  # pSelf.instance.pipeType['id'] — used to identify the sub-agent node
+        invoke: Any = Field(default=None)  # full pSelf IInstance — passed to AgentHostServices(d.invoke)
+        model_config = ConfigDict(extra='allow')
+
+
 class IJson(Impl_IJson):
     """
     A wrapper class for IJson that provides utility methods for handling JSON-like structures.


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

  - Adds a new DeepAgent Subagent node type so a top-level Deep Agent can hierarchically delegate work to specialized sub-agents over a deepagent invoke channel, each with its own LLM  and tool roster.                        
  - Adds a CrewAI-style Advanced Mode checkbox to both nodes — Normal mode shows just Instructions (and Description on the subagent); Advanced mode swaps in Agent Description + System Prompt for full control.                        
  - Locks the subagent down to invoke-only (removed lanes/input, narrowed classType to ["deepagent"]) so it can't be mis-wired as a top-level pipeline agent.                    
  - Hardens the JSON tool-call envelope used by the LangChain wrapper: real JSON Schema for args_schema (so the LLM picks correct arg names like description instead of guessing prompt/task_description), \n{ stop-word + tolerant first-object parser to defeat duplicate/hallucinated JSON outputs.

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #664


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DeepAgent sub-agent support with orchestrator discovery
  * Configurable system_prompt field for finer agent behavior control
  * advanced_mode toggle to switch simplified vs advanced config
  * New DeepAgent Subagent node type for delegation workflows

* **Bug Fixes**
  * More robust JSON extraction from model outputs to handle prose/code/trailing text
<!-- end of auto-generated comment: release notes by coderabbit.ai -->