### PR TITLE
Enable Deep Agent multi-task tool calls

### DIFF
--- a/nodes/src/nodes/agent_deepagent/deepagent.py
+++ b/nodes/src/nodes/agent_deepagent/deepagent.py
@@ -25,8 +25,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Callable, Dict, List, Optional
 
 from rocketlib import ToolDescriptor, error
@@ -354,7 +356,8 @@ class DeepAgentDriver(AgentBase):
                 subagents=subagents_list if subagents_list else None,
             )
             stage = 'invoke'
-            state = agent.invoke(
+            state = _invoke_deepagent_with_parallel_tools(
+                agent,
                 {'messages': [HumanMessage(content=_safe_str(question.getPrompt() or ''))]},
                 config={'callbacks': [_SSECallbackHandler(_send_sse)]},
             )
@@ -466,6 +469,25 @@ class DeepAgentDriver(AgentBase):
 # ────────────────────────────────────────────────────────────────────────────────
 
 
+def _invoke_deepagent_with_parallel_tools(agent: Any, input_state: Dict[str, Any], *, config: Dict[str, Any]) -> Any:
+    """Invoke DeepAgents through its async graph path so tool calls fan out."""
+    ainvoke = getattr(agent, 'ainvoke', None)
+    if not callable(ainvoke):
+        return agent.invoke(input_state, config=config)
+    return _run_coroutine_sync(ainvoke(input_state, config=config))
+
+
+def _run_coroutine_sync(coro: Any) -> Any:
+    """Run a coroutine from sync driver code, even if a loop is already active."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(lambda: asyncio.run(coro)).result()
+
+
 def _tool_call_protocol_prompt(bound_tools: List[Dict[str, Any]]) -> str:
     """
     Build the system-prompt preamble that instructs the LLM to output a JSON envelope.
@@ -481,6 +503,8 @@ def _tool_call_protocol_prompt(bound_tools: List[Dict[str, Any]]) -> str:
             'system: Allowed schemas:',
             'system: Tool call:',
             'system: {"type":"tool_call","name":"server.tool","args":{...}}',
+            'system: Multiple independent tool calls in one turn:',
+            'system: {"type":"tool_calls","calls":[{"name":"server.tool","args":{...}},...]}',
             'system: Final answer:',
             'system: {"type":"final","content":"..."}',
             'system: Never wrap JSON in markdown. Never include extra keys unless required.',
@@ -607,17 +631,42 @@ def _parse_tool_call_envelope(raw: str) -> Any:
         return AIMessage(content=_safe_str(obj.get('content', '')))
 
     if msg_type == 'tool_call':
-        name = _safe_str(obj.get('name', '')).strip()
-        if not name:
+        tool_call = _parse_one_tool_call(obj)
+        if tool_call is None:
             return None
-        args = obj.get('args') or {}
-        if not isinstance(args, dict):
-            args = {'input': args}
-
-        tool_call = {'id': f'call_{uuid.uuid4().hex[:12]}', 'type': 'tool_call', 'name': name, 'args': args}
         return AIMessage(content='', tool_calls=[tool_call])
 
+    if msg_type == 'tool_calls':
+        calls = obj.get('calls') or obj.get('tool_calls') or []
+        if not isinstance(calls, list):
+            return None
+        tool_calls = []
+        for call in calls:
+            if not isinstance(call, dict):
+                return None
+            tool_call = _parse_one_tool_call(call)
+            if tool_call is None:
+                return None
+            tool_calls.append(tool_call)
+        if not tool_calls or len(tool_calls) != len(calls):
+            return None
+        return AIMessage(content='', tool_calls=tool_calls)
+
     return None
+
+
+def _parse_one_tool_call(obj: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Parse one tool-call object from the RocketRide LLM envelope."""
+    name = _safe_str(obj.get('name', '')).strip()
+    if not name:
+        return None
+
+    args = obj['args'] if 'args' in obj and obj['args'] is not None else {}
+    if not isinstance(args, dict):
+        args = {'input': args}
+
+    call_id = _safe_str(obj.get('id', '')).strip() or f'call_{uuid.uuid4().hex[:12]}'
+    return {'id': call_id, 'type': 'tool_call', 'name': name, 'args': args}
 
 
 def _safe_str(v: Any) -> str:

--- a/nodes/src/nodes/agent_deepagent/services.agent.json
+++ b/nodes/src/nodes/agent_deepagent/services.agent.json
@@ -105,5 +105,29 @@
 			"title": "Deep Agent",
 			"properties": ["agent_deepagent.default"]
 		}
-	]
+	],
+	"test": {
+		"requires": ["ROCKETRIDE_DEEPAGENT_TEST"],
+		"profiles": ["default"],
+		"controls": ["llm_openai"],
+		"outputs": ["answers"],
+		"timeout": 120,
+		"cases": [
+			{
+				"name": "Answer a simple delegated question",
+				"questions": {
+					"questions": [
+						{
+							"text": "Reply with the word ok."
+						}
+					]
+				},
+				"expect": {
+					"answers": {
+						"notEmpty": true
+					}
+				}
+			}
+		]
+	}
 }

--- a/nodes/test/agent_deepagent/test_deepagent_tool_calls.py
+++ b/nodes/test/agent_deepagent/test_deepagent_tool_calls.py
@@ -1,0 +1,141 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit tests for Deep Agent tool-call envelope parsing."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from nodes.agent_deepagent.deepagent import (
+    _invoke_deepagent_with_parallel_tools,
+    _parse_tool_call_envelope,
+    _tool_call_protocol_prompt,
+)
+from nodes.test.mocks.agent_deepagent import FakeParallelDeepAgent
+
+
+def test_parse_tool_calls_envelope_preserves_all_calls():
+    """Parse multiple task calls while preserving order, falsy args, and IDs."""
+    raw = json.dumps(
+        {
+            'type': 'tool_calls',
+            'calls': [
+                {'id': 'call_a', 'name': 'task', 'args': {'description': 'A', 'subagent_type': 'eng'}},
+                {'name': 'task', 'args': 0},
+                {'id': 'call_c', 'name': 'task', 'args': ''},
+                {'id': 'call_d', 'name': 'task', 'args': None},
+            ],
+        }
+    )
+
+    msg = _parse_tool_call_envelope(raw)
+
+    assert msg is not None
+    assert msg.tool_calls[0]['id'] == 'call_a'
+    assert msg.tool_calls[1]['id'].startswith('call_')
+    assert msg.tool_calls[2]['id'] == 'call_c'
+    assert msg.tool_calls[3]['id'] == 'call_d'
+    assert [call['name'] for call in msg.tool_calls] == ['task', 'task', 'task', 'task']
+    assert [call['args'] for call in msg.tool_calls] == [
+        {'description': 'A', 'subagent_type': 'eng'},
+        {'input': 0},
+        {'input': ''},
+        {},
+    ]
+
+
+def test_parse_tool_calls_envelope_rejects_malformed_batches():
+    """Reject a whole multi-call batch if any entry is malformed."""
+    raw = json.dumps(
+        {
+            'type': 'tool_calls',
+            'calls': [
+                {'id': 'call_a', 'name': 'task', 'args': {'description': 'A'}},
+                {'id': 'call_b', 'args': {'description': 'B'}},
+                {'id': 'call_c', 'name': 'task', 'args': {'description': 'C'}},
+            ],
+        }
+    )
+
+    assert _parse_tool_call_envelope(raw) is None
+    assert _parse_tool_call_envelope(json.dumps({'type': 'tool_calls', 'calls': ['bad']})) is None
+
+
+def test_tool_protocol_prompt_advertises_multi_call_envelope():
+    """Advertise the multi-call envelope so the PM can request fan-out."""
+    prompt = _tool_call_protocol_prompt([{'name': 'task', 'description': 'Run subagent'}])
+
+    assert '"type":"tool_calls"' in prompt
+    assert '"calls"' in prompt
+
+
+def test_multi_task_tool_calls_execute_in_parallel():
+    """Regression-test LangGraph tool fan-out wall time for multi-task turns."""
+    graph_module = pytest.importorskip('langgraph.graph')
+    prebuilt_module = pytest.importorskip('langgraph.prebuilt')
+    tools_module = pytest.importorskip('langchain_core.tools')
+
+    delay = 0.25
+
+    @tools_module.tool
+    def task(description: str) -> str:
+        """Run a subagent task."""
+        time.sleep(delay)
+        return description
+
+    builder = graph_module.StateGraph(graph_module.MessagesState)
+    builder.add_node('tools', prebuilt_module.ToolNode([task]))
+    builder.add_edge(graph_module.START, 'tools')
+    builder.add_edge('tools', graph_module.END)
+    graph = builder.compile()
+
+    raw = json.dumps(
+        {
+            'type': 'tool_calls',
+            'calls': [
+                {'id': 'call_a', 'name': 'task', 'args': {'description': 'A'}},
+                {'id': 'call_b', 'name': 'task', 'args': {'description': 'B'}},
+                {'id': 'call_c', 'name': 'task', 'args': {'description': 'C'}},
+            ],
+        }
+    )
+    msg = _parse_tool_call_envelope(raw)
+
+    start = time.perf_counter()
+    state = graph.invoke({'messages': [msg]})
+    elapsed = time.perf_counter() - start
+
+    tool_messages = state['messages'][1:]
+    assert [message.content for message in tool_messages] == ['A', 'B', 'C']
+    assert elapsed < delay * 2
+
+
+def test_deepagent_invocation_uses_async_parallel_tool_path():
+    """Ensure the driver invokes the async graph path for parallel tool calls."""
+    delay = 0.25
+    raw = json.dumps(
+        {
+            'type': 'tool_calls',
+            'calls': [
+                {'id': 'call_a', 'name': 'task', 'args': {'description': 'A'}},
+                {'id': 'call_b', 'name': 'task', 'args': {'description': 'B'}},
+                {'id': 'call_c', 'name': 'task', 'args': {'description': 'C'}},
+            ],
+        }
+    )
+    msg = _parse_tool_call_envelope(raw)
+
+    start = time.perf_counter()
+    state = _invoke_deepagent_with_parallel_tools(
+        FakeParallelDeepAgent(delay), {'messages': [msg]}, config={'callbacks': []}
+    )
+    elapsed = time.perf_counter() - start
+
+    assert state['messages'] == ['A', 'B', 'C']
+    assert elapsed < delay * 2

--- a/nodes/test/mocks/agent_deepagent/__init__.py
+++ b/nodes/test/mocks/agent_deepagent/__init__.py
@@ -1,0 +1,34 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Mocks used by Deep Agent node tests."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+
+class FakeParallelDeepAgent:
+    """Fake compiled DeepAgents graph whose async path fans out tool calls."""
+
+    def __init__(self, delay: float) -> None:
+        """Store the artificial per-task delay."""
+        self.delay = delay
+
+    def invoke(self, input_state: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
+        """Fail if the synchronous graph path is used."""
+        raise AssertionError('sync invoke should not be used')
+
+    async def ainvoke(self, input_state: dict[str, Any], *, config: dict[str, Any]) -> dict[str, Any]:
+        """Run all supplied task calls concurrently."""
+
+        async def run_one(call: dict[str, Any]) -> str:
+            """Return one task result after the shared delay."""
+            await asyncio.sleep(self.delay)
+            return call['args']['description']
+
+        calls = input_state['messages'][0].tool_calls
+        return {'messages': await asyncio.gather(*(run_one(call) for call in calls))}


### PR DESCRIPTION
## Summary

- Added a multi-tool-call envelope to the Deep Agent LLM protocol so the PM can emit several independent `task` calls in one assistant turn.
- Parse `tool_calls` envelopes into one `AIMessage` with multiple LangChain tool calls.
- Added focused tests covering three `task` calls and the advertised protocol schema.

## Type

refactor

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #784 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deep agent now supports parallel tool-call execution, preserving call order and improving throughput.

* **Bug Fixes**
  * Enhanced parsing and validation of multi-tool-call responses, including stable call IDs and normalized arguments (handles falsy values).

* **Refactor**
  * Unified per-call processing for single- and multi-call envelopes to reduce parsing errors.

* **Tests**
  * Added end-to-end tests for multi-call protocol, parsing, parallel execution, and async invocation paths.

* **Chores**
  * Added test config and a mock parallel agent to validate async parallel behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/876?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->