### PR TITLE
fix(client-python): clean pending DAP request on send failure

### DIFF
--- a/packages/client-python/src/rocketride/core/dap_client.py
+++ b/packages/client-python/src/rocketride/core/dap_client.py
@@ -229,6 +229,7 @@ class DAPClient(DAPBase):
             # Send request through transport
             await self._send(message)
         except Exception:
+            self._pending_requests.pop(seq, None)
             self.raise_exception(ConnectionError('Could not send request'))
 
         try:

--- a/packages/client-python/tests/test_dap_client.py
+++ b/packages/client-python/tests/test_dap_client.py
@@ -1,0 +1,35 @@
+import asyncio
+
+import pytest
+
+from rocketride.core.dap_client import DAPClient
+
+
+class FailingSendTransport:
+    def __init__(self):
+        self.send_count = 0
+        self.handlers = {}
+
+    def bind(self, **handlers):
+        self.handlers = handlers
+
+    def is_connected(self):
+        return True
+
+    async def send(self, message):
+        self.send_count += 1
+        raise RuntimeError('send failed')
+
+
+def test_request_cleans_pending_request_when_send_fails():
+    async def run_test():
+        transport = FailingSendTransport()
+        client = DAPClient(module='TEST', transport=transport)
+
+        with pytest.raises(ConnectionError, match='Could not send request'):
+            await client.request({'type': 'request', 'command': 'example', 'seq': 42})
+
+        assert transport.send_count == 1
+        assert client._pending_requests == {}
+
+    asyncio.run(run_test())


### PR DESCRIPTION
## Summary

- Clean up Python DAP pending request state when transport send fails.
- Prevent stale pending request futures after failed sends.
- Add focused regression coverage with a fake transport.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

## Linked Issue

Fixes #735

## Problem

`DAPClient.request()` registers a pending request before sending. If the send path raises, the method exits before the normal pending-request cleanup runs, leaving stale state behind.

## Fix

Remove the request's pending entry when send fails, while preserving the existing exception behavior.

Successful request handling, timeout behavior, response correlation, and disconnect cleanup are unchanged.

## Local Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest packages/client-python/tests/test_dap_client.py -q` ✅
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest packages/client-python/tests/test_dap_client.py packages/client-python/tests/test_client_env_loading.py -q` ✅

## Notes

This PR is intentionally scoped to the Python client DAP send-failure path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed issue where pending requests were not properly cleaned up when transport send operations failed, preventing stale pending state and potential resource leaks.

* **Tests**
  * Added comprehensive test coverage for transport send failure scenarios, verifying proper error conversion and internal state cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->