### PR TITLE
fix(vscode): realign view:ready handshake — chat webview blank screen

### DIFF
--- a/apps/chat-ui/src/App.tsx
+++ b/apps/chat-ui/src/App.tsx
@@ -40,14 +40,14 @@ const App: React.FC = () => {
 			return {
 				theme: null,
 				isVSCode: false,
-				isReady: true
+				isReady: true,
 			};
 		} else {
 			// VSCode mode - not ready yet
 			return {
 				theme: null,
 				isVSCode: true,
-				isReady: false
+				isReady: false,
 			};
 		}
 	});
@@ -94,8 +94,6 @@ const App: React.FC = () => {
 		// Try to get the token from session storage (skip in VSCode webview - shared storage would mix auth across tabs)
 		if (!isVSCode) {
 			token = sessionStorage.getItem('auth') || '';
-			if (token) {
-			}
 		}
 
 		// If we don't have a token yet
@@ -114,7 +112,7 @@ const App: React.FC = () => {
 			// If we got it from the query string...
 			if (token) {
 				// Remove it so the user doesn't see it in the URL
-				window.history.replaceState({}, "", window.location.pathname);
+				window.history.replaceState({}, '', window.location.pathname);
 			}
 		}
 
@@ -129,11 +127,11 @@ const App: React.FC = () => {
 		// Set the config
 		setAPIConfig({
 			ROCKETRIDE_APIKEY: token,
-			ROCKETRIDE_URI: uri
+			ROCKETRIDE_URI: uri,
 		});
 
 		// Start the client with persistent connection
-		startClient(token).catch(error => {
+		startClient(token).catch((error) => {
 			console.error('Failed to start client:', error);
 		});
 
@@ -160,7 +158,7 @@ const App: React.FC = () => {
 					setVscodeState({
 						theme: message.theme,
 						isVSCode: true,
-						isReady: true
+						isReady: true,
 					});
 				}
 			};
@@ -168,7 +166,7 @@ const App: React.FC = () => {
 			window.addEventListener('message', handleVSCodeData);
 
 			// Send ready message to parent
-			window.parent.postMessage({ type: 'ready' }, '*');
+			window.parent.postMessage({ type: 'view:ready' }, '*');
 
 			return () => window.removeEventListener('message', handleVSCodeData);
 		} else {

--- a/apps/dropper-ui/src/App.tsx
+++ b/apps/dropper-ui/src/App.tsx
@@ -22,14 +22,14 @@ const App: React.FC = () => {
 			return {
 				theme: null,
 				isVSCode: false,
-				isReady: true
+				isReady: true,
 			};
 		} else {
 			// VSCode mode - not ready yet
 			return {
 				theme: null,
 				isVSCode: true,
-				isReady: false
+				isReady: false,
 			};
 		}
 	});
@@ -86,10 +86,10 @@ const App: React.FC = () => {
 
 		setAPIConfig({
 			ROCKETRIDE_APIKEY: token,
-			ROCKETRIDE_URI: uri
+			ROCKETRIDE_URI: uri,
 		});
 
-		startClient(token).catch(error => {
+		startClient(token).catch((error) => {
 			console.error('Failed to start client:', error);
 		});
 
@@ -105,12 +105,12 @@ const App: React.FC = () => {
 					setVscodeState({
 						theme: message.theme,
 						isVSCode: true,
-						isReady: true
+						isReady: true,
 					});
 				}
 			};
 			window.addEventListener('message', handleVSCodeData);
-			window.parent.postMessage({ type: 'ready' }, '*');
+			window.parent.postMessage({ type: 'view:ready' }, '*');
 			return () => window.removeEventListener('message', handleVSCodeData);
 		}
 		return undefined;

--- a/apps/vscode/src/providers/PageProjectProvider.ts
+++ b/apps/vscode/src/providers/PageProjectProvider.ts
@@ -708,7 +708,7 @@ export class PageProjectProvider implements vscode.CustomTextEditorProvider {
 
 	window.addEventListener('message', (event) => {
 		if (event.source === iframe.contentWindow) {
-			if (event.data.type === 'ready') sendDataToIframe();
+			if (event.data.type === 'view:ready') sendDataToIframe();
 			if (event.data.type === 'requestPaste') vscode.postMessage({ type: 'requestPaste' });
 			if (event.data.type === 'copyText' && event.data.text) vscode.postMessage({ type: 'copyText', text: event.data.text });
 			if (event.data.type === 'requestFileDialog') vscode.postMessage({ type: 'requestFileDialog' });

--- a/apps/vscode/src/providers/PageProjectProvider.ts
+++ b/apps/vscode/src/providers/PageProjectProvider.ts
@@ -708,7 +708,7 @@ export class PageProjectProvider implements vscode.CustomTextEditorProvider {
 
 	window.addEventListener('message', (event) => {
 		if (event.source === iframe.contentWindow) {
-			if (event.data.type === 'view:ready') sendDataToIframe();
+			if (event.data.type === 'ready' || event.data.type === 'view:ready') sendDataToIframe();
 			if (event.data.type === 'requestPaste') vscode.postMessage({ type: 'requestPaste' });
 			if (event.data.type === 'copyText' && event.data.text) vscode.postMessage({ type: 'copyText', text: event.data.text });
 			if (event.data.type === 'requestFileDialog') vscode.postMessage({ type: 'requestFileDialog' });


### PR DESCRIPTION
## Summary

- `apps/chat-ui/src/App.tsx`: send `'view:ready'` instead of `'ready'`
- `apps/vscode/src/providers/PageProjectProvider.ts`: listen for `'view:ready'` (source now matches compiled extension)
- Removed a dead empty `if (token) {}` block caught by ESLint

## Root Cause

Commit `f0af0fa8` (Rod, Apr 17) renamed the iframe ready message from `'ready'` → `'view:ready'` in both files and recompiled the extension. Later, both source files were reverted to `'ready'` and the chat-ui was rebuilt (Apr 21) — but the extension was **not** recompiled, so it kept `'view:ready'`.

Result: running extension waited for `'view:ready'`, running chat-ui sent `'ready'`. Handshake never completed → `isReady` stayed `false` → `return null` → blank screen.

## Test plan

- [ ] Open a running chat pipeline in VS Code and click "Chat now"
- [ ] Confirm chat webview loads (no blank screen)
- [ ] Confirm theme colors apply correctly from VS Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved readiness signaling between app UIs and VS Code integration (readiness payload adjusted and receiver updated) to make initialization and view readiness detection more robust.
* **Style**
  * Minor formatting and consistency cleanups (trailing commas, quote normalization, arrow function formatting) with no behavioral changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->