### PR TITLE
fix(vscode): loop-strip HTML tags in firstSentence to handle nested/malformed tags

### DIFF
--- a/apps/vscode/src/agents/services.ts
+++ b/apps/vscode/src/agents/services.ts
@@ -55,8 +55,18 @@ async function writeIfChanged(uri: vscode.Uri, content: string): Promise<boolean
  */
 function firstSentence(description: string | undefined): string {
 	if (!description) return '';
-	// Strip HTML tags
-	const text = description.replace(/<[^>]*>/g, '').trim();
+	// Strip HTML tags. Loop until idempotent so nested or malformed tags like
+	// `<scri<x>pt>` collapse fully — a single regex pass would leave `<script>`
+	// behind after consuming only the inner `<x>`. Defense-in-depth: the
+	// output here lands in a JSON catalog file, not rendered as HTML, but
+	// the consumer surface may grow.
+	let stripped = description;
+	let prev: string;
+	do {
+		prev = stripped;
+		stripped = stripped.replace(/<[^>]*>/g, '');
+	} while (stripped !== prev);
+	const text = stripped.trim();
 	// Take first sentence (ends with . ! or ?)
 	const match = text.match(/^[^.!?]*[.!?]/);
 	return match ? match[0].trim() : text;


### PR DESCRIPTION
## Summary

Closes CodeQL **high** alert [#476](https://github.com/rocketride-org/rocketride-server/security/code-scanning/476) — \`js/incomplete-multi-character-sanitization\` on \`apps/vscode/src/agents/services.ts:59\`.

CodeQL flagged the single-pass \`description.replace(/<[^>]*>/g, '')\` as leaving residual \`<script\` after one substitution on inputs like \`<scri<x>pt>\` — the inner \`<x>\` gets consumed, but the outer pair re-forms a \`<script>\` tag.

Fix: loop the same regex until \`stripped === prev\` (fixed point). Each pass removes a complete \`<...>\` span; nested or malformed tags need at most O(depth) passes (typically 2-3, always terminates because output is monotonically shorter on each non-fixed-point iteration).

## Reachability

In practice today, the output of \`firstSentence\` lands in a JSON catalog file (\`.rocketride/services-catalog.json\`) via \`JSON.stringify\` — any residual HTML would be JSON-escaped before write and not rendered as live HTML. So this is **defense-in-depth, not a live XSS vector**. The consumer surface could grow (the catalog could be sourced into a webview tooltip, an LLM context window, or a markdown preview), and loop-stripping is cheap insurance that closes the SAST signal at the source.

## Test plan

- [ ] CI passes (TypeScript compile, lint).
- [ ] After merge, alert #476 closes on the next CodeQL scan.

## Notes for reviewers

The other 8 non-critical CodeQL findings on this repo are being addressed in parallel — 3 small fixes (this PR, server.py auth error generic, state.js proto-pollution guard) plus 5 dismissals with reasoning for the false positives and accepted risks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced HTML tag removal in descriptions to properly handle nested and malformed tags for cleaner text display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->