### PR TITLE
chore(ci): pin remaining GHA actions and Docker bases by SHA/digest

### DIFF
--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -23,7 +23,7 @@ jobs:
       REPO: ${{ github.repository }}
     steps:
       - name: Checkout helper script
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |

--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -21,7 +21,7 @@ jobs:
       REPO: ${{ github.repository }}
     steps:
       - name: Checkout helper script
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -42,7 +42,7 @@ jobs:
       # to the trusted default branch (not PR head) so a fork PR can't substitute
       # a malicious helper script before we source it.
       - name: Checkout helper script
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
           sparse-checkout: |

--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -21,15 +21,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
 
       - name: Cache pip dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-sync-models-${{ hashFiles('tools/requirements.txt') }}
@@ -139,7 +139,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           title: 'chore(models): sync LLM model lists'
           base: develop

--- a/docker/Dockerfile.engine
+++ b/docker/Dockerfile.engine
@@ -6,7 +6,7 @@
 # ---------------------------------------------------------------------------
 
 # === Runtime stage =========================================================
-FROM ubuntu:jammy-20240808
+FROM ubuntu:jammy-20240808@sha256:adbb90115a21969d2fe6fa7f9af4253e16d45f8d4c1e930182610c4731962658
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.mcp
+++ b/docker/Dockerfile.mcp
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:9d3abd9fc11d06998ccdbdd93b4dd49b5ad7d67fcbbc11c016eb0eb2c2194891
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
## Summary

Closes the 9 mechanically-fixable Scorecard \`PinnedDependenciesID\` alerts. Mutable tag references become immutable hash references; Dependabot continues to bump the SHAs as new versions ship.

## GitHub Actions (7 alerts)

| File | Action | Tag → SHA | Alert |
|---|---|---|---|
| sync-models.yml | actions/checkout | v4 → \`34e1148\` | [#599](https://github.com/rocketride-org/rocketride-server/security/code-scanning/599) |
| sync-models.yml | actions/setup-python | v5 → \`a26af69\` | [#600](https://github.com/rocketride-org/rocketride-server/security/code-scanning/600) |
| sync-models.yml | actions/cache | v4 → \`0057852\` | [#601](https://github.com/rocketride-org/rocketride-server/security/code-scanning/601) |
| sync-models.yml | peter-evans/create-pull-request | v7 → \`22a9089\` | [#602](https://github.com/rocketride-org/rocketride-server/security/code-scanning/602) |
| discord-discussions.yml | actions/checkout | v4 → \`34e1148\` | [#644](https://github.com/rocketride-org/rocketride-server/security/code-scanning/644) |
| discord-issues.yml | actions/checkout | v4 → \`34e1148\` | [#645](https://github.com/rocketride-org/rocketride-server/security/code-scanning/645) |
| discord-pr.yml | actions/checkout | v4 → \`34e1148\` | [#646](https://github.com/rocketride-org/rocketride-server/security/code-scanning/646) |

## Docker base images (2 alerts)

| File | Image | Digest | Alert |
|---|---|---|---|
| docker/Dockerfile.engine | ubuntu:jammy-20240808 | \`@sha256:adbb901...\` | [#561](https://github.com/rocketride-org/rocketride-server/security/code-scanning/561) |
| docker/Dockerfile.mcp | python:3.12-slim | \`@sha256:9d3abd9...\` | [#471](https://github.com/rocketride-org/rocketride-server/security/code-scanning/471) |

Both digests are the OCI image index (multi-platform manifest list), so platform resolution still happens at build time. \`jammy-20240808\` is already a date-pinned snapshot tag; \`3.12-slim\` is a floating upstream tag and was pinned at the digest current as of 2026-05-20.

## Related cleanup

The remaining 6 \`PinnedDependenciesID\` alerts (#465, #466, #467, #468, #472, #603) flag pip/npm install commands with already-exact version pins (\`twine==6.1.0\`, \`@vscode/vsce@3.7.1\`, \`ovsx@0.10.9\`, etc.). Scorecard wants \`pip install --require-hashes\` or lockfile-driven installs for these; the ergonomics of doing that for one-shot workflow installs (and for the \`./client-python\` local-path install in \`Dockerfile.mcp\`, which can't be hash-pinned at all) outweigh the incremental supply-chain hardening over an already-exact version constraint. Those alerts are being dismissed separately with \`won't fix\` + per-alert justification.

## Test plan

- [ ] Workflow YAML parses cleanly (verified locally with ruby-yaml).
- [ ] Next \`sync-models\` schedule run completes (uses 4 of the pinned actions).
- [ ] Docker images build cleanly with digest pins (CI \`build\` job exercises both Dockerfiles).
- [ ] Discord webhook workflows fire on the next issue/PR/discussion event.
- [ ] Confirm the 9 Scorecard alerts close after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned GitHub Actions and Docker image versions to specific commits and digests for build consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/933?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->