### PR TITLE
fix(ci): add id-token: write to release docker job (preemptive fix)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -60,6 +60,15 @@ jobs:
     permissions:
       contents: read
       packages: write
+      # _docker.yaml's docker job declares id-token: write for cosign
+      # keyless Sigstore signing. GitHub validates at workflow-start that
+      # the caller covers every permission the reusable job declares.
+      # Without it the workflow fails with startup_failure — same bug
+      # that broke nightly.yaml in PR #929 / fixed in #955. Latent here
+      # only because this job is gated by `if: server_tag_exists ==
+      # 'false'`, so the misconfiguration only surfaces on a fresh
+      # release cut. Fixing preemptively.
+      id-token: write
     with:
       server_version: ${{ needs.init.outputs.server_version }}
     secrets: inherit


### PR DESCRIPTION
## Summary

Preemptive companion fix to #955.

\`release.yaml\`'s docker job has the same gap that broke nightly.yaml: it omits \`id-token: write\` even though \`_docker.yaml\`'s docker job declares it (cosign keyless Sigstore signing).

This hasn't surfaced as a \`startup_failure\` because the docker job here is gated by:

\`\`\`yaml
if: needs.init.outputs.server_tag_exists == 'false'
\`\`\`

GitHub's start-time permission-coverage validation appears to only run on jobs that get instantiated. Every \`release.yaml\` dispatch where the tag already exists (the common case — most release.yaml runs are on a re-publish where the tag is already there) skips the docker job entirely, so the misconfiguration stays invisible.

But the next **fresh** release cut (server-vX where the tag doesn't yet exist) would instantiate the docker job and hit the same \`startup_failure\` mode nightly did. Fixing preemptively rather than waiting for the cut to surface it.

## Diff

```diff
   docker:
     name: Docker
     needs: [init, release]
     if: needs.init.outputs.server_tag_exists == 'false'
     uses: ./.github/workflows/_docker.yaml
     permissions:
       contents: read
       packages: write
+      id-token: write
     with:
       server_version: ${{ needs.init.outputs.server_version }}
     secrets: inherit
```

(Plus an in-file comment referencing the nightly outage as the breadcrumb for the next person editing this block.)

## Test plan

- [ ] CI passes on the PR (the change is purely permission scoping; doesn't exercise the path).
- [ ] After merge, no observable change until the next fresh release cut — at that point the docker job will instantiate successfully and cosign signing will work.
- [ ] If a verification dispatch is desired before then: \`gh workflow run release.yaml --ref develop\` against a state where \`server_tag_exists == 'false'\` would exercise the docker path. But this is a real release publish, so probably better to just let the next planned release validate it.