### PR TITLE
fix(builder): prevent deadlock when conditional skips a dedup branch

### DIFF
--- a/scripts/lib/action-runner.js
+++ b/scripts/lib/action-runner.js
@@ -449,9 +449,28 @@ function buildBracketTask(bracket, seen, logModule, options) {
 function buildWhenTask(when, seen, logModule, options) {
     const variant = when._variant || 'when';
 
-    // Pre-build both branches so structure is known
-    const thenTasks = buildTaskTree(when.then, seen, logModule, options);
-    const elseTasks = when.else?.length ? buildTaskTree(when.else, seen, logModule, options) : [];
+    // Pre-build both branches with cloned `seen` sets so the branch contents
+    // do NOT pollute the parent's dedup state.
+    //
+    // Why this matters: a `when`/`whenNot` block decides which branch runs at
+    // RUNTIME, but its branches' subtrees are built upfront. If we share the
+    // parent's `seen` set, a compound action `X` referenced inside (say) the
+    // then-branch would be marked seen at the parent level. Any later
+    // reference to `X` elsewhere in the tree then becomes a dedup stub
+    // (`Waiting for: X`) whose resolver lives inside the conditional branch's
+    // own subtree. When the condition skips that branch at runtime, the
+    // resolver never fires and the stub hangs forever.
+    //
+    // Cloning isolates each branch's `seen` so:
+    //   - Actions exclusively inside a branch don't appear in the parent's
+    //     dedup state. Later references outside the conditional build their
+    //     own real subtree.
+    //   - Runtime `completedActions`/lock check at line 130/192 still skips
+    //     duplicate executions if both the branch AND another path do run.
+    //   - `getOrCreateCompletion` is process-global, so a real reference
+    //     anywhere still satisfies dedup stubs that share the same name.
+    const thenTasks = buildTaskTree(when.then, new Set(seen), logModule, options);
+    const elseTasks = when.else?.length ? buildTaskTree(when.else, new Set(seen), logModule, options) : [];
     
     return {
         title: `? ${variant} ${when.name}`,


### PR DESCRIPTION
## Summary

- `builder test` could deadlock on `tika:submodule-build` when the source tree was already locally compiled (`serverReady=true`, `serverDownloaded=false`). The `whenNot ready` branch in `server:build-core` was pre-built with the parent's shared `seen` set, so the build-time-dedup stub referenced from `tika:submodule-test`'s pipeline waited on a completion promise whose resolver lived inside the never-executed `then`-branch.
- `buildWhenTask` now clones the `seen` set when pre-building each `when`/`whenNot` branch, so conditional-branch contents no longer pollute the parent's dedup state. If the same action is referenced both inside a conditional branch and elsewhere, both locations now build their own real subtree; runtime `completedActions` and the process-global `getOrCreateCompletion` still ensure exactly one execution.

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

Reproduction: run `builder build` once on a clean tree, then re-run `builder test` against the same unchanged tree. Before the fix this would hang at `Waiting for: tika:submodule-build`. After the fix, the test pipeline completes.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where conditional action branches could cause subsequent action references to fail when those branches were skipped at runtime. The fix properly isolates branch construction to prevent cross-branch conflicts and ensures consistent action resolution throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/925?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->