### PR TITLE
chore(ci): document why CodeQL/container-scan are not required-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,14 @@ jobs:
       - run: echo "Build skipped — no code changes detected"
 
   # ---------------------------------------------------------------------------
-  #  CodeQL — scheduled + push only (not on PRs to avoid blocking releases)
+  #  CodeQL — scheduled + push only (not on PRs to avoid blocking releases).
+  #
+  #  ⚠ DO NOT add this job (or `codeql-cpp` below) to develop/main
+  #  required-status-checks. The `if:` guard skips these on PR runs, and a
+  #  skipped status never satisfies a required check → PRs would hang forever
+  #  in "Expected" state. The aggregator job `CI OK` is the canonical required
+  #  check. Security findings still surface in the Security tab via SARIF
+  #  upload from scheduled runs (weekly cron + every push to develop/main).
   # ---------------------------------------------------------------------------
   codeql:
     name: CodeQL / ${{ matrix.language }}
@@ -135,6 +142,7 @@ jobs:
         with:
           category: '/language:${{ matrix.language }}'
 
+  # codeql-cpp: see ⚠ note above the `codeql` job — same not-required rule applies.
   codeql-cpp:
     name: CodeQL / cpp
     if: github.event_name == 'schedule'
@@ -153,7 +161,12 @@ jobs:
     secrets: inherit
 
   # ---------------------------------------------------------------------------
-  #  Container scan
+  #  Container scan — non-PR only (push/schedule/etc.).
+  #
+  #  ⚠ DO NOT add to develop/main required-status-checks (same caveat as
+  #  CodeQL above). Skipped on PR runs → would block merges. Trivy SARIF
+  #  uploads to the Security tab on every push to develop/main, so findings
+  #  remain visible without gating PR merges.
   # ---------------------------------------------------------------------------
   container-scan:
     name: Container scan / ${{ matrix.dockerfile }}


### PR DESCRIPTION
## Summary

Pure documentation. Adds explicit ⚠ warnings above \`codeql\`, \`codeql-cpp\`, and \`container-scan\` in \`ci.yml\` noting that these jobs MUST NOT be added to \`develop\`/\`main\` required-status-checks.

## Why

These jobs are gated by \`if:\` conditions that skip them on PR events — author intent is already documented in the existing one-line comment (\"scheduled + push only — not on PRs to avoid blocking releases\"). A skipped status check never satisfies GitHub branch protection's required-status check, so PRs hang in \"Expected\" state forever.

That's exactly what surfaced earlier today: PRs couldn't merge because branch protection was waiting on \`CodeQL / *\` and \`Container scan / *\` checks that intentionally don't run on PRs. @stepmikhaylov resolved it by removing them from the required list, leaving only the \`CI OK\` aggregator (the correct pattern). This PR adds the missing context so the same misconfig doesn't get re-applied later by mistake.

## Test plan

- [ ] CI green — change is comments only, zero functional impact
- [ ] Branch protection on \`develop\` continues to require only \`CI OK\` (unchanged)
- [ ] Security tab continues to receive SARIF uploads from scheduled CodeQL + Trivy runs (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration and documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->