### PR TITLE
feat(llm_anthropic): implement prompt caching via payload tunneling

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -25,10 +25,11 @@
 Anthropic binding for the ChatLLM.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import SystemMessage, HumanMessage
 
 # --- ANTI-SIGBUS PATCH: disable fast tokenizers and Claude-specific token counting ---
 # 1) Disable tokenizer parallelism
@@ -111,3 +112,29 @@ class Chat(ChatBase):
 
         # Save our chat class into the bag
         bag['chat'] = self
+
+    def _chat(self, payload: Union[str, Any]) -> str:
+        prompt_str = payload.getPrompt() if hasattr(payload, 'getPrompt') else payload
+
+        if hasattr(payload, 'getPrompt'):
+            # Split the string to separate the static instructions from the dynamic user query
+            parts = prompt_str.rsplit('### Current Task:', 1)
+            if len(parts) == 2:
+                static_str = parts[0]
+                dynamic_str = '### Current Task:' + parts[1]
+
+                # Cache the heavy static context
+                static_msg = SystemMessage(
+                    content=static_str,
+                    additional_kwargs={"cache_control": {"type": "ephemeral"}}
+                )
+                
+                # Dynamic user question without caching
+                dynamic_msg = HumanMessage(content=dynamic_str)
+
+                results = self._llm.invoke([static_msg, dynamic_msg])
+                return results.content
+
+        # Fallback for strings or un-splittable prompts
+        results = self._llm.invoke(prompt_str)
+        return results.content

--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -30,6 +30,7 @@ from ai.common.chat import ChatBase
 from ai.common.config import Config
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import SystemMessage, HumanMessage
+from ai.common.schema import Question
 
 # --- ANTI-SIGBUS PATCH: disable fast tokenizers and Claude-specific token counting ---
 # 1) Disable tokenizer parallelism
@@ -110,13 +111,16 @@ class Chat(ChatBase):
         # Get the LLM
         self._llm = ChatAnthropic(model=model, api_key=apikey, temperature=0, max_tokens=self._modelOutputTokens)
 
+        # Initialize caching configuration
+        self._caching_enabled = config.get('caching', True) and config.get('anthropic_prompt_caching', True)
+
         # Save our chat class into the bag
         bag['chat'] = self
 
-    def _chat(self, payload: Union[str, Any]) -> str:
+    def _chat(self, payload: Union[str, Question]) -> str:
         prompt_str = payload.getPrompt() if hasattr(payload, 'getPrompt') else payload
 
-        if hasattr(payload, 'getPrompt'):
+        if self._caching_enabled and hasattr(payload, 'getPrompt'):
             # Split the string to separate the static instructions from the dynamic user query
             parts = prompt_str.rsplit('### Current Task:', 1)
             if len(parts) == 2:
@@ -125,8 +129,13 @@ class Chat(ChatBase):
 
                 # Cache the heavy static context
                 static_msg = SystemMessage(
-                    content=static_str,
-                    additional_kwargs={"cache_control": {"type": "ephemeral"}}
+                    content=[
+                        {
+                            "type": "text",
+                            "text": static_str,
+                            "cache_control": {"type": "ephemeral"}
+                        }
+                    ]
                 )
                 
                 # Dynamic user question without caching

--- a/nodes/src/nodes/llm_gemini/gemini.py
+++ b/nodes/src/nodes/llm_gemini/gemini.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # =============================================================================
 
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from google import genai
@@ -115,7 +115,7 @@ class Chat(ChatBase):
         word_count = len(value.split())
         return int(word_count / 0.75)
 
-    def _chat(self, prompt: str) -> str:
+    def _chat(self, payload: Union[str, Any]) -> str:
         """
         Send a chat prompt to the Gemini model and return the response.
 
@@ -123,7 +123,7 @@ class Chat(ChatBase):
         to the configured Gemini model and returning the generated text response.
 
         Args:
-            prompt (str): The user's input prompt/message
+            payload (Union[str, Any]): The user's input prompt/message or Question payload
 
         Returns:
             str: The model's text response
@@ -136,8 +136,10 @@ class Chat(ChatBase):
             This method assumes self._model is set by the parent class.
             The model should be a valid Gemini model identifier (e.g., 'gemini-pro').
         """
+        prompt_str = payload.getPrompt() if hasattr(payload, 'getPrompt') else payload
+        
         # Generate content using the configured model
-        response = self._client.models.generate_content(model=self._model, contents=prompt)
+        response = self._client.models.generate_content(model=self._model, contents=prompt_str)
 
         # Extract and return the text response
         return response.text

--- a/nodes/src/nodes/llm_gemini/gemini.py
+++ b/nodes/src/nodes/llm_gemini/gemini.py
@@ -24,6 +24,7 @@
 from typing import Any, Dict, Union
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.schema import Question
 from google import genai
 
 
@@ -115,7 +116,7 @@ class Chat(ChatBase):
         word_count = len(value.split())
         return int(word_count / 0.75)
 
-    def _chat(self, payload: Union[str, Any]) -> str:
+    def _chat(self, payload: Union[str, Question]) -> str:
         """
         Send a chat prompt to the Gemini model and return the response.
 

--- a/nodes/src/nodes/llm_gemini/gemini.py
+++ b/nodes/src/nodes/llm_gemini/gemini.py
@@ -124,7 +124,7 @@ class Chat(ChatBase):
         to the configured Gemini model and returning the generated text response.
 
         Args:
-            payload (Union[str, Any]): The user's input prompt/message or Question payload
+            payload (Union[str, Question]): The user's input prompt/message or Question payload
 
         Returns:
             str: The model's text response

--- a/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
+++ b/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
@@ -25,6 +25,7 @@ import re
 from typing import Any, Dict, Union
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.schema import Question
 from ibm_watsonx_ai import Credentials
 from ibm_watsonx_ai.foundation_models import ModelInference
 from ibm_watsonx_ai.foundation_models.schema import TextChatParameters
@@ -127,7 +128,7 @@ class Chat(ChatBase):
         # Save our chat class into the bag
         bag['chat'] = self
 
-    def _chat(self, payload: Union[str, Any]) -> str:
+    def _chat(self, payload: Union[str, Question]) -> str:
         """
         Send prompt to IBM Watson and receive response.
 

--- a/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
+++ b/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
@@ -22,7 +22,7 @@
 # =============================================================================
 
 import re
-from typing import Any, Dict
+from typing import Any, Dict, Union
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from ibm_watsonx_ai import Credentials
@@ -127,7 +127,7 @@ class Chat(ChatBase):
         # Save our chat class into the bag
         bag['chat'] = self
 
-    def _chat(self, prompt: str) -> str:
+    def _chat(self, payload: Union[str, Any]) -> str:
         """
         Send prompt to IBM Watson and receive response.
 
@@ -135,12 +135,13 @@ class Chat(ChatBase):
         communication with the IBM Watson API.
 
         Args:
-            prompt (str): The complete prompt to send to the model
+            payload (Union[str, Any]): The complete prompt payload to send to the model
 
         Returns:
             str: The generated text response from the model
         """
-        messages = [{'role': 'user', 'content': prompt}]
+        prompt_str = payload.getPrompt() if hasattr(payload, 'getPrompt') else payload
+        messages = [{'role': 'user', 'content': prompt_str}]
 
         response = self._llm.chat(messages=messages)
 

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -13,7 +13,7 @@ communication with their respective APIs.
 import time
 import json
 import importlib
-from typing import Dict, Any
+from typing import Dict, Any, Union
 from rocketlib import debug
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
@@ -104,7 +104,7 @@ class ChatBase:
         """
         return self._modelOutputTokens
 
-    def _chat(self, prompt: str) -> str:
+    def _chat(self, payload: Union[str, Question]) -> str:
         """
         Send prompt, recieve response.
 
@@ -118,7 +118,7 @@ class ChatBase:
         - Error handling for API failures
 
         Args:
-            prompt (str): The complete prompt to send to the AI model
+            payload (Union[str, Question]): The prompt payload to send to the AI model
 
         Returns:
             str: The raw response from the AI model
@@ -128,7 +128,8 @@ class ChatBase:
             errors, or other provider-specific issues
         """
         # Ask the LLM
-        results = self._llm.invoke(prompt)
+        prompt_str = payload.getPrompt() if hasattr(payload, 'getPrompt') else payload
+        results = self._llm.invoke(prompt_str)
 
         # Return the results
         return results.content
@@ -273,7 +274,7 @@ class ChatBase:
         # Default to retryable for unknown errors (conservative approach)
         return True
 
-    def _chat_with_retries(self, prompt: str) -> str:
+    def _chat_with_retries(self, payload: Union[str, Question]) -> str:
         """
         Handle chat requests with retries for transient errors.
 
@@ -282,7 +283,7 @@ class ChatBase:
         using exponential backoff.
 
         Args:
-            prompt (str): The complete prompt to send to the AI model
+            payload (Union[str, Question]): The prompt payload to send to the AI model
 
         Returns:
             str: The raw response from the AI model
@@ -300,7 +301,7 @@ class ChatBase:
         for attempt in range(max_network_retries):
             try:
                 # Call the actual chat implementation provided by the subclass
-                return self._chat(prompt)
+                return self._chat(payload)
 
             except Exception as e:
                 # Determine if this is a retryable error
@@ -326,7 +327,7 @@ class ChatBase:
         # This should never be reached due to the raise in the loop
         raise Exception('Unexpected exit from retry loop')
 
-    def chat_string(self, prompt: str) -> str:
+    def chat_string(self, payload: Union[str, Question]) -> str:
         """
         Invoke the chat interface with string input, token management, and network retry handling.
 
@@ -343,7 +344,7 @@ class ChatBase:
         6. Return the result
 
         Args:
-            prompt (str): The complete prompt to send to the model
+            payload (Union[str, Question]): The prompt payload to send to the model
 
         Returns:
             str: The model's response
@@ -356,12 +357,14 @@ class ChatBase:
             Exception: If network/API retries are exhausted or non-retryable
                       errors occur
         """
+        prompt_str = payload.getPrompt() if hasattr(payload, 'getPrompt') else payload
+
         # Validate and sanitize the prompt before processing
-        prompt = validate_prompt(prompt, self._modelTotalTokens, self.getTokens)
+        prompt_str = validate_prompt(prompt_str, self._modelTotalTokens, self.getTokens)
 
         # Count tokens in the input prompt to check against limits
         # This is important for preventing API errors and ensuring quality responses
-        prompt_tokens = self.getTokens(prompt)
+        prompt_tokens = self.getTokens(prompt_str)
 
         # Check if the prompt is too long, leaving insufficient space for response
         # We reserve 100 tokens for the response to ensure the model has room to answer
@@ -373,7 +376,7 @@ class ChatBase:
 
         # Call the chat implementation with network retry logic
         # This is where the real communication with the AI provider happens
-        result = self._chat_with_retries(prompt)
+        result = self._chat_with_retries(payload)
 
         # Count tokens in the response to check for potential truncation
         # This helps identify cases where the model's response was cut off
@@ -414,7 +417,7 @@ class ChatBase:
                       errors occur
         """
         # Use chat_string which already handles network retries and token management
-        response = self.chat_string(question.getPrompt())
+        response = self.chat_string(question)
 
         # If JSON output is expected, validate the response and retry if needed.
         # Store the parsed result so setAnswer receives a dict/list directly —


### PR DESCRIPTION
## Summary
- Implements Anthropic prompt caching in the `llm_anthropic` node to significantly reduce input token costs and latency for large system prompts.
- Refactors `ChatBase` middleware to safely tunnel un-flattened `Question` objects down to the provider layer without breaking legacy string payloads, network retries, or JSON healing loops.
- Safely splits static instructions from dynamic user queries (via the `### Current Task:` delimiter) to avoid the Anthropic "Prefix-Cache Trap."

## Type
feature, refactor

## Testing
- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue
Resolves #785

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now accepts either raw text or question objects across multiple providers.
  * Anthropic chat adds optional prompt caching that splits prompts into static and dynamic parts to reuse cached context.

* **Improvements**
  * Unified prompt extraction and handling across chat backends for more consistent behavior and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/806)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->