### PR TITLE
feat(nodes): add anthropic vision node

### DIFF
--- a/nodes/src/nodes/llm_vision_anthropic/IGlobal.py
+++ b/nodes/src/nodes/llm_vision_anthropic/IGlobal.py
@@ -1,0 +1,46 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+from rocketlib import IGlobalBase
+from ai.common.chat import ChatBase
+
+
+class IGlobal(IGlobalBase):
+    """Global lifecycle handler for the Anthropic Vision node."""
+
+    _chat: ChatBase | None = None
+
+    def beginGlobal(self):
+        from depends import depends  # type: ignore
+
+        requirements = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'requirements.txt')
+        depends(requirements)
+
+        from .anthropic_vision import Chat
+
+        bag = self.IEndpoint.endpoint.bag
+        self._chat = Chat(self.glb.logicalType, self.glb.connConfig, bag)
+
+    def endGlobal(self):
+        self._chat = None

--- a/nodes/src/nodes/llm_vision_anthropic/IInstance.py
+++ b/nodes/src/nodes/llm_vision_anthropic/IInstance.py
@@ -75,6 +75,8 @@ class IInstance(IInstanceGenericLLM):
 
             self.image_data = None
             return self.preventDefault()
+        else:
+            raise RuntimeError(f'AVI protocol error: Unknown action {action}')
 
     def writeDocuments(self, documents: list[Doc]):
         """Process incoming image documents inline and emit vision model responses as text documents."""

--- a/nodes/src/nodes/llm_vision_anthropic/IInstance.py
+++ b/nodes/src/nodes/llm_vision_anthropic/IInstance.py
@@ -70,8 +70,11 @@ class IInstance(IInstanceGenericLLM):
                 question.addContext(image_data_url)
                 question.addQuestion(self.IGlobal._chat._prompt)
 
-                answer = self.IGlobal._chat.chat(question)
-                self.instance.writeText(answer.getText())
+                try:
+                    answer = self.IGlobal._chat.chat(question)
+                    self.instance.writeText(answer.getText())
+                except Exception as e:
+                    warning(f'Anthropic Vision: inference failed on image lane: {e}')
 
             self.image_data = None
             return self.preventDefault()

--- a/nodes/src/nodes/llm_vision_anthropic/IInstance.py
+++ b/nodes/src/nodes/llm_vision_anthropic/IInstance.py
@@ -38,7 +38,7 @@ class IInstance(IInstanceGenericLLM):
     # Cached answer text from writeDocuments so writeImage can reuse it without
     # a second API call for the same frame. Cleared at AVI_ACTION.BEGIN so a
     # late-arriving writeDocuments from frame N cannot bleed into frame N+1.
-    _cached_answer: str = None
+    _cached_answer: str | None = None
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         """Handle AVI image protocol for streaming image frames."""
@@ -89,6 +89,7 @@ class IInstance(IInstanceGenericLLM):
                 continue
 
             question = Question()
+            # All Image doc producers (frame_grabber, thumbnail, embedding_image) normalize to PNG
             question.addContext(f'data:image/png;base64,{doc.page_content}')
             question.addQuestion(self.IGlobal._chat._prompt)
 

--- a/nodes/src/nodes/llm_vision_anthropic/IInstance.py
+++ b/nodes/src/nodes/llm_vision_anthropic/IInstance.py
@@ -96,7 +96,8 @@ class IInstance(IInstanceGenericLLM):
             try:
                 answer = self.IGlobal._chat.chat(question)
             except Exception as e:
-                warning(f'Anthropic Vision: inference failed for chunk {doc.metadata.chunkId}: {e}')
+                chunk_id = doc.metadata.chunkId if doc.metadata else 'unknown'
+                warning(f'Anthropic Vision: inference failed for chunk {chunk_id}: {e}')
                 continue
 
             answer_text = answer.getText()

--- a/nodes/src/nodes/llm_vision_anthropic/IInstance.py
+++ b/nodes/src/nodes/llm_vision_anthropic/IInstance.py
@@ -1,0 +1,109 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from nodes.llm_base import IInstanceGenericLLM
+from rocketlib import AVI_ACTION, warning
+from ai.common.schema import Doc
+
+
+class IInstance(IInstanceGenericLLM):
+    """Instance handler for the Anthropic Vision node."""
+
+    IGlobal: IGlobal
+
+    # Raw image data accumulated across AVI_WRITE chunks
+    image_data: bytearray | None = None
+
+    # Cached answer text from writeDocuments so writeImage can reuse it without
+    # a second API call for the same frame. Cleared at AVI_ACTION.BEGIN so a
+    # late-arriving writeDocuments from frame N cannot bleed into frame N+1.
+    _cached_answer: str = None
+
+    def writeImage(self, action: int, mimeType: str, buffer: bytes):
+        """Handle AVI image protocol for streaming image frames."""
+        if action == AVI_ACTION.BEGIN:
+            self.image_data = bytearray()
+            self._cached_answer = None
+            return self.preventDefault()
+        elif action == AVI_ACTION.WRITE:
+            if self.image_data is None:
+                raise RuntimeError('AVI protocol error: WRITE received before BEGIN')
+            self.image_data += buffer
+            return self.preventDefault()
+        elif action == AVI_ACTION.END:
+            if self.image_data is None:
+                raise RuntimeError('AVI protocol error: END received while there is no data')
+
+            if self._cached_answer is not None:
+                # writeDocuments already called Claude for this frame — reuse the result.
+                self.instance.writeText(self._cached_answer)
+                self._cached_answer = None
+            else:
+                # Only the image lane is connected; call Claude directly.
+                from ai.common.schema import Question
+                import base64
+
+                question = Question()
+                image_base64 = base64.b64encode(bytes(self.image_data)).decode('utf-8')
+                image_data_url = f'data:{mimeType};base64,{image_base64}'
+                question.addContext(image_data_url)
+                question.addQuestion(self.IGlobal._chat._prompt)
+
+                answer = self.IGlobal._chat.chat(question)
+                self.instance.writeText(answer.getText())
+
+            self.image_data = None
+            return self.preventDefault()
+
+    def writeDocuments(self, documents: list[Doc]):
+        """Process incoming image documents inline and emit vision model responses as text documents."""
+        from ai.common.schema import Question
+
+        for doc in documents:
+            if doc.type != 'Image':
+                warning(f'Anthropic Vision: skipping document with unexpected type "{doc.type}"')
+                continue
+            if not doc.page_content:
+                warning('Anthropic Vision: skipping Image document with empty content')
+                continue
+
+            question = Question()
+            question.addContext(f'data:image/png;base64,{doc.page_content}')
+            question.addQuestion(self.IGlobal._chat._prompt)
+
+            try:
+                answer = self.IGlobal._chat.chat(question)
+            except Exception as e:
+                warning(f'Anthropic Vision: inference failed for chunk {doc.metadata.chunkId}: {e}')
+                continue
+
+            answer_text = answer.getText()
+
+            # Cache so writeImage can emit the same text without a second API call.
+            self._cached_answer = answer_text
+
+            self.instance.writeDocuments([Doc(type='Text', page_content=answer_text, metadata=doc.metadata)])
+
+        # Prevent the original Image docs from flowing downstream.
+        self.preventDefault()

--- a/nodes/src/nodes/llm_vision_anthropic/IInstance.py
+++ b/nodes/src/nodes/llm_vision_anthropic/IInstance.py
@@ -35,16 +35,20 @@ class IInstance(IInstanceGenericLLM):
     # Raw image data accumulated across AVI_WRITE chunks
     image_data: bytearray | None = None
 
-    # Cached answer text from writeDocuments so writeImage can reuse it without
-    # a second API call for the same frame. Cleared at AVI_ACTION.BEGIN so a
-    # late-arriving writeDocuments from frame N cannot bleed into frame N+1.
+    # Cached answer text shared between the two lanes to avoid a second Claude
+    # call when both lanes are active for the same frame.
+    # _cache_from_image distinguishes who set it: True = writeImage, False = writeDocuments.
+    # writeDocuments must only consume the cache when writeImage set it, otherwise a
+    # cached answer from doc[N] would bleed into doc[N+1] in a multi-doc batch.
     _cached_answer: str | None = None
+    _cache_from_image: bool = False
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         """Handle AVI image protocol for streaming image frames."""
         if action == AVI_ACTION.BEGIN:
             self.image_data = bytearray()
             self._cached_answer = None
+            self._cache_from_image = False
             return self.preventDefault()
         elif action == AVI_ACTION.WRITE:
             if self.image_data is None:
@@ -59,6 +63,9 @@ class IInstance(IInstanceGenericLLM):
                 # writeDocuments already called Claude for this frame — reuse the result.
                 self.instance.writeText(self._cached_answer)
                 self._cached_answer = None
+                self._cache_from_image = False
+            elif not self.image_data:
+                warning('Anthropic Vision: skipping empty image frame')
             else:
                 # Only the image lane is connected; call Claude directly.
                 from ai.common.schema import Question
@@ -72,7 +79,10 @@ class IInstance(IInstanceGenericLLM):
 
                 try:
                     answer = self.IGlobal._chat.chat(question)
-                    self.instance.writeText(answer.getText())
+                    answer_text = answer.getText()
+                    self._cached_answer = answer_text
+                    self._cache_from_image = True
+                    self.instance.writeText(answer_text)
                 except Exception as e:
                     warning(f'Anthropic Vision: inference failed on image lane: {e}')
 
@@ -98,17 +108,26 @@ class IInstance(IInstanceGenericLLM):
             question.addContext(f'data:image/png;base64,{doc.page_content}')
             question.addQuestion(self.IGlobal._chat._prompt)
 
-            try:
-                answer = self.IGlobal._chat.chat(question)
-            except Exception as e:
-                chunk_id = doc.metadata.chunkId if doc.metadata else 'unknown'
-                warning(f'Anthropic Vision: inference failed for chunk {chunk_id}: {e}')
-                continue
+            if self._cached_answer is not None and self._cache_from_image:
+                # writeImage already called Claude for this frame — reuse the result.
+                answer_text = self._cached_answer
+                self._cached_answer = None
+                self._cache_from_image = False
+            else:
+                # Discard any stale doc-sourced cache (multi-doc batch safety).
+                self._cached_answer = None
+                self._cache_from_image = False
+                try:
+                    answer = self.IGlobal._chat.chat(question)
+                    answer_text = answer.getText()
+                except Exception as e:
+                    chunk_id = doc.metadata.chunkId if doc.metadata else 'unknown'
+                    warning(f'Anthropic Vision: inference failed for chunk {chunk_id}: {e}')
+                    continue
 
-            answer_text = answer.getText()
-
-            # Cache so writeImage can emit the same text without a second API call.
-            self._cached_answer = answer_text
+                # Cache so writeImage can reuse it if it fires after us.
+                self._cached_answer = answer_text
+                # _cache_from_image stays False — writeImage checks for this.
 
             self.instance.writeDocuments([Doc(type='Text', page_content=answer_text, metadata=doc.metadata)])
 

--- a/nodes/src/nodes/llm_vision_anthropic/README.md
+++ b/nodes/src/nodes/llm_vision_anthropic/README.md
@@ -36,7 +36,7 @@ Sends images to Anthropic Claude vision-capable models and returns text analysis
 
 Anthropic enforces a **5 MB limit on the base64-encoded image string**. If a frame exceeds this, the node automatically re-encodes it as JPEG at progressively lower quality (85 → 70 → 55 → 40). A warning is logged when compression occurs:
 
-```
+```text
 Anthropic Vision: image is 5.4MB, exceeds 5MB limit — compressing to JPEG
 Anthropic Vision: compressed to 0.5MB at JPEG quality=85
 ```

--- a/nodes/src/nodes/llm_vision_anthropic/README.md
+++ b/nodes/src/nodes/llm_vision_anthropic/README.md
@@ -1,0 +1,49 @@
+---
+title: Anthropic Vision
+date: 2026-04-14
+sidebar_position: 1
+---
+
+## What it does
+
+Sends images to Anthropic Claude vision-capable models and returns text analysis. Accepts either a single image or a stream of image documents (e.g. from the frame grabber). Metadata such as frame number and timestamp is preserved on the `documents` output.
+
+**Lanes:**
+
+| Lane in     | Lane out    | Description                                                                    |
+| ----------- | ----------- | ------------------------------------------------------------------------------ |
+| `image`     | `text`      | Analyze a single image, receive text                                           |
+| `documents` | `documents` | Analyze image documents, return text analysis with original metadata preserved |
+
+## Configuration
+
+| Field               | Description                                             |
+| ------------------- | ------------------------------------------------------- |
+| Model               | Vision model to use (see profiles below)                |
+| API Key             | Anthropic API key (starts with `sk-ant-`)               |
+| System Instructions | Define the model's role and behavior for image analysis |
+| Analysis Prompt     | Describe what to analyze or extract from the image      |
+
+## Profiles
+
+| Profile                     | Model               | Context |
+| --------------------------- | ------------------- | ------- |
+| Claude Opus 4.6 _(default)_ | `claude-opus-4-6`   | 200,000 |
+| Claude Sonnet 4.6           | `claude-sonnet-4-6` | 200,000 |
+| Claude Haiku 4.5            | `claude-haiku-4-5`  | 200,000 |
+
+## Image size limit
+
+Anthropic enforces a **5 MB limit on the base64-encoded image string**. If a frame exceeds this, the node automatically re-encodes it as JPEG at progressively lower quality (85 → 70 → 55 → 40). A warning is logged when compression occurs:
+
+```
+Anthropic Vision: image is 5.4MB, exceeds 5MB limit — compressing to JPEG
+Anthropic Vision: compressed to 0.5MB at JPEG quality=85
+```
+
+If the image cannot be brought under 5 MB at any quality level, the frame is skipped. This limit is specific to Anthropic — other vision nodes (Gemini, Ollama, Mistral) do not have this restriction.
+
+## Upstream docs
+
+- [Anthropic Claude vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision.md)
+- [Anthropic API keys](https://console.anthropic.com)

--- a/nodes/src/nodes/llm_vision_anthropic/__init__.py
+++ b/nodes/src/nodes/llm_vision_anthropic/__init__.py
@@ -1,0 +1,39 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+
+def getChat():
+    """Get the Chat class from the module."""
+    from .anthropic_vision import Chat
+
+    return Chat
+
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+    'getChat',
+]

--- a/nodes/src/nodes/llm_vision_anthropic/anthropic_vision.py
+++ b/nodes/src/nodes/llm_vision_anthropic/anthropic_vision.py
@@ -1,0 +1,235 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+import time
+import threading
+from depends import depends  # type: ignore
+from typing import Any, Dict
+from ai.common.schema import Answer, Question
+from ai.common.chat import ChatBase
+from ai.common.config import Config
+from rocketlib import warning
+
+# Load requirements
+requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+depends(requirements)
+
+import anthropic as anthropic_sdk
+
+
+class Chat(ChatBase):
+    """Anthropic Claude Vision chat for general-purpose image analysis."""
+
+    _model: str = ''
+    _api_key: str = ''
+    _system_prompt: str = ''
+    _prompt: str = ''
+
+    def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
+        """Initialize the Anthropic Vision chat instance."""
+        super().__init__(provider, connConfig, bag)
+        config = Config.getNodeConfig(provider, connConfig)
+
+        self._model = config.get('model', 'claude-opus-4-6')
+        api_key = config.get('apikey')
+
+        self._system_prompt = config.get('vision.systemPrompt') or config.get('systemPrompt') or ''
+        self._prompt = config.get('vision.prompt') or config.get('prompt') or 'Describe this image in detail.'
+
+        if not api_key:
+            raise ValueError('Missing Anthropic API key. Get one at https://console.anthropic.com')
+        if not api_key.startswith('sk-ant-'):
+            raise ValueError('Invalid Anthropic API key format. Keys should start with "sk-ant-". Please check your key at https://console.anthropic.com')
+
+        self._api_key = api_key
+        self._modelTotalTokens = config.get('modelTotalTokens', 200000)
+        bag['chat'] = self
+
+    def getTotalTokens(self) -> int:
+        """Get the total token limit for the current model."""
+        return self._modelTotalTokens
+
+    def getTokens(self, value: str) -> int:
+        """Approximate token count (4 chars per token heuristic)."""
+        if not value.strip():
+            return 0
+        return len(value) // 4
+
+    def _format_user_error(self, error_msg: str) -> str:
+        """Convert API error messages to user-friendly format."""
+        error_lower = error_msg.lower()
+        if any(p in error_lower for p in ['authentication', 'invalid x-api-key', 'api_key', 'unauthorized']):
+            return 'Authentication failed. Please check your Anthropic API key.'
+        if any(p in error_lower for p in ['rate limit', 'too many requests', '429']):
+            return 'Rate limit exceeded. Please wait a moment before trying again.'
+        if any(p in error_lower for p in ['credit', 'billing', 'quota', 'insufficient']):
+            return 'API quota exceeded or billing issue. Please check your Anthropic account status.'
+        if any(p in error_lower for p in ['invalid request', 'bad request', '400']):
+            return 'Invalid input. Please check your image format and prompt.'
+        if any(p in error_lower for p in ['not found', '404']):
+            return f"Model '{self._model}' not found. Please check the model name."
+        if any(p in error_lower for p in ['timeout', 'timed out']):
+            return 'Request timed out. Please try again.'
+        if any(p in error_lower for p in ['overloaded', '529']):
+            return 'Anthropic API is overloaded. Please try again later.'
+        if any(p in error_lower for p in ['server error', '500', '502', '503', '504']):
+            return 'Anthropic API is temporarily unavailable. Please try again later.'
+        return f'Anthropic error: {error_msg}'
+
+    def _compress_image(self, b64_data: str, mime_type: str) -> tuple[str, str]:
+        """Compress image to fit Anthropic's 5MB limit, converting to JPEG if needed.
+        Returns (b64_data, mime_type) — possibly updated. Raises on failure.
+        """
+        import base64
+        import io
+        from PIL import Image
+
+        _MAX_BYTES = 5 * 1024 * 1024  # 5 MB — Anthropic measures base64 string length
+
+        # Check base64 string length, not decoded size — that's what Anthropic counts
+        if len(b64_data) <= _MAX_BYTES:
+            return b64_data, mime_type
+
+        raw = base64.b64decode(b64_data)
+        original_mb = len(b64_data) / (1024 * 1024)
+        warning(f'Anthropic Vision: image is {original_mb:.1f}MB, exceeds 5MB limit — compressing to JPEG')
+
+        img = Image.open(io.BytesIO(raw))
+        if img.mode in ('RGBA', 'P', 'LA'):
+            img = img.convert('RGB')
+
+        for quality in (85, 70, 55, 40):
+            buf = io.BytesIO()
+            img.save(buf, format='JPEG', quality=quality, optimize=True)
+            compressed_b64 = base64.b64encode(buf.getvalue()).decode('utf-8')
+            if len(compressed_b64) <= _MAX_BYTES:
+                compressed_mb = len(compressed_b64) / (1024 * 1024)
+                warning(f'Anthropic Vision: compressed to {compressed_mb:.1f}MB at JPEG quality={quality}')
+                return compressed_b64, 'image/jpeg'
+
+        raise ValueError('Image could not be compressed under 5MB at any JPEG quality — skipping frame')
+
+    def _shouldRetry(self, error: Exception) -> bool:
+        """Determine if an error is retryable."""
+        error_msg = str(error).lower()
+        retryable = ['timeout', 'timed out', 'connection', '500', '502', '503', '504', '529', 'overloaded', 'server error']
+        return any(p in error_msg for p in retryable)
+
+    def chat(self, question: Question) -> Answer:
+        """Send an image to Claude Vision and get the response."""
+        max_retries = 1
+        base_delay = 1.0
+        last_error = None
+
+        # Extract image data from context
+        image_data = None
+        prompt_text = self._prompt
+        for context_item in question.context:
+            if context_item.startswith(('data:image/', 'data:application/')):
+                image_data = context_item
+                break
+
+        if question.questions and len(question.questions) > 0:
+            prompt_text = question.questions[0].text
+
+        if not image_data:
+            raise ValueError('No image provided. Please connect an image source to this node.')
+
+        # Parse the data URL once outside the retry loop
+        try:
+            header, b64_data = image_data.split(',', 1)
+            mime_type = header.split(':')[1].split(';')[0]
+        except (ValueError, IndexError) as e:
+            raise ValueError('Malformed image data URL. Expected format: data:<mime>;base64,<data>') from e
+
+        # Anthropic's hard limit is 5MB — compress if needed
+        try:
+            b64_data, mime_type = self._compress_image(b64_data, mime_type)
+        except Exception as compress_err:
+            raise ValueError(f'Anthropic Vision: {compress_err}') from compress_err
+
+        hard_timeout = 30
+
+        for attempt in range(max_retries + 1):
+            try:
+                result = [None]
+                exc = [None]
+
+                def _invoke():
+                    try:
+                        # Fresh client per attempt — avoids exhausting the shared HTTP connection
+                        # pool when daemon threads from prior timed-out attempts are still running
+                        client = anthropic_sdk.Anthropic(api_key=self._api_key, max_retries=0)
+
+                        content = [
+                            {
+                                'type': 'image',
+                                'source': {
+                                    'type': 'base64',
+                                    'media_type': mime_type,
+                                    'data': b64_data,
+                                },
+                            },
+                            {'type': 'text', 'text': prompt_text},
+                        ]
+
+                        kwargs: Dict[str, Any] = {
+                            'model': self._model,
+                            'max_tokens': 1024,
+                            'messages': [{'role': 'user', 'content': content}],
+                        }
+                        if self._system_prompt:
+                            kwargs['system'] = self._system_prompt
+
+                        result[0] = client.messages.create(**kwargs)
+                    except Exception as e:
+                        exc[0] = e
+
+                t = threading.Thread(target=_invoke, daemon=True)
+                t.start()
+                t.join(timeout=hard_timeout)
+                if t.is_alive():
+                    warning(f'Anthropic Vision: inference timed out after {hard_timeout}s (attempt {attempt + 1}/{max_retries + 1}) — daemon thread still running')
+                    raise TimeoutError(f'Vision inference timed out after {hard_timeout}s (attempt {attempt + 1})')
+                if exc[0]:
+                    raise exc[0]
+
+                response = result[0]
+                text = next((b.text for b in response.content if b.type == 'text'), '')
+                answer = Answer(expectJson=question.expectJson)
+                answer.setAnswer(text)
+                return answer
+            except Exception as e:
+                last_error = e
+                # Don't spin on repeated timeouts — a second 30s wait is enough.
+                if isinstance(e, TimeoutError) and attempt >= 1:
+                    break
+                if attempt < max_retries and self._shouldRetry(e):
+                    delay = base_delay * (2**attempt)
+                    time.sleep(delay)
+                    continue
+                break
+
+        user_friendly_error = self._format_user_error(str(last_error))
+        raise Exception(user_friendly_error) from last_error

--- a/nodes/src/nodes/llm_vision_anthropic/requirements.txt
+++ b/nodes/src/nodes/llm_vision_anthropic/requirements.txt
@@ -1,0 +1,2 @@
+anthropic>=0.40.0
+Pillow>=10.0.0

--- a/nodes/src/nodes/llm_vision_anthropic/requirements.txt
+++ b/nodes/src/nodes/llm_vision_anthropic/requirements.txt
@@ -1,2 +1,2 @@
 anthropic>=0.40.0
-Pillow>=10.0.0
+pillow

--- a/nodes/src/nodes/llm_vision_anthropic/services.json
+++ b/nodes/src/nodes/llm_vision_anthropic/services.json
@@ -1,0 +1,136 @@
+{
+	"title": "Anthropic Vision",
+	"protocol": "image_vision_anthropic://",
+	"classType": ["image"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.llm_vision_anthropic",
+	"prefix": "image_vision_anthropic",
+	"description": ["A component that connects to Anthropic's Claude vision-capable models for image analysis, ", "OCR, visual understanding, and scene description. Supports Claude Opus, Sonnet, and Haiku models ", "with multimodal capabilities. Features robust error handling, automatic image processing, ", "and flexible prompt configuration for a wide range of vision use cases."],
+	"icon": "anthropic.svg",
+	"documentation": "https://docs.rocketride.org",
+	"tile": ["Model: ${parameters.image_vision_anthropic.profile}"],
+	"lanes": {
+		"image": ["text"],
+		"documents": ["documents"]
+	},
+	"input": [
+		{
+			"lane": "image",
+			"description": "Image to analyze with Claude Vision models",
+			"output": [
+				{
+					"lane": "text",
+					"description": "Text analysis of the image content"
+				}
+			]
+		},
+		{
+			"lane": "documents",
+			"description": "Image documents to analyze with Claude Vision models",
+			"output": [
+				{
+					"lane": "documents",
+					"description": "Text analysis of each image document with original metadata (frame number, timestamp) preserved"
+				}
+			]
+		}
+	],
+	"preconfig": {
+		"default": "claude-opus-4-6",
+		"profiles": {
+			"claude-opus-4-6": {
+				"title": "Claude Opus 4.6 - Most Capable (200K tokens)",
+				"model": "claude-opus-4-6",
+				"modelTotalTokens": 200000,
+				"apikey": ""
+			},
+			"claude-sonnet-4-6": {
+				"title": "Claude Sonnet 4.6 - Balanced Speed & Quality (200K tokens)",
+				"model": "claude-sonnet-4-6",
+				"modelTotalTokens": 200000,
+				"apikey": ""
+			},
+			"claude-haiku-4-5": {
+				"title": "Claude Haiku 4.5 - Fastest & Most Affordable (200K tokens)",
+				"model": "claude-haiku-4-5",
+				"modelTotalTokens": 200000,
+				"apikey": ""
+			}
+		}
+	},
+	"fields": {
+		"image_vision_anthropic.apikey": {
+			"type": "string",
+			"title": "API Key",
+			"description": "Anthropic API key. Get one at https://console.anthropic.com",
+			"secure": true,
+			"ui": {
+				"ui:widget": "ApiKeyWidget"
+			}
+		},
+		"model": {
+			"type": "string",
+			"title": "Model",
+			"description": "Claude Vision model"
+		},
+		"modelTotalTokens": {
+			"type": "number",
+			"title": "Tokens",
+			"description": "Maximum context length in tokens"
+		},
+		"vision.systemPrompt": {
+			"type": "string",
+			"format": "textarea",
+			"title": "System Instructions",
+			"description": "Define the model's role and behavior for image analysis"
+		},
+		"vision.prompt": {
+			"type": "string",
+			"format": "textarea",
+			"title": "Analysis Prompt",
+			"description": "Describe what you want to analyze or extract from the image"
+		},
+		"image_vision_anthropic.claude-opus-4-6": {
+			"object": "claude-opus-4-6",
+			"properties": ["image_vision_anthropic.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_anthropic.claude-sonnet-4-6": {
+			"object": "claude-sonnet-4-6",
+			"properties": ["image_vision_anthropic.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_anthropic.claude-haiku-4-5": {
+			"object": "claude-haiku-4-5",
+			"properties": ["image_vision_anthropic.apikey", "vision.systemPrompt", "vision.prompt"]
+		},
+		"image_vision_anthropic.profile": {
+			"title": "Vision Model",
+			"description": "Select the Claude vision model to use",
+			"type": "string",
+			"default": "claude-opus-4-6",
+			"enum": ["*>preconfig.profiles.*.title"],
+			"conditional": [
+				{
+					"value": "claude-opus-4-6",
+					"properties": ["image_vision_anthropic.claude-opus-4-6"]
+				},
+				{
+					"value": "claude-sonnet-4-6",
+					"properties": ["image_vision_anthropic.claude-sonnet-4-6"]
+				},
+				{
+					"value": "claude-haiku-4-5",
+					"properties": ["image_vision_anthropic.claude-haiku-4-5"]
+				}
+			]
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Anthropic Vision",
+			"properties": ["image_vision_anthropic.profile"]
+		}
+	]
+}


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->
- Adds a new Anthropic Vision node (llm_vision_anthropic) that routes image frames through Claude Opus 4.6, Sonnet 4.6, and Haiku 4.5 with the same dual-lane architecture as the Gemini and Ollama vision nodes                                                                                                                                                                        
- Implements automatic JPEG compression for frames exceeding Anthropic's 5MB base64 string limit (not decoded size), with progressive quality reduction from 85→40 before skipping the frame entirely                                                                                                                                                                                   
- Caps inference retries at 1 with a 30s hard timeout per attempt, matching the Ollama/Gemini pattern to prevent pipeline stalls

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
feat

## Testing

- [ ] Tests added or updated
- [X] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Anthropic Vision" image-analysis node using Anthropic Claude vision models
  * Supports single-image and documents lanes, per-frame streaming, cached responses, and preserved metadata
  * Configurable model profiles, API key, system/user prompts, and UI profile selector
  * Returns text answers per image/document, enforces 5MB base64 limit with automatic JPEG compression and warnings, and improves timeout/retry/error handling

* **Documentation**
  * Added user guide describing usage, model options, size limits, compression behavior, and setup instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->