### PR TITLE
fix(ci): add id-token: write to nightly docker job (unblock prereleases)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -156,6 +156,12 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # _docker.yaml's docker job declares id-token: write for cosign
+      # keyless Sigstore signing. GitHub validates at workflow-start that
+      # the caller covers every permission the reusable job declares;
+      # omitting id-token: write here is what produced the workflow-level
+      # `startup_failure` on every nightly run after PR #929 merged.
+      id-token: write
     with:
       ref: ${{ github.event.workflow_run.head_sha || github.ref }}
       server_version: ${{ needs.init.outputs.server_version }}


### PR DESCRIPTION
## Summary

**Hotfix for the prerelease pipeline.** PR #929 (per-job permissions scoping on \`nightly.yaml\`) missed \`id-token: write\` on the docker job. \`_docker.yaml\`'s docker job declares:

\`\`\`yaml
permissions:
  contents: read
  packages: write
  id-token: write   # for cosign keyless Sigstore signing
\`\`\`

GitHub validates at workflow-start that the caller's permissions cover every permission the reusable job declares. The missing \`id-token: write\` produced a workflow-level \`startup_failure\` on every nightly run after #929 merged at 2026-05-20T21:45 — the workflow couldn't even instantiate jobs (\`gh run view\` returns \`jobs: []\`, \`log not found\`).

## Failure pattern

13 consecutive \`workflow_run\` triggers against develop have been failing the same way:

| Time | Run | Outcome |
|---|---|---|
| 2026-05-20T19:49 | 26186092595 | ✅ success (last pre-#929) |
| 2026-05-20T21:39 | 26191563220 | failure (unrelated, pre-#929) |
| **2026-05-20T21:45** | — | **#929 merged** |
| 2026-05-20T21:52 → 2026-05-21T00:35 | 13 runs | ❌ all \`startup_failure\` |

## Fix

Add \`id-token: write\` to nightly.yaml's docker job permissions, with an in-file comment explaining the constraint so the next person editing this block doesn't drop it again.

## Latent bug in release.yaml

\`release.yaml\`'s docker job *also* omits \`id-token: write\` and was the pattern I mirrored. It hasn't surfaced because that docker job is gated by \`if: server_tag_exists == 'false'\` and only fires on a fresh release cut. Should be fixed in a follow-up pass once nightlies are recovered — opening as a separate PR keeps this hotfix minimal.

## Test plan

- [ ] Merge.
- [ ] Wait for next CI completion on develop to trigger the \`workflow_run\` → confirm nightly starts successfully (no \`startup_failure\`).
- [ ] Confirm the \`docker\` job runs and cosign signing succeeds.
- [ ] If desired, dispatch nightly manually via \`workflow_dispatch\` from this branch BEFORE merging to validate (\`gh workflow run nightly.yaml --ref chore/nightly-docker-id-token-write\`) — workflow_dispatch uses the dispatched ref's version of the file, so the fix can be exercised pre-merge.