### PR TITLE
feat(engine): load workspace-local nodes via --node_path

### DIFF
--- a/docs/README-nodes.md
+++ b/docs/README-nodes.md
@@ -323,7 +323,7 @@ Develop a node in your own workspace -- next to your `.pipe` -- without changing
 the installed engine. Set `--node_path` to the directory that holds your
 `local_nodes` folder (the folder name is required):
 
-```
+```sh
 engine --node_path=/path/to/dir-containing-local_nodes ...
 ```
 
@@ -331,11 +331,12 @@ Its nodes are scanned like the built-in ones but imported as `local_nodes.<node>
 (set this in each `services.json` `"path"`), so they never clash with the
 built-in `nodes` package.
 
-```
+```text
 my-workspace/
 └── local_nodes/
     ├── __init__.py          # empty -- just marks local_nodes as a package
     └── my_node/
+        ├── __init__.py      # required -- runs depends(requirements.txt) and exports IGlobal/IInstance (see "Adding a New Node")
         ├── services.json    # "path": "local_nodes.my_node"
         ├── IGlobal.py
         ├── IInstance.py

--- a/docs/README-nodes.md
+++ b/docs/README-nodes.md
@@ -317,6 +317,43 @@ standalone catalog nodes.
 
 ---
 
+## Prototyping Local Nodes
+
+Develop a node in your own workspace -- next to your `.pipe` -- without changing
+the installed engine. Set `--node_path` to the directory that holds your
+`local_nodes` folder (the folder name is required):
+
+```
+engine --node_path=/path/to/dir-containing-local_nodes ...
+```
+
+Its nodes are scanned like the built-in ones but imported as `local_nodes.<node>`
+(set this in each `services.json` `"path"`), so they never clash with the
+built-in `nodes` package.
+
+```
+my-workspace/
+└── local_nodes/
+    ├── __init__.py          # empty -- just marks local_nodes as a package
+    └── my_node/
+        ├── services.json    # "path": "local_nodes.my_node"
+        ├── IGlobal.py
+        ├── IInstance.py
+        └── requirements.txt
+```
+
+Build the node exactly as in [Adding a New Node](#adding-a-new-node) -- its
+`IGlobal` installs the node's own `requirements.txt`, so dependencies work the
+same as any built-in node.
+
+To ship a node so it becomes part of RocketRide, clone the
+[rocketride-server](https://github.com/rocketride-org/rocketride-server) repo,
+move your node into `nodes/src/nodes/<node>/`, change its `services.json`
+`"path"` to `nodes.<node>`, and open a pull request following the
+[contributing guide](../CONTRIBUTING.md).
+
+---
+
 ## License
 
 MIT License, see [LICENSE](../LICENSE).

--- a/packages/server/engine-core/apLib/application/init.cpp
+++ b/packages/server/engine-core/apLib/application/init.cpp
@@ -26,6 +26,14 @@ void engine() {
         "    --stream     Sends task instructions via stdin. If not specified");
     LOGOUTPUT(
         "                 tasks must be specified as taskFile or taskDir");
+    LOGOUTPUT(
+        "    --node_path=<dir>  Directory containing a 'local_nodes' folder of");
+    LOGOUTPUT(
+        "                 workspace-local nodes to load alongside the built-in");
+    LOGOUTPUT(
+        "                 nodes. Each node's services.json must use");
+    LOGOUTPUT(
+        "                 \"path\": \"local_nodes.<node>\".");
     LOGOUTPUT("\n");
 }
 

--- a/packages/server/engine-lib/engLib/python/init.cpp
+++ b/packages/server/engine-lib/engLib/python/init.cpp
@@ -39,6 +39,14 @@ static application::Opt ExecPython{"--python"};
 
 //-------------------------------------------------------------------------
 /// @details
+///		Optional path to a directory that contains a `local_nodes` folder,
+///		e.g. --node_path=/work. The directory is added to sys.path so the
+///		nodes import under the local_nodes.<node> package.
+//-------------------------------------------------------------------------
+static application::Opt NodePath{"--node_path"};
+
+//-------------------------------------------------------------------------
+/// @details
 ///		This holds the generated configuration which will be active while
 ///		the python interpreter is active
 //-------------------------------------------------------------------------
@@ -147,6 +155,21 @@ Error setPaths() {
         if (paths.empty()) {
             LOG(Python, "Python production path:", root);
             paths.push_back(root);
+        }
+
+        // If --node_path=<dir> holds a `local_nodes` folder, put <dir> on
+        // sys.path so its nodes import as local_nodes.<node> (like nodes/src
+        // for the built-in `nodes` package).
+        if (NodePath) {
+            auto searchDir = _cast<file::Path>(*NodePath);
+            auto localDir = searchDir / "local_nodes";
+            if (file::exists(localDir) && file::isDir(localDir)) {
+                LOG(Python, "Python local node path:", localDir);
+                paths.push_back(searchDir);
+            } else {
+                LOG(Python, "Warning: no local_nodes directory under --node_path:",
+                    searchDir);
+            }
         }
 
         // Access Python's sys.path

--- a/packages/server/engine-lib/engLib/store/services/services.cpp
+++ b/packages/server/engine-lib/engLib/store/services/services.cpp
@@ -32,6 +32,13 @@ static application::Opt ServiceName{"--serviceName"};
 static application::Opt ServiceCat{"--serviceCategory"};
 
 //-------------------------------------------------------------------------
+/// @details
+///		Optional directory that holds a `local_nodes` folder, scanned in
+///		addition to the built-in nodes, e.g. --node_path=/work
+//-------------------------------------------------------------------------
+static application::Opt NodePath{"--node_path"};
+
+//-------------------------------------------------------------------------
 //
 //	The format for the service entries is pretty complex, but easy
 //	once you understand it. Each service .json file, located in the
@@ -1976,6 +1983,20 @@ Error IServices::init() noexcept {
 
     // Start at the root
     if (auto ccode = loadServices(rootPath, (Text) "*")) return ccode;
+
+    // Also scan a `local_nodes` folder under --node_path=<dir>, if given. The
+    // fixed name keeps these imported as local_nodes.<node>, never clashing
+    // with the built-in `nodes` package. setPaths() puts <dir> on sys.path.
+    if (NodePath) {
+        auto localRoot = _cast<file::Path>(*NodePath) / "local_nodes";
+        if (file::exists(localRoot) && file::isDir(localRoot)) {
+            LOG(Services, "Loading workspace-local nodes from", localRoot);
+            if (auto ccode = loadServices(localRoot, (Text) "*")) return ccode;
+        } else {
+            LOG(Services, "No local_nodes directory under --node_path:",
+                _cast<file::Path>(*NodePath));
+        }
+    }
 
     // Update all the fields
     if (auto ccode = updateDefinitions()) return ccode;


### PR DESCRIPTION
## Summary
<img width="1728" height="823" alt="Captura de pantalla 2026-05-30 a las 17 33 12" src="https://github.com/user-attachments/assets/fc291072-65b6-4968-bab2-3f4c6d902930" />|<img width="1476" height="878" alt="Captura de pantalla 2026-05-30 a las 17 33 27" src="https://github.com/user-attachments/assets/f10c4c4b-242c-40e9-bae0-87777c6eba61" />
-|-

The engine can now load **workspace-local nodes** directly, so contributors can prototype a node right next to their `.pipe` without copying it into the installed engine.

**How it works:** pass `--node_path=<dir>` to the engine, where `<dir>` is the directory that *contains* a `local_nodes` folder. At startup the engine scans `<dir>/local_nodes` for `services.json` exactly like the built-in nodes, and adds `<dir>` to `sys.path`. The nodes import under the **`local_nodes.<node>`** package — never `nodes` — so there is no collision with the built-in `nodes` package (a regular package bound to a single location).

This is an **engine-side, in-place** mechanism: no copying, no symlinks, no per-OS branching, no admin rights, and no stale files to clean up. The nodes are read where they live, so edits are picked up on the next engine start and debugging hits the real source file.

### Why `--node_path` instead of mirroring into the engine

Node discovery and registration live in the C++ engine (`IServices::init` → `loadServices`); there is no Python/TS hook to register a node at runtime. Earlier revisions of this PR mirrored files into the engine's catalog from the extension (copy/symlink) to work around that. Per review feedback (@rod), this moves the logic to where discovery actually happens, removing the file duplication — and the symlinks — entirely. The fixed `local_nodes` package name also keeps the Python module loader and debugger from confusing local nodes with the built-in `nodes` package.

### Changes
- `packages/server/engine-lib/engLib/store/services/services.cpp`: after loading the built-in nodes, also scan the fixed `local_nodes` subdir under `--node_path`.
- `packages/server/engine-lib/engLib/python/init.cpp`: add `<node_path>` to `sys.path` when it contains a `local_nodes` folder (warns if it does not).
- `packages/server/engine-core/apLib/application/init.cpp`: document `--node_path` in `--engine_help`.
- `docs/README-nodes.md`: "Prototyping Local Nodes" workflow + promotion steps.

No VS Code extension code changes are needed: the extension passes `--node_path` through the existing `rocketride.development.local.engineArgs` setting. The prior copy/symlink-based mirroring is gone.

### Author workflow
1. Create `<workspace>/local_nodes/__init__.py` — empty; it just marks `local_nodes` as a package.
2. Add `<workspace>/local_nodes/<node>/` with its own `__init__.py` (runs `depends(requirements.txt)` and exports `IGlobal`/`IInstance`, exactly like a built-in node) and a `services.json` whose `"path"` is `local_nodes.<node>`.
3. Set `rocketride.development.local.engineArgs` to `--node_path=<abs path to the workspace that contains local_nodes>` and restart the engine.

To promote a local node into the repo, move it to `nodes/src/nodes/<node>/` and change its `services.json` `"path"` from `local_nodes.<node>` to `nodes.<node>`.

## Type

feat

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #
