### PR TITLE
fix(ci): drop artifact retention to 1 day to fit 0.5 GB org storage cap

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -36,10 +36,14 @@ on:
         type: boolean
         default: false
       retention_days:
+        # 1 day is enough to chain build → release → docker within the same
+        # workflow run; downloads inside a run work even after "expiry".
+        # Higher retention multiplies the 3-platform artifact set (~2 GB)
+        # against the 0.5 GB org storage cap and overflows it within a day.
         description: Artifact retention in days
         required: false
         type: number
-        default: 3
+        default: 1
 
 jobs:
   build:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -74,7 +74,7 @@ jobs:
       build_stamp: ${{ needs.init.outputs.build_stamp }}
       nodownload: true
       package: true
-      retention_days: 3
+      # retention_days inherits _build.yaml's default (1 day) — see comment there.
     secrets: inherit
 
   cleanup-prereleases:


### PR DESCRIPTION
## Why

Joe flagged in the Ops Teams thread that the org's GitHub Actions storage hit 100% (0.5 GB / 0.5 GB on the free tier). Once it overflows, every `actions/upload-artifact` step and every `docker push` to GHCR fails until storage frees up.

Diagnosed: `rocketride-server` was holding **5.5 GB** of active artifacts (71 of them, all from the last 4 days). Already cleaned them up manually, freeing the cap — but without a retention change we'd be back over within ~24 hours of the next nightly.

## What's actually big

The 3-platform nightly build matrix uploads:
- Windows server-artifacts: ~226 MB
- Linux server-artifacts: ~150 MB
- macOS server-artifacts: ~150 MB
- vscode + 3 client artifacts: smaller, but additive

Per nightly run, total artifact churn is ~2 GB. At the previous 3-day retention that's ~6 GB of steady-state — well over the 0.5 GB cap.

## Fix

- `_build.yaml` — change `retention_days` default from 3 → 1
- `nightly.yaml` — drop the now-redundant explicit `retention_days: 3` (rely on the default)

## Why 1 day is safe

Within a single workflow run, downstream jobs (`prerelease`, `docker`) use `actions/download-artifact` to pull what `build` uploaded. Those in-run downloads continue to work even after the retention timer "expires" — retention only governs persistence beyond the run.

So nothing breaks for the build → release → docker chain. The only thing this changes: you can no longer manually re-download yesterday's nightly artifacts from the GitHub UI 25–72 hours after the run. Acceptable trade — published prereleases are tagged on GitHub Releases anyway.

## Steady-state after merge

~2 GB max (one day's worth of nightly), which still exceeds the free 0.5 GB. Two follow-ups possible (not in this PR):
1. Absorb as overage billing (~$0.40/month at current rates).
2. Stop uploading platform binaries as workflow artifacts entirely — they're already published to GitHub Releases by the prerelease job and don't need to be artifact-attached past the run.

## Test plan

- [x] Diff is minimal (2 files, 6/2 lines)
- [ ] CI passes on this branch
- [ ] After merge, watch the next nightly run: artifacts uploaded with `retention-days: 1` should be visible in the run summary; build → release → docker chain completes
- [ ] 24h after that nightly: artifacts auto-deleted, storage stays under cap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to reduce artifact retention duration from 3 days to 1 day as the default configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->