### PR TITLE
fix(shared-ui): explorer empty-state create + annotation double-click editor

### DIFF
--- a/packages/shared-ui/src/components/canvas/components/node/node-annotation/NodeAnnotation.tsx
+++ b/packages/shared-ui/src/components/canvas/components/node/node-annotation/NodeAnnotation.tsx
@@ -46,6 +46,7 @@ import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { INodeData, INodeType } from '../../../types';
 import ConditionalRender from '../../ConditionalRender';
 import NodeHeader from '../node-component/header';
+import { useFlow } from '../../../hooks';
 
 // =============================================================================
 // Styles
@@ -167,6 +168,8 @@ interface INodeAnnotationProps {
  * @returns The rendered annotation node.
  */
 export default function NodeAnnotation({ id, data, type, parentId, selected }: INodeAnnotationProps): ReactElement {
+	const { setEditingNodeId } = useFlow();
+
 	// Annotation-specific display fields from node config
 	const bgColor = (data.config?.bgColor as string) || DEFAULT_BG_COLOR;
 	const fgColor = (data.config?.fgColor as string) || DEFAULT_FG_COLOR;
@@ -191,6 +194,10 @@ export default function NodeAnnotation({ id, data, type, parentId, selected }: I
 					color: fgColor,
 				}}
 				className="nowheel rr-annotation-root"
+				onDoubleClick={(e) => {
+					e.stopPropagation();
+					setEditingNodeId(id);
+				}}
 			>
 				{/* Header — hidden until hover via CSS */}
 				<div style={{ ...styles.header, color: 'var(--rr-text-primary)' }} className="annotation-header">
@@ -199,7 +206,7 @@ export default function NodeAnnotation({ id, data, type, parentId, selected }: I
 
 				{/* Content area — rendered markdown */}
 				<div className="rr-annotation-content">
-					<ConditionalRender condition={content} fallback={<span style={styles.placeholder}>Double-click gear to add content...</span>}>
+					<ConditionalRender condition={content} fallback={<span style={styles.placeholder}>Double-click to add content...</span>}>
 						<ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} components={markdownComponents}>
 							{content}
 						</ReactMarkdown>

--- a/packages/shared-ui/src/modules/explorer/Explorer.tsx
+++ b/packages/shared-ui/src/modules/explorer/Explorer.tsx
@@ -742,9 +742,14 @@ export const Explorer: React.FC<IExplorerProps> = ({ vfs, config, entries, statu
 			</div>
 
 			{/* ── File tree ───────────────────────────────────────────── */}
+			{/* When the tree is empty we still need to render the inline create
+			    input if the user just clicked +File / +Folder at the root, since
+			    that input lives inside renderChildren(). */}
 			<div style={S.treeList}>
-				{entries.length === 0 && <div style={S.emptyState}>{config.emptyMessage ?? 'No files'}</div>}
-				{entries.length > 0 && renderChildren()}
+				{entries.length === 0 && !(createState && createState.parentDir === '') && (
+					<div style={S.emptyState}>{config.emptyMessage ?? 'No files'}</div>
+				)}
+				{(entries.length > 0 || (createState && createState.parentDir === '')) && renderChildren()}
 			</div>
 		</div>
 	);

--- a/packages/shared-ui/src/modules/explorer/Explorer.tsx
+++ b/packages/shared-ui/src/modules/explorer/Explorer.tsx
@@ -435,10 +435,10 @@ export const Explorer: React.FC<IExplorerProps> = ({ vfs, config, entries, statu
 		(type: 'file' | 'folder') => {
 			let parentDir = '';
 			if (selectedPath) {
-				const isDir = entries.some((e) => e.type === 'dir' && e.path === selectedPath);
-				if (isDir) {
+				const selectedEntry = entries.find((e) => e.path === selectedPath);
+				if (selectedEntry?.type === 'dir') {
 					parentDir = selectedPath;
-				} else {
+				} else if (selectedEntry) {
 					parentDir = selectedPath.includes('/') ? selectedPath.substring(0, selectedPath.lastIndexOf('/')) : '';
 				}
 			}


### PR DESCRIPTION
## Summary

Two small canvas/builder fixes surfaced during QA on the SaaS app (`rocketride-saas` PR #98 picks these up via submodule pointer).

- **Explorer: create folder/file are no-ops on an empty tree.** The inline create input was gated behind `entries.length > 0`, so once the project tree was empty (after deleting everything during QA), the New folder / New file buttons silently did nothing. Render the inline input when either entries exist or a root-level create is pending.
- **Annotation: note editor is unreachable.** The canvas note placeholder said _"Double-click gear to add content..."_, but the gear icon is hidden until parent hover (CSS opacity:0 on `.rr-annotation-root:hover .annotation-header`) and opens on single-click, not double-click. The note body had no `onDoubleClick` handler. Add the handler on the annotation root that calls `setEditingNodeId(id)`, and correct the placeholder text. The single-click-gear path is unchanged.

## Commits

- `0003f64` — fix(shared-ui/explorer): render inline create input when tree is empty
- `7b395f1` — fix(shared-ui/annotation): make note editor reachable via double-click

## Files

- `packages/shared-ui/src/modules/explorer/Explorer.tsx` — render `renderChildren()` when entries exist OR a root-level create is pending; only show the "No files" empty-state when neither
- `packages/shared-ui/src/components/canvas/components/node/node-annotation/NodeAnnotation.tsx` — import `useFlow`, add `onDoubleClick` on the annotation root, fix placeholder text

## Test plan

- [ ] Delete every pipeline from the Pipelines tree so it's empty → click the "New folder" or "New file" button at the top of the sidebar → inline create input appears and accepts input
- [ ] Drop a Note (annotation) on the canvas → placeholder reads "Double-click to add content..." → double-click anywhere on the note body → NodePanel opens for editing
- [ ] Hover the note → gear icon fades in → single-click the gear → same NodePanel opens (regression check on the existing path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Node editing now activates on double-click and the empty-state hint text instructs users to double-click to edit.
  * Inline file/folder creation at the root now appears correctly when the file tree is empty, and root-level creation uses the selected entry type to determine parent placement.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/901?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->