### PR TITLE
Fix python truthiness traps in test mocks

### DIFF
--- a/nodes/test/mocks/chromadb/__init__.py
+++ b/nodes/test/mocks/chromadb/__init__.py
@@ -182,7 +182,8 @@ class MockCollection:
             count += 1
 
             # Apply limit
-            if limit and len(results['ids']) >= limit:
+            # `limit=0` should return zero rows (don't rely on truthiness).
+            if limit is not None and len(results['ids']) >= limit:
                 break
 
         return results

--- a/nodes/test/mocks/psycopg2/__init__.py
+++ b/nodes/test/mocks/psycopg2/__init__.py
@@ -182,7 +182,7 @@ class MockCursor:
                     query_vector = p.tolist()
                 elif isinstance(p, (list, tuple)) and len(p) > 3:
                     query_vector = list(p)
-                elif isinstance(p, int) and p < 1000:
+                elif isinstance(p, int) and not isinstance(p, bool) and p < 1000:
                     limit = p
                 else:
                     filter_params.append(p)
@@ -318,7 +318,7 @@ class MockCursor:
         if 'limit' in query.lower() and params:
             # Last param is often the limit
             for p in reversed(params):
-                if isinstance(p, int) and p < 10000:
+                if isinstance(p, int) and not isinstance(p, bool) and p < 10000:
                     return p
         return None
 

--- a/nodes/test/mocks/weaviate/__init__.py
+++ b/nodes/test/mocks/weaviate/__init__.py
@@ -278,7 +278,9 @@ class MockQuery:
             )
 
         # Sort by distance (lower is better for cosine distance)
-        results.sort(key=lambda x: x.metadata.distance if x.metadata.distance else 1.0)
+        results.sort(
+            key=lambda x: 1.0 if x.metadata.distance is None else x.metadata.distance,
+        )
 
         return QueryResult(objects=results[:limit])
 


### PR DESCRIPTION
## Summary
- Fix bool-as-int LIMIT detection in psycopg2 mock (avoid ).
- Fix chromadb mock so  returns zero rows (no truthiness guard).
- Fix weaviate mock sorting so  doesn't get treated as falsy.

## Test plan
- Run existing test suite in CI.

Refs #747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed database query limit handling to correctly process zero-value limits
  * Improved semantic search parameter validation to properly handle boolean type values
  * Resolved vector search distance sorting to correctly handle missing distance metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->