### PR TITLE
fix: resolve chunkId scoping bug in _processFullTables

### DIFF
--- a/packages/ai/src/ai/common/store.py
+++ b/packages/ai/src/ai/common/store.py
@@ -154,7 +154,7 @@ class DocumentStoreBase(ABC):
 
             # Update the score if this one is higher
             if doc.score > tableDocs[tableKey].score:
-                tableDocs[tableKey] = doc.score
+                tableDocs[tableKey].score = doc.score
 
         # If there are no tables, done
         if not len(tableIds):
@@ -182,8 +182,11 @@ class DocumentStoreBase(ABC):
 
                 # If this is the first part of the table
                 if tableKey not in tableDocs:
+                    original_content = chunk.page_content
                     chunk.page_content = ''
                     tableDocs[tableKey] = chunk
+                    tableDocs[tableKey].page_content += original_content
+                    continue
 
                 # Append the text
                 tableDocs[tableKey].page_content += chunk.page_content

--- a/packages/ai/src/ai/common/store.py
+++ b/packages/ai/src/ai/common/store.py
@@ -182,9 +182,8 @@ class DocumentStoreBase(ABC):
 
                 # If this is the first part of the table
                 if tableKey not in tableDocs:
-                    # Add it to the list
-                    # TODO: Fix this
-                    tableDocs[tableKey] = Doc(objectId=objectId, chunk=doc.metadata.chunkId, score=chunk.score)
+                    chunk.page_content = ''
+                    tableDocs[tableKey] = chunk
 
                 # Append the text
                 tableDocs[tableKey].page_content += chunk.page_content


### PR DESCRIPTION
## Problem

In _processFullTables (packages/ai/src/ai/common/store.py), when a table key is
seen for the first time in the inner loop, the code does:

    # TODO: Fix this
    tableDocs[tableKey] = Doc(objectId=objectId, chunk=doc.metadata.chunkId, score=chunk.score)

Two bugs:
1. `doc` is a stale variable from the outer `for docKey, doc in documents.items()` loop.
   Inside `for chunk in tableChunks`, the correct reference is `chunk`.
2. Doc() is called with `objectId` and `chunk` kwargs that don't exist on the Pydantic model,
   producing a malformed Doc object.

## Fix

Use the same pattern as _processFullDocuments: reset page_content on the chunk itself
and store it directly.

    if tableKey not in tableDocs:
        chunk.page_content = ''
        tableDocs[tableKey] = chunk

Resolves #776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed document storage so table chunks are correctly concatenated into single aggregated table documents, improving data consistency.
  * Preserved and updated the highest chunk relevance score when aggregating table chunks to ensure correct ranking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->