### PR TITLE
chore(deps): pin cryptography>=46.0.7 in baseline node requirements

### DIFF
--- a/nodes/src/nodes/requirements.txt
+++ b/nodes/src/nodes/requirements.txt
@@ -5,6 +5,11 @@
 # Make sure wheel is loaded so we can load all older dependencies
 certifi
 charset-normalizer
+# Transitive dep of requests/urllib3; pinned explicitly to cover
+# GHSA-r6ph-v2qm-q3c2 (SECT curve subgroup attack, fix 46.0.5),
+# GHSA-m959-cc7f-wv43 (DNS constraint enforcement, fix 46.0.6),
+# GHSA-p423-j2cm-9vmq (buffer overflow, fix 46.0.7).
+cryptography>=46.0.7,<47
 idna
 requests
 urllib3


### PR DESCRIPTION
## Summary

Closes 3 Dependabot alerts on \`cryptography\` (pip, transitive in the Python backend baseline).

The two per-node files that pull \`cryptography\` directly (\`db_mysql/requirements.txt\`, \`text_output/requirements.txt\`) were already at \`cryptography==46.0.7\`, but the baseline at \`nodes/src/nodes/requirements.txt\` left cryptography unmentioned — so the transitive resolution fell to whatever \`requests\`/\`urllib3\`/\`httpx\` pulled, and Dependabot kept flagging.

## Alerts closed

| Alert | Severity | GHSA | Fix |
|---|---|---|---|
| [#64](https://github.com/rocketride-org/rocketride-server/security/dependabot/64) | High | [GHSA-r6ph-v2qm-q3c2](https://github.com/advisories/GHSA-r6ph-v2qm-q3c2) — SECT curve subgroup-attack validation gap | 46.0.5 |
| [#65](https://github.com/rocketride-org/rocketride-server/security/dependabot/65) | Low | [GHSA-m959-cc7f-wv43](https://github.com/advisories/GHSA-m959-cc7f-wv43) — incomplete DNS name constraint enforcement | 46.0.6 |
| [#66](https://github.com/rocketride-org/rocketride-server/security/dependabot/66) | Medium | [GHSA-p423-j2cm-9vmq](https://github.com/advisories/GHSA-p423-j2cm-9vmq) — buffer overflow on non-contiguous buffers | 46.0.7 |

## Range choice

\`cryptography>=46.0.7,<47\` — bounded range matches the repo convention for security-driven dependency floors (handlebars: \`">=4.7.9 <5"\`, protobufjs: \`">=7.5.5 <8"\`, the npm overrides set on root package.json). One floor covers all three CVEs and guards against future drift via the upper bound.

## Test plan

- [ ] CI Python build resolves \`cryptography>=46.0.7\` cleanly (no version conflict with existing transitive callers).
- [ ] Confirm alerts #64, #65, #66 close on the next Dependabot scan after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated cryptography dependency to address security advisories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/934?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->