### PR TITLE
fix(tool_git): eliminate pytest-xdist race in path-traversal tests

### DIFF
--- a/nodes/test/tool_git/test_tools.py
+++ b/nodes/test/tool_git/test_tools.py
@@ -816,20 +816,21 @@ class TestPathTraversalGuards(unittest.TestCase):
 
     def setUp(self) -> None:
         """Create a tmp directory to stand in for the repo working directory."""
-        self._tmp = tempfile.TemporaryDirectory()
-        # Resolve to match how GitRepo resolves workdir internally.
-        self._workdir = str(Path(self._tmp.name).resolve())
-        # Create a sibling file outside the workdir to confirm traversal would actually escape.
-        self._outside = Path(self._workdir).parent / 'outside.txt'
+        # Outer tmp dir gives each test (and each pytest-xdist worker) its own
+        # private "outside" area. Anchoring outside.txt to the system temp root
+        # caused cross-test races where one tearDown unlinked the file while
+        # another test's assertion was mid-read.
+        self._outer = tempfile.TemporaryDirectory()
+        outer = Path(self._outer.name).resolve()
+        workdir_path = outer / 'repo'
+        workdir_path.mkdir()
+        self._workdir = str(workdir_path)
+        self._outside = outer / 'outside.txt'
         self._outside.write_text('do-not-overwrite', encoding='utf-8')
 
     def tearDown(self) -> None:
         """Remove the tmp directory."""
-        try:
-            self._outside.unlink()
-        except OSError:
-            pass
-        self._tmp.cleanup()
+        self._outer.cleanup()
 
     # ----- write_file -----
 

--- a/packages/ai/scripts/tasks.js
+++ b/packages/ai/scripts/tasks.js
@@ -80,12 +80,13 @@ function makeRunPytestAction(options = {}) {
             // The two paths don't match, so coverage reports 0%. Pinning
             // --cov to the absolute source directory bypasses the import-time
             // package resolution and tracks the directory we actually run.
+            const HTMLCOV_DIR = path.join(SERVER_DIR, 'htmlcov', 'ai');
             const pytestArgs = [
                 '-m', 'pytest', TESTS_DIR, '-v', '--rootdir', PACKAGE_DIR,
                 // Coverage flags
                 '--cov', SRC_DIR,
                 '--cov-report=term-missing',
-                '--cov-report=html',
+                `--cov-report=html:${HTMLCOV_DIR}`,
             ];
             if (options.pytest) {
                 pytestArgs.push(...options.pytest);


### PR DESCRIPTION
## Summary

- `TestPathTraversalGuards` was flaky under `pytest-xdist`. All 6 methods in the class wrote/unlinked the same `C:\…\Temp\outside.txt`, because `Path(workdir).parent` of a `tempfile.TemporaryDirectory()` is the *shared* system temp root. One worker's `tearDown` could unlink the file mid-assertion in another worker, surfacing as `FileNotFoundError` at `test_write_file_rejects_parent_traversal` line 843. Fixed by wrapping `workdir` in an outer per-test tempdir so `outside.txt` lives at `<unique-tmp>/outside.txt` and `../outside.txt` traversal still resolves correctly.
- `packages/ai/scripts/tasks.js`: route `--cov-report=html` to `dist/server/htmlcov/ai/` so a future `nodes:test` coverage run can't overwrite the AI report.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure for filesystem-based validation tests with simplified cleanup logic.

* **Chores**
  * Updated test coverage reporting configuration for better output organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/872)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->