### PR TITLE
chore(security): allowlist Exa-search test-key placeholder in gitleaksignore

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,11 @@
 # Stripe publishable key (pk_test_*) is a public client-side key, not a secret.
 .config:generic-api-key:58
+
+# Placeholder credential in the test-fixture block of the tool_exa_search node
+# config from PR #509. The file has an inline comment two lines above the
+# value explicitly documenting it as a placeholder for config-validation tests
+# (not a live key). The string was refactored away in a later commit on stage
+# (the test block now uses a cases array), so the value only appears in the
+# historical commit fd6b61d5 when gitleaks scans the full main..stage range.
+# See PR #971 (release: stage to main) for context.
+fd6b61d56b0671f7a3d24d0314d060a3d0d61b8c:nodes/src/nodes/tool_exa_search/services.json:pipe-file-api-key:138


### PR DESCRIPTION
## Summary

**Release-day unblock for PR #971 (release: stage → main).** Gitleaks is failing on #971 with one finding — a literal \`"apikey": "test-key"\` placeholder in the test-fixture block of \`nodes/src/nodes/tool_exa_search/services.json\` at line 138 of commit \`fd6b61d5\` (PR #509, Charlie's Exa search node, 2026-04-21).

## Why this is a false positive

The file's own inline comment two lines above the value explicitly says:

\`\`\`
//	Test configuration for automated node testing.
//	"apikey" is intentionally set to a placeholder — config validation is
//	tested here, not live API calls.
\`\`\`

Entropy of 2.5 matches — the literal value is 8 chars, the lowest-entropy real string the rule's minimum would accept.

## Why it's failing now (and not on #509's own CI back in April)

\`release.yaml\`-triggering PRs like #971 merge \`stage\` into \`main\`. Since main hasn't moved since 2026-03-29, the gitleaks scan range on #971 is the full 227 commits — including #509's introduction of the placeholder. A later commit on stage refactored the test block to use a \`"cases"\` array, so the literal value no longer appears in the current file. But gitleaks scans the full commit range, not just the diff against base, so a later refactor doesn't clear a historical match.

PRs onto develop scan a much narrower range and never had this commit in their delta after #509 itself landed.

## Two known gitleaks config inconsistencies — follow-up after release

While investigating, I noticed two things about \`.gitleaks.toml\` that don't match the actual rule firing. Worth a follow-up ticket, **not blocking this release**:

1. The \`pipe-file-api-key\` rule's \`paths = ['''\.pipe(\.json)?$''']\` shouldn't match \`services.json\` — yet gitleaks attributed the finding to that rule.
2. The \`services-json-api-key\` rule (which DOES match \`services.json\` paths) has a 16-char minimum, which the 8-char placeholder wouldn't trigger.

Neither rule should have fired given the documented config; one of them did. Likely a gitleaks version mismatch or rule-precedence quirk. Investigate after the release lands.

## Diff

\`\`\`diff
 # Stripe publishable key (pk_test_*) is a public client-side key, not a secret.
 .config:generic-api-key:58
+
+# Placeholder credential in the test-fixture block of the tool_exa_search node
+# config from PR #509. ... (full rationale in the file)
+fd6b61d56b0671f7a3d24d0314d060a3d0d61b8c:nodes/src/nodes/tool_exa_search/services.json:pipe-file-api-key:138
\`\`\`

Fingerprint format \`<commit>:<path>:<rule>:<line>\` — gitleaks matches this exact occurrence only, so this doesn't silence future findings.

## Test plan

- [ ] CI on this PR passes (gitleaks itself should pass on this PR since it doesn't span the historical Exa commit — only #971 does).
- [ ] After merge, re-run CI on #971 (or wait for the next push); gitleaks should now pass against the updated \`.gitleaksignore\`.
- [ ] #971 proceeds with the release.