### PR TITLE
fix(canvas): fix rotate on stopping button and coloring on stop button

### DIFF
--- a/packages/shared-ui/src/components/canvas/components/node/node-component/run-button/RunButton.tsx
+++ b/packages/shared-ui/src/components/canvas/components/node/node-component/run-button/RunButton.tsx
@@ -140,7 +140,7 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 				}}
 			>
 				<span style={styles.button}>
-					<Square size={12} style={{ ...styles.icon, color: 'var(--rr-error)', fill: 'transparent', strokeWidth: 2.5 }} />
+					<Square size={12} style={{ ...styles.icon, color: 'var(--rr-color-error)', strokeWidth: 2.5 }} />
 				</span>
 			</div>
 		);

--- a/packages/shared-ui/src/components/canvas/components/reactflow-overrides.css
+++ b/packages/shared-ui/src/components/canvas/components/reactflow-overrides.css
@@ -270,6 +270,18 @@
 	height: 18px !important;
 }
 
+@keyframes rr-spin {
+	from {
+		transform: rotate(0deg);
+	}
+	to {
+		transform: rotate(360deg);
+	}
+}
+.rotate {
+	animation: rr-spin 1s linear infinite;
+}
+
 @keyframes rr-indeterminate {
 	0% {
 		transform: translateX(-100%);


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- coloring on the stop button now mirrors play button on hover
- arrows on 'stopping' button now rotate properly

<img width="1330" height="910" alt="image" src="https://github.com/user-attachments/assets/f120f393-377c-407f-aa4b-e464716a6e60" />

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #
