### PR TITLE
feat(nodes): add gemini vision node

### DIFF
--- a/nodes/src/nodes/llm_vision_gemini/IGlobal.py
+++ b/nodes/src/nodes/llm_vision_gemini/IGlobal.py
@@ -1,0 +1,211 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+import re
+import json
+import ast
+from typing import Optional
+from rocketlib import IGlobalBase, OPEN_MODE, warning
+from ai.common.config import Config
+from ai.common.chat import ChatBase
+
+
+class IGlobal(IGlobalBase):
+    """Global interface for Gemini Vision node."""
+
+    _chat: Optional[ChatBase] = None
+
+    VALIDATION_PROMPT = 'Hi'
+
+    def validateConfig(self):
+        """Validate Gemini configuration at save-time using a minimal API probe."""
+        from depends import depends  # type: ignore
+
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        try:
+            from google import genai
+
+            try:
+                from google.api_core.exceptions import (
+                    GoogleAPICallError,
+                    ClientError,
+                    BadRequest,
+                    Unauthorized,
+                    Forbidden,
+                    NotFound,
+                    TooManyRequests,
+                    ServiceUnavailable,
+                    InternalServerError,
+                    DeadlineExceeded,
+                    InvalidArgument,
+                )
+            except Exception:
+                GoogleAPICallError = Exception  # type: ignore
+                ClientError = BadRequest = Unauthorized = Forbidden = NotFound = TooManyRequests = ServiceUnavailable = InternalServerError = DeadlineExceeded = InvalidArgument = Exception  # type: ignore
+            try:
+                from google.auth.exceptions import GoogleAuthError, RefreshError
+            except Exception:
+                GoogleAuthError = RefreshError = Exception  # type: ignore
+
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            apikey = config.get('apikey')
+            model = config.get('model')
+
+            # Skip probe if key not yet set — UI will prompt for it
+            if not apikey:
+                return
+
+            try:
+                client = genai.Client(api_key=apikey)
+                client.models.generate_content(model=model, contents=self.VALIDATION_PROMPT)
+            except (BadRequest, Unauthorized, Forbidden, NotFound, TooManyRequests, ServiceUnavailable, InternalServerError, DeadlineExceeded, InvalidArgument, ClientError, GoogleAPICallError) as e:
+                try:
+                    prov_code = e.code  # type: ignore[attr-defined]
+                except Exception:
+                    prov_code = None
+                raw = str(e)
+
+                status = None
+                emsg = None
+                code = None
+                try:
+                    status, emsg, code = self._extract_status_message_code(raw, prov_code)
+                    if isinstance(status, str) and status.upper() == 'INVALID_ARGUMENT' and isinstance(emsg, str) and 'response modalities' in emsg.lower():
+                        return
+                except Exception:
+                    pass
+
+                if emsg is None:
+                    m_msg = re.search(r"[\"']message[\"']\s*:\s*[\"']([^\"']+)[\"']", raw)
+                    if m_msg:
+                        emsg = m_msg.group(1)
+                if status is None:
+                    m_stat = re.search(r'\b(\d{3})\s+([A-Z_]+)\b', raw)
+                    if m_stat:
+                        if code is None:
+                            try:
+                                code = int(m_stat.group(1))
+                            except Exception:
+                                code = m_stat.group(1)
+                        status = m_stat.group(2)
+
+                display_code = code
+                if hasattr(display_code, 'value'):
+                    display_code = display_code.value
+                elif hasattr(display_code, 'name'):
+                    display_code = display_code.name
+
+                message = self._format_error(display_code, status, emsg, raw)
+                warning(message)
+                return
+            except (GoogleAuthError, RefreshError) as e:
+                warning(str(e))
+                return
+            except Exception as e:
+                raw = str(e)
+                status, emsg, code = self._extract_status_message_code(raw, None)
+                display_code = code
+                if hasattr(display_code, 'value'):
+                    display_code = display_code.value
+                elif hasattr(display_code, 'name'):
+                    display_code = display_code.name
+                message = self._format_error(display_code, status, emsg, raw)
+                warning(message)
+                return
+
+        except Exception:
+            warning('Gemini Vision validation setup error. Please check your configuration.')
+
+    def beginGlobal(self):
+        """Initialize the global chat instance."""
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            pass
+        else:
+            from depends import depends  # type: ignore
+
+            requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+            depends(requirements)
+
+            from .gemini_vision import Chat
+
+            bag = self.IEndpoint.endpoint.bag
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            self._max_concurrent = config.get('maxConcurrent', 5)
+            self._chat = Chat(self.glb.logicalType, config, bag)
+
+    def endGlobal(self):
+        """Clean up the global chat instance."""
+        self._chat = None
+
+    def _format_error(self, status_or_code, etype_or_status, emsg, fallback: str) -> str:
+        parts: list[str] = []
+        if status_or_code is not None:
+            parts.append(f'Error {status_or_code}:')
+        if etype_or_status:
+            parts.append(str(etype_or_status))
+        if emsg:
+            if etype_or_status:
+                parts.append('-')
+            parts.append(str(emsg))
+        message = ' '.join(parts) if parts else fallback
+        return re.sub(r'\s+', ' ', message).strip()
+
+    def _extract_status_message_code(self, raw: str, prov_code):
+        status = None
+        emsg = None
+        code = None
+        idx = raw.rfind('{')
+        if idx != -1:
+            js = raw[idx:].strip()
+            data = None
+            try:
+                data = json.loads(js)
+            except Exception:
+                try:
+                    data = ast.literal_eval(js)
+                except Exception:
+                    data = None
+            if isinstance(data, dict):
+                err = data.get('error') or {}
+                status = err.get('status') or data.get('status')
+                emsg = err.get('message') or data.get('message')
+                code = err.get('code') or data.get('code') or prov_code
+
+        if emsg is None:
+            m_msg = re.search(r"[\"']message[\"']\s*:\s*[\"']([^\"']+)[\"']", raw)
+            if m_msg:
+                emsg = m_msg.group(1)
+        if status is None or code is None:
+            m_hdr = re.search(r'\b(\d{3})\s+([A-Z_]+)\b', raw)
+            if m_hdr:
+                if code is None:
+                    try:
+                        code = int(m_hdr.group(1))
+                    except Exception:
+                        code = m_hdr.group(1)
+                if status is None:
+                    status = m_hdr.group(2)
+        return status, emsg, code

--- a/nodes/src/nodes/llm_vision_gemini/IInstance.py
+++ b/nodes/src/nodes/llm_vision_gemini/IInstance.py
@@ -64,8 +64,11 @@ class IInstance(IInstanceGenericLLM):
                 question.addContext(image_data_url)
                 question.addQuestion(self.IGlobal._chat._prompt)
 
-                answer = self.IGlobal._chat.chat(question)
-                self.instance.writeText(answer.getText())
+                try:
+                    answer = self.IGlobal._chat.chat(question)
+                    self.instance.writeText(answer.getText())
+                except Exception as e:
+                    warning(f'Gemini Vision: inference failed for image frame: {e}')
 
             self.image_data = None
             return self.preventDefault()
@@ -89,7 +92,8 @@ class IInstance(IInstanceGenericLLM):
             try:
                 answer = self.IGlobal._chat.chat(question)
             except Exception as e:
-                warning(f'Gemini Vision: inference failed for chunk {doc.metadata.chunkId}: {e}')
+                chunk_id = doc.metadata.chunkId if doc.metadata else 'unknown'
+                warning(f'Gemini Vision: inference failed for chunk {chunk_id}: {e}')
                 continue
 
             answer_text = answer.getText()

--- a/nodes/src/nodes/llm_vision_gemini/IInstance.py
+++ b/nodes/src/nodes/llm_vision_gemini/IInstance.py
@@ -35,17 +35,24 @@ class IInstance(IInstanceGenericLLM):
     # Raw image data accumulated across AVI_WRITE chunks
     image_data: bytearray = None
 
-    # Cached answer text from writeDocuments so writeImage can reuse it without
-    # a second Gemini call for the same frame.
+    # Cached answer text shared between the two lanes to avoid a second Gemini
+    # call when both lanes are active for the same frame.
+    # _cache_from_image distinguishes who set it: True = writeImage, False = writeDocuments.
+    # writeDocuments must only consume the cache when writeImage set it, otherwise a
+    # cached answer from doc[N] would bleed into doc[N+1] in a multi-doc batch.
     _cached_answer: str = None
+    _cache_from_image: bool = False
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         """Handle AVI image protocol for streaming image frames."""
         if action == AVI_ACTION.BEGIN:
             self.image_data = bytearray()
             self._cached_answer = None
+            self._cache_from_image = False
             return self.preventDefault()
         elif action == AVI_ACTION.WRITE:
+            if self.image_data is None:
+                raise RuntimeError('AVI protocol error: WRITE received before BEGIN')
             self.image_data += buffer
             return self.preventDefault()
         elif action == AVI_ACTION.END:
@@ -53,6 +60,7 @@ class IInstance(IInstanceGenericLLM):
                 # writeDocuments already called Gemini for this frame — reuse the result.
                 self.instance.writeText(self._cached_answer)
                 self._cached_answer = None
+                self._cache_from_image = False
             elif not self.image_data:
                 warning('Gemini Vision: skipping empty image frame')
             else:
@@ -70,12 +78,15 @@ class IInstance(IInstanceGenericLLM):
                     answer = self.IGlobal._chat.chat(question)
                     answer_text = answer.getText()
                     self._cached_answer = answer_text
+                    self._cache_from_image = True
                     self.instance.writeText(answer_text)
                 except Exception as e:
                     warning(f'Gemini Vision: inference failed for image frame: {e}')
 
             self.image_data = None
             return self.preventDefault()
+        else:
+            raise RuntimeError(f'AVI protocol error: unknown action {action}')
 
     def writeDocuments(self, documents: list[Doc]):
         """Process incoming image documents inline and emit vision model responses as text documents."""
@@ -93,21 +104,25 @@ class IInstance(IInstanceGenericLLM):
             question.addContext(f'data:image/png;base64,{doc.page_content}')
             question.addQuestion(self.IGlobal._chat._prompt)
 
-            if self._cached_answer is not None:
+            if self._cached_answer is not None and self._cache_from_image:
                 # writeImage already called Gemini for this frame — reuse the result.
                 answer_text = self._cached_answer
                 self._cached_answer = None
+                self._cache_from_image = False
             else:
+                # Discard any stale doc-sourced cache (multi-doc batch safety).
+                self._cached_answer = None
+                self._cache_from_image = False
                 try:
                     answer = self.IGlobal._chat.chat(question)
+                    answer_text = answer.getText()
                 except Exception as e:
                     chunk_id = doc.metadata.chunkId if doc.metadata else 'unknown'
                     warning(f'Gemini Vision: inference failed for chunk {chunk_id}: {e}')
                     continue
-
-                answer_text = answer.getText()
                 # Cache so writeImage can reuse it if it fires after us.
                 self._cached_answer = answer_text
+                # _cache_from_image stays False — writeImage checks for this.
 
             self.instance.writeDocuments([Doc(type='Text', page_content=answer_text, metadata=doc.metadata)])
 

--- a/nodes/src/nodes/llm_vision_gemini/IInstance.py
+++ b/nodes/src/nodes/llm_vision_gemini/IInstance.py
@@ -53,6 +53,8 @@ class IInstance(IInstanceGenericLLM):
                 # writeDocuments already called Gemini for this frame — reuse the result.
                 self.instance.writeText(self._cached_answer)
                 self._cached_answer = None
+            elif not self.image_data:
+                warning('Gemini Vision: skipping empty image frame')
             else:
                 # Only the image lane is connected; call Gemini directly.
                 from ai.common.schema import Question
@@ -66,7 +68,9 @@ class IInstance(IInstanceGenericLLM):
 
                 try:
                     answer = self.IGlobal._chat.chat(question)
-                    self.instance.writeText(answer.getText())
+                    answer_text = answer.getText()
+                    self._cached_answer = answer_text
+                    self.instance.writeText(answer_text)
                 except Exception as e:
                     warning(f'Gemini Vision: inference failed for image frame: {e}')
 
@@ -89,17 +93,21 @@ class IInstance(IInstanceGenericLLM):
             question.addContext(f'data:image/png;base64,{doc.page_content}')
             question.addQuestion(self.IGlobal._chat._prompt)
 
-            try:
-                answer = self.IGlobal._chat.chat(question)
-            except Exception as e:
-                chunk_id = doc.metadata.chunkId if doc.metadata else 'unknown'
-                warning(f'Gemini Vision: inference failed for chunk {chunk_id}: {e}')
-                continue
+            if self._cached_answer is not None:
+                # writeImage already called Gemini for this frame — reuse the result.
+                answer_text = self._cached_answer
+                self._cached_answer = None
+            else:
+                try:
+                    answer = self.IGlobal._chat.chat(question)
+                except Exception as e:
+                    chunk_id = doc.metadata.chunkId if doc.metadata else 'unknown'
+                    warning(f'Gemini Vision: inference failed for chunk {chunk_id}: {e}')
+                    continue
 
-            answer_text = answer.getText()
-
-            # Cache so writeImage can emit the same text without a second API call.
-            self._cached_answer = answer_text
+                answer_text = answer.getText()
+                # Cache so writeImage can reuse it if it fires after us.
+                self._cached_answer = answer_text
 
             self.instance.writeDocuments([Doc(type='Text', page_content=answer_text, metadata=doc.metadata)])
 

--- a/nodes/src/nodes/llm_vision_gemini/IInstance.py
+++ b/nodes/src/nodes/llm_vision_gemini/IInstance.py
@@ -1,0 +1,102 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from nodes.llm_base import IInstanceGenericLLM
+from rocketlib import AVI_ACTION, warning
+from ai.common.schema import Doc
+
+
+class IInstance(IInstanceGenericLLM):
+    """Instance handler for the Gemini Vision node."""
+
+    IGlobal: IGlobal
+
+    # Raw image data accumulated across AVI_WRITE chunks
+    image_data: bytearray = None
+
+    # Cached answer text from writeDocuments so writeImage can reuse it without
+    # a second Gemini call for the same frame.
+    _cached_answer: str = None
+
+    def writeImage(self, action: int, mimeType: str, buffer: bytes):
+        """Handle AVI image protocol for streaming image frames."""
+        if action == AVI_ACTION.BEGIN:
+            self.image_data = bytearray()
+            return self.preventDefault()
+        elif action == AVI_ACTION.WRITE:
+            self.image_data += buffer
+            return self.preventDefault()
+        elif action == AVI_ACTION.END:
+            if self._cached_answer is not None:
+                # writeDocuments already called Gemini for this frame — reuse the result.
+                self.instance.writeText(self._cached_answer)
+                self._cached_answer = None
+            else:
+                # Only the image lane is connected; call Gemini directly.
+                from ai.common.schema import Question
+                import base64
+
+                question = Question()
+                image_base64 = base64.b64encode(bytes(self.image_data)).decode('utf-8')
+                image_data_url = f'data:{mimeType};base64,{image_base64}'
+                question.addContext(image_data_url)
+                question.addQuestion(self.IGlobal._chat._prompt)
+
+                answer = self.IGlobal._chat.chat(question)
+                self.instance.writeText(answer.getText())
+
+            self.image_data = None
+            return self.preventDefault()
+
+    def writeDocuments(self, documents: list[Doc]):
+        """Process incoming image documents inline and emit vision model responses as text documents."""
+        from ai.common.schema import Question
+
+        for doc in documents:
+            if doc.type != 'Image':
+                warning(f'Gemini Vision: skipping document with unexpected type "{doc.type}"')
+                continue
+            if not doc.page_content:
+                warning('Gemini Vision: skipping Image document with empty content')
+                continue
+
+            question = Question()
+            question.addContext(f'data:image/png;base64,{doc.page_content}')
+            question.addQuestion(self.IGlobal._chat._prompt)
+
+            try:
+                answer = self.IGlobal._chat.chat(question)
+            except Exception as e:
+                warning(f'Gemini Vision: inference failed for chunk {doc.metadata.chunkId}: {e}')
+                continue
+
+            answer_text = answer.getText()
+
+            # Cache so writeImage can emit the same text without a second API call.
+            self._cached_answer = answer_text
+
+            self.instance.writeDocuments([Doc(type='Text', page_content=answer_text, metadata=doc.metadata)])
+
+        # Prevent the original Image docs from flowing downstream.
+        self.preventDefault()

--- a/nodes/src/nodes/llm_vision_gemini/IInstance.py
+++ b/nodes/src/nodes/llm_vision_gemini/IInstance.py
@@ -43,6 +43,7 @@ class IInstance(IInstanceGenericLLM):
         """Handle AVI image protocol for streaming image frames."""
         if action == AVI_ACTION.BEGIN:
             self.image_data = bytearray()
+            self._cached_answer = None
             return self.preventDefault()
         elif action == AVI_ACTION.WRITE:
             self.image_data += buffer

--- a/nodes/src/nodes/llm_vision_gemini/README.md
+++ b/nodes/src/nodes/llm_vision_gemini/README.md
@@ -1,0 +1,67 @@
+---
+title: Gemini Vision
+date: 2026-04-14
+sidebar_position: 1
+---
+
+<head>
+  <title>Gemini Vision - RocketRide Documentation</title>
+</head>
+
+## What it does
+
+Sends images to Google Gemini vision-capable models and returns text analysis. Accepts either a single image or a stream of image documents (e.g. from the frame grabber). Metadata such as frame number and timestamp is preserved on the `documents` output.
+
+All profiles support a 1M token context window, making Gemini Vision well-suited for high-volume frame analysis pipelines where many images are processed in sequence.
+
+**Lanes:**
+
+| Lane in     | Lane out    | Description                                                                    |
+| ----------- | ----------- | ------------------------------------------------------------------------------ |
+| `image`     | `text`      | Analyze a single image, receive text                                           |
+| `documents` | `documents` | Analyze image documents, return text analysis with original metadata preserved |
+
+## Configuration
+
+| Field               | Description                                             |
+| ------------------- | ------------------------------------------------------- |
+| Model               | Gemini vision model to use (see profiles below)         |
+| API Key             | Google AI API key (see below)                           |
+| System Instructions | Define the model's role and behavior for image analysis |
+| Analysis Prompt     | Describe what to analyze or extract from the image      |
+
+## API Key
+
+Get a key at [aistudio.google.com/apikey](https://aistudio.google.com/apikey). Keys are free for development use and grant access to all Gemini models listed below.
+
+## Profiles
+
+**Gemini 2.5**
+
+| Profile                      | Model                          | Context   |
+| ---------------------------- | ------------------------------ | --------- |
+| Gemini 2.5 Flash _(default)_ | `models/gemini-2.5-flash`      | 1,048,576 |
+| Gemini 2.5 Pro               | `models/gemini-2.5-pro`        | 1,048,576 |
+| Gemini 2.5 Flash Lite        | `models/gemini-2.5-flash-lite` | 1,048,576 |
+
+**Gemini 3.1 (Preview)**
+
+| Profile                        | Model                                   | Context   |
+| ------------------------------ | --------------------------------------- | --------- |
+| Gemini 3.1 Pro Preview         | `models/gemini-3.1-pro-preview`         | 1,048,576 |
+| Gemini 3.1 Flash Image Preview | `models/gemini-3.1-flash-image-preview` | 131,072   |
+
+**Custom** — specify any Gemini model ID and token limit directly.
+
+### Choosing a profile
+
+- **Flash Lite** — fastest and cheapest; good for high-throughput frame pipelines where speed matters more than detail
+- **Flash** — balanced speed and quality; the recommended default for most vision tasks
+- **Pro** — highest quality analysis; use when accuracy is critical and latency is acceptable
+- **3.1 Pro Preview / Flash Image Preview** — latest generation previews; expect higher capability but potential instability as models are still in preview
+
+## Upstream docs
+
+- [Gemini API documentation](https://ai.google.dev/gemini-api/docs)
+- [Gemini model overview](https://ai.google.dev/gemini-api/docs/models)
+- [Google AI Studio](https://aistudio.google.com/)

--- a/nodes/src/nodes/llm_vision_gemini/README.md
+++ b/nodes/src/nodes/llm_vision_gemini/README.md
@@ -12,7 +12,7 @@ sidebar_position: 1
 
 Sends images to Google Gemini vision-capable models and returns text analysis. Accepts either a single image or a stream of image documents (e.g. from the frame grabber). Metadata such as frame number and timestamp is preserved on the `documents` output.
 
-All profiles support a 1M token context window, making Gemini Vision well-suited for high-volume frame analysis pipelines where many images are processed in sequence.
+Most profiles support a 1M token context window, making Gemini Vision well-suited for high-volume frame analysis pipelines where many images are processed in sequence. The exception is Gemini 3.1 Flash Image Preview, which has a 131,072 token limit.
 
 **Lanes:**
 

--- a/nodes/src/nodes/llm_vision_gemini/__init__.py
+++ b/nodes/src/nodes/llm_vision_gemini/__init__.py
@@ -1,0 +1,38 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+
+def getChat():
+    from .gemini_vision import Chat
+
+    return Chat
+
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+    'getChat',
+]

--- a/nodes/src/nodes/llm_vision_gemini/gemini_vision.py
+++ b/nodes/src/nodes/llm_vision_gemini/gemini_vision.py
@@ -1,0 +1,202 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+import time
+import base64
+import threading
+from depends import depends  # type: ignore
+from typing import Any, Dict
+from ai.common.schema import Answer, Question
+from ai.common.chat import ChatBase
+from ai.common.config import Config
+from rocketlib import warning
+
+# Load requirements
+requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+depends(requirements)
+
+from google import genai
+from google.genai.types import Part, Content
+
+
+class Chat(ChatBase):
+    """Google Gemini Vision chat for general-purpose image analysis."""
+
+    _model: str = ''
+    _client: genai.Client
+    _system_prompt: str = ''
+    _prompt: str = ''
+
+    def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
+        """Initialize the Gemini Vision chat instance."""
+        super().__init__(provider, connConfig, bag)
+        config = Config.getNodeConfig(provider, connConfig)
+
+        self._model = config.get('model', 'models/gemini-2.5-flash')
+        api_key = config.get('apikey')
+
+        self._system_prompt = config.get('vision.systemPrompt') or config.get('systemPrompt') or ''
+        self._prompt = config.get('vision.prompt') or config.get('prompt') or 'Describe this image in detail.'
+
+        if not api_key:
+            raise ValueError('Missing Google AI API key. Get one at https://aistudio.google.com/apikey')
+        if api_key.startswith('sk-'):
+            raise ValueError('Invalid API key format. This appears to be an OpenAI key. Please provide a Google AI API key.')
+        if not api_key.startswith('AI'):
+            raise ValueError('Invalid Gemini API key format. Google AI API keys start with "AI". Please check your API key at https://aistudio.google.com/apikey')
+
+        try:
+            self._api_key = api_key
+            self._client = genai.Client(api_key=api_key)
+        except Exception as e:
+            raise ValueError(f'Failed to initialize Google AI client: {e!s}') from e
+
+        self._modelTotalTokens = config.get('modelTotalTokens', 1048576)
+        bag['chat'] = self
+
+    def getTotalTokens(self) -> int:
+        """Get the total token limit for the current model."""
+        return self._modelTotalTokens
+
+    def getTokens(self, value: str) -> int:
+        """Approximate token count (4 chars per token heuristic)."""
+        if not value.strip():
+            return 0
+        return len(value) // 4
+
+    def _format_user_error(self, error_msg: str) -> str:
+        """Convert API error messages to user-friendly format."""
+        error_lower = error_msg.lower()
+        if any(p in error_lower for p in ['unauthorized', 'invalid api key', 'authentication', 'api_key']):
+            return 'Authentication failed. Please check your Google AI API key.'
+        if any(p in error_lower for p in ['rate limit', 'too many requests', '429', 'quota']):
+            return 'Rate limit exceeded. Please wait a moment before trying again.'
+        if any(p in error_lower for p in ['billing', 'insufficient', 'credits']):
+            return 'API quota exceeded or billing issue. Please check your Google AI account status.'
+        if any(p in error_lower for p in ['invalid input', 'bad request', '400']):
+            return 'Invalid input. Please check your image format and prompt.'
+        if any(p in error_lower for p in ['model not found', 'unavailable', 'not supported']):
+            return f"Model '{self._model}' is currently unavailable. Please try a different model."
+        if any(p in error_lower for p in ['timeout', 'timed out']):
+            return 'Request timed out. Please try again.'
+        if any(p in error_lower for p in ['content policy', 'safety', 'blocked']):
+            return 'Image was blocked by safety filters. Please try a different image.'
+        if any(p in error_lower for p in ['internal server error', '500', '502', '503', '504']):
+            return 'Google AI vision service is temporarily unavailable. Please try again later.'
+        return f'Google AI error: {error_msg}'
+
+    def _shouldRetry(self, error: Exception) -> bool:
+        """Determine if an error is retryable."""
+        error_msg = str(error).lower()
+        retryable = ['timeout', 'timed out', 'connection', '500', '502', '503', '504', 'internal server error', 'service unavailable']
+        return any(p in error_msg for p in retryable)
+
+    def chat(self, question: Question) -> Answer:
+        """Send an image to Gemini Vision and get the response."""
+        max_retries = 1
+        base_delay = 1.0
+        last_error = None
+
+        # Extract image data from context
+        image_data = None
+        prompt_text = self._prompt
+        for context_item in question.context:
+            if context_item.startswith(('data:image/', 'data:application/')):
+                image_data = context_item
+                break
+
+        if question.questions and len(question.questions) > 0:
+            prompt_text = question.questions[0].text
+
+        if not image_data:
+            raise ValueError('No image provided. Please connect an image source to this node.')
+
+        # Parse the data URL once outside the retry loop
+        try:
+            header, b64_data = image_data.split(',', 1)
+            mime_type = header.split(':')[1].split(';')[0]
+            image_bytes = base64.b64decode(b64_data)
+        except (ValueError, IndexError, base64.binascii.Error) as e:
+            raise ValueError('Malformed image data URL. Expected format: data:<mime>;base64,<data>') from e
+
+        # Build request contents once (deterministic, no need to rebuild per retry)
+        contents = [
+            Content(
+                role='user',
+                parts=[
+                    Part.from_bytes(data=image_bytes, mime_type=mime_type),
+                    Part.from_text(text=prompt_text),
+                ],
+            )
+        ]
+
+        generate_config: Dict[str, Any] = {}
+        if self._system_prompt:
+            generate_config['system_instruction'] = self._system_prompt
+
+        hard_timeout = 30
+
+        for attempt in range(max_retries + 1):
+            try:
+                result = [None]
+                exc = [None]
+
+                def _invoke():
+                    try:
+                        # Fresh client per call — isolates the httpx session so concurrent
+                        # calls from multiple threads don't share a non-thread-safe connection
+                        client = genai.Client(api_key=self._api_key)
+                        result[0] = client.models.generate_content(
+                            model=self._model,
+                            contents=contents,
+                            config=generate_config if generate_config else None,
+                        )
+                    except Exception as e:
+                        exc[0] = e
+
+                t = threading.Thread(target=_invoke, daemon=True)
+                t.start()
+                t.join(timeout=hard_timeout)
+                if t.is_alive():
+                    warning(f'Gemini Vision: inference timed out after {hard_timeout}s (attempt {attempt + 1}/{max_retries + 1}) — daemon thread still running')
+                    raise TimeoutError(f'Vision inference timed out after {hard_timeout}s (attempt {attempt + 1})')
+                if exc[0]:
+                    raise exc[0]
+
+                answer = Answer(expectJson=question.expectJson)
+                answer.setAnswer(result[0].text)
+                return answer
+            except Exception as e:
+                last_error = e
+                # Don't spin on repeated timeouts — a second 30s wait is enough.
+                if isinstance(e, TimeoutError) and attempt >= 1:
+                    break
+                if attempt < max_retries and self._shouldRetry(e):
+                    delay = base_delay * (2**attempt)
+                    time.sleep(delay)
+                    continue
+                break
+
+        user_friendly_error = self._format_user_error(str(last_error))
+        raise Exception(user_friendly_error) from last_error

--- a/nodes/src/nodes/llm_vision_gemini/requirements.txt
+++ b/nodes/src/nodes/llm_vision_gemini/requirements.txt
@@ -1,0 +1,1 @@
+google-genai>=1.14.0

--- a/nodes/src/nodes/llm_vision_gemini/services.json
+++ b/nodes/src/nodes/llm_vision_gemini/services.json
@@ -1,0 +1,164 @@
+{
+	"title": "Gemini Vision",
+	"protocol": "image_vision_gemini://",
+	"classType": ["image"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.llm_vision_gemini",
+	"prefix": "image_vision_gemini",
+	"description": ["A component that connects to Google Gemini's vision-capable models for image analysis, ", "OCR, visual understanding, and scene description. Supports Gemini 2.5 and 3.x models ", "with multimodal capabilities. Features robust error handling, automatic image processing, ", "and flexible prompt configuration for a wide range of vision use cases."],
+	"icon": "gemini.svg",
+	"documentation": "https://docs.rocketride.org",
+	"tile": ["Model: ${parameters.image_vision_gemini.profile}"],
+	"lanes": {
+		"image": ["text"],
+		"documents": ["documents"]
+	},
+	"input": [
+		{
+			"lane": "image",
+			"description": "Image to analyze with Gemini Vision models",
+			"output": [
+				{
+					"lane": "text",
+					"description": "Text analysis of the image content"
+				}
+			]
+		},
+		{
+			"lane": "documents",
+			"description": "Image documents to analyze with Gemini Vision models",
+			"output": [
+				{
+					"lane": "documents",
+					"description": "Text analysis of each image document with original metadata (frame number, timestamp) preserved"
+				}
+			]
+		}
+	],
+	"preconfig": {
+		"default": "gemini-2_5-flash",
+		"profiles": {
+			"gemini-2_5-flash": {
+				"title": "Gemini 2.5 Flash - Fast Vision (1M tokens)",
+				"model": "models/gemini-2.5-flash",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"gemini-2_5-pro": {
+				"title": "Gemini 2.5 Pro - High Quality Vision (1M tokens)",
+				"model": "models/gemini-2.5-pro",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"gemini-2_5-flash-lite": {
+				"title": "Gemini 2.5 Flash Lite - Fastest & Cheapest (1M tokens)",
+				"model": "models/gemini-2.5-flash-lite",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"gemini-3_1-pro-preview": {
+				"title": "Gemini 3.1 Pro - Latest Vision (1M tokens)",
+				"model": "models/gemini-3.1-pro-preview",
+				"modelTotalTokens": 1048576,
+				"apikey": ""
+			},
+			"gemini-3_1-flash-image-preview": {
+				"title": "Gemini 3.1 Flash Image Preview (131k tokens)",
+				"model": "models/gemini-3.1-flash-image-preview",
+				"modelTotalTokens": 131072,
+				"apikey": ""
+			}
+		}
+	},
+	"fields": {
+		"image_vision_gemini.apikey": {
+			"type": "string",
+			"title": "API Key",
+			"description": "Google AI API key. Get one at https://aistudio.google.com/apikey",
+			"secure": true,
+			"ui": {
+				"ui:widget": "ApiKeyWidget"
+			}
+		},
+		"model": {
+			"type": "string",
+			"title": "Model",
+			"description": "Gemini Vision model"
+		},
+		"modelTotalTokens": {
+			"type": "number",
+			"title": "Tokens",
+			"description": "Maximum context length in tokens"
+		},
+		"vision.systemPrompt": {
+			"type": "string",
+			"format": "textarea",
+			"title": "System Instructions",
+			"description": "Define the model's role and behavior for image analysis"
+		},
+		"vision.prompt": {
+			"type": "string",
+			"format": "textarea",
+			"title": "Analysis Prompt",
+			"description": "Describe what you want to analyze or extract from the image"
+		},
+		"image_vision_gemini.gemini-2_5-flash": {
+			"object": "gemini-2_5-flash",
+			"properties": ["image_vision_gemini.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_gemini.gemini-2_5-pro": {
+			"object": "gemini-2_5-pro",
+			"properties": ["image_vision_gemini.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_gemini.gemini-2_5-flash-lite": {
+			"object": "gemini-2_5-flash-lite",
+			"properties": ["image_vision_gemini.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_gemini.gemini-3_1-pro-preview": {
+			"object": "gemini-3_1-pro-preview",
+			"properties": ["image_vision_gemini.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_gemini.gemini-3_1-flash-image-preview": {
+			"object": "gemini-3_1-flash-image-preview",
+			"properties": ["image_vision_gemini.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_gemini.profile": {
+			"title": "Vision Model",
+			"description": "Select the Gemini vision model to use",
+			"type": "string",
+			"default": "gemini-2_5-flash",
+			"enum": ["*>preconfig.profiles.*.title"],
+			"conditional": [
+				{
+					"value": "gemini-2_5-flash",
+					"properties": ["image_vision_gemini.gemini-2_5-flash"]
+				},
+				{
+					"value": "gemini-2_5-pro",
+					"properties": ["image_vision_gemini.gemini-2_5-pro"]
+				},
+				{
+					"value": "gemini-2_5-flash-lite",
+					"properties": ["image_vision_gemini.gemini-2_5-flash-lite"]
+				},
+				{
+					"value": "gemini-3_1-pro-preview",
+					"properties": ["image_vision_gemini.gemini-3_1-pro-preview"]
+				},
+				{
+					"value": "gemini-3_1-flash-image-preview",
+					"properties": ["image_vision_gemini.gemini-3_1-flash-image-preview"]
+				}
+			]
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Gemini Vision",
+			"properties": ["image_vision_gemini.profile"]
+		}
+	]
+}


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->
- Adds a new Gemini Vision node (llm_vision_gemini) that routes image frames through Google's Gemini 2.5/3.1 models and emits text analysis downstream
- Supports dual-lane input (AVI image stream + document lane) with a cache to avoid double API calls when both lanes carry the same frame
- Caps inference retries at 1 (matching the Ollama Vision pattern) to prevent connection errors from stalling the pipeline for up to 127s per frame

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
feature

## Testing

- [ ] Tests added or updated
- [X] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a Gemini Vision node for image and document analysis with selectable model profiles, secure API-key authentication, configurable system/prompt settings, per-request timeouts, and retry logic.
  * Supports streaming frame input and batched document-to-text processing with response caching to reduce duplicate outputs.

* **Documentation**
  * New usage guide covering configuration, model profiles, API key setup, prompts, and integration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->