### PR TITLE
feat(dap): add BillingCommands mixin — stub for rrext_account_billing

### DIFF
--- a/packages/ai/src/ai/modules/task/commands/cmd_billing.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_billing.py
@@ -1,0 +1,145 @@
+"""
+BillingCommands: DAP Command Handler for Account Billing Operations.
+
+This module implements the `rrext_account_billing` DAP command as a
+first-class member of the `TaskConn` inheritance chain, rather than
+monkey-patching handlers on at runtime. The OSS build ships a stub that
+reports `not_configured` for every subcommand; SaaS builds override this
+file via the `ai/account` overlay to plug in the real wallet /
+subscription / checkout flows.
+
+Why a stub in OSS:
+------------------
+The RocketRide frontend (cloud-ui) issues `rrext_account_billing`
+requests whenever a user opens the billing page, picks a credit pack,
+cancels a subscription, etc. Without a class-level handler the DAP
+dispatcher would silently succeed with an empty body, leaving the UI
+in a half-rendered state. A stub that explicitly returns
+`{"success": False, "message": "billing not configured"}` gives the
+frontend something unambiguous to branch on and keeps OSS deployments
+functional when no billing backend is wired up.
+
+Subcommands:
+------------
+- `credits_balance`  — per-org compute-credit wallet balance
+- `credits_packs`    — purchasable credit packs (from Stripe catalog)
+- `credits_checkout` — one-off Stripe Checkout session for a credit pack
+- `prices`           — plans available for a Stripe product
+- `get`              — per-org app subscription rows
+- `checkout`         — create a Stripe subscription for an app
+- `portal`           — Stripe Billing Portal session URL
+- `cancel`           — schedule subscription cancellation at period end
+
+The SaaS overlay replaces this file with one that delegates to the
+`Account` / `Billing` facades in `ai.account.auth`.
+"""
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from ai.common.dap import DAPConn, TransportBase
+
+# Only import for type checking to avoid circular import errors
+if TYPE_CHECKING:
+    from ..task_server import TaskServer
+
+
+# Subcommands recognised by the handler contract. The stub accepts every
+# name here so `success=False` is distinguishable from `unknown subcommand`,
+# but each returns `not_configured` when no real backend is present.
+_KNOWN_SUBCOMMANDS = frozenset({
+    # Compute credits wallet
+    'credits_balance',
+    'credits_packs',
+    'credits_checkout',
+    # Per-app subscription lifecycle
+    'prices',
+    'get',
+    'checkout',
+    'portal',
+    'cancel',
+})
+
+
+class BillingCommands(DAPConn):
+    """
+    DAP command handler for account-billing operations.
+
+    The OSS class is a no-op stub: every call returns
+    `{"success": False, "message": "billing not configured", "code":
+    "not_configured"}`. SaaS deployments supply a replacement via the
+    existing `packages/ai/src/ai/account/` overlay that overrides this
+    file at build time with one that delegates to the Billing facade.
+
+    Attributes:
+        _server: Reference to the TaskServer for context
+        connection_id: Unique identifier for this DAP connection
+        transport: Underlying transport mechanism for DAP communication
+    """
+
+    def __init__(
+        self,
+        connection_id: int,
+        server: 'TaskServer',
+        transport: TransportBase,
+        **kwargs,
+    ) -> None:
+        """
+        Initialise a new BillingCommands mixin.
+
+        Args match every other DAP command mixin in the TaskConn chain so
+        TaskConn's co-operative multiple-inheritance pattern works. The
+        stub holds no state; SaaS overrides may populate clients here.
+
+        Args:
+            connection_id: Unique identifier for this DAP connection.
+            server: TaskServer instance for context + utilities.
+            transport: Transport layer for DAP messaging.
+            **kwargs: Forwarded to DAPConn / parent mixins.
+        """
+        # All state sits on TaskConn via the other mixins; nothing specific
+        # to billing needs to exist on the OSS stub.
+        pass
+
+    async def on_rrext_account_billing(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Handle DAP 'rrext_account_billing' — stub implementation.
+
+        The OSS build has no billing backend. Every subcommand returns a
+        structured "not configured" response so the frontend can branch
+        on `code='not_configured'` and render a graceful empty state
+        rather than hanging or throwing.
+
+        Args:
+            request: DAP request with `arguments.subcommand` selecting
+                     the operation plus subcommand-specific arguments.
+
+        Returns:
+            DAP response. Always `success=False` on OSS.
+
+        Usage Example:
+            { "command": "rrext_account_billing",
+              "arguments": { "subcommand": "credits_balance",
+                             "orgId": "..." } }
+        """
+        args       = (request.get('arguments') or {})
+        subcommand = args.get('subcommand', '')
+
+        if subcommand not in _KNOWN_SUBCOMMANDS:
+            # Unknown subcommand — separate error code so SaaS clients can
+            # distinguish "typo" from "backend not wired up".
+            return self.build_response(
+                request,
+                success=False,
+                message=f'unknown rrext_account_billing subcommand: {subcommand!r}',
+                body={'code': 'unknown_subcommand'},
+            )
+
+        # Known subcommand, no backend to dispatch it to — signal
+        # "not_configured" explicitly. The SaaS overlay replaces this
+        # class entirely and never hits this path.
+        return self.build_response(
+            request,
+            success=False,
+            message='billing not configured on this deployment',
+            body={'code': 'not_configured', 'subcommand': subcommand},
+        )

--- a/packages/ai/src/ai/modules/task/commands/cmd_billing.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_billing.py
@@ -121,8 +121,19 @@ class BillingCommands(DAPConn):
               "arguments": { "subcommand": "credits_balance",
                              "orgId": "..." } }
         """
-        args       = (request.get('arguments') or {})
+        # Harden against malformed requests — a non-dict `arguments`
+        # (bug in a client, someone poking the wire by hand) or a
+        # non-hashable `subcommand` would otherwise crash the handler
+        # with AttributeError / TypeError before reaching the structured
+        # error response. Normalise both and fall through to the
+        # `unknown_subcommand` branch with a repr() for diagnosis.
+        args = request.get('arguments') or {}
+        if not isinstance(args, dict):
+            args = {}
+
         subcommand = args.get('subcommand', '')
+        if not isinstance(subcommand, str):
+            subcommand = repr(subcommand)
 
         if subcommand not in _KNOWN_SUBCOMMANDS:
             # Unknown subcommand — separate error code so SaaS clients can

--- a/packages/ai/src/ai/modules/task/commands/cmd_billing.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_billing.py
@@ -126,12 +126,17 @@ class BillingCommands(DAPConn):
 
         if subcommand not in _KNOWN_SUBCOMMANDS:
             # Unknown subcommand — separate error code so SaaS clients can
-            # distinguish "typo" from "backend not wired up".
+            # distinguish "typo" from "backend not wired up". We encode the
+            # failure in the response body rather than using build_error /
+            # kwargs that build_response doesn't accept (per DAP base API).
             return self.build_response(
                 request,
-                success=False,
-                message=f'unknown rrext_account_billing subcommand: {subcommand!r}',
-                body={'code': 'unknown_subcommand'},
+                body={
+                    'success':    False,
+                    'code':       'unknown_subcommand',
+                    'subcommand': subcommand,
+                    'message':    f'unknown rrext_account_billing subcommand: {subcommand!r}',
+                },
             )
 
         # Known subcommand, no backend to dispatch it to — signal
@@ -139,7 +144,10 @@ class BillingCommands(DAPConn):
         # class entirely and never hits this path.
         return self.build_response(
             request,
-            success=False,
-            message='billing not configured on this deployment',
-            body={'code': 'not_configured', 'subcommand': subcommand},
+            body={
+                'success':    False,
+                'code':       'not_configured',
+                'subcommand': subcommand,
+                'message':    'billing not configured on this deployment',
+            },
         )

--- a/packages/ai/src/ai/modules/task/commands/cmd_billing.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_billing.py
@@ -86,19 +86,23 @@ class BillingCommands(DAPConn):
         """
         Initialise a new BillingCommands mixin.
 
-        Args match every other DAP command mixin in the TaskConn chain so
-        TaskConn's co-operative multiple-inheritance pattern works. The
-        stub holds no state; SaaS overrides may populate clients here.
+        Args match every other DAP command mixin in the TaskConn chain.
+        Note that TaskConn initializes each mixin explicitly (see
+        task_conn.py) rather than relying on cooperative MRO; this
+        constructor deliberately does not call ``super().__init__`` to
+        avoid double-initialising DAPConn. Args are accepted for
+        signature parity but dropped on the OSS stub — the SaaS overlay
+        subclass is where real per-connection state lives.
 
         Args:
             connection_id: Unique identifier for this DAP connection.
             server: TaskServer instance for context + utilities.
             transport: Transport layer for DAP messaging.
-            **kwargs: Forwarded to DAPConn / parent mixins.
+            **kwargs: Accepted for signature parity with sibling mixins.
         """
         # All state sits on TaskConn via the other mixins; nothing specific
         # to billing needs to exist on the OSS stub.
-        pass
+        del connection_id, server, transport, kwargs  # unused on OSS stub
 
     async def on_rrext_account_billing(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/packages/ai/src/ai/modules/task/commands/cmd_billing.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_billing.py
@@ -140,29 +140,29 @@ class BillingCommands(DAPConn):
             subcommand = repr(subcommand)
 
         if subcommand not in _KNOWN_SUBCOMMANDS:
-            # Unknown subcommand — separate error code so SaaS clients can
-            # distinguish "typo" from "backend not wired up". We encode the
-            # failure in the response body rather than using build_error /
-            # kwargs that build_response doesn't accept (per DAP base API).
-            return self.build_response(
-                request,
-                body={
-                    'success':    False,
-                    'code':       'unknown_subcommand',
-                    'subcommand': subcommand,
-                    'message':    f'unknown rrext_account_billing subcommand: {subcommand!r}',
-                },
-            )
+            # Unknown subcommand — use build_error so the DAP envelope-
+            # level `success` field is False. build_response would emit
+            # `success: true` at the envelope, making generic clients
+            # that only check the top-level field miss the failure.
+            # A structured body is attached for clients that *do* want
+            # to distinguish "typo" from "backend not wired up".
+            message = f'unknown rrext_account_billing subcommand: {subcommand!r}'
+            response = self.build_error(request, message)
+            response['body'] = {
+                'code':       'unknown_subcommand',
+                'subcommand': subcommand,
+                'message':    message,
+            }
+            return response
 
         # Known subcommand, no backend to dispatch it to — signal
-        # "not_configured" explicitly. The SaaS overlay replaces this
-        # class entirely and never hits this path.
-        return self.build_response(
-            request,
-            body={
-                'success':    False,
-                'code':       'not_configured',
-                'subcommand': subcommand,
-                'message':    'billing not configured on this deployment',
-            },
-        )
+        # "not_configured" with DAP-level failure. The SaaS overlay
+        # replaces this class entirely and never hits this path.
+        message = 'billing not configured on this deployment'
+        response = self.build_error(request, message)
+        response['body'] = {
+            'code':       'not_configured',
+            'subcommand': subcommand,
+            'message':    message,
+        }
+        return response

--- a/packages/ai/src/ai/modules/task/task_conn.py
+++ b/packages/ai/src/ai/modules/task/task_conn.py
@@ -46,6 +46,7 @@ from .commands.cmd_data import DataCommands
 from .commands.cmd_monitor import MonitorCommands
 from .commands.cmd_debug import DebugCommands
 from .commands.cmd_misc import MiscCommands
+from .commands.cmd_billing import BillingCommands
 from ai.web import AccountInfo
 from ai.common.account import AccountPipelineValidation
 
@@ -70,6 +71,7 @@ class TaskConn(
     MonitorCommands,
     DebugCommands,
     MiscCommands,
+    BillingCommands,
     DAPConn,
 ):
     """
@@ -101,6 +103,8 @@ class TaskConn(
     - MonitorCommands: Event subscription and monitoring
     - DebugCommands: Debugging session management
     - MiscCommands: Miscellaneous utility commands (services, etc.)
+    - BillingCommands: Account billing (stub in OSS; SaaS overlays the
+                       real wallet + subscription implementation)
     - DAPConn: Base DAP protocol implementation and transport handling
 
     Attributes:
@@ -152,6 +156,7 @@ class TaskConn(
         TaskCommands.__init__(self, connection_id, server, transport, **kwargs)
         DebugCommands.__init__(self, connection_id, server, transport, **kwargs)
         MiscCommands.__init__(self, connection_id, server, transport, **kwargs)
+        BillingCommands.__init__(self, connection_id, server, transport, **kwargs)
 
         # Store connection identifier for tracking and logging
         self._connection_id = connection_id


### PR DESCRIPTION
## Summary

Adds a proper \`BillingCommands\` mixin to the \`TaskConn\` inheritance chain handling the \`rrext_account_billing\` DAP command. OSS build ships a stub; SaaS overlay replaces this file to plug in real wallet + subscription logic.

Replaces a runtime monkey-patch approach on the SaaS side (\`TaskConn.on_rrext_account_billing = ...\`) per review feedback — a class-level handler is cleaner and keeps the OSS build in a known-good state for any frontend that issues \`rrext_account_billing\` even without a billing backend.

## What changes

- **\`packages/ai/src/ai/modules/task/commands/cmd_billing.py\`** (new) — \`BillingCommands(DAPConn)\` stub with \`on_rrext_account_billing\`.
  - Known subcommands (\`credits_balance\` / \`credits_packs\` / \`credits_checkout\` / \`prices\` / \`get\` / \`checkout\` / \`portal\` / \`cancel\`) return \`{success: False, body: {code: 'not_configured', subcommand}}\`.
  - Unknown subcommands return \`{success: False, body: {code: 'unknown_subcommand'}}\`.
- **\`packages/ai/src/ai/modules/task/task_conn.py\`** — import \`BillingCommands\`, add to inheritance chain, initialise in \`__init__\` (mirrors every other mixin).

## SaaS integration

SaaS builds drop a replacement \`cmd_billing.py\` onto the dist via the existing overlay mechanism (same path used for \`ai/account/auth/\`). The overlay version imports \`Billing\` / \`Account\` facades and dispatches each subcommand to the real backend.

## Contract the frontend sees

| OSS build | SaaS build |
|---|---|
| \`{success: false, body: {code: 'not_configured'}}\` | Real response (credit balance, checkout URL, etc.) |

Clients branch on \`body.code\` rather than silently succeeding with an empty body.

## Tests

- [x] Python AST parse on both files
- [ ] Manual DAP probe — \`{command: 'rrext_account_billing', arguments: {subcommand: 'credits_balance'}}\` returns \`not_configured\` on OSS
- [ ] Same probe on SaaS build returns a real balance

## Follow-ups

- Revert SaaS monkey-patch commit (rocketride-saas \`dbd7791\`) and replace with an overlay \`cmd_billing.py\` — separate PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a billing command handler that normalizes requests and returns clear, structured error or status responses for unknown or unconfigured billing actions.
  * Enabled billing command handling over connections so billing-related requests can be invoked remotely and report consistent outcomes.
  * Included an OSS placeholder implementation that no-ops by default and can be replaced or extended in SaaS deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->