### PR TITLE
fix: normalize WebSocket URI path to prevent /task/service duplicationFix/websocket uri 755

### DIFF
--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -314,8 +314,12 @@ class ConnectionMixin(DAPClient):
         parsed = urllib.parse.urlparse(normalized)
 
         ws_scheme = 'wss' if parsed.scheme in ('https', 'wss') else 'ws'
-        ws_uri = parsed._replace(scheme=ws_scheme)
-        return f'{ws_uri.geturl()}/task/service'
+
+        path = parsed.path.rstrip('/')
+        if not path.endswith('/task/service'):
+            path = path + '/task/service'
+
+        return urllib.parse.urlunparse((ws_scheme, parsed.netloc, path, '', '', ''))
 
     def _set_uri(self, uri: str) -> None:
         """Update the server URI (internal)."""

--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -2370,6 +2370,10 @@ Integration tests may fail. Please ensure:
         ('https://cloud.rocketride.ai', 'wss://cloud.rocketride.ai/task/service'),
         ('ws://localhost:5565', 'ws://localhost:5565/task/service'),
         ('http://localhost:5565', 'ws://localhost:5565/task/service'),
+        # Path already contains /task/service - must not duplicate
+        ('wss://cloud.rocketride.ai/task/service', 'wss://cloud.rocketride.ai/task/service'),
+        # Trailing slash must not produce double slash
+        ('http://localhost:5565/', 'ws://localhost:5565/task/service'),
     ],
 )
 def test_get_websocket_uri_normalization(input_uri: str, expected_uri: str) -> None:


### PR DESCRIPTION
## Problem

`_get_websocket_uri` built the final URL via string concatenation:

    return f'{ws_uri.geturl()}/task/service'

This produced malformed URLs in two cases:
1. If the caller passed a URI that already contained `/task/service`
   (e.g. after reconnect), the suffix was appended again, yielding
   `.../task/service/task/service`.
2. A trailing slash on the input produced a double slash:
   `ws://localhost:5565//task/service`.

## Fix

Strip the trailing slash, guard against an existing `/task/service`
suffix, and construct the final URL with `urllib.parse.urlunparse`
instead of string formatting:

    path = parsed.path.rstrip('/')
    if not path.endswith('/task/service'):
        path = path + '/task/service'
    return urllib.parse.urlunparse((ws_scheme, parsed.netloc, path, '', '', ''))

## Tests

Added two parametrized cases to the existing
`test_get_websocket_uri_normalization` suite covering both failure modes.

Resolves #755


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection URL handling to properly normalize paths and prevent duplicate segments or malformed URLs when base URLs contain trailing slashes or existing path segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->