### PR TITLE
ci: restore -s (sequential) on Test step — fix flaky Windows timeouts breaking nightly prerelease

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -170,7 +170,9 @@ jobs:
         # (.env.template, the engine's built-in dev key).
         env:
           ROCKETRIDE_APIKEY: MYAPIKEY
-        run: ${{ matrix.builder_cmd }} test --verbose
+        # note: Sequential execution should be changed to parallel execution
+        #       after the appropriate fixes have been made, see #743 #1048 for details.
+        run: ${{ matrix.builder_cmd }} test --verbose --sequential
 
       - name: Perform CodeQL Analysis
         if: inputs.codeql && matrix.platform == 'ubuntu'


### PR DESCRIPTION
Stopgap to unbreak the **nightly prerelease** (Stepan flagged: without it every CI run rebuilds the vcpkg C++ deps from scratch).

## Root cause (not vcpkg)
`-s` in the builder = `--sequential` (`scripts/build.js:67`). #743 ("parallel test server isolation") dropped `-s` from the Test command in `_build.yaml`, so the suites now run **in parallel**. That surfaced a **pre-existing teardown/open-handle leak** in the TypeScript client suite (`tests/RocketRideClient.test.ts` → Jest *"A worker process has failed to exit gracefully… improper teardown"*), which on the **slow Windows runner** intermittently flips into 120s async-callback timeouts.

Evidence its flakiness from parallelism, not a deterministic regression:
- The *set* of timing-out tests differs run-to-run (e0338562/#743 vs 78ff7578/#1020 timed out on different tests, both landing on "2 failed, 66 passed"), with the same teardown warning that was present-but-tolerated pre-#743 (with `-s`).
- Confined to Windows; Ubuntu + macOS pass. **vcpkg built clean on all 3 platforms** in #1020 — this is not a vcpkg/#39 toolchain issue.

This failed develop CI on both `e0338562` (#743) and `78ff7578` (#1020); the nightly gate (`workflow_run.conclusion == success`) then correctly skipped the prerelease for #1020.

## Fix
Restore the prior known-good `-s` (sequential) on the Test step. Sequential masks the parallel teardown race → Windows stops timing out → nightly prerelease produces the artifact again.

## Follow-up (not this PR)
Durable fix is the TS-client teardown leak (unref/await disconnect + timers in `afterAll`/`afterEach`), owner = #743 author (@asclearuc). Re-drop `-s` to regain parallel speed once that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)