### PR TITLE
fix: normalize python websocket task uri without duplicating path

### DIFF
--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -314,8 +314,17 @@ class ConnectionMixin(DAPClient):
         parsed = urllib.parse.urlparse(normalized)
 
         ws_scheme = 'wss' if parsed.scheme in ('https', 'wss') else 'ws'
-        ws_uri = parsed._replace(scheme=ws_scheme)
-        return f'{ws_uri.geturl()}/task/service'
+        path = (parsed.path or '/').rstrip('/')
+        if path.endswith('/task/service'):
+            new_path = path
+        elif path == '':
+            new_path = '/task/service'
+        else:
+            new_path = f'{path}/task/service'
+
+        return urllib.parse.urlunparse(
+            (ws_scheme, parsed.netloc, new_path, parsed.params, parsed.query, parsed.fragment),
+        )
 
     def _set_uri(self, uri: str) -> None:
         """Update the server URI (internal)."""

--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -2368,8 +2368,11 @@ Integration tests may fail. Please ensure:
     [
         ('wss://cloud.rocketride.ai', 'wss://cloud.rocketride.ai/task/service'),
         ('https://cloud.rocketride.ai', 'wss://cloud.rocketride.ai/task/service'),
+        ('https://cloud.rocketride.ai/', 'wss://cloud.rocketride.ai/task/service'),
         ('ws://localhost:5565', 'ws://localhost:5565/task/service'),
         ('http://localhost:5565', 'ws://localhost:5565/task/service'),
+        ('ws://localhost:5565/task/service', 'ws://localhost:5565/task/service'),
+        ('ws://localhost:5565/task/service/', 'ws://localhost:5565/task/service'),
     ],
 )
 def test_get_websocket_uri_normalization(input_uri: str, expected_uri: str) -> None:


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

-

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved WebSocket URL construction to reliably handle various URL format variations.
  * Enhanced URL normalization to ensure consistent routing to the service endpoint.
  * Fixed potential path composition issues in WebSocket URI generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->