### PR TITLE
feat(database): add QuestionType.EXECUTE for direct SQL/Cypher

### DIFF
--- a/nodes/src/nodes/db_mysql/IInstance.py
+++ b/nodes/src/nodes/db_mysql/IInstance.py
@@ -17,3 +17,6 @@ class IInstance(DatabaseInstanceBase):
 
     def _db_display_name(self) -> str:
         return 'MySQL'
+
+    def _db_dialect(self) -> str:
+        return 'mysql'

--- a/nodes/src/nodes/db_mysql/services.json
+++ b/nodes/src/nodes/db_mysql/services.json
@@ -170,9 +170,15 @@
 			"maximum": 20,
 			"description": "Maximum number of times to re-ask the LLM if EXPLAIN rejects the generated SQL"
 		},
+		"mysql.allow_execute": {
+			"type": "boolean",
+			"title": "Allow direct query execution",
+			"default": false,
+			"description": "Permit QuestionType.EXECUTE callers to run raw SQL without LLM translation or safety checks. Leave OFF unless a trusted application explicitly needs to issue SQL directly."
+		},
 		"mysql.default": {
 			"object": "default",
-			"properties": ["mysql.db_description", "mysql.host", "mysql.user", "mysql.password", "mysql.database", "mysql.table", "mysql.max_attempts"]
+			"properties": ["mysql.db_description", "mysql.host", "mysql.user", "mysql.password", "mysql.database", "mysql.table", "mysql.max_attempts", "mysql.allow_execute"]
 		},
 		"mysql.profile": {
 			"hidden": true,

--- a/nodes/src/nodes/db_neo4j/IGlobal.py
+++ b/nodes/src/nodes/db_neo4j/IGlobal.py
@@ -60,6 +60,7 @@ class IGlobal(IGlobalBase):
     # label: str = 'Row'
     db_description: str = ''
     max_validation_attempts: int = 5
+    allow_execute: bool = False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -79,6 +80,11 @@ class IGlobal(IGlobalBase):
             self.max_validation_attempts = int(config.get('max_attempts', 5))
         except (ValueError, TypeError):
             self.max_validation_attempts = 5
+
+        # EXECUTE path is opt-in: a caller passing QuestionType.EXECUTE bypasses
+        # the LLM translation + _is_cypher_safe gate, so the node owner must
+        # explicitly enable the capability.
+        self.allow_execute = bool(config.get('allow_execute', False))
 
         auth = self._build_auth(config)
 

--- a/nodes/src/nodes/db_neo4j/IGlobal.py
+++ b/nodes/src/nodes/db_neo4j/IGlobal.py
@@ -137,6 +137,31 @@ class IGlobal(IGlobalBase):
             result = session.run(neo4j.Query(cypher, timeout=timeout), params)
             return [_record_to_dict(record) for record in result]
 
+    def _run_query_raw(self, cypher: str, *, timeout: float = QUERY_TIMEOUT) -> Dict[str, Any]:
+        """Execute a raw Cypher statement without the ``_is_cypher_safe`` gate.
+
+        Used by the EXECUTE path where the caller has accepted the risk of running
+        write/admin Cypher directly. Returns ``{'rows': [...], 'affected_rows': N}``
+        to mirror the SQL ``_executeRawQuery`` shape — ``affected_rows`` is derived
+        from the result summary counters when no rows are returned (e.g. CREATE
+        without RETURN, DELETE).
+
+        Raises:
+            neo4j.exceptions.Neo4jError: Caught at the IInstance handler per precedent.
+        """
+        with self.driver.session(database=self.database) as session:
+            result = session.run(neo4j.Query(cypher, timeout=timeout))
+            rows = [_record_to_dict(record) for record in result]
+            counters = result.consume().counters
+            affected = (
+                counters.nodes_created
+                + counters.nodes_deleted
+                + counters.relationships_created
+                + counters.relationships_deleted
+                + counters.properties_set
+            )
+            return {'rows': rows, 'affected_rows': 0 if rows else affected}
+
     def _validate_query(self, cypher: str) -> Tuple[bool, str]:
         """Run EXPLAIN on a Cypher statement to check syntax without executing it.
 

--- a/nodes/src/nodes/db_neo4j/IGlobal.py
+++ b/nodes/src/nodes/db_neo4j/IGlobal.py
@@ -61,6 +61,7 @@ class IGlobal(IGlobalBase):
     db_description: str = ''
     max_validation_attempts: int = 5
     allow_execute: bool = False
+    max_execute_rows: int = 25000
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -83,8 +84,18 @@ class IGlobal(IGlobalBase):
 
         # EXECUTE path is opt-in: a caller passing QuestionType.EXECUTE bypasses
         # the LLM translation + _is_cypher_safe gate, so the node owner must
-        # explicitly enable the capability.
-        self.allow_execute = bool(config.get('allow_execute', False))
+        # explicitly enable the capability. Strings like 'false' / '0' must
+        # not be truthy here, so don't use bool() directly.
+        allow_execute = config.get('allow_execute', False)
+        if isinstance(allow_execute, str):
+            self.allow_execute = allow_execute.strip().lower() in {'1', 'true', 'yes', 'on'}
+        else:
+            self.allow_execute = bool(allow_execute)
+
+        try:
+            self.max_execute_rows = max(1, int(config.get('max_execute_rows', 25000)))
+        except (TypeError, ValueError):
+            self.max_execute_rows = 25000
 
         auth = self._build_auth(config)
 
@@ -155,9 +166,12 @@ class IGlobal(IGlobalBase):
         Raises:
             neo4j.exceptions.Neo4jError: Caught at the IInstance handler per precedent.
         """
+        max_rows = self.max_execute_rows
         with self.driver.session(database=self.database) as session:
             result = session.run(neo4j.Query(cypher, timeout=timeout))
-            rows = [_record_to_dict(record) for record in result]
+            rows = [_record_to_dict(record) for _, record in zip(range(max_rows + 1), result)]
+            if len(rows) > max_rows:
+                raise ValueError(f'EXECUTE query exceeded max_execute_rows={max_rows}')
             counters = result.consume().counters
             affected = (
                 counters.nodes_created

--- a/nodes/src/nodes/db_neo4j/IGlobal.py
+++ b/nodes/src/nodes/db_neo4j/IGlobal.py
@@ -41,6 +41,8 @@ from ai.common.config import Config
 
 from .utils import _is_cypher_safe
 
+DEFAULT_MAX_EXECUTE_ROWS = 25000
+
 
 class IGlobal(IGlobalBase):
     """Neo4J-specific global connection state."""
@@ -61,7 +63,7 @@ class IGlobal(IGlobalBase):
     db_description: str = ''
     max_validation_attempts: int = 5
     allow_execute: bool = False
-    max_execute_rows: int = 25000
+    max_execute_rows: int = DEFAULT_MAX_EXECUTE_ROWS
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -93,9 +95,9 @@ class IGlobal(IGlobalBase):
             self.allow_execute = bool(allow_execute)
 
         try:
-            self.max_execute_rows = max(1, int(config.get('max_execute_rows', 25000)))
+            self.max_execute_rows = max(1, int(config.get('max_execute_rows', DEFAULT_MAX_EXECUTE_ROWS)))
         except (TypeError, ValueError):
-            self.max_execute_rows = 25000
+            self.max_execute_rows = DEFAULT_MAX_EXECUTE_ROWS
 
         auth = self._build_auth(config)
 

--- a/nodes/src/nodes/db_neo4j/IInstance.py
+++ b/nodes/src/nodes/db_neo4j/IInstance.py
@@ -208,26 +208,27 @@ class IInstance(IInstanceBase):
 
         # EXECUTE: caller passes raw Cypher; bypass LLM translation + safety check.
         if question.type == QuestionType.EXECUTE:
+            if not self.IGlobal.allow_execute:
+                warning('QuestionType.EXECUTE is disabled for this node (set allow_execute=true to enable).')
+                return
             try:
                 execute_result = self.IGlobal._run_query_raw(question_text)
+                rows = execute_result['rows']
+                affected = execute_result['affected_rows']
+                markdown = self._formatResultAsMarkdown(rows) if rows else None
+
+                if 'text' in lanes:
+                    self.instance.writeText(markdown if markdown else f'{affected} rows affected')
+
+                if 'table' in lanes and rows:
+                    self.instance.writeTable(markdown)
+
+                if 'answers' in lanes:
+                    answer = Answer()
+                    answer.setAnswer(json.dumps(execute_result, default=str))
+                    self.instance.writeAnswers(answer)
             except Exception as e:
-                error(f'Error executing raw Cypher query: {e}')
-                return
-
-            rows = execute_result['rows']
-            affected = execute_result['affected_rows']
-            markdown = self._formatResultAsMarkdown(rows) if rows else None
-
-            if 'text' in lanes:
-                self.instance.writeText(markdown if markdown else f'{affected} rows affected')
-
-            if 'table' in lanes and rows:
-                self.instance.writeTable(markdown)
-
-            if 'answers' in lanes:
-                answer = Answer()
-                answer.setAnswer(json.dumps(execute_result))
-                self.instance.writeAnswers(answer)
+                error(f'Error handling execute question: {e}')
             return
 
         try:

--- a/nodes/src/nodes/db_neo4j/IInstance.py
+++ b/nodes/src/nodes/db_neo4j/IInstance.py
@@ -206,6 +206,16 @@ class IInstance(IInstanceBase):
 
         lanes = self.instance.getListeners()
 
+        # DIALECT: dialect-discovery request — emit {'dialect': 'neo4j'} on the
+        # answers lane so SDK callers can tell they're talking to a graph DB
+        # rather than a relational one.
+        if question.type == QuestionType.DIALECT:
+            if 'answers' in lanes:
+                answer = Answer()
+                answer.setAnswer(json.dumps({'dialect': 'neo4j'}))
+                self.instance.writeAnswers(answer)
+            return
+
         # EXECUTE: caller passes raw Cypher; bypass LLM translation + safety check.
         if question.type == QuestionType.EXECUTE:
             if not self.IGlobal.allow_execute:

--- a/nodes/src/nodes/db_neo4j/IInstance.py
+++ b/nodes/src/nodes/db_neo4j/IInstance.py
@@ -21,7 +21,7 @@ from ai.common.schema import Answer, Question, QuestionType
 from ai.common.table import Table
 from rocketlib.types import IInvokeLLM
 
-from .IGlobal import IGlobal
+from .IGlobal import DEFAULT_MAX_EXECUTE_ROWS, IGlobal
 from .utils import _is_cypher_safe, _parse_is_valid
 
 
@@ -45,7 +45,7 @@ class IInstance(IInstanceBase):
                 },
                 'limit': {
                     'type': 'integer',
-                    'description': 'Maximum number of rows to return (default 250, max 25000).',
+                    'description': f'Maximum number of rows to return (default 250, max {DEFAULT_MAX_EXECUTE_ROWS}).',
                 },
             },
         },
@@ -414,8 +414,8 @@ class IInstance(IInstanceBase):
 
 
 def _clamp_limit(raw_limit) -> int:
-    """Clamp a user-supplied limit to [1, 25000]."""
+    """Clamp a user-supplied limit to [1, DEFAULT_MAX_EXECUTE_ROWS]."""
     try:
-        return max(1, min(int(raw_limit), 25000)) if raw_limit is not None else 250
+        return max(1, min(int(raw_limit), DEFAULT_MAX_EXECUTE_ROWS)) if raw_limit is not None else 250
     except (ValueError, TypeError):
         return 250

--- a/nodes/src/nodes/db_neo4j/IInstance.py
+++ b/nodes/src/nodes/db_neo4j/IInstance.py
@@ -13,6 +13,7 @@ queries, and inserts data as graph nodes.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, Optional
 
 from rocketlib import IInstanceBase, tool_function, error, warning
@@ -204,6 +205,30 @@ class IInstance(IInstanceBase):
             return
 
         lanes = self.instance.getListeners()
+
+        # EXECUTE: caller passes raw Cypher; bypass LLM translation + safety check.
+        if question.type == QuestionType.EXECUTE:
+            try:
+                execute_result = self.IGlobal._run_query_raw(question_text)
+            except Exception as e:
+                error(f'Error executing raw Cypher query: {e}')
+                return
+
+            rows = execute_result['rows']
+            affected = execute_result['affected_rows']
+            markdown = self._formatResultAsMarkdown(rows) if rows else None
+
+            if 'text' in lanes:
+                self.instance.writeText(markdown if markdown else f'{affected} rows affected')
+
+            if 'table' in lanes and rows:
+                self.instance.writeTable(markdown)
+
+            if 'answers' in lanes:
+                answer = Answer()
+                answer.setAnswer(json.dumps(execute_result))
+                self.instance.writeAnswers(answer)
+            return
 
         try:
             query_json = self._buildCypherQuery(question_text)

--- a/nodes/src/nodes/db_neo4j/services.json
+++ b/nodes/src/nodes/db_neo4j/services.json
@@ -195,6 +195,12 @@
 			"maximum": 20,
 			"description": "Maximum number of times to re-ask the LLM if EXPLAIN rejects the generated Cypher query"
 		},
+		"neo4jdb.allow_execute": {
+			"type": "boolean",
+			"title": "Allow direct query execution",
+			"default": false,
+			"description": "Permit QuestionType.EXECUTE callers to run raw Cypher without LLM translation or safety checks. Leave OFF unless a trusted application explicitly needs to issue Cypher directly."
+		},
 		"neo4jdb.default": {
 			"object": "default",
 			"properties": [
@@ -203,7 +209,8 @@
 				"neo4jdb.auth_method",
 				"neo4jdb.database",
 				// "neo4jdb.label",
-				"neo4jdb.max_attempts"
+				"neo4jdb.max_attempts",
+				"neo4jdb.allow_execute"
 			]
 		},
 		"neo4jdb.profile": {

--- a/nodes/src/nodes/db_postgres/IInstance.py
+++ b/nodes/src/nodes/db_postgres/IInstance.py
@@ -17,3 +17,6 @@ class IInstance(DatabaseInstanceBase):
 
     def _db_display_name(self) -> str:
         return 'PostgreSQL'
+
+    def _db_dialect(self) -> str:
+        return 'postgres'

--- a/nodes/src/nodes/db_postgres/services.json
+++ b/nodes/src/nodes/db_postgres/services.json
@@ -169,9 +169,15 @@
 			"maximum": 20,
 			"description": "Maximum number of times to re-ask the LLM if EXPLAIN rejects the generated SQL"
 		},
+		"postgresdb.allow_execute": {
+			"type": "boolean",
+			"title": "Allow direct query execution",
+			"default": false,
+			"description": "Permit QuestionType.EXECUTE callers to run raw SQL without LLM translation or safety checks. Leave OFF unless a trusted application explicitly needs to issue SQL directly."
+		},
 		"postgresdb.default": {
 			"object": "default",
-			"properties": ["postgresdb.db_description", "postgresdb.host", "postgresdb.user", "postgresdb.password", "postgresdb.database", "postgresdb.table", "postgresdb.max_attempts"]
+			"properties": ["postgresdb.db_description", "postgresdb.host", "postgresdb.user", "postgresdb.password", "postgresdb.database", "postgresdb.table", "postgresdb.max_attempts", "postgresdb.allow_execute"]
 		},
 		"postgresdb.profile": {
 			"hidden": true,

--- a/packages/ai/src/ai/common/database/db_global_base.py
+++ b/packages/ai/src/ai/common/database/db_global_base.py
@@ -71,6 +71,8 @@ class DatabaseGlobalBase(IGlobalBase, ABC):
     schema: Dict[str, Tuple[str, str]] = {}
     db_schema: Dict[str, Dict] = {}
     max_validation_attempts: int = 5
+    allow_execute: bool = False
+    max_execute_rows: int = 25000
 
     # ------------------------------------------------------------------
     # Abstract interface — derived classes MUST implement these two methods
@@ -442,6 +444,15 @@ class DatabaseGlobalBase(IGlobalBase, ABC):
         # they're available to the instance as soon as beginGlobal returns.
         self.max_validation_attempts = max(1, self._max_validation_attempts(raw))
         self.db_description = (self._db_description(raw) or '').strip()
+
+        # EXECUTE path is opt-in: a caller passing QuestionType.EXECUTE bypasses
+        # the LLM translation + is_sql_safe gate, so the node owner must
+        # explicitly enable the capability.
+        self.allow_execute = bool(raw.get('allow_execute', False))
+        try:
+            self.max_execute_rows = max(1, int(raw.get('max_execute_rows', 25000)))
+        except (TypeError, ValueError):
+            self.max_execute_rows = 25000
 
         self.database = params['database']
         self.table = params['table']

--- a/packages/ai/src/ai/common/database/db_global_base.py
+++ b/packages/ai/src/ai/common/database/db_global_base.py
@@ -447,8 +447,13 @@ class DatabaseGlobalBase(IGlobalBase, ABC):
 
         # EXECUTE path is opt-in: a caller passing QuestionType.EXECUTE bypasses
         # the LLM translation + is_sql_safe gate, so the node owner must
-        # explicitly enable the capability.
-        self.allow_execute = bool(raw.get('allow_execute', False))
+        # explicitly enable the capability. Strings like 'false' / '0' must
+        # not be truthy here, so don't use bool() directly.
+        allow_execute = raw.get('allow_execute', False)
+        if isinstance(allow_execute, str):
+            self.allow_execute = allow_execute.strip().lower() in {'1', 'true', 'yes', 'on'}
+        else:
+            self.allow_execute = bool(allow_execute)
         try:
             self.max_execute_rows = max(1, int(raw.get('max_execute_rows', 25000)))
         except (TypeError, ValueError):

--- a/packages/ai/src/ai/common/database/db_global_base.py
+++ b/packages/ai/src/ai/common/database/db_global_base.py
@@ -60,6 +60,8 @@ from sqlalchemy.exc import DBAPIError
 from rocketlib import IGlobalBase, error, warning
 from ai.common.config import Config
 
+DEFAULT_MAX_EXECUTE_ROWS = 25000
+
 
 class DatabaseGlobalBase(IGlobalBase, ABC):
     """Abstract base for the IGlobal layer of any relational database node."""
@@ -72,7 +74,7 @@ class DatabaseGlobalBase(IGlobalBase, ABC):
     db_schema: Dict[str, Dict] = {}
     max_validation_attempts: int = 5
     allow_execute: bool = False
-    max_execute_rows: int = 25000
+    max_execute_rows: int = DEFAULT_MAX_EXECUTE_ROWS
 
     # ------------------------------------------------------------------
     # Abstract interface — derived classes MUST implement these two methods
@@ -455,9 +457,9 @@ class DatabaseGlobalBase(IGlobalBase, ABC):
         else:
             self.allow_execute = bool(allow_execute)
         try:
-            self.max_execute_rows = max(1, int(raw.get('max_execute_rows', 25000)))
+            self.max_execute_rows = max(1, int(raw.get('max_execute_rows', DEFAULT_MAX_EXECUTE_ROWS)))
         except (TypeError, ValueError):
-            self.max_execute_rows = 25000
+            self.max_execute_rows = DEFAULT_MAX_EXECUTE_ROWS
 
         self.database = params['database']
         self.table = params['table']

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -428,6 +428,29 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             error(f'Error executing SQL query: {e}')
             return None
 
+    def _executeRawQuery(self, query: str) -> dict | None:
+        """Execute a raw SQL statement (read or write) without LLM or safety gating.
+
+        Uses ``engine.begin()`` so writes auto-commit. Returns
+        ``{'rows': [...], 'affected_rows': N}`` on success or ``None`` on error
+        (logged via ``error()`` to match the ``_executeSQLQuery`` precedent).
+        """
+        try:
+            with self.IGlobal.engine.begin() as conn:
+                result = conn.execute(text(query))
+                if result.returns_rows:
+                    rows = result.fetchall()
+                    column_names = result.keys()
+                    return {
+                        'rows': [dict(zip(column_names, row)) for row in rows],
+                        'affected_rows': 0,
+                    }
+                return {'rows': [], 'affected_rows': result.rowcount}
+
+        except SQLAlchemyError as e:
+            error(f'Error executing raw SQL query: {e}')
+            return None
+
     def _formatResultAsMarkdown(self, result: Any) -> str:
         """Convert a query result to a markdown table string."""
         headers = None
@@ -463,6 +486,28 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             return
 
         lanes = self.instance.getListeners()
+
+        # EXECUTE: caller passes raw SQL; bypass LLM translation + safety check.
+        if question.type == QuestionType.EXECUTE:
+            execute_result = self._executeRawQuery(question_text)
+            if execute_result is None:
+                return
+
+            rows = execute_result['rows']
+            affected = execute_result['affected_rows']
+            markdown = self._formatResultAsMarkdown(rows) if rows else None
+
+            if 'text' in lanes:
+                self.instance.writeText(markdown if markdown else f'{affected} rows affected')
+
+            if 'table' in lanes and rows:
+                self.instance.writeTable(markdown)
+
+            if 'answers' in lanes:
+                answer = Answer()
+                answer.setAnswer(json.dumps(execute_result))
+                self.instance.writeAnswers(answer)
+            return
 
         try:
             # Ask the LLM to translate the natural-language question into SQL.

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -70,6 +70,14 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
     def _db_display_name(self) -> str:
         """Return the human-readable database name (e.g. 'MySQL', 'PostgreSQL')."""
 
+    @abstractmethod
+    def _db_dialect(self) -> str:
+        """Return the machine-readable dialect identifier (e.g. 'mysql', 'postgres').
+
+        Surfaced to SDK callers via ``QuestionType.DIALECT`` so applications can
+        branch on the underlying engine (dialect-specific SQL, type coercion, etc.).
+        """
+
     # ------------------------------------------------------------------
     # Tool methods — dispatched by IInstanceBase.invoke() via @tool_function
     # ------------------------------------------------------------------
@@ -496,6 +504,17 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             return
 
         lanes = self.instance.getListeners()
+
+        # DIALECT: dialect-discovery request — emit {'dialect': '...'} on the
+        # answers lane so the SDK can branch on the engine. No gate needed:
+        # the value is metadata, not data, and the node already exposed itself
+        # by being connected.
+        if question.type == QuestionType.DIALECT:
+            if 'answers' in lanes:
+                answer = Answer()
+                answer.setAnswer(json.dumps({'dialect': self._db_dialect()}))
+                self.instance.writeAnswers(answer)
+            return
 
         # EXECUTE: caller passes raw SQL; bypass LLM translation + safety check.
         if question.type == QuestionType.EXECUTE:

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -434,18 +434,28 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         Uses ``engine.begin()`` so writes auto-commit. Returns
         ``{'rows': [...], 'affected_rows': N}`` on success or ``None`` on error
         (logged via ``error()`` to match the ``_executeSQLQuery`` precedent).
+
+        SELECT results are bounded by ``IGlobal.max_execute_rows`` to keep a
+        large query from exhausting worker memory. ``rowcount`` is normalized
+        to a non-negative int — some dialects return -1 when unknown.
         """
         try:
             with self.IGlobal.engine.begin() as conn:
                 result = conn.execute(text(query))
                 if result.returns_rows:
-                    rows = result.fetchall()
+                    max_rows = self.IGlobal.max_execute_rows
+                    rows = result.fetchmany(max_rows + 1)
+                    if len(rows) > max_rows:
+                        error(f'EXECUTE query exceeded max_execute_rows={max_rows}')
+                        return None
                     column_names = result.keys()
                     return {
                         'rows': [dict(zip(column_names, row)) for row in rows],
                         'affected_rows': 0,
                     }
-                return {'rows': [], 'affected_rows': result.rowcount}
+                rowcount = result.rowcount
+                affected = rowcount if isinstance(rowcount, int) and rowcount >= 0 else 0
+                return {'rows': [], 'affected_rows': affected}
 
         except SQLAlchemyError as e:
             error(f'Error executing raw SQL query: {e}')
@@ -489,24 +499,31 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
 
         # EXECUTE: caller passes raw SQL; bypass LLM translation + safety check.
         if question.type == QuestionType.EXECUTE:
-            execute_result = self._executeRawQuery(question_text)
-            if execute_result is None:
+            if not self.IGlobal.allow_execute:
+                warning('QuestionType.EXECUTE is disabled for this node (set allow_execute=true to enable).')
                 return
+            try:
+                execute_result = self._executeRawQuery(question_text)
+                if execute_result is None:
+                    return
 
-            rows = execute_result['rows']
-            affected = execute_result['affected_rows']
-            markdown = self._formatResultAsMarkdown(rows) if rows else None
+                rows = [self._sanitize_row(row) for row in execute_result['rows']]
+                affected = execute_result['affected_rows']
+                payload = {'rows': rows, 'affected_rows': affected}
+                markdown = self._formatResultAsMarkdown(rows) if rows else None
 
-            if 'text' in lanes:
-                self.instance.writeText(markdown if markdown else f'{affected} rows affected')
+                if 'text' in lanes:
+                    self.instance.writeText(markdown if markdown else f'{affected} rows affected')
 
-            if 'table' in lanes and rows:
-                self.instance.writeTable(markdown)
+                if 'table' in lanes and rows:
+                    self.instance.writeTable(markdown)
 
-            if 'answers' in lanes:
-                answer = Answer()
-                answer.setAnswer(json.dumps(execute_result))
-                self.instance.writeAnswers(answer)
+                if 'answers' in lanes:
+                    answer = Answer()
+                    answer.setAnswer(json.dumps(payload, default=str))
+                    self.instance.writeAnswers(answer)
+            except Exception as e:
+                error(f'Error handling execute question: {e}')
             return
 
         try:

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -49,7 +49,7 @@ from ai.common.schema import Answer, Question, QuestionType
 from ai.common.table import Table
 from rocketlib.types import IInvokeLLM
 
-from .db_global_base import DatabaseGlobalBase
+from .db_global_base import DEFAULT_MAX_EXECUTE_ROWS, DatabaseGlobalBase
 from .sql_safety import is_sql_safe
 
 
@@ -85,7 +85,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
                 },
                 'limit': {
                     'type': 'integer',
-                    'description': 'Maximum number of rows to return (default 250, max 25000). Increase when you need the full result set.',
+                    'description': f'Maximum number of rows to return (default 250, max {DEFAULT_MAX_EXECUTE_ROWS}). Increase when you need the full result set.',
                 },
             },
         },
@@ -127,7 +127,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         question = question.strip()
         raw_limit = args.get('limit')
         try:
-            limit = max(1, min(int(raw_limit), 25000)) if raw_limit is not None else 250
+            limit = max(1, min(int(raw_limit), DEFAULT_MAX_EXECUTE_ROWS)) if raw_limit is not None else 250
         except (TypeError, ValueError):
             limit = 250
 

--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -46,6 +46,7 @@ from functools import cached_property
 from .core import DAPClient, RocketRideException, CONST_DEFAULT_WEB_CLOUD
 from .account import AccountApi
 from .billing import BillingApi
+from .database import DatabaseApi
 from .mixins.connection import ConnectionMixin
 from .mixins.execution import ExecutionMixin
 from .mixins.data import DataMixin
@@ -317,6 +318,11 @@ class RocketRideClient(
     def billing(self) -> BillingApi:
         """Billing and subscription operations (plans, checkout, credits)."""
         return BillingApi(self)
+
+    @cached_property
+    def database(self) -> DatabaseApi:
+        """Direct database query operations (raw SQL/Cypher execution)."""
+        return DatabaseApi(self)
 
     # =========================================================================
     # TASK METHODS

--- a/packages/client-python/src/rocketride/database.py
+++ b/packages/client-python/src/rocketride/database.py
@@ -33,6 +33,8 @@ Usage:
 
 from __future__ import annotations
 
+import json
+from enum import Enum
 from typing import TYPE_CHECKING, Optional
 
 from .schema.question import Question, QuestionType
@@ -40,6 +42,20 @@ from .types.data import PIPELINE_RESULT
 
 if TYPE_CHECKING:
     from .client import RocketRideClient
+
+
+class DatabaseDialect(str, Enum):
+    """
+    Underlying database engine a pipeline is connected to.
+
+    Returned by ``client.database.dialect(...)`` so applications can branch on
+    dialect-specific behavior (e.g. SQL syntax differences, type coercion) and
+    detect when they're talking to a graph DB instead of a relational one.
+    """
+
+    POSTGRES = 'postgres'
+    MYSQL = 'mysql'
+    NEO4J = 'neo4j'
 
 
 class DatabaseApi:
@@ -88,3 +104,39 @@ class DatabaseApi:
         question = Question(type=QuestionType.EXECUTE)
         question.addQuestion(sql)
         return await self._client.chat(token=token, question=question, on_sse=on_sse)
+
+    async def dialect(self, *, token: str) -> DatabaseDialect:
+        """
+        Discover the underlying database engine for a pipeline.
+
+        Sends a ``Question(type=DIALECT)``; the database node replies on the
+        ``answers`` lane with ``{"dialect": "<engine>"}``. Use this to branch
+        on dialect-specific SQL or to assert you're not pointed at the wrong
+        kind of database (e.g. Neo4j when you expected Postgres).
+
+        Args:
+            token: Pipeline token for authentication and resource access.
+
+        Returns:
+            DatabaseDialect: The dialect reported by the node.
+
+        Raises:
+            ValueError: If ``token`` is empty/whitespace, the pipeline returns
+                no answer, or the response is not a recognized dialect.
+        """
+        if not isinstance(token, str) or not token.strip():
+            raise ValueError('token must be a non-empty string')
+
+        question = Question(type=QuestionType.DIALECT)
+        question.addQuestion('dialect')
+        result = await self._client.chat(token=token, question=question)
+
+        answers = result.get('answers') if isinstance(result, dict) else None
+        if not answers:
+            raise ValueError('Pipeline returned no dialect answer; is the endpoint a database node?')
+
+        try:
+            payload = json.loads(answers[0])
+            return DatabaseDialect(payload['dialect'])
+        except (TypeError, KeyError, ValueError, json.JSONDecodeError) as e:
+            raise ValueError(f'Unexpected dialect response from pipeline: {answers[0]!r}') from e

--- a/packages/client-python/src/rocketride/database.py
+++ b/packages/client-python/src/rocketride/database.py
@@ -76,7 +76,15 @@ class DatabaseApi:
         Returns:
             PIPELINE_RESULT: The pipeline response. The ``answers`` lane carries
             a JSON-encoded payload of shape ``{"rows": [...], "affected_rows": N}``.
+
+        Raises:
+            ValueError: If ``token`` or ``sql`` is empty or whitespace-only.
         """
+        if not isinstance(token, str) or not token.strip():
+            raise ValueError('token must be a non-empty string')
+        if not isinstance(sql, str) or not sql.strip():
+            raise ValueError('sql must be a non-empty string')
+
         question = Question(type=QuestionType.EXECUTE)
         question.addQuestion(sql)
         return await self._client.chat(token=token, question=question, on_sse=on_sse)

--- a/packages/client-python/src/rocketride/database.py
+++ b/packages/client-python/src/rocketride/database.py
@@ -1,0 +1,82 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Database API namespace for the RocketRide Python SDK.
+
+Exposes ``client.database.query(...)`` for issuing raw SQL or Cypher directly
+against a database pipeline, bypassing the LLM translation layer that the
+default ``client.chat(...)`` flow uses.
+
+Usage:
+    rows = await client.database.query(token=t, sql='SELECT 1 AS one')
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from .schema.question import Question, QuestionType
+from .types.data import PIPELINE_RESULT
+
+if TYPE_CHECKING:
+    from .client import RocketRideClient
+
+
+class DatabaseApi:
+    """
+    Direct database-query namespace on RocketRideClient.
+
+    Accessed via ``client.database`` -- not instantiated directly. Statements
+    submitted through this namespace bypass the LLM translation layer and
+    safety checks, so the caller is responsible for the SQL/Cypher they pass.
+    """
+
+    def __init__(self, client: 'RocketRideClient') -> None:
+        self._client = client
+
+    async def query(
+        self,
+        *,
+        token: str,
+        sql: str,
+        on_sse: Optional[object] = None,
+    ) -> PIPELINE_RESULT:
+        """
+        Execute a raw SQL or Cypher statement against a database pipeline.
+
+        Sends a Question with ``type=QuestionType.EXECUTE`` so the database
+        node treats ``sql`` as the literal statement to run -- no LLM call,
+        no ``is_sql_safe`` / ``_is_cypher_safe`` gating.
+
+        Args:
+            token: Pipeline token for authentication and resource access.
+            sql: Raw SQL or Cypher statement to execute.
+            on_sse: Optional callback for streaming events (matches ``chat``).
+
+        Returns:
+            PIPELINE_RESULT: The pipeline response. The ``answers`` lane carries
+            a JSON-encoded payload of shape ``{"rows": [...], "affected_rows": N}``.
+        """
+        question = Question(type=QuestionType.EXECUTE)
+        question.addQuestion(sql)
+        return await self._client.chat(token=token, question=question, on_sse=on_sse)

--- a/packages/client-python/src/rocketride/schema/question.py
+++ b/packages/client-python/src/rocketride/schema/question.py
@@ -295,6 +295,7 @@ class QuestionType(str, Enum):
         GET: Retrieves specific information or data
         PROMPT: Raw prompt without additional processing
         EXECUTE: Direct query execution against database nodes (bypasses LLM + safety checks)
+        DIALECT: Database-dialect discovery (node responds with its engine name)
     """
 
     QUESTION = 'question'  # Basic question-answering
@@ -303,6 +304,7 @@ class QuestionType(str, Enum):
     GET = 'get'  # Information retrieval
     PROMPT = 'prompt'  # Raw prompt processing
     EXECUTE = 'execute'  # Direct DB query execution (no LLM, no safety check)
+    DIALECT = 'dialect'  # Ask a database node which engine it is connected to
 
 
 class Question(BaseModel):

--- a/packages/client-python/src/rocketride/schema/question.py
+++ b/packages/client-python/src/rocketride/schema/question.py
@@ -294,6 +294,7 @@ class QuestionType(str, Enum):
         KEYWORD: Uses keyword matching and text search
         GET: Retrieves specific information or data
         PROMPT: Raw prompt without additional processing
+        EXECUTE: Direct query execution against database nodes (bypasses LLM + safety checks)
     """
 
     QUESTION = 'question'  # Basic question-answering
@@ -301,6 +302,7 @@ class QuestionType(str, Enum):
     KEYWORD = 'keyword'  # Keyword-based search
     GET = 'get'  # Information retrieval
     PROMPT = 'prompt'  # Raw prompt processing
+    EXECUTE = 'execute'  # Direct DB query execution (no LLM, no safety check)
 
 
 class Question(BaseModel):

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -30,6 +30,7 @@ import { CONST_DEFAULT_WEB_CLOUD, CONST_DEFAULT_WEB_PROTOCOL, CONST_DEFAULT_WEB_
 import { Question } from './schema/Question.js';
 import { AccountApi } from './account.js';
 import { BillingApi } from './billing.js';
+import { DatabaseApi } from './database.js';
 import { AuthenticationException, ConnectionException, PipeException } from './exceptions/index.js';
 
 // Global counter for generating unique client IDs
@@ -317,6 +318,9 @@ export class RocketRideClient extends DAPClient {
 
 	/** Lazily-created billing API namespace. */
 	private _billing?: BillingApi;
+
+	/** Lazily-created database API namespace. */
+	private _database?: DatabaseApi;
 
 	/** Optional trace callback for observing all call() traffic. */
 	private _onTrace?: (traceType: TraceType, message: DAPMessage) => void;
@@ -2480,6 +2484,24 @@ export class RocketRideClient extends DAPClient {
 			this._billing = new BillingApi(this);
 		}
 		return this._billing;
+	}
+
+	/**
+	 * Lazily-initialised database API namespace.
+	 *
+	 * Provides direct SQL/Cypher execution against database pipelines, bypassing
+	 * the LLM translation layer that {@link RocketRideClient.chat} uses.
+	 *
+	 * @example
+	 * ```typescript
+	 * const result = await client.database.query({ token, sql: 'SELECT 1' });
+	 * ```
+	 */
+	get database(): DatabaseApi {
+		if (!this._database) {
+			this._database = new DatabaseApi(this);
+		}
+		return this._database;
 	}
 
 	// ============================================================================

--- a/packages/client-typescript/src/client/database.ts
+++ b/packages/client-typescript/src/client/database.ts
@@ -1,0 +1,73 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Database API namespace for the RocketRide TypeScript SDK.
+ *
+ * Exposes `client.database.query(...)` for issuing raw SQL or Cypher directly
+ * against a database pipeline, bypassing the LLM translation layer that the
+ * default `client.chat(...)` flow uses.
+ */
+
+import type { RocketRideClient } from './client.js';
+import type { PIPELINE_RESULT } from './types/index.js';
+import { Question, QuestionType } from './schema/Question.js';
+
+// =============================================================================
+// DATABASE API CLASS
+// =============================================================================
+
+/**
+ * Direct database-query namespace on RocketRideClient.
+ *
+ * Accessed via `client.database` — not instantiated directly. Statements
+ * submitted through this namespace bypass the LLM translation layer and
+ * safety checks, so the caller is responsible for the SQL/Cypher they pass.
+ */
+export class DatabaseApi {
+	constructor(private readonly client: RocketRideClient) {}
+
+	/**
+	 * Execute a raw SQL or Cypher statement against a database pipeline.
+	 *
+	 * Sends a Question with `type=QuestionType.EXECUTE` so the database node
+	 * treats `sql` as the literal statement to run — no LLM call, no
+	 * `is_sql_safe` / `_is_cypher_safe` gating.
+	 *
+	 * @param options.token - Pipeline token for authentication and resource access.
+	 * @param options.sql - Raw SQL or Cypher statement to execute.
+	 * @param options.onSSE - Optional streaming callback (matches `chat`).
+	 * @returns The pipeline response. The `answers` lane carries a JSON-encoded
+	 *   payload of shape `{"rows": [...], "affected_rows": N}`.
+	 */
+	async query(options: {
+		token: string;
+		sql: string;
+		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
+	}): Promise<PIPELINE_RESULT> {
+		const question = new Question({ type: QuestionType.EXECUTE });
+		question.addQuestion(options.sql);
+		return this.client.chat({ token: options.token, question, onSSE: options.onSSE });
+	}
+}

--- a/packages/client-typescript/src/client/database.ts
+++ b/packages/client-typescript/src/client/database.ts
@@ -66,6 +66,13 @@ export class DatabaseApi {
 		sql: string;
 		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
 	}): Promise<PIPELINE_RESULT> {
+		if (typeof options.token !== 'string' || options.token.trim() === '') {
+			throw new Error('token must be a non-empty string');
+		}
+		if (typeof options.sql !== 'string' || options.sql.trim() === '') {
+			throw new Error('sql must be a non-empty string');
+		}
+
 		const question = new Question({ type: QuestionType.EXECUTE });
 		question.addQuestion(options.sql);
 		return this.client.chat({ token: options.token, question, onSSE: options.onSSE });

--- a/packages/client-typescript/src/client/database.ts
+++ b/packages/client-typescript/src/client/database.ts
@@ -35,6 +35,23 @@ import type { PIPELINE_RESULT } from './types/index.js';
 import { Question, QuestionType } from './schema/Question.js';
 
 // =============================================================================
+// DIALECT ENUM
+// =============================================================================
+
+/**
+ * Underlying database engine a pipeline is connected to.
+ *
+ * Returned by `client.database.dialect(...)` so applications can branch on
+ * dialect-specific behavior (e.g. SQL syntax differences, type coercion) and
+ * detect when they're talking to a graph DB instead of a relational one.
+ */
+export enum DatabaseDialect {
+	POSTGRES = 'postgres',
+	MYSQL = 'mysql',
+	NEO4J = 'neo4j',
+}
+
+// =============================================================================
 // DATABASE API CLASS
 // =============================================================================
 
@@ -76,5 +93,46 @@ export class DatabaseApi {
 		const question = new Question({ type: QuestionType.EXECUTE });
 		question.addQuestion(options.sql);
 		return this.client.chat({ token: options.token, question, onSSE: options.onSSE });
+	}
+
+	/**
+	 * Discover the underlying database engine for a pipeline.
+	 *
+	 * Sends a `Question(type=DIALECT)`; the database node replies on the
+	 * `answers` lane with `{"dialect": "<engine>"}`. Use this to branch on
+	 * dialect-specific SQL or to assert you're not pointed at the wrong kind
+	 * of database (e.g. Neo4j when you expected Postgres).
+	 *
+	 * @param options.token - Pipeline token for authentication and resource access.
+	 * @returns The dialect reported by the node.
+	 * @throws If `token` is empty, the pipeline returns no answer, or the
+	 *   response is not a recognized dialect.
+	 */
+	async dialect(options: { token: string }): Promise<DatabaseDialect> {
+		if (typeof options.token !== 'string' || options.token.trim() === '') {
+			throw new Error('token must be a non-empty string');
+		}
+
+		const question = new Question({ type: QuestionType.DIALECT });
+		question.addQuestion('dialect');
+		const result = await this.client.chat({ token: options.token, question });
+
+		const answers = (result as { answers?: string[] })?.answers;
+		if (!answers || answers.length === 0) {
+			throw new Error('Pipeline returned no dialect answer; is the endpoint a database node?');
+		}
+
+		let payload: { dialect?: string };
+		try {
+			payload = JSON.parse(answers[0]);
+		} catch {
+			throw new Error(`Unexpected dialect response from pipeline: ${answers[0]}`);
+		}
+
+		const known = Object.values(DatabaseDialect) as string[];
+		if (!payload.dialect || !known.includes(payload.dialect)) {
+			throw new Error(`Unexpected dialect response from pipeline: ${answers[0]}`);
+		}
+		return payload.dialect as DatabaseDialect;
 	}
 }

--- a/packages/client-typescript/src/client/index.ts
+++ b/packages/client-typescript/src/client/index.ts
@@ -45,3 +45,6 @@ export * from './constants.js';
 
 // Export the main client and utilities
 export * from './client.js';
+
+// Export the database API namespace (DatabaseApi class, DatabaseDialect enum)
+export * from './database.js';

--- a/packages/client-typescript/src/client/schema/Question.ts
+++ b/packages/client-typescript/src/client/schema/Question.ts
@@ -33,7 +33,8 @@ export enum QuestionType {
 	SEMANTIC = 'semantic',
 	KEYWORD = 'keyword',
 	GET = 'get',
-	PROMPT = 'prompt'
+	PROMPT = 'prompt',
+	EXECUTE = 'execute'
 }
 
 /**

--- a/packages/client-typescript/src/client/schema/Question.ts
+++ b/packages/client-typescript/src/client/schema/Question.ts
@@ -34,7 +34,8 @@ export enum QuestionType {
 	KEYWORD = 'keyword',
 	GET = 'get',
 	PROMPT = 'prompt',
-	EXECUTE = 'execute'
+	EXECUTE = 'execute',
+	DIALECT = 'dialect'
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds `QuestionType.EXECUTE` so callers can submit raw SQL/Cypher to a database pipeline and bypass the LLM-translation layer (and `is_sql_safe` / `_is_cypher_safe` gating). Default `QUESTION` flow is unchanged.
- New `client.database.query({ token, sql })` namespace on both the Python and TypeScript SDKs as a thin wrapper that builds the `Question(type=EXECUTE)` for you.
- Wires the new branch through `DatabaseInstanceBase.writeQuestions` (covers `db_postgres` / `db_mysql`) and `db_neo4j.IInstance.writeQuestions`. Adds `_executeRawQuery` (SQLAlchemy `engine.begin()` for auto-commit on writes) and `_run_query_raw` (Neo4j `session.run`, accumulates `affected_rows` from the result counters when no rows are returned).
- Lane output: `answers` lane carries a JSON-encoded `{rows, affected_rows}` payload; `table` lane gets a markdown table when there are rows; `text` lane gets the table or `"N rows affected"`. Errors match existing precedent — caught + logged via `error()`, no lane emission.

## Files changed
- `packages/client-python/src/rocketride/schema/question.py` — `EXECUTE = 'execute'`
- `packages/client-typescript/src/client/schema/Question.ts` — `EXECUTE = 'execute'`
- `packages/ai/src/ai/common/database/db_instance_base.py` — EXECUTE branch + `_executeRawQuery`
- `nodes/src/nodes/db_neo4j/IInstance.py` — EXECUTE branch
- `nodes/src/nodes/db_neo4j/IGlobal.py` — `_run_query_raw`
- `packages/client-python/src/rocketride/database.py` — **new** `DatabaseApi`
- `packages/client-python/src/rocketride/client.py` — register `database` cached_property
- `packages/client-typescript/src/client/database.ts` — **new** `DatabaseApi`
- `packages/client-typescript/src/client/client.ts` — register `database` getter

## Test plan
- [x] `./builder ai:build nodes:build client-python:build client-typescript:build` — clean
- [x] `./builder nodes:test` — 733 passed (well above the 310+ floor)
- [x] `ruff check` clean on changed Python files
- [x] `eslint` 0 errors on changed TS files (15 pre-existing `no-explicit-any` warnings in `client.ts`, none in new code)
- [x] **End-to-end** verified locally against Postgres + Neo4j on both SDKs (8/8 cases per language):
  - SQL: `SELECT` 3 rows, `INSERT`/`UPDATE`/`DELETE` with `affected_rows=1`, bad SQL emits no answer
  - Cypher: `CREATE … RETURN n`, `CREATE` no-RETURN with `affected_rows>=1` from counters, `MATCH count(n)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct database.query() in Python and TypeScript SDKs via a lazy client.database namespace.
  * Introduced EXECUTE question type to submit raw SQL/Cypher (bypasses LLM translation/safety when enabled).
  * Execution is opt-in (default off) with configurable max-row cap (default 25,000).
  * Execution returns markdown tables for display and a JSON payload with rows and affected_rows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/782)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->