### PR TITLE
chore(deps): patch util/SVG (svgo, flatted, immutable, underscore) (PR #6d)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,10 @@
 			"cross-spawn": ">=6.0.6",
 			"dompurify": ">=3.4.0 <3.5.0",
 			"fast-uri": ">=3.1.2 <4",
+			"flatted": ">=3.4.2 <4",
 			"glob": ">=11.1.0",
 			"handlebars": ">=4.7.9 <5",
+			"immutable@5": ">=5.1.5 <6",
 			"js-yaml": ">=4.1.1",
 			"lodash": ">=4.18.1 <5",
 			"lodash-es": ">=4.18.1 <5",
@@ -70,6 +72,9 @@
 			"protobufjs": ">=7.5.5 <8",
 			"qs": ">=6.14.1",
 			"serialize-javascript": ">=7.0.5 <8",
+			"svgo@2": ">=2.8.1 <3",
+			"svgo@4": ">=4.0.1 <5",
+			"underscore": ">=1.13.8 <2",
 			"undici": ">=7.24.0 <8"
 		},
 		"supportedArchitectures": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,8 +8,10 @@ overrides:
   cross-spawn: '>=6.0.6'
   dompurify: '>=3.4.0 <3.5.0'
   fast-uri: '>=3.1.2 <4'
+  flatted: '>=3.4.2 <4'
   glob: '>=11.1.0'
   handlebars: '>=4.7.9 <5'
+  immutable@5: '>=5.1.5 <6'
   js-yaml: '>=4.1.1'
   lodash: '>=4.18.1 <5'
   lodash-es: '>=4.18.1 <5'
@@ -23,6 +25,9 @@ overrides:
   protobufjs: '>=7.5.5 <8'
   qs: '>=6.14.1'
   serialize-javascript: '>=7.0.5 <8'
+  svgo@2: '>=2.8.1 <3'
+  svgo@4: '>=4.0.1 <5'
+  underscore: '>=1.13.8 <2'
   undici: '>=7.24.0 <8'
 
 importers:
@@ -3008,10 +3013,6 @@ packages:
   '@textlint/types@15.5.1':
     resolution: {integrity: sha512-IY1OVZZk8LOOrbapYCsaeH7XSJT89HVukixDT8CoiWMrKGCTCZ3/Kzoa3DtMMbY8jtY777QmPOVCNnR+8fF6YQ==}
 
-  '@trysound/sax@0.2.0':
-    resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
-    engines: {node: '>=10.13.0'}
-
   '@tsconfig/node10@1.0.12':
     resolution: {integrity: sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==}
 
@@ -4880,8 +4881,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  flatted@3.3.3:
-    resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   flux@4.0.4:
     resolution: {integrity: sha512-NCj3XlayA2UsapRpM7va6wU1+9rE5FIL7qoMcmxWHRzbp0yujihMBm9BBHZ1MDIk5h5o2Bl6eGiCe8rYELAmYw==}
@@ -5273,8 +5274,8 @@ packages:
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
 
-  immutable@5.1.4:
-    resolution: {integrity: sha512-p6u1bG3YSnINT5RQmx/yRZBpenIl30kVxkTLDyHLIMk0gict704Q9n+thfDI7lTRm9vXdDYutVzXhzcThxTnXA==}
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
 
   import-cwd@3.0.0:
     resolution: {integrity: sha512-4pnzH16plW+hgvRECbDWpQl3cqtvSofHWh44met7ESfZ8UZOWWddm8hEyDTqREJ9RbYHY8gi8DqmaelApoOGMg==}
@@ -7611,6 +7612,10 @@ packages:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
@@ -7984,8 +7989,8 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  svgo@2.8.0:
-    resolution: {integrity: sha512-+N/Q9kV1+F+UeWYoSiULYo4xYSDQlTgb+ayMobAXPwMnLvop7oxKMo9OzIrX5x3eS4L4f2UHhc9axXwY8DpChg==}
+  svgo@2.8.2:
+    resolution: {integrity: sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==}
     engines: {node: '>=10.13.0'}
     hasBin: true
 
@@ -8277,8 +8282,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  underscore@1.13.7:
-    resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+  underscore@1.13.8:
+    resolution: {integrity: sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==}
 
   undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
@@ -11232,8 +11237,6 @@ snapshots:
     dependencies:
       '@textlint/ast-node-types': 15.5.1
 
-  '@trysound/sax@0.2.0': {}
-
   '@tsconfig/node10@1.0.12':
     optional: true
 
@@ -13445,12 +13448,12 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.3
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
-  flatted@3.3.3: {}
+  flatted@3.4.2: {}
 
   flux@4.0.4(react@18.3.1):
     dependencies:
@@ -13909,7 +13912,7 @@ snapshots:
 
   immer@9.0.21: {}
 
-  immutable@5.1.4: {}
+  immutable@5.1.5: {}
 
   import-cwd@3.0.0:
     dependencies:
@@ -15036,7 +15039,7 @@ snapshots:
     dependencies:
       date-format: 4.0.14
       debug: 4.4.3(supports-color@8.1.1)
-      flatted: 3.3.3
+      flatted: 3.4.2
       rfdc: 1.4.1
       streamroller: 3.1.5
     transitivePeerDependencies:
@@ -16127,7 +16130,7 @@ snapshots:
     dependencies:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
-      svgo: 2.8.0
+      svgo: 2.8.2
 
   postcss-unique-selectors@5.1.1(postcss@8.5.6):
     dependencies:
@@ -16842,7 +16845,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       colorjs.io: 0.5.2
-      immutable: 5.1.4
+      immutable: 5.1.5
       rxjs: 7.8.2
       supports-color: 8.1.1
       sync-child-process: 1.0.2
@@ -16870,13 +16873,15 @@ snapshots:
   sass@1.97.3:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.4
+      immutable: 5.1.5
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6
     optional: true
 
   sax@1.4.4: {}
+
+  sax@1.6.0: {}
 
   scheduler@0.23.2:
     dependencies:
@@ -17271,14 +17276,14 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svgo@2.8.0:
+  svgo@2.8.2:
     dependencies:
-      '@trysound/sax': 0.2.0
       commander: 7.2.0
       css-select: 4.3.0
       css-tree: 1.1.3
       csso: 4.2.0
       picocolors: 1.1.1
+      sax: 1.6.0
       stable: 0.1.8
 
   sync-child-process@1.0.2:
@@ -17568,7 +17573,7 @@ snapshots:
     dependencies:
       qs: 6.14.1
       tunnel: 0.0.6
-      underscore: 1.13.7
+      underscore: 1.13.8
 
   typescript-eslint@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -17597,7 +17602,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  underscore@1.13.7: {}
+  underscore@1.13.8: {}
 
   undici-types@5.26.5: {}
 


### PR DESCRIPTION
## Summary
Final themed long-tail PR (#6d — utilities and SVG). Closes out the four-PR sweep that started with #6a/#914.

## Override entries

```diff
 "overrides": {
   ...
+  "flatted":     ">=3.4.2 <4",
   ...
+  "immutable@5": ">=5.1.5 <6",
   ...
+  "svgo@2":      ">=2.8.1 <3",
+  "underscore":  ">=1.13.8 <2",
   ...
 }
```

## Resolved versions (before → after)

| Pkg | Before | After | Selector |
|---|---|---|---|
| svgo | 2.8.0 | **2.8.2** | `svgo@2` |
| flatted | 3.3.3 | **3.4.2** | (unbounded major) |
| immutable | 5.1.4 | **5.1.5** | `immutable@5` |
| underscore | 1.13.7 | **1.13.8** | (unbounded major) |

## Advisories cleared (4 total, all high)

| GHSA | Pkg | Issue |
|---|---|---|
| GHSA-xpqw-6gx7-v673 | svgo | ReDoS via crafted SVG path attribute parsing (2.x) |
| GHSA-rf6f-7fwh-wjgh | flatted | Prototype pollution via crafted circular reference |
| GHSA-wf6x-7x77-mvgw | immutable | ReDoS in `toJSON` serialization path (5.x) |
| GHSA-qpx9-hpmf-5gmw | underscore | Command injection in `_.template` with user-controlled templates |

## Per-major scoping

- `svgo@2`: svgo 3.x exists and is API-incompatible (changed CommonJS exports). Scoping to `2` keeps the 2.x callers on 2.x.
- `immutable@5`: 4.x co-exists in older deps but isn't affected by this advisory (range starts at 5.0.0). Scoping prevents collateral 4.x→5.x bumps.

## Test plan
- [ ] CI green across 3 platforms
- [ ] gitleaks clean
- [ ] After merge: Dependabot rescan auto-closes alerts #116 (svgo), #126 (flatted), #115 (immutable), #113 (underscore)

## Long-tail sweep — final status

| PR | Theme | Alerts | Status |
|---|---|---|---|
| #6a (#914) | routing | 2 | CI green, awaits review |
| #6b (#915) | parsers | 5 | CI green, awaits review |
| #6c (#916) | middleware | 4 | CI green, awaits review |
| **#6d (this PR)** | util/SVG | 4 | CI running |

**Total when all 4 merge**: 15 of 19 outstanding alerts cleared. Remaining 4 are zombie/stale (3× cryptography pip, 1× @rspack/core) and will auto-close on next Dependabot rescan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency overrides to tighten version constraints and improve compatibility across build tooling.

---

Note: This release contains no user-facing changes; the updates are internal dependency management adjustments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/917?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->