### PR TITLE
fix: test(client-typescript) disconnect timeout guard should reject instead of resolve

### DIFF
--- a/packages/client-typescript/tests/RocketRideClient.test.ts
+++ b/packages/client-typescript/tests/RocketRideClient.test.ts
@@ -71,7 +71,7 @@ describe('RocketRideClient Integration Tests', () => {
 	afterEach(async () => {
 		if (client.isConnected()) {
 			// Use a bounded timeout so teardown never hangs the suite
-			await Promise.race([client.disconnect(), new Promise<void>((resolve) => setTimeout(resolve, 10000))]);
+			await Promise.race([client.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
 		}
 	});
 
@@ -1669,7 +1669,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 						}
 					})
 				),
-				new Promise<void>((resolve) => setTimeout(resolve, 15000)),
+				new Promise<void>((_, reject) => setTimeout(() => reject(new Error('pipeline cleanup timeout exceeded')), 15000)),
 			]);
 			pipelineTokens = [];
 		});
@@ -2042,7 +2042,7 @@ Line 3: random data ${Math.random().toString(36).substring(2)}`;
 					expect(uniqueTexts.size).toBe(SENDS_PER_CLIENT * 2);
 				} finally {
 					if (clientB.isConnected()) {
-						await Promise.race([clientB.disconnect(), new Promise<void>((resolve) => setTimeout(resolve, 10000))]);
+						await Promise.race([clientB.disconnect(), new Promise<void>((_, reject) => setTimeout(() => reject(new Error('disconnect timeout exceeded')), 10000))]);
 					}
 				}
 			},


### PR DESCRIPTION
## Summary

- Fixed the disconnect timeout guard in the TypeScript client tests which was swallowing errors by resolving instead of rejecting.
- This ensures test failures on disconnect are properly caught and reported.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #968
