### PR TITLE
fix: route RAG chat query through embedding before vector store

### DIFF
--- a/packages/shared-ui/src/components/canvas/templates/templates.json
+++ b/packages/shared-ui/src/components/canvas/templates/templates.json
@@ -41,7 +41,10 @@
 				"id": "embedding_transformer_1",
 				"provider": "embedding_transformer",
 				"position": { "x": 721, "y": -163 },
-				"input": [{ "lane": "documents", "from": "preprocessor_langchain_1" }],
+				"input": [
+					{ "lane": "documents", "from": "preprocessor_langchain_1" },
+					{ "lane": "questions", "from": "chat_1" }
+				],
 				"control": []
 			},
 			{
@@ -50,7 +53,7 @@
 				"position": { "x": 948, "y": -79 },
 				"input": [
 					{ "lane": "documents", "from": "embedding_transformer_1" },
-					{ "lane": "questions", "from": "chat_1" }
+					{ "lane": "questions", "from": "embedding_transformer_1" }
 				],
 				"control": []
 			},


### PR DESCRIPTION
## Summary

- The `chat_1` node's `questions` output was wired directly to `store_1` (vector DB), bypassing the embedding step entirely.
- Fixed by routing `chat_1` questions through the existing `embedding_transformer_1` node first, so queries are embedded before reaching the vector store — matching the same embedding space as the ingested document vectors.
- No new nodes were introduced; the fix reuses the embedding node already present on the document ingestion path.

## Test Plan

- [ ] Open the RAG chat template in the canvas and verify the `chat_1` → `embedding_transformer_1` → `store_1` connection is present on the `questions` lane.
- [ ] Confirm no direct `chat_1` → `store_1` edge exists for the `questions` output.
- [ ] Run an end-to-end RAG query and verify similarity search returns relevant results from the vector store.
- [ ] Confirm the document ingestion path (`embedding_transformer_1` → `store_1` on the `documents` lane) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the RAG-chat template's data flow configuration to optimize how questions are processed and routed through system components for improved information handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->