### PR TITLE
fix(ci): allow Nightly workflow_dispatch from stage and main

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -20,13 +20,19 @@ permissions:
 # and the `if:` below skips the run, so a broken develop commit never
 # becomes a published prerelease.
 #
-# `workflow_dispatch` is kept as the manual escape hatch for hot-fix
-# flows or for re-publishing a known-good ref out of cycle.
+# `workflow_dispatch` is the manual escape hatch for hot-fix flows
+# or for re-publishing a known-good ref out of cycle. Allowed from
+# develop, stage, or main — the long-lived release branches — so a
+# release manager can promote any of those branches into the current
+# nightly slot (e.g. publishing stage as the prerelease ahead of a
+# stable cut). Feature branches are intentionally not allowed: see
+# the trust-boundary discussion in the init job's `if:` comment.
 #
 # NB: per GitHub's rules, `workflow_run` triggers always execute the
-# version of this file from the *default* branch (main), not from the
-# branch that produced the triggering CI run. So edits here only take
-# effect after they land on main — keep that in mind if iterating.
+# version of this file from the repo's *default* branch (develop),
+# not from the branch that produced the triggering CI run. So edits
+# here only take effect after they land on develop — keep that in
+# mind if iterating.
 on:
   workflow_run:
     workflows: ["CI"]
@@ -37,23 +43,33 @@ on:
 jobs:
   init:
     name: Initialize
-    # Skip when CI failed; manual dispatch always runs.
+    # Skip when CI failed; manual dispatch runs for any of the allowed
+    # release branches (develop, stage, main).
     #
-    # The `head_branch == 'develop'` guard makes explicit what the
-    # `branches: [develop]` filter on the trigger already enforces:
-    # this workflow runs privileged jobs (secrets: inherit, contents:
-    # write) on the head_sha of the triggering CI run. Static analyzers
-    # (e.g. OSSF Scorecard's DangerousWorkflow rule) flag workflow_run
-    # patterns that checkout `head_sha` without a branch check, since
-    # in principle workflow_run can be triggered by CI runs on any
-    # branch and a checkout of an untrusted ref with secrets is the
-    # canonical supply-chain attack vector. The explicit branch check
-    # below ties the trust boundary to develop's branch protection
-    # (PR + code-owner review + required checks), which is the actual
-    # safety guarantee.
+    # The `head_branch == 'develop'` guard on the workflow_run side
+    # makes explicit what the `branches: [develop]` filter on the
+    # trigger already enforces: this workflow runs privileged jobs
+    # (secrets: inherit, contents: write) on the head_sha of the
+    # triggering CI run. Static analyzers (e.g. OSSF Scorecard's
+    # DangerousWorkflow rule) flag workflow_run patterns that
+    # checkout `head_sha` without a branch check, since in principle
+    # workflow_run can be triggered by CI runs on any branch and a
+    # checkout of an untrusted ref with secrets is the canonical
+    # supply-chain attack vector. The explicit branch check below ties
+    # the trust boundary to develop's branch protection (PR +
+    # code-owner review + required checks), which is the actual safety
+    # guarantee.
+    #
+    # On the workflow_dispatch side the dispatcher already needs
+    # `Actions: write` on the repo, so the branch allowlist is more
+    # about preventing accidents (someone dispatching from a stale
+    # personal branch and publishing a broken prerelease) than a true
+    # privilege boundary.
     if: >
       (github.event_name == 'workflow_dispatch' &&
-       github.ref == 'refs/heads/develop') ||
+       (github.ref == 'refs/heads/develop' ||
+        github.ref == 'refs/heads/stage' ||
+        github.ref == 'refs/heads/main')) ||
       (github.event.workflow_run.conclusion == 'success' &&
        github.event.workflow_run.head_branch == 'develop')
     uses: ./.github/workflows/_init.yaml


### PR DESCRIPTION
## Cause

Rod tried to publish `stage` as the latest nightly prerelease yesterday:
selecting `stage` from the Nightly run-workflow dropdown silently caused
the run to **skip** ([run 25958595209](https://github.com/rocketride-org/rocketride-server/actions/runs/25958595209)). All downstream jobs (`build`, `cleanup-prereleases`, `prerelease`, `docker`) cascaded to skipped as well — the UI rendered that as a cancelled run.

The `init` job's guard only accepted `workflow_dispatch` when `github.ref == 'refs/heads/develop'`:

```yaml
if: >
  (github.event_name == 'workflow_dispatch' &&
   github.ref == 'refs/heads/develop') ||
  (github.event.workflow_run.conclusion == 'success' &&
   github.event.workflow_run.head_branch == 'develop')
```

Dispatch from `stage` failed the first branch of the OR; the second only matches `workflow_run` events; init skipped → cascade.

## Fix

Expand the dispatch allowlist to the three long-lived release branches `develop`, `stage`, `main`. Feature branches stay disallowed.

The `workflow_run` (auto-nightly) path is **unchanged** — CI on develop still triggers nightly automatically, gated by `head_branch == 'develop'` and `conclusion == 'success'`.

### Trust boundary

- **workflow_run side:** still requires `develop` (which has branch protection: PR + 1 approval + required checks). Unchanged.
- **workflow_dispatch side:** dispatcher already needs `Actions: write` on the repo, so this is more about preventing accidents (someone dispatching from a stale personal branch and publishing a broken prerelease) than a true privilege boundary. Restricting to the three release branches gives the team a stable list of "safe-to-promote" refs.

Also fixes a stale comment that claimed the default branch was `main` — it's actually `develop`, so `workflow_run` actually uses develop's `nightly.yaml`, not main's.

## Test plan
- [ ] After merge, dispatch Nightly from `stage` → init runs, build & prerelease publish from stage's head_sha
- [ ] Dispatch from `develop` still works (regression check)
- [ ] CI on develop still auto-triggers nightly via workflow_run

## Follow-up
- After this merges, sync the change to `stage` so a workflow_dispatch *from* stage uses the fixed file (GitHub Actions resolves workflow files from the dispatched ref, not the default branch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly prerelease workflow configuration to support multiple release branches and expanded manual trigger permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/906?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->