### PR TITLE
chore(ci): extend rsbuild/rslib/rspack ignore to root npm ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,16 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
+      # The root-level groups (npm-production, npm-development) span the
+      # whole pnpm workspace, so rsbuild/rslib/rspack updates that the
+      # per-app ecosystems ignore still get re-emitted here. PR #866
+      # tried to *downgrade* @rsbuild/* from 1.x to 0.7.10 across seven
+      # workspaces because chat-ui/dropper-ui are pinned to 0.4.x and
+      # Dependabot harmonised to the floor. Match the per-app ignores at
+      # the root to keep the npm-development group from re-creating that.
+      - dependency-name: "@rsbuild/*"
+      - dependency-name: "@rslib/*"
+      - dependency-name: "@rspack/*"
 
   # ---------------------------------------------------------------------------
   # npm — packages/client-typescript (published SDK)


### PR DESCRIPTION
## Summary

Follow-up to #862. The per-app ignores landed there only cover the ecosystems scoped to a single `package.json` (`/apps/chat-ui`, `/apps/dropper-ui`, `/packages/shared-ui`). The **root `/` npm ecosystem** runs two groups (`npm-production`, `npm-development`) that span the whole pnpm workspace, so the per-app ignores do not apply to it.

## Context

PR #866 (closed) exposed the gap: it tried to **downgrade** `@rsbuild/*` from 1.x to 0.7.10 in seven workspaces (hello-ui, monitor-ui, profiler-ui, shell-ui, world-ui, vscode, shared-ui) because Dependabot harmonised the version across the monorepo to the 0.4.x floor still pinned in chat-ui/dropper-ui. It also pulled in `@rslib/core ~0.13 → ~0.21` — the same 0.x breaker already blocked at the per-app level.

This adds three `dependency-name` entries to the root ecosystem's ignore list with an inline `# WHY:` comment referencing #866.

## Validation

- `git diff` shows +10 lines, ignore additions only.
- `jsonschema` Draft7 against SchemaStore `dependabot-2.0.json` — **schema: OK**.

## Test plan

- [ ] CI green on the PR.
- [ ] Next Monday's Dependabot cycle: the npm-development group should *not* re-emit any `@rsbuild/*`, `@rslib/*`, or `@rspack/*` rows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated root-level Dependabot configuration to exclude certain build and framework packages from automated update consideration, ensuring consistent dependency management across the workspace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/874)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->