### PR TITLE
chore(security): add top-level permissions to 5 reusable workflows

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -1,5 +1,11 @@
 name: Build
 
+# Default least-privilege permissions for the workflow. Individual jobs
+# below raise to write where they actually need it (Docker push, SARIF
+# upload, etc.). Closes Scorecard TokenPermissionsID #513.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_docker.yaml
+++ b/.github/workflows/_docker.yaml
@@ -1,5 +1,11 @@
 name: Docker
 
+# Default least-privilege permissions for the workflow. Individual jobs
+# below raise to write where they actually need it (image push to GHCR).
+# Closes Scorecard TokenPermissionsID #514.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_init.yaml
+++ b/.github/workflows/_init.yaml
@@ -1,5 +1,11 @@
 name: Initialize
 
+# Default least-privilege permissions for the workflow. The init job
+# only reads the repo to compute version/build variables; no writes
+# needed. Closes Scorecard TokenPermissionsID #515.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -1,5 +1,12 @@
 name: Release
 
+# Default least-privilege permissions for the workflow. Individual
+# release jobs below raise to write where they actually need it
+# (tag pushes, GitHub releases, package publishing).
+# Closes Scorecard TokenPermissionsID #516.
+permissions:
+  contents: read
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -1,5 +1,12 @@
 name: Sync LLM Models
 
+# Default least-privilege permissions for the workflow. The `sync`
+# job below raises to contents:write + pull-requests:write to commit
+# updated model manifests and open the PR. Closes Scorecard
+# TokenPermissionsID #605.
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 5 * * 1' # Mondays 05:00 UTC


### PR DESCRIPTION
## Summary

Adds `permissions: contents: read` (least-privilege default) to the top of five workflow files that had no top-level permissions declaration. Closes 5 Scorecard `TokenPermissionsID` alerts.

## Files changed

| File | Closes Scorecard alert | Existing job-level permissions preserved |
|---|---|---|
| `.github/workflows/_build.yaml` | #513 | Yes (Docker push job retains `packages: write`) |
| `.github/workflows/_docker.yaml` | #514 | Yes |
| `.github/workflows/_init.yaml` | #515 | Yes (no job-level changes needed) |
| `.github/workflows/_release.yaml` | #516 | Yes (release jobs retain `contents: write`, `packages: write`) |
| `.github/workflows/sync-models.yml` | #605 | Yes (`sync` job retains `contents: write`, `pull-requests: write`) |

## Why this is safe

- All five are **reusable workflows** invoked via `uses: ./.github/workflows/_*.yaml` from caller workflows, except `sync-models.yml` which runs on schedule
- Top-level `permissions:` acts as a **default ceiling**, not a hard cap — individual jobs raise to write where they need it
- Existing job-level `permissions:` blocks are unchanged
- `contents: read` matches the pattern in `secret-scan.yml` and `ci.yml`

## Type

chore (security hardening)

## Linked Issue

Fixes #789

## Out of scope (follow-up PRs)

- **Stage 2** — narrow broad top-level writes in `nightly.yaml` + `storage-cleanup.yml` (3 alerts)
- **Stage 3** — justify or selectively dismiss the 7 job-level write alerts on legitimate release/build operations

## SOC2 Notes

CC7.1 vulnerability management — mechanical batch resolution of 5 critical/high TokenPermissionsID findings within the SLA window. SECURITY.md disposition: **Fixed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow permissions across build, deployment, and sync pipelines to enforce least-privilege access controls at the workflow level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->