### PR TITLE
chore(security): codesigning stage 1 — cosign for GHCR + GPG scaffold

### DIFF
--- a/.github/workflows/_docker.yaml
+++ b/.github/workflows/_docker.yaml
@@ -29,6 +29,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # Required for cosign keyless signing via Sigstore (GitHub OIDC).
+      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -62,6 +64,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
+        id: build
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
@@ -71,3 +74,17 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/rocketride-engine:${{ inputs.server_version }}${{ inputs.prerelease && '-prerelease' || '' }}
             ${{ inputs.prerelease == false && format('ghcr.io/{0}/rocketride-engine:latest', github.repository_owner) || '' }}
+
+      # Cosign keyless signing via GitHub OIDC. Signs the image manifest by
+      # digest, which covers every tag pointing at it. Verification:
+      #   cosign verify ghcr.io/<owner>/rocketride-engine:<tag> \
+      #     --certificate-identity-regexp 'https://github\.com/<owner>/rocketride-server/.+' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      - name: Install cosign
+        uses: sigstore/cosign-installer@1aa8e0f2454b781fbf0fbf306a4c9533a0c57409 # v3.7.0
+
+      - name: Sign image with cosign
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          IMAGE: ghcr.io/${{ github.repository_owner }}/rocketride-engine
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -108,6 +108,61 @@ jobs:
         if: inputs.prerelease || steps.tag_check.outputs.exists == 'false'
         run: find release-assets -type f | sort
 
+      # --- GPG-sign server tarballs/zips ---
+      #
+      # Produces detached ASCII-armored signatures (.asc) attached to the
+      # GitHub release alongside the originals. Skips cleanly when the
+      # signing secrets aren't configured, so this is safe to merge before
+      # key generation.
+      #
+      # User verification:
+      #   gpg --verify rocketride-server-X.Y.Z-linux-x64.tar.gz.asc \
+      #                rocketride-server-X.Y.Z-linux-x64.tar.gz
+      #
+      # One-time setup:
+      #   1. Generate a dedicated release-signing key (offline, on a trusted machine):
+      #        gpg --quick-generate-key 'RocketRide Releases <releases@rocketride.ai>' ed25519 sign 2y
+      #   2. Export the private key and store as repo secret GPG_SIGNING_KEY:
+      #        gpg --armor --export-secret-keys releases@rocketride.ai
+      #   3. Store the key passphrase as repo secret GPG_SIGNING_PASSPHRASE.
+      #   4. Publish the public key for users:
+      #        gpg --armor --export releases@rocketride.ai > scripts/release-pubkey.asc
+      #      Commit it; also upload to keys.openpgp.org and add the
+      #      fingerprint to README/SECURITY.md.
+      - name: Check GPG signing availability
+        id: gpg_check
+        if: matrix.type == 'server' && (inputs.prerelease || steps.tag_check.outputs.exists == 'false')
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+        run: |
+          if [ -n "${GPG_SIGNING_KEY:-}" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GPG_SIGNING_KEY not configured — server tarballs will be released unsigned"
+          fi
+
+      - name: GPG-sign server artifacts
+        if: matrix.type == 'server' && (inputs.prerelease || steps.tag_check.outputs.exists == 'false') && steps.gpg_check.outputs.available == 'true'
+        env:
+          GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
+        run: |
+          set -euo pipefail
+          echo "$GPG_SIGNING_KEY" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+          echo "Signing with key ${KEY_ID}"
+          shopt -s nullglob
+          for f in release-assets/*.tar.gz release-assets/*.zip; do
+            echo "$GPG_SIGNING_PASSPHRASE" | gpg --batch --yes \
+              --pinentry-mode loopback --passphrase-fd 0 \
+              --local-user "$KEY_ID" \
+              --detach-sign --armor \
+              --output "${f}.asc" "$f"
+            echo "Signed ${f} -> ${f}.asc"
+          done
+          ls -la release-assets/
+
       # --- npm: rocketride ---
       - name: Set up Node.js
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-typescript'

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -134,12 +134,20 @@ jobs:
         if: matrix.type == 'server' && (inputs.prerelease || steps.tag_check.outputs.exists == 'false')
         env:
           GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          GPG_SIGNING_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSPHRASE }}
         run: |
-          if [ -n "${GPG_SIGNING_KEY:-}" ]; then
+          # Require BOTH secrets — the signing step pipes the passphrase to
+          # gpg via --passphrase-fd 0, so a key-only setup would hard-fail
+          # at sign time. Skip cleanly on partial setup; surface which
+          # secret is missing for faster debugging.
+          if [ -n "${GPG_SIGNING_KEY:-}" ] && [ -n "${GPG_SIGNING_PASSPHRASE:-}" ]; then
             echo "available=true" >> "$GITHUB_OUTPUT"
           else
             echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::GPG_SIGNING_KEY not configured — server tarballs will be released unsigned"
+            missing=()
+            [ -z "${GPG_SIGNING_KEY:-}" ] && missing+=("GPG_SIGNING_KEY")
+            [ -z "${GPG_SIGNING_PASSPHRASE:-}" ] && missing+=("GPG_SIGNING_PASSPHRASE")
+            echo "::warning::Missing secret(s): ${missing[*]} — server tarballs will be released unsigned"
           fi
 
       - name: GPG-sign server artifacts

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -161,7 +161,17 @@ jobs:
           KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
           echo "Signing with key ${KEY_ID}"
           shopt -s nullglob
-          for f in release-assets/*.tar.gz release-assets/*.zip; do
+          # Fail loudly if invoked with no input — reaching this step
+          # means both secrets are configured, so signing is expected
+          # to happen. Silent no-ops here would ship the release
+          # unsigned without any warning.
+          files=(release-assets/*.tar.gz release-assets/*.zip)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "::error::No server archives (.tar.gz/.zip) found in release-assets/ to sign"
+            ls -la release-assets/ || true
+            exit 1
+          fi
+          for f in "${files[@]}"; do
             echo "$GPG_SIGNING_PASSPHRASE" | gpg --batch --yes \
               --pinentry-mode loopback --passphrase-fd 0 \
               --local-user "$KEY_ID" \

--- a/docs/commit-signing.md
+++ b/docs/commit-signing.md
@@ -47,6 +47,7 @@ GitHub stores **authentication keys** and **signing keys** as separate entries. 
    - **Key type**: **Signing Key** (the dropdown — *not* "Authentication Key")
    - **Key**: paste the line printed by step 5 above
    - Click **Add SSH key**
+   - **Verify it landed in the right section**: open <https://github.com/settings/keys> and confirm your new key appears under **SSH signing keys**, not **SSH keys**. If it shows up under the wrong heading, you selected the wrong key type — delete it and re-add.
 
 2. **Verify your commit email is registered and verified on your GitHub account**
    - Open <https://github.com/settings/emails>

--- a/docs/commit-signing.md
+++ b/docs/commit-signing.md
@@ -1,0 +1,80 @@
+# Commit Signing
+
+All commits to this repo should be SSH-signed. After setup, your commits show a green **Verified** badge on github.com and `git log --show-signature` reports `Good "git" signature` locally.
+
+## Setup
+
+Run on macOS or Linux (Windows: use WSL or Git-Bash). Steps assume you already have a GitHub account with access to this repo.
+
+```bash
+# 1. Make sure you have an ed25519 SSH key. Reuse your existing one if you do.
+ls ~/.ssh/*.pub 2>/dev/null
+# If empty, generate one:
+ssh-keygen -t ed25519 -C "$(git config --global user.email)"
+# (accept the default path; passphrase optional but recommended)
+
+# 2. Configure git to sign commits & tags with that key
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/id_ed25519.pub
+git config --global commit.gpgsign true
+git config --global tag.gpgsign true
+
+# 3. Set up allowed_signers so `git log --show-signature` verifies locally
+mkdir -p ~/.config/git
+git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers
+printf '%s %s\n' \
+  "$(git config --global user.email)" \
+  "$(awk '{print $1, $2}' ~/.ssh/id_ed25519.pub)" \
+  >> ~/.config/git/allowed_signers
+
+# 4. Verify locally with a throwaway commit (no repo touched)
+TMPDIR=$(mktemp -d) && (cd "$TMPDIR" && git init -q && \
+  git commit --allow-empty -m "signing-test" -q && \
+  git log --show-signature -1) && rm -rf "$TMPDIR"
+# Expect: a line starting with `Good "git" signature for <your email>`
+
+# 5. Print your public key — you'll paste this into GitHub next
+cat ~/.ssh/id_ed25519.pub
+```
+
+## GitHub configuration (one-time, in the browser)
+
+GitHub stores **authentication keys** and **signing keys** as separate entries. Even if your key is already registered for SSH login, you must register it again as a signing key.
+
+1. **Add the SSH key as a Signing Key**
+   - Open <https://github.com/settings/ssh/new>
+   - **Title**: `<your-laptop-name> signing key`
+   - **Key type**: **Signing Key** (the dropdown — *not* "Authentication Key")
+   - **Key**: paste the line printed by step 5 above
+   - Click **Add SSH key**
+
+2. **Verify your commit email is registered and verified on your GitHub account**
+   - Open <https://github.com/settings/emails>
+   - The email shown by `git config --global user.email` must appear here with no "Unverified" label.
+   - If it's missing, click **Add email address**, enter it, then click the verification link sent to that inbox.
+
+   *Skipping this step is the most common mistake.* Without it, GitHub returns `reason: no_user` for your signed commits — they sign correctly but show as "Unverified" on github.com.
+
+## Verifying it worked
+
+After your next pushed commit:
+
+```bash
+SHA=$(git rev-parse HEAD)
+gh api "repos/<owner>/<repo>/commits/${SHA}" --jq '.commit.verification.verified'
+# Expect: true
+```
+
+Or just look at the commit on github.com — it should show a green **Verified** badge.
+
+## Common gotchas
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| GitHub shows "Unverified", API returns `reason: no_user` | Commit's email isn't a verified email on your GitHub account | Add it at <https://github.com/settings/emails> |
+| GitHub shows "Unverified", API returns `reason: unsigned` | `commit.gpgsign` not enabled, or git installed in a way that ignores global config | Re-run step 2; check `git config --global commit.gpgsign` returns `true` |
+| Local `git log --show-signature` says "No principal matched" | Email in `user.email` doesn't match any line in `~/.config/git/allowed_signers` | Re-run step 3, or add a second line for the missing email |
+| Passphrase prompt on every commit (macOS) | SSH agent not loaded with the key | `ssh-add --apple-use-keychain ~/.ssh/id_ed25519` |
+| Passphrase prompt on every commit (Linux) | `ssh-agent` not running for the session | `eval "$(ssh-agent -s)" && ssh-add ~/.ssh/id_ed25519` |
+| Already use 1Password as SSH agent | Same key can sign | Skip step 1; in step 2 set `user.signingkey` to the public key copied from the 1Password SSH key entry |
+| Was previously using GPG signing | `gpg.format ssh` overrides GPG | Both can stay registered on GitHub; only the active `gpg.format` matters |

--- a/docs/commit-signing.md
+++ b/docs/commit-signing.md
@@ -6,6 +6,8 @@ All commits to this repo should be SSH-signed. After setup, your commits show a 
 
 Run on macOS or Linux (Windows: use WSL or Git-Bash). Steps assume you already have a GitHub account with access to this repo.
 
+> **Note:** Commit signing is independent of how you push. The SSH key generated below is used only for *signing* — your `origin` URL can be `https://github.com/...` or `git@github.com:...` and the steps are identical. If you push via HTTPS, see [If you push via HTTPS](#if-you-push-via-https-windows-or-linux) below for auth setup notes.
+
 ```bash
 # 1. Make sure you have an ed25519 SSH key. Reuse your existing one if you do.
 ls ~/.ssh/*.pub 2>/dev/null
@@ -55,6 +57,70 @@ GitHub stores **authentication keys** and **signing keys** as separate entries. 
    - If it's missing, click **Add email address**, enter it, then click the verification link sent to that inbox.
 
    *Skipping this step is the most common mistake.* Without it, GitHub returns `reason: no_user` for your signed commits — they sign correctly but show as "Unverified" on GitHub.com.
+
+## If you push via HTTPS (Windows or Linux)
+
+The signing setup above is **the same** whether you push via SSH or HTTPS — the SSH key on disk is used only to sign. This section covers HTTPS push authentication, which is a separate concern from signing.
+
+If `git push` already works for you via HTTPS (you have a credential manager, `gh auth login` cached, or a PAT in your config), nothing else is needed — your next signed commit will push and verify normally.
+
+If you don't yet have HTTPS auth set up, pick one of:
+
+**Option A — GitHub CLI (recommended):**
+
+```bash
+# Linux (Debian/Ubuntu):
+#   sudo apt install gh
+# Linux (Fedora/RHEL):
+#   sudo dnf install gh
+# Windows:
+#   winget install --id GitHub.cli
+#   or: choco install gh
+
+gh auth login -p https -h github.com
+# Choose: Login with a web browser → follow the device-code flow.
+# When asked "Authenticate Git with your GitHub credentials?", answer Yes.
+```
+
+`gh auth login` writes a token into Git's credential helper, so subsequent `git push` calls reuse it without prompting.
+
+**Option B — Personal access token + credential helper:**
+
+1. Create a fine-grained PAT at <https://github.com/settings/personal-access-tokens> with at least **Contents: Read and write** for the repo(s) you'll push to.
+
+2. Cache it via a credential helper:
+
+   - **Linux / Git Bash on Windows:**
+     ```bash
+     git config --global credential.helper store
+     ```
+     The first `git push` after this prompts for username (your GitHub login) and password (paste the PAT). The helper stores it for future pushes.
+
+   - **Windows native (PowerShell or CMD):** [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager) is bundled with Git for Windows and configured by default. The first `git push` opens a browser window for OAuth; no manual PAT needed unless you prefer.
+
+### Verify HTTPS push works before adding signing
+
+If you're new to HTTPS push, confirm auth works on its own first:
+
+```bash
+# Clone via HTTPS:
+git clone https://github.com/<owner>/<repo>.git
+cd <repo>
+# Make a trivial change, commit (signing not yet required for this test), and push:
+git commit --allow-empty -m "https-push-test"
+git push
+# If this succeeds without an auth prompt, HTTPS push is ready.
+# Now proceed with the signing setup above.
+```
+
+### Windows path notes
+
+The Bash commands in this guide use `~/.ssh/id_ed25519.pub` and `~/.config/git/allowed_signers`. These resolve correctly inside **Git Bash** and **WSL**. If you're running PowerShell directly, either:
+
+- Run the setup from Git Bash instead (simplest), or
+- Substitute `$env:USERPROFILE\.ssh\id_ed25519.pub` and `$env:USERPROFILE\.config\git\allowed_signers` for the `~/...` paths, and translate `mkdir -p` to `New-Item -ItemType Directory -Force <path> | Out-Null`.
+
+The signing config commands (`git config --global ...`) work identically in any shell.
 
 ## Verifying it worked
 

--- a/docs/commit-signing.md
+++ b/docs/commit-signing.md
@@ -1,6 +1,6 @@
 # Commit Signing
 
-All commits to this repo should be SSH-signed. After setup, your commits show a green **Verified** badge on github.com and `git log --show-signature` reports `Good "git" signature` locally.
+All commits to this repo should be SSH-signed. After setup, your commits show a green **Verified** badge on GitHub.com and `git log --show-signature` reports `Good "git" signature` locally.
 
 ## Setup
 
@@ -54,7 +54,7 @@ GitHub stores **authentication keys** and **signing keys** as separate entries. 
    - The email shown by `git config --global user.email` must appear here with no "Unverified" label.
    - If it's missing, click **Add email address**, enter it, then click the verification link sent to that inbox.
 
-   *Skipping this step is the most common mistake.* Without it, GitHub returns `reason: no_user` for your signed commits — they sign correctly but show as "Unverified" on github.com.
+   *Skipping this step is the most common mistake.* Without it, GitHub returns `reason: no_user` for your signed commits — they sign correctly but show as "Unverified" on GitHub.com.
 
 ## Verifying it worked
 
@@ -66,7 +66,7 @@ gh api "repos/<owner>/<repo>/commits/${SHA}" --jq '.commit.verification.verified
 # Expect: true
 ```
 
-Or just look at the commit on github.com — it should show a green **Verified** badge.
+Or just look at the commit on GitHub.com — it should show a green **Verified** badge.
 
 ## Common gotchas
 


### PR DESCRIPTION
Adds two pieces of release-artifact codesigning:

1. _docker.yaml: cosign keyless signing of the rocketride-engine image via Sigstore + GitHub OIDC. Signs by digest (covers all tags pointing at the manifest). No new secrets; auth is via the workflow's id-token. Verification: cosign verify ghcr.io/<owner>/rocketride-engine:<tag> \ --certificate-identity-regexp 'https://github\.com/<owner>/rocketride-server/.+' \ --certificate-oidc-issuer https://token.actions.githubusercontent.com

2. _release.yaml: GPG detached-signature step for server tarballs/zips (.asc alongside each artifact in the GitHub release). Step is gated on the GPG_SIGNING_KEY repo secret being set, so it's safe to merge ahead of key generation — emits a warning and skips when unset, then activates automatically once GPG_SIGNING_KEY + GPG_SIGNING_PASSPHRASE secrets land. One-time key-generation steps are documented inline.

Stage 1 of company-wide codesigning rollout. Stage 2 (PyPI Trusted Publishing migration) follows in a separate PR after the PyPI publishers are configured. Stage 3 (paid Apple Developer ID + Authenticode) is gated on identity verification and tracked separately.

## Summary

<!-- Describe your changes in 1-3 bullet points -->

-

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Security**
  * Published container images are OIDC keyless-signed (cosign) and the workflow exposes the image digest for provenance.
  * Server release artifacts will be GPG-signed when signing keys are configured; the release process reports missing signing configuration and only signs server artifacts when available and applicable.

* **Documentation**
  * Added a guide for configuring and verifying SSH (ed25519) commit signing, with troubleshooting tips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->