### PR TITLE
ci: pass ROCKETRIDE_APIKEY into Test step env

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -124,6 +124,14 @@ jobs:
 
       - name: Test
         if: inputs.codeql == false
+        # Integration tests boot a local server on :5565 and connect a test
+        # client. Both sides need the same shared secret to authenticate;
+        # without ROCKETRIDE_APIKEY the server raises AuthenticationException
+        # and the client tests fail with "No authentication configured".
+        # The secret value itself doesn't matter — it just has to match
+        # between server and client in this single CI run.
+        env:
+          ROCKETRIDE_APIKEY: ${{ secrets.ROCKETRIDE_APIKEY }}
         run: ${{ matrix.builder_cmd }} test --verbose
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary

- Adds `ROCKETRIDE_APIKEY` to the Test step env in `_build.yaml`, sourced from the new repo secret of the same name.
- Fixes the integration-test failure Alex flagged on phase2: server boots on :5565 expecting an APIKEY for auth, test client connects without one, server returns `AuthenticationException: No authentication configured — set ROCKETRIDE_APIKEY`, jest/pytest assertions fail.
- The value is arbitrary; it just needs to match server-side and client-side inside one CI run. Stored in a repo secret so the CI run logs don't expose it.

## Type

ci

## Testing

- [x] Repo secret `ROCKETRIDE_APIKEY` is set
- [ ] CI rerun on phase2 (PR #678) — Test steps pass with APIKEY in env

## Related

- Reported by Alex on phase2 PR #678
- Failed run: https://github.com/rocketride-org/rocketride-server/actions/runs/25002509407/job/73216286243

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Resolved integration test authentication issues to improve overall test reliability and release stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->