### PR TITLE
feat: stream llm output to the UI

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -83,6 +83,8 @@ class Chat(ChatBase):
     Create an Anthropic chat bot.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatAnthropic
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/nodes/src/nodes/llm_base/IInstance.py
+++ b/nodes/src/nodes/llm_base/IInstance.py
@@ -67,14 +67,12 @@ class IInstanceGenericLLM(IInstanceBase):
                 )
 
         try:
-            answer = self.IGlobal._chat.chat_stream(question, lambda delta: emit(delta))
+            answer = self.IGlobal._chat.chat_stream(question, emit)
         except Exception as e:
-            # Run the exception through the provider's map_exception before
-            # surfacing to the client — raw SDK errors can contain auth
-            # tokens, server paths, or echoed prompts.
-            mapped = self.IGlobal._chat.map_exception(e)
-            emit(done=True, error=str(mapped))
-            raise mapped from e
+            # `_chat_stream_with_retries` already runs map_exception before
+            # raising, so `e` is the friendly form. Don't remap.
+            emit(done=True, error=str(e))
+            raise
 
         emit(done=True)
         return answer

--- a/nodes/src/nodes/llm_base/IInstance.py
+++ b/nodes/src/nodes/llm_base/IInstance.py
@@ -21,13 +21,63 @@
 # SOFTWARE.
 # =============================================================================
 
+import itertools
+import threading
+from typing import Optional
+
 from rocketlib import IInstanceBase, invoke_function
 from ai.common.schema import Question, Answer
 
 
 class IInstanceGenericLLM(IInstanceBase):
     def _question(self, question: Question) -> Answer:
-        return self.IGlobal._chat.chat(question)
+        chat = self.IGlobal._chat
+        if getattr(chat, 'SUPPORTS_STREAMING', False) and not question.expectJson:
+            return self._question_stream(question)
+        return chat.chat(question)
+
+    def _question_stream(self, question: Question) -> Answer:
+        """
+        Streaming question path: forwards each LLM text delta to the UI as
+        an `llm.chunk` SSE event, then returns the final Answer (same shape
+        as `_question`). The output lane consumed by downstream nodes is
+        unchanged — chunks are observation-only.
+
+        Emit calls are serialized under a per-call lock so chunks reach the
+        SSE transport in source order; the transport preserves order from
+        there to the client.
+        """
+        try:
+            nodeId = self.IGlobal.glb.logicalType
+        except Exception:
+            nodeId = ''
+
+        counter = itertools.count()
+        lock = threading.Lock()
+
+        def emit(text: str = '', done: bool = False, error: Optional[str] = None) -> None:
+            with lock:
+                self.instance.sendSSE(
+                    'llm.chunk',
+                    nodeId=nodeId,
+                    seq=next(counter),
+                    text=text,
+                    done=done,
+                    error=error,
+                )
+
+        try:
+            answer = self.IGlobal._chat.chat_stream(question, lambda delta: emit(delta))
+        except Exception as e:
+            # Run the exception through the provider's map_exception before
+            # surfacing to the client — raw SDK errors can contain auth
+            # tokens, server paths, or echoed prompts.
+            mapped = self.IGlobal._chat.map_exception(e)
+            emit(done=True, error=str(mapped))
+            raise mapped from e
+
+        emit(done=True)
+        return answer
 
     def writeQuestions(self, question: Question):
         answer = self._question(question)

--- a/nodes/src/nodes/llm_bedrock/bedrock.py
+++ b/nodes/src/nodes/llm_bedrock/bedrock.py
@@ -36,6 +36,8 @@ class Chat(ChatBase):
     Create a Bedrock chat bot.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatBedrock
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/nodes/src/nodes/llm_deepseek/deepseek.py
+++ b/nodes/src/nodes/llm_deepseek/deepseek.py
@@ -36,6 +36,8 @@ class Chat(ChatBase):
     Creates an Deepseek chat bot.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatOpenAI
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/nodes/src/nodes/llm_gemini/gemini.py
+++ b/nodes/src/nodes/llm_gemini/gemini.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # =============================================================================
 
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from google import genai
@@ -42,6 +42,8 @@ class Chat(ChatBase):
         >>> chat = Chat(provider='gemini', connConfig={'apikey': 'your-api-key'}, bag={})
         >>> response = chat._chat('Hello, how are you?')
     """
+
+    SUPPORTS_STREAMING = True
 
     _client: genai.Client
 
@@ -114,6 +116,16 @@ class Chat(ChatBase):
         # Simple approximation: ~0.75 tokens per word
         word_count = len(value.split())
         return int(word_count / 0.75)
+
+    def _chat_stream(self, prompt: str, on_chunk: Callable[[str], None]) -> str:
+        """Stream a chat prompt via google-genai's `generate_content_stream`."""
+        pieces = []
+        for chunk in self._client.models.generate_content_stream(model=self._model, contents=prompt):
+            text = getattr(chunk, 'text', None)
+            if text:
+                pieces.append(text)
+                on_chunk(text)
+        return ''.join(pieces)
 
     def _chat(self, prompt: str) -> str:
         """

--- a/nodes/src/nodes/llm_gmi_cloud/gmi_cloud.py
+++ b/nodes/src/nodes/llm_gmi_cloud/gmi_cloud.py
@@ -33,6 +33,8 @@ from langchain_openai import ChatOpenAI
 class Chat(ChatBase):
     """Creates a GMI Cloud chat bot."""
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatOpenAI
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
+++ b/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
@@ -22,7 +22,7 @@
 # =============================================================================
 
 import re
-from typing import Any, Dict
+from typing import Any, Callable, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from ibm_watsonx_ai import Credentials
@@ -77,6 +77,8 @@ class Chat(ChatBase):
     IBM Watson chat class.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ModelInference
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
@@ -124,6 +126,20 @@ class Chat(ChatBase):
 
         # Save our chat class into the bag
         bag['chat'] = self
+
+    def _chat_stream(self, prompt: str, on_chunk: Callable[[str], None]) -> str:
+        """Stream a chat prompt via ibm-watsonx-ai's `ModelInference.chat_stream`."""
+        messages = [{'role': 'user', 'content': prompt}]
+        pieces = []
+        for chunk in self._llm.chat_stream(messages=messages):
+            try:
+                text = chunk['choices'][0]['delta'].get('content')
+            except (KeyError, IndexError, TypeError):
+                text = None
+            if text:
+                pieces.append(text)
+                on_chunk(text)
+        return ''.join(pieces)
 
     def _chat(self, prompt: str) -> str:
         """

--- a/nodes/src/nodes/llm_mistral/mistral.py
+++ b/nodes/src/nodes/llm_mistral/mistral.py
@@ -37,7 +37,7 @@ from rocketlib import debug
 requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
 depends(requirements)
 
-from typing import Any, Dict, Tuple
+from typing import Any, Callable, Dict, Tuple
 from ai.common.schema import Answer, Question
 from ai.common.chat import ChatBase
 from ai.common.config import Config
@@ -53,6 +53,8 @@ class Chat(ChatBase):
     """
     Create a Mistral AI chat bot.
     """
+
+    SUPPORTS_STREAMING = True
 
     _model: str = ''
     _client: Mistral
@@ -239,6 +241,21 @@ class Chat(ChatBase):
             return (2, 1.5)  # 2 retries, 1.5 second base delay for medium models
         else:
             return (2, 1.0)  # 2 retries, 1 second base delay for small models
+
+    def _chat_stream(self, prompt: str, on_chunk: Callable[[str], None]) -> str:
+        """Stream a chat prompt via mistralai's `client.chat.stream`."""
+        messages = [{'role': 'user', 'content': prompt}]
+        pieces = []
+        for event in self._client.chat.stream(model=self._model, messages=messages, temperature=0.0):
+            try:
+                delta = event.data.choices[0].delta
+            except (AttributeError, IndexError):
+                continue
+            text = getattr(delta, 'content', None)
+            if text:
+                pieces.append(text)
+                on_chunk(text)
+        return ''.join(pieces)
 
     def chat(self, question: Question) -> Answer:
         """Send a chat message to Mistral AI and get the response."""

--- a/nodes/src/nodes/llm_ollama/ollama.py
+++ b/nodes/src/nodes/llm_ollama/ollama.py
@@ -36,6 +36,8 @@ class Chat(ChatBase):
     Create an ollama chat bot.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatOpenAI
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/nodes/src/nodes/llm_openai/openai_client.py
+++ b/nodes/src/nodes/llm_openai/openai_client.py
@@ -37,6 +37,8 @@ class Chat(ChatBase):
     Create an OpenAI chat bot.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatOpenAI
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/nodes/src/nodes/llm_openai_api/openai_client.py
+++ b/nodes/src/nodes/llm_openai_api/openai_client.py
@@ -15,6 +15,8 @@ class Chat(ChatBase):
     Create an OpenAI-compatible API chat bot with custom base_url support.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatOpenAI
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
@@ -33,10 +35,10 @@ class Chat(ChatBase):
 
         # Build kwargs for ChatOpenAI
         kwargs = {
-            "model": self._model,
-            "api_key": apikey,
-            "temperature": 0,
-            "max_tokens": self._modelOutputTokens,
+            'model': self._model,
+            'api_key': apikey,
+            'temperature': 0,
+            'max_tokens': self._modelOutputTokens,
         }
         if base_url:
             kwargs['base_url'] = base_url

--- a/nodes/src/nodes/llm_perplexity/perplexity.py
+++ b/nodes/src/nodes/llm_perplexity/perplexity.py
@@ -49,6 +49,8 @@ class Chat(ChatBase):
     Perplexity AI chat node with search-enhanced language models.
     """
 
+    SUPPORTS_STREAMING = True
+
     _model: str = ''
     _llm: ChatOpenAI
 

--- a/nodes/src/nodes/llm_qwen/qwen_client.py
+++ b/nodes/src/nodes/llm_qwen/qwen_client.py
@@ -43,6 +43,8 @@ class Chat(ChatBase):
     Create a Qwen chat bot via DashScope's OpenAI-compatible API.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatOpenAI
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/nodes/src/nodes/llm_vertex/vertex.py
+++ b/nodes/src/nodes/llm_vertex/vertex.py
@@ -52,6 +52,8 @@ class Chat(ChatBase):
     Create an vertex chat bot.
     """
 
+    SUPPORTS_STREAMING = True
+
     """
     Privates
     """

--- a/nodes/src/nodes/llm_xai/xai.py
+++ b/nodes/src/nodes/llm_xai/xai.py
@@ -36,6 +36,8 @@ class Chat(ChatBase):
     Create an XAI chat bot.
     """
 
+    SUPPORTS_STREAMING = True
+
     _llm: ChatXAI
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -507,12 +507,12 @@ class ChatBase:
                 return self._chat_stream(prompt, gated)
             except Exception as e:
                 if emitted['value']:
-                    raise self.map_exception(e)
+                    raise self.map_exception(e) from e
 
                 is_retryable = self.is_retryable_error(e)
                 if not is_retryable or attempt == max_network_retries - 1:
                     debug(f'Chat stream failed after {attempt + 1} attempts: {str(e)}')
-                    raise self.map_exception(e)
+                    raise self.map_exception(e) from e
 
                 delay = min(base_delay * (2**attempt), max_delay)
                 debug(f'Network/API error on streaming attempt {attempt + 1}/{max_network_retries}: {str(e)}. Retrying in {delay:.1f} seconds...')

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -13,7 +13,7 @@ communication with their respective APIs.
 import time
 import json
 import importlib
-from typing import Dict, Any
+from typing import Dict, Any, Callable
 from rocketlib import debug
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
@@ -132,6 +132,33 @@ class ChatBase:
 
         # Return the results
         return results.content
+
+    def _chat_stream(self, prompt: str, on_chunk: Callable[[str], None]) -> str:
+        """
+        Streaming variant of `_chat`. Default implementation iterates the
+        LangChain Runnable's `.stream()` method, emits each text delta via
+        `on_chunk(delta)`, and returns the accumulated full response.
+
+        Providers whose `_llm` is not a LangChain Runnable (e.g. native
+        google-genai, mistral, ibm-watsonx-ai) should override this with
+        their SDK's native streaming call.
+        """
+        pieces = []
+        for chunk in self._llm.stream(prompt):
+            text = getattr(chunk, 'content', None)
+            if not text:
+                continue
+            # Some chat models return a list of content blocks (vision / tool
+            # use) — flatten to the text parts only.
+            if not isinstance(text, str):
+                try:
+                    text = ''.join(p.get('text', '') for p in text if isinstance(p, dict))
+                except Exception:
+                    text = str(text)
+            if text:
+                pieces.append(text)
+                on_chunk(text)
+        return ''.join(pieces)
 
     def getTokens(self, value: str) -> int:
         """
@@ -450,6 +477,86 @@ class ChatBase:
 
             # And return it
             return answer
+
+    SUPPORTS_STREAMING: bool = False
+
+    def _chat_stream_with_retries(self, prompt: str, on_chunk: Callable[[str], None]) -> str:
+        """
+        Streaming variant of `_chat_with_retries`.
+
+        Network retries are only attempted before any chunk is emitted. Once
+        a chunk has reached the caller, a mid-stream failure is propagated
+        immediately rather than restarting the visible output — the caller
+        finalizes the stream with an error marker and the user keeps the
+        partial text already on screen.
+        """
+        from ai.constants import CONST_CHAT_MAX_RETRIES, CONST_CHAT_BASE_DELAY, CONST_CHAT_MAX_DELAY
+
+        max_network_retries = CONST_CHAT_MAX_RETRIES
+        base_delay = CONST_CHAT_BASE_DELAY
+        max_delay = CONST_CHAT_MAX_DELAY
+
+        for attempt in range(max_network_retries):
+            emitted = {'value': False}
+
+            def gated(text: str) -> None:
+                emitted['value'] = True
+                on_chunk(text)
+
+            try:
+                return self._chat_stream(prompt, gated)
+            except Exception as e:
+                if emitted['value']:
+                    raise self.map_exception(e)
+
+                is_retryable = self.is_retryable_error(e)
+                if not is_retryable or attempt == max_network_retries - 1:
+                    debug(f'Chat stream failed after {attempt + 1} attempts: {str(e)}')
+                    raise self.map_exception(e)
+
+                delay = min(base_delay * (2**attempt), max_delay)
+                debug(f'Network/API error on streaming attempt {attempt + 1}/{max_network_retries}: {str(e)}. Retrying in {delay:.1f} seconds...')
+                time.sleep(delay)
+
+        raise Exception('Unexpected exit from streaming retry loop')
+
+    def chat_stream(self, question: Question, on_chunk: Callable[[str], None]) -> Answer:
+        """
+        Streaming variant of `chat()`.
+
+        Emits incremental text via `on_chunk(delta)` as the model generates,
+        then returns the final `Answer` (identical shape to what `chat()`
+        would return). The Answer written to the output lane is canonical;
+        chunks are observation-only.
+
+        Falls back to non-streaming `chat()` when `question.expectJson` is
+        True — partial JSON cannot be safely parsed or rendered.
+
+        `on_chunk` receives only the new text since the previous call
+        (deltas, not cumulative). The caller is responsible for any
+        cross-thread serialization of emit calls.
+        """
+        if question.expectJson:
+            return self.chat(question)
+
+        prompt = validate_prompt(question.getPrompt(), self._modelTotalTokens, self.getTokens)
+
+        prompt_tokens = self.getTokens(prompt)
+        if prompt_tokens >= self._modelTotalTokens - 100:
+            debug(f'Warning: Prompt ({prompt_tokens} tokens) exceeds input allocation ({self._modelTotalTokens} tokens)')
+
+        response = self._chat_stream_with_retries(prompt, on_chunk)
+
+        try:
+            result_tokens = self.getTokens(response)
+            if prompt_tokens + result_tokens >= self._modelTotalTokens - 5:
+                debug(f'Warning: Result ({result_tokens} tokens) was probably truncated')
+        except Exception:
+            pass
+
+        answer = Answer(expectJson=False)
+        answer.setAnswer(response)
+        return answer
 
 
 def getChat(provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]) -> ChatBase:

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -551,8 +551,10 @@ class ChatBase:
             result_tokens = self.getTokens(response)
             if prompt_tokens + result_tokens >= self._modelTotalTokens - 5:
                 debug(f'Warning: Result ({result_tokens} tokens) was probably truncated')
-        except Exception:
-            pass
+        except Exception as e:
+            # Don't fail the call: chunks are already on the wire. But log
+            # so tokenizer issues are visible instead of silently swallowed.
+            debug(f'Warning: getTokens(response) failed after streaming (modelTotalTokens={self._modelTotalTokens}, prompt_tokens={prompt_tokens}): {e}')
 
         answer = Answer(expectJson=False)
         answer.setAnswer(response)


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->
Streams the LLM output to the user so user does not need to wait to see the output until the entire output is generated

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
feature

## Testing
`./builder test` passes


## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes https://github.com/rocketride-org/rocketride-server/issues/730



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time streaming enabled across many LLM providers and core chat, delivering progressive responses.
  * New streaming API returns ordered, sequenced intermediate chunks (SSE) while producing a final consolidated answer.
  * Streaming automatically falls back to non‑streaming for JSON/structured-output requests.

* **Bug Fixes / Resilience**
  * Improved retry handling and explicit terminal/error chunk emission to ensure robust streaming recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->