### PR TITLE
feat(shared-ui): chat module

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -56,6 +56,7 @@
 		"react-markdown": "^10.1.0",
 		"react-syntax-highlighter": "^15.6.6",
 		"rehype-raw": "^7.0.0",
+		"rehype-sanitize": "^6.0.0",
 		"remark-gfm": "^4.0.1"
 	},
 	"devDependencies": {

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -7,6 +7,7 @@
 	"types": "./index.ts",
 	"peerDependencies": {
 		"chart.js": "^4.4.0",
+		"react-chartjs-2": "^5.2.0",
 		"@dnd-kit/core": "~6.1.0",
 		"@dnd-kit/modifiers": "~7.0.0",
 		"@dnd-kit/sortable": "~8.0.0",

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -74,6 +74,13 @@ export { BillingView } from './modules/billing';
 export type { IBillingViewProps } from './modules/billing';
 export { CreditsPanel } from './modules/billing';
 
+// --- Chat module (conversational chat surface) --------------------------------
+export { ChatView } from './modules/chat';
+export type { IChatViewProps, ChatMessage, ChatViewProps, UseChatMessagesOptions, TextResult } from './modules/chat';
+export { MessageList, MessageBubble, ChatInputField, MarkdownRenderer, ChartRenderer, TypingIndicator } from './modules/chat';
+export { useChatMessages } from './modules/chat';
+export type { UseChatMessagesReturn } from './modules/chat';
+
 // --- Shared hooks & utilities ------------------------------------------------
 export { useClickOutside } from './hooks/useClickOutside';
 export { useFixedPopupPosition } from './hooks/useFixedPopupPosition';

--- a/packages/shared-ui/src/modules/chat/ChatView.tsx
+++ b/packages/shared-ui/src/modules/chat/ChatView.tsx
@@ -1,0 +1,49 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * ChatView — host-agnostic conversational chat surface.
+ *
+ * Renders a full-height flex column: scrollable message list + pinned input bar.
+ * All data flows in as props; all actions flow out via callbacks. The host is
+ * responsible for wiring useChatMessages and the RocketRide client singleton.
+ *
+ * Styling uses only predefined --rr-* CSS custom property tokens so the view
+ * automatically adapts to every RocketRide theme (light, dark, VS Code, etc.).
+ */
+
+import React, { type CSSProperties } from 'react';
+import { commonStyles } from '../../themes/styles';
+import type { IChatViewProps } from './types';
+import { MessageList } from './components/MessageList';
+import { ChatInputField } from './components/ChatInputField';
+
+// =============================================================================
+// STYLES
+// =============================================================================
+
+const S = {
+	/** Root — fills whatever container the host provides. */
+	root: {
+		...commonStyles.columnFill,
+		backgroundColor: 'var(--rr-bg-default)',
+		fontFamily: 'var(--rr-font-family-widget)',
+		fontSize: 'var(--rr-font-size-widget)',
+	} as CSSProperties,
+};
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+const ChatView: React.FC<IChatViewProps> = ({ messages, isTyping, isConnected, onSend, placeholder }) => (
+	<div style={S.root}>
+		<MessageList messages={messages} isTyping={isTyping} />
+		<ChatInputField onSend={onSend} disabled={!isConnected} placeholder={placeholder} />
+	</div>
+);
+
+export default ChatView;
+export type { IChatViewProps };

--- a/packages/shared-ui/src/modules/chat/components/ChartRenderer.tsx
+++ b/packages/shared-ui/src/modules/chat/components/ChartRenderer.tsx
@@ -1,0 +1,102 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import React, { useMemo, type CSSProperties } from 'react';
+import { Chart as ChartJS, CategoryScale, LinearScale, RadialLinearScale, PointElement, LineElement, BarElement, ArcElement, Filler, Tooltip, Legend, Title } from 'chart.js';
+import { Bar, Line, Pie, Doughnut, Radar, PolarArea, Scatter, Bubble } from 'react-chartjs-2';
+import { commonStyles } from '../../../themes/styles';
+
+ChartJS.register(CategoryScale, LinearScale, RadialLinearScale, PointElement, LineElement, BarElement, ArcElement, Filler, Tooltip, Legend, Title);
+
+const CHART_COMPONENTS: Record<string, React.ComponentType<any>> = {
+	bar: Bar,
+	line: Line,
+	pie: Pie,
+	doughnut: Doughnut,
+	radar: Radar,
+	polarArea: PolarArea,
+	scatter: Scatter,
+	bubble: Bubble,
+};
+
+const S = {
+	container: {
+		padding: 16,
+		maxWidth: 600,
+		border: '1px solid var(--rr-border)',
+		borderRadius: 6,
+		backgroundColor: 'var(--rr-bg-paper)',
+	} as CSSProperties,
+
+	error: {
+		...commonStyles.cardFlat,
+		border: '1px solid var(--rr-color-error)',
+		fontSize: 13,
+		color: 'var(--rr-color-error)',
+	} as CSSProperties,
+
+	errorPre: {
+		marginTop: 8,
+		fontSize: 12,
+		color: 'var(--rr-text-secondary)',
+		overflowX: 'auto' as const,
+	} as CSSProperties,
+};
+
+/** Recursively strips stringified function values (LLMs may generate these). */
+function stripFunctionStrings(obj: unknown, visited = new Set<unknown>()): unknown {
+	if (typeof obj === 'string' && /^\s*(function\s*\(|\(.*\)\s*=>|[a-zA-Z_$][\w$]*\s*=>)/.test(obj)) return undefined;
+	if (Array.isArray(obj)) return obj.map((v) => stripFunctionStrings(v, visited));
+	if (obj !== null && typeof obj === 'object') {
+		if (visited.has(obj)) return undefined;
+		visited.add(obj);
+		const cleaned: Record<string, unknown> = {};
+		for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+			const c = stripFunctionStrings(v, visited);
+			if (c !== undefined) cleaned[k] = c;
+		}
+		return cleaned;
+	}
+	return obj;
+}
+
+interface ChartRendererProps {
+	config: string;
+}
+
+export const ChartRenderer: React.FC<ChartRendererProps> = ({ config }) => {
+	const result = useMemo(() => {
+		try {
+			let clean = config.trim();
+			if (clean.startsWith('```chartjs')) {
+				clean = clean.slice(10).trim();
+				if (clean.endsWith('```')) clean = clean.slice(0, -3).trim();
+			}
+			const raw = JSON.parse(clean);
+			const parsed = stripFunctionStrings(raw) as Record<string, any>;
+			if (!parsed.type || !parsed.data) return { error: 'Chart config must include "type" and "data".', parsed: null };
+			return { error: null, parsed };
+		} catch {
+			return { error: 'Invalid JSON in chart configuration.', parsed: null };
+		}
+	}, [config]);
+
+	if (result.error || !result.parsed) {
+		return (
+			<div style={S.error}>
+				<strong>{result.error}</strong>
+				<pre style={S.errorPre}>{config}</pre>
+			</div>
+		);
+	}
+
+	const { type, data, options = {} } = result.parsed;
+	const ChartComponent = CHART_COMPONENTS[type] ?? Bar;
+	return (
+		<div style={S.container}>
+			<ChartComponent data={data} options={{ ...options, responsive: true, maintainAspectRatio: true }} />
+		</div>
+	);
+};

--- a/packages/shared-ui/src/modules/chat/components/ChatInputField.tsx
+++ b/packages/shared-ui/src/modules/chat/components/ChatInputField.tsx
@@ -3,7 +3,7 @@
 // Copyright (c) 2026 Aparavi Software AG
 // =============================================================================
 
-import React, { useState, type CSSProperties } from 'react';
+import React, { useRef, useState, type CSSProperties } from 'react';
 import { commonStyles } from '../../../themes/styles';
 
 const S = {
@@ -53,17 +53,21 @@ export const ChatInputField: React.FC<ChatInputFieldProps> = ({ onSend, disabled
 	const [value, setValue] = useState('');
 	const [focused, setFocused] = useState(false);
 	const [hovered, setHovered] = useState(false);
+	const textareaRef = useRef<HTMLTextAreaElement>(null);
 
 	const submit = () => {
 		if (!value.trim() || disabled) return;
 		onSend(value.trim());
 		setValue('');
+		// Reset auto-expanded height so the textarea snaps back to one row
+		if (textareaRef.current) textareaRef.current.style.height = 'auto';
 	};
 
 	return (
 		<div style={S.container}>
 			<div style={S.inner}>
 				<textarea
+					ref={textareaRef}
 					rows={1}
 					style={S.textarea(focused, disabled)}
 					value={value}
@@ -77,7 +81,8 @@ export const ChatInputField: React.FC<ChatInputFieldProps> = ({ onSend, disabled
 					onFocus={() => setFocused(true)}
 					onBlur={() => setFocused(false)}
 					onKeyDown={(e) => {
-						if (e.key === 'Enter' && !e.shiftKey) {
+						// Guard against firing during IME composition (CJK input methods)
+						if (e.key === 'Enter' && !e.shiftKey && !e.nativeEvent.isComposing) {
 							e.preventDefault();
 							submit();
 						}

--- a/packages/shared-ui/src/modules/chat/components/ChatInputField.tsx
+++ b/packages/shared-ui/src/modules/chat/components/ChatInputField.tsx
@@ -1,0 +1,92 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import React, { useState, type CSSProperties } from 'react';
+import { commonStyles } from '../../../themes/styles';
+
+const S = {
+	container: {
+		flexShrink: 0,
+		borderTop: '1px solid var(--rr-border)',
+		padding: '10px 16px',
+		backgroundColor: 'var(--rr-bg-paper)',
+	} as CSSProperties,
+
+	inner: {
+		display: 'flex',
+		alignItems: 'flex-end',
+		gap: 8,
+		maxWidth: 720,
+		margin: '0 auto',
+	} as CSSProperties,
+
+	textarea: (focused: boolean, disabled: boolean): CSSProperties => ({
+		...commonStyles.inputField,
+		resize: 'none' as const,
+		minHeight: 36,
+		maxHeight: 120,
+		overflowY: 'auto' as const,
+		lineHeight: 1.5,
+		borderColor: focused ? 'var(--rr-border-focus)' : disabled ? 'var(--rr-border)' : 'var(--rr-border-input)',
+		opacity: disabled ? 0.6 : 1,
+		transition: 'border-color 0.15s',
+	}),
+
+	sendBtn: (disabled: boolean, hovered: boolean): CSSProperties => ({
+		...commonStyles.buttonPrimary,
+		flexShrink: 0,
+		padding: '7px 14px',
+		...(disabled ? commonStyles.buttonDisabled : {}),
+		...(hovered && !disabled ? { opacity: 0.85 } : {}),
+	}),
+};
+
+interface ChatInputFieldProps {
+	onSend: (text: string) => void;
+	disabled?: boolean;
+	placeholder?: string;
+}
+
+export const ChatInputField: React.FC<ChatInputFieldProps> = ({ onSend, disabled = false, placeholder = 'Ask anything…' }) => {
+	const [value, setValue] = useState('');
+	const [focused, setFocused] = useState(false);
+	const [hovered, setHovered] = useState(false);
+
+	const submit = () => {
+		if (!value.trim() || disabled) return;
+		onSend(value.trim());
+		setValue('');
+	};
+
+	return (
+		<div style={S.container}>
+			<div style={S.inner}>
+				<textarea
+					rows={1}
+					style={S.textarea(focused, disabled)}
+					value={value}
+					disabled={disabled}
+					placeholder={disabled ? 'Connecting…' : placeholder}
+					onChange={(e) => {
+						setValue(e.target.value);
+						e.target.style.height = 'auto';
+						e.target.style.height = `${Math.min(e.target.scrollHeight, 120)}px`;
+					}}
+					onFocus={() => setFocused(true)}
+					onBlur={() => setFocused(false)}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' && !e.shiftKey) {
+							e.preventDefault();
+							submit();
+						}
+					}}
+				/>
+				<button type="button" style={S.sendBtn(disabled || !value.trim(), hovered)} disabled={disabled || !value.trim()} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)} onClick={submit}>
+					Send
+				</button>
+			</div>
+		</div>
+	);
+};

--- a/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
+++ b/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
@@ -116,11 +116,15 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) =
 				),
 				th: ({ children }: any) => <th style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', textAlign: 'left', fontWeight: 600, fontSize: 12, color: 'var(--rr-text-secondary)' }}>{children}</th>,
 				td: ({ children }: any) => <td style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', fontSize: 12 }}>{children}</td>,
-				a: ({ href, children }: any) => (
-					<a href={href} target="_blank" rel="noopener noreferrer" style={S.link} onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')} onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}>
-						{children}
-					</a>
-				),
+				a: ({ href, children }: any) => {
+					// Only allow safe URL schemes — reject javascript:, data:, vbscript: etc.
+					const safeHref = /^(https?|mailto|tel):/i.test(href ?? '') ? href : undefined;
+					return (
+						<a href={safeHref} target="_blank" rel="noopener noreferrer" style={S.link} onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')} onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}>
+							{children}
+						</a>
+					);
+				},
 				blockquote: ({ children }: any) => <blockquote style={S.blockquote}>{children}</blockquote>,
 				ul: ({ children }: any) => <ul style={{ margin: '6px 0', paddingLeft: 20 }}>{children}</ul>,
 				ol: ({ children }: any) => <ol style={{ margin: '6px 0', paddingLeft: 20 }}>{children}</ol>,

--- a/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
+++ b/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
@@ -6,7 +6,6 @@
 import React, { type CSSProperties } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import rehypeRaw from 'rehype-raw';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { ChartRenderer } from './ChartRenderer';
@@ -73,7 +72,6 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) =
 	<div style={S.wrapper}>
 		<ReactMarkdown
 			remarkPlugins={[remarkGfm]}
-			rehypePlugins={[rehypeRaw]}
 			components={{
 				pre: ({ children, ...rest }: any) => {
 					// Skip <pre> wrapper for non-code elements (charts, iframes)

--- a/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
+++ b/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
@@ -1,0 +1,133 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import React, { type CSSProperties } from 'react';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { ChartRenderer } from './ChartRenderer';
+
+const S = {
+	wrapper: {
+		fontSize: 13,
+		lineHeight: 1.6,
+		color: 'var(--rr-text-primary)',
+		fontFamily: 'var(--rr-font-family)',
+	} as CSSProperties,
+
+	iframe: {
+		width: '100%',
+		minHeight: 300,
+		border: '1px solid var(--rr-border)',
+		borderRadius: 6,
+		backgroundColor: 'var(--rr-bg-paper)',
+	} as CSSProperties,
+
+	table: {
+		width: '100%',
+		borderCollapse: 'collapse' as const,
+		margin: '8px 0',
+		fontSize: 12,
+	} as CSSProperties,
+
+	tableWrapper: {
+		overflowX: 'auto' as const,
+		margin: '6px 0',
+	} as CSSProperties,
+
+	inlineCode: {
+		backgroundColor: 'var(--rr-bg-widget)',
+		border: '1px solid var(--rr-border)',
+		borderRadius: 3,
+		padding: '1px 4px',
+		fontSize: 12,
+		fontFamily: 'var(--rr-font-mono, monospace)',
+		color: 'var(--rr-text-primary)',
+	} as CSSProperties,
+
+	blockquote: {
+		borderLeft: '3px solid var(--rr-brand)',
+		paddingLeft: 12,
+		margin: '6px 0',
+		color: 'var(--rr-text-secondary)',
+		fontStyle: 'italic',
+	} as CSSProperties,
+
+	link: {
+		color: 'var(--rr-text-link)',
+		textDecoration: 'none',
+	} as CSSProperties,
+};
+
+const HTML_WRAPPER = (body: string) => `<!DOCTYPE html><html><head><meta charset="UTF-8"><style>body{margin:0;padding:16px;font-family:system-ui,sans-serif;}</style></head><body>${body}</body></html>`;
+
+interface MarkdownRendererProps {
+	content: string;
+}
+
+export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) => (
+	<div style={S.wrapper}>
+		<ReactMarkdown
+			remarkPlugins={[remarkGfm]}
+			rehypePlugins={[rehypeRaw]}
+			components={{
+				pre: ({ children, ...rest }: any) => {
+					// Skip <pre> wrapper for non-code elements (charts, iframes)
+					if (React.isValidElement(children)) {
+						const child = children as React.ReactElement<any>;
+						if (child.type !== 'code') return <>{children}</>;
+					}
+					return <pre {...rest}>{children}</pre>;
+				},
+				code: ({ inline, className, children, ...rest }: any) => {
+					const match = /language-(\w+)/.exec(className ?? '');
+					const lang = match?.[1];
+					const code = String(children).replace(/\n$/, '');
+
+					if (!inline && lang === 'html') {
+						const isDoc = code.trim().startsWith('<!DOCTYPE') || code.trim().startsWith('<html');
+						return <iframe srcDoc={isDoc ? code : HTML_WRAPPER(code)} sandbox="allow-scripts" title="Rendered HTML" style={S.iframe} />;
+					}
+
+					if (!inline && lang === 'chartjs') return <ChartRenderer config={code} />;
+
+					if (!inline && lang) {
+						return (
+							<SyntaxHighlighter style={oneDark} language={lang} PreTag="div" customStyle={{ margin: 0, borderRadius: 6, fontSize: 12 }}>
+								{code}
+							</SyntaxHighlighter>
+						);
+					}
+
+					return (
+						<code style={inline ? S.inlineCode : undefined} className={className} {...rest}>
+							{children}
+						</code>
+					);
+				},
+				table: ({ children }: any) => (
+					<div style={S.tableWrapper}>
+						<table style={S.table}>{children}</table>
+					</div>
+				),
+				th: ({ children }: any) => <th style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', textAlign: 'left', fontWeight: 600, fontSize: 12, color: 'var(--rr-text-secondary)' }}>{children}</th>,
+				td: ({ children }: any) => <td style={{ padding: '6px 10px', borderBottom: '1px solid var(--rr-border)', fontSize: 12 }}>{children}</td>,
+				a: ({ href, children }: any) => (
+					<a href={href} target="_blank" rel="noopener noreferrer" style={S.link} onMouseEnter={(e) => (e.currentTarget.style.textDecoration = 'underline')} onMouseLeave={(e) => (e.currentTarget.style.textDecoration = 'none')}>
+						{children}
+					</a>
+				),
+				blockquote: ({ children }: any) => <blockquote style={S.blockquote}>{children}</blockquote>,
+				ul: ({ children }: any) => <ul style={{ margin: '6px 0', paddingLeft: 20 }}>{children}</ul>,
+				ol: ({ children }: any) => <ol style={{ margin: '6px 0', paddingLeft: 20 }}>{children}</ol>,
+				p: ({ children }: any) => <p style={{ margin: '4px 0', color: 'var(--rr-text-primary)' }}>{children}</p>,
+			}}
+		>
+			{content}
+		</ReactMarkdown>
+	</div>
+);

--- a/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
+++ b/packages/shared-ui/src/modules/chat/components/MarkdownRenderer.tsx
@@ -6,6 +6,8 @@
 import React, { type CSSProperties } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { ChartRenderer } from './ChartRenderer';
@@ -72,6 +74,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({ content }) =
 	<div style={S.wrapper}>
 		<ReactMarkdown
 			remarkPlugins={[remarkGfm]}
+			rehypePlugins={[rehypeRaw, rehypeSanitize]}
 			components={{
 				pre: ({ children, ...rest }: any) => {
 					// Skip <pre> wrapper for non-code elements (charts, iframes)

--- a/packages/shared-ui/src/modules/chat/components/MessageBubble.tsx
+++ b/packages/shared-ui/src/modules/chat/components/MessageBubble.tsx
@@ -1,0 +1,109 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import React, { type CSSProperties } from 'react';
+import type { ChatMessage } from '../types';
+import { MarkdownRenderer } from './MarkdownRenderer';
+
+const S = {
+	// ── User bubble ────────────────────────────────────────────────────────────
+	userRow: {
+		display: 'flex',
+		justifyContent: 'flex-end',
+		marginBottom: 12,
+	} as CSSProperties,
+
+	userBubble: {
+		maxWidth: '78%',
+		padding: '9px 14px',
+		borderRadius: '14px 14px 4px 14px',
+		backgroundColor: 'var(--rr-bg-widget)',
+		border: '1px solid var(--rr-border)',
+		color: 'var(--rr-text-primary)',
+		fontSize: 13,
+		lineHeight: 1.5,
+	} as CSSProperties,
+
+	// ── Bot / system bubble ─────────────────────────────────────────────────────
+	botRow: {
+		marginBottom: 16,
+	} as CSSProperties,
+
+	// ── Status dot row ──────────────────────────────────────────────────────────
+	statusRow: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: 6,
+		padding: '2px 0',
+		marginBottom: 4,
+	} as CSSProperties,
+
+	statusDot: {
+		width: 5,
+		height: 5,
+		borderRadius: '50%',
+		backgroundColor: 'var(--rr-brand)',
+		opacity: 0.5,
+		flexShrink: 0,
+	} as CSSProperties,
+
+	statusText: {
+		fontSize: 11,
+		color: 'var(--rr-text-caption)',
+		fontStyle: 'italic',
+	} as CSSProperties,
+
+	// ── Shared ──────────────────────────────────────────────────────────────────
+	timestamp: {
+		fontSize: 10,
+		color: 'var(--rr-text-caption)',
+		marginTop: 4,
+	} as CSSProperties,
+
+	resultKey: {
+		fontSize: 10,
+		color: 'var(--rr-text-caption)',
+		fontStyle: 'italic',
+		marginLeft: 6,
+	} as CSSProperties,
+};
+
+interface MessageBubbleProps {
+	message: ChatMessage;
+}
+
+export const MessageBubble: React.FC<MessageBubbleProps> = ({ message }) => {
+	if (message.sender === 'status') {
+		return (
+			<div style={S.statusRow}>
+				<span style={S.statusDot} />
+				<span style={S.statusText}>{message.text}</span>
+			</div>
+		);
+	}
+
+	if (message.sender === 'user') {
+		return (
+			<div style={S.userRow}>
+				<div style={S.userBubble}>
+					<p style={{ margin: 0 }}>{message.text}</p>
+					<div style={{ ...S.timestamp, textAlign: 'right' }}>{message.timestamp}</div>
+				</div>
+			</div>
+		);
+	}
+
+	// bot / system — use markdown renderer
+	const hasChart = /^```chartjs/m.test(message.text);
+	return (
+		<div style={{ ...S.botRow, maxWidth: hasChart ? '100%' : '85%' }}>
+			<MarkdownRenderer content={message.text} />
+			<div style={S.timestamp}>
+				{message.timestamp}
+				{message.resultKey && <span style={S.resultKey}>{message.resultKey}</span>}
+			</div>
+		</div>
+	);
+};

--- a/packages/shared-ui/src/modules/chat/components/MessageList.tsx
+++ b/packages/shared-ui/src/modules/chat/components/MessageList.tsx
@@ -1,0 +1,118 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import React, { useEffect, useRef, useMemo, useState, type CSSProperties } from 'react';
+import type { ChatMessage } from '../types';
+import { MessageBubble } from './MessageBubble';
+import { TypingIndicator } from './TypingIndicator';
+
+const S = {
+	scroll: {
+		flex: 1,
+		overflowY: 'auto' as const,
+		padding: '16px 20px',
+		minHeight: 0,
+		scrollbarWidth: 'thin' as const,
+		scrollbarColor: 'var(--rr-bg-scrollbar-thumb) transparent',
+	} as CSSProperties,
+
+	thinkingGroup: {
+		marginBottom: 8,
+	} as CSSProperties,
+
+	thinkingToggle: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: 6,
+		background: 'none',
+		border: 'none',
+		cursor: 'pointer',
+		padding: '2px 0',
+		color: 'var(--rr-text-caption)',
+		fontSize: 11,
+		fontStyle: 'italic',
+		type: 'button',
+	} as CSSProperties,
+
+	thinkingChevron: (open: boolean): CSSProperties => ({
+		width: 0,
+		height: 0,
+		borderLeft: '4px solid transparent',
+		borderRight: '4px solid transparent',
+		borderTop: '5px solid currentColor',
+		transition: 'transform 0.15s',
+		transform: open ? 'rotate(0deg)' : 'rotate(-90deg)',
+	}),
+
+	thinkingBody: {
+		paddingLeft: 12,
+		borderLeft: '2px solid var(--rr-border)',
+		marginLeft: 2,
+		marginTop: 2,
+	} as CSSProperties,
+};
+
+// Collapsible thinking group
+const ThinkingGroup: React.FC<{ messages: ChatMessage[] }> = ({ messages }) => {
+	const [open, setOpen] = useState(false);
+	return (
+		<div style={S.thinkingGroup}>
+			<button type="button" style={S.thinkingToggle} onClick={() => setOpen((o) => !o)}>
+				<span style={S.thinkingChevron(open)} />
+				Thinking…
+			</button>
+			{open && (
+				<div style={S.thinkingBody}>
+					{messages.map((m) => (
+						<MessageBubble key={m.id} message={m} />
+					))}
+				</div>
+			)}
+		</div>
+	);
+};
+
+// RenderItem union
+type RenderItem = { kind: 'message'; message: ChatMessage } | { kind: 'thinking-group'; id: number; messages: ChatMessage[] };
+
+interface MessageListProps {
+	messages: ChatMessage[];
+	isTyping: boolean;
+}
+
+export const MessageList: React.FC<MessageListProps> = ({ messages, isTyping }) => {
+	const endRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		endRef.current?.scrollIntoView({ behavior: 'smooth' });
+	}, [messages, isTyping]);
+
+	const items = useMemo((): RenderItem[] => {
+		const out: RenderItem[] = [];
+		let group: ChatMessage[] | null = null;
+
+		for (const msg of messages) {
+			if (msg.sender === 'status' && msg.sseType === 'thinking') {
+				if (!group) {
+					group = [];
+					out.push({ kind: 'thinking-group', id: msg.id, messages: group });
+				}
+				group.push(msg);
+			} else {
+				group = null;
+				out.push({ kind: 'message', message: msg });
+			}
+		}
+		return out;
+	}, [messages]);
+
+	return (
+		<div style={S.scroll}>
+			{items.map((item) => (item.kind === 'thinking-group' ? <ThinkingGroup key={`tg-${item.id}`} messages={item.messages} /> : <MessageBubble key={item.message.id} message={item.message} />))}
+			{isTyping && <TypingIndicator />}
+			<div ref={endRef} />
+		</div>
+	);
+};

--- a/packages/shared-ui/src/modules/chat/components/TypingIndicator.tsx
+++ b/packages/shared-ui/src/modules/chat/components/TypingIndicator.tsx
@@ -1,0 +1,58 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import React, { type CSSProperties } from 'react';
+
+// Keyframe injected once per session
+const KF_ID = 'rr-chat-typing-kf';
+function injectKeyframe() {
+	if (typeof document === 'undefined' || document.getElementById(KF_ID)) return;
+	const el = document.createElement('style');
+	el.id = KF_ID;
+	el.textContent = '@keyframes rr-chat-dot{0%,80%,100%{transform:scale(0.6);opacity:0.4}40%{transform:scale(1);opacity:1}}';
+	document.head.appendChild(el);
+}
+
+const S = {
+	row: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: 4,
+		padding: '6px 0',
+	} as CSSProperties,
+
+	dot: (delay: number) =>
+		({
+			width: 7,
+			height: 7,
+			borderRadius: '50%',
+			backgroundColor: 'var(--rr-text-secondary)',
+			animation: 'rr-chat-dot 1.2s ease-in-out infinite',
+			animationDelay: `${delay}s`,
+		}) as CSSProperties,
+
+	label: {
+		fontSize: 12,
+		color: 'var(--rr-text-caption)',
+		fontStyle: 'italic',
+		marginLeft: 4,
+	} as CSSProperties,
+};
+
+interface TypingIndicatorProps {
+	label?: string;
+}
+
+export const TypingIndicator: React.FC<TypingIndicatorProps> = ({ label }) => {
+	injectKeyframe();
+	return (
+		<div style={S.row}>
+			<span style={S.dot(0)} />
+			<span style={S.dot(0.16)} />
+			<span style={S.dot(0.32)} />
+			{label && <span style={S.label}>{label}</span>}
+		</div>
+	);
+};

--- a/packages/shared-ui/src/modules/chat/components/index.ts
+++ b/packages/shared-ui/src/modules/chat/components/index.ts
@@ -1,0 +1,6 @@
+export { TypingIndicator } from './TypingIndicator';
+export { ChartRenderer } from './ChartRenderer';
+export { MarkdownRenderer } from './MarkdownRenderer';
+export { MessageBubble } from './MessageBubble';
+export { MessageList } from './MessageList';
+export { ChatInputField } from './ChatInputField';

--- a/packages/shared-ui/src/modules/chat/hooks/index.ts
+++ b/packages/shared-ui/src/modules/chat/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useChatMessages } from './useChatMessages';
+export type { UseChatMessagesReturn } from './useChatMessages';

--- a/packages/shared-ui/src/modules/chat/hooks/useChatMessages.ts
+++ b/packages/shared-ui/src/modules/chat/hooks/useChatMessages.ts
@@ -102,7 +102,7 @@ export function useChatMessages({ welcomeMessage }: UseChatMessagesOptions = {})
 				token: authToken,
 				question,
 				onSSE: async (type: string, data: Record<string, unknown>) => {
-					const text = data.message as string | undefined;
+					const text = typeof data.message === 'string' ? data.message : undefined;
 					if (text) {
 						updateMessages((prev) => [
 							...prev,

--- a/packages/shared-ui/src/modules/chat/hooks/useChatMessages.ts
+++ b/packages/shared-ui/src/modules/chat/hooks/useChatMessages.ts
@@ -1,0 +1,174 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import { useState, useCallback, useRef } from 'react';
+import { Question, QuestionType, PIPELINE_RESULT } from 'rocketride';
+import type { ChatMessage, TextResult, UseChatMessagesOptions } from '../types';
+
+// Module-level monotonic counter — guarantees unique IDs even when multiple
+// messages are created within the same millisecond (e.g. batched SSE updates).
+let _nextId = 1;
+const nextId = () => _nextId++;
+
+// =============================================================================
+// extractTextFromResult
+// =============================================================================
+
+/**
+ * Extracts displayable text responses from a RocketRide pipeline result.
+ * Handles the dynamic field system where result_types maps field names to types.
+ */
+function extractTextFromResult(result: PIPELINE_RESULT): TextResult[] {
+	const out: TextResult[] = [];
+
+	if (!result.result_types) {
+		out.push({ text: '### No answers found\nAre you sure your pipeline returns them?', key: '' });
+		return out;
+	}
+
+	for (const [field, type] of Object.entries(result.result_types)) {
+		if (type !== 'text' && type !== 'answers') continue;
+		const data = result[field];
+
+		if (Array.isArray(data)) {
+			data.filter((v) => typeof v === 'string' && v.trim()).forEach((v) => out.push({ text: v, key: field }));
+		} else if (typeof data === 'string' && data.trim()) {
+			out.push({ text: data, key: field });
+		} else if (data !== null && typeof data === 'object' && typeof (data as Record<string, unknown>).answer === 'string') {
+			const text = ((data as Record<string, unknown>).answer as string).trim();
+			if (text) out.push({ text, key: field });
+		}
+	}
+
+	return out;
+}
+
+// =============================================================================
+// useChatMessages
+// =============================================================================
+
+export interface UseChatMessagesReturn {
+	messages: ChatMessage[];
+	isTyping: boolean;
+	sendMessage: (text: string, client: any, authToken: string) => Promise<void>;
+	clearMessages: () => void;
+	addSystemMessage: (text: string) => void;
+}
+
+/**
+ * Manages chat message state and RocketRide API communication.
+ *
+ * IMPORTANT: always use the internal updateMessages helper — never call
+ * setMessages directly. Direct setMessages calls bypass the messagesRef
+ * sync and will cause sendMessage to build history from a stale snapshot.
+ */
+export function useChatMessages({ welcomeMessage }: UseChatMessagesOptions = {}): UseChatMessagesReturn {
+	const [messages, setMessages] = useState<ChatMessage[]>([]);
+	const [isTyping, setIsTyping] = useState(false);
+
+	const messagesRef = useRef<ChatMessage[]>([]);
+
+	const updateMessages = useCallback((updater: (prev: ChatMessage[]) => ChatMessage[]) => {
+		setMessages((prev) => {
+			const next = updater(prev);
+			messagesRef.current = next;
+			return next;
+		});
+	}, []);
+
+	const ts = () => new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+	const sendMessageToAPI = useCallback(
+		async (userMessage: string, client: any, authToken: string): Promise<TextResult[]> => {
+			if (!client || !authToken) throw new Error('Not connected. Please refresh the page.');
+
+			const question = new Question({ type: QuestionType.PROMPT, expectJson: false });
+			question.addQuestion(userMessage);
+
+			// Use ref so history is always built from the latest messages
+			messagesRef.current
+				.filter((m) => m.sender !== 'system' && m.sender !== 'status')
+				.slice(-6)
+				.forEach((m) =>
+					question.addHistory({
+						role: m.sender === 'user' ? 'user' : 'assistant',
+						content: m.text,
+					})
+				);
+
+			const result: PIPELINE_RESULT = await client.chat({
+				token: authToken,
+				question,
+				onSSE: async (type: string, data: Record<string, unknown>) => {
+					const text = data.message as string | undefined;
+					if (text) {
+						updateMessages((prev) => [
+							...prev,
+							{
+								id: nextId(),
+								text,
+								sender: 'status',
+								sseType: type,
+								timestamp: ts(),
+							},
+						]);
+					}
+				},
+			});
+
+			const responses = extractTextFromResult(result);
+			return responses.length > 0 ? responses : [{ text: 'No valid response received', key: '' }];
+		},
+		[updateMessages]
+	);
+
+	const sendMessage = useCallback(
+		async (text: string, client: any, authToken: string) => {
+			if (!text.trim()) return;
+
+			updateMessages((prev) => [...prev, { id: nextId(), text, sender: 'user', timestamp: ts() }]);
+			setIsTyping(true);
+
+			try {
+				const answers = await sendMessageToAPI(text, client, authToken);
+				const botMsgs: ChatMessage[] = answers.map((a) => ({
+					id: nextId(),
+					text: a.text,
+					sender: 'bot' as const,
+					timestamp: ts(),
+					...(a.key ? { resultKey: a.key } : {}),
+				}));
+				updateMessages((prev) => [...prev, ...botMsgs]);
+			} catch (err) {
+				updateMessages((prev) => [
+					...prev,
+					{
+						id: nextId(),
+						text: err instanceof Error ? err.message : 'An unexpected error occurred. Please try again.',
+						sender: 'bot',
+						timestamp: ts(),
+					},
+				]);
+			} finally {
+				setIsTyping(false);
+			}
+		},
+		[sendMessageToAPI, updateMessages]
+	);
+
+	const addSystemMessage = useCallback(
+		(text: string) => {
+			updateMessages((prev) => [...prev, { id: nextId(), text, sender: 'system', timestamp: ts() }]);
+		},
+		[updateMessages]
+	);
+
+	const clearMessages = useCallback(() => {
+		const text = welcomeMessage ?? 'Chat cleared. How can I help you?';
+		updateMessages(() => [{ id: nextId(), text, sender: 'system', timestamp: ts() }]);
+	}, [welcomeMessage, updateMessages]);
+
+	return { messages, isTyping, sendMessage, clearMessages, addSystemMessage };
+}

--- a/packages/shared-ui/src/modules/chat/index.ts
+++ b/packages/shared-ui/src/modules/chat/index.ts
@@ -1,0 +1,38 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * Chat module — host-agnostic conversational chat surface.
+ *
+ * Typical usage:
+ *   const { messages, isTyping, sendMessage } = useChatMessages();
+ *   const { client, isConnected } = useRocketRideClient();
+ *
+ *   <ChatView
+ *     messages={messages}
+ *     isTyping={isTyping}
+ *     isConnected={isConnected}
+ *     onSend={(text) => sendMessage(text, client, userToken)}
+ *   />
+ */
+
+// ── View ─────────────────────────────────────────────────────────────────────
+export { default as ChatView } from './ChatView';
+export type { IChatViewProps } from './types';
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+export { MessageList } from './components/MessageList';
+export { MessageBubble } from './components/MessageBubble';
+export { ChatInputField } from './components/ChatInputField';
+export { MarkdownRenderer } from './components/MarkdownRenderer';
+export { ChartRenderer } from './components/ChartRenderer';
+export { TypingIndicator } from './components/TypingIndicator';
+
+// ── Hooks ─────────────────────────────────────────────────────────────────────
+export { useChatMessages } from './hooks/useChatMessages';
+export type { UseChatMessagesReturn } from './hooks/useChatMessages';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+export type { ChatMessage, IChatViewProps as ChatViewProps, UseChatMessagesOptions, TextResult } from './types';

--- a/packages/shared-ui/src/modules/chat/types.ts
+++ b/packages/shared-ui/src/modules/chat/types.ts
@@ -1,0 +1,65 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * Type definitions for the chat module.
+ */
+
+// =============================================================================
+// MESSAGE
+// =============================================================================
+
+/** A single message in the conversation. */
+export interface ChatMessage {
+	/** Unique monotonic ID — never collides even within the same millisecond. */
+	id: number;
+	/** Raw text content (may contain markdown). */
+	text: string;
+	/** Who produced the message. */
+	sender: 'user' | 'bot' | 'system' | 'status';
+	/** Formatted time string, e.g. "14:32". */
+	timestamp: string;
+	/** Pipeline result key — shown as a small label below bot messages. */
+	resultKey?: string;
+	/** SSE event type — used to identify thinking-group status messages. */
+	sseType?: string;
+}
+
+// =============================================================================
+// VIEW PROPS
+// =============================================================================
+
+/** Props for the top-level ChatView component. */
+export interface IChatViewProps {
+	/** Current message list managed by the host via useChatMessages. */
+	messages: ChatMessage[];
+	/** Whether the assistant is currently composing a response. */
+	isTyping: boolean;
+	/** Whether the underlying WebSocket client is connected. */
+	isConnected: boolean;
+	/** Called when the user submits a message. */
+	onSend: (text: string) => void;
+	/** Placeholder shown in the input when idle. Defaults to "Ask anything…". */
+	placeholder?: string;
+}
+
+// =============================================================================
+// HOOK OPTIONS
+// =============================================================================
+
+/** Options for useChatMessages. */
+export interface UseChatMessagesOptions {
+	/** System message shown after clearMessages(). */
+	welcomeMessage?: string;
+}
+
+// =============================================================================
+// PIPELINE RESULT (from rocketride SDK)
+// =============================================================================
+
+export interface TextResult {
+	text: string;
+	key: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -548,6 +548,9 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       remark-gfm:
         specifier: ^4.0.1
         version: 4.0.1
@@ -4688,6 +4691,9 @@ packages:
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
 
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
@@ -6782,6 +6788,9 @@ packages:
 
   rehype-raw@7.0.0:
     resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-gfm@4.0.1:
     resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
@@ -12662,6 +12671,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.8
@@ -15364,6 +15379,11 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-raw: 9.1.0
       vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   remark-gfm@4.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -512,6 +512,9 @@ importers:
       react-canny:
         specifier: ~0.0.8
         version: 0.0.9(react@18.3.1)
+      react-chartjs-2:
+        specifier: ^5.2.0
+        version: 5.3.1(chart.js@4.5.1)(react@18.3.1)
       react-device-detect:
         specifier: ~2.2.3
         version: 2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
## Summary

- Adds `packages/shared-ui/src/modules/chat/` — a host-agnostic chat surface following the established shared-ui module pattern (alongside billing, sidebar, account, project)
- Adds `react-chartjs-2` to shared-ui peerDependencies
- Exports chat module from `shared-ui/src/index.ts`

## What's in the chat module

| File | Purpose |
|------|---------|
| `ChatView` | Top-level component — MessageList + ChatInputField |
| `MessageBubble` | User/bot/system/status bubbles; markdown rendering for bot messages |
| `MessageList` | Scrollable list, collapsible thinking groups, auto-scroll |
| `ChatInputField` | Textarea + Send button using `commonStyles` tokens |
| `MarkdownRenderer` | react-markdown + GFM tables + syntax highlighting + chartjs blocks |
| `ChartRenderer` | chart.js renderer with circular-reference guard |
| `TypingIndicator` | Animated bouncing dots |
| `useChatMessages` | Message state, `sendMessage(text, client, token)`, monotonic ID counter |

## Design rules followed

- All colors use `--rr-*` CSS custom property tokens — zero hardcoded hex values
- Props-in, callbacks-out — no internal API calls, host wires the client
- `commonStyles` used for buttons, inputs, layout
- Monotonic `nextId()` counter prevents React key collisions on batched SSE updates

## Test plan

- [ ] Import `ChatView` from `shared` in cloud-ui and verify it renders
- [ ] Send a message and confirm markdown/tables/charts render
- [ ] Verify `useChatMessages` history context is correctly built across turns
- [ ] Confirm all `--rr-*` tokens resolve in both light and dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a complete chat module with ChatView, MessageList, MessageBubble, TypingIndicator, MarkdownRenderer, ChartRenderer, and ChatInputField.
  * Added useChatMessages hook to manage chat state, SSE-style intermediate updates, and message lifecycle controls.
  * Supports rendering charts in messages and an adaptive, connection-aware input experience.

* **Chores**
  * Declared react-chartjs-2 and rehype-sanitize as peer dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->