### PR TITLE
fix: guard against falsy-value traps in psycopg2, chromadb, weaviate mocks

### DIFF
--- a/nodes/test/mocks/chromadb/__init__.py
+++ b/nodes/test/mocks/chromadb/__init__.py
@@ -182,7 +182,7 @@ class MockCollection:
             count += 1
 
             # Apply limit
-            if limit and len(results['ids']) >= limit:
+            if limit is not None and len(results['ids']) >= limit:
                 break
 
         return results

--- a/nodes/test/mocks/psycopg2/__init__.py
+++ b/nodes/test/mocks/psycopg2/__init__.py
@@ -182,7 +182,7 @@ class MockCursor:
                     query_vector = p.tolist()
                 elif isinstance(p, (list, tuple)) and len(p) > 3:
                     query_vector = list(p)
-                elif isinstance(p, int) and p < 1000:
+                elif isinstance(p, int) and not isinstance(p, bool) and p < 1000:
                     limit = p
                 else:
                     filter_params.append(p)
@@ -318,7 +318,7 @@ class MockCursor:
         if 'limit' in query.lower() and params:
             # Last param is often the limit
             for p in reversed(params):
-                if isinstance(p, int) and p < 10000:
+                if isinstance(p, int) and not isinstance(p, bool) and p < 10000:
                     return p
         return None
 

--- a/nodes/test/mocks/weaviate/__init__.py
+++ b/nodes/test/mocks/weaviate/__init__.py
@@ -278,7 +278,7 @@ class MockQuery:
             )
 
         # Sort by distance (lower is better for cosine distance)
-        results.sort(key=lambda x: x.metadata.distance if x.metadata.distance else 1.0)
+        results.sort(key=lambda x: x.metadata.distance if x.metadata.distance is not None else 1.0)
 
         return QueryResult(objects=results[:limit])
 


### PR DESCRIPTION
## Problem

Three test mocks mishandled falsy values (0, False, 0.0), causing tests
to pass against mocks while failing against real services in production.

**psycopg2** — `bool` subclasses `int` in Python, so `isinstance(False, int)`
returns `True`. SQL WHERE params like `isDeleted=False` were being matched
as LIMIT values in `_handle_semantic_search` and `_extract_limit`.

**chromadb** — `if limit and ...` treated `limit=0` as falsy, returning
all rows instead of zero rows when `get(limit=0)` was called.

**weaviate** — Sort key `distance if distance else 1.0` collapsed `0.0`
(exact match, the best possible cosine distance) to `1.0`, ranking
perfect matches last instead of first.

## Fix

- psycopg2: added `not isinstance(p, bool)` guard at both int-detection sites
- chromadb: replaced `if limit` with `if limit is not None`
- weaviate: replaced `if distance` with `if distance is not None`

Resolves #748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test mock accuracy for edge cases involving zero and false parameter values, ensuring proper handling in parameter validation and result sorting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->