### PR TITLE
fix(ci): grant nightly workflow workflows:write to publish prereleases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,6 +13,15 @@ permissions:
   contents: write
   packages: write
   id-token: write
+  # Required so the prerelease tag-push step can push tags whose target
+  # commit touches files under .github/workflows/. Without this, GitHub
+  # rejects with "refusing to allow a GitHub App to create or update
+  # workflow ... without `workflows` permission" — and silently bricks
+  # the whole prerelease pipeline. `Clean up prereleases` runs first and
+  # deletes existing tags, then every prerelease-creation job fails to
+  # push, leaving the repo with zero -prerelease tags until the next
+  # nightly run on a commit that doesn't touch any workflow file.
+  workflows: write
 
 # Triggered when develop's CI run completes successfully — this is the
 # gate. A red CI on develop (whether from a bad merge, a flaky test, or


### PR DESCRIPTION
## Summary

The nightly prerelease pipeline has been silently bricked since at least this morning. **Right now there are zero \`-prerelease\` tags in the repo**, which means anything downstream that consumes the prerelease channel (engine-builder download.js, VS Code extension prerelease, GMI deploy scripts) hits 404.

Joe ran into this trying to download the prerelease engine; Ryan was helping him troubleshoot. Root cause traced from run [25460175734](https://github.com/rocketride-org/rocketride-server/actions/runs/25460175734).

## Root cause

The workflow's tag-push step fails with:

\`\`\`
! [remote rejected] server-v3.1.2-prerelease
  (refusing to allow a GitHub App to create or update workflow
   \`.github/workflows/ci.yml\` without \`workflows\` permission)
\`\`\`

GitHub rejects any tag push whose target commit touches files under \`.github/workflows/\` unless the token has \`workflows: write\`. The nightly's \`permissions:\` block had \`contents: write\` (enough for normal tag pushes) but not \`workflows: write\`.

In practice \`develop\`'s tip often includes workflow edits, so this hits regularly. The failure mode is **invisibly destructive**:

1. \`Clean up prereleases\` runs first → deletes existing \`-prerelease\` tags
2. All 5 prerelease creation jobs (Server, TypeScript Client, Python Client, MCP Client, VS Code Extension) try to push new tags → all rejected
3. End state: zero prereleases, downstream tools 404

## Fix

Add \`workflows: write\` to the workflow-level \`permissions:\` block. Minimal-blast-radius: the token still can't modify workflow files (that's contents-write scoped), it can only tag commits that *contain* workflow file changes — which is the legitimate operation we need.

## Recovery after merge

Once this lands on develop the next nightly run will succeed and the five \`-prerelease\` tags will be re-published. To skip the wait, manually trigger via \`workflow_dispatch\`:

\`\`\`bash
gh workflow run nightly.yaml --repo rocketride-org/rocketride-server --ref develop
\`\`\`

## Test plan

- [ ] CI on this PR passes (it shouldn't even hit the broken path because this PR doesn't trigger nightly)
- [ ] After merge: trigger nightly manually, confirm all 5 prerelease jobs succeed, confirm tags appear: \`server-v3.1.2-prerelease\`, etc.
- [ ] Joe / Ryan verify their downstream tooling can resolve the prerelease again

🤖 Generated with [Claude Code](https://claude.com/claude-code)