### PR TITLE
Feat/vscode linux runtime deps check

### DIFF
--- a/apps/vscode/src/engine/shared/engine-installer.ts
+++ b/apps/vscode/src/engine/shared/engine-installer.ts
@@ -34,6 +34,7 @@ import * as https from 'https';
 import * as http from 'http';
 import * as os from 'os';
 import * as lockfile from 'proper-lockfile';
+import { execFile, execFileSync } from 'child_process';
 import { getLogger } from '../../shared/util/output';
 import { icons } from '../../shared/util/icons';
 
@@ -222,7 +223,15 @@ export class EngineInstaller {
 		}
 
 		try {
-			return await this.installUnderLock(versionSpec, progress, token, githubToken);
+			const exePath = await this.installUnderLock(versionSpec, progress, token, githubToken);
+			// Run the runtime-dep check on EVERY install attempt, not just fresh
+			// downloads. installUnderLock has three return paths (fresh download,
+			// "already up to date" short-circuit, GitHub-unreachable fallback);
+			// users whose engine was installed before this check existed only hit
+			// the latter two, so putting the check here is the only way to reach
+			// them without forcing a manual uninstall+reinstall.
+			this.checkLinuxRuntimeDeps(exePath);
+			return exePath;
 		} finally {
 			try { await release(); } catch { /* ignore stale lock */ }
 		}
@@ -348,6 +357,9 @@ export class EngineInstaller {
 			if (!fs.existsSync(exePath)) {
 				throw new Error(`Engine extraction completed but executable not found at: ${exePath}`);
 			}
+
+			// (Runtime dep check runs in install() after this returns, so it
+			// covers fresh downloads AND "already installed" short-circuits.)
 
 			// Write version file so we know what's installed
 			this.writeVersionJson({ tag: release.tag_name, publishedAt: release.published_at });
@@ -701,6 +713,56 @@ export class EngineInstaller {
 	/** Simple delay helper. */
 	private delay(ms: number): Promise<void> {
 		return new Promise(resolve => setTimeout(resolve, ms));
+	}
+
+	// =========================================================================
+	// LINUX RUNTIME DEPENDENCY CHECK
+	// =========================================================================
+
+	private static readonly LIB_TO_PACKAGE: Record<string, string> = {
+		'libc++.so.1': 'libc++1',
+		'libc++abi.so.1': 'libc++abi1',
+		'libgomp.so.1': 'libgomp1',
+	};
+
+	private async checkLinuxRuntimeDeps(exePath: string): Promise<void> {
+		if (process.platform !== 'linux') return;
+
+		let lddOutput = '';
+		try {
+			lddOutput = execFileSync('ldd', [exePath], { encoding: 'utf8' });
+		} catch { return; }
+
+		const packages = [...new Set(
+			lddOutput.split('\n')
+				.filter(l => l.includes('=> not found'))
+				.map(l => l.trim().match(/^(\S+)/)?.[1])
+				.map(lib => lib ? EngineInstaller.LIB_TO_PACKAGE[lib] : undefined)
+				.filter((p): p is string => !!p),
+		)];
+		if (!packages.length) return;
+
+		const choice = await vscode.window.showWarningMessage(
+			`RocketRide needs these system libraries: ${packages.join(', ')}.`,
+			{ modal: true, detail: 'Without these libraries the engine cannot start.' },
+			'Install',
+		);
+		if (choice !== 'Install') return;
+
+		try {
+			await vscode.window.withProgress(
+				{ location: vscode.ProgressLocation.Notification, title: 'Installing system libraries...', cancellable: false },
+				() => new Promise<void>((resolve, reject) => {
+					execFile('pkexec', ['apt', 'install', '-y', ...packages], { timeout: 5 * 60 * 1000 }, (err, _stdout, stderr) => {
+						if (err) reject(new Error(stderr?.trim() || err.message));
+						else resolve();
+					});
+				}),
+			);
+			void vscode.window.showInformationMessage('System libraries installed.');
+		} catch (err) {
+			void vscode.window.showErrorMessage(`Install failed: ${err instanceof Error ? err.message : String(err)}`);
+		}
 	}
 }
 

--- a/apps/vscode/src/engine/shared/engine-installer.ts
+++ b/apps/vscode/src/engine/shared/engine-installer.ts
@@ -230,7 +230,7 @@ export class EngineInstaller {
 			// users whose engine was installed before this check existed only hit
 			// the latter two, so putting the check here is the only way to reach
 			// them without forcing a manual uninstall+reinstall.
-			this.checkLinuxRuntimeDeps(exePath);
+			await this.checkLinuxRuntimeDeps(exePath);
 			return exePath;
 		} finally {
 			try { await release(); } catch { /* ignore stale lock */ }
@@ -741,6 +741,16 @@ export class EngineInstaller {
 				.filter((p): p is string => !!p),
 		)];
 		if (!packages.length) return;
+
+		// One-click install assumes apt; on non-Debian distros show the list and let the user handle it.
+		const hasApt = fs.existsSync('/usr/bin/apt') || fs.existsSync('/bin/apt');
+		if (!hasApt) {
+			void vscode.window.showWarningMessage(
+				`RocketRide needs these system libraries: ${packages.join(', ')}. Install them with your system package manager.`,
+				{ modal: true },
+			);
+			return;
+		}
 
 		const choice = await vscode.window.showWarningMessage(
 			`RocketRide needs these system libraries: ${packages.join(', ')}.`,

--- a/docs/README-vscode.md
+++ b/docs/README-vscode.md
@@ -22,6 +22,14 @@
 
 <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/docs/images/canvas.png" alt="RocketRide visual canvas builder" width="800">
 
+> **Linux users:** the downloaded engine is dynamically linked against the system C++ runtime. On Ubuntu/Debian, install once:
+>
+> ```bash
+> sudo apt install -y libc++1 libc++abi1 libgomp1
+> ```
+>
+> The extension auto-detects missing libraries on first run and offers a one-click install prompt. See [issue #989](https://github.com/rocketride-org/rocketride-server/issues/989) for background and troubleshooting.
+
 ## What is RocketRide?
 
 [RocketRide](https://rocketride.org) is an open-source, developer-native AI pipeline platform.


### PR DESCRIPTION
## Summary

- Detection: when the engine is downloaded, runs ldd against the binary, parses => not found lines, and maps the missing .so files to known apt packages (libc++1, libc++abi1, libgomp1). If nothing is missing, stays silent.
- Confirmation modal: shows "RocketRide needs these system libraries: <list>." with a single Install button + Cancel. Blocking, doesn't auto-dismiss.

- GUI-prompted install: if the user clicks Install, runs pkexec apt install -y <packages> — the desktop shows its native password dialog (polkit handles the  password, not the extension), apt runs in the background with a progress notification, and ends with a success or error toast

## Type

feature

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes # https://github.com/rocketride-org/rocketride-server/issues/989


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux users now get automatic detection of missing runtime libraries on every engine install attempt, with a one-click, elevated prompt to install required packages on Debian/Ubuntu. If automatic install isn’t possible, a clear warning lists the packages to install manually.

* **Documentation**
  * Added Linux prerequisite notes and auto-detection/one-click install details to the Quick Start guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->