### PR TITLE
fix(autoinstall): detect root + cover libc++ runtime in compiler-unix.sh

### DIFF
--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -16,6 +16,17 @@ set -e
 # Navigate to project root
 cd "$(dirname "$0")/.."
 
+# Detect whether we're running as root (Docker container, automation,
+# minimal install) so the auto-install path doesn't unconditionally
+# invoke `sudo`. Containers typically don't ship `sudo`, so prefixing
+# `apt-get` with `sudo` crashes the install before any package lands.
+# `apt-get` itself works fine when called as root.
+if [ "$EUID" -eq 0 ]; then
+    SUDO=""
+else
+    SUDO="sudo"
+fi
+
 # Function to check if a command exists
 command_exists() {
     command -v "$1" >/dev/null 2>&1
@@ -175,8 +186,8 @@ select_linux_triplet() {
     if [ -n "$CC_RESOLVED" ] && [ -n "$CXX_RESOLVED" ]; then
         if [ "$CC_RESOLVED" != "$CC_LINK" ] || [ "$CXX_RESOLVED" != "$CXX_LINK" ]; then
             COMMANDS+=("    # Set default cc/c++ to $CC and $CXX")
-            COMMANDS+=("    sudo update-alternatives --install /usr/bin/cc cc $CC_PATH 100")
-            COMMANDS+=("    sudo update-alternatives --install /usr/bin/c++ c++ $CXX_PATH 100")
+            COMMANDS+=("    $SUDO update-alternatives --install /usr/bin/cc cc $CC_PATH 100")
+            COMMANDS+=("    $SUDO update-alternatives --install /usr/bin/c++ c++ $CXX_PATH 100")
         fi
     fi
 
@@ -214,6 +225,12 @@ select_macos_triplet() {
 # =============================================================================
 
 check_linux_sudo() {
+    # When already running as root (SUDO=""), apt-get is invoked directly
+    # — no point installing sudo just to satisfy a check that no longer
+    # gates anything.
+    if [ -z "$SUDO" ]; then
+        return 0
+    fi
     if ! command_exists "sudo"; then
         COMMANDS+=("    # Installing sudo")
         COMMANDS+=("    apt update")
@@ -230,11 +247,11 @@ check_linux_cmake() {
         if [ "$CMAKE_MAJOR" -lt 3 ] || [ "$CMAKE_MAJOR" -eq 3 -a "$CMAKE_MINOR" -lt 19 ]; then
             echo "CMake version $CMAKE_VERSION is too old (minimum required: 3.19)"
             COMMANDS+=("    # Upgrading CMake")
-            COMMANDS+=("    sudo apt install -y cmake")
+            COMMANDS+=("    $SUDO apt install -y cmake")
         fi
     else
         COMMANDS+=("    # Installing CMake")
-        COMMANDS+=("    sudo apt install -y cmake")
+        COMMANDS+=("    $SUDO apt install -y cmake")
     fi
 }
 
@@ -307,6 +324,18 @@ check_linux_dependencies() {
         "liblzma-dev"
         "libxmlsec1-dev"
         "zlib1g-dev"
+        # libc++ runtime libraries — the downloaded prebuilt engine
+        # binary is linked against clang's libc++/libc++abi (not GNU
+        # libstdc++), so executing it during `--autoinstall`'s pip
+        # bootstrap fails with:
+        #   error while loading shared libraries: libc++.so.1: cannot open
+        # The matching `libc++-${CLANG_VERSION}-dev` headers above only
+        # cover the build path; the prebuilt binary needs the *runtime*
+        # libs at execute time. libgomp1 is required by some bundled
+        # OMP-using transitive deps.
+        "libc++1"
+        "libc++abi1"
+        "libgomp1"
     )
 
     for package in "${REQUIRES[@]}"; do
@@ -324,7 +353,7 @@ check_linux_dependencies() {
                 if ! command_exists "gpg"; then
                     echo "✗ gnupg: gpg not available"
                     COMMANDS+=("    # Install package gnupg")
-                    COMMANDS+=("    sudo apt install gnupg")
+                    COMMANDS+=("    $SUDO apt install gnupg")
                 else
                     echo "✓ gnupg: gpg available"
                 fi
@@ -336,7 +365,7 @@ check_linux_dependencies() {
                 else
                     echo "✗ ca-certificates: package not installed and update-ca-certificates not on PATH"
                     COMMANDS+=("    # Install package ca-certificates")
-                    COMMANDS+=("    sudo apt install -y ca-certificates")
+                    COMMANDS+=("    $SUDO apt install -y ca-certificates")
                 fi
                 ;;
             libncurses-dev)
@@ -345,16 +374,28 @@ check_linux_dependencies() {
                    ! dpkg -l "libncurses5-dev" 2>/dev/null | grep -q "^ii"; then
                     echo "✗ libncurses-dev"
                     COMMANDS+=("    # Install development library (ncurses)")
-                    COMMANDS+=("    sudo apt install -y libncurses-dev")
+                    COMMANDS+=("    $SUDO apt install -y libncurses-dev")
                 else
                     echo "✓ ncurses"
+                fi
+                ;;
+            libc++1 | libc++abi1 | libgomp1)
+                # Runtime libraries (no CLI command), so check via dpkg
+                # rather than command_exists. Required to execute the
+                # downloaded prebuilt engine during pip bootstrap.
+                if ! dpkg -l "$package" 2>/dev/null | grep -q "^ii"; then
+                    echo "✗ $package"
+                    COMMANDS+=("    # Install runtime library $package")
+                    COMMANDS+=("    $SUDO apt install -y $package")
+                else
+                    echo "✓ $package"
                 fi
                 ;;
             *-dev)
                 if ! dpkg -l "$package" 2>/dev/null | grep -q "^ii"; then
                     echo "✗ $package"
                     COMMANDS+=("    # Install development library $package")
-                    COMMANDS+=("    sudo apt install -y $package")
+                    COMMANDS+=("    $SUDO apt install -y $package")
                 else
                     echo "✓ $package"
                 fi
@@ -371,7 +412,7 @@ check_linux_dependencies() {
                         if ! dpkg -l "$package" 2>/dev/null | grep -q "^ii"; then
                             echo "✗ $package"
                             COMMANDS+=("    # Install package $package")
-                            COMMANDS+=("    sudo apt install -y $package")
+                            COMMANDS+=("    $SUDO apt install -y $package")
                         else
                             echo "✓ $package"
                         fi
@@ -386,7 +427,7 @@ check_linux_dependencies() {
                         echo "✗ $package: $cmd_name not available"
                     fi
                     COMMANDS+=("    # Install package $package")
-                    COMMANDS+=("    sudo apt install -y $package")
+                    COMMANDS+=("    $SUDO apt install -y $package")
                 else
                     if [ "$package" == "$cmd_name" ]; then
                         echo "✓ $package"
@@ -403,7 +444,7 @@ check_linux_dependencies() {
             echo "Auto-installing missing dependencies..."
             echo ""
             echo "Updating apt..."
-            sudo apt update
+            $SUDO apt update
             for cmd in "${COMMANDS[@]}"; do
                 if [[ "$cmd" == *"# "* ]]; then
                     echo "$cmd"
@@ -655,7 +696,7 @@ if [ ${#MISSING_TOOLS[@]} -ne 0 ]; then
     echo ""
     echo "=========================================="
     echo "Missing Python build tools. Please install:"
-    echo "  sudo apt install -y ${MISSING_TOOLS[*]}"
+    echo "  $SUDO apt install -y ${MISSING_TOOLS[*]}"
     echo ""
     echo "Or with pip (Ubuntu 24.04+ requires --break-system-packages):"
     echo "  pip install build wheel --break-system-packages"


### PR DESCRIPTION
## Summary

Two genuine bugs in `scripts/compiler-unix.sh`'s auto-install path that have been forcing downstream Dockerfiles (notably `rocketride-ai/rocketride-saas/docker/Dockerfile.alb` per the closed [PR #145](https://github.com/rocketride-ai/rocketride-saas/pull/145)) to duplicate the apt dependency list by hand instead of relying on `--autoinstall`:

### 1. `sudo` used unconditionally

In a Docker container running as root (no `sudo` on PATH), the script crashed before installing any package — even the "install sudo" recovery command was prefixed with `sudo`. Fixed by detecting `[ "$EUID" -eq 0 ]` at script start, deriving `$SUDO` accordingly, and substituting throughout the COMMANDS array and direct apt invocations. `check_linux_sudo` early-returns when running as root.

### 2. libc++ runtime packages missing from REQUIRES

Build variants (`libc++-${CLANG_VERSION}-dev`) were already conditionally added — sufficient for compile. But the prebuilt engine binary downloaded during `--autoinstall`'s pip bootstrap is linked against clang's `libc++`/`libc++abi` (not GNU `libstdc++`), so executing it fails with:

```
error while loading shared libraries: libc++.so.1: cannot open
```

Added `libc++1`, `libc++abi1`, `libgomp1` to REQUIRES with an explicit case in the dependency check switch (these are libraries with no CLI command, so the existing `command_exists` default would have created install commands unconditionally on every rerun — explicit `dpkg -l` check is idempotent).

## Source

Both findings come from PR #145's own patch comments — that PR worked around the bugs in the Dockerfile instead of fixing them at the source. Per Rod's directive to root-cause-fix rather than paper-over, this PR puts the fixes in the autoinstall script itself.

## Test plan

- [x] `bash -n scripts/compiler-unix.sh` passes (syntax)
- [ ] CI green on this PR
- [ ] Downstream PR in rocketride-saas (Dockerfile.model-server) will exercise the autoinstall path end-to-end in a clean `ubuntu:22.04` Docker stage and prove the path works without manual apt duplication

## Backwards compat

- Non-root users see identical behavior (`$SUDO` resolves to `"sudo"`).
- Already-installed `libc++1` etc. are no-ops via the `dpkg -l ... grep -q "^ii"` check.
- No change to the public `--autoinstall` flag semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced Linux compiler setup to properly handle installations in both root and non-root environments, improving compatibility with containerized builds and automated deployment scenarios.

* **Chores**
  * Updated Linux dependency installation process to include necessary runtime packages alongside development tools for more reliable builds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->