### PR TITLE
ci(nightly): trigger from develop on green CI; drop stage as a build source

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,10 @@
 name: Nightly prerelease
-run-name: Nightly ${{ github.event_name == 'workflow_dispatch' && '(manual)' || '(scheduled)' }}
+run-name: Nightly ${{ github.event_name == 'workflow_dispatch' && '(manual)' || '(auto)' }}
 
+# `cancel-in-progress` is what makes the "every green develop commit"
+# cadence safe under load: if 5 PRs land in 30 minutes, only the last
+# one's nightly run completes — the previous 4 are cancelled mid-build.
+# Without this we'd burn ~25 min × 5 = 2 hours of CI minutes per burst.
 concurrency:
   group: nightly
   cancel-in-progress: true
@@ -10,23 +14,44 @@ permissions:
   packages: write
   id-token: write
 
+# Triggered when develop's CI run completes successfully — this is the
+# gate. A red CI on develop (whether from a bad merge, a flaky test, or
+# a PR that slipped through) leaves `workflow_run.conclusion=failure`
+# and the `if:` below skips the run, so a broken develop commit never
+# becomes a published prerelease.
+#
+# `workflow_dispatch` is kept as the manual escape hatch for hot-fix
+# flows or for re-publishing a known-good ref out of cycle.
+#
+# NB: per GitHub's rules, `workflow_run` triggers always execute the
+# version of this file from the *default* branch (main), not from the
+# branch that produced the triggering CI run. So edits here only take
+# effect after they land on main — keep that in mind if iterating.
 on:
-  schedule:
-    - cron: '0 2 * * *'
+  workflow_run:
+    workflows: ["CI"]
+    branches: [develop]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
   init:
     name: Initialize
+    # Skip when CI failed; manual dispatch always runs.
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/_init.yaml
     with:
-      ref: stage
+      # `head_sha` pins the build to the exact commit whose CI passed,
+      # rather than `develop` HEAD which might have moved on by the time
+      # this nightly job acquires a runner. For workflow_dispatch we use
+      # the ref the user picked when dispatching.
+      ref: ${{ github.event.workflow_run.head_sha || github.ref }}
   build:
     name: Build
     needs: init
     uses: ./.github/workflows/_build.yaml
     with:
-      ref: stage
+      ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       full_version: ${{ needs.init.outputs.full_server_version }}
       build_hash: ${{ needs.init.outputs.build_hash }}
       build_stamp: ${{ needs.init.outputs.build_stamp }}
@@ -43,7 +68,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: stage
+          ref: ${{ github.event.workflow_run.head_sha || github.ref }}
           fetch-depth: 0
 
       - name: Delete existing prerelease tags and releases
@@ -73,7 +98,7 @@ jobs:
     needs: [init, build, cleanup-prereleases]
     uses: ./.github/workflows/_release.yaml
     with:
-      ref: stage
+      ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       prerelease: true
       server_version: ${{ needs.init.outputs.server_version }}
       vscode_version: ${{ needs.init.outputs.vscode_version }}
@@ -87,7 +112,7 @@ jobs:
     needs: [init, build]
     uses: ./.github/workflows/_docker.yaml
     with:
-      ref: stage
+      ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       server_version: ${{ needs.init.outputs.server_version }}
       prerelease: true
     secrets: inherit


### PR DESCRIPTION
## Summary

- Replaces the cron + `ref: stage` trigger in `nightly.yaml` with `workflow_run` on develop's CI completion + `if: conclusion == 'success'`.
- Each prerelease build is pinned to the exact green commit (`head_sha`), not stage HEAD.
- `workflow_dispatch` is kept for manual hot-fix publishes.

## Why

The `stage` branch was a manually-promoted gate. Every time it diverged from develop, the prerelease artefact that downstream CI/CD pulls grew stale, and someone had to remember to FF-merge develop into stage. Develop's own CI run is the cheaper and more accurate signal — if CI is green, the commit is publishable; if not, no prerelease.

Discussed with @stepmikhaylov in DM today. His three concerns about the cadence:

| Concern | Already handled by |
|---|---|
| Burst load | `concurrency: { group: nightly, cancel-in-progress: true }` |
| Tag churn | `cleanup-prereleases` job |
| Artefact bloat | `retention_days: 3` |
| Cross-workflow interference | isolated concurrency group |

## Type

ci

## Caveat

Per GitHub Actions, `workflow_run` always executes the version of the file from the **default branch (main)**, not develop. Future edits here only become active after they land on main. Documented in the file comments.

## Testing

- [ ] Land on main + develop
- [ ] First green develop CI fires Nightly automatically
- [ ] `workflow_dispatch` still works for manual ref publishes

## Follow-up

Once this is verified for a few days, delete the `stage` branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly workflow to trigger automatically after successful CI completion on the develop branch, replacing the schedule-based approach. Manual triggering remains available. Improved commit tracking for automatic workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->