### PR TITLE
chore(security): narrow storage-cleanup.yml permissions to job-level

### DIFF
--- a/.github/workflows/storage-cleanup.yml
+++ b/.github/workflows/storage-cleanup.yml
@@ -28,7 +28,6 @@ on:
         default: '7'
 
 permissions:
-  actions: write
   contents: read
 
 concurrency:
@@ -40,6 +39,12 @@ jobs:
     name: Delete old artifacts and caches
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Narrowed from top-level: actions:write only at job scope so other
+    # jobs added to this workflow in the future inherit the read default.
+    # Closes Scorecard TokenPermissionsID #528.
+    permissions:
+      actions: write
+      contents: read
     steps:
       - name: Delete old artifacts
         env:


### PR DESCRIPTION
## Summary

Moves `actions: write` from the workflow-level permissions block to the `cleanup` job's own permissions block. Top-level default narrows from `actions: write + contents: read` to `contents: read` only.

## Behavior

Unchanged. The `cleanup` job's effective permissions stay the same (`actions: write` + `contents: read`). The narrowing only affects any future jobs added to this workflow — they'll inherit `contents: read` by default rather than the broad cleanup token.

## Diff

```yaml
 permissions:
-  actions: write
   contents: read

 jobs:
   cleanup:
     name: Delete old artifacts and caches
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: read
     steps:
```

## Type

chore (security hardening)

## Linked Issue

Fixes #793

## Stage tracking

This is Stage 2a of the 3-stage TokenPermissionsID cleanup:
- Stage 1 (✅ #790 merged): `permissions: contents: read` added to 5 reusable workflows
- **Stage 2a (this PR):** narrow `storage-cleanup.yml` top-level
- Stage 2b (deferred): narrow `nightly.yaml` top-level — wait for stage-branch rewrite to settle
- Stage 3 (deferred): justify/dismiss 7 job-level write alerts on legitimate release operations

## SOC2 Notes

CC7.1 vulnerability management — closes Scorecard alert #528 (TokenPermissionsID). Following SECURITY.md disposition framework: **Fixed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow job permissions to use job-scoped configuration, restricting access to only necessary permissions for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->