### PR TITLE
fix: test(mocks) resolve Python truthiness and isinstance traps

### DIFF
--- a/nodes/test/mocks/chromadb/__init__.py
+++ b/nodes/test/mocks/chromadb/__init__.py
@@ -150,7 +150,7 @@ class MockCollection:
         items = list(self._storage.items())
 
         # Filter by ids if provided
-        if ids:
+        if ids is not None:
             items = [(id, data) for id, data in items if id in ids]
 
         count = 0
@@ -214,7 +214,7 @@ class MockCollection:
 
     def delete(self, ids: List[str] = None, where: Optional[Dict] = None):
         """Delete items from the collection."""
-        if ids:
+        if ids is not None:
             for id in ids:
                 if id in self._storage:
                     del self._storage[id]
@@ -228,7 +228,7 @@ class MockCollection:
 
     def update(self, ids: List[str] = None, where: Optional[Dict] = None, new_metadata: Dict = None):
         """Update items in the collection."""
-        if ids:
+        if ids is not None:
             for id in ids:
                 if id in self._storage and new_metadata:
                     self._storage[id]['metadata'].update(new_metadata)

--- a/nodes/test/mocks/psycopg2/__init__.py
+++ b/nodes/test/mocks/psycopg2/__init__.py
@@ -154,7 +154,7 @@ class MockCursor:
 
         # Apply LIMIT
         limit = self._extract_limit(query, params)
-        if limit:
+        if limit is not None:
             results = results[:limit]
 
         self._results = results
@@ -182,7 +182,7 @@ class MockCursor:
                     query_vector = p.tolist()
                 elif isinstance(p, (list, tuple)) and len(p) > 3:
                     query_vector = list(p)
-                elif isinstance(p, int) and p < 1000:
+                elif isinstance(p, int) and not isinstance(p, bool) and p < 1000:
                     limit = p
                 else:
                     filter_params.append(p)
@@ -318,7 +318,7 @@ class MockCursor:
         if 'limit' in query.lower() and params:
             # Last param is often the limit
             for p in reversed(params):
-                if isinstance(p, int) and p < 10000:
+                if isinstance(p, int) and not isinstance(p, bool) and p < 10000:
                     return p
         return None
 
@@ -331,7 +331,7 @@ class MockCursor:
         """Check if data matches filter parameters."""
         # Check isDeleted
         is_deleted = data.get('isdeleted', False)
-        if False in params and is_deleted:
+        if any(p is False for p in params) and is_deleted:
             return False
         return True
 

--- a/nodes/test/mocks/weaviate/__init__.py
+++ b/nodes/test/mocks/weaviate/__init__.py
@@ -133,7 +133,7 @@ class Filter:
             elif op == 'like':
                 # Simple wildcard matching
                 pattern = value.replace('*', '')
-                results.append(pattern.lower() in str(prop_value).lower() if prop_value else False)
+                results.append(pattern.lower() in str(prop_value).lower() if prop_value is not None else False)
             elif op == 'greater_or_equal':
                 results.append(prop_value >= value if prop_value is not None else False)
             elif op == 'less_or_equal':


### PR DESCRIPTION
## Summary

- Fixed Python truthiness and `isinstance` traps in test mocks for ChromaDB, psycopg2, and Weaviate.
- Resolved an issue where empty lists `[]` or integers like `0` were incorrectly evaluating to `False` (e.g., `if ids:` vs `if ids is not None:`).
- Fixed an `isinstance` trap where `False` matched `isinstance(x, int)` since booleans are a subclass of integers in Python.
- Fixed a bug where `False in params` evaluated to `True` if `params` contained a `0` value.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #747


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of test infrastructure for database and search operations.
  * Enhanced handling of edge cases with empty inputs and falsy values in mock services.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->