### PR TITLE
fix(autoinstall): align clang to distro default — unblocks repo-wide Ubuntu CI

### DIFF
--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -59,15 +59,18 @@ detect_linux_distro() {
 
 # Detect installed clang version (12 or later)
 detect_installed_clang() {
-    # Try to find any clang version 12 or later that's already installed
-    for ver in 18 17 16 15 14 13 12; do
-        if command_exists "clang-$ver"; then
-            echo "$ver"
-            return 0
-        fi
-    done
-    
-    # Check if generic 'clang' command exists and get its version
+    # Prefer the distro-DEFAULT unversioned `clang` when it's >=12. The image
+    # provisions the matching libc++ stack — including the UNVERSIONED
+    # libc++-dev / libc++abi-dev that own the multiarch symlink
+    # /usr/lib/x86_64-linux-gnu/libc++.so, which is what the linker resolves
+    # `-lc++` against. Picking a DIFFERENT (higher) versioned clang here makes
+    # the libc++ check below force-install libc++-<higher>-dev, and apt resolves
+    # the conflict by REMOVING the unversioned libc++-dev — deleting that
+    # symlink and breaking every `-stdlib=libc++` link with
+    # `/usr/bin/ld: cannot find -lc++`. Seen on GHA ubuntu-22.04 image
+    # 20260525: default clang is 14 but clang-15 is also present, so taking the
+    # highest version silently broke the build. Aligning to the default keeps
+    # compiler and its fully-installed libc++ in lockstep, no apt mutation.
     if command_exists "clang"; then
         CLANG_VER=$(clang --version | head -n1 | grep -o '[0-9]\+\.[0-9]\+' | head -1 | cut -d. -f1)
         if [ "$CLANG_VER" -ge 12 ] 2>/dev/null; then
@@ -75,7 +78,15 @@ detect_installed_clang() {
             return 0
         fi
     fi
-    
+
+    # Fallback: highest installed versioned clang (no usable default `clang`).
+    for ver in 18 17 16 15 14 13 12; do
+        if command_exists "clang-$ver"; then
+            echo "$ver"
+            return 0
+        fi
+    done
+
     return 1
 }
 
@@ -135,15 +146,13 @@ select_linux_triplet() {
         
         # Use generic triplet and set CC/CXX to point to the installed version
         TRIPLET_NAME="x64-linux-clang-rocketride.cmake"
-        
-        # Check if generic clang/clang++ exist, otherwise use versioned ones
-        if command_exists "clang" && command_exists "clang++"; then
-            export CC=clang
-            export CXX=clang++
-        else
-            export CC=clang-${CLANG_VERSION}
-            export CXX=clang++-${CLANG_VERSION}
-        fi
+
+        # CLANG_VERSION is the DEFAULT clang's version (see
+        # detect_installed_clang), so its libc++ stack — including the
+        # unversioned multiarch libc++.so the linker needs for `-lc++` — is
+        # already installed and consistent. Pin CC/CXX to that exact version.
+        export CC=clang-${CLANG_VERSION}
+        export CXX=clang++-${CLANG_VERSION}
         
         # Check if required libc++ libraries are installed for this version
         if ! dpkg -l "libc++-${CLANG_VERSION}-dev" 2>/dev/null | grep -q "^ii"; then

--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -150,9 +150,17 @@ select_linux_triplet() {
         # CLANG_VERSION is the DEFAULT clang's version (see
         # detect_installed_clang), so its libc++ stack — including the
         # unversioned multiarch libc++.so the linker needs for `-lc++` — is
-        # already installed and consistent. Pin CC/CXX to that exact version.
-        export CC=clang-${CLANG_VERSION}
-        export CXX=clang++-${CLANG_VERSION}
+        # already installed and consistent. Prefer the versioned frontend, but
+        # fall back to the bare `clang`/`clang++` when no versioned symlink
+        # exists (clang via update-alternatives or a source build) — otherwise
+        # we'd set an invalid CC/CXX that only fails later at compile time.
+        if command_exists "clang-${CLANG_VERSION}" && command_exists "clang++-${CLANG_VERSION}"; then
+            export CC=clang-${CLANG_VERSION}
+            export CXX=clang++-${CLANG_VERSION}
+        else
+            export CC=clang
+            export CXX=clang++
+        fi
         
         # Check if required libc++ libraries are installed for this version
         if ! dpkg -l "libc++-${CLANG_VERSION}-dev" 2>/dev/null | grep -q "^ii"; then


### PR DESCRIPTION
## What

Fixes the repo-wide **Ubuntu Build / 22.04** failure that's been blocking every PR + nightly since ~2026-05-27 20:51 PT.

## Root cause

GHA `ubuntu-22.04` image **20260525** made the default `clang` → clang-14 (clang-15 still present as a versioned binary). `detect_installed_clang()` picked the **highest** version (15), so the libc++ check force-installed `libc++-15-dev`. apt resolved the conflict by **REMOVING** the unversioned `libc++-dev`/`libc++abi-dev` — the packages that own the multiarch symlink `/usr/lib/x86_64-linux-gnu/libc++.so` that the linker resolves `-lc++` against.

Result: every `-stdlib=libc++` link failed with `/usr/bin/ld: cannot find -lc++`, which CMake surfaced as the **misleading** vcpkg `detect_compiler` cascade (`CMAKE_MAKE_PROGRAM is not set` / `CMAKE_CXX_COMPILER not set` / `Ninja not found`). vcpkg/cmake/ninja versions were all red herrings — confirmed by #1020, where bumping vcpkg to 2026.04.27 fails Ubuntu identically.

## Fix

`detect_installed_clang()` now prefers the **distro-default** unversioned `clang`, falling back to the highest versioned clang only when no default exists. This keeps the compiler aligned with its already-installed, multiarch-symlinked libc++ — no apt removal, `-lc++` resolves.

## Verification

All-green on the dot-release branch (this exact change): **Build / Ubuntu 22.04 ✅, Windows ✅, macOS ✅**. Single-file change, no behavior change on images where the default clang is already the highest version (e.g. the prior image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Linux compiler detection to prefer a suitable unversioned compiler when present, falling back to specific versioned compilers as needed.
  * Updated CC/CXX selection to prefer matching versioned compiler executables when available, otherwise use generic compiler names — reducing mismatches and improving build consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->