### PR TITLE
feat(llm_anthropic): emit per-call token usage via stateless payload wrapper

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -114,6 +114,16 @@ class Chat(ChatBase):
 
     def _chat(self, prompt: str) -> ChatResponse:
         results = self._llm.invoke(prompt)
+        
+        # Extract base usage
         meta = getattr(results, 'usage_metadata', None) or getattr(results, 'response_metadata', {})
-        usage_dict = meta.get('usage', {}) if 'usage' in meta else meta
+        usage_dict = dict(meta.get('usage', {}) if 'usage' in meta else meta)
+        
+        # Flatten LangChain's nested cache metrics if present
+        input_details = usage_dict.get('input_token_details', {})
+        if 'cache_read' in input_details:
+            usage_dict['cache_read_input_tokens'] = input_details['cache_read']
+        if 'cache_creation' in input_details:
+            usage_dict['cache_creation_input_tokens'] = input_details['cache_creation']
+
         return ChatResponse(content=results.content, metadata={'usage': usage_dict})

--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -26,7 +26,7 @@ Anthropic binding for the ChatLLM.
 """
 
 from typing import Any, Dict
-from ai.common.chat import ChatBase
+from ai.common.chat import ChatBase, ChatResponse
 from ai.common.config import Config
 from langchain_anthropic import ChatAnthropic
 
@@ -111,3 +111,9 @@ class Chat(ChatBase):
 
         # Save our chat class into the bag
         bag['chat'] = self
+
+    def _chat(self, prompt: str) -> ChatResponse:
+        results = self._llm.invoke(prompt)
+        meta = getattr(results, 'usage_metadata', None) or getattr(results, 'response_metadata', {})
+        usage_dict = meta.get('usage', {}) if 'usage' in meta else meta
+        return ChatResponse(content=results.content, metadata={'usage': usage_dict})

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -13,12 +13,19 @@ communication with their respective APIs.
 import time
 import json
 import importlib
-from typing import Dict, Any
+from typing import Dict, Any, Union
+from dataclasses import dataclass, field
 from rocketlib import debug
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
 from ai.common.util import parseJson
 from ai.common.validation import validate_model_name, validate_max_tokens, validate_prompt
+
+
+@dataclass
+class ChatResponse:
+    content: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 class ChatBase:
@@ -300,7 +307,8 @@ class ChatBase:
         for attempt in range(max_network_retries):
             try:
                 # Call the actual chat implementation provided by the subclass
-                return self._chat(prompt)
+                raw_result = self._chat(prompt)
+                return raw_result if isinstance(raw_result, ChatResponse) else ChatResponse(content=raw_result)
 
             except Exception as e:
                 # Determine if this is a retryable error
@@ -374,10 +382,13 @@ class ChatBase:
         # Call the chat implementation with network retry logic
         # This is where the real communication with the AI provider happens
         result = self._chat_with_retries(prompt)
+        
+        # Extract response content safely for token math
+        response_content = result.content if isinstance(result, ChatResponse) else result
 
         # Count tokens in the response to check for potential truncation
         # This helps identify cases where the model's response was cut off
-        result_tokens = self.getTokens(result)
+        result_tokens = self.getTokens(response_content)
 
         # Check if the total token usage suggests the response was truncated
         # We use a small buffer (5 tokens) to account for tokenization differences
@@ -425,12 +436,16 @@ class ChatBase:
 
             for retry_count in range(max_retries):
                 try:
+                    # Extract response content safely
+                    response_content = response.content if isinstance(response, ChatResponse) else response
                     # Parse (and strip any markdown fences) — reuse the result below
-                    parsed_response = parseJson(response)
+                    parsed_response = parseJson(response_content)
 
                     # Create the json answer and return it
                     answer = Answer(expectJson=True)
                     answer.setAnswer(parsed_response)
+                    if isinstance(response, ChatResponse):
+                        answer.usage = response.metadata.get('usage')
                     return answer
 
                 except (json.JSONDecodeError, ValueError):
@@ -448,9 +463,13 @@ class ChatBase:
                         raise ValueError(error_msg)
 
         else:
+            # Extract response content safely
+            response_content = response.content if isinstance(response, ChatResponse) else response
             # Create the answer and assign the text
             answer = Answer(expectJson=False)
-            answer.setAnswer(response)
+            answer.setAnswer(response_content)
+            if isinstance(response, ChatResponse):
+                answer.usage = response.metadata.get('usage')
 
             # And return it
             return answer

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -111,7 +111,7 @@ class ChatBase:
         """
         return self._modelOutputTokens
 
-    def _chat(self, prompt: str) -> str:
+    def _chat(self, prompt: str) -> Union[str, ChatResponse]:
         """
         Send prompt, recieve response.
 
@@ -128,7 +128,7 @@ class ChatBase:
             prompt (str): The complete prompt to send to the AI model
 
         Returns:
-            str: The raw response from the AI model
+            Union[str, ChatResponse]: The raw response or stateless wrapper from the AI model
 
         Raises:
             Should raise appropriate exceptions for API failures, authentication
@@ -280,7 +280,7 @@ class ChatBase:
         # Default to retryable for unknown errors (conservative approach)
         return True
 
-    def _chat_with_retries(self, prompt: str) -> str:
+    def _chat_with_retries(self, prompt: str) -> Union[str, ChatResponse]:
         """
         Handle chat requests with retries for transient errors.
 
@@ -292,7 +292,7 @@ class ChatBase:
             prompt (str): The complete prompt to send to the AI model
 
         Returns:
-            str: The raw response from the AI model
+            Union[str, ChatResponse]: The raw response or stateless wrapper from the AI model
 
         Raises:
             Exception: If network/API retries are exhausted or non-retryable
@@ -334,7 +334,7 @@ class ChatBase:
         # This should never be reached due to the raise in the loop
         raise Exception('Unexpected exit from retry loop')
 
-    def chat_string(self, prompt: str) -> str:
+    def chat_string(self, prompt: str) -> Union[str, ChatResponse]:
         """
         Invoke the chat interface with string input, token management, and network retry handling.
 
@@ -354,7 +354,7 @@ class ChatBase:
             prompt (str): The complete prompt to send to the model
 
         Returns:
-            str: The model's response
+            Union[str, ChatResponse]: The model's response or stateless wrapper
 
         Warnings:
             - Issues debug warning if prompt is too long

--- a/packages/client-python/src/rocketride/schema/question.py
+++ b/packages/client-python/src/rocketride/schema/question.py
@@ -85,6 +85,7 @@ class Answer(BaseModel):
 
     answer: Optional[Union[str, dict, list]] = None
     expectJson: bool = False
+    usage: Optional[dict] = Field(default=None, description="Token usage metadata")
 
     @field_validator('answer', mode='before')
     @classmethod


### PR DESCRIPTION
## Summary
- **Feature:** Implements token telemetry extraction (`cache_creation_input_tokens`, `cache_read_input_tokens`, etc.) for the `llm_anthropic` node, routing the usage data directly into the `Answer` schema so it is automatically emitted via the C++ `apaevt_flow` trace engine.
- **Architecture:** Introduces a stateless `ChatResponse` dataclass in the `ChatBase` middleware to tunnel metadata cleanly up the stack. 
- **Backward Compatibility:** Implemented a Defensive Wrapper (Adapter Pattern) inside `_chat_with_retries`. Legacy nodes (OpenAI, Gemini, Mistral, Watson) that still return raw strings are safely and automatically coerced into `ChatResponse` objects. This ensures zero downstream breakage for existing nodes while establishing the infrastructure for future observability migrations.

## Type
feature, refactor

## Testing
- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes (Verified legacy node backward compatibility)

## Checklist
- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated 
- [ ] Breaking changes documented

## Linked Issue
Resolves #786

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat responses now bundle content with usage metadata for clearer token accounting.
  * Chat APIs may return a wrapped response object (content + metadata) for richer provider data.
  * Answers now include an optional usage field so returned results can carry token-usage details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/867)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->