### PR TITLE
fix(sdk): align CreditBalance type with backend camelCase wire shape

### DIFF
--- a/packages/client-python/src/rocketride/types/billing.py
+++ b/packages/client-python/src/rocketride/types/billing.py
@@ -95,13 +95,13 @@ class CreditBalance(TypedDict):
 
     Attributes:
         balance: Current unspent credit balance for the org.
-        lifetime_purchased: Total credits ever purchased.
-        lifetime_consumed: Total credits ever consumed.
+        lifetimePurchased: Total credits ever purchased.
+        lifetimeConsumed: Total credits ever consumed.
     """
 
     balance: int
-    lifetime_purchased: int
-    lifetime_consumed: int
+    lifetimePurchased: int
+    lifetimeConsumed: int
 
 
 class CreditPack(TypedDict):

--- a/packages/client-typescript/src/client/types/billing.ts
+++ b/packages/client-typescript/src/client/types/billing.ts
@@ -89,10 +89,10 @@ export interface CreditBalance {
 	balance: number;
 
 	/** Total credits ever purchased — useful for ledger display. */
-	lifetime_purchased: number;
+	lifetimePurchased: number;
 
 	/** Total credits ever consumed — useful for ledger display. */
-	lifetime_consumed: number;
+	lifetimeConsumed: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- TS interface \`CreditBalance\` (\`packages/client-typescript/src/client/types/billing.ts\`) and Python TypedDict (\`packages/client-python/src/rocketride/types/billing.py\`) declared snake_case fields (\`lifetime_purchased\`, \`lifetime_consumed\`).
- Backend wire (\`extension/src/extension/saas/credits_service.py:get_balance\`) returns camelCase: \`{balance, lifetimePurchased, lifetimeConsumed}\`. Same convention as \`CreditPack\` in the same file.
- TS callers reading \`body.lifetime_purchased\` get \`undefined\` → credits panel renders \`NaN\`. Python TypedDict consumers get KeyError despite the type "passing".
- This PR fixes the SDK types (and docstrings) to match the wire.

## Why type-side, not backend-side

\`CreditPack\`, \`StripePlan\`, etc. in the same SDK file already use camelCase. The backend is consistent with the rest of phase2's standardised camelCase API. Snake_case here was the outlier.

## Type

fix

## Testing

- [x] Manually verified backend returns camelCase keys (\`credits_service.py\` line 66, 69-70 in saas extension)
- [x] No other callsites reference \`lifetime_purchased\` / \`lifetime_consumed\` in the repo (grep clean)
- [ ] Smoke test via saas#58 already asserts the camelCase keys, so it'll catch any regression

## Found while

Migrating \`scripts/smoke_billing.py\` to the new \`client.billing.*\` SDK namespace ([saas#58](https://github.com/rocketride-ai/rocketride-saas/pull/58)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Billing credit balance field names updated to camelCase naming convention across Python and TypeScript clients. The fields `lifetimePurchased` and `lifetimeConsumed` now replace their snake_case equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->