### PR TITLE
Feat: Filesystem Tool

### DIFF
--- a/nodes/src/nodes/tool_filesystem/IGlobal.py
+++ b/nodes/src/nodes/tool_filesystem/IGlobal.py
@@ -1,0 +1,141 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+File system tool node — global (shared) state.
+
+Resolves the account's ``client_id`` from the ``ROCKETRIDE_CLIENT_ID`` env var
+(injected by the task engine in ``task_engine.py``) and builds a single
+``FileStore`` scoped to ``users/<client_id>/files/``. The instance exposes
+per-operation allow-flags and a path whitelist that IInstance enforces before
+every tool call.
+
+Only the operations already implemented by ``FileStore`` are surfaced:
+``read_file``, ``write_file``, ``delete_file``, ``list_directory``,
+``create_directory``, ``stat_file``.
+
+Not yet implemented (follow-up — require new primitives on ``FileStore`` and
+all ``IStore`` providers first):
+  * ``edit_file``  — atomic in-place patch (add edit primitive or compose
+                     read+write with concurrency control).
+  * ``move_file``  — requires ``FileStore.rename(src, dst)`` plus DAP and
+                     client-SDK propagation.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+from ai.account.store import Store
+from ai.common.config import Config
+from rocketlib import IGlobalBase, OPEN_MODE, warning
+
+
+class IGlobal(IGlobalBase):
+    """Global state for tool_filesystem."""
+
+    client_id: str | None = None
+    file_store: object | None = None  # ai.account.file_store.FileStore
+    allow_read: bool = True
+    allow_write: bool = True
+    allow_list: bool = True
+    allow_mkdir: bool = True
+    allow_stat: bool = True
+    allow_delete: bool = False
+    path_patterns: list[re.Pattern] | None = None
+
+    def beginGlobal(self) -> None:
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            return
+
+        cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+
+        self.allow_read = bool(cfg.get('allowRead', True))
+        self.allow_write = bool(cfg.get('allowWrite', True))
+        self.allow_list = bool(cfg.get('allowList', True))
+        self.allow_mkdir = bool(cfg.get('allowMkdir', True))
+        self.allow_stat = bool(cfg.get('allowStat', True))
+        self.allow_delete = bool(cfg.get('allowDelete', False))
+        self.path_patterns = self._build_path_patterns(cfg)
+
+        client_id = os.environ.get('ROCKETRIDE_CLIENT_ID', '').strip()
+        if not client_id:
+            warning('tool_filesystem: ROCKETRIDE_CLIENT_ID env var is missing; tool methods will be disabled. This usually means the node is running outside the task engine.')
+            self.client_id = None
+            self.file_store = None
+            return
+
+        try:
+            store = Store.create()
+            self.file_store = store.get_file_store(client_id)
+            self.client_id = client_id
+        except Exception as e:
+            warning(f'tool_filesystem: failed to initialise FileStore: {e}')
+            self.client_id = None
+            self.file_store = None
+
+    @staticmethod
+    def _build_path_patterns(cfg: dict) -> list[re.Pattern]:
+        """Parse the repeated ``whitelistPattern`` rows into compiled regexes."""
+        raw = cfg.get('pathWhitelist') or []
+        if not isinstance(raw, list):
+            import json
+
+            try:
+                raw = json.loads(str(raw))
+                if not isinstance(raw, list):
+                    raise ValueError(f'pathWhitelist must be a JSON array, got {type(raw).__name__}')
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                raise ValueError(f'pathWhitelist is malformed and cannot be parsed: {e}') from e
+
+        patterns: list[re.Pattern] = []
+        for row in raw:
+            if not hasattr(row, 'get'):
+                continue
+            pat_str = str(row.get('whitelistPattern') or '').strip()
+            if pat_str:
+                try:
+                    patterns.append(re.compile(pat_str))
+                except re.error as e:
+                    warning(f'tool_filesystem: invalid path whitelist regex {pat_str!r}: {e}')
+
+        return patterns
+
+    def validateConfig(self) -> None:
+        try:
+            cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            server_name = str((cfg.get('serverName') or '')).strip()
+            if not server_name:
+                warning('serverName is required')
+
+            patterns = self._build_path_patterns(cfg)
+            if not patterns:
+                warning('Path whitelist is empty — all paths under users/<client_id>/files/ will be allowed')
+        except Exception as e:
+            warning(str(e))
+
+    def endGlobal(self) -> None:
+        self.client_id = None
+        self.file_store = None
+        self.path_patterns = []

--- a/nodes/src/nodes/tool_filesystem/IGlobal.py
+++ b/nodes/src/nodes/tool_filesystem/IGlobal.py
@@ -125,13 +125,7 @@ class IGlobal(IGlobalBase):
     def validateConfig(self) -> None:
         try:
             cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
-            server_name = str((cfg.get('serverName') or '')).strip()
-            if not server_name:
-                warning('serverName is required')
-
-            patterns = self._build_path_patterns(cfg)
-            if not patterns:
-                warning('Path whitelist is empty — all paths under users/<client_id>/files/ will be allowed')
+            self._build_path_patterns(cfg)
         except Exception as e:
             warning(str(e))
 

--- a/nodes/src/nodes/tool_filesystem/IGlobal.py
+++ b/nodes/src/nodes/tool_filesystem/IGlobal.py
@@ -30,16 +30,9 @@ Resolves the account's ``client_id`` from the ``ROCKETRIDE_CLIENT_ID`` env var
 per-operation allow-flags and a path whitelist that IInstance enforces before
 every tool call.
 
-Only the operations already implemented by ``FileStore`` are surfaced:
-``read_file``, ``write_file``, ``delete_file``, ``list_directory``,
-``create_directory``, ``stat_file``.
-
-Not yet implemented (follow-up — require new primitives on ``FileStore`` and
-all ``IStore`` providers first):
-  * ``edit_file``  — atomic in-place patch (add edit primitive or compose
-                     read+write with concurrency control).
-  * ``move_file``  — requires ``FileStore.rename(src, dst)`` plus DAP and
-                     client-SDK propagation.
+Surfaces ``read_file``, ``write_file``, ``delete_file``, ``list_directory``,
+``create_directory``, and ``stat_file`` as ``@tool_function`` methods on
+``IInstance``.
 """
 
 from __future__ import annotations

--- a/nodes/src/nodes/tool_filesystem/IGlobal.py
+++ b/nodes/src/nodes/tool_filesystem/IGlobal.py
@@ -74,7 +74,9 @@ class IGlobal(IGlobalBase):
 
         client_id = os.environ.get('ROCKETRIDE_CLIENT_ID', '').strip()
         if not client_id:
-            warning('tool_filesystem: ROCKETRIDE_CLIENT_ID env var is missing; tool methods will be disabled. This usually means the node is running outside the task engine.')
+            warning(
+                'tool_filesystem: ROCKETRIDE_CLIENT_ID env var is missing; tool methods will be disabled. This usually means the node is running outside the task engine.'
+            )
             self.client_id = None
             self.file_store = None
             return

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -77,10 +77,7 @@ class IInstance(IInstanceBase):
         description=('Read a file from the account file store and return its contents as a decoded string. Required: "path" (relative path). Optional: "encoding" (default "utf-8"). Returns: {path, content, size} where size is the byte length before decoding.'),
     )
     def read_file(self, args):
-        args = self._prepare(args, 'read_file')
-        path = _require_str(args, 'path')
-        encoding = _optional_str(args, 'encoding', default='utf-8') or 'utf-8'
-        self._check_path(path)
+        path, encoding, _ = self._prepare(args, 'read_file', needs_encoding=True)
 
         data = _run_async(self.IGlobal.file_store.read(path))
         try:
@@ -113,13 +110,7 @@ class IInstance(IInstanceBase):
         description=('Write (or overwrite) a file in the account file store. Required: "path", "content". Optional: "encoding" (default "utf-8"). Returns: {path, bytesWritten}.'),
     )
     def write_file(self, args):
-        args = self._prepare(args, 'write_file')
-        path = _require_str(args, 'path')
-        content = args.get('content')
-        if not isinstance(content, str):
-            raise ValueError('content is required and must be a string')
-        encoding = _optional_str(args, 'encoding', default='utf-8') or 'utf-8'
-        self._check_path(path)
+        path, encoding, content = self._prepare(args, 'write_file', needs_encoding=True, needs_content=True)
 
         try:
             data = content.encode(encoding)
@@ -144,9 +135,7 @@ class IInstance(IInstanceBase):
         description=('Delete a file from the account file store. Only available when the operator has enabled "allowDelete" on this node. Required: "path". Returns: {path, deleted: true}.'),
     )
     def delete_file(self, args):
-        args = self._prepare(args, 'delete_file')
-        path = _require_str(args, 'path')
-        self._check_path(path)
+        path, _, _ = self._prepare(args, 'delete_file')
 
         _run_async(self.IGlobal.file_store.delete(path))
         return {'path': path, 'deleted': True}
@@ -166,11 +155,7 @@ class IInstance(IInstanceBase):
         description=('List the immediate children of a directory in the account file store. Optional: "path" (defaults to the account root). Returns: {entries: [{name, type, size?, modified?}], count}.'),
     )
     def list_directory(self, args):
-        args = self._prepare(args, 'list_directory')
-        path = args.get('path', '')
-        if not isinstance(path, str):
-            raise ValueError('path must be a string')
-        self._check_path(path)
+        path, _, _ = self._prepare(args, 'list_directory', path_required=False)
 
         result = _run_async(self.IGlobal.file_store.list_dir(path))
         return result
@@ -190,9 +175,7 @@ class IInstance(IInstanceBase):
         description=('Create a directory in the account file store. Intermediate segments are created as needed. Required: "path". Returns: {path, created: true}.'),
     )
     def create_directory(self, args):
-        args = self._prepare(args, 'create_directory')
-        path = _require_str(args, 'path')
-        self._check_path(path)
+        path, _, _ = self._prepare(args, 'create_directory')
 
         _run_async(self.IGlobal.file_store.mkdir(path))
         return {'path': path, 'created': True}
@@ -212,9 +195,7 @@ class IInstance(IInstanceBase):
         description=('Get metadata for a file or directory in the account file store. Required: "path". Returns: {exists, type?, size?, modified?}.'),
     )
     def stat_file(self, args):
-        args = self._prepare(args, 'stat_file')
-        path = _require_str(args, 'path')
-        self._check_path(path)
+        path, _, _ = self._prepare(args, 'stat_file')
 
         return _run_async(self.IGlobal.file_store.stat(path))
 
@@ -258,13 +239,24 @@ class IInstance(IInstanceBase):
             return True
         return bool(getattr(self.IGlobal, flag, False))
 
-    def _prepare(self, args: Any, tool_name: str) -> dict:
-        """Shared prologue for every ``@tool_function`` method:
-        validate ``args`` is a dict (``None`` becomes ``{}``), verify the
-        FileStore initialised, and enforce the allow-flag for this op.
+    def _prepare(
+        self,
+        args: Any,
+        tool_name: str,
+        *,
+        path_required: bool = True,
+        needs_encoding: bool = False,
+        needs_content: bool = False,
+    ) -> tuple[str, str | None, str | None]:
+        """Shared prologue for every ``@tool_function`` method: validates
+        ``args`` is a dict (``None`` becomes ``{}``), verifies the FileStore
+        initialised, enforces the allow-flag, extracts the per-op fields, and
+        checks ``path`` against the whitelist.
 
-        Returns the validated args dict so the caller can read per-op fields
-        without re-validating. Raises ``ValueError`` on any failure.
+        ``path_required=False`` makes ``path`` optional (defaults to ``''``,
+        meaning the account root) — use this for directory-listing-style ops.
+        ``needs_encoding`` / ``needs_content`` pull those fields for ops that
+        take them. Fields not requested are returned as ``None``.
 
         This duplicates the filtering done by ``_collect_tool_methods``
         intentionally — defence-in-depth against direct method calls that
@@ -276,7 +268,26 @@ class IInstance(IInstanceBase):
         if not getattr(self.IGlobal, flag_attr, False):
             label = flag_attr.removeprefix('allow_')
             raise ValueError(f'{label} access is not enabled for this filesystem tool')
-        return args
+
+        if path_required:
+            path = _require_str(args, 'path')
+        else:
+            path = args.get('path', '')
+            if not isinstance(path, str):
+                raise ValueError('path must be a string')
+        self._check_path(path)
+
+        encoding: str | None = None
+        if needs_encoding:
+            encoding = _optional_str(args, 'encoding', default='utf-8') or 'utf-8'
+
+        content: str | None = None
+        if needs_content:
+            content = args.get('content')
+            if not isinstance(content, str):
+                raise ValueError('content is required and must be a string')
+
+        return path, encoding, content
 
     def _check_ready(self) -> None:
         """Verify the FileStore was successfully initialised in beginGlobal()."""

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -1,0 +1,315 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+File system tool node — instance.
+
+Exposes one ``@tool_function`` per operation already implemented by
+``ai.account.file_store.FileStore``:
+
+  * ``read_file(path, encoding?)``
+  * ``write_file(path, content, encoding?)``
+  * ``delete_file(path)``          — gated by ``allowDelete`` (default off)
+  * ``list_directory(path?)``
+  * ``create_directory(path)``
+  * ``stat_file(path)``
+
+Each method checks the corresponding allow-flag on ``self.IGlobal``, validates
+the path against the configured regex whitelist, and then invokes the
+``FileStore`` coroutine via a per-call event loop. Exceptions from the store
+(``StorageError``, ``ValueError``) propagate to the agent as tool errors.
+
+TODO (follow-up — see IGlobal.py docstring):
+  * ``edit_file(path, old_string, new_string, replace_all?)``
+  * ``move_file(src, dst)``
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from rocketlib import IInstanceBase, tool_function
+
+from .IGlobal import IGlobal
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    # ------------------------------------------------------------------
+    # Tool methods
+    # ------------------------------------------------------------------
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['path'],
+            'properties': {
+                'path': {
+                    'type': 'string',
+                    'description': 'Relative path within the account file store (e.g. "notes/todo.md").',
+                },
+                'encoding': {
+                    'type': 'string',
+                    'description': 'Text encoding for decoding the file contents. Defaults to "utf-8".',
+                    'default': 'utf-8',
+                },
+            },
+            'additionalProperties': False,
+        },
+        description=('Read a file from the account file store and return its contents as a decoded string. Required: "path" (relative path). Optional: "encoding" (default "utf-8"). Returns: {path, content, size} where size is the byte length before decoding.'),
+    )
+    def read_file(self, args):
+        args = _require_dict(args)
+        self._check_ready()
+        if not self.IGlobal.allow_read:
+            raise ValueError('read access is not enabled for this filesystem tool')
+
+        path = _require_str(args, 'path')
+        encoding = _optional_str(args, 'encoding', default='utf-8') or 'utf-8'
+        self._check_path(path)
+
+        data = _run_async(self.IGlobal.file_store.read(path))
+        try:
+            content = data.decode(encoding)
+        except UnicodeDecodeError as e:
+            raise ValueError(f'Failed to decode file {path!r} using encoding {encoding!r}: {e}') from e
+        return {'path': path, 'content': content, 'size': len(data)}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['path', 'content'],
+            'properties': {
+                'path': {
+                    'type': 'string',
+                    'description': 'Relative path within the account file store.',
+                },
+                'content': {
+                    'type': 'string',
+                    'description': 'File contents (text). Encoded using the "encoding" field before writing.',
+                },
+                'encoding': {
+                    'type': 'string',
+                    'description': 'Text encoding used to encode "content" before writing. Defaults to "utf-8".',
+                    'default': 'utf-8',
+                },
+            },
+            'additionalProperties': False,
+        },
+        description=('Write (or overwrite) a file in the account file store. Required: "path", "content". Optional: "encoding" (default "utf-8"). Returns: {path, bytesWritten}.'),
+    )
+    def write_file(self, args):
+        args = _require_dict(args)
+        self._check_ready()
+        if not self.IGlobal.allow_write:
+            raise ValueError('write access is not enabled for this filesystem tool')
+
+        path = _require_str(args, 'path')
+        content = args.get('content')
+        if not isinstance(content, str):
+            raise ValueError('content is required and must be a string')
+        encoding = _optional_str(args, 'encoding', default='utf-8') or 'utf-8'
+        self._check_path(path)
+
+        try:
+            data = content.encode(encoding)
+        except UnicodeEncodeError as e:
+            raise ValueError(f'Failed to encode content using encoding {encoding!r}: {e}') from e
+
+        _run_async(self.IGlobal.file_store.write(path, data))
+        return {'path': path, 'bytesWritten': len(data)}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['path'],
+            'properties': {
+                'path': {
+                    'type': 'string',
+                    'description': 'Relative path of the file to delete.',
+                },
+            },
+            'additionalProperties': False,
+        },
+        description=('Delete a file from the account file store. Only available when the operator has enabled "allowDelete" on this node. Required: "path". Returns: {path, deleted: true}.'),
+    )
+    def delete_file(self, args):
+        args = _require_dict(args)
+        self._check_ready()
+        if not self.IGlobal.allow_delete:
+            raise ValueError('delete access is not enabled for this filesystem tool')
+
+        path = _require_str(args, 'path')
+        self._check_path(path)
+
+        _run_async(self.IGlobal.file_store.delete(path))
+        return {'path': path, 'deleted': True}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'path': {
+                    'type': 'string',
+                    'description': 'Relative directory path. Defaults to the account root.',
+                    'default': '',
+                },
+            },
+            'additionalProperties': False,
+        },
+        description=('List the immediate children of a directory in the account file store. Optional: "path" (defaults to the account root). Returns: {entries: [{name, type, size?, modified?}], count}.'),
+    )
+    def list_directory(self, args):
+        args = _require_dict(args) if args is not None else {}
+        self._check_ready()
+        if not self.IGlobal.allow_list:
+            raise ValueError('list access is not enabled for this filesystem tool')
+
+        path = args.get('path', '')
+        if not isinstance(path, str):
+            raise ValueError('path must be a string')
+        if path:
+            self._check_path(path)
+
+        result = _run_async(self.IGlobal.file_store.list_dir(path))
+        return result
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['path'],
+            'properties': {
+                'path': {
+                    'type': 'string',
+                    'description': 'Relative directory path to create.',
+                },
+            },
+            'additionalProperties': False,
+        },
+        description=('Create a directory in the account file store. Intermediate segments are created as needed. Required: "path". Returns: {path, created: true}.'),
+    )
+    def create_directory(self, args):
+        args = _require_dict(args)
+        self._check_ready()
+        if not self.IGlobal.allow_mkdir:
+            raise ValueError('mkdir access is not enabled for this filesystem tool')
+
+        path = _require_str(args, 'path')
+        self._check_path(path)
+
+        _run_async(self.IGlobal.file_store.mkdir(path))
+        return {'path': path, 'created': True}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['path'],
+            'properties': {
+                'path': {
+                    'type': 'string',
+                    'description': 'Relative path to stat.',
+                },
+            },
+            'additionalProperties': False,
+        },
+        description=('Get metadata for a file or directory in the account file store. Required: "path". Returns: {exists, type?, size?, modified?}.'),
+    )
+    def stat_file(self, args):
+        args = _require_dict(args)
+        self._check_ready()
+        if not self.IGlobal.allow_stat:
+            raise ValueError('stat access is not enabled for this filesystem tool')
+
+        path = _require_str(args, 'path')
+        self._check_path(path)
+
+        return _run_async(self.IGlobal.file_store.stat(path))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _check_ready(self) -> None:
+        """Verify the FileStore was successfully initialised in beginGlobal()."""
+        if self.IGlobal.file_store is None:
+            raise ValueError('filesystem tool is not available: ROCKETRIDE_CLIENT_ID is missing or the account store failed to initialise (check pipeline logs)')
+
+    def _check_path(self, path: str) -> None:
+        """Enforce the configured path whitelist (if any)."""
+        patterns = self.IGlobal.path_patterns or []
+        if patterns and not any(p.search(path) for p in patterns):
+            raise ValueError(f'path {path!r} does not match any allowed path pattern')
+
+
+# ----------------------------------------------------------------------
+# Module-level helpers
+# ----------------------------------------------------------------------
+
+
+def _require_dict(args: Any) -> dict:
+    if not isinstance(args, dict):
+        raise ValueError('Tool input must be a JSON object (dict)')
+    return args
+
+
+def _require_str(args: dict, key: str) -> str:
+    val = args.get(key)
+    if not isinstance(val, str) or not val.strip():
+        raise ValueError(f'{key} is required and must be a non-empty string')
+    return val
+
+
+def _optional_str(args: dict, key: str, *, default: str | None = None) -> str | None:
+    val = args.get(key, default)
+    if val is None:
+        return default
+    if not isinstance(val, str):
+        raise ValueError(f'{key} must be a string')
+    return val
+
+
+def _run_async(coro):
+    """Run an async coroutine from a synchronous ``@tool_function`` method.
+
+    The tool dispatcher invokes us synchronously. If no event loop is running
+    on this thread, create a dedicated one and tear it down after the call;
+    otherwise we'd deadlock reusing the already-running loop.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop — safe to spin up our own.
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+    # We are already inside an event loop — still need our own isolated loop
+    # to drive the coroutine synchronously.
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -38,10 +38,6 @@ Each method checks the corresponding allow-flag on ``self.IGlobal``, validates
 the path against the configured regex whitelist, and then invokes the
 ``FileStore`` coroutine via a per-call event loop. Exceptions from the store
 (``StorageError``, ``ValueError``) propagate to the agent as tool errors.
-
-TODO (follow-up — see IGlobal.py docstring):
-  * ``edit_file(path, old_string, new_string, replace_all?)``
-  * ``move_file(src, dst)``
 """
 
 from __future__ import annotations

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -186,8 +186,7 @@ class IInstance(IInstanceBase):
         path = args.get('path', '')
         if not isinstance(path, str):
             raise ValueError('path must be a string')
-        if path:
-            self._check_path(path)
+        self._check_path(path)
 
         result = _run_async(self.IGlobal.file_store.list_dir(path))
         return result
@@ -271,6 +270,13 @@ class IInstance(IInstanceBase):
         return {name: m for name, m in methods.items() if self._is_method_allowed(name)}
 
     def _is_method_allowed(self, name: str) -> bool:
+        # When FileStore couldn't be initialised (e.g. ROCKETRIDE_CLIENT_ID
+        # missing), hide every tool method so the LLM never sees something it
+        # can't successfully invoke. ``beginGlobal()`` already logged a warning
+        # with the reason.
+        if self.IGlobal.file_store is None:
+            return False
+
         flag = self._ALLOW_FLAG_BY_TOOL.get(name)
         if flag is None:
             return True
@@ -318,9 +324,21 @@ def _optional_str(args: dict, key: str, *, default: str | None = None) -> str | 
 def _run_async(coro):
     """Run an async coroutine from a synchronous ``@tool_function`` method.
 
-    Always uses an isolated event loop so we don't deadlock if (now or later)
-    this is invoked from a thread that already has a running loop.
+    Only safe to call from a thread with no running event loop — the engine's
+    tool dispatcher (``filters.py::_dispatch_tool``) calls ``@tool_function``
+    methods synchronously, which is the supported caller. If invoked from a
+    thread that already has a running loop, ``loop.run_until_complete`` on a
+    fresh loop would block the thread and deadlock any work the coroutine
+    tries to route back through the outer loop; raise a clear error instead
+    of failing opaquely.
     """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        raise RuntimeError('_run_async must not be called from a thread with a running event loop; the tool_filesystem @tool_function methods are designed to be dispatched synchronously by the engine.')
+
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(coro)

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -251,6 +251,35 @@ class IInstance(IInstanceBase):
     # Internal helpers
     # ------------------------------------------------------------------
 
+    # Map each @tool_function name to the IGlobal allow-flag that gates it.
+    # Used by ``_collect_tool_methods`` to hide disabled tools from the agent
+    # at ``tool.query`` discovery time (not just at invocation).
+    _ALLOW_FLAG_BY_TOOL = {
+        'read_file': 'allow_read',
+        'write_file': 'allow_write',
+        'delete_file': 'allow_delete',
+        'list_directory': 'allow_list',
+        'create_directory': 'allow_mkdir',
+        'stat_file': 'allow_stat',
+    }
+
+    def _collect_tool_methods(self):
+        """Filter out tool methods whose allow-flag is disabled.
+
+        The base implementation returns every ``@tool_function`` method on the
+        class. We override here so the engine's ``tool.query`` only advertises
+        ops the operator has enabled — the LLM never sees a tool it isn't
+        allowed to call.
+        """
+        methods = super()._collect_tool_methods()
+        return {name: m for name, m in methods.items() if self._is_method_allowed(name)}
+
+    def _is_method_allowed(self, name: str) -> bool:
+        flag = self._ALLOW_FLAG_BY_TOOL.get(name)
+        if flag is None:
+            return True
+        return bool(getattr(self.IGlobal, flag, False))
+
     def _check_ready(self) -> None:
         """Verify the FileStore was successfully initialised in beginGlobal()."""
         if self.IGlobal.file_store is None:

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -322,21 +322,9 @@ def _optional_str(args: dict, key: str, *, default: str | None = None) -> str | 
 def _run_async(coro):
     """Run an async coroutine from a synchronous ``@tool_function`` method.
 
-    The tool dispatcher invokes us synchronously. If no event loop is running
-    on this thread, create a dedicated one and tear it down after the call;
-    otherwise we'd deadlock reusing the already-running loop.
+    Always uses an isolated event loop so we don't deadlock if (now or later)
+    this is invoked from a thread that already has a running loop.
     """
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        # No running loop — safe to spin up our own.
-        loop = asyncio.new_event_loop()
-        try:
-            return loop.run_until_complete(coro)
-        finally:
-            loop.close()
-    # We are already inside an event loop — still need our own isolated loop
-    # to drive the coroutine synchronously.
     loop = asyncio.new_event_loop()
     try:
         return loop.run_until_complete(coro)

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -77,11 +77,7 @@ class IInstance(IInstanceBase):
         description=('Read a file from the account file store and return its contents as a decoded string. Required: "path" (relative path). Optional: "encoding" (default "utf-8"). Returns: {path, content, size} where size is the byte length before decoding.'),
     )
     def read_file(self, args):
-        args = _require_dict(args)
-        self._check_ready()
-        if not self.IGlobal.allow_read:
-            raise ValueError('read access is not enabled for this filesystem tool')
-
+        args = self._prepare(args, 'read_file')
         path = _require_str(args, 'path')
         encoding = _optional_str(args, 'encoding', default='utf-8') or 'utf-8'
         self._check_path(path)
@@ -117,11 +113,7 @@ class IInstance(IInstanceBase):
         description=('Write (or overwrite) a file in the account file store. Required: "path", "content". Optional: "encoding" (default "utf-8"). Returns: {path, bytesWritten}.'),
     )
     def write_file(self, args):
-        args = _require_dict(args)
-        self._check_ready()
-        if not self.IGlobal.allow_write:
-            raise ValueError('write access is not enabled for this filesystem tool')
-
+        args = self._prepare(args, 'write_file')
         path = _require_str(args, 'path')
         content = args.get('content')
         if not isinstance(content, str):
@@ -152,11 +144,7 @@ class IInstance(IInstanceBase):
         description=('Delete a file from the account file store. Only available when the operator has enabled "allowDelete" on this node. Required: "path". Returns: {path, deleted: true}.'),
     )
     def delete_file(self, args):
-        args = _require_dict(args)
-        self._check_ready()
-        if not self.IGlobal.allow_delete:
-            raise ValueError('delete access is not enabled for this filesystem tool')
-
+        args = self._prepare(args, 'delete_file')
         path = _require_str(args, 'path')
         self._check_path(path)
 
@@ -178,11 +166,7 @@ class IInstance(IInstanceBase):
         description=('List the immediate children of a directory in the account file store. Optional: "path" (defaults to the account root). Returns: {entries: [{name, type, size?, modified?}], count}.'),
     )
     def list_directory(self, args):
-        args = _require_dict(args) if args is not None else {}
-        self._check_ready()
-        if not self.IGlobal.allow_list:
-            raise ValueError('list access is not enabled for this filesystem tool')
-
+        args = self._prepare(args, 'list_directory')
         path = args.get('path', '')
         if not isinstance(path, str):
             raise ValueError('path must be a string')
@@ -206,11 +190,7 @@ class IInstance(IInstanceBase):
         description=('Create a directory in the account file store. Intermediate segments are created as needed. Required: "path". Returns: {path, created: true}.'),
     )
     def create_directory(self, args):
-        args = _require_dict(args)
-        self._check_ready()
-        if not self.IGlobal.allow_mkdir:
-            raise ValueError('mkdir access is not enabled for this filesystem tool')
-
+        args = self._prepare(args, 'create_directory')
         path = _require_str(args, 'path')
         self._check_path(path)
 
@@ -232,11 +212,7 @@ class IInstance(IInstanceBase):
         description=('Get metadata for a file or directory in the account file store. Required: "path". Returns: {exists, type?, size?, modified?}.'),
     )
     def stat_file(self, args):
-        args = _require_dict(args)
-        self._check_ready()
-        if not self.IGlobal.allow_stat:
-            raise ValueError('stat access is not enabled for this filesystem tool')
-
+        args = self._prepare(args, 'stat_file')
         path = _require_str(args, 'path')
         self._check_path(path)
 
@@ -281,6 +257,26 @@ class IInstance(IInstanceBase):
         if flag is None:
             return True
         return bool(getattr(self.IGlobal, flag, False))
+
+    def _prepare(self, args: Any, tool_name: str) -> dict:
+        """Shared prologue for every ``@tool_function`` method:
+        validate ``args`` is a dict (``None`` becomes ``{}``), verify the
+        FileStore initialised, and enforce the allow-flag for this op.
+
+        Returns the validated args dict so the caller can read per-op fields
+        without re-validating. Raises ``ValueError`` on any failure.
+
+        This duplicates the filtering done by ``_collect_tool_methods``
+        intentionally — defence-in-depth against direct method calls that
+        bypass the tool dispatcher.
+        """
+        args = _require_dict(args) if args is not None else {}
+        self._check_ready()
+        flag_attr = self._ALLOW_FLAG_BY_TOOL[tool_name]
+        if not getattr(self.IGlobal, flag_attr, False):
+            label = flag_attr.removeprefix('allow_')
+            raise ValueError(f'{label} access is not enabled for this filesystem tool')
+        return args
 
     def _check_ready(self) -> None:
         """Verify the FileStore was successfully initialised in beginGlobal()."""

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -299,7 +299,9 @@ class IInstance(IInstanceBase):
         """
         args = _require_dict(args) if args is not None else {}
         self._check_ready()
-        flag_attr = self._ALLOW_FLAG_BY_TOOL[tool_name]
+        flag_attr = self._ALLOW_FLAG_BY_TOOL.get(tool_name)
+        if flag_attr is None:
+            raise RuntimeError(f'no allow-flag mapping for tool {tool_name!r}')
         if not getattr(self.IGlobal, flag_attr, False):
             label = flag_attr.removeprefix('allow_')
             raise ValueError(f'{label} access is not enabled for this filesystem tool')
@@ -376,10 +378,9 @@ def _run_async(coro):
     Only safe to call from a thread with no running event loop — the engine's
     tool dispatcher (``filters.py::_dispatch_tool``) calls ``@tool_function``
     methods synchronously, which is the supported caller. If invoked from a
-    thread that already has a running loop, ``loop.run_until_complete`` on a
-    fresh loop would block the thread and deadlock any work the coroutine
-    tries to route back through the outer loop; raise a clear error instead
-    of failing opaquely.
+    thread that already has a running loop, ``asyncio.run`` would raise a
+    generic ``RuntimeError``; we pre-check so the failure surfaces with a
+    tool_filesystem-specific message that points at the dispatcher contract.
     """
     try:
         asyncio.get_running_loop()
@@ -390,8 +391,4 @@ def _run_async(coro):
             '_run_async must not be called from a thread with a running event loop; the tool_filesystem @tool_function methods are designed to be dispatched synchronously by the engine.'
         )
 
-    loop = asyncio.new_event_loop()
-    try:
-        return loop.run_until_complete(coro)
-    finally:
-        loop.close()
+    return asyncio.run(coro)

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -283,11 +283,16 @@ class IInstance(IInstanceBase):
 
         if path_required:
             path = _require_str(args, 'path')
+            self._check_path(path)
         else:
             path = args.get('path', '')
             if not isinstance(path, str):
                 raise ValueError('path must be a string')
-        self._check_path(path)
+            # Empty path means "account root" for list-style ops; skip the
+            # whitelist check so a configured whitelist doesn't block listing
+            # the root (an empty string can't match a non-trivial regex).
+            if path:
+                self._check_path(path)
 
         encoding: str | None = None
         if needs_encoding:

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -74,7 +74,9 @@ class IInstance(IInstanceBase):
             },
             'additionalProperties': False,
         },
-        description=('Read a file from the account file store and return its contents as a decoded string. Required: "path" (relative path). Optional: "encoding" (default "utf-8"). Returns: {path, content, size} where size is the byte length before decoding.'),
+        description=(
+            'Read a file from the account file store and return its contents as a decoded string. Required: "path" (relative path). Optional: "encoding" (default "utf-8"). Returns: {path, content, size} where size is the byte length before decoding.'
+        ),
     )
     def read_file(self, args):
         path, encoding, _ = self._prepare(args, 'read_file', needs_encoding=True)
@@ -107,7 +109,9 @@ class IInstance(IInstanceBase):
             },
             'additionalProperties': False,
         },
-        description=('Write (or overwrite) a file in the account file store. Required: "path", "content". Optional: "encoding" (default "utf-8"). Returns: {path, bytesWritten}.'),
+        description=(
+            'Write (or overwrite) a file in the account file store. Required: "path", "content". Optional: "encoding" (default "utf-8"). Returns: {path, bytesWritten}.'
+        ),
     )
     def write_file(self, args):
         path, encoding, content = self._prepare(args, 'write_file', needs_encoding=True, needs_content=True)
@@ -132,7 +136,9 @@ class IInstance(IInstanceBase):
             },
             'additionalProperties': False,
         },
-        description=('Delete a file from the account file store. Only available when the operator has enabled "allowDelete" on this node. Required: "path". Returns: {path, deleted: true}.'),
+        description=(
+            'Delete a file from the account file store. Only available when the operator has enabled "allowDelete" on this node. Required: "path". Returns: {path, deleted: true}.'
+        ),
     )
     def delete_file(self, args):
         path, _, _ = self._prepare(args, 'delete_file')
@@ -152,7 +158,9 @@ class IInstance(IInstanceBase):
             },
             'additionalProperties': False,
         },
-        description=('List the immediate children of a directory in the account file store. Optional: "path" (defaults to the account root). Returns: {entries: [{name, type, size?, modified?}], count}.'),
+        description=(
+            'List the immediate children of a directory in the account file store. Optional: "path" (defaults to the account root). Returns: {entries: [{name, type, size?, modified?}], count}.'
+        ),
     )
     def list_directory(self, args):
         path, _, _ = self._prepare(args, 'list_directory', path_required=False)
@@ -172,7 +180,9 @@ class IInstance(IInstanceBase):
             },
             'additionalProperties': False,
         },
-        description=('Create a directory in the account file store. Intermediate segments are created as needed. Required: "path". Returns: {path, created: true}.'),
+        description=(
+            'Create a directory in the account file store. Intermediate segments are created as needed. Required: "path". Returns: {path, created: true}.'
+        ),
     )
     def create_directory(self, args):
         path, _, _ = self._prepare(args, 'create_directory')
@@ -192,7 +202,9 @@ class IInstance(IInstanceBase):
             },
             'additionalProperties': False,
         },
-        description=('Get metadata for a file or directory in the account file store. Required: "path". Returns: {exists, type?, size?, modified?}.'),
+        description=(
+            'Get metadata for a file or directory in the account file store. Required: "path". Returns: {exists, type?, size?, modified?}.'
+        ),
     )
     def stat_file(self, args):
         path, _, _ = self._prepare(args, 'stat_file')
@@ -292,7 +304,9 @@ class IInstance(IInstanceBase):
     def _check_ready(self) -> None:
         """Verify the FileStore was successfully initialised in beginGlobal()."""
         if self.IGlobal.file_store is None:
-            raise ValueError('filesystem tool is not available: ROCKETRIDE_CLIENT_ID is missing or the account store failed to initialise (check pipeline logs)')
+            raise ValueError(
+                'filesystem tool is not available: ROCKETRIDE_CLIENT_ID is missing or the account store failed to initialise (check pipeline logs)'
+            )
 
     def _check_path(self, path: str) -> None:
         """Enforce the configured path whitelist (if any)."""
@@ -344,7 +358,9 @@ def _run_async(coro):
     except RuntimeError:
         pass
     else:
-        raise RuntimeError('_run_async must not be called from a thread with a running event loop; the tool_filesystem @tool_function methods are designed to be dispatched synchronously by the engine.')
+        raise RuntimeError(
+            '_run_async must not be called from a thread with a running event loop; the tool_filesystem @tool_function methods are designed to be dispatched synchronously by the engine.'
+        )
 
     loop = asyncio.new_event_loop()
     try:

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -49,6 +49,13 @@ from rocketlib import IInstanceBase, tool_function
 
 from .IGlobal import IGlobal
 
+# Cap on bytes returned by a single read_file call. The underlying FileStore
+# defaults to 100 MB, which can blow the agent's context window or OOM the
+# engine subprocess long before the LLM ever sees the result. Agents that need
+# more than MAX_READ_LIMIT in one shot must use a streaming approach.
+DEFAULT_READ_LIMIT = 256 * 1024  # 256 KB
+MAX_READ_LIMIT = 4 * 1024 * 1024  # 4 MB
+
 
 class IInstance(IInstanceBase):
     IGlobal: IGlobal
@@ -71,17 +78,33 @@ class IInstance(IInstanceBase):
                     'description': 'Text encoding for decoding the file contents. Defaults to "utf-8".',
                     'default': 'utf-8',
                 },
+                'maxBytes': {
+                    'type': 'integer',
+                    'description': f'Maximum bytes to read. Default {DEFAULT_READ_LIMIT}, hard ceiling {MAX_READ_LIMIT}. Files larger than the cap are rejected with an error — use a smaller maxBytes for sampling, or split the file.',
+                    'default': DEFAULT_READ_LIMIT,
+                    'minimum': 1,
+                    'maximum': MAX_READ_LIMIT,
+                },
             },
             'additionalProperties': False,
         },
         description=(
-            'Read a file from the account file store and return its contents as a decoded string. Required: "path" (relative path). Optional: "encoding" (default "utf-8"). Returns: {path, content, size} where size is the byte length before decoding.'
+            'Read a file from the account file store and return its contents as a decoded string. Required: "path" (relative path). Optional: "encoding" (default "utf-8"), "maxBytes" (default 256 KB, max 4 MB). Returns: {path, content, size} where size is the byte length before decoding. Files larger than maxBytes are rejected.'
         ),
     )
     def read_file(self, args):
         path, encoding, _ = self._prepare(args, 'read_file', needs_encoding=True)
 
-        data = _run_async(self.IGlobal.file_store.read(path))
+        # `_prepare` accepts None for `args` but doesn't return the normalised
+        # dict, so guard here before pulling the per-op `maxBytes` field.
+        max_bytes = (args or {}).get('maxBytes', DEFAULT_READ_LIMIT)
+        if not isinstance(max_bytes, int) or isinstance(max_bytes, bool):
+            raise ValueError('maxBytes must be an integer')
+        if max_bytes < 1:
+            raise ValueError('maxBytes must be at least 1')
+        max_bytes = min(max_bytes, MAX_READ_LIMIT)
+
+        data = _run_async(self.IGlobal.file_store.read(path, max_size=max_bytes))
         try:
             content = data.decode(encoding)
         except UnicodeDecodeError as e:

--- a/nodes/src/nodes/tool_filesystem/README.md
+++ b/nodes/src/nodes/tool_filesystem/README.md
@@ -34,14 +34,14 @@ Each tool is namespaced by the node id: e.g. an agent sees `tool_filesystem_1.re
 | List directories   | Enable `list_directory`                                                                                           |
 | Create directories | Enable `create_directory`                                                                                         |
 | Stat (metadata)    | Enable `stat_file`                                                                                                |
-| Delete files       |                                                                                                                   |
+| Delete files       | Enable `delete_file`                                                                                              |
 | Path Whitelist     | Optional regex patterns. If non-empty, every operation's path must match at least one pattern. Empty = allow all. |
 
 ## Storage location
 
 Files land under the configured storage backend (defaults to `~/.rocketlib/store/`). For the default filesystem backend the absolute path is:
 
-```
+```text
 <store>/users/<client_id>/files/<path>
 ```
 

--- a/nodes/src/nodes/tool_filesystem/README.md
+++ b/nodes/src/nodes/tool_filesystem/README.md
@@ -1,0 +1,48 @@
+---
+title: File System
+date: 2026-04-16
+sidebar_position: 1
+---
+
+<head>
+  <title>File System - RocketRide Documentation</title>
+</head>
+
+## What it does
+
+Gives agents read/write access to the account-scoped RocketRide file store — the same storage area exposed to the client SDK via `fs_*` methods. All paths are relative to `users/<client_id>/files/`, so files and agent writes via this tool are visible to the client SDK and vice versa. This node has no pipeline lanes — it is connected to agents via the `tool` invoke channel.
+
+## Tools
+
+| Tool               | Description                                            |
+| ------------------ | ------------------------------------------------------ |
+| `read_file`        | Read a file and return its decoded contents            |
+| `write_file`       | Create or overwrite a file with text content           |
+| `list_directory`   | List the immediate children of a directory             |
+| `create_directory` | Create a directory (intermediate segments are created) |
+| `stat_file`        | Get metadata for a file or directory                   |
+| `delete_file`      | Delete a file (only when `Delete files` is enabled)    |
+
+Each tool is namespaced by the node id: e.g. an agent sees `tool_filesystem_1.read_file`. Tools whose corresponding allow-flag is disabled are hidden from the agent at discovery time, not just blocked at invocation.
+
+## Configuration
+
+| Field              | Description                                                                                                       |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| Read files         | Enable `read_file`                                                                                                |
+| Write files        | Enable `write_file`                                                                                               |
+| List directories   | Enable `list_directory`                                                                                           |
+| Create directories | Enable `create_directory`                                                                                         |
+| Stat (metadata)    | Enable `stat_file`                                                                                                |
+| Delete files       |                                                                                                                   |
+| Path Whitelist     | Optional regex patterns. If non-empty, every operation's path must match at least one pattern. Empty = allow all. |
+
+## Storage location
+
+Files land under the configured storage backend (defaults to `~/.rocketlib/store/`). For the default filesystem backend the absolute path is:
+
+```
+<store>/users/<client_id>/files/<path>
+```
+
+Each account gets its own isolated `files/` directory — the node picks up the current account automatically, no configuration needed.

--- a/nodes/src/nodes/tool_filesystem/__init__.py
+++ b/nodes/src/nodes/tool_filesystem/__init__.py
@@ -23,6 +23,15 @@
 # SOFTWARE.
 # =============================================================================
 
+# =============================================================================
+
+"""Tool filesystem package.
+
+This module exports the public interfaces for filesystem operations:
+- IGlobal: Global filesystem interface
+- IInstance: Instance-level filesystem interface
+"""
+
 from .IGlobal import IGlobal
 from .IInstance import IInstance
 

--- a/nodes/src/nodes/tool_filesystem/__init__.py
+++ b/nodes/src/nodes/tool_filesystem/__init__.py
@@ -1,0 +1,29 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/tool_filesystem/__init__.py
+++ b/nodes/src/nodes/tool_filesystem/__init__.py
@@ -23,8 +23,6 @@
 # SOFTWARE.
 # =============================================================================
 
-# =============================================================================
-
 """Tool filesystem package.
 
 This module exports the public interfaces for filesystem operations:

--- a/nodes/src/nodes/tool_filesystem/requirements.txt
+++ b/nodes/src/nodes/tool_filesystem/requirements.txt
@@ -1,0 +1,3 @@
+# tool_filesystem has no external runtime dependencies.
+# It reuses ai.account.store.FileStore (already installed as part of the
+# engine's built-in `ai` package) plus the standard library.

--- a/nodes/src/nodes/tool_filesystem/requirements.txt
+++ b/nodes/src/nodes/tool_filesystem/requirements.txt
@@ -1,3 +1,0 @@
-# tool_filesystem has no external runtime dependencies.
-# It reuses ai.account.store.FileStore (already installed as part of the
-# engine's built-in `ai` package) plus the standard library.

--- a/nodes/src/nodes/tool_filesystem/services.json
+++ b/nodes/src/nodes/tool_filesystem/services.json
@@ -7,29 +7,19 @@
 	"node": "python",
 	"path": "nodes.tool_filesystem",
 	"prefix": "fs",
-	"icon": "http.svg",
+	"icon": "file-system.svg",
 	"documentation": "https://docs.rocketride.org",
-	"description": ["File system tool for agents. Reads, writes, deletes, lists, and creates directories within the account-scoped RocketRide file store (the same store exposed via the client SDK's fs_* methods).", "All operations are scoped to users/<client_id>/files/ — resolved from the ROCKETRIDE_CLIENT_ID env var injected by the task engine.", "Per-operation toggles (allowRead, allowWrite, allowDelete, allowList, allowMkdir, allowStat) gate which methods the agent can call. Destructive operations (allowDelete) default to off."],
-	"tile": ["Tool: ${parameters.filesystem.serverName}.filesystem"],
+	"description": ["File system tool for agents. Reads, writes, deletes, lists, and creates directories within the account-scoped RocketRide file store (the same store exposed via the client SDK's fs_* methods).", "All operations are scoped to users/<client_id>/files/ — resolved from the ROCKETRIDE_CLIENT_ID env var injected by the task engine.", "Per-operation toggles (allowRead, allowWrite, allowDelete, allowList, allowMkdir, allowStat) gate which methods the agent can call."],
 	"lanes": {},
 	"preconfig": {
 		"default": "default",
 		"profiles": {
 			"default": {
-				"title": "Default",
-				"serverName": "fs"
+				"title": "Default"
 			}
 		}
 	},
 	"fields": {
-		"filesystem.serverName": {
-			"hidden": true,
-			"type": "string",
-			"title": "Server name",
-			"description": "Namespace prefix for tools: <serverName>.read_file, <serverName>.write_file, etc.",
-			"default": "fs"
-		},
-
 		"filesystem.allowRead": {
 			"type": "boolean",
 			"title": "Read files",
@@ -78,7 +68,7 @@
 		"filesystem.allowDelete": {
 			"type": "boolean",
 			"title": "Delete files",
-			"description": "Destructive — off by default. Enable only when the agent is trusted to delete account files.",
+			"description": "Destructive — enable only when the agent is trusted to delete account files.",
 			"default": false,
 			"enum": [
 				[true, "Yes"],

--- a/nodes/src/nodes/tool_filesystem/services.json
+++ b/nodes/src/nodes/tool_filesystem/services.json
@@ -1,0 +1,113 @@
+{
+	"title": "File System",
+	"protocol": "tool_filesystem://",
+	"classType": ["tool"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.tool_filesystem",
+	"prefix": "fs",
+	"icon": "http.svg",
+	"documentation": "https://docs.rocketride.org",
+	"description": ["File system tool for agents. Reads, writes, deletes, lists, and creates directories within the account-scoped RocketRide file store (the same store exposed via the client SDK's fs_* methods).", "All operations are scoped to users/<client_id>/files/ — resolved from the ROCKETRIDE_CLIENT_ID env var injected by the task engine.", "Per-operation toggles (allowRead, allowWrite, allowDelete, allowList, allowMkdir, allowStat) gate which methods the agent can call. Destructive operations (allowDelete) default to off."],
+	"tile": ["Tool: ${parameters.filesystem.serverName}.filesystem"],
+	"lanes": {},
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"title": "Default",
+				"serverName": "fs"
+			}
+		}
+	},
+	"fields": {
+		"filesystem.serverName": {
+			"hidden": true,
+			"type": "string",
+			"title": "Server name",
+			"description": "Namespace prefix for tools: <serverName>.read_file, <serverName>.write_file, etc.",
+			"default": "fs"
+		},
+
+		"filesystem.allowRead": {
+			"type": "boolean",
+			"title": "Read files",
+			"default": true,
+			"enum": [
+				[true, "Yes"],
+				[false, "No"]
+			]
+		},
+		"filesystem.allowWrite": {
+			"type": "boolean",
+			"title": "Write files",
+			"default": true,
+			"enum": [
+				[true, "Yes"],
+				[false, "No"]
+			]
+		},
+		"filesystem.allowList": {
+			"type": "boolean",
+			"title": "List directories",
+			"default": true,
+			"enum": [
+				[true, "Yes"],
+				[false, "No"]
+			]
+		},
+		"filesystem.allowMkdir": {
+			"type": "boolean",
+			"title": "Create directories",
+			"default": true,
+			"enum": [
+				[true, "Yes"],
+				[false, "No"]
+			]
+		},
+		"filesystem.allowStat": {
+			"type": "boolean",
+			"title": "Stat (metadata)",
+			"default": true,
+			"enum": [
+				[true, "Yes"],
+				[false, "No"]
+			]
+		},
+		"filesystem.allowDelete": {
+			"type": "boolean",
+			"title": "Delete files",
+			"description": "Destructive — off by default. Enable only when the agent is trusted to delete account files.",
+			"default": false,
+			"enum": [
+				[true, "Yes"],
+				[false, "No"]
+			]
+		},
+
+		"filesystem.whitelistPattern": {
+			"type": "string",
+			"title": "Path Pattern (regex)",
+			"default": ""
+		},
+		"filesystem.pathWhitelist": {
+			"title": "Path Whitelist",
+			"description": "Regex patterns applied to the relative path of every operation. If non-empty, a path must match at least one pattern. If empty, all paths under users/<client_id>/files/ are allowed.",
+			"type": "array",
+			"optional": true,
+			"minItems": 0,
+			"items": {
+				"type": "object",
+				"properties": ["filesystem.whitelistPattern"]
+			}
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "File System",
+			"properties": ["type", "filesystem.allowRead", "filesystem.allowWrite", "filesystem.allowList", "filesystem.allowMkdir", "filesystem.allowStat", "filesystem.allowDelete", "filesystem.pathWhitelist"]
+		}
+	]
+}

--- a/nodes/src/nodes/tool_filesystem/services.json
+++ b/nodes/src/nodes/tool_filesystem/services.json
@@ -83,7 +83,7 @@
 		},
 		"filesystem.pathWhitelist": {
 			"title": "Path Whitelist",
-			"description": "Regex patterns applied to the relative path of every operation. If non-empty, a path must match at least one pattern. If empty, all paths under users/<client_id>/files/ are allowed.",
+			"description": "Regex patterns applied to the relative path of every operation using re.search semantics — a partial match anywhere in the path is enough, so a pattern like 'secret' will also match 'notsecret/file.txt'. Anchor with ^ and $ if you need a full-path match (e.g. '^docs/.*$'). If non-empty, a path must match at least one pattern. If empty, all paths under users/<client_id>/files/ are allowed.",
 			"type": "array",
 			"optional": true,
 			"minItems": 0,

--- a/nodes/test/tool_filesystem/test_read_size_cap.py
+++ b/nodes/test/tool_filesystem/test_read_size_cap.py
@@ -1,0 +1,317 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit tests for the tool_filesystem ``read_file`` size cap.
+
+Covers the per-call ``maxBytes`` cap added on top of ``FileStore.read``:
+* default applied when the field is omitted,
+* explicit value forwarded as ``max_size`` to FileStore,
+* clamped to ``MAX_READ_LIMIT`` when callers ask for more,
+* rejected with ``ValueError`` on non-int / non-positive input.
+
+These are pure-Python unit tests — no server, no engine, no real FileStore.
+The node module is imported under a stubbed ``rocketlib`` and a stubbed
+``tool_filesystem`` package so the relative ``from .IGlobal import IGlobal``
+resolves without dragging in the engine runtime.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Module-import scaffolding
+# ---------------------------------------------------------------------------
+
+
+_NODE_DIR = Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 'tool_filesystem'
+
+
+def _install_rocketlib_stub() -> None:
+    """Install a minimal ``rocketlib`` stub so ``IInstance.py`` can import it.
+
+    The real ``rocketlib`` only exists inside the engine subprocess. We only
+    need ``IInstanceBase`` (a bare base class) and ``tool_function`` (a
+    decorator that stamps ``__tool_meta__`` on the wrapped method) — both
+    are surface used by ``IInstance.py`` at import time.
+    """
+    if 'rocketlib' in sys.modules:
+        return
+
+    stub = types.ModuleType('rocketlib')
+
+    class _IInstanceBase:
+        """Stand-in for the real engine base class — empty is enough."""
+
+        pass
+
+    def _tool_function(**meta):
+        """Decorator stub mirroring the real ``tool_function``.
+
+        Stamps ``__tool_meta__`` on the function so the production
+        ``_collect_tool_methods`` discovery would still recognise it.
+        """
+
+        def wrap(fn):
+            """Attach ``meta`` to ``fn.__tool_meta__`` and return ``fn``."""
+            fn.__tool_meta__ = meta
+            return fn
+
+        return wrap
+
+    stub.IInstanceBase = _IInstanceBase
+    stub.tool_function = _tool_function
+    sys.modules['rocketlib'] = stub
+
+
+def _install_tool_filesystem_pkg_stub() -> None:
+    """Install a synthetic ``tool_filesystem`` package with a stub ``IGlobal``.
+
+    Importing the production ``tool_filesystem.IGlobal`` would pull in
+    ``ai.account.store`` and friends. We replace the submodule with a tiny
+    stand-in that mirrors the attribute surface ``IInstance`` reads
+    (``file_store``, ``allow_*``, ``path_patterns``).
+
+    The synthesised package's ``__path__`` points at the real node directory,
+    so a subsequent ``import tool_filesystem.IInstance`` finds the production
+    ``IInstance.py`` while the relative ``from .IGlobal`` lookup resolves to
+    our stub.
+    """
+    if 'tool_filesystem' in sys.modules:
+        return
+
+    pkg = types.ModuleType('tool_filesystem')
+    pkg.__path__ = [str(_NODE_DIR)]
+    sys.modules['tool_filesystem'] = pkg
+
+    iglobal_mod = types.ModuleType('tool_filesystem.IGlobal')
+
+    class _IGlobalStub:
+        """Mirror of the production ``IGlobal`` attribute surface for tests."""
+
+        client_id: str | None = None
+        file_store: object | None = None
+        allow_read: bool = True
+        allow_write: bool = True
+        allow_list: bool = True
+        allow_mkdir: bool = True
+        allow_stat: bool = True
+        allow_delete: bool = False
+        path_patterns: list | None = None
+
+    iglobal_mod.IGlobal = _IGlobalStub
+    sys.modules['tool_filesystem.IGlobal'] = iglobal_mod
+
+
+_install_rocketlib_stub()
+_install_tool_filesystem_pkg_stub()
+
+from tool_filesystem.IInstance import (  # noqa: E402  — must follow sys.modules setup
+    DEFAULT_READ_LIMIT,
+    MAX_READ_LIMIT,
+    IInstance,
+)
+from tool_filesystem.IGlobal import IGlobal  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def file_store():
+    """Build an ``AsyncMock`` shaped like the relevant FileStore methods.
+
+    ``read`` is an async method so we use ``AsyncMock`` — that way the
+    coroutine returned by ``read(...)`` is awaitable inside the production
+    ``_run_async`` helper. Default return is empty bytes (caller-overridable
+    per-test).
+
+    Returns:
+        AsyncMock with a pre-configured ``read`` returning ``b''``.
+    """
+    fs = AsyncMock()
+    fs.read = AsyncMock(return_value=b'')
+    return fs
+
+
+@pytest.fixture
+def instance(file_store):
+    """Construct an ``IInstance`` wired to a fresh stub IGlobal.
+
+    The engine normally attaches ``self.IGlobal`` from C++; for unit tests
+    we set it directly. ``allow_read`` defaults to True, ``file_store`` is
+    the AsyncMock from the ``file_store`` fixture.
+
+    Returns:
+        IInstance with ``self.IGlobal.file_store`` set to the mock.
+    """
+    inst = IInstance()
+    glb = IGlobal()
+    glb.file_store = file_store
+    glb.allow_read = True
+    glb.path_patterns = None
+    inst.IGlobal = glb
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# Default and explicit maxBytes
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultMaxBytes:
+    """``maxBytes`` defaults to ``DEFAULT_READ_LIMIT`` when omitted."""
+
+    def test_default_applied_when_field_missing(self, instance, file_store):
+        """No ``maxBytes`` in args → FileStore.read called with the default."""
+        instance.read_file({'path': 'notes.txt'})
+
+        file_store.read.assert_awaited_once()
+        _, kwargs = file_store.read.await_args
+        assert kwargs['max_size'] == DEFAULT_READ_LIMIT
+
+    def test_default_is_under_one_megabyte(self):
+        """Sanity: default sits well below any common LLM context limit."""
+        assert DEFAULT_READ_LIMIT <= 1 * 1024 * 1024
+
+    def test_ceiling_is_at_or_below_four_megabytes(self):
+        """Sanity: ceiling sits at or below 4 MB to bound worst-case context."""
+        assert MAX_READ_LIMIT <= 4 * 1024 * 1024
+
+
+class TestExplicitMaxBytes:
+    """Explicit ``maxBytes`` is forwarded verbatim when below the ceiling."""
+
+    def test_smaller_value_forwarded(self, instance, file_store):
+        """A modest explicit value flows through unchanged."""
+        instance.read_file({'path': 'a.txt', 'maxBytes': 1024})
+
+        _, kwargs = file_store.read.await_args
+        assert kwargs['max_size'] == 1024
+
+    def test_value_just_below_ceiling_forwarded(self, instance, file_store):
+        """A value just under the hard ceiling flows through unchanged."""
+        target = MAX_READ_LIMIT - 1
+        instance.read_file({'path': 'a.txt', 'maxBytes': target})
+
+        _, kwargs = file_store.read.await_args
+        assert kwargs['max_size'] == target
+
+    def test_value_equal_to_ceiling_forwarded(self, instance, file_store):
+        """Exactly the ceiling is allowed."""
+        instance.read_file({'path': 'a.txt', 'maxBytes': MAX_READ_LIMIT})
+
+        _, kwargs = file_store.read.await_args
+        assert kwargs['max_size'] == MAX_READ_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# Clamping
+# ---------------------------------------------------------------------------
+
+
+class TestClampToCeiling:
+    """Values above ``MAX_READ_LIMIT`` are silently clamped to the ceiling.
+
+    The schema's ``maximum`` keyword is advisory for the LLM; runtime defence
+    in IInstance keeps the ceiling enforced even if a caller bypasses the
+    schema.
+    """
+
+    def test_value_above_ceiling_clamped(self, instance, file_store):
+        """A value 10x the ceiling is clamped down to the ceiling."""
+        instance.read_file({'path': 'big.bin', 'maxBytes': MAX_READ_LIMIT * 10})
+
+        _, kwargs = file_store.read.await_args
+        assert kwargs['max_size'] == MAX_READ_LIMIT
+
+    def test_huge_value_clamped(self, instance, file_store):
+        """A nonsense-large value (1 GB) is also clamped to the ceiling."""
+        instance.read_file({'path': 'big.bin', 'maxBytes': 1024 * 1024 * 1024})
+
+        _, kwargs = file_store.read.await_args
+        assert kwargs['max_size'] == MAX_READ_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+class TestMaxBytesValidation:
+    """``maxBytes`` rejects non-integer and non-positive inputs."""
+
+    @pytest.mark.parametrize(
+        'bad_value',
+        [
+            '1024',  # numeric string — bool/int isinstance trap
+            1024.0,  # float — would otherwise sneak past int comparisons
+            None,  # explicit None overrides the default
+            [1024],  # list
+            {'value': 1024},  # dict
+        ],
+        ids=['string', 'float', 'none', 'list', 'dict'],
+    )
+    def test_non_integer_rejected(self, instance, file_store, bad_value):
+        """Anything that isn't a strict int raises ``ValueError``."""
+        with pytest.raises(ValueError, match='maxBytes must be an integer'):
+            instance.read_file({'path': 'a.txt', 'maxBytes': bad_value})
+        file_store.read.assert_not_awaited()
+
+    def test_bool_rejected(self, instance, file_store):
+        """``bool`` is an ``int`` subclass in Python — must be rejected too.
+
+        Otherwise ``maxBytes=True`` would silently mean ``max_size=1`` and
+        ``maxBytes=False`` would fail the ``< 1`` check with a misleading
+        message.
+        """
+        with pytest.raises(ValueError, match='maxBytes must be an integer'):
+            instance.read_file({'path': 'a.txt', 'maxBytes': True})
+        file_store.read.assert_not_awaited()
+
+    @pytest.mark.parametrize('bad_value', [0, -1, -1024], ids=['zero', 'minus_one', 'large_negative'])
+    def test_non_positive_rejected(self, instance, file_store, bad_value):
+        """``maxBytes`` must be at least 1."""
+        with pytest.raises(ValueError, match='maxBytes must be at least 1'):
+            instance.read_file({'path': 'a.txt', 'maxBytes': bad_value})
+        file_store.read.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Result shape
+# ---------------------------------------------------------------------------
+
+
+class TestReadResult:
+    """End-to-end shape of the value returned by ``read_file``."""
+
+    def test_returns_decoded_content_and_size(self, instance, file_store):
+        """The returned dict carries decoded ``content`` and pre-decode ``size``."""
+        payload = b'hello world'
+        file_store.read = AsyncMock(return_value=payload)
+
+        result = instance.read_file({'path': 'greeting.txt'})
+
+        assert result == {
+            'path': 'greeting.txt',
+            'content': 'hello world',
+            'size': len(payload),
+        }
+
+    def test_decode_error_raises_value_error(self, instance, file_store):
+        """A bytes payload that can't decode under the requested encoding fails clearly."""
+        # 0xff is invalid in UTF-8 but valid in latin-1.
+        file_store.read = AsyncMock(return_value=b'\xff\xfe\xfd')
+
+        with pytest.raises(ValueError, match='Failed to decode'):
+            instance.read_file({'path': 'binary.bin'})


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

  Adds a tool_filesystem node that exposes the existing account-scoped FileStore as agent tools.                                           
                                                                                                                                           
  What it does:                                                                                                                             
                                                                                                                                           
  - Six @tool_function methods: read_file, write_file, delete_file, list_directory, create_directory, stat_file                            
  - Wraps ai.account.file_store.FileStore — same per-account scope (users/<client_id>/files/) as the client SDK's fs_* methods
  - Resolves client_id from ROCKETRIDE_CLIENT_ID env var (injected by task_engine.py:1557)                                                 
  - Per-operation allow flags + optional regex path whitelist; disabled ops are hidden at tool.query discovery so the LLM never sees them 

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
feature

## Testing

- [] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #652


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a File System tool exposing read/write/list/create/stat/delete operations, scoped per-client via a configured client ID (tool disabled when no client ID)
  * Granular per-operation permission flags; disabled operations are hidden from discovery (delete disabled by default)
  * Path restriction support via regex and whitelist entries; operations validate paths against configured patterns

* **Documentation**
  * Added README and registration metadata describing usage, configuration fields, and behavior of the File System tool
<!-- end of auto-generated comment: release notes by coderabbit.ai -->