### PR TITLE
fix(ai): return generic auth errors, log exception details server-side

### DIFF
--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -427,6 +427,13 @@ class WebServer:
         """
         # Walk each registered authenticator in registration order.
         # The first one that returns a non-None AccountInfo wins; the rest are skipped.
+        #
+        # On exception, the client gets a generic message; the actual exception
+        # text goes to the server-side debug log only. Returning str(e) to the
+        # client used to leak library internals (JWT verifier internals, crypto
+        # error specifics, occasional file paths) — CodeQL py/stack-trace-exposure
+        # alerts #5 and #6 flagged this taint flow into the HTMLResponse /
+        # PlainTextResponse error path.
         for authenticator in self._authenticators:
             try:
                 account_info = await authenticator(authorization)
@@ -436,10 +443,12 @@ class WebServer:
                 return account_info
             except PermissionError as e:
                 # Authenticator explicitly denied access (known-bad credential)
-                return (401, str(e))
+                debug(f'auth: PermissionError from authenticator: {str(e)}')
+                return (401, 'Authentication failed')
             except Exception as e:
                 # Authenticator raised an unexpected error — treat as a bad-request failure
-                return (400, str(e))
+                debug(f'auth: authenticator raised unexpected error: {str(e)}')
+                return (400, 'Bad request')
 
         # No registered authenticator matched; fall back to the built-in account authenticator
         try:
@@ -450,7 +459,8 @@ class WebServer:
             return account_info
         except Exception as e:
             # Built-in authenticator raised an unexpected error
-            return (400, str(e))
+            debug(f'auth: built-in account authenticator raised: {str(e)}')
+            return (400, 'Bad request')
 
     async def authenticate_request(
         self,


### PR DESCRIPTION
## Summary

Closes CodeQL **medium** alerts [#5](https://github.com/rocketride-org/rocketride-server/security/code-scanning/5) and [#6](https://github.com/rocketride-org/rocketride-server/security/code-scanning/6) — \`py/stack-trace-exposure\` on \`packages/ai/src/ai/web/server.py:533\` (HTMLResponse) and \`:538\` (PlainTextResponse).

## Root cause

\`_authenticate_credential_inner\` had three call sites returning \`(code, str(e))\` straight to the client:

  - \`except PermissionError as e:\` → \`(401, str(e))\` (registered authenticator denied)
  - \`except Exception as e:\` → \`(400, str(e))\` (registered authenticator unexpected error)
  - \`except Exception as e:\` → \`(400, str(e))\` (built-in account fallback unexpected error)

The downstream \`_format_error\` helper wraps the message into the HTML / plain-text / JSON response template — meaning \`str(e)\` flowed straight to whatever the client requested via the Accept header. The exception text can leak library internals (JWT verifier specifics, cryptography binding errors, occasional file paths) which an attacker probing the auth endpoint can use to fingerprint the stack.

## Fix

At each of the three sites:

1. Log the actual exception via \`debug()\` (the codebase's standard logging facility from \`rocketlib\`) — operators still see the full text in server logs for triage.
2. Return a generic message to the client — \`Authentication failed\` for 401, \`Bad request\` for 400.

The downstream \`_format_error\` helper is unchanged; only the message contents flowing into it are sanitized at the source. The pre-existing generic branches (\`'No authorization provided'\`, \`'Invalid authorization provided'\`) are unaffected.

## Test plan

- [ ] CI passes (ruff format + lint, Python test suite).
- [ ] Manual probe: hit the auth endpoint with a malformed bearer token; confirm response body says \`Authentication failed\` (not the raw exception), and the server-side debug log carries the underlying message.
- [ ] After merge, alerts #5 and #6 close on the next CodeQL scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication error messages are now more generic, providing consistent and standardized feedback for authentication failures and invalid requests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/939?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->