### PR TITLE
fix(sidebar): wire docs link to browser and update announcements

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -391,6 +391,9 @@ function registerUtilityCommands(context: vscode.ExtensionContext): void {
 	const agentManager = new AgentManager();
 
 	const commands = [
+		vscode.commands.registerCommand('rocketride.sidebar.documentation.open', () => {
+			vscode.env.openExternal(vscode.Uri.parse('https://docs.rocketride.org/'));
+		}),
 		vscode.commands.registerCommand('rocketride.sidebar.connection.connect', async () => {
 			await connectionManager?.connect();
 		}),

--- a/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
+++ b/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
@@ -319,11 +319,8 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 	// ── Announcements ticker (flat mode) ────────────────────────────────────
 	const announcements: { title: string; body: string; linkText: string; linkUrl: string }[] = useMemo(
 		() => [
-			{ title: 'Join us in SF', body: 'Hack-with-the-Bay, Tue June 25–26.', linkText: 'Details & RSVP', linkUrl: 'https://rocketride.dev/events/sf-hack' },
-			{ title: 'RocketRide 2.4 is live', body: 'Streaming pipelines, token tracing, new connectors.', linkText: 'See what\'s new', linkUrl: 'https://rocketride.dev/changelog' },
-			{ title: 'NYC Meetup', body: 'AI Pipeline Workshop, Thu July 10.', linkText: 'Register now', linkUrl: 'https://rocketride.dev/events/nyc-workshop' },
-			{ title: 'New RAG template', body: 'Pinecone + OpenAI in 3 nodes — ready to go.', linkText: 'Try it out', linkUrl: 'https://rocketride.dev/templates/rag-pinecone' },
-			{ title: 'Community spotlight', body: '1,200+ pipelines built this month.', linkText: 'Join Discord', linkUrl: 'https://discord.gg/rocketride' },
+			{ title: 'Agentic AI Hackathon - SF', body: 'Hack-with-the-Bay, Fri June 5.', linkText: 'Details & RSVP', linkUrl: 'https://luma.com/zemh10km' },
+			{ title: 'Connect with us', body: 'See what others are building.', linkText: 'Join Discord', linkUrl: 'https://discord.gg/9hr3tdZmEG' },
 		],
 		[]
 	);


### PR DESCRIPTION
## Summary

- Registers `rocketride.sidebar.documentation.open` command — previously unregistered, clicking Documentation was a silent no-op. Now opens https://docs.rocketride.org/ in the system browser via `vscode.env.openExternal`
- Updates sidebar announcement ticker: replaces SF hackathon with correct title/date (Agentic AI Hackathon - SF, Fri June 5) and Luma link
- Removes stale announcements: RocketRide 2.4 is live, NYC Meetup, New RAG template
- Renames "Community spotlight" → "Connect with us" with updated copy and correct Discord URL

## Test plan

- [ ] Click Documentation button in sidebar — should open https://docs.rocketride.org/ in browser
- [ ] Sidebar ticker cycles through 2 announcements (Agentic AI Hackathon, Connect with us)
- [ ] Hackathon "Details & RSVP" link opens https://luma.com/zemh10km
- [ ] "Join Discord" link opens https://discord.gg/9hr3tdZmEG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new documentation command accessible in the extension sidebar that opens the official documentation website directly in your default web browser for quick reference.

* **Updates**
  * Refreshed the announcements section with newly featured content, including details about the upcoming Agentic AI Hackathon event in San Francisco and community engagement opportunities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->