### PR TITLE
fix(ci): push release/prerelease tags via WORKFLOW_PAT (repo+workflow scope)

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -200,11 +200,35 @@ jobs:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
 
       # --- Tag and GitHub Release ---
+      #
+      # IMPORTANT: tag push uses WORKFLOW_PAT (a Personal Access Token with
+      # `repo` + `workflow` scopes) instead of the default GITHUB_TOKEN.
+      #
+      # GitHub rejects any tag push from GITHUB_TOKEN whose target commit
+      # modifies files under `.github/workflows/`, with the error:
+      #
+      #   refusing to allow a GitHub App to create or update workflow
+      #   `.github/workflows/<file>` without `workflows` permission
+      #
+      # `workflows` is a token-level scope, not a YAML permission, so the
+      # only fix is to swap to a credential that has it. WORKFLOW_PAT is
+      # that credential. Without this, every nightly that lands on a
+      # workflow-touching commit silently bricks the prerelease pipeline:
+      # the cleanup job runs first and deletes existing -prerelease tags,
+      # then all 5 prerelease creation jobs fail to push the new ones,
+      # leaving the repo with zero prereleases until the next clean
+      # commit.
       - name: Create tag
         if: inputs.prerelease || steps.tag_check.outputs.exists == 'false'
+        env:
+          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # Swap the remote URL to authenticate with WORKFLOW_PAT for the
+          # push. This affects only this step's git config and goes away
+          # when the runner tears down.
+          git remote set-url origin "https://x-access-token:${WORKFLOW_PAT}@github.com/${GITHUB_REPOSITORY}.git"
           if [ "${{ inputs.prerelease }}" = "true" ]; then
             git tag -f "${{ matrix.tag_name }}"
             git push -f origin "${{ matrix.tag_name }}"


### PR DESCRIPTION
## Summary

The tag-push step in \`_release.yaml\` is silently bricking both prerelease and (eventually) stable release pipelines whenever the target commit touches files under \`.github/workflows/\`. Joe ran into the resulting 404 today; root cause traced and the proper fix landed here.

## Root cause

The \`Create tag\` step in \`_release.yaml\` (lines 208-213) does:

\`\`\`bash
git push -f origin "\$TAG"   # for prerelease (force)
git push origin "\$TAG"      # for stable
\`\`\`

…using the default \`GITHUB_TOKEN\` from \`actions/checkout\`. GitHub's policy rejects any push from a GitHub App / GITHUB_TOKEN that creates or updates a ref pointing at a commit modifying \`.github/workflows/*\`, returning:

\`\`\`
refusing to allow a GitHub App to create or update workflow
\`.github/workflows/<file>\` without \`workflows\` permission
\`\`\`

\`workflows\` is a **token scope** (PAT / App), not a YAML \`permissions:\` key. There's no way to grant it through the workflow file — \`permissions: workflows: write\` is invalid YAML and causes a parser error (PR #772 / #773).

## Destructive sequence when this hits

1. \`cleanup-prereleases\` runs first → deletes existing \`-prerelease\` tags
2. All 5 prerelease creation jobs (Server / TypeScript Client / Python Client / MCP Client / VS Code Extension) fail to push the new tags
3. Repo ends up with **zero \`-prerelease\` tags** until the next nightly run on a workflow-untouched commit

…which is exactly the state the repo is in right now.

## Fix

Set \`origin\` remote URL to authenticate with \`WORKFLOW_PAT\` for the duration of the tag-push step:

\`\`\`yaml
- name: Create tag
  env:
    WORKFLOW_PAT: \${{ secrets.WORKFLOW_PAT }}
  run: |
    ...
    git remote set-url origin "https://x-access-token:\${WORKFLOW_PAT}@github.com/\${GITHUB_REPOSITORY}.git"
    if [ "\${{ inputs.prerelease }}" = "true" ]; then
      git tag -f "\$TAG" && git push -f origin "\$TAG"
    else
      git tag "\$TAG" && git push origin "\$TAG"
    fi
\`\`\`

\`WORKFLOW_PAT\` (a Personal Access Token with \`repo\` + \`workflow\` scopes) was created and added as a repo secret out-of-band before this PR.

## Why this also fixes stable releases

The same \`Create tag\` step handles the prerelease (\`if: prerelease == true\`, force push) and stable (\`else\`, regular push) paths. The PAT swap applies to both. Future \`v3.2.0\` (or any subsequent stable) won't hit the same wall.

## Recovery after merge

\`\`\`bash
gh workflow run nightly.yaml --repo rocketride-org/rocketride-server --ref develop
\`\`\`

Five prerelease tags get republished within ~30 min. Downstream tooling resolves again.

## Test plan

- [ ] CI passes (workflow YAML parse, no functional change to non-tag steps)
- [ ] After merge: manual nightly trigger, verify all 5 prerelease jobs reach the tag-push step and succeed
- [ ] Verify \`gh api repos/.../releases\` lists the 5 \`-prerelease\` tags
- [ ] Joe / Ryan verify engine-builder downloads work again
- [ ] Bonus: at next stable release cut (v3.2.0), confirm tag push works for that too

## Future hardening

- Set a calendar reminder to rotate \`WORKFLOW_PAT\` before its expiration (90 days from today, ~Aug 5).
- Consider migrating to a GitHub App with \`workflows: write\` (more granular, no expiration). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)