### PR TITLE
fix: resolve uvicorn signal restoration TypeError on shutdown (python 3.12+)

### DIFF
--- a/packages/ai/src/ai/eaas.py
+++ b/packages/ai/src/ai/eaas.py
@@ -167,12 +167,13 @@ async def run(config: Dict[str, Any] = None) -> None:
 
 
 def main():
+    """Run the EaaS server."""
     # Workaround for Python 3.12+ Uvicorn signal handler restoration bug
     # where signal.signal() raises TypeError if the handler is None.
     import signal
     import platform
     
-    if platform.system() == "Windows":
+    if platform.system() == 'Windows':
         for sig in (signal.SIGINT, signal.SIGTERM, getattr(signal, "SIGBREAK", None)):
             if sig is not None:
                 try:
@@ -181,7 +182,7 @@ def main():
                 except (ValueError, OSError):
                     pass
 
-    """Run the EaaS server."""
+    
     try:
         asyncio.run(run())
     except (KeyboardInterrupt, SystemExit):

--- a/packages/ai/src/ai/eaas.py
+++ b/packages/ai/src/ai/eaas.py
@@ -167,6 +167,20 @@ async def run(config: Dict[str, Any] = None) -> None:
 
 
 def main():
+    # Workaround for Python 3.12+ Uvicorn signal handler restoration bug
+    # where signal.signal() raises TypeError if the handler is None.
+    import signal
+    import platform
+    
+    if platform.system() == "Windows":
+        for sig in (signal.SIGINT, signal.SIGTERM, getattr(signal, "SIGBREAK", None)):
+            if sig is not None:
+                try:
+                    if signal.getsignal(sig) is None:
+                        signal.signal(sig, signal.SIG_DFL)
+                except (ValueError, OSError):
+                    pass
+
     """Run the EaaS server."""
     try:
         asyncio.run(run())


### PR DESCRIPTION
## Summary

- Add explicit signal initialization (`SIG_DFL`) in `eaas.py` to prevent a `TypeError` during Uvicorn shutdown/restarts on Python 3.12+ (Windows environments).

## Type

- [x] Fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #764

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability on Windows when running under Python 3.12 and later by initializing OS interrupt handlers so the server responds to termination/interrupt signals more consistently, reducing unexpected shutdowns during normal operation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/802)
<!-- end of auto-generated comment: release notes by coderabbit.ai --> 
