### PR TITLE
fix(milvus): apply retrieval_score_threshold filter in searchSemantic (#642)

### DIFF
--- a/nodes/src/nodes/milvus/milvus.py
+++ b/nodes/src/nodes/milvus/milvus.py
@@ -269,7 +269,7 @@ class Store(DocumentStoreBase):
                 else:
                     score = float(1.0 / (1.0 + np.exp(point.get('distance') / -100)))  # expit function unwrapped
                 # Ignore it if it doesn't have a high enough score
-                if score < 0.20:
+                if score < self.threshold_search:
                     continue
 
             # Process the entity as needed
@@ -374,6 +374,9 @@ class Store(DocumentStoreBase):
         points = self.client.search(collection_name=self.collection, data=[query.embedding], filter=filter_expression, limit=25 if docFilter.limit <= 10 else docFilter.limit, output_fields=['meta', 'content'])
 
         docs = self._convertToDocs(points[0])
+
+        # Filter results based on retrieval_score_threshold (self.threshold_search)
+        docs = [doc for doc in docs if doc.score >= self.threshold_search]
 
         # Return the results
         return docs

--- a/nodes/test/milvus/test_search_semantic.py
+++ b/nodes/test/milvus/test_search_semantic.py
@@ -1,0 +1,114 @@
+"""
+Tests for Milvus Store.searchSemantic score threshold filtering.
+
+Validates that hits below ``retrieval_score_threshold`` are excluded
+from the result set returned by ``searchSemantic``.
+"""
+
+import sys
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'nodes', 'milvus'))
+
+# Mock heavy dependencies only for the duration of the milvus import so that
+# real modules (numpy, ai.*) remain available to other test files collected in
+# the same pytest session.
+class _FakeDocumentStoreBase:
+    pass
+
+with patch.dict(
+    sys.modules,
+    {
+        'numpy': MagicMock(),
+        'pymilvus': MagicMock(),
+        'depends': MagicMock(),
+        'engLib': MagicMock(),
+        'ai': MagicMock(),
+        'ai.common': MagicMock(),
+        'ai.common.schema': MagicMock(),
+        'ai.common.store': MagicMock(DocumentStoreBase=_FakeDocumentStoreBase),
+        'ai.common.config': MagicMock(),
+    },
+):
+    from milvus import Store
+
+
+class _Doc:
+    def __init__(self, score: float, page_content: str) -> None:
+        self.score = score
+        self.page_content = page_content
+
+
+class TestSearchSemanticScoreThreshold(unittest.TestCase):
+    """``searchSemantic`` must filter out hits below retrieval_score_threshold."""
+
+    def _make_self(self, threshold: float = 0.5) -> MagicMock:
+        mock_self = MagicMock()
+        mock_self.collection = 'c'
+        mock_self.threshold_search = threshold
+        mock_self.doesCollectionExist.return_value = True
+        mock_self._convertFilter.return_value = []
+        mock_self.client.search.return_value = [[]]
+        return mock_self
+
+    def _make_query_and_filter(self) -> tuple[MagicMock, MagicMock]:
+        query = MagicMock()
+        query.embedding = [0.1, 0.2]
+        doc_filter = MagicMock()
+        doc_filter.limit = 10
+        doc_filter.offset = 0
+        return query, doc_filter
+
+    def test_filters_below_threshold(self):
+        mock_self = self._make_self(threshold=0.5)
+        mock_self._convertToDocs.return_value = [
+            _Doc(0.6, 'high 1'),
+            _Doc(0.25, 'low'),
+            _Doc(0.8, 'high 2'),
+        ]
+        query, doc_filter = self._make_query_and_filter()
+
+        results = Store.searchSemantic(mock_self, query, doc_filter)
+
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].page_content, 'high 1')
+        self.assertEqual(results[1].page_content, 'high 2')
+
+    def test_exact_threshold_included(self):
+        mock_self = self._make_self(threshold=0.5)
+        mock_self._convertToDocs.return_value = [_Doc(0.5, 'exact')]
+        query, doc_filter = self._make_query_and_filter()
+
+        results = Store.searchSemantic(mock_self, query, doc_filter)
+
+        self.assertEqual(len(results), 1)
+
+    def test_all_below_threshold_returns_empty(self):
+        mock_self = self._make_self(threshold=0.9)
+        mock_self._convertToDocs.return_value = [
+            _Doc(0.3, 'a'),
+            _Doc(0.5, 'b'),
+        ]
+        query, doc_filter = self._make_query_and_filter()
+
+        results = Store.searchSemantic(mock_self, query, doc_filter)
+
+        self.assertEqual(results, [])
+
+    def test_all_above_threshold_returned(self):
+        mock_self = self._make_self(threshold=0.1)
+        mock_self._convertToDocs.return_value = [
+            _Doc(0.6, 'a'),
+            _Doc(0.7, 'b'),
+        ]
+        query, doc_filter = self._make_query_and_filter()
+
+        results = Store.searchSemantic(mock_self, query, doc_filter)
+
+        self.assertEqual(len(results), 2)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

- Applied the configured `retrieval_score_threshold` inside the `searchSemantic` method of the Milvus vector store.
- Excluded hits mapping below standard user constraints.
- Integrated unit checks via isolated paths (`test_search_semantic.py`).

## Type

Fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

## Linked Issue

Fixes #642


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Semantic search now uses the configured score threshold to filter results, ensuring returned matches meet or exceed the configured threshold.

* **Tests**
  * Added unit tests validating threshold behavior: excludes below-threshold items, includes items equal to threshold, preserves ordering for above-threshold results, and handles all-below/all-above scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->