### PR TITLE
chore(deps): own SQLAlchemy at the ai layer

### DIFF
--- a/nodes/src/nodes/db_mysql/requirements.txt
+++ b/nodes/src/nodes/db_mysql/requirements.txt
@@ -1,3 +1,2 @@
 pymysql==1.1.2
 cryptography==46.0.0
-SQLAlchemy==2.0.43

--- a/nodes/src/nodes/db_postgres/requirements.txt
+++ b/nodes/src/nodes/db_postgres/requirements.txt
@@ -1,2 +1,1 @@
 psycopg2-binary==2.9.10
-SQLAlchemy==2.0.43

--- a/packages/ai/src/ai/requirements.txt
+++ b/packages/ai/src/ai/requirements.txt
@@ -8,3 +8,5 @@ httpx
 psutil
 tenacity
 nvidia-ml-py
+
+SQLAlchemy==2.0.43


### PR DESCRIPTION

## Summary

`ai/common/database/db_global_base.py` and `db_instance_base.py` `import sqlalchemy` at module load, so the dep belongs to the package that defines those base classes — not to the database nodes that just consume them.

## Type

chore

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [x] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL database driver pinned to version 2.9.10 for improved compatibility and stability.
  * Maintained MySQL driver versions with encryption support across database modules.
  * Reorganized dependencies across database and AI packages to enhance overall platform consistency and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/804)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->