### PR TITLE
Fix/store chunk scoping

### DIFF
--- a/packages/ai/src/ai/common/store.py
+++ b/packages/ai/src/ai/common/store.py
@@ -183,8 +183,7 @@ class DocumentStoreBase(ABC):
                 # If this is the first part of the table
                 if tableKey not in tableDocs:
                     # Add it to the list
-                    # TODO: Fix this
-                    tableDocs[tableKey] = Doc(objectId=objectId, chunk=doc.metadata.chunkId, score=chunk.score)
+                    tableDocs[tableKey] = Doc(objectId=objectId, chunk=chunk.metadata.chunkId, score=chunk.score)
 
                 # Append the text
                 tableDocs[tableKey].page_content += chunk.page_content

--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -817,6 +817,9 @@ export class RocketRideCLI {
 	private setupSignalHandlers(): void {
 		const signalHandler = () => {
 			this.cancel();
+			// Hard-exit guard: if graceful cancellation doesn't propagate within 5s,
+			// force exit with POSIX code 130 (128 + SIGINT) to prevent process hang.
+			setTimeout(() => process.exit(130), 5000).unref();
 		};
 		process.on('SIGINT', signalHandler);
 		process.on('SIGTERM', signalHandler);

--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -815,12 +815,11 @@ export class RocketRideCLI {
 	}
 
 	private setupSignalHandlers(): void {
-		// TODO: Enable proper signal handling
-		// const signalHandler = () => {
-		// 	this.cancel();
-		// };
-		// process.on('SIGINT', signalHandler);
-		// process.on('SIGTERM', signalHandler);
+		const signalHandler = () => {
+			this.cancel();
+		};
+		process.on('SIGINT', signalHandler);
+		process.on('SIGTERM', signalHandler);
 	}
 
 	private createProgram(): Command {


### PR DESCRIPTION
## Summary

This PR patches a variable closure/scoping bug in store.py during full-table reconstruction. In _processFullTables(), when iterating over tableChunks, the code incorrectly referenced doc.metadata.chunkId to build the Doc object. Because doc was defined in a prior outer scope (for docKey, doc in documents.items():), every table chunk incorrectly inherited the chunkId of the last processed document from that previous loop, rather than its own chunk.metadata.chunkId. This scoping bug led to corrupted chunk tracking during table rehydration. This PR corrects the reference to chunk.metadata.chunkId, resolving the inline TODO.

## Type
fix

## Testing
- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue
Resolves inline TODO in store.py



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now installs handlers for termination signals (e.g., Ctrl+C), allowing graceful cancellation with a forced exit fallback.

* **Bug Fixes**
  * Improved table reconstruction so aggregated table entries correctly carry associated metadata and scoring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->