### PR TITLE
ci(release): add diagnostic logging to TS publish to debug OIDC

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -208,14 +208,24 @@ jobs:
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-typescript'
         run: |
           npm install -g npm@latest
-          npm --version  # log npm version for OIDC trusted-publisher debugging (needs >= 11.5.1)
+          echo "=== OIDC env diagnostics ==="
+          echo "npm: $(npm --version)"
+          echo "CI=$CI"
+          echo "GITHUB_ACTIONS=$GITHUB_ACTIONS"
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL is $([ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && echo SET || echo UNSET)"
+          echo "ACTIONS_ID_TOKEN_REQUEST_TOKEN is $([ -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ] && echo SET || echo UNSET)"
+          echo "NODE_AUTH_TOKEN is $([ -n "$NODE_AUTH_TOKEN" ] && echo SET || echo UNSET)"
+          echo "npm config get registry: $(npm config get registry)"
+          ls -la "$RUNNER_TEMP/.npmrc" 2>/dev/null || echo ".npmrc not in RUNNER_TEMP"
+          ls -la "$HOME/.npmrc" 2>/dev/null || echo ".npmrc not in HOME"
+          echo "=== begin publish ==="
           VERSION="${{ matrix.version }}"
           if npm view "rocketride@${VERSION}" version 2>/dev/null; then
             echo "rocketride@${VERSION} already exists on npm — skipping"
           else
             TARBALL=$(find release-assets -name '*.tgz' | head -n1)
             echo "Publishing ${TARBALL}"
-            npm publish "./${TARBALL}" --access public --provenance
+            npm publish "./${TARBALL}" --access public --provenance --loglevel verbose
           fi
 
       # --- PyPI ---


### PR DESCRIPTION
## Summary

#976 + #977 set up OIDC trusted publishing for the TS client, but `npm publish --provenance` is failing with `ENEEDAUTH` instead of engaging the OIDC trusted-publisher exchange. npm 11.15.0 should auto-OIDC when running on GitHub Actions with `id-token: write`, but something isn't triggering.

This PR is **diagnostic-only**. It adds logging to surface:

- npm version (confirms 11.5+)
- `CI` / `GITHUB_ACTIONS` env vars
- `ACTIONS_ID_TOKEN_REQUEST_URL` / `_TOKEN` (OIDC env vars from `id-token: write`)
- `NODE_AUTH_TOKEN` (should be UNSET)
- `npm config get registry`
- presence of `.npmrc` files

And switches the publish to `--loglevel verbose` so the auth-flow internals are in the log.

Once we see what npm sees, the actual fix is one targeted commit away.

## Test plan

- [ ] CI green (Build / Ubuntu 22.04, gitleaks)
- [ ] After merge, the next release.yaml run logs the diagnostic block on the TS Client job