### PR TITLE
fix(cli): implement signal handlers for graceful shutdown (RR-655)

### DIFF
--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -801,6 +801,7 @@ export class RocketRideCLI {
 	private connected: boolean = false;
 	private attempt: number = 0;
 	private cancelled: boolean = false;
+	private signalShutdownPromise?: Promise<never>;
 
 	constructor() {
 		this.setupSignalHandlers();
@@ -814,13 +815,53 @@ export class RocketRideCLI {
 		return this.cancelled;
 	}
 
+	isShuttingDown(): boolean {
+		return this.signalShutdownPromise !== undefined;
+	}
+
+	// Resolves only when the signal handler calls process.exit, so any
+	// command/run/main flow that awaits this will stand down and let the
+	// signal handler own the exit code.
+	awaitShutdown(): Promise<never> {
+		return this.signalShutdownPromise ?? new Promise<never>(() => {});
+	}
+
 	private setupSignalHandlers(): void {
-		// TODO: Enable proper signal handling
-		// const signalHandler = () => {
-		// 	this.cancel();
-		// };
-		// process.on('SIGINT', signalHandler);
-		// process.on('SIGTERM', signalHandler);
+		const FORCE_EXIT_TIMEOUT_MS = 5000;
+
+		const signalHandler = async (signal: string) => {
+			const exitCode = 128 + (signal === 'SIGINT' ? 2 : 15);
+
+			if (this.signalShutdownPromise) {
+				// Second signal: force exit immediately
+				process.exit(exitCode);
+			}
+
+			// Park a promise that never resolves; other flows await it to
+			// stand down while the signal handler drives the exit.
+			this.signalShutdownPromise = new Promise<never>(() => {});
+
+			this.cancel();
+
+			// Force exit if cleanup hangs
+			const forceExitTimer = setTimeout(() => {
+				console.error(`\nCleanup timed out after ${FORCE_EXIT_TIMEOUT_MS}ms, forcing exit`);
+				process.exit(exitCode);
+			}, FORCE_EXIT_TIMEOUT_MS);
+
+			try {
+				await this.cleanupClient();
+			} catch {
+				// Ignore cleanup errors during signal handling
+			} finally {
+				clearTimeout(forceExitTimer);
+			}
+
+			process.exit(exitCode);
+		};
+
+		process.on('SIGINT', () => signalHandler('SIGINT'));
+		process.on('SIGTERM', () => signalHandler('SIGTERM'));
 	}
 
 	private createProgram(): Command {
@@ -858,10 +899,14 @@ export class RocketRideCLI {
 
 				try {
 					const exitCode = await this.cmdStart();
-					process.exit(exitCode);
+					if (!this.isCancelled()) {
+						process.exit(exitCode);
+					}
 				} finally {
-					this.cancel();
-					await this.cleanupClient();
+					if (!this.isCancelled()) {
+						this.cancel();
+						await this.cleanupClient();
+					}
 				}
 			});
 
@@ -896,10 +941,14 @@ export class RocketRideCLI {
 
 				try {
 					const exitCode = await this.cmdUpload();
-					process.exit(exitCode);
+					if (!this.isCancelled()) {
+						process.exit(exitCode);
+					}
 				} finally {
-					this.cancel();
-					await this.cleanupClient();
+					if (!this.isCancelled()) {
+						this.cancel();
+						await this.cleanupClient();
+					}
 				}
 			});
 
@@ -925,10 +974,14 @@ export class RocketRideCLI {
 
 				try {
 					const exitCode = await this.cmdStatus();
-					process.exit(exitCode);
+					if (!this.isCancelled()) {
+						process.exit(exitCode);
+					}
 				} finally {
-					this.cancel();
-					await this.cleanupClient();
+					if (!this.isCancelled()) {
+						this.cancel();
+						await this.cleanupClient();
+					}
 				}
 			});
 
@@ -954,10 +1007,14 @@ export class RocketRideCLI {
 
 				try {
 					const exitCode = await this.cmdStop();
-					process.exit(exitCode);
+					if (!this.isCancelled()) {
+						process.exit(exitCode);
+					}
 				} finally {
-					this.cancel();
-					await this.cleanupClient();
+					if (!this.isCancelled()) {
+						this.cancel();
+						await this.cleanupClient();
+					}
 				}
 			});
 
@@ -1188,16 +1245,20 @@ export class RocketRideCLI {
 		}
 	}
 
+	private _cleanupPromise?: Promise<void>;
+
 	private async cleanupClient(): Promise<void> {
-		if (this.client) {
-			try {
-				await this.client.disconnect();
-			} catch {
-				// Ignore cleanup errors
-			} finally {
-				this.client = undefined;
-			}
+		if (this._cleanupPromise) {
+			return this._cleanupPromise;
 		}
+		const client = this.client;
+		if (!client) {
+			return;
+		}
+		this.client = undefined;
+		this._cleanupPromise = client.disconnect().catch(() => {});
+		await this._cleanupPromise;
+		this._cleanupPromise = undefined;
 	}
 
 	private loadPipelineConfig(pipelineFile: string): PipelineConfig {
@@ -1693,8 +1754,15 @@ export class RocketRideCLI {
 		// Parse command line arguments - commander will handle command routing
 		try {
 			await program.parseAsync(process.argv);
+			if (this.isShuttingDown()) {
+				// Signal handler owns the exit; park until it calls process.exit.
+				await this.awaitShutdown();
+			}
 			return 0; // If we get here, a command was executed successfully
 		} catch (error) {
+			if (this.isShuttingDown()) {
+				await this.awaitShutdown();
+			}
 			if (error instanceof Error && error.message.includes('interrupted')) {
 				console.log('\nOperation interrupted by user');
 				return 1;
@@ -1721,11 +1789,18 @@ function formatError(e: Error): string {
 }
 
 export async function main(): Promise<void> {
+	const cli = new RocketRideCLI();
 	try {
-		const cli = new RocketRideCLI();
 		const exitCode = await cli.run();
+		if (cli.isShuttingDown()) {
+			// Signal handler owns the exit code; never race it to process.exit.
+			await cli.awaitShutdown();
+		}
 		process.exit(exitCode);
 	} catch (error) {
+		if (cli.isShuttingDown()) {
+			await cli.awaitShutdown();
+		}
 		if (error instanceof Error && error.message.includes('interrupted')) {
 			console.log('\n\nOperation interrupted by user');
 		} else {


### PR DESCRIPTION
## Summary

- Implements SIGINT/SIGTERM signal handlers in the CLI (`packages/client-typescript/src/cli/rocketride.ts`)
- On signal: cancels the current operation, calls `cleanupClient()` to disconnect from the server, and exits with proper signal exit codes (130 for SIGINT, 143 for SIGTERM)
- Adds a 5-second force-exit timeout if cleanup hangs, and a second signal always force-exits immediately
- Idempotent `cleanupClient()` via dedup promise to prevent double-disconnect races
- `isCancelled()` guards on command actions (start, upload, status, stop) to prevent racing the signal handler to `process.exit`
- `run()` / `main()` park on `awaitShutdown()` when the signal handler is driving the exit

## Context

Rebased from #581 (by @charliegillet) onto current `develop`. Changes already merged separately (redaction regex, CSS comment fix, PageStatus UI, upload progress math) were dropped — only the signal handler work remains.

Closes #655

## Test plan

- [ ] Run `rocketride start --pipeline test.pipeline` and press Ctrl+C — verify graceful disconnect and exit code 130
- [ ] Send SIGTERM to a running CLI process — verify cleanup and exit code 143
- [ ] Press Ctrl+C twice rapidly — verify immediate force exit on second signal
- [ ] Simulate a hanging `disconnect()` — verify force exit after 5s timeout
- [ ] `./builder client-typescript:clean client-typescript:build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced shutdown handling to ensure reliable graceful exit when terminating the CLI with Ctrl+C or system signals
  * Implemented coordinated cleanup procedures to prevent race conditions between command execution and signal-driven exits, resulting in more predictable termination behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/891)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->