### PR TITLE
fix(scripts): guard state.js dot-paths against prototype pollution

### DIFF
--- a/scripts/lib/state.js
+++ b/scripts/lib/state.js
@@ -22,7 +22,14 @@ const STATE_FILE = path.join(BUILD_ROOT, 'state.json');
 // closes CodeQL js/prototype-pollution-utility alert #274.
 const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
 function assertSafePath(parts) {
-    for (const part of parts) {
+    // Coerce each segment with String() before the Set check. Bracket access
+    // (obj[part]) coerces its operand to a string property key, so passing
+    // `new String('__proto__')` (a wrapper object, not a primitive) would
+    // bypass FORBIDDEN_KEYS.has() — identity equality in Set — while still
+    // resolving to '__proto__' at the actual write site. String() normalizes
+    // wrappers, numbers, etc. to the same key form the property access uses.
+    for (const rawPart of parts) {
+        const part = String(rawPart);
         if (FORBIDDEN_KEYS.has(part)) {
             throw new Error(`state: forbidden key segment "${part}" in path`);
         }

--- a/scripts/lib/state.js
+++ b/scripts/lib/state.js
@@ -13,6 +13,22 @@ const { BUILD_ROOT } = require('./paths');
 
 const STATE_FILE = path.join(BUILD_ROOT, 'state.json');
 
+// Block dot-notation keys that would land on Object.prototype or its
+// accessor properties. setState/updateState walk `parts` and create
+// nested objects as needed; without this guard a caller passing
+// `setState('__proto__.polluted', 'x')` would set Object.prototype.polluted
+// for the entire process. Callers in this codebase are all in-repo build
+// scripts (not network input), but the guard is defense-in-depth and
+// closes CodeQL js/prototype-pollution-utility alert #274.
+const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+function assertSafePath(parts) {
+    for (const part of parts) {
+        if (FORBIDDEN_KEYS.has(part)) {
+            throw new Error(`state: forbidden key segment "${part}" in path`);
+        }
+    }
+}
+
 // ============================================================================
 // In-Memory Cache
 // ============================================================================
@@ -178,6 +194,7 @@ async function setState(key, value) {
     return withLock('state', async () => {
         const state = await ensureLoaded();
         const parts = Array.isArray(key) ? key : key.split('.');
+        assertSafePath(parts);
         if (value === null) {
             deleteKeyAndPrune(state, parts);
         } else {
@@ -207,6 +224,7 @@ async function updateState(updates) {
 
         for (const [key, value] of Object.entries(updates)) {
             const parts = key.split('.');
+            assertSafePath(parts);
             if (value === null) {
                 deleteKeyAndPrune(state, parts);
             } else {


### PR DESCRIPTION
## Summary

Closes CodeQL **medium** alert [#274](https://github.com/rocketride-org/rocketride-server/security/code-scanning/274) — \`js/prototype-pollution-utility\` on \`scripts/lib/state.js:192\`.

## Root cause

\`setState(key, value)\` splits a dot-notation key into parts, walks them creating empty objects as needed, then assigns the value at the leaf. Without a guard, a caller passing \`setState('__proto__.polluted', 'x')\` writes \`Object.prototype.polluted\` for the entire process. \`updateState\` has the same shape.

Callers in this codebase are all in-repo build scripts (not network input), so this is defense-in-depth rather than a live exploit. But \`state.js\` is a shared utility used by every build/deploy script, and guarding once at the entry of the two write paths is far cheaper than auditing every call site (current + future).

## Fix

Single \`assertSafePath(parts)\` helper added at the top of the module:

\`\`\`js
const FORBIDDEN_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
function assertSafePath(parts) {
    for (const part of parts) {
        if (FORBIDDEN_KEYS.has(part)) {
            throw new Error(\`state: forbidden key segment "\${part}" in path\`);
        }
    }
}
\`\`\`

Called at the entry of \`setState\` and \`updateState\`. Throws synchronously if any path segment is forbidden; error message names the offending segment so a legitimate caller would see exactly what to fix.

## What's not guarded (and why)

- \`deleteKeyAndPrune\`: only reachable through \`setState\`/\`updateState\` (both guarded), so adding it there would just duplicate the check.
- \`getState\`: read-only path. Reading \`__proto__\` returns an object the caller already has access to — no pollution risk.

## Test plan

- [ ] CI passes.
- [ ] Smoke: \`node -e \"require('./scripts/lib/state.js')\"\` loads cleanly (verified locally).
- [ ] After merge, alert #274 closes on the next CodeQL scan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened state-management validation to block prototype-pollution-style path segments, rejecting dangerous inputs and raising an error before any in-memory change or disk persistence occurs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/940?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->