### PR TITLE
fix(depends): bootstrap setuptools alongside wheel

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -248,6 +248,42 @@ def _ensure_wheel():
     debug('wheel installed successfully')
 
 
+def _setuptools_available() -> bool:
+    """Check if setuptools module is available."""
+    try:
+        import importlib.util
+
+        return importlib.util.find_spec('setuptools') is not None
+    except Exception:
+        return False
+
+
+def _ensure_setuptools():
+    """Ensure setuptools is installed in the parent env.
+
+    Required because we compile/install with --no-build-isolation, which means uv
+    builds source-only wheels (e.g. docopt 0.6.2, transitively pulled by kokoro →
+    misaki → num2words) against the parent env. Several legacy sdists declare
+    setup.py-style builds without listing setuptools in build-system.requires,
+    so uv can't auto-bootstrap them. Mirroring _ensure_wheel so the parent env
+    has the standard PEP 517 backend available at compile/install time.
+    """
+    if _setuptools_available():
+        debug('setuptools is available')
+        return
+
+    monitorStatus('Installing setuptools...')
+    result = _run(
+        [sys.executable, '-m', 'pip', 'install', 'setuptools', '--quiet', '--disable-pip-version-check'], check=False
+    )
+
+    if result.returncode != 0:
+        error(f'Failed to install setuptools: {result.stderr}')
+        raise RuntimeError('Failed to install setuptools')
+
+    debug('setuptools installed successfully')
+
+
 def _ensure_uv():
     """Ensure uv is installed."""
     if _uv_available():
@@ -355,10 +391,11 @@ def _ensure_site_packages():
 
 
 def bootstrap():
-    """Bootstrap the environment: ensure pip, uv, wheel."""
+    """Bootstrap the environment: ensure pip, uv, wheel, setuptools."""
     _ensure_site_packages()  # Must be first!
     _ensure_pip()
     _ensure_wheel()  # Needed for building packages with --no-build-isolation
+    _ensure_setuptools()  # Same reason — required by sdists with legacy setup.py builds
     _ensure_uv()
 
 

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -281,6 +281,10 @@ def _ensure_setuptools():
         error(f'Failed to install setuptools: {result.stderr}')
         raise RuntimeError('Failed to install setuptools')
 
+    # Verify installation
+    if not _setuptools_available():
+        raise RuntimeError('setuptools installed but not found')
+
     debug('setuptools installed successfully')
 
 


### PR DESCRIPTION
## Summary

- Adds `_ensure_setuptools()` to `depends.py` bootstrap, mirroring the existing `_ensure_wheel()` pattern.
- Fixes the engine refusing to start after `kokoro → misaki → num2words → docopt 0.6.2` landed (PR #662, Apr 24) on top of the uv-based bootstrap from #803.

## Why this is needed

`depends.py` runs `uv pip compile` and `uv pip install` with `--no-build-isolation` (because engine.exe can't spawn temp venvs). Under that mode, source-only sdists are built against the parent env. Several legacy sdists, including the famously-broken `docopt 0.6.2`, declare setup.py-style builds without listing setuptools in `build-system.requires` — uv can't auto-bootstrap them.

Under the old pip-based bootstrap this was a non-issue: pip ships setuptools with itself. After #803 switched the runtime to uv, that implicit availability went away. The first transitive dep that triggered it was `docopt 0.6.2` once #662 added `kokoro>=0.9.4` (which depends on `misaki[en] → num2words → docopt>=0.6.2`).

## Repro

Deploying the new model-server image (built today from develop) to the H100 errored at engine boot:

```
RuntimeError: Failed to compile constraints
× Failed to build `docopt==0.6.2`
╰─▶ Call to setuptools.build_meta:__legacy__.prepare_metadata_for_build_wheel
    failed (exit status: 1)
    [stderr] ModuleNotFoundError: No module named 'setuptools'
```

This change pre-installs setuptools the same way `_ensure_wheel()` does so the PEP 517 legacy backend is available and the constraint compile succeeds.

## Test plan

- [x] CI green
- [ ] Engine boots from a fresh nightly + model-server image rebuild on the H100
- [ ] DAP `initialize` returns `success: true` over `wss://model.rocketride.dev/models`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment bootstrap to ensure build tooling (including setuptools) is present and automatically provisioned if missing, boosting reliability of package installation and error diagnostics.
* **Documentation**
  * Updated bootstrap documentation to list the fuller set of environment components that are ensured during startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/871)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->