### PR TITLE
fix: test(client-typescript) disconnect timeout guard should reject instead of resolve

### DIFF
--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -71,7 +71,7 @@ describe('RocketRideClient Integration Tests', () => {
 	afterEach(async () => {
 		if (client.isConnected()) {
 			// Use a bounded timeout so teardown never hangs the suite
-			await Promise.race([client.disconnect(), new Promise<void>((resolve) => setTimeout(resolve, 10000))]);
+			await Promise.race([client.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
 		}
 	});
 
@@ -1669,7 +1669,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 						}
 					})
 				),
-				new Promise<void>((resolve) => setTimeout(resolve, 15000)),
+				new Promise<void>((_, reject) => setTimeout(() => reject(new Error('pipeline cleanup timeout exceeded')), 15000)),
 			]);
 			pipelineTokens = [];
 		});
@@ -2042,7 +2042,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					expect(uniqueTexts.size).toBe(SENDS_PER_CLIENT * 2);
 				} finally {
 					if (clientB.isConnected()) {
-						await Promise.race([clientB.disconnect(), new Promise<void>((resolve) => setTimeout(resolve, 10000))]);
+						await Promise.race([clientB.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
 					}
 				}
 			},

--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -28,6 +28,7 @@ import type { LoginAttemptCancellationReason } from '../src/client/exceptions';
 import { describe, it, expect, beforeEach, afterEach, beforeAll, jest } from '@jest/globals';
 import { getEchoPipeline } from './echo.pipeline';
 import { getChatPipeline } from './chat.pipeline';
+import { withTimeoutGuard } from './timeoutGuard';
 // Skip chat tests when no LLM API key is available (must match env vars used by chat.pipeline.ts)
 const hasLLMKey = !!(process.env.ROCKETRIDE_OPENAI_KEY || process.env.ROCKETRIDE_ANTHROPIC_KEY || process.env.ROCKETRIDE_GEMINI_KEY || process.env.ROCKETRIDE_OLLAMA_HOST);
 const describeIfLLM = hasLLMKey ? describe : describe.skip;
@@ -73,7 +74,7 @@ describe('RocketRideClient Integration Tests', () => {
 	afterEach(async () => {
 		if (client.isConnected()) {
 			// Use a bounded timeout so teardown never hangs the suite
-			await Promise.race([client.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
+			await withTimeoutGuard(client.disconnect(), 10000, 'disconnect');
 		}
 	});
 
@@ -1672,7 +1673,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 
 		afterEach(async () => {
 			// Clean up all pipelines with a bounded timeout so teardown never hangs
-			await Promise.race([
+			await withTimeoutGuard(
 				Promise.all(
 					pipelineTokens.map(async (token) => {
 						try {
@@ -1682,8 +1683,9 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 						}
 					})
 				),
-				new Promise<void>((_, reject) => setTimeout(() => reject(new Error('pipeline cleanup timeout exceeded')), 15000)),
-			]);
+				15000,
+				'pipeline cleanup'
+			);
 			pipelineTokens = [];
 		});
 
@@ -2071,7 +2073,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					expect(uniqueTexts.size).toBe(SENDS_PER_CLIENT * 2);
 				} finally {
 					if (clientB.isConnected()) {
-						await Promise.race([clientB.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
+						await withTimeoutGuard(clientB.disconnect(), 10000, 'disconnect');
 					}
 				}
 			},

--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -73,7 +73,7 @@ describe('RocketRideClient Integration Tests', () => {
 	afterEach(async () => {
 		if (client.isConnected()) {
 			// Use a bounded timeout so teardown never hangs the suite
-			await Promise.race([client.disconnect(), new Promise<void>((resolve) => setTimeout(resolve, 10000))]);
+			await Promise.race([client.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
 		}
 	});
 
@@ -1682,7 +1682,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 						}
 					})
 				),
-				new Promise<void>((resolve) => setTimeout(resolve, 15000)),
+				new Promise<void>((_, reject) => setTimeout(() => reject(new Error('pipeline cleanup timeout exceeded')), 15000)),
 			]);
 			pipelineTokens = [];
 		});
@@ -2071,7 +2071,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					expect(uniqueTexts.size).toBe(SENDS_PER_CLIENT * 2);
 				} finally {
 					if (clientB.isConnected()) {
-						await Promise.race([clientB.disconnect(), new Promise<void>((resolve) => setTimeout(resolve, 10000))]);
+						await Promise.race([clientB.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
 					}
 				}
 			},

--- a/packages/client-typescript/tests/deploy.test.ts
+++ b/packages/client-typescript/tests/deploy.test.ts
@@ -24,6 +24,7 @@
 
 import { RocketRideClient } from '../src/client';
 import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { withTimeoutGuard } from './timeoutGuard';
 
 const TEST_CONFIG = {
 	uri: process.env.ROCKETRIDE_URI || 'http://localhost:5565',
@@ -85,7 +86,7 @@ describe('Deploy API Integration Tests', () => {
 
 	afterEach(async () => {
 		if (client.isConnected()) {
-			await Promise.race([client.disconnect(), new Promise<void>((resolve) => setTimeout(resolve, 10000))]);
+			await withTimeoutGuard(client.disconnect(), 10000, 'disconnect');
 		}
 	});
 

--- a/packages/client-typescript/tests/timeoutGuard.ts
+++ b/packages/client-typescript/tests/timeoutGuard.ts
@@ -1,0 +1,28 @@
+export function makeTimeoutRejector(
+	ms: number,
+	context: string
+): { promise: Promise<void>; clear: () => void } {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	const promise = new Promise<void>((_, reject) => {
+		timer = setTimeout(() => reject(new Error(`${context} timeout ${ms}ms`)), ms);
+	});
+	return {
+		promise,
+		clear: () => {
+			if (timer !== undefined) clearTimeout(timer);
+		},
+	};
+}
+
+export async function withTimeoutGuard<T>(
+	operation: Promise<T>,
+	ms: number,
+	context: string
+): Promise<T> {
+	const guard = makeTimeoutRejector(ms, context);
+	try {
+		return await Promise.race([operation, guard.promise]);
+	} finally {
+		guard.clear();
+	}
+}

--- a/packages/client-typescript/tests/timeoutGuard.ts
+++ b/packages/client-typescript/tests/timeoutGuard.ts
@@ -1,9 +1,33 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
 export function makeTimeoutRejector(
 	ms: number,
 	context: string
-): { promise: Promise<void>; clear: () => void } {
+): { promise: Promise<never>; clear: () => void } {
 	let timer: ReturnType<typeof setTimeout> | undefined;
-	const promise = new Promise<void>((_, reject) => {
+	const promise = new Promise<never>((_, reject) => {
 		timer = setTimeout(() => reject(new Error(`${context} timeout ${ms}ms`)), ms);
 	});
 	return {


### PR DESCRIPTION
Fixes #968

The previous implementation of the disconnect timeout guard in the TypeScript client tests used `resolve()` instead of `reject()` when the timeout was reached. This meant that if `client.disconnect()` hung, the test would silently pass instead of failing as intended.

This commit updates the timeout promises to use `reject()` with an appropriate error message, ensuring that test failures on disconnect are properly caught and reported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized integration-test cleanup with bounded timeout handling.
  * Added consistent timeout limits for client disconnects and concurrent pipeline cleanup, including 10- and 15-second safeguards.
  * Updated deployment and client integration tests to use the shared timeout behavior, helping prevent teardown operations from hanging indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->