### PR TITLE
fix(autoinstall): make gnupg apt install non-interactive

### DIFF
--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -353,7 +353,7 @@ check_linux_dependencies() {
                 if ! command_exists "gpg"; then
                     echo "✗ gnupg: gpg not available"
                     COMMANDS+=("    # Install package gnupg")
-                    COMMANDS+=("    $SUDO apt install gnupg")
+                    COMMANDS+=("    $SUDO apt install -y gnupg")
                 else
                     echo "✓ gnupg: gpg available"
                 fi


### PR DESCRIPTION
## Summary

Follow-up to #1008 (which Anand approved, merged 9:15 AM PT). The `gnupg` install command in `check_linux_dependencies()` was the only `apt install` line in the file without `-y` — under `--autoinstall` in a non-interactive context (Docker build, CI runner), apt prompts for confirmation and the build hangs waiting for stdin.

Flagged by CodeRabbit on the parent PR; Anand suggested splitting the fix out. One-character diff.

## Diff

```diff
-                    COMMANDS+=("    $SUDO apt install gnupg")
+                    COMMANDS+=("    $SUDO apt install -y gnupg")
```

## Test plan

- [x] `bash -n` passes
- [ ] CI green
- [ ] Combined with #1008, the autoinstall path now runs end-to-end in Docker (next: rocketride-saas Dockerfile.model-server rewrite to exercise this)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Linux system dependency installation to work seamlessly in non-interactive environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->