### PR TITLE
chore(deps): pin cryptography>=46.0.7 in text_output

### DIFF
--- a/nodes/src/nodes/text_output/requirements.txt
+++ b/nodes/src/nodes/text_output/requirements.txt
@@ -1,6 +1,6 @@
 # smbprotocol
 cffi
-cryptography
+cryptography==46.0.7
 pycparser
 pyspnego
 smbprotocol


### PR DESCRIPTION
## Summary
- Pins `cryptography>=46.0.7` in `nodes/src/nodes/text_output/requirements.txt` (was unpinned).
- Resolves 3 open Dependabot alerts (1 high / 1 medium / 1 low) — all clear at `46.0.7`.
- Sibling node `db_mysql/requirements.txt` already pins `==46.0.7` (landed in #856); this aligns `text_output` so the alerts auto-close on next Dependabot rescan.

## Alerts resolved
| GHSA | Severity | Issue |
|---|---|---|
| GHSA-r6ph-v2qm-q3c2 | high | Subgroup attack on SECT curves (missing subgroup validation) |
| GHSA-p423-j2cm-9vmq | medium | Buffer overflow on non-contiguous buffers |
| GHSA-m959-cc7f-wv43 | low | Incomplete DNS name constraint enforcement on peer names |

## Test plan
- [ ] CI green (Build / Ubuntu, Windows, macOS)
- [ ] `gitleaks` clean
- [ ] After merge: confirm Dependabot rescan auto-closes alerts #64, #65, #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the cryptography dependency to version 46.0.7 for the text output component to improve dependency stability and security compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/884)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/884)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->