### PR TITLE
fix(nodes): correct GMI Cloud Gemini model IDs (RR-996)

### DIFF
--- a/nodes/src/nodes/llm_gmi_cloud/README.md
+++ b/nodes/src/nodes/llm_gmi_cloud/README.md
@@ -32,20 +32,21 @@ GMI Cloud has three tiers:
 
 **Shared (always-on)** — available immediately, API key only:
 
-| Profile                 | Model                                 | Context |
-| ----------------------- | ------------------------------------- | ------- |
-| DeepSeek V3 _(default)_ | `deepseek-ai/DeepSeek-V3-0324`        | 163,840 |
-| DeepSeek V3.2           | `deepseek-ai/DeepSeek-V3.2`           | 163,840 |
-| DeepSeek R1             | `deepseek-ai/DeepSeek-R1`             | 131,072 |
-| DeepSeek Prover V2      | `deepseek-ai/DeepSeek-Prover-V2-671B` | 131,072 |
-| GPT-5.2                 | `openai/gpt-5.2`                      | 128,000 |
-| GPT-5.1                 | `openai/gpt-5.1`                      | 128,000 |
-| GPT-5                   | `openai/gpt-5`                        | 128,000 |
-| GPT-4o                  | `openai/gpt-4o`                       | 128,000 |
-| Claude Opus 4.5         | `anthropic/claude-opus-4.5`           | 200,000 |
-| Claude Sonnet 4.5       | `anthropic/claude-sonnet-4.5`         | 200,000 |
-| Gemini 3 Pro            | `google/gemini-3-pro-preview`         | 128,000 |
-| Gemini 3 Flash          | `google/gemini-3-flash-preview`       | 128,000 |
+| Profile                 | Model                                  | Context |
+| ----------------------- | -------------------------------------- | ------- |
+| DeepSeek V3 _(default)_ | `deepseek-ai/DeepSeek-V3-0324`         | 163,840 |
+| DeepSeek V3.2           | `deepseek-ai/DeepSeek-V3.2`            | 163,840 |
+| DeepSeek R1             | `deepseek-ai/DeepSeek-R1`              | 131,072 |
+| DeepSeek Prover V2      | `deepseek-ai/DeepSeek-Prover-V2-671B`  | 131,072 |
+| GPT-5.2                 | `openai/gpt-5.2`                       | 128,000 |
+| GPT-5.1                 | `openai/gpt-5.1`                       | 128,000 |
+| GPT-5                   | `openai/gpt-5`                         | 128,000 |
+| GPT-4o                  | `openai/gpt-4o`                        | 128,000 |
+| Claude Opus 4.5         | `anthropic/claude-opus-4.5`            | 200,000 |
+| Claude Sonnet 4.5       | `anthropic/claude-sonnet-4.5`          | 200,000 |
+| Gemini 3.1 Pro          | `google/gemini-3.1-pro-preview`        | 128,000 |
+| Gemini 3 Flash          | `google/gemini-3-flash-preview`        | 128,000 |
+| Gemini 3.1 Flash Lite   | `google/gemini-3.1-flash-lite-preview` | 128,000 |
 
 **Deploy-on-demand** — deploy first at [console.gmicloud.ai](https://console.gmicloud.ai), then paste the provided endpoint URL into the **Endpoint URL** field:
 

--- a/nodes/src/nodes/llm_gmi_cloud/services.json
+++ b/nodes/src/nodes/llm_gmi_cloud/services.json
@@ -221,8 +221,8 @@
 				"modelTotalTokens": 200000
 			},
 			"gemini-3-pro": {
-				"title": "Gemini 3 Pro",
-				"model": "google/gemini-3-pro-preview",
+				"title": "Gemini 3.1 Pro",
+				"model": "google/gemini-3.1-pro-preview",
 				"serverbase": "https://api.gmi-serving.com/v1",
 				"apikey": "",
 				"modelTotalTokens": 128000
@@ -230,6 +230,13 @@
 			"gemini-3-flash": {
 				"title": "Gemini 3 Flash",
 				"model": "google/gemini-3-flash-preview",
+				"serverbase": "https://api.gmi-serving.com/v1",
+				"apikey": "",
+				"modelTotalTokens": 128000
+			},
+			"gemini-3-1-flash-lite": {
+				"title": "Gemini 3.1 Flash Lite",
+				"model": "google/gemini-3.1-flash-lite-preview",
 				"serverbase": "https://api.gmi-serving.com/v1",
 				"apikey": "",
 				"modelTotalTokens": 128000
@@ -343,6 +350,10 @@
 			"object": "gemini-3-flash",
 			"properties": ["llm.cloud.apikey"]
 		},
+		"gmi_cloud.gemini-3-1-flash-lite": {
+			"object": "gemini-3-1-flash-lite",
+			"properties": ["llm.cloud.apikey"]
+		},
 		"gmi_cloud.profile": {
 			"title": "Model",
 			"description": "GMI Cloud LLM model",
@@ -433,6 +444,10 @@
 				{
 					"value": "gemini-3-flash",
 					"properties": ["gmi_cloud.gemini-3-flash"]
+				},
+				{
+					"value": "gemini-3-1-flash-lite",
+					"properties": ["gmi_cloud.gemini-3-1-flash-lite"]
 				}
 			]
 		}


### PR DESCRIPTION
## Summary

- Replace stale `google/gemini-3-pro-preview` with `google/gemini-3.1-pro-preview` in the `llm_gmi_cloud` node — GMI Cloud rejected the old ID and blocked Gemini Pro runs at the May 23 hackathon.
- Add new `Gemini 3.1 Flash Lite` profile pointing at `google/gemini-3.1-flash-lite-preview`. Existing `Gemini 3 Flash` (`gemini-3-flash-preview`) left alone — still in catalog.
- Profile keys preserved (`gemini-3-pro`, `gemini-3-flash`) so saved pipelines keep working without migration.

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Closes #996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Gemini 3.1 Flash Lite model option to GMI Cloud service
  * Updated Gemini 3 Pro to Gemini 3.1 Pro with new model identifier

* **Documentation**
  * Updated model profiles reference documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1010?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->