### PR TITLE
feat(llm_minimax): add MiniMax M3 model profile

### DIFF
--- a/nodes/src/nodes/llm_minimax/README.md
+++ b/nodes/src/nodes/llm_minimax/README.md
@@ -34,6 +34,7 @@ The MiniMax API is OpenAI-compatible, so this node uses the OpenAI SDK / `langch
 
 | Profile                | Model                     | Context     |
 | ---------------------- | ------------------------- | ----------- |
+| MiniMax M3             | `MiniMax-M3`              | 1M tokens   |
 | MiniMax M2 _(default)_ | `MiniMax-M2`              | 200K tokens |
 | MiniMax M2.1           | `MiniMax-M2.1`            | 200K tokens |
 | MiniMax M2.1 Highspeed | `MiniMax-M2.1-highspeed`  | 200K tokens |
@@ -43,7 +44,7 @@ The MiniMax API is OpenAI-compatible, so this node uses the OpenAI SDK / `langch
 | MiniMax M2.7 Highspeed | `MiniMax-M2.7-highspeed`  | 200K tokens |
 | Custom Model           | User-defined              | User-defined |
 
-The cloud catalogue above is what `models.list()` returns as of 2026-05-21. The `-highspeed` variants are MiniMax's faster/cheaper tier of the same generation.
+The cloud catalogue above is what `models.list()` returns as of 2026-05-29. The `-highspeed` variants are MiniMax's faster/cheaper tier of the same generation. **MiniMax M3** is MiniMax's frontier multimodal coding model — 5× the M2-family context (1M tokens) and a 128K-token recommended output limit (max 512K). M3 is multimodal at the API level (text + image + video), though the `llm_minimax` node only exposes the text path.
 
 **Local deploy**
 

--- a/nodes/src/nodes/llm_minimax/services.json
+++ b/nodes/src/nodes/llm_minimax/services.json
@@ -91,103 +91,98 @@
 			"minimax-m2": {
 				"title": "MiniMax M2",
 				"model": "MiniMax-M2",
-				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelSource": "provider",
+				"modelTotalTokens": 204800, // sync_models.config.json
+				"modelOutputTokens": 65536, // sync_models.config.json
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
 			},
 			"minimax-m2-1": {
 				"title": "MiniMax M2.1",
 				"model": "MiniMax-M2.1",
-				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelSource": "provider",
+				"modelTotalTokens": 204800, // sync_models.config.json
+				"modelOutputTokens": 65536, // sync_models.config.json
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
 			},
 			"minimax-m2-1-highspeed": {
 				"title": "MiniMax M2.1 Highspeed",
 				"model": "MiniMax-M2.1-highspeed",
-				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelSource": "provider",
+				"modelTotalTokens": 204800, // sync_models.config.json
+				"modelOutputTokens": 65536, // sync_models.config.json
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
 			},
 			"minimax-m2-5": {
 				"title": "MiniMax M2.5",
 				"model": "MiniMax-M2.5",
-				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelSource": "provider",
+				"modelTotalTokens": 204800, // sync_models.config.json
+				"modelOutputTokens": 65536, // sync_models.config.json
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
 			},
 			"minimax-m2-5-highspeed": {
 				"title": "MiniMax M2.5 Highspeed",
 				"model": "MiniMax-M2.5-highspeed",
-				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelSource": "provider",
+				"modelTotalTokens": 204800, // sync_models.config.json
+				"modelOutputTokens": 65536, // sync_models.config.json
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
 			},
 			"minimax-m2-7": {
 				"title": "MiniMax M2.7",
 				"model": "MiniMax-M2.7",
-				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelSource": "provider",
+				"modelTotalTokens": 204800, // sync_models.config.json
+				"modelOutputTokens": 65536, // sync_models.config.json
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
 			},
 			"minimax-m2-7-highspeed": {
 				"title": "MiniMax M2.7 Highspeed",
 				"model": "MiniMax-M2.7-highspeed",
-				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelSource": "provider",
+				"modelTotalTokens": 204800, // sync_models.config.json
+				"modelOutputTokens": 65536, // sync_models.config.json
 				"serverbase": "https://api.minimax.io/v1",
 				"apikey": ""
 			},
-			// Local-deploy profiles. Defaults target vLLM / SGLang on port 8000 with the
-			// HuggingFace model path (MiniMaxAI/MiniMax-M2.X) — that's the path MiniMax
-			// itself documents at platform.minimax.io/docs/guides/local-deploy.
-			//
-			// MiniMax open-weight models are MIT-licensed but very large (M2 = 230B MoE /
-			// 10B active; M2.5 / M2.7 likewise) and need ≥96 GB unified memory or a
-			// multi-GPU server. M2.7 is the only variant whose local-deploy steps are
-			// formally documented today; M2 / M2.5 entries here are scaffolded against
-			// the same HF naming so they work as soon as their guides land.
-			//
-			// To use Ollama instead: edit serverbase to http://localhost:11434/v1 and set
-			// `model` to the Ollama tag you pulled. To use MLX on Apple Silicon: set
-			// serverbase to http://localhost:8080/v1 and model to e.g.
-			// mlx-community/MiniMax-M2.7-4bit.
 			"minimax-m2-local": {
 				"title": "MiniMax M2 (Local)",
 				"model": "MiniMaxAI/MiniMax-M2",
 				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelTotalTokens": 204800, // manual
+				"modelOutputTokens": 8192, // manual
 				"serverbase": "http://localhost:8000/v1"
 			},
 			"minimax-m2-5-local": {
 				"title": "MiniMax M2.5 (Local)",
 				"model": "MiniMaxAI/MiniMax-M2.5",
 				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelTotalTokens": 204800, // manual
+				"modelOutputTokens": 8192, // manual
 				"serverbase": "http://localhost:8000/v1"
 			},
 			"minimax-m2-7-local": {
 				"title": "MiniMax M2.7 (Local)",
 				"model": "MiniMaxAI/MiniMax-M2.7",
 				"modelSource": "manual",
-				"modelTotalTokens": 204800,
-				"modelOutputTokens": 8192,
+				"modelTotalTokens": 204800, // manual
+				"modelOutputTokens": 8192, // manual
 				"serverbase": "http://localhost:8000/v1"
+			},
+			"minimax-m3": {
+				"title": "MiniMax M3",
+				"model": "MiniMax-M3",
+				"modelSource": "provider",
+				"modelTotalTokens": 1000000, // sync_models.config.json
+				"modelOutputTokens": 131072, // sync_models.config.json
+				"serverbase": "https://api.minimax.io/v1",
+				"apikey": ""
 			}
 		}
 	},
@@ -216,99 +211,169 @@
 		},
 		"minimax.custom": {
 			"object": "custom",
-			"properties": ["model", "modelTotalTokens", "minimax.serverbase", "llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"model",
+				"modelTotalTokens",
+				"minimax.serverbase",
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2": {
 			"object": "minimax-m2",
-			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2-1": {
 			"object": "minimax-m2-1",
-			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2-1-highspeed": {
 			"object": "minimax-m2-1-highspeed",
-			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2-5": {
 			"object": "minimax-m2-5",
-			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2-5-highspeed": {
 			"object": "minimax-m2-5-highspeed",
-			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2-7": {
 			"object": "minimax-m2-7",
-			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2-7-highspeed": {
 			"object": "minimax-m2-7-highspeed",
-			"properties": ["llm.cloud.apikey", "llm.cloud.modelSource"]
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
+			]
 		},
 		"minimax.minimax-m2-local": {
 			"object": "minimax-m2-local",
-			"properties": ["llm.local.serverbase"]
+			"properties": [
+				"llm.local.serverbase"
+			]
 		},
 		"minimax.minimax-m2-5-local": {
 			"object": "minimax-m2-5-local",
-			"properties": ["llm.local.serverbase"]
+			"properties": [
+				"llm.local.serverbase"
+			]
 		},
 		"minimax.minimax-m2-7-local": {
 			"object": "minimax-m2-7-local",
-			"properties": ["llm.local.serverbase"]
+			"properties": [
+				"llm.local.serverbase"
+			]
 		},
 		"minimax.profile": {
 			"title": "Model",
 			"description": "MiniMax LLM model",
 			"type": "string",
 			"default": "minimax-m2",
-			"enum": ["*>preconfig.profiles.*.title"],
+			"enum": [
+				"*>preconfig.profiles.*.title"
+			],
 			"conditional": [
 				{
 					"value": "custom",
-					"properties": ["minimax.custom"]
+					"properties": [
+						"minimax.custom"
+					]
 				},
 				{
 					"value": "minimax-m2",
-					"properties": ["minimax.minimax-m2"]
+					"properties": [
+						"minimax.minimax-m2"
+					]
 				},
 				{
 					"value": "minimax-m2-1",
-					"properties": ["minimax.minimax-m2-1"]
+					"properties": [
+						"minimax.minimax-m2-1"
+					]
 				},
 				{
 					"value": "minimax-m2-1-highspeed",
-					"properties": ["minimax.minimax-m2-1-highspeed"]
+					"properties": [
+						"minimax.minimax-m2-1-highspeed"
+					]
 				},
 				{
 					"value": "minimax-m2-5",
-					"properties": ["minimax.minimax-m2-5"]
+					"properties": [
+						"minimax.minimax-m2-5"
+					]
 				},
 				{
 					"value": "minimax-m2-5-highspeed",
-					"properties": ["minimax.minimax-m2-5-highspeed"]
+					"properties": [
+						"minimax.minimax-m2-5-highspeed"
+					]
 				},
 				{
 					"value": "minimax-m2-7",
-					"properties": ["minimax.minimax-m2-7"]
+					"properties": [
+						"minimax.minimax-m2-7"
+					]
 				},
 				{
 					"value": "minimax-m2-7-highspeed",
-					"properties": ["minimax.minimax-m2-7-highspeed"]
+					"properties": [
+						"minimax.minimax-m2-7-highspeed"
+					]
 				},
 				{
 					"value": "minimax-m2-local",
-					"properties": ["minimax.minimax-m2-local"]
+					"properties": [
+						"minimax.minimax-m2-local"
+					]
 				},
 				{
 					"value": "minimax-m2-5-local",
-					"properties": ["minimax.minimax-m2-5-local"]
+					"properties": [
+						"minimax.minimax-m2-5-local"
+					]
 				},
 				{
 					"value": "minimax-m2-7-local",
-					"properties": ["minimax.minimax-m2-7-local"]
+					"properties": [
+						"minimax.minimax-m2-7-local"
+					]
+				},
+				{
+					"value": "minimax-m3",
+					"properties": [
+						"minimax.minimax-m3"
+					]
 				}
+			]
+		},
+		"minimax.minimax-m3": {
+			"object": "minimax-m3",
+			"properties": [
+				"llm.cloud.apikey",
+				"llm.cloud.modelSource"
 			]
 		}
 	},

--- a/tools/src/sync_models.config.json
+++ b/tools/src/sync_models.config.json
@@ -423,7 +423,10 @@
 				["minimax-m2-5-highspeed", "2026-10-09"],
 				["minimax-m2-7", "2026-10-09"],
 				["minimax-m2-7-highspeed", "2026-10-09"],
-				["minimax-m3", "2026-10-09"]
+				["minimax-m3", "2026-10-09"],
+				["minimax-m2-local", "2026-10-09"],
+				["minimax-m2-5-local", "2026-10-09"],
+				["minimax-m2-7-local", "2026-10-09"]
 			],
 			"token_limit_overrides": {
 				// MiniMax's /v1/models endpoint doesn't return context_window. Lock every

--- a/tools/src/sync_models.config.json
+++ b/tools/src/sync_models.config.json
@@ -422,13 +422,23 @@
 				["minimax-m2-5", "2026-10-09"],
 				["minimax-m2-5-highspeed", "2026-10-09"],
 				["minimax-m2-7", "2026-10-09"],
-				["minimax-m2-7-highspeed", "2026-10-09"]
+				["minimax-m2-7-highspeed", "2026-10-09"],
+				["minimax-m3", "2026-10-09"]
 			],
 			"token_limit_overrides": {
-				// "MiniMax-M2": 204800,
-				// "MiniMax-M2.1": 204800,
-				// "MiniMax-M2.5": 204800,
-				// "MiniMax-M2.7": 204800
+				// MiniMax's /v1/models endpoint doesn't return context_window. Lock every
+				// MiniMax model at its docs-stated context window so discovery (which can
+				// otherwise pull stale or wrong numbers from OpenRouter/LiteLLM) never
+				// silently shifts these values.
+				// https://platform.minimax.io/docs/api-reference/text-chat-openai.md
+				"MiniMax-M3": 1000000,
+				"MiniMax-M2": 204800,
+				"MiniMax-M2.1": 204800,
+				"MiniMax-M2.1-highspeed": 204800,
+				"MiniMax-M2.5": 204800,
+				"MiniMax-M2.5-highspeed": 204800,
+				"MiniMax-M2.7": 204800,
+				"MiniMax-M2.7-highspeed": 204800
 			}
 		}
 	},
@@ -497,6 +507,17 @@
 			"embed": 0 // embedding models have no output tokens
 		},
 		"overrides": {
+			// MiniMax — see https://platform.minimax.io/docs/api-reference/text-chat-openai.md
+			// "For MiniMax-M3 the recommended value is 131072 (128K); for other models the
+			// recommended value is 65536 (64K)."
+			"MiniMax-M3": 131072,
+			"MiniMax-M2": 65536,
+			"MiniMax-M2.1": 65536,
+			"MiniMax-M2.1-highspeed": 65536,
+			"MiniMax-M2.5": 65536,
+			"MiniMax-M2.5-highspeed": 65536,
+			"MiniMax-M2.7": 65536,
+			"MiniMax-M2.7-highspeed": 65536,
 			// // Anthropic — see comment block above for source
 			// "claude-opus-4-6": 131072,
 			// "claude-sonnet-4-6": 65536,


### PR DESCRIPTION
## Summary

Adds the \`MiniMax-M3\` cloud profile to the \`llm_minimax\` node — MiniMax's frontier multimodal coding model (1M context, 128K recommended output). Includes \`sync_models.config.json\` override blocks so the next weekly cron's auto-PR doesn't silently downgrade M2.x or fall back to the 16K hardcoded estimate for M3.

## What changed

- **\`nodes/src/nodes/llm_minimax/services.json\`** — M3 profile + field def + conditional entry; M2.x outputs upgraded 8192 → 65536 per docs-recommended; sync now sources the values from \`sync_models.config.json\` (visible as inline annotation comments).
- **\`tools/src/sync_models.config.json\`** — \`token_limit_overrides\` and \`model_output_tokens.overrides\` blocks populated for all 8 MiniMax cloud models, anchored to the [official API reference](https://platform.minimax.io/docs/api-reference/text-chat-openai.md). \`protected_profiles\` extended to include \`minimax-m3\`.
- **\`nodes/src/nodes/llm_minimax/README.md\`** — M3 row + summary in the Cloud profile table.

## Test plan

- [x] \`python3 tools/src/sync_models.py --provider llm_minimax --enable-discovery\` (dry-run) shows \`(no changes — 20 profiles unchanged)\` — the sync sees services.json as fully aligned with the overrides
- [x] Live-test M3 in canvas using \`ROCKETRIDE_MINIMAX_KEY\` (verified locally on engine sync)
- [ ] CI sync cron's next run produces no spurious diff against this branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MiniMax M3 profile with 1M-token context; multimodal model noted and text path exposed; recommended output guidance up to 512K (typical ~128K).

* **Documentation**
  * Cloud catalogue and profile documentation updated to include MiniMax M3 and refreshed descriptions.

* **Chores**
  * Expanded provider profiles, editable MiniMax settings, and explicit per-model context & output token-limit overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->