### PR TITLE
fix/RR-1023-duplicate-discussion-sync

### DIFF
--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -210,15 +210,20 @@ jobs:
             MARKER_COMMENT_ID=$(echo "$MARKER" | jq -r '.id')
           fi
 
-          WEBHOOK_ID=$(echo    "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $(NF-1)}')
-          WEBHOOK_TOKEN=$(echo "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $NF}')
+          # Normalize webhook URL so POST and PATCH share one base. The previous
+          # awk-split approach desynced if DISCORD_DISCUSSIONS_WEBHOOK_URL had a
+          # trailing slash or query string (e.g. ?thread_id=...): PATCH 404'd,
+          # the 404 branch deleted the marker as "message gone", then fell through
+          # to POST → fresh repost on every discussion update.
+          BASE="${DISCORD_WEBHOOK_URL%%\?*}"
+          BASE="${BASE%/}"
 
           # ── Post or patch ────────────────────────────────────────────────
           if [ -n "$DISCORD_MSG_ID" ]; then
             PATCH_BODY=$(discord_curl -X PATCH \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID") || true
+              "$BASE/messages/$DISCORD_MSG_ID") || true
             PATCH_STATUS=$(cat "$DISCORD_STATUS_FILE")
             echo "PATCH status: $PATCH_STATUS"
 
@@ -234,10 +239,13 @@ jobs:
           fi
 
           if [ -z "$DISCORD_MSG_ID" ]; then
-            if ! RESPONSE=$(discord_curl \
+            # --no-retry-5xx makes POST at-most-once per the discord-helper
+            # contract: only 429 is safe to retry (request guaranteed rejected);
+            # transient 5xx or no-response could each create a duplicate message.
+            if ! RESPONSE=$(discord_curl --no-retry-5xx -X POST \
               -H "Content-Type: application/json" \
               -d "$PAYLOAD" \
-              "${DISCORD_WEBHOOK_URL}?wait=true"); then
+              "$BASE?wait=true"); then
               echo "::error::Discord POST failed (status $(cat "$DISCORD_STATUS_FILE")) after retries"
               exit 1
             fi
@@ -248,10 +256,10 @@ jobs:
 
             if [ -n "$EXISTING_MARKER" ] && [ "$EXISTING_MARKER" != "null" ]; then
               # Another run won the race — delete our duplicate message, use theirs
-              discord_curl -X DELETE "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$NEW_MSG_ID" > /dev/null || true
+              discord_curl -X DELETE "$BASE/messages/$NEW_MSG_ID" > /dev/null || true
               DISCORD_MSG_ID=$(echo "$EXISTING_MARKER" | jq -r '.body' | grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2)
               discord_curl -X PATCH -H "Content-Type: application/json" -d "$PAYLOAD" \
-                "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null || true
+                "$BASE/messages/$DISCORD_MSG_ID" > /dev/null || true
             else
               DISCORD_MSG_ID="$NEW_MSG_ID"
               gh api graphql \


### PR DESCRIPTION
Closes #1023

## Root cause
POST used the raw `DISCORD_DISCUSSIONS_WEBHOOK_URL`; PATCH rebuilt the URL via `awk -F'/'` over the same secret. Any deviation from `https://discord.com/api/webhooks/{id}/{token}` — trailing slash, `?thread_id=...`, alternate host — silently breaks the PATCH target while POST keeps working.

## Cascade
Malformed PATCH → Discord 404 → handler treats it as "message deleted" → deletes the marker comment → falls through to POST → posts a fresh message + writes a new marker → next edit hits the same broken PATCH again. Repost on every update.

(Local repro with a trailing-slash webhook returns 405 rather than 404; in that shape the job would `exit 1` instead of reposting. Whichever shape prod actually sees, the URL is malformed and this PR eliminates both failure modes.)

## Fix
- Normalize the secret once into `$BASE` (strip query string + trailing slash). Reuse `$BASE` for the marker-hit PATCH, the create POST, and the race-guard DELETE + PATCH.
- Add `--no-retry-5xx -X POST` to the create call per the `discord-helper` contract. Without it a transient Discord 5xx could create a duplicate message on retry — a second, independent duplicate source fixed in the same PR.

## Verification
Local-only; final acceptance needs a `develop` merge + a real discussion edit.

- `${URL%%\?*}` + `${BASE%/}` tested against canonical, trailing-slash, `?thread_id=`, combined, and `discordapp.com` shapes — all produce a clean base.
- Local e2e against a throwaway Discord webhook:
  - POST: 200
  - PATCH via `$BASE`: 200 (message edited in place, no duplicate)
  - PATCH via old awk-split: 405 (broken path confirmed)
- `bash -n` on the inline script passes.

## Acceptance criteria
- Editing a discussion with an existing marker returns PATCH 200; original Discord message is edited in place, no duplicate is posted.
- POST is at-most-once on transient 5xx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Discord API requests with optimized retry behavior.

* **Chores**
  * Enhanced Discord webhook integration efficiency through streamlined URL handling and endpoint routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rocketride-org/rocketride-server/pull/1027?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->