### PR TITLE
fix(workflows): add retry/backoff to Discord webhook calls

### DIFF
--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -30,6 +30,54 @@ jobs:
             exit 0
           fi
 
+          # ── Discord webhook call helper with retry/backoff ───────────────
+          # Discord webhooks return 429 (rate limit, with Retry-After) and
+          # transient 5xx during incidents. Without retry any blip aborts
+          # the job. This wraps curl so 429/5xx are retried; non-429 4xx
+          # are returned to the caller. Sets $DISCORD_LAST_STATUS.
+          discord_curl() {
+            local max_attempts=5 attempt=1 backoff=1
+            local headers response status body retry_after
+            headers=$(mktemp); trap 'rm -f "$headers"' RETURN
+            while [ $attempt -le $max_attempts ]; do
+              : > "$headers"
+              response=$(curl -sS -D "$headers" -w "\n%{http_code}" "$@") || true
+              status=$(printf '%s' "$response" | tail -n 1)
+              body=$(printf '%s' "$response" | sed '$d')
+
+              if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$body"
+                return 0
+              fi
+
+              if [ "$status" = "429" ]; then
+                retry_after=$(awk 'tolower($1)=="retry-after:"{print $2}' "$headers" | tr -d '\r' | head -n1)
+                retry_after=${retry_after:-$backoff}
+                retry_after=$(awk -v n="$retry_after" 'BEGIN{ x=n+0; printf "%d", (x<1?1:(x==int(x)?x:int(x)+1)) }')
+                [ "$retry_after" -gt 60 ] && retry_after=60
+                echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$retry_after"
+              elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
+                echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+              elif [ -z "$status" ]; then
+                echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+              else
+                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$body"
+                return 1
+              fi
+              attempt=$((attempt + 1))
+            done
+            DISCORD_LAST_STATUS="${status:-000}"
+            printf '%s' "$body"
+            return 1
+          }
+
           NUMBER="${{ github.event.discussion.number }}"
           OWNER="${REPO%/*}"
           NAME="${REPO#*/}"
@@ -202,13 +250,11 @@ jobs:
 
           # ── Post or patch ────────────────────────────────────────────────
           if [ -n "$DISCORD_MSG_ID" ]; then
-            PATCH_RESPONSE=$(curl -sS -w "\n%{http_code}" -X PATCH \
+            PATCH_BODY=$(discord_curl -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID")
-
-            PATCH_BODY=$(echo "$PATCH_RESPONSE" | head -n -1)
-            PATCH_STATUS=$(echo "$PATCH_RESPONSE" | tail -n 1)
+              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID") || true
+            PATCH_STATUS="$DISCORD_LAST_STATUS"
             echo "PATCH status: $PATCH_STATUS"
 
             if [ "$PATCH_STATUS" = "404" ]; then
@@ -223,10 +269,13 @@ jobs:
           fi
 
           if [ -z "$DISCORD_MSG_ID" ]; then
-            RESPONSE=$(curl -sS -f \
+            if ! RESPONSE=$(discord_curl \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "${DISCORD_WEBHOOK_URL}?wait=true")
+              "${DISCORD_WEBHOOK_URL}?wait=true"); then
+              echo "::error::Discord POST failed (status ${DISCORD_LAST_STATUS}) after retries"
+              exit 1
+            fi
             NEW_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
 
             # ── Race guard: re-search for a marker created by a concurrent run ──
@@ -234,10 +283,10 @@ jobs:
 
             if [ -n "$EXISTING_MARKER" ] && [ "$EXISTING_MARKER" != "null" ]; then
               # Another run won the race — delete our duplicate message, use theirs
-              curl -sS -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" || true
+              discord_curl -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" > /dev/null || true
               DISCORD_MSG_ID=$(echo "$EXISTING_MARKER" | jq -r '.body' | grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2)
-              curl -sS -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
-                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null
+              discord_curl -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
+                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null || true
             else
               DISCORD_MSG_ID="$NEW_MSG_ID"
               gh api graphql \

--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -22,6 +22,15 @@ jobs:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_DISCUSSIONS_WEBHOOK_URL }}
       REPO: ${{ github.repository }}
     steps:
+      - name: Checkout helper script
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/workflows/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Build embed, post or patch Discord
         run: |
           # ── Guard: bail if webhook is not configured ─────────────────────
@@ -30,61 +39,9 @@ jobs:
             exit 0
           fi
 
-          # ── Discord webhook call helper with retry/backoff ───────────────
-          # Discord webhooks return 429 (rate limit, with Retry-After) and
-          # transient 5xx during incidents. Without retry any blip aborts
-          # the job. This wraps curl so 429/5xx are retried; non-429 4xx
-          # are returned to the caller.
-          #
-          # Status sink: callers invoke discord_curl via $(...), which runs
-          # in a subshell — shell variables set inside don't propagate back.
-          # Publish the HTTP status through a step-owned temp file so callers
-          # can read it after the substitution returns.
-          DISCORD_STATUS_FILE=$(mktemp)
-          trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
-
-          discord_curl() {
-            local max_attempts=5 attempt=1 backoff=1
-            local headers response status body retry_after
-            headers=$(mktemp); trap 'rm -f "$headers"' RETURN
-            while [ $attempt -le $max_attempts ]; do
-              : > "$headers"
-              response=$(curl -sS --connect-timeout 10 --max-time 60 -D "$headers" -w "\n%{http_code}" "$@") || true
-              status=$(printf '%s' "$response" | tail -n 1)
-              body=$(printf '%s' "$response" | sed '$d')
-
-              if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
-                printf '%s' "$body"
-                return 0
-              fi
-
-              if [ "$status" = "429" ]; then
-                retry_after=$(awk 'tolower($1)=="retry-after:"{print $2}' "$headers" | tr -d '\r' | head -n1)
-                retry_after=${retry_after:-$backoff}
-                retry_after=$(awk -v n="$retry_after" 'BEGIN{ x=n+0; printf "%d", (x<1?1:(x==int(x)?x:int(x)+1)) }')
-                [ "$retry_after" -gt 60 ] && retry_after=60
-                echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$retry_after"
-              elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
-                echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$backoff"
-                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-              elif [ -z "$status" ]; then
-                echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$backoff"
-                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-              else
-                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
-                printf '%s' "$body"
-                return 1
-              fi
-              attempt=$((attempt + 1))
-            done
-            printf '%s' "${status:-000}" > "$DISCORD_STATUS_FILE"
-            printf '%s' "$body"
-            return 1
-          }
+          # ── Source the shared discord_curl helper (retry/backoff + status sink) ──
+          # shellcheck source=scripts/discord-helper.sh
+          source "${GITHUB_WORKSPACE}/.github/workflows/scripts/discord-helper.sh"
 
           NUMBER="${{ github.event.discussion.number }}"
           OWNER="${REPO%/*}"

--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -34,19 +34,27 @@ jobs:
           # Discord webhooks return 429 (rate limit, with Retry-After) and
           # transient 5xx during incidents. Without retry any blip aborts
           # the job. This wraps curl so 429/5xx are retried; non-429 4xx
-          # are returned to the caller. Sets $DISCORD_LAST_STATUS.
+          # are returned to the caller.
+          #
+          # Status sink: callers invoke discord_curl via $(...), which runs
+          # in a subshell — shell variables set inside don't propagate back.
+          # Publish the HTTP status through a step-owned temp file so callers
+          # can read it after the substitution returns.
+          DISCORD_STATUS_FILE=$(mktemp)
+          trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
+
           discord_curl() {
             local max_attempts=5 attempt=1 backoff=1
             local headers response status body retry_after
             headers=$(mktemp); trap 'rm -f "$headers"' RETURN
             while [ $attempt -le $max_attempts ]; do
               : > "$headers"
-              response=$(curl -sS -D "$headers" -w "\n%{http_code}" "$@") || true
+              response=$(curl -sS --connect-timeout 10 --max-time 60 -D "$headers" -w "\n%{http_code}" "$@") || true
               status=$(printf '%s' "$response" | tail -n 1)
               body=$(printf '%s' "$response" | sed '$d')
 
               if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
                 printf '%s' "$body"
                 return 0
               fi
@@ -67,13 +75,13 @@ jobs:
                 sleep "$backoff"
                 backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
               else
-                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
                 printf '%s' "$body"
                 return 1
               fi
               attempt=$((attempt + 1))
             done
-            DISCORD_LAST_STATUS="${status:-000}"
+            printf '%s' "${status:-000}" > "$DISCORD_STATUS_FILE"
             printf '%s' "$body"
             return 1
           }
@@ -254,7 +262,7 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID") || true
-            PATCH_STATUS="$DISCORD_LAST_STATUS"
+            PATCH_STATUS=$(cat "$DISCORD_STATUS_FILE")
             echo "PATCH status: $PATCH_STATUS"
 
             if [ "$PATCH_STATUS" = "404" ]; then
@@ -273,7 +281,7 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "${DISCORD_WEBHOOK_URL}?wait=true"); then
-              echo "::error::Discord POST failed (status ${DISCORD_LAST_STATUS}) after retries"
+              echo "::error::Discord POST failed (status $(cat "$DISCORD_STATUS_FILE")) after retries"
               exit 1
             fi
             NEW_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')

--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -20,6 +20,15 @@ jobs:
       DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_ISSUES_WEBHOOK_URL }}
       REPO: ${{ github.repository }}
     steps:
+      - name: Checkout helper script
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/workflows/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Build embed, post or patch Discord
         run: |
           # ── Guard: bail if webhook is not configured ─────────────────────
@@ -28,61 +37,9 @@ jobs:
             exit 0
           fi
 
-          # ── Discord webhook call helper with retry/backoff ───────────────
-          # Discord webhooks return 429 (rate limit, with Retry-After) and
-          # transient 5xx during incidents. Without retry any blip aborts
-          # the job. This wraps curl so 429/5xx are retried; non-429 4xx
-          # are returned to the caller.
-          #
-          # Status sink: callers invoke discord_curl via $(...), which runs
-          # in a subshell — shell variables set inside don't propagate back.
-          # Publish the HTTP status through a step-owned temp file so callers
-          # can read it after the substitution returns.
-          DISCORD_STATUS_FILE=$(mktemp)
-          trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
-
-          discord_curl() {
-            local max_attempts=5 attempt=1 backoff=1
-            local headers response status body retry_after
-            headers=$(mktemp); trap 'rm -f "$headers"' RETURN
-            while [ $attempt -le $max_attempts ]; do
-              : > "$headers"
-              response=$(curl -sS --connect-timeout 10 --max-time 60 -D "$headers" -w "\n%{http_code}" "$@") || true
-              status=$(printf '%s' "$response" | tail -n 1)
-              body=$(printf '%s' "$response" | sed '$d')
-
-              if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
-                printf '%s' "$body"
-                return 0
-              fi
-
-              if [ "$status" = "429" ]; then
-                retry_after=$(awk 'tolower($1)=="retry-after:"{print $2}' "$headers" | tr -d '\r' | head -n1)
-                retry_after=${retry_after:-$backoff}
-                retry_after=$(awk -v n="$retry_after" 'BEGIN{ x=n+0; printf "%d", (x<1?1:(x==int(x)?x:int(x)+1)) }')
-                [ "$retry_after" -gt 60 ] && retry_after=60
-                echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$retry_after"
-              elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
-                echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$backoff"
-                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-              elif [ -z "$status" ]; then
-                echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$backoff"
-                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-              else
-                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
-                printf '%s' "$body"
-                return 1
-              fi
-              attempt=$((attempt + 1))
-            done
-            printf '%s' "${status:-000}" > "$DISCORD_STATUS_FILE"
-            printf '%s' "$body"
-            return 1
-          }
+          # ── Source the shared discord_curl helper (retry/backoff + status sink) ──
+          # shellcheck source=scripts/discord-helper.sh
+          source "${GITHUB_WORKSPACE}/.github/workflows/scripts/discord-helper.sh"
 
           NUMBER="${{ github.event.issue.number }}"
 

--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -28,6 +28,54 @@ jobs:
             exit 0
           fi
 
+          # ── Discord webhook call helper with retry/backoff ───────────────
+          # Discord webhooks return 429 (rate limit, with Retry-After) and
+          # transient 5xx during incidents. Without retry any blip aborts
+          # the job. This wraps curl so 429/5xx are retried; non-429 4xx
+          # are returned to the caller. Sets $DISCORD_LAST_STATUS.
+          discord_curl() {
+            local max_attempts=5 attempt=1 backoff=1
+            local headers response status body retry_after
+            headers=$(mktemp); trap 'rm -f "$headers"' RETURN
+            while [ $attempt -le $max_attempts ]; do
+              : > "$headers"
+              response=$(curl -sS -D "$headers" -w "\n%{http_code}" "$@") || true
+              status=$(printf '%s' "$response" | tail -n 1)
+              body=$(printf '%s' "$response" | sed '$d')
+
+              if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$body"
+                return 0
+              fi
+
+              if [ "$status" = "429" ]; then
+                retry_after=$(awk 'tolower($1)=="retry-after:"{print $2}' "$headers" | tr -d '\r' | head -n1)
+                retry_after=${retry_after:-$backoff}
+                retry_after=$(awk -v n="$retry_after" 'BEGIN{ x=n+0; printf "%d", (x<1?1:(x==int(x)?x:int(x)+1)) }')
+                [ "$retry_after" -gt 60 ] && retry_after=60
+                echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$retry_after"
+              elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
+                echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+              elif [ -z "$status" ]; then
+                echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+              else
+                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$body"
+                return 1
+              fi
+              attempt=$((attempt + 1))
+            done
+            DISCORD_LAST_STATUS="${status:-000}"
+            printf '%s' "$body"
+            return 1
+          }
+
           NUMBER="${{ github.event.issue.number }}"
 
           # ── Fetch current issue state (always fresh, not from stale event payload) ──
@@ -93,13 +141,11 @@ jobs:
 
           # ── Post or patch ────────────────────────────────────────────────
           if [ -n "$DISCORD_MSG_ID" ]; then
-            PATCH_RESPONSE=$(curl -sS -w "\n%{http_code}" -X PATCH \
+            PATCH_BODY=$(discord_curl -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID")
-
-            PATCH_BODY=$(echo "$PATCH_RESPONSE" | head -n -1)
-            PATCH_STATUS=$(echo "$PATCH_RESPONSE" | tail -n 1)
+              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID") || true
+            PATCH_STATUS="$DISCORD_LAST_STATUS"
             echo "PATCH status: $PATCH_STATUS"
 
             if [ "$PATCH_STATUS" = "404" ]; then
@@ -114,10 +160,13 @@ jobs:
           fi
 
           if [ -z "$DISCORD_MSG_ID" ]; then
-            RESPONSE=$(curl -sS -f \
+            if ! RESPONSE=$(discord_curl \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "${DISCORD_WEBHOOK_URL}?wait=true")
+              "${DISCORD_WEBHOOK_URL}?wait=true"); then
+              echo "::error::Discord POST failed (status ${DISCORD_LAST_STATUS}) after retries"
+              exit 1
+            fi
             NEW_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
 
             # ── Race guard: re-check for a comment created by a concurrent run ──
@@ -126,11 +175,11 @@ jobs:
 
             if [ -n "$EXISTING" ]; then
               # Another run won the race — delete our duplicate message, use theirs
-              curl -sS -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" || true
+              discord_curl -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" > /dev/null || true
               DISCORD_MSG_ID=$(echo "$EXISTING" | jq -r '.body' | grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2)
               # Patch the existing message with our payload
-              curl -sS -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
-                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null
+              discord_curl -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
+                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null || true
             else
               DISCORD_MSG_ID="$NEW_MSG_ID"
               gh api "/repos/$REPO/issues/$NUMBER/comments" \

--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -32,19 +32,27 @@ jobs:
           # Discord webhooks return 429 (rate limit, with Retry-After) and
           # transient 5xx during incidents. Without retry any blip aborts
           # the job. This wraps curl so 429/5xx are retried; non-429 4xx
-          # are returned to the caller. Sets $DISCORD_LAST_STATUS.
+          # are returned to the caller.
+          #
+          # Status sink: callers invoke discord_curl via $(...), which runs
+          # in a subshell — shell variables set inside don't propagate back.
+          # Publish the HTTP status through a step-owned temp file so callers
+          # can read it after the substitution returns.
+          DISCORD_STATUS_FILE=$(mktemp)
+          trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
+
           discord_curl() {
             local max_attempts=5 attempt=1 backoff=1
             local headers response status body retry_after
             headers=$(mktemp); trap 'rm -f "$headers"' RETURN
             while [ $attempt -le $max_attempts ]; do
               : > "$headers"
-              response=$(curl -sS -D "$headers" -w "\n%{http_code}" "$@") || true
+              response=$(curl -sS --connect-timeout 10 --max-time 60 -D "$headers" -w "\n%{http_code}" "$@") || true
               status=$(printf '%s' "$response" | tail -n 1)
               body=$(printf '%s' "$response" | sed '$d')
 
               if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
                 printf '%s' "$body"
                 return 0
               fi
@@ -65,13 +73,13 @@ jobs:
                 sleep "$backoff"
                 backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
               else
-                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
                 printf '%s' "$body"
                 return 1
               fi
               attempt=$((attempt + 1))
             done
-            DISCORD_LAST_STATUS="${status:-000}"
+            printf '%s' "${status:-000}" > "$DISCORD_STATUS_FILE"
             printf '%s' "$body"
             return 1
           }
@@ -145,7 +153,7 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID") || true
-            PATCH_STATUS="$DISCORD_LAST_STATUS"
+            PATCH_STATUS=$(cat "$DISCORD_STATUS_FILE")
             echo "PATCH status: $PATCH_STATUS"
 
             if [ "$PATCH_STATUS" = "404" ]; then
@@ -164,7 +172,7 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "${DISCORD_WEBHOOK_URL}?wait=true"); then
-              echo "::error::Discord POST failed (status ${DISCORD_LAST_STATUS}) after retries"
+              echo "::error::Discord POST failed (status $(cat "$DISCORD_STATUS_FILE")) after retries"
               exit 1
             fi
             NEW_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -46,6 +46,56 @@ jobs:
             exit 0
           fi
 
+          # ── Discord webhook call helper with retry/backoff ───────────────
+          # Discord webhooks return 429 (rate limit, with Retry-After) and
+          # transient 5xx during incidents. Without retry any blip aborts
+          # the job, blocking the PR's checks queue. This wraps curl so
+          # 429/5xx are retried; non-429 4xx are returned to the caller.
+          # Sets $DISCORD_LAST_STATUS for callers that need the HTTP code.
+          discord_curl() {
+            local max_attempts=5 attempt=1 backoff=1
+            local headers response status body retry_after
+            headers=$(mktemp); trap 'rm -f "$headers"' RETURN
+            while [ $attempt -le $max_attempts ]; do
+              : > "$headers"
+              response=$(curl -sS -D "$headers" -w "\n%{http_code}" "$@") || true
+              status=$(printf '%s' "$response" | tail -n 1)
+              body=$(printf '%s' "$response" | sed '$d')
+
+              if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$body"
+                return 0
+              fi
+
+              if [ "$status" = "429" ]; then
+                retry_after=$(awk 'tolower($1)=="retry-after:"{print $2}' "$headers" | tr -d '\r' | head -n1)
+                retry_after=${retry_after:-$backoff}
+                retry_after=$(awk -v n="$retry_after" 'BEGIN{ x=n+0; printf "%d", (x<1?1:(x==int(x)?x:int(x)+1)) }')
+                [ "$retry_after" -gt 60 ] && retry_after=60
+                echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$retry_after"
+              elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
+                echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+              elif [ -z "$status" ]; then
+                echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+                sleep "$backoff"
+                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+              else
+                # 4xx other than 429 — non-retryable, surface to caller
+                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$body"
+                return 1
+              fi
+              attempt=$((attempt + 1))
+            done
+            DISCORD_LAST_STATUS="${status:-000}"
+            printf '%s' "$body"
+            return 1
+          }
+
           # ── Resolve PR number ────────────────────────────────────────────
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
             PR_NUMBER="${{ github.event.pull_request.number }}"
@@ -187,13 +237,11 @@ jobs:
 
           # ── Post or patch ────────────────────────────────────────────────
           if [ -n "$DISCORD_MSG_ID" ]; then
-            PATCH_RESPONSE=$(curl -sS -w "\n%{http_code}" -X PATCH \
+            PATCH_BODY=$(discord_curl -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID")
-
-            PATCH_BODY=$(echo "$PATCH_RESPONSE" | head -n -1)
-            PATCH_STATUS=$(echo "$PATCH_RESPONSE" | tail -n 1)
+              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID") || true
+            PATCH_STATUS="$DISCORD_LAST_STATUS"
             echo "PATCH status: $PATCH_STATUS"
 
             if [ "$PATCH_STATUS" = "404" ]; then
@@ -208,10 +256,13 @@ jobs:
           fi
 
           if [ -z "$DISCORD_MSG_ID" ]; then
-            RESPONSE=$(curl -sS -f \
+            if ! RESPONSE=$(discord_curl \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "${DISCORD_WEBHOOK_URL}?wait=true")
+              "${DISCORD_WEBHOOK_URL}?wait=true"); then
+              echo "::error::Discord POST failed (status ${DISCORD_LAST_STATUS}) after retries"
+              exit 1
+            fi
             NEW_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')
 
             # ── Race guard: re-check for a comment created by a concurrent run ──
@@ -220,11 +271,11 @@ jobs:
 
             if [ -n "$EXISTING" ]; then
               # Another run won the race — delete our duplicate message, use theirs
-              curl -sS -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" || true
+              discord_curl -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" > /dev/null || true
               DISCORD_MSG_ID=$(echo "$EXISTING" | jq -r '.body' | grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2)
               # Patch the existing message with our payload
-              curl -sS -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
-                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null
+              discord_curl -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
+                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null || true
             else
               DISCORD_MSG_ID="$NEW_MSG_ID"
               gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -38,6 +38,18 @@ jobs:
       REPO: ${{ github.repository }}
       EVENT_NAME: ${{ github.event_name }}
     steps:
+      # Checkout default branch only — we just need the helper script. Pinning
+      # to the trusted default branch (not PR head) so a fork PR can't substitute
+      # a malicious helper script before we source it.
+      - name: Checkout helper script
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/workflows/scripts
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
       - name: Resolve PR, build embed, post or patch Discord
         run: |
           # ── Guard: bail if webhook is not configured ─────────────────────
@@ -46,62 +58,9 @@ jobs:
             exit 0
           fi
 
-          # ── Discord webhook call helper with retry/backoff ───────────────
-          # Discord webhooks return 429 (rate limit, with Retry-After) and
-          # transient 5xx during incidents. Without retry any blip aborts
-          # the job, blocking the PR's checks queue. This wraps curl so
-          # 429/5xx are retried; non-429 4xx are returned to the caller.
-          #
-          # Status sink: callers invoke discord_curl via $(...), which runs
-          # in a subshell — shell variables set inside don't propagate back.
-          # Publish the HTTP status through a step-owned temp file so callers
-          # can read it after the substitution returns.
-          DISCORD_STATUS_FILE=$(mktemp)
-          trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
-
-          discord_curl() {
-            local max_attempts=5 attempt=1 backoff=1
-            local headers response status body retry_after
-            headers=$(mktemp); trap 'rm -f "$headers"' RETURN
-            while [ $attempt -le $max_attempts ]; do
-              : > "$headers"
-              response=$(curl -sS --connect-timeout 10 --max-time 60 -D "$headers" -w "\n%{http_code}" "$@") || true
-              status=$(printf '%s' "$response" | tail -n 1)
-              body=$(printf '%s' "$response" | sed '$d')
-
-              if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
-                printf '%s' "$body"
-                return 0
-              fi
-
-              if [ "$status" = "429" ]; then
-                retry_after=$(awk 'tolower($1)=="retry-after:"{print $2}' "$headers" | tr -d '\r' | head -n1)
-                retry_after=${retry_after:-$backoff}
-                retry_after=$(awk -v n="$retry_after" 'BEGIN{ x=n+0; printf "%d", (x<1?1:(x==int(x)?x:int(x)+1)) }')
-                [ "$retry_after" -gt 60 ] && retry_after=60
-                echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$retry_after"
-              elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
-                echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$backoff"
-                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-              elif [ -z "$status" ]; then
-                echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
-                sleep "$backoff"
-                backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-              else
-                # 4xx other than 429 — non-retryable, surface to caller
-                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
-                printf '%s' "$body"
-                return 1
-              fi
-              attempt=$((attempt + 1))
-            done
-            printf '%s' "${status:-000}" > "$DISCORD_STATUS_FILE"
-            printf '%s' "$body"
-            return 1
-          }
+          # ── Source the shared discord_curl helper (retry/backoff + status sink) ──
+          # shellcheck source=scripts/discord-helper.sh
+          source "${GITHUB_WORKSPACE}/.github/workflows/scripts/discord-helper.sh"
 
           # ── Resolve PR number ────────────────────────────────────────────
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -51,19 +51,26 @@ jobs:
           # transient 5xx during incidents. Without retry any blip aborts
           # the job, blocking the PR's checks queue. This wraps curl so
           # 429/5xx are retried; non-429 4xx are returned to the caller.
-          # Sets $DISCORD_LAST_STATUS for callers that need the HTTP code.
+          #
+          # Status sink: callers invoke discord_curl via $(...), which runs
+          # in a subshell — shell variables set inside don't propagate back.
+          # Publish the HTTP status through a step-owned temp file so callers
+          # can read it after the substitution returns.
+          DISCORD_STATUS_FILE=$(mktemp)
+          trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
+
           discord_curl() {
             local max_attempts=5 attempt=1 backoff=1
             local headers response status body retry_after
             headers=$(mktemp); trap 'rm -f "$headers"' RETURN
             while [ $attempt -le $max_attempts ]; do
               : > "$headers"
-              response=$(curl -sS -D "$headers" -w "\n%{http_code}" "$@") || true
+              response=$(curl -sS --connect-timeout 10 --max-time 60 -D "$headers" -w "\n%{http_code}" "$@") || true
               status=$(printf '%s' "$response" | tail -n 1)
               body=$(printf '%s' "$response" | sed '$d')
 
               if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
-                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
                 printf '%s' "$body"
                 return 0
               fi
@@ -85,13 +92,13 @@ jobs:
                 backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
               else
                 # 4xx other than 429 — non-retryable, surface to caller
-                DISCORD_LAST_STATUS="$status"
+                printf '%s' "$status" > "$DISCORD_STATUS_FILE"
                 printf '%s' "$body"
                 return 1
               fi
               attempt=$((attempt + 1))
             done
-            DISCORD_LAST_STATUS="${status:-000}"
+            printf '%s' "${status:-000}" > "$DISCORD_STATUS_FILE"
             printf '%s' "$body"
             return 1
           }
@@ -241,7 +248,7 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID") || true
-            PATCH_STATUS="$DISCORD_LAST_STATUS"
+            PATCH_STATUS=$(cat "$DISCORD_STATUS_FILE")
             echo "PATCH status: $PATCH_STATUS"
 
             if [ "$PATCH_STATUS" = "404" ]; then
@@ -260,7 +267,7 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
               "${DISCORD_WEBHOOK_URL}?wait=true"); then
-              echo "::error::Discord POST failed (status ${DISCORD_LAST_STATUS}) after retries"
+              echo "::error::Discord POST failed (status $(cat "$DISCORD_STATUS_FILE")) after retries"
               exit 1
             fi
             NEW_MSG_ID=$(echo "$RESPONSE" | jq -r '.id')

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -1,0 +1,65 @@
+# shellcheck shell=bash
+# Discord webhook call helper with retry/backoff.
+#
+# Sourced by .github/workflows/discord-{pr,issues,discussions}.yml. Each
+# workflow performs actions/checkout (default branch / PR head), then:
+#
+#   source "${GITHUB_WORKSPACE}/.github/workflows/scripts/discord-helper.sh"
+#   PATCH_BODY=$(discord_curl -X PATCH ...) || true
+#   PATCH_STATUS=$(cat "$DISCORD_STATUS_FILE")
+#
+# Discord webhooks return 429 (with Retry-After) and transient 5xx during
+# incidents. Without retry any blip aborts the job, blocking the calling
+# workflow's checks queue. discord_curl wraps curl so 429/5xx are retried;
+# non-429 4xx are returned to the caller unchanged.
+#
+# Status sink: callers invoke discord_curl via $(...), which runs in a
+# subshell, so shell variables set inside don't propagate back. The HTTP
+# status is published through DISCORD_STATUS_FILE (a step-owned temp file)
+# so callers can read it after the substitution returns.
+
+DISCORD_STATUS_FILE=$(mktemp)
+trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
+
+discord_curl() {
+  local max_attempts=5 attempt=1 backoff=1
+  local headers response status body retry_after
+  headers=$(mktemp); trap 'rm -f "$headers"' RETURN
+  while [ $attempt -le $max_attempts ]; do
+    : > "$headers"
+    response=$(curl -sS --connect-timeout 10 --max-time 60 -D "$headers" -w "\n%{http_code}" "$@") || true
+    status=$(printf '%s' "$response" | tail -n 1)
+    body=$(printf '%s' "$response" | sed '$d')
+
+    if [ -n "$status" ] && [ "$status" -ge 200 ] && [ "$status" -lt 300 ]; then
+      printf '%s' "$status" > "$DISCORD_STATUS_FILE"
+      printf '%s' "$body"
+      return 0
+    fi
+
+    if [ "$status" = "429" ]; then
+      retry_after=$(awk 'tolower($1)=="retry-after:"{print $2}' "$headers" | tr -d '\r' | head -n1)
+      retry_after=${retry_after:-$backoff}
+      retry_after=$(awk -v n="$retry_after" 'BEGIN{ x=n+0; printf "%d", (x<1?1:(x==int(x)?x:int(x)+1)) }')
+      [ "$retry_after" -gt 60 ] && retry_after=60
+      echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
+      sleep "$retry_after"
+    elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
+      echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+      sleep "$backoff"
+      backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+    elif [ -z "$status" ]; then
+      echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
+      sleep "$backoff"
+      backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
+    else
+      printf '%s' "$status" > "$DISCORD_STATUS_FILE"
+      printf '%s' "$body"
+      return 1
+    fi
+    attempt=$((attempt + 1))
+  done
+  printf '%s' "${status:-000}" > "$DISCORD_STATUS_FILE"
+  printf '%s' "$body"
+  return 1
+}

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -13,6 +13,18 @@
 # workflow's checks queue. discord_curl wraps curl so 429/5xx are retried;
 # non-429 4xx are returned to the caller unchanged.
 #
+# Non-idempotent callers (POST that creates a message) should pass
+# --no-retry-5xx as the first argument. That restricts retries to 429
+# (which guarantees the request was rejected) and surfaces 5xx and
+# network failures to the caller, avoiding duplicate Discord messages
+# on uncertain delivery. The flag name only mentions 5xx, but it also
+# disables the no-response-received retry path (000/empty status), which
+# is the correct at-most-once choice for POST.
+#
+#   CREATE_BODY=$(discord_curl --no-retry-5xx -X POST \
+#                  -H 'Content-Type: application/json' -d "$payload" \
+#                  "${DISCORD_WEBHOOK_URL}?wait=true") || true
+#
 # Status sink: callers invoke discord_curl via $(...), which runs in a
 # subshell, so shell variables set inside don't propagate back. The HTTP
 # status is published through DISCORD_STATUS_FILE (a step-owned temp file)

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -49,7 +49,7 @@ discord_curl() {
       echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
       sleep "$backoff"
       backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-    elif [ -z "$status" ] && [ "$retry_5xx" -eq 1 ]; then
+    elif { [ -z "$status" ] || [ "$status" = "000" ]; } && [ "$retry_5xx" -eq 1 ]; then
       echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
       sleep "$backoff"
       backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -22,7 +22,8 @@ DISCORD_STATUS_FILE=$(mktemp)
 trap 'rm -f "$DISCORD_STATUS_FILE"' EXIT
 
 discord_curl() {
-  local max_attempts=5 attempt=1 backoff=1
+  local max_attempts=5 attempt=1 backoff=1 retry_5xx=1
+  if [ "${1:-}" = "--no-retry-5xx" ]; then retry_5xx=0; shift; fi
   local headers response status body retry_after
   headers=$(mktemp); trap 'rm -f "$headers"' RETURN
   while [ $attempt -le $max_attempts ]; do
@@ -44,11 +45,11 @@ discord_curl() {
       [ "$retry_after" -gt 60 ] && retry_after=60
       echo "::warning::Discord 429 (rate limited); sleeping ${retry_after}s before retry $((attempt+1))/${max_attempts}" >&2
       sleep "$retry_after"
-    elif [ -n "$status" ] && [ "$status" -ge 500 ]; then
+    elif [ -n "$status" ] && [ "$status" -ge 500 ] && [ "$retry_5xx" -eq 1 ]; then
       echo "::warning::Discord ${status} (transient); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
       sleep "$backoff"
       backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30
-    elif [ -z "$status" ]; then
+    elif [ -z "$status" ] && [ "$retry_5xx" -eq 1 ]; then
       echo "::warning::Discord call failed (no HTTP response); sleeping ${backoff}s before retry $((attempt+1))/${max_attempts}" >&2
       sleep "$backoff"
       backoff=$((backoff * 2)); [ "$backoff" -gt 30 ] && backoff=30


### PR DESCRIPTION
## Summary

Discord webhooks return 429 (with `Retry-After`) and transient 5xx during incidents. The three Discord notification workflows previously had **zero retry tolerance** — any non-2xx aborted the `notify` job and surfaced as a red check on PRs/issues/discussions even when underlying CI was healthy.

Observed on PR #796: `curl: (22) ... error: 429`, then `curl: (22) ... error: 503` on rerun ([log](https://github.com/rocketride-org/rocketride-server/actions/runs/25575520094/job/75083167528)). Exit 22 from curl, job marked failed, PR's check queue went red.

## Fix

Adds a `discord_curl` bash helper to `discord-pr.yml`, `discord-issues.yml`, `discord-discussions.yml` that:

- Retries on **429**, honoring `Retry-After` (fractional values ceil'd, capped at 60s)
- Retries on **5xx** with exponential backoff (1s → 30s cap, 5 attempts)
- Retries on **network errors** (no HTTP response captured)
- Returns **non-429 4xx** to caller for normal handling — preserves the existing `404 → delete stale marker comment` flow
- Exposes status via `$DISCORD_LAST_STATUS` for callers that need it

All four curl-to-Discord call sites in each file are refactored to use the helper:

1. `PATCH` to update existing message (status-aware — handles 404 path)
2. `POST` with `?wait=true` to create new message (failure escalates after retries)
3. Fire-and-forget `DELETE` after race-loss (best-effort)
4. Fire-and-forget `PATCH` on race-loss (best-effort)

The concurrency-group race guard semantics are unchanged. `gh api` calls (GitHub side, different rate limits) are unaffected.

## Why retry is safe

- `PATCH` of a known message is idempotent — repeating on transient error is harmless
- `DELETE` is idempotent — repeating after a real success returns 404, which the helper treats as non-retryable and the caller already discards
- `POST` with `?wait=true` could in theory create a duplicate if a successful response was lost mid-transit, but the existing race guard (which dedupes against the GitHub-side marker comment) catches that case for concurrent runs; for retry-of-self the window is small enough that a brief orphaned Discord message is preferable to a red check on every flap

## Test plan

- [ ] Merge triggers `discord-pr.yml` on the PR itself — green check on this PR
- [ ] Verify Discord embed updates correctly on subsequent edits to this PR (PATCH path)
- [ ] Spot-check that an existing open issue still updates its Discord embed on a label change (issues PATCH path)
- [ ] If a 429 occurs in practice, confirm the warning lines (`::warning::Discord 429 (rate limited)...`) appear in the run log and the job ultimately succeeds

## Out of scope

- Throttling concurrent fires (separate issue — would require workflow-level coordination beyond the existing concurrency group)
- Migrating to a third-party Discord action (e.g. `rjstone/discord-webhook-notify`) — these scripts have rich custom logic (race guards, marker comments, GraphQL discussion fetches) that would need to be re-implemented around any off-the-shelf action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Workflows now source a shared helper for Discord webhook requests for consistent handling.
  * Improved notification reliability with retries, exponential backoff for rate limits, and transient-error handling.
  * The helper records final HTTP status so steps can report diagnostics after failures.
  * Creates/updates explicitly surface failures after retry exhaustion.
  * Race-guard duplicate cleanup and winner-patch remain best-effort and non-blocking.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/797)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->