### PR TITLE
fix(engine): in-process clients connect to wrong port when engine binds to OS-assigned port

### DIFF
--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -661,13 +661,9 @@ class WebServer:
         """
         Get the port number on which the server is running.
 
-        Resolves the actual bound port lazily on first use. When the server is
-        configured with port=0 the OS picks an ephemeral port at bind time, but
-        the configured value stored in self._port stays 0. Uvicorn binds sockets
-        *after* the FastAPI lifespan startup hook runs, so the resolution cannot
-        happen at startup-time — it has to wait until the first caller (e.g. an
-        incoming request handler) asks for the port, by which point the sockets
-        are guaranteed to be bound.
+        Resolved lazily from the bound socket on first use: with port=0 the OS
+        assigns the real port at bind time, which uvicorn does *after* the
+        lifespan startup hook, so self._port is still 0 until a request arrives.
 
         Returns:
             int: The port number actually bound by uvicorn.
@@ -677,16 +673,16 @@ class WebServer:
             5565
         """
         if not self._port and self.server is not None:
-            try:
-                for srv in getattr(self.server, 'servers', None) or []:
-                    for sock in getattr(srv, 'sockets', None) or []:
+            for srv in getattr(self.server, 'servers', None) or []:
+                for sock in getattr(srv, 'sockets', None) or []:
+                    try:
                         bound = sock.getsockname()
-                        bound_port = bound[1] if isinstance(bound, tuple) and len(bound) >= 2 else None
-                        if bound_port:
-                            self._port = bound_port
-                            return self._port
-            except Exception:
-                pass
+                    except OSError:
+                        continue  # closed/bad socket; try the next one
+                    bound_port = bound[1] if isinstance(bound, tuple) and len(bound) >= 2 else None
+                    if bound_port:
+                        self._port = bound_port
+                        return self._port
         return self._port
 
     def registerStatusCallback(self, callback: Callable[[Dict[str, any]], None]) -> None:

--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -661,13 +661,32 @@ class WebServer:
         """
         Get the port number on which the server is running.
 
+        Resolves the actual bound port lazily on first use. When the server is
+        configured with port=0 the OS picks an ephemeral port at bind time, but
+        the configured value stored in self._port stays 0. Uvicorn binds sockets
+        *after* the FastAPI lifespan startup hook runs, so the resolution cannot
+        happen at startup-time — it has to wait until the first caller (e.g. an
+        incoming request handler) asks for the port, by which point the sockets
+        are guaranteed to be bound.
+
         Returns:
-            int: The port number.
+            int: The port number actually bound by uvicorn.
 
         Example:
             >>> port = get_port()
             5565
         """
+        if not self._port and self.server is not None:
+            try:
+                for srv in getattr(self.server, 'servers', None) or []:
+                    for sock in getattr(srv, 'sockets', None) or []:
+                        bound = sock.getsockname()
+                        bound_port = bound[1] if isinstance(bound, tuple) and len(bound) >= 2 else None
+                        if bound_port:
+                            self._port = bound_port
+                            return self._port
+            except Exception:
+                pass
         return self._port
 
     def registerStatusCallback(self, callback: Callable[[Dict[str, any]], None]) -> None:

--- a/packages/client-python/src/rocketride/mixins/connection.py
+++ b/packages/client-python/src/rocketride/mixins/connection.py
@@ -380,7 +380,11 @@ class ConnectionMixin(DAPClient):
 
         parsed = urllib.parse.urlparse(uri)
 
-        if not parsed.port and 'rocketride.ai' not in (parsed.hostname or ''):
+        # Use `is None` (not `not parsed.port`) so port=0 stays as 0 instead of
+        # being silently rewritten to CONST_DEFAULT_WEB_PORT. Port 0 reaching this
+        # code is a caller bug; the substitution would mask it as a connection
+        # error against the wrong host.
+        if parsed.port is None and 'rocketride.ai' not in (parsed.hostname or ''):
             hostname = parsed.hostname
             if not hostname:
                 raise ValueError(f"Invalid URI '{uri}': missing hostname")


### PR DESCRIPTION

## Summary

- `WebServer.get_port()` now lazily resolves the actual bound port from `uvicorn.Server.servers[*].sockets[*].getsockname()` on first call. Before this, when the launcher started the engine with `port=0` (let the OS pick a free port), `self._port` stayed `0` even though the OS assigned a real port — every consumer of `get_port()` got `0` instead of the listening port.
- `ConnectionMixin.normalize_uri()` now uses `parsed.port is None` instead of `not parsed.port`. The old check treated port `0` as falsy and silently rewrote `http://localhost:0` to `http://localhost:5565` (the default port constant), which made in-process clients try to connect to a port nothing was listening on.

The two bugs combined: webhook hit the engine on the real port → handler built `RocketRideClient(uri='http://localhost:0', ...)` → URI was rewritten to `ws://localhost:5565/task/service` → WebSocket connect refused with `WinError 1225`.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Manual repro before fix:

```
curl -X POST "http://localhost:<port>/webhook" \
  -H "Content-Type: application/json" \
  -H "Authorization: Bearer <api_key>" \
  -d '{"event":"test","message":"hello"}'

{"status":"Error","error":{"message":"[WinError 1225] The remote computer refused the network connection","file":"transport_websocket.py","lineno":411}}
```

After fix, the same curl returns `{"status":"OK", ...}` and the pipeline processes the payload.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #991



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Server now correctly detects and returns the actual OS-assigned port when a dynamic port is used, ensuring reported port matches the bound socket.
  * URI handling now preserves explicitly specified port values (including zero) instead of substituting a default, while retaining hostname-specific behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->