### PR TITLE
chore(ci): ignore semver-major updates across all Dependabot ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # npm — packages/shared-ui
@@ -100,6 +103,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # npm — apps/dropper-ui
@@ -122,6 +128,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # npm — apps/chat-ui
@@ -144,6 +153,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # Python — root pyproject.toml (covers most ai/nodes deps via workspace)
@@ -166,6 +178,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # Python — published SDK
@@ -182,6 +197,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # Python — MCP client SDK
@@ -198,6 +216,9 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # Python — pipeline node deps (ML/AI runtime)
@@ -222,6 +243,9 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   # ---------------------------------------------------------------------------
   # GitHub Actions — workflow file SHA pin updates
@@ -247,3 +271,6 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

The root npm ecosystem already had:
\`\`\`yaml
ignore:
  - dependency-name: \"*\"
    update-types: [\"version-update:semver-major\"]
\`\`\`
The other 10 ecosystem entries did not. Dependabot's first full cycle (2026-05-11) opened **18 major-bump PRs that all failed CI** — exactly the noise the root rule was designed to prevent.

This PR mirrors the same block to the remaining 10 ecosystems:

- 4 npm sub-package ecosystems: \`client-typescript\`, \`shared-ui\`, \`dropper-ui\`, \`chat-ui\`
- 4 pip ecosystems: root, \`client-python\`, \`client-mcp\`, \`nodes/src/nodes\`
- 1 \`github-actions\` ecosystem

## What this does NOT block

\`version-update:semver-major\` only suppresses **cadence-driven** majors. Dependabot's **security advisory** PRs (vulnerability fixes) still come through regardless of version jump, because they originate from a different code path. So we keep the CC7.1 vulnerability-management posture intact.

## Effect on the open PR queue (2026-05-11)

Already handled separately:
- 4 green PRs (#816, #821, #832, #841) — minor/patch, auto-merge enabled
- 11 distinct-major PRs — closed with \`@dependabot ignore this major version\` (sets a per-package permanent ignore)
- 7 duplicate/grouped PRs — closed with \`@dependabot close\`

This config change ensures we won't see the same flood next cycle.

## Future major upgrades

Major version bumps remain available as a deliberate, human-driven activity:
- \`pnpm outdated\` / \`pnpm up --interactive --latest\`
- \`pip list --outdated\`
- Coordinated upgrade PRs for breaking-change deps (React 19, Tailwind 4, TypeScript 6, etc.)

## Test plan

- [ ] YAML syntax valid (verified locally; no parse errors)
- [ ] All 10 added \`ignore:\` blocks pass GitHub's Dependabot config validation (will show on PR if invalid)
- [ ] Next weekly cycle (Monday 2026-05-18) produces no major-bump PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)