### PR TITLE
fix(qdrant): correct score-space mismatch and isDeleted filter

### DIFF
--- a/nodes/src/nodes/qdrant/qdrant.py
+++ b/nodes/src/nodes/qdrant/qdrant.py
@@ -77,6 +77,10 @@ enabled by building qdrant from source with
 --features multiling-chinese,multiling-japanese,multiling-korean flags.
 """
 
+# Minimum rescaled [0, 1] similarity for a result to count as relevant; below
+# this it is dropped as noise regardless of the configured retrieval score.
+MIN_RELEVANCE_SCORE = 0.20
+
 
 class Store(DocumentStoreBase):
     apikey: str | None = None
@@ -248,18 +252,12 @@ class Store(DocumentStoreBase):
         if docFilter.objectIds is not None:
             must.append(models.FieldCondition(key='meta.objectId', match=models.MatchAny(any=docFilter.objectIds)))
 
-        # If we are not going after deleted docs, add a condition.
-        # Match isDeleted=False OR isDeleted=null OR isDeleted field absent —
-        # all three mean "not explicitly deleted" since the Qdrant client strips
-        # None values via exclude_none, so old/edge-case docs may lack the field.
+        # Exclude only docs explicitly marked deleted. A null/absent isDeleted
+        # (the client strips None via exclude_none) must still count as not deleted.
         if docFilter.isDeleted is None or not docFilter.isDeleted:
             must.append(
                 models.Filter(
-                    should=[
-                        models.FieldCondition(key='meta.isDeleted', match=models.MatchValue(value=False)),
-                        models.IsNullCondition(is_null=models.PayloadField(key='meta.isDeleted')),
-                        models.IsEmptyCondition(is_empty=models.PayloadField(key='meta.isDeleted')),
-                    ]
+                    must_not=[models.FieldCondition(key='meta.isDeleted', match=models.MatchValue(value=True))]
                 )
             )
 
@@ -305,7 +303,7 @@ class Store(DocumentStoreBase):
                     score = float(1.0 / (1.0 + np.exp(point.score / -100)))
 
                 # Ignore it if it doesn't have a high enough score
-                if score < self.threshold_search:
+                if score < MIN_RELEVANCE_SCORE:
                     continue
             else:
                 score = 0
@@ -399,15 +397,9 @@ class Store(DocumentStoreBase):
         if docFilter.offset:
             raise BaseException('Non-zero offset is not supported in semantic searching')
 
-        # For Cosine similarity, Qdrant applies score_threshold against raw [-1,1]
-        # scores before our (score + 1) / 2 normalization. Inverse-transform the
-        # [0,1] config threshold back to the raw space so the API filter is correct.
-        if self.similarity == 'Cosine':
-            raw_threshold = (self.threshold_search * 2) - 1
-        else:
-            raw_threshold = self.threshold_search
-
-        # Perform the search
+        # Don't pass score_threshold: Qdrant compares it against the raw similarity
+        # score, but threshold_search is in the rescaled [0,1] space. The cut is
+        # applied post-rescale by the base store (_addDoc).
         points = self.client.query_points(
             collection_name=self.collection,
             query=query.embedding,
@@ -415,7 +407,6 @@ class Store(DocumentStoreBase):
             with_vectors=False,
             with_payload=True,
             limit=docFilter.limit if docFilter.limit is not None else 25,
-            score_threshold=raw_threshold,
             search_params=SearchParams(exact=True),
         ).points
 

--- a/nodes/src/nodes/qdrant/qdrant.py
+++ b/nodes/src/nodes/qdrant/qdrant.py
@@ -248,9 +248,20 @@ class Store(DocumentStoreBase):
         if docFilter.objectIds is not None:
             must.append(models.FieldCondition(key='meta.objectId', match=models.MatchAny(any=docFilter.objectIds)))
 
-        # If we are not going after deleted docs, add a condition
+        # If we are not going after deleted docs, add a condition.
+        # Match isDeleted=False OR isDeleted=null OR isDeleted field absent —
+        # all three mean "not explicitly deleted" since the Qdrant client strips
+        # None values via exclude_none, so old/edge-case docs may lack the field.
         if docFilter.isDeleted is None or not docFilter.isDeleted:
-            must.append(models.FieldCondition(key='meta.isDeleted', match=models.MatchValue(value=False)))
+            must.append(
+                models.Filter(
+                    should=[
+                        models.FieldCondition(key='meta.isDeleted', match=models.MatchValue(value=False)),
+                        models.IsNullCondition(is_null=models.PayloadField(key='meta.isDeleted')),
+                        models.IsEmptyCondition(is_empty=models.PayloadField(key='meta.isDeleted')),
+                    ]
+                )
+            )
 
         # If we are not going after chunks, add a condition
         if docFilter.chunkIds is not None:
@@ -294,7 +305,7 @@ class Store(DocumentStoreBase):
                     score = float(1.0 / (1.0 + np.exp(point.score / -100)))
 
                 # Ignore it if it doesn't have a high enough score
-                if score < 0.20:
+                if score < self.threshold_search:
                     continue
             else:
                 score = 0
@@ -388,6 +399,14 @@ class Store(DocumentStoreBase):
         if docFilter.offset:
             raise BaseException('Non-zero offset is not supported in semantic searching')
 
+        # For Cosine similarity, Qdrant applies score_threshold against raw [-1,1]
+        # scores before our (score + 1) / 2 normalization. Inverse-transform the
+        # [0,1] config threshold back to the raw space so the API filter is correct.
+        if self.similarity == 'Cosine':
+            raw_threshold = (self.threshold_search * 2) - 1
+        else:
+            raw_threshold = self.threshold_search
+
         # Perform the search
         points = self.client.query_points(
             collection_name=self.collection,
@@ -396,7 +415,7 @@ class Store(DocumentStoreBase):
             with_vectors=False,
             with_payload=True,
             limit=docFilter.limit if docFilter.limit is not None else 25,
-            score_threshold=self.threshold_search,
+            score_threshold=raw_threshold,
             search_params=SearchParams(exact=True),
         ).points
 

--- a/nodes/test/mocks/qdrant_client/__init__.py
+++ b/nodes/test/mocks/qdrant_client/__init__.py
@@ -448,23 +448,22 @@ class QdrantClient:
         """
         points = QdrantClient._points.get(collection_name, [])
 
-        # Filter out the schema document (isDeleted=True)
-        # This document is created by the RocketRide store to track metadata
-        # and should never appear in search results
+        # Replicate the real Qdrant filter: exclude only documents explicitly
+        # marked isDeleted=True. Null/missing isDeleted means not deleted,
+        # matching the should=[MatchValue(False), IsNullCondition, IsEmptyCondition]
+        # filter used in _convertFilter().
         filtered_points = []
         for p in points:
             meta = p.payload.get('meta') if p.payload else None
-            is_deleted = False
+            is_deleted = None
 
             if meta is not None:
                 if hasattr(meta, 'isDeleted'):
-                    # meta is a DocMetadata object
                     is_deleted = meta.isDeleted
                 elif isinstance(meta, dict):
-                    # meta is already serialized to dict
-                    is_deleted = meta.get('isDeleted', False)
+                    is_deleted = meta.get('isDeleted')
 
-            if not is_deleted:
+            if is_deleted is not True:
                 filtered_points.append(p)
 
         # Return mock scored points

--- a/nodes/test/qdrant/test_search_threshold.py
+++ b/nodes/test/qdrant/test_search_threshold.py
@@ -4,326 +4,79 @@
 # =============================================================================
 
 """
-Tests for Qdrant score threshold fixes in searchSemantic / _convertToDocs.
+Regression test for the Qdrant score-threshold fix in searchSemantic.
 
-Two bugs were fixed in qdrant.py:
-
-1. ``score_threshold`` passed to ``query_points()`` is now inverse-transformed
-   for Cosine similarity so the raw [-1, 1] Qdrant space matches the normalised
-   [0, 1] user threshold:
-       raw_threshold = (threshold_search * 2) - 1
-
-2. The hardcoded ``if score < 0.20`` guard in ``_convertToDocs()`` was replaced
-   with ``if score < self.threshold_search``, so the configured threshold is
-   actually applied.
-
-Usage:
-    python -m pytest nodes/test/qdrant/test_search_threshold.py -v
+threshold_search is in the rescaled [0, 1] space, but Qdrant's score_threshold
+filters against the raw similarity score, so it must not be passed to the engine.
+The threshold cut is applied post-rescale by the base store (_addDoc).
 """
 
-import math
 import sys
-import threading
-import importlib
 import importlib.util
+import unittest
 from pathlib import Path
-from unittest.mock import MagicMock, patch
-
-
-# ---------------------------------------------------------------------------
-# Bootstrap mocks so qdrant.py can be imported without real dependencies
-# ---------------------------------------------------------------------------
+from unittest.mock import MagicMock
 
 NODES_SRC = Path(__file__).parent.parent.parent / 'src' / 'nodes'
 
 
-# --- ai.common.store: provide a real DocumentStoreBase with stub methods ---
 class _FakeDocumentStoreBase:
-    """Minimal stand-in for ai.common.store.DocumentStoreBase."""
-
-    def __init__(self, *a, **kw):
-        self.vectorSize = 0
-        self.modelName = ''
-        self.threshold_search = 0.5
-        self.collectionLock = threading.Lock()
-
     def doesCollectionExist(self, *a, **kw):
         return True
 
-    def _doesCollectionExist(self):
-        return True
 
-    def _checkCollectionExists(self):
-        return True
+for _name in (
+    'numpy',
+    'qdrant_client',
+    'qdrant_client.models',
+    'qdrant_client.http',
+    'qdrant_client.http.models',
+    'qdrant_client.conversions',
+    'qdrant_client.conversions.common_types',
+    'depends',
+    'ai',
+    'ai.common',
+    'ai.common.schema',
+    'ai.common.config',
+):
+    sys.modules.setdefault(_name, MagicMock())
 
-    def createCollection(self, *a, **kw):
-        return True
+_store_mod = MagicMock()
+_store_mod.DocumentStoreBase = _FakeDocumentStoreBase
+sys.modules['ai.common.store'] = _store_mod
 
-
-# Install module-level stubs before any qdrant imports
-_mock_store_mod = MagicMock()
-_mock_store_mod.DocumentStoreBase = _FakeDocumentStoreBase
-
-_mock_config_mod = MagicMock()
-_mock_schema_mod = MagicMock()
-
-for name, mock in {
-    'numpy': MagicMock(),
-    'qdrant_client': MagicMock(),
-    'qdrant_client.models': MagicMock(),
-    'qdrant_client.http': MagicMock(),
-    'qdrant_client.http.models': MagicMock(),
-    'qdrant_client.conversions': MagicMock(),
-    'qdrant_client.conversions.common_types': MagicMock(),
-}.items():
-    sys.modules.setdefault(name, mock)
-
-
-# ---------------------------------------------------------------------------
-# Import qdrant.py DIRECTLY (bypassing __init__.py which pulls IEndpoint etc.)
-# ---------------------------------------------------------------------------
-
-_qdrant_path = NODES_SRC / 'qdrant' / 'qdrant.py'
-_spec = importlib.util.spec_from_file_location('_qdrant_store', str(_qdrant_path))
+_spec = importlib.util.spec_from_file_location('_qdrant_store', str(NODES_SRC / 'qdrant' / 'qdrant.py'))
 _qdrant_mod = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_qdrant_mod)
-
 Store = _qdrant_mod.Store
 
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _make_store(threshold: float = 0.5, similarity: str = 'Cosine') -> Store:
-    """Create a Store instance with a mocked QdrantClient (bypasses __init__)."""
+def _make_store(similarity: str) -> Store:
     store = object.__new__(Store)
     store.client = MagicMock()
-    store.collection = 'test-collection'
-    store.vectorSize = 384
-    store.modelName = 'test-model'
-    store.threshold_search = threshold
+    store.client.query_points.return_value.points = []
+    store.collection = 'c'
+    store.threshold_search = 0.7
     store.similarity = similarity
-    store.collectionLock = threading.Lock()
-    store._checkCollectionExists = lambda: True
     return store
 
 
-def _fake_query_result(points):
-    """Wrap a list of points in a mock QueryResult-like object."""
-    result = MagicMock()
-    result.points = points
-    return result
+def _run_search(store: Store) -> None:
+    query = MagicMock(embedding=[0.1, 0.2], embedding_model='m')
+    store.searchSemantic(query, MagicMock(offset=0, limit=10))
 
 
-def _approx_equal(a: float, b: float, tol: float = 1e-9) -> bool:
-    """Float equality with tolerance (avoids pytest.approx which touches numpy)."""
-    return math.isclose(a, b, abs_tol=tol)
+class TestScoreThresholdNotPassedToEngine(unittest.TestCase):
+    def test_cosine(self):
+        store = _make_store('Cosine')
+        _run_search(store)
+        self.assertNotIn('score_threshold', store.client.query_points.call_args.kwargs)
+
+    def test_non_cosine(self):
+        store = _make_store('Dot')
+        _run_search(store)
+        self.assertNotIn('score_threshold', store.client.query_points.call_args.kwargs)
 
 
-# ---------------------------------------------------------------------------
-# Tests: score_threshold inverse-transform for query_points()
-# ---------------------------------------------------------------------------
-
-
-class TestScoreThresholdTransform:
-    """Verify that score_threshold is correctly inverse-transformed before being
-    passed to query_points() for Cosine similarity.
-    """
-
-    def _call_search_semantic(self, store: Store) -> None:
-        """Invoke searchSemantic with the minimal QuestionText / DocFilter mocks."""
-        question = MagicMock()
-        question.embedding = [0.1, 0.2, 0.3]
-        question.embedding_model = 'test-model'
-
-        doc_filter = MagicMock()
-        doc_filter.nodeId = None
-        doc_filter.isTable = None
-        doc_filter.tableIds = None
-        doc_filter.parent = None
-        doc_filter.permissions = None
-        doc_filter.objectIds = None
-        doc_filter.isDeleted = None
-        doc_filter.chunkIds = None
-        doc_filter.minChunkId = None
-        doc_filter.maxChunkId = None
-        doc_filter.offset = 0
-        doc_filter.limit = 10
-
-        # query_points must return something iterable via .points
-        store.client.query_points.return_value = _fake_query_result([])
-
-        store.searchSemantic(question, doc_filter)
-
-    def test_cosine_threshold_0_7_passed_as_0_4(self):
-        """threshold_search=0.7, Cosine → score_threshold=0.4 sent to Qdrant."""
-        store = _make_store(threshold=0.7, similarity='Cosine')
-
-        self._call_search_semantic(store)
-
-        store.client.query_points.assert_called_once()
-        _, kwargs = store.client.query_points.call_args
-        expected_raw = (0.7 * 2) - 1  # 0.4
-        assert _approx_equal(kwargs['score_threshold'], expected_raw), (
-            f'Expected score_threshold={expected_raw} but got {kwargs["score_threshold"]}'
-        )
-
-    def test_cosine_threshold_0_0_passed_as_minus_1(self):
-        """threshold_search=0.0 (All results), Cosine → score_threshold=-1.0."""
-        store = _make_store(threshold=0.0, similarity='Cosine')
-
-        self._call_search_semantic(store)
-
-        store.client.query_points.assert_called_once()
-        _, kwargs = store.client.query_points.call_args
-        expected_raw = (0.0 * 2) - 1  # -1.0
-        assert _approx_equal(kwargs['score_threshold'], expected_raw), (
-            f'Expected score_threshold={expected_raw} but got {kwargs["score_threshold"]}'
-        )
-
-    def test_cosine_threshold_0_5_passed_as_0_0(self):
-        """threshold_search=0.5, Cosine → score_threshold=0.0."""
-        store = _make_store(threshold=0.5, similarity='Cosine')
-
-        self._call_search_semantic(store)
-
-        _, kwargs = store.client.query_points.call_args
-        expected_raw = (0.5 * 2) - 1  # 0.0
-        assert _approx_equal(kwargs['score_threshold'], expected_raw)
-
-    def test_non_cosine_threshold_not_transformed(self):
-        """threshold_search=0.7, Dot similarity → score_threshold=0.7 (no transform)."""
-        store = _make_store(threshold=0.7, similarity='Dot')
-
-        self._call_search_semantic(store)
-
-        _, kwargs = store.client.query_points.call_args
-        assert _approx_equal(kwargs['score_threshold'], 0.7), (
-            f'Expected score_threshold=0.7 for Dot similarity but got {kwargs["score_threshold"]}'
-        )
-
-    def test_euclid_threshold_not_transformed(self):
-        """threshold_search=0.3, Euclid similarity → score_threshold=0.3 (no transform)."""
-        store = _make_store(threshold=0.3, similarity='Euclid')
-
-        self._call_search_semantic(store)
-
-        _, kwargs = store.client.query_points.call_args
-        assert _approx_equal(kwargs['score_threshold'], 0.3)
-
-
-# ---------------------------------------------------------------------------
-# Tests: _convertToDocs() threshold filtering
-# ---------------------------------------------------------------------------
-
-
-class TestConvertToDocsThreshold:
-    """Verify that _convertToDocs() uses threshold_search (not 0.20) to filter."""
-
-    def _run_convert(self, store: Store, raw_scores: list) -> list:
-        """
-        Call _convertToDocs with fake ScoredPoints having the given raw scores.
-
-        Because qdrant_client is fully mocked, ScoredPoint in _qdrant_mod is itself
-        a MagicMock.  We replace it temporarily with a real sentinel class so that
-        ``isinstance(point, ScoredPoint)`` works correctly inside _convertToDocs.
-        We also patch DocMetadata so payload unpacking does not raise.
-        """
-
-        # Create a real (non-mock) class to stand in for ScoredPoint
-        class _RealScoredPoint:
-            def __init__(self, score, payload):
-                self.score = score
-                self.payload = payload
-
-        fake_metadata = MagicMock()
-        DocMetadata_mock = MagicMock(return_value=fake_metadata)
-
-        points = [
-            _RealScoredPoint(
-                score=raw,
-                payload={'content': 'chunk text', 'meta': {}},
-            )
-            for raw in raw_scores
-        ]
-
-        # Doc is a Pydantic model that validates its fields; replace it with a
-        # plain container so tests that reach the Doc(...) call don't fail on
-        # metadata type validation.
-        class _FakeDoc:
-            def __init__(self, **kwargs):
-                for k, v in kwargs.items():
-                    setattr(self, k, v)
-
-        with (
-            patch.object(_qdrant_mod, 'ScoredPoint', _RealScoredPoint),
-            patch.object(_qdrant_mod, 'DocMetadata', DocMetadata_mock),
-            patch.object(_qdrant_mod, 'Doc', _FakeDoc),
-        ):
-            docs = store._convertToDocs(points)
-
-        return docs
-
-    def test_cosine_score_above_threshold_passes(self):
-        """
-        Raw score=0.8 → normalised=(0.8+1)/2=0.9; threshold=0.7 → doc is kept.
-        """
-        store = _make_store(threshold=0.7, similarity='Cosine')
-        # raw 0.8 → normalised 0.9, which is >= 0.7
-        docs = self._run_convert(store, raw_scores=[0.8])
-        assert len(docs) == 1, f'Expected 1 doc (score above threshold) but got {len(docs)}'
-
-    def test_cosine_score_at_threshold_passes(self):
-        """
-        Raw score=0.4 → normalised=(0.4+1)/2=0.7; threshold=0.7 → doc is kept (equal).
-        """
-        store = _make_store(threshold=0.7, similarity='Cosine')
-        # raw 0.4 → normalised exactly 0.7
-        docs = self._run_convert(store, raw_scores=[0.4])
-        assert len(docs) == 1, f'Expected 1 doc (score at threshold) but got {len(docs)}'
-
-    def test_cosine_score_below_threshold_filtered(self):
-        """
-        Raw score=0.2 → normalised=(0.2+1)/2=0.6; threshold=0.7 → doc is filtered out.
-        """
-        store = _make_store(threshold=0.7, similarity='Cosine')
-        # raw 0.2 → normalised 0.6, which is < 0.7
-        docs = self._run_convert(store, raw_scores=[0.2])
-        assert len(docs) == 0, f'Expected 0 docs (score below threshold) but got {len(docs)}'
-
-    def test_threshold_0_0_keeps_all_results(self):
-        """
-        threshold_search=0.0 → all results pass regardless of score.
-        """
-        store = _make_store(threshold=0.0, similarity='Cosine')
-        # raw -0.5 → normalised 0.25, still >= 0.0
-        docs = self._run_convert(store, raw_scores=[-0.5, 0.0, 0.95])
-        assert len(docs) == 3, f'Expected 3 docs (threshold=0) but got {len(docs)}'
-
-    def test_score_previously_hardcoded_0_20_passes_with_low_threshold(self):
-        """
-        Regression: the old code had ``if score < 0.20`` hardcoded.
-
-        A normalised score of 0.15 (raw=-0.7) with threshold_search=0.10
-        should now PASS, whereas the old code would have filtered it out.
-        """
-        store = _make_store(threshold=0.10, similarity='Cosine')
-        # raw -0.7 → normalised (-0.7+1)/2 = 0.15, which is >= 0.10
-        docs = self._run_convert(store, raw_scores=[-0.7])
-        assert len(docs) == 1, (
-            'Score 0.15 should pass when threshold=0.10 (regression: old hardcoded 0.20 would have filtered it)'
-        )
-
-    def test_mixed_scores_partial_filter(self):
-        """
-        Multiple points: only those with normalised score >= threshold pass.
-        threshold=0.7:
-          raw 0.8 → 0.9  (pass)
-          raw 0.2 → 0.6  (fail)
-          raw 0.4 → 0.7  (pass, equal)
-        """
-        store = _make_store(threshold=0.7, similarity='Cosine')
-        docs = self._run_convert(store, raw_scores=[0.8, 0.2, 0.4])
-        assert len(docs) == 2, f'Expected 2 docs but got {len(docs)}'
+if __name__ == '__main__':
+    unittest.main()

--- a/nodes/test/qdrant/test_search_threshold.py
+++ b/nodes/test/qdrant/test_search_threshold.py
@@ -1,0 +1,329 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Tests for Qdrant score threshold fixes in searchSemantic / _convertToDocs.
+
+Two bugs were fixed in qdrant.py:
+
+1. ``score_threshold`` passed to ``query_points()`` is now inverse-transformed
+   for Cosine similarity so the raw [-1, 1] Qdrant space matches the normalised
+   [0, 1] user threshold:
+       raw_threshold = (threshold_search * 2) - 1
+
+2. The hardcoded ``if score < 0.20`` guard in ``_convertToDocs()`` was replaced
+   with ``if score < self.threshold_search``, so the configured threshold is
+   actually applied.
+
+Usage:
+    python -m pytest nodes/test/qdrant/test_search_threshold.py -v
+"""
+
+import math
+import sys
+import threading
+import importlib
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap mocks so qdrant.py can be imported without real dependencies
+# ---------------------------------------------------------------------------
+
+NODES_SRC = Path(__file__).parent.parent.parent / 'src' / 'nodes'
+
+
+# --- ai.common.store: provide a real DocumentStoreBase with stub methods ---
+class _FakeDocumentStoreBase:
+    """Minimal stand-in for ai.common.store.DocumentStoreBase."""
+
+    def __init__(self, *a, **kw):
+        self.vectorSize = 0
+        self.modelName = ''
+        self.threshold_search = 0.5
+        self.collectionLock = threading.Lock()
+
+    def doesCollectionExist(self, *a, **kw):
+        return True
+
+    def _doesCollectionExist(self):
+        return True
+
+    def _checkCollectionExists(self):
+        return True
+
+    def createCollection(self, *a, **kw):
+        return True
+
+
+# Install module-level stubs before any qdrant imports
+_mock_store_mod = MagicMock()
+_mock_store_mod.DocumentStoreBase = _FakeDocumentStoreBase
+
+_mock_config_mod = MagicMock()
+_mock_schema_mod = MagicMock()
+
+for name, mock in {
+    'numpy': MagicMock(),
+    'qdrant_client': MagicMock(),
+    'qdrant_client.models': MagicMock(),
+    'qdrant_client.http': MagicMock(),
+    'qdrant_client.http.models': MagicMock(),
+    'qdrant_client.conversions': MagicMock(),
+    'qdrant_client.conversions.common_types': MagicMock(),
+}.items():
+    sys.modules.setdefault(name, mock)
+
+
+# ---------------------------------------------------------------------------
+# Import qdrant.py DIRECTLY (bypassing __init__.py which pulls IEndpoint etc.)
+# ---------------------------------------------------------------------------
+
+_qdrant_path = NODES_SRC / 'qdrant' / 'qdrant.py'
+_spec = importlib.util.spec_from_file_location('_qdrant_store', str(_qdrant_path))
+_qdrant_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_qdrant_mod)
+
+Store = _qdrant_mod.Store
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_store(threshold: float = 0.5, similarity: str = 'Cosine') -> Store:
+    """Create a Store instance with a mocked QdrantClient (bypasses __init__)."""
+    store = object.__new__(Store)
+    store.client = MagicMock()
+    store.collection = 'test-collection'
+    store.vectorSize = 384
+    store.modelName = 'test-model'
+    store.threshold_search = threshold
+    store.similarity = similarity
+    store.collectionLock = threading.Lock()
+    store._checkCollectionExists = lambda: True
+    return store
+
+
+def _fake_query_result(points):
+    """Wrap a list of points in a mock QueryResult-like object."""
+    result = MagicMock()
+    result.points = points
+    return result
+
+
+def _approx_equal(a: float, b: float, tol: float = 1e-9) -> bool:
+    """Float equality with tolerance (avoids pytest.approx which touches numpy)."""
+    return math.isclose(a, b, abs_tol=tol)
+
+
+# ---------------------------------------------------------------------------
+# Tests: score_threshold inverse-transform for query_points()
+# ---------------------------------------------------------------------------
+
+
+class TestScoreThresholdTransform:
+    """Verify that score_threshold is correctly inverse-transformed before being
+    passed to query_points() for Cosine similarity.
+    """
+
+    def _call_search_semantic(self, store: Store) -> None:
+        """Invoke searchSemantic with the minimal QuestionText / DocFilter mocks."""
+        question = MagicMock()
+        question.embedding = [0.1, 0.2, 0.3]
+        question.embedding_model = 'test-model'
+
+        doc_filter = MagicMock()
+        doc_filter.nodeId = None
+        doc_filter.isTable = None
+        doc_filter.tableIds = None
+        doc_filter.parent = None
+        doc_filter.permissions = None
+        doc_filter.objectIds = None
+        doc_filter.isDeleted = None
+        doc_filter.chunkIds = None
+        doc_filter.minChunkId = None
+        doc_filter.maxChunkId = None
+        doc_filter.offset = 0
+        doc_filter.limit = 10
+
+        # query_points must return something iterable via .points
+        store.client.query_points.return_value = _fake_query_result([])
+
+        store.searchSemantic(question, doc_filter)
+
+    def test_cosine_threshold_0_7_passed_as_0_4(self):
+        """threshold_search=0.7, Cosine → score_threshold=0.4 sent to Qdrant."""
+        store = _make_store(threshold=0.7, similarity='Cosine')
+
+        self._call_search_semantic(store)
+
+        store.client.query_points.assert_called_once()
+        _, kwargs = store.client.query_points.call_args
+        expected_raw = (0.7 * 2) - 1  # 0.4
+        assert _approx_equal(kwargs['score_threshold'], expected_raw), (
+            f'Expected score_threshold={expected_raw} but got {kwargs["score_threshold"]}'
+        )
+
+    def test_cosine_threshold_0_0_passed_as_minus_1(self):
+        """threshold_search=0.0 (All results), Cosine → score_threshold=-1.0."""
+        store = _make_store(threshold=0.0, similarity='Cosine')
+
+        self._call_search_semantic(store)
+
+        store.client.query_points.assert_called_once()
+        _, kwargs = store.client.query_points.call_args
+        expected_raw = (0.0 * 2) - 1  # -1.0
+        assert _approx_equal(kwargs['score_threshold'], expected_raw), (
+            f'Expected score_threshold={expected_raw} but got {kwargs["score_threshold"]}'
+        )
+
+    def test_cosine_threshold_0_5_passed_as_0_0(self):
+        """threshold_search=0.5, Cosine → score_threshold=0.0."""
+        store = _make_store(threshold=0.5, similarity='Cosine')
+
+        self._call_search_semantic(store)
+
+        _, kwargs = store.client.query_points.call_args
+        expected_raw = (0.5 * 2) - 1  # 0.0
+        assert _approx_equal(kwargs['score_threshold'], expected_raw)
+
+    def test_non_cosine_threshold_not_transformed(self):
+        """threshold_search=0.7, Dot similarity → score_threshold=0.7 (no transform)."""
+        store = _make_store(threshold=0.7, similarity='Dot')
+
+        self._call_search_semantic(store)
+
+        _, kwargs = store.client.query_points.call_args
+        assert _approx_equal(kwargs['score_threshold'], 0.7), (
+            f'Expected score_threshold=0.7 for Dot similarity but got {kwargs["score_threshold"]}'
+        )
+
+    def test_euclid_threshold_not_transformed(self):
+        """threshold_search=0.3, Euclid similarity → score_threshold=0.3 (no transform)."""
+        store = _make_store(threshold=0.3, similarity='Euclid')
+
+        self._call_search_semantic(store)
+
+        _, kwargs = store.client.query_points.call_args
+        assert _approx_equal(kwargs['score_threshold'], 0.3)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _convertToDocs() threshold filtering
+# ---------------------------------------------------------------------------
+
+
+class TestConvertToDocsThreshold:
+    """Verify that _convertToDocs() uses threshold_search (not 0.20) to filter."""
+
+    def _run_convert(self, store: Store, raw_scores: list) -> list:
+        """
+        Call _convertToDocs with fake ScoredPoints having the given raw scores.
+
+        Because qdrant_client is fully mocked, ScoredPoint in _qdrant_mod is itself
+        a MagicMock.  We replace it temporarily with a real sentinel class so that
+        ``isinstance(point, ScoredPoint)`` works correctly inside _convertToDocs.
+        We also patch DocMetadata so payload unpacking does not raise.
+        """
+
+        # Create a real (non-mock) class to stand in for ScoredPoint
+        class _RealScoredPoint:
+            def __init__(self, score, payload):
+                self.score = score
+                self.payload = payload
+
+        fake_metadata = MagicMock()
+        DocMetadata_mock = MagicMock(return_value=fake_metadata)
+
+        points = [
+            _RealScoredPoint(
+                score=raw,
+                payload={'content': 'chunk text', 'meta': {}},
+            )
+            for raw in raw_scores
+        ]
+
+        # Doc is a Pydantic model that validates its fields; replace it with a
+        # plain container so tests that reach the Doc(...) call don't fail on
+        # metadata type validation.
+        class _FakeDoc:
+            def __init__(self, **kwargs):
+                for k, v in kwargs.items():
+                    setattr(self, k, v)
+
+        with (
+            patch.object(_qdrant_mod, 'ScoredPoint', _RealScoredPoint),
+            patch.object(_qdrant_mod, 'DocMetadata', DocMetadata_mock),
+            patch.object(_qdrant_mod, 'Doc', _FakeDoc),
+        ):
+            docs = store._convertToDocs(points)
+
+        return docs
+
+    def test_cosine_score_above_threshold_passes(self):
+        """
+        Raw score=0.8 → normalised=(0.8+1)/2=0.9; threshold=0.7 → doc is kept.
+        """
+        store = _make_store(threshold=0.7, similarity='Cosine')
+        # raw 0.8 → normalised 0.9, which is >= 0.7
+        docs = self._run_convert(store, raw_scores=[0.8])
+        assert len(docs) == 1, f'Expected 1 doc (score above threshold) but got {len(docs)}'
+
+    def test_cosine_score_at_threshold_passes(self):
+        """
+        Raw score=0.4 → normalised=(0.4+1)/2=0.7; threshold=0.7 → doc is kept (equal).
+        """
+        store = _make_store(threshold=0.7, similarity='Cosine')
+        # raw 0.4 → normalised exactly 0.7
+        docs = self._run_convert(store, raw_scores=[0.4])
+        assert len(docs) == 1, f'Expected 1 doc (score at threshold) but got {len(docs)}'
+
+    def test_cosine_score_below_threshold_filtered(self):
+        """
+        Raw score=0.2 → normalised=(0.2+1)/2=0.6; threshold=0.7 → doc is filtered out.
+        """
+        store = _make_store(threshold=0.7, similarity='Cosine')
+        # raw 0.2 → normalised 0.6, which is < 0.7
+        docs = self._run_convert(store, raw_scores=[0.2])
+        assert len(docs) == 0, f'Expected 0 docs (score below threshold) but got {len(docs)}'
+
+    def test_threshold_0_0_keeps_all_results(self):
+        """
+        threshold_search=0.0 → all results pass regardless of score.
+        """
+        store = _make_store(threshold=0.0, similarity='Cosine')
+        # raw -0.5 → normalised 0.25, still >= 0.0
+        docs = self._run_convert(store, raw_scores=[-0.5, 0.0, 0.95])
+        assert len(docs) == 3, f'Expected 3 docs (threshold=0) but got {len(docs)}'
+
+    def test_score_previously_hardcoded_0_20_passes_with_low_threshold(self):
+        """
+        Regression: the old code had ``if score < 0.20`` hardcoded.
+
+        A normalised score of 0.15 (raw=-0.7) with threshold_search=0.10
+        should now PASS, whereas the old code would have filtered it out.
+        """
+        store = _make_store(threshold=0.10, similarity='Cosine')
+        # raw -0.7 → normalised (-0.7+1)/2 = 0.15, which is >= 0.10
+        docs = self._run_convert(store, raw_scores=[-0.7])
+        assert len(docs) == 1, (
+            'Score 0.15 should pass when threshold=0.10 (regression: old hardcoded 0.20 would have filtered it)'
+        )
+
+    def test_mixed_scores_partial_filter(self):
+        """
+        Multiple points: only those with normalised score >= threshold pass.
+        threshold=0.7:
+          raw 0.8 → 0.9  (pass)
+          raw 0.2 → 0.6  (fail)
+          raw 0.4 → 0.7  (pass, equal)
+        """
+        store = _make_store(threshold=0.7, similarity='Cosine')
+        docs = self._run_convert(store, raw_scores=[0.8, 0.2, 0.4])
+        assert len(docs) == 2, f'Expected 2 docs but got {len(docs)}'


### PR DESCRIPTION
## Summary

- **Score-space mismatch (primary bug):** `threshold_search` is a `[0,1]` value but was passed to Qdrant as `score_threshold`, which Qdrant applies against raw cosine scores in `[-1,1]` (the `(score+1)/2` rescaling only happens afterwards in `_convertToDocs`). Every non-zero category had an effective bar far higher than intended → zero results; "All results" (0.0) worked by accident. **Fix:** stop passing `score_threshold` to the engine; the cut is applied post-rescale by the base store (`_addDoc`), consistent with the other vector stores.
- **isDeleted filter too strict:** `MatchValue(False)` excluded docs whose `isDeleted` is null/absent (the client strips `None` via `exclude_none`, so older/edge-case docs lack the field). **Fix:** `must_not=[MatchValue(True)]` — exclude only docs explicitly marked deleted; null/absent counts as not deleted.
- **Magic number:** the `0.20` relevance floor in `_convertToDocs` is now the named constant `MIN_RELEVANCE_SCORE`.

## Test plan

- [ ] `nodes/test/qdrant/test_search_threshold.py`: asserts the engine never receives `score_threshold` (Cosine + non-Cosine).
- [ ] Existing `test_mark_deleted.py` (4 tests) still passing.
- [ ] Mock `query_points()` mirrors real Qdrant semantics (exclude only when `isDeleted` is explicitly `True`).
- [ ] CI `test_dynamic[qdrant:services:local]` (live Qdrant) returns results for non-zero retrieval categories — this E2E is the real validator of the isDeleted fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected deletion filtering so items with missing or null deletion flags are treated as not deleted.
  * Applied a configurable relevance threshold to semantic results (replaced hardcoded literal) to more consistently filter low-relevance matches.

* **Tests**
  * Added unit tests verifying search threshold behavior and that engine-specific score thresholds are handled correctly by the store.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/958?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
