### PR TITLE
fix(cli): enable proper signal handling for graceful shutdown

### DIFF
--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -815,12 +815,11 @@ export class RocketRideCLI {
 	}
 
 	private setupSignalHandlers(): void {
-		// TODO: Enable proper signal handling
-		// const signalHandler = () => {
-		// 	this.cancel();
-		// };
-		// process.on('SIGINT', signalHandler);
-		// process.on('SIGTERM', signalHandler);
+		const signalHandler = () => {
+			this.cancel();
+		};
+		process.on('SIGINT', signalHandler);
+		process.on('SIGTERM', signalHandler);
 	}
 
 	private createProgram(): Command {


### PR DESCRIPTION
This PR addresses an open TODO in rocketride.ts regarding process signal handling. Previously, the CLI lacked handlers for SIGINT and SIGTERM, meaning that if a user interrupted a long-running pipeline execution (e.g., via Ctrl+C), the Node process would terminate abruptly. This prevented the RocketRideCLI instance from gracefully disconnecting or halting ongoing background tasks. By hooking into process.on, we now immediately invoke this.cancel(), ensuring active file uploads or monitor streams are cleanly aborted before exit.

## Type
fix

## Testing
- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue
Resolves inline TODO in rocketride.ts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* CLI interrupt and termination signal handling is now functional, enabling graceful shutdown when interrupted with Ctrl+C or system termination requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->