### PR TITLE
ci(release): drop registry-url to unblock OIDC npm publish

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -196,12 +196,19 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
-          registry-url: https://registry.npmjs.org
+          # No `registry-url` — when it's set, setup-node auto-injects
+          # NODE_AUTH_TOKEN into the job env (sourced from the `token`
+          # input, which defaults to ${{ github.token }}). npm CLI picks
+          # that up and uses token auth, bypassing the OIDC trusted
+          # publisher exchange. npmjs.org is the default registry anyway
+          # for unscoped packages, so dropping the line is functionally
+          # safe and is what unlocks OIDC.
 
       - name: Publish to npm
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-typescript'
         run: |
           npm install -g npm@latest
+          npm --version  # log npm version for OIDC trusted-publisher debugging (needs >= 11.5.1)
           VERSION="${{ matrix.version }}"
           if npm view "rocketride@${VERSION}" version 2>/dev/null; then
             echo "rocketride@${VERSION} already exists on npm — skipping"


### PR DESCRIPTION
## Summary

Follow-up to #976. That PR enabled OIDC trusted publishing for the TS client but the publish still failed because `actions/setup-node@v4` was auto-injecting `NODE_AUTH_TOKEN` into the publish step's env, preempting the OIDC flow.

## Root cause

setup-node's auth setup runs whenever `registry-url` is set. It:
1. Writes a `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`
2. Exports `NODE_AUTH_TOKEN` to the job env, sourced from its `with.token` input
3. The `token` input defaults to `${{ github.token }}` — the workflow's auto-injected GitHub token

With NODE_AUTH_TOKEN in env, npm CLI uses static-token auth (not the npm-recommended OIDC flow). The GITHUB_TOKEN isn't a valid npm credential, so the PUT returns 404 with the "permission denied" wording.

## Fix

Remove `registry-url` from the setup-node step. Then setup-node skips auth setup entirely — no `.npmrc`, no NODE_AUTH_TOKEN injection. npm CLI defaults to `https://registry.npmjs.org/` (npm's built-in default for unscoped packages like `rocketride`) and, finding no static token + seeing `--provenance`, performs the OIDC trusted-publisher exchange against the config already set up on npmjs.com (repo `rocketride-org/rocketride-server`, workflow `_release.yaml`, environment `release`).

Also logs `npm --version` after the explicit upgrade so future debugging can confirm npm >= 11.5.1 is in effect.

## Test plan

- [ ] CI green (Build / Ubuntu 22.04, gitleaks)
- [ ] After merge, release.yaml fires from main. TS Client step:
  - Logs `npm: 11.x.x` after the explicit upgrade
  - Auth path is OIDC (no NODE_AUTH_TOKEN in env)
  - PUT to `registry.npmjs.org/rocketride` succeeds with provenance attestation
- [ ] Delete the `NPM_TOKEN` repo secret after confirmation (no longer used)