### PR TITLE
chore(ci): ruff and gitleaks checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,9 @@ jobs:
       - run: ruff format --check
 
   # ---------------------------------------------------------------------------
-  #  gitleaks — secret scan. Mirrors the local lefthook hook.
+  #  gitleaks — secret scan. Installs the binary directly because the upstream
+  #  gitleaks-action v2 requires a paid GITLEAKS_LICENSE for org-owned repos;
+  #  the binary itself is MIT-licensed and free. Mirrors the local lefthook hook.
   # ---------------------------------------------------------------------------
   gitleaks:
     name: gitleaks
@@ -220,9 +222,15 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+      - name: Install gitleaks
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin gitleaks
+          gitleaks version
+      - name: Run gitleaks
+        run: gitleaks detect --config .gitleaks.toml --verbose --redact
 
   # ---------------------------------------------------------------------------
   #  Gatekeeper — the ONLY job to mark as "Required" in branch protection.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,12 +196,41 @@ jobs:
           category: 'trivy-${{ matrix.dockerfile }}'
 
   # ---------------------------------------------------------------------------
+  #  Ruff — Python lint + format check. Mirrors the local lefthook hook so
+  #  contributors who bypass lefthook (--no-verify) still get caught in CI.
+  # ---------------------------------------------------------------------------
+  ruff-check:
+    name: Ruff
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3
+      - run: ruff check
+      - run: ruff format --check
+
+  # ---------------------------------------------------------------------------
+  #  gitleaks — secret scan. Mirrors the local lefthook hook.
+  # ---------------------------------------------------------------------------
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # ---------------------------------------------------------------------------
   #  Gatekeeper — the ONLY job to mark as "Required" in branch protection.
   #  Aggregates all CI results so skipped builds don't block PRs.
   # ---------------------------------------------------------------------------
   ci-ok:
     name: CI OK
-    needs: [init, changes, build]
+    needs: [init, changes, build, ruff-check, gitleaks]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -209,11 +238,11 @@ jobs:
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
             echo "❌ One or more CI jobs failed or were cancelled."
-            echo "Results: init=${{ needs.init.result }}, changes=${{ needs.changes.result }}, build=${{ needs.build.result }}"
+            echo "Results: init=${{ needs.init.result }}, changes=${{ needs.changes.result }}, build=${{ needs.build.result }}, ruff-check=${{ needs['ruff-check'].result }}, gitleaks=${{ needs.gitleaks.result }}"
             exit 1
           fi
           echo "✅ All CI checks passed (or were correctly skipped)."
-          echo "Results: init=${{ needs.init.result }}, changes=${{ needs.changes.result }}, build=${{ needs.build.result }}"
+          echo "Results: init=${{ needs.init.result }}, changes=${{ needs.changes.result }}, build=${{ needs.build.result }}, ruff-check=${{ needs['ruff-check'].result }}, gitleaks=${{ needs.gitleaks.result }}"
 
   # ---------------------------------------------------------------------------
   #  Discord — update PR embed with final check counts after CI completes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,7 +230,9 @@ jobs:
             | sudo tar -xz -C /usr/local/bin gitleaks
           gitleaks version
       - name: Run gitleaks
-        run: gitleaks detect --config .gitleaks.toml --verbose --redact
+        run: |
+          BASE="${{ github.event.pull_request.base.sha || github.event.before }}"
+          gitleaks detect --config .gitleaks.toml --verbose --redact --log-opts="${BASE}..HEAD"
 
   # ---------------------------------------------------------------------------
   #  Gatekeeper — the ONLY job to mark as "Required" in branch protection.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,9 @@
     "**/__pycache__": true,
     "**/node_modules": true,
   },
-  "cmake.sourceDirectory": "${workspaceFolder}/packages/server"
+  "cmake.sourceDirectory": "${workspaceFolder}/packages/server",
+  "python.analysis.extraPaths": [
+    "packages/server/engine-lib/rocketlib-python/lib",
+    "packages/ai/src"
+  ]
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -4,12 +4,14 @@ pre-commit:
     gitleaks:
       tags: security
       run: gitleaks protect --verbose --redact --staged --config .gitleaks.toml
-    eslint:
-      glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
-      run: npx eslint {staged_files}
-    prettier:
-      glob: '*.{js,ts,jsx,tsx,mjs,cjs,json,css,scss,html,md,yaml,yml}'
-      run: npx prettier --check {staged_files}
+    # Note: ESLint and Prettier are temporarily disabled in lefthook in order
+    #       to enable them later in both lefthook and CI workflow.
+    # eslint:
+    #   glob: '*.{js,ts,jsx,tsx,mjs,cjs}'
+    #   run: npx eslint {staged_files}
+    # prettier:
+    #   glob: '*.{js,ts,jsx,tsx,mjs,cjs,json,css,scss,html,md,yaml,yml}'
+    #   run: npx prettier --check {staged_files}
     ruff-check:
       glob: '*.py'
       run: ruff check {staged_files}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@
 
 [tool.ruff]
 # Line length disabled - set high to avoid enforcement
-line-length = 320
+line-length = 120
 
 # Target Python version
 target-version = "py310"
@@ -49,14 +49,18 @@ fixable = ["D", "Q"]
 # D102 Ignore no public method docstring
 # D103 Ignore no public function docstring
 # D104 Ignore no public package docstring
+# D105 Ignore undocumented magic method
+# D106 Ignore undocumented public nested class
+# D107 Ignore undocumented public __init__
 # D200 Ignore single line docstring
 # D205 1 blank line required between summary line and description
 # D301 Use `r"""` if any backslashes in a docstring
 # D400 First line should end with a period
+# D401 First line should be in imperative mood
 # E203 Ignore whitespace before ':' - ruff puts it there and then produces an error on it
 # E402 Ignore missing module level docstring - we need depends first
 # E501 Line too long
-ignore = ["D100", "D101", "D102", "D103", "D104", "D200", "D205", "D301", "D400", "E203", "E402", "E501"]
+ignore = ["D100", "D101", "D102", "D103", "D104", "D105", "D106", "D107", "D200", "D205", "D301", "D400", "D401", "E203", "E402", "E501"]
 
 [tool.ruff.lint.flake8-quotes]
 # Enforce single quotes for inline strings


### PR DESCRIPTION
## Summary

The `ruff-check` and `gitleaks` checks are mandatory in CI

* ✅  `gitleaks` is green.
* 🔴 `Ruff` is red and fixed with #723 (separate commit is needed for blame ignore).
  * ✅ Green `Ruff` run https://github.com/rocketride-org/rocketride-server/actions/runs/25324036485/job/74240027917 
* 🚫 `Eslint` and `Prettier` are temporarily disabled in lefthook.
* 💡 Rocketride python libs `rocketlib` and `ai` are visible for IDE.