### PR TITLE
ci: add /assign self-service issue-claim bot

### DIFF
--- a/.github/workflows/issue-self-assign.yml
+++ b/.github/workflows/issue-self-assign.yml
@@ -1,0 +1,39 @@
+name: Self-assign issues
+
+# Lets community contributors and interns claim issues WITHOUT being granted
+# write/triage: commenting "/assign" on an issue assigns the commenter,
+# "/unassign" removes them. The workflow's GITHUB_TOKEN performs the
+# assignment, so no per-person role hand-out is needed for self-service
+# claiming. (Requested by Josh — pairs with the fork-and-PR contribution
+# model.)
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  assign:
+    # Only on issues (not PR comments), and only for the /assign|/unassign verbs.
+    if: >-
+      ${{ !github.event.issue.pull_request &&
+          (startsWith(github.event.comment.body, '/assign') ||
+           startsWith(github.event.comment.body, '/unassign')) }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const user = context.payload.comment.user.login;
+            const unassign = context.payload.comment.body.trim().startsWith('/unassign');
+            if (unassign) {
+              await github.rest.issues.removeAssignees({ owner, repo, issue_number, assignees: [user] });
+            } else {
+              await github.rest.issues.addAssignees({ owner, repo, issue_number, assignees: [user] });
+            }
+            await github.rest.reactions.createForIssueComment({
+              owner, repo, comment_id: context.payload.comment.id, content: 'eyes',
+            });


### PR DESCRIPTION
## What
Adds `.github/workflows/issue-self-assign.yml` — a comment-driven bot that lets community contributors and interns claim issues themselves:

- `/assign` on an issue → assigns the commenter
- `/unassign` → removes them
- reacts 👀 to confirm it ran

## Why
Requested by Josh. Self-assignment normally needs Triage/write on the repo; this bot performs the assignment via the workflow's `GITHUB_TOKEN` instead, so we don't have to hand out roles to community members. Pairs with the fork-and-PR contribution model (no write access on the engine repo).

## Notes
- `permissions: issues: write` only (least privilege).
- `actions/github-script` pinned to the same SHA already used elsewhere in the repo.
- Triggers only on issue comments (not PR comments) starting with the verbs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Issue comments with `/assign` or `/unassign` commands now automatically update issue assignees.
  * Comments triggering these commands receive an emoji reaction indicator.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1026?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->