### PR TITLE
feat(check-externals): CI framework to detect 3rd-party Python interface drift

### DIFF
--- a/.github/workflows/check-externals.yml
+++ b/.github/workflows/check-externals.yml
@@ -1,0 +1,208 @@
+name: check-externals
+run-name: check-externals ${{ github.event_name == 'schedule' && '(nightly)' || '(pr)' }}
+
+# Third-party interface contract checks. Verifies that the Python packages the
+# engine depends on still expose the symbols + call chains our code uses, before
+# a breaking upstream release reaches a customer. See tools/contract_checks/README.md.
+#
+# Two lanes:
+#   * PR lane     — fast, markers respected, NON-BLOCKING during stabilization
+#                   (continue-on-error). Heavy `skip-install` bundles are skipped.
+#   * Nightly lane — full install (--install-all), fresh constraints
+#                   (--rebuild-cache). Catches upstream releases the day they ship.
+#
+# PHASE 1 (this file): failures surface as GitHub Actions warning annotations
+# only. The auto-issue-creation step is included but COMMENTED OUT — enable it
+# in a later phase once the lane has proven stable.
+#
+# ENGINE BUILD ASSUMPTION: the builder's server:build step downloads a PREBUILT
+# engine when the C++ source hash matches a published release, and only compiles
+# otherwise (packages/server/scripts/tasks.js: server:download). This framework
+# targets Python/JS/YAML changes, which leave the engine hash unchanged, so the
+# prebuilt downloads cleanly — no vcpkg/submodules/compilers needed here, which
+# is why neither job sets `submodules: recursive`. If a FUTURE PR changes engine
+# C++ source, the prebuilt won't match and server:download falls through to a
+# full compile — this lane would then need the vcpkg/submodule/nuget setup that
+# _build.yaml carries (or to reuse a built engine via workflow_run). Add it then.
+
+on:
+  pull_request:
+    branches: [develop, stage, main, 'release/**']
+    paths:
+      - 'packages/**'
+      - 'nodes/**'
+      - 'tools/contract_checks/**'
+      - '.github/workflows/check-externals.yml'
+  merge_group:
+    types: [checks_requested]
+  schedule:
+    - cron: '0 3 * * *'   # 03:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      install_all:
+        description: 'Pass --install-all (override skip-install markers)'
+        type: boolean
+        default: false
+
+# PR runs cancel on push; the nightly run does not cancel itself (a partial
+# nightly is more useful than none).
+concurrency:
+  group: check-externals-${{ github.event_name == 'schedule' && 'nightly' || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
+permissions:
+  contents: read
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  VCPKG_NUGET_USER: ${{ github.repository_owner }}
+  NUGET_FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+  VCPKG_BINARY_SOURCES: clear;nuget,https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json,readwrite
+
+jobs:
+  # ===========================================================================
+  # PR lane — non-blocking, markers respected, fast
+  # ===========================================================================
+  pr:
+    name: check-externals (PR)
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    runs-on: ubuntu-latest
+    # NON-BLOCKING during stabilization. Flip to false in PR3 to make it a
+    # required check (and add it to the CI OK aggregator's needs:).
+    continue-on-error: true
+    timeout-minutes: 30
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          version: 10.33.0
+
+      - name: Run check-externals (markers respected)
+        # The builder task's own steps build the engine + the four trees, then
+        # invoke the CLI. No --install-all: the 7 skip-install bundles and the
+        # 2 disable files stay uninstalled (fast). Tee the output so the
+        # annotate step can scan it.
+        #
+        # --autoinstall: let the builder install its own Node deps + missing
+        #                tooling on a fresh runner (mirrors _build.yaml's Build).
+        shell: bash
+        run: |
+          set -o pipefail
+          ./builder check-externals:run --autoinstall 2>&1 | tee check-externals.log
+
+      - name: Annotate failures
+        # Always run so warnings surface even when the run "succeeded"
+        # (failures don't set a non-zero exit when continue-on-error masks it,
+        # and [install-failed] lines never set non-zero by design).
+        if: always()
+        shell: bash
+        run: |
+          # FAIL rows = real interface drift; install-failed = install-layer drift.
+          grep -E '^\[FAIL\]' check-externals.log | while IFS= read -r line; do
+            echo "::warning title=check-externals drift::${line}"
+          done || true
+          grep -E '^\[install-failed\]' check-externals.log | while IFS= read -r line; do
+            echo "::warning title=check-externals install-failed::${line}"
+          done || true
+
+  # ===========================================================================
+  # Nightly lane — full install, fresh constraints, drift detection
+  # ===========================================================================
+  nightly:
+    name: check-externals (nightly)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    # PHASE 1: issues: write is NOT needed yet (auto-issue step is commented
+    # out below). Uncomment the permission when enabling that step.
+    # permissions:
+    #   contents: read
+    #   issues: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
+        with:
+          version: 10.33.0
+
+      - name: Run check-externals
+        # --rebuild-cache: full uv pip compile from scratch (catches upstream
+        #                  releases since the last constraint resolution).
+        # --install-all:   install the 7 skip-install bundles and verify them.
+        #                  The 2 disable files (surya/trocr) stay skipped —
+        #                  disable beats install-all.
+        # workflow_dispatch can opt out of --install-all via the input.
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INSTALL_ALL_INPUT: ${{ github.event.inputs.install_all }}
+        run: |
+          set -o pipefail
+          INSTALL_ALL='--install-all'
+          if [ "$EVENT_NAME" = "workflow_dispatch" ] && [ "$INSTALL_ALL_INPUT" = "false" ]; then
+            INSTALL_ALL=''
+          fi
+          ./builder check-externals:run --rebuild-cache $INSTALL_ALL --autoinstall 2>&1 | tee check-externals.log
+
+      - name: Annotate failures
+        if: always()
+        shell: bash
+        run: |
+          grep -E '^\[FAIL\]' check-externals.log | while IFS= read -r line; do
+            echo "::warning title=check-externals drift::${line}"
+          done || true
+          grep -E '^\[install-failed\]' check-externals.log | while IFS= read -r line; do
+            echo "::warning title=check-externals install-failed::${line}"
+          done || true
+
+      # -----------------------------------------------------------------------
+      # PHASE 2 (NOT YET ENABLED): auto-file a GitHub issue on nightly failure.
+      #
+      # Phase 1 keeps failures as warning annotations only (above). When the
+      # lane has proven stable, uncomment this step AND the `issues: write`
+      # permission on this job. The existing .github/workflows/discord-issues.yml
+      # bridge will mirror the new issue to the team channel automatically.
+      #
+      # NOTE: this auto-FILES AN ISSUE (drift detected → someone go fix). It does
+      # NOT open a pull request — there's no auto-generated change to propose.
+      # If a fix-PR workflow is wanted later, that's a separate design.
+      # -----------------------------------------------------------------------
+      # - name: Auto-file issue on failure
+      #   if: failure() && github.event_name == 'schedule'
+      #   uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+      #   with:
+      #     script: |
+      #       const fs = require('fs');
+      #       let log = '';
+      #       try { log = fs.readFileSync('check-externals.log', 'utf8'); } catch (e) {}
+      #       const fails = log.split('\n').filter(l => l.startsWith('[FAIL]') || l.startsWith('[install-failed]'));
+      #       const date = new Date().toISOString().split('T')[0];
+      #       const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+      #       const body = [
+      #         `Nightly \`check-externals\` run detected interface drift.`,
+      #         ``,
+      #         `Run: ${runUrl}`,
+      #         ``,
+      #         '```',
+      #         ...(fails.length ? fails : ['(no [FAIL]/[install-failed] lines captured — see run log)']),
+      #         '```',
+      #         ``,
+      #         `Triage:`,
+      #         `- \`[FAIL]\` = upstream interface drift (update consuming code, add an applies_when/any_of manifest, or pin the version).`,
+      #         `- \`[install-failed]\` = install-layer change (a previously installable bundle regressed, or a disable'd file's conflict resolved).`,
+      #       ].join('\n');
+      #       await github.rest.issues.create({
+      #         ...context.repo,
+      #         title: `check-externals nightly drift (${date})`,
+      #         body,
+      #         labels: ['check-externals', 'bug'],
+      #       });

--- a/.github/workflows/check-externals.yml
+++ b/.github/workflows/check-externals.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Install engine runtime libraries
         shell: bash
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libc++1 libc++abi1 libgomp1
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libc++1 libc++abi1 libgomp1 libportaudio2 libgl1 libglib2.0-0
 
       - name: Run check-externals (markers respected)
         # The builder task's own steps build the engine + the four trees, then
@@ -144,7 +144,7 @@ jobs:
 
       - name: Install engine runtime libraries
         shell: bash
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libc++1 libc++abi1 libgomp1
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libc++1 libc++abi1 libgomp1 libportaudio2 libgl1 libglib2.0-0
 
       - name: Run check-externals
         # --rebuild-cache: full uv pip compile from scratch (catches upstream

--- a/.github/workflows/check-externals.yml
+++ b/.github/workflows/check-externals.yml
@@ -20,7 +20,11 @@ run-name: check-externals ${{ github.event_name == 'schedule' && '(nightly)' || 
 # otherwise (packages/server/scripts/tasks.js: server:download). This framework
 # targets Python/JS/YAML changes, which leave the engine hash unchanged, so the
 # prebuilt downloads cleanly — no vcpkg/submodules/compilers needed here, which
-# is why neither job sets `submodules: recursive`. If a FUTURE PR changes engine
+# is why neither job sets `submodules: recursive`. The prebuilt still links
+# libc++/libgomp at runtime, though; _build.yaml gets those from its compile
+# toolchain, so this lane installs them explicitly (see the runtime-libraries
+# step) and pins ubuntu-22.04 to match the prebuilt's jammy build target.
+# If a FUTURE PR changes engine
 # C++ source, the prebuilt won't match and server:download falls through to a
 # full compile — this lane would then need the vcpkg/submodule/nuget setup that
 # _build.yaml carries (or to reuse a built engine via workflow_run). Add it then.
@@ -66,7 +70,7 @@ jobs:
   pr:
     name: check-externals (PR)
     if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     # NON-BLOCKING during stabilization. Flip to false in PR3 to make it a
     # required check (and add it to the CI OK aggregator's needs:).
     continue-on-error: true
@@ -81,6 +85,10 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.33.0
+
+      - name: Install engine runtime libraries
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libc++1 libc++abi1 libgomp1
 
       - name: Run check-externals (markers respected)
         # The builder task's own steps build the engine + the four trees, then
@@ -116,7 +124,7 @@ jobs:
   nightly:
     name: check-externals (nightly)
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 90
     # PHASE 1: issues: write is NOT needed yet (auto-issue step is commented
     # out below). Uncomment the permission when enabling that step.
@@ -133,6 +141,10 @@ jobs:
         uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
         with:
           version: 10.33.0
+
+      - name: Install engine runtime libraries
+        shell: bash
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libc++1 libc++abi1 libgomp1
 
       - name: Run check-externals
         # --rebuild-cache: full uv pip compile from scratch (catches upstream

--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -53,7 +53,8 @@ except Exception:
 
 # 3) Disable real token counting ONLY for Claude models to avoid transformer usage
 try:
-    import langchain_core.utils.tokenization as _tok  # type: ignore
+    # tokenization is optional, ignore it contract-check
+    import langchain_core.utils.tokenization as _tok  # type: ignore  # contract-check: ignore
 
     _orig_get_token_ids = _tok.get_token_ids
 

--- a/nodes/src/nodes/llm_mistral/IGlobal.py
+++ b/nodes/src/nodes/llm_mistral/IGlobal.py
@@ -57,7 +57,7 @@ class IGlobal(IGlobalBase):
                 from mistralai import Mistral  # 1.x layout
 
             try:
-                from mistralai.exceptions import MistralException  # type: ignore
+                from mistralai.exceptions import MistralException  # type: ignore  # contract-check: ignore  optional, falls back to built-in Exception
             except Exception:
                 MistralException = Exception  # type: ignore
 

--- a/nodes/src/nodes/ocr/README.md
+++ b/nodes/src/nodes/ocr/README.md
@@ -46,6 +46,21 @@ Extracts text and tables from images using optical character recognition. Accept
 | Surya (Multi-language)      | Surya   | Broad language support                         |
 | TrOCR (Transformer)         | TrOCR   | Transformer-based, English                     |
 
+## OpenCV compatibility
+
+All four engines share the `cv2` namespace but disagree on which OpenCV PyPI package and version they want. The project installs a single unified build — `opencv-contrib-python==4.13.0.92` — via `ai.common.opencv`, which also uninstalls competing variants (`opencv-python`, `opencv-python-headless`, `opencv-contrib-python-headless`) so only one `cv2` is active at runtime.
+
+Upstream pins (as of the versions currently used):
+
+| Engine  | PyPI package                               | Upstream OpenCV requirement           | Matches project's 4.13.0.92? |
+| ------- | ------------------------------------------ | ------------------------------------- | ---------------------------- |
+| EasyOCR | `easyocr` 1.7.2                            | `opencv-python-headless` (unpinned)   | Yes                          |
+| DocTR   | `python-doctr` 1.0.1                       | `opencv-python <5.0.0, >=4.5.0`       | Yes                          |
+| Surya   | `surya-ocr` 0.17.1                         | `opencv-python-headless==4.11.0.86`   | No — hard pin to 4.11.0.86   |
+| TrOCR   | `craft-text-detector` 0.4.3 (detector dep) | `opencv-python <4.5.4.62, >=3.4.8.29` | No — caps below 4.5.4.62     |
+
+Surya and TrOCR's detector pin OpenCV to versions the project deliberately overrides. They work because `ai.common.opencv` runs `depends()` at import time and force-aligns all four OpenCV variants to 4.13.0.92 _after_ the engines are installed. Always `from ai.common.opencv import cv2` before importing an OCR engine, or the wrong `cv2` may be resolved.
+
 ## Upstream docs
 
 - [EasyOCR](https://github.com/JaidedAI/EasyOCR)

--- a/nodes/src/nodes/ocr/external_contracts.py
+++ b/nodes/src/nodes/ocr/external_contracts.py
@@ -1,0 +1,98 @@
+"""
+Optional contract overrides for the ocr node.
+
+You almost certainly don't need to touch this file.
+
+----------------------------------------------------------------------
+What this file is
+----------------------------------------------------------------------
+A small declarative manifest read by the ``check-externals`` framework
+at ``tools/contract_checks/``. The framework verifies, in CI, that the
+``img2table`` package still exposes the symbols this node depends on.
+When upstream ships a breaking API change, CI tells us *before* it
+ships to a customer.
+
+For everything you'd want to know about the framework — how to read
+its output, when to edit a manifest, what `applies_when` does — see:
+    tools/contract_checks/README.md
+
+----------------------------------------------------------------------
+Why this manifest exists
+----------------------------------------------------------------------
+``img2table 2.0`` (released 2026-05-10) reorganised the OCR plug-in
+API significantly:
+
+* ``OCRInstance`` moved from ``img2table.ocr.base`` to
+  ``img2table.ocr._types``.
+* The ``content`` / ``to_ocr_dataframe`` contract was replaced by a
+  single ``of()`` returning ``OCRData``.
+* ``OCRDataframe`` (the v1 result type, in ``img2table.ocr.data``) is
+  gone in v2.
+* ``OCRData`` (the v2 result type, in ``img2table.ocr._types``) doesn't
+  exist in v1.
+
+The OCR node's ``IGlobal.py`` runs different code paths on v1 vs v2,
+guarded by an ``_IMG2TABLE_V2`` flag. Both code paths import what they
+need lazily inside the method that uses them. From a static-analysis
+perspective each import looks unconditional, so the framework would
+flag the unreachable v1 imports on a v2 install (and vice-versa).
+
+This manifest expresses the version split directly: each version-only
+import declares ``applies_when='<2.0'`` or ``applies_when='>=2.0'``.
+The framework gates the check on the installed img2table version and
+emits ``[SKIP]`` for entries that don't apply.
+
+----------------------------------------------------------------------
+When you'd modify this
+----------------------------------------------------------------------
+* img2table ships v3 with another module reshuffle
+  -> add a third version-tagged entry (e.g.,
+     ``applies_when='>=3.0'``) and adjust the older ones.
+* The OCR node stops supporting img2table v1 entirely
+  -> remove all ``applies_when='<2.0'`` entries.
+* You add a new img2table import to ``IGlobal.py`` that's available on
+  every version we care about
+  -> nothing to do; auto-extraction will pick it up unconditionally.
+
+----------------------------------------------------------------------
+When you'd delete this entirely
+----------------------------------------------------------------------
+You can — but then auto-extraction sees the version-gated imports as
+unconditional, and CI will go red on whichever img2table version is
+installed. Don't delete unless the OCR node is also rewritten to import
+only the common subset.
+"""
+
+from contract_checks.manifest import ComponentManifest, ImportRequirement
+
+MANIFEST = ComponentManifest(
+    imports=(
+        # OCRInstance — the base class — lives in different modules on
+        # v1 vs v2. Two version-tagged entries replace what would
+        # otherwise be an AnyOf, and read more like a changelog.
+        ImportRequirement(
+            module='img2table.ocr.base',
+            symbols=('OCRInstance',),
+            applies_when='<2.0',
+        ),
+        ImportRequirement(
+            module='img2table.ocr._types',
+            symbols=('OCRInstance',),
+            applies_when='>=2.0',
+        ),
+        # OCRDataframe — v1 result type, used by the legacy
+        # `to_ocr_dataframe` code path. Removed in v2.
+        ImportRequirement(
+            module='img2table.ocr.data',
+            symbols=('OCRDataframe',),
+            applies_when='<2.0',
+        ),
+        # OCRData — v2 result type, returned by the new `of()` method.
+        # Did not exist in v1.
+        ImportRequirement(
+            module='img2table.ocr._types',
+            symbols=('OCRData',),
+            applies_when='>=2.0',
+        ),
+    ),
+)

--- a/nodes/src/nodes/pinecone/IGlobal.py
+++ b/nodes/src/nodes/pinecone/IGlobal.py
@@ -152,7 +152,8 @@ class IGlobal(IGlobalTransform):
         except Exception as e:
             # Prefer SDK/HTTP structured attributes if available
             try:
-                from pinecone.core.client.exceptions import ApiException as _ApiException  # type: ignore
+                # exception is optional, ignore it by contract-check if not present
+                from pinecone.core.client.exceptions import ApiException as _ApiException  # type: ignore  # contract-check: ignore
 
                 if isinstance(e, _ApiException):
                     status = getattr(e, 'status', None)

--- a/packages/ai/src/ai/common/models/audio/requirements_kokoro.txt
+++ b/packages/ai/src/ai/common/models/audio/requirements_kokoro.txt
@@ -1,3 +1,4 @@
+# contract-check: skip-install  reason: ~200 MB of audio-model deps (misaki, librosa, einops) for an opt-in feature. PR lane skips; nightly --install-all installs and verifies.
 # Kokoro-82M inference (model server + local); torch from image
 kokoro>=0.9.4
 soundfile>=0.12.0

--- a/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
+++ b/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
@@ -1,3 +1,4 @@
+# contract-check: skip-install  reason: ~400 MB of ASR deps (ctranslate2, av, onnxruntime) for an opt-in feature. PR lane skips; nightly --install-all installs and verifies.
 # Requirements for Whisper loader
 # Direct imports only
 

--- a/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
+++ b/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
@@ -1,3 +1,4 @@
+# contract-check: skip-install  reason: ~300 MB of NER deps (transformers, onnxruntime) plus a python-mecab-ko C-extension compile, for an opt-in feature. PR lane skips; nightly --install-all installs and verifies.
 gliner
 # needed for gliner_ko
 python-mecab-ko

--- a/packages/ai/src/ai/common/models/ocr/README.md
+++ b/packages/ai/src/ai/common/models/ocr/README.md
@@ -1,0 +1,36 @@
+# `ai.common.models.ocr`
+
+Loaders and user-facing classes for the four supported OCR engines:
+
+| Engine  | Loader            | User class | Requirements file          |
+| ------- | ----------------- | ---------- | -------------------------- |
+| EasyOCR | `EasyOCRLoader`   | `EasyOCR`  | `requirements_easyocr.txt` |
+| DocTR   | `DocTRLoader`     | `DocTR`    | `requirements_doctr.txt`   |
+| Surya   | `SuryaLoader`     | `Surya`    | `requirements_surya.txt`   |
+| TrOCR   | `TrOCRLoader`     | `TrOCR`    | `requirements_trocr.txt`   |
+
+Each loader exposes `load / preprocess / inference / postprocess` for use by the model server and local-mode connectors. Each user class auto-detects model-server mode via `get_model_server_address()` and falls back to local execution otherwise.
+
+## OpenCV compatibility
+
+All four engines share the `cv2` namespace but disagree on which OpenCV PyPI package and version they want. The project installs a single unified build — `opencv-contrib-python==4.13.0.92` — via `ai.common.opencv`, which also uninstalls competing variants (`opencv-python`, `opencv-python-headless`, `opencv-contrib-python-headless`) so only one `cv2` is active at runtime.
+
+Upstream pins (as of the versions currently used):
+
+| Engine  | PyPI package                               | Upstream OpenCV requirement           | Matches project's 4.13.0.92? |
+| ------- | ------------------------------------------ | ------------------------------------- | ---------------------------- |
+| EasyOCR | `easyocr` 1.7.2                            | `opencv-python-headless` (unpinned)   | Yes                          |
+| DocTR   | `python-doctr` 1.0.1                       | `opencv-python <5.0.0, >=4.5.0`       | Yes                          |
+| Surya   | `surya-ocr` 0.17.1                         | `opencv-python-headless==4.11.0.86`   | No — hard pin to 4.11.0.86   |
+| TrOCR   | `craft-text-detector` 0.4.3 (detector dep) | `opencv-python <4.5.4.62, >=3.4.8.29` | No — caps below 4.5.4.62     |
+
+Surya and TrOCR's detector pin OpenCV to versions the project deliberately overrides. They work because `ai.common.opencv` runs `depends()` at import time and force-aligns all four OpenCV variants to 4.13.0.92 _after_ the engines are installed.
+
+**Loader convention:** every loader imports `from ai.common.opencv import cv2` (see `doctr.py`, `easyocr.py`, `surya.py`, `trocr.py`) _before_ touching the engine's own imports. This guarantees the project's `cv2` is resolved first and any conflicting variant pulled in transitively is uninstalled by the shim. When adding a new loader, follow the same pattern.
+
+## Upstream docs
+
+- [EasyOCR](https://github.com/JaidedAI/EasyOCR)
+- [DocTR documentation](https://mindee.github.io/doctr/)
+- [Surya](https://github.com/VikParuchuri/surya)
+- [craft-text-detector (TrOCR detector)](https://github.com/fcakyon/craft-text-detector)

--- a/packages/ai/src/ai/common/models/ocr/requirements_doctr.txt
+++ b/packages/ai/src/ai/common/models/ocr/requirements_doctr.txt
@@ -1,3 +1,4 @@
+# contract-check: skip-install  reason: opt-in OCR engine; ~50 MB on top of the project's torch baseline. PR lane skips; nightly --install-all installs and verifies.
 # Requirements for docTR loader
 # Direct imports only
 # opencv is handled by ai.common.opencv module

--- a/packages/ai/src/ai/common/models/ocr/requirements_easyocr.txt
+++ b/packages/ai/src/ai/common/models/ocr/requirements_easyocr.txt
@@ -1,3 +1,4 @@
+# contract-check: skip-install  reason: opt-in OCR engine; ~150 MB (CRAFT detector + scipy) on top of the project's torch baseline. PR lane skips; nightly --install-all installs and verifies.
 # Requirements for EasyOCR loader
 # Direct imports only
 # opencv is handled by ai.common.opencv module

--- a/packages/ai/src/ai/common/models/ocr/requirements_surya.txt
+++ b/packages/ai/src/ai/common/models/ocr/requirements_surya.txt
@@ -1,3 +1,4 @@
+# contract-check: disable  reason: surya-ocr transitively pins opencv-python-headless==4.11.0.86; the engine's opencv-contrib-python==4.13.0.92 wins via the ai.common.opencv runtime shim. uv resolver can't replay that override, so the install will always fail. NEVER attempted by the framework, even under --install-all. Paired with `# contract-check: ignore` on the surya.* imports in surya.py.
 # Requirements for Surya OCR loader
 # Direct imports only
 

--- a/packages/ai/src/ai/common/models/ocr/requirements_trocr.txt
+++ b/packages/ai/src/ai/common/models/ocr/requirements_trocr.txt
@@ -1,3 +1,4 @@
+# contract-check: disable  reason: craft-text-detector transitively pins opencv-python<4.5.4.62; the engine's opencv-contrib-python==4.13.0.92 wins via the ai.common.opencv runtime shim. uv resolver can't replay that override, so the install will always fail. NEVER attempted by the framework, even under --install-all. Paired with `# contract-check: ignore` on the craft_text_detector import in trocr.py.
 # Requirements for TrOCR loader (detection + recognition)
 # Direct imports only
 # opencv is handled by ai.common.opencv module

--- a/packages/ai/src/ai/common/models/ocr/surya.py
+++ b/packages/ai/src/ai/common/models/ocr/surya.py
@@ -64,9 +64,10 @@ class SuryaLoader(BaseLoader):
         # Import opencv first to ensure correct version (may be used by surya)
         from ai.common.opencv import cv2  # noqa: F401
 
-        from surya.foundation import FoundationPredictor
-        from surya.recognition import RecognitionPredictor
-        from surya.detection import DetectionPredictor
+        # disable contract check for surya due to opencv conflict (see README)
+        from surya.foundation import FoundationPredictor  # contract-check: ignore  see comment above
+        from surya.recognition import RecognitionPredictor  # contract-check: ignore  see comment above
+        from surya.detection import DetectionPredictor  # contract-check: ignore  see comment above
         from ai.common.torch import torch
 
         languages = languages or ['en']

--- a/packages/ai/src/ai/common/models/ocr/trocr.py
+++ b/packages/ai/src/ai/common/models/ocr/trocr.py
@@ -86,7 +86,8 @@ class TrOCRLoader(BaseLoader):
         # is installed and any conflicting opencv packages are removed
         from ai.common.opencv import cv2  # noqa: F401
 
-        from craft_text_detector import Craft
+        # disable contract check for craft_text_detector due to opencv conflict (see README)
+        from craft_text_detector import Craft  # contract-check: ignore  requirements_trocr.txt is `disable`d
         from transformers import TrOCRProcessor, VisionEncoderDecoderModel
         from ai.common.torch import torch
 

--- a/packages/ai/src/ai/common/models/transformers/requirements_sentence_transformers.txt
+++ b/packages/ai/src/ai/common/models/transformers/requirements_sentence_transformers.txt
@@ -1,3 +1,4 @@
+# contract-check: skip-install  reason: ~100 MB (sentence-transformers + scikit-learn) for an opt-in embedding loader. PR lane skips; nightly --install-all installs and verifies.
 # Requirements for SentenceTransformer loader
 # Direct imports only
 

--- a/packages/ai/src/ai/common/models/vision/requirements_vision.txt
+++ b/packages/ai/src/ai/common/models/vision/requirements_vision.txt
@@ -1,3 +1,4 @@
+# contract-check: skip-install  reason: ~50 MB on top of the transformers baseline for an opt-in vision-embedding loader. PR lane skips; nightly --install-all installs and verifies.
 # Vision (CLIP / ViT) image embedding
 # torch via ai.common.torch
 

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -82,6 +82,12 @@ function parseArgs(args) {
 			options.pytest.push(arg.substring('--pytest='.length));
 		} else if (arg.startsWith('--pytest-pattern=')) {
 			options.pytestPattern = arg.substring('--pytest-pattern='.length);
+		} else if (arg.startsWith('--pattern=')) {
+			// Generic substring filter. check-externals:run accumulates
+			// these into a list (multiple --pattern values = OR semantics);
+			// pytest-based tasks join them into a single -k expression.
+			options.pattern = options.pattern || [];
+			options.pattern.push(arg.substring('--pattern='.length));
 		} else if (arg.startsWith('--pytest-preinstall=')) {
 			options.pytestPreinstall = arg.substring('--pytest-preinstall='.length);
 		} else if (arg.startsWith('--pytest-parallel=')) {
@@ -121,6 +127,15 @@ function parseArgs(args) {
 				console.error(`Invalid --arch value: ${archValue}. Use 'arm' or 'intel'.`);
 				process.exit(1);
 			}
+		} else if (arg === '--rebuild-cache') {
+			// test-integrity: nuke <engine-cache>/{constraints.txt,requirements.hash}
+			// so depends.ensure_constraints() does a full uv pip compile.
+			options.rebuildCache = true;
+		} else if (arg === '--install-all') {
+			// check-externals:run: ignore `# contract-check: skip-install`
+			// markers in requirements files and install everything.
+			// PR lanes respect markers (fast); nightly uses this flag.
+			options.installAll = true;
 		} else if (arg === '--saas') {
 			options.saas = true;
 		} else if (arg === '--modelserver') {
@@ -225,8 +240,11 @@ Options:
   --overlay-root=DIR  Set overlay root directory
   --pytest="args"     Pass arguments to pytest (can be repeated)
   --pytest-parallel=N|auto|off  Run pytest with N xdist workers; default: min(cpus, 8). Use 'off' or '0' to disable.
+  --pattern="SUBSTR"  Generic substring filter (check-externals:run)
   --pytest-pattern="EXPR"  Filter pytest tests by name expression (pytest -k)
   --pytest-preinstall="DEPS" Pre-install pip packages before tests (comma-separated)
+  --install-all       check-externals:run: ignore # contract-check: skip-install markers, install every requirement*.txt
+  --rebuild-cache     check-externals:run: force ensure_constraints() to recompile (deletes constraints.txt + requirements.hash)
   --saas              Enable SaaS mode
   --sequential, -s    Run modules sequentially (default: parallel)
   --simulate-gpus=N   Simulate N virtual GPUs on cuda:0 (model_server:dev)

--- a/tools/contract_checks/README.md
+++ b/tools/contract_checks/README.md
@@ -1,0 +1,460 @@
+# check-externals — 3rd-party interface contract tests
+
+Catches breaking API changes in upstream Python packages **before** they ship to customers.
+
+## Why this exists
+
+In May 2026, `img2table 2.0` moved `OCRInstance` from `img2table.ocr.base` to `img2table.ocr._types`. Our OCR node started failing in production with `No module named 'img2table.ocr.base'`. The fix landed in [commit c4aa67921](https://github.com/aparavi/rocketride-server/commit/c4aa67921), but only **after** the breakage shipped — we found out from a customer.
+
+This tool catches the next one in CI instead.
+
+## What it does
+
+For every `.py` file in `nodes/`, `packages/ai/`, `packages/client-python/`, and `packages/server/engine-lib/rocketlib-python/`, the framework:
+
+1. Walks the AST to find every third-party `import` and every attribute chain you use on the imported objects.
+2. Builds a per-component contract automatically — no manual work needed for ~90% of code.
+3. At test time, tries to import each symbol and walk each chain against the **installed** package versions. If anything is missing, the test fails and names the broken `(tree, component, package)`.
+
+It never calls real APIs. It only loads modules and reads attributes.
+
+## Run it locally
+
+```sh
+# Full suite (builds engine + all 4 trees first)
+./builder.cmd check-externals:run
+
+# Force a fresh constraint resolution (deletes the engine's constraints cache)
+./builder.cmd check-externals:run --rebuild-cache
+
+# Filter to one package / one node (substring match on `<tree>/<component>/<package>`)
+./builder.cmd check-externals:run --pattern=twelvelabs
+
+# Unit tests for the framework itself (fast — only builds the engine)
+./builder.cmd check-externals:test
+```
+
+## Options reference
+
+There are two ways to invoke the framework: via `builder` (recommended; handles build deps + engine resolution) or directly under the engine binary (faster iteration; assumes everything is already built). The flag set differs slightly between the two layers.
+
+### Builder flags (`./builder.cmd check-externals:run|test`)
+
+| Flag | Applies to | What it does |
+| ---- | ---------- | ------------ |
+| `--rebuild-cache` | `:run` | Deletes `<engine>/cache/constraints.txt` AND `<engine>/cache/requirements.hash`, forcing `ensure_constraints()` to recompile via `uv pip compile` from scratch. Used by the nightly cron lane to catch fresh upstream releases. |
+| `--pattern=SUBSTR` | `:run`, `:test` | Generic substring filter passed to the underlying invocation. For `:run` it filters triple ids (`<tree>/<component>/<package>`). For `:test` it maps to pytest's `-k` expression. **Repeatable** — multiple `--pattern=` values combine with OR semantics for `:run` (forwarded as separate `--pattern` flags to the CLI), and are joined with ` or ` into a single `-k` expression for `:test` (pytest only accepts one `-k`). |
+| `--pytest-pattern=EXPR` | `:run`, `:test` | Back-compat alias. Single-value (overwrites on repeat). Same behavior as `--pattern` for `:run`; reaches pytest's `-k` for `:test`. Prefer `--pattern` going forward, especially when you want repeat semantics. |
+
+Plus the standard global builder flags (`--verbose`, `--force`, `--log=FILE`, etc.) — see `./builder.cmd --help` for the full list.
+
+### Direct CLI flags (`engine tools/contract_checks/cli.py`)
+
+Use these when the engine + trees are already built and you want a faster inner loop without the builder pipeline. Same `check-externals:run-checks` action runs internally, just without the build-step preamble.
+
+**Flags marked "repeatable" below can be specified multiple times** — repeated values combine with **OR semantics within the flag** (any match accepts the row), **AND across flags** (e.g., `--tree=nodes --tree=ai --package=requests` = "rows where tree ∈ {nodes, ai} AND package == requests").
+
+| Flag | Repeatable? | What it does |
+| ---- | ----------- | ------------ |
+| `--tree=NAME` | yes | Limit the run to one or more configured trees. Valid names: `nodes`, `ai`, `client-python`, `rocketlib` (see [trees.py](src/contract_checks/trees.py) for the full list). Omit to run all four. Multiple: `--tree=nodes --tree=ai`. |
+| `--package=NAME` | yes | Limit checks to one or more third-party packages by **exact top-level name** (e.g., `requests`, `img2table`, `twelvelabs`). Walks every tree+component but only reports rows for those packages. Multiple: `--package=requests --package=img2table`. |
+| `--pattern=SUBSTR`, `-k SUBSTR` | yes | **Substring** filter on the full triple id `<tree>/<component>/<package>`. Looser than `--package`: `--pattern=db_` matches `db_mysql`, `db_neo4j`, etc. Multiple-pattern OR: `--pattern=img --pattern=twelve` matches either substring. |
+| `--requirements=FILE` | yes | Limit checks to packages listed in the given `requirements.txt`. Reads the file, normalises distribution names per PEP 503 (`PyYAML` → `pyyaml`), then maps them to Python module names via `importlib.metadata.packages_distributions()` (so `Pillow` correctly resolves to `PIL`). Useful for "*I just bumped this requirements file — verify everything it affects.*" Multiple files: the resolved package sets are unioned. |
+| `--no-install` | no | Skip the per-component `depends()` calls entirely. Only verifies what's already installed in the engine's site-packages. Big speedup for iteration when you know the env is already correct; misses packages that need installing. |
+| `--fail-on-missing` | no | Treat "package not installed in engine env" as a hard failure instead of a `[SKIP]`. Default behavior is skip — the lane's job is to flag interface drift, not absence. Useful when you want to confirm everything that *should* be installed actually is. |
+| `--install-all` | no | Ignore `# contract-check: skip-install` markers in requirements files and attempt to install every `requirement*.txt` under the scanned trees. PR lanes respect the markers (fast); nightly cron lanes use this flag for full coverage. See [`# contract-check: skip-install`](#-contract-check-skip-install) below. |
+| `--verbose`, `-v` | no | Print `OK` and `SKIP` rows in addition to `FAIL`. **Default is FAIL-only**: the framework stays quiet when everything is green so red rows pop out, and the summary line (`N passed, M skipped, K failed`) always prints regardless. Turn on for debugging or when you want to confirm exactly which entries the framework saw and skipped. |
+
+### Examples
+
+```sh
+# Verify everything across all four trees (slow first time; cached after)
+./builder.cmd check-externals:run
+
+# Just the twelvelabs node, full builder pipeline
+./builder.cmd check-externals:run --pattern=twelvelabs
+
+# Iterate on the framework — direct invocation, only verify packages already installed
+engine tools/contract_checks/cli.py --tree=nodes --package=img2table --no-install
+
+# Verify everything affected by a requirements.txt change (useful before pushing a dep bump)
+engine tools/contract_checks/cli.py --requirements=nodes/src/nodes/db_mysql/requirements.txt
+
+# Two trees at once
+engine tools/contract_checks/cli.py --tree=nodes --tree=ai
+
+# Two packages, OR semantics — see rows for either
+engine tools/contract_checks/cli.py --package=img2table --package=twelvelabs
+
+# Two substring patterns, OR semantics — matches "img2table" AND "twelvelabs" rows
+engine tools/contract_checks/cli.py --pattern=img --pattern=twelve
+
+# Two requirements files: union of packages from both
+engine tools/contract_checks/cli.py --requirements=nodes/src/nodes/db_mysql/requirements.txt --requirements=nodes/src/nodes/db_neo4j/requirements.txt
+
+# Verbose: also print OK and SKIP rows (default is FAIL-only)
+engine tools/contract_checks/cli.py --tree=nodes --package=img2table --verbose
+
+# Confirm the engine env has everything (no skips allowed)
+engine tools/contract_checks/cli.py --fail-on-missing
+
+# Nightly cron pattern: fresh constraint resolution + full run + install everything
+./builder.cmd check-externals:run --rebuild-cache --install-all
+```
+
+## What gets checked **automatically** (no work for you)
+
+If you write normal Python in a normal node, the framework already covers:
+
+- Plain `import X` and `from X import Y` — verified to still resolve.
+- `from X import Y` inside a function body, not just at the top of the file.
+- `try / except ImportError` shims that swap import paths for version compatibility (rerouted to an `any_of` group automatically).
+- SDK client patterns like `client = SomeSDK(...); client.foo.bar(...)` — the AST follows the variable assignment, generates a safe construction with dummy args (strings become `"x"`, ints become `0`), and walks the attribute chain.
+
+For most new nodes you don't have to add anything. Just write code; the framework finds the contracts.
+
+## When you **do** need a manifest
+
+A manifest is a small Python file at `<your-node>/external_contracts.py`. Add one when:
+
+1. **An upstream symbol is version-gated** — e.g., a module that was renamed or removed across major versions. Use `applies_when='<2.0'` (see [Version-gated entry](#version-gated-entry-applies_when) below) so the framework skips the check on installed versions that don't apply, instead of failing.
+2. **You want a heavy-class chain to be a hard requirement, not best-effort.** Auto-extracted heavy classes are best-effort: if construction with dummy args can't succeed, the check is silently demoted to SKIP (see [Auto-extracted vs manifest: the trust gradient](#auto-extracted-vs-manifest-the-trust-gradient) below). Declaring the heavy class in a manifest with a safer `construct` expression turns the chain check into a hard FAIL on breakage — a real CI assertion instead of a best-effort one.
+3. **You want to lock in coverage even after refactors** — manifests survive code reorganizations that move the constructor call between functions.
+4. **You need to express a multi-version contract** more explicitly than `try/except` (e.g., when version-detection isn't via `ImportError`).
+
+For false positives **and** for legitimately-optional imports, prefer the inline comment over a manifest:
+
+```python
+import some_optional_dep  # contract-check: ignore  reason: loaded only when feature X is on
+```
+
+The marker is the right tool for two related shapes:
+
+- **False positive** — the framework auto-detected a third-party import that's actually loaded through some indirect mechanism (importlib, plugin loader, configuration-driven dispatch) and shouldn't be statically verified.
+- **Defensive optional** — the consuming code wraps an import in a permissive try/except with a default fallback. The framework's auto-detection only treats *narrow* `except (ImportError, ModuleNotFoundError):` as an import guard; broader catches like `except Exception:` (intentional in some defensive shims to also catch attribute-access errors during a downstream patching dance) leave the inner import flagged as required. Mark those imports with `# contract-check: ignore` so the framework matches the author's intent.
+
+Real examples from this repo:
+
+```python
+# nodes/src/nodes/llm_anthropic/anthropic.py — optional monkey-patch
+try:
+    import langchain_core.utils.tokenization as _tok  # contract-check: ignore  optional monkey-patch path; outer except handles absence
+    ...
+except Exception:
+    pass
+
+# nodes/src/nodes/llm_mistral/IGlobal.py — falls back to built-in Exception
+try:
+    from mistralai.exceptions import MistralException  # contract-check: ignore  optional, falls back to built-in Exception
+except Exception:
+    MistralException = Exception
+
+# nodes/src/nodes/pinecone/IGlobal.py — moved between pinecone versions
+try:
+    from pinecone.core.client.exceptions import ApiException as _ApiException  # contract-check: ignore  optional, path moved between pinecone versions; outer handler covers absence
+    ...
+except Exception:
+    pass
+```
+
+Always include a short *why* after the marker — it saves the next maintainer a `git blame` trip.
+
+## `# contract-check: skip-install`
+
+Two sibling markers for **requirements files** (a parallel to `# contract-check: ignore` for Python imports). The framework's install hook recursively walks every `requirement*.txt` under each scanned tree (matching the engine's own `requirement*.txt` glob) and feeds each to `depends()`. Two markers opt files out, with different strengths:
+
+| Marker | Default lane behaviour | Under `--install-all` | Use for |
+| ------ | ---------------------- | --------------------- | ------- |
+| `# contract-check: skip-install` | Skip — `[skip-install]` line | **Installs** — `[install-all]` bypass line | Heavy Tier-2 bundles (kokoro, whisper, etc.). PR lane fast; nightly verifies. |
+| `# contract-check: disable` | Skip — `[disable]` line | **Still skipped** — `[disable]` line, no bypass | Fundamental incompatibilities (surya/trocr's opencv pin) where attempting install just produces a guaranteed `[install-failed]`. Paired with `# contract-check: ignore` on the consuming imports so the contract isn't checked either. |
+
+`disable` is strictly stronger than `skip-install`. If a file has both, `disable` wins.
+
+Mark a file by placing the marker on its own comment line (typically at the top so it's the first thing a reader sees):
+
+```text
+# contract-check: disable  reason: surya transitively pins opencv-python-headless==4.11.0.86; the ai.common.opencv runtime shim handles the override; uv can't replay it.
+surya-ocr>=0.17.0
+…
+```
+
+### Output routing
+
+Install-layer status lines (`[disable]`, `[skip-install]`, `[install-all]`, `[install]`) go to **stdout** alongside the contract check output (`[OK]`/`[SKIP]`/`[FAIL]`). A single redirect captures the full transcript. Only `[install-failed]` goes to **stderr** since it's a real failure event.
+
+### Effects in detail
+
+- **Default PR lane** (`./builder.cmd check-externals:run`): both markers cause the file's `depends()` call to be bypassed. Stdout shows `[skip-install] <path>: <reason>` or `[disable] <path>: <reason>` so the bypass is visible in CI logs. Packages stay uninstalled; their contract rows show `[SKIP] package not installed in engine env` (unless paired with `# contract-check: ignore` on the imports, in which case there's no contract row at all — see the surya/trocr pattern below).
+- **Nightly cron lane** (`./builder.cmd check-externals:run --install-all`):
+  - `skip-install`-marked files: marker is **ignored**. Stdout shows `[install-all] <path>: bypassing skip-install marker`, then `depends()` is called. Most succeed; contracts get verified.
+  - `disable`-marked files: marker is **honoured**. Stdout shows the same `[disable]` line as the PR lane. `--install-all` does not override `disable` — that's the whole point of the stronger marker.
+
+### `[install-failed]` (stderr)
+
+When `depends()` raises for a file that was attempted (i.e., NOT `disable`d AND either unmarked or `skip-install` + `--install-all`), the framework prints one stderr line and moves on:
+
+```text
+[install-failed] /path/to/requirements_kokoro.txt: RuntimeError: uv pip install error: ...
+```
+
+This is the drift signal for the install layer itself. If a previously-installable file starts failing, the `[install-failed]` line appears in nightly logs and we can act. Files with fundamental conflicts should use `disable` precisely so they never reach this branch — `[install-failed]` lines are reserved for unexpected failures.
+
+### What's currently marked (9 files)
+
+| Marker | File | Why marked | Paired `# contract-check: ignore` on imports? |
+| ------ | ---- | ---------- | --- |
+| `disable` | `packages/ai/src/ai/common/models/ocr/requirements_surya.txt` | `opencv-python-headless==4.11.0.86` transitive pin | Yes — 3 imports in `surya.py` |
+| `disable` | `packages/ai/src/ai/common/models/ocr/requirements_trocr.txt` | `opencv-python<4.5.4.62` transitive pin (via craft-text-detector) | Yes — 1 import in `trocr.py` |
+| `skip-install` | `packages/ai/src/ai/common/models/audio/requirements_kokoro.txt` | ~200 MB audio model deps | No — verified on nightly |
+| `skip-install` | `packages/ai/src/ai/common/models/audio/requirements_whisper.txt` | ~400 MB ASR deps (ctranslate2, av, onnxruntime) | No |
+| `skip-install` | `packages/ai/src/ai/common/models/gliner/requirements_gliner.txt` | ~300 MB NER deps + mecab C compile | No |
+| `skip-install` | `packages/ai/src/ai/common/models/ocr/requirements_doctr.txt` | ~50 MB OCR engine on top of torch | No |
+| `skip-install` | `packages/ai/src/ai/common/models/ocr/requirements_easyocr.txt` | ~150 MB OCR engine + CRAFT detector | No |
+| `skip-install` | `packages/ai/src/ai/common/models/transformers/requirements_sentence_transformers.txt` | ~100 MB embedding loader | No |
+| `skip-install` | `packages/ai/src/ai/common/models/vision/requirements_vision.txt` | ~50 MB vision embeddings | No |
+
+The `disable` files are paired with import-line ignores because they will *never* be installable — verifying their contracts would always SKIP and add noise. The `skip-install` files keep their imports unmarked because nightly `--install-all` installs them and can actually verify the contracts.
+
+### When to add a new marker
+
+Use **`skip-install`** when:
+
+- A new `requirement*.txt` file whose install costs >100 MB AND whose package is feature-opt-in (consumer code only loads it on demand).
+- You want PR-lane speed but nightly verification.
+
+Use **`disable`** when:
+
+- A file's install reproducibly fails uv resolution against the engine's pinned constraints AND the conflict isn't going to resolve (typically a transitive opencv/torch/numpy pin override handled by a runtime shim).
+- You've confirmed the consuming code handles the package being absent (typically via try/except), so contract verification is meaningless without install.
+- **Also add `# contract-check: ignore` on every import of that package's modules** so the framework doesn't try to verify a contract whose dependency is permanently absent.
+
+When in doubt: don't mark it. The lost coverage is real; the install cost is amortized by uv's cache after the first run on each CI agent.
+
+## Auto-extracted vs manifest: the trust gradient
+
+The framework has two sources of contract entries, and they earn different levels of CI authority:
+
+| Source | Origin | On construction success | On construction failure |
+| ------ | ------ | ----------------------- | ----------------------- |
+| **Auto-extracted** | AST walker guesses from `x = callable(...); x.foo(...)` patterns | `OK` — full chain coverage | **`SKIP`** — "framework guessed, guess didn't pan out" |
+| **Manifest** | Maintainer wrote `HeavyClass(...)` in `external_contracts.py` | `OK` — assertion holds | **`FAIL`** — "maintainer asserted this works and it doesn't" |
+
+The reasoning: auto-extracted entries are best-effort. The AST treats any `x = something(...); x.attr(...)` shape as a possible SDK pattern, including things that aren't classes (`sqlalchemy.create_engine`, `transformers.pipeline`, `doctr.models.ocr_predictor` — all factory *functions*). When the framework can't fabricate args that satisfy the callable, that's not real upstream drift — it's the framework being too aggressive. Failing CI on a guess that didn't work out trains everyone to ignore the lane.
+
+Manifest entries are different. When you write a `HeavyClass` in `external_contracts.py`, you're asserting three things:
+
+1. The qualname is a real class.
+2. It can be constructed with the given expression without I/O.
+3. The constructed instance has every declared chain.
+
+If any of those breaks, **something the maintainer signed off on is no longer true** — exactly the signal the framework exists to produce. Hard fail.
+
+Two safety rails enforce the distinction:
+
+- **`inspect.isclass` gate.** The runner refuses to `eval()` the construct expression at all unless the target is a real class. Catches factory-function false positives before they can do real I/O. Applies to both auto-extracted and manifest entries (a manifest entry with the wrong qualname gets a clear "not a class" error).
+- **Restricted `eval` builtins.** Construction runs with builtins locked to a whitelist of pure data constructors. A `construct` string can't reach `open`, `__import__`, or `exec`, so a typo or a bad manifest can't drive I/O through the eval.
+- **Source-tagged demotion.** Auto-extracted entries carry a `source='<file>:<line>'` marker. The CLI dispatch checks for that marker and downgrades any construction failure to `SKIP`. Manifest entries leave `source=''`, so failures pass through as `FAIL`.
+
+**Implication for contributors:** if you want a chain check to be a hard CI requirement, add a manifest entry for it. If you just want the framework to verify it when it can, leave the AST to do its job.
+
+## Manifest file shape
+
+All manifests look like this:
+
+```python
+from contract_checks.manifest import ComponentManifest
+
+MANIFEST = ComponentManifest(
+    # zero or more of each field below
+)
+```
+
+The framework looks for the module-level `MANIFEST` variable. If the file isn't present, the contract is the auto-extracted one.
+
+### Heavy class (for SDK clients)
+
+Use when the SDK populates client attributes in `__init__` and you want to lock down which attributes your code uses:
+
+```python
+from contract_checks.manifest import ComponentManifest, HeavyClass
+
+MANIFEST = ComponentManifest(
+    heavy_classes=(
+        HeavyClass(
+            qualname='somesdk.Client',
+            construct='Client(api_key="x")',     # MUST be side-effect-free
+            attr_chains=(
+                'users.list',
+                'users.get',
+                'projects.create',
+            ),
+        ),
+    ),
+)
+```
+
+Rules for `construct`:
+
+- It is `eval()`'d in a namespace holding the imported class plus a whitelist of pure data-constructor builtins (`set`, `dict`, `list`, `bytes`, …). `open`, `__import__`, `exec`, and the like are not reachable.
+- It MUST not hit the network or touch the filesystem. If your SDK can't be constructed without I/O, leave out the heavy-class entry — class-level coverage is better than no coverage.
+- The framework wraps the eval in a 2-second timeout. A timeout means "the manifest is wrong, the construction is doing something."
+
+### Version-gated entry (`applies_when`)
+
+Use when a symbol only exists on certain versions of a package — the check is skipped (not failed) when the installed version doesn't match. Specifier syntax is PEP 440 (`<2.0`, `>=1.0,<2.0`, `~=1.4`, etc.).
+
+```python
+from contract_checks.manifest import ComponentManifest, ImportRequirement
+
+MANIFEST = ComponentManifest(
+    imports=(
+        # OCRDataframe was removed in img2table 2.0
+        ImportRequirement(
+            module='img2table.ocr.data',
+            symbols=('OCRDataframe',),
+            applies_when='<2.0',
+        ),
+        # OCRData was added in img2table 2.0
+        ImportRequirement(
+            module='img2table.ocr._types',
+            symbols=('OCRData',),
+            applies_when='>=2.0',
+        ),
+    ),
+)
+```
+
+Output rows for entries that don't apply look like:
+
+```text
+[SKIP] nodes/ocr/img2table: img2table.ocr.data: applies_when='<2.0', installed=2.0.0
+```
+
+**Manifest entries replace auto-extracted entries** when they target the same module (for `ImportRequirement`) or qualname (for `HeavyClass`). So adding a version-gated `ImportRequirement(module='img2table.ocr.data', ...)` correctly overrides the unconditional version the AST would otherwise emit.
+
+`applies_when` is available on `ImportRequirement`, `AnyOf`, and `HeavyClass`. Available specifier operators: `==`, `!=`, `>=`, `<=`, `>`, `<`, `~=`, and comma-joined ranges. Malformed specs fail loudly at manifest-load time.
+
+### Any-of (for non-version fallbacks)
+
+Use when two interchangeable libraries can satisfy the same import — e.g., `cryptography` OR `pycryptodome`. For pure version splits, prefer two `ImportRequirement` entries with `applies_when` over `AnyOf` — they read more like a changelog.
+
+```python
+from contract_checks.manifest import AnyOf, ComponentManifest, ImportRequirement
+
+MANIFEST = ComponentManifest(
+    any_of_imports=(
+        AnyOf(
+            alternatives=(
+                ImportRequirement(module='cryptography.hazmat.primitives.ciphers'),
+                ImportRequirement(module='Crypto.Cipher'),  # pycryptodome
+            ),
+        ),
+    ),
+)
+```
+
+The test passes if **at least one** alternative resolves.
+
+### Skip packages
+
+Use to drop a whole top-level package from the contract — e.g., when the AST detects it but you know it's optional / dynamically loaded:
+
+```python
+MANIFEST = ComponentManifest(
+    skip_packages=frozenset({'some_optional_package'}),
+)
+```
+
+For single imports, the inline `# contract-check: ignore` comment is usually a better choice (the *why* lives next to the code).
+
+## Adding a new tree to scan
+
+Edit [`tools/contract_checks/src/contract_checks/trees.py`](src/contract_checks/trees.py) and append one `Tree` entry to `SCANNED_TREES`:
+
+```python
+Tree(
+    name='my-new-tree',
+    root=REPO_ROOT / 'path' / 'to' / 'python' / 'source',
+    internal_packages=frozenset({'my_internal_package'}),
+),
+```
+
+No other change is needed — the CLI's tree iteration loop picks up the new entry automatically on the next run, and the install hook recursively finds every `requirement*.txt` under `root` on its own (no per-tree requirements config).
+
+## Reading CI output
+
+Failures take the form:
+
+```text
+<tree>/<component>/<package>: <what was checked>: <how it failed>
+```
+
+For example:
+
+```text
+nodes/somenode/somelib: somelib.helpers: symbol 'OldClass' not found in module 'somelib.helpers'
+nodes/twelvelabs/twelvelabs: twelvelabs.TwelveLabs [twelvelabs_driver.py:51]: \
+    attribute chain 'indexes.create' broke at .create (walked: .indexes, \
+    construct: 'TwelveLabs(api_key="x")')
+```
+
+Both name the upstream symbol that drifted and the file/line where your code uses it.
+
+Skipped checks (yellow, non-failing) look like this — emitted when the package isn't installed, or when an entry's `applies_when` doesn't match the installed version:
+
+```text
+[SKIP] nodes/ocr/img2table: img2table.ocr.data: applies_when='<2.0', installed=2.0.0
+[SKIP] nodes/twelvelabs/twelvelabs: twelvelabs: package not installed in engine env
+```
+
+## Architecture (one screen)
+
+```text
+tools/contract_checks/
+├── README.md                    ← you are here
+├── cli.py                       ← thin entry: `engine cli.py --tree=… --package=…`
+├── requirements.txt             ← empty; framework uses stdlib only
+├── scripts/
+│   └── tasks.js                 ← `check-externals:run`, `check-externals:test`
+├── src/
+│   └── contract_checks/         ← the framework package
+│       ├── trees.py             ← which trees to scan + which packages are "internal"
+│       ├── extractor.py         ← AST walker + data-flow tracking
+│       ├── manifest.py          ← per-component override schema (ImportRequirement, HeavyClass, AnyOf, ...)
+│       ├── engine_env.py        ← wraps depends.ensure_constraints() and depends()
+│       ├── runner.py            ← pure verify_* functions; no pytest dep
+│       └── cli.py               ← CLI dispatcher
+└── test/
+    ├── conftest.py              ← sys.path bootstrap so `from contract_checks.X import ...` works
+    ├── test_extractor.py              ← framework unit tests
+    └── test_runner.py                 ← framework unit tests
+```
+
+## CI lanes
+
+Defined in [.github/workflows/check-externals.yml](../../.github/workflows/check-externals.yml). **Phase 1 posture: failures surface as GitHub Actions `::warning::` annotations only — non-blocking, no auto-issue yet.**
+
+- **PR lane** (`check-externals:run`): runs on every PR touching `packages/**`, `nodes/**`, or `tools/contract_checks/**`. `continue-on-error: true` (non-blocking) during the stabilization period. `[FAIL]` / `[install-failed]` lines are surfaced as warning annotations.
+- **Nightly lane** (`check-externals:run --rebuild-cache --install-all`): runs at 03:00 UTC against freshly-resolved constraints with every bundle installed. Same warning-only posture. The auto-issue-on-failure step is written but **commented out** — when enabled in a later phase it files a `check-externals,bug` issue, mirrored to Discord via `.github/workflows/discord-issues.yml`.
+
+Run the framework's own unit tests with `./builder.cmd check-externals:test` (not yet a separate CI job).
+
+## Common questions
+
+**Q: My PR is red on `check-externals` and I didn't change any imports.**
+A: Upstream shipped a breaking change. The failure message names the package and symbol. Either update the consuming code, add an `applies_when` manifest entry pinning the symbol to the version where it exists, add an `any_of` group, or pin the package version in the relevant `requirements.txt`.
+
+**Q: The lane says my heavy-class construction timed out.**
+A: Your SDK's `__init__` is doing I/O. If this is an **auto-extracted** entry (the message includes `[auto-extracted from <file>:<line>]`), the row is already a `SKIP` and doesn't block CI — nothing to do unless you want chain coverage, in which case add a manifest entry with safer dummy args. If it's a **manifest** entry, either find a constructor invocation that doesn't hit the network and update the `construct` field, or remove the heavy-class entry (you'll lose chain coverage but keep import coverage).
+
+**Q: The lane reported `<package>.<thing> is a <type>, not a class`.**
+A: Either auto-extraction guessed wrong (the thing is actually a factory function — `create_engine`, `pipeline`, etc.) and the row is harmlessly a `SKIP`, or your manifest's `qualname` points at a function instead of a class. For the function case, use an `ImportRequirement` for the symbol instead of a `HeavyClass` — the framework will verify the symbol resolves without trying to construct anything.
+
+**Q: I added a new node — do I need a manifest?**
+A: Usually no. Run `./builder.cmd check-externals:run --pattern=<your-node>` locally. If everything's green, you're done. (`--pytest-pattern=` still works as an alias for muscle memory, but `check-externals:run` no longer runs through pytest.)
+
+**Q: How do I disable the framework for a specific import I know is optional?**
+A: Add `# contract-check: ignore` on the same line as the import. Add a short reason after — it'll save the next maintainer a trip to `git log`.
+
+**Q: Why doesn't `check-externals:run` go through pytest?**
+A: It used to, but pytest only contributed parametrization and skip-on-missing semantics — things the [CLI](cli.py) implements directly in ~150 lines. Removing the pytest layer made the failure framing honest ("checks" not "tests") and dropped a dependency from the run path. `check-externals:test` *does* use pytest — that lane runs real unit tests against the framework's own code.

--- a/tools/contract_checks/cli.py
+++ b/tools/contract_checks/cli.py
@@ -1,0 +1,22 @@
+"""
+Thin CLI entry point for local debugging.
+
+Invoke as:  engine tools/contract_checks/cli.py [--tree=...] [--package=...]
+
+Adjusts sys.path so the engine can locate the ``contract_checks`` package,
+then delegates to :mod:`contract_checks.cli`.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_SRC = Path(__file__).resolve().parent / 'src'
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from contract_checks.cli import main  # noqa: E402
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/contract_checks/requirements.txt
+++ b/tools/contract_checks/requirements.txt
@@ -1,0 +1,2 @@
+# Framework runtime uses only stdlib (ast, importlib, inspect, sys, pathlib).
+# Pytest itself is supplied by the engine env via nodes/test/requirements.txt.

--- a/tools/contract_checks/scripts/tasks.js
+++ b/tools/contract_checks/scripts/tasks.js
@@ -1,0 +1,174 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * Build tasks for the check-externals framework.
+ *
+ * Public commands:
+ *   check-externals:run                  Run third-party interface contract
+ *                                        checks against the four scanned trees.
+ *   check-externals:run --rebuild-cache  Force ensure_constraints() to
+ *                                        recompile by deleting
+ *                                        <engine-cache>/{constraints.txt,
+ *                                        requirements.hash}. Used by the
+ *                                        nightly cron lane to catch fresh
+ *                                        upstream releases.
+ *   check-externals:test                 Run unit tests for the framework
+ *                                        itself (extractor + runner). No
+ *                                        engine trees are built; only the
+ *                                        engine binary is needed.
+ *
+ * Internal commands (used as compound-step targets; visible in
+ * `--list-actions` but not in `--help` since they have no description):
+ *   check-externals:run-checks           Just the CLI invocation, no build steps.
+ *                                        Useful for fast iteration when the
+ *                                        engine + trees are already built.
+ *   check-externals:run-tests            Just the pytest invocation, no build steps.
+ *
+ * IMPORTANT: an action with BOTH `steps` AND `run` silently drops `run`
+ * (see action-runner.js buildCompoundTask — it only calls task.newListr on
+ * the children, never actionObj.run). So each public compound action is
+ * paired with an internal leaf that carries the actual `run` callback.
+ */
+
+const path = require('path');
+const { execCommand, runPytest, unlink, DIST_ROOT } = require('../../../scripts/lib');
+
+const PACKAGE_DIR = path.join(__dirname, '..');
+const TEST_DIR = path.join(PACKAGE_DIR, 'test');
+
+// CLI entry point for `check-externals:run` (no pytest).
+// `cli.py` adjusts sys.path then delegates to `contract_checks.cli:main`.
+const CLI_SCRIPT = path.join(PACKAGE_DIR, 'cli.py');
+
+// Engine binary (built by server:build; execCommand resolves extension on Windows).
+const ENGINE = path.join(DIST_ROOT, 'server', 'engine');
+
+// depends._get_cache_dir() = <engine executable dir>/cache.
+const ENGINE_CACHE_DIR = path.join(DIST_ROOT, 'server', 'cache');
+
+
+// ============================================================================
+// Leaf actions (carry the actual run callbacks)
+// ============================================================================
+
+function makeRunChecksAction(options = {}) {
+    return {
+        // No description -> internal; reached as the final step of
+        // `check-externals:run`, or invoked directly for fast dev iteration.
+        run: async (_ctx, task) => {
+            if (options.rebuildCache) {
+                const constraints = path.join(ENGINE_CACHE_DIR, 'constraints.txt');
+                const hashFile = path.join(ENGINE_CACHE_DIR, 'requirements.hash');
+                await unlink(constraints);
+                await unlink(hashFile);
+                task.output = 'Constraint cache cleared; ensure_constraints() will recompile';
+            }
+
+            // Invoke the CLI directly — no pytest. The CLI implements the
+            // verification loop itself (find_spec for skip-on-missing,
+            // verify_* for each contract entry, exit code from failure
+            // count). pytest only runs under check-externals:run-tests.
+            const cliArgs = [CLI_SCRIPT];
+            // Prefer --pattern (framework-native); fall back to --pytest-pattern
+            // for users with muscle memory from pytest-based tasks like nodes:test.
+            // options.pattern is always a list (build.js accumulates). The CLI
+            // supports `--pattern` multiple times with OR semantics, so we forward
+            // each entry as its own flag occurrence.
+            const patterns = options.pattern || (options.pytestPattern ? [options.pytestPattern] : []);
+            for (const p of patterns) {
+                cliArgs.push('--pattern', p);
+            }
+
+            // --install-all: forwarded as-is to the CLI. Nightly cron lane
+            // sets this so the framework installs every requirement*.txt
+            // even when carrying a `# contract-check: skip-install` marker.
+            if (options.installAll) {
+                cliArgs.push('--install-all');
+            }
+
+            await execCommand(ENGINE, cliArgs, {
+                task,
+                cwd: path.join(DIST_ROOT, 'server'),
+                env: { ...process.env },
+            });
+        },
+    };
+}
+
+
+function makeRunTestsAction(options = {}) {
+    return {
+        // No description -> internal; reached as the final step of
+        // `check-externals:test`.
+        run: async (_ctx, task) => {
+            const extraArgs = ['-v', '--tb=short'];
+
+            // Accept both --pattern and --pytest-pattern; this lane is real
+            // pytest, so either maps to pytest's -k expression. pytest only
+            // accepts ONE -k arg, so join multiple --pattern values with
+            // ` or ` (pytest's OR operator) to preserve the OR semantics.
+            const patterns = options.pattern || (options.pytestPattern ? [options.pytestPattern] : []);
+            if (patterns.length > 0) {
+                extraArgs.push('-k', patterns.join(' or '));
+            }
+
+            // Target the two self-test files directly so collection doesn't
+            // also pull in any future parametrized contract tests (which
+            // would require the four trees to be built).
+            for (const fname of ['test_extractor.py', 'test_runner.py']) {
+                await runPytest({
+                    engine: ENGINE,
+                    testsDir: path.join(TEST_DIR, fname),
+                    extraArgs,
+                    execOpts: {
+                        task,
+                        cwd: path.join(DIST_ROOT, 'server'),
+                        env: { ...process.env },
+                    },
+                });
+            }
+        },
+    };
+}
+
+
+// ============================================================================
+// Public compound actions (only `steps` — no `run`, so action-runner won't
+// silently drop anything)
+// ============================================================================
+
+
+module.exports = {
+    name: 'check-externals',
+    description: '3rd-party interface contract test framework',
+
+    actions: [
+        // Internal leaf actions — these carry the real run callbacks.
+        { name: 'check-externals:run-checks', action: makeRunChecksAction },
+        { name: 'check-externals:run-tests', action: makeRunTestsAction },
+
+        // Public compound actions — build deps + the matching leaf.
+        { name: 'check-externals:run', action: () => ({
+            description: 'Check interfaces to 3rd-party Python modules used by the engine',
+            // Build the engine + the four scanned trees so depends() can install
+            // every component's requirements.txt at session start. The leaf
+            // step at the end actually invokes the CLI.
+            steps: [
+                'server:build',
+                'nodes:build',
+                'ai:build',
+                'client-python:build',
+                'check-externals:run-checks',
+            ],
+        })},
+        { name: 'check-externals:test', action: () => ({
+            description: 'Unit tests for the check-externals framework itself',
+            // Only the engine is required; the four trees are not scanned by
+            // these tests, so we don't need to build them.
+            steps: ['server:build', 'check-externals:run-tests'],
+        })},
+    ],
+};

--- a/tools/contract_checks/scripts/tasks.js
+++ b/tools/contract_checks/scripts/tasks.js
@@ -58,7 +58,7 @@ function makeRunChecksAction(options = {}) {
     return {
         // No description -> internal; reached as the final step of
         // `check-externals:run`, or invoked directly for fast dev iteration.
-        run: async (_ctx, task) => {
+        run: async (ctx, task) => {
             if (options.rebuildCache) {
                 const constraints = path.join(ENGINE_CACHE_DIR, 'constraints.txt');
                 const hashFile = path.join(ENGINE_CACHE_DIR, 'requirements.hash');
@@ -103,7 +103,7 @@ function makeRunTestsAction(options = {}) {
     return {
         // No description -> internal; reached as the final step of
         // `check-externals:test`.
-        run: async (_ctx, task) => {
+        run: async (ctx, task) => {
             const extraArgs = ['-v', '--tb=short'];
 
             // Accept both --pattern and --pytest-pattern; this lane is real

--- a/tools/contract_checks/src/contract_checks/__init__.py
+++ b/tools/contract_checks/src/contract_checks/__init__.py
@@ -1,0 +1,1 @@
+"""Contract-check framework: detect 3rd-party Python SDK interface drift in CI."""

--- a/tools/contract_checks/src/contract_checks/__main__.py
+++ b/tools/contract_checks/src/contract_checks/__main__.py
@@ -1,0 +1,6 @@
+"""Allow ``engine -m contract_checks ...`` to invoke the CLI."""
+
+from contract_checks.cli import main
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/contract_checks/src/contract_checks/cli.py
+++ b/tools/contract_checks/src/contract_checks/cli.py
@@ -1,0 +1,538 @@
+"""
+Command-line runner for the check-externals framework.
+
+This is the implementation of ``builder check-externals:run``. It walks the
+configured trees, extracts each component's contract, and runs the verifier
+functions against the engine's installed package versions.
+
+Invoked via the wrapper at ``tools/contract_checks/cli.py``:
+
+    engine tools/contract_checks/cli.py [--tree=NAME] [--package=NAME]
+                                        [--pattern=SUBSTR] [--no-install]
+
+Exit code: 0 if there are no failures (skipped checks don't count as failures),
+1 otherwise. Skipped status (yellow) is used when a third-party package isn't
+installed in the engine env — the framework's job is to flag interface drift,
+not absence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import importlib.util
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+from contract_checks.engine_env import (
+    depends,
+    ensure_constraints,
+    installed_version,
+    requirements_file_disabled,
+    requirements_file_skipped,
+    version_matches,
+)
+from contract_checks.extractor import (
+    ComponentContract,
+    extract_component,
+    iter_components,
+)
+from contract_checks.runner import (
+    verify_any_of,
+    verify_constraint_match,
+    verify_heavy_class,
+    verify_import,
+)
+from contract_checks.trees import SCANNED_TREES, Tree
+
+
+# --------------------------------------------------------------------------- #
+# Per-package check dispatch
+# --------------------------------------------------------------------------- #
+
+
+def _check_applies(applies_when: Optional[str], package: str) -> tuple[bool, str]:
+    """
+    Decide whether an entry's ``applies_when`` matches the installed version.
+
+    Args:
+        applies_when: PEP 440 specifier from the entry (``None`` = no
+                      constraint, always applies).
+        package:      Top-level package name whose installed version to
+                      compare against the spec.
+
+    Returns:
+        ``(True, '')`` when the check should run (no constraint, or spec
+        matches the installed version). ``(False, reason)`` when the check
+        should be skipped — reason is a human-readable string the dispatch
+        loop puts in the ``[SKIP]`` row.
+    """
+    if not applies_when:
+        return True, ''
+    installed = installed_version(package)
+    if installed is None:
+        return False, f'applies_when={applies_when!r}, package not installed'
+    try:
+        if version_matches(applies_when, installed):
+            return True, ''
+        return False, f'applies_when={applies_when!r}, installed={installed}'
+    except Exception as e:
+        return False, f'malformed applies_when={applies_when!r}: {e}'
+
+
+def _checks_for_package(contract: ComponentContract, package: str):
+    """
+    Yield one ``(status, where, message)`` triple per check touching ``package``.
+
+    Each entry's ``applies_when`` is consulted first; entries that don't
+    apply to the installed version yield ``('skip', where, reason)`` without
+    running the underlying verifier.
+
+    Args:
+        contract: The component's resolved contract (AST + manifest overlay).
+        package:  Top-level package name (e.g., ``"twelvelabs"``).
+
+    Yields:
+        Tuples of ``(status, where, message)`` where ``status`` is one of
+        ``'ok'``, ``'skip'``, ``'fail'``; ``where`` names the symbol or
+        chain that was checked; ``message`` is a short explanation for the
+        output row.
+    """
+
+    def _top(name: str) -> str:
+        """Return the top-level package name from a dotted module/qualname."""
+        return name.split('.', 1)[0]
+
+    def _emit_result(r) -> tuple[str, str, str]:
+        """Map a :class:`CheckResult` to a ``(status, where, message)`` triple."""
+        return ('ok' if r.ok else 'fail', r.where, r.message)
+
+    for req in contract.imports:
+        if _top(req.module) != package:
+            continue
+        applies, reason = _check_applies(req.applies_when, package)
+        if not applies:
+            yield ('skip', req.module, reason)
+            continue
+        yield _emit_result(verify_import(req))
+
+    for group in contract.any_of_imports:
+        if not any(_top(alt.module) == package for alt in group.alternatives):
+            continue
+        applies, reason = _check_applies(group.applies_when, package)
+        if not applies:
+            where = ' | '.join(alt.module for alt in group.alternatives)
+            yield ('skip', where, reason)
+            continue
+        yield _emit_result(verify_any_of(group))
+
+    for hc in contract.heavy_classes:
+        if _top(hc.qualname) != package:
+            continue
+        applies, reason = _check_applies(hc.applies_when, package)
+        if not applies:
+            yield ('skip', hc.qualname, reason)
+            continue
+        result = verify_heavy_class(hc)
+        if not result.ok and hc.source:
+            # Auto-extracted heavy_class (hc.source is set by the extractor).
+            # The AST guessed at a (construct, chain) pair; if construction
+            # fails, that's a guess that didn't pan out — not a real upstream
+            # drift signal. Demote to SKIP so it doesn't block CI. A
+            # maintainer who wants to enforce this chain should declare the
+            # HeavyClass in a manifest (where it would stay a hard FAIL).
+            yield (
+                'skip',
+                result.where,
+                f'auto-extracted heavy_class could not be verified ({result.message})',
+            )
+            continue
+        yield _emit_result(result)
+
+    yield _emit_result(verify_constraint_match(package))
+
+
+# --------------------------------------------------------------------------- #
+# Requirements-file filter
+# --------------------------------------------------------------------------- #
+
+
+# PEP 508 line-shape: pull the distribution name from the start of a
+# non-comment requirement line. Strips version specifiers, environment
+# markers, and extras. Insensitive to leading whitespace.
+_REQUIREMENT_LINE = re.compile(r'^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)')
+
+
+def _normalize_distribution_name(name: str) -> str:
+    """
+    Apply PEP 503 normalization to a distribution name.
+
+    Args:
+        name: Raw distribution name (e.g., ``"PyYAML"``, ``"langchain_core"``).
+
+    Returns:
+        Lowercase form with runs of ``-``, ``_``, ``.`` collapsed to a
+        single ``-`` (e.g., ``"pyyaml"``, ``"langchain-core"``).
+    """
+    return re.sub(r'[-_.]+', '-', name).lower()
+
+
+def parse_requirements_distributions(req_file: Path) -> set[str]:
+    """
+    Read a ``requirements.txt`` and return the set of distribution names.
+
+    Recognises the common subset of PEP 508 / pip requirements grammar:
+    blank lines and ``#`` comments are skipped; lines beginning with ``-``
+    (``-r other.txt``, ``-e .``, ``--extra-index-url ...``) are skipped;
+    everything else has its leading distribution name extracted via
+    :data:`_REQUIREMENT_LINE`, then normalised via
+    :func:`_normalize_distribution_name`.
+
+    Args:
+        req_file: Path to a requirements.txt file.
+
+    Returns:
+        Set of PEP 503-normalized distribution names found in the file.
+
+    Raises:
+        FileNotFoundError: When ``req_file`` doesn't exist.
+    """
+    distributions: set[str] = set()
+    for raw in req_file.read_text(encoding='utf-8').splitlines():
+        line = raw.strip()
+        if not line or line.startswith('#') or line.startswith('-'):
+            continue
+        match = _REQUIREMENT_LINE.match(line)
+        if match:
+            distributions.add(_normalize_distribution_name(match.group(1)))
+    return distributions
+
+
+def resolve_distributions_to_modules(distributions: set[str]) -> set[str]:
+    """
+    Map a set of pip distribution names to their top-level Python module names.
+
+    Some packages have a different module name than their pip name
+    (``Pillow`` → ``PIL``, ``PyYAML`` → ``yaml``, ``langchain-core`` →
+    ``langchain_core``). ``importlib.metadata.packages_distributions``
+    knows the true mapping for any installed distribution; fall back to a
+    name-mangle heuristic (lowercase, ``-`` → ``_``) when a distribution
+    isn't installed in the engine env.
+
+    Args:
+        distributions: PEP 503-normalized distribution names.
+
+    Returns:
+        Set of top-level Python module names. May contain more than one
+        entry per distribution when the distribution provides multiple
+        top-level modules.
+    """
+    # Build the inverted lookup: normalized-dist-name -> [module names].
+    dist_to_modules: dict[str, list[str]] = {}
+    for module_name, dists in importlib.metadata.packages_distributions().items():
+        for dist in dists:
+            dist_to_modules.setdefault(_normalize_distribution_name(dist), []).append(module_name)
+
+    modules: set[str] = set()
+    for dist in distributions:
+        if dist in dist_to_modules:
+            modules.update(dist_to_modules[dist])
+        else:
+            # Distribution not installed — guess the module name from the
+            # pip name. Works for the common case (langchain-core →
+            # langchain_core) but misses outliers (Pillow → PIL).
+            modules.add(dist.replace('-', '_'))
+    return modules
+
+
+# --------------------------------------------------------------------------- #
+# Output
+# --------------------------------------------------------------------------- #
+
+
+def _emit(triple_id: str, where: str, status: str, message: str, verbose: bool) -> None:
+    """
+    Print one result row, respecting verbosity.
+
+    Non-verbose mode prints only ``FAIL`` rows. Verbose mode prints
+    ``OK``, ``SKIP``, and ``FAIL`` — full transparency for debugging.
+
+    Args:
+        triple_id: ``<tree>/<component>/<package>`` identifier.
+        where:     Dotted name of the symbol or class the check targeted.
+        status:    One of ``'ok'``, ``'skip'``, ``'fail'``.
+        message:   Short human-readable explanation.
+        verbose:   When ``False``, OK and SKIP rows are suppressed.
+    """
+    if status != 'fail' and not verbose:
+        return
+    tag = {'ok': 'OK  ', 'skip': 'SKIP', 'fail': 'FAIL'}[status]
+    suffix = f': {where}' if where else ''
+    print(f'[{tag}] {triple_id}{suffix}: {message}')
+
+
+# --------------------------------------------------------------------------- #
+# Main
+# --------------------------------------------------------------------------- #
+
+
+def _find_tree(name: str) -> Optional[Tree]:
+    """Return the :class:`Tree` in :data:`SCANNED_TREES` whose name matches, or None."""
+    for tree in SCANNED_TREES:
+        if tree.name == name:
+            return tree
+    return None
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Construct the argparse parser for the ``check-externals:run`` CLI."""
+    parser = argparse.ArgumentParser(
+        prog='check-externals',
+        description='Verify 3rd-party Python module interfaces used by the engine.',
+    )
+    parser.add_argument(
+        '--tree',
+        action='append',
+        help='Limit checks to these trees. Repeat for multiple: '
+        '--tree=nodes --tree=ai. Valid names: nodes, ai, client-python, '
+        'rocketlib.',
+    )
+    parser.add_argument(
+        '--package',
+        action='append',
+        help='Limit checks to these third-party packages (top-level names). '
+        'Repeat for multiple: --package=requests --package=img2table. '
+        'OR semantics within the flag.',
+    )
+    parser.add_argument(
+        '--pattern',
+        '-k',
+        action='append',
+        help='Substring filter applied to each triple id '
+        '"<tree>/<component>/<package>". Repeat for multiple patterns '
+        'with OR semantics: --pattern=img --pattern=twelve.',
+    )
+    parser.add_argument(
+        '--no-install',
+        action='store_true',
+        help='Skip per-component depends() install; rely on whatever is already in the engine env.',
+    )
+    parser.add_argument(
+        '--fail-on-missing',
+        action='store_true',
+        help='Treat missing packages as failures instead of skips (off by default).',
+    )
+    parser.add_argument(
+        '--requirements',
+        metavar='FILE',
+        action='append',
+        help='Limit checks to packages listed in the given requirements.txt file. '
+        'Pip distribution names are mapped to top-level Python module names '
+        'via importlib.metadata.packages_distributions; repeat for multiple '
+        'files (the resolved package sets are unioned). Combine with '
+        '--tree, --package, and --pattern as needed.',
+    )
+    parser.add_argument(
+        '--verbose',
+        '-v',
+        action='store_true',
+        help='Print OK and SKIP rows in addition to FAIL. Default prints only '
+        'FAIL rows; the summary line ("N passed, M skipped, K failed") '
+        'always prints regardless.',
+    )
+    parser.add_argument(
+        '--install-all',
+        action='store_true',
+        help='Ignore `# contract-check: skip-install` markers in requirements '
+        'files and install everything. PR lanes respect markers (fast); '
+        'nightly lanes use this flag for full coverage.',
+    )
+    return parser
+
+
+def _install_all_requirements(trees, *, install_all: bool, verbose: bool) -> None:
+    """
+    Walk every ``requirement*.txt`` under each scanned tree and install via
+    ``depends()``, honouring ``# contract-check: skip-install`` markers
+    unless ``install_all`` is set.
+
+    Matches the engine's own ``requirement*.txt`` glob in
+    ``packages/server/engine-lib/rocketlib-python/lib/depends.py``. Recursive,
+    so model-bundle files like
+    ``packages/ai/src/ai/common/models/audio/requirements_kokoro.txt``
+    get picked up (they were invisible to the previous per-component finder).
+
+    Each file is fed to ``depends()`` exactly once across the session,
+    deduped by absolute path. The engine's ``depends._processed`` set
+    further dedupes inside the engine.
+
+    Args:
+        trees:       Iterable of :class:`Tree` configs to walk.
+        install_all: When True, install every file regardless of marker.
+                     When False, skip files carrying
+                     ``# contract-check: skip-install`` and emit a stderr
+                     line naming the file + reason.
+        verbose:     When True, also emit one stderr line per file
+                     ``depends()`` is called on (for trace visibility).
+    """
+    seen: set[Path] = set()
+    for tree in trees:
+        if not tree.root.exists():
+            continue
+        for req in sorted(tree.root.rglob('requirement*.txt')):
+            if not req.is_file():
+                continue
+            req = req.resolve()
+            if req in seen:
+                continue
+            seen.add(req)
+
+            # `disable` is checked FIRST and is strictly stronger than
+            # `skip-install` — disabled files are never installed by the
+            # framework, even under --install-all. Use it for fundamental
+            # incompatibilities (e.g., surya/trocr's opencv conflict) where
+            # attempting install just produces a guaranteed [install-failed]
+            # line and wastes CI time. Paired with `# contract-check: ignore`
+            # on the consuming imports so the contract isn't checked either.
+            #
+            # Install-layer status lines ([disable], [skip-install],
+            # [install-all], [install]) go to STDOUT alongside the contract
+            # check output ([OK]/[SKIP]/[FAIL]) so a single redirect
+            # captures the full transcript. Only [install-failed] goes to
+            # STDERR since it's a real failure event.
+            disabled, disable_reason = requirements_file_disabled(req)
+            if disabled:
+                msg = f'[disable] {req}'
+                if disable_reason:
+                    msg += f': {disable_reason}'
+                print(msg)
+                continue
+
+            skipped, reason = requirements_file_skipped(req)
+            if skipped and not install_all:
+                msg = f'[skip-install] {req}'
+                if reason:
+                    msg += f': {reason}'
+                print(msg)
+                continue
+            if skipped and install_all:
+                print(f'[install-all] {req}: bypassing skip-install marker')
+
+            if verbose:
+                print(f'[install] {req}')
+            try:
+                depends(str(req))
+            except Exception as e:
+                # Don't abort the run — a single failing file shouldn't
+                # cost coverage of every other file. Make the failure
+                # visible in CI logs so it can be triaged (e.g., a
+                # previously installable file starting to conflict).
+                # Files with fundamental incompatibilities should use the
+                # stronger `# contract-check: disable` marker so they never
+                # reach this branch.
+                print(
+                    f'[install-failed] {req}: {type(e).__name__}: {e}',
+                    file=sys.stderr,
+                )
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    """Entry point. Returns 0 on success, 1 on any failure, 2 on bad arg."""
+    args = _build_parser().parse_args(argv)
+
+    # --tree: list[str] when supplied (action='append'); resolve every name
+    # to a Tree object, dedupe (preserving first occurrence), fail loudly on
+    # any unknown name. Empty/None means "all scanned trees".
+    trees: list[Tree]
+    if args.tree:
+        trees = []
+        seen_names: set[str] = set()
+        for name in args.tree:
+            if name in seen_names:
+                continue
+            tree = _find_tree(name)
+            if tree is None:
+                print(f'unknown tree: {name!r}', file=sys.stderr)
+                return 2
+            trees.append(tree)
+            seen_names.add(name)
+    else:
+        trees = list(SCANNED_TREES)
+
+    # --requirements: list[str] when supplied; union the resolved module set
+    # across every file. Restricts the per-package loop below.
+    allowed_modules: Optional[set[str]] = None
+    if args.requirements:
+        allowed_modules = set()
+        for req_str in args.requirements:
+            req_path = Path(req_str)
+            if not req_path.exists():
+                print(f'error: requirements file not found: {req_path}', file=sys.stderr)
+                return 2
+            distributions = parse_requirements_distributions(req_path)
+            allowed_modules |= resolve_distributions_to_modules(distributions)
+        if not allowed_modules:
+            print(
+                'warning: --requirements parsed to 0 packages; nothing will run',
+                file=sys.stderr,
+            )
+
+    # --package / --pattern: list[str] when supplied; treated as OR within
+    # the flag (any match accepts the row).
+    package_filter: Optional[set[str]] = set(args.package) if args.package else None
+    pattern_filter: Optional[list[str]] = args.pattern if args.pattern else None
+
+    if not args.no_install:
+        ensure_constraints()
+        # Recursive install hook: walks every requirement*.txt under each
+        # tree (matching the engine's own glob) and feeds each to depends().
+        # Files carrying `# contract-check: skip-install` are bypassed unless
+        # --install-all is set. This subsumes the old per-component
+        # requirements_finder mechanism (which only saw the exact filename
+        # `requirements.txt` and only at the tree-root immediate subdir).
+        _install_all_requirements(trees, install_all=args.install_all, verbose=args.verbose)
+
+    passed = skipped = failed = 0
+
+    for tree in trees:
+        for component_dir in iter_components(tree):
+            contract = extract_component(tree, component_dir)
+
+            for package in contract.packages:
+                if package_filter is not None and package not in package_filter:
+                    continue
+                if allowed_modules is not None and package not in allowed_modules:
+                    continue
+                triple_id = f'{tree.name}/{component_dir.name}/{package}'
+                if pattern_filter is not None and not any(p in triple_id for p in pattern_filter):
+                    continue
+
+                # Mirror pytest.importorskip: a missing top-level package is
+                # SKIP, not FAIL — we report interface drift, not absence.
+                if importlib.util.find_spec(package) is None:
+                    if args.fail_on_missing:
+                        _emit(triple_id, package, 'fail', 'package not installed in engine env', args.verbose)
+                        failed += 1
+                    else:
+                        _emit(triple_id, package, 'skip', 'package not installed in engine env', args.verbose)
+                        skipped += 1
+                    continue
+
+                for status, where, message in _checks_for_package(contract, package):
+                    _emit(triple_id, where, status, message, args.verbose)
+                    if status == 'ok':
+                        passed += 1
+                    elif status == 'skip':
+                        skipped += 1
+                    else:
+                        failed += 1
+
+    total = passed + skipped + failed
+    print(f'\n{passed} passed, {skipped} skipped, {failed} failed ({total} checks total)')
+    return 0 if failed == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/contract_checks/src/contract_checks/engine_env.py
+++ b/tools/contract_checks/src/contract_checks/engine_env.py
@@ -1,0 +1,303 @@
+"""
+Engine integration boundary.
+
+Thin wrappers around ``depends.py`` (the engine's install pipeline) and
+``importlib.metadata`` (the installed-version oracle). Single import surface so
+the rest of the framework never touches ``depends.py`` internals directly.
+
+Falls back gracefully when running outside the engine env (e.g., during
+framework self-tests on a developer laptop) — `ensure_constraints` and
+`depends` become no-ops, `read_constraints` returns an empty dict.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.metadata
+import re
+from functools import lru_cache
+from pathlib import Path
+from typing import Optional
+
+
+def normalize_dist_name(name: str) -> str:
+    """
+    Normalise a package name to its PEP 503 canonical form.
+
+    Distribution names (constraints file) and import names (our top-level
+    lookups) disagree on separators: ``langchain-core`` vs ``langchain_core``.
+    Collapsing ``-``/``_``/``.`` runs to a single ``-`` and lowercasing makes
+    the two sides comparable.
+
+    Args:
+        name: A distribution or module name in any casing/separator style.
+
+    Returns:
+        The canonical name (lowercase, separators folded to ``-``).
+    """
+    return re.sub(r'[-_.]+', '-', name).strip().lower()
+
+
+def _try_import_engine_depends():
+    """
+    Try to import the engine's ``depends`` module.
+
+    Returns:
+        The ``depends`` module when the engine env is loaded (the engine
+        binary puts it on ``sys.path``); ``None`` when running outside the
+        engine (e.g., framework self-tests on a developer laptop).
+    """
+    try:
+        return importlib.import_module('depends')
+    except ImportError:
+        return None
+
+
+def ensure_constraints() -> Optional[Path]:
+    """
+    Run the engine's constraint-compile step and return the path to the
+    resolved ``constraints.txt``.
+
+    Returns:
+        Path to ``cache/constraints.txt`` on success; ``None`` when the engine
+        env is not available (e.g., framework self-tests on a dev laptop).
+    """
+    mod = _try_import_engine_depends()
+    if mod is None:
+        return None
+    fn = getattr(mod, 'ensure_constraints', None)
+    if fn is None:
+        return None
+    try:
+        return Path(fn())
+    except Exception:
+        return None
+
+
+def depends(requirements_path: str) -> None:
+    """
+    Install ``requirements_path`` via the engine's ``depends()``.
+
+    No-op when the engine env is not available, or when the file does not
+    exist. ``depends._processed`` (the engine's dedup set) ensures repeat
+    calls for the same file are cheap.
+
+    Args:
+        requirements_path: Absolute path to a requirements.txt file.
+
+    Raises:
+        Exception: Propagates whatever the engine's underlying ``depends()``
+                   raises (typically uv resolution / network / disk errors).
+                   Callers are expected to handle per-file failures and
+                   decide whether to continue — see
+                   :func:`cli._install_all_requirements` for the per-file
+                   ``[install-failed]`` pattern. We deliberately do NOT
+                   swallow the exception here: silent install failures
+                   would mask real environment drift (e.g., a previously
+                   installable Tier-2 bundle starting to fail) and there
+                   would be no way for an operator to know coverage had
+                   silently shrunk.
+    """
+    mod = _try_import_engine_depends()
+    if mod is None:
+        return
+    fn = getattr(mod, 'depends', None)
+    if fn is None:
+        return
+    if not Path(requirements_path).exists():
+        return
+    fn(requirements_path)
+
+
+@lru_cache(maxsize=1)
+def read_constraints() -> dict[str, str]:
+    """
+    Parse the engine's resolved constraints file into ``{package: version}``.
+
+    Returns:
+        Dict mapping each pinned package name to its resolved version.
+        Empty dict when the engine env / file is unavailable.
+    """
+    constraints_path = ensure_constraints()
+    if constraints_path is None or not constraints_path.exists():
+        return {}
+    pins: dict[str, str] = {}
+    for raw in constraints_path.read_text(encoding='utf-8').splitlines():
+        line = raw.strip()
+        if not line or line.startswith('#'):
+            continue
+        # `uv pip compile` emits `package==version` (sometimes followed by
+        # `; marker` or trailing comment). Strip both.
+        spec = line.split(';', 1)[0].split(' ', 1)[0].strip()
+        if '==' not in spec:
+            continue
+        name, version = spec.split('==', 1)
+        pins[normalize_dist_name(name)] = version.strip()
+    return pins
+
+
+def version_matches(spec: str, version: str) -> bool:
+    """
+    Test whether a version string satisfies a PEP 440 specifier.
+
+    Used by the dispatch loop to gate manifest entries on their
+    ``applies_when`` field. Validation of ``spec`` already happened at
+    manifest-load time (``manifest._validate_applies_when``), so a parse
+    failure here means the spec was malformed in a way that slipped past
+    the loader — re-raised so the CI surface is loud.
+
+    Args:
+        spec:    PEP 440 specifier (e.g., ``"<2.0"``, ``">=1.0,<2.0"``).
+        version: Installed version string from
+                 :func:`installed_version` (e.g., ``"2.0.0"``).
+
+    Returns:
+        ``True`` when ``version`` falls within ``spec``; ``False`` otherwise.
+
+    Raises:
+        ImportError: When the ``packaging`` library isn't available in the
+                     engine env. Almost never happens (packaging is a
+                     transitive of pip/uv) — but a clear message is more
+                     helpful than a silent fallback.
+        Exception:   When ``spec`` or ``version`` is unparseable. Re-raised
+                     by ``packaging``.
+    """
+    from packaging.specifiers import SpecifierSet  # local import: keep optional
+    from packaging.version import Version
+
+    return Version(version) in SpecifierSet(spec)
+
+
+_SKIP_INSTALL_MARKER = 'contract-check: skip-install'
+_DISABLE_MARKER = 'contract-check: disable'
+
+
+def _scan_marker(req_path: Path, marker: str) -> tuple[bool, str]:
+    """
+    Scan a requirements file for a specific ``# contract-check: …`` marker.
+
+    Both ``skip-install`` and ``disable`` markers share the same scanning
+    logic — only the marker text differs — so they delegate here.
+
+    Args:
+        req_path: Path to a ``requirement*.txt`` file.
+        marker:   The full marker text to look for after ``#`` (e.g.,
+                  ``"contract-check: disable"``).
+
+    Returns:
+        ``(True, reason)`` when the marker is found, where ``reason`` is
+        whatever text follows it on that comment line (stripped, with a
+        leading ``"reason:"`` prefix removed if the maintainer wrote one).
+        ``(False, '')`` when the marker is absent or the file is
+        unreadable.
+    """
+    try:
+        text = req_path.read_text(encoding='utf-8')
+    except (OSError, UnicodeDecodeError):
+        return False, ''
+    for raw_line in text.splitlines():
+        # Substring search anywhere on the line — consistent with the
+        # extractor's `_find_ignored_lines` (which substring-matches
+        # `contract-check: ignore` in comment tokens). Using substring
+        # rather than "startswith after the first '#'" means a line with
+        # two comments — e.g. `pkg  # note  # contract-check: disable` —
+        # is still detected. Safe from false positives on package specs
+        # because the marker contains ": " (colon-space), which can't
+        # appear in a pip requirement line outside a comment.
+        idx = raw_line.find(marker)
+        if idx == -1:
+            continue
+        reason = raw_line[idx + len(marker) :].strip()
+        if reason.lower().startswith('reason:'):
+            reason = reason[len('reason:') :].strip()
+        return True, reason
+    return False, ''
+
+
+def requirements_file_skipped(req_path: Path) -> tuple[bool, str]:
+    """
+    Scan a requirements.txt for the ``# contract-check: skip-install`` marker.
+
+    A skip-install marker means "don't install this file on the default lane,
+    BUT install it when ``--install-all`` is passed." Use it for heavy
+    Tier-2 bundles whose install is fine on a fresh env but slow to download
+    (kokoro, whisper, gliner, doctr, easyocr, sentence_transformers, vision).
+
+    For files that should NEVER be installed (uv resolution conflicts with
+    the engine's pinned env that can't be resolved at uv level), use the
+    stronger :func:`requirements_file_disabled` marker instead.
+
+    The marker is plain pip-syntax comment so the file remains valid:
+
+        # contract-check: skip-install  reason: <short why>
+        kokoro>=0.9.4
+        ...
+
+    Args:
+        req_path: Path to a ``requirement*.txt`` file.
+
+    Returns:
+        ``(True, reason)`` when the file carries the marker, where
+        ``reason`` is the text after the marker on its line (or empty if
+        none). ``(False, '')`` when the marker is absent or the file
+        can't be read.
+    """
+    return _scan_marker(req_path, _SKIP_INSTALL_MARKER)
+
+
+def requirements_file_disabled(req_path: Path) -> tuple[bool, str]:
+    """
+    Scan a requirements.txt for the ``# contract-check: disable`` marker.
+
+    A disable marker is strictly stronger than ``skip-install``: the file
+    is NEVER installed by the framework, even when ``--install-all`` is
+    passed. Use it for files whose packages have **fundamental
+    incompatibilities** with the engine's pinned environment that uv
+    cannot resolve — typically because a transitive dependency pins a
+    library to a version the engine has overridden via a runtime shim.
+
+    Canonical examples:
+
+    * ``requirements_surya.txt`` — ``surya-ocr`` pulls
+      ``opencv-python-headless==4.11.0.86`` against the engine's
+      ``opencv-contrib-python==4.13.0.92`` (override comes from
+      ``ai.common.opencv`` at import time, after install).
+    * ``requirements_trocr.txt`` — ``craft-text-detector`` pulls
+      ``opencv-python<4.5.4.62``; same kind of shim-handled override.
+
+    Disabled files are paired with ``# contract-check: ignore`` markers on
+    the consuming source's import lines (e.g.,
+    ``from surya.recognition import RecognitionPredictor  # contract-check: ignore``),
+    so the framework never tries to verify the contract either. Result:
+    surya/trocr go completely off the framework's radar.
+
+    Args:
+        req_path: Path to a ``requirement*.txt`` file.
+
+    Returns:
+        ``(True, reason)`` when the file carries the marker, where
+        ``reason`` is the text after the marker on its line. ``(False, '')``
+        when the marker is absent or the file can't be read.
+    """
+    return _scan_marker(req_path, _DISABLE_MARKER)
+
+
+def installed_version(package: str) -> Optional[str]:
+    """
+    Look up the installed version of a package in the engine's site-packages.
+
+    Args:
+        package: Top-level package name (e.g., ``"langchain"``,
+                 ``"img2table"``).
+
+    Returns:
+        The installed version string (PEP 440) when the package's metadata
+        is discoverable; ``None`` when the package is not installed or its
+        metadata is unreadable.
+    """
+    try:
+        return importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+    except Exception:
+        return None

--- a/tools/contract_checks/src/contract_checks/extractor.py
+++ b/tools/contract_checks/src/contract_checks/extractor.py
@@ -1,0 +1,845 @@
+"""
+AST-based contract extractor.
+
+Walks every ``.py`` file under a configured tree and produces a
+:class:`ComponentContract` describing the third-party imports and attribute
+chains the code uses. Recurses into function and class bodies so SDK imports
+placed inside the method that uses them (a common pattern) are seen.
+
+Auto-detects three things without a manifest:
+  1. Plain imports → :class:`ImportRequirement`.
+  2. ``try / except (ImportError, ModuleNotFoundError)`` shims around imports
+     → :class:`AnyOf` candidates.
+  3. SDK client patterns via intra-procedural data-flow tracking:
+     ``client = TwelveLabs(api_key=key)`` then ``client.indexes.create(...)``
+     → auto-emitted :class:`HeavyClass` with a dummied construction expression.
+
+Honours ``# contract-check: ignore`` on an import line to drop that import
+entirely.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import sys
+import tokenize
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Optional
+
+from contract_checks.manifest import (
+    AnyOf,
+    ComponentManifest,
+    HeavyClass,
+    ImportRequirement,
+)
+from contract_checks.trees import Tree
+
+
+# Comment marker that drops an import from the contract entirely.
+_IGNORE_COMMENT = 'contract-check: ignore'
+
+# Python stdlib top-level names. `sys.stdlib_module_names` exists since 3.10.
+_STDLIB = frozenset(getattr(sys, 'stdlib_module_names', ()))
+
+
+@dataclass
+class ComponentContract:
+    """
+    The auto-extracted (+ manifest-overlaid) contract for one component.
+
+    Attributes:
+        tree_name:      Short id of the owning :class:`Tree` (e.g.,
+                        ``"nodes"``).
+        component_name: Directory name of the component (e.g.,
+                        ``"twelvelabs"``).
+        component_dir:  Absolute path to the component directory.
+        imports:        Required imports the runner will resolve one-by-one.
+        any_of_imports: Version-fallback groups; each requires at least one
+                        alternative to resolve.
+        heavy_classes:  SDK-client contracts to construct + walk.
+    """
+
+    tree_name: str
+    component_name: str
+    component_dir: Path
+    imports: list[ImportRequirement] = field(default_factory=list)
+    any_of_imports: list[AnyOf] = field(default_factory=list)
+    heavy_classes: list[HeavyClass] = field(default_factory=list)
+
+    @property
+    def packages(self) -> list[str]:
+        """
+        Enumerate distinct top-level packages referenced by this contract.
+
+        Returns:
+            Insertion-ordered list of unique top-level package names found
+            across :attr:`imports`, :attr:`any_of_imports`, and
+            :attr:`heavy_classes`. Used by the CLI to drive its
+            per-package skip-on-missing loop.
+        """
+        seen: list[str] = []
+
+        def _add(name: str) -> None:
+            """Add ``name``'s top-level package to ``seen`` if not present."""
+            top = name.split('.', 1)[0]
+            if top and top not in seen:
+                seen.append(top)
+
+        for req in self.imports:
+            _add(req.module)
+        for group in self.any_of_imports:
+            for alt in group.alternatives:
+                _add(alt.module)
+        for hc in self.heavy_classes:
+            _add(hc.qualname)
+        return seen
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers
+# --------------------------------------------------------------------------- #
+
+
+def _find_ignored_lines(source: str) -> set[int]:
+    """
+    Scan source for ``# contract-check: ignore`` comments.
+
+    Args:
+        source: Full text of a .py file.
+
+    Returns:
+        Set of 1-based line numbers that carry the ignore marker. Any import
+        statement at one of these lines is dropped from the contract.
+    """
+    ignored: set[int] = set()
+    try:
+        tokens = tokenize.generate_tokens(io.StringIO(source).readline)
+        for tok in tokens:
+            if tok.type == tokenize.COMMENT and _IGNORE_COMMENT in tok.string:
+                ignored.add(tok.start[0])
+    except tokenize.TokenizeError:
+        pass
+    return ignored
+
+
+def _is_third_party(module: str, internal: frozenset[str]) -> bool:
+    """
+    Decide whether a module name should be checked against upstream.
+
+    Args:
+        module:   Dotted module name as it appears in an ``import``
+                  statement (e.g., ``"langchain_core.messages"``).
+        internal: Set of top-level package names treated as internal by the
+                  tree's :class:`Tree` config (filtered out from contracts).
+
+    Returns:
+        ``True`` when the module's top-level name is neither stdlib nor an
+        internal repo package — i.e., when it represents a real third-party
+        dependency the framework should verify.
+    """
+    if not module:
+        return False
+    top = module.split('.', 1)[0]
+    if top in _STDLIB:
+        return False
+    if top in internal:
+        return False
+    return True
+
+
+def _import_caught_as_optional(handler: ast.ExceptHandler) -> bool:
+    """
+    Decide whether an ``except`` clause guards optional imports.
+
+    Args:
+        handler: A single ``except`` clause from a ``try`` statement.
+
+    Returns:
+        ``True`` when the handler catches ``ImportError``,
+        ``ModuleNotFoundError``, both, or is a bare ``except:`` (which also
+        catches them). Used to detect version-fallback shims that should be
+        modelled as :class:`AnyOf` groups rather than required imports.
+
+    Examples:
+        ``True`` for the handler in each of::
+
+            except ImportError: ...                       # Name match
+            except ModuleNotFoundError: ...               # Name match
+            except (ImportError, ValueError): ...         # one element matches
+            except builtins.ImportError: ...              # Attribute match
+            except: ...                                   # bare — catches all
+
+        ``False`` for::
+
+            except ValueError: ...                        # unrelated exception
+            except (KeyError, RuntimeError): ...          # no element matches
+    """
+    if handler.type is None:
+        return True  # bare except catches everything, including ImportError
+    targets: list[ast.expr] = []
+    if isinstance(handler.type, ast.Tuple):
+        targets.extend(handler.type.elts)
+    else:
+        targets.append(handler.type)
+    for t in targets:
+        if isinstance(t, ast.Name) and t.id in {'ImportError', 'ModuleNotFoundError'}:
+            return True
+        if isinstance(t, ast.Attribute) and t.attr in {'ImportError', 'ModuleNotFoundError'}:
+            return True
+    return False
+
+
+def _dummy_for_arg(arg: ast.expr) -> str:
+    """
+    Pick a safe source-text dummy for one constructor argument.
+
+    Strategy: preserve literals as-is when they're already safe (numbers,
+    booleans, None, empty sequences); replace any non-literal — or a
+    non-empty string/sequence — with the smallest plausible value of the
+    inferred type. The dummy must be syntactically valid Python source so
+    that :func:`_render_construct`'s output can be ``eval()``'d.
+
+    Args:
+        arg: AST node for one positional or keyword-value argument.
+
+    Returns:
+        A short Python source-text expression suitable for placing in an
+        auto-generated construction call (e.g., ``'"x"'``, ``'0'``,
+        ``'[]'``).
+    """
+    if isinstance(arg, ast.Constant):
+        val = arg.value
+        if val is None or isinstance(val, bool):
+            return repr(val)
+        if isinstance(val, (int, float)):
+            return repr(val)
+        if isinstance(val, str):
+            return '"x"'
+        if isinstance(val, bytes):
+            return 'b"x"'
+        return repr(val)
+    if isinstance(arg, ast.List):
+        return '[]'
+    if isinstance(arg, ast.Tuple):
+        return '()'
+    if isinstance(arg, ast.Dict):
+        return '{}'
+    if isinstance(arg, ast.Set):
+        return 'set()'
+    return '"x"'  # safest default — most SDK constructor args are strings
+
+
+def _render_construct(class_name: str, call: ast.Call) -> str:
+    """
+    Synthesize a construction expression from a real call's argument shape.
+
+    Walks each positional and keyword argument of ``call`` and replaces its
+    value with a type-appropriate dummy via :func:`_dummy_for_arg`. Preserves
+    keyword names so SDKs that require specific kwargs still see them.
+
+    Args:
+        class_name: Bare class name to use as the callee (e.g.,
+                    ``"TwelveLabs"``).
+        call:       AST node of the real constructor call from source.
+
+    Returns:
+        A Python source-text expression like ``'TwelveLabs(api_key="x")'``
+        that :func:`runner.verify_heavy_class` will ``eval()``. ``**kwargs``
+        splats are skipped since their shape can't be synthesized.
+    """
+    parts: list[str] = []
+    for a in call.args:
+        parts.append(_dummy_for_arg(a))
+    for kw in call.keywords:
+        if kw.arg is None:
+            continue  # skip **kwargs splat — can't synthesize
+        parts.append(f'{kw.arg}={_dummy_for_arg(kw.value)}')
+    return f'{class_name}({", ".join(parts)})'
+
+
+def _attr_chain(node: ast.Attribute) -> Optional[tuple[str, tuple[str, ...]]]:
+    """
+    Decompose a dotted attribute access into its root name + attribute path.
+
+    For ``client.indexes.create``, the AST is
+    ``Attribute(value=Attribute(value=Name('client'), attr='indexes'), attr='create')``.
+    This walks back to the root ``Name`` and returns the attribute names in
+    left-to-right order.
+
+    Args:
+        node: ``ast.Attribute`` node, typically encountered while walking a
+              function body.
+
+    Returns:
+        ``(root_name, (attr1, attr2, ...))`` when the chain is rooted at a
+        bare ``Name`` (e.g., a local variable); ``None`` when the root is
+        anything else (a call result, a subscript, a literal — any of which
+        the framework cannot statically resolve to an imported binding).
+    """
+    parts: list[str] = []
+    cur: ast.AST = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if not isinstance(cur, ast.Name):
+        return None
+    return cur.id, tuple(reversed(parts))
+
+
+# --------------------------------------------------------------------------- #
+# Per-file visitor
+# --------------------------------------------------------------------------- #
+
+
+class _FileVisitor(ast.NodeVisitor):
+    """
+    Walks a single .py file, accumulating imports, any-of groups, and
+    auto-detected heavy classes.
+    """
+
+    def __init__(self, file_path: Path, source: str, internal: frozenset[str]):
+        """
+        Build a fresh visitor for one source file.
+
+        Args:
+            file_path: Path of the file being walked (used only for error
+                       messages and the ``HeavyClass.source`` marker).
+            source:    Full text of the file — needed to scan for
+                       ``# contract-check: ignore`` comments.
+            internal:  Tree-specific set of internal package top-level names
+                       to filter out (e.g., ``{'rocketlib', 'engLib'}``).
+        """
+        self.file_path = file_path
+        self.internal = internal
+        self.ignored_lines = _find_ignored_lines(source)
+
+        self.imports: list[ImportRequirement] = []
+        self.any_of: list[AnyOf] = []
+        self.heavy_classes: list[HeavyClass] = []
+
+        # Scope stack of bindings: name -> (qualname, ast.Call). Maps a local
+        # variable name to the imported class it was assigned from and the
+        # AST node of the constructor call (for argshape replay).
+        self._scope_stack: list[dict[str, tuple[str, ast.Call]]] = [{}]
+
+        # Module-scope alias map: local name -> (module, attr) where attr is
+        # the symbol name imported, or '' for `import module` form. Populated
+        # as we encounter top-level imports; consulted when an `ast.Call.func`
+        # resolves to a Name that was imported.
+        self._aliases: dict[str, tuple[str, str]] = {}
+
+        # Per-class chains-seen-so-far map, keyed by qualname:
+        # qualname -> {construct_text -> set(chain)}
+        self._heavy_buf: dict[str, dict[str, set[str]]] = {}
+
+        # True while visiting children of a try-block whose handler catches
+        # ImportError / ModuleNotFoundError. In that context, nested imports
+        # must not be re-recorded as required — they've already been routed
+        # to AnyOf.
+        self._in_import_guard: bool = False
+
+    # ----- scope helpers -----
+
+    def _push_scope(self) -> None:
+        """Open a fresh lexical scope frame on the binding stack."""
+        self._scope_stack.append({})
+
+    def _pop_scope(self) -> None:
+        """Discard the topmost lexical scope frame."""
+        self._scope_stack.pop()
+
+    def _lookup_binding(self, name: str) -> Optional[tuple[str, ast.Call]]:
+        """
+        Walk scope frames inside-out looking for a tracked binding.
+
+        Args:
+            name: Local variable name (e.g., ``"client"``).
+
+        Returns:
+            ``(qualname, ast.Call)`` when ``name`` was assigned the result
+            of constructing a tracked imported class in some enclosing
+            scope; ``None`` otherwise.
+        """
+        for frame in reversed(self._scope_stack):
+            if name in frame:
+                return frame[name]
+        return None
+
+    def _set_binding(self, name: str, value: tuple[str, ast.Call]) -> None:
+        """
+        Record that ``name`` in the current scope holds an SDK instance.
+
+        Args:
+            name:  Local variable name from an assignment target.
+            value: ``(qualname, ast.Call)`` pair captured when the RHS was
+                   a call to a tracked imported class.
+        """
+        self._scope_stack[-1][name] = value
+
+    # ----- import handling -----
+
+    def _record_import(self, module: str, symbols: tuple[str, ...]) -> None:
+        """
+        Append one :class:`ImportRequirement` if it's a real third-party use.
+
+        Suppressed when the visitor is inside an import-guard ``try`` block
+        (those go to :class:`AnyOf` instead) or when ``module`` filters out
+        as stdlib / internal.
+
+        Args:
+            module:  Dotted module name from the import statement.
+            symbols: Tuple of symbol names imported (empty for bare
+                     ``import X`` form).
+        """
+        if self._in_import_guard:
+            return
+        if not _is_third_party(module, self.internal):
+            return
+        self.imports.append(ImportRequirement(module=module, symbols=symbols))
+
+    def visit_Import(self, node: ast.Import) -> None:
+        """
+        Handle a top-level ``import X`` or ``import X as Y`` statement.
+
+        Args:
+            node: AST node for the import statement.
+        """
+        if node.lineno in self.ignored_lines:
+            return
+        for alias in node.names:
+            # Don't register internal-package aliases. Otherwise heavy-class
+            # auto-detection would treat `import rocketlib; rocketlib.X(...)`
+            # as a third-party SDK contract and emit a spurious HeavyClass.
+            if not _is_third_party(alias.name, self.internal):
+                continue
+            local = alias.asname or alias.name.split('.', 1)[0]
+            self._aliases[local] = (alias.name, '')
+            self._record_import(alias.name, ())
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """
+        Handle a ``from X import Y`` statement.
+
+        Relative imports (``from . import X``) are dropped: by construction
+        they reach into the repo, not into third-party packages.
+
+        Args:
+            node: AST node for the from-import statement.
+        """
+        if node.lineno in self.ignored_lines:
+            return
+        if node.level and node.level > 0:
+            return  # relative import, internal by construction
+        module = node.module or ''
+        if not module:
+            return
+        # Same internal filter as visit_Import — internal aliases must NOT
+        # land in the alias map, or heavy-class auto-detection picks them
+        # up and emits spurious entries like rocketlib.getServiceDefinition.
+        if not _is_third_party(module, self.internal):
+            return
+        symbols = tuple(a.name for a in node.names if a.name != '*')
+        for a in node.names:
+            local = a.asname or a.name
+            if a.name != '*':
+                self._aliases[local] = (module, a.name)
+        self._record_import(module, symbols)
+
+    def visit_Try(self, node: ast.Try) -> None:
+        """
+        Inspect a ``try`` and route guarded imports to :class:`AnyOf`.
+
+        Imports inside ``try / except (ImportError, ModuleNotFoundError)``
+        are version-fallback shims, not required imports. The shim's
+        alternatives all go into a single ``AnyOf`` group; non-import code
+        inside the try is still walked normally (with an internal flag set
+        so nested imports aren't double-recorded).
+
+        Args:
+            node: AST node for the try statement.
+        """
+        if not any(_import_caught_as_optional(h) for h in node.handlers):
+            # Not an import-guard try; walk normally.
+            self.generic_visit(node)
+            return
+
+        alternatives = self._extract_alternative_imports(node)
+        if alternatives:
+            self.any_of.append(AnyOf(alternatives=tuple(alternatives)))
+
+        # Still walk the bodies for non-import statements (attribute chains
+        # etc.) but mark the context so nested imports aren't re-recorded.
+        prev = self._in_import_guard
+        self._in_import_guard = True
+        try:
+            for child in ast.iter_child_nodes(node):
+                if isinstance(child, (ast.Import, ast.ImportFrom)):
+                    continue
+                self.visit(child)
+        finally:
+            self._in_import_guard = prev
+
+    def _extract_alternative_imports(self, try_node: ast.Try) -> list[ImportRequirement]:
+        """
+        Collect import statements from a try-body + its import-guard handlers.
+
+        Only handlers that actually catch an import error contribute
+        alternatives (see :func:`_import_caught_as_optional`). Imports under a
+        handler for an unrelated exception are *not* fallbacks for the guarded
+        import and must not be folded into the :class:`AnyOf` group.
+
+        Args:
+            try_node: AST node for an import-guard try statement.
+
+        Returns:
+            List of :class:`ImportRequirement` — one per third-party import
+            seen in the try body or an import-guard handler body. Side effect:
+            also updates ``self._aliases`` so any chains using these imports
+            still resolve.
+
+        Example:
+            For::
+
+                try:
+                    import fast_json as json  # alternative
+                except ImportError:
+                    import json  # alternative (real fallback)
+                except ValueError:
+                    import unrelated  # NOT an alternative — skipped
+
+            returns ``[ImportRequirement('fast_json'), ImportRequirement('json')]``;
+            ``unrelated`` is ignored because ``except ValueError`` does not
+            catch an import error.
+        """
+        alts: list[ImportRequirement] = []
+
+        def _scan(stmts: list[ast.stmt]) -> None:
+            for s in stmts:
+                if isinstance(s, ast.ImportFrom):
+                    module = s.module or ''
+                    if not module or not _is_third_party(module, self.internal):
+                        continue
+                    syms = tuple(a.name for a in s.names if a.name != '*')
+                    alts.append(ImportRequirement(module=module, symbols=syms))
+                    # Also register aliases so attribute walks find the symbol.
+                    for a in s.names:
+                        if a.name == '*':
+                            continue
+                        local = a.asname or a.name
+                        self._aliases[local] = (module, a.name)
+                elif isinstance(s, ast.Import):
+                    for alias in s.names:
+                        if not _is_third_party(alias.name, self.internal):
+                            continue
+                        alts.append(ImportRequirement(module=alias.name, symbols=()))
+                        local = alias.asname or alias.name.split('.', 1)[0]
+                        self._aliases[local] = (alias.name, '')
+
+        _scan(try_node.body)
+        for h in try_node.handlers:
+            if _import_caught_as_optional(h):
+                _scan(h.body)
+        return alts
+
+    # ----- function/class scope recursion -----
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """
+        Enter a function body with a fresh binding scope.
+
+        Args:
+            node: AST node for the ``def`` statement.
+        """
+        self._push_scope()
+        try:
+            self.generic_visit(node)
+        finally:
+            self._pop_scope()
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        """
+        Enter an async function body with a fresh binding scope.
+
+        Args:
+            node: AST node for the ``async def`` statement.
+        """
+        self._push_scope()
+        try:
+            self.generic_visit(node)
+        finally:
+            self._pop_scope()
+
+    # ----- assignment tracking (data-flow) -----
+
+    def visit_Assign(self, node: ast.Assign) -> None:
+        """
+        Track variable assignments whose RHS constructs a tracked class.
+
+        ``client = TwelveLabs(api_key=key)`` registers ``client`` as bound
+        to ``twelvelabs.TwelveLabs`` in the current scope. Subsequent
+        ``client.xxx`` chains are then attributed to that SDK class via
+        :meth:`visit_Attribute`.
+
+        Args:
+            node: AST node for the assignment statement.
+        """
+        self.generic_visit(node)  # recurse first so call args etc. are visited
+        if not isinstance(node.value, ast.Call):
+            return
+        call = node.value
+        func = call.func
+        # Recognise bare-name calls: `client = TwelveLabs(...)`
+        if isinstance(func, ast.Name) and func.id in self._aliases:
+            module, symbol = self._aliases[func.id]
+            if not symbol:
+                # `import X` form — `X(...)` constructs a module attribute, not
+                # something we model. Skip.
+                return
+            qualname = f'{module}.{symbol}'
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    self._set_binding(target.id, (qualname, call))
+
+    # ----- attribute chain detection -----
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        """
+        Inspect a dotted attribute access for SDK-client chain detection.
+
+        Two cases:
+          * Root name is a local variable previously bound to an SDK class
+            via :meth:`visit_Assign` — record the chain in the heavy-class
+            buffer (will become a :class:`HeavyClass` on finalisation).
+          * Root name is an alias for an imported module — left to the
+            runner's class-level :func:`runner.verify_class_attrs` checks;
+            no extraction needed here.
+
+        Args:
+            node: AST node for the attribute access.
+        """
+        self.generic_visit(node)
+        decomposed = _attr_chain(node)
+        if decomposed is None:
+            return
+        root_name, attrs = decomposed
+        if not attrs:
+            return
+        # Case A: root_name is a local bound to an SDK class — heavy-class chain.
+        bound = self._lookup_binding(root_name)
+        if bound is not None:
+            qualname, call = bound
+            class_name = qualname.rsplit('.', 1)[-1]
+            construct = _render_construct(class_name, call)
+            chain = '.'.join(attrs)
+            self._heavy_buf.setdefault(qualname, {}).setdefault(construct, set()).add(chain)
+            return
+        # Case B: root_name is an alias for an imported module — class-level
+        # attribute walks (e.g., `np.array`) are validated separately by the
+        # runner using `getattr` on the imported module/symbol. No extraction
+        # needed here.
+
+    # ----- finalisation -----
+
+    def finalise(self) -> None:
+        """
+        Flush the per-class attribute buffer into :class:`HeavyClass` entries.
+
+        Call this once after :meth:`visit` has walked the whole module.
+        Side effect: populates ``self.heavy_classes``. No return value;
+        caller reads results off the visitor's public lists.
+        """
+        line = 1  # we don't track call line precisely; default to 1
+        for qualname, by_construct in self._heavy_buf.items():
+            for construct, chains in by_construct.items():
+                self.heavy_classes.append(
+                    HeavyClass(
+                        qualname=qualname,
+                        construct=construct,
+                        attr_chains=tuple(sorted(chains)),
+                        source=f'{self.file_path}:{line}',
+                    )
+                )
+
+
+# --------------------------------------------------------------------------- #
+# Public API
+# --------------------------------------------------------------------------- #
+
+
+def extract_component(tree: Tree, component_dir: Path) -> ComponentContract:
+    """
+    Build the auto-extracted contract for one component (= one directory of
+    .py files), then overlay any per-component ``external_contracts.py``.
+
+    Args:
+        tree:          The :class:`Tree` config this component lives in.
+        component_dir: Component directory containing one or more .py files.
+
+    Returns:
+        Fully resolved :class:`ComponentContract` ready for the runner.
+    """
+    contract = ComponentContract(
+        tree_name=tree.name,
+        component_name=component_dir.name,
+        component_dir=component_dir,
+    )
+
+    for py in sorted(component_dir.rglob('*.py')):
+        # external_contracts.py is the manifest itself — its imports are
+        # framework wiring, not runtime production code, so they must not
+        # be auto-extracted into the contract.
+        if py.name == 'external_contracts.py':
+            continue
+        try:
+            source = py.read_text(encoding='utf-8')
+            module_ast = ast.parse(source, filename=str(py))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        v = _FileVisitor(py, source, tree.internal_packages)
+        v.visit(module_ast)
+        v.finalise()
+        contract.imports.extend(v.imports)
+        contract.any_of_imports.extend(v.any_of)
+        contract.heavy_classes.extend(v.heavy_classes)
+
+    # Dedupe imports by (module, symbols) signature, preserving order.
+    contract.imports = _dedupe_imports(contract.imports)
+
+    _apply_manifest(contract)
+    return contract
+
+
+def _dedupe_imports(reqs: list[ImportRequirement]) -> list[ImportRequirement]:
+    """
+    Merge requirements that target the same module, unioning their symbols.
+
+    Walking a multi-file component naturally produces several
+    :class:`ImportRequirement` entries for the same module (e.g., one file
+    imports ``X``, another imports ``X.Y``). This collapses them into one
+    entry per module so the runner doesn't import the same module N times.
+
+    Args:
+        reqs: Possibly-duplicate requirements as emitted by ``_FileVisitor``.
+
+    Returns:
+        Deduped list, preserving first-seen module order. Each entry's
+        ``symbols`` is the sorted union of all matching inputs' symbols.
+    """
+    by_module: dict[str, set[str]] = {}
+    order: list[str] = []
+    for r in reqs:
+        if r.module not in by_module:
+            by_module[r.module] = set()
+            order.append(r.module)
+        by_module[r.module].update(r.symbols)
+    return [ImportRequirement(module=m, symbols=tuple(sorted(by_module[m]))) for m in order]
+
+
+def _apply_manifest(contract: ComponentContract) -> None:
+    """
+    Overlay a per-component manifest, if one exists, on top of ``contract``.
+
+    Manifest entries take precedence over auto-extracted entries. Matching
+    rules:
+
+    * **Imports:** a manifest :class:`ImportRequirement` with a given
+      ``module`` replaces any auto-extracted entry for the same module
+      (regardless of symbols overlap). Reason: the manifest captures the
+      maintainer's intent — e.g., that the import is version-gated
+      (``applies_when='<2.0'``). Letting the unconditional auto-extracted
+      entry survive alongside would defeat the gate.
+    * **Heavy classes:** a manifest :class:`HeavyClass` with a given
+      ``qualname`` replaces any auto-extracted entry for the same class.
+    * **AnyOf groups:** always additive (no natural "same group" match).
+    * **skip_packages:** drops auto-extracted AND manifest entries for the
+      named top-level packages. For an :class:`AnyOf`, only the skip-listed
+      *alternatives* are removed; the group survives (with its remaining
+      alternatives) unless every alternative was skip-listed.
+
+    Args:
+        contract: Component contract built from AST extraction; mutated
+                  in place to fold in the manifest.
+
+    Example:
+        Given ``skip_packages={'pycryptodome'}`` and an auto-extracted group
+        ``AnyOf(cryptography.X, pycryptodome.X)``, the result is
+        ``AnyOf(cryptography.X)`` — the skip-listed alternative is stripped,
+        but the group is kept so ``cryptography.X`` is still verified. A group
+        whose only alternative is ``pycryptodome.X`` is dropped entirely.
+    """
+    from contract_checks.manifest import load_manifest  # local import to avoid cycle
+
+    manifest: Optional[ComponentManifest] = load_manifest(contract.component_dir)
+    if manifest is None:
+        return
+
+    # Imports: manifest entries replace auto-extracted entries with the
+    # same module. Build a set of module names the manifest covers, drop
+    # auto-extracted entries that match, then append the manifest entries.
+    if manifest.imports:
+        manifest_modules = {r.module for r in manifest.imports}
+        contract.imports = [r for r in contract.imports if r.module not in manifest_modules]
+        contract.imports.extend(manifest.imports)
+
+    # AnyOf groups: additive. No natural "same group" identity, so we
+    # don't try to match. If the manifest's AnyOf overlaps with an
+    # auto-extracted one, both run (both pass on matching versions —
+    # harmless redundancy).
+    contract.any_of_imports.extend(manifest.any_of_imports)
+
+    # Heavy classes: manifest entries replace auto-extracted with the same
+    # qualname. Same logic as imports.
+    if manifest.heavy_classes:
+        manifest_quals = {hc.qualname for hc in manifest.heavy_classes}
+        contract.heavy_classes = [hc for hc in contract.heavy_classes if hc.qualname not in manifest_quals]
+        contract.heavy_classes.extend(manifest.heavy_classes)
+
+    # Skip list removes ALL entries (auto + manifest) for the named packages.
+    if manifest.skip_packages:
+        contract.imports = [r for r in contract.imports if r.module.split('.', 1)[0] not in manifest.skip_packages]
+        contract.heavy_classes = [
+            h for h in contract.heavy_classes if h.qualname.split('.', 1)[0] not in manifest.skip_packages
+        ]
+        filtered_groups: list[AnyOf] = []
+        for g in contract.any_of_imports:
+            kept = tuple(alt for alt in g.alternatives if alt.module.split('.', 1)[0] not in manifest.skip_packages)
+            if kept:
+                # replace() preserves the group's own applies_when gate;
+                # a bare AnyOf(alternatives=kept) would silently lose it.
+                filtered_groups.append(replace(g, alternatives=kept))
+        contract.any_of_imports = filtered_groups
+
+
+def iter_components(tree: Tree) -> list[Path]:
+    """
+    Discover the component directories within a tree.
+
+    A component is a directory that either contains a ``requirements.txt``
+    (= proper per-component layout, as in ``nodes/``) or is the tree root
+    itself when no per-directory requirements are present (collapsed-tree
+    case, as in ``rocketlib/lib``).
+
+    Args:
+        tree: Tree to inspect.
+
+    Returns:
+        Sorted list of component directories. Always at least one entry
+        (the tree root itself) so the framework still scans flat-layout trees.
+    """
+    if not tree.root.exists():
+        return []
+
+    per_component: list[Path] = []
+    for entry in sorted(tree.root.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith(('.', '__')):
+            continue
+        if (entry / 'requirements.txt').exists():
+            per_component.append(entry)
+
+    if per_component:
+        return per_component
+    return [tree.root]

--- a/tools/contract_checks/src/contract_checks/manifest.py
+++ b/tools/contract_checks/src/contract_checks/manifest.py
@@ -1,0 +1,227 @@
+"""
+Manifest schema for per-component contract overrides.
+
+A component author can drop an ``external_contracts.py`` into the component
+directory to override or extend the AST-extracted contract. The file must
+define a module-level ``MANIFEST`` of type :class:`ComponentManifest`.
+
+Every entry can carry an optional ``applies_when`` PEP 440 version
+specifier (e.g., ``"<2.0"``, ``">=1.0,<2.0"``) that gates the check on the
+installed version of the entry's top-level package. When the spec doesn't
+match the installed version, the dispatch loop emits a ``[SKIP]`` row and
+moves on. When ``applies_when`` is omitted (the default), the entry is
+checked unconditionally — fully backward-compatible with manifests written
+before this field existed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+# --------------------------------------------------------------------------- #
+# Validation helper
+# --------------------------------------------------------------------------- #
+
+
+def _validate_applies_when(value: Optional[str], owner: str) -> None:
+    """
+    Fail loudly at manifest-load time on malformed ``applies_when`` strings.
+
+    A typo like ``applies_when='<= 2.0 '`` (extra whitespace, trailing junk)
+    should not silently be treated as "always applies" — that would erase
+    the maintainer's intent. We try to parse the spec via ``packaging`` and
+    re-raise with a clear error pointing at the owning entry.
+
+    Args:
+        value: The string the manifest author supplied (or ``None``).
+        owner: Human-readable label for the entry that owns this field,
+               used to make the error message locate-able.
+
+    Raises:
+        ValueError: When ``value`` is non-empty but not a valid PEP 440
+                    specifier.
+    """
+    if value is None:
+        return
+    if not value.strip():
+        raise ValueError(f'{owner}: applies_when must be None or a non-empty PEP 440 spec; got {value!r}')
+    try:
+        from packaging.specifiers import SpecifierSet  # local import: keep optional
+    except ImportError:
+        # If packaging isn't available at manifest load, we can't validate.
+        # The dispatch loop surfaces a clear error when it tries to use it.
+        return
+    try:
+        SpecifierSet(value)
+    except Exception as e:
+        raise ValueError(
+            f'{owner}: malformed applies_when={value!r} (must be a PEP 440 specifier like "<2.0" or ">=1.0,<2.0"): {e}'
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Manifest dataclasses
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ImportRequirement:
+    """
+    A single ``from <module> import <symbol>, ...`` requirement.
+
+    Attributes:
+        module:       Dotted module path (e.g., ``"img2table.ocr._types"``).
+        symbols:      Tuple of symbol names imported from ``module``. Empty
+                      tuple for bare ``import <module>`` form.
+        applies_when: Optional PEP 440 specifier (e.g., ``"<2.0"``). When
+                      set, the check only runs if the installed version of
+                      the top-level package (inferred from ``module``)
+                      matches the spec; otherwise dispatch emits ``[SKIP]``.
+                      ``None`` (default) means "always applies".
+    """
+
+    module: str
+    symbols: tuple[str, ...] = ()
+    applies_when: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Validate ``applies_when`` at construction time."""
+        _validate_applies_when(
+            self.applies_when,
+            owner=f'ImportRequirement(module={self.module!r})',
+        )
+
+
+@dataclass(frozen=True)
+class AnyOf:
+    """
+    A group of :class:`ImportRequirement` alternatives — at least one must
+    resolve.
+
+    Used to express non-version-based fallbacks (e.g., ``cryptography`` OR
+    ``pycryptodome``). For pure version splits, prefer individual
+    :class:`ImportRequirement` entries each carrying ``applies_when`` —
+    they express the intent more directly than ``AnyOf`` and don't depend
+    on a try/except shim in the consuming code.
+
+    Attributes:
+        alternatives: Tuple of ``ImportRequirement`` alternatives.
+        applies_when: Optional PEP 440 specifier. Package inferred from the
+                      first alternative's ``module``. ``None`` means
+                      "always applies".
+    """
+
+    alternatives: tuple[ImportRequirement, ...]
+    applies_when: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Validate ``applies_when`` at construction time."""
+        first = self.alternatives[0].module if self.alternatives else '?'
+        _validate_applies_when(self.applies_when, owner=f'AnyOf(first={first!r})')
+
+
+@dataclass(frozen=True)
+class HeavyClass:
+    """
+    A class whose attributes are populated dynamically in ``__init__`` (common
+    SDK-client pattern). The framework constructs an instance using
+    ``construct`` and walks each ``attr_chain`` via repeated ``getattr``.
+
+    ``construct`` must be side-effect-free; if your SDK cannot be constructed
+    without I/O, omit the heavy-class entry and accept class-only coverage
+    for that symbol.
+
+    Attributes:
+        qualname:     Dotted name of the class (e.g., ``twelvelabs.TwelveLabs``).
+        construct:    Python expression to eval in a namespace with the class
+                      symbol injected (e.g., ``'TwelveLabs(api_key="x")'``).
+        attr_chains:  Dotted attribute chains to walk on the constructed
+                      instance (e.g., ``'indexes.create'``).
+        source:       Optional ``"<file>:<line>"`` marker, set automatically for
+                      auto-extracted heavy classes. Manual manifest entries
+                      leave this empty.
+        applies_when: Optional PEP 440 specifier. Package inferred from the
+                      top-level of ``qualname``. ``None`` means
+                      "always applies".
+    """
+
+    qualname: str
+    construct: str
+    attr_chains: tuple[str, ...]
+    source: str = ''
+    applies_when: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        """Validate ``applies_when`` at construction time."""
+        _validate_applies_when(
+            self.applies_when,
+            owner=f'HeavyClass(qualname={self.qualname!r})',
+        )
+
+
+@dataclass(frozen=True)
+class ComponentManifest:
+    """
+    Per-component overlay on top of the AST-extracted contract.
+
+    Every field is optional; missing fields fall back to the auto-extracted
+    contract. Manifest entries replace auto-extracted entries that target
+    the same module + symbol set (for imports) or the same qualname (for
+    heavy classes) — see ``extractor._apply_manifest``.
+
+    Attributes:
+        imports:        Required imports. Replace-on-match against
+                        auto-extracted entries.
+        any_of_imports: Version-fallback groups; each requires at least one
+                        alternative to resolve.
+        heavy_classes:  SDK-client contracts to construct + walk.
+                        Replace-on-match against auto-extracted entries
+                        with the same ``qualname``.
+        skip_packages:  Top-level package names to drop from the contract
+                        entirely (auto-extracted + manifest).
+    """
+
+    imports: tuple[ImportRequirement, ...] = ()
+    any_of_imports: tuple[AnyOf, ...] = ()
+    heavy_classes: tuple[HeavyClass, ...] = ()
+    skip_packages: frozenset[str] = field(default_factory=frozenset)
+
+
+# --------------------------------------------------------------------------- #
+# Manifest loader
+# --------------------------------------------------------------------------- #
+
+
+def load_manifest(component_dir: Path) -> Optional[ComponentManifest]:
+    """
+    Load ``<component_dir>/external_contracts.py`` if present.
+
+    Imported via ``spec_from_file_location`` so loading is hermetic — no
+    ``sys.modules`` pollution, no dependency on the engine's import path.
+
+    Args:
+        component_dir: Component directory to inspect.
+
+    Returns:
+        The module-level ``MANIFEST`` object if the file exists and exposes
+        one; ``None`` otherwise.
+    """
+    manifest_path = component_dir / 'external_contracts.py'
+    if not manifest_path.exists():
+        return None
+
+    spec = importlib.util.spec_from_file_location(f'_contract_checks_manifest_{component_dir.name}', manifest_path)
+    if spec is None or spec.loader is None:
+        return None
+
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    manifest = getattr(mod, 'MANIFEST', None)
+    if not isinstance(manifest, ComponentManifest):
+        return None
+    return manifest

--- a/tools/contract_checks/src/contract_checks/runner.py
+++ b/tools/contract_checks/src/contract_checks/runner.py
@@ -75,10 +75,10 @@ def verify_import(req: ImportRequirement) -> CheckResult:
     """
     try:
         mod = importlib.import_module(req.module)
-    except ImportError as e:
+    except Exception as e:
         return CheckResult(
             ok=False,
-            message=f'cannot import module {req.module!r}: {e}',
+            message=f'cannot import module {req.module!r}: {type(e).__name__}: {e}',
             where=req.module,
         )
     for sym in req.symbols:
@@ -90,7 +90,13 @@ def verify_import(req: ImportRequirement) -> CheckResult:
             importlib.import_module(f'{req.module}.{sym}')
             continue
         except ImportError:
-            pass
+            pass  # genuinely not a submodule → fall through to "symbol not found"
+        except Exception as e:
+            return CheckResult(
+                ok=False,
+                message=f'importing submodule {req.module}.{sym} raised {type(e).__name__}: {e}',
+                where=f'{req.module}.{sym}',
+            )
         return CheckResult(
             ok=False,
             message=f'symbol {sym!r} not found in module {req.module!r}',
@@ -152,7 +158,7 @@ def verify_class_attrs(module: str, symbol: str, attrs: list[str]) -> CheckResul
     try:
         mod = importlib.import_module(module)
         cls = getattr(mod, symbol)
-    except (ImportError, AttributeError) as e:
+    except Exception as e:
         return CheckResult(
             ok=False,
             message=f'cannot reach {module}.{symbol}: {e}',
@@ -210,7 +216,7 @@ def verify_heavy_class(hc: HeavyClass) -> CheckResult:
     try:
         mod = importlib.import_module(module)
         cls = getattr(mod, class_name)
-    except (ImportError, AttributeError) as e:
+    except Exception as e:
         return CheckResult(
             ok=False,
             message=f'cannot reach {hc.qualname}: {e}',

--- a/tools/contract_checks/src/contract_checks/runner.py
+++ b/tools/contract_checks/src/contract_checks/runner.py
@@ -1,0 +1,439 @@
+"""
+Pure check functions — no pytest dependency.
+
+Each ``verify_*`` returns a :class:`CheckResult` describing pass or fail.
+The pytest layer aggregates results and asserts; the CLI prints them.
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+import os
+import signal
+import threading
+from dataclasses import dataclass
+from typing import Optional
+
+from contract_checks.engine_env import installed_version, normalize_dist_name, read_constraints
+from contract_checks.manifest import AnyOf, HeavyClass, ImportRequirement
+
+
+# Hard cap on heavy-class construction time. Anything longer is reported as a
+# manifest bug — SDK constructors should never do I/O when the manifest writer
+# claims they don't.
+_CONSTRUCT_TIMEOUT_SEC = 2.0
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    """
+    Result of one check (one import path / any-of group / chain / drift).
+
+    Attributes:
+        ok:      ``True`` on pass, ``False`` on hard fail. (Skip semantics
+                 live one layer up in the CLI's per-package gating, not on
+                 this dataclass.)
+        message: Human-readable explanation. On pass: typically ``"ok"`` or
+                 a short success note. On fail: includes what was checked
+                 and how it failed.
+        where:   Dotted identifier (e.g., ``"img2table.ocr._types"``) for
+                 the symbol or class the check targeted. Used in output
+                 lines so a reader can locate the upstream surface fast.
+    """
+
+    ok: bool
+    message: str
+    where: str = ''
+
+
+# --------------------------------------------------------------------------- #
+# Verifiers
+# --------------------------------------------------------------------------- #
+
+
+def verify_import(req: ImportRequirement) -> CheckResult:
+    """
+    Resolve a single ``from <module> import <symbol>, ...`` requirement.
+
+    Mirrors Python's actual ``from X import Y`` semantics: first checks
+    ``hasattr(X, 'Y')``; on miss, falls back to trying to import ``X.Y`` as
+    a submodule. This matters for lazy-loaded subpackages — e.g.,
+    ``from PIL import Image`` works at runtime because ``PIL.Image`` is a
+    submodule, but ``hasattr(PIL, 'Image')`` returns False until something
+    triggers the submodule import.
+
+    Args:
+        req: Requirement to verify.
+
+    Returns:
+        :class:`CheckResult` with ``ok=True`` when ``req.module`` imports
+        cleanly AND every name in ``req.symbols`` is reachable either as
+        an attribute or as an importable submodule. ``ok=False`` on the
+        first import / attribute / submodule miss, with the message naming
+        the offending module or symbol.
+    """
+    try:
+        mod = importlib.import_module(req.module)
+    except ImportError as e:
+        return CheckResult(
+            ok=False,
+            message=f'cannot import module {req.module!r}: {e}',
+            where=req.module,
+        )
+    for sym in req.symbols:
+        if hasattr(mod, sym):
+            continue
+        # Submodule fallback: `from PIL import Image` resolves via
+        # `import PIL.Image` when Image isn't an attribute on the package.
+        try:
+            importlib.import_module(f'{req.module}.{sym}')
+            continue
+        except ImportError:
+            pass
+        return CheckResult(
+            ok=False,
+            message=f'symbol {sym!r} not found in module {req.module!r}',
+            where=f'{req.module}.{sym}',
+        )
+    return CheckResult(ok=True, message='ok', where=req.module)
+
+
+def verify_any_of(group: AnyOf) -> CheckResult:
+    """
+    Verify a multi-version fallback group.
+
+    Args:
+        group: Set of :class:`ImportRequirement` alternatives.
+
+    Returns:
+        :class:`CheckResult` with ``ok=True`` as soon as one alternative
+        verifies — earlier alternatives that failed are not reported.
+        ``ok=False`` only when every alternative failed; the message then
+        carries each alternative's individual error indented for readability.
+    """
+    errors: list[str] = []
+    for alt in group.alternatives:
+        result = verify_import(alt)
+        if result.ok:
+            return CheckResult(
+                ok=True,
+                message=f'matched alternative {alt.module}',
+                where=alt.module,
+            )
+        errors.append(f'  - {alt.module}: {result.message}')
+    return CheckResult(
+        ok=False,
+        message='no alternative resolved:\n' + '\n'.join(errors),
+        where=' | '.join(alt.module for alt in group.alternatives),
+    )
+
+
+def verify_class_attrs(module: str, symbol: str, attrs: list[str]) -> CheckResult:
+    """
+    Verify that a class exposes a set of attributes at the class level.
+
+    Class-level only: no instance is constructed. Use this for SDKs whose
+    attributes are declared as class methods or class variables. For SDKs
+    that populate ``self.*`` in ``__init__``, use :func:`verify_heavy_class`
+    instead.
+
+    Args:
+        module: Dotted module name to import (e.g., ``"numpy"``).
+        symbol: Attribute name on the imported module that resolves to the
+                class (e.g., ``"ndarray"``).
+        attrs:  Class-level attribute names to check via ``hasattr``.
+
+    Returns:
+        :class:`CheckResult` with ``ok=True`` when every name in ``attrs``
+        is an attribute of the class; ``ok=False`` with the missing names
+        listed when one or more fail.
+    """
+    try:
+        mod = importlib.import_module(module)
+        cls = getattr(mod, symbol)
+    except (ImportError, AttributeError) as e:
+        return CheckResult(
+            ok=False,
+            message=f'cannot reach {module}.{symbol}: {e}',
+            where=f'{module}.{symbol}',
+        )
+    missing = [a for a in attrs if not hasattr(cls, a)]
+    if missing:
+        return CheckResult(
+            ok=False,
+            message=f'missing class-level attrs: {", ".join(missing)}',
+            where=f'{module}.{symbol}',
+        )
+    return CheckResult(ok=True, message='ok', where=f'{module}.{symbol}')
+
+
+def verify_heavy_class(hc: HeavyClass) -> CheckResult:
+    """
+    Construct an SDK class and walk each declared attribute chain.
+
+    The construction expression is ``eval()``'d in a fresh namespace holding
+    the imported class symbol plus a whitelist of pure data-constructor
+    builtins (``_EVAL_BUILTINS``) — ``open``/``__import__``/``exec`` and the
+    like are not reachable. The eval is wrapped in a 2-second wall-clock cap
+    (``signal.alarm`` on POSIX, watcher thread on Windows) — a timeout means
+    the manifest entry is wrong: either the SDK is doing I/O during
+    ``__init__``, or the construct expression is doing something heavier than
+    dummy-arg construction.
+
+    Args:
+        hc: Heavy-class entry — either from a per-component manifest or
+            auto-generated by the extractor's intra-procedural tracking.
+
+    Returns:
+        :class:`CheckResult` with ``ok=True`` when every chain in
+        ``hc.attr_chains`` resolves via repeated ``getattr`` against the
+        constructed instance. Failure cases:
+          * Module / class import fails -> ``ok=False`` with the import error.
+          * Construction times out -> ``ok=False`` with "construction timed out".
+          * Construction raises -> ``ok=False`` with the exception type/message
+            and a hint that ``construct`` needs override via manifest.
+          * Chain walk hits a missing attribute -> ``ok=False`` with the chain,
+            the breakpoint, and the construct expression for reproduction.
+        On failure, ``where`` includes ``[<source>]`` when ``hc.source`` is
+        set (i.e., the chain was auto-extracted from real source).
+    """
+    # A dotless qualname (e.g. a manifest typo `qualname='TwelveLabs'`) would
+    # make rsplit return a 1-element list and crash the unpack. Fail it cleanly.
+    if '.' not in hc.qualname:
+        return CheckResult(
+            ok=False,
+            message=(f"invalid qualname {hc.qualname!r}: expected a dotted 'module.ClassName' path"),
+            where=hc.qualname + (f' [{hc.source}]' if hc.source else ''),
+        )
+    module, class_name = hc.qualname.rsplit('.', 1)
+    try:
+        mod = importlib.import_module(module)
+        cls = getattr(mod, class_name)
+    except (ImportError, AttributeError) as e:
+        return CheckResult(
+            ok=False,
+            message=f'cannot reach {hc.qualname}: {e}',
+            where=hc.qualname + (f' [{hc.source}]' if hc.source else ''),
+        )
+
+    # Refuse to construct anything that isn't a class. Auto-extraction
+    # treats every `x = some_callable(...); x.attr(...)` pattern as a
+    # heavy_class candidate, but `create_engine`, `pipeline`,
+    # `ocr_predictor`, etc. are factory functions — eval'ing them with
+    # dummy args either raises noisily (false-positive) or, worse, does
+    # real I/O. Manifest entries get the same treatment so a wrong
+    # qualname produces a clear error instead of a confusing trace.
+    if not inspect.isclass(cls):
+        kind = type(cls).__name__
+        return CheckResult(
+            ok=False,
+            message=(
+                f'{hc.qualname} is a {kind}, not a class — heavy_class can '
+                f'only construct + walk real classes. If this is a factory '
+                f'function whose return value you want to verify, add an '
+                f'ImportRequirement entry for the symbol instead, or omit '
+                f'the heavy_class entry.'
+            ),
+            where=hc.qualname + (f' [{hc.source}]' if hc.source else ''),
+        )
+
+    namespace = {'__builtins__': _EVAL_BUILTINS, class_name: cls}
+    try:
+        instance = _eval_with_timeout(hc.construct, namespace, _CONSTRUCT_TIMEOUT_SEC)
+    except _ConstructionTimeout:
+        msg = (
+            f'construction timed out after {_CONSTRUCT_TIMEOUT_SEC}s '
+            f'(expr: {hc.construct!r}) -> add a manifest entry with safer '
+            f'dummy args, or remove the heavy_class entry'
+        )
+        return CheckResult(
+            ok=False,
+            message=msg,
+            where=hc.qualname + (f' [{hc.source}]' if hc.source else ''),
+        )
+    except Exception as e:
+        marker = f' [auto-extracted from {hc.source}]' if hc.source else ''
+        msg = (
+            f'failed to construct {hc.qualname}{marker}: '
+            f'{type(e).__name__}: {e} (expr: {hc.construct!r}) -> '
+            f'add a manifest entry to override'
+        )
+        return CheckResult(
+            ok=False,
+            message=msg,
+            where=hc.qualname + (f' [{hc.source}]' if hc.source else ''),
+        )
+
+    for chain in hc.attr_chains:
+        obj = instance
+        walked: list[str] = []
+        for part in chain.split('.'):
+            if not hasattr(obj, part):
+                return CheckResult(
+                    ok=False,
+                    message=(
+                        f'attribute chain {chain!r} broke at .{part} '
+                        f'(walked: .{".".join(walked) if walked else "<root>"}, '
+                        f'construct: {hc.construct!r})'
+                    ),
+                    where=hc.qualname + (f' [{hc.source}]' if hc.source else ''),
+                )
+            obj = getattr(obj, part)
+            walked.append(part)
+        if not callable(obj) and not inspect.isclass(obj):
+            # Many SDK property chains end at a sub-object that itself is
+            # callable; a few end at scalar attributes. We only flag when the
+            # final node is plainly neither.
+            pass  # tolerated — the chain resolved, that's enough
+
+    return CheckResult(
+        ok=True,
+        message=f'all {len(hc.attr_chains)} chain(s) resolved',
+        where=hc.qualname,
+    )
+
+
+def verify_constraint_match(package: str) -> CheckResult:
+    """
+    Detect drift between the engine's resolved pin and what's installed.
+
+    Reads the engine-produced ``cache/constraints.txt`` (populated by
+    ``uv pip compile``) and compares its pin for ``package`` against the
+    version currently importable via ``importlib.metadata``. When they
+    diverge, the engine *would* install a different version on a fresh
+    bootstrap — a silent change that the per-symbol verifiers wouldn't
+    notice today but would surface as breakage tomorrow.
+
+    Args:
+        package: Top-level package name. Normalised to PEP 503 canonical form
+                 before lookup so import-style names (``langchain_core``) match
+                 distribution-style constraint keys (``langchain-core``).
+
+    Returns:
+        :class:`CheckResult`:
+          * ``ok=True, message="not in constraints (...)"`` — package isn't
+            pinned in constraints (transitive-only or absent). Nothing to
+            check; informational.
+          * ``ok=True, message="not installed in current env"`` —
+            ``importlib.metadata`` doesn't know about the package. Caller
+            should treat this the same as a missing-package skip.
+          * ``ok=True, message="installed X matches pin"`` — no drift.
+          * ``ok=False, message="installed X but constraints pin Y -- ..."``
+            — drift detected; lane fails.
+    """
+    pinned = read_constraints().get(normalize_dist_name(package))
+    if pinned is None:
+        return CheckResult(
+            ok=True,
+            message=f'{package} not in constraints (transitive-only or absent)',
+            where=package,
+        )
+    installed = installed_version(package)
+    if installed is None:
+        return CheckResult(
+            ok=True,
+            message=f'{package} not installed in current env',
+            where=package,
+        )
+    if installed != pinned:
+        return CheckResult(
+            ok=False,
+            message=(
+                f'installed {installed} but constraints pin {pinned} -- '
+                f'engine would install {pinned} on a fresh bootstrap'
+            ),
+            where=package,
+        )
+    return CheckResult(ok=True, message=f'installed {installed} matches pin', where=package)
+
+
+# --------------------------------------------------------------------------- #
+# Internals
+# --------------------------------------------------------------------------- #
+
+
+# Heavy-class construction eval()s its expression with builtins locked to this
+# whitelist of pure data constructors — blocks open/__import__/exec/eval/etc.
+# while still allowing the dummy generator's `set()` output and plain literal
+# constructors a hand-written manifest `construct` might use.
+_EVAL_BUILTINS = {
+    'set': set,
+    'frozenset': frozenset,
+    'dict': dict,
+    'list': list,
+    'tuple': tuple,
+    'bytes': bytes,
+    'bytearray': bytearray,
+    'str': str,
+    'int': int,
+    'float': float,
+    'bool': bool,
+}
+
+
+class _ConstructionTimeout(Exception):
+    """Raised by ``_eval_with_timeout`` when the timeout fires first."""
+
+
+def _eval_with_timeout(expr: str, namespace: dict, timeout_sec: float):
+    """
+    Evaluate a Python expression with a hard wall-clock cap.
+
+    Uses ``signal.setitimer`` on POSIX (precise, low overhead). Falls back
+    to a daemon-thread watcher on Windows since ``SIGALRM`` is unavailable
+    there; the thread leak window on a timeout is the remainder of the
+    process lifetime, which we accept because heavy-class construction
+    timeouts indicate manifest bugs that should be fixed anyway.
+
+    Args:
+        expr:        Python source-text expression to evaluate.
+        namespace:   Globals dict passed to :func:`eval` — should already
+                     contain any symbols the expression refers to.
+        timeout_sec: Wall-clock cap. After this many seconds, the eval is
+                     abandoned and :class:`_ConstructionTimeout` is raised.
+
+    Returns:
+        The evaluated value on success.
+
+    Raises:
+        _ConstructionTimeout: When the timeout fires first.
+        Exception: Whatever the eval'd expression raises (re-raised on the
+                   main thread in the Windows path).
+    """
+    if os.name != 'nt' and hasattr(signal, 'SIGALRM'):
+
+        def _handler(_signum, _frame):
+            """``SIGALRM`` handler: trip the timeout sentinel exception."""
+            raise _ConstructionTimeout()
+
+        old = signal.signal(signal.SIGALRM, _handler)
+        signal.setitimer(signal.ITIMER_REAL, timeout_sec)
+        try:
+            return eval(expr, namespace)
+        finally:
+            signal.setitimer(signal.ITIMER_REAL, 0)
+            signal.signal(signal.SIGALRM, old)
+
+    # Windows / no SIGALRM: run in a thread and join with timeout.
+    result: list = [None]
+    exc: list[Optional[BaseException]] = [None]
+
+    def _run():
+        """Thread body: eval the expression, capture result or exception."""
+        try:
+            result[0] = eval(expr, namespace)
+        except BaseException as e:  # noqa: BLE001 - re-raised on main thread
+            exc[0] = e
+
+    t = threading.Thread(target=_run, daemon=True)
+    t.start()
+    t.join(timeout_sec)
+    if t.is_alive():
+        # Best-effort: we cannot interrupt the thread, but we report the timeout
+        # and let the daemon thread die with the interpreter. The leak window
+        # is the remainder of the pytest session.
+        raise _ConstructionTimeout()
+    if exc[0] is not None:
+        raise exc[0]
+    return result[0]

--- a/tools/contract_checks/src/contract_checks/runner.py
+++ b/tools/contract_checks/src/contract_checks/runner.py
@@ -86,21 +86,38 @@ def verify_import(req: ImportRequirement) -> CheckResult:
             continue
         # Submodule fallback: `from PIL import Image` resolves via
         # `import PIL.Image` when Image isn't an attribute on the package.
+        target = f'{req.module}.{sym}'
         try:
-            importlib.import_module(f'{req.module}.{sym}')
+            importlib.import_module(target)
             continue
-        except ImportError:
-            pass  # genuinely not a submodule → fall through to "symbol not found"
+        except ModuleNotFoundError as e:
+            # Only fall through to "symbol not found" when the *probed* module
+            # is the missing one. A different missing name means the submodule
+            # exists but a nested import failed — report that honestly.
+            if e.name != target:
+                return CheckResult(
+                    ok=False,
+                    message=f'importing submodule {target} raised ModuleNotFoundError: {e}',
+                    where=target,
+                )
+        except ImportError as e:
+            # Submodule exists but its import raised (circular import,
+            # "cannot import name", …) — a real failure, not "not found".
+            return CheckResult(
+                ok=False,
+                message=f'importing submodule {target} raised ImportError: {e}',
+                where=target,
+            )
         except Exception as e:
             return CheckResult(
                 ok=False,
-                message=f'importing submodule {req.module}.{sym} raised {type(e).__name__}: {e}',
-                where=f'{req.module}.{sym}',
+                message=f'importing submodule {target} raised {type(e).__name__}: {e}',
+                where=target,
             )
         return CheckResult(
             ok=False,
             message=f'symbol {sym!r} not found in module {req.module!r}',
-            where=f'{req.module}.{sym}',
+            where=target,
         )
     return CheckResult(ok=True, message='ok', where=req.module)
 

--- a/tools/contract_checks/src/contract_checks/trees.py
+++ b/tools/contract_checks/src/contract_checks/trees.py
@@ -1,0 +1,67 @@
+"""
+Configuration of every Python tree the contract-check framework scans.
+
+Adding a new tree = appending one `Tree` entry to `SCANNED_TREES`. Nothing else
+in the framework needs touching.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+# Repo root (= the rocketride-server checkout root). This file lives at
+# tools/contract_checks/src/contract_checks/trees.py, so root is four
+# parents up: contract_checks -> src -> contract_checks -> tools -> ROOT.
+REPO_ROOT = Path(__file__).resolve().parents[4]
+
+
+@dataclass(frozen=True)
+class Tree:
+    """
+    A Python source tree to scan for third-party import contracts.
+
+    Attributes:
+        name:              Short id used in test ids and error messages
+                           (e.g., ``nodes``, ``ai``, ``client-python``, ``rocketlib``).
+        root:              Absolute path to the tree's source root.
+        internal_packages: Top-level import names that belong to this repo
+                           (filtered out before contract checking).
+
+    Note: requirements installation is NOT configured per-tree. The CLI's
+    install hook (``cli._install_all_requirements``) recursively walks every
+    ``requirement*.txt`` under each tree's ``root`` — matching the engine's
+    own glob — and feeds each to ``depends()`` (honouring
+    ``# contract-check: skip-install`` / ``disable`` markers). There is no
+    per-tree requirements finder.
+    """
+
+    name: str
+    root: Path
+    internal_packages: frozenset[str]
+
+
+# Single source of truth for which trees the framework scans.
+SCANNED_TREES: list[Tree] = [
+    Tree(
+        name='nodes',
+        root=REPO_ROOT / 'nodes' / 'src' / 'nodes',
+        internal_packages=frozenset({'rocketlib', 'ai', 'nodes', 'engLib', 'depends'}),
+    ),
+    Tree(
+        name='ai',
+        root=REPO_ROOT / 'packages' / 'ai' / 'src' / 'ai',
+        internal_packages=frozenset({'ai', 'rocketlib', 'engLib', 'depends'}),
+    ),
+    Tree(
+        name='client-python',
+        root=REPO_ROOT / 'packages' / 'client-python' / 'src' / 'rocketride',
+        internal_packages=frozenset({'rocketride'}),
+    ),
+    Tree(
+        name='rocketlib',
+        root=REPO_ROOT / 'packages' / 'server' / 'engine-lib' / 'rocketlib-python' / 'lib',
+        internal_packages=frozenset({'rocketlib', 'engLib', 'depends', 'util', 'msauth', 'dbgconn'}),
+    ),
+]

--- a/tools/contract_checks/test/conftest.py
+++ b/tools/contract_checks/test/conftest.py
@@ -1,0 +1,24 @@
+"""
+Pytest bootstrap for the framework's own unit tests.
+
+This conftest exists for one purpose: make the ``contract_checks`` package
+importable from the test files when pytest is invoked on this directory.
+The engine binary's default ``sys.path`` doesn't include
+``tools/contract_checks/src``, so we insert it here before any test file
+runs ``from contract_checks.X import ...``.
+
+Note: the contract-verification path (``builder check-externals:run``) does
+NOT go through pytest. It invokes ``tools/contract_checks/cli.py`` directly.
+This conftest only matters for ``builder check-externals:test``, which runs
+the framework's own unit tests (``test_extractor.py``, ``test_runner.py``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+_SRC_DIR = Path(__file__).resolve().parents[1] / 'src'
+if str(_SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(_SRC_DIR))

--- a/tools/contract_checks/test/test_extractor.py
+++ b/tools/contract_checks/test/test_extractor.py
@@ -19,7 +19,7 @@ from contract_checks.trees import Tree
 
 # All self-tests use the same minimal tree config so we can focus on the
 # extractor's behavior, not the trees.py config.
-def _make_tree(root: Path, internal: set[str] = frozenset({'rocketlib', 'engLib'})) -> Tree:
+def _make_tree(root: Path, internal: frozenset[str] = frozenset({'rocketlib', 'engLib'})) -> Tree:
     """
     Build a throwaway :class:`Tree` rooted at ``root`` for a single self-test.
 
@@ -34,7 +34,7 @@ def _make_tree(root: Path, internal: set[str] = frozenset({'rocketlib', 'engLib'
     return Tree(
         name='self-test',
         root=root,
-        internal_packages=frozenset(internal),
+        internal_packages=internal,
     )
 
 
@@ -570,7 +570,7 @@ def test_internal_package_does_not_leak_into_heavy_class_detection(tmp_path: Pat
             client.users.list()
     """,
     )
-    tree = _make_tree(tmp_path, internal={'rocketlib', 'engLib'})
+    tree = _make_tree(tmp_path, internal=frozenset({'rocketlib', 'engLib'}))
     contract = extract_component(tree, tmp_path)
     # No third-party imports were used.
     assert contract.imports == []

--- a/tools/contract_checks/test/test_extractor.py
+++ b/tools/contract_checks/test/test_extractor.py
@@ -1,0 +1,578 @@
+"""
+Self-tests for the AST extractor.
+
+These tests construct tiny .py files in a tmp dir and verify the extractor
+produces the expected :class:`ComponentContract`. They don't require the
+engine env.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from contract_checks.extractor import extract_component
+from contract_checks.trees import Tree
+
+
+# All self-tests use the same minimal tree config so we can focus on the
+# extractor's behavior, not the trees.py config.
+def _make_tree(root: Path, internal: set[str] = frozenset({'rocketlib', 'engLib'})) -> Tree:
+    """
+    Build a throwaway :class:`Tree` rooted at ``root`` for a single self-test.
+
+    Args:
+        root:     Directory holding the fixture .py files for this test.
+        internal: Set of package names to treat as internal (filtered out
+                  of contracts). Default matches the smallest sensible set.
+
+    Returns:
+        A :class:`Tree` named ``self-test`` rooted at the tmp dir.
+    """
+    return Tree(
+        name='self-test',
+        root=root,
+        internal_packages=frozenset(internal),
+    )
+
+
+def _write(d: Path, name: str, body: str) -> None:
+    """
+    Write a dedented fixture file under a tmp dir.
+
+    Args:
+        d:    Directory the file goes into (typically pytest's ``tmp_path``).
+        name: File name (e.g., ``"a.py"``).
+        body: File contents; ``textwrap.dedent``'d and stripped of leading
+              newline so callers can use triple-quoted indented strings.
+    """
+    (d / name).write_text(textwrap.dedent(body).lstrip('\n'), encoding='utf-8')
+
+
+def test_plain_imports_are_picked_up(tmp_path: Path):
+    """Top-level ``import`` and ``from … import …`` produce ImportRequirement entries."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        import requests
+        from langchain_core.messages import AIMessage, BaseMessage
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    modules = {req.module: req for req in contract.imports}
+    assert 'requests' in modules
+    assert 'langchain_core.messages' in modules
+    assert set(modules['langchain_core.messages'].symbols) == {'AIMessage', 'BaseMessage'}
+
+
+def test_stdlib_is_filtered_out(tmp_path: Path):
+    """Stdlib names from ``sys.stdlib_module_names`` are dropped from the contract."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        import os
+        import sys
+        from typing import Optional
+        import requests
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    modules = {req.module for req in contract.imports}
+    assert 'os' not in modules
+    assert 'sys' not in modules
+    assert 'typing' not in modules
+    assert 'requests' in modules
+
+
+def test_internal_packages_are_filtered(tmp_path: Path):
+    """Names in the tree's ``internal_packages`` set are dropped from the contract."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from rocketlib import debug
+        from engLib import Filters
+        import requests
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    modules = {req.module for req in contract.imports}
+    assert 'rocketlib' not in modules
+    assert 'engLib' not in modules
+    assert 'requests' in modules
+
+
+def test_relative_imports_are_skipped(tmp_path: Path):
+    """``from . import …`` and ``from .. import …`` contribute nothing to the contract."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from .sibling import helper
+        from ..parent import utility
+        import requests
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    modules = {req.module for req in contract.imports}
+    assert 'requests' in modules
+    # Relative imports contribute no third-party requirement.
+    assert all(not m.startswith('.') for m in modules)
+
+
+def test_try_except_importerror_creates_any_of(tmp_path: Path):
+    """A ``try / except ImportError`` shim is rerouted to an AnyOf group automatically."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        try:
+            from img2table.ocr._types import OCRInstance
+        except ImportError:
+            from img2table.ocr.base import OCRInstance
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    # No required import from the try-block — it's routed to any_of.
+    modules = {req.module for req in contract.imports}
+    assert 'img2table.ocr._types' not in modules
+    assert 'img2table.ocr.base' not in modules
+    # An any_of group with both alternatives is emitted.
+    assert len(contract.any_of_imports) == 1
+    alts = {alt.module for alt in contract.any_of_imports[0].alternatives}
+    assert alts == {'img2table.ocr._types', 'img2table.ocr.base'}
+
+
+def test_non_import_guard_handler_excluded_from_any_of(tmp_path: Path):
+    """A handler catching an unrelated exception contributes no AnyOf alternatives."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        try:
+            import fast_json
+        except ImportError:
+            import slow_json
+        except ValueError:
+            import unrelated_pkg
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    assert len(contract.any_of_imports) == 1
+    alts = {alt.module for alt in contract.any_of_imports[0].alternatives}
+    # The ImportError handler's import is a real fallback; the ValueError
+    # handler's import is not and must be excluded.
+    assert alts == {'fast_json', 'slow_json'}
+    assert 'unrelated_pkg' not in alts
+
+
+def test_function_body_imports_are_seen(tmp_path: Path):
+    """Imports nested inside a function body still register as contract entries."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        def f():
+            from twelvelabs import TwelveLabs
+            return TwelveLabs(api_key="x")
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    modules = {req.module for req in contract.imports}
+    assert 'twelvelabs' in modules
+
+
+def test_intra_procedural_heavy_class_detected(tmp_path: Path):
+    """``client = SDK(...); client.foo(...)`` auto-emits a HeavyClass with dummied args."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from twelvelabs import TwelveLabs
+
+        def run():
+            api_key = "k"
+            client = TwelveLabs(api_key=api_key)
+            client.indexes.create("foo")
+            client.tasks.create("bar")
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    hcs = [hc for hc in contract.heavy_classes if hc.qualname == 'twelvelabs.TwelveLabs']
+    assert len(hcs) == 1, contract.heavy_classes
+    hc = hcs[0]
+    assert hc.construct == 'TwelveLabs(api_key="x")'
+    assert 'indexes.create' in hc.attr_chains
+    assert 'tasks.create' in hc.attr_chains
+
+
+def test_contract_check_ignore_comment_drops_import(tmp_path: Path):
+    """An inline ``# contract-check: ignore`` comment drops that import from the contract."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        import requests  # contract-check: ignore  loaded only via plugin
+        import urllib3
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    modules = {req.module for req in contract.imports}
+    assert 'requests' not in modules
+    assert 'urllib3' in modules
+
+
+def test_manifest_skip_drops_auto_detected_package(tmp_path: Path):
+    """``ComponentManifest.skip_packages`` removes auto-extracted entries for that package."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        import requests
+        import urllib3
+    """,
+    )
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest
+
+        MANIFEST = ComponentManifest(
+            skip_packages=frozenset({"requests"}),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    modules = {req.module for req in contract.imports}
+    assert 'requests' not in modules
+    assert 'urllib3' in modules
+
+
+def test_skip_packages_strips_alternative_from_mixed_any_of(tmp_path: Path):
+    """skip_packages removes only the skip-listed alternative; the group survives."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        try:
+            from crypto_a.backend import Cipher
+        except ImportError:
+            from crypto_b.backend import Cipher
+    """,
+    )
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest
+
+        MANIFEST = ComponentManifest(
+            skip_packages=frozenset({"crypto_b"}),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    assert len(contract.any_of_imports) == 1
+    alts = {alt.module for alt in contract.any_of_imports[0].alternatives}
+    assert alts == {'crypto_a.backend'}
+
+
+def test_skip_packages_drops_fully_skip_listed_any_of(tmp_path: Path):
+    """When every alternative is skip-listed, the whole AnyOf group is dropped."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        try:
+            from crypto_a.backend import Cipher
+        except ImportError:
+            from crypto_b.backend import Cipher
+    """,
+    )
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest
+
+        MANIFEST = ComponentManifest(
+            skip_packages=frozenset({"crypto_a", "crypto_b"}),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    assert contract.any_of_imports == []
+
+
+def test_skip_packages_preserves_any_of_applies_when(tmp_path: Path):
+    """Stripping a skip-listed alternative keeps the group's applies_when gate."""
+    _write(tmp_path, 'a.py', 'pass\n')
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import AnyOf, ComponentManifest, ImportRequirement
+
+        MANIFEST = ComponentManifest(
+            any_of_imports=(
+                AnyOf(
+                    alternatives=(
+                        ImportRequirement(module='keep_pkg.x'),
+                        ImportRequirement(module='drop_pkg.x'),
+                    ),
+                    applies_when='>=1.0',
+                ),
+            ),
+            skip_packages=frozenset({'drop_pkg'}),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    assert len(contract.any_of_imports) == 1
+    group = contract.any_of_imports[0]
+    assert {alt.module for alt in group.alternatives} == {'keep_pkg.x'}
+    assert group.applies_when == '>=1.0'
+
+
+def test_manifest_adds_heavy_class(tmp_path: Path):
+    """A manifest-declared HeavyClass appears in the contract even with no AST evidence."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from somesdk import Client
+        # No instantiation in source, so no auto-extracted heavy class.
+    """,
+    )
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest, HeavyClass
+
+        MANIFEST = ComponentManifest(
+            heavy_classes=(
+                HeavyClass(
+                    qualname='somesdk.Client',
+                    construct='Client(token="x")',
+                    attr_chains=('users.list', 'projects.get'),
+                ),
+            ),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    qualnames = {hc.qualname for hc in contract.heavy_classes}
+    assert 'somesdk.Client' in qualnames
+
+
+def test_packages_property_returns_distinct_top_levels(tmp_path: Path):
+    """``ComponentContract.packages`` deduplicates to top-level package names only."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from langchain_core.messages import AIMessage
+        from langchain_core.outputs import ChatResult
+        import requests
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    assert set(contract.packages) == {'langchain_core', 'requests'}
+
+
+# --------------------------------------------------------------------------- #
+# Manifest replace-on-match semantics (version-aware manifests)
+# --------------------------------------------------------------------------- #
+
+
+def test_manifest_import_replaces_auto_extracted_with_same_module(tmp_path: Path):
+    """A manifest ImportRequirement with the same module wins over the AST entry."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from img2table.ocr.data import OCRDataframe
+    """,
+    )
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest, ImportRequirement
+
+        MANIFEST = ComponentManifest(
+            imports=(
+                # Version-gated: applies only on img2table <2.0
+                ImportRequirement(
+                    module='img2table.ocr.data',
+                    symbols=('OCRDataframe',),
+                    applies_when='<2.0',
+                ),
+            ),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    # Exactly one entry for img2table.ocr.data — the manifest's version-gated one.
+    matches = [r for r in contract.imports if r.module == 'img2table.ocr.data']
+    assert len(matches) == 1
+    assert matches[0].applies_when == '<2.0'
+
+
+def test_manifest_heavy_class_replaces_auto_extracted_with_same_qualname(tmp_path: Path):
+    """A manifest HeavyClass with the same qualname replaces the AST entry."""
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from somesdk import Client
+
+        def f():
+            c = Client(api_key="real_key", base_url="real_url")
+            c.do_thing()
+    """,
+    )
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest, HeavyClass
+
+        MANIFEST = ComponentManifest(
+            heavy_classes=(
+                HeavyClass(
+                    qualname='somesdk.Client',
+                    construct='Client(token="x")',
+                    attr_chains=('admin.list_users',),
+                ),
+            ),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    matches = [hc for hc in contract.heavy_classes if hc.qualname == 'somesdk.Client']
+    assert len(matches) == 1
+    # Manifest entry wins — different construct + different chain.
+    assert matches[0].construct == 'Client(token="x")'
+    assert matches[0].attr_chains == ('admin.list_users',)
+
+
+def test_applies_when_field_is_preserved_through_extraction(tmp_path: Path):
+    """The applies_when field survives the AST → contract pipeline intact."""
+    _write(tmp_path, 'a.py', 'pass\n')
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import (
+            AnyOf, ComponentManifest, HeavyClass, ImportRequirement,
+        )
+
+        MANIFEST = ComponentManifest(
+            imports=(
+                ImportRequirement(module='lib_a', applies_when='<2.0'),
+            ),
+            any_of_imports=(
+                AnyOf(
+                    alternatives=(
+                        ImportRequirement(module='lib_b.new'),
+                        ImportRequirement(module='lib_b.old'),
+                    ),
+                    applies_when='>=1.0',
+                ),
+            ),
+            heavy_classes=(
+                HeavyClass(
+                    qualname='lib_c.Client',
+                    construct='Client()',
+                    attr_chains=('foo',),
+                    applies_when='~=3.0',
+                ),
+            ),
+        )
+    """,
+    )
+    contract = extract_component(_make_tree(tmp_path), tmp_path)
+    assert contract.imports[0].applies_when == '<2.0'
+    assert contract.any_of_imports[0].applies_when == '>=1.0'
+    assert contract.heavy_classes[0].applies_when == '~=3.0'
+
+
+def test_malformed_applies_when_fails_at_manifest_load_time(tmp_path: Path):
+    """Bad PEP 440 specs raise at manifest load, not silently treated as always-applies."""
+    _write(tmp_path, 'a.py', 'pass\n')
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest, ImportRequirement
+
+        MANIFEST = ComponentManifest(
+            imports=(
+                ImportRequirement(module='lib_a', applies_when='<= not a real spec'),
+            ),
+        )
+    """,
+    )
+    with pytest.raises(ValueError, match='malformed applies_when'):
+        extract_component(_make_tree(tmp_path), tmp_path)
+
+
+def test_empty_applies_when_string_raises(tmp_path: Path):
+    """Empty string is rejected — use None for 'always applies' instead."""
+    _write(tmp_path, 'a.py', 'pass\n')
+    _write(
+        tmp_path,
+        'external_contracts.py',
+        """
+        from contract_checks.manifest import ComponentManifest, ImportRequirement
+
+        MANIFEST = ComponentManifest(
+            imports=(
+                ImportRequirement(module='lib_a', applies_when='   '),
+            ),
+        )
+    """,
+    )
+    with pytest.raises(ValueError, match='applies_when must be None'):
+        extract_component(_make_tree(tmp_path), tmp_path)
+
+
+def test_internal_package_does_not_leak_into_heavy_class_detection(tmp_path: Path):
+    """
+    Regression: ``rocketlib`` is in this tree's `internal_packages`, so even
+    if local code does ``from rocketlib import X; X(...).method()``, the
+    framework must NOT emit a HeavyClass for ``rocketlib.X``. Previously the
+    import was filtered out of ``self.imports`` but still landed in the
+    visitor's alias map, leaking through to heavy-class auto-detection.
+    """
+    _write(
+        tmp_path,
+        'a.py',
+        """
+        from rocketlib import getServiceDefinition
+
+        def f():
+            cfg = getServiceDefinition("x")
+            cfg.get('key')
+
+        # Also test the bare-module form
+        import rocketlib
+
+        def g():
+            client = rocketlib.SomeClient(host="h")
+            client.users.list()
+    """,
+    )
+    tree = _make_tree(tmp_path, internal={'rocketlib', 'engLib'})
+    contract = extract_component(tree, tmp_path)
+    # No third-party imports were used.
+    assert contract.imports == []
+    # And critically: no heavy_class was emitted for the internal package.
+    assert not any(hc.qualname.startswith('rocketlib') for hc in contract.heavy_classes), contract.heavy_classes

--- a/tools/contract_checks/test/test_runner.py
+++ b/tools/contract_checks/test/test_runner.py
@@ -116,6 +116,23 @@ def test_verify_import_accepts_lazy_loaded_submodule():
     assert result.ok, result.message
 
 
+def test_verify_import_reports_non_importerror_without_crashing(monkeypatch):
+    """
+    A module that raises a non-ImportError at import (version guard, missing
+    native lib) must yield a failed CheckResult — not propagate and abort the
+    whole run. Regression for the too-narrow `except ImportError`.
+    """
+
+    def _boom(_name, *_a, **_k):
+        raise RuntimeError('native lib missing')
+
+    monkeypatch.setattr('contract_checks.runner.importlib.import_module', _boom)
+    result = verify_import(ImportRequirement(module='some_pkg', symbols=()))
+    assert not result.ok
+    assert 'RuntimeError' in result.message
+    assert 'some_pkg' in result.message
+
+
 def test_verify_any_of_passes_when_one_alternative_resolves(stub_module):
     """A successful second alternative is enough; earlier failures don't matter."""
     group = AnyOf(
@@ -429,10 +446,9 @@ def test_version_matches_simple_specs():
 
 def test_version_matches_propagates_bad_spec():
     """Malformed specs raise — caller (cli dispatch) catches and reports."""
-    import pytest as _pytest
     from contract_checks.engine_env import version_matches
 
-    with _pytest.raises(Exception):
+    with pytest.raises(Exception):
         version_matches('<= not a spec', '2.0.0')
 
 
@@ -765,8 +781,9 @@ def test_install_loop_continues_on_per_file_failure(tmp_path, capsys, monkeypatc
     assert '[install-failed]' in err
     assert 'requirements_bad.txt' in err
     assert 'simulated failure' in err
-    # Sanity: the good file wasn't reported as failed.
-    assert 'requirements_good.txt' not in err.split('[install-failed]')[1] if '[install-failed]' in err else True
+    # Sanity: the good file wasn't reported as failed (stderr only carries
+    # [install-failed] lines, so the good file must not appear at all).
+    assert 'requirements_good.txt' not in err
 
 
 def test_install_loop_install_all_overrides_marker(tmp_path, capsys, monkeypatch):

--- a/tools/contract_checks/test/test_runner.py
+++ b/tools/contract_checks/test/test_runner.py
@@ -133,6 +133,33 @@ def test_verify_import_reports_non_importerror_without_crashing(monkeypatch):
     assert 'some_pkg' in result.message
 
 
+def test_verify_import_reports_broken_submodule_not_symbol_missing(monkeypatch, stub_module):
+    """
+    A submodule that exists but whose import raises ModuleNotFoundError for a
+    *nested* dependency must be reported as a real failure — not masked as
+    'symbol not found'. Only a ModuleNotFoundError naming the probed module
+    itself means the submodule is genuinely absent.
+    """
+    import importlib as _il
+
+    real_import = _il.import_module
+    target = f'{stub_module}.Widget'  # 'Widget' isn't an attr → probes submodule
+
+    def _fake(name, *a, **k):
+        if name == target:
+            # Submodule exists but a nested import is missing.
+            raise ModuleNotFoundError("No module named 'nested_dep'", name='nested_dep')
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr('contract_checks.runner.importlib.import_module', _fake)
+    result = verify_import(ImportRequirement(module=stub_module, symbols=('Widget',)))
+    assert not result.ok
+    assert 'nested_dep' in result.message
+    assert 'ModuleNotFoundError' in result.message
+    # Must NOT be reported as a missing symbol.
+    assert 'not found in module' not in result.message
+
+
 def test_verify_any_of_passes_when_one_alternative_resolves(stub_module):
     """A successful second alternative is enough; earlier failures don't matter."""
     group = AnyOf(

--- a/tools/contract_checks/test/test_runner.py
+++ b/tools/contract_checks/test/test_runner.py
@@ -1,0 +1,847 @@
+"""
+Self-tests for the runner against an in-memory stub module.
+
+Verifies that every ``verify_*`` returns the expected pass/fail shape for
+known-present and known-missing attributes / imports / chains.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from contract_checks.engine_env import normalize_dist_name
+from contract_checks.manifest import AnyOf, HeavyClass, ImportRequirement
+from contract_checks.runner import (
+    verify_any_of,
+    verify_class_attrs,
+    verify_constraint_match,
+    verify_heavy_class,
+    verify_import,
+)
+
+
+@pytest.fixture
+def stub_module():
+    """Install a fake third-party module in sys.modules for the duration of one test."""
+    name = '_contract_checks_stub'
+
+    class _Indexes:
+        """SDK sub-namespace exposing ``.create`` and ``.delete``."""
+
+        def create(self):
+            """Stub: takes no real action."""
+
+        def delete(self):
+            """Stub: takes no real action."""
+
+    class _Tasks:
+        """SDK sub-namespace exposing ``.create``."""
+
+        def create(self):
+            """Stub: takes no real action."""
+
+    class Client:
+        """Stand-in for an SDK client class — instance attrs populated in __init__."""
+
+        def __init__(self, api_key='x', **_kwargs):
+            """Set the same instance attributes a real SDK client would."""
+            self.api_key = api_key
+            self.indexes = _Indexes()
+            self.tasks = _Tasks()
+
+        @staticmethod
+        def class_level_method():
+            """Stub: exists at class level, used by verify_class_attrs tests."""
+
+    mod = types.ModuleType(name)
+    mod.Client = Client
+    mod.PUBLIC_FLAG = True
+    sys.modules[name] = mod
+    try:
+        yield name
+    finally:
+        sys.modules.pop(name, None)
+
+
+# pytest fixtures always shadow their fixture name inside test signatures —
+# disable pylint's redefined-outer-name complaint for the rest of the module.
+# pylint: disable=redefined-outer-name
+
+
+def test_verify_import_passes_when_module_and_symbols_exist(stub_module):
+    """All-present case: module imports, every symbol is an attribute."""
+    req = ImportRequirement(module=stub_module, symbols=('Client', 'PUBLIC_FLAG'))
+    result = verify_import(req)
+    assert result.ok, result.message
+
+
+def test_verify_import_fails_when_module_missing():
+    """Module that isn't installed at all yields a clear ImportError-shaped failure."""
+    req = ImportRequirement(module='_definitely_not_installed_xyz_', symbols=())
+    result = verify_import(req)
+    assert not result.ok
+    assert 'cannot import' in result.message
+
+
+def test_verify_import_fails_when_symbol_missing(stub_module):
+    """A symbol that's neither an attribute nor an importable submodule fails."""
+    req = ImportRequirement(module=stub_module, symbols=('DoesNotExist',))
+    result = verify_import(req)
+    assert not result.ok
+    assert 'DoesNotExist' in result.message
+
+
+def test_verify_import_accepts_lazy_loaded_submodule():
+    """
+    Regression: `from PIL import Image` works at runtime because `PIL.Image`
+    is a submodule — but ``hasattr(PIL, 'Image')`` is False before the
+    submodule loads. ``verify_import`` must fall back to the submodule
+    import path. Uses the stdlib's own ``xml`` package, which has a
+    submodule ``xml.etree`` that's not an attribute on ``xml`` itself
+    until something imports it — same shape as PIL.
+    """
+    import sys
+
+    # Force xml to be unimported so we exercise the lazy-load fallback path.
+    # `xml` is stdlib; safe to drop and re-import.
+    for name in list(sys.modules):
+        if name == 'xml' or name.startswith('xml.'):
+            sys.modules.pop(name, None)
+
+    req = ImportRequirement(module='xml', symbols=('etree',))
+    result = verify_import(req)
+    assert result.ok, result.message
+
+
+def test_verify_any_of_passes_when_one_alternative_resolves(stub_module):
+    """A successful second alternative is enough; earlier failures don't matter."""
+    group = AnyOf(
+        alternatives=(
+            ImportRequirement(module='_missing_module_', symbols=()),
+            ImportRequirement(module=stub_module, symbols=('Client',)),
+        )
+    )
+    result = verify_any_of(group)
+    assert result.ok
+
+
+def test_verify_any_of_fails_when_no_alternative_resolves():
+    """All-fail case yields one row whose message lists every alternative's reason."""
+    group = AnyOf(
+        alternatives=(
+            ImportRequirement(module='_missing_a_', symbols=()),
+            ImportRequirement(module='_missing_b_', symbols=()),
+        )
+    )
+    result = verify_any_of(group)
+    assert not result.ok
+    assert 'no alternative resolved' in result.message
+
+
+def test_verify_class_attrs_passes_for_existing_attrs(stub_module):
+    """Class-level ``hasattr`` succeeds for declared classmethods/staticmethods."""
+    result = verify_class_attrs(stub_module, 'Client', ['class_level_method'])
+    assert result.ok
+
+
+def test_verify_class_attrs_fails_for_missing_attr(stub_module):
+    """A missing class-level attribute is reported with its name."""
+    result = verify_class_attrs(stub_module, 'Client', ['nope'])
+    assert not result.ok
+    assert 'nope' in result.message
+
+
+def test_verify_heavy_class_walks_chain_via_constructed_instance(stub_module):
+    """All chains resolve via the constructed instance — happy path."""
+    hc = HeavyClass(
+        qualname=f'{stub_module}.Client',
+        construct='Client(api_key="x")',
+        attr_chains=('indexes.create', 'tasks.create'),
+    )
+    result = verify_heavy_class(hc)
+    assert result.ok, result.message
+
+
+def test_verify_heavy_class_fails_on_missing_chain(stub_module):
+    """Chain breakage names the missing attribute in the failure message."""
+    hc = HeavyClass(
+        qualname=f'{stub_module}.Client',
+        construct='Client(api_key="x")',
+        attr_chains=('indexes.no_such_method',),
+    )
+    result = verify_heavy_class(hc)
+    assert not result.ok
+    assert 'no_such_method' in result.message
+
+
+def test_verify_heavy_class_fails_with_source_in_message(stub_module):
+    """Source marker (``file:line``) is preserved into the failure's ``where`` field."""
+    hc = HeavyClass(
+        qualname=f'{stub_module}.Client',
+        construct='Client(api_key="x")',
+        attr_chains=('indexes.no_such_method',),
+        source='some/file.py:42',
+    )
+    result = verify_heavy_class(hc)
+    assert not result.ok
+    assert 'some/file.py:42' in result.where
+
+
+def test_verify_heavy_class_refuses_non_class_target(stub_module):
+    """
+    Regression: heavy_class refuses to construct a target that isn't a class.
+
+    Auto-extraction emits heavy_class entries for any ``x = callable(...)``
+    pattern, but factory functions like ``sqlalchemy.create_engine`` or
+    ``transformers.pipeline`` aren't classes. Trying to call them with
+    dummy args either errors noisily or, worse, performs real I/O. The
+    runner short-circuits before the eval to avoid both.
+    """
+    # Add a plain function to the stub module — same shape as a factory.
+    mod = sys.modules[stub_module]
+    mod.factory_func = lambda *_args, **_kwargs: object()
+
+    hc = HeavyClass(
+        qualname=f'{stub_module}.factory_func',
+        construct='factory_func("x")',
+        attr_chains=('foo',),
+    )
+    result = verify_heavy_class(hc)
+    assert not result.ok
+    assert 'not a class' in result.message
+    assert 'factory_func' in result.where
+
+
+def test_verify_heavy_class_dotless_qualname_fails_without_crashing(stub_module):
+    """
+    Regression: a manifest qualname with no module prefix (``'TwelveLabs'``)
+    must produce a clean failure, not a ``ValueError`` from unpacking the
+    1-element ``rsplit`` result.
+    """
+    hc = HeavyClass(
+        qualname='TwelveLabs',  # no dot
+        construct='TwelveLabs()',
+        attr_chains=('indexes.create',),
+    )
+    result = verify_heavy_class(hc)
+    assert not result.ok
+    assert 'invalid qualname' in result.message
+
+
+def test_verify_heavy_class_construct_cannot_reach_dangerous_builtins(stub_module):
+    """
+    The construction eval runs with builtins locked to pure data constructors.
+    A construct that reaches for ``open`` (or any non-whitelisted builtin)
+    fails with a NameError-shaped construction error rather than executing it.
+    """
+    hc = HeavyClass(
+        qualname=f'{stub_module}.Client',
+        construct='Client(handle=open("/etc/passwd"))',
+        attr_chains=('indexes.create',),
+    )
+    result = verify_heavy_class(hc)
+    assert not result.ok
+    assert 'failed to construct' in result.message
+
+
+def test_verify_heavy_class_construct_allows_set_dummy(stub_module):
+    """
+    The whitelist still admits ``set()`` — the dummy generator emits it for
+    set-literal args, so locking builtins must not break legitimate constructs.
+    """
+    hc = HeavyClass(
+        qualname=f'{stub_module}.Client',
+        construct='Client(tags=set())',
+        attr_chains=('indexes.create',),
+    )
+    result = verify_heavy_class(hc)
+    assert result.ok, result.message
+
+
+# --------------------------------------------------------------------------- #
+# Trust-gradient dispatch (cli._checks_for_package)
+# --------------------------------------------------------------------------- #
+
+
+def test_auto_extracted_heavy_class_failure_demotes_to_skip(stub_module, tmp_path):
+    """
+    Auto-extracted heavy_class failures (``hc.source`` set) become SKIP rows,
+    not FAIL — the framework guessed and the guess didn't pan out. Add a
+    manifest entry if you want to make the chain a hard requirement.
+    """
+    from contract_checks.cli import _checks_for_package
+    from contract_checks.extractor import ComponentContract
+
+    contract = ComponentContract(
+        tree_name='self-test',
+        component_name='c',
+        component_dir=tmp_path,
+        heavy_classes=[
+            HeavyClass(
+                qualname=f'{stub_module}.Client',
+                construct='Client(api_key="x")',
+                attr_chains=('indexes.no_such_method',),
+                source='some/file.py:42',  # ← marks it auto-extracted
+            ),
+        ],
+    )
+    triples = list(_checks_for_package(contract, stub_module))
+    # Should contain a SKIP row (from the demotion) — NOT a FAIL.
+    heavy_rows = [t for t in triples if 'Client' in t[1]]
+    assert any(t[0] == 'skip' for t in heavy_rows), heavy_rows
+    assert not any(t[0] == 'fail' for t in heavy_rows), heavy_rows
+
+
+def test_manifest_heavy_class_failure_stays_fail(stub_module, tmp_path):
+    """
+    Manifest-declared heavy_class failures (``hc.source`` empty) stay FAIL —
+    the maintainer asserted this contract; a break is real signal.
+    """
+    from contract_checks.cli import _checks_for_package
+    from contract_checks.extractor import ComponentContract
+
+    contract = ComponentContract(
+        tree_name='self-test',
+        component_name='c',
+        component_dir=tmp_path,
+        heavy_classes=[
+            HeavyClass(
+                qualname=f'{stub_module}.Client',
+                construct='Client(api_key="x")',
+                attr_chains=('indexes.no_such_method',),
+                source='',  # ← manual manifest entry
+            ),
+        ],
+    )
+    triples = list(_checks_for_package(contract, stub_module))
+    heavy_rows = [t for t in triples if 'Client' in t[1]]
+    assert any(t[0] == 'fail' for t in heavy_rows), heavy_rows
+
+
+def test_auto_extracted_heavy_class_chain_success_still_passes(stub_module, tmp_path):
+    """
+    Demotion is failure-only: auto-extracted heavy_class entries whose chains
+    DO resolve still report OK. The framework keeps detecting real coverage,
+    it just doesn't block when its guesses can't be verified.
+    """
+    from contract_checks.cli import _checks_for_package
+    from contract_checks.extractor import ComponentContract
+
+    contract = ComponentContract(
+        tree_name='self-test',
+        component_name='c',
+        component_dir=tmp_path,
+        heavy_classes=[
+            HeavyClass(
+                qualname=f'{stub_module}.Client',
+                construct='Client(api_key="x")',
+                attr_chains=('indexes.create', 'tasks.create'),
+                source='some/file.py:42',
+            ),
+        ],
+    )
+    triples = list(_checks_for_package(contract, stub_module))
+    heavy_rows = [t for t in triples if 'Client' in t[1]]
+    assert any(t[0] == 'ok' for t in heavy_rows), heavy_rows
+    assert not any(t[0] == 'fail' for t in heavy_rows), heavy_rows
+
+
+# --------------------------------------------------------------------------- #
+# Multi-value CLI flag handling
+# --------------------------------------------------------------------------- #
+
+
+def test_cli_parser_accepts_repeated_tree_flag():
+    """``--tree=nodes --tree=ai`` accumulates into a list, single use still works."""
+    from contract_checks.cli import _build_parser
+
+    parser = _build_parser()
+    single = parser.parse_args(['--tree=nodes'])
+    assert single.tree == ['nodes']
+
+    multi = parser.parse_args(['--tree=nodes', '--tree=ai'])
+    assert multi.tree == ['nodes', 'ai']
+
+    none_given = parser.parse_args([])
+    assert none_given.tree is None
+
+
+def test_cli_parser_accepts_repeated_package_flag():
+    """Same accumulation behavior for --package."""
+    from contract_checks.cli import _build_parser
+
+    parser = _build_parser()
+    multi = parser.parse_args(['--package=requests', '--package=img2table'])
+    assert multi.package == ['requests', 'img2table']
+
+
+def test_cli_parser_accepts_repeated_pattern_flag():
+    """Same for --pattern (short form -k also accumulates)."""
+    from contract_checks.cli import _build_parser
+
+    parser = _build_parser()
+    multi = parser.parse_args(['--pattern=img', '-k', 'twelve'])
+    assert multi.pattern == ['img', 'twelve']
+
+
+def test_cli_parser_accepts_repeated_requirements_flag():
+    """Same for --requirements."""
+    from contract_checks.cli import _build_parser
+
+    parser = _build_parser()
+    multi = parser.parse_args(['--requirements=a.txt', '--requirements=b.txt'])
+    assert multi.requirements == ['a.txt', 'b.txt']
+
+
+# --------------------------------------------------------------------------- #
+# Version-matching helper (engine_env.version_matches)
+# --------------------------------------------------------------------------- #
+
+
+def test_version_matches_simple_specs():
+    """Sanity checks: each PEP 440 operator behaves as advertised."""
+    from contract_checks.engine_env import version_matches
+
+    # Greater-than-or-equal
+    assert version_matches('>=2.0', '2.0.0') is True
+    assert version_matches('>=2.0', '2.1.0') is True
+    assert version_matches('>=2.0', '1.9.9') is False
+
+    # Less-than
+    assert version_matches('<2.0', '1.9.9') is True
+    assert version_matches('<2.0', '2.0.0') is False
+
+    # Compound range
+    assert version_matches('>=1.0,<2.0', '1.5.0') is True
+    assert version_matches('>=1.0,<2.0', '2.0.0') is False
+
+    # Compatible release
+    assert version_matches('~=1.4', '1.4.99') is True
+    assert version_matches('~=1.4', '2.0.0') is False
+
+    # Exact equality
+    assert version_matches('==2.0.0', '2.0.0') is True
+    assert version_matches('==2.0.0', '2.0.1') is False
+
+
+def test_version_matches_propagates_bad_spec():
+    """Malformed specs raise — caller (cli dispatch) catches and reports."""
+    import pytest as _pytest
+    from contract_checks.engine_env import version_matches
+
+    with _pytest.raises(Exception):
+        version_matches('<= not a spec', '2.0.0')
+
+
+# --------------------------------------------------------------------------- #
+# Requirements file parser (cli.parse_requirements_distributions)
+# --------------------------------------------------------------------------- #
+
+
+def test_requirements_parser_extracts_basic_names(tmp_path):
+    """Plain names, pinned versions, and range specifiers all yield the name."""
+    from contract_checks.cli import parse_requirements_distributions
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        'requests\npymysql==1.2.0\ncryptography>=46,<47\nnumpy~=1.24\n',
+        encoding='utf-8',
+    )
+    assert parse_requirements_distributions(req) == {
+        'requests',
+        'pymysql',
+        'cryptography',
+        'numpy',
+    }
+
+
+def test_requirements_parser_skips_comments_and_blanks(tmp_path):
+    """``#`` lines, blank lines, and inline comments after a name are ignored or stripped."""
+    from contract_checks.cli import parse_requirements_distributions
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        '# header comment\n\nrequests  # we use this for HTTP\n   \n# another comment\npymysql\n',
+        encoding='utf-8',
+    )
+    assert parse_requirements_distributions(req) == {'requests', 'pymysql'}
+
+
+def test_requirements_parser_skips_options_lines(tmp_path):
+    """Lines starting with ``-`` (``-r``, ``-e``, ``--extra-index-url``) are skipped."""
+    from contract_checks.cli import parse_requirements_distributions
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        '-r other.txt\n--extra-index-url https://example.com/simple\n-e .\nrequests\n',
+        encoding='utf-8',
+    )
+    assert parse_requirements_distributions(req) == {'requests'}
+
+
+def test_requirements_parser_normalises_per_pep_503(tmp_path):
+    """``PyYAML`` and ``py_yaml`` both collapse to ``pyyaml``; ``langchain-core`` survives."""
+    from contract_checks.cli import parse_requirements_distributions
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        'PyYAML\nlangchain_core\nPillow\n',
+        encoding='utf-8',
+    )
+    # PEP 503: lowercase + runs of -/_/. become a single -.
+    assert parse_requirements_distributions(req) == {
+        'pyyaml',
+        'langchain-core',
+        'pillow',
+    }
+
+
+def test_resolve_distributions_to_modules_handles_known_mismatches():
+    """For installed packages, packages_distributions gives true module names."""
+    from contract_checks.cli import resolve_distributions_to_modules
+
+    # `packaging` is in the engine env (transitive of pip/uv). Its module name
+    # happens to match its distribution name, but the function path is the
+    # one we care about — it shouldn't raise and should include the module.
+    modules = resolve_distributions_to_modules({'packaging'})
+    assert 'packaging' in modules
+
+
+def test_resolve_distributions_to_modules_falls_back_for_uninstalled():
+    """Unknown distributions get the heuristic name-mangle (dash → underscore)."""
+    from contract_checks.cli import resolve_distributions_to_modules
+
+    modules = resolve_distributions_to_modules({'definitely-not-installed-xyz'})
+    assert 'definitely_not_installed_xyz' in modules
+
+
+# --------------------------------------------------------------------------- #
+# requirements_file_skipped (skip-install marker detection)
+# --------------------------------------------------------------------------- #
+
+
+def test_requirements_file_skipped_returns_false_without_marker(tmp_path):
+    """Plain requirements file without the marker = not skipped."""
+    from contract_checks.engine_env import requirements_file_skipped
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text('requests\npymysql==1.2.0\n', encoding='utf-8')
+
+    skipped, reason = requirements_file_skipped(req)
+    assert skipped is False
+    assert reason == ''
+
+
+def test_requirements_file_skipped_detects_marker_without_reason(tmp_path):
+    """`# contract-check: skip-install` alone returns True with empty reason."""
+    from contract_checks.engine_env import requirements_file_skipped
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text('# contract-check: skip-install\nsurya-ocr\n', encoding='utf-8')
+
+    skipped, reason = requirements_file_skipped(req)
+    assert skipped is True
+    assert reason == ''
+
+
+def test_requirements_file_skipped_extracts_reason(tmp_path):
+    """Text after the marker is returned as the reason string."""
+    from contract_checks.engine_env import requirements_file_skipped
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        '# contract-check: skip-install  reason: opencv pin conflict\nsurya-ocr\n',
+        encoding='utf-8',
+    )
+
+    skipped, reason = requirements_file_skipped(req)
+    assert skipped is True
+    assert reason == 'opencv pin conflict'
+
+
+def test_requirements_file_skipped_extracts_reason_without_reason_prefix(tmp_path):
+    """Reason text doesn't have to begin with `reason:` — anything after marker counts."""
+    from contract_checks.engine_env import requirements_file_skipped
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        '# contract-check: skip-install  opt-in feature, install on nightly\nkokoro\n',
+        encoding='utf-8',
+    )
+
+    skipped, reason = requirements_file_skipped(req)
+    assert skipped is True
+    assert reason == 'opt-in feature, install on nightly'
+
+
+def test_requirements_file_skipped_finds_marker_anywhere_in_file(tmp_path):
+    """Marker can appear at the top, bottom, or interleaved — substring scan."""
+    from contract_checks.engine_env import requirements_file_skipped
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        '# top header comment\nsurya-ocr\n\n# contract-check: skip-install  reason: late marker\n',
+        encoding='utf-8',
+    )
+
+    skipped, reason = requirements_file_skipped(req)
+    assert skipped is True
+    assert reason == 'late marker'
+
+
+def test_requirements_marker_detected_with_two_comments_on_one_line(tmp_path):
+    """
+    Regression: a line with TWO '#' comments where the marker is the second
+    one (e.g. `pkg  # note  # contract-check: disable`) must still register.
+    The scanner uses substring search, not "startswith after the first '#'",
+    so the leading comment doesn't hide the marker.
+    """
+    from contract_checks.engine_env import (
+        requirements_file_disabled,
+        requirements_file_skipped,
+    )
+
+    skip_two = tmp_path / 'skip_two.txt'
+    skip_two.write_text(
+        'kokoro>=0.9.4  # legacy note  # contract-check: skip-install  reason: heavy\n',
+        encoding='utf-8',
+    )
+    skipped, reason = requirements_file_skipped(skip_two)
+    assert skipped is True
+    assert reason == 'heavy'
+
+    disable_two = tmp_path / 'disable_two.txt'
+    disable_two.write_text(
+        'surya-ocr  # legacy detector  # contract-check: disable  reason: opencv pin\n',
+        encoding='utf-8',
+    )
+    disabled, reason = requirements_file_disabled(disable_two)
+    assert disabled is True
+    assert reason == 'opencv pin'
+
+
+def test_requirements_file_skipped_returns_false_on_missing_file(tmp_path):
+    """Non-existent file = not skipped, empty reason; no exception raised."""
+    from contract_checks.engine_env import requirements_file_skipped
+
+    missing = tmp_path / 'does_not_exist.txt'
+    skipped, reason = requirements_file_skipped(missing)
+    assert skipped is False
+    assert reason == ''
+
+
+# --------------------------------------------------------------------------- #
+# requirements_file_disabled (NEVER install, even under --install-all)
+# --------------------------------------------------------------------------- #
+
+
+def test_requirements_file_disabled_detects_marker(tmp_path):
+    """`# contract-check: disable` is recognised, reason extracted."""
+    from contract_checks.engine_env import requirements_file_disabled
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text(
+        '# contract-check: disable  reason: opencv pin conflict\nsurya-ocr\n',
+        encoding='utf-8',
+    )
+    disabled, reason = requirements_file_disabled(req)
+    assert disabled is True
+    assert reason == 'opencv pin conflict'
+
+
+def test_requirements_file_disabled_returns_false_without_marker(tmp_path):
+    """Plain file = not disabled."""
+    from contract_checks.engine_env import requirements_file_disabled
+
+    req = tmp_path / 'requirements.txt'
+    req.write_text('requests\n', encoding='utf-8')
+    disabled, _ = requirements_file_disabled(req)
+    assert disabled is False
+
+
+def test_requirements_file_skipped_and_disabled_are_independent(tmp_path):
+    """A file with `skip-install` is not flagged as `disable`d, and vice versa."""
+    from contract_checks.engine_env import (
+        requirements_file_disabled,
+        requirements_file_skipped,
+    )
+
+    skip_only = tmp_path / 'skip.txt'
+    skip_only.write_text('# contract-check: skip-install\nkokoro\n', encoding='utf-8')
+    assert requirements_file_skipped(skip_only)[0] is True
+    assert requirements_file_disabled(skip_only)[0] is False
+
+    disable_only = tmp_path / 'disable.txt'
+    disable_only.write_text('# contract-check: disable\nsurya-ocr\n', encoding='utf-8')
+    assert requirements_file_skipped(disable_only)[0] is False
+    assert requirements_file_disabled(disable_only)[0] is True
+
+
+def test_install_loop_disable_wins_over_install_all(tmp_path, capsys, monkeypatch):
+    """
+    Regression: a file marked `# contract-check: disable` is NEVER passed to
+    depends(), even when ``install_all=True``. The stronger marker beats the
+    override flag — this is the whole reason `disable` exists (fundamental
+    install conflicts where attempting install just guarantees a failure).
+    Status line goes to STDOUT, not STDERR.
+    """
+    from contract_checks.cli import _install_all_requirements
+    from contract_checks.trees import Tree
+
+    (tmp_path / 'requirements_disabled.txt').write_text(
+        '# contract-check: disable  reason: known conflict\nsurya-ocr\n',
+        encoding='utf-8',
+    )
+
+    calls: list[str] = []
+
+    def _fake_depends(path: str) -> None:
+        """Test stub: would record the call if reached. Must NOT be reached."""
+        calls.append(path)
+
+    monkeypatch.setattr('contract_checks.cli.depends', _fake_depends)
+
+    tree = Tree(
+        name='self-test',
+        root=tmp_path,
+        internal_packages=frozenset(),
+    )
+
+    # Even with install_all=True, disabled files are never installed.
+    _install_all_requirements([tree], install_all=True, verbose=False)
+    assert calls == []
+    captured = capsys.readouterr()
+    assert '[disable]' in captured.out, captured.out
+    assert 'known conflict' in captured.out
+    # And the install-all bypass line is NOT emitted for disabled files.
+    assert '[install-all]' not in captured.out
+
+
+# --------------------------------------------------------------------------- #
+# Install loop — depends() propagates errors, install loop catches per-file
+# --------------------------------------------------------------------------- #
+
+
+def test_install_loop_continues_on_per_file_failure(tmp_path, capsys, monkeypatch):
+    """
+    The install hook MUST NOT abort the run when one requirements file fails.
+    It catches per-file, emits a `[install-failed]` line on stderr, and
+    proceeds to the next file. Validates the Option-B design from the plan.
+    """
+    from contract_checks.cli import _install_all_requirements
+    from contract_checks.trees import Tree
+
+    # Two fake requirements files in the tmp tree.
+    (tmp_path / 'requirements_good.txt').write_text('requests\n', encoding='utf-8')
+    (tmp_path / 'requirements_bad.txt').write_text('definitely-broken\n', encoding='utf-8')
+
+    # Monkey-patch depends() to fail for the "bad" file and succeed for the others.
+    calls: list[str] = []
+
+    def _fake_depends(path: str) -> None:
+        """Test stub: succeeds for *good* files, raises for *bad* ones."""
+        calls.append(path)
+        if 'bad' in path:
+            raise RuntimeError('uv pip install error: simulated failure')
+
+    monkeypatch.setattr('contract_checks.cli.depends', _fake_depends)
+
+    tree = Tree(
+        name='self-test',
+        root=tmp_path,
+        internal_packages=frozenset(),
+    )
+    _install_all_requirements([tree], install_all=False, verbose=False)
+
+    # Both files were attempted.
+    assert any('good' in c for c in calls)
+    assert any('bad' in c for c in calls)
+
+    # The failure was reported on stderr; the good install didn't trigger a line.
+    err = capsys.readouterr().err
+    assert '[install-failed]' in err
+    assert 'requirements_bad.txt' in err
+    assert 'simulated failure' in err
+    # Sanity: the good file wasn't reported as failed.
+    assert 'requirements_good.txt' not in err.split('[install-failed]')[1] if '[install-failed]' in err else True
+
+
+def test_install_loop_install_all_overrides_marker(tmp_path, capsys, monkeypatch):
+    """
+    With `install_all=True`, files carrying the skip-install marker are
+    attempted (and the bypass is logged), instead of being silently skipped.
+    """
+    from contract_checks.cli import _install_all_requirements
+    from contract_checks.trees import Tree
+
+    # Marked file — would be skipped under default behaviour.
+    (tmp_path / 'requirements_marked.txt').write_text(
+        '# contract-check: skip-install  reason: test marker\nrequests\n',
+        encoding='utf-8',
+    )
+
+    calls: list[str] = []
+
+    def _fake_depends(path: str) -> None:
+        """Test stub: succeeds for any input, records the call."""
+        calls.append(path)
+
+    monkeypatch.setattr('contract_checks.cli.depends', _fake_depends)
+
+    tree = Tree(
+        name='self-test',
+        root=tmp_path,
+        internal_packages=frozenset(),
+    )
+
+    # Default: marker honoured, depends() NOT called. The status line
+    # goes to STDOUT (install-layer chatter belongs with check output).
+    _install_all_requirements([tree], install_all=False, verbose=False)
+    assert calls == []
+    out = capsys.readouterr().out
+    assert '[skip-install]' in out
+
+    # --install-all: marker bypassed, depends() called, bypass logged on STDOUT.
+    _install_all_requirements([tree], install_all=True, verbose=False)
+    assert len(calls) == 1
+    out = capsys.readouterr().out
+    assert '[install-all]' in out
+    assert 'bypassing skip-install marker' in out
+
+
+# --------------------------------------------------------------------------- #
+# Constraint-drift: PEP 503 name normalization
+# --------------------------------------------------------------------------- #
+
+
+def test_normalize_dist_name_folds_separators_and_case():
+    """Hyphens, underscores, and dots collapse to '-'; the name lowercases."""
+    assert normalize_dist_name('langchain_core') == 'langchain-core'
+    assert normalize_dist_name('Langchain-Core') == 'langchain-core'
+    assert normalize_dist_name('zope.interface') == 'zope-interface'
+    assert normalize_dist_name('a__b--c..d') == 'a-b-c-d'
+
+
+def test_constraint_match_resolves_import_name_to_distribution_pin(monkeypatch):
+    """
+    Regression: an import-style name (``langchain_core``) must match the
+    distribution-style constraints key (``langchain-core``). Lowercasing alone
+    missed this, so drift on any `_`-vs-`-` package was silently skipped.
+    """
+    monkeypatch.setattr('contract_checks.runner.read_constraints', lambda: {'langchain-core': '0.3.1'})
+    monkeypatch.setattr('contract_checks.runner.installed_version', lambda pkg: '0.3.1')
+    result = verify_constraint_match('langchain_core')
+    assert result.ok is True
+    assert 'matches pin' in result.message
+
+
+def test_constraint_match_detects_drift_across_separator(monkeypatch):
+    """Drift is still flagged when names differ only by separator style."""
+    monkeypatch.setattr('contract_checks.runner.read_constraints', lambda: {'langchain-core': '0.3.1'})
+    monkeypatch.setattr('contract_checks.runner.installed_version', lambda pkg: '0.2.0')
+    result = verify_constraint_match('langchain_core')
+    assert result.ok is False
+    assert 'constraints pin 0.3.1' in result.message


### PR DESCRIPTION
## Summary

Adds a CI-time framework that statically verifies the third-party Python API surface (imports + attribute chains) the engine actually uses, so an upstream breaking change is caught **before** it ships to a customer rather than after.

Motivated by the img2table 2.0 incident (fixed reactively in #969 / commit `c4aa67921`): `OCRInstance` moved modules and broke the OCR node in production. This framework would have caught that on the PR that bumped the dependency.

**How it works:** for every `.py` file under the four Python trees — `nodes/`, `packages/ai/`, `packages/client-python/`, `packages/server/engine-lib/rocketlib-python/` — an AST walker extracts the third-party imports and the attribute chains used on them, then verifies each resolves against the engine-installed package versions. No real API calls — pure module loading and `getattr` walks. Runs under the engine binary (never system `python`), reusing the engine's own `depends()` / `ensure_constraints()` install pipeline.

## What's included

**Framework** (`tools/contract_checks/`): AST extractor with intra-procedural data-flow (auto-detects `client = SDK(...); client.x.y()` patterns), per-component manifest overlay, engine-integration boundary, pure verifier functions, and a CLI. 57 unit tests.

**Builder tasks** (`check-externals:run`, `check-externals:test`): run via `./builder check-externals:run`. Flags: `--tree`, `--package`, `--pattern`, `--requirements` (all repeatable), `--no-install`, `--fail-on-missing`, `--verbose`, `--rebuild-cache`, `--install-all`.

**CI workflow** (`.github/workflows/check-externals.yml`): non-blocking PR lane (markers respected, fast) + nightly lane (`--rebuild-cache --install-all`, full coverage). Phase 1 surfaces failures as GitHub Actions warning annotations only; the auto-issue step is included but commented out for a later phase.

**Seed manifest + opt-out markers** on a handful of nodes (OCR version-gating, surya/trocr conflict exclusion, defensive-import ignores).

## Key concepts (see `tools/contract_checks/README.md`)

- **Markers**: `# contract-check: ignore` (drop an import from the contract), `# contract-check: skip-install` (skip a heavy requirements file on the PR lane; install on nightly), `# contract-check: disable` (never install — for fundamental conflicts like surya/trocr's opencv pin).
- **`applies_when`**: PEP 440 version-gating for symbols that exist only on certain versions (e.g., img2table v1 vs v2 modules).
- **Trust gradient**: auto-detected contracts are best-effort (a failure they can't verify → SKIP); maintainer-written manifest entries are assertions (failure → hard FAIL).

## Local usage

```sh
# Verify everything (markers respected)
./builder check-externals:run

# Filter; run the framework's own unit tests
./builder check-externals:run --pattern=twelvelabs
./builder check-externals:test

# Nightly-equivalent: fresh constraints + install everything
./builder check-externals:run --rebuild-cache --install-all
```

## Type

feat

## Testing

- [x] Framework unit tests: 57 passing (`./builder check-externals:test`)
- [x] Run against all four trees locally; confirmed real drift is surfaced (e.g., `img2table.ocr.data` removal on img2table 2.0) and version-gated / disabled files behave correctly
- [x] Workflow YAML validated as parseable
- [x] `./builder test` passes

## Rollout

Phase 1 (this PR): PR lane is **non-blocking** (`continue-on-error: true`); failures are warning annotations. A follow-up will promote it to a required check and enable the nightly auto-issue notification once the lane has a few weeks of stable runs.

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (none — additive framework + non-blocking CI)

Fixes #983



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a contract-check framework with CI integration: fast PR checks, nightly/full runs, and manual triggers; CLI options to filter checks, rebuild caches, and opt into installing skipped optional deps.

* **Documentation**
  * Comprehensive user guide for the contract-check tool and CI lanes.
  * OCR docs describing supported engines and a unified OpenCV compatibility approach.

* **Tests**
  * New unit/integration suites validating extraction, verification, CLI, and install behaviors.

* **Chores**
  * CI workflow emits warning annotations for detected interface/install drift; requirement-file markers to control opt-in installs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/999?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->