### PR TITLE
fix(chroma): exclude soft-deleted documents from default searches (cherry-pick #959 → stage)

### DIFF
--- a/nodes/src/nodes/chroma/chroma.py
+++ b/nodes/src/nodes/chroma/chroma.py
@@ -163,8 +163,14 @@ class Store(DocumentStoreBase):
             filters.append({'permissionId': {'$in': docFilter.permissions}})
         if docFilter.objectIds is not None:
             filters.append({'objectId': {'$in': docFilter.objectIds}})
-        if docFilter.isDeleted is not None:
-            filters.append({'isDeleted': {'$eq': docFilter.isDeleted}})
+        if docFilter.isDeleted is None or not docFilter.isDeleted:
+            # Exclude only docs explicitly marked deleted. A null/absent isDeleted
+            # (the client strips None via exclude_none) must still count as not
+            # deleted, so use $ne True (which matches absent-key records) instead of
+            # $eq False (which would drop them).
+            filters.append({'isDeleted': {'$ne': True}})
+        else:
+            filters.append({'isDeleted': {'$eq': True}})
         if docFilter.chunkIds is not None:
             filters.append({'chunkId': {'$in': docFilter.chunkIds}})
         # If we are min chunk id, add a condition

--- a/nodes/test/chroma/test_convert_filter_explicit_none.py
+++ b/nodes/test/chroma/test_convert_filter_explicit_none.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Aparavi Software AG
 # =============================================================================
 
-"""Regression tests for Chroma `_convertFilter` explicit-None vs empty-container semantics."""
+"""Regression tests for Chroma `_convertFilter`: isDeleted default-exclusion and explicit-None vs empty-container semantics."""
 
 from __future__ import annotations
 
@@ -98,7 +98,7 @@ def test_convert_filter_empty_object_ids_list_is_not_omitted() -> None:
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter(objectIds=[]))
-    assert converted == {'objectId': {'$in': []}}
+    assert converted == {'$and': [{'objectId': {'$in': []}}, {'isDeleted': {'$ne': True}}]}
 
 
 def test_convert_filter_empty_string_node_id_is_included() -> None:
@@ -106,7 +106,7 @@ def test_convert_filter_empty_string_node_id_is_included() -> None:
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter(nodeId=''))
-    assert converted == {'nodeId': {'$eq': ''}}
+    assert converted == {'$and': [{'nodeId': {'$eq': ''}}, {'isDeleted': {'$ne': True}}]}
 
 
 def test_convert_filter_empty_table_ids_list_is_not_omitted() -> None:
@@ -114,12 +114,39 @@ def test_convert_filter_empty_table_ids_list_is_not_omitted() -> None:
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter(tableIds=[]))
-    assert converted == {'tableId': {'$in': []}}
+    assert converted == {'$and': [{'tableId': {'$in': []}}, {'isDeleted': {'$ne': True}}]}
 
 
-def test_convert_filter_omits_object_ids_when_unset() -> None:
-    """When objectIds is unset (None), no objectId filter clause is added."""
+def test_convert_filter_default_excludes_deleted() -> None:
+    """Default filter (isDeleted=None) must include the isDeleted $ne True clause."""
     Store = _load_store_class()
     store = Store.__new__(Store)
     converted = store._convertFilter(_doc_filter())
-    assert converted is None
+    assert converted == {'isDeleted': {'$ne': True}}
+
+
+# --- Regression tests for isDeleted behaviour ---
+
+
+def test_convert_filter_is_deleted_none_excludes_deleted() -> None:
+    """isDeleted=None -> {'isDeleted': {'$ne': True}} (bug was: previously returned None)."""
+    Store = _load_store_class()
+    store = Store.__new__(Store)
+    converted = store._convertFilter(_doc_filter(isDeleted=None))
+    assert converted == {'isDeleted': {'$ne': True}}
+
+
+def test_convert_filter_is_deleted_false_excludes_deleted() -> None:
+    """isDeleted=False -> {'isDeleted': {'$ne': True}}."""
+    Store = _load_store_class()
+    store = Store.__new__(Store)
+    converted = store._convertFilter(_doc_filter(isDeleted=False))
+    assert converted == {'isDeleted': {'$ne': True}}
+
+
+def test_convert_filter_is_deleted_true_includes_only_deleted() -> None:
+    """isDeleted=True -> {'isDeleted': {'$eq': True}}."""
+    Store = _load_store_class()
+    store = Store.__new__(Store)
+    converted = store._convertFilter(_doc_filter(isDeleted=True))
+    assert converted == {'isDeleted': {'$eq': True}}


### PR DESCRIPTION
## Summary

Cherry-pick of **#959** (`b535bfa6`) onto `stage` so the Chroma `isDeleted` fix makes the release cut. The original is already merged to `develop`; the stage cut (`14c26b66`) was taken at #957 — before #959 landed on develop — so it is not otherwise in this release.

- **Soft-deleted documents leaked into default searches:** `_convertFilter` only added an `isDeleted` clause when `docFilter.isDeleted is not None`. Since the default `DocFilter.isDeleted` is `None`, normal searches added **no** filter and returned soft-deleted documents. **Fix:** when `isDeleted` is `None`/`False`, exclude only explicitly-deleted docs via `{'isDeleted': {'$ne': True}}` (in Chroma, `$ne True` also matches records lacking the key, so absent/null counts as not-deleted); when `True`, return deleted docs via `{'isDeleted': {'$eq': True}}`. Mirrors the Qdrant fix in #958.

## Test plan

- [x] `nodes/test/chroma/test_convert_filter_explicit_none.py` — 7/7 pass (4 existing tests updated to expect the new clause, 3 added for None/False/True).
- [x] Clean cherry-pick onto `stage` (no conflicts); content identical to develop commit `b535bfa6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
