### PR TITLE
doc: added documentation for inti command for terminal

### DIFF
--- a/docs/README-python-client.md
+++ b/docs/README-python-client.md
@@ -527,7 +527,8 @@ asyncio.run(main())
 The `rocketride` command is installed automatically with the package.
 
 ```bash
-rocketride start pipeline.json              # Start a pipeline
+rocketride init                              # Scaffold .rocketride/ in the current directory
+rocketride start pipeline.json               # Start a pipeline
 rocketride upload *.pdf --token <token>      # Upload files to a running pipeline
 rocketride status --token <token>            # Monitor task progress
 rocketride stop --token <token>              # Terminate a running task
@@ -536,7 +537,9 @@ rocketride events ALL --token <token>        # Stream task events
 rocketride rrext_store get_all_projects      # List stored projects
 ```
 
-All commands accept `--uri` and `--apikey` flags, or read from environment variables.
+`rocketride init` scaffolds `.rocketride/docs/` and installs a stub for the coding agent it detects (Cursor, Claude Code, Windsurf, Copilot, `CLAUDE.md`, or `AGENTS.md`). Re-runs are idempotent — stubs use `<!-- ROCKETRIDE:BEGIN/END -->` markers, so content outside is preserved. Flags: `--agent <name>` (repeatable; `all` for every stub), `--no-agents` (docs only), `--force` / `--no-overwrite` (mutually exclusive; default is to prompt).
+
+All other commands accept `--uri` and `--apikey` flags, or read from environment variables.
 
 ## Configuration
 


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

-Updated the documentation for the init command

## Type

Docs>

## Testing

Only documentation update no testing

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue
Fixes https://github.com/rocketride-org/rocketride-server/issues/656


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the new `rocketride init` command for scaffolding project content with agent and documentation stubs.
  * Documented command flags (`--agent`, `--no-agents`, `--force`, `--no-overwrite`) for controlling initialization behavior.
  * Clarified configuration options for other commands including `--uri` and `--apikey` flags and environment variable support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->