### PR TITLE
fix(easyocr): unwrap DataParallel to prevent SIGABRT under concurrent load

### DIFF
--- a/packages/ai/src/ai/common/models/ocr/easyocr.py
+++ b/packages/ai/src/ai/common/models/ocr/easyocr.py
@@ -147,9 +147,16 @@ class EasyOCRLoader(BaseLoader):
             target = torch.device(f'cuda:{gpu_index}')
             for attr in ('detector', 'recognizer'):
                 module = getattr(reader, attr, None)
-                if isinstance(module, torch.nn.DataParallel):
+                if module is None:
+                    logger.info(f'EasyOCR reader has no {attr} attribute — skipping device pinning')
+                elif isinstance(module, torch.nn.DataParallel):
                     setattr(reader, attr, module.module.to(target))
                     logger.debug(f'EasyOCR {attr}: unwrapped DataParallel → cuda:{gpu_index}')
+                else:
+                    device = next(module.parameters()).device if hasattr(module, 'parameters') else 'unknown'
+                    logger.info(
+                        f'EasyOCR {attr}: not wrapped in DataParallel (type={type(module).__name__}, device={device})'
+                    )
 
         model_bundle = {
             'reader': reader,

--- a/packages/ai/src/ai/common/models/ocr/easyocr.py
+++ b/packages/ai/src/ai/common/models/ocr/easyocr.py
@@ -250,12 +250,26 @@ class EasyOCRLoader(BaseLoader):
         reader = models['reader']
         images = preprocessed['images']
         dimensions = preprocessed.get('dimensions', [])
+        device = models.get('device', 'cpu')
+
+        # Set the active CUDA device so tensors created inside readtext
+        # (e.g. input preprocessing, workspace buffers) land on the same GPU
+        # as the model weights that were pinned during load.
+        import contextlib
+        from ai.common.torch import torch
+
+        if device.startswith('cuda'):
+            gpu_id = int(device.split(':')[1]) if ':' in device else 0
+            cuda_ctx = torch.cuda.device(gpu_id)
+        else:
+            cuda_ctx = contextlib.nullcontext()
 
         results = []
 
         for idx, img_np in enumerate(images):
             try:
-                raw_results = reader.readtext(img_np)
+                with cuda_ctx:
+                    raw_results = reader.readtext(img_np)
 
                 # Convert EasyOCR format to standard box format
                 boxes = []

--- a/packages/ai/src/ai/common/models/ocr/easyocr.py
+++ b/packages/ai/src/ai/common/models/ocr/easyocr.py
@@ -138,6 +138,19 @@ class EasyOCRLoader(BaseLoader):
             logger.error(f'Failed to load EasyOCR: {e}')
             raise Exception(f'Failed to load EasyOCR: {e}')
 
+        # EasyOCR wraps its detector and recognizer in DataParallel, which
+        # scatters every batch across ALL visible GPUs via parallel_apply().
+        # Under concurrent server load this causes CUDA heap corruption and
+        # a FATAL crash (SIGABRT from parallel_apply worker threads). Pin both
+        # sub-models to the single allocated GPU by unwrapping DataParallel.
+        if use_gpu and gpu_index >= 0:
+            target = torch.device(f'cuda:{gpu_index}')
+            for attr in ('detector', 'recognizer'):
+                module = getattr(reader, attr, None)
+                if isinstance(module, torch.nn.DataParallel):
+                    setattr(reader, attr, module.module.to(target))
+                    logger.debug(f'EasyOCR {attr}: unwrapped DataParallel → cuda:{gpu_index}')
+
         model_bundle = {
             'reader': reader,
             'languages': languages,

--- a/packages/ai/src/ai/common/models/ocr/easyocr.py
+++ b/packages/ai/src/ai/common/models/ocr/easyocr.py
@@ -153,6 +153,8 @@ class EasyOCRLoader(BaseLoader):
                     setattr(reader, attr, module.module.to(target))
                     logger.debug(f'EasyOCR {attr}: unwrapped DataParallel → cuda:{gpu_index}')
                 else:
+                    if isinstance(module, torch.nn.Module):
+                        setattr(reader, attr, module.to(target))
                     first_param = (
                         next(module.parameters(), None) if callable(getattr(module, 'parameters', None)) else None
                     )

--- a/packages/ai/src/ai/common/models/ocr/easyocr.py
+++ b/packages/ai/src/ai/common/models/ocr/easyocr.py
@@ -160,6 +160,12 @@ class EasyOCRLoader(BaseLoader):
                     logger.info(
                         f'EasyOCR {attr}: not wrapped in DataParallel (type={type(module).__name__}, device={device})'
                     )
+            # Align reader.device so EasyOCR's internal img.to(self.device) calls
+            # send inputs to the same GPU as the pinned model weights. Without this,
+            # reader.device stays 'cuda' (→ cuda:0) regardless of which GPU was
+            # allocated, causing a device mismatch on any non-0 allocation.
+            reader.device = str(target)
+            logger.debug(f'EasyOCR reader.device aligned to {target}')
 
         model_bundle = {
             'reader': reader,

--- a/packages/ai/src/ai/common/models/ocr/easyocr.py
+++ b/packages/ai/src/ai/common/models/ocr/easyocr.py
@@ -153,7 +153,10 @@ class EasyOCRLoader(BaseLoader):
                     setattr(reader, attr, module.module.to(target))
                     logger.debug(f'EasyOCR {attr}: unwrapped DataParallel → cuda:{gpu_index}')
                 else:
-                    device = next(module.parameters()).device if hasattr(module, 'parameters') else 'unknown'
+                    first_param = (
+                        next(module.parameters(), None) if callable(getattr(module, 'parameters', None)) else None
+                    )
+                    device = first_param.device if first_param is not None else 'unknown'
                     logger.info(
                         f'EasyOCR {attr}: not wrapped in DataParallel (type={type(module).__name__}, device={device})'
                     )


### PR DESCRIPTION
## Summary

EasyOCR initialises its `detector` and `recogniser` wrapped in `torch.nn.DataParallel`, which scatters every inference call across **all visible GPUs** via `parallel_apply()` worker threads. On an 8× H200 box this spawns up to 8 CUDA threads per inference request. Under the chaos test's OVERLOAD phase (32 concurrent workers), these threads collide and produce a **FATAL crash** — `tcache_thread_shutdown()` SIGABRT from a `parallel_apply` worker thread:

```
easyocr/recognition.py: recognizer_predict
easyocr/recognition.py: get_text
easyocr/easyocr.py: recognize / readtext
torch/nn/parallel/parallel_apply.py: parallel_apply   ← crash here
FATAL ERROR: Application has terminated unexpectedly
[14,250MB] Minidump created: /tmp/...dmp
```

**Fix:** After `Reader()` initialises, unwrap `DataParallel` for both `detector` and `recogniser` and move them to the single GPU the model server allocated. Each EasyOCR instance stays on its own device with no cross-GPU scatter.

## Test plan

- [x] `./builder model_server:test` — 35 passed, 11 deselected
- [x] `./builder model_server:test-chaos` — **1 passed (17 min)**, server previously crashed 9× per run; with this fix the server stays up for the full chaos duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OCR now reliably pins processing to the selected GPU during inference, reducing unintended replication across devices and improving stability and performance under concurrent workloads.
  * Improved checks and clearer logging when GPU pinning isn't applicable, preventing failures and making GPU selection behavior more transparent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->