### PR TITLE
ci(release): switch TS client npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -182,16 +182,26 @@ jobs:
           ls -la release-assets/
 
       # --- npm: rocketride ---
+      #
+      # Authenticated via npm trusted publishing (OIDC), configured on the
+      # npm side for package `rocketride` against this repo + this workflow
+      # file + the `release` environment. No NODE_AUTH_TOKEN — npm CLI
+      # exchanges the GitHub OIDC token for a short-lived registry token
+      # automatically when --provenance is used and no static token is set.
+      #
+      # Requires npm >= 11.5.1 for the auto-exchange; Node 22's bundled npm
+      # is still 10.x, so we upgrade explicitly before publishing.
       - name: Set up Node.js
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-typescript'
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org
 
       - name: Publish to npm
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-typescript'
         run: |
+          npm install -g npm@latest
           VERSION="${{ matrix.version }}"
           if npm view "rocketride@${VERSION}" version 2>/dev/null; then
             echo "rocketride@${VERSION} already exists on npm — skipping"
@@ -200,8 +210,6 @@ jobs:
             echo "Publishing ${TARBALL}"
             npm publish "./${TARBALL}" --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # --- PyPI ---
       - name: Set up Python


### PR DESCRIPTION
## Summary

Switch the TypeScript client `npm publish` step in `_release.yaml` from token-based auth to **npm trusted publishing (OIDC)**.

- Bump `node-version` from 20 → 22 (Node 20 ships npm 10.x; auto-exchange of GitHub OIDC for an npm registry token requires npm 11.5.1+)
- Add `npm install -g npm@latest` inline before publish to get npm 11.5+ (Node 22 still bundles npm 10.x at time of writing)
- Remove `env.NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` — when no static token is set and `--provenance` is used, npm CLI auto-requests an OIDC token from GitHub and exchanges it for a short-lived registry token via the trusted-publisher config on npmjs.com

## Background

The `rocketride` npm package has a Trusted Publisher already configured on npm side (repo `rocketride-org/rocketride-server`, workflow `_release.yaml`, environment `release`). However:

- The `NPM_TOKEN` repo secret was rotated as a Granular Access Token, which is **incompatible with `npm publish --provenance`** (provenance only works with legacy Classic Automation tokens or OIDC).
- Even though OIDC trusted publishing was configured, the workflow's `env.NODE_AUTH_TOKEN` took precedence over the OIDC fallback, so OIDC was never attempted.

Today's 2026-05-22 release pipeline shipped VS Code, Server, MCP, and Python clients successfully but TS Client npm publish failed 3× with the misleading `404 PUT https://registry.npmjs.org/rocketride - 'rocketride@1.1.0' is not in this registry` — the canonical npm error when auth is rejected.

## Test plan

- [ ] CI passes (Build / Ubuntu 22.04, gitleaks)
- [ ] After merge, the `release.yaml` run that fires from this commit should:
  - Skip Server / VS Code / Python / MCP publishes (tags already exist from earlier today)
  - Re-attempt TS Client publish under OIDC → succeeds with provenance attestation
  - Re-evaluate Docker job (gated on full release matrix success)
- [ ] After successful publish, delete the `NPM_TOKEN` repo secret (no longer needed)