### PR TITLE
fix(whisper): bound version guard to < 4.8 + guard explicit CUDA devices

### DIFF
--- a/packages/ai/src/ai/common/models/audio/whisper.py
+++ b/packages/ai/src/ai/common/models/audio/whisper.py
@@ -89,7 +89,8 @@ class WhisperLoader(BaseLoader):
             # 1. Version guard: ctranslate2 4.7.x + CUDA 12.8 causes a
             #    tcache_thread_shutdown() SIGABRT during GPU transcription on H200
             #    (heap corruption in cuBLAS 12.8.4). Exit non-zero to force CPU.
-            #    Remove this guard once ctranslate2 ships a fix.
+            #    Upper bound at 4.8 so the guard lifts automatically once
+            #    ctranslate2 ships a fix (expected in 4.8+).
             # 2. StorageView sanity: verify a CUDA StorageView can be created via
             #    the documented from_array() API (no direct (shape,dtype,device)
             #    constructor exists in the Python bindings).
@@ -102,7 +103,7 @@ class WhisperLoader(BaseLoader):
                 'except (ValueError, AttributeError):\n'
                 '    ct2 = (999, 999)\n'
                 'cuda = torch.version.cuda or ""\n'
-                'if ct2 >= (4, 7) and cuda.startswith("12.8"):\n'
+                'if (4, 7) <= ct2 < (4, 8) and cuda.startswith("12.8"):\n'
                 '    sys.exit(1)\n'
                 't = torch.zeros(1, dtype=torch.float32, device="cuda")\n'
                 'sv = ctranslate2.StorageView.from_array(t)\n'
@@ -213,6 +214,15 @@ class WhisperLoader(BaseLoader):
                     device = 'cuda'
                 else:
                     device = 'cpu'
+            elif device != 'cpu' and not WhisperLoader._check_gpu_compatible():
+                # Explicit cuda / cuda:N requested but probe failed — fall back to CPU
+                # so the same SIGABRT protection applies regardless of how the caller
+                # specified the device.
+                logger.warning(
+                    'ctranslate2 CUDA probe failed for explicit device=%r — Whisper will use CPU instead.',
+                    device,
+                )
+                device = 'cpu'
 
             if device == 'cpu':
                 gpu_index = -1


### PR DESCRIPTION
## Summary

Follow-up to #1043, addressing two non-blocking nits from kwit75's review:

**1. Bound the version guard to `(4,7) <= ct2 < (4,8)`**

The previous `ct2 >= (4, 7)` check would have kept 4.8/4.9/5.x forced to CPU even after CTranslate2 ships a fix. Adding `< (4, 8)` as an upper bound means the guard auto-lifts once 4.8+ is installed.

**2. Guard explicit `device='cuda'`/`device='cuda:N'` in local mode**

`_check_gpu_compatible()` was only called on the auto-detect path (`device=None`). Callers passing an explicit CUDA device bypassed the probe entirely and could still hit the SIGABRT. The fix adds the same probe check for any non-CPU explicit device:

```python
elif device != 'cpu' and not WhisperLoader._check_gpu_compatible():
    logger.warning('ctranslate2 CUDA probe failed for explicit device=%r — will use CPU', device)
    device = 'cpu'
```

Server mode was already fully protected (probe runs before `allocate_gpu`, which is the only GPU selection path in that mode).

## Test plan

- [x] `./builder model_server:test` — 35 passed, 11 deselected on 8× H200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced GPU compatibility checks for audio processing with automatic fallback to CPU when GPU requirements aren't met, ensuring stable operation across different hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->