### PR TITLE
fix: forward runtime env vars to task execution (RR-655)

### DIFF
--- a/apps/vscode/src/debugger/session.ts
+++ b/apps/vscode/src/debugger/session.ts
@@ -75,6 +75,17 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 		return ++this.responseSeq;
 	}
 
+	private getFilteredLaunchEnv(): Record<string, string> {
+		const env = this.configManager.getEnv();
+		const filtered: Record<string, string> = {};
+		for (const [key, value] of Object.entries(env)) {
+			if (key.startsWith('ROCKETRIDE_')) {
+				filtered[key] = String(value);
+			}
+		}
+		return filtered;
+	}
+
 	private async initializeConnection(): Promise<void> {
 		const rocketrideConfig = this.configManager.getConfig();
 		const uri = this.configManager.getHttpUrl();
@@ -257,7 +268,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			if (this.isLaunchRequest(message)) {
 				message.arguments.pipeline = this.pipeline;
 				message.arguments.args = this.configManager.getEffectiveEngineArgs();
-				message.arguments.env = this.configManager.getEnv();
+				message.arguments.env = this.getFilteredLaunchEnv();
 			} else if (this.isAttachRequest(message)) {
 				this.token = message.arguments?.token;
 			}

--- a/apps/vscode/src/debugger/session.ts
+++ b/apps/vscode/src/debugger/session.ts
@@ -37,10 +37,7 @@ import { icons } from '../shared/util/icons';
 import { ConfigManager } from '../config';
 import { GenericEvent, GenericResponse, GenericRequest } from '../shared/types/protocol';
 
-import {
-	LaunchRequest,
-	AttachRequest
-} from '../shared/types/protocol';
+import { LaunchRequest, AttachRequest } from '../shared/types/protocol';
 
 /**
  * Debug Adapter with individual RocketRideClient connection
@@ -101,7 +98,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 				this.emitEvent({
 					type: 'event',
 					event: 'terminated',
-					body: {}
+					body: {},
 				});
 			},
 			onConnectError: async (error: ConnectionException) => {
@@ -119,7 +116,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 				this.emitEvent({
 					type: 'event',
 					event: 'terminated',
-					body: {}
+					body: {},
 				});
 			},
 		});
@@ -128,14 +125,14 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 	private emitResponse(message: GenericResponse): void {
 		this.messageEmitter.fire({
 			...message,
-			seq: this.getNextSeq()
+			seq: this.getNextSeq(),
 		});
 	}
 
 	private emitEvent(message: GenericEvent): void {
 		this.messageEmitter.fire({
 			...message,
-			seq: this.getNextSeq()
+			seq: this.getNextSeq(),
 		});
 	}
 
@@ -260,7 +257,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			if (this.isLaunchRequest(message)) {
 				message.arguments.pipeline = this.pipeline;
 				message.arguments.args = this.configManager.getEffectiveEngineArgs();
-
+				message.arguments.env = this.configManager.getEnv();
 			} else if (this.isAttachRequest(message)) {
 				this.token = message.arguments?.token;
 			}
@@ -268,11 +265,7 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			// Include token in the request
 			message.token = this.token;
 
-			const response = await this.client.dapRequest(
-				message.command,
-				message.arguments,
-				message.token
-			);
+			const response = await this.client.dapRequest(message.command, message.arguments, message.token);
 
 			// Cast DAPMessage to GenericResponse
 			const genericResponse = response as unknown as GenericResponse;
@@ -286,14 +279,13 @@ export class RocketRideDebugAdapter implements vscode.DebugAdapter {
 			}
 
 			this.emitResponse(genericResponse);
-
 		} catch (error) {
 			this.emitResponse({
 				type: 'response',
 				request_seq: message.seq,
 				command: message.command,
 				success: false,
-				message: error instanceof Error ? error.message : String(error)
+				message: error instanceof Error ? error.message : String(error),
 			});
 		}
 	}

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -111,6 +111,11 @@ class Task(DAPBase):
         _termination_lock (asyncio.Lock): Atomic termination operations
     """
 
+    # Only environment variables with this prefix are permitted to resolve in pipelines.
+    # All other env vars are blocked to prevent exfiltration of secrets via ${VAR} expansion.
+    ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
+    ALLOWED_ENV_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
     class TaskDbgStdio(DbgStdio):
         """DAP client for stdio communication with subprocess."""
 
@@ -303,11 +308,6 @@ class Task(DAPBase):
 
         # Initialize DAP base
         super().__init__(f'TASK-{self.id}', **kwargs)
-
-    # Only environment variables with this prefix are permitted to resolve in pipelines.
-    # All other env vars are blocked to prevent exfiltration of secrets via ${VAR} expansion.
-    ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
-    ALLOWED_ENV_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
 
     def _sanitize_launch_env(self, env: Any) -> Dict[str, str]:
         """

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1415,9 +1415,8 @@ class Task(DAPBase):
             # Set the restart flag to inhibit termination/start events
             self._is_restarting = True
 
-            if env is not None:
-                self._launch_env = self._sanitize_launch_env(env)
-                self._launch_args['env'] = dict(self._launch_env)
+            self._launch_env = self._sanitize_launch_env(env)
+            self._launch_args['env'] = dict(self._launch_env)
 
             # Update internal task configuration
             self._pipeline = pipeline

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -297,6 +297,7 @@ class Task(DAPBase):
 
         # Store complete configuration
         self._launch_args = launch_args
+        self._launch_env: Dict[str, str] = self._sanitize_launch_env(launch_args.get('env'))
         self._launch_type: LAUNCH_TYPE = launch_type
         self._pipeline: Dict[str, Any] = pipeline
 
@@ -306,6 +307,32 @@ class Task(DAPBase):
     # Only environment variables with this prefix are permitted to resolve in pipelines.
     # All other env vars are blocked to prevent exfiltration of secrets via ${VAR} expansion.
     ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
+    ALLOWED_ENV_NAME_PATTERN = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+    def _sanitize_launch_env(self, env: Any) -> Dict[str, str]:
+        """
+        Keep only safe runtime env overrides supplied by the client.
+
+        Accepted keys must:
+        - be strings
+        - start with ALLOWED_ENV_PREFIX
+        - match shell env naming rules
+        """
+        if not isinstance(env, dict):
+            return {}
+
+        result: Dict[str, str] = {}
+        for key, value in env.items():
+            if not isinstance(key, str):
+                continue
+            if not key.startswith(self.ALLOWED_ENV_PREFIX):
+                continue
+            if not self.ALLOWED_ENV_NAME_PATTERN.match(key):
+                continue
+            if value is None:
+                continue
+            result[key] = str(value)
+        return result
 
     def _resolve_pipeline(self, pipeline: Dict[str, Any]) -> Dict[str, Any]:
         """
@@ -329,7 +356,7 @@ class Task(DAPBase):
             env_var = match.group(1)
             if env_var.startswith(self.ALLOWED_ENV_PREFIX):
                 # Check JSON injection vulnerability in env var resolution.
-                value = os.environ.get(env_var, match.group(0))
+                value = self._launch_env.get(env_var, os.environ.get(env_var, match.group(0)))
                 if value == match.group(0):
                     return value  # placeholder not found
                 return json.dumps(value)[1:-1]  # escape but strip outer quotes
@@ -1353,6 +1380,7 @@ class Task(DAPBase):
         project_id: str,
         source: str,
         provider: str,
+        env: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Restart the task with new pipeline configuration.
@@ -1386,6 +1414,10 @@ class Task(DAPBase):
 
             # Set the restart flag to inhibit termination/start events
             self._is_restarting = True
+
+            if env is not None:
+                self._launch_env = self._sanitize_launch_env(env)
+                self._launch_args['env'] = dict(self._launch_env)
 
             # Update internal task configuration
             self._pipeline = pipeline
@@ -1554,6 +1586,7 @@ class Task(DAPBase):
 
             # Launch subprocess - pass environment with account context for store access
             subprocess_env = os.environ.copy()
+            subprocess_env.update(self._launch_env)
             subprocess_env['ROCKETRIDE_CLIENT_ID'] = self.client_id
 
             # avoidMocks: strip ROCKETRIDE_MOCK so node.py loads real libraries

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1587,9 +1587,14 @@ class Task(DAPBase):
             subprocess_env = os.environ.copy()
             subprocess_env.update(self._launch_env)
             subprocess_env['ROCKETRIDE_CLIENT_ID'] = self.client_id
+            launch_client_id = self._launch_env.get('ROCKETRIDE_CLIENT_ID')
+            if subprocess_env.get('ROCKETRIDE_CLIENT_ID') != launch_client_id:
+                self.debug_message(f'Server overrode client-supplied ROCKETRIDE_CLIENT_ID while preparing subprocess_env (launch={launch_client_id!r}, server={self.client_id!r}, effective={subprocess_env.get("ROCKETRIDE_CLIENT_ID")!r})')
 
             # avoidMocks: strip ROCKETRIDE_MOCK so node.py loads real libraries
             if self._pipeline.get('avoidMocks'):
+                if 'ROCKETRIDE_MOCK' in self._launch_env:
+                    self.debug_message(f'avoidMocks from self._pipeline stripped ROCKETRIDE_MOCK from subprocess_env (launch={self._launch_env.get("ROCKETRIDE_MOCK")!r})')
                 subprocess_env.pop('ROCKETRIDE_MOCK', None)
 
             self._engine_process = await asyncio.create_subprocess_exec(

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1588,8 +1588,8 @@ class Task(DAPBase):
             subprocess_env.update(self._launch_env)
             subprocess_env['ROCKETRIDE_CLIENT_ID'] = self.client_id
             launch_client_id = self._launch_env.get('ROCKETRIDE_CLIENT_ID')
-            if subprocess_env.get('ROCKETRIDE_CLIENT_ID') != launch_client_id:
-                self.debug_message(f'Server overrode client-supplied ROCKETRIDE_CLIENT_ID while preparing subprocess_env (launch={launch_client_id!r}, server={self.client_id!r}, effective={subprocess_env.get("ROCKETRIDE_CLIENT_ID")!r})')
+            if launch_client_id is not None and launch_client_id != self.client_id:
+                self.debug_message(f'Server overrode client-supplied ROCKETRIDE_CLIENT_ID while preparing subprocess_env (launch={launch_client_id!r}, server={self.client_id!r})')
 
             # avoidMocks: strip ROCKETRIDE_MOCK so node.py loads real libraries
             if self._pipeline.get('avoidMocks'):

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1030,6 +1030,7 @@ class TaskServer(DAPBase):
                 - arguments: Task configuration including:
                     - token: Task token to restart (required)
                     - pipeline: New pipeline configuration (required)
+                    - env: Optional runtime environment overrides
             conn (TaskConn, optional): Connection requesting restart (must match launch_owner)
             attach_debugger (bool): Ignored for restart (debugger must be detached)
             wait_for_running (bool): If True, wait for task to reach running state
@@ -1085,6 +1086,7 @@ class TaskServer(DAPBase):
             pipeline = args.get('pipeline', None)
             if not pipeline:
                 raise ValueError('Missing pipeline configuration in restart request')
+            env = args.get('env', None)
 
             # Validate task existence and get control structure
             control = self.get_task_control(token)
@@ -1114,6 +1116,7 @@ class TaskServer(DAPBase):
                 project_id=control.project_id,
                 source=control.source,
                 provider=control.provider,
+                env=env,
             )
 
             # Wait for running state if requested

--- a/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
+++ b/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
@@ -23,12 +23,15 @@ class _FakeTask:
     ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
 
     def __init__(self):
+        """Initialize per-launch env overrides used by the fake resolver."""
         self._launch_env = {}
 
     def _resolve_pipeline(self, pipeline):
+        """Resolve `${VAR}` placeholders using allowlisted env sources."""
         pipeline_str = json.dumps(pipeline)
 
         def replacer(match):
+            """Replace one `${VAR}` token while enforcing the allowlist."""
             env_var = match.group(1)
             if env_var.startswith(self.ALLOWED_ENV_PREFIX):
                 # Check JSON injection vulnerability in env var resolution.
@@ -44,6 +47,7 @@ class _FakeTask:
 
 @pytest.fixture
 def task():
+    """Provide a fresh fake task instance per test."""
     return _FakeTask()
 
 
@@ -64,6 +68,7 @@ class TestAllowedEnvVars:
         ],
     )
     def test_allowed_prefix_resolves(self, task, var_name, value):
+        """Allowlisted vars should resolve to their env value."""
         with patch.dict(os.environ, {var_name: value}):
             pipeline = {'config': f'${{{var_name}}}'}
             result = task._resolve_pipeline(pipeline)
@@ -76,6 +81,7 @@ class TestAllowedEnvVars:
         assert result['config'] == '${ROCKETRIDE_MISSING}'
 
     def test_multiple_allowed_vars(self, task):
+        """Multiple allowlisted placeholders should all resolve."""
         env = {
             'ROCKETRIDE_HOST': 'localhost',
             'ROCKETRIDE_PORT': '8080',
@@ -86,12 +92,14 @@ class TestAllowedEnvVars:
             assert result['url'] == 'localhost:8080'
 
     def test_launch_env_resolves_allowed_var(self, task):
+        """Launch payload env should resolve allowlisted placeholders."""
         task._launch_env = {'ROCKETRIDE_HOST': 'from-launch-env'}
         pipeline = {'host': '${ROCKETRIDE_HOST}'}
         result = task._resolve_pipeline(pipeline)
         assert result['host'] == 'from-launch-env'
 
     def test_launch_env_takes_precedence_over_process_env(self, task):
+        """Launch payload env should override process env for allowlisted vars."""
         task._launch_env = {'ROCKETRIDE_HOST': 'launch'}
         with patch.dict(os.environ, {'ROCKETRIDE_HOST': 'process'}):
             pipeline = {'host': '${ROCKETRIDE_HOST}'}
@@ -126,6 +134,7 @@ class TestBlockedEnvVars:
         ],
     )
     def test_sensitive_var_redacted(self, task, var_name):
+        """Sensitive non-allowlisted vars should always be redacted."""
         with patch.dict(os.environ, {var_name: 'super-secret-value'}):
             pipeline = {'leak': f'${{{var_name}}}'}
             result = task._resolve_pipeline(pipeline)
@@ -139,6 +148,7 @@ class TestBlockedEnvVars:
         assert result['leak'] == '<REDACTED>'
 
     def test_launch_env_cannot_bypass_allowlist(self, task):
+        """Launch env cannot bypass redaction for blocked variable names."""
         task._launch_env = {'AWS_SECRET_ACCESS_KEY': 'super-secret-value'}
         pipeline = {'leak': '${AWS_SECRET_ACCESS_KEY}'}
         result = task._resolve_pipeline(pipeline)
@@ -146,6 +156,7 @@ class TestBlockedEnvVars:
         assert 'super-secret-value' not in json.dumps(result)
 
     def test_mixed_allowed_and_blocked(self, task):
+        """Mixed placeholders should resolve allowlisted and redact blocked vars."""
         env = {
             'ROCKETRIDE_HOST': 'localhost',
             'AWS_SECRET_ACCESS_KEY': 'AKIA...',
@@ -195,12 +206,16 @@ class TestBlockedEnvVars:
 
 
 class TestEdgeCases:
+    """Edge-case behavior for placeholder matching and passthrough values."""
+
     def test_no_placeholders(self, task):
+        """Pipelines without placeholders should be returned unchanged."""
         pipeline = {'key': 'plain value'}
         result = task._resolve_pipeline(pipeline)
         assert result == pipeline
 
     def test_empty_pipeline(self, task):
+        """An empty pipeline object should remain empty after resolution."""
         result = task._resolve_pipeline({})
         assert result == {}
 
@@ -269,6 +284,7 @@ class TestJsonInjection:
             assert result['msg'] == payload
 
     def test_tab_and_control_chars_are_escaped(self, task):
+        """Control characters in allowlisted values should survive safely."""
         payload = 'col1\tcol2\x08end'  # tab + backspace; null bytes are rejected by the OS
         with patch.dict(os.environ, {'ROCKETRIDE_DATA': payload}):
             pipeline = {'data': '${ROCKETRIDE_DATA}'}

--- a/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
+++ b/packages/ai/tests/ai/modules/task/test_env_var_exfil.py
@@ -22,6 +22,9 @@ class _FakeTask:
 
     ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
 
+    def __init__(self):
+        self._launch_env = {}
+
     def _resolve_pipeline(self, pipeline):
         pipeline_str = json.dumps(pipeline)
 
@@ -29,7 +32,7 @@ class _FakeTask:
             env_var = match.group(1)
             if env_var.startswith(self.ALLOWED_ENV_PREFIX):
                 # Check JSON injection vulnerability in env var resolution.
-                value = os.environ.get(env_var, match.group(0))
+                value = self._launch_env.get(env_var, os.environ.get(env_var, match.group(0)))
                 if value == match.group(0):
                     return value  # placeholder not found
                 return json.dumps(value)[1:-1]  # escape but strip outer quotes
@@ -52,11 +55,14 @@ def task():
 class TestAllowedEnvVars:
     """Env vars with the ROCKETRIDE_ prefix should be resolved normally."""
 
-    @pytest.mark.parametrize('var_name,value', [
-        ('ROCKETRIDE_API_KEY', 'rr-key-123'),
-        ('ROCKETRIDE_HOST', 'localhost'),
-        ('ROCKETRIDE_DEBUG', 'true'),
-    ])
+    @pytest.mark.parametrize(
+        'var_name,value',
+        [
+            ('ROCKETRIDE_API_KEY', 'rr-key-123'),
+            ('ROCKETRIDE_HOST', 'localhost'),
+            ('ROCKETRIDE_DEBUG', 'true'),
+        ],
+    )
     def test_allowed_prefix_resolves(self, task, var_name, value):
         with patch.dict(os.environ, {var_name: value}):
             pipeline = {'config': f'${{{var_name}}}'}
@@ -79,6 +85,19 @@ class TestAllowedEnvVars:
             result = task._resolve_pipeline(pipeline)
             assert result['url'] == 'localhost:8080'
 
+    def test_launch_env_resolves_allowed_var(self, task):
+        task._launch_env = {'ROCKETRIDE_HOST': 'from-launch-env'}
+        pipeline = {'host': '${ROCKETRIDE_HOST}'}
+        result = task._resolve_pipeline(pipeline)
+        assert result['host'] == 'from-launch-env'
+
+    def test_launch_env_takes_precedence_over_process_env(self, task):
+        task._launch_env = {'ROCKETRIDE_HOST': 'launch'}
+        with patch.dict(os.environ, {'ROCKETRIDE_HOST': 'process'}):
+            pipeline = {'host': '${ROCKETRIDE_HOST}'}
+            result = task._resolve_pipeline(pipeline)
+            assert result['host'] == 'launch'
+
 
 # ==========================================================================
 # Tests that BLOCKED (sensitive) vars are redacted
@@ -88,21 +107,24 @@ class TestAllowedEnvVars:
 class TestBlockedEnvVars:
     """Env vars outside the allowlist must be redacted."""
 
-    @pytest.mark.parametrize('var_name', [
-        'AWS_SECRET_ACCESS_KEY',
-        'AWS_ACCESS_KEY_ID',
-        'DATABASE_URL',
-        'PYPI_TOKEN',
-        'GITHUB_TOKEN',
-        'HOME',
-        'PATH',
-        'SSH_PRIVATE_KEY',
-        'OPENAI_API_KEY',
-        'STRIPE_SECRET_KEY',
-        'PIPELINE_MODE',
-        'NODE_ENV',
-        'ROCKET_DEBUG',
-    ])
+    @pytest.mark.parametrize(
+        'var_name',
+        [
+            'AWS_SECRET_ACCESS_KEY',
+            'AWS_ACCESS_KEY_ID',
+            'DATABASE_URL',
+            'PYPI_TOKEN',
+            'GITHUB_TOKEN',
+            'HOME',
+            'PATH',
+            'SSH_PRIVATE_KEY',
+            'OPENAI_API_KEY',
+            'STRIPE_SECRET_KEY',
+            'PIPELINE_MODE',
+            'NODE_ENV',
+            'ROCKET_DEBUG',
+        ],
+    )
     def test_sensitive_var_redacted(self, task, var_name):
         with patch.dict(os.environ, {var_name: 'super-secret-value'}):
             pipeline = {'leak': f'${{{var_name}}}'}
@@ -115,6 +137,13 @@ class TestBlockedEnvVars:
         pipeline = {'leak': '${AWS_SECRET_ACCESS_KEY}'}
         result = task._resolve_pipeline(pipeline)
         assert result['leak'] == '<REDACTED>'
+
+    def test_launch_env_cannot_bypass_allowlist(self, task):
+        task._launch_env = {'AWS_SECRET_ACCESS_KEY': 'super-secret-value'}
+        pipeline = {'leak': '${AWS_SECRET_ACCESS_KEY}'}
+        result = task._resolve_pipeline(pipeline)
+        assert result['leak'] == '<REDACTED>'
+        assert 'super-secret-value' not in json.dumps(result)
 
     def test_mixed_allowed_and_blocked(self, task):
         env = {
@@ -146,10 +175,13 @@ class TestBlockedEnvVars:
 
     def test_inline_mixed_text(self, task):
         """Blocked var embedded in a larger string is still redacted."""
-        with patch.dict(os.environ, {
-            'ROCKETRIDE_HOST': 'myhost',
-            'AWS_SECRET_ACCESS_KEY': 'secret123',
-        }):
+        with patch.dict(
+            os.environ,
+            {
+                'ROCKETRIDE_HOST': 'myhost',
+                'AWS_SECRET_ACCESS_KEY': 'secret123',
+            },
+        ):
             pipeline = {'cmd': 'connect ${ROCKETRIDE_HOST} using ${AWS_SECRET_ACCESS_KEY}'}
             result = task._resolve_pipeline(pipeline)
             assert 'myhost' in result['cmd']

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -1008,15 +1008,17 @@ export class RocketRideClient extends DAPClient {
 	 */
 	async restart(options: { token?: string; projectId: string; source: string; pipeline: Record<string, unknown> }): Promise<void> {
 		const runtimeEnv = this.getRuntimeEnv();
-		const arguments_: Record<string, unknown> = {
-			token: options.token,
-			projectId: options.projectId,
-			source: options.source,
-			pipeline: options.pipeline,
-			// Always send explicit env so restart can clear previously-set vars.
-			env: runtimeEnv,
-		};
-		const response = await this.dapRequest('restart', arguments_, '*');
+		const response = await this.dapRequest(
+			'restart',
+			{
+				token: options.token,
+				projectId: options.projectId,
+				source: options.source,
+				pipeline: options.pipeline,
+				env: runtimeEnv,
+			},
+			'*'
+		);
 
 		if (this.didFail(response)) {
 			const errorMsg = response.message || 'Unknown restart error';

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -651,6 +651,22 @@ export class RocketRideClient extends DAPClient {
 		this._env = { ...env };
 	}
 
+	/**
+	 * Build the runtime environment payload forwarded to the server task process.
+	 *
+	 * To avoid exposing arbitrary host environment variables, only ROCKETRIDE_*
+	 * keys are forwarded.
+	 */
+	private getRuntimeEnv(): Record<string, string> {
+		const runtimeEnv: Record<string, string> = {};
+		for (const [key, value] of Object.entries(this._env)) {
+			if (key.startsWith('ROCKETRIDE_')) {
+				runtimeEnv[key] = String(value);
+			}
+		}
+		return runtimeEnv;
+	}
+
 	// ============================================================================
 	// PING METHODS
 	// ============================================================================
@@ -911,6 +927,10 @@ export class RocketRideClient extends DAPClient {
 			pipeline: processedConfig,
 			args: args || [],
 		};
+		const runtimeEnv = this.getRuntimeEnv();
+		// Always send an explicit env snapshot so the server can distinguish
+		// "empty env" from "env omitted".
+		arguments_.env = runtimeEnv;
 
 		// Add TTL if provided (server uses its default if not specified)
 		if (ttl !== undefined) {
@@ -987,16 +1007,16 @@ export class RocketRideClient extends DAPClient {
 	 * @param options.pipeline - The pipeline configuration to restart with.
 	 */
 	async restart(options: { token?: string; projectId: string; source: string; pipeline: Record<string, unknown> }): Promise<void> {
-		const response = await this.dapRequest(
-			'restart',
-			{
-				token: options.token,
-				projectId: options.projectId,
-				source: options.source,
-				pipeline: options.pipeline,
-			},
-			'*'
-		);
+		const runtimeEnv = this.getRuntimeEnv();
+		const arguments_: Record<string, unknown> = {
+			token: options.token,
+			projectId: options.projectId,
+			source: options.source,
+			pipeline: options.pipeline,
+			// Always send explicit env so restart can clear previously-set vars.
+			env: runtimeEnv,
+		};
+		const response = await this.dapRequest('restart', arguments_, '*');
 
 		if (this.didFail(response)) {
 			const errorMsg = response.message || 'Unknown restart error';

--- a/packages/client-typescript/tests/RuntimeEnvForwarding.test.ts
+++ b/packages/client-typescript/tests/RuntimeEnvForwarding.test.ts
@@ -1,0 +1,99 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+import { RocketRideClient } from '../src/client';
+
+function makeMinimalPipeline() {
+	return {
+		project_id: '11111111-1111-1111-1111-111111111111',
+		source: 'src_1',
+		components: [
+			{
+				id: 'src_1',
+				provider: 'webhook',
+				config: { mode: 'Source', type: 'webhook' },
+			},
+		],
+	};
+}
+
+describe('Runtime env forwarding', () => {
+	it('forwards only ROCKETRIDE_* env vars on use()', async () => {
+		const client = new RocketRideClient({
+			auth: 'MYAPIKEY',
+			uri: 'http://localhost:5565',
+			env: {
+				ROCKETRIDE_ALLOWED: 'yes',
+				PATH: '/usr/bin',
+				AWS_SECRET_ACCESS_KEY: 'blocked',
+			},
+		});
+
+		const requestSpy = jest.spyOn(client as unknown as { request: (msg: unknown) => Promise<unknown> }, 'request').mockResolvedValue({
+			success: true,
+			body: { token: 'tk_test' },
+		});
+
+		await client.use({ pipeline: makeMinimalPipeline() });
+
+		expect(requestSpy).toHaveBeenCalledTimes(1);
+		const req = requestSpy.mock.calls[0][0] as { arguments?: { env?: Record<string, string> } };
+		expect(req.arguments?.env).toEqual({ ROCKETRIDE_ALLOWED: 'yes' });
+	});
+
+	it('forwards only ROCKETRIDE_* env vars on restart()', async () => {
+		const client = new RocketRideClient({
+			auth: 'MYAPIKEY',
+			uri: 'http://localhost:5565',
+			env: {
+				ROCKETRIDE_ALLOWED: 'yes',
+				HOME: '/Users/test',
+			},
+		});
+
+		const dapSpy = jest.spyOn(client as unknown as { dapRequest: (...args: unknown[]) => Promise<unknown> }, 'dapRequest').mockResolvedValue({
+			success: true,
+		});
+
+		await client.restart({
+			token: 'tk_test',
+			projectId: '11111111-1111-1111-1111-111111111111',
+			source: 'src_1',
+			pipeline: makeMinimalPipeline(),
+		});
+
+		expect(dapSpy).toHaveBeenCalledTimes(1);
+		const callArgs = dapSpy.mock.calls[0] as [string, { env?: Record<string, string> }, string];
+		expect(callArgs[0]).toBe('restart');
+		expect(callArgs[1].env).toEqual({ ROCKETRIDE_ALLOWED: 'yes' });
+	});
+
+	it('sends empty env on restart when no ROCKETRIDE_* vars are present', async () => {
+		const client = new RocketRideClient({
+			auth: 'MYAPIKEY',
+			uri: 'http://localhost:5565',
+			env: {
+				HOME: '/Users/test',
+			},
+		});
+
+		const dapSpy = jest.spyOn(client as unknown as { dapRequest: (...args: unknown[]) => Promise<unknown> }, 'dapRequest').mockResolvedValue({
+			success: true,
+		});
+
+		await client.restart({
+			token: 'tk_test',
+			projectId: '11111111-1111-1111-1111-111111111111',
+			source: 'src_1',
+			pipeline: makeMinimalPipeline(),
+		});
+
+		const callArgs = dapSpy.mock.calls[0] as [string, { env?: Record<string, string> }, string];
+		expect(callArgs[0]).toBe('restart');
+		expect(callArgs[1].env).toEqual({});
+	});
+});


### PR DESCRIPTION
## Problem

Issue #655: environment variables configured in the UI were not reliably available during pipeline execution.  
As a result, nodes depending on runtime env values could fail or fall back to defaults.

## Current vs Expected

- Current: runtime env handoff was incomplete across launch/restart paths.
- Expected: UI-configured runtime env vars should be available to the task runtime and downstream nodes on both launch and restart.

## Root Cause

- Missing env forwarding in some client/debug paths.
- Restart path did not always receive an explicit env snapshot, which could leave stale values.
- Runtime relied on process env for `${ROCKETRIDE_*}` resolution instead of consistently using launch-provided env.

## What Changed

- Forward runtime env from client `use()` and `restart()` requests.
- Forward env from VS Code debug launch requests.
- Restrict forwarded env to `ROCKETRIDE_*` keys.
- Always send explicit env snapshot on restart (including `{}`) so stale values are cleared.
- Sanitize env in task runtime before use (key format + allowlist).
- Use sanitized launch env for `${ROCKETRIDE_*}` resolution.
- Inject sanitized launch env into task subprocess env.
- Wire server restart path to pass env through to task restart.

## Safety / Compatibility

- No breaking API changes.
- Backward compatible with existing pipelines.
- Security guardrails preserved: only allowlisted `ROCKETRIDE_*` env vars are forwarded/resolved.

## Testing

- `CI=true PNPM_HOME=/tmp/pnpm ./builder client-typescript:test` ✅
- `CI=true PNPM_HOME=/tmp/pnpm ./builder ai:test` ✅
- Added TS regression tests for env forwarding on launch/restart.
- Extended Python tests for env allowlist, precedence, and exfiltration protection.
- `gitleaks` scan on commit range: no leaks found ✅

## Notes

- ESLint output contains existing warnings in `client.ts` (`no-explicit-any`), no new errors.

Closes #655


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pipelines now attach an explicit, allowlisted ROCKETRIDE_* environment snapshot on start and restart; debug launches receive the same filtered env.

* **Bug Fixes**
  * Restart requests accept and apply sanitized env overrides that take precedence over the process environment.
  * Subprocess startup and placeholder resolution consistently enforce the ROCKETRIDE_* allowlist.

* **Tests**
  * Added tests covering env forwarding, precedence, and allowlist enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->