### PR TITLE
fix: nodes(gmi_cloud) update Gemini model IDs to 3.1 to pass validation

### DIFF
--- a/nodes/src/nodes/llm_gmi_cloud/services.json
+++ b/nodes/src/nodes/llm_gmi_cloud/services.json
@@ -230,16 +230,16 @@
 				"apikey": "",
 				"modelTotalTokens": 200000
 			},
-			"gemini-3-pro": {
-				"title": "Gemini 3 Pro",
-				"model": "google/gemini-3-pro-preview",
+			"gemini-3.1-pro": {
+				"title": "Gemini 3.1 Pro",
+				"model": "google/gemini-3.1-pro-preview",
 				"serverbase": "https://api.gmi-serving.com/v1",
 				"apikey": "",
 				"modelTotalTokens": 128000
 			},
-			"gemini-3-flash": {
-				"title": "Gemini 3 Flash",
-				"model": "google/gemini-3-flash-preview",
+			"gemini-3.1-flash": {
+				"title": "Gemini 3.1 Flash",
+				"model": "google/gemini-3.1-flash-preview",
 				"serverbase": "https://api.gmi-serving.com/v1",
 				"apikey": "",
 				"modelTotalTokens": 128000
@@ -256,7 +256,7 @@
 		"model": {
 			"type": "string",
 			"title": "Model",
-			"description": "GMI Cloud model identifier. Use org/model-name for open-weight models (e.g. deepseek-ai/DeepSeek-R1, Qwen/Qwen3-32B-FP8) or provider/model-name for proxied models (e.g. openai/gpt-4o, anthropic/claude-sonnet-4.5, google/gemini-3-flash-preview). Full list: https://www.gmicloud.ai/models"
+			"description": "GMI Cloud model identifier. Use org/model-name for open-weight models (e.g. deepseek-ai/DeepSeek-R1, Qwen/Qwen3-32B-FP8) or provider/model-name for proxied models (e.g. openai/gpt-4o, anthropic/claude-sonnet-4.5, google/gemini-3.1-flash-preview). Full list: https://www.gmicloud.ai/models"
 		},
 		"modelTotalTokens": {
 			"type": "number",
@@ -345,12 +345,12 @@
 			"object": "claude-sonnet-4-5",
 			"properties": ["llm.cloud.apikey"]
 		},
-		"gmi_cloud.gemini-3-pro": {
-			"object": "gemini-3-pro",
+		"gmi_cloud.gemini-3.1-pro": {
+			"object": "gemini-3.1-pro",
 			"properties": ["llm.cloud.apikey"]
 		},
-		"gmi_cloud.gemini-3-flash": {
-			"object": "gemini-3-flash",
+		"gmi_cloud.gemini-3.1-flash": {
+			"object": "gemini-3.1-flash",
 			"properties": ["llm.cloud.apikey"]
 		},
 		"gmi_cloud.profile": {
@@ -437,12 +437,12 @@
 					"properties": ["gmi_cloud.claude-sonnet-4-5"]
 				},
 				{
-					"value": "gemini-3-pro",
-					"properties": ["gmi_cloud.gemini-3-pro"]
+					"value": "gemini-3.1-pro",
+					"properties": ["gmi_cloud.gemini-3.1-pro"]
 				},
 				{
-					"value": "gemini-3-flash",
-					"properties": ["gmi_cloud.gemini-3-flash"]
+					"value": "gemini-3.1-flash",
+					"properties": ["gmi_cloud.gemini-3.1-flash"]
 				}
 			]
 		}


### PR DESCRIPTION
## Summary

- Updated GMI Cloud LLM configuration to use Gemini 3.1 model IDs instead of 3.0.
- Since GMI Cloud only serves Gemini 3.1, sending the 3.0 IDs caused validation failures. This change aligns the provider mappings with the supported versions.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #996


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gemini 3.1 models (Pro and Flash variants) now available for GMI Cloud configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1004?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->