### PR TITLE
fix(vscode): add osx python path for Python-EaaS debugger

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,9 @@
 			"linux": {
 				"python": "${workspaceFolder}/dist/server/engine"
 			},
+			"osx": {
+				"python": "${workspaceFolder}/dist/server/engine"
+			},
 			"justMyCode": false,
 			"subProcess": true,
 			"cwd": "${workspaceFolder}/dist/server",


### PR DESCRIPTION
## Summary

- The `Python - EaaS` launch config had `windows` and `linux` python path entries but was missing `osx`, causing VS Code on Mac to fall back to system Python which doesn't have the right modules (`No module named 'ai'`)

## Test plan

- [ ] Launch `Python - EaaS` debug config on macOS — should start without `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development debugging configuration for macOS compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->