### PR TITLE
fix(ci): scope nightly.yaml writes to per-job permissions

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,10 +9,11 @@ concurrency:
   group: nightly
   cancel-in-progress: true
 
+# Top-level least-privilege. Individual jobs below raise to write only
+# where they actually need it (image push, tag/release publish, prerelease
+# cleanup). Closes Scorecard TokenPermissionsID #566 and #567.
 permissions:
-  contents: write
-  packages: write
-  id-token: write
+  contents: read
 
 # Triggered when develop's CI run completes successfully — this is the
 # gate. A red CI on develop (whether from a bad merge, a flaky test, or
@@ -83,6 +84,9 @@ jobs:
     name: Build
     needs: init
     uses: ./.github/workflows/_build.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       full_version: ${{ needs.init.outputs.full_server_version }}
@@ -97,6 +101,8 @@ jobs:
     name: Clean up prereleases
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -130,6 +136,9 @@ jobs:
     name: Prerelease
     needs: [init, build, cleanup-prereleases]
     uses: ./.github/workflows/_release.yaml
+    permissions:
+      contents: write
+      id-token: write
     with:
       ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       prerelease: true
@@ -144,6 +153,9 @@ jobs:
     name: Docker
     needs: [init, build]
     uses: ./.github/workflows/_docker.yaml
+    permissions:
+      contents: read
+      packages: write
     with:
       ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       server_version: ${{ needs.init.outputs.server_version }}


### PR DESCRIPTION
## Summary

- Closes Scorecard **high** alerts [#566](https://github.com/rocketride-org/rocketride-server/security/code-scanning/566) and [#567](https://github.com/rocketride-org/rocketride-server/security/code-scanning/567) — \`TokenPermissionsID\` flagging top-level \`contents: write\` and \`packages: write\` on \`nightly.yaml\`.
- Drops top-level to \`contents: read\` and adds per-job \`permissions:\` blocks on every job that actually writes. Mirrors the canonical pattern already in place on \`release.yaml\`.

## Per-job grants

| Job | Permissions | Why |
|---|---|---|
| \`init\` | (inherits read) | \`_init.yaml\` is read-only |
| \`build\` | \`contents: read\`, \`packages: write\` | Forwarded to \`_build.yaml\` for vcpkg/NuGet writes to ghcr.io |
| \`cleanup-prereleases\` | \`contents: write\` | \`git push origin --delete <tag>\` + \`gh release delete\` |
| \`prerelease\` | \`contents: write\`, \`id-token: write\` | Forwarded to \`_release.yaml\` for tag push, GH release, Sigstore signing |
| \`docker\` | \`contents: read\`, \`packages: write\` | Forwarded to \`_docker.yaml\` for ghcr image push |

## Related cleanup

The remaining 10 \`TokenPermissionsID\` alerts on this repo (#451, #452, #454, #455, #489, #490, #604, #635, #649, #650) flag job-level writes that are required for the job's function (image push, release publish, artifact cleanup, model-sync commits). Those are being dismissed separately with \`won't fix\` + per-alert justification — Scorecard penalizes any write, including the unavoidable kind, so there is no code edit that closes them without breaking the workflow.

## Test plan

- [ ] Workflow YAML parses cleanly (verified locally; CI \`actionlint\` will re-verify).
- [ ] Next nightly run completes all stages: \`init → build → cleanup-prereleases → prerelease → docker\` — confirms no permission was dropped that the workflow actually needed.
- [ ] Confirm Scorecard alerts #566 and #567 close after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve permission management across build processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->