### PR TITLE
chore(ci): add Dependabot smoke tests for litellm and pipeline-node deps

### DIFF
--- a/tools/dependabot-smoke/README.md
+++ b/tools/dependabot-smoke/README.md
@@ -1,0 +1,35 @@
+# Dependabot Smoke Tests
+
+PR CI currently runs build, lint, secret scanning, and CodeQL — but **not** unit/integration tests. For Python dependency bumps, that means a bumped `litellm` or `spacy-transformers` can pass CI yet break runtime code (the weekly model-sync workflow, pipeline node execution).
+
+These scripts exist to give a reviewer a 30-second answer to "does this dep bump actually run?" before merging a Dependabot PR.
+
+## Scripts
+
+| Script | Use when Dependabot bumps anything in… |
+| --- | --- |
+| `smoke-litellm.sh` | `tools/requirements.txt` (litellm consumer) |
+| `smoke-nodes.sh` | `nodes/src/nodes/<node>/*.txt` (Python pipeline node deps) |
+
+## Manual invocation (from a Dependabot PR branch)
+
+```bash
+gh pr checkout <PR-number>
+
+# litellm bumps:
+bash tools/dependabot-smoke/smoke-litellm.sh
+
+# pipeline-node Python bumps (only the nodes whose .txt files changed):
+bash tools/dependabot-smoke/smoke-nodes.sh --changed-only
+```
+
+Exit `0` means imports + key APIs work. Non-zero means a real breakage — report on the PR, do not merge.
+
+## Future work — wire into PR CI
+
+These are designed to be cheap and parallelizable. The follow-up to actually gate Dependabot PRs on them is tracked in a separate issue (link in the PR that introduced this directory). Sketch:
+
+- New workflow `.github/workflows/dependabot-smoke.yml`
+- Triggers on `pull_request` from `app/dependabot`
+- Detects which paths changed; runs the matching script
+- Status check name added to `CI OK` aggregator so it gates auto-merge

--- a/tools/dependabot-smoke/smoke-litellm.sh
+++ b/tools/dependabot-smoke/smoke-litellm.sh
@@ -30,6 +30,12 @@ echo "==> Installing tools/requirements.txt"
 echo "==> Smoke: litellm import + core APIs"
 "$VENV/bin/python" - <<'PY'
 import litellm
+from importlib.metadata import version as _pkg_version
+
+# litellm >=1.83 dropped the module-level __version__ attribute and raises
+# AttributeError on access via its custom __getattr__. Use the standard
+# importlib.metadata route instead so this smoke test works across versions.
+litellm_version = _pkg_version("litellm")
 
 # 1. model_cost is the big lookup table sync_models.py reads
 assert hasattr(litellm, "model_cost"), "litellm.model_cost missing"
@@ -43,7 +49,7 @@ assert isinstance(info, dict), f"get_model_info returned {type(info).__name__}, 
 assert "max_input_tokens" in info or "max_tokens" in info, \
     f"get_model_info missing context-window key; got {sorted(info.keys())}"
 
-print(f"litellm {litellm.__version__}: model_cost={len(litellm.model_cost)} entries; get_model_info OK")
+print(f"litellm {litellm_version}: model_cost={len(litellm.model_cost)} entries; get_model_info OK")
 PY
 
 echo "==> Smoke: project consumer imports + calls"

--- a/tools/dependabot-smoke/smoke-litellm.sh
+++ b/tools/dependabot-smoke/smoke-litellm.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Dependabot smoke test: litellm version bumps
+#
+# Verifies that `tools/src/sync_models.py` (the consumer of litellm in this repo)
+# continues to work with the current pin in `tools/requirements.txt`. PR CI runs
+# build/lint only, not this tool, so a bumped litellm could silently break the
+# weekly sync-models.yml cron without anyone noticing until Monday.
+#
+# Run from a PR branch:
+#
+#     bash tools/dependabot-smoke/smoke-litellm.sh
+#
+# Exit 0 = imports + key APIs work end-to-end. Exit non-zero = breakage; open
+# the PR-trigger comment to see the captured stderr.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+VENV=$(mktemp -d)
+trap 'rm -rf "$VENV"' EXIT
+
+echo "==> Creating venv at $VENV"
+python3 -m venv "$VENV"
+"$VENV/bin/pip" install --quiet --upgrade pip
+
+echo "==> Installing tools/requirements.txt"
+"$VENV/bin/pip" install --quiet -r tools/requirements.txt
+
+echo "==> Smoke: litellm import + core APIs"
+"$VENV/bin/python" - <<'PY'
+import litellm
+
+# 1. model_cost is the big lookup table sync_models.py reads
+assert hasattr(litellm, "model_cost"), "litellm.model_cost missing"
+assert isinstance(litellm.model_cost, dict), "litellm.model_cost not a dict"
+assert len(litellm.model_cost) > 100, f"litellm.model_cost suspiciously small: {len(litellm.model_cost)}"
+
+# 2. get_model_info is the direct-lookup helper merger._litellm_info uses
+assert hasattr(litellm, "get_model_info"), "litellm.get_model_info missing"
+info = litellm.get_model_info("gpt-4o-mini")
+assert isinstance(info, dict), f"get_model_info returned {type(info).__name__}, expected dict"
+assert "max_input_tokens" in info or "max_tokens" in info, \
+    f"get_model_info missing context-window key; got {sorted(info.keys())}"
+
+print(f"litellm {litellm.__version__}: model_cost={len(litellm.model_cost)} entries; get_model_info OK")
+PY
+
+echo "==> Smoke: project consumer imports + calls"
+PYTHONPATH="$REPO_ROOT/tools/src" "$VENV/bin/python" - <<'PY'
+from core.merger import _litellm_info
+# This helper does the direct-lookup + model_cost scan dance. Any breakage
+# in either litellm API surfaces here.
+ctx, out = _litellm_info("openai/gpt-4o-mini")
+print(f"merger._litellm_info('openai/gpt-4o-mini') => ctx={ctx} out={out}")
+assert ctx is not None or out is not None, "both context and output token counts came back None"
+PY
+
+echo "==> Smoke: sync_models.py --help (verifies argparse + module load)"
+"$VENV/bin/python" tools/src/sync_models.py --help > /dev/null
+
+echo
+echo "PASS: litellm smoke test."

--- a/tools/dependabot-smoke/smoke-nodes.sh
+++ b/tools/dependabot-smoke/smoke-nodes.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Dependabot smoke test: pipeline node Python deps
+#
+# Verifies that each affected pipeline node still imports cleanly with the
+# current pins in its requirements.txt / nltk.txt / spacy.txt. PR CI runs
+# build/lint only and never imports these node modules, so a bumped Python
+# dep can silently break a pipeline at runtime.
+#
+# Run from a PR branch (optionally with a path filter to only test nodes
+# touched by the diff):
+#
+#     # test all known nodes:
+#     bash tools/dependabot-smoke/smoke-nodes.sh
+#
+#     # test only nodes whose requirements changed in this PR:
+#     bash tools/dependabot-smoke/smoke-nodes.sh --changed-only
+#
+# Exit 0 = every (node, package) pair imports. Exit non-zero = one or more
+# imports failed; check the per-node section for the FAIL lines.
+set -uo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT"
+
+# Node directory → packages to import-test once requirements are installed.
+# Keep import names (not pip names) here — they differ (e.g. opensearchpy
+# pips as opensearch-py).
+declare -A NODE_IMPORTS=(
+  [nodes/src/nodes/db_mysql]="pymysql"
+  [nodes/src/nodes/db_postgres]="psycopg2"
+  [nodes/src/nodes/index_search]="opensearchpy"
+  [nodes/src/nodes/preprocessor_langchain]="nltk spacy"
+)
+
+# Optional --changed-only flag: filter to nodes whose .txt files are in the diff.
+CHANGED_ONLY=0
+if [ "${1:-}" = "--changed-only" ]; then
+  CHANGED_ONLY=1
+fi
+
+filter_to_changed() {
+  local node="$1"
+  if [ "$CHANGED_ONLY" -eq 0 ]; then
+    return 0
+  fi
+  # Compare against develop. Works in CI (origin/develop is fetched) and locally.
+  if git diff --name-only origin/develop...HEAD -- "$node" 2>/dev/null | grep -qE '\.txt$'; then
+    return 0
+  fi
+  return 1
+}
+
+OVERALL_RC=0
+for node_dir in "${!NODE_IMPORTS[@]}"; do
+  imports="${NODE_IMPORTS[$node_dir]}"
+
+  if ! filter_to_changed "$node_dir"; then
+    echo "--- $node_dir: skipped (no .txt changes in this diff) ---"
+    continue
+  fi
+
+  echo "--- $node_dir (imports: $imports) ---"
+
+  VENV=$(mktemp -d)
+  python3 -m venv "$VENV" >/dev/null
+  "$VENV/bin/pip" install --quiet --upgrade pip
+
+  # Install every .txt requirement file in the node dir. Some nodes split
+  # heavy deps across multiple files (e.g. preprocessor_langchain has both
+  # nltk.txt and spacy.txt).
+  for req_file in "$node_dir"/*.txt; do
+    [ -f "$req_file" ] || continue
+    echo "  pip install -r $req_file"
+    if ! "$VENV/bin/pip" install --quiet -r "$req_file" 2>&1 | tail -20; then
+      echo "  FAIL: pip install $req_file"
+      OVERALL_RC=1
+    fi
+  done
+
+  # Smoke import each expected module.
+  for module in $imports; do
+    if "$VENV/bin/python" -c '
+import sys
+mod = sys.argv[1]
+m = __import__(mod)
+ver = getattr(m, "__version__", "<no __version__>")
+print(f"  OK: import {mod}={ver}")
+' "$module"; then
+      :
+    else
+      echo "  FAIL: import $module"
+      OVERALL_RC=1
+    fi
+  done
+
+  rm -rf "$VENV"
+  echo
+done
+
+if [ $OVERALL_RC -eq 0 ]; then
+  echo "PASS: nodes smoke test."
+else
+  echo "FAIL: one or more node imports failed (see FAIL lines above)."
+  exit 1
+fi

--- a/tools/dependabot-smoke/smoke-nodes.sh
+++ b/tools/dependabot-smoke/smoke-nodes.sh
@@ -77,13 +77,21 @@ for node_dir in "${!NODE_IMPORTS[@]}"; do
     fi
   done
 
-  # Smoke import each expected module.
+  # Smoke import each expected module. Use importlib.metadata for the
+  # version (some packages — e.g. PyMySQL — set a misleading __version__
+  # constant on the module that doesn't match the installed package).
   for module in $imports; do
     if "$VENV/bin/python" -c '
 import sys
+from importlib.metadata import version, PackageNotFoundError
 mod = sys.argv[1]
 m = __import__(mod)
-ver = getattr(m, "__version__", "<no __version__>")
+# Map import name -> pip package name for the cases where they differ.
+pip_name = {"opensearchpy": "opensearch-py", "psycopg2": "psycopg2-binary"}.get(mod, mod)
+try:
+    ver = version(pip_name)
+except PackageNotFoundError:
+    ver = getattr(m, "__version__", "<unknown>")
 print(f"  OK: import {mod}={ver}")
 ' "$module"; then
       :


### PR DESCRIPTION
## Summary

Adds two reviewer-runnable smoke scripts under \`tools/dependabot-smoke/\`:

| Script | Use when Dependabot bumps anything in… |
| --- | --- |
| \`smoke-litellm.sh\` | \`tools/requirements.txt\` (litellm consumer) |
| \`smoke-nodes.sh\` | \`nodes/src/nodes/<node>/*.txt\` (Python pipeline node deps) |

## Why

PR CI runs build, lint, secret scan, CodeQL — but no unit/integration tests, no Python import checks. That means Dependabot can bump litellm 33 minor versions and pass CI just because the *build* still works, even though the underlying code paths (\`sync_models.py\`, pipeline nodes) are never exercised.

Concrete triggers right now: open PRs #816 (litellm \`~=1.50 → ~=1.83\`) and #837 (spacy-transformers, opensearch-py and friends). Both passed CI; neither has been runtime-verified.

## What each script does

**\`smoke-litellm.sh\`** — 30 seconds:
1. Builds an ephemeral venv, installs \`tools/requirements.txt\`
2. Verifies \`litellm.model_cost\` is a populated dict (>100 entries)
3. Verifies \`litellm.get_model_info('gpt-4o-mini')\` returns a dict with a context-window key
4. Imports the project's consumer \`tools/src/core/merger._litellm_info\` and confirms it returns sensible numbers for a known model
5. Runs \`sync_models.py --help\` (catches module-load and argparse breakage)

**\`smoke-nodes.sh\`** — 1–2 minutes (one venv per node):
1. For each affected node (\`db_mysql\`, \`db_postgres\`, \`index_search\`, \`preprocessor_langchain\`), installs every \`*.txt\` requirement file
2. Imports the key Python module(s) (\`pymysql\`, \`psycopg2\`, \`opensearchpy\`, \`nltk\`, \`spacy\`)
3. Prints the resolved \`__version__\` so the reviewer sees what actually got pinned
4. Supports \`--changed-only\` to skip nodes whose \`.txt\` files aren't in the current PR diff

## Manual invocation

\`\`\`bash
gh pr checkout 816
bash tools/dependabot-smoke/smoke-litellm.sh

gh pr checkout 837
bash tools/dependabot-smoke/smoke-nodes.sh --changed-only
\`\`\`

## Out of scope (tracked separately)

Wiring these into PR CI as required checks for Dependabot PRs is a separate piece of work — see the linked issue. This PR delivers the runnable scripts so reviewers can use them on #816 and #837 right now.

## Test plan

- [ ] \`bash -n\` passes on both scripts (verified locally)
- [ ] \`bash tools/dependabot-smoke/smoke-litellm.sh\` from PR #816's branch exits 0
- [ ] \`bash tools/dependabot-smoke/smoke-nodes.sh --changed-only\` from PR #837's branch exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)