### PR TITLE
fix(canvas): improve QuickAdd popup label copy

### DIFF
--- a/packages/shared-ui/src/components/canvas/components/panels/quick-add/QuickAddPopup.tsx
+++ b/packages/shared-ui/src/components/canvas/components/panels/quick-add/QuickAddPopup.tsx
@@ -371,7 +371,7 @@ export default function QuickAddPopup(): ReactElement | null {
 						inputRef={searchRef}
 						size="small"
 						fullWidth
-						placeholder={mode === 'invoke' ? (isSource ? `Add ${renameInvokeType(invokeKey)} provider...` : 'Add invoker...') : `Add ${laneType} node...`}
+						placeholder={mode === 'invoke' ? (isSource ? `Add ${renameInvokeType(invokeKey ?? 'invoke')} provider...` : 'Add invoker...') : `Add ${laneType} node...`}
 						value={search}
 						onChange={(e) => setSearch(e.target.value)}
 						InputProps={{

--- a/packages/shared-ui/src/components/canvas/components/panels/quick-add/QuickAddPopup.tsx
+++ b/packages/shared-ui/src/components/canvas/components/panels/quick-add/QuickAddPopup.tsx
@@ -18,7 +18,7 @@ import { Search } from 'lucide-react';
 import { useFlowGraph } from '../../../context/FlowGraphContext';
 import { useFlowProject } from '../../../context/FlowProjectContext';
 import { IService, IServiceCapabilities, IServiceLane } from '../../../types';
-import { getOutputLaneDisplayValues } from '../../../util/helpers';
+import { getOutputLaneDisplayValues, renameInvokeType } from '../../../util/helpers';
 import { generateNodeId } from '../../../util';
 import { getIconPath } from '../../../util/get-icon-path';
 import { commonStyles } from '../../../../../themes/styles';
@@ -371,7 +371,7 @@ export default function QuickAddPopup(): ReactElement | null {
 						inputRef={searchRef}
 						size="small"
 						fullWidth
-						placeholder={mode === 'invoke' ? (isSource ? `Add ${invokeKey ?? 'invoke'} provider...` : 'Add invoker...') : `Add ${laneType} ${isSource ? 'consumer' : 'producer'}...`}
+						placeholder={mode === 'invoke' ? (isSource ? `Add ${renameInvokeType(invokeKey)} provider...` : 'Add invoker...') : `Add ${laneType} node...`}
 						value={search}
 						onChange={(e) => setSearch(e.target.value)}
 						InputProps={{


### PR DESCRIPTION
## Summary
- Replaces "consumer" / "producer" in the QuickAdd lane placeholder text with "node" (e.g. `Add text node...`)
- Uses `renameInvokeType()` to properly format invoke lane labels in the placeholder (e.g. `Add LLM provider...` instead of `Add llm provider...`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Clarified Quick Add popup placeholder text: provider placeholders now use a normalized invoke type label in invoke mode, and lane-mode placeholders use "node" instead of "consumer"/"producer" for clearer guidance when adding items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->