### PR TITLE
feat(shell-ui): apply saved theme on init to prevent tan loading flash

### DIFF
--- a/apps/shell-ui/index.html
+++ b/apps/shell-ui/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="RocketRide" />
     <link rel="icon" href="/shell/favicon.svg" type="image/svg+xml" />
+    <script>(function(){try{var h=localStorage.getItem('rr:home:theme'),t=localStorage.getItem('rr:theme');var d=h==='dark'||(h!=='light'&&!!t&&t!=='rocketride-light'&&t!=='light');if(d){document.documentElement.style.setProperty('--rr-bg-default','#080808');document.documentElement.style.background='#080808';}}catch(e){}})();</script>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/shell-ui/src/createShellConfig.ts
+++ b/apps/shell-ui/src/createShellConfig.ts
@@ -110,9 +110,18 @@ export function buildShellConfig(apps: AppManifestEntry[], capabilities: string[
 			welcomeSubtitle: 'Select an app to get started.',
 		},
 
-		// Apply the default theme on first mount.
-		// Theme JSON files are served under /shell/themes/ by the shell module.
-		onInit: () => fetchAndApplyTheme('rocketride-light', '/shell/themes').catch(console.error),
+		// Apply the user's saved theme on first mount so the loading screen
+		// background matches their preference instead of always showing light.
+		// Falls back to rocketride-light if nothing is saved yet.
+		onInit: () => {
+			const homeTheme = (() => { try { return localStorage.getItem('rr:home:theme'); } catch { return null; } })();
+			const saved = (() => {
+				if (homeTheme === 'dark') return 'rocketride';
+				if (homeTheme === 'light') return 'rocketride-light';
+				try { return localStorage.getItem('rr:theme') || 'rocketride-light'; } catch { return 'rocketride-light'; }
+			})();
+			return fetchAndApplyTheme(saved, '/shell/themes').catch(console.error);
+		},
 
 		themeConfig: {
 			options: THEME_OPTIONS,


### PR DESCRIPTION
## Summary

Eliminates the tan/light background flash during the OAuth sign-in loading window for users who have a dark theme preference saved.

- **`index.html`**: Inline script sets `--rr-bg-default` and `body.background` to `#080808` synchronously before React renders, so the page starts dark before `applyDefaults.ts` fires.
- **`createShellConfig.ts` `onInit`**: Reads `localStorage['rr:home:theme']` then `localStorage['rr:theme']` to apply the user's saved theme instead of always defaulting to `rocketride-light`, eliminating the tan background during the 1.5s OAuth code-exchange loading window.

Both changes are required together — `index.html` wins the race before `applyDefaults` overwrites the CSS variable, and `createShellConfig` keeps it dark once the async theme fetch completes.

## Test plan
- [ ] Sign out and back in with dark mode saved — no tan flash during loading
- [ ] First-time user (no saved preference) — still loads with light theme correctly
- [ ] Light mode users — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Your theme preference is now saved and automatically restored when you return to the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/878)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->