### PR TITLE
chore(ci): ignore @types/vscode in root npm Dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,14 @@ updates:
       - dependency-name: "@rsbuild/*"
       - dependency-name: "@rslib/*"
       - dependency-name: "@rspack/*"
+      # @types/vscode is constrained by apps/vscode/package.json's
+      # engines.vscode field — vsce package fails the build if
+      # @types/vscode exceeds engines.vscode. PR #921 hit this when the
+      # npm-development group bumped @types/vscode 1.108→1.120 while
+      # engines.vscode stayed at ^1.99. Pinned manually in apps/vscode/
+      # to ~1.99 instead; bumps land via an explicit engines.vscode
+      # PR when the team raises the supported VS Code floor.
+      - dependency-name: "@types/vscode"
 
   # ---------------------------------------------------------------------------
   # npm — packages/client-typescript (published SDK)


### PR DESCRIPTION
## Summary

Companion to the fix commit on PR #921. The npm-development group bump in #921 raised \`@types/vscode\` 1.108 → 1.120, which broke \`vsce package\` on all three Build matrix runners:

\`\`\`
::error::@types/vscode ^1.120.0 greater than engines.vscode ^1.99.3.
Consider upgrade engines.vscode or use an older @types/vscode version
\`\`\`

\`vsce\` enforces \`@types/vscode\` ≤ \`engines.vscode\` at build time. \`apps/vscode/package.json\`'s \`engines.vscode\` floor is \`^1.99.3\` — that's a product/UX choice (it caps the supported VS Code range), not something Dependabot should ratchet up automatically through a routine group bump.

This PR adds \`@types/vscode\` to the root npm ecosystem's ignore list so the \`npm-development\` group stops trying to bump it. Future \`@types/vscode\` updates land when the team raises \`engines.vscode\` in a deliberate PR.

## Precedent

Matches the existing ignores for \`@rsbuild/*\`, \`@rslib/*\`, \`@rspack/*\` (added after PR #866 tried to downgrade rsbuild across seven workspaces because Dependabot harmonised to the older per-app pin). Same shape of problem: a workspace-wide package that has a product constraint elsewhere in the repo.

## Test plan

- [ ] Wait for next Monday's Dependabot run; confirm @types/vscode does not appear in any new bump PR.