### PR TITLE
fix(ci): use literal ROCKETRIDE_APIKEY in Test step instead of secret

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -128,10 +128,23 @@ jobs:
         # client. Both sides need the same shared secret to authenticate;
         # without ROCKETRIDE_APIKEY the server raises AuthenticationException
         # and the client tests fail with "No authentication configured".
-        # The secret value itself doesn't matter — it just has to match
-        # between server and client in this single CI run.
+        #
+        # Use a literal CI-only value rather than ${{ secrets.ROCKETRIDE_APIKEY }}.
+        # The original PR #712 wired this through a secret, but as its own
+        # inline comment noted, "the secret value itself doesn't matter — it
+        # just has to match between server and client in this single CI run."
+        # Sourcing it from a secret introduced an empty-string failure mode:
+        # when the secret is unset / cleared / rotated, the workflow silently
+        # passes ROCKETRIDE_APIKEY="" into the test step. The test client
+        # then picks that empty value up via os.getenv (which returns "" —
+        # not the MYAPIKEY default — when the variable is set-but-empty),
+        # and all 48 client-python integration tests fail uniformly with
+        # AuthenticationException. The literal below has no production
+        # significance — it never leaves the runner — and matches the
+        # documented "MYAPIKEY" placeholder used elsewhere in the codebase
+        # (.env.template, the engine's built-in dev key).
         env:
-          ROCKETRIDE_APIKEY: ${{ secrets.ROCKETRIDE_APIKEY }}
+          ROCKETRIDE_APIKEY: MYAPIKEY
         run: ${{ matrix.builder_cmd }} test --verbose -s
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
## Summary

Replace `ROCKETRIDE_APIKEY: ${{ secrets.ROCKETRIDE_APIKEY }}` with a literal `MYAPIKEY` in the Test step's env block. Companion fix to #734 — together they clear the two CI/CD failure modes that have been blocking the queue.

## Why

PR #712 added the env var to unblock client-python integration tests. Its own inline comment correctly noted that *"the secret value itself doesn't matter — it just has to match between server and client in this single CI run"*. Sourcing it from `secrets.ROCKETRIDE_APIKEY` introduced an empty-string failure mode:

1. The secret was created 2026-04-27 and never updated since. If it's set to `""` (or rotated to a value the engine no longer accepts), the workflow silently expands the expression to `ROCKETRIDE_APIKEY=""`.
2. The test client reads it via `os.getenv('ROCKETRIDE_APIKEY', 'MYAPIKEY')`. **`os.getenv` returns the empty string when the variable is set-but-empty — not the default** — so the client authenticates with `""`.
3. The server sees the same empty key, returns `AuthenticationException`, and all 48 client-python tests fail uniformly across Ubuntu / Windows / macOS.

That's exactly the symptom on develop's most recent CI run and on PRs #715, #728, #738.

A literal eliminates the failure mode without changing observable behaviour. The value isn't a secret (the inline comment was always explicit on this), never leaves the runner, and matches the existing `MYAPIKEY` placeholder used elsewhere (`.env.template`, the engine's built-in dev key).

## Test plan

- [x] YAML syntax validates (`python3 -c "import yaml; yaml.safe_load(...)"`).
- [ ] CI on this PR goes green on all three platforms (Ubuntu / Windows / macOS).
- [ ] After merge, the auth-cluster PRs (#715, #728, #738) update-branch and turn green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

This release contains internal infrastructure updates with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->