### PR TITLE
chore(ci): block rsbuild/rslib/rspack 0.x churn and pip requirement-update majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -106,6 +106,14 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # rsbuild/rslib/rspack are pre-1.x or early-1.x and ship breaking
+      # changes in minor releases (e.g. @rslib/core 0.13 → 0.21 broke the
+      # rollup-dts pipeline in PR #860). semver-minor ignore wouldn't fit
+      # — we still want minors for other deps. These are upgraded manually
+      # in coordinated bumps across shared-ui + apps/{chat,dropper}-ui.
+      - dependency-name: "@rsbuild/*"
+      - dependency-name: "@rslib/*"
+      - dependency-name: "@rspack/*"
 
   # ---------------------------------------------------------------------------
   # npm — apps/dropper-ui
@@ -131,6 +139,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # See shared-ui ecosystem above. Apps are pinned to @rsbuild 0.4.x
+      # while shared-ui is on 1.x; 0.x → 0.x bumps (e.g. #855: 0.4 → 0.7)
+      # strand the apps at an intermediate version. Upgrade together.
+      - dependency-name: "@rsbuild/*"
 
   # ---------------------------------------------------------------------------
   # npm — apps/chat-ui
@@ -156,6 +168,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # See shared-ui ecosystem above. Same pattern as dropper-ui:
+      # apps pinned to 0.x while shared-ui is on 1.x — block intermediate
+      # 0.x → 0.x bumps (e.g. #854: 0.4 → 0.7) to avoid stranding.
+      - dependency-name: "@rsbuild/*"
 
   # ---------------------------------------------------------------------------
   # Python — root pyproject.toml (covers most ai/nodes deps via workspace)
@@ -246,6 +262,14 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # The semver-major rule above only catches `version-update:*`
+      # update-types. Pip `requirement-update` PRs (where Dependabot
+      # rewrites a `>=X,<Y` constraint to a higher Y) take a different
+      # classification path and slipped through — see #839
+      # (elasticsearch 8→9) and #857 (google-genai 1→2). Pin these by
+      # name so the requirement-update path is also blocked.
+      - dependency-name: "elasticsearch"
+      - dependency-name: "google-genai"
 
   # ---------------------------------------------------------------------------
   # GitHub Actions — workflow file SHA pin updates


### PR DESCRIPTION
## Summary

Extends `.github/dependabot.yml` to close two gaps in the existing `version-update:semver-major` wildcard ignore:

- **`@rsbuild/*` / `@rslib/*` / `@rspack/*` pre-1.x churn** — these ship breaking changes in minor releases, so the existing major-ignore doesn't help. Block in `packages/shared-ui` (all three) and `apps/{chat,dropper}-ui` (rsbuild only — those apps don't depend on rslib/rspack). Upgrades will be coordinated manually so shared-ui and apps move together.
- **Pip `requirement-update` majors** — Dependabot rewrites `>=X,<Y` constraints under a different update-type that the `version-update:semver-major` wildcard does not catch. Block `elasticsearch` and `google-genai` by name in `nodes/src/nodes` so the slip-through path (#839, #857) is closed.

Inline `# WHY:` comments next to each new entry so the rationale doesn't rot.

## Context

This week's Dependabot cycle produced 5 PRs that the existing config should arguably have prevented (#839, #854, #855, #857, #860). All five were closed manually; this PR stops them from re-emitting next Monday.

## Validation

- `ruby -ryaml -e 'YAML.load_file(...)'` — parse clean.
- `jsonschema` validation against SchemaStore `dependabot-2.0.json` (Draft7) — **schema: OK**.
- Diff is +24 lines, ignore additions only; no removals or restructuring.

## Test plan

- [ ] CI green on the PR (Ruff / gitleaks / actionlint / Build matrix).
- [ ] After merge, watch next Monday's Dependabot cycle — confirm no new PRs in any of the blocked dimensions.
- [ ] Manual upgrade plan for rsbuild/rslib/rspack remains a tracked follow-up (out of scope here).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to improve stability of automatic package updates by constraining version changes for critical build and ecosystem packages across project workspaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/862)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->