### PR TITLE
fix(scripts): skip pytest tasks when target dir has no test files

### DIFF
--- a/nodes/scripts/tasks.js
+++ b/nodes/scripts/tasks.js
@@ -40,6 +40,7 @@ const {
     startServer,
     stopServer,
     execCommand,
+    runPytest,
     parallel,
     bracket,
     parseServerAddress
@@ -150,10 +151,10 @@ function makeRunPytestAction(options = {}) {
             };
 
             // Use absolute paths since cwd is dist/server
-            const pytestArgs = ['-m', 'pytest', TEST_DIR, '-v', '--rootdir', PACKAGE_DIR];
+            const extraArgs = ['-v', '--rootdir', PACKAGE_DIR];
 
             if (!options.test_full) {
-                pytestArgs.push(
+                extraArgs.push(
                     '--ignore-glob', '**/test_*_full.py',
                     '--ignore-glob', '**/test_*_full/**');
             }
@@ -170,7 +171,7 @@ function makeRunPytestAction(options = {}) {
                 return tokens.some(t => t === '-m' || (t.startsWith('-m') && !t.startsWith('--')));
             })();
             if (!hasExplicitMarkers) {
-                pytestArgs.push('-m', 'not skip_node');
+                extraArgs.push('-m', 'not skip_node');
             }
 
             // Add any additional pytest options (from CLI or direct options)
@@ -179,10 +180,10 @@ function makeRunPytestAction(options = {}) {
                 // Handle both string and array formats
                 // CLI passes array like ["-v -s"], so split each element by spaces
                 if (typeof pytestOpts === 'string') {
-                    pytestArgs.push(...pytestOpts.split(/\s+/).filter(x => x));
+                    extraArgs.push(...pytestOpts.split(/\s+/).filter(x => x));
                 } else if (Array.isArray(pytestOpts)) {
                     for (const opt of pytestOpts) {
-                        pytestArgs.push(...opt.split(/\s+/).filter(x => x));
+                        extraArgs.push(...opt.split(/\s+/).filter(x => x));
                     }
                 }
             }
@@ -191,10 +192,10 @@ function makeRunPytestAction(options = {}) {
             const markers = options.markers;
             const pattern = options.pytestPattern;
             if (markers) {
-                pytestArgs.push('-m', markers);
+                extraArgs.push('-m', markers);
             }
             if (pattern) {
-                pytestArgs.push('-k', pattern);
+                extraArgs.push('-k', pattern);
             }
 
             // Parallel execution via pytest-xdist. Defaults to min(cpus, 8) when the
@@ -204,13 +205,14 @@ function makeRunPytestAction(options = {}) {
             const parallelRaw = options.pytestParallel ?? String(Math.min(os.cpus().length, 8));
             const parallelVal = String(parallelRaw).trim().toLowerCase();
             if (parallelVal && parallelVal !== 'off' && parallelVal !== '0') {
-                pytestArgs.push('-n', parallelVal);
+                extraArgs.push('-n', parallelVal);
             }
 
-            await execCommand(ENGINE, pytestArgs, {
-                task,
-                cwd: PACKAGE_DIR,
-                env: testEnv,
+            await runPytest({
+                engine: ENGINE,
+                testsDir: TEST_DIR,
+                extraArgs,
+                execOpts: { task, cwd: PACKAGE_DIR, env: testEnv },
             });
         }
     };
@@ -219,16 +221,11 @@ function makeRunPytestAction(options = {}) {
 function makeRunContractTestsAction() {
     return {
         run: async (ctx, task) => {
-            const pytestArgs = [
-                '-m', 'pytest',
-                path.join(TEST_DIR, 'test_contracts.py'),
-                '-v',
-                '--rootdir', PACKAGE_DIR
-            ];
-
-            await execCommand(ENGINE, pytestArgs, {
-                task,
-                cwd: PACKAGE_DIR
+            await runPytest({
+                engine: ENGINE,
+                testsDir: path.join(TEST_DIR, 'test_contracts.py'),
+                extraArgs: ['-v', '--rootdir', PACKAGE_DIR],
+                execOpts: { task, cwd: PACKAGE_DIR },
             });
         }
     };

--- a/packages/ai/scripts/tasks.js
+++ b/packages/ai/scripts/tasks.js
@@ -33,7 +33,7 @@
  */
 const path = require('path');
 const {
-    execCommand, syncDir, formatSyncStats, DIST_ROOT
+    execCommand, runPytest, syncDir, formatSyncStats, DIST_ROOT
 } = require('../../../scripts/lib');
 
 const PACKAGE_DIR = path.join(__dirname, '..');
@@ -81,20 +81,22 @@ function makeRunPytestAction(options = {}) {
             // --cov to the absolute source directory bypasses the import-time
             // package resolution and tracks the directory we actually run.
             const HTMLCOV_DIR = path.join(SERVER_DIR, 'htmlcov', 'ai');
-            const pytestArgs = [
-                '-m', 'pytest', TESTS_DIR, '-v', '--rootdir', PACKAGE_DIR,
+            const extraArgs = [
+                '-v', '--rootdir', PACKAGE_DIR,
                 // Coverage flags
                 '--cov', SRC_DIR,
                 '--cov-report=term-missing',
                 `--cov-report=html:${HTMLCOV_DIR}`,
             ];
             if (options.pytest) {
-                pytestArgs.push(...options.pytest);
+                extraArgs.push(...options.pytest);
             }
 
-            await execCommand(ENGINE, pytestArgs, {
-                task,
-                cwd: SERVER_DIR
+            await runPytest({
+                engine: ENGINE,
+                testsDir: TESTS_DIR,
+                extraArgs,
+                execOpts: { task, cwd: SERVER_DIR },
             });
         }
     };

--- a/packages/client-mcp/scripts/tasks.js
+++ b/packages/client-mcp/scripts/tasks.js
@@ -32,7 +32,7 @@
  */
 const path = require('path');
 const {
-    execCommand, syncDir, formatSyncStats,
+    execCommand, runPytest, syncDir, formatSyncStats,
     removeDirs, removeMatching, removeDirAndParents, PROJECT_ROOT, BUILD_ROOT, DIST_ROOT,
     mkdir, copyFile, exists,
     hasSourceChanged, saveSourceHash, setState,
@@ -130,18 +130,23 @@ function makeRunPytestAction(options = {}) {
             // Run pytest
             const buildSrcDir = path.join(BUILD_DIR, 'src');
             const testsDir = path.join(PACKAGE_DIR, 'tests');
-            const pytestArgs = ['-m', 'pytest', testsDir, '-v', '--rootdir', PACKAGE_DIR];
+            const extraArgs = ['-v', '--rootdir', PACKAGE_DIR];
             if (options.pytest) {
-                pytestArgs.push(...options.pytest);
+                extraArgs.push(...options.pytest);
             }
-            await execCommand(ENGINE, pytestArgs, {
-                task,
-                cwd:  SERVER_DIR,
-                env: {
-                    ...process.env,
-                    ROCKETRIDE_URI: serverUri,
-                    PYTHONPATH: buildSrcDir
-                }
+            await runPytest({
+                engine: ENGINE,
+                testsDir,
+                extraArgs,
+                execOpts: {
+                    task,
+                    cwd: SERVER_DIR,
+                    env: {
+                        ...process.env,
+                        ROCKETRIDE_URI: serverUri,
+                        PYTHONPATH: buildSrcDir,
+                    },
+                },
             });
         }
     };

--- a/packages/client-python/scripts/tasks.js
+++ b/packages/client-python/scripts/tasks.js
@@ -31,7 +31,7 @@
  *   clean - Remove build artifacts
  */
 const path = require('path');
-const { execCommand, syncDir, formatSyncStats, removeDirs, removeMatching, removeDirAndParents, PROJECT_ROOT, BUILD_ROOT, DIST_ROOT, mkdir, copyFile, exists, startServer, stopServer, bracket, parallel, hasSourceChanged, saveSourceHash, setState, parseServerAddress } = require('../../../scripts/lib');
+const { execCommand, runPytest, syncDir, formatSyncStats, removeDirs, removeMatching, removeDirAndParents, PROJECT_ROOT, BUILD_ROOT, DIST_ROOT, mkdir, copyFile, exists, startServer, stopServer, bracket, parallel, hasSourceChanged, saveSourceHash, setState, parseServerAddress } = require('../../../scripts/lib');
 
 const PACKAGE_DIR = path.join(__dirname, '..');
 const SRC_DIR = path.join(PACKAGE_DIR, 'src', 'rocketride');
@@ -208,16 +208,17 @@ function makeRunPytestAction(options = {}) {
 
 			// Use absolute paths since cwd is dist/server
 			const testsDir = path.join(PACKAGE_DIR, 'tests');
-			const pytestArgs = ['-m', 'pytest', testsDir, '-v', '--rootdir', PACKAGE_DIR];
+			const extraArgs = ['-v', '--rootdir', PACKAGE_DIR];
 			if (options.pytest) {
-				pytestArgs.push(...options.pytest);
+				extraArgs.push(...options.pytest);
 			}
 
 			// engine.exe uses an isolated environment - cwd must be dist/server
-			await execCommand(ENGINE, pytestArgs, {
-				task,
-				cwd: SERVER_DIR,
-				env: testEnv,
+			await runPytest({
+				engine: ENGINE,
+				testsDir,
+				extraArgs,
+				execOpts: { task, cwd: SERVER_DIR, env: testEnv },
 			});
 		},
 	};

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -29,7 +29,7 @@
 const path = require('path');
 const os = require('os');
 const { glob } = require('glob');
-const { getState, setState, updateState, removeDirs, syncDir, syncFile, removeFiles, formatSyncStats, execCommand, PROJECT_ROOT, BUILD_ROOT, DIST_ROOT, isWindows, isMac, isLinux, exists, readFile, readJson, writeJson, mkdir, copyFile, removeFile, loadPackageJson, downloadGitHubFile, createArchive, extractArchive, parallel, whenNot, fingerprint, contentHash, taskDebug, STATE_FILE } = require('../../../scripts/lib');
+const { getState, setState, updateState, removeDirs, syncDir, syncFile, removeFiles, formatSyncStats, execCommand, runPytest, PROJECT_ROOT, BUILD_ROOT, DIST_ROOT, isWindows, isMac, isLinux, exists, readFile, readJson, writeJson, mkdir, copyFile, removeFile, loadPackageJson, downloadGitHubFile, createArchive, extractArchive, parallel, whenNot, fingerprint, contentHash, taskDebug, STATE_FILE } = require('../../../scripts/lib');
 const { runCompilerSetup } = require('../../../scripts/compiler');
 
 // Paths
@@ -1003,20 +1003,20 @@ function makeRocketlibPythonTestAction(options = {}) {
 			const exeExt = isWindows() ? '.exe' : '';
 			const engine = path.join(DIST_DIR, 'engine' + exeExt);
 
-			if (!(await exists(rocketrideTests))) {
-				task.output = 'rocketlib tests not found, skipping';
-				return;
-			}
-
-			const pytestArgs = ['-m', 'pytest', rocketrideTests, '-v'];
+			const extraArgs = ['-v'];
 			if (options.pytest) {
 				const tokens = typeof options.pytest === 'string'
 					? options.pytest.split(/\s+/).filter(Boolean)
 					: options.pytest.flatMap((o) => String(o).split(/\s+/).filter(Boolean));
-				pytestArgs.push(...tokens);
+				extraArgs.push(...tokens);
 			}
 
-			await execCommand(engine, pytestArgs, { task, cwd: DIST_DIR });
+			await runPytest({
+				engine,
+				testsDir: rocketrideTests,
+				extraArgs,
+				execOpts: { task, cwd: DIST_DIR },
+			});
 		},
 	};
 }

--- a/scripts/lib/index.js
+++ b/scripts/lib/index.js
@@ -23,6 +23,9 @@ module.exports = {
 	// Execution utilities (exec.js)
 	...require('./exec'),
 
+	// Pytest runner with empty-dir skip (pytest.js)
+	...require('./pytest'),
+
 	// Path constants (paths.js)
 	...require('./paths'),
 

--- a/scripts/lib/pytest.js
+++ b/scripts/lib/pytest.js
@@ -21,6 +21,7 @@
  */
 
 const fs = require('fs').promises;
+const path = require('path');
 const { glob } = require('glob');
 const { execCommand } = require('./exec');
 const { exists } = require('./fs');
@@ -43,6 +44,14 @@ async function runPytest({ engine, testsDir, extraArgs = [], execOpts = {} }) {
 	if (!testsDir) throw new TypeError('runPytest: testsDir is required');
 
 	if (!(await exists(testsDir))) {
+		// Single-file targets (paths with an extension, e.g. ``test_contracts.py``)
+		// must fail loudly when missing — renaming or moving the file is a real
+		// regression that we must not silently mask. Directory targets are
+		// treated as optional: a refactor may legitimately remove the last test
+		// in a directory without breaking the build.
+		if (path.extname(testsDir) !== '') {
+			throw new Error(`pytest: target file ${testsDir} not found`);
+		}
 		if (execOpts.task) {
 			execOpts.task.output = `pytest: ${testsDir} not found, skipping`;
 		}

--- a/scripts/lib/pytest.js
+++ b/scripts/lib/pytest.js
@@ -1,0 +1,75 @@
+// =============================================================================
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * Pytest runner helper.
+ *
+ * Wraps the standard ``engine -m pytest <dir> [extra args]`` invocation with a
+ * pre-flight check that skips when the target directory does not exist OR
+ * contains no test files (matches ``pyproject.toml`` ``[tool.pytest.ini_options]``
+ * ``python_files`` patterns).
+ *
+ * Why: pytest exits with code 5 (``no tests collected``) when invoked on an
+ * empty directory. The engine binary surfaces that as ``Python error 5`` and
+ * the builder reports the whole task as failed. Refactors that move the last
+ * test out of a dir (or soft resets that recreate a dir) trigger this
+ * failure repeatedly; centralising the guard means every pytest task gets
+ * the same protection.
+ */
+
+const fs = require('fs').promises;
+const { glob } = require('glob');
+const { execCommand } = require('./exec');
+const { exists } = require('./fs');
+
+/**
+ * Run pytest with empty-directory skip.
+ *
+ * @param {object} opts
+ * @param {string} opts.engine          Absolute path to the engine binary (or ``python``).
+ * @param {string} opts.testsDir        Absolute path to the directory pytest will target.
+ * @param {string[]} [opts.extraArgs]   Extra args appended after ``['-m', 'pytest', testsDir]``
+ *                                      (e.g. ``['-v', '--rootdir', ...]``).
+ * @param {object} [opts.execOpts]      Forwarded to ``execCommand`` (e.g. ``{ task, cwd, env }``).
+ * @returns {Promise<{ skipped: boolean, reason?: string }>}
+ *          ``{ skipped: false }`` on a normal pytest run.
+ *          ``{ skipped: true, reason: 'missing' | 'empty' }`` when the guard skips.
+ */
+async function runPytest({ engine, testsDir, extraArgs = [], execOpts = {} }) {
+	if (!engine) throw new TypeError('runPytest: engine path is required');
+	if (!testsDir) throw new TypeError('runPytest: testsDir is required');
+
+	if (!(await exists(testsDir))) {
+		if (execOpts.task) {
+			execOpts.task.output = `pytest: ${testsDir} not found, skipping`;
+		}
+		return { skipped: true, reason: 'missing' };
+	}
+
+	// Empty-directory guard only applies when ``testsDir`` is a directory.
+	// Callers also pass a single file path (e.g. test_contracts.py) — in
+	// that case ``exists`` is enough; pytest can run the file directly.
+	const stat = await fs.stat(testsDir);
+	if (stat.isDirectory()) {
+		// Matches pyproject.toml ``python_files = ["test_*.py", "*_test.py"]``.
+		const testFiles = [
+			...(await glob('**/test_*.py', { cwd: testsDir })),
+			...(await glob('**/*_test.py', { cwd: testsDir })),
+		];
+		if (testFiles.length === 0) {
+			if (execOpts.task) {
+				execOpts.task.output = `pytest: ${testsDir} has no test files, skipping`;
+			}
+			return { skipped: true, reason: 'empty' };
+		}
+	}
+
+	const args = ['-m', 'pytest', testsDir, ...extraArgs];
+	await execCommand(engine, args, execOpts);
+	return { skipped: false };
+}
+
+module.exports = { runPytest };


### PR DESCRIPTION
## Summary

- New `runPytest({ engine, testsDir, extraArgs, execOpts })` helper in `scripts/lib/pytest.js`. Skips pytest invocation when the target directory does not exist, OR when it exists but contains no `test_*.py` / `*_test.py` files (matches `pyproject.toml [tool.pytest.ini_options] python_files`). When the target is a single file path, the empty-directory guard is skipped — pytest runs the file directly.
- Six pytest invocations migrated to the helper: `server:run-rocketlib-test`, `ai:run-pytest`, `nodes:run-pytest`, `nodes:run-contracts`, `client-python:run-pytest`, `client-mcp:run-pytest`. The previous per-task `exists` checks (where present) and the inline `engine.exe -m pytest <dir>` argv assembly are gone.
- Fixes the recurring "Python error 5" build failure that surfaced whenever a refactor moved the last test out of a directory and left the empty directory behind (or a soft git reset recreated one). Cost two debugging cycles during the recent `ai.common.utils` consolidation.

## Type

fix

## Testing

- [x] Tests added or updated (manual test script verifies 7 edge cases: missing dir, empty dir, dir-with-only-`__pycache__`, dir with `test_*.py`, single file path, dir with `*_test.py`, nested test files)
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #953


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized pytest execution so all test runners use a shared runner for consistent behavior.
  * Test invocations now uniformly accept forwarded pytest options, marker and pattern filters, and parallelization flags.

* **Bug Fixes**
  * Test runs gracefully skip when targets are missing or contain no test files, providing clearer skip reasons and avoiding false failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->