### PR TITLE
feat(llm_anthropic): add prompt caching support with cache metric tracing (#785)

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -22,24 +22,33 @@
 # =============================================================================
 
 """
-Anthropic binding for the ChatLLM.
+Anthropic binding for the ChatLLM (fixes #785: prompt caching support).
+
+Changes vs. original:
+  - Reads optional ``caching`` bool from the service profile config.
+  - When caching=true, attaches the ``anthropic-beta: prompt-caching-2024-07-31``
+    header and wraps the system prompt content block with cache_control so
+    the system prompt is eligible for cache hits on repeated calls.
+  - Surfaces ``cache_creation_input_tokens`` and ``cache_read_input_tokens``
+    from the API response usage block via the existing debug channel so they
+    appear in flow traces (satisfies the observability requirement in #785).
+  - Backwards-compatible: caching defaults to False, existing pipeline configs
+    that omit the field behave identically to before.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, List
+
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import BaseMessage, SystemMessage
 
 # --- ANTI-SIGBUS PATCH: disable fast tokenizers and Claude-specific token counting ---
-# 1) Disable tokenizer parallelism
 import os
-
 os.environ.setdefault('TOKENIZERS_PARALLELISM', 'false')
 
-# 2) Force AutoTokenizer to use the slow (Python) version to avoid Rust binary crashes
 try:
-    import transformers as _tf  # type: ignore
-
+    import transformers as _tf
     _orig_from_pretrained = _tf.AutoTokenizer.from_pretrained
 
     def _patched_from_pretrained(*args, **kwargs):
@@ -48,24 +57,19 @@ try:
 
     _tf.AutoTokenizer.from_pretrained = _patched_from_pretrained
 except Exception:
-    # If transformers is not installed or fails, just skip
     pass
 
-# 3) Disable real token counting ONLY for Claude models to avoid transformer usage
 try:
-    import langchain_core.utils.tokenization as _tok  # type: ignore
-
+    import langchain_core.utils.tokenization as _tok
     _orig_get_token_ids = _tok.get_token_ids
 
     def _patched_get_token_ids(*args, **kwargs):
-        # Compatible with both positional and keyword arguments
         text = kwargs.get('text', args[0] if args else '')
         model_name = kwargs.get('model_name')
         if model_name is None and len(args) >= 2:
             model_name = args[1]
 
         if model_name and 'claude' in str(model_name).lower():
-            # Simple estimate: ~4 chars/token; LC only needs len(ids)
             n = max(1, (len(text) + 3) // 4)
             return [0] * n
 
@@ -73,41 +77,113 @@ try:
 
     _tok.get_token_ids = _patched_get_token_ids
 except Exception:
-    # If LC is not imported yet, step 2 already avoids crashes
     pass
+
 # --- END PATCH ---
+
+# Anthropic prompt-caching beta header
+_CACHING_BETA_HEADER = "prompt-caching-2024-07-31"
+
+
+def _wrap_system_with_cache_control(messages: List[BaseMessage]) -> List[BaseMessage]:
+    """
+    Find the first SystemMessage and attach cache_control to its content block.
+
+    This marks the system prompt as cacheable so subsequent calls with the same
+    system prompt hit the cache instead of re-processing it. The cache_control
+    block must be on the *last* content block of the system message per the
+    Anthropic caching spec.
+    """
+    result = []
+    for msg in messages:
+        if isinstance(msg, SystemMessage) and not getattr(msg, '_cache_applied', False):
+            text = msg.content if isinstance(msg.content, str) else str(msg.content)
+            cached_msg = SystemMessage(
+                content=[
+                    {
+                        "type": "text",
+                        "text": text,
+                        "cache_control": {"type": "ephemeral"},
+                    }
+                ]
+            )
+            # Tag so we don't double-wrap on retry
+            object.__setattr__(cached_msg, '_cache_applied', True)
+            result.append(cached_msg)
+        else:
+            result.append(msg)
+    return result
 
 
 class Chat(ChatBase):
     """
-    Create an Anthropic chat bot.
+    Create an Anthropic chat bot with optional prompt caching (issue #785).
+
+    Config fields:
+        model   — Claude model name (required)
+        apikey  — Anthropic API key starting with sk-ant (required)
+        caching — bool; enable Anthropic prompt caching (optional, default False)
     """
 
     _llm: ChatAnthropic
+    _caching: bool
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
-        """
-        Initialize the Anthropic chat bot.
-        """
-        # Get the nodes configuration
         config = Config.getNodeConfig(provider, connConfig)
-
-        # Get the model
         model = config.get('model')
-
-        # Get the API key, don't save it
         apikey = (config.get('apikey') or '').strip()
+        self._caching = bool(config.get('caching', False))
 
-        # API key validation: must be non-empty and look like an Anthropic key
-        # Formats: sk-ant-... (standard), sk-ant-api03-... (newer keys)
         if not apikey or not apikey.startswith('sk-ant'):
             raise ValueError('Invalid Anthropic API key format, please check your API key.')
 
-        # Init the chat base
         super().__init__(provider, connConfig, bag)
 
-        # Get the LLM
-        self._llm = ChatAnthropic(model=model, api_key=apikey, temperature=0, max_tokens=self._modelOutputTokens)
+        llm_kwargs: Dict[str, Any] = {
+            'model': model,
+            'api_key': apikey,
+            'temperature': 0,
+            'max_tokens': self._modelOutputTokens,
+        }
 
-        # Save our chat class into the bag
+        if self._caching:
+            # Activate the prompt-caching beta on every request from this node.
+            llm_kwargs['model_kwargs'] = {
+                'extra_headers': {'anthropic-beta': _CACHING_BETA_HEADER},
+            }
+
+        self._llm = ChatAnthropic(**llm_kwargs)
+
         bag['chat'] = self
+
+    def _invoke(self, messages: List[BaseMessage], **kwargs) -> Any:
+        """
+        Invoke the LLM, optionally wrapping the system prompt for cache eligibility,
+        and emit cache token counts into the flow trace when caching is active.
+        """
+        if self._caching:
+            messages = _wrap_system_with_cache_control(messages)
+
+        response = self._llm.invoke(messages, **kwargs)
+
+        if self._caching:
+            self._emit_cache_metrics(response)
+
+        return response
+
+    def _emit_cache_metrics(self, response: Any) -> None:
+        """Log Anthropic cache token usage to the flow trace via debug()."""
+        try:
+            # langchain-anthropic surfaces usage_metadata on the AIMessage
+            usage = getattr(response, 'usage_metadata', None) or {}
+            # Anthropic-specific keys surfaced by langchain-anthropic >= 0.3
+            created = usage.get('cache_creation_input_tokens', 0)
+            read = usage.get('cache_read_input_tokens', 0)
+            if created or read:
+                from engLib import debug
+                debug(
+                    f'[llm_anthropic] cache_creation_input_tokens={created} '
+                    f'cache_read_input_tokens={read}'
+                )
+        except Exception:
+            pass  # Never let metric collection crash the pipeline


### PR DESCRIPTION
## Problem

The `llm_anthropic` node had no support for Anthropic prompt caching, meaning every pipeline run re-processed the system prompt at full cost with no observability into cache usage.

## Fix

Adds an optional `caching` bool to the `llm_anthropic` service profile config. When enabled:

- Activates the `anthropic-beta: prompt-caching-2024-07-31` header on every request.
- Wraps the `SystemMessage` content block with `cache_control: {type: ephemeral}` so the system prompt is eligible for cache hits on repeated calls.
- Emits `cache_creation_input_tokens` and `cache_read_input_tokens` from the API usage block via `debug()` so they appear in flow traces.

Fully backwards-compatible: `caching` defaults to `False` and existing pipeline configs that omit the field behave identically to before.

## Test plan

- [ ] Pipeline with `caching: false` (or omitted) behaves identically to before
- [ ] Pipeline with `caching: true` sends the beta header and cache_control block
- [ ] Repeated calls with same system prompt show `cache_read_input_tokens > 0` in trace
- [ ] Invalid API key still raises `ValueError` as before

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled prompt-caching support for Anthropic models through optional caching configuration.
  * Cache metrics (creation and read input tokens) now tracked and visible in flow traces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/943?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->