### PR TITLE
chore(server): vcpkg 2026.04.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
               - 'builder'
               - 'builder.cmd'
               - '.github/workflows/**'
+              - 'package.json'
 
   # ---------------------------------------------------------------------------
   #  Helm lint + schema validation (only on PRs touching deploy/helm/**)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"private": true,
 	"license": "MIT",
 	"vcpkg": {
-		"version": "2026.02.27"
+		"version": "2026.04.27"
 	},
 	"java": {
 		"jdkVersion": "17",

--- a/packages/server/engine-lib/engLib/headers.h
+++ b/packages/server/engine-lib/engLib/headers.h
@@ -77,12 +77,20 @@
 // https://github.com/aws/aws-sdk-cpp/pull/1189
 #pragma push_macro("JSON_USE_EXCEPTION")
 #undef JSON_USE_EXCEPTION
+// atlbase.h (included above) pulls in wingdi.h, which defines the ERROR macro
+// (#define ERROR 0). The newer aws-sdk-cpp declares `typedef E ERROR;` in
+// aws/core/utils/Outcome.h, so the macro expands it to `typedef E 0;` and the
+// header fails to compile. Suppress the GDI macro across the AWS includes and
+// restore it afterwards so Windows code below is unaffected.
+#pragma push_macro("ERROR")
+#undef ERROR
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include <aws/core/http/Scheme.h>
 #include <aws/core/utils/memory/stl/AWSSet.h>
 #include <aws/core/utils/logging/DefaultLogSystem.h>
 #include <aws/core/utils/logging/AWSLogging.h>
+#pragma pop_macro("ERROR")
 #pragma pop_macro("JSON_USE_EXCEPTION")
 
 #if ROCKETRIDE_PLAT_WIN


### PR DESCRIPTION
### VCPKG upgraded to 2026.04.27
* Windows and Ubuntu builds are failing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vcpkg dependency version.
  * Modified CI workflow configuration to trigger full builds when package.json is modified, ensuring build consistency.

* **Bug Fixes**
  * Fixed Windows compatibility issue with macro expansion in SDK headers by implementing proper macro isolation during compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->