### PR TITLE
fix(test/mocks): correct three Python truthiness/isinstance traps

### DIFF
--- a/nodes/test/mocks/chromadb/__init__.py
+++ b/nodes/test/mocks/chromadb/__init__.py
@@ -199,7 +199,7 @@ class MockCollection:
             count += 1
             
             # Apply limit
-            if limit and len(results["ids"]) >= limit:
+            if limit is not None and len(results["ids"]) >= limit:
                 break
         
         return results

--- a/nodes/test/mocks/chromadb/__init__.py
+++ b/nodes/test/mocks/chromadb/__init__.py
@@ -187,7 +187,11 @@ class MockCollection:
             if count < offset:
                 count += 1
                 continue
-            
+
+            # Apply limit (must be checked before append so limit=0 returns zero items)
+            if limit is not None and len(results["ids"]) >= limit:
+                break
+
             results["ids"].append(id)
             if "metadatas" in include:
                 results["metadatas"].append(self._serialize_metadata(metadata))
@@ -197,11 +201,7 @@ class MockCollection:
                 results["embeddings"].append(data.get("embedding"))
             
             count += 1
-            
-            # Apply limit
-            if limit is not None and len(results["ids"]) >= limit:
-                break
-        
+
         return results
     
     def upsert(

--- a/nodes/test/mocks/psycopg2/__init__.py
+++ b/nodes/test/mocks/psycopg2/__init__.py
@@ -181,7 +181,7 @@ class MockCursor:
                     query_vector = p.tolist()
                 elif isinstance(p, (list, tuple)) and len(p) > 3:
                     query_vector = list(p)
-                elif isinstance(p, int) and p < 1000:
+                elif isinstance(p, int) and not isinstance(p, bool) and p < 1000:
                     limit = p
                 else:
                     filter_params.append(p)
@@ -305,7 +305,7 @@ class MockCursor:
         if "limit" in query.lower() and params:
             # Last param is often the limit
             for p in reversed(params):
-                if isinstance(p, int) and p < 10000:
+                if isinstance(p, int) and not isinstance(p, bool) and p < 10000:
                     return p
         return None
     

--- a/nodes/test/mocks/weaviate/__init__.py
+++ b/nodes/test/mocks/weaviate/__init__.py
@@ -275,7 +275,7 @@ class MockQuery:
             ))
         
         # Sort by distance (lower is better for cosine distance)
-        results.sort(key=lambda x: x.metadata.distance if x.metadata.distance else 1.0)
+        results.sort(key=lambda x: x.metadata.distance if x.metadata.distance is not None else 1.0)
         
         return QueryResult(objects=results[:limit])
     


### PR DESCRIPTION
## Summary

Fixes three pre-existing Python truthiness / `isinstance` bugs in test mocks, identified by CodeRabbit during review of #744. All three are the same class of bug, applied as one commit per file:

1. `nodes/test/mocks/psycopg2/__init__.py` — booleans were matching `isinstance(p, int)` and getting assigned as a SQL `LIMIT`. Fixed by adding `not isinstance(p, bool)` at both call sites (`_handle_semantic_search` line 184 and `_extract_limit` line 308).

2. `nodes/test/mocks/chromadb/__init__.py` — `if limit and ...` treated `limit=0` as "no limit," returning all rows instead of zero. Fixed with `is not None`.

3. `nodes/test/mocks/weaviate/__init__.py` — sort key collapsed `0.0` cosine distance (exact match) into the `1.0` fallback, ranking exact matches last. Fixed with `is not None`.

## Why this matters

Mock-only bugs are sneaky: tests pass against the mock, real behavior diverges in production, and the gap is hard to spot. Catching the truthiness trap class across all three mocks at once seemed worth doing as one PR.

## Testing

Each fix is a one-liner with no behavior change in the cases that previously worked. Existing test suite should remain green; the bugs only manifested in edge cases that no current test exercises.

## Breaking changes

None.

Fixes #747


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mock query handling so numeric controls correctly treat zero as a valid limit and do not conflate booleans with integers.
  * Improved mock vector search ordering so zero distances are recognized as valid and sorted appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->