### PR TITLE
fix(chroma): exclude soft-deleted documents from default searches

### DIFF
--- a/nodes/src/nodes/chroma/chroma.py
+++ b/nodes/src/nodes/chroma/chroma.py
@@ -163,8 +163,14 @@ class Store(DocumentStoreBase):
             filters.append({'permissionId': {'$in': docFilter.permissions}})
         if docFilter.objectIds is not None:
             filters.append({'objectId': {'$in': docFilter.objectIds}})
-        if docFilter.isDeleted is not None:
-            filters.append({'isDeleted': {'$eq': docFilter.isDeleted}})
+        if docFilter.isDeleted is None or not docFilter.isDeleted:
+            # Exclude only docs explicitly marked deleted. A null/absent isDeleted
+            # (the client strips None via exclude_none) must still count as not
+            # deleted, so use $ne True (which matches absent-key records) instead of
+            # $eq False (which would drop them).
+            filters.append({'isDeleted': {'$ne': True}})
+        else:
+            filters.append({'isDeleted': {'$eq': True}})
         if docFilter.chunkIds is not None:
             filters.append({'chunkId': {'$in': docFilter.chunkIds}})
         # If we are min chunk id, add a condition

--- a/nodes/test/chroma/test_convert_filter_explicit_none.py
+++ b/nodes/test/chroma/test_convert_filter_explicit_none.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Aparavi Software AG
 # =============================================================================
 
-"""Regression tests for Chroma `_convertFilter` explicit-None vs empty-container semantics."""
+"""Regression tests for Chroma `_convertFilter`: isDeleted default-exclusion and explicit-None vs empty-container semantics."""
 
 from __future__ import annotations
 
@@ -98,7 +98,7 @@ def test_convert_filter_empty_object_ids_list_is_not_omitted() -> None:
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter(objectIds=[]))
-    assert converted == {'objectId': {'$in': []}}
+    assert converted == {'$and': [{'objectId': {'$in': []}}, {'isDeleted': {'$ne': True}}]}
 
 
 def test_convert_filter_empty_string_node_id_is_included() -> None:
@@ -106,7 +106,7 @@ def test_convert_filter_empty_string_node_id_is_included() -> None:
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter(nodeId=''))
-    assert converted == {'nodeId': {'$eq': ''}}
+    assert converted == {'$and': [{'nodeId': {'$eq': ''}}, {'isDeleted': {'$ne': True}}]}
 
 
 def test_convert_filter_empty_table_ids_list_is_not_omitted() -> None:
@@ -114,12 +114,39 @@ def test_convert_filter_empty_table_ids_list_is_not_omitted() -> None:
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter(tableIds=[]))
-    assert converted == {'tableId': {'$in': []}}
+    assert converted == {'$and': [{'tableId': {'$in': []}}, {'isDeleted': {'$ne': True}}]}
 
 
-def test_convert_filter_omits_object_ids_when_unset() -> None:
-    """When objectIds is unset (None), no objectId filter clause is added."""
+def test_convert_filter_default_excludes_deleted() -> None:
+    """Default filter (isDeleted=None) must include the isDeleted $ne True clause."""
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter())
-    assert converted is None
+    assert converted == {'isDeleted': {'$ne': True}}
+
+
+# --- Regression tests for isDeleted behaviour ---
+
+
+def test_convert_filter_is_deleted_none_excludes_deleted() -> None:
+    """isDeleted=None -> {'isDeleted': {'$ne': True}} (bug was: previously returned None)."""
+    Store = _load_store_class()
+    store = Store.__new__(Store)
+    converted = store._convertFilter(_doc_filter(isDeleted=None))
+    assert converted == {'isDeleted': {'$ne': True}}
+
+
+def test_convert_filter_is_deleted_false_excludes_deleted() -> None:
+    """isDeleted=False -> {'isDeleted': {'$ne': True}}."""
+    Store = _load_store_class()
+    store = Store.__new__(Store)
+    converted = store._convertFilter(_doc_filter(isDeleted=False))
+    assert converted == {'isDeleted': {'$ne': True}}
+
+
+def test_convert_filter_is_deleted_true_includes_only_deleted() -> None:
+    """isDeleted=True -> {'isDeleted': {'$eq': True}}."""
+    Store = _load_store_class()
+    store = Store.__new__(Store)
+    converted = store._convertFilter(_doc_filter(isDeleted=True))
+    assert converted == {'isDeleted': {'$eq': True}}


### PR DESCRIPTION
## Summary

- **Soft-deleted documents leaked into default searches (primary bug):** `_convertFilter` only added an `isDeleted` clause when `docFilter.isDeleted is not None`. Since the default `DocFilter.isDeleted` is `None`, normal searches added **no** `isDeleted` filter and returned soft-deleted documents. **Fix:** when `isDeleted` is `None` or `False`, exclude only docs explicitly marked deleted — `{'isDeleted': {'$ne': True}}`. This mirrors the Qdrant fix in #958.
- **Absent/null `isDeleted` was dropped:** the old equality path (`$eq False`) does not match documents whose `isDeleted` key is absent (the client strips `None` via `exclude_none`, so older/edge-case docs lack the field). In Chroma, `$ne True` **does** match absent-key records, so absent/null now correctly counts as not-deleted. Querying `isDeleted=True` still returns deleted docs via `{'isDeleted': {'$eq': True}}`.

## Test plan

- [x] `nodes/test/chroma/test_convert_filter_explicit_none.py`: updated the 4 existing tests to expect the new `isDeleted` clause (original intent preserved — empty lists/strings still not dropped); renamed `test_convert_filter_omits_object_ids_when_unset` → `test_convert_filter_default_excludes_deleted` (its old `None` assertion was exactly the bug); added regression tests for `isDeleted` None / False / True. **7/7 pass.**
- [x] Verified the base store control-document lookup (`_checkCollectionExists`, which queries with `isDeleted=True`) still finds the `objectId='schema'` doc, and that normal searches now exclude it.
- [ ] CI `test_dynamic[chroma:...]` (live Chroma) — the real E2E validator of the filter behavior.

## Notes / out of scope

- The `$ne True` "matches absent-key records" behavior holds for Chroma 1.x (client pinned `chromadb-client==1.5.9`).
- Pre-existing and left for separate follow-ups: `count()` / `getPaths()` / `render()` do not filter `isDeleted`; the chromadb test mock does not implement `$ne` (these are filter-builder unit tests, so they assert the emitted filter dict — runtime `$ne` semantics are Chroma-documented); Chroma's cosine score normalization is a separate score-space issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document filtering to ensure deleted documents are excluded by default in queries. Previously, deleted documents could be inadvertently included when filter parameters were unset. Now, deleted documents are consistently excluded unless explicitly requested.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->