### PR TITLE
fix(ai): preserve parallel tool-call identity in transcript replay

### DIFF
--- a/packages/ai/src/ai/common/utils/agent_tools.py
+++ b/packages/ai/src/ai/common/utils/agent_tools.py
@@ -136,29 +136,41 @@ def langchain_messages_to_transcript(messages: Any) -> str:
             role = 'tool'
             try:
                 name = safe_str(getattr(m, 'name', ''))
-                if name:
-                    role = f'tool[{name}]'
+                # Carry the tool_call_id so each result stays paired with the
+                # specific call that produced it. Without this, a turn that
+                # replays *parallel* calls to the same tool loses the
+                # call->result mapping and the model can mis-attribute results.
+                call_id = safe_str(getattr(m, 'tool_call_id', ''))
+                label = f'{name}#{call_id}' if name and call_id else (name or call_id)
+                if label:
+                    role = f'tool[{label}]'
             except Exception:
                 pass
         elif isinstance(m, AIMessage):
             role = 'assistant'
             try:
-                tool_calls = getattr(m, 'tool_calls', None) or []
+                tool_calls = [tc for tc in (getattr(m, 'tool_calls', None) or []) if isinstance(tc, dict)]
                 if tool_calls:
-                    rendered_calls = [
-                        json.dumps(
-                            {
-                                'type': 'tool_call',
-                                'name': safe_str(tc.get('name', '')),
-                                'args': tc.get('args', {}),
-                            },
-                            ensure_ascii=False,
-                            default=str,
-                        )
+                    calls = [
+                        {
+                            'id': safe_str(tc.get('id', '')),
+                            'name': safe_str(tc.get('name', '')),
+                            'args': tc.get('args', {}),
+                        }
                         for tc in tool_calls
-                        if isinstance(tc, dict)
                     ]
-                    content = '\n'.join(filter(None, [content, *rendered_calls]))
+                    # Preserve the original grouping and per-call ids so a replayed
+                    # turn is unambiguous. A single call renders as the singular
+                    # envelope; multiple parallel calls render as ONE plural
+                    # ``tool_calls`` envelope (the same shape the model emitted)
+                    # rather than being flattened into separate single-call lines,
+                    # which erased both the grouping and the id->result pairing.
+                    if len(calls) == 1:
+                        envelope: Dict[str, Any] = {'type': 'tool_call', **calls[0]}
+                    else:
+                        envelope = {'type': 'tool_calls', 'calls': calls}
+                    rendered = json.dumps(envelope, ensure_ascii=False, default=str)
+                    content = '\n'.join(filter(None, [content, rendered]))
             except Exception:
                 pass
 

--- a/packages/ai/tests/ai/common/utils/test_agent_tools.py
+++ b/packages/ai/tests/ai/common/utils/test_agent_tools.py
@@ -185,9 +185,10 @@ def lc_messages(monkeypatch):
                 self.tool_calls = tool_calls
 
     class ToolMessage:
-        def __init__(self, content='', name=''):
+        def __init__(self, content='', name='', tool_call_id=''):
             self.content = content
             self.name = name
+            self.tool_call_id = tool_call_id
 
     mod = types.ModuleType('langchain_core.messages')
     mod.SystemMessage = SystemMessage
@@ -281,3 +282,64 @@ class TestLangchainMessagesToTranscript:
         msg = lc_messages.HumanMessage(content='x')
         out = langchain_messages_to_transcript([msg])
         assert not out.endswith('\n')
+
+    # -- parallel tool-call identity (regression) ---------------------------
+    #
+    # On every turn the transcript is replayed to the LLM as context. When an
+    # assistant turn issued *parallel* tool calls, the prior implementation
+    # flattened them into separate single-call lines and dropped both the
+    # per-call ``id`` and the ``ToolMessage.tool_call_id``, so the replayed
+    # turn lost the call->result pairing — the model could mis-attribute
+    # results, especially when several parallel calls hit the *same* tool
+    # (e.g. ``task`` for subagent fan-out). These tests pin the identity.
+
+    def test_single_tool_call_round_trips_with_id(self, lc_messages):
+        """A lone tool call renders as the singular envelope and carries its id."""
+        messages = [
+            lc_messages.AIMessage(
+                content='',
+                tool_calls=[{'id': 'call_solo', 'name': 'search', 'args': {'q': 'x'}}],
+            ),
+            lc_messages.ToolMessage(content='hit', name='search', tool_call_id='call_solo'),
+        ]
+        out = langchain_messages_to_transcript(messages)
+
+        assert '"type": "tool_call"' in out
+        assert '"id": "call_solo"' in out
+        # The result line is pinned to the same id.
+        assert 'tool[search#call_solo]: hit' in out
+
+    def test_parallel_calls_preserve_grouping_and_per_call_identity(self, lc_messages):
+        """Two parallel calls to the SAME tool keep distinct ids on call and result."""
+        messages = [
+            lc_messages.HumanMessage(content='do both'),
+            lc_messages.AIMessage(
+                content='',
+                tool_calls=[
+                    {'id': 'call_a', 'name': 'task', 'args': {'description': 'A'}},
+                    {'id': 'call_b', 'name': 'task', 'args': {'description': 'B'}},
+                ],
+            ),
+            lc_messages.ToolMessage(content='result A', name='task', tool_call_id='call_a'),
+            lc_messages.ToolMessage(content='result B', name='task', tool_call_id='call_b'),
+        ]
+        out = langchain_messages_to_transcript(messages)
+
+        # Grouping preserved: ONE plural envelope, not two flattened single-call lines.
+        assert '"type": "tool_calls"' in out
+        assert out.count('"type": "tool_call"') == 0
+
+        # Both call ids survive on the assistant side.
+        assert '"id": "call_a"' in out
+        assert '"id": "call_b"' in out
+
+        # Each result is explicitly pinned to the call that produced it — this is
+        # the pairing that was lost before the fix.
+        assert 'tool[task#call_a]: result A' in out
+        assert 'tool[task#call_b]: result B' in out
+
+    def test_missing_tool_call_id_degrades_gracefully(self, lc_messages):
+        """A ToolMessage with no tool_call_id still renders by name (no crash, no '#')."""
+        msg = lc_messages.ToolMessage(content='ok', name='search', tool_call_id='')
+        out = langchain_messages_to_transcript([msg])
+        assert out == 'tool[search]: ok'


### PR DESCRIPTION
## Problem

`langchain_messages_to_transcript` (`ai.common.utils.agent_tools`) renders prior conversation history into the plain-text transcript that is replayed to the LLM on **every** turn.

When an assistant turn issued **parallel** tool calls, the function:
- flattened them into separate single-call `tool_call` lines, and
- dropped both the per-call `id` and the `ToolMessage.tool_call_id`.

So on the next turn the replayed transcript had lost the call→result pairing. The model could mis-attribute results — most acutely when several parallel calls hit the **same** tool (e.g. `task` for `agent_deepagent` subagent fan-out, where every result line read identically as `tool[task]: ...`).

This is the CodeRabbit **Major** flagged as a follow-up to the concurrent fan-out work in #990. The first-turn execution path was never affected (it runs on live id-bearing message objects); the drift only appeared on multi-turn replay, which is why #990's tests passed.

## Fix

In `langchain_messages_to_transcript`:

- **ToolMessage** now renders `tool[name#tool_call_id]`, pinning each result to the call that produced it. Degrades to `tool[name]` when no `tool_call_id` is present (no crash, no dangling `#`).
- **AIMessage** preserves the original grouping and per-call ids:
  - a single call emits the singular `{"type":"tool_call","id":...,"name":...,"args":...}` envelope;
  - multiple parallel calls emit **one** plural `{"type":"tool_calls","calls":[...]}` envelope — the same shape the model emitted — instead of being flattened into separate single-call lines.

## Tests

Adds 3 regression tests to `TestLangchainMessagesToTranscript` in `packages/ai/tests/ai/common/utils/test_agent_tools.py`:

- `test_single_tool_call_round_trips_with_id` — singular envelope carries its `id`; result pinned to `tool[search#call_solo]`.
- `test_parallel_calls_preserve_grouping_and_per_call_identity` — two parallel calls to the **same** tool keep distinct ids on both call and result; exactly **one** plural envelope, zero flattened single-call lines.
- `test_missing_tool_call_id_degrades_gracefully` — renders `tool[search]: ok`.

RED→GREEN verified: with the source fix stashed, the two identity tests fail against develop (the failure output shows the two flattened `tool_call` lines with no ids); restoring the fix makes all pass.

## Verification

- `packages/ai/tests/ai/common/utils/test_agent_tools.py` — 27 passed
- `packages/ai/tests/ai/common/utils/` — 178 passed
- `packages/ai/tests/` — 1181 passed, 120 skipped (one pre-existing collection error in `test_task_scheduler.py` from a missing `time_machine` dependency, unrelated to this change)
- `ruff check` + `ruff format` clean on both files

## Notes

The fix lives in the shared util now (develop moved these helpers out of `deepagent.py` into `ai.common.utils.agent_tools` after #990 merged), so every consumer of the transcript renderer benefits, not just `agent_deepagent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool call results now properly associate with their source calls through unique identifiers, improving accuracy in multi-tool scenarios.
  * Enhanced formatting of parallel tool calls using structured JSON envelopes while preserving call grouping.

* **Tests**
  * Added regression tests verifying tool result pairing, parallel call handling, and graceful degradation when identifiers are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->