### PR TITLE
fix(ci): match GraphQL author login in discord-discussions marker lookup (RR-671)

### DIFF
--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -170,9 +170,11 @@ jobs:
                   -f owner="$OWNER" -f name="$NAME" -F number="$NUMBER")
               fi
 
+              # GraphQL returns author.login as "github-actions" (no [bot] suffix);
+              # REST returns "github-actions[bot]". Match either to be safe.
               m=$(echo "$page" | jq -c '
                 [.data.repository.discussion.comments.nodes[]
-                  | select(.author.login == "github-actions[bot]"
+                  | select((.author.login == "github-actions" or .author.login == "github-actions[bot]")
                     and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$")))
                 ] | first // empty')
 


### PR DESCRIPTION
## Summary

- Discord discussion marker lookup filtered for `author.login == "github-actions[bot]"`, but GitHub's GraphQL API returns `author.login` as plain `"github-actions"` (the `[bot]` suffix only appears via the REST API — which is why `discord-pr.yml` worked).
- Because the filter never matched, every workflow fire treated the discussion as markerless, posted a new Discord message, and added another orphan marker comment (discussion #615 accumulated 4 of them).
- This PR accepts either `"github-actions"` or `"github-actions[bot]"` so the lookup succeeds regardless of which API introduced the comment. Follow-up to #698.

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

End-to-end verification requires merging (`on: discussion` runs from default branch only). Post-merge: edit any existing discussion, confirm the same Discord message updates (check `gh run view <id> --log` for `PATCH status: 200`).

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Closes #671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved discussion-processing workflow to more reliably detect and match bot-authored marker comments.
  * Broadened marker recognition to accept multiple bot author formats, reducing missed markers.
  * Minor efficiency and robustness improvements in discussion scanning and selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->