### PR TITLE
Change cloud port from 433 to 443 in services.json

### DIFF
--- a/nodes/src/nodes/weaviate/services.json
+++ b/nodes/src/nodes/weaviate/services.json
@@ -146,7 +146,7 @@
 				"mode": "cloud",
 				"title": "Weaviate cloud server",
 				"host": "",
-				"port": 433,
+				"port": 443,
 				"apikey": "",
 				"collection": "ROCKETRIDE"
 			}
@@ -163,7 +163,7 @@
 			"description": "Enter the server IP address e.g. <your-instance-name>.weaviate.cloud"
 		},
 		"vector.cloud.port": {
-			"default": 433
+			"default": 443
 		},
 		"vector.local.host": {
 			"default": "localhost"


### PR DESCRIPTION
## Summary

* Updated cloud service port from `433` to `443` in `services.json` to ensure proper HTTPS communication.
* Fixed incorrect port configuration that could cause connection failures.

## Type

fix

## Testing

* [x] Tests added or updated
* [x] Tested locally
* [x] `./builder test` passes

## Checklist

* [x] Commit messages follow [[conventional commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)
* [x] No secrets or credentials included
* [ ] Wiki updated (if applicable)
* [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #644 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Weaviate cloud connection port configuration to use port 443 instead of 433, ensuring proper connectivity to cloud endpoints and aligning both the cloud profile settings and default configuration values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->