### PR TITLE
fix(test): fix parallel test server isolation — remove shared ctx.port fallback

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -170,7 +170,7 @@ jobs:
         # (.env.template, the engine's built-in dev key).
         env:
           ROCKETRIDE_APIKEY: MYAPIKEY
-        run: ${{ matrix.builder_cmd }} test --verbose -s
+        run: ${{ matrix.builder_cmd }} test --verbose
 
       - name: Perform CodeQL Analysis
         if: inputs.codeql && matrix.platform == 'ubuntu'

--- a/nodes/scripts/tasks.js
+++ b/nodes/scripts/tasks.js
@@ -141,8 +141,8 @@ function makeRunPytestAction(options = {}) {
             require('dotenv').config({ path: path.join(PROJECT_ROOT, '.env') });
 
             const bracket = ctx.brackets?.['node-test-server'];
-            const port = bracket?.port || ctx.port;
-            const serverUri = bracket?.serverUri || `http://localhost:${port}`;
+            if (!bracket?.port) throw new Error('node-test-server bracket missing — server did not start');
+            const serverUri = bracket.serverUri || `http://localhost:${bracket.port}`;
 
             const testEnv = {
                 ...process.env,

--- a/packages/client-mcp/scripts/tasks.js
+++ b/packages/client-mcp/scripts/tasks.js
@@ -122,8 +122,8 @@ function makeRunPytestAction(options = {}) {
             require('dotenv').config({ path: path.join(PROJECT_ROOT, '.env') });
 
             const bracket = ctx.brackets?.['mcp-test-server'];
-            const port = bracket?.port || ctx.port;
-            const serverUri = bracket?.serverUri || `http://localhost:${port}`;
+            if (!bracket?.port) throw new Error('mcp-test-server bracket missing — server did not start');
+            const serverUri = bracket.serverUri || `http://localhost:${bracket.port}`;
 
             // MCP and python-dotenv are installed by server:setup-pip
 

--- a/packages/client-python/scripts/tasks.js
+++ b/packages/client-python/scripts/tasks.js
@@ -193,9 +193,9 @@ function makeRunPytestAction(options = {}) {
 			require('dotenv').config({ path: path.join(PROJECT_ROOT, '.env') });
 
 			const bracket = ctx.brackets?.['py-test-server'];
-			const port = bracket?.port || ctx.port;
+			if (!bracket?.port) throw new Error('py-test-server bracket missing — server did not start');
 			// Use existing server URI when set (e.g. ROCKETRIDE_URI=http://localhost:5678 for debugging)
-			const serverUri = bracket?.serverUri || `http://localhost:${port}`;
+			const serverUri = bracket.serverUri || `http://localhost:${bracket.port}`;
 
 			const testEnv = {
 				...process.env,

--- a/packages/client-typescript/scripts/tasks.js
+++ b/packages/client-typescript/scripts/tasks.js
@@ -281,8 +281,8 @@ function makeRunJestAction(options = {}) {
 			require('dotenv').config({ path: path.join(PROJECT_ROOT, '.env') });
 
 			const bracket = ctx.brackets?.['ts-test-server'];
-			const port = bracket?.port || ctx.port;
-			const serverUri = bracket?.serverUri || `http://localhost:${port}`;
+			if (!bracket?.port) throw new Error('ts-test-server bracket missing — server did not start');
+			const serverUri = bracket.serverUri || `http://localhost:${bracket.port}`;
 
 			const testEnv = {
 				...process.env,


### PR DESCRIPTION
## Summary

- Replace `|| ctx.port` shared-context fallback with a hard assertion in all four test modules (`client-typescript`, `client-python`, `client-mcp`, `nodes`); each module already starts its own server on a dynamically assigned port (`--port=0`), but the fallback silently routed subprocesses to whichever module's port was written last to the shared Listr2 context
- Remove the `-s` sequential workaround from CI (added in #734) — parallel execution is now safe by construction
- Update stale `:5565` comment in `_build.yaml` to reflect dynamic per-module port allocation

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #741



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Test runs now fail fast with clear errors when test servers don't start, instead of silently falling back to defaults.

* **Chores**
  * Standardized test command and server URI resolution across build and test environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->