### PR TITLE
fix(sidebar): wire docs link to browser and update announcements

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -391,6 +391,9 @@ function registerUtilityCommands(context: vscode.ExtensionContext): void {
 	const agentManager = new AgentManager();
 
 	const commands = [
+		vscode.commands.registerCommand('rocketride.sidebar.documentation.open', () => {
+			vscode.env.openExternal(vscode.Uri.parse('https://docs.rocketride.org/'));
+		}),
 		vscode.commands.registerCommand('rocketride.sidebar.connection.connect', async () => {
 			await connectionManager?.connect();
 		}),

--- a/nodes/src/nodes/agent_crewai/crewai_base.py
+++ b/nodes/src/nodes/agent_crewai/crewai_base.py
@@ -42,6 +42,114 @@ from ai.common.agent import AgentBase, AgentContext
 
 
 # ────────────────────────────────────────────────────────────────────────────────
+# CREWAI ASYNC COMPATIBILITY PATCHES (applied once at import time)
+#
+# Two related issues in CrewAI 1.14.x when running inside a shared asyncio loop:
+#
+# 1. PLANNING — Crew._handle_crew_planning() calls planner_task.execute_sync()
+#    → agent.execute_task() (sync) which raises RuntimeError when it detects a
+#    running event loop. Fix: offload planning to a ThreadPoolExecutor worker
+#    thread that has no running loop (_patch_crewai_planning).
+#
+# 2. DELEGATION — DelegateWorkTool / BaseAgentTool have no _arun / _aexecute,
+#    so hierarchical crews fall back to the sync execute_task() path from inside
+#    the async loop → RuntimeError. Fix: patch both classes with async variants
+#    that use aexecute_task() instead (_patch_crewai_delegation).
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def _patch_crewai_planning() -> None:
+    """
+    Patch Crew._handle_crew_planning() to be safe when called from inside a
+    running event loop (e.g. via akickoff() on the CrewRunner daemon thread).
+
+    CrewAI's planning step calls planner_task.execute_sync() -> agent.execute_task(),
+    which raises RuntimeError when it detects a running event loop. We fix this by
+    offloading the entire planning call to a ThreadPoolExecutor worker thread, which
+    has no running loop. Planning mutates self.tasks in-place, so the crew sees the
+    updated task descriptions when the worker returns.
+    """
+    try:
+        import concurrent.futures
+
+        from crewai.crew import Crew
+
+        if getattr(Crew, '_rr_planning_patched', False):
+            return
+
+        _orig_planning = Crew._handle_crew_planning
+
+        def _safe_handle_crew_planning(self) -> None:
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                _orig_planning(self)
+                return
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                ex.submit(_orig_planning, self).result()
+
+        Crew._handle_crew_planning = _safe_handle_crew_planning  # type: ignore[method-assign]
+        Crew._rr_planning_patched = True  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+
+def _patch_crewai_delegation() -> None:
+    try:
+        from crewai.task import Task
+        from crewai.tools.agent_tools.ask_question_tool import AskQuestionTool
+        from crewai.tools.agent_tools.base_agent_tools import BaseAgentTool
+        from crewai.tools.agent_tools.delegate_work_tool import DelegateWorkTool
+        from crewai.utilities.i18n import I18N_DEFAULT
+
+        if hasattr(BaseAgentTool, '_aexecute'):
+            return  # already patched
+
+        async def _aexecute(self, agent_name, task, context=None):  # type: ignore[override]
+            try:
+                if agent_name is None:
+                    agent_name = ''
+                sanitized = self.sanitize_agent_name(agent_name)
+                agent = [a for a in self.agents if self.sanitize_agent_name(a.role) == sanitized]
+            except (AttributeError, ValueError) as e:
+                return I18N_DEFAULT.errors('agent_tool_unexisting_coworker').format(
+                    coworkers='\n'.join([f'- {self.sanitize_agent_name(a.role)}' for a in self.agents]),
+                    error=str(e),
+                )
+            if not agent:
+                return I18N_DEFAULT.errors('agent_tool_unexisting_coworker').format(
+                    coworkers='\n'.join([f'- {self.sanitize_agent_name(a.role)}' for a in self.agents]),
+                    error=f"No agent found with role '{sanitized}'",
+                )
+            selected = agent[0]
+            try:
+                t = Task(description=task, agent=selected, expected_output=I18N_DEFAULT.slice('manager_request'))
+                return await selected.aexecute_task(t, context)
+            except Exception as e:
+                return I18N_DEFAULT.errors('agent_tool_execution_error').format(
+                    agent_role=self.sanitize_agent_name(selected.role), error=str(e)
+                )
+
+        async def _delegate_arun(self, task, context, coworker=None, **kwargs):  # type: ignore[override]
+            coworker = self._get_coworker(coworker, **kwargs)
+            return await self._aexecute(coworker, task, context)
+
+        async def _ask_arun(self, question, context, coworker=None, **kwargs):  # type: ignore[override]
+            coworker = self._get_coworker(coworker, **kwargs)
+            return await self._aexecute(coworker, question, context)
+
+        BaseAgentTool._aexecute = _aexecute  # type: ignore[attr-defined]
+        DelegateWorkTool._arun = _delegate_arun  # type: ignore[attr-defined]
+        AskQuestionTool._arun = _ask_arun  # type: ignore[attr-defined]
+    except Exception:
+        pass  # if crewai isn't installed yet, skip silently
+
+
+_patch_crewai_planning()
+_patch_crewai_delegation()
+
+
+# ────────────────────────────────────────────────────────────────────────────────
 # CREWBASE
 # ────────────────────────────────────────────────────────────────────────────────
 
@@ -243,6 +351,16 @@ class CrewBase(AgentBase):
             name: str
             description: str
             args_schema: type[BaseModel] = _ToolInput
+
+            def __repr__(self) -> str:
+                # Strip JSON schema suffix and CrewAI-reformatted header so planning
+                # prompts see a clean one-liner — same as native CrewAI tool reprs.
+                desc = self.description.split('\n\nTool input schema (JSON):')[0]
+                if '\nTool Description: ' in desc:
+                    desc = desc.split('\nTool Description: ', 1)[1].split('\n')[0]
+                return f'Tool(name={self.name!r}, description={desc!r})'
+
+            __str__ = __repr__
 
             def _run(self, **framework_args: Any) -> str:
                 try:

--- a/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
+++ b/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
@@ -243,12 +243,11 @@ class CrewManager(CrewBase):
                 allow_delegation=False,
             )
 
-            task_text = d.task_description or ''
-            if not task_text:
-                task_text = prompt or 'Complete the user request.'
-            elif prompt:
-                task_text = f'{task_text}\n\nUser request: {prompt}'
-            task_desc = self._escape_braces(task_text)
+            # Mirror native CrewAI template substitution: leave braces unescaped so
+            # _interpolate_inputs() can fill {user_request} (and any other vars the
+            # user placed in their task_description).  Fall back to bare {user_request}
+            # when no task_description is configured, which resolves to the raw prompt.
+            task_desc = d.task_description or '{user_request}'
 
             # No implicit inter-task context wiring.  In hierarchical mode the
             # manager agent decides what to pass to each delegate via its

--- a/nodes/src/nodes/qdrant/qdrant.py
+++ b/nodes/src/nodes/qdrant/qdrant.py
@@ -77,6 +77,10 @@ enabled by building qdrant from source with
 --features multiling-chinese,multiling-japanese,multiling-korean flags.
 """
 
+# Minimum rescaled [0, 1] similarity for a result to count as relevant; below
+# this it is dropped as noise regardless of the configured retrieval score.
+MIN_RELEVANCE_SCORE = 0.20
+
 
 class Store(DocumentStoreBase):
     apikey: str | None = None
@@ -248,9 +252,14 @@ class Store(DocumentStoreBase):
         if docFilter.objectIds is not None:
             must.append(models.FieldCondition(key='meta.objectId', match=models.MatchAny(any=docFilter.objectIds)))
 
-        # If we are not going after deleted docs, add a condition
+        # Exclude only docs explicitly marked deleted. A null/absent isDeleted
+        # (the client strips None via exclude_none) must still count as not deleted.
         if docFilter.isDeleted is None or not docFilter.isDeleted:
-            must.append(models.FieldCondition(key='meta.isDeleted', match=models.MatchValue(value=False)))
+            must.append(
+                models.Filter(
+                    must_not=[models.FieldCondition(key='meta.isDeleted', match=models.MatchValue(value=True))]
+                )
+            )
 
         # If we are not going after chunks, add a condition
         if docFilter.chunkIds is not None:
@@ -294,7 +303,7 @@ class Store(DocumentStoreBase):
                     score = float(1.0 / (1.0 + np.exp(point.score / -100)))
 
                 # Ignore it if it doesn't have a high enough score
-                if score < 0.20:
+                if score < MIN_RELEVANCE_SCORE:
                     continue
             else:
                 score = 0
@@ -388,7 +397,9 @@ class Store(DocumentStoreBase):
         if docFilter.offset:
             raise BaseException('Non-zero offset is not supported in semantic searching')
 
-        # Perform the search
+        # Don't pass score_threshold: Qdrant compares it against the raw similarity
+        # score, but threshold_search is in the rescaled [0,1] space. The cut is
+        # applied post-rescale by the base store (_addDoc).
         points = self.client.query_points(
             collection_name=self.collection,
             query=query.embedding,
@@ -396,7 +407,6 @@ class Store(DocumentStoreBase):
             with_vectors=False,
             with_payload=True,
             limit=docFilter.limit if docFilter.limit is not None else 25,
-            score_threshold=self.threshold_search,
             search_params=SearchParams(exact=True),
         ).points
 

--- a/nodes/test/mocks/qdrant_client/__init__.py
+++ b/nodes/test/mocks/qdrant_client/__init__.py
@@ -448,23 +448,22 @@ class QdrantClient:
         """
         points = QdrantClient._points.get(collection_name, [])
 
-        # Filter out the schema document (isDeleted=True)
-        # This document is created by the RocketRide store to track metadata
-        # and should never appear in search results
+        # Replicate the real Qdrant filter: exclude only documents explicitly
+        # marked isDeleted=True. Null/missing isDeleted means not deleted,
+        # matching the should=[MatchValue(False), IsNullCondition, IsEmptyCondition]
+        # filter used in _convertFilter().
         filtered_points = []
         for p in points:
             meta = p.payload.get('meta') if p.payload else None
-            is_deleted = False
+            is_deleted = None
 
             if meta is not None:
                 if hasattr(meta, 'isDeleted'):
-                    # meta is a DocMetadata object
                     is_deleted = meta.isDeleted
                 elif isinstance(meta, dict):
-                    # meta is already serialized to dict
-                    is_deleted = meta.get('isDeleted', False)
+                    is_deleted = meta.get('isDeleted')
 
-            if not is_deleted:
+            if is_deleted is not True:
                 filtered_points.append(p)
 
         # Return mock scored points

--- a/nodes/test/qdrant/test_search_threshold.py
+++ b/nodes/test/qdrant/test_search_threshold.py
@@ -1,0 +1,82 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Regression test for the Qdrant score-threshold fix in searchSemantic.
+
+threshold_search is in the rescaled [0, 1] space, but Qdrant's score_threshold
+filters against the raw similarity score, so it must not be passed to the engine.
+The threshold cut is applied post-rescale by the base store (_addDoc).
+"""
+
+import sys
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+
+NODES_SRC = Path(__file__).parent.parent.parent / 'src' / 'nodes'
+
+
+class _FakeDocumentStoreBase:
+    def doesCollectionExist(self, *a, **kw):
+        return True
+
+
+for _name in (
+    'numpy',
+    'qdrant_client',
+    'qdrant_client.models',
+    'qdrant_client.http',
+    'qdrant_client.http.models',
+    'qdrant_client.conversions',
+    'qdrant_client.conversions.common_types',
+    'depends',
+    'ai',
+    'ai.common',
+    'ai.common.schema',
+    'ai.common.config',
+):
+    sys.modules.setdefault(_name, MagicMock())
+
+_store_mod = MagicMock()
+_store_mod.DocumentStoreBase = _FakeDocumentStoreBase
+sys.modules['ai.common.store'] = _store_mod
+
+_spec = importlib.util.spec_from_file_location('_qdrant_store', str(NODES_SRC / 'qdrant' / 'qdrant.py'))
+_qdrant_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_qdrant_mod)
+Store = _qdrant_mod.Store
+
+
+def _make_store(similarity: str) -> Store:
+    store = object.__new__(Store)
+    store.client = MagicMock()
+    store.client.query_points.return_value.points = []
+    store.collection = 'c'
+    store.threshold_search = 0.7
+    store.similarity = similarity
+    return store
+
+
+def _run_search(store: Store) -> None:
+    query = MagicMock(embedding=[0.1, 0.2], embedding_model='m')
+    store.searchSemantic(query, MagicMock(offset=0, limit=10))
+
+
+class TestScoreThresholdNotPassedToEngine(unittest.TestCase):
+    def test_cosine(self):
+        store = _make_store('Cosine')
+        _run_search(store)
+        self.assertNotIn('score_threshold', store.client.query_points.call_args.kwargs)
+
+    def test_non_cosine(self):
+        store = _make_store('Dot')
+        _run_search(store)
+        self.assertNotIn('score_threshold', store.client.query_points.call_args.kwargs)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
+++ b/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
@@ -319,11 +319,8 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 	// ── Announcements ticker (flat mode) ────────────────────────────────────
 	const announcements: { title: string; body: string; linkText: string; linkUrl: string }[] = useMemo(
 		() => [
-			{ title: 'Join us in SF', body: 'Hack-with-the-Bay, Tue June 25–26.', linkText: 'Details & RSVP', linkUrl: 'https://rocketride.dev/events/sf-hack' },
-			{ title: 'RocketRide 2.4 is live', body: 'Streaming pipelines, token tracing, new connectors.', linkText: 'See what\'s new', linkUrl: 'https://rocketride.dev/changelog' },
-			{ title: 'NYC Meetup', body: 'AI Pipeline Workshop, Thu July 10.', linkText: 'Register now', linkUrl: 'https://rocketride.dev/events/nyc-workshop' },
-			{ title: 'New RAG template', body: 'Pinecone + OpenAI in 3 nodes — ready to go.', linkText: 'Try it out', linkUrl: 'https://rocketride.dev/templates/rag-pinecone' },
-			{ title: 'Community spotlight', body: '1,200+ pipelines built this month.', linkText: 'Join Discord', linkUrl: 'https://discord.gg/rocketride' },
+			{ title: 'Agentic AI Hackathon - SF', body: 'Hack-with-the-Bay, Fri June 5.', linkText: 'Details & RSVP', linkUrl: 'https://luma.com/zemh10km' },
+			{ title: 'Connect with us', body: 'See what others are building.', linkText: 'Join Discord', linkUrl: 'https://discord.gg/9hr3tdZmEG' },
 		],
 		[]
 	);

--- a/scripts/lib/action-runner.js
+++ b/scripts/lib/action-runner.js
@@ -449,9 +449,28 @@ function buildBracketTask(bracket, seen, logModule, options) {
 function buildWhenTask(when, seen, logModule, options) {
     const variant = when._variant || 'when';
 
-    // Pre-build both branches so structure is known
-    const thenTasks = buildTaskTree(when.then, seen, logModule, options);
-    const elseTasks = when.else?.length ? buildTaskTree(when.else, seen, logModule, options) : [];
+    // Pre-build both branches with cloned `seen` sets so the branch contents
+    // do NOT pollute the parent's dedup state.
+    //
+    // Why this matters: a `when`/`whenNot` block decides which branch runs at
+    // RUNTIME, but its branches' subtrees are built upfront. If we share the
+    // parent's `seen` set, a compound action `X` referenced inside (say) the
+    // then-branch would be marked seen at the parent level. Any later
+    // reference to `X` elsewhere in the tree then becomes a dedup stub
+    // (`Waiting for: X`) whose resolver lives inside the conditional branch's
+    // own subtree. When the condition skips that branch at runtime, the
+    // resolver never fires and the stub hangs forever.
+    //
+    // Cloning isolates each branch's `seen` so:
+    //   - Actions exclusively inside a branch don't appear in the parent's
+    //     dedup state. Later references outside the conditional build their
+    //     own real subtree.
+    //   - Runtime `completedActions`/lock check at line 130/192 still skips
+    //     duplicate executions if both the branch AND another path do run.
+    //   - `getOrCreateCompletion` is process-global, so a real reference
+    //     anywhere still satisfies dedup stubs that share the same name.
+    const thenTasks = buildTaskTree(when.then, new Set(seen), logModule, options);
+    const elseTasks = when.else?.length ? buildTaskTree(when.else, new Set(seen), logModule, options) : [];
     
     return {
         title: `? ${variant} ${when.name}`,


### PR DESCRIPTION
## Summary

- Registers `rocketride.sidebar.documentation.open` command — previously unregistered, clicking Documentation was a silent no-op. Now opens https://docs.rocketride.org/ in the system browser via `vscode.env.openExternal`
- Updates sidebar announcement ticker: replaces SF hackathon with correct title/date (Agentic AI Hackathon - SF, Fri June 5) and Luma link
- Removes stale announcements: RocketRide 2.4 is live, NYC Meetup, New RAG template
- Renames "Community spotlight" → "Connect with us" with updated copy and correct Discord URL

## Test plan

- [ ] Click Documentation button in sidebar — should open https://docs.rocketride.org/ in browser
- [ ] Sidebar ticker cycles through 2 announcements (Agentic AI Hackathon, Connect with us)
- [ ] Hackathon "Details & RSVP" link opens https://luma.com/zemh10km
- [ ] "Join Discord" link opens https://discord.gg/9hr3tdZmEG

🤖 Generated with [Claude Code](https://claude.com/claude-code)