### PR TITLE
fix(server): signal handler crash on teardown + /api/chat dev proxy

### DIFF
--- a/apps/shell-ui/rsbuild.config.mts
+++ b/apps/shell-ui/rsbuild.config.mts
@@ -89,6 +89,12 @@ export default defineConfig(({ command }) => {
 					// built app bundles at dist/server/static/shell/apps/*.
 					{ name: path.join(process.env.ROCKETRIDE_DIST_ROOT || path.resolve(__dirname, '../../dist'), 'server', 'static'), watch: false },
 				],
+				// Forward landing-page WebSocket connections to the engine.
+				// http-proxy-middleware accepts ws://, wss://, http://, and https:// targets
+				// with ws: true — no scheme normalisation needed.
+				proxy: {
+					'/api/chat': { target: env['ROCKETRIDE_URI'] ?? 'http://localhost:5565', ws: true, changeOrigin: true },
+				},
 			}),
 		},
 		plugins: [

--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -55,8 +55,9 @@ import uvicorn
 import asyncio
 import importlib
 import time
+from contextlib import asynccontextmanager, contextmanager
 from dotenv import load_dotenv
-from contextlib import asynccontextmanager
+from typing import Generator
 from typing import Dict, Any, Callable, Awaitable, List, Optional, Union, Tuple
 from fastapi import FastAPI, Request, Response
 from fastapi.responses import HTMLResponse, PlainTextResponse
@@ -120,6 +121,19 @@ async def _lifespan(app: FastAPI):
     yield
     # Call the shutdown method
     await app.state.server._on_shutdown()
+
+
+class _NoSignalUvicornServer(uvicorn.Server):
+    """Uvicorn server that skips signal handler capture/restore.
+
+    The C++ engine installs C-level signal handlers that Python cannot
+    represent as callables, so uvicorn's capture_signals() crashes on
+    teardown when it tries to restore them.
+    """
+
+    @contextmanager
+    def capture_signals(self) -> Generator[None, None, None]:
+        yield
 
 
 class WebServer:
@@ -388,7 +402,7 @@ class WebServer:
         )
 
         # Return the configured server instance
-        return uvicorn.Server(config)
+        return _NoSignalUvicornServer(config)
 
     async def _on_startup(self):
         """


### PR DESCRIPTION
## Summary

Two backend changes needed to support running a uvicorn-based WebSocket server inside the C++ engine process.

### Changes

**`packages/ai/src/ai/web/server.py`**
Add `_NoSignalUvicornServer` subclass that no-ops `capture_signals()`. The C++ engine installs C-level signal handlers before the embedded Python interpreter starts. These handlers are not Python callables — when uvicorn tries to restore them on teardown it raises `TypeError: signal handler must be signal.SIG_IGN, signal.SIG_DFL, or a callable object`. This fix applies to any uvicorn server running inside the engine process.

**`apps/shell-ui/rsbuild.config.mts`**
Simplify the dev proxy to a single `/api/chat` WebSocket rule. The chat endpoint now connects directly over WebSocket — no token-fetch step needed. `ROCKETRIDE_URI` is passed through as-is; `http-proxy-middleware` accepts `ws://`, `wss://`, `http://`, and `https://` targets natively with `ws: true`.

## Testing
- Dev server: `/api/chat` WebSocket connects and responds end-to-end
- Shutdown: server exits cleanly without signal handler crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)