### PR TITLE
chore(ci): cmake 4

### DIFF
--- a/packages/server/engine-core/apLib/file/pathLiterals.hpp
+++ b/packages/server/engine-core/apLib/file/pathLiterals.hpp
@@ -26,11 +26,11 @@
 namespace ap {
 
 // Path literals
-inline file::FilePath<char> operator"" _pth(const char *str,
+inline file::FilePath<char> operator""_pth(const char *str,
                                             std::size_t count) noexcept {
     return file::FilePath<char>(string::StrView<char>{str, count});
 }
-inline file::FilePath<Utf16Chr> operator"" _pth(const Utf16Chr * str,
+inline file::FilePath<Utf16Chr> operator""_pth(const Utf16Chr * str,
                                                 std::size_t count) noexcept {
     return file::FilePath<Utf16Chr>(string::StrView<Utf16Chr>{str, count});
 }

--- a/packages/server/engine-core/apLib/json/toJson.hpp
+++ b/packages/server/engine-core/apLib/json/toJson.hpp
@@ -28,7 +28,7 @@
 
 namespace ap {
 // Allow specifying R"(json...)"_json string
-inline json::Value operator"" _json(const char *str,
+inline json::Value operator""_json(const char *str,
                                     std::size_t count) noexcept {
     return json::parse(str);
 }

--- a/packages/server/engine-core/apLib/literals.hpp
+++ b/packages/server/engine-core/apLib/literals.hpp
@@ -26,39 +26,39 @@
 namespace ap {
 
 // Size literals
-constexpr Size operator"" _tb(long double count) noexcept {
+constexpr Size operator""_tb(long double count) noexcept {
     return Size::terabytes(count);
 }
-constexpr Size operator"" _gb(long double count) noexcept {
+constexpr Size operator""_gb(long double count) noexcept {
     return Size::gigabytes(count);
 }
-constexpr Size operator"" _mb(long double count) noexcept {
+constexpr Size operator""_mb(long double count) noexcept {
     return Size::megabytes(count);
 }
-constexpr Size operator"" _kb(long double count) noexcept {
+constexpr Size operator""_kb(long double count) noexcept {
     return Size::kilobytes(count);
 }
-constexpr Size operator"" _b(long double count) noexcept {
+constexpr Size operator""_b(long double count) noexcept {
     return Size::bytes(count);
 }
-constexpr Size operator"" _tb(unsigned long long count) noexcept {
+constexpr Size operator""_tb(unsigned long long count) noexcept {
     return Size::kTerabyte * count;
 }
-constexpr Size operator"" _gb(unsigned long long count) noexcept {
+constexpr Size operator""_gb(unsigned long long count) noexcept {
     return Size::kGigabyte * count;
 }
-constexpr Size operator"" _mb(unsigned long long count) noexcept {
+constexpr Size operator""_mb(unsigned long long count) noexcept {
     return Size::kMegabyte * count;
 }
-constexpr Size operator"" _kb(unsigned long long count) noexcept {
+constexpr Size operator""_kb(unsigned long long count) noexcept {
     return Size::kKilobyte * count;
 }
-constexpr Size operator"" _b(unsigned long long count) noexcept {
+constexpr Size operator""_b(unsigned long long count) noexcept {
     return count;
 }
 
 // Url literals
-inline Url operator"" _url(const char *str, std::size_t count) noexcept {
+inline Url operator""_url(const char *str, std::size_t count) noexcept {
     return {TextView{str, count}};
 }
 

--- a/packages/server/engine-core/apLib/memory/literals.hpp
+++ b/packages/server/engine-core/apLib/memory/literals.hpp
@@ -25,7 +25,7 @@
 
 namespace ap {
 
-inline memory::DataView<const char> operator"" _dv(const char *str,
+inline memory::DataView<const char> operator""_dv(const char *str,
                                                    std::size_t count) noexcept {
     return {str, count};
 }

--- a/packages/server/engine-core/apLib/string/literals.hpp
+++ b/packages/server/engine-core/apLib/string/literals.hpp
@@ -30,78 +30,78 @@ namespace ap {
 //	u"blah"	<-- char16_t (ucs2/16)
 //	U"blah"	<-- char32_t (utf32)
 //	L"blah"	<-- windows utf16, linux utf32
-inline Text operator"" _t(const char *str, std::size_t count) noexcept {
+inline Text operator""_t(const char *str, std::size_t count) noexcept {
     return {str, count};
 }
-inline Text operator"" _utf8(const char *str, std::size_t count) noexcept {
+inline Text operator""_utf8(const char *str, std::size_t count) noexcept {
     return {str, count};
 }
-inline Utf16 operator"" _utf16(const char16_t *str,
+inline Utf16 operator""_utf16(const char16_t *str,
                                std::size_t count) noexcept {
     return {str, count};
 }
-inline Utf32 operator"" _utf32(const char32_t *str,
+inline Utf32 operator""_utf32(const char32_t *str,
                                std::size_t count) noexcept {
     return {str, count};
 }
 
 #if ROCKETRIDE_PLAT_WIN
 static_assert(sizeof(wchar_t) == 2, "Expected wchar_t size mismatch");
-inline Utf16 operator"" _utf16(const wchar_t *str, std::size_t count) noexcept {
+inline Utf16 operator""_utf16(const wchar_t *str, std::size_t count) noexcept {
     return {str, count};
 }
-inline Utf16 operator"" _txtos(const wchar_t *str, std::size_t count) noexcept {
+inline Utf16 operator""_txtos(const wchar_t *str, std::size_t count) noexcept {
     return {str, count};
 }
 #else
 static_assert(sizeof(wchar_t) == 4, "Expected wchar_t size mismatch");
-inline Utf32 operator"" _utf32(const wchar_t *str, std::size_t count) noexcept {
+inline Utf32 operator""_utf32(const wchar_t *str, std::size_t count) noexcept {
     return {str, count};
 }
 #endif
 
-constexpr TextView operator"" _tv(const Utf8Chr *str,
+constexpr TextView operator""_tv(const Utf8Chr *str,
                                   std::size_t count) noexcept {
     return {str, count};
 }
-constexpr TextView operator"" _tv(const char8_t *str,
+constexpr TextView operator""_tv(const char8_t *str,
                                   std::size_t count) noexcept {
     return {str, count};
 }
-constexpr Utf16View operator"" _tv(const Utf16Chr *str,
+constexpr Utf16View operator""_tv(const Utf16Chr *str,
                                    std::size_t count) noexcept {
     return {str, count};
 }
 #if ROCKETRIDE_PLAT_WIN
-constexpr Utf16View operator"" _tv(const char16_t *str,
+constexpr Utf16View operator""_tv(const char16_t *str,
                                    std::size_t count) noexcept {
     return {str, count};
 }
 #endif
-constexpr Utf32View operator"" _tv(const Utf32Chr *str,
+constexpr Utf32View operator""_tv(const Utf32Chr *str,
                                    std::size_t count) noexcept {
     return {str, count};
 }
 
-constexpr iTextView operator"" _itv(const Utf8Chr *str,
+constexpr iTextView operator""_itv(const Utf8Chr *str,
                                     std::size_t count) noexcept {
     return {str, count};
 }
-constexpr iTextView operator"" _itv(const char8_t *str,
+constexpr iTextView operator""_itv(const char8_t *str,
                                     std::size_t count) noexcept {
     return {str, count};
 }
-constexpr iUtf16View operator"" _itv(const Utf16Chr *str,
+constexpr iUtf16View operator""_itv(const Utf16Chr *str,
                                      std::size_t count) noexcept {
     return {str, count};
 }
 #if ROCKETRIDE_PLAT_WIN
-constexpr iUtf16View operator"" _itv(const char16_t *str,
+constexpr iUtf16View operator""_itv(const char16_t *str,
                                      std::size_t count) noexcept {
     return {str, count};
 }
 #endif
-constexpr iUtf32View operator"" _itv(const Utf32Chr *str,
+constexpr iUtf32View operator""_itv(const Utf32Chr *str,
                                      std::size_t count) noexcept {
     return {str, count};
 }

--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -222,38 +222,19 @@ check_linux_sudo() {
 }
 
 check_linux_cmake() {
-    if ! command_exists "wget"; then
-        COMMANDS+=("    # Installing wget")
-        COMMANDS+=("    sudo apt install -y wget")
-    fi
-
     if command_exists cmake; then
         CMAKE_VERSION=$(cmake --version | head -n1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
         CMAKE_MAJOR=$(echo "$CMAKE_VERSION" | cut -d. -f1)
         CMAKE_MINOR=$(echo "$CMAKE_VERSION" | cut -d. -f2)
-        
+
         if [ "$CMAKE_MAJOR" -lt 3 ] || [ "$CMAKE_MAJOR" -eq 3 -a "$CMAKE_MINOR" -lt 19 ]; then
             echo "CMake version $CMAKE_VERSION is too old (minimum required: 3.19)"
-            COMMANDS+=("    # Updating CMake")
-            COMMANDS+=("    sudo rm -f /usr/local/bin/cmake* && sudo rm -rf /opt/cmake*")
-            COMMANDS+=("    (cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-x86_64.tar.gz)")
-            COMMANDS+=("    (cd /tmp && tar -xzf cmake-3.30.1-linux-x86_64.tar.gz && sudo mv cmake-3.30.1-linux-x86_64 /opt/cmake)")
-            COMMANDS+=("    sudo ln -sf /opt/cmake/bin/* /usr/local/bin/")
-        fi
-        if [ "$CMAKE_MAJOR" -gt 3 ]; then
-            echo "CMake version $CMAKE_VERSION is too new (must be < version 4)"
-            COMMANDS+=("    # Downgrading CMake")
-            COMMANDS+=("    sudo rm -f /usr/local/bin/cmake* && sudo rm -rf /opt/cmake*")
-            COMMANDS+=("    (cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-x86_64.tar.gz)")
-            COMMANDS+=("    (cd /tmp && tar -xzf cmake-3.30.1-linux-x86_64.tar.gz && sudo mv cmake-3.30.1-linux-x86_64 /opt/cmake)")
-            COMMANDS+=("    sudo ln -sf /opt/cmake/bin/* /usr/local/bin/")
+            COMMANDS+=("    # Upgrading CMake")
+            COMMANDS+=("    sudo apt install -y cmake")
         fi
     else
         COMMANDS+=("    # Installing CMake")
-        COMMANDS+=("    sudo rm -f /usr/local/bin/cmake* && sudo rm -rf /opt/cmake*")
-        COMMANDS+=("    (cd /tmp && wget https://github.com/Kitware/CMake/releases/download/v3.30.1/cmake-3.30.1-linux-x86_64.tar.gz)")
-        COMMANDS+=("    (cd /tmp && tar -xzf cmake-3.30.1-linux-x86_64.tar.gz && sudo mv cmake-3.30.1-linux-x86_64 /opt/cmake)")
-        COMMANDS+=("    sudo ln -sf /opt/cmake/bin/* /usr/local/bin/")
+        COMMANDS+=("    sudo apt install -y cmake")
     fi
 }
 
@@ -472,42 +453,16 @@ check_mac_cmake() {
         CMAKE_VERSION=$(cmake --version | head -n1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
         CMAKE_MAJOR=$(echo "$CMAKE_VERSION" | cut -d. -f1)
         CMAKE_MINOR=$(echo "$CMAKE_VERSION" | cut -d. -f2)
-        
+
         if [ "$CMAKE_MAJOR" -lt 3 ] || [ "$CMAKE_MAJOR" -eq 3 -a "$CMAKE_MINOR" -lt 19 ]; then
             echo "CMake version $CMAKE_VERSION is too old (minimum required: 3.19)"
-            COMMANDS+=("    # Upgrading CMake to 3.30.1")
-            COMMANDS+=("    (cd /tmp && curl -LO https://cmake.org/files/v3.30/cmake-3.30.1-macos-universal.tar.gz)")
-            COMMANDS+=("    (cd /tmp && tar -xzf cmake-3.30.1-macos-universal.tar.gz)")
-            COMMANDS+=("    sudo mv /tmp/cmake-3.30.1-macos-universal /Applications/CMake-3.30.1")
-            COMMANDS+=("    sudo rm -f /usr/local/bin/cmake /usr/local/bin/ctest /usr/local/bin/cpack")
-            COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/cmake /usr/local/bin/cmake")
-            COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/ctest /usr/local/bin/ctest")
-            COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/cpack /usr/local/bin/cpack")
-            COMMANDS+=("    rm -f /tmp/cmake-3.30.1-macos-universal.tar.gz")
-        fi
-        if [ "$CMAKE_MAJOR" -gt 3 ]; then
-            echo "CMake version $CMAKE_VERSION is too new (must be < version 4)"
-            COMMANDS+=("    # Downgrading CMake to 3.30.1")
-            COMMANDS+=("    brew uninstall cmake --ignore-dependencies || true")
-            COMMANDS+=("    (cd /tmp && curl -LO https://cmake.org/files/v3.30/cmake-3.30.1-macos-universal.tar.gz)")
-            COMMANDS+=("    (cd /tmp && tar -xzf cmake-3.30.1-macos-universal.tar.gz)")
-            COMMANDS+=("    sudo mv /tmp/cmake-3.30.1-macos-universal /Applications/CMake-3.30.1")
-            COMMANDS+=("    sudo rm -f /usr/local/bin/cmake /usr/local/bin/ctest /usr/local/bin/cpack")
-            COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/cmake /usr/local/bin/cmake")
-            COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/ctest /usr/local/bin/ctest")
-            COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/cpack /usr/local/bin/cpack")
-            COMMANDS+=("    rm -f /tmp/cmake-3.30.1-macos-universal.tar.gz")
+            COMMANDS+=("    # Upgrading CMake")
+            COMMANDS+=("    brew upgrade cmake")
         fi
     else
-        echo "CMake is not installed. Installing CMake 3.30.1..."
-        COMMANDS+=("    # Installing CMake 3.30.1")
-        COMMANDS+=("    (cd /tmp && curl -LO https://cmake.org/files/v3.30/cmake-3.30.1-macos-universal.tar.gz)")
-        COMMANDS+=("    (cd /tmp && tar -xzf cmake-3.30.1-macos-universal.tar.gz)")
-        COMMANDS+=("    sudo mv /tmp/cmake-3.30.1-macos-universal /Applications/CMake-3.30.1")
-        COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/cmake /usr/local/bin/cmake")
-        COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/ctest /usr/local/bin/ctest")
-        COMMANDS+=("    sudo ln -sf /Applications/CMake-3.30.1/CMake.app/Contents/bin/cpack /usr/local/bin/cpack")
-        COMMANDS+=("    rm -f /tmp/cmake-3.30.1-macos-universal.tar.gz")
+        echo "CMake is not installed."
+        COMMANDS+=("    # Installing CMake")
+        COMMANDS+=("    brew install cmake")
     fi
 }
 


### PR DESCRIPTION
## CMake 4

Removes the custom CMake tarball install in favor of standard package managers, and lifts the artificial CMake 4 version ceiling.

### Changes

**`scripts/compiler-unix.sh`**
- **macOS/Linux**: Replace manual wget/curl + tarball extraction + symlinking of CMake 3.30.1 with `brew install/upgrade cmake` and `apt install cmake`.
- Remove the CMake 4+ downgrade guard — the script previously treated CMake ≥ 4 as "too new" and forced a downgrade to 3.30.1; that block is gone.
- Remove the `wget` prerequisite check on Linux (no longer needed).

**`packages/server/engine-core/apLib/**/*.hpp`**
- Fixed minor new compilation warnings introduced by the CMake 4 build.

### Platform status

| Platform | CMake version | How installed |
|----------|--------------|---------------|
| macOS | 4.x (latest via Homebrew) | `brew install cmake` |
| Linux (Ubuntu 22.04 / 24.04) | 3.x (apt ceiling) | `apt install cmake` |
| Windows | 3.x | VS component `VC.CMake.Project` (unchanged) |

Linux and Windows will continue using CMake 3.x until their respective package sources ship a 4.x release; the build is confirmed compatible on macOS with CMake 4.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Standardized formatting of internal literal operator declarations across multiple components for consistency.

* **Chores**
  * Simplified CMake dependency checking in the build system for Linux and macOS, now only enforcing minimum version requirements instead of managing pinned versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/807)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->