### PR TITLE
fix(crewai): patch 1.14.x async loop, delegation, and template bugs

### DIFF
--- a/nodes/src/nodes/agent_crewai/crewai_base.py
+++ b/nodes/src/nodes/agent_crewai/crewai_base.py
@@ -42,6 +42,114 @@ from ai.common.agent import AgentBase, AgentContext
 
 
 # ────────────────────────────────────────────────────────────────────────────────
+# CREWAI ASYNC COMPATIBILITY PATCHES (applied once at import time)
+#
+# Two related issues in CrewAI 1.14.x when running inside a shared asyncio loop:
+#
+# 1. PLANNING — Crew._handle_crew_planning() calls planner_task.execute_sync()
+#    → agent.execute_task() (sync) which raises RuntimeError when it detects a
+#    running event loop. Fix: offload planning to a ThreadPoolExecutor worker
+#    thread that has no running loop (_patch_crewai_planning).
+#
+# 2. DELEGATION — DelegateWorkTool / BaseAgentTool have no _arun / _aexecute,
+#    so hierarchical crews fall back to the sync execute_task() path from inside
+#    the async loop → RuntimeError. Fix: patch both classes with async variants
+#    that use aexecute_task() instead (_patch_crewai_delegation).
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def _patch_crewai_planning() -> None:
+    """
+    Patch Crew._handle_crew_planning() to be safe when called from inside a
+    running event loop (e.g. via akickoff() on the CrewRunner daemon thread).
+
+    CrewAI's planning step calls planner_task.execute_sync() -> agent.execute_task(),
+    which raises RuntimeError when it detects a running event loop. We fix this by
+    offloading the entire planning call to a ThreadPoolExecutor worker thread, which
+    has no running loop. Planning mutates self.tasks in-place, so the crew sees the
+    updated task descriptions when the worker returns.
+    """
+    try:
+        import concurrent.futures
+
+        from crewai.crew import Crew
+
+        if getattr(Crew, '_rr_planning_patched', False):
+            return
+
+        _orig_planning = Crew._handle_crew_planning
+
+        def _safe_handle_crew_planning(self) -> None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                _orig_planning(self)
+                return
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                ex.submit(_orig_planning, self).result()
+
+        Crew._handle_crew_planning = _safe_handle_crew_planning  # type: ignore[method-assign]
+        Crew._rr_planning_patched = True  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+
+def _patch_crewai_delegation() -> None:
+    try:
+        from crewai.task import Task
+        from crewai.tools.agent_tools.ask_question_tool import AskQuestionTool
+        from crewai.tools.agent_tools.base_agent_tools import BaseAgentTool
+        from crewai.tools.agent_tools.delegate_work_tool import DelegateWorkTool
+        from crewai.utilities.i18n import I18N_DEFAULT
+
+        if hasattr(BaseAgentTool, '_aexecute'):
+            return  # already patched
+
+        async def _aexecute(self, agent_name, task, context=None):  # type: ignore[override]
+            try:
+                if agent_name is None:
+                    agent_name = ''
+                sanitized = self.sanitize_agent_name(agent_name)
+                agent = [a for a in self.agents if self.sanitize_agent_name(a.role) == sanitized]
+            except (AttributeError, ValueError) as e:
+                return I18N_DEFAULT.errors('agent_tool_unexisting_coworker').format(
+                    coworkers='\n'.join([f'- {self.sanitize_agent_name(a.role)}' for a in self.agents]),
+                    error=str(e),
+                )
+            if not agent:
+                return I18N_DEFAULT.errors('agent_tool_unexisting_coworker').format(
+                    coworkers='\n'.join([f'- {self.sanitize_agent_name(a.role)}' for a in self.agents]),
+                    error=f"No agent found with role '{sanitized}'",
+                )
+            selected = agent[0]
+            try:
+                t = Task(description=task, agent=selected, expected_output=I18N_DEFAULT.slice('manager_request'))
+                return await selected.aexecute_task(t, context)
+            except Exception as e:
+                return I18N_DEFAULT.errors('agent_tool_execution_error').format(
+                    agent_role=self.sanitize_agent_name(selected.role), error=str(e)
+                )
+
+        async def _delegate_arun(self, task, context, coworker=None, **kwargs):  # type: ignore[override]
+            coworker = self._get_coworker(coworker, **kwargs)
+            return await self._aexecute(coworker, task, context)
+
+        async def _ask_arun(self, question, context, coworker=None, **kwargs):  # type: ignore[override]
+            coworker = self._get_coworker(coworker, **kwargs)
+            return await self._aexecute(coworker, question, context)
+
+        BaseAgentTool._aexecute = _aexecute  # type: ignore[attr-defined]
+        DelegateWorkTool._arun = _delegate_arun  # type: ignore[attr-defined]
+        AskQuestionTool._arun = _ask_arun  # type: ignore[attr-defined]
+    except Exception:
+        pass  # if crewai isn't installed yet, skip silently
+
+
+_patch_crewai_planning()
+_patch_crewai_delegation()
+
+
+# ────────────────────────────────────────────────────────────────────────────────
 # CREWBASE
 # ────────────────────────────────────────────────────────────────────────────────
 
@@ -243,6 +351,16 @@ class CrewBase(AgentBase):
             name: str
             description: str
             args_schema: type[BaseModel] = _ToolInput
+
+            def __repr__(self) -> str:
+                # Strip JSON schema suffix and CrewAI-reformatted header so planning
+                # prompts see a clean one-liner — same as native CrewAI tool reprs.
+                desc = self.description.split('\n\nTool input schema (JSON):')[0]
+                if '\nTool Description: ' in desc:
+                    desc = desc.split('\nTool Description: ', 1)[1].split('\n')[0]
+                return f'Tool(name={self.name!r}, description={desc!r})'
+
+            __str__ = __repr__
 
             def _run(self, **framework_args: Any) -> str:
                 try:

--- a/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
+++ b/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
@@ -243,12 +243,11 @@ class CrewManager(CrewBase):
                 allow_delegation=False,
             )
 
-            task_text = d.task_description or ''
-            if not task_text:
-                task_text = prompt or 'Complete the user request.'
-            elif prompt:
-                task_text = f'{task_text}\n\nUser request: {prompt}'
-            task_desc = self._escape_braces(task_text)
+            # Mirror native CrewAI template substitution: leave braces unescaped so
+            # _interpolate_inputs() can fill {user_request} (and any other vars the
+            # user placed in their task_description).  Fall back to bare {user_request}
+            # when no task_description is configured, which resolves to the raw prompt.
+            task_desc = d.task_description or '{user_request}'
 
             # No implicit inter-task context wiring.  In hierarchical mode the
             # manager agent decides what to pass to each delegate via its


### PR DESCRIPTION
## Summary

- Patch `Crew._handle_crew_planning()` to offload `execute_sync()` to a `ThreadPoolExecutor`, avoiding `RuntimeError` in a running asyncio loop.
- Add async `_arun`/`_aexecute` variants to `DelegateWorkTool`, `AskQuestionTool`, and `BaseAgentTool` using `aexecute_task()`.
- Replace manual brace-escaping in `manager.py` with native `_interpolate_inputs()` and `{user_request}` template substitution.

## Test plan

- [ ] Call `_patch_crewai_planning()` inside a running asyncio event loop, trigger `Crew._handle_crew_planning()`, and verify it executes in a `ThreadPoolExecutor` thread rather than blocking the event loop thread.
- [ ] Call `_patch_crewai_planning()` outside any event loop and confirm `Crew._handle_crew_planning()` runs synchronously without raising an error, preserving backward compatibility.
- [ ] Invoke `DelegateWorkTool._arun()` and `AskQuestionTool._aexecute()` from an async context in the hierarchical crew and assert they return the same result as their synchronous counterparts without raising `RuntimeError: This event loop is already running`.
- [ ] Run a full hierarchical crew task end-to-end with a manager agent that delegates to at least two sub-agents, confirming no asyncio deadlock or `nest_asyncio` workaround is required post-patch.
- [ ] In a planning-enabled crew, capture the prompt sent to the manager LLM and confirm `_CrewTool.__repr__` output omits JSON schema blocks, keeping tool descriptions concise.
- [ ] In `manager.py`, pass a `user_request` value containing literal curly braces (e.g., `"load file {config}.yaml"`) and verify the template interpolates correctly without raising `KeyError` or double-escaping the braces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime errors when executing agents within existing asyncio event loops
  * Improved async delegation support for crew-based agents

* **Improvements**
  * Cleaner formatting of tools displayed in agent planning prompts
  * Enhanced task description template handling for agent execution

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/951?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->