### PR TITLE
revert: workflows:write permission (invalid YAML key, was breaking nightly parser)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,15 +13,6 @@ permissions:
   contents: write
   packages: write
   id-token: write
-  # Required so the prerelease tag-push step can push tags whose target
-  # commit touches files under .github/workflows/. Without this, GitHub
-  # rejects with "refusing to allow a GitHub App to create or update
-  # workflow ... without `workflows` permission" — and silently bricks
-  # the whole prerelease pipeline. `Clean up prereleases` runs first and
-  # deletes existing tags, then every prerelease-creation job fails to
-  # push, leaving the repo with zero -prerelease tags until the next
-  # nightly run on a commit that doesn't touch any workflow file.
-  workflows: write
 
 # Triggered when develop's CI run completes successfully — this is the
 # gate. A red CI on develop (whether from a bad merge, a flaky test, or


### PR DESCRIPTION
## Summary

Reverts #772. My fix to add \`workflows: write\` to the nightly's permissions block was based on a misread of the GitHub error message — \`workflows\` is **not** a valid permission key in workflow YAML (it's a PAT scope, not a GITHUB_TOKEN permission). The merged commit broke nightly.yaml parsing entirely:

\`\`\`
failed to parse workflow: (Line: 24, Col: 3): Unexpected value 'workflows'
\`\`\`

So nightly went from "fails on tag push step" to "fails to parse at all" — strictly worse. Reverting restores the original (still-broken-but-parseable) state while we figure out the real fix.

## What the real fix looks like

The error from GitHub:

\`\`\`
refusing to allow a GitHub App to create or update workflow
\`.github/workflows/ci.yml\` without \`workflows\` permission
\`\`\`

…refers to a **token scope**, not a YAML permission. \`GITHUB_TOKEN\` cannot push refs whose target commit modifies workflow files, full stop. The fix needs to be one of:

1. **PAT (Personal Access Token)** with \`repo\` + \`workflow\` scopes, stored as a repo secret (e.g. \`WORKFLOW_PAT\`), used for the tag-push step:

   \`\`\`yaml
   - name: Push prerelease tag
     env:
       GH_TOKEN: \${{ secrets.WORKFLOW_PAT }}
     run: |
       git remote set-url origin https://x-access-token:\${GH_TOKEN}@github.com/\${{ github.repository }}.git
       git push -f origin "\$TAG"
   \`\`\`

2. **GitHub App** with \`workflows: write\` permission, exchanged for a token via \`actions/create-github-app-token\`. Cleaner long-term but more setup.

Either path requires a separate PR + a new secret created by an org owner. I'll do that as a follow-up — for now this revert unblocks the parser.

## Test plan

- [ ] CI passes (this is a pure revert of a workflow YAML change)
- [ ] After merge: \`gh workflow run nightly.yaml --repo rocketride-org/rocketride-server --ref develop\` parses and runs (will still fail at the tag-push step with the original error, but at least it parses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions configuration to streamline CI/CD pipeline operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->