### PR TITLE
docs(security): document two-person control on alert dismissals

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,7 +68,7 @@ When closing an alert, choose one of:
 ### Secret Scanning & Dependabot
 
 - **Secret Scanning Push Protection** is enabled org-wide. Pushes containing detected secrets are blocked at push time; bypasses require committer justification and are recorded in the audit log.
-- **Dependabot alerts** are dismissed only by repository admins, with the dismissal reason and any SLA exception recorded in the dismissal comment. Fixes are tracked via Dependabot security update PRs against the SLAs above.
+- **Dependabot alerts** follow the same two-person Delegated Alert Dismissal flow described above (request by any write-access maintainer; approval by a different organization owner, security manager, or holder of an explicitly delegated custom role). Dismissal reason and any SLA exception must be recorded in the dismissal comment. Fixes are tracked via Dependabot security update PRs against the SLAs above.
 
 ## Security Best Practices
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,7 +49,7 @@ This project uses GitHub-native scanning on the `develop` branch — CodeQL (Def
 To prevent unilateral dismissal of security findings, this repository operates under GitHub's **Delegated Alert Dismissal**, enabled at the `rocketride-org` organization level:
 
 1. **Request** — any maintainer with write access can submit a dismissal request. The request **must** include a documented justification: compensating controls, mitigation rationale, or basis for "won't fix". This justification is recorded as the dismissal comment on the alert.
-2. **Approval** — must be given by a *different* maintainer with admin permissions on the repository. The requester cannot self-approve.
+2. **Approval** — must be given by a *different* authorized reviewer under GitHub Delegated Alert Dismissal (organization owner, security manager, or explicitly delegated custom role). The requester cannot self-approve.
 3. **Dismissal** — GitHub auto-applies the dismissal once approval lands. The full `request → approval → dismissal` trail is preserved on the alert and serves as the system-of-record for audit.
 
 Direct (one-step) dismissal is blocked at the organization level.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,36 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 - We request a 90-day disclosure window for non-critical issues
 - We will credit reporters (unless anonymity is requested)
 
+## Vulnerability & Alert Triage
+
+This project uses GitHub-native scanning on the `develop` branch — CodeQL (Default Setup), Secret Scanning with Push Protection, Scorecard, and Dependabot. All findings are triaged against the SLAs in [What to Expect](#what-to-expect).
+
+### Two-Person Control on Code Scanning Alert Dismissals
+
+To prevent unilateral dismissal of security findings, this repository operates under GitHub's **Delegated Alert Dismissal**, enabled at the `rocketride-org` organization level:
+
+1. **Request** — any maintainer with write access can submit a dismissal request. The request **must** include a documented justification: compensating controls, mitigation rationale, or basis for "won't fix". This justification is recorded as the dismissal comment on the alert.
+2. **Approval** — must be given by a *different* maintainer with admin permissions on the repository. The requester cannot self-approve.
+3. **Dismissal** — GitHub auto-applies the dismissal once approval lands. The full `request → approval → dismissal` trail is preserved on the alert and serves as the system-of-record for audit.
+
+Direct (one-step) dismissal is blocked at the organization level.
+
+### Triage Dispositions
+
+When closing an alert, choose one of:
+
+| Disposition | When to use | Evidence captured |
+| --- | --- | --- |
+| **Fix** | Vulnerability is exploitable in our usage | PR linking the alert (auto-closes on merge) |
+| **Mitigated** | Code path is reachable but compensating controls neutralize the risk | Two-person dismissal with controls listed in comment |
+| **False positive** | Tool flagged a non-issue (e.g., test fixture, intentional pattern) | Two-person dismissal with explanation |
+| **Won't fix** | Risk accepted by ownership | Two-person dismissal with named approver and rationale |
+
+### Secret Scanning & Dependabot
+
+- **Secret Scanning Push Protection** is enabled org-wide. Pushes containing detected secrets are blocked at push time; bypasses require committer justification and are recorded in the audit log.
+- **Dependabot alerts** are dismissed only by repository admins, with the dismissal reason and any SLA exception recorded in the dismissal comment. Fixes are tracked via Dependabot security update PRs against the SLAs above.
+
 ## Security Best Practices
 
 When using RocketRide Engine:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -68,6 +68,7 @@ When closing an alert, choose one of:
 ### Secret Scanning & Dependabot
 
 - **Secret Scanning Push Protection** is enabled org-wide. Pushes containing detected secrets are blocked at push time; bypasses require committer justification and are recorded in the audit log.
+- **Secret Scanning alerts** for secrets already in the repository follow the same two-person Delegated Alert Dismissal flow (request, approval by a different authorized reviewer, auto-dismissal with audit trail).
 - **Dependabot alerts** follow the same two-person Delegated Alert Dismissal flow described above (request by any write-access maintainer; approval by a different organization owner, security manager, or holder of an explicitly delegated custom role). Dismissal reason and any SLA exception must be recorded in the dismissal comment. Fixes are tracked via Dependabot security update PRs against the SLAs above.
 
 ## Security Best Practices

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -44,7 +44,7 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 This project uses GitHub-native scanning on the `develop` branch — CodeQL (Default Setup), Secret Scanning with Push Protection, Scorecard, and Dependabot. CodeQL and Scorecard findings both surface as code scanning alerts in the same GitHub UI and share the dismissal workflow described below. All findings are triaged against the SLAs in [What to Expect](#what-to-expect).
 
-### Two-Person Control on Code Scanning Alert Dismissals
+### Two-Person Control on Alert Dismissals
 
 To prevent unilateral dismissal of security findings, this repository operates under GitHub's **Delegated Alert Dismissal**, enabled at the `rocketride-org` organization level:
 
@@ -68,8 +68,11 @@ When closing an alert, choose one of:
 ### Secret Scanning & Dependabot
 
 - **Secret Scanning Push Protection** is enabled org-wide. Pushes containing detected secrets are blocked at push time; bypasses require committer justification and are recorded in the audit log.
-- **Secret Scanning alerts** for secrets already in the repository follow the same two-person Delegated Alert Dismissal flow (request, approval by a different authorized reviewer, auto-dismissal with audit trail).
-- **Dependabot alerts** follow the same two-person Delegated Alert Dismissal flow described above (request by any write-access maintainer; approval by a different organization owner, security manager, or holder of an explicitly delegated custom role). Dismissal reason and any SLA exception must be recorded in the dismissal comment. Fixes are tracked via Dependabot security update PRs against the SLAs above.
+- **Secret Scanning alerts** for secrets already in the repository follow the same two-person Delegated Alert Dismissal flow (request by any write-access maintainer; approval by a different organization owner, security manager, or holder of an explicitly delegated custom role; auto-dismissal with audit trail).
+- **Dependabot alerts** follow the same two-person Delegated Alert Dismissal flow described above:
+  - Request by any write-access maintainer; approval by a different organization owner, security manager, or holder of an explicitly delegated custom role.
+  - Dismissal reason and any SLA exception must be recorded in the dismissal comment.
+  - Fixes are tracked via Dependabot security update PRs against the SLAs above.
 
 ## Security Best Practices
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,7 +42,7 @@ We take security vulnerabilities seriously. If you discover a security issue, pl
 
 ## Vulnerability & Alert Triage
 
-This project uses GitHub-native scanning on the `develop` branch — CodeQL (Default Setup), Secret Scanning with Push Protection, Scorecard, and Dependabot. All findings are triaged against the SLAs in [What to Expect](#what-to-expect).
+This project uses GitHub-native scanning on the `develop` branch — CodeQL (Default Setup), Secret Scanning with Push Protection, Scorecard, and Dependabot. CodeQL and Scorecard findings both surface as code scanning alerts in the same GitHub UI and share the dismissal workflow described below. All findings are triaged against the SLAs in [What to Expect](#what-to-expect).
 
 ### Two-Person Control on Code Scanning Alert Dismissals
 


### PR DESCRIPTION
## Summary

Adds a **Vulnerability & Alert Triage** section to `SECURITY.md` that codifies the alert-dismissal flow we already operate under (and that GitHub's Delegated Alert Dismissal enforces at the org level). Documentation-only change — no code impact.

The new section covers:

- **Two-person control on code scanning alert dismissals**: request → approval (by a different admin) → auto-dismissal
- **Triage dispositions** (Fix / Mitigated / False positive / Won't fix) and the evidence each requires
- **Secret Scanning Push Protection** bypass logging
- **Dependabot** dismissal owner + comment requirement

## Why

This is a SOC2 CC8 (change-management) and CC7.1 (vulnerability management) artifact. The policy in the file maps 1:1 to the system-of-record GitHub already preserves on each alert (request comment → approver → dismissal timestamp), giving an auditor a single document to compare against the alert metadata.

## Audit traceability (for the auditor's records — not in the file itself)

The two-person flow was verified end-to-end on Scorecard alert #565:

- **Request**: `anandray` submitted dismissal as "Mitigated" with documented compensating controls (PR #771 fix in flight, branch protection prevents direct push, etc.)
- **Approval**: `kwit75` approved as the second admin principal
- **Result**: GitHub auto-applied the dismissal; full `request → approval → dismissal` trail visible on the alert page

Org-level controls in place that back this policy:

- ✅ "Prevent direct alert dismissals" — confirmed enabled
- ✅ Secret Scanning Push Protection — enabled org-wide on all 4 public repos
- ✅ CodeQL Default Setup — confirmed (PR #768, C++ autobuild verified)
- ✅ Dependabot alerts + security updates — enabled on all 4 public repos

## Test plan

- [ ] Render check: SECURITY.md renders correctly on the GitHub web UI (table formatting, anchor links)
- [ ] Anchor: `[What to Expect](#what-to-expect)` link in the new section resolves to the existing `### What to Expect` heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Vulnerability & Alert Triage" policy: documents GitHub-native scanning and a delegated two-person alert-dismissal workflow requiring a request, recorded justification, and separate approver; defines allowed dispositions (Fix, Mitigated, False positive, Won’t fix); mandates push-time secret-scanning rules and recorded bypass justification; requires dismissal-comment details/SLA-exception recording for dependency alerts; removed prior security best-practices/closing text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->