### PR TITLE
Fix WebServer signal restoration on restart/shutdown (#764)

### DIFF
--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -49,14 +49,16 @@ Usage::
 """
 
 import os
+import signal
 import sys
+import threading
 import urllib.parse
 import uvicorn
 import asyncio
 import importlib
 import time
 from dotenv import load_dotenv
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from typing import Dict, Any, Callable, Awaitable, List, Optional, Union, Tuple
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import HTMLResponse, PlainTextResponse
@@ -98,6 +100,58 @@ logo = r"""
             Copyright (c) 2026 Aparavi Software AG
                     All rights reserved
     """
+
+
+def _is_restorable_signal_handler(handler: Any) -> bool:
+    """Return True when Python's signal.signal() accepts the saved handler."""
+    return handler in (signal.SIG_IGN, signal.SIG_DFL) or callable(handler)
+
+
+def _build_signal_safe_capture(server: uvicorn.Server):
+    """
+    Build a Uvicorn-compatible signal capture context manager.
+
+    Some embedded or supervisor-driven runtimes can leave a C-level signal
+    handler installed. Python exposes that previous handler as None, but rejects
+    None when a later signal.signal(sig, handler) call tries to restore it.
+    Uvicorn's default capture_signals() restores every saved handler verbatim,
+    which makes shutdown/restart noisy with:
+        TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object
+
+    This preserves Uvicorn's normal behavior while skipping handlers Python
+    cannot restore.
+    """
+    uvicorn_server_module = getattr(uvicorn, 'server', None)
+    handled_signals = getattr(uvicorn_server_module, 'HANDLED_SIGNALS', None)
+    if handled_signals is None:
+        return None
+
+    @contextmanager
+    def capture_signals():
+        if threading.current_thread() is not threading.main_thread():
+            yield
+            return
+
+        original_handlers = {}
+        for sig in handled_signals:
+            try:
+                original_handlers[sig] = signal.signal(sig, server.handle_exit)
+            except (OSError, RuntimeError, ValueError) as exc:
+                debug(f'Unable to install signal handler for {sig}: {exc}')
+
+        try:
+            yield
+        finally:
+            for sig, handler in original_handlers.items():
+                if not _is_restorable_signal_handler(handler):
+                    debug(f'Skipping unrestorable signal handler for {sig}: {handler!r}')
+                    continue
+                signal.signal(sig, handler)
+
+            for captured_signal in reversed(getattr(server, '_captured_signals', [])):
+                signal.raise_signal(captured_signal)
+
+    return capture_signals
 
 
 @asynccontextmanager
@@ -388,7 +442,13 @@ class WebServer:
         )
 
         # Return the configured server instance
-        return uvicorn.Server(config)
+        server = uvicorn.Server(config)
+
+        signal_safe_capture = _build_signal_safe_capture(server)
+        if signal_safe_capture is not None:
+            server.capture_signals = signal_safe_capture
+
+        return server
 
     async def _on_startup(self):
         """

--- a/packages/ai/tests/ai/web/test_server.py
+++ b/packages/ai/tests/ai/web/test_server.py
@@ -1,5 +1,6 @@
 """Tests for ALLOWED_MODULES allowlist and WebServer.use() validation."""
 
+import signal
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -65,7 +66,7 @@ _inject('dotenv', MagicMock())
 _inject('uvicorn', MagicMock())
 
 # Now we can safely import the module under test
-from ai.web.server import WebServer
+from ai.web.server import WebServer, _build_signal_safe_capture
 from ai.modules import ALL as ALLOWED_MODULES
 
 
@@ -163,3 +164,34 @@ class TestUseMethod:
 
         mock_import.assert_not_called()
         cached_module.initModule.assert_not_called()
+
+
+class TestSignalCapture:
+    """Verify Uvicorn shutdown signal restoration is tolerant of embedded runtimes."""
+
+    def test_capture_signals_skips_unrestorable_previous_handler(self, monkeypatch):
+        import ai.web.server as server_module
+
+        handled_signal = signal.SIGTERM
+        fake_server = SimpleNamespace(handle_exit=MagicMock(), _captured_signals=[])
+        calls = []
+
+        server_module.uvicorn.server.HANDLED_SIGNALS = [handled_signal]
+
+        def fake_signal(sig, handler):
+            calls.append((sig, handler))
+            if handler is fake_server.handle_exit:
+                return None
+            if handler is None:
+                raise TypeError('signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object')
+            return signal.SIG_DFL
+
+        monkeypatch.setattr(server_module.signal, 'signal', fake_signal)
+        monkeypatch.setattr(server_module.signal, 'raise_signal', MagicMock())
+
+        capture_signals = _build_signal_safe_capture(fake_server)
+
+        with capture_signals():
+            pass
+
+        assert calls == [(handled_signal, fake_server.handle_exit)]


### PR DESCRIPTION
## Summary

- Fixes RocketRide WebServer shutdown/restart handling when Uvicorn captures a previous signal handler that Python cannot restore.
- Adds a signal-safe capture wrapper that skips unrestorable handlers while preserving Uvicorn’s normal captured-signal replay behavior.
- Adds regression coverage for the unrestorable signal-handler case.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Local checks run:

```text
python -m pytest packages\ai\tests\ai\web\test_server.py
python -m py_compile packages\ai\src\ai\web\server.py
git diff --check

## Checklist

- [ x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ x] No secrets or credentials included
- [ x] Wiki updated (if applicable)
- [ x] Breaking changes documented (if applicable)

## Linked Issue
Fixes #764


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTTP authentication error responses with improved formatting and consistency
  * Better error message handling across different request types
  * Improved server stability during signal handling events

<!-- end of auto-generated comment: release notes by coderabbit.ai -->