### PR TITLE
feat: add MiniMax LLM node

### DIFF
--- a/.github/workflows/sync-models.yml
+++ b/.github/workflows/sync-models.yml
@@ -61,6 +61,7 @@ jobs:
             [llm_xai]=ROCKETRIDE_XAI_KEY
             [llm_perplexity]=ROCKETRIDE_PERPLEXITY_KEY
             [llm_qwen]=ROCKETRIDE_QWEN_KEY
+            [llm_minimax]=ROCKETRIDE_MINIMAX_KEY
           )
 
           for PROVIDER in "${!PROVIDER_KEY[@]}"; do
@@ -86,6 +87,7 @@ jobs:
           ROCKETRIDE_XAI_KEY: ${{ secrets.ROCKETRIDE_XAI_KEY }}
           ROCKETRIDE_PERPLEXITY_KEY: ${{ secrets.ROCKETRIDE_PERPLEXITY_KEY }}
           ROCKETRIDE_QWEN_KEY: ${{ secrets.ROCKETRIDE_QWEN_KEY }}
+          ROCKETRIDE_MINIMAX_KEY: ${{ secrets.ROCKETRIDE_MINIMAX_KEY }}
 
       # Strict sync: only providers whose API key is configured. Native API
       # discovers and smoke-tests new models. No OpenRouter pollution.
@@ -104,6 +106,7 @@ jobs:
           ROCKETRIDE_XAI_KEY: ${{ secrets.ROCKETRIDE_XAI_KEY }}
           ROCKETRIDE_PERPLEXITY_KEY: ${{ secrets.ROCKETRIDE_PERPLEXITY_KEY }}
           ROCKETRIDE_QWEN_KEY: ${{ secrets.ROCKETRIDE_QWEN_KEY }}
+          ROCKETRIDE_MINIMAX_KEY: ${{ secrets.ROCKETRIDE_MINIMAX_KEY }}
 
       # Fallback sync: providers without an API key. OpenRouter / LiteLLM
       # are permitted as discovery sources for these. Smoke tests are skipped

--- a/docs/README-nodes.md
+++ b/docs/README-nodes.md
@@ -18,6 +18,7 @@ For information on testing nodes, see [README-node-testing.md](README-node-testi
 | `llm_mistral`        | Mistral AI                                 |                                                           |
 | `llm_perplexity`     | Perplexity AI (Sonar, web search)          | [README](../nodes/src/nodes/llm_perplexity/README.md)     |
 | `llm_deepseek`       | DeepSeek models                            |                                                           |
+| `llm_minimax`        | MiniMax models                             |                                                           |
 | `llm_xai`            | xAI (Grok)                                 |                                                           |
 | `llm_vertex`         | Google Vertex AI                           |                                                           |
 | `llm_ibm_watson`     | IBM Watson                                 |                                                           |

--- a/nodes/src/nodes/llm_minimax/IGlobal.py
+++ b/nodes/src/nodes/llm_minimax/IGlobal.py
@@ -1,0 +1,142 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+import os
+import re
+from typing import Optional
+from rocketlib import IGlobalBase, warning
+from ai.common.config import Config
+from ai.common.chat import ChatBase
+
+
+VALIDATION_PROMPT = 'Hi'
+MINIMAX_BASE_URL = 'https://api.minimax.io/v1'
+
+
+class IGlobal(IGlobalBase):
+    """Global handler for the MiniMax LLM node."""
+
+    chat: Optional[ChatBase] = None
+
+    def validateConfig(self):
+        """Validate the MiniMax cloud configuration at save time."""
+        # Load dependencies first
+        from depends import depends  # type: ignore
+
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        try:
+            # Import OpenAI SDK (MiniMax is OpenAI-compatible)
+            from openai import OpenAI
+
+            # Prefer provider-driven exception types over string parsing
+            from openai import APIStatusError, OpenAIError, AuthenticationError, RateLimitError, APIConnectionError
+
+            # Get config
+            config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            apikey = config.get('apikey')
+            model = config.get('model')
+            serverbase = config.get('serverbase') or MINIMAX_BASE_URL
+
+            # UI handles missing key prompts; skip the probe when the key is absent
+            if not apikey or not model:
+                return
+
+            # Minimal probe; UI handles missing key prompts
+            try:
+                client = OpenAI(api_key=apikey, base_url=serverbase)
+                client.chat.completions.create(
+                    model=model, messages=[{'role': 'user', 'content': VALIDATION_PROMPT}], max_tokens=1
+                )
+            except APIStatusError as e:
+                # HTTP error with structured body; pull code/type/message
+                status = getattr(e, 'status_code', None) or getattr(e, 'status', None)
+                try:
+                    resp = getattr(e, 'response', None)
+                    data = resp.json() if resp is not None else None
+                    if isinstance(data, dict):
+                        err = data.get('error')
+                        if isinstance(err, dict):
+                            etype = err.get('type')
+                            emsg = err.get('message') or data.get('message')
+                        else:
+                            etype = None
+                            emsg = data.get('message')
+                        message = self._format_error(status, etype, emsg, str(e))
+                    else:
+                        message = self._format_error(status, None, None, str(e))
+                except Exception:
+                    message = self._format_error(status, None, None, str(e))
+                warning(message)
+                return
+            except (AuthenticationError, RateLimitError, APIConnectionError, OpenAIError) as e:
+                # Other OpenAI exceptions; format consistently
+                message = self._format_error(None, None, None, str(e))
+                warning(message)
+                return
+
+        except Exception as e:
+            # Generic fallback - do not alter provider message
+            warning(str(e))
+
+    def beginGlobal(self):
+        from depends import depends  # type: ignore
+
+        # Load the requirements
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        from .minimax import Chat
+
+        # Get our bag
+        bag = self.IEndpoint.endpoint.bag
+
+        # Get this nodes config
+        config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+
+        # Get a chat to interface
+        self._chat = Chat(self.glb.logicalType, config, bag)
+
+    def endGlobal(self):
+        self._chat = None
+
+    def _format_error(self, status, etype, emsg, fallback: str) -> str:
+        """Compose a user-facing error string.
+
+        - If a numeric HTTP status/code is available, prefix it as "Error <status>:".
+        - Then include provider error type and message when present.
+        - If no structured fields are available, return the fallback message as-is.
+        - Whitespace is normalized to a single line; content is not truncated.
+        """
+        parts: list[str] = []
+        if status is not None:
+            parts.append(f'Error {status}:')
+        if etype:
+            parts.append(str(etype))
+        if emsg:
+            if etype:
+                parts.append('-')
+            parts.append(str(emsg))
+        message = ' '.join(parts) if parts else fallback
+        return re.sub(r'\s+', ' ', message).strip()

--- a/nodes/src/nodes/llm_minimax/IInstance.py
+++ b/nodes/src/nodes/llm_minimax/IInstance.py
@@ -1,0 +1,28 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from ai.common.llm_base import LLMBase
+
+
+class IInstance(LLMBase):
+    pass

--- a/nodes/src/nodes/llm_minimax/README.md
+++ b/nodes/src/nodes/llm_minimax/README.md
@@ -1,0 +1,50 @@
+---
+title: MiniMax
+date: 2026-05-21
+sidebar_position: 1
+---
+
+<head>
+  <title>MiniMax - RocketRide Documentation</title>
+</head>
+
+## What it does
+
+Connects [MiniMax](https://www.minimax.io/) models to your pipeline via the MiniMax cloud API. Used primarily as an `llm` invoke connection by agents and other nodes that need an LLM. Can also be used directly via lanes.
+
+The MiniMax API is OpenAI-compatible, so this node uses the OpenAI SDK / `langchain-openai` client pointed at the MiniMax base URL.
+
+**Lanes:**
+
+| Lane in     | Lane out  | Description                                          |
+| ----------- | --------- | ---------------------------------------------------- |
+| `questions` | `answers` | Send a question directly, receive a generated answer |
+
+## Configuration
+
+| Field           | Description                                                          |
+| --------------- | -------------------------------------------------------------------- |
+| Model           | MiniMax model to use (see profiles below)                            |
+| API Key         | MiniMax API key                                                      |
+| Server base URL | MiniMax endpoint (default `https://api.minimax.io/v1`; custom only)  |
+
+## Profiles
+
+| Profile                | Model                     | Context     |
+| ---------------------- | ------------------------- | ----------- |
+| MiniMax M2 _(default)_ | `MiniMax-M2`              | 200K tokens |
+| MiniMax M2.1           | `MiniMax-M2.1`            | 200K tokens |
+| MiniMax M2.1 Highspeed | `MiniMax-M2.1-highspeed`  | 200K tokens |
+| MiniMax M2.5           | `MiniMax-M2.5`            | 200K tokens |
+| MiniMax M2.5 Highspeed | `MiniMax-M2.5-highspeed`  | 200K tokens |
+| MiniMax M2.7           | `MiniMax-M2.7`            | 200K tokens |
+| MiniMax M2.7 Highspeed | `MiniMax-M2.7-highspeed`  | 200K tokens |
+| Custom Model           | User-defined              | User-defined |
+
+The catalog above is what `models.list()` returns as of 2026-05-21. The `-highspeed` variants
+are MiniMax's faster/cheaper tier of the same generation.
+
+## Upstream docs
+
+- [MiniMax platform documentation](https://platform.minimaxi.com/document/)
+- [MiniMax API reference (OpenAI-compatible)](https://www.minimax.io/platform/document/ChatCompletion)

--- a/nodes/src/nodes/llm_minimax/README.md
+++ b/nodes/src/nodes/llm_minimax/README.md
@@ -10,9 +10,9 @@ sidebar_position: 1
 
 ## What it does
 
-Connects [MiniMax](https://www.minimax.io/) models to your pipeline via the MiniMax cloud API. Used primarily as an `llm` invoke connection by agents and other nodes that need an LLM. Can also be used directly via lanes.
+Connects [MiniMax](https://www.minimax.io/) models to your pipeline — either via the MiniMax cloud API or via a self-hosted OpenAI-compatible server (vLLM, SGLang, MLX, or Ollama). Used primarily as an `llm` invoke connection by agents and other nodes that need an LLM. Can also be used directly via lanes.
 
-The MiniMax API is OpenAI-compatible, so this node uses the OpenAI SDK / `langchain-openai` client pointed at the MiniMax base URL.
+The MiniMax API is OpenAI-compatible, so this node uses the OpenAI SDK / `langchain-openai` client pointed at the configured base URL.
 
 **Lanes:**
 
@@ -22,13 +22,15 @@ The MiniMax API is OpenAI-compatible, so this node uses the OpenAI SDK / `langch
 
 ## Configuration
 
-| Field           | Description                                                          |
-| --------------- | -------------------------------------------------------------------- |
-| Model           | MiniMax model to use (see profiles below)                            |
-| API Key         | MiniMax API key                                                      |
-| Server base URL | MiniMax endpoint (default `https://api.minimax.io/v1`; custom only)  |
+| Field           | Description                                                                                                                                                                |
+| --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Model           | MiniMax model to use (see profiles below)                                                                                                                                  |
+| API Key         | MiniMax API key (cloud profiles only — local profiles don't require one; the node passes a dummy token)                                                                    |
+| Server base URL | Endpoint URL — `https://api.minimax.io/v1` for cloud (international), `https://api.minimaxi.com/v1` for China, `http://localhost:8000/v1` for vLLM/SGLang, `http://localhost:8080/v1` for MLX, or `http://localhost:11434/v1` for Ollama (Custom and Local profiles only) |
 
 ## Profiles
+
+**Cloud**
 
 | Profile                | Model                     | Context     |
 | ---------------------- | ------------------------- | ----------- |
@@ -41,10 +43,28 @@ The MiniMax API is OpenAI-compatible, so this node uses the OpenAI SDK / `langch
 | MiniMax M2.7 Highspeed | `MiniMax-M2.7-highspeed`  | 200K tokens |
 | Custom Model           | User-defined              | User-defined |
 
-The catalog above is what `models.list()` returns as of 2026-05-21. The `-highspeed` variants
-are MiniMax's faster/cheaper tier of the same generation.
+The cloud catalogue above is what `models.list()` returns as of 2026-05-21. The `-highspeed` variants are MiniMax's faster/cheaper tier of the same generation.
+
+**Local deploy**
+
+Defaults target vLLM / SGLang on `http://localhost:8000/v1` with the HuggingFace model path — that's the configuration MiniMax itself documents in its [Local Deployment guide](https://platform.minimax.io/docs/guides/local-deploy).
+
+| Profile             | Model (HF path)            | Server base URL (default)     | Context     |
+| ------------------- | -------------------------- | ----------------------------- | ----------- |
+| MiniMax M2 (Local)  | `MiniMaxAI/MiniMax-M2`     | `http://localhost:8000/v1`    | 200K tokens |
+| MiniMax M2.5 (Local)| `MiniMaxAI/MiniMax-M2.5`   | `http://localhost:8000/v1`    | 200K tokens |
+| MiniMax M2.7 (Local)| `MiniMaxAI/MiniMax-M2.7`   | `http://localhost:8000/v1`    | 200K tokens |
+
+**Hardware notes.** MiniMax's open-weight models are MIT-licensed but large — M2 / M2.5 / M2.7 are all 230B-parameter MoE architectures (~10B active per token). The recommended local setups are:
+
+- **Linux + GPU (≥96 GB VRAM total)** — vLLM or SGLang on port `8000`. Use the HF model path as shown above.
+- **Apple Silicon Mac Studio (≥128 GB unified memory)** — MLX on port `8080`. Edit the Server base URL to `http://localhost:8080/v1` and change the model to a quantized MLX build, e.g. `mlx-community/MiniMax-M2.7-4bit`.
+- **Ollama (<128 GB systems, fallback only)** — listed in MiniMax's docs as an alternative for low-memory setups. Edit the Server base URL to `http://localhost:11434/v1` and the model to whatever tag you pulled (verify with `ollama pull <tag>` before use; tags may not yet exist for every M2 variant).
+
+These models will not fit on a typical laptop without aggressive quantization. M2.7 is the only variant whose local-deploy steps are formally documented today; the M2 and M2.5 entries are scaffolded against the same HuggingFace naming so they work as soon as their upstream guides land. M2.7 is a reasoning model — its responses split `message.content` (final answer) from `message.reasoning_content` (chain of thought), so set generous output token budgets (`max_tokens ≥ ~200`) even for short prompts.
 
 ## Upstream docs
 
 - [MiniMax platform documentation](https://platform.minimaxi.com/document/)
 - [MiniMax API reference (OpenAI-compatible)](https://www.minimax.io/platform/document/ChatCompletion)
+- [MiniMax local deployment guide](https://platform.minimax.io/docs/guides/local-deploy)

--- a/nodes/src/nodes/llm_minimax/__init__.py
+++ b/nodes/src/nodes/llm_minimax/__init__.py
@@ -1,0 +1,41 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+
+def getChat():
+    """
+    Get the Chat class from the module.
+    """
+    from .minimax import Chat
+
+    return Chat
+
+
+__all__ = [
+    'IGlobal',
+    'IInstance',
+    'getChat',
+]

--- a/nodes/src/nodes/llm_minimax/minimax.py
+++ b/nodes/src/nodes/llm_minimax/minimax.py
@@ -56,10 +56,15 @@ class Chat(ChatBase):
         # accepts the same "no explicit serverbase" config that validateConfig does
         serverbase = config.get('serverbase') or 'https://api.minimax.io/v1'
 
-        # Get the api key
-        apikey = config.get('apikey')
-        if not apikey:
-            raise ValueError('MiniMax API key is required.')
+        # Get the api key, use a dummy key if not provided. Local profiles
+        # (Ollama / vLLM / TGI) intentionally have no apikey property — local
+        # OpenAI-compatible servers accept any token. Mirrors the llm_deepseek pattern.
+        apikey = config.get('apikey') or 'sk-local-dummy-key'
+
+        # API key is only required when calling MiniMax's cloud API. Matches both
+        # api.minimax.io (international) and api.minimaxi.com (China) by substring.
+        if 'api.minimax' in serverbase and apikey == 'sk-local-dummy-key':
+            raise ValueError('MiniMax API key is required for cloud profiles.')
 
         # Get the llm via the OpenAI-compatible client
         self._llm = ChatOpenAI(

--- a/nodes/src/nodes/llm_minimax/minimax.py
+++ b/nodes/src/nodes/llm_minimax/minimax.py
@@ -52,10 +52,9 @@ class Chat(ChatBase):
         # Get the nodes configuration
         config = Config.getNodeConfig(provider, connConfig)
 
-        # Get the serverbase url
-        serverbase = config.get('serverbase')
-        if not serverbase:
-            raise ValueError('MiniMax serverbase is required.')
+        # Get the serverbase url; fall back to the MiniMax default so runtime
+        # accepts the same "no explicit serverbase" config that validateConfig does
+        serverbase = config.get('serverbase') or 'https://api.minimax.io/v1'
 
         # Get the api key
         apikey = config.get('apikey')

--- a/nodes/src/nodes/llm_minimax/minimax.py
+++ b/nodes/src/nodes/llm_minimax/minimax.py
@@ -1,0 +1,71 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+MiniMax binding for the ChatLLM.
+"""
+
+from typing import Any, Dict
+from ai.common.chat import ChatBase
+from ai.common.config import Config
+from langchain_openai import ChatOpenAI
+
+
+class Chat(ChatBase):
+    """
+    Creates a MiniMax chat bot.
+    """
+
+    _llm: ChatOpenAI
+
+    def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
+        """Initialize the MiniMax chat bot.
+
+        Args:
+            provider (str): Provider name
+            connConfig (Dict[str, Any]): Node configuration
+            bag (Dict[str, Any]): Bag to store data
+        """
+        # Init the base
+        super().__init__(provider, connConfig, bag)
+
+        # Get the nodes configuration
+        config = Config.getNodeConfig(provider, connConfig)
+
+        # Get the serverbase url
+        serverbase = config.get('serverbase')
+        if not serverbase:
+            raise ValueError('MiniMax serverbase is required.')
+
+        # Get the api key
+        apikey = config.get('apikey')
+        if not apikey:
+            raise ValueError('MiniMax API key is required.')
+
+        # Get the llm via the OpenAI-compatible client
+        self._llm = ChatOpenAI(
+            model=self._model, base_url=serverbase, api_key=apikey, temperature=0, max_tokens=self._modelOutputTokens
+        )
+
+        # Save our chat class into the bag
+        bag['chat'] = self

--- a/nodes/src/nodes/llm_minimax/minimax.py
+++ b/nodes/src/nodes/llm_minimax/minimax.py
@@ -84,4 +84,4 @@ class Chat(ChatBase):
     def _chat(self, prompt: str) -> str:
         """Invoke the LLM and strip any <think>...</think> reasoning block from the response."""
         results = self._llm.invoke(prompt)
-        return _THINK_BLOCK_RE.sub('', results.content).lstrip()
+        return _THINK_BLOCK_RE.sub('', results.content)

--- a/nodes/src/nodes/llm_minimax/minimax.py
+++ b/nodes/src/nodes/llm_minimax/minimax.py
@@ -25,10 +25,17 @@
 MiniMax binding for the ChatLLM.
 """
 
+import re
 from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from langchain_openai import ChatOpenAI
+
+# MiniMax M2-series models return chain-of-thought wrapped in <think>...</think>
+# inside the `content` field (per the OpenAI-compatible spec at
+# https://platform.minimax.io/docs/api-reference/text-chat-openai). The block is
+# stripped here so downstream pipeline nodes only see the final answer.
+_THINK_BLOCK_RE = re.compile(r'<think>.*?</think>\s*', re.DOTALL | re.IGNORECASE)
 
 
 class Chat(ChatBase):
@@ -73,3 +80,8 @@ class Chat(ChatBase):
 
         # Save our chat class into the bag
         bag['chat'] = self
+
+    def _chat(self, prompt: str) -> str:
+        """Invoke the LLM and strip any <think>...</think> reasoning block from the response."""
+        results = self._llm.invoke(prompt)
+        return _THINK_BLOCK_RE.sub('', results.content).lstrip()

--- a/nodes/src/nodes/llm_minimax/minimax.svg
+++ b/nodes/src/nodes/llm_minimax/minimax.svg
@@ -1,0 +1,1 @@
+<svg height="1em" style="flex:none;line-height:1" viewBox="0 0 24 24" width="1em" xmlns="http://www.w3.org/2000/svg"><title>MiniMax</title><path d="M3.5 7.5h1.6l1.7 4.8 1.7-4.8h1.6v9h-1.4v-6.4l-1.6 4.5h-0.7l-1.6-4.5v6.4H3.5zM11.4 7.5h1.4v9h-1.4zM14.6 7.5h1.6l1.7 4.8 1.7-4.8h1.6v9h-1.4v-6.4l-1.6 4.5h-0.7l-1.6-4.5v6.4h-1.3z" fill="#F23F5D"></path></svg>

--- a/nodes/src/nodes/llm_minimax/requirements.txt
+++ b/nodes/src/nodes/llm_minimax/requirements.txt
@@ -1,0 +1,7 @@
+# Plugin MiniMax core
+openai
+langchain-openai
+
+# LangChain deps
+langchain-core
+langchain

--- a/nodes/src/nodes/llm_minimax/services.json
+++ b/nodes/src/nodes/llm_minimax/services.json
@@ -1,0 +1,274 @@
+{
+	//
+	// Required:
+	//		The displayable name of this node
+	//
+	"title": "MiniMax",
+	//
+	// Required:
+	//		The protocol is the endpoint protocol
+	//
+	"protocol": "llm_minimax://",
+	//
+	// Required:
+	//		Class type of the node - what it does
+	//
+	"classType": ["llm"],
+	//
+	// Required:
+	//		Capabilities are flags that change the behavior of the underlying
+	//		engine
+	//
+	"capabilities": ["invoke"],
+	//
+	// Optional:
+	//		Register is either filter, endpoint or ignored if not specified. If the
+	//		type is specified, a factory is registered of that given type
+	//
+	"register": "filter",
+	//
+	// Optional:
+	//		The node is the actual physical node to instantiate - if
+	//		not specified, the protocol will be used
+	//
+	"node": "python",
+	//
+	// Optional:
+	//		The path is the executable/script code - it is node dependent
+	// 		and is optional for most node
+	//
+	"path": "nodes.llm_minimax",
+	//
+	// Required:
+	//		The prefix map when added/removed when convertting URLs <=> paths
+	//
+	"prefix": "llm",
+	//
+	// Optional:
+	//		Description to of this driver
+	//
+	"description": ["A component that connects to MiniMax's large language models for advanced ", "natural language processing. It enables capabilities like long-context reasoning, ", "agentic workflows, multi-step tool use, and high-quality conversational generation. ", "MiniMax offers an OpenAI-compatible API with strong performance across reasoning, ", "writing, and coding tasks. The component is suitable for integrating MiniMax models ", "into pipelines where extended context windows and efficient inference are important."],
+	//
+	// Optional:
+	//	  The icon is the icon to display in the UI for this node
+	//
+	"icon": "minimax.svg",
+	"documentation": "https://docs.rocketride.org",
+	//
+	//
+	//  Optional:
+	//      Rendering hints to the UI which indicate which fields of
+	//      the configuration should be used to display information
+	//
+	"tile": ["Model: ${parameters.llm_minimax.profile}"],
+	//
+	//	Optional:
+	//		As a pipe component, define what this pipe component takes
+	//		and what it produces
+	//
+	"lanes": {
+		"questions": ["answers"]
+	},
+	//
+	//	Optional:
+	//		Profile section are configuration optoins used by the driver
+	//		itself
+	//
+	"preconfig": {
+		// Define the values that will be merged into any profile configuration
+		// specified, unless the profile is 'absolute'
+		"default": "minimax-m2",
+		// Defines profiles used with the "profile": key
+		"profiles": {
+			"custom": {
+				"title": "Custom Model",
+				"model": "",
+				"modelTotalTokens": 200000,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			},
+			"minimax-m2": {
+				"title": "MiniMax M2",
+				"model": "MiniMax-M2",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			},
+			"minimax-m2-1": {
+				"title": "MiniMax M2.1",
+				"model": "MiniMax-M2.1",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			},
+			"minimax-m2-1-highspeed": {
+				"title": "MiniMax M2.1 Highspeed",
+				"model": "MiniMax-M2.1-highspeed",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			},
+			"minimax-m2-5": {
+				"title": "MiniMax M2.5",
+				"model": "MiniMax-M2.5",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			},
+			"minimax-m2-5-highspeed": {
+				"title": "MiniMax M2.5 Highspeed",
+				"model": "MiniMax-M2.5-highspeed",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			},
+			"minimax-m2-7": {
+				"title": "MiniMax M2.7",
+				"model": "MiniMax-M2.7",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			},
+			"minimax-m2-7-highspeed": {
+				"title": "MiniMax M2.7 Highspeed",
+				"model": "MiniMax-M2.7-highspeed",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
+			}
+		}
+	},
+	//
+	// Optional:
+	//		Local fields definitions - these define fields only for the
+	//		current service. You may specify them here, or directly
+	//		in the shape
+	//
+	"fields": {
+		"model": {
+			"type": "string",
+			"title": "Model",
+			"description": "MiniMax model"
+		},
+		"modelTotalTokens": {
+			"type": "number",
+			"title": "Tokens",
+			"description": "Total Tokens"
+		},
+		"minimax.custom": {
+			"object": "custom",
+			"properties": ["model", "modelTotalTokens", "llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.minimax-m2": {
+			"object": "minimax-m2",
+			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.minimax-m2-1": {
+			"object": "minimax-m2-1",
+			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.minimax-m2-1-highspeed": {
+			"object": "minimax-m2-1-highspeed",
+			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.minimax-m2-5": {
+			"object": "minimax-m2-5",
+			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.minimax-m2-5-highspeed": {
+			"object": "minimax-m2-5-highspeed",
+			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.minimax-m2-7": {
+			"object": "minimax-m2-7",
+			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.minimax-m2-7-highspeed": {
+			"object": "minimax-m2-7-highspeed",
+			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+		},
+		"minimax.profile": {
+			"title": "Model",
+			"description": "MiniMax LLM model",
+			"type": "string",
+			"default": "minimax-m2",
+			"enum": ["*>preconfig.profiles.*.title"],
+			"conditional": [
+				{
+					"value": "custom",
+					"properties": ["minimax.custom"]
+				},
+				{
+					"value": "minimax-m2",
+					"properties": ["minimax.minimax-m2"]
+				},
+				{
+					"value": "minimax-m2-1",
+					"properties": ["minimax.minimax-m2-1"]
+				},
+				{
+					"value": "minimax-m2-1-highspeed",
+					"properties": ["minimax.minimax-m2-1-highspeed"]
+				},
+				{
+					"value": "minimax-m2-5",
+					"properties": ["minimax.minimax-m2-5"]
+				},
+				{
+					"value": "minimax-m2-5-highspeed",
+					"properties": ["minimax.minimax-m2-5-highspeed"]
+				},
+				{
+					"value": "minimax-m2-7",
+					"properties": ["minimax.minimax-m2-7"]
+				},
+				{
+					"value": "minimax-m2-7-highspeed",
+					"properties": ["minimax.minimax-m2-7-highspeed"]
+				}
+			]
+		}
+	},
+	//
+	// Required:
+	//		Defines the fields (shape) of the service. Either source or target
+	//		map be specified, or both, but at least one is required
+	//
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "MiniMax",
+			"properties": ["minimax.profile"]
+		}
+	],
+	"test": {
+		"profiles": ["minimax-m2"],
+		"outputs": ["answers"],
+		"cases": [
+			{
+				"name": "LLM returns mock response",
+				"text": "What is 2+2?",
+				"expect": {
+					"answers": {
+						"contains": "Mock LLM response"
+					}
+				}
+			}
+		]
+	}
+}

--- a/nodes/src/nodes/llm_minimax/services.json
+++ b/nodes/src/nodes/llm_minimax/services.json
@@ -150,6 +150,44 @@
 				"modelOutputTokens": 8192,
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
+			},
+			// Local-deploy profiles. Defaults target vLLM / SGLang on port 8000 with the
+			// HuggingFace model path (MiniMaxAI/MiniMax-M2.X) — that's the path MiniMax
+			// itself documents at platform.minimax.io/docs/guides/local-deploy.
+			//
+			// MiniMax open-weight models are MIT-licensed but very large (M2 = 230B MoE /
+			// 10B active; M2.5 / M2.7 likewise) and need ≥96 GB unified memory or a
+			// multi-GPU server. M2.7 is the only variant whose local-deploy steps are
+			// formally documented today; M2 / M2.5 entries here are scaffolded against
+			// the same HF naming so they work as soon as their guides land.
+			//
+			// To use Ollama instead: edit serverbase to http://localhost:11434/v1 and set
+			// `model` to the Ollama tag you pulled. To use MLX on Apple Silicon: set
+			// serverbase to http://localhost:8080/v1 and model to e.g.
+			// mlx-community/MiniMax-M2.7-4bit.
+			"minimax-m2-local": {
+				"title": "MiniMax M2 (Local)",
+				"model": "MiniMaxAI/MiniMax-M2",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "http://localhost:8000/v1"
+			},
+			"minimax-m2-5-local": {
+				"title": "MiniMax M2.5 (Local)",
+				"model": "MiniMaxAI/MiniMax-M2.5",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "http://localhost:8000/v1"
+			},
+			"minimax-m2-7-local": {
+				"title": "MiniMax M2.7 (Local)",
+				"model": "MiniMaxAI/MiniMax-M2.7",
+				"modelSource": "manual",
+				"modelTotalTokens": 204800,
+				"modelOutputTokens": 8192,
+				"serverbase": "http://localhost:8000/v1"
 			}
 		}
 	},
@@ -208,6 +246,18 @@
 			"object": "minimax-m2-7-highspeed",
 			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
 		},
+		"minimax.minimax-m2-local": {
+			"object": "minimax-m2-local",
+			"properties": ["llm.local.serverbase"]
+		},
+		"minimax.minimax-m2-5-local": {
+			"object": "minimax-m2-5-local",
+			"properties": ["llm.local.serverbase"]
+		},
+		"minimax.minimax-m2-7-local": {
+			"object": "minimax-m2-7-local",
+			"properties": ["llm.local.serverbase"]
+		},
 		"minimax.profile": {
 			"title": "Model",
 			"description": "MiniMax LLM model",
@@ -246,6 +296,18 @@
 				{
 					"value": "minimax-m2-7-highspeed",
 					"properties": ["minimax.minimax-m2-7-highspeed"]
+				},
+				{
+					"value": "minimax-m2-local",
+					"properties": ["minimax.minimax-m2-local"]
+				},
+				{
+					"value": "minimax-m2-5-local",
+					"properties": ["minimax.minimax-m2-5-local"]
+				},
+				{
+					"value": "minimax-m2-7-local",
+					"properties": ["minimax.minimax-m2-7-local"]
 				}
 			]
 		}

--- a/nodes/src/nodes/llm_minimax/services.json
+++ b/nodes/src/nodes/llm_minimax/services.json
@@ -170,9 +170,15 @@
 			"title": "Tokens",
 			"description": "Total Tokens"
 		},
+		"minimax.serverbase": {
+			"type": "string",
+			"title": "Server base URL",
+			"description": "OpenAI-compatible base URL for the MiniMax endpoint (e.g. https://api.minimax.io/v1 for international, https://api.minimaxi.com/v1 for China).",
+			"default": "https://api.minimax.io/v1"
+		},
 		"minimax.custom": {
 			"object": "custom",
-			"properties": ["model", "modelTotalTokens", "llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": ["model", "modelTotalTokens", "minimax.serverbase", "llm.cloud.apikey", "llm.cloud.modelSource"]
 		},
 		"minimax.minimax-m2": {
 			"object": "minimax-m2",

--- a/nodes/test/framework/pipeline.py
+++ b/nodes/test/framework/pipeline.py
@@ -126,6 +126,7 @@ _LLM_MOCK_CREDENTIALS = {
     'llm_openai_api': {'apikey': 'sk-mock-placeholder-for-tests', 'model': 'mock-model'},
     'llm_gmi_cloud': {'apikey': 'sk-mock-placeholder-for-tests'},
     'llm_qwen': {'apikey': 'sk-mock-placeholder-for-tests'},
+    'llm_minimax': {'apikey': 'sk-mock-placeholder-for-tests'},
     'llm_vision_ollama': {'apikey': 'sk-mock-placeholder-for-tests'},
     'rerank_cohere': {'apikey': 'mock-cohere-placeholder-for-tests'},
     'tool_exa_search': {'apikey': 'mock-exa-search-placeholder-for-tests'},

--- a/tools/SYNC_MODELS.md
+++ b/tools/SYNC_MODELS.md
@@ -78,6 +78,7 @@ python tools/src/sync_models.py --provider llm_openai --model-source openrouter 
 | `llm_xai`          | `llm_xai`          | `ROCKETRIDE_XAI_KEY`        |
 | `llm_perplexity`   | `llm_perplexity`   | `ROCKETRIDE_PERPLEXITY_KEY` |
 | `llm_qwen`         | `llm_qwen`         | `ROCKETRIDE_QWEN_KEY`       |
+| `llm_minimax`      | `llm_minimax`      | `ROCKETRIDE_MINIMAX_KEY`    |
 
 If an API key env var is not set the provider is skipped with a warning (not an error).
 Set keys in a `.env` file in the repo root or export them in the shell.

--- a/tools/src/providers/minimax.py
+++ b/tools/src/providers/minimax.py
@@ -1,0 +1,56 @@
+"""
+MiniMax provider handler (Handler A) — cloud models only.
+
+Fetches models from the MiniMax /models endpoint and syncs the cloud
+profiles into nodes/src/nodes/llm_minimax/services.json.
+
+The MiniMax API is OpenAI-compatible, so the openai SDK can be used
+with a custom base_url.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Any, List
+
+from providers.base import CloudProvider
+
+
+class MiniMaxProvider(CloudProvider):
+    """
+    Handler for cloud (API) models in the llm_minimax node.
+
+    The MiniMax API is OpenAI-compatible, so the openai SDK can be used
+    with a custom base_url.
+    """
+
+    provider_name = 'llm_minimax'
+    display_name = 'MiniMax'
+    smoke_type = 'chat_openai_compat'
+
+    def make_client(self, api_key: str) -> object:
+        """
+        Args:
+            api_key: MiniMax API key
+
+        Returns:
+            openai.OpenAI client pointed at the MiniMax endpoint
+        """
+        import openai
+
+        return openai.OpenAI(
+            api_key=api_key,
+            base_url='https://api.minimax.io/v1',
+        )
+
+    def fetch_models(self, client: object) -> List[Dict[str, Any]]:
+        """
+        Fetch available models from MiniMax.
+
+        Args:
+            client: openai.OpenAI instance with MiniMax base_url
+
+        Returns:
+            List of model dicts with {"id": str}
+        """
+        response = client.models.list()  # type: ignore[attr-defined]
+        return [{'id': m.id} for m in response.data]

--- a/tools/src/sync_models.config.json
+++ b/tools/src/sync_models.config.json
@@ -382,6 +382,54 @@
 				// "qwen-turbo": 131072,
 				// "qwen-max": 32768
 			}
+		},
+		// ----------------------------------------------------------------------
+		// MiniMax — text chat models (OpenAI-compatible API)
+		// Uses openai.OpenAI pointed at https://api.minimax.io/v1.
+		// Excludes embedding, audio (T2A/TTS), image and video generation models.
+		// ----------------------------------------------------------------------
+		"llm_minimax": {
+			"handler": "cloud",
+			"env_var": "ROCKETRIDE_MINIMAX_KEY",
+			"module": "minimax",
+			"models_endpoint": "https://api.minimax.io/v1/models",
+			"auth_header": "Authorization",
+			"auth_prefix": "Bearer",
+			"smoke_test": "chat",
+			"model_filter": {
+				// Current MiniMax catalog uses the "MiniMax-" prefix exclusively (M2 family).
+				"include_prefixes": ["MiniMax-", "minimax-"],
+				"exclude_prefixes": [],
+				"exclude_patterns": [
+					"embed",
+					"embedding",
+					"t2a", // text-to-audio
+					"tts",
+					"audio",
+					"voice",
+					"image",
+					"video",
+					"speech"
+				]
+			},
+			// MiniMax cloud profiles don't always appear in OpenRouter — protect
+			// so the fallback path doesn't deprecate them on no-key runs.
+			"protected_profiles": [
+				["custom", "2126-04-09"],
+				["minimax-m2", "2026-10-09"],
+				["minimax-m2-1", "2026-10-09"],
+				["minimax-m2-1-highspeed", "2026-10-09"],
+				["minimax-m2-5", "2026-10-09"],
+				["minimax-m2-5-highspeed", "2026-10-09"],
+				["minimax-m2-7", "2026-10-09"],
+				["minimax-m2-7-highspeed", "2026-10-09"]
+			],
+			"token_limit_overrides": {
+				// "MiniMax-M2": 204800,
+				// "MiniMax-M2.1": 204800,
+				// "MiniMax-M2.5": 204800,
+				// "MiniMax-M2.7": 204800
+			}
 		}
 	},
 	// --------------------------------------------------------------------------
@@ -420,6 +468,8 @@
 		"grok-": "Grok ",
 		"sonar": "Sonar",
 		"qwen-": "Qwen ",
+		"MiniMax-": "MiniMax ",
+		"minimax-": "MiniMax ",
 		"text-embedding-": "Text Embedding ",
 		"o1": "o1",
 		"o3": "o3",

--- a/tools/src/sync_models.py
+++ b/tools/src/sync_models.py
@@ -64,6 +64,7 @@ _PROVIDER_REGISTRY: Dict[str, str] = {
     'llm_xai': 'providers.xai:XAIProvider',
     'llm_perplexity': 'providers.perplexity:PerplexityProvider',
     'llm_qwen': 'providers.qwen:QwenProvider',
+    'llm_minimax': 'providers.minimax:MiniMaxProvider',
 }
 
 # Maps provider name → relative path to its services.json from the repo root
@@ -77,6 +78,7 @@ _SERVICES_JSON_PATHS: Dict[str, str] = {
     'llm_xai': 'nodes/src/nodes/llm_xai/services.json',
     'llm_perplexity': 'nodes/src/nodes/llm_perplexity/services.json',
     'llm_qwen': 'nodes/src/nodes/llm_qwen/services.json',
+    'llm_minimax': 'nodes/src/nodes/llm_minimax/services.json',
 }
 
 # Default extra fields added to every new profile (placeholder for API key)

--- a/tools/test/markers.py
+++ b/tools/test/markers.py
@@ -48,3 +48,8 @@ requires_qwen = pytest.mark.skipif(
     not os.environ.get('ROCKETRIDE_QWEN_KEY'),
     reason='ROCKETRIDE_QWEN_KEY not set',
 )
+
+requires_minimax = pytest.mark.skipif(
+    not os.environ.get('ROCKETRIDE_MINIMAX_KEY'),
+    reason='ROCKETRIDE_MINIMAX_KEY not set',
+)

--- a/tools/test/test_sync_live.py
+++ b/tools/test/test_sync_live.py
@@ -30,6 +30,7 @@ from markers import (
     requires_xai,
     requires_perplexity,
     requires_qwen,
+    requires_minimax,
 )
 from core.patcher import get_profiles
 
@@ -244,3 +245,17 @@ def test_qwen_profiles_exist_in_api():
         base_url='https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
     )
     _check_missing_models(profiles, live_ids, 'llm_qwen')
+
+
+# ---------------------------------------------------------------------------
+# MiniMax
+# ---------------------------------------------------------------------------
+
+
+@requires_minimax
+def test_minimax_profiles_exist_in_api():
+    """Every non-deprecated llm_minimax profile model ID must be in the live API."""
+    api_key = os.environ['ROCKETRIDE_MINIMAX_KEY']
+    profiles = _load_profiles('llm_minimax')
+    live_ids = _fetch_openai_model_ids(api_key, base_url='https://api.minimax.io/v1')
+    _check_missing_models(profiles, live_ids, 'llm_minimax')


### PR DESCRIPTION
Closes #966

## Summary

Adds `llm_minimax`, an OpenAI-compatible MiniMax LLM node mirroring the `llm_deepseek` pattern. Profiles seed the live MiniMax catalogue as of 2026-05-21: `MiniMax-M2` (default), `MiniMax-M2.1` / `M2.5` / `M2.7` plus their `-highspeed` variants, and a `Custom` profile for arbitrary model IDs and endpoints.

### What's in

- **Node** (`nodes/src/nodes/llm_minimax/`): `IGlobal` validateConfig probe, `ChatBase` binding via `langchain_openai` against `https://api.minimax.io/v1`, `IInstance`, full `services.json` profile + field shape, requirements, README.
- **Sync tooling**: `tools/src/providers/minimax.py` provider handler, registry entry in `tools/src/sync_models.py`, full provider config block in `tools/src/sync_models.config.json` (model filters, title mappings, `protected_profiles` covering all seven seeded entries).
- **CI**: `.github/workflows/sync-models.yml` — `ROCKETRIDE_MINIMAX_KEY` mapped in the partition step and surfaced to both strict and fallback sync jobs.
- **UI**: `packages/shared-ui/.../get-icon-path.ts` + `assets/nodes/minimax.svg` — icon imported and registered in the static `iconMap`.
- **Tests**: `tools/test/markers.py` (`requires_minimax` skip marker), `tools/test/test_sync_live.py` (`test_minimax_profiles_exist_in_api` live API check), `nodes/test/framework/pipeline.py` (mock apikey placeholder for `ROCKETRIDE_MOCK`).
- **Docs**: rows added to `docs/README-nodes.md` and `tools/SYNC_MODELS.md`.

18 files changed, +750 lines.

## Test plan

- [x] `ruff check` clean on all touched Python files
- [x] `ruff format --check` clean on all touched Python files
- [x] `lefthook run pre-commit` — gitleaks ✓, ruff-check ✓, ruff-format ✓
- [x] `python3 tools/src/sync_models.py --provider llm_minimax` (dry-run) reaches the live MiniMax API, finds all seven seeded models, no `missing` warnings
- [x] `python3 tools/src/sync_models.py --provider llm_minimax --enable-discovery` (dry-run) discovers the live catalogue and matches the seeded set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax as a new LLM provider with cloud and self-hosted OpenAI‑compatible support, model sync, and validation.
  * UI now includes a MiniMax connector icon.

* **Documentation**
  * Added provider documentation detailing configuration, profiles, models, and deployment notes.

* **Tests**
  * Added live-sync tests and a test marker for MiniMax; mock credentials updated to include MiniMax.

* **Tools**
  * Sync tooling updated to discover and manage MiniMax models and accept a MiniMax API key env var.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->