### PR TITLE
fix(client-python): normalize server URI paths before appending task service

### DIFF
--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -313,8 +313,11 @@ class ConnectionMixin(DAPClient):
         parsed = urllib.parse.urlparse(normalized)
 
         ws_scheme = 'wss' if parsed.scheme in ('https', 'wss') else 'ws'
-        ws_uri = parsed._replace(scheme=ws_scheme)
-        return f'{ws_uri.geturl()}/task/service'
+        path = parsed.path.rstrip('/')
+        if not path.endswith('/task/service'):
+            path = f'{path}/task/service' if path else '/task/service'
+        ws_uri = parsed._replace(scheme=ws_scheme, path=path)
+        return ws_uri.geturl()
 
     def _set_uri(self, uri: str) -> None:
         """Update the server URI (internal)."""

--- a/packages/client-python/tests/test_connection_uri.py
+++ b/packages/client-python/tests/test_connection_uri.py
@@ -1,0 +1,18 @@
+import pytest
+
+from rocketride.mixins.connection import ConnectionMixin
+
+
+@pytest.mark.parametrize(
+    ('input_uri', 'expected_uri'),
+    [
+        ('https://cloud.rocketride.ai', 'wss://cloud.rocketride.ai/task/service'),
+        ('https://cloud.rocketride.ai/', 'wss://cloud.rocketride.ai/task/service'),
+        ('wss://cloud.rocketride.ai/task/service', 'wss://cloud.rocketride.ai/task/service'),
+        ('ws://localhost:5565', 'ws://localhost:5565/task/service'),
+        ('ws://localhost:5565/', 'ws://localhost:5565/task/service'),
+        ('ws://localhost:5565/task/service', 'ws://localhost:5565/task/service'),
+    ],
+)
+def test_get_websocket_uri_normalizes_task_service_path(input_uri, expected_uri):
+    assert ConnectionMixin._get_websocket_uri(input_uri) == expected_uri

--- a/packages/client-python/tests/test_connection_uri.py
+++ b/packages/client-python/tests/test_connection_uri.py
@@ -6,8 +6,12 @@ from rocketride.mixins.connection import ConnectionMixin
 @pytest.mark.parametrize(
     ('input_uri', 'expected_uri'),
     [
+        ('http://localhost:5565', 'ws://localhost:5565/task/service'),
+        ('http://localhost:5565/', 'ws://localhost:5565/task/service'),
         ('https://cloud.rocketride.ai', 'wss://cloud.rocketride.ai/task/service'),
         ('https://cloud.rocketride.ai/', 'wss://cloud.rocketride.ai/task/service'),
+        ('wss://cloud.rocketride.ai', 'wss://cloud.rocketride.ai/task/service'),
+        ('wss://cloud.rocketride.ai/', 'wss://cloud.rocketride.ai/task/service'),
         ('wss://cloud.rocketride.ai/task/service', 'wss://cloud.rocketride.ai/task/service'),
         ('ws://localhost:5565', 'ws://localhost:5565/task/service'),
         ('ws://localhost:5565/', 'ws://localhost:5565/task/service'),

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -435,13 +435,23 @@ export class RocketRideClient extends DAPClient {
 	 */
 	private _getWebsocketUri(uri: string): string {
 		const httpUrl = RocketRideClient.normalizeUri(uri);
+		const SERVICE_PATH = '/task/service';
 
 		try {
 			const url = new URL(httpUrl);
 			const wsScheme = url.protocol === 'https:' || url.protocol === 'wss:' ? 'wss:' : 'ws:';
-			return `${wsScheme}//${url.host}/task/service`;
+			// Normalize the path: strip trailing slash, then append /task/service
+			// only if it isn't already present (prevents double-path when callers
+			// pass an already-normalized WebSocket endpoint).
+			let path = url.pathname.replace(/\/+$/, '');
+			if (!path.endsWith(SERVICE_PATH)) {
+				path = path ? `${path}${SERVICE_PATH}` : SERVICE_PATH;
+			}
+			return `${wsScheme}//${url.host}${path}`;
 		} catch {
-			return `${httpUrl}/task/service`;
+			// Fallback for unparseable URIs — same trailing-slash + dedup logic
+			const stripped = httpUrl.replace(/\/+$/, '');
+			return stripped.endsWith(SERVICE_PATH) ? stripped : `${stripped}${SERVICE_PATH}`;
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Normalize Python SDK server URI paths before building the WebSocket task-service endpoint.
- Prevent `//task/service` for trailing-slash server URLs.
- Prevent duplicate `/task/service/task/service` when callers pass an already-normalized WebSocket endpoint.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

## Linked Issue

Fixes #737

## Problem

`ConnectionMixin._get_websocket_uri()` converted the URI scheme and then appended `/task/service` to the full URL string unconditionally. Inputs with a trailing slash produced a double slash before `task/service`, and inputs already ending in `/task/service` duplicated the service path.

## Fix

Normalize the parsed URL path first, then append `/task/service` only when the cleaned path does not already end with it.

This preserves existing host-only URI behavior and keeps successful scheme conversion unchanged.

## Local Testing

- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest packages/client-python/tests/test_connection_uri.py -q` ✅
- `PYTHONDONTWRITEBYTECODE=1 python3 -m pytest packages/client-python/tests/test_connection_uri.py packages/client-python/tests/test_client_env_loading.py -q` ✅

## Notes

This PR is intentionally scoped to Python client URI path normalization and does not change authentication, environment loading, connection retry behavior, or network transport behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected WebSocket URI normalization in Python and TypeScript clients to handle trailing slashes and prevent duplicate path segments, ensuring reliable endpoint construction and scheme conversion.

* **Tests**
  * Added tests covering multiple URL formats and schemes to validate consistent WebSocket URI normalization and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->