### PR TITLE
security: make gitleaks pre-commit hook blocking

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -6,13 +6,14 @@
 useDefault = true
 
 # Custom rule: detect hardcoded API keys in .pipe pipeline files
+# Matches both `.pipe` and `.pipe.json` (the editor saves as the latter).
 [[rules]]
 id = "pipe-file-api-key"
 description = "Hardcoded API key in .pipe pipeline file"
 regex = '''(?i)"(apikey|api_key|secret|token|password|auth)"\s*:\s*"([^"]{8,})"'''
 secretGroup = 2
 keywords = ["apikey", "api_key", "secret", "token", "password", "auth"]
-paths = ['''\.pipe$''']
+paths = ['''\.pipe(\.json)?$''']
 
     [rules.allowlist]
     regexes = [

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     gitleaks:
       tags: security
-      run: gitleaks protect --verbose --staged --config .gitleaks.toml || true
+      run: gitleaks protect --verbose --redact --staged --config .gitleaks.toml
     eslint:
       glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
       run: npx eslint {staged_files}


### PR DESCRIPTION
## Summary
Two small but important fixes to the gitleaks pre-commit hook, prompted by the credential leak in \`rocketride-examples#d6c90c7\` (OpenAI key + GitHub PAT + Discord webhook committed to \`pipeline.pipe.json\`).

1. **Drop \`|| true\` from the gitleaks command** in \`lefthook.yml\`. This was a silent anti-pattern — gitleaks would detect the secret, print \"STOP\" with the finding, and the commit would go through anyway. Now the hook refuses the commit.
2. **Fix \`paths\` regex** on the \`pipe-file-api-key\` rule in \`.gitleaks.toml\`. The regex \`\\.pipe\$\` matched literal \`.pipe\` extensions, but the VS Code extension saves pipelines as \`.pipe.json\`. So the rule never fired on the actual file format. Changed to \`\\.pipe(\\.json)?\$\`.
3. Added \`--redact\` so the matched secret doesn't echo to the terminal — important because terminal output often ends up in screenshots and bug reports.

## Why this matters
The leak we just cleaned up was exactly the scenario this hook is supposed to block. It didn't, for two reasons above. This PR closes both gaps.

## Test plan
- [x] Locally verified: the new config blocks the exact content that leaked (3 rules fire — \`pipe-file-api-key\`, \`services-json-api-key\`, default \`openai-api-key\`)
- [x] Locally verified: clean Python/JS source files still pass with no findings
- [ ] After merge: everyone re-runs \`lefthook install\` to pick up the updated config (should be automatic on next commit since lefthook reads the file at commit time, but worth noting)

## Follow-up (separate PRs)
- \`rocketride-examples\` has no lefthook at all — adding it in a separate PR against that repo
- Enabling GitHub Secret Scanning + Push Protection at the org level as a server-side backstop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced secret detection configuration to cover additional file format variants
  * Strengthened pre-commit security checks to enforce secret detection and redact sensitive content in output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->