### PR TITLE
fix: MF stability, ModelClient SDK refactor, settings UX, billing, and UI polish

### DIFF
--- a/apps/chat-ui/scripts/tasks.js
+++ b/apps/chat-ui/scripts/tasks.js
@@ -55,24 +55,18 @@ const BUILD_HASH_KEY = 'chat-ui.buildHash';
 function makeBundleAction() {
 	return {
 		run: async (ctx, task) => {
-			// Check if any build inputs changed; skip when nothing moved.
-			if (!ctx.options.force) {
-				const { changed } = await hasBuildInputChanged(
-					BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
-				const outputExists = await exists(BUILD_DIR);
-				if (!changed && outputExists) {
-					task.output = 'No changes detected';
-					return;
-				}
+			// Fingerprint inputs before building so concurrent edits are detected on the next run.
+			const { changed, hash } = await hasBuildInputChanged(
+				BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
+			if (!ctx.options.force && !changed && (await exists(BUILD_DIR))) {
+				task.output = 'No changes detected';
+				return;
 			}
 
 			// Clean build output before rebuilding to prevent stale chunks
 			await removeDir(BUILD_DIR);
 			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
 
-			// Persist the hash so the next run can skip if nothing changed
-			const { hash } = await hasBuildInputChanged(
-				BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
 			await saveSourceHash(BUILD_HASH_KEY, hash);
 		},
 	};

--- a/apps/chat-ui/scripts/tasks.js
+++ b/apps/chat-ui/scripts/tasks.js
@@ -23,95 +23,118 @@
 
 /**
  * Chat UI Build Module
- * 
+ *
  * React-based chat interface application.
  */
 const path = require('path');
 const {
-    execCommand, syncDir, formatSyncStats, removeDir, BUILD_ROOT, DIST_ROOT,
-    hasSourceChanged, saveSourceHash, setState, exists
+	execCommand, syncDir, formatSyncStats, removeDir, BUILD_ROOT, DIST_ROOT,
+	hasBuildInputChanged, saveSourceHash, setState, exists,
 } = require('../../../scripts/lib');
+const { PROJECT_ROOT } = require('../../../scripts/lib/paths');
 
 // Paths
-const APP_ROOT = path.join(__dirname, '..');
-const SRC_DIR = path.join(APP_ROOT, 'src');
-const BUILD_DIR = path.join(BUILD_ROOT, 'chat-ui');
+const APP_ROOT          = path.join(__dirname, '..');
+const BUILD_DIR         = path.join(BUILD_ROOT, 'chat-ui');
 const SERVER_STATIC_DIR = path.join(DIST_ROOT, 'server', 'static', 'chat');
 
-// State key for source fingerprint
-const SRC_HASH_KEY = 'chat-ui.srcHash';
+// Build inputs: own src + MF host + shared package + package.json
+const SRC_DIR       = path.join(APP_ROOT, 'src');
+const SHELL_UI_SRC  = path.join(PROJECT_ROOT, 'apps', 'shell-ui', 'src');
+const SHARED_UI_SRC = path.join(PROJECT_ROOT, 'packages', 'shared-ui', 'src');
+const PKG_JSON      = path.join(APP_ROOT, 'package.json');
+const BUILD_HASH_KEY = 'chat-ui.buildHash';
 
 // =============================================================================
-// Action Factories
+// ACTION FACTORIES
 // =============================================================================
 
-function makeBuildChatUiAction() {
-    return {
-        run: async (ctx, task) => {
-            // Check if source changed
-            const { changed, hash } = await hasSourceChanged(SRC_DIR, SRC_HASH_KEY);
-            const outputExists = await exists(BUILD_DIR);
+/**
+ * Bundles the chat-ui app via rsbuild with build-input caching.
+ */
+function makeBundleAction() {
+	return {
+		run: async (ctx, task) => {
+			// Check if any build inputs changed; skip when nothing moved.
+			if (!ctx.options.force) {
+				const { changed } = await hasBuildInputChanged(
+					BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
+				const outputExists = await exists(BUILD_DIR);
+				if (!changed && outputExists) {
+					task.output = 'No changes detected';
+					return;
+				}
+			}
 
-            if (!changed && outputExists) {
-                task.output = 'No changes detected';
-                return;
-            }
+			// Clean build output before rebuilding to prevent stale chunks
+			await removeDir(BUILD_DIR);
+			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
 
-            await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
-
-            // Save hash after successful build
-            await saveSourceHash(SRC_HASH_KEY, hash);
-        }
-    };
+			// Persist the hash so the next run can skip if nothing changed
+			const { hash } = await hasBuildInputChanged(
+				BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
+			await saveSourceHash(BUILD_HASH_KEY, hash);
+		},
+	};
 }
 
-function makeCopyChatUiAction() {
-    return {
-        run: async (ctx, task) => {
-            const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR, { package: true });
-            task.output = formatSyncStats(stats);
-        }
-    };
+/**
+ * Copies the built output to the server's static directory.
+ */
+function makeCopyAction() {
+	return {
+		run: async (ctx, task) => {
+			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR, { package: true });
+			task.output = formatSyncStats(stats);
+		},
+	};
 }
 
 // =============================================================================
-// Module Definition
+// MODULE DEFINITION
 // =============================================================================
 
 module.exports = {
-    name: 'chat-ui',
-    description: 'Chat Interface Application',
+	name: 'chat-ui',
+	description: 'Chat Interface Application',
 
-    actions: [
-        // Internal actions
-        { name: 'chat-ui:bundle', action: makeBuildChatUiAction },
-        { name: 'chat-ui:copy', action: makeCopyChatUiAction },
+	actions: [
+		{ name: 'chat-ui:bundle', action: makeBundleAction },
+		{ name: 'chat-ui:copy',   action: makeCopyAction },
 
-        // Public actions (have descriptions)
-        { name: 'chat-ui:build', action: () => ({
-            description: 'Build chat UI',
-            steps: [
-                'client-typescript:build',
-                'chat-ui:bundle',
-                'chat-ui:copy'
-            ]
-        })},
-        { name: 'chat-ui:dev', action: () => ({
-            description: 'Dev chat UI',
-            run: async (ctx, task) => {
-                task.output = 'Starting development server on http://localhost:3000';
-                await execCommand('npx', ['rsbuild', 'dev'], { task, cwd: APP_ROOT });
-            }
-        })},
-        { name: 'chat-ui:clean', action: () => ({
-            description: 'Clean chat UI',
-            run: async (ctx, task) => {
-                await removeDir(BUILD_DIR);
-                await removeDir(SERVER_STATIC_DIR);
-                await removeDir(path.join(APP_ROOT, 'dist'));
-                await setState(SRC_HASH_KEY, null);
-                task.output = 'Cleaned chat-ui';
-            }
-        })}
-    ]
+		{
+			name: 'chat-ui:build',
+			action: () => ({
+				description: 'Build chat-ui',
+				steps: [
+					'client-typescript:build',
+					'chat-ui:bundle',
+					'chat-ui:copy',
+				],
+			}),
+		},
+		{
+			name: 'chat-ui:dev',
+			action: () => ({
+				description: 'Starting chat-ui (dev)',
+				run: async (ctx, task) => {
+					task.output = 'Starting development server on http://localhost:3000';
+					await execCommand('npx', ['rsbuild', 'dev'], { task, cwd: APP_ROOT });
+				},
+			}),
+		},
+		{
+			name: 'chat-ui:clean',
+			action: () => ({
+				description: 'Cleaning chat-ui',
+				run: async (ctx, task) => {
+					await removeDir(BUILD_DIR);
+					await removeDir(SERVER_STATIC_DIR);
+					await removeDir(path.join(APP_ROOT, 'dist'));
+					await setState(BUILD_HASH_KEY, null);
+					task.output = 'Cleaned chat-ui';
+				},
+			}),
+		},
+	],
 };

--- a/apps/dropper-ui/scripts/tasks.js
+++ b/apps/dropper-ui/scripts/tasks.js
@@ -38,24 +38,18 @@ const BUILD_HASH_KEY = 'dropper-ui.buildHash';
 function makeBundleAction() {
 	return {
 		run: async (ctx, task) => {
-			// Check if any build inputs changed; skip when nothing moved.
-			if (!ctx.options.force) {
-				const { changed } = await hasBuildInputChanged(
-					BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
-				const outputExists = await exists(BUILD_DIR);
-				if (!changed && outputExists) {
-					task.output = 'No changes detected';
-					return;
-				}
+			// Fingerprint inputs before building so concurrent edits are detected on the next run.
+			const { changed, hash } = await hasBuildInputChanged(
+				BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
+			if (!ctx.options.force && !changed && (await exists(BUILD_DIR))) {
+				task.output = 'No changes detected';
+				return;
 			}
 
 			// Clean build output before rebuilding to prevent stale chunks
 			await removeDir(BUILD_DIR);
 			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
 
-			// Persist the hash so the next run can skip if nothing changed
-			const { hash } = await hasBuildInputChanged(
-				BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
 			await saveSourceHash(BUILD_HASH_KEY, hash);
 		},
 	};

--- a/apps/dropper-ui/scripts/tasks.js
+++ b/apps/dropper-ui/scripts/tasks.js
@@ -6,95 +6,118 @@
 
 /**
  * Dropper UI Build Module
- * 
+ *
  * React-based file dropper/uploader interface application.
  */
 const path = require('path');
 const {
-    execCommand, syncDir, formatSyncStats, removeDir, BUILD_ROOT, DIST_ROOT,
-    hasSourceChanged, saveSourceHash, setState, exists
+	execCommand, syncDir, formatSyncStats, removeDir, BUILD_ROOT, DIST_ROOT,
+	hasBuildInputChanged, saveSourceHash, setState, exists,
 } = require('../../../scripts/lib');
+const { PROJECT_ROOT } = require('../../../scripts/lib/paths');
 
 // Paths
-const APP_ROOT = path.join(__dirname, '..');
-const SRC_DIR = path.join(APP_ROOT, 'src');
-const BUILD_DIR = path.join(BUILD_ROOT, 'dropper-ui');
+const APP_ROOT          = path.join(__dirname, '..');
+const BUILD_DIR         = path.join(BUILD_ROOT, 'dropper-ui');
 const SERVER_STATIC_DIR = path.join(DIST_ROOT, 'server', 'static', 'dropper');
 
-// State key for source fingerprint
-const SRC_HASH_KEY = 'dropper-ui.srcHash';
+// Build inputs: own src + MF host + shared package + package.json
+const SRC_DIR       = path.join(APP_ROOT, 'src');
+const SHELL_UI_SRC  = path.join(PROJECT_ROOT, 'apps', 'shell-ui', 'src');
+const SHARED_UI_SRC = path.join(PROJECT_ROOT, 'packages', 'shared-ui', 'src');
+const PKG_JSON      = path.join(APP_ROOT, 'package.json');
+const BUILD_HASH_KEY = 'dropper-ui.buildHash';
 
 // =============================================================================
-// Action Factories
+// ACTION FACTORIES
 // =============================================================================
 
-function makeBuildDropperUiAction() {
-    return {
-        run: async (ctx, task) => {
-            // Check if source changed
-            const { changed, hash } = await hasSourceChanged(SRC_DIR, SRC_HASH_KEY);
-            const outputExists = await exists(BUILD_DIR);
+/**
+ * Bundles the dropper-ui app via rsbuild with build-input caching.
+ */
+function makeBundleAction() {
+	return {
+		run: async (ctx, task) => {
+			// Check if any build inputs changed; skip when nothing moved.
+			if (!ctx.options.force) {
+				const { changed } = await hasBuildInputChanged(
+					BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
+				const outputExists = await exists(BUILD_DIR);
+				if (!changed && outputExists) {
+					task.output = 'No changes detected';
+					return;
+				}
+			}
 
-            if (!changed && outputExists) {
-                task.output = 'No changes detected';
-                return;
-            }
+			// Clean build output before rebuilding to prevent stale chunks
+			await removeDir(BUILD_DIR);
+			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
 
-            await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
-
-            // Save hash after successful build
-            await saveSourceHash(SRC_HASH_KEY, hash);
-        }
-    };
+			// Persist the hash so the next run can skip if nothing changed
+			const { hash } = await hasBuildInputChanged(
+				BUILD_HASH_KEY, [SRC_DIR, SHELL_UI_SRC, SHARED_UI_SRC], [PKG_JSON]);
+			await saveSourceHash(BUILD_HASH_KEY, hash);
+		},
+	};
 }
 
-function makeCopyDropperUiAction() {
-    return {
-        run: async (ctx, task) => {
-            const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR, { package: true });
-            task.output = formatSyncStats(stats);
-        }
-    };
+/**
+ * Copies the built output to the server's static directory.
+ */
+function makeCopyAction() {
+	return {
+		run: async (ctx, task) => {
+			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR, { package: true });
+			task.output = formatSyncStats(stats);
+		},
+	};
 }
 
 // =============================================================================
-// Module Definition
+// MODULE DEFINITION
 // =============================================================================
 
 module.exports = {
-    name: 'dropper-ui',
-    description: 'File Dropper Application',
+	name: 'dropper-ui',
+	description: 'File Dropper Application',
 
-    actions: [
-        // Internal actions
-        { name: 'dropper-ui:bundle', action: makeBuildDropperUiAction },
-        { name: 'dropper-ui:copy', action: makeCopyDropperUiAction },
+	actions: [
+		{ name: 'dropper-ui:bundle', action: makeBundleAction },
+		{ name: 'dropper-ui:copy',   action: makeCopyAction },
 
-        // Public actions (have descriptions)
-        { name: 'dropper-ui:build', action: () => ({
-            description: 'Build dropper UI',
-            steps: [
-                'client-typescript:build',
-                'dropper-ui:bundle',
-                'dropper-ui:copy'
-            ]
-        })},
-        { name: 'dropper-ui:dev', action: () => ({
-            description: 'Dev dropper UI',
-            run: async (ctx, task) => {
-                task.output = 'Starting development server on http://localhost:3000';
-                await execCommand('npx', ['rsbuild', 'dev'], { task, cwd: APP_ROOT });
-            }
-        })},
-        { name: 'dropper-ui:clean', action: () => ({
-            description: 'Clean dropper UI',
-            run: async (ctx, task) => {
-                await removeDir(BUILD_DIR);
-                await removeDir(SERVER_STATIC_DIR);
-                await removeDir(path.join(APP_ROOT, 'dist'));
-                await setState(SRC_HASH_KEY, null);
-                task.output = 'Cleaned dropper-ui';
-            }
-        })}
-    ]
+		{
+			name: 'dropper-ui:build',
+			action: () => ({
+				description: 'Build dropper-ui',
+				steps: [
+					'client-typescript:build',
+					'dropper-ui:bundle',
+					'dropper-ui:copy',
+				],
+			}),
+		},
+		{
+			name: 'dropper-ui:dev',
+			action: () => ({
+				description: 'Starting dropper-ui (dev)',
+				run: async (ctx, task) => {
+					task.output = 'Starting development server on http://localhost:3000';
+					await execCommand('npx', ['rsbuild', 'dev'], { task, cwd: APP_ROOT });
+				},
+			}),
+		},
+		{
+			name: 'dropper-ui:clean',
+			action: () => ({
+				description: 'Cleaning dropper-ui',
+				run: async (ctx, task) => {
+					await removeDir(BUILD_DIR);
+					await removeDir(SERVER_STATIC_DIR);
+					await removeDir(path.join(APP_ROOT, 'dist'));
+					await setState(BUILD_HASH_KEY, null);
+					task.output = 'Cleaned dropper-ui';
+				},
+			}),
+		},
+	],
 };

--- a/apps/hello-ui/rsbuild.config.ts
+++ b/apps/hello-ui/rsbuild.config.ts
@@ -25,9 +25,16 @@ export default defineConfig(() => {
 					'./AppDescriptor': './src/AppDescriptor.ts',
 				},
 				dts: false,
+				// runtime: false — the host (shell-ui) provides the MF runtime;
+				// remotes don't embed their own copy, keeping remoteEntry.js
+				// stable across app-code-only rebuilds.
+				runtime: false,
 				shared: {
-					react: { singleton: true, requiredVersion: '^18.2.0' },
-					'react-dom': { singleton: true, requiredVersion: '^18.2.0' },
+					// eager: true makes shared-scope negotiation synchronous on
+					// both host and remote, eliminating the async deadlock that
+					// hangs the browser when only one remote is recompiled.
+					react: { singleton: true, eager: true, requiredVersion: '^18.2.0' },
+					'react-dom': { singleton: true, eager: true, requiredVersion: '^18.2.0' },
 					// import: false tells MF to NOT bundle a fallback copy —
 					// the host (shell-ui) always provides these at runtime.
 					// Without this, MF bundles the entire shared-ui tree

--- a/apps/hello-ui/scripts/tasks.js
+++ b/apps/hello-ui/scripts/tasks.js
@@ -24,110 +24,13 @@
  * Hello UI Build Module
  *
  * OSS landing page and dashboard — default app for non-SaaS installations.
- *
- * Actions:
- *   hello-ui:bundle   — run rsbuild build
- *   hello-ui:register — register app in apps.json manifest
- *   hello-ui:copy     — sync build output to dist/server/static/apps/hello-ui
- *   hello-ui:build    — full build: client-typescript → bundle → register → copy
- *   hello-ui:dev      — start rsbuild dev server
- *   hello-ui:clean    — remove build artifacts
  */
 const path = require('path');
-const {
-	execCommand,
-	syncDir,
-	formatSyncStats,
-	removeDir,
-	BUILD_ROOT,
-	DIST_ROOT,
-} = require('../../../scripts/lib');
-const { registerApp } = require('../../../scripts/lib/registerApp');
+const { createAppModule } = require('../../../scripts/lib/appModule');
 
-// Paths
-const APP_ROOT          = path.join(__dirname, '..');
-const BUILD_DIR         = path.join(BUILD_ROOT, 'apps', 'hello-ui');
-const SERVER_STATIC_DIR = path.join(DIST_ROOT, 'server', 'static', 'shell', 'apps', 'hello-ui');
-
-// =============================================================================
-// ACTION FACTORIES
-// =============================================================================
-
-/**
- * Bundles the hello-ui app via rsbuild.
- *
- * @returns {object} Action with run function.
- */
-function makeBundleAction() {
-	return {
-		run: async (ctx, task) => {
-			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
-		},
-	};
-}
-
-/**
- * Copies the built output to the server's static directory.
- *
- * @returns {object} Action with run function.
- */
-function makeCopyAction() {
-	return {
-		run: async (ctx, task) => {
-			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR);
-			task.output = formatSyncStats(stats);
-		},
-	};
-}
-
-// =============================================================================
-// MODULE DEFINITION
-// =============================================================================
-
-module.exports = {
+module.exports = createAppModule({
 	name: 'hello-ui',
 	description: 'RocketRide Hello — OSS Landing Application',
-
-	actions: [
-		// Internal actions (no description)
-		{ name: 'hello-ui:bundle',   action: makeBundleAction },
-		{ name: 'hello-ui:register', action: () => registerApp(APP_ROOT) },
-		{ name: 'hello-ui:copy',     action: makeCopyAction },
-
-		{
-			// Full build: compile TS client SDK, bundle, register in apps.json, copy to dist.
-			name: 'hello-ui:build',
-			action: () => ({
-				description: 'Build production bundle',
-				steps: [
-					'client-typescript:build',
-					'hello-ui:bundle',
-					'hello-ui:register',
-					'hello-ui:copy',
-				],
-			}),
-		},
-		{
-			name: 'hello-ui:dev',
-			action: () => ({
-				description: 'Start development server',
-				run: async (ctx, task) => {
-					task.output = 'Starting development server...';
-					await execCommand('npx', ['rsbuild', 'dev'], { task, cwd: APP_ROOT });
-				},
-			}),
-		},
-		{
-			name: 'hello-ui:clean',
-			action: () => ({
-				description: 'Clean build artifacts',
-				run: async (ctx, task) => {
-					await removeDir(BUILD_DIR);
-					await removeDir(SERVER_STATIC_DIR);
-					await removeDir(path.join(APP_ROOT, 'dist'));
-					task.output = 'Cleaned hello-ui';
-				},
-			}),
-		},
-	],
-};
+	appRoot: path.join(__dirname, '..'),
+	dev: true,
+});

--- a/apps/monitor-ui/rsbuild.config.ts
+++ b/apps/monitor-ui/rsbuild.config.ts
@@ -22,9 +22,16 @@ export default defineConfig(() => {
 					'./AppDescriptor': './src/AppDescriptor.ts',
 				},
 				dts: false,
+				// runtime: false — the host (shell-ui) provides the MF runtime;
+				// remotes don't embed their own copy, keeping remoteEntry.js
+				// stable across app-code-only rebuilds.
+				runtime: false,
 				shared: {
-					react: { singleton: true, requiredVersion: '^18.2.0' },
-					'react-dom': { singleton: true, requiredVersion: '^18.2.0' },
+					// eager: true makes shared-scope negotiation synchronous on
+					// both host and remote, eliminating the async deadlock that
+					// hangs the browser when only one remote is recompiled.
+					react: { singleton: true, eager: true, requiredVersion: '^18.2.0' },
+					'react-dom': { singleton: true, eager: true, requiredVersion: '^18.2.0' },
 					// import: false — host always provides these, no fallback needed.
 					'shell-ui': { singleton: true, requiredVersion: false, import: false },
 					'shared':   { singleton: true, requiredVersion: false, import: false },

--- a/apps/monitor-ui/scripts/tasks.js
+++ b/apps/monitor-ui/scripts/tasks.js
@@ -24,99 +24,12 @@
  * Monitor UI Build Module
  *
  * Server monitoring dashboard — connections, tasks, activity.
- *
- * Actions:
- *   monitor-ui:bundle   — run rsbuild build
- *   monitor-ui:register — register app in apps.json manifest
- *   monitor-ui:copy     — sync build output to dist/server/static/apps/monitor-ui
- *   monitor-ui:build    — full build: client-typescript → bundle → register → copy
- *   monitor-ui:clean    — remove build artifacts
  */
 const path = require('path');
-const {
-	execCommand,
-	syncDir,
-	formatSyncStats,
-	removeDir,
-	BUILD_ROOT,
-	DIST_ROOT,
-} = require('../../../scripts/lib');
-const { registerApp } = require('../../../scripts/lib/registerApp');
+const { createAppModule } = require('../../../scripts/lib/appModule');
 
-// Paths
-const APP_ROOT          = path.join(__dirname, '..');
-const BUILD_DIR         = path.join(BUILD_ROOT, 'apps', 'monitor-ui');
-const SERVER_STATIC_DIR = path.join(DIST_ROOT, 'server', 'static', 'shell', 'apps', 'monitor-ui');
-
-// =============================================================================
-// ACTION FACTORIES
-// =============================================================================
-
-/**
- * Bundles the monitor-ui app via rsbuild.
- *
- * @returns {object} Action with run function.
- */
-function makeBundleAction() {
-	return {
-		run: async (ctx, task) => {
-			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
-		},
-	};
-}
-
-/**
- * Copies the built output to the server's static directory.
- *
- * @returns {object} Action with run function.
- */
-function makeCopyAction() {
-	return {
-		run: async (ctx, task) => {
-			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR);
-			task.output = formatSyncStats(stats);
-		},
-	};
-}
-
-// =============================================================================
-// MODULE DEFINITION
-// =============================================================================
-
-module.exports = {
+module.exports = createAppModule({
 	name: 'monitor-ui',
 	description: 'Server Monitor Application',
-
-	actions: [
-		// Internal actions (no description)
-		{ name: 'monitor-ui:bundle',   action: makeBundleAction },
-		{ name: 'monitor-ui:register', action: () => registerApp(APP_ROOT) },
-		{ name: 'monitor-ui:copy',     action: makeCopyAction },
-
-		{
-			// Full build: compile TS client SDK, bundle, register in apps.json, copy to dist.
-			name: 'monitor-ui:build',
-			action: () => ({
-				description: 'Build production bundle',
-				steps: [
-					'client-typescript:build',
-					'monitor-ui:bundle',
-					'monitor-ui:register',
-					'monitor-ui:copy',
-				],
-			}),
-		},
-		{
-			name: 'monitor-ui:clean',
-			action: () => ({
-				description: 'Clean build artifacts',
-				run: async (ctx, task) => {
-					await removeDir(BUILD_DIR);
-					await removeDir(SERVER_STATIC_DIR);
-					await removeDir(path.join(APP_ROOT, 'dist'));
-					task.output = 'Cleaned monitor-ui';
-				},
-			}),
-		},
-	],
-};
+	appRoot: path.join(__dirname, '..'),
+});

--- a/apps/profiler-ui/rsbuild.config.ts
+++ b/apps/profiler-ui/rsbuild.config.ts
@@ -22,9 +22,16 @@ export default defineConfig(() => {
 					'./AppDescriptor': './src/AppDescriptor.ts',
 				},
 				dts: false,
+				// runtime: false — the host (shell-ui) provides the MF runtime;
+				// remotes don't embed their own copy, keeping remoteEntry.js
+				// stable across app-code-only rebuilds.
+				runtime: false,
 				shared: {
-					react: { singleton: true, requiredVersion: '^18.2.0' },
-					'react-dom': { singleton: true, requiredVersion: '^18.2.0' },
+					// eager: true makes shared-scope negotiation synchronous on
+					// both host and remote, eliminating the async deadlock that
+					// hangs the browser when only one remote is recompiled.
+					react: { singleton: true, eager: true, requiredVersion: '^18.2.0' },
+					'react-dom': { singleton: true, eager: true, requiredVersion: '^18.2.0' },
 					// import: false — host always provides these, no fallback needed.
 					'shell-ui': { singleton: true, requiredVersion: false, import: false },
 					'shared':   { singleton: true, requiredVersion: false, import: false },

--- a/apps/profiler-ui/scripts/tasks.js
+++ b/apps/profiler-ui/scripts/tasks.js
@@ -24,99 +24,12 @@
  * Profiler UI Build Module
  *
  * cProfile process profiler — start/stop sessions and view reports.
- *
- * Actions:
- *   profiler-ui:bundle   — run rsbuild build
- *   profiler-ui:register — register app in apps.json manifest
- *   profiler-ui:copy     — sync build output to dist/server/static/apps/profiler-ui
- *   profiler-ui:build    — full build: client-typescript → bundle → register → copy
- *   profiler-ui:clean    — remove build artifacts
  */
 const path = require('path');
-const {
-	execCommand,
-	syncDir,
-	formatSyncStats,
-	removeDir,
-	BUILD_ROOT,
-	DIST_ROOT,
-} = require('../../../scripts/lib');
-const { registerApp } = require('../../../scripts/lib/registerApp');
+const { createAppModule } = require('../../../scripts/lib/appModule');
 
-// Paths
-const APP_ROOT          = path.join(__dirname, '..');
-const BUILD_DIR         = path.join(BUILD_ROOT, 'apps', 'profiler-ui');
-const SERVER_STATIC_DIR = path.join(DIST_ROOT, 'server', 'static', 'shell', 'apps', 'profiler-ui');
-
-// =============================================================================
-// ACTION FACTORIES
-// =============================================================================
-
-/**
- * Bundles the profiler-ui app via rsbuild.
- *
- * @returns {object} Action with run function.
- */
-function makeBundleAction() {
-	return {
-		run: async (ctx, task) => {
-			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
-		},
-	};
-}
-
-/**
- * Copies the built output to the server's static directory.
- *
- * @returns {object} Action with run function.
- */
-function makeCopyAction() {
-	return {
-		run: async (ctx, task) => {
-			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR);
-			task.output = formatSyncStats(stats);
-		},
-	};
-}
-
-// =============================================================================
-// MODULE DEFINITION
-// =============================================================================
-
-module.exports = {
+module.exports = createAppModule({
 	name: 'profiler-ui',
 	description: 'cProfile Process Profiler',
-
-	actions: [
-		// Internal actions (no description)
-		{ name: 'profiler-ui:bundle',   action: makeBundleAction },
-		{ name: 'profiler-ui:register', action: () => registerApp(APP_ROOT) },
-		{ name: 'profiler-ui:copy',     action: makeCopyAction },
-
-		{
-			// Full build: compile TS client SDK, bundle, register in apps.json, copy to dist.
-			name: 'profiler-ui:build',
-			action: () => ({
-				description: 'Build production bundle',
-				steps: [
-					'client-typescript:build',
-					'profiler-ui:bundle',
-					'profiler-ui:register',
-					'profiler-ui:copy',
-				],
-			}),
-		},
-		{
-			name: 'profiler-ui:clean',
-			action: () => ({
-				description: 'Clean build artifacts',
-				run: async (ctx, task) => {
-					await removeDir(BUILD_DIR);
-					await removeDir(SERVER_STATIC_DIR);
-					await removeDir(path.join(APP_ROOT, 'dist'));
-					task.output = 'Cleaned profiler-ui';
-				},
-			}),
-		},
-	],
-};
+	appRoot: path.join(__dirname, '..'),
+});

--- a/apps/shell-ui/rsbuild.config.ts
+++ b/apps/shell-ui/rsbuild.config.ts
@@ -215,6 +215,15 @@ export default defineConfig(({ command }) => {
 			// Remove stale files from the output directory before each build to
 			// prevent leftover chunks from a previous build being served.
 			cleanDistPath: true,
+
+			// Copy theme JSON files into the build output so they are served at
+			// /shell/themes/*.json in both dev and production.  rsbuild's publicDir
+			// serves files at the root path, but assetPrefix: '/shell/' means the
+			// app requests /shell/themes/ — placing them in the build output
+			// ensures they resolve correctly under the prefix.
+			copy: [
+				{ from: path.resolve(__dirname, 'public/themes'), to: 'themes' },
+			],
 		},
 	};
 });

--- a/apps/shell-ui/scripts/tasks.js
+++ b/apps/shell-ui/scripts/tasks.js
@@ -43,12 +43,23 @@ const {
 	BUILD_ROOT,
 	DIST_ROOT,
 	isWindows,
+	hasBuildInputChanged,
+	saveSourceHash,
+	setState,
+	exists,
 } = require('../../../scripts/lib');
 
 // Paths
 const APP_ROOT = path.join(__dirname, '..');
 const BUILD_DIR = path.join(BUILD_ROOT, 'shell-ui');
 const SERVER_STATIC_DIR = path.join(DIST_ROOT, 'server', 'static', 'shell');
+
+// Source directories and files that affect the shell build output.
+// Shell bundles shared-ui with eager: true, so shared-ui changes require a rebuild.
+const SRC_DIR       = path.join(APP_ROOT, 'src');
+const SHARED_UI_SRC = path.join(APP_ROOT, '..', '..', 'packages', 'shared-ui', 'src');
+const PKG_JSON      = path.join(APP_ROOT, 'package.json');
+const BUILD_HASH_KEY = 'shell-ui.buildHash';
 
 // =============================================================================
 // HELPERS
@@ -98,7 +109,25 @@ async function killPort(port) {
 function makeBundleAction() {
 	return {
 		run: async (ctx, task) => {
+			// Check if any build inputs changed; skip rebuild when nothing moved.
+			if (!ctx.options.force) {
+				const { changed, hash } = await hasBuildInputChanged(
+					BUILD_HASH_KEY, [SRC_DIR, SHARED_UI_SRC], [PKG_JSON]);
+				const outputExists = await exists(BUILD_DIR);
+				if (!changed && outputExists) {
+					task.output = 'No changes detected';
+					return;
+				}
+			}
+
+			// Clean build output before rebuilding to prevent stale chunks
+			await removeDir(BUILD_DIR);
 			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
+
+			// Persist the hash so the next run can skip if nothing changed
+			const { hash } = await hasBuildInputChanged(
+				BUILD_HASH_KEY, [SRC_DIR, SHARED_UI_SRC], [PKG_JSON]);
+			await saveSourceHash(BUILD_HASH_KEY, hash);
 		},
 	};
 }
@@ -136,7 +165,7 @@ module.exports = {
 			// Full build: compile TS client SDK, bundle shell, copy to dist.
 			name: 'shell-ui:build',
 			action: () => ({
-				description: 'Build production shell bundle',
+				description: 'Build shell-ui',
 				steps: [
 					'client-typescript:build',
 					'shell-ui:bundle',
@@ -148,7 +177,7 @@ module.exports = {
 			// Start the rsbuild dev server with HTTPS on port 3000.
 			name: 'shell-ui:dev',
 			action: () => ({
-				description: 'Start development server',
+				description: 'Starting shell-ui (dev)',
 				run: async (_ctx, task) => {
 					// Kill any stale process holding port 3000 before starting rsbuild.
 					task.output = 'Clearing port 3000...';
@@ -161,11 +190,12 @@ module.exports = {
 		{
 			name: 'shell-ui:clean',
 			action: () => ({
-				description: 'Clean build artifacts',
+				description: 'Cleaning shell-ui',
 				run: async (_ctx, task) => {
 					await removeDir(BUILD_DIR);
 					await removeDir(SERVER_STATIC_DIR);
 					await removeDir(path.join(APP_ROOT, 'dist'));
+					await setState(BUILD_HASH_KEY, null);
 					task.output = 'Cleaned shell-ui';
 				},
 			}),

--- a/apps/shell-ui/scripts/tasks.js
+++ b/apps/shell-ui/scripts/tasks.js
@@ -109,24 +109,18 @@ async function killPort(port) {
 function makeBundleAction() {
 	return {
 		run: async (ctx, task) => {
-			// Check if any build inputs changed; skip rebuild when nothing moved.
-			if (!ctx.options.force) {
-				const { changed, hash } = await hasBuildInputChanged(
-					BUILD_HASH_KEY, [SRC_DIR, SHARED_UI_SRC], [PKG_JSON]);
-				const outputExists = await exists(BUILD_DIR);
-				if (!changed && outputExists) {
-					task.output = 'No changes detected';
-					return;
-				}
+			// Fingerprint inputs before building so concurrent edits are detected on the next run.
+			const { changed, hash } = await hasBuildInputChanged(
+				BUILD_HASH_KEY, [SRC_DIR, SHARED_UI_SRC], [PKG_JSON]);
+			if (!ctx.options.force && !changed && (await exists(BUILD_DIR))) {
+				task.output = 'No changes detected';
+				return;
 			}
 
 			// Clean build output before rebuilding to prevent stale chunks
 			await removeDir(BUILD_DIR);
 			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
 
-			// Persist the hash so the next run can skip if nothing changed
-			const { hash } = await hasBuildInputChanged(
-				BUILD_HASH_KEY, [SRC_DIR, SHARED_UI_SRC], [PKG_JSON]);
 			await saveSourceHash(BUILD_HASH_KEY, hash);
 		},
 	};

--- a/apps/shell-ui/src/components/layout/Shell.tsx
+++ b/apps/shell-ui/src/components/layout/Shell.tsx
@@ -164,7 +164,6 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 	// ── Desktop apps — derived from identity, falls back to static config ──
 	const apps = useMemo(() => {
 		if (identity?.apps?.length) {
-			console.log('identity.apps', identity.apps);
 			return registerAndMapApps(identity.apps as Parameters<typeof registerAndMapApps>[0]);
 		}
 		return config.apps;

--- a/apps/shell-ui/src/components/layout/Shell.tsx
+++ b/apps/shell-ui/src/components/layout/Shell.tsx
@@ -164,6 +164,7 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 	// ── Desktop apps — derived from identity, falls back to static config ──
 	const apps = useMemo(() => {
 		if (identity?.apps?.length) {
+			console.log('identity.apps', identity.apps);
 			return registerAndMapApps(identity.apps as Parameters<typeof registerAndMapApps>[0]);
 		}
 		return config.apps;

--- a/apps/shell-ui/src/lib/appLoader.ts
+++ b/apps/shell-ui/src/lib/appLoader.ts
@@ -73,16 +73,21 @@ export interface ServerAppEntry {
  * @returns Array of AppManifestEntry objects ready for the shell.
  */
 export function registerAndMapApps(serverApps: ServerAppEntry[]): AppManifestEntry[] {
+	// Drop entries missing a remoteEntry URL — the server may include
+	// apps that have no built UI yet (e.g. server-only nodes).
+	// Without this guard, MF's normalizeRemote crashes on undefined.
+	const validApps = serverApps.filter((a) => a.entry);
+
 	// Register all MF remotes so loadRemote() can resolve them.
 	// force: true overwrites any previously registered remotes (e.g. from
 	// the pre-auth probe) with the post-auth set.
 	registerRemotes(
-		serverApps.map((a) => ({ name: a.moduleId, entry: a.entry })),
+		validApps.map((a) => ({ name: a.moduleId, entry: a.entry })),
 		{ force: true },
 	);
 
 	// Map server entries to runtime AppManifestEntry objects with lazy loaders
-	return serverApps.map((a) => ({
+	return validApps.map((a) => ({
 		id:            a.id,
 		moduleId:      a.moduleId,
 		name:          a.name,

--- a/apps/shell-ui/src/views/account/AccountPage.tsx
+++ b/apps/shell-ui/src/views/account/AccountPage.tsx
@@ -76,13 +76,6 @@ const AccountPage: React.FC = () => {
 	const logout = useLogout();
 	const { appManifest } = useWorkspace();
 
-	// Build appId → displayName map from the manifest
-	const appNames = React.useMemo(() => {
-		const map: Record<string, string> = {};
-		for (const app of appManifest) map[app.id] = app.name;
-		return map;
-	}, [appManifest]);
-
 	// ── Navigation state ────────────────────────────────────────────────────
 	const [section, setSection] = useState<AccountSection>('profile');
 	const [activeTeamId, setActiveTeamId] = useState<string | null>(null);
@@ -424,7 +417,7 @@ const AccountPage: React.FC = () => {
 			billingError={billingError}
 			creditBalance={creditBalance}
 			creditPacks={creditPacks}
-			appNames={appNames}
+			apps={appManifest}
 			onCancelSubscription={handleCancelSubscription}
 			onOpenPortal={handleOpenPortal}
 			onBuyCredits={handleBuyCredits}

--- a/apps/shell-ui/src/views/billing/BillingPage.tsx
+++ b/apps/shell-ui/src/views/billing/BillingPage.tsx
@@ -32,6 +32,7 @@ import { BillingView } from 'shared';
 import type { BillingDetail, CreditBalance, CreditPack } from 'rocketride';
 import { useShellConnection } from '../../connection/ConnectionContext';
 import { useAuthUser } from '../../hooks/useAuthUser';
+import { useWorkspace } from '../../workspace/WorkspaceContext';
 
 // =============================================================================
 // COMPONENT
@@ -47,6 +48,7 @@ import { useAuthUser } from '../../hooks/useAuthUser';
 const BillingPage: React.FC<{ onClose?: () => void }> = ({ onClose }) => {
 	const { client, isConnected } = useShellConnection();
 	const identity = useAuthUser();
+	const { appManifest } = useWorkspace();
 
 	// ── State ────────────────────────────────────────────────────────────────
 	const [subscriptions, setSubscriptions] = useState<BillingDetail[]>([]);
@@ -137,6 +139,7 @@ const BillingPage: React.FC<{ onClose?: () => void }> = ({ onClose }) => {
 			onCancelSubscription={handleCancel}
 			onOpenPortal={handlePortal}
 			onBuyCredits={handleBuyCredits}
+			apps={appManifest}
 		/>
 	);
 };

--- a/apps/shell-ui/src/views/settings/SettingsPage.tsx
+++ b/apps/shell-ui/src/views/settings/SettingsPage.tsx
@@ -527,20 +527,31 @@ const SettingsPage: React.FC = () => {
 					placeholder="Search settings…"
 					style={styles.searchInput as CSSProperties}
 				/>
-				<button
-					onClick={handleSave}
-					disabled={!isDirty}
-					style={{
-						...commonStyles.buttonPrimary,
-						fontWeight: 600,
-						fontFamily: 'var(--rr-font-family)',
-						...(isDirty ? {} : commonStyles.buttonDisabled),
-					} as CSSProperties}
-				>
-					Save
-				</button>
 				{saved && (
 					<span style={{ fontSize: 13, color: 'var(--rr-color-success)' }}>Saved</span>
+				)}
+				{isDirty && (
+					<>
+						<button
+							onClick={() => { setDraft({}); setSaved(false); }}
+							style={{
+								...commonStyles.buttonSecondary,
+								fontFamily: 'var(--rr-font-family)',
+							} as CSSProperties}
+						>
+							Cancel
+						</button>
+						<button
+							onClick={handleSave}
+							style={{
+								...commonStyles.buttonPrimary,
+								fontWeight: 600,
+								fontFamily: 'var(--rr-font-family)',
+							} as CSSProperties}
+						>
+							Save
+						</button>
+					</>
 				)}
 			</div>
 

--- a/apps/vscode/scripts/tasks.js
+++ b/apps/vscode/scripts/tasks.js
@@ -268,7 +268,7 @@ module.exports = {
 		{
 			name: 'vscode:compile',
 			action: () => ({
-				description: 'Compiling vscode',
+				description: 'Compile vscode',
 				steps: ['client-typescript:build', 'vscode:build-webview', 'vscode:compile-typescript', 'vscode:bundle-extension'],
 			}),
 		},
@@ -282,7 +282,7 @@ module.exports = {
 		{
 			name: 'vscode:clean',
 			action: () => ({
-				description: 'Cleaning vscode',
+				description: 'Clean vscode',
 				run: async (ctx, task) => {
 					await removeDirs([BUILD_DIR, path.join(APP_ROOT, 'dist'), path.join(APP_ROOT, 'out'), VSCODE_DIST_DIR]);
 					await removeMatching(APP_ROOT, '.vsix');

--- a/apps/vscode/scripts/tasks.js
+++ b/apps/vscode/scripts/tasks.js
@@ -268,21 +268,21 @@ module.exports = {
 		{
 			name: 'vscode:compile',
 			action: () => ({
-				description: 'Compile VSCode extension',
+				description: 'Compiling vscode',
 				steps: ['client-typescript:build', 'vscode:build-webview', 'vscode:compile-typescript', 'vscode:bundle-extension'],
 			}),
 		},
 		{
 			name: 'vscode:build',
 			action: () => ({
-				description: 'Build VSCode extension',
+				description: 'Build vscode',
 				steps: ['client-typescript:build', 'vscode:copy-readme', 'vscode:build-webview', 'vscode:compile-typescript', 'vscode:bundle-extension', 'vscode:stage-files', 'vscode:package-vsix'],
 			}),
 		},
 		{
 			name: 'vscode:clean',
 			action: () => ({
-				description: 'Clean VSCode extension',
+				description: 'Cleaning vscode',
 				run: async (ctx, task) => {
 					await removeDirs([BUILD_DIR, path.join(APP_ROOT, 'dist'), path.join(APP_ROOT, 'out'), VSCODE_DIST_DIR]);
 					await removeMatching(APP_ROOT, '.vsix');

--- a/apps/vscode/src/providers/shared/connection-message-handler.ts
+++ b/apps/vscode/src/providers/shared/connection-message-handler.ts
@@ -172,16 +172,6 @@ export class ConnectionMessageHandler {
 			console.log(`[ConnectionMessageHandler] probeServerInfo result: capabilities=${JSON.stringify(info.capabilities)}, version=${info.version}`);
 			this.cachedServerInfo = info;
 			webview.postMessage({ type: 'serverInfo', ...info });
-
-			// If server is SaaS and user is signed in, fetch teams immediately
-			const caps: string[] = info.capabilities ?? [];
-			if (caps.includes('saas')) {
-				const cloudAuth = CloudAuthProvider.getInstance();
-				if (await cloudAuth.isSignedIn()) {
-					console.log('[ConnectionMessageHandler] SaaS + signed in — fetching teams');
-					await this.fetchCloudTeams(webview, hostUrl);
-				}
-			}
 		} catch (error) {
 			console.log(`[ConnectionMessageHandler] probeServerInfo FAILED: ${error}`);
 			// Fall back to showing all modes if probe fails
@@ -198,7 +188,6 @@ export class ConnectionMessageHandler {
 		const signedIn = await cloudAuth.isSignedIn();
 		const userName = await cloudAuth.getUserName();
 		webview.postMessage({ type: 'cloud:status', signedIn, userName });
-		// Teams are fetched by CloudPanel after it confirms the server is SaaS
 	}
 
 	/**

--- a/apps/vscode/src/providers/views/Account/AccountWebview.tsx
+++ b/apps/vscode/src/providers/views/Account/AccountWebview.tsx
@@ -326,6 +326,7 @@ const AccountWebview: React.FC = () => {
 			billingError={billingError}
 			creditBalance={creditBalance}
 			creditPacks={creditPacks}
+			apps={authUser?.apps ?? profile?.apps}
 			onCancelSubscription={handleCancelSubscription}
 			onOpenPortal={handleOpenPortal}
 			onBuyCredits={handleBuyCredits}

--- a/apps/vscode/src/providers/views/Settings/ConnectionSettings.tsx
+++ b/apps/vscode/src/providers/views/Settings/ConnectionSettings.tsx
@@ -23,6 +23,9 @@ interface ConnectionSettingsProps {
 	settings: SettingsData;
 	onSettingsChange: (settings: Partial<SettingsData>) => void;
 	onSave: () => void;
+	onCancel?: () => void;
+	dirty?: boolean;
+	saved?: boolean;
 	onClearCredentials: () => void;
 	onTestConnection: (hostUrl: string, apiKey: string) => void;
 	testMessage: MessageData | null;
@@ -106,7 +109,7 @@ export const ConnectionSettings: React.FC<ConnectionSettingsProps> = (props) => 
 			}}
 			id="developmentSection"
 		>
-			<SettingsCardHeader title="Development Mode" onSave={onSave} />
+			<SettingsCardHeader title="Development Mode" onSave={onSave} onCancel={props.onCancel} dirty={props.dirty} saved={props.saved} />
 			<div style={S.cardBody}>
 				<div style={S.sectionDescription}>Where pipelines run during development. Cloud and Direct Connect modes require authentication.</div>
 				<div style={S.formGrid}>

--- a/apps/vscode/src/providers/views/Settings/DebuggingSettings.tsx
+++ b/apps/vscode/src/providers/views/Settings/DebuggingSettings.tsx
@@ -32,20 +32,23 @@ interface DebuggingSettingsProps {
 	settings: SettingsData;
 	onSettingsChange: (settings: Partial<SettingsData>) => void;
 	onSave: () => void;
+	onCancel?: () => void;
+	dirty?: boolean;
+	saved?: boolean;
 }
 
 // ============================================================================
 // COMPONENT
 // ============================================================================
 
-export const DebuggingSettings: React.FC<DebuggingSettingsProps> = ({ settings, onSettingsChange, onSave }) => {
+export const DebuggingSettings: React.FC<DebuggingSettingsProps> = ({ settings, onSettingsChange, onSave, onCancel, dirty, saved }) => {
 	const handleRestartBehaviorChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
 		onSettingsChange({ pipelineRestartBehavior: e.target.value as 'auto' | 'manual' | 'prompt' });
 	};
 
 	return (
 		<div style={S.card}>
-			<SettingsCardHeader title="Debugging Settings" onSave={onSave} />
+			<SettingsCardHeader title="Debugging Settings" onSave={onSave} onCancel={onCancel} dirty={dirty} saved={saved} />
 			<div style={S.cardBody}>
 				<div style={S.sectionDescription}>Configure debugging and pipeline restart behavior</div>
 				<div style={S.formGrid}>

--- a/apps/vscode/src/providers/views/Settings/DeploySettings.tsx
+++ b/apps/vscode/src/providers/views/Settings/DeploySettings.tsx
@@ -26,6 +26,9 @@ interface DeploySettingsProps {
 	settings: SettingsData;
 	onSettingsChange: (settings: Partial<SettingsData>) => void;
 	onSave: () => void;
+	onCancel?: () => void;
+	dirty?: boolean;
+	saved?: boolean;
 	onClearCredentials: () => void;
 	onTestConnection: (hostUrl: string, apiKey: string) => void;
 	testMessage: MessageData | null;
@@ -98,7 +101,7 @@ export const DeploySettings: React.FC<DeploySettingsProps> = (props) => {
 
 	return (
 		<div style={S.card}>
-			<SettingsCardHeader title="Deployment Target" onSave={onSave} />
+			<SettingsCardHeader title="Deployment Target" onSave={props.onSave} onCancel={props.onCancel} dirty={props.dirty} saved={props.saved} />
 			<div style={S.cardBody}>
 				<div style={S.sectionDescription}>Where pipelines are deployed for production. Leave unchecked to deploy to the same target as development.</div>
 				<div style={S.formGrid}>

--- a/apps/vscode/src/providers/views/Settings/IntegrationSettings.tsx
+++ b/apps/vscode/src/providers/views/Settings/IntegrationSettings.tsx
@@ -32,6 +32,9 @@ interface IntegrationSettingsProps {
 	settings: SettingsData;
 	onSettingsChange: (settings: Partial<SettingsData>) => void;
 	onSave: () => void;
+	onCancel?: () => void;
+	dirty?: boolean;
+	saved?: boolean;
 }
 
 type BooleanKeys<T> = { [K in keyof T]: T[K] extends boolean ? K : never }[keyof T];
@@ -77,10 +80,10 @@ const INTEGRATIONS: { key: BooleanKeys<SettingsData>; label: string; description
 // COMPONENT
 // ============================================================================
 
-export const IntegrationSettings: React.FC<IntegrationSettingsProps> = ({ settings, onSettingsChange, onSave }) => {
+export const IntegrationSettings: React.FC<IntegrationSettingsProps> = ({ settings, onSettingsChange, onSave, onCancel, dirty, saved }) => {
 	return (
 		<div style={S.card}>
-			<SettingsCardHeader title="Integrations" onSave={onSave} />
+			<SettingsCardHeader title="Integrations" onSave={onSave} onCancel={onCancel} dirty={dirty} saved={saved} />
 			<div style={S.cardBody}>
 				<div style={S.sectionDescription}>Enable integrations with AI coding assistants</div>
 				<div style={S.formGrid}>

--- a/apps/vscode/src/providers/views/Settings/PipelineSettings.tsx
+++ b/apps/vscode/src/providers/views/Settings/PipelineSettings.tsx
@@ -32,20 +32,23 @@ interface PipelineSettingsProps {
 	settings: SettingsData;
 	onSettingsChange: (settings: Partial<SettingsData>) => void;
 	onSave: () => void;
+	onCancel?: () => void;
+	dirty?: boolean;
+	saved?: boolean;
 }
 
 // ============================================================================
 // COMPONENT
 // ============================================================================
 
-export const PipelineSettings: React.FC<PipelineSettingsProps> = ({ settings, onSettingsChange, onSave }) => {
+export const PipelineSettings: React.FC<PipelineSettingsProps> = ({ settings, onSettingsChange, onSave, onCancel, dirty, saved }) => {
 	const handleDefaultPipelinePathChange = (e: React.ChangeEvent<HTMLInputElement>) => {
 		onSettingsChange({ defaultPipelinePath: e.target.value });
 	};
 
 	return (
 		<div style={S.card}>
-			<SettingsCardHeader title="Pipeline Settings" onSave={onSave} />
+			<SettingsCardHeader title="Pipeline Settings" onSave={onSave} onCancel={onCancel} dirty={dirty} saved={saved} />
 			<div style={S.cardBody}>
 				<div style={S.sectionDescription}>Configure default settings for pipeline creation and management</div>
 				<div style={S.formGrid}>

--- a/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
+++ b/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
@@ -383,6 +383,7 @@ export const Settings: React.FC = () => {
 						if (clearAfter) setTimeout(() => setMessage(null), clearAfter);
 						// Show "Saved" in card header on successful save
 						if (message.level === 'success') {
+							savedSettingsRef.current = JSON.parse(JSON.stringify(settings));
 							setDirty(false);
 							setSaved(true);
 							setTimeout(() => setSaved(false), 5000);

--- a/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
+++ b/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
@@ -325,6 +325,7 @@ export const Settings: React.FC = () => {
 	const [dirty, setDirty] = useState(false);
 	const [saved, setSaved] = useState(false);
 	const savedSettingsRef = useRef<SettingsData | null>(null);
+	const pendingSaveSnapshotRef = useRef<SettingsData | null>(null);
 
 	// ========================================================================
 	// WEBVIEW MESSAGING
@@ -383,7 +384,8 @@ export const Settings: React.FC = () => {
 						if (clearAfter) setTimeout(() => setMessage(null), clearAfter);
 						// Show "Saved" in card header on successful save
 						if (message.level === 'success') {
-							savedSettingsRef.current = JSON.parse(JSON.stringify(settings));
+							savedSettingsRef.current = pendingSaveSnapshotRef.current ?? JSON.parse(JSON.stringify(settings)) as SettingsData;
+							pendingSaveSnapshotRef.current = null;
 							setDirty(false);
 							setSaved(true);
 							setTimeout(() => setSaved(false), 5000);
@@ -455,7 +457,9 @@ export const Settings: React.FC = () => {
 	 * Save all settings to extension storage
 	 */
 	const handleSaveSettings = (): void => {
-		sendMessage({ type: 'saveSettings', settings });
+		const snapshot = JSON.parse(JSON.stringify(settings)) as SettingsData;
+		pendingSaveSnapshotRef.current = snapshot;
+		sendMessage({ type: 'saveSettings', settings: snapshot });
 	};
 
 	/** Revert to last-saved settings and clear dirty state. */

--- a/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
+++ b/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
@@ -211,7 +211,7 @@ export const settingsStyles = {
 export const SettingsCardHeader: React.FC<{ title: string; onSave: () => void }> = ({ title, onSave }) => (
 	<div style={settingsStyles.cardHeader}>
 		{title}
-		<button style={commonStyles.buttonPrimary} onClick={onSave}>
+		<button style={{ ...commonStyles.buttonPrimary, ...commonStyles.cardHeaderButton }} onClick={onSave}>
 			Save All Settings
 		</button>
 	</div>

--- a/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
+++ b/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
@@ -21,7 +21,7 @@
 // SOFTWARE.
 // =============================================================================
 
-import React, { useState, useMemo, CSSProperties } from 'react';
+import React, { useState, useRef, useMemo, useCallback, CSSProperties } from 'react';
 import { useMessaging } from '../hooks/useMessaging';
 import { ConnectionSettings } from './ConnectionSettings';
 import { PipelineSettings } from './PipelineSettings';
@@ -208,12 +208,30 @@ export const settingsStyles = {
 // SHARED CARD HEADER WITH SAVE BUTTON
 // ============================================================================
 
-export const SettingsCardHeader: React.FC<{ title: string; onSave: () => void }> = ({ title, onSave }) => (
+export const SettingsCardHeader: React.FC<{
+	title: string;
+	onSave: () => void;
+	onCancel?: () => void;
+	dirty?: boolean;
+	saved?: boolean;
+}> = ({ title, onSave, onCancel, dirty, saved }) => (
 	<div style={settingsStyles.cardHeader}>
 		{title}
-		<button style={{ ...commonStyles.buttonPrimary, ...commonStyles.cardHeaderButton }} onClick={onSave}>
-			Save All Settings
-		</button>
+		<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+			{saved && <span style={{ fontSize: 11, color: 'var(--rr-color-success)' }}>Saved</span>}
+			{dirty && (
+				<>
+					{onCancel && (
+						<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardHeaderButton } as CSSProperties} onClick={onCancel}>
+							Cancel
+						</button>
+					)}
+					<button style={{ ...commonStyles.buttonPrimary, ...commonStyles.cardHeaderButton } as CSSProperties} onClick={onSave}>
+						Save All Settings
+					</button>
+				</>
+			)}
+		</div>
 	</div>
 );
 
@@ -303,6 +321,11 @@ export const Settings: React.FC = () => {
 	// Active settings tab
 	const [activeTab, setActiveTab] = useState('development');
 
+	// Dirty-state tracking — buttons only appear when user has edited something
+	const [dirty, setDirty] = useState(false);
+	const [saved, setSaved] = useState(false);
+	const savedSettingsRef = useRef<SettingsData | null>(null);
+
 	// ========================================================================
 	// WEBVIEW MESSAGING
 	// ========================================================================
@@ -313,6 +336,9 @@ export const Settings: React.FC = () => {
 			switch (message.type) {
 				case 'settingsLoaded':
 					setSettings(message.settings);
+					// Snapshot for cancel/reset and clear dirty state
+					savedSettingsRef.current = JSON.parse(JSON.stringify(message.settings));
+					setDirty(false);
 					if (message.settings.development.connectionMode === 'local') {
 						setEngineVersionsLoading(true);
 						sendMessage({ type: 'fetchEngineVersions' });
@@ -355,6 +381,12 @@ export const Settings: React.FC = () => {
 					} else {
 						setMessage(msg);
 						if (clearAfter) setTimeout(() => setMessage(null), clearAfter);
+						// Show "Saved" in card header on successful save
+						if (message.level === 'success') {
+							setDirty(false);
+							setSaved(true);
+							setTimeout(() => setSaved(false), 5000);
+						}
 					}
 					break;
 				}
@@ -425,6 +457,15 @@ export const Settings: React.FC = () => {
 		sendMessage({ type: 'saveSettings', settings });
 	};
 
+	/** Revert to last-saved settings and clear dirty state. */
+	const handleCancelSettings = useCallback((): void => {
+		if (savedSettingsRef.current) {
+			setSettings(JSON.parse(JSON.stringify(savedSettingsRef.current)));
+		}
+		setDirty(false);
+		setSaved(false);
+	}, []);
+
 	/**
 	 * Test development connection (run/debug server)
 	 */
@@ -460,6 +501,8 @@ export const Settings: React.FC = () => {
 	 * Update settings with partial changes
 	 */
 	const handleSettingsChange = (changes: Partial<SettingsData>): void => {
+		setDirty(true);
+		setSaved(false);
 		setSettings((prev) => {
 			const next = { ...prev };
 
@@ -576,6 +619,9 @@ export const Settings: React.FC = () => {
 							settings={settings}
 							onSettingsChange={handleSettingsChange}
 							onSave={handleSaveSettings}
+							onCancel={handleCancelSettings}
+							dirty={dirty}
+							saved={saved}
 							onClearCredentials={handleClearCredentials}
 							onTestDevelopmentConnection={handleTestConnection}
 							serverCapabilities={serverCapabilities}
@@ -632,6 +678,9 @@ export const Settings: React.FC = () => {
 							settings={settings}
 							onSettingsChange={handleSettingsChange}
 							onSave={handleSaveSettings}
+							onCancel={handleCancelSettings}
+							dirty={dirty}
+							saved={saved}
 							serverCapabilities={serverCapabilities}
 							teams={teams}
 							engineVersions={engineVersions}
@@ -684,7 +733,7 @@ export const Settings: React.FC = () => {
 				content: (
 					<div style={commonStyles.tabContent}>
 						<MessageDisplay message={message} />
-						<PipelineSettings settings={settings} onSettingsChange={handleSettingsChange} onSave={handleSaveSettings} />
+						<PipelineSettings settings={settings} onSettingsChange={handleSettingsChange} onSave={handleSaveSettings} onCancel={handleCancelSettings} dirty={dirty} saved={saved} />
 					</div>
 				),
 			},
@@ -692,7 +741,7 @@ export const Settings: React.FC = () => {
 				content: (
 					<div style={commonStyles.tabContent}>
 						<MessageDisplay message={message} />
-						<DebuggingSettings settings={settings} onSettingsChange={handleSettingsChange} onSave={handleSaveSettings} />
+						<DebuggingSettings settings={settings} onSettingsChange={handleSettingsChange} onSave={handleSaveSettings} onCancel={handleCancelSettings} dirty={dirty} saved={saved} />
 					</div>
 				),
 			},
@@ -700,7 +749,7 @@ export const Settings: React.FC = () => {
 				content: (
 					<div style={commonStyles.tabContent}>
 						<MessageDisplay message={message} />
-						<IntegrationSettings settings={settings} onSettingsChange={handleSettingsChange} onSave={handleSaveSettings} />
+						<IntegrationSettings settings={settings} onSettingsChange={handleSettingsChange} onSave={handleSaveSettings} onCancel={handleCancelSettings} dirty={dirty} saved={saved} />
 					</div>
 				),
 			},

--- a/apps/vscode/src/providers/views/components/panels/CloudPanel.tsx
+++ b/apps/vscode/src/providers/views/components/panels/CloudPanel.tsx
@@ -42,18 +42,22 @@ export interface CloudPanelProps {
 // COMPONENT
 // =============================================================================
 
-export const CloudPanel: React.FC<CloudPanelProps> = ({ cloudSignedIn, cloudUserName, onCloudSignIn, onCloudSignOut, teams, selectedTeamId, onTeamChange, idPrefix, isSaas, onProbeServer, onFetchTeams: _onFetchTeams }) => {
+export const CloudPanel: React.FC<CloudPanelProps> = ({ cloudSignedIn, cloudUserName, onCloudSignIn, onCloudSignOut, teams, selectedTeamId, onTeamChange, idPrefix, isSaas, onProbeServer, onFetchTeams }) => {
 	const id = (name: string) => `${idPrefix}-${name}`;
 	const theme = useTheme();
 
-	// Probe on mount to check if server supports cloud/OAuth.
-	// The probe also fetches teams automatically if SaaS + signed in,
-	// so no separate fetchTeams effect is needed.
-	// Probe the cloud endpoint on mount
 	const cloudUrl = process.env.ROCKETRIDE_URI || '';
+
+	// Step 1: Probe on mount to confirm server is SaaS.
 	useEffect(() => {
 		if (onProbeServer && cloudUrl) onProbeServer(cloudUrl);
 	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+	// Step 3: Once SaaS is confirmed and user is signed in, fetch teams.
+	// (Step 2 — sign-in — is handled by the Sign In button / auth listener.)
+	useEffect(() => {
+		if (isSaas && cloudSignedIn && onFetchTeams && cloudUrl) onFetchTeams(cloudUrl);
+	}, [isSaas, cloudSignedIn]); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return (
 		<>

--- a/apps/world-ui/rsbuild.config.ts
+++ b/apps/world-ui/rsbuild.config.ts
@@ -22,9 +22,16 @@ export default defineConfig(() => {
 					'./AppDescriptor': './src/AppDescriptor.ts',
 				},
 				dts: false,
+				// runtime: false — the host (shell-ui) provides the MF runtime;
+				// remotes don't embed their own copy, keeping remoteEntry.js
+				// stable across app-code-only rebuilds.
+				runtime: false,
 				shared: {
-					react: { singleton: true, requiredVersion: '^18.2.0' },
-					'react-dom': { singleton: true, requiredVersion: '^18.2.0' },
+					// eager: true makes shared-scope negotiation synchronous on
+					// both host and remote, eliminating the async deadlock that
+					// hangs the browser when only one remote is recompiled.
+					react: { singleton: true, eager: true, requiredVersion: '^18.2.0' },
+					'react-dom': { singleton: true, eager: true, requiredVersion: '^18.2.0' },
 					// import: false — host always provides these, no fallback needed.
 					'shell-ui': { singleton: true, requiredVersion: false, import: false },
 					'shared':   { singleton: true, requiredVersion: false, import: false },

--- a/apps/world-ui/scripts/tasks.js
+++ b/apps/world-ui/scripts/tasks.js
@@ -24,99 +24,12 @@
  * World UI Build Module
  *
  * Hello World demo application — reference MF remote app.
- *
- * Actions:
- *   world-ui:bundle   — run rsbuild build
- *   world-ui:register — register app in apps.json manifest
- *   world-ui:copy     — sync build output to dist/server/static/apps/world-ui
- *   world-ui:build    — full build: client-typescript → bundle → register → copy
- *   world-ui:clean    — remove build artifacts
  */
 const path = require('path');
-const {
-	execCommand,
-	syncDir,
-	formatSyncStats,
-	removeDir,
-	BUILD_ROOT,
-	DIST_ROOT,
-} = require('../../../scripts/lib');
-const { registerApp } = require('../../../scripts/lib/registerApp');
+const { createAppModule } = require('../../../scripts/lib/appModule');
 
-// Paths
-const APP_ROOT          = path.join(__dirname, '..');
-const BUILD_DIR         = path.join(BUILD_ROOT, 'apps', 'world-ui');
-const SERVER_STATIC_DIR = path.join(DIST_ROOT, 'server', 'static', 'shell', 'apps', 'world-ui');
-
-// =============================================================================
-// ACTION FACTORIES
-// =============================================================================
-
-/**
- * Bundles the world-ui app via rsbuild.
- *
- * @returns {object} Action with run function.
- */
-function makeBundleAction() {
-	return {
-		run: async (ctx, task) => {
-			await execCommand('npx', ['rsbuild', 'build'], { task, cwd: APP_ROOT });
-		},
-	};
-}
-
-/**
- * Copies the built output to the server's static directory.
- *
- * @returns {object} Action with run function.
- */
-function makeCopyAction() {
-	return {
-		run: async (ctx, task) => {
-			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR);
-			task.output = formatSyncStats(stats);
-		},
-	};
-}
-
-// =============================================================================
-// MODULE DEFINITION
-// =============================================================================
-
-module.exports = {
+module.exports = createAppModule({
 	name: 'world-ui',
 	description: 'Hello World Demo Application',
-
-	actions: [
-		// Internal actions (no description)
-		{ name: 'world-ui:bundle',   action: makeBundleAction },
-		{ name: 'world-ui:register', action: () => registerApp(APP_ROOT) },
-		{ name: 'world-ui:copy',     action: makeCopyAction },
-
-		{
-			// Full build: compile TS client SDK, bundle, register in apps.json, copy to dist.
-			name: 'world-ui:build',
-			action: () => ({
-				description: 'Build production bundle',
-				steps: [
-					'client-typescript:build',
-					'world-ui:bundle',
-					'world-ui:register',
-					'world-ui:copy',
-				],
-			}),
-		},
-		{
-			name: 'world-ui:clean',
-			action: () => ({
-				description: 'Clean build artifacts',
-				run: async (ctx, task) => {
-					await removeDir(BUILD_DIR);
-					await removeDir(SERVER_STATIC_DIR);
-					await removeDir(path.join(APP_ROOT, 'dist'));
-					task.output = 'Cleaned world-ui';
-				},
-			}),
-		},
-	],
-};
+	appRoot: path.join(__dirname, '..'),
+});

--- a/nodes/scripts/tasks.js
+++ b/nodes/scripts/tasks.js
@@ -236,7 +236,7 @@ function makeRunContractTestsAction() {
 
 function makeTestAction(options = {}) {
     return {
-        description: 'Test pipeline nodes (full integration)',
+        description: 'Testing nodes',
         steps: [
             'server:build',
             parallel([
@@ -278,17 +278,17 @@ module.exports = {
 
         // Public actions (have descriptions)
         { name: 'nodes:build', action: () => ({
-            description: 'Build pipeline nodes',
+            description: 'Build nodes',
             steps: ['server:build', 'nodes:sync']
         })},
         { name: 'nodes:test', action: (options) => makeTestAction({ ...options, test_full: false }) },
         { name: 'nodes:test-full', action: (options) => makeTestAction({ ...options, test_full: true }) },
         { name: 'nodes:test-contracts', action: () => ({
-            description: 'Test node contracts',
+            description: 'Testing nodes (contracts)',
             steps: ['server:build', 'nodes:run-contracts']
         })},
         { name: 'nodes:clean', action: () => ({
-            description: 'Clean pipeline nodes',
+            description: 'Cleaning nodes',
             run: async (ctx, task) => {
                 await removeDir(DIST_DIR);
                 task.output = 'Cleaned nodes';

--- a/nodes/src/nodes/audio_tts/IGlobal.py
+++ b/nodes/src/nodes/audio_tts/IGlobal.py
@@ -58,8 +58,7 @@ class IGlobal(IGlobalBase):
 
         addr = get_model_server_address()
         if addr:
-            host, port = addr
-            self._remote_client = ModelClient(port, host)
+            self._remote_client = ModelClient(addr)
             self._remote_client.load_model(
                 _KOKORO_REPO_ID,
                 _KOKORO_LOADER_TYPE,

--- a/packages/ai/scripts/tasks.js
+++ b/packages/ai/scripts/tasks.js
@@ -116,13 +116,13 @@ module.exports = {
         // Public actions (have descriptions)
         {
             name: 'ai:build', action: () => ({
-                description: 'Build AI modules',
+                description: 'Build ai',
                 steps: ['server:build', 'ai:sync']
             })
         },
         {
             name: 'ai:test', action: () => ({
-                description: 'Test AI modules',
+                description: 'Testing ai',
                 steps: [
                     'ai:build',
                     'ai:run-pytest'
@@ -131,7 +131,7 @@ module.exports = {
         },
         {
             name: 'ai:clean', action: () => ({
-                description: 'Clean AI modules',
+                description: 'Cleaning ai',
                 run: async (ctx, task) => {
                     const { removeDir } = require('../../../scripts/lib');
                     await removeDir(DIST_DIR);

--- a/packages/ai/src/ai/common/models/audio/whisper.py
+++ b/packages/ai/src/ai/common/models/audio/whisper.py
@@ -488,8 +488,7 @@ class Whisper:
         if should_proxy:
             # === REMOTE MODE ===
             self._proxy_mode = True
-            host, port = server_addr
-            self._client = ModelClient(port, host)
+            self._client = ModelClient(server_addr)
             self._model = None
             self._metadata = {}
             self._init_proxy()

--- a/packages/ai/src/ai/common/models/base.py
+++ b/packages/ai/src/ai/common/models/base.py
@@ -1,8 +1,34 @@
-"""
-Base Model Client: Shared WebSocket/DAP client for model proxies.
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
-This module provides the base functionality for communicating with the
-model server over WebSocket using DAP protocol.
+"""
+Base Model Client: Shared client for model server proxies.
+
+ModelClient subclasses RocketRideClient with ws_path='/models' so it
+connects to the model server endpoint.  All URI normalisation, protocol
+selection (ws vs wss), auth, and reconnection are handled by the SDK.
+
+get_model_server_address() reads --modelserver=<addr> from sys.argv and
+returns the raw string — no parsing or URL construction.
 """
 
 import hashlib
@@ -12,8 +38,13 @@ import asyncio
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
-from ai.common.dap import DAPClient, TransportWebSocket
+from rocketride import RocketRideClient
 from ai import node as ai_node
+
+
+# =============================================================================
+# BASE LOADER
+# =============================================================================
 
 
 class BaseLoader:
@@ -158,76 +189,64 @@ class BaseLoader:
         raise NotImplementedError('Subclasses must implement postprocess()')
 
 
-def get_model_server_address() -> Optional[tuple]:
+# =============================================================================
+# MODEL SERVER ADDRESS
+# =============================================================================
+
+
+def get_model_server_address() -> Optional[str]:
     """
     Extract --modelserver=<address> from command line arguments.
 
-    Accepts:
-        --modelserver=5590          -> ('localhost', 5590)
-        --modelserver=localhost:5590 -> ('localhost', 5590)
-        --modelserver=192.168.1.1:5590 -> ('192.168.1.1', 5590)
+    Returns the raw address string exactly as provided — no parsing,
+    no protocol prefixing.  The RocketRide client SDK handles URI
+    normalisation (ws vs wss, default ports, etc.).
+
+    Accepts any format the client SDK understands:
+        --modelserver=5590
+        --modelserver=localhost:5590
+        --modelserver=model.rocketride.dev:443
+        --modelserver=wss://model.rocketride.dev:443
 
     Returns:
-        (host, port) tuple if found, None otherwise
+        Address string if --modelserver is set, None otherwise.
     """
     for arg in sys.argv:
         if arg.startswith('--modelserver='):
-            try:
-                value = arg.split('=')[1]
-                if ':' in value:
-                    # Full address: host:port
-                    host, port_str = value.rsplit(':', 1)
-                    return (host, int(port_str))
-                else:
-                    # Just port number
-                    return ('localhost', int(value))
-            except (IndexError, ValueError):
-                return None
+            value = arg.split('=', 1)[1]
+            return value if value else None
     return None
 
 
-def get_model_server_port() -> Optional[int]:
+# =============================================================================
+# MODEL CLIENT
+# =============================================================================
+
+
+class ModelClient(RocketRideClient):
     """
-    Legacy function - returns just the port number.
+    Client for communicating with the model server.
 
-    Returns:
-        Port number if --modelserver is set, None otherwise
-    """
-    addr = get_model_server_address()
-    return addr[1] if addr else None
+    Subclasses RocketRideClient with ws_path='/models' so all URI
+    normalisation, protocol selection, auth, and transport management
+    are inherited from the SDK.
 
-
-class ModelClient:
-    """
-    Simple DAP client for communicating with model server.
-
-    This class provides a shared connection that multiple threads can use
-    concurrently. DAP supports concurrent commands over a single connection.
-
-    Attributes:
-        port (int): Model server port
-        url (str): WebSocket URL for model server
-        client (DAPClient): DAP client for communication
-        model_id (Optional[str]): Server-assigned model ID
-        metadata (Dict): Model metadata from server
-        _model_name (Optional[str]): Model name to load
-        _model_type (Optional[str]): Model type
-        _model_kwargs (Dict): Model loading arguments
-        _connect_lock (asyncio.Lock): Lock for thread-safe connection
+    Adds model-specific functionality:
+    - load_model / unload via rrext_ms_load_model / rrext_ms_unload_model
+    - send_command with auto-reconnect and model reload on transport errors
+    - Metrics recording from server-reported perf counters
     """
 
-    def __init__(self, port: int, host: str = 'localhost'):
+    def __init__(self, address: str):
         """
         Initialize the model client.
 
         Args:
-            port: Model server port number
-            host: Model server host (default: localhost)
+            address: Model server address in any format the client SDK
+                     understands (e.g. "5590", "localhost:5590",
+                     "model.rocketride.dev:443", "wss://host:443").
         """
-        self.port = port
-        self.host = host
-        self.url = f'ws://{host}:{port}/models'
-        self.client: Optional[DAPClient] = None
+        super().__init__(uri=address, module='MODEL_CLIENT', ws_path='/models')
         self.model_id: Optional[str] = None
         self.metadata: Dict = {}
         self._model_name: Optional[str] = None
@@ -278,7 +297,7 @@ class ModelClient:
         async with self._connect_lock:
             # Double-check if already connected (prevents multiple
             # threads from reconnecting simultaneously)
-            if self.client and self.client._transport.is_connected():
+            if self.is_connected():
                 return
 
             # Retry parameters
@@ -290,25 +309,20 @@ class ModelClient:
 
             while True:
                 try:
-                    # Clean up old connection if any (reconnection scenario)
-                    if self.client:
+                    # Disconnect old connection if any (reconnection scenario)
+                    if self.is_connected():
                         print('[MODEL_CLIENT] Disconnecting old client')
                         try:
-                            await self.client.disconnect()
+                            await super().disconnect()
                         except Exception:
                             pass  # Ignore errors during cleanup
-                    else:
-                        # Create a new client connection
-                        print(f'[MODEL_CLIENT] Creating new client for {self.url}')
-                        transport = TransportWebSocket(self.url)
-                        self.client = DAPClient(module='MODEL_CLIENT', transport=transport)
 
                     # Clear model ID before reconnection
                     self.model_id = None
 
-                    # Connect (or reconnect) to server
-                    print(f'[MODEL_CLIENT] Connecting to {self.url} (attempt {attempt + 1})')
-                    await self.client.connect()
+                    # Connect to server using RocketRideClient.connect()
+                    print(f'[MODEL_CLIENT] Connecting to {self._uri} (attempt {attempt + 1})')
+                    await super().connect()
                     print('[MODEL_CLIENT] Connected successfully')
 
                     # Load model on server (if model info is stored)
@@ -324,8 +338,7 @@ class ModelClient:
                         if self._loader_options:
                             arguments['loader_options'] = self._loader_options
 
-                        request = self.client.build_request('rrext_ms_load_model', arguments=arguments)
-                        result = await self.client.request(request)
+                        result = await super().request(self.build_request('rrext_ms_load_model', arguments=arguments))
 
                         # Check for errors in response
                         if not result.get('success', True):
@@ -366,35 +379,31 @@ class ModelClient:
 
                     await asyncio.sleep(delay)
 
-    def disconnect(self) -> None:
-        """Disconnect from model server."""
-        # Run async disconnect on global event loop
-        future = asyncio.run_coroutine_threadsafe(self._disconnect_async(), ai_node.server_loop)
-        future.result()  # Block until complete
-
     async def _disconnect_async(self) -> None:
-        """Disconnect from server asynchronously (internal use only)."""
+        """Disconnect from server, unloading the model first."""
         async with self._connect_lock:
-            # If we have a connection and loaded model
-            if self.client and self.model_id:
+            if self.is_connected() and self.model_id:
                 # Unload model from server first
-                if self.model_id:
-                    try:
-                        request = self.client.build_request(
-                            'rrext_ms_unload_model', arguments={'model_id': self.model_id}
-                        )
-                        await self.client.request(request)
-                    except Exception:
-                        pass  # Ignore errors during cleanup
+                try:
+                    await super().request(
+                        self.build_request('rrext_ms_unload_model', arguments={'model_id': self.model_id})
+                    )
+                except Exception:
+                    pass  # Ignore errors during cleanup
 
-                    # Reset model
-                    self.model_id = None
+                self.model_id = None
 
-                # Close WebSocket connection
-                await self.client.disconnect()
+            await super().disconnect()
 
-                # Release the client - we will get a new one if we connect again
-                self.client = None
+    def disconnect(self) -> None:
+        """Disconnect from model server (synchronous).
+
+        Overrides the async RocketRideClient.disconnect() because ModelClient
+        callers (model wrappers, tests, OCR cleanup) call disconnect()
+        synchronously from worker threads.
+        """
+        future = asyncio.run_coroutine_threadsafe(self._disconnect_async(), ai_node.server_loop)
+        future.result()
 
     def send_command(self, command: str, arguments: Dict[str, Any], retry_on_error: bool = True) -> Any:
         """
@@ -424,7 +433,7 @@ class ModelClient:
 
         # Record server-reported perf counters (preprocess, gpu, postprocess,
         # queue_wait, latency) into the metrics singleton — one call covers
-        # all 9 model wrappers that go through ModelClient
+        # all model wrappers that go through ModelClient
         perf = body.get('perf') if isinstance(body, dict) else None
         if perf:
             from ai.web.metrics import metrics
@@ -446,8 +455,9 @@ class ModelClient:
             # Send the DAP request over WebSocket.  Transport-level failures
             # (connection dropped, WebSocket error) raise here and are caught
             # by the except below for retry.
-            request = self.client.build_request(command, arguments={**arguments, 'model_id': self.model_id})
-            response = await self.client.request(request)
+            response = await super().request(
+                self.build_request(command, arguments={**arguments, 'model_id': self.model_id})
+            )
         except BaseException as e:
             # Transport-level failure — reconnect and retry once if allowed
             print(f'[MODEL_CLIENT] Transport error for "{command}": {e}')
@@ -461,16 +471,14 @@ class ModelClient:
             # Retry the command once after successful reconnection
             print(f'[MODEL_CLIENT] Retrying command "{command}" with model_id={self.model_id}')
             try:
-                request = self.client.build_request(command, arguments={**arguments, 'model_id': self.model_id})
-                response = await self.client.request(request)
+                response = await super().request(
+                    self.build_request(command, arguments={**arguments, 'model_id': self.model_id})
+                )
             except BaseException as retry_error:
                 print(f'[MODEL_CLIENT] Retry failed for "{command}": {retry_error}')
                 raise
 
         # Check if the server returned an error in the response.
-        # The round-trip succeeded (we got a valid DAP message back) but
-        # the server reported a failure (e.g. batch processing crashed).
-        # Do not retry — propagate immediately to the caller.
         if not response.get('success', True):
             error_msg = response.get('message', 'Unknown error')
             raise RuntimeError(f'Command failed: {error_msg}')

--- a/packages/ai/src/ai/common/models/gliner/gliner.py
+++ b/packages/ai/src/ai/common/models/gliner/gliner.py
@@ -342,8 +342,7 @@ class GLiNER:
         if should_proxy:
             # === REMOTE MODE ===
             self._proxy_mode = True
-            host, port = server_addr
-            self._client = ModelClient(port, host)
+            self._client = ModelClient(server_addr)
             self._model = None
             self._metadata = {}
             self._init_proxy()

--- a/packages/ai/src/ai/common/models/ocr/doctr.py
+++ b/packages/ai/src/ai/common/models/ocr/doctr.py
@@ -239,10 +239,9 @@ class DocTR:
             **self._kwargs,
         )
 
-    def _init_proxy(self, server_addr: tuple) -> None:
+    def _init_proxy(self, server_addr: str) -> None:
         """Initialize proxy to model server."""
-        host, port = server_addr
-        self._client = ModelClient(port=port, host=host)
+        self._client = ModelClient(server_addr)
         self._client.load_model(
             model_name='doctr',
             model_type='doctr',

--- a/packages/ai/src/ai/common/models/ocr/easyocr.py
+++ b/packages/ai/src/ai/common/models/ocr/easyocr.py
@@ -339,10 +339,9 @@ class EasyOCR:
             **self._kwargs,
         )
 
-    def _init_proxy(self, server_addr: tuple) -> None:
+    def _init_proxy(self, server_addr: str) -> None:
         """Initialize proxy to model server."""
-        host, port = server_addr
-        self._client = ModelClient(port=port, host=host)
+        self._client = ModelClient(server_addr)
         self._client.load_model(
             model_name='easyocr',
             model_type='easyocr',

--- a/packages/ai/src/ai/common/models/ocr/surya.py
+++ b/packages/ai/src/ai/common/models/ocr/surya.py
@@ -256,10 +256,9 @@ class Surya:
             **self._kwargs,
         )
 
-    def _init_proxy(self, server_addr: tuple) -> None:
+    def _init_proxy(self, server_addr: str) -> None:
         """Initialize proxy to model server."""
-        host, port = server_addr
-        self._client = ModelClient(port=port, host=host)
+        self._client = ModelClient(server_addr)
         self._client.load_model(
             model_name='surya',
             model_type='surya',

--- a/packages/ai/src/ai/common/models/ocr/trocr.py
+++ b/packages/ai/src/ai/common/models/ocr/trocr.py
@@ -344,10 +344,9 @@ class TrOCR:
             **self._kwargs,
         )
 
-    def _init_proxy(self, server_addr: tuple) -> None:
+    def _init_proxy(self, server_addr: str) -> None:
         """Initialize proxy to model server."""
-        host, port = server_addr
-        self._client = ModelClient(port=port, host=host)
+        self._client = ModelClient(server_addr)
         self._client.load_model(
             model_name='trocr',
             model_type='trocr',

--- a/packages/ai/src/ai/common/models/transformers/sentence_transformers.py
+++ b/packages/ai/src/ai/common/models/transformers/sentence_transformers.py
@@ -301,8 +301,7 @@ class SentenceTransformer:
         if should_proxy:
             # === REMOTE MODE ===
             self._proxy_mode = True
-            host, port = server_addr
-            self._client = ModelClient(port, host)
+            self._client = ModelClient(server_addr)
             self._model = None
             self._metadata = {}
             self._init_proxy()

--- a/packages/ai/src/ai/common/models/transformers/transformers.py
+++ b/packages/ai/src/ai/common/models/transformers/transformers.py
@@ -501,8 +501,7 @@ def pipeline(
     output_fields = output_fields or _get_output_fields_for_task(task)
 
     if should_proxy:
-        host, port = server_addr
-        return PipelineProxy(task, model, port, host, output_fields, **kwargs)
+        return PipelineProxy(task, model, server_addr, output_fields, **kwargs)
     else:
         return PipelineLocal(task, model, output_fields, device, **kwargs)
 
@@ -514,8 +513,7 @@ class PipelineProxy:
         self,
         task: str,
         model: Optional[str],
-        port: int,
-        host: str,
+        address: str,
         output_fields: List[str],
         **kwargs,
     ):
@@ -524,7 +522,7 @@ class PipelineProxy:
         self.model = model
         self.output_fields = output_fields
         self.kwargs = kwargs
-        self._client = ModelClient(port, host)
+        self._client = ModelClient(address)
         self._metadata: dict = {}
 
         self._init_proxy()
@@ -657,8 +655,7 @@ class AutoModel:
         output_fields = output_fields or ['output']
 
         if should_proxy:
-            host, port = server_addr
-            return ModelProxy(model_name, port, host, output_fields, **kwargs)
+            return ModelProxy(model_name, server_addr, output_fields, **kwargs)
         else:
             return ModelLocal(model_name, output_fields, device, **kwargs)
 
@@ -669,8 +666,7 @@ class ModelProxy:
     def __init__(
         self,
         model_name: str,
-        port: int,
-        host: str,
+        address: str,
         output_fields: List[str],
         **kwargs,
     ):
@@ -678,7 +674,7 @@ class ModelProxy:
         self.model_name = model_name
         self.output_fields = output_fields
         self.kwargs = kwargs
-        self._client = ModelClient(port, host)
+        self._client = ModelClient(address)
 
         self._init_proxy()
 

--- a/packages/ai/src/ai/common/models/vision/vision.py
+++ b/packages/ai/src/ai/common/models/vision/vision.py
@@ -275,8 +275,7 @@ class CLIPModel:
         should_proxy = server_addr and (device is None or device == 'server')
 
         if should_proxy:
-            host, port = server_addr
-            client = ModelClient(port, host)
+            client = ModelClient(server_addr)
             loader_options = {'variant': 'clip', 'output_spec': output_spec, **kwargs}
             client.load_model(
                 model_name=model_name,
@@ -338,8 +337,7 @@ class ViTModel:
         should_proxy = server_addr and (device is None or device == 'server')
 
         if should_proxy:
-            host, port = server_addr
-            client = ModelClient(port, host)
+            client = ModelClient(server_addr)
             loader_options = {'variant': 'vit', 'output_spec': output_spec, **kwargs}
             client.load_model(
                 model_name=model_name,

--- a/packages/ai/tests/ai/common/models/audio/test_whisper.py
+++ b/packages/ai/tests/ai/common/models/audio/test_whisper.py
@@ -124,7 +124,7 @@ def test_transcribe_requires_bytes():
     # to avoid loading. We only test the type check at the start of transcribe().
     from unittest.mock import patch, MagicMock
 
-    with patch('ai.common.models.audio.whisper.get_model_server_address', return_value=('localhost', 5590)):
+    with patch('ai.common.models.audio.whisper.get_model_server_address', return_value='localhost:5590'):
         with patch('ai.common.models.audio.whisper.ModelClient') as MockClient:
             mock_client = MagicMock()
             MockClient.return_value = mock_client

--- a/packages/ai/tests/ai/web/metrics/test_gpu_guard.py
+++ b/packages/ai/tests/ai/web/metrics/test_gpu_guard.py
@@ -119,7 +119,7 @@ class TestInstallGPUGuard:
     def test_installs_when_model_server_set(self):
         """install_gpu_guard should install hook when --modelserver is set."""
         # Patch get_model_server_address to simulate --modelserver=5590
-        with patch('ai.common.models.gpu_guard.get_model_server_address', return_value=('localhost', 5590)):
+        with patch('ai.common.models.gpu_guard.get_model_server_address', return_value='localhost:5590'):
             install_gpu_guard()
 
         # Verify a blocker was installed in sys.meta_path
@@ -138,7 +138,7 @@ class TestInstallGPUGuard:
 
     def test_idempotent(self):
         """Calling install_gpu_guard multiple times should only install once."""
-        with patch('ai.common.models.gpu_guard.get_model_server_address', return_value=('localhost', 5590)):
+        with patch('ai.common.models.gpu_guard.get_model_server_address', return_value='localhost:5590'):
             install_gpu_guard()
             install_gpu_guard()
             install_gpu_guard()

--- a/packages/client-mcp/scripts/tasks.js
+++ b/packages/client-mcp/scripts/tasks.js
@@ -219,7 +219,7 @@ module.exports = {
 
         // Public actions (have descriptions)
         { name: 'client-mcp:build', action: () => ({
-            description: 'Build MCP client',
+            description: 'Build client-mcp',
             steps: [
                 'server:build',
                 'client-mcp:sync-source',
@@ -229,7 +229,7 @@ module.exports = {
         })},
         { name: 'client-mcp:build-wheel', action: makeBuildWheelAction },
         { name: 'client-mcp:test', action: () => ({
-            description: 'Test MCP client',
+            description: 'Testing client-mcp',
             steps: [
                 'server:build',
                 parallel([
@@ -247,7 +247,7 @@ module.exports = {
             ]
         })},
         { name: 'client-mcp:clean', action: () => ({
-            description: 'Clean MCP client',
+            description: 'Cleaning client-mcp',
             run: async (ctx, task) => {
                 await removeDirs([
                     path.join(PACKAGE_DIR, 'build'),

--- a/packages/client-python/scripts/tasks.js
+++ b/packages/client-python/scripts/tasks.js
@@ -246,14 +246,14 @@ module.exports = {
 		{
 			name: 'client-python:build',
 			action: () => ({
-				description: 'Build Python client',
+				description: 'Build client-python',
 				steps: ['server:build', 'client-python:sync-source', 'client-python:wheel-source', 'client-python:copy-readme', 'client-python:wheel-build', 'client-python:sync'],
 			}),
 		},
 		{
 			name: 'client-python:test',
 			action: () => ({
-				description: 'Test Python client',
+				description: 'Testing client-python',
 				steps: [
 					'server:build',
 					parallel(['nodes:build', 'ai:build', 'client-python:build'], 'Build dependencies'),
@@ -269,7 +269,7 @@ module.exports = {
 		{
 			name: 'client-python:clean',
 			action: () => ({
-				description: 'Clean Python client',
+				description: 'Cleaning client-python',
 				run: async (ctx, task) => {
 					await removeDirs([path.join(PACKAGE_DIR, 'build'), path.join(PACKAGE_DIR, 'dist')]);
 					await removeDirAndParents(PROJECT_ROOT, [BUILD_DIR, DIST_DIR, SERVER_CLIENTS_DIR, SERVER_STATIC_DIR]);

--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -144,6 +144,8 @@ class RocketRideClient(
             **kwargs: Additional options:
                 - env: Dictionary of environment variables to use instead of os.environ
                 - module: Custom module name for client identification
+                - ws_path: Custom WebSocket path override (default: '/task/service').
+                    Use '/models' for the model server.
                 - request_timeout: Default timeout in ms for individual requests (default: no timeout)
                 - max_retry_time: Max total time in ms to keep retrying connections (default: forever)
                 - persist: Enable automatic reconnection with exponential backoff (default: False)
@@ -203,9 +205,10 @@ class RocketRideClient(
         # Normalize the URI into a fully-formed WebSocket address
         from .mixins.connection import ConnectionMixin
 
-        # Convert the HTTP/HTTPS URI (or bare host:port) to a wss:// or ws:// URI
-        # pointing at the /task/service WebSocket endpoint.
-        self._uri = ConnectionMixin._get_websocket_uri(uri)
+        # Convert the HTTP/HTTPS URI (or bare host:port) to a wss:// or ws:// URI.
+        # ws_path defaults to '/task/service'; model server clients pass '/models'.
+        self._ws_path = kwargs.get('ws_path', '/task/service')
+        self._uri = ConnectionMixin._get_websocket_uri(uri, self._ws_path)
         self._apikey = auth
 
         # Initialize chat question counter — each chat request gets a unique sequential ID
@@ -236,8 +239,18 @@ class RocketRideClient(
         # Public mode — permanently unauthenticated, only rrext_public_* commands
         self._public = kwargs.get('public', False)
 
+        # Pop kwargs consumed by this constructor so they don't collide
+        # with the explicit keyword arguments passed to super().__init__().
+        module = kwargs.pop('module', client_name)
+        kwargs.pop('ws_path', None)
+        kwargs.pop('client_name', None)
+        kwargs.pop('client_version', None)
+        kwargs.pop('public', None)
+        kwargs.pop('on_trace', None)
+        kwargs.pop('env', None)
+
         # Initialize the underlying DAP client; transport is created in _internal_connect
-        super().__init__(transport=None, module=kwargs.get('module', client_name), **kwargs)
+        super().__init__(transport=None, module=module, **kwargs)
 
     # =========================================================================
     # CALL — PUBLIC DAP COMMAND INTERFACE

--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -401,8 +401,9 @@ class ConnectionMixin(DAPClient):
         parsed = urllib.parse.urlparse(normalized)
 
         ws_scheme = 'wss' if parsed.scheme in ('https', 'wss') else 'ws'
-        ws_uri = parsed._replace(scheme=ws_scheme)
-        return f'{ws_uri.geturl()}{ws_path}'
+        normalized_ws_path = f'/{ws_path.lstrip("/")}'
+        ws_uri = parsed._replace(scheme=ws_scheme, path=normalized_ws_path, params='', query='', fragment='')
+        return ws_uri.geturl()
 
     def _set_uri(self, uri: str) -> None:
         """Update the server URI (internal)."""

--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -389,14 +389,20 @@ class ConnectionMixin(DAPClient):
         return parsed.geturl()
 
     @staticmethod
-    def _get_websocket_uri(uri: str) -> str:
-        """Normalize a user-provided URI into a fully-formed WebSocket address."""
+    def _get_websocket_uri(uri: str, ws_path: str = '/task/service') -> str:
+        """Normalize a user-provided URI into a fully-formed WebSocket address.
+
+        Args:
+            uri: Raw URI (bare host:port, http://, https://, ws://, wss://).
+            ws_path: WebSocket endpoint path (default: '/task/service').
+                     Use '/models' for the model server.
+        """
         normalized = ConnectionMixin.normalize_uri(uri)
         parsed = urllib.parse.urlparse(normalized)
 
         ws_scheme = 'wss' if parsed.scheme in ('https', 'wss') else 'ws'
         ws_uri = parsed._replace(scheme=ws_scheme)
-        return f'{ws_uri.geturl()}/task/service'
+        return f'{ws_uri.geturl()}{ws_path}'
 
     def _set_uri(self, uri: str) -> None:
         """Update the server URI (internal)."""

--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -2093,9 +2093,19 @@ class TestConcurrentPipelineOperations:
             for i in range(PIPELINE_COUNT):
                 await ensure_clean_pipeline(client, f'{self.CONCURRENT_TOKEN}-m{i}')
 
-            # Create pipelines concurrently
+            # Create pipelines concurrently — each needs a unique project_id
+            # to avoid server-side contention during concurrent startup.
+            MIXED_PROJECT_IDS = [
+                'a1b2c3d4-1111-4000-a000-000000000001',
+                'a1b2c3d4-1111-4000-a000-000000000002',
+                'a1b2c3d4-1111-4000-a000-000000000003',
+                'a1b2c3d4-1111-4000-a000-000000000004',
+            ]
+
             async def create_pipeline(index):
-                result = await client.use(pipeline=get_echo_pipeline(), token=f'{self.CONCURRENT_TOKEN}-m{index}')
+                result = await client.use(
+                    pipeline=get_echo_pipeline(MIXED_PROJECT_IDS[index]), token=f'{self.CONCURRENT_TOKEN}-m{index}'
+                )
                 return {'index': index, 'token': result['token']}
 
             pipeline_tasks = [create_pipeline(i) for i in range(PIPELINE_COUNT)]
@@ -2190,9 +2200,21 @@ class TestConcurrentPipelineOperations:
             for i in range(SUBPROCESS_COUNT):
                 await ensure_clean_pipeline(client, f'{self.CONCURRENT_TOKEN}-s{i}')
 
-            # Create 4 independent subprocesses concurrently
+            # Create 4 independent subprocesses concurrently — each needs a
+            # unique project_id to avoid server-side contention during startup.
+            CYCLE_PROJECT_IDS = [
+                'b2c3d4e5-2222-4000-b000-000000000001',
+                'b2c3d4e5-2222-4000-b000-000000000002',
+                'b2c3d4e5-2222-4000-b000-000000000003',
+                'b2c3d4e5-2222-4000-b000-000000000004',
+            ]
             sub_tokens = [f'{self.CONCURRENT_TOKEN}-s{i}' for i in range(SUBPROCESS_COUNT)]
-            await asyncio.gather(*[client.use(pipeline=get_echo_pipeline(), token=token) for token in sub_tokens])
+            await asyncio.gather(
+                *[
+                    client.use(pipeline=get_echo_pipeline(CYCLE_PROJECT_IDS[i]), token=token)
+                    for i, token in enumerate(sub_tokens)
+                ]
+            )
 
             # Each pipeline independently cycles 32 send/recv — all 4 run in parallel
             async def run_pipeline(token, pipeline_index):
@@ -2259,8 +2281,16 @@ class TestConcurrentPipelineOperations:
             # client.use() attaches to the existing task instead of starting a
             # fresh one.  This is what makes both clients fan into ONE shared
             # eaas->subprocess _data_client.
-            res_a = await client_a.use(pipeline=get_echo_pipeline(), token=SHARED_TOKEN, use_existing=True)
-            res_b = await client_b.use(pipeline=get_echo_pipeline(), token=SHARED_TOKEN, use_existing=True)
+            res_a = await client_a.use(
+                pipeline=get_echo_pipeline('c3d4e5f6-3333-4000-c000-000000000001'),
+                token=SHARED_TOKEN,
+                use_existing=True,
+            )
+            res_b = await client_b.use(
+                pipeline=get_echo_pipeline('c3d4e5f6-3333-4000-c000-000000000001'),
+                token=SHARED_TOKEN,
+                use_existing=True,
+            )
             assert res_b['token'] == res_a['token']
 
             # Generate distinct payloads per client so we can verify no cross-routing.

--- a/packages/client-python/tests/echo_pipeline.py
+++ b/packages/client-python/tests/echo_pipeline.py
@@ -36,12 +36,16 @@ Usage:
 from typing import Dict, Any
 
 
-def get_echo_pipeline() -> Dict[str, Any]:
+def get_echo_pipeline(project_id: str = 'e612b741-748c-4b35-a8b7-186797a8ea42') -> Dict[str, Any]:
     """
     Get the echo pipeline configuration.
 
     This pipeline receives data and returns it unchanged, making it ideal
     for testing basic connectivity and data transmission.
+
+    Args:
+        project_id: Unique project identifier. Concurrent pipelines must use
+            distinct project_ids to avoid server-side contention during startup.
 
     Returns:
         Echo pipeline configuration.
@@ -67,5 +71,5 @@ def get_echo_pipeline() -> Dict[str, Any]:
             },
         ],
         'source': 'webhook_1',
-        'project_id': 'e612b741-748c-4b35-a8b7-186797a8ea42',
+        'project_id': project_id,
     }

--- a/packages/client-typescript/scripts/tasks.js
+++ b/packages/client-typescript/scripts/tasks.js
@@ -328,14 +328,14 @@ module.exports = {
 		{
 			name: 'client-typescript:build',
 			action: () => ({
-				description: 'Build TypeScript client',
+				description: 'Build client-typescript',
 				steps: ['client-typescript:sync-version', 'client-typescript:copy-readme', parallel(['client-typescript:compile-cjs', 'client-typescript:compile-esm', 'client-typescript:generate-types'], 'Compile sources'), 'client-typescript:compile-cli', 'client-typescript:post-build', 'client-typescript:create-package', 'client-typescript:sync'],
 			}),
 		},
 		{
 			name: 'client-typescript:test',
 			action: () => ({
-				description: 'Test TypeScript client',
+				description: 'Testing client-typescript',
 				steps: [
 					'server:build',
 					parallel(['ai:build', 'nodes:build', 'client-python:build', 'client-typescript:build'], 'Build dependencies'),
@@ -351,7 +351,7 @@ module.exports = {
 		{
 			name: 'client-typescript:clean',
 			action: () => ({
-				description: 'Clean TypeScript client',
+				description: 'Cleaning client-typescript',
 				run: async (ctx, task) => {
 					await removeDirs([LOCAL_DIST]);
 					await removeDirAndParents(PROJECT_ROOT, [PACKAGE_DIST, SERVER_STATIC_DIR, path.join(BUILD_ROOT, 'clients', 'typescript')]);

--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -1829,11 +1829,18 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					await ensureCleanPipeline(client, `${CONCURRENT_TOKEN}-m${i}`);
 				}
 
-				// Create all pipelines concurrently
+				// Create all pipelines concurrently — each needs a unique project_id
+				// to avoid server-side contention during concurrent startup.
+				const MIXED_PROJECT_IDS = [
+					'a1b2c3d4-1111-4000-a000-000000000001',
+					'a1b2c3d4-1111-4000-a000-000000000002',
+					'a1b2c3d4-1111-4000-a000-000000000003',
+					'a1b2c3d4-1111-4000-a000-000000000004',
+				];
 				const pipelines = await Promise.all(
 					Array.from({ length: PIPELINE_COUNT }, async (_, index) => {
 						const result = await client.use({
-							pipeline: getEchoPipeline(),
+							pipeline: getEchoPipeline(MIXED_PROJECT_IDS[index]),
 							token: `${CONCURRENT_TOKEN}-m${index}`,
 						});
 						return { index, token: result.token };
@@ -1915,9 +1922,18 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					await ensureCleanPipeline(client, `${CONCURRENT_TOKEN}-s${i}`);
 				}
 
-				// Create 4 independent subprocesses concurrently
+				// Create 4 independent subprocesses concurrently — each needs a
+				// unique project_id to avoid server-side contention during startup.
+				const CYCLE_PROJECT_IDS = [
+					'b2c3d4e5-2222-4000-b000-000000000001',
+					'b2c3d4e5-2222-4000-b000-000000000002',
+					'b2c3d4e5-2222-4000-b000-000000000003',
+					'b2c3d4e5-2222-4000-b000-000000000004',
+				];
 				const tokens = Array.from({ length: SUBPROCESS_COUNT }, (_, i) => `${CONCURRENT_TOKEN}-s${i}`);
-				await Promise.all(tokens.map((token) => client.use({ pipeline: getEchoPipeline(), token })));
+				await Promise.all(tokens.map((token, i) =>
+					client.use({ pipeline: getEchoPipeline(CYCLE_PROJECT_IDS[i]), token })
+				));
 				pipelineTokens.push(...tokens);
 
 				// Each pipeline independently cycles send/recv — all 4 run in parallel
@@ -1985,12 +2001,12 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					// fresh one.  This is what makes both clients fan into ONE shared
 					// eaas->subprocess _data_client.
 					const resA = await client.use({
-						pipeline: getEchoPipeline(),
+						pipeline: getEchoPipeline('c3d4e5f6-3333-4000-c000-000000000001'),
 						token: SHARED_TOKEN,
 						useExisting: true,
 					});
 					const resB = await clientB.use({
-						pipeline: getEchoPipeline(),
+						pipeline: getEchoPipeline('c3d4e5f6-3333-4000-c000-000000000001'),
 						token: SHARED_TOKEN,
 						useExisting: true,
 					});

--- a/packages/client-typescript/tests/echo.pipeline.ts
+++ b/packages/client-typescript/tests/echo.pipeline.ts
@@ -30,7 +30,7 @@
  * 
  * @returns Echo pipeline configuration
  */
-export function getEchoPipeline() {
+export function getEchoPipeline(projectId: string = 'e612b741-748c-4b35-a8b7-186797a8ea42') {
 	return {
 		components: [
 			{
@@ -52,6 +52,6 @@ export function getEchoPipeline() {
 			}
 		],
 		source: "webhook_1",
-		project_id: "e612b741-748c-4b35-a8b7-186797a8ea42"
+		project_id: projectId
 	};
 }

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -899,7 +899,7 @@ function makeBuildCoreAction() {
 
 function makeBuildAction() {
 	return {
-		description: 'Build server',
+		description: 'Build server (core)',
 		steps: [
 			'server:build-core',
 			'server:setup-pip',
@@ -913,7 +913,7 @@ function makeBuildAction() {
 
 function makeCleanServerAction() {
 	return {
-		description: 'Clean server',
+		description: 'Cleaning server',
 		run: async (ctx, task) => {
 			await setState('server', {});
 			await setState('package', null);
@@ -938,7 +938,7 @@ function makeCleanServerAction() {
 
 function makeBuildAllAction() {
 	return {
-		description: 'Build server and modules',
+		description: 'Build server (all modules)',
 		steps: [
 			'server:build',
 			// Build external modules
@@ -949,21 +949,21 @@ function makeBuildAllAction() {
 
 function makeCompileAction() {
 	return {
-		description: 'Compile server',
+		description: 'Compiling server',
 		steps: ['server:configure', 'server:setup-python', 'server:compile-engine'],
 	};
 }
 
 function makeConfigureAction() {
 	return {
-		description: 'Configure server',
+		description: 'Configuring server',
 		steps: ['server:setup-tools', 'server:configure'],
 	};
 }
 
 function makeTestAction() {
 	return {
-		description: 'Test server',
+		description: 'Testing server',
 		steps: [
 			'server:build',
 			whenNot({
@@ -1019,7 +1019,7 @@ function makeRocketlibPythonTestAction(options = {}) {
 
 function makePackageAction(options = {}) {
 	return {
-		description: 'Package server distribution',
+		description: 'Packaging server',
 		run: async (_ctx, _task) => {
 			const { manifestFilename, distFilename, symDistFilename, distFile, symDistFile } = await getPackageInfo(options);
 			const symFilename = isWindows() ? 'engine.pdb' : null;
@@ -1074,7 +1074,7 @@ function makePackageAction(options = {}) {
 
 function makeCleanAction() {
 	return {
-		description: 'Clean all',
+		description: 'Cleaning server (all)',
 		steps: ['server:clean', 'vcpkg:submodule-clean', 'java:submodule-clean', 'tika:submodule-clean'],
 	};
 }
@@ -1110,7 +1110,7 @@ module.exports = {
 		{
 			name: 'server:dev',
 			action: (options = {}) => ({
-				description: 'Start EaaS development server + shell-ui rsbuild dev server',
+				description: 'Starting server (dev)',
 				steps: [
 					'server:build',
 					parallel(['server:run-eaas', 'shell-ui:dev'], 'Start dev servers'),
@@ -1128,7 +1128,7 @@ module.exports = {
 					servers.push('model_server:run-process');
 				}
 				return {
-					description: 'Build and run EaaS server (no dev tools)',
+					description: 'Running server',
 					steps: [
 						'server:build',
 						parallel(servers, 'Start servers'),

--- a/packages/shared-ui/src/modules/account/AccountView.tsx
+++ b/packages/shared-ui/src/modules/account/AccountView.tsx
@@ -243,7 +243,7 @@ const AccountView: React.FC<IAccountViewProps> = (props) => {
 
 	// Build appId → app lookup for display name resolution
 	const appMap = useMemo(() => {
-		const map: Record<string, { name: string }> = {};
+		const map: Record<string, { id: string; name: string; icon?: string; description?: string }> = {};
 		for (const a of apps ?? []) map[a.id] = a;
 		return map;
 	}, [apps]);

--- a/packages/shared-ui/src/modules/account/AccountView.tsx
+++ b/packages/shared-ui/src/modules/account/AccountView.tsx
@@ -140,8 +140,8 @@ export interface IAccountViewProps {
 	creditBalance: CreditBalance | null;
 	/** Available credit packs for purchase. */
 	creditPacks: CreditPack[];
-	/** Map of appId → display name for subscription rows. */
-	appNames?: Record<string, string>;
+	/** App manifest entries for resolving display names, icons, etc. from appId. */
+	apps?: Array<{ id: string; name: string; icon?: string; description?: string }>;
 
 	// -- Billing callbacks -----------------------------------------------------
 	/** Cancel a subscription. Host re-fetches and updates subscriptions prop. */
@@ -232,7 +232,7 @@ export interface IAccountViewProps {
  * to the host via async callback props defined in IAccountViewProps.
  */
 const AccountView: React.FC<IAccountViewProps> = (props) => {
-	const { isConnected, sectionError, profile, authUser, keys, org, members, teams, teamDetail, subscriptions, billingLoading, billingError, creditBalance, creditPacks, appNames, onCancelSubscription, onOpenPortal, onBuyCredits, section, onSectionChange, activeTeamId, onActiveTeamIdChange, onSaveProfile, onSetDefaultTeam, onLogout, onDeleteAccount, onSaveOrgName, onCreateKey, onRevokeKey, onInviteMember, onUpdateMemberRole, onRemoveMember, onCreateTeam, onDeleteTeam, onAddTeamMember, onEditTeamMemberPerms, onRemoveTeamMember, onLoadTeamDetail, onLoadEnv, onSaveEnv, refreshSignal } = props;
+	const { isConnected, sectionError, profile, authUser, keys, org, members, teams, teamDetail, subscriptions, billingLoading, billingError, creditBalance, creditPacks, apps, onCancelSubscription, onOpenPortal, onBuyCredits, section, onSectionChange, activeTeamId, onActiveTeamIdChange, onSaveProfile, onSetDefaultTeam, onLogout, onDeleteAccount, onSaveOrgName, onCreateKey, onRevokeKey, onInviteMember, onUpdateMemberRole, onRemoveMember, onCreateTeam, onDeleteTeam, onAddTeamMember, onEditTeamMemberPerms, onRemoveTeamMember, onLoadTeamDetail, onLoadEnv, onSaveEnv, refreshSignal } = props;
 
 	// =========================================================================
 	// PERMISSION HELPERS
@@ -240,6 +240,13 @@ const AccountView: React.FC<IAccountViewProps> = (props) => {
 
 	/** The primary organization's ID (used for org-scoped env calls). */
 	const orgId = profile?.organizations?.[0]?.id;
+
+	// Build appId → app lookup for display name resolution
+	const appMap = useMemo(() => {
+		const map: Record<string, { name: string }> = {};
+		for (const a of apps ?? []) map[a.id] = a;
+		return map;
+	}, [apps]);
 
 	/** True when the current user has org.admin on their primary organization. */
 	const isOrgAdmin = useMemo(() => {
@@ -733,7 +740,7 @@ const AccountView: React.FC<IAccountViewProps> = (props) => {
 			billing: {
 				content: (
 					<div style={commonStyles.tabContent}>
-						<BillingPanel isConnected={isConnected} subscriptions={subscriptions} loading={billingLoading} error={billingError} creditBalance={creditBalance} creditPacks={creditPacks} appNames={appNames} onCancelSubscription={openCancelSub} onOpenPortal={handlePortal} onBuyCredits={onBuyCredits} isOrgAdmin={isOrgAdmin} />
+						<BillingPanel isConnected={isConnected} subscriptions={subscriptions} loading={billingLoading} error={billingError} creditBalance={creditBalance} creditPacks={creditPacks} apps={apps} onCancelSubscription={openCancelSub} onOpenPortal={handlePortal} onBuyCredits={onBuyCredits} isOrgAdmin={isOrgAdmin} />
 					</div>
 				),
 			},
@@ -1118,7 +1125,7 @@ const AccountView: React.FC<IAccountViewProps> = (props) => {
 					}
 				>
 					<p style={{ fontSize: 13, color: 'var(--rr-text-secondary)', lineHeight: 1.5 }}>
-						Are you sure you want to cancel <strong style={{ color: 'var(--rr-text-primary)' }}>{cancelSubAppId}</strong>? Your access will continue until the end of the current billing period, after which the subscription will not renew.
+						Are you sure you want to cancel <strong style={{ color: 'var(--rr-text-primary)' }}>{appMap[cancelSubAppId]?.name ?? cancelSubAppId}</strong>? Your access will continue until the end of the current billing period, after which the subscription will not renew.
 					</p>
 					{saveError && <div style={{ fontSize: 11, color: 'var(--rr-color-error)', marginTop: 8 }}>{saveError}</div>}
 				</Modal>

--- a/packages/shared-ui/src/modules/account/components/ApiKeysPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/ApiKeysPanel.tsx
@@ -50,7 +50,7 @@ export const ApiKeysPanel: React.FC<ApiKeysPanelProps> = ({ keys, onCreateKey, o
 				<span style={commonStyles.labelUppercase}>
 					API Keys — {keys.length} key{keys.length !== 1 ? 's' : ''}
 				</span>
-				<button style={commonStyles.buttonPrimarySmall as CSSProperties} onClick={onCreateKey}>
+				<button style={{ ...commonStyles.buttonPrimary, ...commonStyles.cardHeaderButton } as CSSProperties} onClick={onCreateKey}>
 					+ New Key
 				</button>
 			</div>
@@ -73,7 +73,7 @@ export const ApiKeysPanel: React.FC<ApiKeysPanelProps> = ({ keys, onCreateKey, o
 						</div>
 						{k.active && !k.isSession && (
 							<div style={S.rowActions}>
-								<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={() => onRevokeKey(k)}>
+								<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => onRevokeKey(k)}>
 									Revoke
 								</button>
 							</div>

--- a/packages/shared-ui/src/modules/account/components/BillingPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/BillingPanel.tsx
@@ -180,7 +180,7 @@ export const BillingPanel: React.FC<BillingPanelProps> = ({ isConnected, subscri
 						{subscriptions.length} subscription{subscriptions.length !== 1 ? 's' : ''}
 					</span>
 					{isOrgAdmin && (
-						<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={onOpenPortal}>
+						<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardHeaderButton } as CSSProperties} onClick={onOpenPortal}>
 							Manage Payment Methods →
 						</button>
 					)}
@@ -275,7 +275,7 @@ export const BillingPanel: React.FC<BillingPanelProps> = ({ isConnected, subscri
 									<div style={SharedS.rowActions}>
 										<Badge variant={sv.variant}>{sv.label}</Badge>
 										{isCancelable && isOrgAdmin && (
-											<button style={commonStyles.buttonDangerSmall as CSSProperties} onClick={() => onCancelSubscription(sub.appId)}>
+											<button style={{ ...commonStyles.buttonDanger, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => onCancelSubscription(sub.appId)}>
 												Cancel
 											</button>
 										)}

--- a/packages/shared-ui/src/modules/account/components/BillingPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/BillingPanel.tsx
@@ -161,7 +161,7 @@ export interface BillingPanelProps {
 export const BillingPanel: React.FC<BillingPanelProps> = ({ isConnected, subscriptions, loading, error, creditBalance, creditPacks, apps, onCancelSubscription, onOpenPortal, onBuyCredits, isOrgAdmin }) => {
 	// Build appId → app lookup for display name resolution
 	const appMap = React.useMemo(() => {
-		const map: Record<string, { name: string }> = {};
+		const map: Record<string, { id: string; name: string; icon?: string; description?: string }> = {};
 		for (const a of apps ?? []) map[a.id] = a;
 		return map;
 	}, [apps]);

--- a/packages/shared-ui/src/modules/account/components/BillingPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/BillingPanel.tsx
@@ -144,8 +144,8 @@ export interface BillingPanelProps {
 	onBuyCredits: (pack: CreditPack) => Promise<void>;
 	/** True when the current user has org.admin permissions. */
 	isOrgAdmin: boolean;
-	/** Map of appId → display name for subscription rows. */
-	appNames?: Record<string, string>;
+	/** App manifest entries for resolving display names, icons, etc. from appId. */
+	apps?: Array<{ id: string; name: string; icon?: string; description?: string }>;
 }
 
 // =============================================================================
@@ -158,7 +158,13 @@ export interface BillingPanelProps {
  * Renders compute credits and subscription rows using the standard card
  * pattern. The cancel confirmation dialog is owned by AccountView.
  */
-export const BillingPanel: React.FC<BillingPanelProps> = ({ isConnected, subscriptions, loading, error, creditBalance, creditPacks, appNames, onCancelSubscription, onOpenPortal, onBuyCredits, isOrgAdmin }) => {
+export const BillingPanel: React.FC<BillingPanelProps> = ({ isConnected, subscriptions, loading, error, creditBalance, creditPacks, apps, onCancelSubscription, onOpenPortal, onBuyCredits, isOrgAdmin }) => {
+	// Build appId → app lookup for display name resolution
+	const appMap = React.useMemo(() => {
+		const map: Record<string, { name: string }> = {};
+		for (const a of apps ?? []) map[a.id] = a;
+		return map;
+	}, [apps]);
 	return (
 		<section>
 			{/* Error banner */}
@@ -193,7 +199,7 @@ export const BillingPanel: React.FC<BillingPanelProps> = ({ isConnected, subscri
 								<div key={sub.appId} style={{ ...SharedS.rowItem, borderBottom: i < subscriptions.length - 1 ? '1px solid var(--rr-border)' : 'none', alignItems: 'flex-start' }}>
 									<div style={SharedS.rowInfo}>
 										{/* App name + renewal info */}
-										<div style={SharedS.rowName}>{appNames?.[sub.appId] ?? sub.appId}</div>
+										<div style={SharedS.rowName}>{appMap[sub.appId]?.name ?? sub.appId}</div>
 										{sub.currentPeriodEnd && <div style={S.meta}>{sub.cancelAtPeriodEnd ? `Cancels on ${new Date(sub.currentPeriodEnd).toLocaleDateString()}` : `Renews on ${new Date(sub.currentPeriodEnd).toLocaleDateString()}`}</div>}
 
 										{/* Subscription detail grid */}

--- a/packages/shared-ui/src/modules/account/components/EnvironmentPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/EnvironmentPanel.tsx
@@ -196,7 +196,7 @@ export const EnvScopeCard: React.FC<{
 									setError(null);
 								}}
 								disabled={saving}
-								style={commonStyles.buttonSecondarySmall as CSSProperties}
+								style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardHeaderButton } as CSSProperties}
 							>
 								Cancel
 							</button>
@@ -205,7 +205,8 @@ export const EnvScopeCard: React.FC<{
 								disabled={saving}
 								style={
 									{
-										...commonStyles.buttonPrimarySmall,
+										...commonStyles.buttonPrimary,
+										...commonStyles.cardHeaderButton,
 										...(saving ? commonStyles.buttonDisabled : {}),
 									} as CSSProperties
 								}
@@ -227,10 +228,10 @@ export const EnvScopeCard: React.FC<{
 							<div key={idx} style={styles.row}>
 								<input value={key} onChange={(e) => updateEntry(idx, 'key', e.target.value)} placeholder="ROCKETRIDE_KEY_NAME" style={styles.keyInput as CSSProperties} />
 								<input type={revealedKeys.has(key) ? 'text' : 'password'} value={value} onChange={(e) => updateEntry(idx, 'value', e.target.value)} placeholder="••••••••" style={styles.valueInput as CSSProperties} />
-								<button onClick={() => toggleReveal(key)} style={commonStyles.buttonSecondarySmall as CSSProperties}>
+								<button onClick={() => toggleReveal(key)} style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties}>
 									{revealedKeys.has(key) ? 'Hide' : 'Show'}
 								</button>
-								<button onClick={() => removeEntry(idx)} style={commonStyles.buttonSecondarySmall as CSSProperties}>
+								<button onClick={() => removeEntry(idx)} style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties}>
 									Delete
 								</button>
 							</div>
@@ -238,7 +239,7 @@ export const EnvScopeCard: React.FC<{
 
 						{/* Add button */}
 						<div style={styles.addRow}>
-							<button onClick={addEntry} style={{ ...commonStyles.buttonSecondarySmall, fontSize: 11 } as CSSProperties}>
+							<button onClick={addEntry} style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties}>
 								+ Add Variable
 							</button>
 						</div>

--- a/packages/shared-ui/src/modules/account/components/MembersPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/MembersPanel.tsx
@@ -185,7 +185,7 @@ export const MembersPanel: React.FC<MembersPanelProps> = ({ org, members, profil
 					<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
 						<input type="text" placeholder="Search by name or email…" value={search} onChange={(e) => setSearch(e.target.value)} style={styles.search} />
 						{isOrgAdmin && (
-							<button style={commonStyles.buttonPrimarySmall as CSSProperties} onClick={onInvite}>
+							<button style={{ ...commonStyles.buttonPrimary, ...commonStyles.cardHeaderButton } as CSSProperties} onClick={onInvite}>
 								+ Invite
 							</button>
 						)}
@@ -215,7 +215,7 @@ export const MembersPanel: React.FC<MembersPanelProps> = ({ org, members, profil
 									<div style={S.rowActions}>
 										<Badge variant="pending">Pending</Badge>
 										{isOrgAdmin && (
-											<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={() => onRemove(m)}>
+											<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => onRemove(m)}>
 												Cancel
 											</button>
 										)}
@@ -226,10 +226,10 @@ export const MembersPanel: React.FC<MembersPanelProps> = ({ org, members, profil
 										<Badge variant={m.role === 'admin' ? 'admin' : 'member'}>{m.role}</Badge>
 										{isOrgAdmin && (
 											<>
-												<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.buttonSmall, border: 'none', background: 'transparent' } as CSSProperties} onClick={() => onChangeRole(m)}>
+												<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton, border: 'none', background: 'transparent' } as CSSProperties} onClick={() => onChangeRole(m)}>
 													Edit
 												</button>
-												<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={() => onRemove(m)}>
+												<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => onRemove(m)}>
 													Remove
 												</button>
 											</>

--- a/packages/shared-ui/src/modules/account/components/OrganizationPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/OrganizationPanel.tsx
@@ -99,7 +99,7 @@ export const OrganizationPanel: React.FC<OrganizationPanelProps> = ({ org, onSav
 										setError(null);
 									}}
 									disabled={saving}
-									style={commonStyles.buttonSecondarySmall as CSSProperties}
+									style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardHeaderButton } as CSSProperties}
 								>
 									Cancel
 								</button>
@@ -108,7 +108,8 @@ export const OrganizationPanel: React.FC<OrganizationPanelProps> = ({ org, onSav
 									disabled={saving}
 									style={
 										{
-											...commonStyles.buttonPrimarySmall,
+											...commonStyles.buttonPrimary,
+											...commonStyles.cardHeaderButton,
 											...(saving ? commonStyles.buttonDisabled : {}),
 										} as CSSProperties
 									}

--- a/packages/shared-ui/src/modules/account/components/ProfilePanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/ProfilePanel.tsx
@@ -164,7 +164,7 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({ profile, authUser, o
 						</div>
 					</div>
 
-					<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={openEdit}>
+					<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={openEdit}>
 						Edit Profile
 					</button>
 				</div>
@@ -205,7 +205,7 @@ export const ProfilePanel: React.FC<ProfilePanelProps> = ({ profile, authUser, o
 											{isDefault ? (
 												<span style={{ fontSize: 11, color: 'var(--rr-color-success)', fontWeight: 600 }}>{'\u2713'} Default</span>
 											) : (
-												<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={() => onSetDefaultTeam(t.id)}>
+												<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => onSetDefaultTeam(t.id)}>
 													Set default
 												</button>
 											)}

--- a/packages/shared-ui/src/modules/account/components/TeamsPanel.tsx
+++ b/packages/shared-ui/src/modules/account/components/TeamsPanel.tsx
@@ -72,7 +72,7 @@ export const TeamsPanel: React.FC<TeamsPanelProps> = ({ teams, teamDetail, activ
 				<div style={{ ...commonStyles.card, marginBottom: 14 }}>
 					<div style={commonStyles.cardHeader}>
 						<div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-							<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.buttonSmall, border: 'none', background: 'transparent', fontSize: 20, fontWeight: 900, padding: '0 6px', lineHeight: '1rem' } as CSSProperties} onClick={onBack}>
+							<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardHeaderButton, border: 'none', background: 'transparent', fontSize: 20, fontWeight: 900, padding: '0 6px', lineHeight: '1rem' } as CSSProperties} onClick={onBack}>
 								{'\u2190'}
 							</button>
 							<div style={{ width: 22, height: 22, borderRadius: 5, background: avatarColor(teamDetail.name), display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 11, fontWeight: 700, color: 'var(--rr-fg-button)', flexShrink: 0 }}>{teamDetail.name[0]}</div>
@@ -81,7 +81,7 @@ export const TeamsPanel: React.FC<TeamsPanelProps> = ({ teams, teamDetail, activ
 							</span>
 						</div>
 						{isTeamAdmin && (
-							<button style={commonStyles.buttonPrimarySmall as CSSProperties} onClick={onAddMember}>
+							<button style={{ ...commonStyles.buttonPrimary, ...commonStyles.cardHeaderButton } as CSSProperties} onClick={onAddMember}>
 								+ Add Member
 							</button>
 						)}
@@ -110,12 +110,12 @@ export const TeamsPanel: React.FC<TeamsPanelProps> = ({ teams, teamDetail, activ
 										</div>
 										{isTeamAdmin && (
 											<div style={S.rowActions}>
-												<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={() => onEditPerms(m)}>
+												<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => onEditPerms(m)}>
 													Edit Perms
 												</button>
 												{/* Hide Remove if this is the last admin (team must always have one). */}
 												{!isLastAdmin && (
-													<button style={commonStyles.buttonSecondarySmall as CSSProperties} onClick={() => onRemoveMember(m.userId, m.displayName)}>
+													<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => onRemoveMember(m.userId, m.displayName)}>
 														Remove
 													</button>
 												)}
@@ -140,7 +140,7 @@ export const TeamsPanel: React.FC<TeamsPanelProps> = ({ teams, teamDetail, activ
 						Teams — {teams.length} team{teams.length !== 1 ? 's' : ''}
 					</span>
 					{isOrgAdmin && (
-						<button style={commonStyles.buttonPrimarySmall as CSSProperties} onClick={onCreateTeam}>
+						<button style={{ ...commonStyles.buttonPrimary, ...commonStyles.cardHeaderButton } as CSSProperties} onClick={onCreateTeam}>
 							+ New Team
 						</button>
 					)}
@@ -158,7 +158,7 @@ export const TeamsPanel: React.FC<TeamsPanelProps> = ({ teams, teamDetail, activ
 							<div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
 								{isOrgAdmin && (
 									<button
-										style={commonStyles.buttonSecondarySmall as CSSProperties}
+										style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties}
 										onClick={(e) => {
 											e.stopPropagation();
 											onDeleteTeam(t.id);
@@ -168,7 +168,7 @@ export const TeamsPanel: React.FC<TeamsPanelProps> = ({ teams, teamDetail, activ
 									</button>
 								)}
 								<button
-									style={commonStyles.buttonSecondarySmall as CSSProperties}
+									style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties}
 									onClick={(e) => {
 										e.stopPropagation();
 										onSelectTeam(t.id);

--- a/packages/shared-ui/src/modules/billing/BillingView.tsx
+++ b/packages/shared-ui/src/modules/billing/BillingView.tsx
@@ -408,7 +408,7 @@ const BillingView: React.FC<IBillingViewProps> = ({ isConnected, subscriptions, 
 								{/* Action buttons */}
 								<div style={S.actions}>
 									{isCancelable && (
-										<button style={commonStyles.buttonDangerOutline as CSSProperties} onClick={() => requestCancel(sub.appId)}>
+										<button style={{ ...commonStyles.buttonDangerOutline, ...commonStyles.cardBodyButton } as CSSProperties} onClick={() => requestCancel(sub.appId)}>
 											Cancel Subscription
 										</button>
 									)}
@@ -420,7 +420,7 @@ const BillingView: React.FC<IBillingViewProps> = ({ isConnected, subscriptions, 
 
 					{/* Stripe customer portal link */}
 					<div style={S.portalRow}>
-						<button style={commonStyles.buttonSecondary as CSSProperties} onClick={handlePortal}>
+						<button style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardBodyButton } as CSSProperties} onClick={handlePortal}>
 							Manage Payment Methods →
 						</button>
 					</div>

--- a/packages/shared-ui/src/modules/billing/BillingView.tsx
+++ b/packages/shared-ui/src/modules/billing/BillingView.tsx
@@ -15,7 +15,7 @@
  * VS Code) is responsible for fetching data and executing API calls.
  */
 
-import React, { useState, useCallback, type CSSProperties } from 'react';
+import React, { useState, useCallback, useMemo, type CSSProperties } from 'react';
 import { commonStyles } from '../../themes/styles';
 import type { BillingDetail, CreditBalance, CreditPack } from './types';
 import { CreditsPanel } from './components/CreditsPanel';
@@ -270,6 +270,8 @@ export interface IBillingViewProps {
 	onOpenPortal: () => Promise<void>;
 	/** Purchase a credit pack. Host handles Stripe checkout redirect/URL. */
 	onBuyCredits: (pack: CreditPack) => Promise<void>;
+	/** App manifest entries for resolving display names, icons, etc. from appId. */
+	apps?: Array<{ id: string; name: string; icon?: string; description?: string }>;
 }
 
 // =============================================================================
@@ -277,7 +279,13 @@ export interface IBillingViewProps {
 // =============================================================================
 
 /** Pure subscription and payment management view. */
-const BillingView: React.FC<IBillingViewProps> = ({ isConnected, subscriptions, loading, error: externalError, creditBalance, creditPacks, onCancelSubscription, onOpenPortal, onBuyCredits }) => {
+const BillingView: React.FC<IBillingViewProps> = ({ isConnected, subscriptions, loading, error: externalError, creditBalance, creditPacks, onCancelSubscription, onOpenPortal, onBuyCredits, apps }) => {
+	// Build appId → app lookup for display name resolution
+	const appMap = useMemo(() => {
+		const map: Record<string, { name: string; icon?: string; description?: string }> = {};
+		for (const a of apps ?? []) map[a.id] = a;
+		return map;
+	}, [apps]);
 	// ── Local action error state ────────────────────────────────────────────
 	const [actionError, setActionError] = useState<string | null>(null);
 	const displayError = actionError || externalError;
@@ -353,7 +361,7 @@ const BillingView: React.FC<IBillingViewProps> = ({ isConnected, subscriptions, 
 								<div style={S.row}>
 									<div>
 										<div style={S.appName}>
-											{sub.appId}
+											{appMap[sub.appId]?.name ?? sub.appId}
 											<span style={S.badge(badge.color, badge.bg)}>{badge.label}</span>
 										</div>
 										{/* Renewal / cancellation date */}
@@ -425,7 +433,7 @@ const BillingView: React.FC<IBillingViewProps> = ({ isConnected, subscriptions, 
 					<div style={S.confirmDialog} onClick={(e) => e.stopPropagation()}>
 						<div style={S.confirmTitle}>Cancel Subscription</div>
 						<div style={S.confirmBody}>
-							Are you sure you want to cancel <strong>{confirmAppId}</strong>? Your access will continue until the end of the current billing period, after which the subscription will not renew.
+							Are you sure you want to cancel <strong>{appMap[confirmAppId!]?.name ?? confirmAppId}</strong>? Your access will continue until the end of the current billing period, after which the subscription will not renew.
 						</div>
 						<div style={S.confirmActions}>
 							<button style={commonStyles.buttonSecondary as CSSProperties} onClick={dismissCancel} disabled={cancelling}>

--- a/packages/shared-ui/src/themes/styles.ts
+++ b/packages/shared-ui/src/themes/styles.ts
@@ -92,6 +92,31 @@ const cardFlat: CSSProperties = {
 	padding: 16,
 };
 
+/**
+ * Card header button size modifier — compact sizing for buttons rendered
+ * inside `cardHeader`. Compose with a colour variant:
+ *   style={{ ...commonStyles.buttonSecondary, ...commonStyles.cardHeaderButton }}
+ * Same dimensions as `cardBodyButton` today; split so header vs body
+ * can diverge independently later.
+ */
+const cardHeaderButton: CSSProperties = {
+	padding: '3px 9px',
+	fontSize: 11,
+	lineHeight: 1.4,
+};
+
+/**
+ * Card body button size modifier — compact sizing for buttons rendered
+ * inside `cardBody` rows (actions like Revoke, Remove, Cancel, etc.).
+ * Compose with a colour variant:
+ *   style={{ ...commonStyles.buttonDanger, ...commonStyles.cardBodyButton }}
+ */
+const cardBodyButton: CSSProperties = {
+	padding: '3px 9px',
+	fontSize: 11,
+	lineHeight: 1.4,
+};
+
 // =============================================================================
 // SECTIONS
 // =============================================================================
@@ -842,6 +867,9 @@ export const commonStyles = {
 	buttonSecondarySmall,
 	buttonDangerSmall,
 	buttonDisabled,
+	// Card button size modifiers — compose with colour variants
+	cardHeaderButton,
+	cardBodyButton,
 	// Toggle buttons — toggleGroup wraps toggleButton(active) items
 	toggleButton,
 	toggleGroup,

--- a/scripts/lib/appModule.js
+++ b/scripts/lib/appModule.js
@@ -1,0 +1,195 @@
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * App Module Factory — generates a standard builder module for MF remote apps.
+ *
+ * Every remote app (models-ui, brandy-ui, hello-ui, etc.) follows the same
+ * build pattern: bundle via rsbuild, register in apps.json, copy to dist.
+ * This factory eliminates the boilerplate by generating the full module
+ * definition from a minimal config.
+ *
+ * Build caching: each app's bundle action fingerprints its own src/,
+ * shell-ui/src, shared-ui/src, and package.json.  If nothing changed and
+ * build output exists, the bundle step is skipped.  --force bypasses the
+ * cache.  When a rebuild IS needed, the build output directory is cleaned
+ * first to prevent stale chunks.
+ *
+ * Usage:
+ *   const { createAppModule } = require('../../../scripts/lib/appModule');
+ *
+ *   module.exports = createAppModule({
+ *       name: 'models-ui',
+ *       description: 'Model Server Monitor',
+ *       appRoot: path.join(__dirname, '..'),
+ *   });
+ */
+
+'use strict';
+
+const path = require('path');
+const {
+	execCommand,
+	syncDir,
+	formatSyncStats,
+	removeDir,
+	hasBuildInputChanged,
+	saveSourceHash,
+	setState,
+	exists,
+} = require('./index');
+const { BUILD_ROOT, DIST_ROOT, PROJECT_ROOT } = require('./paths');
+const { registerApp } = require('./registerApp');
+
+// Shared dependency sources — same for every remote app.
+// PROJECT_ROOT is always rocketride-server/, regardless of overlay.
+const SHELL_UI_SRC  = path.join(PROJECT_ROOT, 'apps', 'shell-ui', 'src');
+const SHARED_UI_SRC = path.join(PROJECT_ROOT, 'packages', 'shared-ui', 'src');
+
+/**
+ * Create a standard builder module for an MF remote app.
+ *
+ * Generates actions: bundle, register, copy, build, clean, and optionally dev.
+ *
+ * @param {object} config
+ * @param {string} config.name        - Module name (e.g. 'models-ui').
+ * @param {string} config.description - Human-readable description.
+ * @param {string} config.appRoot     - Absolute path to the app's root directory.
+ * @param {boolean} [config.dev=false] - Include a :dev action for rsbuild dev server.
+ * @returns {object} Builder module definition with name, description, and actions.
+ */
+function createAppModule({ name, description, appRoot, dev = false }) {
+	// Derived paths
+	const buildDir       = path.join(BUILD_ROOT, 'apps', name);
+	const serverStaticDir = path.join(DIST_ROOT, 'server', 'static', 'shell', 'apps', name);
+
+	// Build input tracking
+	const srcDir       = path.join(appRoot, 'src');
+	const pkgJson      = path.join(appRoot, 'package.json');
+	const buildHashKey = `${name}.buildHash`;
+
+	// Source directories that affect this app's build output
+	const inputDirs  = [srcDir, SHELL_UI_SRC, SHARED_UI_SRC];
+	const inputFiles = [pkgJson];
+
+	// =========================================================================
+	// ACTION FACTORIES
+	// =========================================================================
+
+	/**
+	 * Bundle the app via rsbuild with build-input caching.
+	 * Cleans the output directory before rebuilding to prevent stale chunks.
+	 */
+	function makeBundleAction() {
+		return {
+			run: async (ctx, task) => {
+				// Check if any build inputs changed; skip when nothing moved.
+				if (!ctx.options.force) {
+					const { changed } = await hasBuildInputChanged(buildHashKey, inputDirs, inputFiles);
+					const outputExists = await exists(buildDir);
+					if (!changed && outputExists) {
+						task.output = 'No changes detected';
+						return;
+					}
+				}
+
+				// Clean build output before rebuilding to prevent stale chunks
+				await removeDir(buildDir);
+				await execCommand('npx', ['rsbuild', 'build'], { task, cwd: appRoot });
+
+				// Persist the hash so the next run can skip if nothing changed
+				const { hash } = await hasBuildInputChanged(buildHashKey, inputDirs, inputFiles);
+				await saveSourceHash(buildHashKey, hash);
+			},
+		};
+	}
+
+	/**
+	 * Copy the built output to the server's static directory.
+	 */
+	function makeCopyAction() {
+		return {
+			run: async (ctx, task) => {
+				const stats = await syncDir(buildDir, serverStaticDir);
+				task.output = formatSyncStats(stats);
+			},
+		};
+	}
+
+	// =========================================================================
+	// MODULE DEFINITION
+	// =========================================================================
+
+	const actions = [
+		// Internal actions (no description — not shown in builder --help)
+		{ name: `${name}:bundle`,   action: makeBundleAction },
+		{ name: `${name}:register`, action: () => registerApp(appRoot) },
+		{ name: `${name}:copy`,     action: makeCopyAction },
+
+		// Full build: compile TS client SDK → bundle → register → copy
+		{
+			name: `${name}:build`,
+			action: () => ({
+				description: `Build ${name}`,
+				steps: [
+					'client-typescript:build',
+					`${name}:bundle`,
+					`${name}:register`,
+					`${name}:copy`,
+				],
+			}),
+		},
+
+		// Clean build artifacts and cached hash
+		{
+			name: `${name}:clean`,
+			action: () => ({
+				description: `Cleaning ${name}`,
+				run: async (ctx, task) => {
+					await removeDir(buildDir);
+					await removeDir(serverStaticDir);
+					await removeDir(path.join(appRoot, 'dist'));
+					await setState(buildHashKey, null);
+					task.output = `Cleaned ${name}`;
+				},
+			}),
+		},
+	];
+
+	// Optional dev server action
+	if (dev) {
+		actions.push({
+			name: `${name}:dev`,
+			action: () => ({
+				description: `Starting ${name} (dev)`,
+				run: async (ctx, task) => {
+					task.output = 'Starting development server...';
+					await execCommand('npx', ['rsbuild', 'dev'], { task, cwd: appRoot });
+				},
+			}),
+		});
+	}
+
+	return { name, description, actions };
+}
+
+module.exports = { createAppModule };

--- a/scripts/lib/appModule.js
+++ b/scripts/lib/appModule.js
@@ -159,7 +159,7 @@ function createAppModule({ name, description, appRoot, dev = false }) {
 		{
 			name: `${name}:clean`,
 			action: () => ({
-				description: `Cleaning ${name}`,
+				description: `Clean ${name}`,
 				run: async (ctx, task) => {
 					await removeDir(buildDir);
 					await removeDir(serverStaticDir);
@@ -176,7 +176,7 @@ function createAppModule({ name, description, appRoot, dev = false }) {
 		actions.push({
 			name: `${name}:dev`,
 			action: () => ({
-				description: `Starting ${name} (dev)`,
+				description: `Start ${name} (dev)`,
 				run: async (ctx, task) => {
 					task.output = 'Starting development server...';
 					await execCommand('npx', ['rsbuild', 'dev'], { task, cwd: appRoot });

--- a/scripts/lib/appModule.js
+++ b/scripts/lib/appModule.js
@@ -102,22 +102,18 @@ function createAppModule({ name, description, appRoot, dev = false }) {
 	function makeBundleAction() {
 		return {
 			run: async (ctx, task) => {
-				// Check if any build inputs changed; skip when nothing moved.
-				if (!ctx.options.force) {
-					const { changed } = await hasBuildInputChanged(buildHashKey, inputDirs, inputFiles);
-					const outputExists = await exists(buildDir);
-					if (!changed && outputExists) {
-						task.output = 'No changes detected';
-						return;
-					}
+				// Fingerprint inputs before building so concurrent edits are detected on the next run.
+				const { changed, hash } = await hasBuildInputChanged(buildHashKey, inputDirs, inputFiles);
+				if (!ctx.options.force && !changed && (await exists(buildDir))) {
+					task.output = 'No changes detected';
+					return;
 				}
 
 				// Clean build output before rebuilding to prevent stale chunks
 				await removeDir(buildDir);
 				await execCommand('npx', ['rsbuild', 'build'], { task, cwd: appRoot });
 
-				// Persist the hash so the next run can skip if nothing changed
-				const { hash } = await hasBuildInputChanged(buildHashKey, inputDirs, inputFiles);
+				// Persist the pre-build hash so any concurrent edits force a rebuild next time
 				await saveSourceHash(buildHashKey, hash);
 			},
 		};
@@ -129,7 +125,7 @@ function createAppModule({ name, description, appRoot, dev = false }) {
 	function makeCopyAction() {
 		return {
 			run: async (ctx, task) => {
-				const stats = await syncDir(buildDir, serverStaticDir);
+				const stats = await syncDir(buildDir, serverStaticDir, { package: true });
 				task.output = formatSyncStats(stats);
 			},
 		};

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -630,9 +630,13 @@ async function buildInputHash(dirs, files = []) {
             const st = await fsp.stat(file);
             hash.update(file);
             hash.update(`${st.size}:${st.mtimeMs}`);
-        } catch {
-            hash.update(file);
-            hash.update('missing');
+        } catch (err) {
+            if (err?.code === 'ENOENT') {
+                hash.update(file);
+                hash.update('missing');
+                continue;
+            }
+            throw err;
         }
     }
 

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -604,6 +604,56 @@ async function saveSourceHash(stateKey, hash) {
     await setState(stateKey, hash);
 }
 
+/**
+ * Compute a combined MD5 hash of multiple source directories and individual files.
+ * Uses fingerprint() (mtime+size) for speed.  Produces a single cache key for
+ * build actions that depend on several inputs (e.g. own src/ + shared-ui/src +
+ * package.json).
+ *
+ * @param {string[]} dirs   - Directories to fingerprint.
+ * @param {string[]} [files] - Individual files to include (e.g. package.json).
+ * @returns {Promise<string>} Combined hex digest.
+ */
+async function buildInputHash(dirs, files = []) {
+    const hash = crypto.createHash('md5');
+
+    // Fingerprint each source directory
+    for (const dir of dirs) {
+        const fp = await fingerprint(dir);
+        hash.update(dir);
+        hash.update(fp ?? 'missing');
+    }
+
+    // Include individual files by size + mtime
+    for (const file of files) {
+        try {
+            const st = await fsp.stat(file);
+            hash.update(file);
+            hash.update(`${st.size}:${st.mtimeMs}`);
+        } catch {
+            hash.update(file);
+            hash.update('missing');
+        }
+    }
+
+    return hash.digest('hex');
+}
+
+/**
+ * Check if any build inputs have changed since last build.
+ *
+ * @param {string}   stateKey - Key in state.json (e.g. 'models-ui.buildHash').
+ * @param {string[]} dirs     - Source directories to fingerprint.
+ * @param {string[]} [files]  - Individual files to include.
+ * @returns {Promise<{changed: boolean, hash: string}>}
+ */
+async function hasBuildInputChanged(stateKey, dirs, files = []) {
+    const { getState } = require('./state');
+    const currentHash = await buildInputHash(dirs, files);
+    const savedHash = await getState(stateKey);
+    return { changed: currentHash !== savedHash, hash: currentHash };
+}
+
 module.exports = {
     // Existence
     exists,
@@ -661,5 +711,7 @@ module.exports = {
     fingerprint,
     contentHash,
     hasSourceChanged,
-    saveSourceHash
+    saveSourceHash,
+    buildInputHash,
+    hasBuildInputChanged
 };

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -45,7 +45,7 @@ module.exports = {
 			// Clean all UI build artifacts in parallel.
 			name: 'ui:clean',
 			action: () => ({
-				description: 'Clean all UI app build artifacts',
+				description: 'Cleaning ui (all)',
 				steps: [
 					parallel([
 						'shell-ui:clean',
@@ -63,7 +63,7 @@ module.exports = {
 			// Build all UI apps. Shell builds first (host), then remotes in parallel.
 			name: 'ui:build',
 			action: () => ({
-				description: 'Build all UI apps (shell + remotes)',
+				description: 'Build ui (all)',
 				steps: [
 					'shell-ui:build',
 					parallel([

--- a/tools/scripts/tasks.js
+++ b/tools/scripts/tasks.js
@@ -2,7 +2,7 @@
  * Build tasks for model sync tooling
  *
  * Commands:
- *   models:update - Sync LLM model lists from provider APIs, then format services.json files
+ *   models:update - Updating models
  */
 
 const path = require('path');

--- a/tools/scripts/tasks.js
+++ b/tools/scripts/tasks.js
@@ -106,7 +106,7 @@ module.exports = {
 		{
 			name: 'models:update',
 			action: () => ({
-				description: 'Sync LLM model lists from provider APIs and format JSON files',
+				description: 'Updating models',
 				steps: ['models:run-sync', 'models:prettier'],
 			}),
 		},


### PR DESCRIPTION
## Summary

A broad set of fixes and improvements spanning Module Federation infrastructure,
the Python ModelClient SDK, settings page UX, billing display, cloud auth flow,
and card button styling.

### Module Federation stability
- Add `runtime: false` to all MF remote apps (hello-ui, monitor-ui, profiler-ui,
  world-ui) to prevent duplicate runtime copies causing version-mismatch errors
  and stale remoteEntry.js on every rebuild.
- Add `eager: true` to shared react/react-dom configs to break async shared-scope
  deadlocks during single-remote recompilation.
- **appLoader.ts**: Filter out server-only apps with no `entry` URL before calling
  `registerRemotes()`, preventing `normalizeRemote()` crash on undefined.

### ModelClient SDK refactor
- **Derive ModelClient from RocketRideClient** with `ws_path='/models'` so URI
  normalisation, protocol selection (ws vs wss), and auth are handled by the SDK
  automatically. Previously ModelClient built its own hardcoded `ws://` URL,
  breaking TLS connections and skipping auth.
- **Add `ws_path` kwarg** to Python SDK (RocketRideClient + ConnectionMixin),
  matching the TypeScript SDK.
- **Synchronous disconnect()** override — all ModelClient callers are sync worker
  threads; the inherited async version caused "coroutine was never awaited" warnings.
- **Simplify `get_model_server_address()`** to return the raw `--modelserver` string
  instead of parsing into a (host, port) tuple. Remove `get_model_server_port()`.
- **Update all 9 model wrappers** (whisper, gliner, sentence_transformers,
  transformers ×2, vision ×2, doctr, easyocr, surya, trocr) and PipelineProxy/
  ModelProxy constructors.
- **audio_tts/IGlobal.py**: Fix missed callsite still using tuple unpacking.

### Theme loading fix
- shell-ui's `assetPrefix: '/shell/'` caused theme JSON files to be unreachable
  after a clean build (they existed only as stale leftovers from previous builds).
- Add `output.copy` rule to shell-ui rsbuild.config.ts to copy `public/themes/`
  into the build output.

### Settings — dirty-state save pattern
- Implement Cancel/Save/Saved UX across all settings pages:
  - Card header starts clean (no buttons)
  - Editing any field shows Cancel + Save
  - Successful save flashes "Saved" then fades
  - Cancel reverts to last-saved snapshot
- **VSCode** (SettingsWebview.tsx): dirty/saved state, savedSettingsRef, Cancel
  handler, all 5 tab components updated.
- **shell-ui** (SettingsPage): hide Save/Cancel when not dirty, Cancel reverts
  to workspace settings.

### Card button size modifiers
- Add `commonStyles.cardHeaderButton` and `cardBodyButton` — size-only modifiers
  that decouple card button sizing from colour, allowing header vs body sizing to
  diverge independently.
- Migrated all card-context buttons across Account (7 panels), Billing, and VSCode
  Settings.

### Billing — app display names
- Subscription cards and cancel dialogs now show the human-readable app name
  (e.g. "Brandy") instead of the raw appId (e.g. "rocketride.brandy").
- Replace `appNames: Record<string, string>` prop with full `apps` manifest array;
  each component builds its own appMap via useMemo.
- Data flow: shell-ui pulls from `useWorkspace().appManifest`; VSCode pulls from
  `authUser.apps ?? profile.apps`.

### VSCode — team fetch decoupling
- Cloud team selector wasn't appearing after sign-in because team fetching was
  embedded in the cached `probeServerInfo()`. If probe ran before auth, teams
  were never fetched.
- Clean separation: (1) Probe on mount — capabilities only, cached. (2) Sign in —
  OAuth completes. (3) Fetch teams — `useEffect([isSaas, cloudSignedIn])` triggers
  when both are true. Covers all timing scenarios.

### Cleanup
- Remove leftover `console.log(identity.apps)` debug logging.

### Builder — build-input caching
- Add `buildInputHash()` / `hasBuildInputChanged()` to `fs.js` for source
  fingerprinting; `./builder build` skips unchanged modules.
- Add `appModule.js` factory for MF remote apps (~80 lines less boilerplate each).
- `--force` bypasses caching; clean clears cached hashes.
- Standardize all task descriptions to consistent verb pattern.

## Test plan
- [ ] `./builder build` — verify cached builds skip unchanged modules
- [ ] `./builder build --force` — verify forced rebuild ignores cache
- [ ] Clean build (`./builder clean build`) — verify themes load correctly at `/shell/themes/`
- [ ] HMR: rebuild a single remote app, verify no MF version mismatch
- [ ] Open settings, edit a field → Cancel/Save appear; Save → "Saved" flash; Cancel → revert
- [ ] Billing page shows app display names, not raw appIds
- [ ] Sign out → sign in → team selector appears without page reload
- [ ] Connect to a TLS model server — verify wss:// and auth work via new ModelClient
- [ ] App manifest with server-only entries (no `entry` URL) — no crash on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now show Cancel/Save when edits are dirty, plus a transient "Saved" indicator and cancel-to-revert behavior.
  * Apps list/manifest is now passed through UI views (Account/Billing) via an apps prop for accurate app names.

* **Bug Fixes**
  * App registration skips entries missing remote endpoints to avoid load errors.
  * Model-server address handling corrected for more reliable proxy connections.

* **Improvements**
  * Build system: input-based caching with hash checking and stale-output cleanup to skip unnecessary rebuilds.
  * Consolidated, consistent button styling across account, billing, teams, and environment UIs.


<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/877)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->