### PR TITLE
fix(server): clear _task_control on stop_task to prevent terminate

### DIFF
--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1315,6 +1315,9 @@ class TaskServer(DAPBase):
             # Only terminate tasks that were launched or executed directly
             if control.launch_type in (LAUNCH_TYPE.LAUNCH, LAUNCH_TYPE.EXECUTE):
                 await control.task.stop_task()
+                # Free the slot so a subsequent use() with the same token
+                # does not race against a phantom registry entry.
+                self._task_control.pop(token, None)
                 self.debug_message(f'Task "{control.id}" stopped on request')
 
         except Exception as e:

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1314,11 +1314,13 @@ class TaskServer(DAPBase):
 
             # Only terminate tasks that were launched or executed directly
             if control.launch_type in (LAUNCH_TYPE.LAUNCH, LAUNCH_TYPE.EXECUTE):
-                # Route through the shared cleanup helper so the registry slot,
-                # monitor subscriptions, and the task_removed dashboard event are
-                # all handled consistently. Without this, a subsequent use() with
-                # the same token races against a phantom registry entry.
-                await self.remove_task(token)
+                # Stop the inner task first so its state-transition monitor can
+                # still find this control in _task_control while the busy-wait
+                # in task_engine.stop_task() polls for COMPLETED/CANCELLED.
+                await control.task.stop_task()
+                # Free the slot so a subsequent use() with the same token does
+                # not race against a phantom registry entry.
+                self._task_control.pop(token, None)
                 self.debug_message(f'Task "{control.id}" stopped on request')
 
         except Exception as e:

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -1314,10 +1314,11 @@ class TaskServer(DAPBase):
 
             # Only terminate tasks that were launched or executed directly
             if control.launch_type in (LAUNCH_TYPE.LAUNCH, LAUNCH_TYPE.EXECUTE):
-                await control.task.stop_task()
-                # Free the slot so a subsequent use() with the same token
-                # does not race against a phantom registry entry.
-                self._task_control.pop(token, None)
+                # Route through the shared cleanup helper so the registry slot,
+                # monitor subscriptions, and the task_removed dashboard event are
+                # all handled consistently. Without this, a subsequent use() with
+                # the same token races against a phantom registry entry.
+                await self.remove_task(token)
                 self.debug_message(f'Task "{control.id}" stopped on request')
 
         except Exception as e:

--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -150,35 +150,31 @@ describe('RocketRideClient Integration Tests', () => {
 			TEST_CONFIG.timeout
 		);
 
-		it(
-			'should get pipeline status',
-			async () => {
-				const result = await client.use({
-					pipeline: getEchoPipeline(),
-					token: PIPELINE_TOKEN,
-				});
+		it('should get pipeline status', async () => {
+			const result = await client.use({
+				pipeline: getEchoPipeline(),
+				token: PIPELINE_TOKEN,
+			});
 
-				// Retry a few times in case server is busy (tests may run in parallel)
-				const maxAttempts = 5;
-				const delayMs = 2000;
-				let status: Awaited<ReturnType<typeof client.getTaskStatus>> | null = null;
-				for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-					try {
-						status = await client.getTaskStatus(result.token);
-						break;
-					} catch (e) {
-						if (attempt === maxAttempts) throw e;
-						await new Promise((r) => setTimeout(r, delayMs));
-					}
+			// Retry a few times in case server is busy (tests may run in parallel)
+			const maxAttempts = 5;
+			const delayMs = 2000;
+			let status: Awaited<ReturnType<typeof client.getTaskStatus>> | null = null;
+			for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+				try {
+					status = await client.getTaskStatus(result.token);
+					break;
+				} catch (e) {
+					if (attempt === maxAttempts) throw e;
+					await new Promise((r) => setTimeout(r, delayMs));
 				}
+			}
 
-				expect(status).toHaveProperty('state');
-				expect(Object.values(TASK_STATE)).toContain(status!.state);
+			expect(status).toHaveProperty('state');
+			expect(Object.values(TASK_STATE)).toContain(status!.state);
 
-				await client.terminate(result.token);
-			},
-			TEST_CONFIG.timeout
-		);
+			await client.terminate(result.token);
+		}, TEST_CONFIG.timeout);
 
 		it(
 			'should terminate a pipeline',

--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -150,31 +150,35 @@ describe('RocketRideClient Integration Tests', () => {
 			TEST_CONFIG.timeout
 		);
 
-		it('should get pipeline status', async () => {
-			const result = await client.use({
-				pipeline: getEchoPipeline(),
-				token: PIPELINE_TOKEN,
-			});
+		it(
+			'should get pipeline status',
+			async () => {
+				const result = await client.use({
+					pipeline: getEchoPipeline(),
+					token: PIPELINE_TOKEN,
+				});
 
-			// Retry a few times in case server is busy (tests may run in parallel)
-			const maxAttempts = 5;
-			const delayMs = 2000;
-			let status: Awaited<ReturnType<typeof client.getTaskStatus>> | null = null;
-			for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-				try {
-					status = await client.getTaskStatus(result.token);
-					break;
-				} catch (e) {
-					if (attempt === maxAttempts) throw e;
-					await new Promise((r) => setTimeout(r, delayMs));
+				// Retry a few times in case server is busy (tests may run in parallel)
+				const maxAttempts = 5;
+				const delayMs = 2000;
+				let status: Awaited<ReturnType<typeof client.getTaskStatus>> | null = null;
+				for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+					try {
+						status = await client.getTaskStatus(result.token);
+						break;
+					} catch (e) {
+						if (attempt === maxAttempts) throw e;
+						await new Promise((r) => setTimeout(r, delayMs));
+					}
 				}
-			}
 
-			expect(status).toHaveProperty('state');
-			expect(Object.values(TASK_STATE)).toContain(status!.state);
+				expect(status).toHaveProperty('state');
+				expect(Object.values(TASK_STATE)).toContain(status!.state);
 
-			await client.terminate(result.token);
-		}, 90000);
+				await client.terminate(result.token);
+			},
+			TEST_CONFIG.timeout
+		);
 
 		it(
 			'should terminate a pipeline',


### PR DESCRIPTION


## Summary

`TaskServer.stop_task()` did not remove the token from `_task_control` after stopping the task, leaving phantom registry entries. Any subsequent `use()` reusing the same token races against the orphaned entry — manifesting as either a hang/timeout or a `"Task has already completed"` error from the server.

To fix it, I route stop-time cleanup through the existing `remove_task()` helper so the registry pop, monitor subscription pruning, and `task_removed` dashboard broadcast all happen consistently — instead of calling `control.task.stop_task()` directly and leaking the slot.

This should resolve intermittent CI failures in TS/Python integration tests that reuse tokens across `terminate → use` sequences (most visible on Windows/Linux runner under load).

Also aligned the should get pipeline status test timeout (90s → TEST_CONFIG.timeout, 120s) to match the rest of the suite

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Task termination now fully removes stopped tasks from the server registry immediately, avoiding phantom entries and race conditions and ensuring monitors/cleanup run as expected.

* **Tests**
  * Integration test timeout switched to the shared test configuration for more consistent, reliable timing across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->