### PR TITLE
fix(ocr): support img2table 2.0 OCRInstance API rewrite (#969)

### DIFF
--- a/nodes/src/nodes/ocr/IGlobal.py
+++ b/nodes/src/nodes/ocr/IGlobal.py
@@ -40,7 +40,16 @@ from PIL import Image
 # img2table internally imports cv2, so this must come first
 from ai.common.opencv import cv2  # noqa: F401 - ensures correct opencv
 
-from img2table.ocr.base import OCRInstance
+# img2table 2.0 (2026-05-10) rewrote its OCR plug-in API and moved the base
+# class. Detect which version is installed so this adapter works against both.
+try:
+    from img2table.ocr._types import OCRInstance  # img2table >= 2.0
+
+    _IMG2TABLE_V2 = True
+except ImportError:
+    from img2table.ocr.base import OCRInstance  # img2table < 2.0
+
+    _IMG2TABLE_V2 = False
 
 
 class ModelServerOCR(OCRInstance):
@@ -135,6 +144,112 @@ class ModelServerOCR(OCRInstance):
             _diag(f'[DIAG] Traceback: {traceback.format_exc()}')
 
         return all_results
+
+    def of(self, document) -> Any:
+        """
+        Entry point called by img2table to run OCR on a document.
+
+        img2table v2 removed the two-step content/to_ocr_dataframe contract and
+        expects subclasses to override `of` directly, returning an `OCRData`.
+        For v1, the base class's `of` already orchestrates `content` +
+        `to_ocr_dataframe`, so we just defer to it.
+
+        Args:
+            document: img2table ``Document`` (or ``MockDocument``) whose
+                ``.images`` attribute yields one numpy array per page.
+
+        Returns:
+            On img2table v2: an ``OCRData`` instance whose ``records`` dict is
+            keyed by zero-based page index. Pages that produced no OCR text
+            still appear with an empty record list — ``None`` is returned only
+            when ``document.images`` is empty (nothing to extract) or an
+            exception was caught while iterating.
+            On img2table v1: whatever the base class's ``of`` returns —
+            typically an ``OCRDataframe`` built from ``content()`` +
+            ``to_ocr_dataframe()``.
+        """
+        if not _IMG2TABLE_V2:
+            return super().of(document)
+
+        from img2table.ocr._types import OCRData
+
+        records = {}
+        try:
+            for page_idx, image in enumerate(document.images):
+                image_bytes = self._to_bytes(image)
+                result = self.ocr.read(image_bytes)
+                records[page_idx] = self._format_to_v2_records(result, image.shape, page_idx)
+        except Exception as e:
+            import traceback
+
+            debug(f'ModelServerOCR.of() error: {e}\n{traceback.format_exc()}')
+            return None
+
+        return OCRData(records=records) if records else None
+
+    def _format_to_v2_records(self, result: dict, image_shape: tuple, page: int) -> List[dict]:
+        """
+        Convert a model-server OCR result into img2table v2 word-record dicts.
+
+        Args:
+            result: OCR result from the model server, shaped as
+                ``{'text': str, 'boxes': [{'bbox': [x1, y1, x2, y2],
+                'text': str, 'confidence': float}, ...]}``.
+            image_shape: Shape of the source image (``(h, w, ...)``), used as a
+                fallback bounding box when ``result`` carries text but no boxes.
+            page: Zero-based page index used to build per-record ``id``/``parent``.
+
+        Returns:
+            List of word-record dicts with keys ``id``, ``parent``, ``value``,
+            ``confidence`` (0-100 int), ``x1``, ``y1``, ``x2``, ``y2`` — the
+            shape img2table v2 expects in ``OCRData.records[page]``.
+        """
+        records = []
+        text = result.get('text', '')
+        boxes = result.get('boxes', [])
+
+        if boxes and isinstance(boxes, list):
+            for idx, box_info in enumerate(boxes):
+                if not isinstance(box_info, dict):
+                    continue
+                bbox = box_info.get('bbox', box_info.get('box', [0, 0, 10, 10]))
+                if not isinstance(bbox, (list, tuple)) or len(bbox) < 4:
+                    continue
+                try:
+                    x1, y1, x2, y2 = int(bbox[0]), int(bbox[1]), int(bbox[2]), int(bbox[3])
+                except (TypeError, ValueError):
+                    continue
+                box_text = box_info.get('text', '')
+                confidence = box_info.get('confidence', 1.0)
+                word_id = f'word_{page + 1}_{idx + 1}'
+                records.append(
+                    {
+                        'id': word_id,
+                        'parent': word_id,
+                        'value': box_text,
+                        'confidence': round(100 * confidence),
+                        'x1': x1,
+                        'y1': y1,
+                        'x2': x2,
+                        'y2': y2,
+                    }
+                )
+        if not records and text:
+            h, w = image_shape[:2]
+            word_id = f'word_{page + 1}_1'
+            records.append(
+                {
+                    'id': word_id,
+                    'parent': word_id,
+                    'value': text,
+                    'confidence': 100,
+                    'x1': 0,
+                    'y1': 0,
+                    'x2': int(w),
+                    'y2': int(h),
+                }
+            )
+        return records
 
     def to_ocr_dataframe(self, content: List[List]) -> Any:
         """

--- a/nodes/test/ocr/test_model_server_ocr.py
+++ b/nodes/test/ocr/test_model_server_ocr.py
@@ -1,0 +1,391 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Unit tests for ``ModelServerOCR``'s img2table v1.x / v2.x compatibility shim.
+
+The shim lives in ``nodes/src/nodes/ocr/IGlobal.py`` and needs to keep working
+against both img2table majors:
+
+- v1.x: subclass implements ``content()`` + ``to_ocr_dataframe()`` and the base
+  ``OCRInstance.of()`` orchestrates them, returning an ``OCRDataframe``.
+- v2.x: subclass overrides ``of()`` directly, returning an ``OCRData`` whose
+  ``records`` dict is keyed by page number.
+
+The OCR engine is stubbed (no model server / no real OCR backend), and
+``IGlobal.py`` is loaded directly by file path so the engine venv's
+``rocketlib`` / ``ai.common.*`` / ``depends`` are not required. ``sys.modules``
+is snapshotted/restored around the stubbing so no state leaks into peer tests
+in the same pytest session.
+
+Usage:
+    ./builder.cmd nodes:test --pytest-pattern=ocr --verbose
+"""
+
+import contextlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Scoped sys.modules manipulation
+# ---------------------------------------------------------------------------
+#
+# IGlobal.py's top-level imports pull in engine-internal modules
+# (rocketlib / ai.common.* / depends) and trigger img2table → cv2 → numpy. We
+# need those to resolve at exec time but we MUST NOT leave our stubs lying in
+# sys.modules afterwards: sibling tests in the same pytest session would
+# either pick them up by accident or be unable to install their own.
+#
+# Mirror the snapshot/restore pattern used by
+# nodes/test/chroma/test_convert_filter_explicit_none.py.
+
+_STUB_NAMES = (
+    'rocketlib',
+    'ai',
+    'ai.common',
+    'ai.common.config',
+    'ai.common.opencv',
+    'depends',
+)
+
+
+class _IGlobalBase:
+    """Stand-in for ``rocketlib.IGlobalBase`` — only the name needs to exist."""
+
+
+class _Config:
+    """Stand-in for ``ai.common.config.Config``."""
+
+    @staticmethod
+    def getNodeConfig(*_a: object, **_kw: object) -> dict:
+        """Return an empty config; ``ModelServerOCR.__init__`` doesn't read it."""
+        return {}
+
+
+def _noop(*_a: object, **_kw: object) -> None:
+    """No-op stub for ``rocketlib.debug`` and ``depends.depends``."""
+
+
+def _install_min_stubs() -> None:
+    """Plant just-enough fake modules so ``IGlobal.py``'s imports resolve."""
+
+    def _mk(name: str, **attrs: object) -> None:
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[name] = m
+
+    rocketlib = types.ModuleType('rocketlib')
+    rocketlib.IGlobalBase = _IGlobalBase
+    rocketlib.debug = _noop
+    sys.modules['rocketlib'] = rocketlib
+
+    ai = types.ModuleType('ai')
+    ai.__path__ = []  # mark as package so sub-imports resolve
+    sys.modules['ai'] = ai
+    ai_common = types.ModuleType('ai.common')
+    ai_common.__path__ = []
+    sys.modules['ai.common'] = ai_common
+
+    _mk('ai.common.config', Config=_Config)
+    _mk('ai.common.opencv', cv2=object())
+    _mk('depends', depends=_noop)
+
+
+@contextlib.contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    """
+    Install stub modules for the duration of the block, restoring on exit.
+
+    Also defends against sibling-test pollution: if a previous test (e.g.
+    ``nodes/test/atlas/test_isdeleted_filter.py``) replaced ``sys.modules['numpy']``
+    with a ``MagicMock``, ``cv2`` (pulled in transitively by img2table) cannot
+    load against it. We pop those fake numpy/cv2 entries inside the scope and
+    restore them on exit, so the previous test's state is preserved for any
+    test that runs after us.
+    """
+    snapshot = {name: sys.modules.get(name) for name in _STUB_NAMES}
+
+    numpy_snapshot: dict[str, types.ModuleType] = {}
+    for name in list(sys.modules):
+        if name == 'numpy' or name.startswith('numpy.') or name == 'cv2':
+            mod = sys.modules[name]
+            # Real packages have __path__; real modules have __file__. Anything
+            # missing both is a stub (e.g. MagicMock) we need to evict so the
+            # real engine package can load.
+            if not hasattr(mod, '__path__') and not hasattr(mod, '__file__'):
+                numpy_snapshot[name] = mod
+                del sys.modules[name]
+
+    _install_min_stubs()
+    try:
+        yield
+    finally:
+        for name, mod in snapshot.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+        for name, mod in numpy_snapshot.items():
+            sys.modules[name] = mod
+
+
+# ---------------------------------------------------------------------------
+# Load IGlobal.py under the scoped stubs
+# ---------------------------------------------------------------------------
+
+_iglobal_path = Path(__file__).parent.parent.parent / 'src' / 'nodes' / 'ocr' / 'IGlobal.py'
+
+with _scoped_stubs():
+    # ``importorskip`` honours the scoped numpy/cv2 cleanup — if img2table
+    # itself isn't installed in this env, the whole module is skipped.
+    pytest.importorskip('img2table', reason='img2table not installed in test env')
+
+    import numpy as np  # noqa: E402  — real numpy bound here, survives restore
+
+    _spec = importlib.util.spec_from_file_location('_ocr_iglobal_direct', _iglobal_path)
+    _iglobal_mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_iglobal_mod)
+
+ModelServerOCR = _iglobal_mod.ModelServerOCR
+_IMG2TABLE_V2 = _iglobal_mod._IMG2TABLE_V2
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubOcr:
+    """Stand-in for an ``ai.common.models`` OCR engine returning a canned result."""
+
+    def __init__(self, result: dict) -> None:
+        """
+        Args:
+            result: dict shaped like a model-server OCR response
+                (``{'text': str, 'boxes': [...]}``) returned from every ``read``.
+        """
+        self.result = result
+        self.calls: list[bytes] = []
+
+    def read(self, image_bytes: bytes) -> dict:
+        """Record the call and return the pre-configured result."""
+        self.calls.append(image_bytes)
+        return self.result
+
+
+class _StubDocument:
+    """Minimal img2table-like document exposing ``.images`` as numpy arrays."""
+
+    def __init__(self, n_pages: int = 1) -> None:
+        """
+        Args:
+            n_pages: how many blank 10x20 RGB pages to attach to ``.images``.
+        """
+        self.images = [np.zeros((10, 20, 3), dtype=np.uint8) for _ in range(n_pages)]
+
+
+@pytest.fixture
+def adapter():
+    """A ``ModelServerOCR`` with a stubbed OCR engine returning one bbox match."""
+    a = ModelServerOCR(engine='doctr')
+    a._ocr = _StubOcr({'text': '', 'boxes': [{'bbox': [0, 0, 5, 5], 'text': 'hi', 'confidence': 0.9}]})
+    return a
+
+
+# ---------------------------------------------------------------------------
+# _format_to_v2_records — pure helper, behaviour identical on both majors
+# ---------------------------------------------------------------------------
+
+
+def test_format_to_v2_records_with_boxes(adapter) -> None:
+    """Each entry in ``boxes`` becomes one v2 word-record with rounded confidence."""
+    result = {
+        'text': 'ignored when boxes present',
+        'boxes': [
+            {'bbox': [1, 2, 3, 4], 'text': 'hello', 'confidence': 0.8},
+            {'bbox': [5, 6, 7, 8], 'text': 'world', 'confidence': 1.0},
+        ],
+    }
+
+    records = adapter._format_to_v2_records(result, (10, 20, 3), page=0)
+
+    assert records == [
+        {
+            'id': 'word_1_1',
+            'parent': 'word_1_1',
+            'value': 'hello',
+            'confidence': 80,
+            'x1': 1,
+            'y1': 2,
+            'x2': 3,
+            'y2': 4,
+        },
+        {
+            'id': 'word_1_2',
+            'parent': 'word_1_2',
+            'value': 'world',
+            'confidence': 100,
+            'x1': 5,
+            'y1': 6,
+            'x2': 7,
+            'y2': 8,
+        },
+    ]
+
+
+def test_format_to_v2_records_text_only_uses_image_bbox(adapter) -> None:
+    """A bare ``text`` field (no boxes) yields one record covering the whole image."""
+    records = adapter._format_to_v2_records({'text': 'fallback', 'boxes': []}, (10, 20, 3), page=2)
+
+    assert records == [
+        {
+            'id': 'word_3_1',
+            'parent': 'word_3_1',
+            'value': 'fallback',
+            'confidence': 100,
+            'x1': 0,
+            'y1': 0,
+            'x2': 20,
+            'y2': 10,
+        }
+    ]
+
+
+def test_format_to_v2_records_empty(adapter) -> None:
+    """An empty result produces no records."""
+    assert adapter._format_to_v2_records({'text': '', 'boxes': []}, (10, 20, 3), 0) == []
+
+
+def test_format_to_v2_records_skips_non_dict_boxes(adapter) -> None:
+    """Non-dict entries in ``boxes`` are ignored (defensive against bad results)."""
+    result = {
+        'text': '',
+        'boxes': [
+            'garbage',
+            {'bbox': [0, 0, 1, 1], 'text': 'ok', 'confidence': 0.5},
+            None,
+        ],
+    }
+
+    records = adapter._format_to_v2_records(result, (10, 20, 3), page=0)
+
+    assert len(records) == 1
+    assert records[0]['value'] == 'ok'
+    assert records[0]['confidence'] == 50
+
+
+def test_format_to_v2_records_skips_malformed_bbox(adapter) -> None:
+    """Boxes with short or non-numeric ``bbox`` values are skipped, not raised."""
+    result = {
+        'text': '',
+        'boxes': [
+            {'bbox': [1, 2, 3], 'text': 'too-short', 'confidence': 1.0},
+            {'bbox': 'not-a-list', 'text': 'wrong-type', 'confidence': 1.0},
+            {'bbox': [1, 'x', 3, 4], 'text': 'non-numeric', 'confidence': 1.0},
+            {'bbox': [10, 20, 30, 40], 'text': 'good', 'confidence': 0.5},
+        ],
+    }
+
+    records = adapter._format_to_v2_records(result, (10, 20, 3), page=0)
+
+    assert len(records) == 1
+    assert records[0]['value'] == 'good'
+
+
+def test_format_to_v2_records_text_fallback_when_all_boxes_invalid(adapter) -> None:
+    """If every entry in ``boxes`` is malformed but ``text`` is set, fall back to text."""
+    result = {
+        'text': 'document-level',
+        'boxes': [
+            {'bbox': [1, 2], 'text': 'bad', 'confidence': 1.0},
+            'garbage',
+        ],
+    }
+
+    records = adapter._format_to_v2_records(result, (10, 20, 3), page=0)
+
+    assert len(records) == 1
+    assert records[0]['value'] == 'document-level'
+    assert records[0]['x2'] == 20  # full-image bbox from image_shape
+
+
+# ---------------------------------------------------------------------------
+# of() — branches on the installed img2table major
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _IMG2TABLE_V2, reason='requires img2table >= 2.0')
+def test_of_returns_ocrdata_on_v2(adapter) -> None:
+    """v2: ``of()`` returns an ``OCRData`` with records keyed by page."""
+    from img2table.ocr._types import OCRData
+
+    out = adapter.of(_StubDocument(n_pages=2))
+
+    assert isinstance(out, OCRData)
+    assert set(out.records.keys()) == {0, 1}
+    assert out.records[0][0]['value'] == 'hi'
+    assert out.records[0][0]['confidence'] == 90
+    # Page index must propagate into the per-record id.
+    assert out.records[1][0]['id'] == 'word_2_1'
+
+
+@pytest.mark.skipif(not _IMG2TABLE_V2, reason='requires img2table >= 2.0')
+def test_of_empty_pages_still_return_ocrdata_v2(adapter) -> None:
+    """v2: pages with no detected text yield ``OCRData`` carrying empty record lists.
+
+    ``None`` is reserved for "couldn't process at all" — see the no-images test
+    below — so downstream code can rely on a non-None ``OCRData`` whenever the
+    document actually had pages.
+    """
+    from img2table.ocr._types import OCRData
+
+    adapter._ocr = _StubOcr({'text': '', 'boxes': []})
+
+    out = adapter.of(_StubDocument(n_pages=2))
+
+    assert isinstance(out, OCRData)
+    assert out.records == {0: [], 1: []}
+
+
+@pytest.mark.skipif(not _IMG2TABLE_V2, reason='requires img2table >= 2.0')
+def test_of_returns_none_for_document_with_no_images_v2(adapter) -> None:
+    """v2: a document with no images returns ``None`` — nothing to extract."""
+
+    class _Empty:
+        images: list = []
+
+    assert adapter.of(_Empty()) is None
+
+
+@pytest.mark.skipif(_IMG2TABLE_V2, reason='requires img2table < 2.0')
+def test_of_delegates_to_base_class_on_v1(adapter) -> None:
+    """v1: ``of()`` defers to the base class, which builds an ``OCRDataframe``."""
+    from img2table.ocr.data import OCRDataframe
+
+    out = adapter.of(_StubDocument())
+
+    assert isinstance(out, OCRDataframe)
+
+
+# ---------------------------------------------------------------------------
+# Legacy v1 surface — must keep working because v1's base-class of() drives it
+# ---------------------------------------------------------------------------
+
+
+def test_content_returns_easyocr_format(adapter) -> None:
+    """``content()`` (called by v1's base ``of``) yields per-page EasyOCR tuples."""
+    pages = adapter.content(_StubDocument())
+
+    assert len(pages) == 1
+    bbox_points, text, conf = pages[0][0]
+    assert text == 'hi'
+    assert conf == 0.9
+    assert bbox_points == [[0, 0], [5, 0], [5, 5], [0, 5]]


### PR DESCRIPTION
Cherry-pick from the `develop` branch

## Summary

- img2table 2.0.0 (2026-05-10) moved `OCRInstance` out of `img2table.ocr.base` and replaced the `content` / `to_ocr_dataframe` contract with a single `of()` returning `OCRData`, breaking the OCR node with `No module named 'img2table.ocr.base'`.
- Make `ModelServerOCR` in `nodes/src/nodes/ocr/IGlobal.py` version-aware: try `img2table.ocr._types.OCRInstance` first (v2), fall back to `img2table.ocr.base.OCRInstance` (v1).
- Implement `of()` so it builds an `OCRData(records=…)` on v2 and defers to the base class on v1 (which still drives the existing `content` + `to_ocr_dataframe`); add `_format_to_v2_records` helper producing the v2 word-record dict shape.
- Add `nodes/test/ocr/test_model_server_ocr.py` covering both branches: 4 pure-helper tests, 3 v2-only `of()` tests, 1 v1-only `of()` test, 1 `content()` test on both. Loads `IGlobal.py` via `spec_from_file_location` inside a `_scoped_stubs()` context manager so `sys.modules` is snapshotted/restored — no leakage into peer tests in the same `pytest-xdist` session.

## Type

fix

## Testing

- [x] Tests added (`nodes/test/ocr/test_model_server_ocr.py` — 8 active, 1 version-skipped)
- [x] Tested locally — `./builder.cmd nodes:test --pytest-pattern=ocr --verbose` → 10 passed, 1 skipped
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #913

