### PR TITLE
feat(test-harness): pipeline test harness — apaevt trace capture, coverage, classification, report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,7 +149,10 @@ vcpkg_installed/
 # -----------------------------------------------------------------------------
 # Test and Coverage
 # -----------------------------------------------------------------------------
-coverage/
+# Tool-generated jest/nyc coverage report dirs only — anchor to repo root so we
+# don't accidentally ignore packages/test-harness/src/coverage/ (real source).
+/coverage/
+**/jest-coverage/
 *.lcov
 .nyc_output/
 testdata/cache/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 build/
 dist/
 out/
+.harness-runs/
 *.o
 *.obj
 *.exe

--- a/packages/test-harness/.gitignore
+++ b/packages/test-harness/.gitignore
@@ -1,0 +1,4 @@
+lib/
+.harness-runs/
+*.log
+dist/

--- a/packages/test-harness/README.md
+++ b/packages/test-harness/README.md
@@ -1,0 +1,155 @@
+# @rocketride/test-harness
+
+TypeScript pipeline test harness for rocketride-server. Spawns the server with `ROCKETRIDE_MOCK=1`, runs every fixture under `pipelines/`, captures the live `apaevt_*` event stream for each run, diffs exercised nodes against `GET /services`, classifies failures into pass / logic / infra / timeout buckets, and emits a markdown + JSON report.
+
+This package sits above the per-node contract framework at `nodes/test/` and the engine-binary task driver at `test/testdata/tests/tasktest.py`. Neither is replaced — the harness owns pipeline-level coverage and trace persistence.
+
+## Quick start
+
+Prerequisites:
+- Engine binary staged at `<workspace>/dist/server/engine[.exe]` (run `builder build:server` or junction-link from a sibling checkout).
+- TypeScript client built: `cd packages/client-typescript && npx tsc -p tsconfig.cjs.json && npx tsc -p tsconfig.types.json`.
+
+```bash
+# Build the harness
+cd packages/test-harness
+npx tsc -p tsconfig.json
+
+# Run the smoke tier (mocked LLMs, fast)
+node lib/cli.js smoke
+
+# Run the integration tier (multi-node composites, still mocked)
+node lib/cli.js integration
+
+# Run both, one server lifecycle
+node lib/cli.js all
+
+# Re-render report.md from an existing run dir without re-running
+node lib/cli.js report .harness-runs/<ISO>
+
+# Emit a starter coverage-exclusions.json populated from /services
+node lib/cli.js scaffold-exclusions
+```
+
+Or via the builder CLI:
+
+```bash
+builder harness:smoke
+builder harness:integration
+builder harness:full              # real APIs, requires keys (no ROCKETRIDE_MOCK)
+builder harness:report --runDir=.harness-runs/<ISO>
+builder harness:scaffold-exclusions
+```
+
+Run artifacts land in `<workspace>/.harness-runs/<ISO>/`:
+
+```
+.harness-runs/2026-05-12T20-30-42-305Z/
+├── traces/
+│   ├── smoke__llm_openai.json
+│   ├── smoke__parse.json
+│   └── ...
+├── report.md       # human-readable
+└── report.json     # structured, same data
+```
+
+`.harness-runs/` is gitignored. The newest `HARNESS_RETAIN_RUNS` dirs are kept; older ones are pruned at the end of each run.
+
+## Environment variables
+
+| Name | Default | Purpose |
+| ---- | ------- | ------- |
+| `HARNESS_TIER` | `smoke` | `smoke` \| `integration` \| `all` (overridden by CLI subcommand). |
+| `HARNESS_MOCK_LLM` | `true` | Sets `ROCKETRIDE_MOCK=1` in the spawned server. Set `false` for real-API runs. |
+| `HARNESS_SERVER_MODE` | `spawn` | `spawn` (harness owns lifecycle) or `external` (server already running). |
+| `HARNESS_SERVER_URL` | `http://localhost:5565` | Used when `HARNESS_SERVER_MODE=external`. |
+| `ROCKETRIDE_APIKEY` | `MYAPIKEY` | Client auth for the spawned server. |
+| `HARNESS_PIPELINE_TIMEOUT_S` | `60` | Per-pipeline terminal-event timeout in seconds. |
+| `HARNESS_RETAIN_RUNS` | `20` | How many `.harness-runs/<ISO>/` dirs to keep. |
+| `HARNESS_BAIL` | `false` | Stop after the first non-pass result. |
+| `HARNESS_RUNS_DIR` | `<workspace>/.harness-runs` | Override the run-artifact root. |
+| `HARNESS_PIPELINES_DIR` | `packages/test-harness/pipelines` | Override the fixture root. |
+
+All `process.env` access lives in `src/config.ts` — nothing else reads env vars directly.
+
+## How to add a smoke pipeline
+
+1. Create `pipelines/smoke/<provider>.json` where `<provider>` matches the directory name under `nodes/src/nodes/` and the `"provider"` value used inside the pipeline JSON.
+2. Use the shape from one of the existing fixtures (`pipelines/smoke/llm_openai.json` is the canonical minimal example for an LLM, `pipelines/smoke/webhook_response.json` for a pure-echo pipeline).
+3. Source components are addressed via `"source": "<component-id>"` plus a component with `"config": { "mode": "Source", ... }`. Downstream nodes use `"input": [{ "lane": "...", "from": "<component-id>" }]`.
+4. For LLMs that pre-validate the key prefix before the mock SDK kicks in (`llm_anthropic`, `llm_gemini`, `llm_xai`), hardcode the required prefix in front of a `${ROCKETRIDE_*_KEY}` substitution placeholder so format validation passes even without a real key:
+   ```json
+   "claude-sonnet-4-6": { "apikey": "sk-ant-${ROCKETRIDE_ANTHROPIC_KEY}" }
+   ```
+5. Pick a unique `project_id` UUID per pipeline; the harness scopes monitor subscriptions by token, but separate project IDs keep cross-pipeline trace bleed impossible to construct by accident.
+6. Re-run `node lib/cli.js smoke`. If the new provider was previously in the gap list, the report will move it from `gaps` → `covered`. If the run fails, inspect `.harness-runs/<latest>/traces/smoke__<provider>.json`.
+
+## How to add an integration pipeline
+
+Same shape as smoke, but live under `pipelines/integration/`. Use these to exercise composite scenarios that touch multiple providers in one run (chain LLMs, fan out to parallel nodes, etc.). Coverage tracking aggregates exercised nodes across all tiers in a `harness:all` run.
+
+## How to add an infra signature
+
+Infra signatures live in `src/classify/infraSignatures.ts` as a single exported `INFRA_SIGNATURES` array. Entries are either literal substrings (matched case-insensitively) or regular expressions:
+
+```typescript
+export const INFRA_SIGNATURES: InfraSignature[] = [
+	'credit balance is too low',
+	/429\s+Too Many Requests/i,
+	// add new entries here
+];
+```
+
+Any error from the live trace (`apaevt_flow.body.trace.error`, `apaevt_status_error.body.message`, or a thrown `pipe.close()` rejection) that matches one of these is bucketed as `infra_failure`. Infra failures show up in the report but don't count against pass/fail totals.
+
+Keep the list narrow — only add patterns specific enough that a real logic bug will not match by accident.
+
+## How to add a coverage exclusion
+
+Open `coverage-exclusions.json` and add an entry under `exclusions`:
+
+```json
+{
+	"node": "tool_my_new_node",
+	"reason": "Requires a running my-service instance with seeded data; defer until harness gains fixture support.",
+	"owner": "<your-handle>",
+	"added": "<YYYY-MM-DD>"
+}
+```
+
+The validator (`src/coverage/exclusions.ts`) enforces three rules:
+
+- **Stale entries** — `node` must match a name returned by `GET /services`. If it doesn't, the entry is ignored and the run logs a warning.
+- **Thin reasons** — `reason` must be at least 3 words. One-word placeholders are ignored.
+- **Old entries** — entries older than 90 days emit a warning (not a failure). Review and either remove or refresh the `added` date.
+
+Use `node lib/cli.js scaffold-exclusions` to emit a starter file pre-populated from the live `/services` registry; fill in real reasons and trim what should be exercised.
+
+## How to run unit tests
+
+```bash
+cd packages/test-harness
+npx vitest run            # one-shot
+npx vitest                # watch mode
+npx vitest run --coverage # with v8 coverage report
+```
+
+Tests mirror the source tree under `tests/`. Coverage excludes `src/cli.ts` and `src/server/lifecycle.ts` — both are thin orchestration layers exercised by the live smoke run.
+
+## Architecture cheat sheet
+
+- **Single env reader.** `src/config.ts` is the only file that reads `process.env`. Everything else takes a typed `HarnessConfig`.
+- **Token-scoped monitor.** Each pipeline uses a fresh `use()` token → `addMonitor({ token }, ['FLOW', 'SSE', 'DETAIL', 'TASK'])`. Cross-pipeline event bleed is impossible by construction.
+- **Subscription type vs event-name distinction.** The server's `rrext_monitor` RPC accepts EVENT_TYPE enum names (`FLOW`, `SSE`, `DETAIL`, `TASK`); wire-level event names use the `apaevt_*` prefix. The harness subscribes by enum name and dispatches by event name.
+- **Reuses existing infra.** `scripts/lib/server.js` for spawn/teardown, `nodes/test/mocks/*` for offline SDK swaps via `ROCKETRIDE_MOCK=1`. No HTTP mock server, no LLM-node patches.
+- **Component-ID → provider name resolution.** `apaevt_flow.body.pipes[-1]` carries component IDs (`llm_openai_1`); the harness resolves them to provider class names (`llm_openai`) via the loaded pipeline config so the coverage diff matches `/services`.
+
+## Common errors
+
+| Symptom | Likely cause |
+| ------- | ------------ |
+| `Server not found at .../dist/server/engine[.exe]` | Run `builder build:server` or junction-link `<workspace>/dist` to a sibling checkout that already has the staged engine. |
+| `Invalid <provider> API key format` thrown from `client.use()` | The LLM node pre-validates the key prefix before the mock SDK is invoked. Hardcode the required prefix in front of the `${ROCKETRIDE_*_KEY}` placeholder in the pipeline JSON. |
+| `Warning: Unknown event type 'apaevt_flow' ignored` from the server | The harness is subscribing by event name instead of EVENT_TYPE enum name. Verify `MONITOR_TYPES` in `src/runner/runPipeline.ts` uses `['FLOW', 'SSE', 'DETAIL', 'TASK']`. |
+| `Component <id> input lane <X> not found in service definition` | Pipeline JSON wires a lane the upstream/downstream provider doesn't declare. Check the provider's `services*.json` `input` / `output` blocks under `nodes/src/nodes/`. |
+| Run exits with `gaps=N` | `N` providers from `/services` aren't covered by any pipeline and aren't in `coverage-exclusions.json`. Either add a fixture or add an entry with a real reason. |

--- a/packages/test-harness/coverage-exclusions.json
+++ b/packages/test-harness/coverage-exclusions.json
@@ -1,0 +1,485 @@
+{
+	"version": 1,
+	"exclusions": [
+		{
+			"node": "accessibility_describe",
+			"reason": "Gemini Vision-backed image describer; requires real image fixture and vendor API access not configured under ROCKETRIDE_MOCK.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "agent_crewai",
+			"reason": "CrewAI agent requires real LLM tool-use plumbing; current mock SDKs do not return structured tool-call envelopes.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "agent_crewai_manager",
+			"reason": "CrewAI manager-agent variant; same tool-use mocking gap as agent_crewai.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "agent_crewai_subagent",
+			"reason": "CrewAI subagent variant; same tool-use mocking gap as agent_crewai.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "agent_deepagent",
+			"reason": "DeepAgent fan-out requires tool-call mocking and parallel subagent dispatch not yet supported by harness mocks.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "agent_deepagent_subagent",
+			"reason": "DeepAgent subagent variant; same tool-use mocking gap as agent_deepagent.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "agent_langchain",
+			"reason": "LangChain agent requires real LLM tool-use plumbing; current mock SDKs do not return structured tool calls.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "agent_rocketride",
+			"reason": "RocketRide-native agent requires tool-call mocking and multi-step orchestration not yet supported.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "anonymize_text",
+			"reason": "PII anonymizer; smoke pipeline wiring deferred until input lane shape and downstream consumer are sorted out.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "astra_db",
+			"reason": "Requires running AstraDB instance with seeded collection; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "audio_player",
+			"reason": "Audio playback sink; requires media file fixture not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "audio_transcribe",
+			"reason": "Whisper/vendor transcription; requires real audio input and vendor API access not under ROCKETRIDE_MOCK.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "audio_tts",
+			"reason": "Text-to-speech requires vendor API access (ElevenLabs/OpenAI TTS) not mocked.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "chat",
+			"reason": "Source-mode component that originates pipelines; never appears as a leaf in apaevt_flow.body.pipes[]. Verified indirectly via every chat-sourced smoke pipeline.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "chroma",
+			"reason": "Requires running Chroma instance with seeded collection; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "db_mysql",
+			"reason": "Requires running MySQL with seeded schema; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "db_neo4j",
+			"reason": "Requires running Neo4j with seeded graph; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "db_postgres",
+			"reason": "Requires running Postgres with seeded schema; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "dictionary",
+			"reason": "Dictionary lookup node; smoke pipeline wiring deferred until input lane and dictionary fixtures are defined.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "dropper",
+			"reason": "Source-mode component that originates pipelines from dropped files; never appears as a leaf in apaevt_flow.body.pipes[].",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "elasticsearch",
+			"reason": "Requires running Elasticsearch instance with seeded index; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "embedding_image",
+			"reason": "Image embedding; requires real image input not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "embedding_openai",
+			"reason": "OpenAI embedding; smoke wiring needs paired vector-store downstream which requires DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "embedding_video",
+			"reason": "Video embedding; requires real video input not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "extract_data",
+			"reason": "Structured-extraction node requires LLM downstream wiring and schema; smoke pipeline deferred.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "filesys",
+			"reason": "Source-mode component reading from filesystem; never appears as a leaf in apaevt_flow.body.pipes[].",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "frame_grabber",
+			"reason": "Extracts frames from video input; requires real video fixture not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "guardrails",
+			"reason": "Guardrails policy enforcement requires paired LLM downstream and policy fixtures; smoke wiring deferred.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "hash",
+			"reason": "Content hashing node; smoke pipeline wiring deferred until input lane shape is verified.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "image_cleanup",
+			"reason": "Image preprocessing; requires real image input not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "image_vision_mistral",
+			"reason": "Mistral vision API requires real image fixture and live API access; no in-process mock SDK module.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "image_vision_ollama",
+			"reason": "Ollama vision endpoint requires real image fixture and running Ollama server.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "llamaparse",
+			"reason": "LlamaParse cloud document parser requires real API key and document fixture; no mock SDK.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "llm_gmi_cloud",
+			"reason": "GMI Cloud LLM requires real API key and live endpoint; no in-process mock SDK module.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "llm_mistral",
+			"reason": "Mistral cloud LLM requires real API key; no in-process mock SDK module under nodes/test/mocks/.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "llm_openai_api",
+			"reason": "Generic OpenAI-compatible endpoint requires user-provided serverbase + key; not covered by ROCKETRIDE_MOCK.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "llm_qwen",
+			"reason": "Qwen cloud LLM requires real API key; no in-process mock SDK module under nodes/test/mocks/.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "llm_vertex-enterprise",
+			"reason": "Google Vertex enterprise endpoint requires GCP credentials and project setup not configured under ROCKETRIDE_MOCK.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "llm_vertex-personal",
+			"reason": "Google Vertex personal endpoint requires GCP credentials; coverage deferred until smoke wiring is verified against the mock.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "local-text-output",
+			"reason": "Output sink that writes text results to a local file; not represented as a leaf node in flow events.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "mcp_client",
+			"reason": "MCP client requires a running MCP server endpoint; out of scope for the offline mock tier.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "memory_internal",
+			"reason": "In-memory state source seeded externally; coverage path differs from leaf-pipe tracking used by the harness.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "milvus",
+			"reason": "Requires running Milvus instance with seeded collection; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "mongodb+srv",
+			"reason": "Source-mode MongoDB connector reading from external Atlas cluster; not exercised as a leaf node.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "ner",
+			"reason": "Named-entity recognition node; smoke pipeline wiring deferred until input lane shape and tagger fixtures are defined.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "ocr",
+			"reason": "Optical character recognition; requires real image fixture not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "opensearch",
+			"reason": "Requires running OpenSearch instance with seeded index; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "pinecone",
+			"reason": "Requires running Pinecone index with vendor API access; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "postgres",
+			"reason": "Postgres source connector requires running database with seeded data; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "preprocessor_code",
+			"reason": "Code preprocessor; smoke pipeline wiring deferred until input lane shape is verified.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "preprocessor_langchain",
+			"reason": "LangChain text splitter; smoke pipeline wiring deferred until input shape and chunk-config are verified.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "preprocessor_llm",
+			"reason": "LLM-driven preprocessor requires paired downstream LLM and prompt config; smoke wiring deferred.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "prompt",
+			"reason": "Prompt-template node; smoke pipeline wiring deferred until paired LLM downstream is configured.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "qdrant",
+			"reason": "Requires running Qdrant instance with seeded collection; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "question",
+			"reason": "Question-rephrasing node; smoke pipeline wiring deferred until paired LLM downstream is configured.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "reducto",
+			"reason": "Reducto document parser requires real API key and document fixture; no mock SDK module.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "remote",
+			"reason": "Source-mode remote-source connector; never appears as a leaf in apaevt_flow.body.pipes[].",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "response_audio",
+			"reason": "Audio response sink; requires real audio fixture upstream not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "response_documents",
+			"reason": "Documents response sink; requires parsed-document fixture upstream not yet wired in the harness.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "response_image",
+			"reason": "Image response sink; requires real image fixture upstream not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "response_table",
+			"reason": "Table response sink; requires structured table fixture upstream not yet wired in the harness.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "response_video",
+			"reason": "Video response sink; requires real video fixture upstream not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "search_exa",
+			"reason": "Exa search API requires real API key; no in-process mock SDK module.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "summarization",
+			"reason": "Summarization node requires paired downstream LLM and prompt config; smoke wiring deferred.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "telegram",
+			"reason": "Source-mode Telegram bot connector; never appears as a leaf in apaevt_flow.body.pipes[].",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "text-output",
+			"reason": "Output sink that writes text results externally; not represented as a leaf node in flow events.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "thumbnail",
+			"reason": "Thumbnail generator; requires real image fixture not yet supported by harness pipe abstraction.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_bland_ai",
+			"reason": "Bland AI voice tool requires real API key and phone-call infrastructure; out of scope for offline mock tier.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_chartjs",
+			"reason": "Chart.js renderer requires structured table input and downstream agent wiring; smoke pipeline deferred.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_exa_search",
+			"reason": "Exa search tool requires real API key; no in-process mock SDK module.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_filesystem",
+			"reason": "Filesystem tool reads/writes real files; out of scope for the offline mock tier.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_firecrawl",
+			"reason": "Firecrawl web scraper requires real API key and live endpoint.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_git",
+			"reason": "Git tool requires real git repository and shell access; out of scope for the offline mock tier.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_github",
+			"reason": "GitHub API tool requires real API token and live endpoint.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_http_request",
+			"reason": "HTTP request tool requires real network access; out of scope for the offline mock tier.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_pipe",
+			"reason": "Pipe tool invokes nested pipelines; smoke wiring deferred until nested-pipeline fixture loader exists.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "tool_python",
+			"reason": "Python sandbox executor requires sandboxed runtime and downstream agent wiring; smoke pipeline deferred.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "twelvelabs",
+			"reason": "Twelve Labs video understanding requires real API key and video fixture; no mock SDK module.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "weaviate",
+			"reason": "Requires running Weaviate instance with seeded class; defer until harness gains DB fixture support.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		},
+		{
+			"node": "webhook",
+			"reason": "Source-mode webhook receiver; never appears as a leaf in apaevt_flow.body.pipes[]. Verified indirectly via every webhook-sourced smoke pipeline.",
+			"owner": "joshua",
+			"added": "2026-05-12"
+		}
+	]
+}

--- a/packages/test-harness/package.json
+++ b/packages/test-harness/package.json
@@ -11,7 +11,9 @@
 	},
 	"scripts": {
 		"build": "tsc -p tsconfig.json",
-		"clean": "rimraf lib"
+		"clean": "rimraf lib",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"rocketride": "workspace:*",
@@ -21,6 +23,7 @@
 		"@types/node": "^20.0.0",
 		"@types/ws": "^8.18.1",
 		"rimraf": "^5.0.5",
-		"typescript": "^5.3.3"
+		"typescript": "^5.3.3",
+		"vitest": "^2.1.5"
 	}
 }

--- a/packages/test-harness/package.json
+++ b/packages/test-harness/package.json
@@ -1,0 +1,26 @@
+{
+	"name": "@rocketride/test-harness",
+	"version": "0.1.0",
+	"description": "Pipeline test harness: smoke + integration tiers with apaevt trace capture",
+	"private": true,
+	"license": "MIT",
+	"type": "commonjs",
+	"main": "./lib/cli.js",
+	"bin": {
+		"rocketride-harness": "./lib/cli.js"
+	},
+	"scripts": {
+		"build": "tsc -p tsconfig.json",
+		"clean": "rimraf lib"
+	},
+	"dependencies": {
+		"rocketride": "workspace:*",
+		"ws": "^8.20.0"
+	},
+	"devDependencies": {
+		"@types/node": "^20.0.0",
+		"@types/ws": "^8.18.1",
+		"rimraf": "^5.0.5",
+		"typescript": "^5.3.3"
+	}
+}

--- a/packages/test-harness/pipelines/integration/multi_llm_chain.json
+++ b/packages/test-harness/pipelines/integration/multi_llm_chain.json
@@ -1,0 +1,35 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000102",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_openai_1",
+			"provider": "llm_openai",
+			"config": {
+				"profile": "openai-5",
+				"openai-5": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "llm_deepseek_1",
+			"provider": "llm_deepseek",
+			"config": {
+				"profile": "cloud-reasoner",
+				"cloud-reasoner": { "apikey": "${ROCKETRIDE_DEEPSEEK_KEY}", "serverbase": "https://mock-deepseek.invalid/v1" }
+			},
+			"input": [{ "lane": "questions", "from": "llm_openai_1" }]
+		},
+		{
+			"id": "response_answers_1",
+			"provider": "response_answers",
+			"config": {},
+			"input": [{ "lane": "answers", "from": "llm_deepseek_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/integration/parallel_llm_routing.json
+++ b/packages/test-harness/pipelines/integration/parallel_llm_routing.json
@@ -1,0 +1,38 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000101",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_openai_1",
+			"provider": "llm_openai",
+			"config": {
+				"profile": "openai-5",
+				"openai-5": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "llm_anthropic_1",
+			"provider": "llm_anthropic",
+			"config": {
+				"profile": "claude-sonnet-4-6",
+				"claude-sonnet-4-6": { "apikey": "sk-ant-${ROCKETRIDE_ANTHROPIC_KEY}" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [
+				{ "lane": "answers", "from": "llm_openai_1" },
+				{ "lane": "answers", "from": "llm_anthropic_1" }
+			]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/integration/parse_embed_chain.json
+++ b/packages/test-harness/pipelines/integration/parse_embed_chain.json
@@ -1,0 +1,32 @@
+{
+	"source": "webhook_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000100",
+	"components": [
+		{
+			"id": "webhook_1",
+			"provider": "webhook",
+			"config": { "hideForm": true, "mode": "Source", "type": "webhook" }
+		},
+		{
+			"id": "parse_1",
+			"provider": "parse",
+			"config": {},
+			"input": [{ "lane": "tags", "from": "webhook_1" }]
+		},
+		{
+			"id": "embedding_transformer_1",
+			"provider": "embedding_transformer",
+			"config": {},
+			"input": [{ "lane": "documents", "from": "parse_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [
+				{ "lane": "text", "from": "parse_1" },
+				{ "lane": "documents", "from": "embedding_transformer_1" }
+			]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/embedding_transformer.json
+++ b/packages/test-harness/pipelines/smoke/embedding_transformer.json
@@ -1,0 +1,29 @@
+{
+	"source": "webhook_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000030",
+	"components": [
+		{
+			"id": "webhook_1",
+			"provider": "webhook",
+			"config": { "hideForm": true, "mode": "Source", "type": "webhook" }
+		},
+		{
+			"id": "parse_1",
+			"provider": "parse",
+			"config": {},
+			"input": [{ "lane": "tags", "from": "webhook_1" }]
+		},
+		{
+			"id": "embedding_transformer_1",
+			"provider": "embedding_transformer",
+			"config": {},
+			"input": [{ "lane": "documents", "from": "parse_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "documents", "from": "embedding_transformer_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_anthropic.json
+++ b/packages/test-harness/pipelines/smoke/llm_anthropic.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000010",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_anthropic_1",
+			"provider": "llm_anthropic",
+			"config": {
+				"profile": "claude-sonnet-4-6",
+				"claude-sonnet-4-6": { "apikey": "sk-ant-${ROCKETRIDE_ANTHROPIC_KEY}" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "answers", "from": "llm_anthropic_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_bedrock.json
+++ b/packages/test-harness/pipelines/smoke/llm_bedrock.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000015",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_bedrock_1",
+			"provider": "llm_bedrock",
+			"config": {
+				"profile": "meta_llama3_3-70b",
+				"meta_llama3_3-70b": { "apikey": "%aws_access_key%", "secretkey": "%aws_secret_key%", "region": "us-east-1" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "answers", "from": "llm_bedrock_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_deepseek.json
+++ b/packages/test-harness/pipelines/smoke/llm_deepseek.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000013",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_deepseek_1",
+			"provider": "llm_deepseek",
+			"config": {
+				"profile": "cloud-reasoner",
+				"cloud-reasoner": { "apikey": "%deepseek_apikey%", "serverbase": "https://mock-deepseek.invalid/v1" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "answers", "from": "llm_deepseek_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_gemini.json
+++ b/packages/test-harness/pipelines/smoke/llm_gemini.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000011",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_gemini_1",
+			"provider": "llm_gemini",
+			"config": {
+				"profile": "gemini-3.1-pro-preview",
+				"gemini-3.1-pro-preview": { "apikey": "AI${ROCKETRIDE_GEMINI_KEY}" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "answers", "from": "llm_gemini_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_ollama.json
+++ b/packages/test-harness/pipelines/smoke/llm_ollama.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000016",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_ollama_1",
+			"provider": "llm_ollama",
+			"config": {
+				"profile": "llama3_3",
+				"llama3_3": { "serverbase": "http://mock-ollama.invalid:11434" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "answers", "from": "llm_ollama_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_openai.json
+++ b/packages/test-harness/pipelines/smoke/llm_openai.json
@@ -1,0 +1,34 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000003",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": {
+				"hideForm": true,
+				"mode": "Source",
+				"type": "chat"
+			}
+		},
+		{
+			"id": "llm_openai_1",
+			"provider": "llm_openai",
+			"config": {
+				"profile": "openai-5",
+				"openai-5": { "apikey": "%openai_apikey%" }
+			},
+			"input": [
+				{ "lane": "questions", "from": "chat_1" }
+			]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [
+				{ "lane": "answers", "from": "llm_openai_1" }
+			]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_perplexity.json
+++ b/packages/test-harness/pipelines/smoke/llm_perplexity.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000014",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_perplexity_1",
+			"provider": "llm_perplexity",
+			"config": {
+				"profile": "sonar",
+				"sonar": { "apikey": "%perplexity_apikey%" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "answers", "from": "llm_perplexity_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/llm_xai.json
+++ b/packages/test-harness/pipelines/smoke/llm_xai.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000012",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_xai_1",
+			"provider": "llm_xai",
+			"config": {
+				"profile": "grok-3",
+				"grok-3": { "apikey": "xai-${ROCKETRIDE_XAI_KEY}" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [{ "lane": "answers", "from": "llm_xai_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/parse.json
+++ b/packages/test-harness/pipelines/smoke/parse.json
@@ -1,0 +1,31 @@
+{
+	"source": "webhook_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000002",
+	"components": [
+		{
+			"id": "webhook_1",
+			"provider": "webhook",
+			"config": {
+				"hideForm": true,
+				"mode": "Source",
+				"type": "webhook"
+			}
+		},
+		{
+			"id": "parse_1",
+			"provider": "parse",
+			"config": {},
+			"input": [
+				{ "lane": "tags", "from": "webhook_1" }
+			]
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [
+				{ "lane": "text", "from": "parse_1" }
+			]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/response_answers.json
+++ b/packages/test-harness/pipelines/smoke/response_answers.json
@@ -1,0 +1,26 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000021",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "llm_openai_1",
+			"provider": "llm_openai",
+			"config": {
+				"profile": "openai-5",
+				"openai-5": { "apikey": "%openai_apikey%" }
+			},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		},
+		{
+			"id": "response_answers_1",
+			"provider": "response_answers",
+			"config": {},
+			"input": [{ "lane": "answers", "from": "llm_openai_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/response_questions.json
+++ b/packages/test-harness/pipelines/smoke/response_questions.json
@@ -1,0 +1,17 @@
+{
+	"source": "chat_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000022",
+	"components": [
+		{
+			"id": "chat_1",
+			"provider": "chat",
+			"config": { "hideForm": true, "mode": "Source", "type": "chat" }
+		},
+		{
+			"id": "response_questions_1",
+			"provider": "response_questions",
+			"config": {},
+			"input": [{ "lane": "questions", "from": "chat_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/response_text.json
+++ b/packages/test-harness/pipelines/smoke/response_text.json
@@ -1,0 +1,17 @@
+{
+	"source": "webhook_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000020",
+	"components": [
+		{
+			"id": "webhook_1",
+			"provider": "webhook",
+			"config": { "hideForm": true, "mode": "Source", "type": "webhook" }
+		},
+		{
+			"id": "response_text_1",
+			"provider": "response_text",
+			"config": {},
+			"input": [{ "lane": "text", "from": "webhook_1" }]
+		}
+	]
+}

--- a/packages/test-harness/pipelines/smoke/webhook_response.json
+++ b/packages/test-harness/pipelines/smoke/webhook_response.json
@@ -1,0 +1,23 @@
+{
+	"source": "webhook_1",
+	"project_id": "a1b2c3d4-0000-4000-8000-000000000001",
+	"components": [
+		{
+			"id": "webhook_1",
+			"provider": "webhook",
+			"config": {
+				"hideForm": true,
+				"mode": "Source",
+				"type": "webhook"
+			}
+		},
+		{
+			"id": "response_1",
+			"provider": "response",
+			"config": { "lanes": [] },
+			"input": [
+				{ "lane": "text", "from": "webhook_1" }
+			]
+		}
+	]
+}

--- a/packages/test-harness/scripts/tasks.js
+++ b/packages/test-harness/scripts/tasks.js
@@ -1,0 +1,119 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Build tasks for @rocketride/test-harness
+ *
+ * Commands:
+ *   harness:build         Compile TypeScript
+ *   harness:smoke         Run smoke-tier pipelines (spawns server, captures traces)
+ *   harness:integration   Run integration-tier pipelines
+ *   harness:full          Run all tiers with real APIs (requires keys)
+ *   harness:clean         Remove build artifacts
+ */
+const path = require('path');
+const { execCommand, removeDirs, exists } = require('../../../scripts/lib');
+
+const PACKAGE_DIR = path.join(__dirname, '..');
+const SRC_DIR = path.join(PACKAGE_DIR, 'src');
+const LOCAL_LIB = path.join(PACKAGE_DIR, 'lib');
+const CLI_ENTRY = path.join(LOCAL_LIB, 'cli.js');
+
+function makeCompileAction() {
+	return {
+		run: async (ctx, task) => {
+			await execCommand('npx', ['tsc', '-p', 'tsconfig.json'], { task, cwd: PACKAGE_DIR });
+			task.output = 'Compiled test-harness';
+		},
+	};
+}
+
+function makeRunAction(tier, extraEnv = {}) {
+	return {
+		run: async (ctx, task) => {
+			if (!(await exists(CLI_ENTRY))) {
+				throw new Error(`Test harness not built. Run: builder harness:build`);
+			}
+			const env = { ...process.env, ...extraEnv };
+			await execCommand('node', [CLI_ENTRY, tier], { task, cwd: PACKAGE_DIR, env });
+			task.output = `Harness ${tier} completed`;
+		},
+	};
+}
+
+module.exports = {
+	name: 'harness',
+	description: 'Pipeline test harness',
+
+	actions: [
+		// Internal actions
+		{ name: 'harness:compile', action: makeCompileAction },
+
+		// Public actions
+		{
+			name: 'harness:build',
+			action: () => ({
+				description: 'Build pipeline test harness',
+				steps: ['client-typescript:build', 'harness:compile'],
+			}),
+		},
+		{
+			name: 'harness:smoke',
+			action: () => ({
+				description: 'Run smoke-tier pipelines (mocked LLMs)',
+				steps: ['server:build', 'harness:build'],
+				run: (ctx, task) => makeRunAction('smoke', { HARNESS_MOCK_LLM: '1' }).run(ctx, task),
+			}),
+		},
+		{
+			name: 'harness:integration',
+			action: () => ({
+				description: 'Run integration-tier pipelines (mocked LLMs)',
+				steps: ['server:build', 'harness:build'],
+				run: (ctx, task) => makeRunAction('integration', { HARNESS_MOCK_LLM: '1' }).run(ctx, task),
+			}),
+		},
+		{
+			name: 'harness:full',
+			action: () => ({
+				description: 'Run all tiers with real APIs (requires keys)',
+				steps: ['server:build', 'harness:build'],
+				run: (ctx, task) => makeRunAction('all', { HARNESS_MOCK_LLM: '0' }).run(ctx, task),
+			}),
+		},
+		{
+			name: 'harness:clean',
+			action: () => ({
+				description: 'Clean test-harness build artifacts',
+				run: async (ctx, task) => {
+					await removeDirs([LOCAL_LIB]);
+					task.output = 'Cleaned test-harness';
+				},
+			}),
+		},
+	],
+};
+
+module.exports.SRC_DIR = SRC_DIR;
+module.exports.LOCAL_LIB = LOCAL_LIB;

--- a/packages/test-harness/scripts/tasks.js
+++ b/packages/test-harness/scripts/tasks.js
@@ -49,15 +49,15 @@ function makeCompileAction() {
 	};
 }
 
-function makeRunAction(tier, extraEnv = {}) {
+function makeRunAction(subcommand, extraEnv = {}, extraArgs = []) {
 	return {
 		run: async (ctx, task) => {
 			if (!(await exists(CLI_ENTRY))) {
 				throw new Error(`Test harness not built. Run: builder harness:build`);
 			}
 			const env = { ...process.env, ...extraEnv };
-			await execCommand('node', [CLI_ENTRY, tier], { task, cwd: PACKAGE_DIR, env });
-			task.output = `Harness ${tier} completed`;
+			await execCommand('node', [CLI_ENTRY, subcommand, ...extraArgs], { task, cwd: PACKAGE_DIR, env });
+			task.output = `Harness ${subcommand} completed`;
 		},
 	};
 }
@@ -100,6 +100,28 @@ module.exports = {
 				description: 'Run all tiers with real APIs (requires keys)',
 				steps: ['server:build', 'harness:build'],
 				run: (ctx, task) => makeRunAction('all', { HARNESS_MOCK_LLM: '0' }).run(ctx, task),
+			}),
+		},
+		{
+			name: 'harness:report',
+			action: (options = {}) => ({
+				description: 'Re-render report.md from an existing run dir (pass --runDir=...)',
+				steps: ['harness:build'],
+				run: (ctx, task) => {
+					const runDir = options.runDir || ctx.options?.runDir;
+					if (!runDir) {
+						throw new Error('harness:report requires --runDir=<path>');
+					}
+					return makeRunAction('report', {}, [runDir]).run(ctx, task);
+				},
+			}),
+		},
+		{
+			name: 'harness:scaffold-exclusions',
+			action: () => ({
+				description: 'Write starter coverage-exclusions.json from /services',
+				steps: ['server:build', 'harness:build'],
+				run: (ctx, task) => makeRunAction('scaffold-exclusions', { HARNESS_MOCK_LLM: '1' }).run(ctx, task),
 			}),
 		},
 		{

--- a/packages/test-harness/src/classify/infraSignatures.ts
+++ b/packages/test-harness/src/classify/infraSignatures.ts
@@ -1,0 +1,54 @@
+/**
+ * Infra-failure signatures.
+ *
+ * When a pipeline error matches one of these, it's bucketed as
+ * `infra_failure` (reported separately, not counted against pass/fail
+ * totals). Anything else with an error is `logic_failure`.
+ *
+ * Keep this list narrow and add entries as new transient patterns appear.
+ * Each entry should be specific enough that a literal node bug never
+ * matches.
+ */
+
+export type InfraSignature = string | RegExp;
+
+export const INFRA_SIGNATURES: InfraSignature[] = [
+	'credit balance is too low',
+	'rate_limit_error',
+	'insufficient_quota',
+	/429\s+Too Many Requests/i,
+	'ECONNREFUSED',
+	'ETIMEDOUT',
+	'connection refused',
+	'socket hang up',
+	'getaddrinfo ENOTFOUND',
+	'EAI_AGAIN',
+	'Service Unavailable',
+	/503\s+Service Unavailable/i,
+];
+
+export type ClassifiedInfra = {
+	signature: string;
+	rawError: string;
+};
+
+function matches(signature: InfraSignature, text: string): boolean {
+	if (typeof signature === 'string') {
+		return text.toLowerCase().includes(signature.toLowerCase());
+	}
+	return signature.test(text);
+}
+
+function signatureLabel(signature: InfraSignature): string {
+	return typeof signature === 'string' ? signature : signature.source;
+}
+
+export function classifyError(errorText: string | undefined): ClassifiedInfra | null {
+	if (!errorText) return null;
+	for (const sig of INFRA_SIGNATURES) {
+		if (matches(sig, errorText)) {
+			return { signature: signatureLabel(sig), rawError: errorText };
+		}
+	}
+	return null;
+}

--- a/packages/test-harness/src/cli.ts
+++ b/packages/test-harness/src/cli.ts
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * Pipeline test harness CLI.
+ *
+ * Subcommands:
+ *   smoke         Run all pipelines/smoke/*.json against a spawned server.
+ *   integration   Run all pipelines/integration/*.json.
+ *   all           Run smoke + integration.
+ *
+ * Phase 1 scope: smoke only. Trace files persist; no markdown report yet.
+ */
+
+import { existsSync, readdirSync } from 'fs';
+import { basename, join } from 'path';
+
+import { RocketRideClient } from 'rocketride';
+
+import { loadConfig, type HarnessConfig } from './config';
+import { TraceCollector } from './runner/collector';
+import { ensureRunDir, isoStamp } from './runner/persist';
+import { runPipeline, type PipelineDef } from './runner/runPipeline';
+import type { TraceFile } from './runner/schema';
+import { startHarnessServer } from './server/lifecycle';
+
+const DEFAULT_INPUT = 'hello from harness';
+
+type TierName = 'smoke' | 'integration';
+
+function discoverPipelines(pipelinesDir: string, tier: TierName): PipelineDef[] {
+	const tierDir = join(pipelinesDir, tier);
+	if (!existsSync(tierDir)) return [];
+	const files = readdirSync(tierDir)
+		.filter((f) => f.endsWith('.json'))
+		.sort();
+
+	return files.map((file) => ({
+		slug: `${tier}/${basename(file, '.json')}`,
+		filePath: join(tierDir, file),
+		input: { mimeType: 'text/plain', data: DEFAULT_INPUT },
+	}));
+}
+
+async function runTier(config: HarnessConfig, runDir: string, tier: TierName): Promise<TraceFile[]> {
+	const pipelines = discoverPipelines(config.pipelinesDir, tier);
+	if (pipelines.length === 0) {
+		process.stdout.write(`[harness] no pipelines under ${tier}/, skipping tier\n`);
+		return [];
+	}
+
+	process.stdout.write(`[harness] starting server (mode=${config.serverMode}, mockLlm=${config.mockLlm})\n`);
+	const server = await startHarnessServer(config);
+	process.stdout.write(`[harness] server ready at ${server.url}\n`);
+
+	const traces: TraceFile[] = [];
+
+	try {
+		for (const def of pipelines) {
+			process.stdout.write(`[harness] run ${def.slug}\n`);
+			const collector = new TraceCollector({
+				token: '',
+				timeoutMs: config.pipelineTimeoutSec * 1000,
+			});
+
+			const client = new RocketRideClient({
+				uri: server.url,
+				auth: config.apiKey,
+				onEvent: collector.onEvent,
+			});
+
+			try {
+				await client.connect();
+				const trace = await runPipeline(client, collector, def, {
+					runDir,
+					timeoutMs: config.pipelineTimeoutSec * 1000,
+				});
+				traces.push(trace);
+				process.stdout.write(`[harness]   result=${trace.result} nodes=${trace.exercised_nodes.length}\n`);
+				if (config.bail && trace.result !== 'pass') {
+					process.stdout.write(`[harness] bail=true, stopping after ${def.slug}\n`);
+					break;
+				}
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				process.stderr.write(`[harness]   ${def.slug} threw: ${message}\n`);
+				if (config.bail) break;
+			} finally {
+				if (client.isConnected()) {
+					await client.disconnect();
+				}
+			}
+		}
+	} finally {
+		process.stdout.write('[harness] stopping server\n');
+		await server.stop();
+	}
+
+	return traces;
+}
+
+async function main(): Promise<number> {
+	const [subcommand = 'smoke'] = process.argv.slice(2);
+	const config = loadConfig();
+
+	if (subcommand !== 'smoke' && subcommand !== 'integration' && subcommand !== 'all') {
+		process.stderr.write(`[harness] unknown subcommand: ${subcommand}\n`);
+		process.stderr.write('[harness] usage: rocketride-harness <smoke|integration|all>\n');
+		return 2;
+	}
+
+	const stamp = isoStamp();
+	const runDir = ensureRunDir(config.runsDir, stamp);
+	process.stdout.write(`[harness] run dir: ${runDir}\n`);
+
+	const tiers: TierName[] = subcommand === 'all' ? ['smoke', 'integration'] : [subcommand];
+	const allTraces: TraceFile[] = [];
+
+	for (const tier of tiers) {
+		const traces = await runTier(config, runDir, tier);
+		allTraces.push(...traces);
+	}
+
+	const passes = allTraces.filter((t) => t.result === 'pass').length;
+	const failures = allTraces.length - passes;
+	process.stdout.write(`[harness] done: ${passes} pass / ${failures} non-pass / ${allTraces.length} total\n`);
+	return failures > 0 ? 1 : 0;
+}
+
+main()
+	.then((code) => process.exit(code))
+	.catch((err) => {
+		process.stderr.write(`[harness] fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
+		process.exit(1);
+	});

--- a/packages/test-harness/src/cli.ts
+++ b/packages/test-harness/src/cli.ts
@@ -3,26 +3,32 @@
  * Pipeline test harness CLI.
  *
  * Subcommands:
- *   smoke         Run all pipelines/smoke/*.json against a spawned server.
- *   integration   Run all pipelines/integration/*.json.
- *   all           Run smoke + integration.
- *
- * Phase 1 scope: smoke only. Trace files persist; no markdown report yet.
+ *   smoke                    Run pipelines/smoke/*.json against a spawned server.
+ *   integration              Run pipelines/integration/*.json.
+ *   all                      Run smoke + integration.
+ *   report <run-dir>         Re-render report.md from existing trace JSONs.
+ *   scaffold-exclusions      Emit a starter coverage-exclusions.json from /services.
  */
 
-import { existsSync, readdirSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync } from 'fs';
 import { basename, join } from 'path';
 
 import { RocketRideClient } from 'rocketride';
 
 import { loadConfig, type HarnessConfig } from './config';
+import { diffCoverage } from './coverage/diff';
+import { loadExclusions, validateExclusions, writeStarterExclusions } from './coverage/exclusions';
+import { fetchServices } from './coverage/services';
+import { renderMarkdown, writeReports } from './report/markdown';
+import { emptyCoverageFrom, type PipelineSummary, type RunReport } from './report/schema';
 import { TraceCollector } from './runner/collector';
-import { ensureRunDir, isoStamp } from './runner/persist';
+import { ensureRunDir, isoStamp, loadTraces, pipelineSlugToFile } from './runner/persist';
 import { runPipeline, type PipelineDef } from './runner/runPipeline';
 import type { TraceFile } from './runner/schema';
-import { startHarnessServer } from './server/lifecycle';
+import { startHarnessServer, type ServerHandle } from './server/lifecycle';
 
 const DEFAULT_INPUT = 'hello from harness';
+const EXCLUSIONS_FILENAME = 'coverage-exclusions.json';
 
 type TierName = 'smoke' | 'integration';
 
@@ -40,89 +46,262 @@ function discoverPipelines(pipelinesDir: string, tier: TierName): PipelineDef[] 
 	}));
 }
 
-async function runTier(config: HarnessConfig, runDir: string, tier: TierName): Promise<TraceFile[]> {
+async function runTier(config: HarnessConfig, runDir: string, server: ServerHandle, tier: TierName): Promise<TraceFile[]> {
 	const pipelines = discoverPipelines(config.pipelinesDir, tier);
 	if (pipelines.length === 0) {
 		process.stdout.write(`[harness] no pipelines under ${tier}/, skipping tier\n`);
 		return [];
 	}
 
-	process.stdout.write(`[harness] starting server (mode=${config.serverMode}, mockLlm=${config.mockLlm})\n`);
-	const server = await startHarnessServer(config);
-	process.stdout.write(`[harness] server ready at ${server.url}\n`);
-
 	const traces: TraceFile[] = [];
 
-	try {
-		for (const def of pipelines) {
-			process.stdout.write(`[harness] run ${def.slug}\n`);
-			const collector = new TraceCollector({
-				token: '',
+	for (const def of pipelines) {
+		process.stdout.write(`[harness] run ${def.slug}\n`);
+		const collector = new TraceCollector({
+			token: '',
+			timeoutMs: config.pipelineTimeoutSec * 1000,
+		});
+
+		const client = new RocketRideClient({
+			uri: server.url,
+			auth: config.apiKey,
+			onEvent: collector.onEvent,
+		});
+
+		try {
+			await client.connect();
+			const trace = await runPipeline(client, collector, def, {
+				runDir,
 				timeoutMs: config.pipelineTimeoutSec * 1000,
 			});
-
-			const client = new RocketRideClient({
-				uri: server.url,
-				auth: config.apiKey,
-				onEvent: collector.onEvent,
-			});
-
-			try {
-				await client.connect();
-				const trace = await runPipeline(client, collector, def, {
-					runDir,
-					timeoutMs: config.pipelineTimeoutSec * 1000,
-				});
-				traces.push(trace);
-				process.stdout.write(`[harness]   result=${trace.result} nodes=${trace.exercised_nodes.length}\n`);
-				if (config.bail && trace.result !== 'pass') {
-					process.stdout.write(`[harness] bail=true, stopping after ${def.slug}\n`);
-					break;
-				}
-			} catch (err) {
-				const message = err instanceof Error ? err.message : String(err);
-				process.stderr.write(`[harness]   ${def.slug} threw: ${message}\n`);
-				if (config.bail) break;
-			} finally {
-				if (client.isConnected()) {
-					await client.disconnect();
-				}
+			traces.push(trace);
+			process.stdout.write(`[harness]   result=${trace.result} nodes=${trace.exercised_nodes.length}\n`);
+			if (config.bail && trace.result !== 'pass') {
+				process.stdout.write(`[harness] bail=true, stopping after ${def.slug}\n`);
+				break;
+			}
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err);
+			process.stderr.write(`[harness]   ${def.slug} threw: ${message}\n`);
+			if (config.bail) break;
+		} finally {
+			if (client.isConnected()) {
+				await client.disconnect();
 			}
 		}
-	} finally {
-		process.stdout.write('[harness] stopping server\n');
-		await server.stop();
 	}
 
 	return traces;
 }
 
-async function main(): Promise<number> {
-	const [subcommand = 'smoke'] = process.argv.slice(2);
-	const config = loadConfig();
+function tracePathFor(trace: TraceFile): string {
+	return `traces/${pipelineSlugToFile(trace.pipeline)}`;
+}
 
-	if (subcommand !== 'smoke' && subcommand !== 'integration' && subcommand !== 'all') {
-		process.stderr.write(`[harness] unknown subcommand: ${subcommand}\n`);
-		process.stderr.write('[harness] usage: rocketride-harness <smoke|integration|all>\n');
-		return 2;
+function summarizePipeline(trace: TraceFile): PipelineSummary {
+	const duration = Date.parse(trace.run_ended) - Date.parse(trace.run_started);
+	return {
+		pipeline: trace.pipeline,
+		result: trace.result,
+		duration_ms: Number.isFinite(duration) ? duration : 0,
+		exercised_nodes: trace.exercised_nodes,
+		error_message: trace.error?.message,
+		infra_signature: trace.infra_signature,
+		trace_path: tracePathFor(trace),
+	};
+}
+
+function aggregateSummary(traces: TraceFile[]): RunReport['summary'] {
+	const summary = { pass: 0, logic_failure: 0, infra_failure: 0, timeout: 0, total: traces.length };
+	for (const t of traces) {
+		summary[t.result] += 1;
 	}
+	return summary;
+}
 
-	const stamp = isoStamp();
+async function buildCoverage(
+	config: HarnessConfig,
+	server: ServerHandle,
+	traces: TraceFile[],
+): Promise<{ coverage?: RunReport['coverage']; skipped?: { reason: string } }> {
+	try {
+		const registry = await fetchServices(server.url, config.apiKey);
+		const exclusionsPath = join(config.pipelinesDir, '..', EXCLUSIONS_FILENAME);
+		const exclusionsFile = loadExclusions(exclusionsPath);
+		const validation = validateExclusions(exclusionsFile, registry.names);
+
+		if (validation.stale.length > 0) {
+			process.stderr.write(`[harness] warning: stale exclusions ignored (not in /services): ${validation.stale.join(', ')}\n`);
+		}
+		if (validation.thinReason.length > 0) {
+			process.stderr.write(`[harness] warning: thin-reason exclusions ignored (need >=3 words): ${validation.thinReason.join(', ')}\n`);
+		}
+
+		const exercised = new Set<string>();
+		for (const t of traces) {
+			for (const n of t.exercised_nodes) exercised.add(n);
+		}
+
+		const diff = diffCoverage({
+			knownNodes: registry.names,
+			exercisedNodes: exercised,
+			excluded: validation.excluded,
+		});
+
+		return { coverage: emptyCoverageFrom(diff, validation.staleWarnings) };
+	} catch (err) {
+		const reason = err instanceof Error ? err.message : String(err);
+		process.stderr.write(`[harness] coverage skipped: ${reason}\n`);
+		return { skipped: { reason } };
+	}
+}
+
+function buildReport(args: {
+	config: HarnessConfig;
+	server: ServerHandle;
+	tier: string;
+	traces: TraceFile[];
+	runStarted: Date;
+	runEnded: Date;
+	coverage?: RunReport['coverage'];
+	skippedCoverage?: { reason: string };
+}): RunReport {
+	const pipelines = args.traces.map(summarizePipeline);
+	return {
+		schema_version: 1,
+		run_started: args.runStarted.toISOString(),
+		run_ended: args.runEnded.toISOString(),
+		duration_ms: args.runEnded.getTime() - args.runStarted.getTime(),
+		tier: args.tier,
+		mock_llm: args.config.mockLlm,
+		server: { mode: args.server.mode, url: args.server.url, port: args.server.port },
+		summary: aggregateSummary(args.traces),
+		coverage: args.coverage,
+		pipelines,
+		skipped_coverage: args.skippedCoverage,
+	};
+}
+
+async function runTiersCommand(tiers: TierName[], config: HarnessConfig, tierLabel: string): Promise<number> {
+	const runStarted = new Date();
+	const stamp = isoStamp(runStarted);
 	const runDir = ensureRunDir(config.runsDir, stamp);
 	process.stdout.write(`[harness] run dir: ${runDir}\n`);
 
-	const tiers: TierName[] = subcommand === 'all' ? ['smoke', 'integration'] : [subcommand];
+	process.stdout.write(`[harness] starting server (mode=${config.serverMode}, mockLlm=${config.mockLlm})\n`);
+	const server = await startHarnessServer(config);
+	process.stdout.write(`[harness] server ready at ${server.url}\n`);
+
 	const allTraces: TraceFile[] = [];
 
-	for (const tier of tiers) {
-		const traces = await runTier(config, runDir, tier);
-		allTraces.push(...traces);
-	}
+	try {
+		for (const tier of tiers) {
+			const traces = await runTier(config, runDir, server, tier);
+			allTraces.push(...traces);
+			if (config.bail && traces.some((t) => t.result !== 'pass')) break;
+		}
 
-	const passes = allTraces.filter((t) => t.result === 'pass').length;
-	const failures = allTraces.length - passes;
-	process.stdout.write(`[harness] done: ${passes} pass / ${failures} non-pass / ${allTraces.length} total\n`);
-	return failures > 0 ? 1 : 0;
+		const coverage = await buildCoverage(config, server, allTraces);
+		const runEnded = new Date();
+		const report = buildReport({
+			config,
+			server,
+			tier: tierLabel,
+			traces: allTraces,
+			runStarted,
+			runEnded,
+			coverage: coverage.coverage,
+			skippedCoverage: coverage.skipped,
+		});
+
+		const paths = writeReports(runDir, report);
+		process.stdout.write(`[harness] report: ${paths.md}\n`);
+
+		const failures = report.summary.logic_failure + report.summary.timeout;
+		const gaps = report.coverage?.gap_count ?? 0;
+		process.stdout.write(
+			`[harness] done: ${report.summary.pass} pass / ${failures} non-pass / ${report.summary.total} total; gaps=${gaps}\n`,
+		);
+		return failures > 0 || gaps > 0 ? 1 : 0;
+	} finally {
+		process.stdout.write('[harness] stopping server\n');
+		await server.stop();
+	}
+}
+
+async function reportCommand(runDir: string, config: HarnessConfig): Promise<number> {
+	if (!existsSync(join(runDir, 'traces'))) {
+		process.stderr.write(`[harness] no traces/ directory under ${runDir}\n`);
+		return 2;
+	}
+	const traces = loadTraces(runDir);
+	const existingJsonPath = join(runDir, 'report.json');
+	const previous = existsSync(existingJsonPath)
+		? (JSON.parse(readFileSync(existingJsonPath, 'utf8')) as RunReport)
+		: undefined;
+
+	const runStarted = previous ? new Date(previous.run_started) : new Date(traces[0]?.run_started ?? Date.now());
+	const runEnded = previous ? new Date(previous.run_ended) : new Date(traces[traces.length - 1]?.run_ended ?? Date.now());
+
+	const report: RunReport = {
+		schema_version: 1,
+		run_started: runStarted.toISOString(),
+		run_ended: runEnded.toISOString(),
+		duration_ms: runEnded.getTime() - runStarted.getTime(),
+		tier: previous?.tier ?? 'unknown',
+		mock_llm: previous?.mock_llm ?? config.mockLlm,
+		server: previous?.server ?? { mode: 'external', url: config.serverUrl, port: 0 },
+		summary: aggregateSummary(traces),
+		coverage: previous?.coverage,
+		pipelines: traces.map(summarizePipeline),
+		skipped_coverage: previous?.skipped_coverage,
+	};
+
+	const paths = writeReports(runDir, report);
+	process.stdout.write(`[harness] re-rendered: ${paths.md}\n`);
+	return 0;
+}
+
+async function scaffoldExclusionsCommand(config: HarnessConfig): Promise<number> {
+	process.stdout.write(`[harness] starting server to fetch /services\n`);
+	const server = await startHarnessServer(config);
+	try {
+		const registry = await fetchServices(server.url, config.apiKey);
+		const outPath = join(config.pipelinesDir, '..', EXCLUSIONS_FILENAME);
+		writeStarterExclusions(outPath, registry.names, 'TODO-owner');
+		process.stdout.write(`[harness] wrote starter exclusions for ${registry.names.size} nodes to ${outPath}\n`);
+		return 0;
+	} finally {
+		await server.stop();
+	}
+}
+
+async function main(): Promise<number> {
+	const [subcommand = 'smoke', ...rest] = process.argv.slice(2);
+	const config = loadConfig();
+
+	switch (subcommand) {
+		case 'smoke':
+			return runTiersCommand(['smoke'], config, 'smoke');
+		case 'integration':
+			return runTiersCommand(['integration'], config, 'integration');
+		case 'all':
+			return runTiersCommand(['smoke', 'integration'], config, 'all');
+		case 'report': {
+			const runDir = rest[0];
+			if (!runDir) {
+				process.stderr.write('[harness] usage: rocketride-harness report <run-dir>\n');
+				return 2;
+			}
+			return reportCommand(runDir, config);
+		}
+		case 'scaffold-exclusions':
+			return scaffoldExclusionsCommand(config);
+		default:
+			process.stderr.write(`[harness] unknown subcommand: ${subcommand}\n`);
+			process.stderr.write('[harness] usage: rocketride-harness <smoke|integration|all|report|scaffold-exclusions>\n');
+			return 2;
+	}
 }
 
 main()
@@ -131,3 +310,6 @@ main()
 		process.stderr.write(`[harness] fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}\n`);
 		process.exit(1);
 	});
+
+// Re-export for unit tests in later phases.
+export { renderMarkdown };

--- a/packages/test-harness/src/cli.ts
+++ b/packages/test-harness/src/cli.ts
@@ -22,7 +22,7 @@ import { fetchServices } from './coverage/services';
 import { renderMarkdown, writeReports } from './report/markdown';
 import { emptyCoverageFrom, type PipelineSummary, type RunReport } from './report/schema';
 import { TraceCollector } from './runner/collector';
-import { ensureRunDir, isoStamp, loadTraces, pipelineSlugToFile } from './runner/persist';
+import { ensureRunDir, isoStamp, loadTraces, pipelineSlugToFile, pruneRuns } from './runner/persist';
 import { runPipeline, type PipelineDef } from './runner/runPipeline';
 import type { TraceFile } from './runner/schema';
 import { startHarnessServer, type ServerHandle } from './server/lifecycle';
@@ -222,6 +222,12 @@ async function runTiersCommand(tiers: TierName[], config: HarnessConfig, tierLab
 		process.stdout.write(
 			`[harness] done: ${report.summary.pass} pass / ${failures} non-pass / ${report.summary.total} total; gaps=${gaps}\n`,
 		);
+
+		const removed = pruneRuns(config.runsDir, config.retainRuns);
+		if (removed.length > 0) {
+			process.stdout.write(`[harness] pruned ${removed.length} old run dir(s) (keeping last ${config.retainRuns})\n`);
+		}
+
 		return failures > 0 || gaps > 0 ? 1 : 0;
 	} finally {
 		process.stdout.write('[harness] stopping server\n');

--- a/packages/test-harness/src/config.ts
+++ b/packages/test-harness/src/config.ts
@@ -1,0 +1,68 @@
+/**
+ * Centralized environment variable access for the harness.
+ *
+ * Single reader of process.env. Everything else takes a typed HarnessConfig.
+ */
+
+export type HarnessTier = 'smoke' | 'integration' | 'all';
+export type HarnessServerMode = 'spawn' | 'external';
+
+export type HarnessConfig = {
+	tier: HarnessTier;
+	mockLlm: boolean;
+	serverMode: HarnessServerMode;
+	serverUrl: string;
+	apiKey: string;
+	pipelineTimeoutSec: number;
+	retainRuns: number;
+	bail: boolean;
+	runsDir: string;
+	pipelinesDir: string;
+};
+
+function readBool(name: string, fallback: boolean): boolean {
+	const raw = process.env[name];
+	if (raw === undefined) return fallback;
+	const v = raw.trim().toLowerCase();
+	if (v === '1' || v === 'true' || v === 'yes') return true;
+	if (v === '0' || v === 'false' || v === 'no') return false;
+	return fallback;
+}
+
+function readInt(name: string, fallback: number): number {
+	const raw = process.env[name];
+	if (raw === undefined) return fallback;
+	const n = parseInt(raw, 10);
+	return Number.isFinite(n) ? n : fallback;
+}
+
+function readTier(): HarnessTier {
+	const raw = (process.env.HARNESS_TIER ?? 'smoke').toLowerCase();
+	if (raw === 'smoke' || raw === 'integration' || raw === 'all') return raw;
+	return 'smoke';
+}
+
+function readServerMode(): HarnessServerMode {
+	const raw = (process.env.HARNESS_SERVER_MODE ?? 'spawn').toLowerCase();
+	return raw === 'external' ? 'external' : 'spawn';
+}
+
+export function loadConfig(overrides: Partial<HarnessConfig> = {}): HarnessConfig {
+	const packageRoot = require('path').resolve(__dirname, '..');
+	const projectRoot = require('path').resolve(packageRoot, '..', '..');
+
+	const base: HarnessConfig = {
+		tier: readTier(),
+		mockLlm: readBool('HARNESS_MOCK_LLM', true),
+		serverMode: readServerMode(),
+		serverUrl: process.env.HARNESS_SERVER_URL ?? 'http://localhost:5565',
+		apiKey: process.env.ROCKETRIDE_APIKEY ?? 'MYAPIKEY',
+		pipelineTimeoutSec: readInt('HARNESS_PIPELINE_TIMEOUT_S', 60),
+		retainRuns: readInt('HARNESS_RETAIN_RUNS', 20),
+		bail: readBool('HARNESS_BAIL', false),
+		runsDir: process.env.HARNESS_RUNS_DIR ?? require('path').join(projectRoot, '.harness-runs'),
+		pipelinesDir: process.env.HARNESS_PIPELINES_DIR ?? require('path').join(packageRoot, 'pipelines'),
+	};
+
+	return { ...base, ...overrides };
+}

--- a/packages/test-harness/src/coverage/diff.ts
+++ b/packages/test-harness/src/coverage/diff.ts
@@ -1,0 +1,44 @@
+/**
+ * Coverage diff: /services list vs exercised nodes vs excluded list.
+ *
+ * Buckets every known node into covered / excluded / gap. A non-empty gap
+ * is the run-level coverage failure signal.
+ */
+
+import type { ExclusionEntry } from './exclusions';
+
+export type CoverageDiff = {
+	knownCount: number;
+	covered: string[];
+	excluded: Array<{ node: string; reason: string }>;
+	gaps: string[];
+};
+
+export function diffCoverage(args: {
+	knownNodes: Set<string>;
+	exercisedNodes: Set<string>;
+	excluded: Map<string, ExclusionEntry>;
+}): CoverageDiff {
+	const covered: string[] = [];
+	const gaps: string[] = [];
+
+	for (const node of Array.from(args.knownNodes).sort()) {
+		if (args.excluded.has(node)) continue;
+		if (args.exercisedNodes.has(node)) {
+			covered.push(node);
+		} else {
+			gaps.push(node);
+		}
+	}
+
+	const excludedList = Array.from(args.excluded.values())
+		.map((e) => ({ node: e.node, reason: e.reason }))
+		.sort((a, b) => a.node.localeCompare(b.node));
+
+	return {
+		knownCount: args.knownNodes.size,
+		covered,
+		excluded: excludedList,
+		gaps,
+	};
+}

--- a/packages/test-harness/src/coverage/exclusions.ts
+++ b/packages/test-harness/src/coverage/exclusions.ts
@@ -1,0 +1,108 @@
+/**
+ * Manages coverage-exclusions.json: nodes the harness deliberately doesn't
+ * exercise, each with a reason.
+ *
+ * Validator rules:
+ *   - node must exist in /services (rejects stale)
+ *   - reason must be >= 3 words (rejects placeholders)
+ *   - entries older than 90 days emit a warning (not failure)
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+
+export type ExclusionEntry = {
+	node: string;
+	reason: string;
+	owner?: string;
+	added?: string; // ISO date
+};
+
+export type ExclusionsFile = {
+	version: 1;
+	exclusions: ExclusionEntry[];
+};
+
+export type ExclusionWarning = {
+	node: string;
+	message: string;
+};
+
+export type ExclusionValidationResult = {
+	excluded: Map<string, ExclusionEntry>;
+	stale: string[];
+	thinReason: string[];
+	staleWarnings: ExclusionWarning[];
+};
+
+const STALE_THRESHOLD_DAYS = 90;
+const MIN_REASON_WORDS = 3;
+
+export function loadExclusions(filePath: string): ExclusionsFile {
+	if (!existsSync(filePath)) {
+		return { version: 1, exclusions: [] };
+	}
+	const raw = readFileSync(filePath, 'utf8');
+	const parsed = JSON.parse(raw) as ExclusionsFile;
+	if (parsed.version !== 1) {
+		throw new Error(`Unsupported exclusions version: ${parsed.version}`);
+	}
+	if (!Array.isArray(parsed.exclusions)) {
+		throw new Error('exclusions field must be an array');
+	}
+	return parsed;
+}
+
+export function validateExclusions(
+	file: ExclusionsFile,
+	knownNodes: Set<string>,
+	now: Date = new Date(),
+): ExclusionValidationResult {
+	const excluded = new Map<string, ExclusionEntry>();
+	const stale: string[] = [];
+	const thinReason: string[] = [];
+	const staleWarnings: ExclusionWarning[] = [];
+
+	for (const entry of file.exclusions) {
+		if (!knownNodes.has(entry.node)) {
+			stale.push(entry.node);
+			continue;
+		}
+		const reasonWords = (entry.reason ?? '').trim().split(/\s+/).filter(Boolean);
+		if (reasonWords.length < MIN_REASON_WORDS) {
+			thinReason.push(entry.node);
+			continue;
+		}
+		excluded.set(entry.node, entry);
+
+		if (entry.added) {
+			const added = new Date(entry.added);
+			if (!Number.isNaN(added.getTime())) {
+				const ageMs = now.getTime() - added.getTime();
+				const ageDays = Math.floor(ageMs / (1000 * 60 * 60 * 24));
+				if (ageDays > STALE_THRESHOLD_DAYS) {
+					staleWarnings.push({
+						node: entry.node,
+						message: `excluded ${ageDays} days ago (added ${entry.added}); review whether still needed`,
+					});
+				}
+			}
+		}
+	}
+
+	return { excluded, stale, thinReason, staleWarnings };
+}
+
+export function writeStarterExclusions(filePath: string, knownNodes: Set<string>, owner: string): void {
+	const today = new Date().toISOString().slice(0, 10);
+	const entries: ExclusionEntry[] = Array.from(knownNodes)
+		.sort()
+		.map((node) => ({
+			node,
+			reason: 'TODO: explain why this node cannot be exercised by the harness.',
+			owner,
+			added: today,
+		}));
+
+	const file: ExclusionsFile = { version: 1, exclusions: entries };
+	writeFileSync(filePath, JSON.stringify(file, null, 2) + '\n', 'utf8');
+}

--- a/packages/test-harness/src/coverage/services.ts
+++ b/packages/test-harness/src/coverage/services.ts
@@ -1,0 +1,68 @@
+/**
+ * Fetches the authoritative node-class registry from GET /services.
+ *
+ * Server route: packages/ai/src/ai/modules/services/__init__.py:18.
+ * Response shape: array of service definitions, each with `name` plus
+ * other fields (`title`, `protocol`, etc.). We only need `name`.
+ */
+
+export type ServiceDefinition = {
+	name: string;
+	[k: string]: unknown;
+};
+
+export type ServicesRegistry = {
+	all: ServiceDefinition[];
+	names: Set<string>;
+};
+
+function toHttpUrl(rawUrl: string): string {
+	// Server's /services is HTTP; normalize ws://localhost:N or http://localhost:N.
+	const url = new URL(rawUrl);
+	if (url.protocol === 'ws:') url.protocol = 'http:';
+	else if (url.protocol === 'wss:') url.protocol = 'https:';
+	return url.toString().replace(/\/$/, '');
+}
+
+export async function fetchServices(serverUrl: string, apiKey: string): Promise<ServicesRegistry> {
+	const base = toHttpUrl(serverUrl);
+	const headers: Record<string, string> = { Accept: 'application/json' };
+	if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+	const res = await fetch(`${base}/services`, { headers });
+	if (!res.ok) {
+		throw new Error(`GET /services failed: ${res.status} ${res.statusText}`);
+	}
+	const body = (await res.json()) as unknown;
+
+	const all = normalizeServices(body);
+	const names = new Set(all.map((s) => s.name));
+	return { all, names };
+}
+
+function normalizeServices(raw: unknown): ServiceDefinition[] {
+	if (Array.isArray(raw)) {
+		return raw.filter((s): s is ServiceDefinition => typeof s === 'object' && s !== null && typeof (s as { name?: unknown }).name === 'string');
+	}
+	if (raw && typeof raw === 'object') {
+		const obj = raw as Record<string, unknown>;
+
+		// Wrapper unwrapping: server returns { status: 'OK', data: { services: { name: {...} } } }.
+		// Recurse into common wrapper keys before falling back to map-style.
+		for (const key of ['services', 'data', 'items', 'result']) {
+			if (obj[key] !== undefined) {
+				const inner = normalizeServices(obj[key]);
+				if (inner.length > 0) return inner;
+			}
+		}
+
+		// Map-style: { name1: {...}, name2: {...} }.
+		// Heuristic: every value is an object — treat keys as service names.
+		const entries = Object.entries(obj);
+		const allObjects = entries.length > 0 && entries.every(([, v]) => v !== null && typeof v === 'object' && !Array.isArray(v));
+		if (allObjects) {
+			return entries.map(([name, value]) => ({ name, ...(value as Record<string, unknown>) }));
+		}
+	}
+	throw new Error('Unrecognised /services response shape');
+}

--- a/packages/test-harness/src/report/markdown.ts
+++ b/packages/test-harness/src/report/markdown.ts
@@ -1,0 +1,152 @@
+/**
+ * Render RunReport → human-readable markdown.
+ *
+ * Sections: Summary, Coverage (with gaps + excluded), Failures (logic + infra),
+ * Timings. Mirrors the layout in the plan document.
+ */
+
+import { writeFileSync } from 'fs';
+import { join } from 'path';
+
+import type { RunReport } from './schema';
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	const s = ms / 1000;
+	if (s < 60) return `${s.toFixed(2)}s`;
+	const m = Math.floor(s / 60);
+	const rem = (s % 60).toFixed(1);
+	return `${m}m ${rem}s`;
+}
+
+function truncate(text: string, max = 240): string {
+	if (text.length <= max) return text;
+	return text.slice(0, max - 1) + '…';
+}
+
+export function renderMarkdown(report: RunReport): string {
+	const lines: string[] = [];
+
+	lines.push(`# Harness Run ${report.run_started}`);
+	lines.push('');
+	lines.push(`- Tier: \`${report.tier}\``);
+	lines.push(`- Mock LLM: \`${report.mock_llm ? 'ROCKETRIDE_MOCK=1' : 'real APIs'}\``);
+	lines.push(`- Server: ${report.server.mode} at \`${report.server.url}\` (port ${report.server.port})`);
+	lines.push(`- Duration: ${formatDuration(report.duration_ms)}`);
+	lines.push('');
+
+	lines.push('## Summary');
+	lines.push('');
+	lines.push('| Bucket | Count |');
+	lines.push('|--------|-------|');
+	lines.push(`| Pass | ${report.summary.pass} |`);
+	lines.push(`| Logic failure | ${report.summary.logic_failure} |`);
+	lines.push(`| Infra failure | ${report.summary.infra_failure} |`);
+	lines.push(`| Timeout | ${report.summary.timeout} |`);
+	lines.push(`| **Total** | **${report.summary.total}** |`);
+	lines.push('');
+
+	if (report.coverage) {
+		const cov = report.coverage;
+		lines.push('## Coverage');
+		lines.push('');
+		lines.push(`- /services nodes: **${cov.known_count}**`);
+		lines.push(`- Covered: **${cov.covered_count}**`);
+		lines.push(`- Excluded: **${cov.excluded_count}**`);
+		lines.push(`- Gap: **${cov.gap_count}**${cov.gap_count > 0 ? ' ← fails the run' : ''}`);
+		lines.push('');
+
+		if (cov.gaps.length > 0) {
+			lines.push('### Coverage gaps');
+			lines.push('');
+			for (const node of cov.gaps) {
+				lines.push(`- \`${node}\`: no pipeline exercises this node. Add coverage or add to coverage-exclusions.json with a reason.`);
+			}
+			lines.push('');
+		}
+
+		if (cov.excluded.length > 0) {
+			lines.push('### Excluded nodes');
+			lines.push('');
+			for (const { node, reason } of cov.excluded) {
+				lines.push(`- \`${node}\`: ${reason}`);
+			}
+			lines.push('');
+		}
+
+		if (cov.stale_warnings.length > 0) {
+			lines.push('### Stale exclusions (>90 days)');
+			lines.push('');
+			for (const warning of cov.stale_warnings) {
+				lines.push(`- \`${warning.node}\`: ${warning.message}`);
+			}
+			lines.push('');
+		}
+	} else if (report.skipped_coverage) {
+		lines.push('## Coverage');
+		lines.push('');
+		lines.push(`_Skipped: ${report.skipped_coverage.reason}_`);
+		lines.push('');
+	}
+
+	const logic = report.pipelines.filter((p) => p.result === 'logic_failure');
+	const infra = report.pipelines.filter((p) => p.result === 'infra_failure');
+	const timeouts = report.pipelines.filter((p) => p.result === 'timeout');
+
+	if (logic.length > 0 || infra.length > 0 || timeouts.length > 0) {
+		lines.push('## Failures');
+		lines.push('');
+
+		if (logic.length > 0) {
+			lines.push('### Logic');
+			lines.push('');
+			for (const p of logic) {
+				lines.push(`- **${p.pipeline}**: ${truncate(p.error_message ?? 'no error message')}`);
+				lines.push(`  - Trace: \`${p.trace_path}\``);
+			}
+			lines.push('');
+		}
+
+		if (infra.length > 0) {
+			lines.push('### Infra');
+			lines.push('');
+			for (const p of infra) {
+				lines.push(`- **${p.pipeline}**: matched \`${p.infra_signature}\`. Skipped from totals.`);
+				lines.push(`  - Trace: \`${p.trace_path}\``);
+			}
+			lines.push('');
+		}
+
+		if (timeouts.length > 0) {
+			lines.push('### Timeout');
+			lines.push('');
+			for (const p of timeouts) {
+				lines.push(`- **${p.pipeline}**: no terminal apaevt_flow op:end within timeout.`);
+				lines.push(`  - Trace: \`${p.trace_path}\``);
+			}
+			lines.push('');
+		}
+	}
+
+	const slowest = [...report.pipelines].sort((a, b) => b.duration_ms - a.duration_ms).slice(0, 5);
+	if (slowest.length > 0) {
+		lines.push('## Timings');
+		lines.push('');
+		lines.push('| Pipeline | Duration |');
+		lines.push('|----------|----------|');
+		for (const p of slowest) {
+			lines.push(`| ${p.pipeline} | ${formatDuration(p.duration_ms)} |`);
+		}
+		lines.push('');
+	}
+
+	return lines.join('\n');
+}
+
+export function writeReports(runDir: string, report: RunReport): { md: string; json: string } {
+	const mdPath = join(runDir, 'report.md');
+	const jsonPath = join(runDir, 'report.json');
+	writeFileSync(mdPath, renderMarkdown(report), 'utf8');
+	writeFileSync(jsonPath, JSON.stringify(report, null, 2) + '\n', 'utf8');
+	return { md: mdPath, json: jsonPath };
+}

--- a/packages/test-harness/src/report/schema.ts
+++ b/packages/test-harness/src/report/schema.ts
@@ -1,0 +1,64 @@
+/**
+ * Run-level report data model. Emitted alongside the per-pipeline trace
+ * JSONs as report.json + rendered to report.md.
+ */
+
+import type { CoverageDiff } from '../coverage/diff';
+import type { ExclusionWarning } from '../coverage/exclusions';
+import type { PipelineResultBucket } from '../runner/schema';
+
+export type PipelineSummary = {
+	pipeline: string;
+	result: PipelineResultBucket;
+	duration_ms: number;
+	exercised_nodes: string[];
+	error_message?: string;
+	infra_signature?: string;
+	trace_path: string; // relative to run dir, e.g. "traces/smoke__llm_openai.json"
+};
+
+export type RunReport = {
+	schema_version: 1;
+	run_started: string;
+	run_ended: string;
+	duration_ms: number;
+	tier: string;
+	mock_llm: boolean;
+	server: {
+		mode: 'spawn' | 'external';
+		url: string;
+		port: number;
+	};
+	summary: {
+		pass: number;
+		logic_failure: number;
+		infra_failure: number;
+		timeout: number;
+		total: number;
+	};
+	coverage?: {
+		known_count: number;
+		covered_count: number;
+		excluded_count: number;
+		gap_count: number;
+		covered: string[];
+		gaps: string[];
+		excluded: Array<{ node: string; reason: string }>;
+		stale_warnings: ExclusionWarning[];
+	};
+	pipelines: PipelineSummary[];
+	skipped_coverage?: { reason: string };
+};
+
+export function emptyCoverageFrom(diff: CoverageDiff, staleWarnings: ExclusionWarning[]): NonNullable<RunReport['coverage']> {
+	return {
+		known_count: diff.knownCount,
+		covered_count: diff.covered.length,
+		excluded_count: diff.excluded.length,
+		gap_count: diff.gaps.length,
+		covered: diff.covered,
+		gaps: diff.gaps,
+		excluded: diff.excluded,
+		stale_warnings: staleWarnings,
+	};
+}

--- a/packages/test-harness/src/runner/collector.ts
+++ b/packages/test-harness/src/runner/collector.ts
@@ -1,0 +1,88 @@
+/**
+ * Token-scoped trace collector.
+ *
+ * One collector per pipeline run. Subscribes to apaevt_flow + apaevt_sse via
+ * the RocketRide TS client, buffers events, resolves when a terminal
+ * apaevt_flow op:'end' arrives or the timeout fires.
+ */
+
+import type { ApaevtAnyEvent, ApaevtFlowEvent, ApaevtSseEvent } from './schema';
+
+export type CollectorOptions = {
+	token: string;
+	timeoutMs: number;
+};
+
+export type CollectorResult = {
+	sse_events: ApaevtSseEvent[];
+	runtime_events: ApaevtFlowEvent[];
+	other_events: ApaevtAnyEvent[];
+	exercised_nodes: string[];
+	timedOut: boolean;
+	terminalEvent?: ApaevtFlowEvent;
+};
+
+export class TraceCollector {
+	private readonly sseEvents: ApaevtSseEvent[] = [];
+	private readonly runtimeEvents: ApaevtFlowEvent[] = [];
+	private readonly otherEvents: ApaevtAnyEvent[] = [];
+	private readonly exercised = new Set<string>();
+	private resolveTerminal?: (ev: ApaevtFlowEvent) => void;
+	private terminalEvent?: ApaevtFlowEvent;
+
+	constructor(private readonly options: CollectorOptions) {}
+
+	/** Hand this to RocketRideClient constructor as onEvent. */
+	readonly onEvent = async (message: unknown): Promise<void> => {
+		const msg = message as ApaevtAnyEvent | undefined;
+		if (!msg || typeof msg.event !== 'string') return;
+
+		if (msg.event === 'apaevt_flow') {
+			const ev = msg as ApaevtFlowEvent;
+			this.runtimeEvents.push(ev);
+			const pipes = ev.body?.pipes;
+			if (Array.isArray(pipes) && pipes.length > 0) {
+				this.exercised.add(pipes[pipes.length - 1]);
+			}
+			if (ev.body?.op === 'end' && !this.terminalEvent) {
+				this.terminalEvent = ev;
+				if (this.resolveTerminal) this.resolveTerminal(ev);
+			}
+			return;
+		}
+
+		if (msg.event === 'apaevt_sse') {
+			this.sseEvents.push(msg as ApaevtSseEvent);
+			return;
+		}
+
+		this.otherEvents.push(msg);
+	};
+
+	/** Resolves when the terminal apaevt_flow op:'end' arrives or the timeout fires. */
+	async waitForTerminal(): Promise<CollectorResult> {
+		const timedOut = await new Promise<boolean>((resolve) => {
+			if (this.terminalEvent) {
+				resolve(false);
+				return;
+			}
+			const timer = setTimeout(() => {
+				this.resolveTerminal = undefined;
+				resolve(true);
+			}, this.options.timeoutMs);
+			this.resolveTerminal = () => {
+				clearTimeout(timer);
+				resolve(false);
+			};
+		});
+
+		return {
+			sse_events: this.sseEvents,
+			runtime_events: this.runtimeEvents,
+			other_events: this.otherEvents,
+			exercised_nodes: Array.from(this.exercised),
+			timedOut,
+			terminalEvent: this.terminalEvent,
+		};
+	}
+}

--- a/packages/test-harness/src/runner/persist.ts
+++ b/packages/test-harness/src/runner/persist.ts
@@ -2,7 +2,7 @@
  * Write per-pipeline trace JSON to .harness-runs/<ISO>/traces/<slug>.json.
  */
 
-import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 import type { TraceFile } from './schema';
@@ -32,4 +32,39 @@ export function loadTraces(runDir: string): TraceFile[] {
 	const tracesDir = join(runDir, 'traces');
 	const files = readdirSync(tracesDir).filter((f) => f.endsWith('.json'));
 	return files.map((f) => JSON.parse(readFileSync(join(tracesDir, f), 'utf8')) as TraceFile);
+}
+
+/**
+ * Prune .harness-runs/ to the newest `keep` run directories.
+ *
+ * ISO timestamps sort lexicographically, so directory names alone suffice
+ * for ordering. Only top-level entries that are directories are considered;
+ * unexpected files at the runsDir root are left alone.
+ */
+export function pruneRuns(runsDir: string, keep: number): string[] {
+	if (keep <= 0 || !existsSync(runsDir)) return [];
+
+	const entries = readdirSync(runsDir).filter((name) => {
+		try {
+			return statSync(join(runsDir, name)).isDirectory();
+		} catch {
+			return false;
+		}
+	});
+
+	const sorted = entries.sort(); // ISO stamps sort chronologically
+	const toRemove = sorted.slice(0, Math.max(0, sorted.length - keep));
+	const removed: string[] = [];
+
+	for (const name of toRemove) {
+		const fullPath = join(runsDir, name);
+		try {
+			rmSync(fullPath, { recursive: true, force: true });
+			removed.push(fullPath);
+		} catch {
+			// Best-effort: a locked or in-progress run dir should not break the run.
+		}
+	}
+
+	return removed;
 }

--- a/packages/test-harness/src/runner/persist.ts
+++ b/packages/test-harness/src/runner/persist.ts
@@ -2,10 +2,14 @@
  * Write per-pipeline trace JSON to .harness-runs/<ISO>/traces/<slug>.json.
  */
 
-import { mkdirSync, writeFileSync } from 'fs';
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 import type { TraceFile } from './schema';
+
+export function pipelineSlugToFile(slug: string): string {
+	return `${slug.replace(/[\\/]/g, '__')}.json`;
+}
 
 export function isoStamp(date: Date = new Date()): string {
 	return date.toISOString().replace(/[:.]/g, '-');
@@ -18,9 +22,14 @@ export function ensureRunDir(runsDir: string, stamp: string): string {
 }
 
 export function writeTrace(runDir: string, trace: TraceFile): string {
-	const slug = trace.pipeline.replace(/[\\/]/g, '__');
-	const outPath = join(runDir, 'traces', `${slug}.json`);
+	const outPath = join(runDir, 'traces', pipelineSlugToFile(trace.pipeline));
 	mkdirSync(dirname(outPath), { recursive: true });
 	writeFileSync(outPath, JSON.stringify(trace, null, 2), 'utf8');
 	return outPath;
+}
+
+export function loadTraces(runDir: string): TraceFile[] {
+	const tracesDir = join(runDir, 'traces');
+	const files = readdirSync(tracesDir).filter((f) => f.endsWith('.json'));
+	return files.map((f) => JSON.parse(readFileSync(join(tracesDir, f), 'utf8')) as TraceFile);
 }

--- a/packages/test-harness/src/runner/persist.ts
+++ b/packages/test-harness/src/runner/persist.ts
@@ -1,0 +1,26 @@
+/**
+ * Write per-pipeline trace JSON to .harness-runs/<ISO>/traces/<slug>.json.
+ */
+
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+import type { TraceFile } from './schema';
+
+export function isoStamp(date: Date = new Date()): string {
+	return date.toISOString().replace(/[:.]/g, '-');
+}
+
+export function ensureRunDir(runsDir: string, stamp: string): string {
+	const runDir = join(runsDir, stamp);
+	mkdirSync(join(runDir, 'traces'), { recursive: true });
+	return runDir;
+}
+
+export function writeTrace(runDir: string, trace: TraceFile): string {
+	const slug = trace.pipeline.replace(/[\\/]/g, '__');
+	const outPath = join(runDir, 'traces', `${slug}.json`);
+	mkdirSync(dirname(outPath), { recursive: true });
+	writeFileSync(outPath, JSON.stringify(trace, null, 2), 'utf8');
+	return outPath;
+}

--- a/packages/test-harness/src/runner/runPipeline.ts
+++ b/packages/test-harness/src/runner/runPipeline.ts
@@ -1,10 +1,9 @@
 /**
  * Run one pipeline end-to-end against a connected RocketRideClient.
  *
- * Phase 1 deliberate scope: capture the trace, persist it. No classification,
- * no coverage diff, no report. Result bucket is 'pass' if a terminal
- * apaevt_flow op:'end' arrives, 'timeout' otherwise; logic/infra split lands
- * in Phase 2.
+ * Subscribes to FLOW/SSE/DETAIL/TASK, writes input via a streaming pipe,
+ * waits for the terminal apaevt_flow op:'end' (or timeout), classifies the
+ * result, and persists the trace JSON.
  */
 
 import { readFileSync } from 'fs';
@@ -12,9 +11,10 @@ import { readFileSync } from 'fs';
 import { RocketRideClient } from 'rocketride';
 import type { PipelineConfig } from 'rocketride';
 
+import { classifyError } from '../classify/infraSignatures';
 import { TraceCollector } from './collector';
 import { writeTrace } from './persist';
-import type { PipelineResultBucket, TraceFile } from './schema';
+import type { ApaevtAnyEvent, ApaevtFlowEvent, PipelineResultBucket, TraceFile } from './schema';
 
 /**
  * Subscription type names for the server's monitor command. These map to
@@ -40,6 +40,98 @@ function loadPipelineConfig(filePath: string): PipelineConfig {
 	return JSON.parse(raw) as PipelineConfig;
 }
 
+/**
+ * Pipeline JSONs identify nodes by component `id` (e.g. `llm_openai_1`) but the
+ * authoritative node-class registry from `/services` uses `provider` names
+ * (e.g. `llm_openai`). Coverage tracking matches against `provider`, so we
+ * resolve `pipes[]` IDs via the loaded pipeline config.
+ */
+function buildIdToProvider(pipelineConfig: PipelineConfig): Map<string, string> {
+	const map = new Map<string, string>();
+	for (const component of pipelineConfig.components ?? []) {
+		if (component && typeof component.id === 'string' && typeof component.provider === 'string') {
+			map.set(component.id, component.provider);
+		}
+	}
+	return map;
+}
+
+function resolveProviders(componentIds: string[], idToProvider: Map<string, string>): string[] {
+	const providers = new Set<string>();
+	for (const id of componentIds) {
+		const provider = idToProvider.get(id);
+		if (provider) providers.add(provider);
+	}
+	return Array.from(providers).sort();
+}
+
+function extractFlowErrors(events: ApaevtFlowEvent[]): string[] {
+	const errors: string[] = [];
+	for (const ev of events) {
+		const trace = ev.body?.trace;
+		if (trace?.result === 'error' && typeof trace.error === 'string' && trace.error.length > 0) {
+			errors.push(trace.error);
+		}
+	}
+	return errors;
+}
+
+function extractStatusErrors(events: ApaevtAnyEvent[]): string[] {
+	const errors: string[] = [];
+	for (const ev of events) {
+		if (ev.event === 'apaevt_status_error') {
+			const body = ev.body ?? {};
+			const msg = (body.message ?? body.error ?? JSON.stringify(body)) as string;
+			if (typeof msg === 'string' && msg.length > 0) {
+				errors.push(msg);
+			}
+		}
+	}
+	return errors;
+}
+
+type Classification = {
+	result: PipelineResultBucket;
+	error?: TraceFile['error'];
+	infra_signature?: string;
+};
+
+function classify(args: {
+	timedOut: boolean;
+	closeError?: TraceFile['error'];
+	flowEvents: ApaevtFlowEvent[];
+	otherEvents: ApaevtAnyEvent[];
+}): Classification {
+	const flowErrors = extractFlowErrors(args.flowEvents);
+	const statusErrors = extractStatusErrors(args.otherEvents);
+	const allErrors = [...flowErrors, ...statusErrors];
+	if (args.closeError?.message) allErrors.push(args.closeError.message);
+
+	for (const msg of allErrors) {
+		const hit = classifyError(msg);
+		if (hit) {
+			return {
+				result: 'infra_failure',
+				infra_signature: hit.signature,
+				error: { message: hit.rawError },
+			};
+		}
+	}
+
+	if (allErrors.length > 0) {
+		return {
+			result: 'logic_failure',
+			error: { message: allErrors[0] },
+		};
+	}
+
+	if (args.timedOut) {
+		return { result: 'timeout' };
+	}
+
+	return { result: 'pass' };
+}
+
 export async function runPipeline(
 	client: RocketRideClient,
 	collector: TraceCollector,
@@ -50,8 +142,9 @@ export async function runPipeline(
 	const pipelineConfig = loadPipelineConfig(def.filePath);
 
 	let token = '';
-	let result: PipelineResultBucket = 'timeout';
-	let errorInfo: TraceFile['error'];
+	let closeError: TraceFile['error'];
+
+	const idToProvider = buildIdToProvider(pipelineConfig);
 
 	try {
 		const useResult = await client.use({ pipeline: pipelineConfig, pipelineTraceLevel: 'full' });
@@ -64,7 +157,7 @@ export async function runPipeline(
 		await pipe.write(new TextEncoder().encode(def.input.data));
 
 		const closePromise = pipe.close().catch((err: unknown) => {
-			errorInfo = {
+			closeError = {
 				message: err instanceof Error ? err.message : String(err),
 				raw: err,
 			};
@@ -74,13 +167,14 @@ export async function runPipeline(
 		const collectorResult = await collector.waitForTerminal();
 		await closePromise;
 
-		if (collectorResult.timedOut) {
-			result = 'timeout';
-		} else {
-			result = 'pass';
-		}
-
 		await client.removeMonitor({ token }, MONITOR_TYPES);
+
+		const classification = classify({
+			timedOut: collectorResult.timedOut,
+			closeError,
+			flowEvents: collectorResult.runtime_events,
+			otherEvents: collectorResult.other_events,
+		});
 
 		const endedAt = new Date();
 
@@ -93,9 +187,11 @@ export async function runPipeline(
 			sse_events: collectorResult.sse_events,
 			runtime_events: collectorResult.runtime_events,
 			other_events: collectorResult.other_events,
-			result,
-			error: errorInfo,
-			exercised_nodes: collectorResult.exercised_nodes,
+			result: classification.result,
+			error: classification.error,
+			infra_signature: classification.infra_signature,
+			exercised_nodes: resolveProviders(collectorResult.exercised_nodes, idToProvider),
+			exercised_components: collectorResult.exercised_nodes,
 		};
 
 		writeTrace(options.runDir, trace);

--- a/packages/test-harness/src/runner/runPipeline.ts
+++ b/packages/test-harness/src/runner/runPipeline.ts
@@ -1,0 +1,112 @@
+/**
+ * Run one pipeline end-to-end against a connected RocketRideClient.
+ *
+ * Phase 1 deliberate scope: capture the trace, persist it. No classification,
+ * no coverage diff, no report. Result bucket is 'pass' if a terminal
+ * apaevt_flow op:'end' arrives, 'timeout' otherwise; logic/infra split lands
+ * in Phase 2.
+ */
+
+import { readFileSync } from 'fs';
+
+import { RocketRideClient } from 'rocketride';
+import type { PipelineConfig } from 'rocketride';
+
+import { TraceCollector } from './collector';
+import { writeTrace } from './persist';
+import type { PipelineResultBucket, TraceFile } from './schema';
+
+/**
+ * Subscription type names for the server's monitor command. These map to
+ * EVENT_TYPE enum members in packages/client-python/.../types/events.py.
+ * Note: subscription names ('FLOW', 'SSE', 'DETAIL', 'TASK') differ from
+ * emitted event names on the wire ('apaevt_flow', 'apaevt_sse', etc.).
+ */
+const MONITOR_TYPES = ['FLOW', 'SSE', 'DETAIL', 'TASK'];
+
+export type PipelineDef = {
+	slug: string;
+	filePath: string;
+	input: { mimeType: string; data: string };
+};
+
+export type RunPipelineOptions = {
+	runDir: string;
+	timeoutMs: number;
+};
+
+function loadPipelineConfig(filePath: string): PipelineConfig {
+	const raw = readFileSync(filePath, 'utf8');
+	return JSON.parse(raw) as PipelineConfig;
+}
+
+export async function runPipeline(
+	client: RocketRideClient,
+	collector: TraceCollector,
+	def: PipelineDef,
+	options: RunPipelineOptions,
+): Promise<TraceFile> {
+	const startedAt = new Date();
+	const pipelineConfig = loadPipelineConfig(def.filePath);
+
+	let token = '';
+	let result: PipelineResultBucket = 'timeout';
+	let errorInfo: TraceFile['error'];
+
+	try {
+		const useResult = await client.use({ pipeline: pipelineConfig, pipelineTraceLevel: 'full' });
+		token = useResult.token;
+
+		await client.addMonitor({ token }, MONITOR_TYPES);
+
+		const pipe = await client.pipe(token, { name: `${def.slug}-input` }, def.input.mimeType);
+		await pipe.open();
+		await pipe.write(new TextEncoder().encode(def.input.data));
+
+		const closePromise = pipe.close().catch((err: unknown) => {
+			errorInfo = {
+				message: err instanceof Error ? err.message : String(err),
+				raw: err,
+			};
+			return undefined;
+		});
+
+		const collectorResult = await collector.waitForTerminal();
+		await closePromise;
+
+		if (collectorResult.timedOut) {
+			result = 'timeout';
+		} else {
+			result = 'pass';
+		}
+
+		await client.removeMonitor({ token }, MONITOR_TYPES);
+
+		const endedAt = new Date();
+
+		const trace: TraceFile = {
+			pipeline: def.slug,
+			run_started: startedAt.toISOString(),
+			run_ended: endedAt.toISOString(),
+			token,
+			prompt: def.input.data,
+			sse_events: collectorResult.sse_events,
+			runtime_events: collectorResult.runtime_events,
+			other_events: collectorResult.other_events,
+			result,
+			error: errorInfo,
+			exercised_nodes: collectorResult.exercised_nodes,
+		};
+
+		writeTrace(options.runDir, trace);
+		return trace;
+	} finally {
+		if (token) {
+			try {
+				await client.terminate(token);
+			} catch {
+				// Cleanup-best-effort: terminate may fail if pipeline already ended
+			}
+		}
+	}
+}

--- a/packages/test-harness/src/runner/schema.ts
+++ b/packages/test-harness/src/runner/schema.ts
@@ -1,0 +1,62 @@
+/**
+ * Trace file shape persisted per pipeline run.
+ *
+ * Greenfield format. The collector buffers apaevt_flow + apaevt_sse events
+ * for a token-scoped monitor and emits one TraceFile per pipeline.
+ */
+
+export type ApaevtFlowOp = 'begin' | 'enter' | 'leave' | 'end';
+
+export type ApaevtFlowEvent = {
+	event: 'apaevt_flow';
+	seq?: number;
+	body: {
+		id: number;
+		op: ApaevtFlowOp;
+		pipes: string[];
+		trace?: {
+			lane?: string;
+			data?: unknown;
+			result?: string;
+			error?: string;
+		};
+		result?: string;
+		project_id: string;
+		source: string;
+	};
+};
+
+export type ApaevtSseEvent = {
+	event: 'apaevt_sse';
+	seq?: number;
+	body: {
+		pipe_id?: number;
+		type?: string;
+		data?: unknown;
+		[k: string]: unknown;
+	};
+};
+
+export type ApaevtAnyEvent = {
+	event: string;
+	seq?: number;
+	body?: Record<string, unknown>;
+	[k: string]: unknown;
+};
+
+export type PipelineResultBucket = 'pass' | 'logic_failure' | 'infra_failure' | 'timeout';
+
+export type TraceFile = {
+	pipeline: string;
+	run_started: string;
+	run_ended: string;
+	token: string;
+	prompt?: unknown;
+	sse_events: ApaevtSseEvent[];
+	runtime_events: ApaevtFlowEvent[];
+	other_events: ApaevtAnyEvent[];
+	result: PipelineResultBucket;
+	infra_signature?: string;
+	error?: { message: string; raw?: unknown };
+	exercised_nodes: string[];
+};

--- a/packages/test-harness/src/runner/schema.ts
+++ b/packages/test-harness/src/runner/schema.ts
@@ -58,5 +58,8 @@ export type TraceFile = {
 	result: PipelineResultBucket;
 	infra_signature?: string;
 	error?: { message: string; raw?: unknown };
+	/** Provider class names exercised (matches /services registry). */
 	exercised_nodes: string[];
+	/** Raw component IDs from apaevt_flow.body.pipes[-1]; preserved for forensics. */
+	exercised_components: string[];
 };

--- a/packages/test-harness/src/server/lifecycle.ts
+++ b/packages/test-harness/src/server/lifecycle.ts
@@ -1,0 +1,74 @@
+/**
+ * Server lifecycle wrapper.
+ *
+ * Wraps scripts/lib/server.js (startServer/stopServer) so the harness can
+ * spawn rocketride-server with ROCKETRIDE_MOCK=1 and tear it down cleanly.
+ */
+
+import { resolve } from 'path';
+
+import type { HarnessConfig } from '../config';
+
+export type ServerHandle = {
+	mode: 'spawn' | 'external';
+	url: string;
+	port: number;
+	stop: () => Promise<void>;
+};
+
+type ServerLib = {
+	startServer: (options: {
+		script: string;
+		basePort?: number;
+		env?: Record<string, string>;
+		onOutput?: (text: string) => void;
+	}) => Promise<{ server: unknown; port: number }>;
+	stopServer: (serverObj: { server: unknown }) => Promise<void>;
+};
+
+function loadServerLib(): ServerLib {
+	const projectRoot = resolve(__dirname, '..', '..', '..', '..');
+	const libPath = resolve(projectRoot, 'scripts', 'lib');
+	// eslint-disable-next-line @typescript-eslint/no-var-requires
+	return require(libPath) as ServerLib;
+}
+
+export async function startHarnessServer(config: HarnessConfig): Promise<ServerHandle> {
+	if (config.serverMode === 'external') {
+		const port = Number.parseInt(new URL(config.serverUrl).port || '5565', 10);
+		return {
+			mode: 'external',
+			url: config.serverUrl,
+			port,
+			stop: async () => {
+				// Nothing to stop — server is owned by the user
+			},
+		};
+	}
+
+	const lib = loadServerLib();
+	const env: Record<string, string> = {};
+	if (config.mockLlm) {
+		env.ROCKETRIDE_MOCK = '1';
+	}
+
+	const onOutput = (text: string) => {
+		process.stdout.write(`[server] ${text}`);
+	};
+
+	const result = await lib.startServer({
+		script: 'ai/eaas.py',
+		basePort: 50000,
+		env,
+		onOutput,
+	});
+
+	return {
+		mode: 'spawn',
+		url: `http://localhost:${result.port}`,
+		port: result.port,
+		stop: async () => {
+			await lib.stopServer({ server: result.server });
+		},
+	};
+}

--- a/packages/test-harness/tests/classify/infraSignatures.test.ts
+++ b/packages/test-harness/tests/classify/infraSignatures.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyError, INFRA_SIGNATURES } from '../../src/classify/infraSignatures';
+
+describe('classifyError', () => {
+	it('returns null for undefined or empty input', () => {
+		expect(classifyError(undefined)).toBeNull();
+		expect(classifyError('')).toBeNull();
+	});
+
+	it('returns null for a normal logic error', () => {
+		expect(classifyError('TypeError: cannot read property foo of undefined')).toBeNull();
+	});
+
+	it('matches a literal substring case-insensitively', () => {
+		const hit = classifyError('Anthropic API returned: Credit Balance Is Too Low');
+		expect(hit).not.toBeNull();
+		expect(hit?.signature).toBe('credit balance is too low');
+	});
+
+	it('matches the rate_limit_error literal', () => {
+		const hit = classifyError('Error code: rate_limit_error');
+		expect(hit?.signature).toBe('rate_limit_error');
+	});
+
+	it('matches a regex signature against 429 responses', () => {
+		const hit = classifyError('HTTP 429 Too Many Requests received from upstream');
+		expect(hit).not.toBeNull();
+		// regex source from infraSignatures.ts; case-insensitive match
+		expect(hit?.signature).toMatch(/429/);
+	});
+
+	it('matches network connection signatures', () => {
+		expect(classifyError('connect ECONNREFUSED 127.0.0.1:5565')?.signature).toBe('ECONNREFUSED');
+		expect(classifyError('Error: getaddrinfo ENOTFOUND api.example.com')?.signature).toBe('getaddrinfo ENOTFOUND');
+		expect(classifyError('socket hang up while reading response')?.signature).toBe('socket hang up');
+	});
+
+	it('does not double-count when the message contains multiple signatures', () => {
+		const hit = classifyError('upstream rate_limit_error and 429 Too Many Requests');
+		expect(hit).not.toBeNull();
+		// First match wins; both candidates are valid signatures
+		expect(['rate_limit_error', '429\\s+Too Many Requests']).toContain(hit?.signature);
+	});
+
+	it('exposes the raw error in rawError for the report', () => {
+		const raw = 'connect ETIMEDOUT 1.2.3.4:443';
+		const hit = classifyError(raw);
+		expect(hit?.rawError).toBe(raw);
+	});
+
+	it('keeps the signature list non-empty', () => {
+		expect(INFRA_SIGNATURES.length).toBeGreaterThan(0);
+	});
+});

--- a/packages/test-harness/tests/coverage/diff.test.ts
+++ b/packages/test-harness/tests/coverage/diff.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { diffCoverage } from '../../src/coverage/diff';
+import type { ExclusionEntry } from '../../src/coverage/exclusions';
+
+function exclusionMap(entries: ExclusionEntry[]): Map<string, ExclusionEntry> {
+	return new Map(entries.map((e) => [e.node, e]));
+}
+
+describe('diffCoverage', () => {
+	it('classifies each known node into covered, excluded, or gap', () => {
+		const result = diffCoverage({
+			knownNodes: new Set(['llm_openai', 'parse', 'qdrant', 'db_mysql']),
+			exercisedNodes: new Set(['llm_openai', 'parse']),
+			excluded: exclusionMap([
+				{ node: 'qdrant', reason: 'requires a running qdrant instance', owner: 'a', added: '2026-01-01' },
+			]),
+		});
+
+		expect(result.knownCount).toBe(4);
+		expect(result.covered).toEqual(['llm_openai', 'parse']);
+		expect(result.excluded).toEqual([{ node: 'qdrant', reason: 'requires a running qdrant instance' }]);
+		expect(result.gaps).toEqual(['db_mysql']);
+	});
+
+	it('ignores exercised nodes that are not in the known set', () => {
+		const result = diffCoverage({
+			knownNodes: new Set(['parse']),
+			exercisedNodes: new Set(['parse', 'response']), // response not in /services
+			excluded: new Map(),
+		});
+
+		expect(result.covered).toEqual(['parse']);
+		expect(result.gaps).toEqual([]);
+	});
+
+	it('does not put excluded nodes in gaps even when not exercised', () => {
+		const result = diffCoverage({
+			knownNodes: new Set(['db_mysql']),
+			exercisedNodes: new Set(),
+			excluded: exclusionMap([
+				{ node: 'db_mysql', reason: 'needs running MySQL instance', owner: 'a', added: '2026-01-01' },
+			]),
+		});
+
+		expect(result.covered).toEqual([]);
+		expect(result.gaps).toEqual([]);
+		expect(result.excluded).toHaveLength(1);
+	});
+
+	it('returns covered + gaps in sorted order for deterministic reports', () => {
+		const result = diffCoverage({
+			knownNodes: new Set(['zeta', 'alpha', 'beta']),
+			exercisedNodes: new Set(['zeta', 'alpha']),
+			excluded: new Map(),
+		});
+
+		expect(result.covered).toEqual(['alpha', 'zeta']);
+		expect(result.gaps).toEqual(['beta']);
+	});
+});

--- a/packages/test-harness/tests/coverage/exclusions.test.ts
+++ b/packages/test-harness/tests/coverage/exclusions.test.ts
@@ -1,0 +1,127 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadExclusions, validateExclusions, writeStarterExclusions, type ExclusionsFile } from '../../src/coverage/exclusions';
+
+describe('exclusions', () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'harness-exclusions-'));
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('loads an empty file when none exists', () => {
+		const result = loadExclusions(join(tmpDir, 'missing.json'));
+		expect(result.exclusions).toEqual([]);
+		expect(result.version).toBe(1);
+	});
+
+	it('rejects unsupported versions', () => {
+		const filePath = join(tmpDir, 'bad-version.json');
+		writeFileSync(filePath, JSON.stringify({ version: 2, exclusions: [] }));
+		expect(() => loadExclusions(filePath)).toThrow(/Unsupported exclusions version/);
+	});
+
+	it('rejects a non-array exclusions field', () => {
+		const filePath = join(tmpDir, 'bad-shape.json');
+		writeFileSync(filePath, JSON.stringify({ version: 1, exclusions: 'not an array' }));
+		expect(() => loadExclusions(filePath)).toThrow(/exclusions field must be an array/);
+	});
+});
+
+describe('validateExclusions', () => {
+	const knownNodes = new Set(['llm_openai', 'qdrant', 'db_mysql']);
+
+	it('accepts valid entries with adequate reasons', () => {
+		const file: ExclusionsFile = {
+			version: 1,
+			exclusions: [
+				{ node: 'qdrant', reason: 'requires running qdrant instance', owner: 'joshua', added: '2026-05-01' },
+			],
+		};
+
+		const result = validateExclusions(file, knownNodes);
+
+		expect(result.excluded.size).toBe(1);
+		expect(result.stale).toEqual([]);
+		expect(result.thinReason).toEqual([]);
+		expect(result.staleWarnings).toEqual([]);
+	});
+
+	it('flags entries whose node is not in /services as stale', () => {
+		const file: ExclusionsFile = {
+			version: 1,
+			exclusions: [
+				{ node: 'no_such_node', reason: 'long enough reason here', owner: 'a', added: '2026-05-01' },
+			],
+		};
+
+		const result = validateExclusions(file, knownNodes);
+
+		expect(result.stale).toEqual(['no_such_node']);
+		expect(result.excluded.size).toBe(0);
+	});
+
+	it('flags entries with thin reasons (< 3 words)', () => {
+		const file: ExclusionsFile = {
+			version: 1,
+			exclusions: [
+				{ node: 'qdrant', reason: 'TODO', owner: 'a', added: '2026-05-01' },
+				{ node: 'db_mysql', reason: 'two words', owner: 'a', added: '2026-05-01' },
+			],
+		};
+
+		const result = validateExclusions(file, knownNodes);
+
+		expect(result.thinReason).toEqual(['qdrant', 'db_mysql']);
+		expect(result.excluded.size).toBe(0);
+	});
+
+	it('warns on entries older than 90 days', () => {
+		const file: ExclusionsFile = {
+			version: 1,
+			exclusions: [
+				{ node: 'qdrant', reason: 'requires running qdrant instance', owner: 'a', added: '2025-01-01' },
+			],
+		};
+
+		const now = new Date('2026-05-01T00:00:00Z');
+		const result = validateExclusions(file, knownNodes, now);
+
+		expect(result.excluded.size).toBe(1);
+		expect(result.staleWarnings).toHaveLength(1);
+		expect(result.staleWarnings[0].node).toBe('qdrant');
+	});
+});
+
+describe('writeStarterExclusions', () => {
+	let tmpDir: string;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'harness-scaffold-'));
+	});
+
+	afterEach(() => {
+		rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	it('writes one entry per known node with placeholder reasons', () => {
+		const filePath = join(tmpDir, 'coverage-exclusions.json');
+		writeStarterExclusions(filePath, new Set(['parse', 'llm_openai']), 'harness-owner');
+
+		const parsed = loadExclusions(filePath);
+		expect(parsed.exclusions).toHaveLength(2);
+		expect(parsed.exclusions.map((e) => e.node).sort()).toEqual(['llm_openai', 'parse']);
+		for (const entry of parsed.exclusions) {
+			expect(entry.owner).toBe('harness-owner');
+			expect(entry.reason.toLowerCase()).toContain('todo');
+		}
+	});
+});

--- a/packages/test-harness/tests/coverage/services.test.ts
+++ b/packages/test-harness/tests/coverage/services.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { fetchServices } from '../../src/coverage/services';
+
+describe('fetchServices', () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		vi.restoreAllMocks();
+	});
+
+	function stubFetch(body: unknown, ok = true): void {
+		globalThis.fetch = vi.fn(async () => ({
+			ok,
+			status: ok ? 200 : 500,
+			statusText: ok ? 'OK' : 'Internal Server Error',
+			async json() {
+				return body;
+			},
+		})) as unknown as typeof fetch;
+	}
+
+	it('parses the wrapped {status, data: {services: {<name>: {...}}}} shape', async () => {
+		stubFetch({
+			status: 'OK',
+			data: {
+				services: {
+					llm_openai: { protocol: 'llm_openai://', title: 'OpenAI' },
+					parse: { protocol: 'parse://', title: 'Parser' },
+				},
+			},
+		});
+
+		const registry = await fetchServices('http://localhost:5565', 'apikey');
+		expect(Array.from(registry.names).sort()).toEqual(['llm_openai', 'parse']);
+		expect(registry.all).toHaveLength(2);
+	});
+
+	it('parses a flat array shape', async () => {
+		stubFetch([
+			{ name: 'llm_openai', title: 'OpenAI' },
+			{ name: 'parse', title: 'Parser' },
+		]);
+
+		const registry = await fetchServices('http://localhost:5565', '');
+		expect(Array.from(registry.names).sort()).toEqual(['llm_openai', 'parse']);
+	});
+
+	it('parses a map-style shape at the top level', async () => {
+		stubFetch({
+			llm_openai: { protocol: 'llm_openai://' },
+			parse: { protocol: 'parse://' },
+		});
+
+		const registry = await fetchServices('http://localhost:5565', '');
+		expect(Array.from(registry.names).sort()).toEqual(['llm_openai', 'parse']);
+	});
+
+	it('throws on non-OK responses', async () => {
+		stubFetch({}, false);
+		await expect(fetchServices('http://localhost:5565', '')).rejects.toThrow(/GET \/services failed/);
+	});
+
+	it('rewrites ws:// to http:// before requesting', async () => {
+		const calls: string[] = [];
+		globalThis.fetch = vi.fn(async (url: unknown) => {
+			calls.push(String(url));
+			return {
+				ok: true,
+				status: 200,
+				statusText: 'OK',
+				async json() {
+					return { status: 'OK', data: { services: {} } };
+				},
+			};
+		}) as unknown as typeof fetch;
+
+		await fetchServices('ws://localhost:5565', '').catch(() => {
+			// shape rejection is fine here; we only assert on the URL
+		});
+		expect(calls[0]).toMatch(/^http:\/\//);
+	});
+});

--- a/packages/test-harness/tests/report/markdown.test.ts
+++ b/packages/test-harness/tests/report/markdown.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+
+import { renderMarkdown } from '../../src/report/markdown';
+import type { RunReport } from '../../src/report/schema';
+
+function baseReport(overrides: Partial<RunReport> = {}): RunReport {
+	return {
+		schema_version: 1,
+		run_started: '2026-05-12T20:00:00.000Z',
+		run_ended: '2026-05-12T20:01:00.000Z',
+		duration_ms: 60000,
+		tier: 'smoke',
+		mock_llm: true,
+		server: { mode: 'spawn', url: 'http://localhost:5565', port: 5565 },
+		summary: { pass: 0, logic_failure: 0, infra_failure: 0, timeout: 0, total: 0 },
+		pipelines: [],
+		...overrides,
+	};
+}
+
+describe('renderMarkdown', () => {
+	it('renders summary counts in the table', () => {
+		const md = renderMarkdown(
+			baseReport({
+				summary: { pass: 3, logic_failure: 1, infra_failure: 1, timeout: 0, total: 5 },
+			}),
+		);
+		expect(md).toContain('| Pass | 3 |');
+		expect(md).toContain('| Logic failure | 1 |');
+		expect(md).toContain('| Infra failure | 1 |');
+		expect(md).toContain('| **Total** | **5** |');
+	});
+
+	it('marks coverage as failing when there are gaps', () => {
+		const md = renderMarkdown(
+			baseReport({
+				coverage: {
+					known_count: 5,
+					covered_count: 1,
+					excluded_count: 3,
+					gap_count: 1,
+					covered: ['parse'],
+					gaps: ['embedding_image'],
+					excluded: [{ node: 'qdrant', reason: 'requires running qdrant instance' }],
+					stale_warnings: [],
+				},
+			}),
+		);
+		expect(md).toContain('Gap: **1** ← fails the run');
+		expect(md).toContain('`embedding_image`');
+		expect(md).toContain('`qdrant`: requires running qdrant instance');
+	});
+
+	it('does not show the failing-run marker when gap is zero', () => {
+		const md = renderMarkdown(
+			baseReport({
+				coverage: {
+					known_count: 2,
+					covered_count: 2,
+					excluded_count: 0,
+					gap_count: 0,
+					covered: ['parse', 'response'],
+					gaps: [],
+					excluded: [],
+					stale_warnings: [],
+				},
+			}),
+		);
+		expect(md).toContain('Gap: **0**');
+		expect(md).not.toContain('fails the run');
+	});
+
+	it('renders logic and infra failure sections separately', () => {
+		const md = renderMarkdown(
+			baseReport({
+				summary: { pass: 0, logic_failure: 1, infra_failure: 1, timeout: 0, total: 2 },
+				pipelines: [
+					{
+						pipeline: 'smoke/broken',
+						result: 'logic_failure',
+						duration_ms: 100,
+						exercised_nodes: ['parse'],
+						error_message: 'TypeError: cannot read property foo',
+						trace_path: 'traces/smoke__broken.json',
+					},
+					{
+						pipeline: 'smoke/throttled',
+						result: 'infra_failure',
+						duration_ms: 100,
+						exercised_nodes: ['llm_openai'],
+						infra_signature: 'rate_limit_error',
+						trace_path: 'traces/smoke__throttled.json',
+					},
+				],
+			}),
+		);
+		expect(md).toContain('### Logic');
+		expect(md).toContain('smoke/broken');
+		expect(md).toContain('### Infra');
+		expect(md).toContain('matched `rate_limit_error`');
+	});
+
+	it('shows the timings table sorted slowest-first', () => {
+		const md = renderMarkdown(
+			baseReport({
+				summary: { pass: 2, logic_failure: 0, infra_failure: 0, timeout: 0, total: 2 },
+				pipelines: [
+					{ pipeline: 'fast', result: 'pass', duration_ms: 500, exercised_nodes: [], trace_path: 'traces/fast.json' },
+					{ pipeline: 'slow', result: 'pass', duration_ms: 5000, exercised_nodes: [], trace_path: 'traces/slow.json' },
+				],
+			}),
+		);
+		const timingsSection = md.split('## Timings')[1] ?? '';
+		const slowIdx = timingsSection.indexOf('slow');
+		const fastIdx = timingsSection.indexOf('fast');
+		expect(slowIdx).toBeGreaterThanOrEqual(0);
+		expect(fastIdx).toBeGreaterThan(slowIdx); // slow appears first
+	});
+
+	it('reports a coverage-skipped reason when /services was unreachable', () => {
+		const md = renderMarkdown(
+			baseReport({
+				skipped_coverage: { reason: 'GET /services failed: 500 Internal Server Error' },
+			}),
+		);
+		expect(md).toContain('_Skipped: GET /services failed: 500 Internal Server Error_');
+	});
+});

--- a/packages/test-harness/tests/runner/collector.test.ts
+++ b/packages/test-harness/tests/runner/collector.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { TraceCollector } from '../../src/runner/collector';
+import type { ApaevtFlowEvent } from '../../src/runner/schema';
+
+function flowEvent(op: 'begin' | 'enter' | 'leave' | 'end', pipes: string[]): ApaevtFlowEvent {
+	return {
+		event: 'apaevt_flow',
+		body: {
+			id: 0,
+			op,
+			pipes,
+			project_id: 'test',
+			source: 'src',
+		},
+	};
+}
+
+describe('TraceCollector', () => {
+	it('routes apaevt_flow into runtime_events and tracks leaf nodes', async () => {
+		const collector = new TraceCollector({ token: 'tk', timeoutMs: 1000 });
+
+		await collector.onEvent(flowEvent('begin', ['src']));
+		await collector.onEvent(flowEvent('enter', ['src', 'parse_1']));
+		await collector.onEvent(flowEvent('enter', ['src', 'parse_1', 'response_1']));
+		await collector.onEvent(flowEvent('end', ['src', 'parse_1', 'response_1']));
+
+		const result = await collector.waitForTerminal();
+		expect(result.timedOut).toBe(false);
+		expect(result.runtime_events).toHaveLength(4);
+		expect(result.exercised_nodes.sort()).toEqual(['parse_1', 'response_1', 'src']);
+		expect(result.terminalEvent?.body.op).toBe('end');
+	});
+
+	it('routes apaevt_sse into sse_events', async () => {
+		const collector = new TraceCollector({ token: 'tk', timeoutMs: 100 });
+
+		await collector.onEvent({
+			event: 'apaevt_sse',
+			body: { pipe_id: 1, type: 'message', data: { text: 'hello' } },
+		});
+		await collector.onEvent(flowEvent('end', ['src']));
+
+		const result = await collector.waitForTerminal();
+		expect(result.sse_events).toHaveLength(1);
+		expect(result.runtime_events).toHaveLength(1);
+		expect(result.other_events).toHaveLength(0);
+	});
+
+	it('routes unknown event types into other_events', async () => {
+		const collector = new TraceCollector({ token: 'tk', timeoutMs: 100 });
+
+		await collector.onEvent({
+			event: 'apaevt_status_message',
+			body: { message: 'hi' },
+		});
+		await collector.onEvent(flowEvent('end', ['src']));
+
+		const result = await collector.waitForTerminal();
+		expect(result.other_events).toHaveLength(1);
+		expect(result.sse_events).toHaveLength(0);
+	});
+
+	it('times out when no apaevt_flow op:end arrives', async () => {
+		const collector = new TraceCollector({ token: 'tk', timeoutMs: 50 });
+
+		const promise = collector.waitForTerminal();
+		await collector.onEvent(flowEvent('begin', ['src']));
+		const result = await promise;
+
+		expect(result.timedOut).toBe(true);
+		expect(result.terminalEvent).toBeUndefined();
+	});
+
+	it('ignores non-event-shaped messages defensively', async () => {
+		const collector = new TraceCollector({ token: 'tk', timeoutMs: 50 });
+
+		await collector.onEvent(undefined);
+		await collector.onEvent({ random: 'object' });
+		await collector.onEvent(flowEvent('end', ['src']));
+
+		const result = await collector.waitForTerminal();
+		expect(result.runtime_events).toHaveLength(1);
+		expect(result.other_events).toHaveLength(0);
+	});
+});

--- a/packages/test-harness/tests/runner/persist.test.ts
+++ b/packages/test-harness/tests/runner/persist.test.ts
@@ -1,0 +1,134 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { ensureRunDir, isoStamp, loadTraces, pipelineSlugToFile, pruneRuns, writeTrace } from '../../src/runner/persist';
+import type { TraceFile } from '../../src/runner/schema';
+
+function makeTrace(slug: string): TraceFile {
+	return {
+		pipeline: slug,
+		run_started: '2026-05-12T20:00:00.000Z',
+		run_ended: '2026-05-12T20:00:01.000Z',
+		token: 'tk_test',
+		prompt: 'hello',
+		sse_events: [],
+		runtime_events: [],
+		other_events: [],
+		result: 'pass',
+		exercised_nodes: ['parse'],
+		exercised_components: ['parse_1'],
+	};
+}
+
+describe('pipelineSlugToFile', () => {
+	it('replaces forward and back slashes with double-underscore', () => {
+		expect(pipelineSlugToFile('smoke/llm_openai')).toBe('smoke__llm_openai.json');
+		expect(pipelineSlugToFile('integration\\multi_llm_chain')).toBe('integration__multi_llm_chain.json');
+	});
+});
+
+describe('isoStamp', () => {
+	it('replaces colons and dots so the result is filesystem-safe', () => {
+		const stamp = isoStamp(new Date('2026-05-12T20:30:45.123Z'));
+		expect(stamp).toBe('2026-05-12T20-30-45-123Z');
+		expect(stamp).not.toMatch(/[:.]/);
+	});
+});
+
+describe('writeTrace + loadTraces', () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), 'harness-persist-'));
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	it('writes a trace file under <runDir>/traces/<slug>.json', () => {
+		const runDir = ensureRunDir(tmpRoot, '2026-05-12T20-00-00-000Z');
+		const tracePath = writeTrace(runDir, makeTrace('smoke/llm_openai'));
+		expect(existsSync(tracePath)).toBe(true);
+		expect(tracePath).toMatch(/smoke__llm_openai\.json$/);
+
+		const parsed = JSON.parse(readFileSync(tracePath, 'utf8'));
+		expect(parsed.pipeline).toBe('smoke/llm_openai');
+	});
+
+	it('loadTraces reads every trace JSON back', () => {
+		const runDir = ensureRunDir(tmpRoot, '2026-05-12T20-00-00-000Z');
+		writeTrace(runDir, makeTrace('smoke/a'));
+		writeTrace(runDir, makeTrace('smoke/b'));
+
+		const traces = loadTraces(runDir);
+		expect(traces.map((t) => t.pipeline).sort()).toEqual(['smoke/a', 'smoke/b']);
+	});
+});
+
+describe('pruneRuns', () => {
+	let tmpRoot: string;
+
+	beforeEach(() => {
+		tmpRoot = mkdtempSync(join(tmpdir(), 'harness-prune-'));
+	});
+
+	afterEach(() => {
+		rmSync(tmpRoot, { recursive: true, force: true });
+	});
+
+	function seed(names: string[]): void {
+		for (const name of names) {
+			mkdirSync(join(tmpRoot, name), { recursive: true });
+			writeFileSync(join(tmpRoot, name, 'sentinel.txt'), 'data');
+		}
+	}
+
+	it('keeps the N newest dirs and removes the rest', () => {
+		seed([
+			'2026-05-10T10-00-00-000Z',
+			'2026-05-11T10-00-00-000Z',
+			'2026-05-12T10-00-00-000Z',
+			'2026-05-13T10-00-00-000Z',
+		]);
+
+		const removed = pruneRuns(tmpRoot, 2);
+
+		expect(removed).toHaveLength(2);
+		expect(existsSync(join(tmpRoot, '2026-05-10T10-00-00-000Z'))).toBe(false);
+		expect(existsSync(join(tmpRoot, '2026-05-11T10-00-00-000Z'))).toBe(false);
+		expect(existsSync(join(tmpRoot, '2026-05-12T10-00-00-000Z'))).toBe(true);
+		expect(existsSync(join(tmpRoot, '2026-05-13T10-00-00-000Z'))).toBe(true);
+	});
+
+	it('is a no-op when there are fewer dirs than keep', () => {
+		seed(['2026-05-12T10-00-00-000Z']);
+		const removed = pruneRuns(tmpRoot, 5);
+		expect(removed).toEqual([]);
+		expect(existsSync(join(tmpRoot, '2026-05-12T10-00-00-000Z'))).toBe(true);
+	});
+
+	it('is a no-op when keep <= 0', () => {
+		seed(['2026-05-12T10-00-00-000Z']);
+		expect(pruneRuns(tmpRoot, 0)).toEqual([]);
+		expect(pruneRuns(tmpRoot, -1)).toEqual([]);
+		expect(existsSync(join(tmpRoot, '2026-05-12T10-00-00-000Z'))).toBe(true);
+	});
+
+	it('is a no-op when the runsDir does not exist', () => {
+		expect(pruneRuns(join(tmpRoot, 'missing'), 5)).toEqual([]);
+	});
+
+	it('ignores non-directory entries at the runsDir root', () => {
+		seed(['2026-05-10T10-00-00-000Z', '2026-05-11T10-00-00-000Z', '2026-05-12T10-00-00-000Z']);
+		writeFileSync(join(tmpRoot, 'README.txt'), 'do not delete');
+
+		const removed = pruneRuns(tmpRoot, 1);
+
+		expect(removed).toHaveLength(2);
+		expect(existsSync(join(tmpRoot, 'README.txt'))).toBe(true);
+	});
+});

--- a/packages/test-harness/tsconfig.json
+++ b/packages/test-harness/tsconfig.json
@@ -1,0 +1,22 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"lib": ["ES2020"],
+		"module": "CommonJS",
+		"moduleResolution": "node",
+		"outDir": "./lib",
+		"rootDir": "./src",
+		"strict": true,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"declaration": false,
+		"sourceMap": true,
+		"noImplicitAny": true,
+		"noImplicitReturns": true,
+		"strictNullChecks": true
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "lib", "dist", "tests"]
+}

--- a/packages/test-harness/vitest.config.ts
+++ b/packages/test-harness/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		include: ['tests/**/*.test.ts'],
+		environment: 'node',
+		globals: false,
+		coverage: {
+			provider: 'v8',
+			reporter: ['text', 'json-summary'],
+			include: ['src/**/*.ts'],
+			exclude: ['src/cli.ts', 'src/server/lifecycle.ts'],
+		},
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,28 @@ importers:
         specifier: ^5.6.3
         version: 5.9.3
 
+  packages/test-harness:
+    dependencies:
+      rocketride:
+        specifier: workspace:*
+        version: link:../client-typescript
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.30
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.10
+      typescript:
+        specifier: ^5.3.3
+        version: 5.9.3
+
 packages:
 
   '@alloc/quick-lru@5.2.0':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,6 +657,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.5
+        version: 2.1.9(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
 
 packages:
 
@@ -1053,16 +1056,34 @@ packages:
   '@emotion/weak-memoize@0.4.0':
     resolution: {integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.12':
@@ -1071,16 +1092,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.12':
@@ -1089,10 +1128,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -1101,10 +1152,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.12':
@@ -1113,10 +1176,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.12':
@@ -1125,10 +1200,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -1137,16 +1224,34 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [linux]
 
   '@esbuild/linux-x64@0.25.12':
@@ -1161,6 +1266,12 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1171,6 +1282,12 @@ packages:
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -1185,11 +1302,23 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
 
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
@@ -1197,10 +1326,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.12':
@@ -3141,6 +3282,35 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
   '@vscode/debugprotocol@1.68.0':
     resolution: {integrity: sha512-2J27dysaXmvnfuhFGhfeuxfHRXunqNPxtBoR3koiTOA9rdxWNDTa1zIFLCFMSHJ9MPTPKFcBeblsyaCJCIlQxg==}
 
@@ -3409,6 +3579,10 @@ packages:
   asn1@0.2.6:
     resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
@@ -3559,6 +3733,10 @@ packages:
     engines: {node: '>=14.14.0'}
     hasBin: true
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -3595,6 +3773,10 @@ packages:
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -3636,6 +3818,10 @@ packages:
   chart.js@4.5.1:
     resolution: {integrity: sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==}
     engines: {pnpm: '>=8'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -4078,6 +4264,10 @@ packages:
     resolution: {integrity: sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -4286,6 +4476,9 @@ packages:
     resolution: {integrity: sha512-BrUQ0cPTB/IwXj23HtwHjS9n7O4h9FX94b4xc5zlTHxeLgTAdzYUDyy6KdExAl9lbN5rtfe44xpjpmj9grxs5w==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -4304,6 +4497,11 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -4408,6 +4606,9 @@ packages:
   estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -4437,6 +4638,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -5677,6 +5882,9 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
@@ -6234,6 +6442,13 @@ packages:
   path-type@6.0.0:
     resolution: {integrity: sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==}
     engines: {node: '>=18'}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -7242,6 +7457,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -7331,8 +7549,14 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   stackframe@1.3.4:
     resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -7583,9 +7807,27 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
 
   tmp@0.2.5:
     resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
@@ -7914,6 +8156,67 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
@@ -7990,6 +8293,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -8607,52 +8915,103 @@ snapshots:
 
   '@emotion/weak-memoize@0.4.0': {}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -8661,10 +9020,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -8673,13 +9038,25 @@ snapshots:
   '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -10807,6 +11184,46 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
   '@vscode/debugprotocol@1.68.0': {}
 
   '@vscode/test-cli@0.0.10':
@@ -11159,6 +11576,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  assertion-error@2.0.1: {}
+
   astral-regex@2.0.0: {}
 
   async-function@1.0.0: {}
@@ -11351,6 +11770,8 @@ snapshots:
       yargs: 17.7.2
       yargs-parser: 21.1.1
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -11387,6 +11808,14 @@ snapshots:
 
   ccount@2.0.1: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -11419,6 +11848,8 @@ snapshots:
   chart.js@4.5.1:
     dependencies:
       '@kurkle/color': 0.3.4
+
+  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -11942,6 +12373,8 @@ snapshots:
 
   deep-diff@1.0.2: {}
 
+  deep-eql@5.0.2: {}
+
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -12213,6 +12646,8 @@ snapshots:
       iterator.prototype: 1.1.5
       safe-array-concat: 1.1.3
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.0.0: {}
 
   es-object-atoms@1.1.1:
@@ -12235,6 +12670,32 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -12388,6 +12849,10 @@ snapshots:
 
   estree-walker@2.0.2: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   eventemitter3@4.0.7: {}
@@ -12426,6 +12891,8 @@ snapshots:
   exit@0.1.2: {}
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -14036,6 +14503,8 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
+  loupe@3.2.1: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -14831,6 +15300,10 @@ snapshots:
   path-type@4.0.0: {}
 
   path-type@6.0.0: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   pend@1.2.0: {}
 
@@ -15925,6 +16398,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
@@ -16008,7 +16483,11 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   stackframe@1.3.4: {}
+
+  std-env@3.10.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -16318,10 +16797,20 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
 
   tmp@0.2.5: {}
 
@@ -16702,6 +17191,71 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  vite-node@2.1.9(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@8.1.1)
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.6
+      rollup: 4.59.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+      fsevents: 2.3.3
+      sass: 1.97.3
+      sass-embedded: 1.97.3
+      terser: 5.46.0
+
+  vitest@2.1.9(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@8.1.1)
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@20.19.30)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.30
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
   void-elements@3.1.0: {}
 
   walker@1.0.8:
@@ -16816,6 +17370,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,9 @@ packages:
   # Client libraries
   - 'packages/client-typescript'
 
+  # Test infrastructure
+  - 'packages/test-harness'
+
   # Applications
   - 'apps/chat-ui'
   - 'apps/dropper-ui'


### PR DESCRIPTION
## Summary

All five phases of the pipeline test harness (issue #849). Adds `packages/test-harness/`, a TypeScript test harness that runs canonical pipelines against rocketride-server, captures the live `apaevt_*` event stream per run, classifies failures, diffs exercised nodes against `GET /services`, and emits a markdown + JSON report.

### What lands in this PR

| Phase | Deliverable |
| ----- | ----------- |
| 1 | Skeleton + server-lifecycle wrapper + token-scoped trace persistence |
| 2 | Failure classification (`pass`/`logic_failure`/`infra_failure`/`timeout`) + `/services` coverage diff + markdown report |
| 3 | Full smoke coverage — 14 smoke pipelines + 80 `coverage-exclusions.json` entries, gap = 0 |
| 4 | Integration tier — 3 multi-node composite pipelines (`parse_embed_chain`, `parallel_llm_routing`, `multi_llm_chain`) |
| 5 | Vitest unit tests (46 passing), retention policy for `.harness-runs/`, full `README.md` |

**Final smoke run:** 14 / 14 pass · 93 services · 13 covered · 80 excluded · **0 gaps** · exit 0.
**Final all-tier run:** 17 / 17 pass · same coverage numbers.

### Builder CLI commands added

- `builder harness:smoke` — smoke tier (mocked LLMs)
- `builder harness:integration` — integration tier (mocked LLMs)
- `builder harness:full` — all tiers, real APIs (requires keys, no `ROCKETRIDE_MOCK`)
- `builder harness:report --runDir=<path>` — re-render `report.md` from existing traces
- `builder harness:scaffold-exclusions` — emit a starter `coverage-exclusions.json` from the live `/services` registry
- `builder harness:build` / `harness:clean`

### Architecture highlights

- **Single env reader.** All `process.env` access lives in `src/config.ts`; everything else takes a typed `HarnessConfig`.
- **Token-scoped monitor.** Each pipeline uses a fresh `use()` token → `addMonitor({ token }, ['FLOW', 'SSE', 'DETAIL', 'TASK'])`. Cross-pipeline event bleed is impossible by construction.
- **Subscription type vs event-name distinction.** The server's `rrext_monitor` RPC accepts EVENT_TYPE enum names (`FLOW`/`SSE`/`DETAIL`/`TASK`); wire-level event names use the `apaevt_*` prefix. Documented in source + README.
- **Reuses existing infra.** `scripts/lib/server.js` for spawn/teardown, `nodes/test/mocks/*` for offline SDK swaps via `ROCKETRIDE_MOCK=1`. No HTTP mock server, no LLM-node patches.
- **/services normalizer is defensive.** Handles flat-array, map-style, and wrapped (`{ status: 'OK', data: { services: {...} } }`) response shapes.
- **Component-ID → provider name resolution.** `apaevt_flow.body.pipes[-1]` carries component IDs (e.g. `llm_openai_1`); the harness resolves them to provider class names (e.g. `llm_openai`) via the loaded pipeline config so the coverage diff matches `/services`. Raw IDs preserved in `exercised_components` for forensics.
- **Retention policy.** `pruneRuns(runsDir, keep)` keeps the newest `HARNESS_RETAIN_RUNS` (default 20) run dirs after each run. ISO timestamps sort lexicographically so name-only ordering suffices.

### Trace + report shape

```typescript
type TraceFile = {
  pipeline: string;
  run_started: string;
  run_ended: string;
  token: string;
  prompt?: unknown;
  sse_events: ApaevtSseEvent[];
  runtime_events: ApaevtFlowEvent[];
  other_events: ApaevtAnyEvent[];
  result: 'pass' | 'logic_failure' | 'infra_failure' | 'timeout';
  infra_signature?: string;
  error?: { message: string; raw?: unknown };
  exercised_nodes: string[];         // provider names (match /services)
  exercised_components: string[];    // raw IDs, for forensics
};
```

### Test plan

- [ ] `cd packages/client-typescript && npx tsc -p tsconfig.cjs.json && npx tsc -p tsconfig.types.json`
- [ ] `cd packages/test-harness && npx tsc -p tsconfig.json`
- [ ] `npx vitest run` → 46 tests pass
- [ ] Engine binary staged at `<workspace>/dist/server/engine[.exe]` (build or junction-link)
- [ ] `node packages/test-harness/lib/cli.js smoke` → 14 / 14 pass, gap 0
- [ ] `node packages/test-harness/lib/cli.js integration` → 3 / 3 pass
- [ ] `node packages/test-harness/lib/cli.js all` → 17 / 17 pass, gap 0
- [ ] `HARNESS_RETAIN_RUNS=3 node packages/test-harness/lib/cli.js smoke` → only 3 dirs remain under `.harness-runs/`

Closes #849

🤖 Generated with [Claude Code](https://claude.com/claude-code)