### PR TITLE
feat(task): scheduled pipeline deployments (deploy v2)

### DIFF
--- a/packages/ai/src/ai/account/deployment_store.py
+++ b/packages/ai/src/ai/account/deployment_store.py
@@ -35,7 +35,7 @@ JSON, not user-uploaded binary data.
 
 from typing import AsyncGenerator, Literal
 
-from rocketlib import debug
+from rocketlib import error
 
 from .models import DeploymentRecord
 from .store import IStore, StorageError
@@ -101,29 +101,31 @@ class DeploymentStore:
 
     async def list(self, client_id: str) -> list[DeploymentRecord]:
         """Return all deployment records for the given client, in no particular order."""
-        paths = await self._store.list_files(self._prefix(client_id))
+        paths = await self._store.list_entries(
+            self._prefix(client_id), recursive=False, include_dirs=False, name_pattern='*.json'
+        )
         records = []
         for path in paths:
             try:
                 data = await self._store.read_file(path)
                 records.append(DeploymentRecord.model_validate_json(data))
             except (StorageError, Exception) as e:
-                debug(f'DeploymentStore.list: skipping {path}: {e}')
+                error(f'DeploymentStore.list: skipping {path}: {e}')
         return records
 
-    async def iter_all(self) -> 'AsyncGenerator[tuple[str, DeploymentRecord], None]':
-        """Async-generate (client_id, DeploymentRecord) for every deployment in store."""
-        paths = await self._store.list_files('users/')
-        for path in paths:
-            if '/deployments/' not in path:
-                continue
-            try:
-                # path format: users/<client_id>/deployments/<project_id>.json
-                client_id = path.split('/')[1]
-                data = await self._store.read_file(path)
-                yield client_id, DeploymentRecord.model_validate_json(data)
-            except Exception as e:
-                debug(f'DeploymentStore.iter_all: skipping {path}: {e}')
+    async def iter_all(self) -> 'AsyncGenerator[DeploymentRecord, None]':
+        """Async-generate every DeploymentRecord in the store, across all users."""
+        users = await self._store.list_entries('users/', recursive=False, include_files=False)
+        for user in users:
+            for dep in await self._store.list_entries(
+                f'{user}deployments/', recursive=False, include_dirs=False, name_pattern='*.json'
+            ):
+                try:
+                    data = await self._store.read_file(dep)
+                    rec = DeploymentRecord.model_validate_json(data)
+                    yield rec
+                except Exception as e:
+                    error(f'DeploymentStore.iter_all: skipping {dep}: {e}')
 
     def _path(self, client_id: str, project_id: str) -> str:
         return f'users/{client_id}/deployments/{project_id}.json'

--- a/packages/ai/src/ai/account/models.py
+++ b/packages/ai/src/ai/account/models.py
@@ -139,15 +139,20 @@ class DeploymentRecord(BaseModel):
     """Persistent deployment control record — single source of truth on disk."""
 
     pipeline: dict
+
     # Cron expression (e.g. "*/15 * * * *") or "manual" for on-demand only.
     schedule: str = 'manual'
 
-    # 'active' | 'paused' | 'errored'
     state: Literal['active', 'paused', 'errored'] = 'active'
 
-    created_by: str  # client_id of the user who deployed
-    created_at: float = Field(default_factory=time.time)
-    updated_at: float = Field(default_factory=time.time)
+    userId: str
+    userToken: str
+
+    createdAt: float = Field(default_factory=time.time)
+    updatedAt: float = Field(default_factory=time.time)
+
+    def to_client_record(self) -> dict:
+        return self.model_dump(exclude={'userToken'})
 
 
 # =============================================================================

--- a/packages/ai/src/ai/modules/task/__init__.py
+++ b/packages/ai/src/ai/modules/task/__init__.py
@@ -2,6 +2,7 @@ import os
 from typing import Dict, Any
 from ai.web import WebServer
 from .task_server import TaskServer
+from .task_scheduler import TaskScheduler
 from depends import depends
 
 requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
@@ -28,9 +29,15 @@ def initModule(server: WebServer, config: Dict[str, Any]):
     # Store task server in server state for access by other modules if needed
     server.app.state.task = task_server
 
-    # Cancel scheduler and background tasks on server shutdown so the process
-    # exits cleanly within the graceful-shutdown window (no force-kill needed).
-    server._user_shutdown = task_server.shutdown
+    scheduler = TaskScheduler(task_server)
+    server.app.state.scheduler = scheduler
+    scheduler.start()
+
+    async def _shutdown() -> None:
+        await scheduler.shutdown()
+        await task_server.shutdown()
+
+    server._user_shutdown = _shutdown
 
     # Register our routes - authentication handled in listen() before accepting
     server.add_socket('/task/service', task_server.listen, public=True)

--- a/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
@@ -39,6 +39,7 @@ from ai.common.dap import DAPConn, TransportBase
 
 if TYPE_CHECKING:
     from ..task_server import TaskServer
+    from ..task_scheduler import TaskScheduler
 
 
 # Cron preset aliases accepted in addition to 5-field expressions.
@@ -87,6 +88,11 @@ class DeployCommands(DAPConn):
         """No-op — all state lives on TaskConn via the other mixins."""
         pass
 
+    @property
+    def _scheduler(self) -> 'TaskScheduler':
+        """The deployment scheduler, created and stored in server state at module init."""
+        return self._server._server.app.state.scheduler
+
     # ── rrext_deploy_add ─────────────────────────────────────────────────────
 
     async def on_rrext_deploy_add(self, request: Dict[str, Any]) -> Dict[str, Any]:
@@ -120,8 +126,8 @@ class DeployCommands(DAPConn):
             updatedAt=time.time(),
         )
         await self._server.deployments.save(self._account_info.userId, record, mode='create')
-        self._server.scheduler.schedule(self._account_info.userId, record)
-        return self.build_response(request, body=record.model_dump())
+        self._scheduler.schedule(record)
+        return self.build_response(request, body=record.to_client_record())
 
     # ── rrext_deploy_remove ──────────────────────────────────────────────────
 
@@ -135,7 +141,7 @@ class DeployCommands(DAPConn):
             raise ValueError('projectId is required')
 
         await self._server.deployments.delete(self._account_info.userId, project_id)
-        self._server.scheduler.unschedule(project_id)
+        self._scheduler.unschedule(project_id)
         return self.build_response(request, body={})
 
     # ── rrext_deploy_list ────────────────────────────────────────────────────
@@ -148,7 +154,7 @@ class DeployCommands(DAPConn):
         return self.build_response(
             request,
             body={
-                'deployments': [r.model_dump() for r in records],
+                'deployments': [r.to_client_record() for r in records],
             },
         )
 
@@ -164,7 +170,7 @@ class DeployCommands(DAPConn):
             raise ValueError('projectId is required')
 
         record = await self._server.deployments.get(self._account_info.userId, project_id)
-        return self.build_response(request, body=record.model_dump())
+        return self.build_response(request, body=record.to_client_record())
 
     # ── rrext_deploy_update ──────────────────────────────────────────────────
 
@@ -198,5 +204,5 @@ class DeployCommands(DAPConn):
         record.updatedAt = time.time()
 
         await self._server.deployments.save(userId, record)
-        self._server.scheduler.schedule(self._account_info.userId, record, mode='update')
+        self._scheduler.schedule(record)
         return self.build_response(request, body={})

--- a/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
@@ -116,8 +116,7 @@ class DeployCommands(DAPConn):
             updated_at=time.time(),
         )
         await self._server.deployments.save(self._account_info.userId, record, mode='create')
-        # todo: feat/deploy2 - enable TaskScheduler
-        # self._server.scheduler.schedule(self._account_info.userId, record)
+        self._server.scheduler.schedule(self._account_info.userId, record)
         return self.build_response(request, body=record.model_dump())
 
     # ── rrext_deploy_remove ──────────────────────────────────────────────────
@@ -132,8 +131,7 @@ class DeployCommands(DAPConn):
             raise ValueError('projectId is required')
 
         await self._server.deployments.delete(self._account_info.userId, project_id)
-        # todo: feat/deploy2 - enable TaskScheduler
-        # self._server.scheduler.unschedule(project_id)
+        self._server.scheduler.unschedule(project_id)
         return self.build_response(request, body={})
 
     # ── rrext_deploy_list ────────────────────────────────────────────────────
@@ -190,6 +188,5 @@ class DeployCommands(DAPConn):
 
         record.updated_at = time.time()
         await self._server.deployments.save(client_id, record)
-        # todo: feat/deploy2 - enable TaskScheduler
-        # self._server.scheduler.schedule(self._account_info.userId, record, mode='update')
+        self._server.scheduler.schedule(self._account_info.userId, record, mode='update')
         return self.build_response(request, body={})

--- a/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_deploy.py
@@ -91,6 +91,9 @@ class DeployCommands(DAPConn):
 
     async def on_rrext_deploy_add(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Accept a pipeline definition, persist it as a deployment, and activate it."""
+        if not self._account_info.userToken:
+            raise ValueError('Cannot deploy: no user token available for scheduled runs')
+
         self.verify_permission('task.control')
 
         args = request.get('arguments') or {}
@@ -111,9 +114,10 @@ class DeployCommands(DAPConn):
             pipeline=pipeline,
             schedule=schedule,
             state='active',
-            created_by=self._account_info.userId,
-            created_at=time.time(),
-            updated_at=time.time(),
+            userId=self._account_info.userId,
+            userToken=self._account_info.userToken,
+            createdAt=time.time(),
+            updatedAt=time.time(),
         )
         await self._server.deployments.save(self._account_info.userId, record, mode='create')
         self._server.scheduler.schedule(self._account_info.userId, record)
@@ -166,6 +170,9 @@ class DeployCommands(DAPConn):
 
     async def on_rrext_deploy_update(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """Modify schedule or pipeline config for an existing deployment."""
+        if not self._account_info.userToken:
+            raise ValueError('Cannot deploy: no user token available for scheduled runs')
+
         self.verify_permission('task.control')
 
         args = request.get('arguments') or {}
@@ -173,8 +180,8 @@ class DeployCommands(DAPConn):
         if not project_id:
             raise ValueError('projectId is required')
 
-        client_id = self._account_info.userId
-        record = await self._server.deployments.get(client_id, project_id)
+        userId = self._account_info.userId
+        record = await self._server.deployments.get(userId, project_id)
 
         if 'pipeline' in args:
             if not isinstance(args['pipeline'], dict):
@@ -186,7 +193,10 @@ class DeployCommands(DAPConn):
             _validate_schedule(args['schedule'])
             record.schedule = args['schedule']
 
-        record.updated_at = time.time()
-        await self._server.deployments.save(client_id, record)
+        record.userId = self._account_info.userId
+        record.userToken = self._account_info.userToken
+        record.updatedAt = time.time()
+
+        await self._server.deployments.save(userId, record)
         self._server.scheduler.schedule(self._account_info.userId, record, mode='update')
         return self.build_response(request, body={})

--- a/packages/ai/src/ai/modules/task/task_scheduler.py
+++ b/packages/ai/src/ai/modules/task/task_scheduler.py
@@ -26,10 +26,10 @@ TaskScheduler — background asyncio loop that fires deployed pipelines on sched
 On startup it scans the store for all active deployments and builds an in-memory
 registry of (next_run, record) entries.  A single asyncio task wakes up when the
 soonest job is due (capped at 60 s) and dispatches overdue runs via
-TaskServer.start_task() — the same path as an on-demand API call.
+start_server_task() — the same authenticated path as an on-demand API call.
 
 Caller responsibilities:
-  • Call scheduler.schedule(client_id, record) after every rrext_deploy_add / _update.
+  • Call scheduler.schedule(record) after every rrext_deploy_add / _update.
   • Call scheduler.unschedule(project_id) after every rrext_deploy_remove.
   • Do NOT call start() more than once.
 """
@@ -41,9 +41,10 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Dict, List
 
 from croniter import croniter
-from rocketlib import debug
+from rocketlib import debug, error
 
 from ai.account.models import DeploymentRecord
+from .task_server_facade import ServerTaskAuthError, start_server_task
 
 if TYPE_CHECKING:
     from .task_server import TaskServer
@@ -54,6 +55,7 @@ class Task:
     next_run: float
     client_id: str = field(compare=False)
     project_id: str = field(compare=False)
+    schedule: str = field(compare=False)
     cancelled: bool = field(default=False, compare=False)
 
 
@@ -68,9 +70,10 @@ class TaskScheduler:
         self._tasks: Dict[str, Task] = {}
         # project_id -> token of the most-recently dispatched task (overlap guard)
         self._active_tokens: Dict[str, str] = {}
-        self._loop_task: asyncio.Task | None = None
+        self._scheduling: asyncio.Task | None = None
+        self._inflight_starts: set[asyncio.Task] = set()
 
-    def schedule(self, client_id: str, record: DeploymentRecord) -> None:
+    def schedule(self, record: DeploymentRecord) -> None:
         """Insert or update a deployment. Removes it when manual or not active."""
         project_id = record.pipeline['project_id']
         old = self._tasks.pop(project_id, None)
@@ -79,7 +82,7 @@ class TaskScheduler:
         if record.schedule == 'manual' or record.state != 'active':
             return
         run_time = croniter(record.schedule, datetime.now()).get_next(datetime).timestamp()
-        task = Task(next_run=run_time, client_id=client_id, project_id=project_id)
+        task = Task(next_run=run_time, client_id=record.userId, project_id=project_id, schedule=record.schedule)
         self._tasks[project_id] = task
         heapq.heappush(self._schedule, task)
 
@@ -90,31 +93,41 @@ class TaskScheduler:
             old.cancelled = True
         self._active_tokens.pop(project_id, None)
 
-    async def start(self) -> None:
-        """Load all persisted deployments then start the scheduler loop."""
-        await self._load_all()
-        self._loop_task = asyncio.create_task(self._loop())
+    def start(self) -> None:
+        """Start the scheduler in the background: load deployments, then run the loop."""
+        self._scheduling = asyncio.create_task(self._main())
 
-    async def stop(self) -> None:
-        """Cancel the scheduler loop and wait for it to finish."""
-        if self._loop_task and not self._loop_task.done():
-            self._loop_task.cancel()
+    async def _main(self) -> None:
+        """Load all persisted deployments, then run the scheduling loop."""
+        await self._load()
+        await self._run()
+
+    async def shutdown(self) -> None:
+        """Cancel the scheduler loop (including any in-flight load), then drain in-flight dispatches."""
+        if self._scheduling and not self._scheduling.done():
+            self._scheduling.cancel()
             try:
-                await self._loop_task
+                await self._scheduling
             except asyncio.CancelledError:
                 pass
-        self._loop_task = None
+        self._scheduling = None
 
-    async def _load_all(self) -> None:
+        if self._inflight_starts:
+            await asyncio.gather(*self._inflight_starts, return_exceptions=True)
+
+    async def _load(self) -> None:
         """Populate the schedule from all persisted deployments across all users."""
         try:
-            async for client_id, record in self._server.deployments.iter_all():
-                self.schedule(client_id, record)
+            async for record in self._server.deployments.iter_all():
+                try:
+                    self.schedule(record)
+                except Exception as e:
+                    error(f'[SCHEDULER] {record.pipeline.get("project_id")}: failed to schedule: {e}')
             debug(f'[SCHEDULER] loaded {len(self._tasks)} scheduled deployment(s)')
         except Exception as e:
-            debug(f'[SCHEDULER] startup scan failed: {e}')
+            error(f'[SCHEDULER] startup scan failed: {e}')
 
-    async def _loop(self) -> None:
+    async def _run(self) -> None:
         while True:
             now = datetime.now().timestamp()
 
@@ -130,26 +143,31 @@ class TaskScheduler:
 
                 heapq.heappop(self._schedule)
 
-                # Skip if the previous run for this deployment is still active.
-                prev_token = self._active_tokens.get(task.project_id)
-                if prev_token:
-                    ctrl = self._server._task_control.get(prev_token)
-                    if ctrl and not ctrl.task.is_task_complete():
-                        debug(f'[SCHEDULER] {task.project_id}: previous run still active, skipping')
-                        record = await self._server.deployments.get(task.client_id, task.project_id)
-                        next_run = croniter(record.schedule, datetime.now()).get_next(datetime).timestamp()
-                        new_task = Task(next_run=next_run, client_id=task.client_id, project_id=task.project_id)
-                        self._tasks[task.project_id] = new_task
-                        heapq.heappush(self._schedule, new_task)
-                        continue
+                try:
+                    next_run = croniter(task.schedule, datetime.now()).get_next(datetime).timestamp()
+                    new_task = Task(
+                        next_run=next_run,
+                        client_id=task.client_id,
+                        project_id=task.project_id,
+                        schedule=task.schedule,
+                    )
+                    self._tasks[task.project_id] = new_task
+                    heapq.heappush(self._schedule, new_task)
 
-                asyncio.create_task(self._dispatch(task.client_id, task.project_id))
+                    # Skip if the previous run for this deployment is still active.
+                    prev_token = self._active_tokens.get(task.project_id)
+                    if prev_token:
+                        ctrl = self._server._task_control.get(prev_token)
+                        if ctrl and not ctrl.task.is_task_complete():
+                            debug(f'[SCHEDULER] {task.project_id}: previous run still active, skipping')
+                            continue
 
-                record = await self._server.deployments.get(task.client_id, task.project_id)
-                next_run = croniter(record.schedule, datetime.now()).get_next(datetime).timestamp()
-                new_task = Task(next_run=next_run, client_id=task.client_id, project_id=task.project_id)
-                self._tasks[task.project_id] = new_task
-                heapq.heappush(self._schedule, new_task)
+                    task_start = asyncio.create_task(self._start_task(task.client_id, task.project_id))
+                    self._inflight_starts.add(task_start)
+                    task_start.add_done_callback(self._inflight_starts.discard)
+
+                except Exception as e:
+                    error(f'[SCHEDULER] {task.project_id}: scheduling tick failed: {e}')
 
             # Sleep until the next scheduled run (max 60 s).
             if self._schedule:
@@ -160,28 +178,42 @@ class TaskScheduler:
 
             await asyncio.sleep(delay)
 
-    async def _dispatch(self, client_id: str, project_id: str) -> None:
+    async def _start_task(self, client_id: str, project_id: str) -> None:
         try:
             record = await self._server.deployments.get(client_id, project_id)
         except Exception as e:
-            debug(f'[SCHEDULER] {project_id}: failed to load record: {e}')
+            error(f'[SCHEDULER] {project_id}: failed to load record: {e}')
+            return
+
+        if not record.userToken:
+            # Without a replayable credential the run can never authenticate.
+            error(f'[SCHEDULER] {project_id}: no user token; cannot dispatch')
             return
 
         try:
-            request = {
-                'command': 'execute',
-                'arguments': {'pipeline': record.pipeline},
-            }
-            # todo: feat/deploy2 - build conn and verify permissions
-            result = await self._server.start_task(
-                request,
-                conn=None,
-                client_id=record.created_by,
-                user_id=record.created_by,
-            )
-            token = result['token']
-            self._active_tokens[project_id] = token
-            debug(f'[SCHEDULER] {project_id}: dispatched -> task {token}')
-
+            task_token = await start_server_task(self._server, record.userToken, record.pipeline)
+        except ServerTaskAuthError as e:
+            error(f'[SCHEDULER] {project_id}: authentication failed: {e}; marking errored')
+            await self._mark_errored(client_id, record)
+            return
         except Exception as e:
-            debug(f'[SCHEDULER] {project_id}: dispatch failed: {e}')
+            error(f'[SCHEDULER] {project_id}: dispatch failed: {e}')
+            return
+
+        self._active_tokens[project_id] = task_token
+        debug(f'[SCHEDULER] {project_id}: dispatched -> task {task_token}')
+
+    async def _mark_errored(self, client_id: str, record: DeploymentRecord) -> None:
+        """Flip a deployment to 'errored' (e.g. its user token expired) and stop scheduling it.
+
+        Persisting the state lets the UI prompt for a re-deploy; unscheduling stops
+        the cron from re-attempting a doomed authentication every tick until then.
+        """
+        project_id = record.pipeline['project_id']
+        try:
+            record.state = 'errored'
+            record.updatedAt = datetime.now().timestamp()
+            await self._server.deployments.save(client_id, record)
+        except Exception as e:
+            error(f'[SCHEDULER] {project_id}: failed to persist errored state: {e}')
+        self.unschedule(project_id)

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -91,8 +91,7 @@ from .task_engine import Task
 from .types import LAUNCH_TYPE
 from .pipeline import resolve_implied_source
 
-# todo: feat/deploy2 - enable TaskScheduler
-# from .task_scheduler import TaskScheduler
+from .task_scheduler import TaskScheduler
 from rocketlib import debug
 
 
@@ -220,8 +219,7 @@ class TaskServer(DAPBase):
         self._deployments_instance: Optional[DeploymentStore] = None
 
         # Scheduler for running deployed pipelines
-        # todo: feat/deploy2 - enable TaskScheduler
-        # self.scheduler = TaskScheduler(self)
+        self.scheduler = TaskScheduler(self)
 
         # Start background tasks that must be cancelled on shutdown.
         self._bg_tasks: List[asyncio.Task] = [
@@ -230,8 +228,7 @@ class TaskServer(DAPBase):
             # TTL monitoring
             asyncio.create_task(self._monitor_ttl()),
             # Run scheduled deployments
-            # todo: feat/deploy2 - enable TaskScheduler
-            # asyncio.create_task(self.scheduler.start()),
+            asyncio.create_task(self.scheduler.start()),
         ]
 
         # Store reference to parent server for statistics integration
@@ -384,8 +381,7 @@ class TaskServer(DAPBase):
 
     async def shutdown(self) -> None:
         """Cancel all background tasks."""
-        # todo: feat/deploy2 - enable TaskScheduler
-        # await self.scheduler.stop()
+        await self.scheduler.stop()
         bg_tasks = getattr(self, '_bg_tasks', [])
         for task in bg_tasks:
             if not task.done():

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -91,7 +91,6 @@ from .task_engine import Task
 from .types import LAUNCH_TYPE
 from .pipeline import resolve_implied_source
 
-from .task_scheduler import TaskScheduler
 from rocketlib import debug
 
 
@@ -218,17 +217,12 @@ class TaskServer(DAPBase):
         self._store_instance: Optional[Store] = None
         self._deployments_instance: Optional[DeploymentStore] = None
 
-        # Scheduler for running deployed pipelines
-        self.scheduler = TaskScheduler(self)
-
         # Start background tasks that must be cancelled on shutdown.
         self._bg_tasks: List[asyncio.Task] = [
             # Cleanup for completed tasks
             asyncio.create_task(self._cleanup_tasks()),
             # TTL monitoring
             asyncio.create_task(self._monitor_ttl()),
-            # Run scheduled deployments
-            asyncio.create_task(self.scheduler.start()),
         ]
 
         # Store reference to parent server for statistics integration
@@ -381,7 +375,6 @@ class TaskServer(DAPBase):
 
     async def shutdown(self) -> None:
         """Cancel all background tasks."""
-        await self.scheduler.stop()
         bg_tasks = getattr(self, '_bg_tasks', [])
         for task in bg_tasks:
             if not task.done():

--- a/packages/ai/src/ai/modules/task/task_server_facade.py
+++ b/packages/ai/src/ai/modules/task/task_server_facade.py
@@ -1,0 +1,114 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Launch a task on a TaskServer via an in-process DAP connection."""
+
+import asyncio
+from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+
+from ai.common.dap import TransportBase
+
+from .task_conn import TaskConn
+
+if TYPE_CHECKING:
+    from .task_server import TaskServer
+
+
+# =============================================================================
+# PUBLIC
+# =============================================================================
+
+
+class ServerTaskAuthError(Exception):
+    """Token authentication failed; distinct from transient execution errors."""
+
+
+async def start_server_task(server: 'TaskServer', token: str, pipeline: Dict[str, Any]) -> str:
+    """Authenticate ``token`` and execute ``pipeline`` on ``server``; return the task token (``tk_…``).
+
+    Raises:
+        ServerTaskAuthError: Authentication failed.
+        RuntimeError: Execute request did not succeed.
+    """
+    conn = _InProcessConn(server)
+
+    try:
+        await conn.request('auth', arguments={'auth': token})
+    except RuntimeError as exc:
+        raise ServerTaskAuthError(str(exc)) from exc
+
+    exec_response = await conn.request('execute', arguments={'pipeline': pipeline})
+
+    return exec_response['body']['token']
+
+
+# =============================================================================
+# PRIVATE
+# =============================================================================
+
+
+class _InProcessConn(TaskConn):
+    """TaskConn wired to an _InProcessTransport instead of a real socket."""
+
+    def __init__(self, server: 'TaskServer'):
+        super().__init__(server._next_connection_id(), server, _InProcessTransport())
+
+    async def request(
+        self,
+        command: str,
+        *,
+        token: Optional[str] = None,
+        arguments: Optional[Dict[str, Any]] = None,
+        data: Union[bytes, str] = None,
+    ) -> Dict[str, Any]:
+        request = self.build_request(command, token=token, arguments=arguments, data=data)
+        await self.on_receive(request)
+        response = self._transport.get_response()
+        if not response or not response.get('success'):
+            reason = (response.get('message') or 'no reason') if response else 'no response'
+            raise RuntimeError(f'{command} failed: {reason}')
+        return response
+
+
+class _InProcessTransport(TransportBase):
+    """DAP transport that keeps the last sent response."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._connected = True
+        self._last_response: Optional[Dict[str, Any]] = None
+
+    async def send(self, message: Dict[str, Any]) -> None:
+        # Currently, other types of messages are not processed in the in-process context
+        if message.get('type') == 'response':
+            self._last_response = message
+
+    def disconnect(self) -> 'asyncio.Task':
+        self._connected = False
+
+        async def _noop() -> None:
+            return None
+
+        return asyncio.ensure_future(_noop())
+
+    def get_response(self) -> Optional[Dict[str, Any]]:
+        return self._last_response

--- a/packages/ai/tests/ai/account/test_deployment_store.py
+++ b/packages/ai/tests/ai/account/test_deployment_store.py
@@ -46,7 +46,7 @@ def store(istore):
 
 
 def make_record(project_id: str = 'proj-1', **kwargs) -> DeploymentRecord:
-    return DeploymentRecord(pipeline={'project_id': project_id}, created_by=CLIENT_1, **kwargs)
+    return DeploymentRecord(pipeline={'project_id': project_id}, userId=CLIENT_1, userToken='rr_test', **kwargs)
 
 
 class TestDeploymentStore:
@@ -57,7 +57,7 @@ class TestDeploymentStore:
         result = await store.get(CLIENT_1, 'proj-1')
         assert result.pipeline['project_id'] == 'proj-1'
         assert result.schedule == '0 * * * *'
-        assert result.created_by == CLIENT_1
+        assert result.userId == CLIENT_1
 
     @pytest.mark.asyncio
     async def test_save_overwrites(self, store):

--- a/packages/ai/tests/ai/account/test_deployment_store.py
+++ b/packages/ai/tests/ai/account/test_deployment_store.py
@@ -45,8 +45,8 @@ def store(istore):
     return DeploymentStore(istore)
 
 
-def make_record(project_id: str = 'proj-1', **kwargs) -> DeploymentRecord:
-    return DeploymentRecord(pipeline={'project_id': project_id}, userId=CLIENT_1, userToken='rr_test', **kwargs)
+def make_record(project_id: str = 'proj-1', userId: str = CLIENT_1, **kwargs) -> DeploymentRecord:
+    return DeploymentRecord(pipeline={'project_id': project_id}, userId=userId, userToken='rr_test', **kwargs)
 
 
 class TestDeploymentStore:
@@ -106,14 +106,28 @@ class TestDeploymentStore:
     async def test_iter_all(self, store):
         await store.save(CLIENT_1, make_record('proj-1'))
         await store.save(CLIENT_1, make_record('proj-2'))
-        await store.save(CLIENT_2, make_record('proj-3'))
-        results = [(cid, r.pipeline['project_id']) async for cid, r in store.iter_all()]
+        await store.save(CLIENT_2, make_record('proj-3', userId=CLIENT_2))
+        results = [(r.userId, r.pipeline['project_id']) async for r in store.iter_all()]
         assert sorted(results) == [(CLIENT_1, 'proj-1'), (CLIENT_1, 'proj-2'), (CLIENT_2, 'proj-3')]
 
     @pytest.mark.asyncio
     async def test_iter_all_empty(self, store):
         results = [r async for r in store.iter_all()]
         assert results == []
+
+    @pytest.mark.asyncio
+    async def test_user_token_persisted_but_excluded_from_client_record(self, store):
+        """The credential must survive the store round-trip (the scheduler replays
+        it) while to_client_record() — used for rrext_deploy_* responses — omits it.
+        """
+        await store.save(CLIENT_1, make_record())
+        result = await store.get(CLIENT_1, 'proj-1')
+        assert result.userToken == 'rr_test'
+
+        client_record = result.to_client_record()
+        assert 'userToken' not in client_record
+        assert client_record['userId'] == CLIENT_1
+        assert client_record['pipeline'] == result.pipeline
 
 
 class TestSaveMode:

--- a/packages/ai/tests/ai/modules/task/test_task_scheduler.py
+++ b/packages/ai/tests/ai/modules/task/test_task_scheduler.py
@@ -45,9 +45,6 @@ from ai.account.models import DeploymentRecord
 from ai.account.store_providers.memory import MemoryStore
 from ai.modules.task.task_scheduler import TaskScheduler
 
-# todo: feat/deploy2 - enable TaskScheduler
-pytestmark = pytest.mark.skip(reason='TaskScheduler disabled')
-
 
 # =============================================================================
 # Helpers

--- a/packages/ai/tests/ai/modules/task/test_task_scheduler.py
+++ b/packages/ai/tests/ai/modules/task/test_task_scheduler.py
@@ -55,12 +55,14 @@ def make_record(
     project_id: str = 'proj-1',
     schedule: str = '*/15 * * * *',
     state: str = 'active',
-    created_by: str = 'user-1',
+    userId: str = 'user-1',
+    userToken: str = 'rr_test',
     **kwargs,
 ) -> DeploymentRecord:
     return DeploymentRecord(
         pipeline={'project_id': project_id, 'components': []},
-        created_by=created_by,
+        userId=userId,
+        userToken=userToken,
         schedule=schedule,
         state=state,
         **kwargs,
@@ -104,11 +106,11 @@ async def _run_loop_once(scheduler: TaskScheduler) -> None:
 def test_scheduling_active_deployment_creates_future_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.created_by, rec)
+    s.schedule(rec.userId, rec)
     assert rec.pipeline['project_id'] in s._tasks
     task = s._tasks[rec.pipeline['project_id']]
     assert task.next_run > datetime.now().timestamp()
-    assert task.client_id == rec.created_by
+    assert task.client_id == rec.userId
     assert not task.cancelled
 
 
@@ -121,10 +123,10 @@ def test_scheduling_manual_deployment_is_ignored():
 def test_switching_active_to_manual_cancels_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.created_by, rec)
+    s.schedule(rec.userId, rec)
     old_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.created_by, make_record(schedule='manual'))
+    s.schedule(rec.userId, make_record(schedule='manual'))
     assert old_task.cancelled
     assert rec.pipeline['project_id'] not in s._tasks
 
@@ -132,10 +134,10 @@ def test_switching_active_to_manual_cancels_task():
 def test_switching_active_to_paused_cancels_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.created_by, rec)
+    s.schedule(rec.userId, rec)
     old_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.created_by, make_record(state='paused'))
+    s.schedule(rec.userId, make_record(state='paused'))
     assert old_task.cancelled
     assert rec.pipeline['project_id'] not in s._tasks
 
@@ -143,10 +145,10 @@ def test_switching_active_to_paused_cancels_task():
 def test_switching_active_to_errored_cancels_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.created_by, rec)
+    s.schedule(rec.userId, rec)
     old_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.created_by, make_record(state='errored'))
+    s.schedule(rec.userId, make_record(state='errored'))
     assert old_task.cancelled
     assert rec.pipeline['project_id'] not in s._tasks
 
@@ -154,10 +156,10 @@ def test_switching_active_to_errored_cancels_task():
 def test_rescheduling_replaces_existing_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.created_by, rec)
+    s.schedule(rec.userId, rec)
     first_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.created_by, rec)
+    s.schedule(rec.userId, rec)
     assert first_task.cancelled
     assert len(s._tasks) == 1
     new_task = s._tasks[rec.pipeline['project_id']]
@@ -173,7 +175,7 @@ def test_rescheduling_replaces_existing_task():
 def test_unschedule_cancels_and_removes_scheduled_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.created_by, rec)
+    s.schedule(rec.userId, rec)
     task = s._tasks[rec.pipeline['project_id']]
 
     s.unschedule(rec.pipeline['project_id'])
@@ -202,7 +204,7 @@ def test_unschedule_unknown_deployment_is_noop():
 async def test_startup_schedules_active_deployments():
     s = _make_scheduler()
     rec = make_record(schedule='@hourly', state='active')
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
     await s.start()
     await s.stop()
     assert rec.pipeline['project_id'] in s._tasks
@@ -212,7 +214,7 @@ async def test_startup_schedules_active_deployments():
 async def test_startup_skips_manual_deployments():
     s = _make_scheduler()
     rec = make_record(schedule='manual')
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
     await s.start()
     await s.stop()
     assert rec.pipeline['project_id'] not in s._tasks
@@ -223,7 +225,7 @@ async def test_startup_loads_multiple_deployments():
     s = _make_scheduler()
     records = [make_record('proj-1'), make_record('proj-2'), make_record('proj-3')]
     for r in records:
-        await s._server.deployments.save(r.created_by, r)
+        await s._server.deployments.save(r.userId, r)
     await s.start()
     await s.stop()
     assert set(s._tasks) == {'proj-1', 'proj-2', 'proj-3'}
@@ -250,10 +252,10 @@ async def test_startup_survives_store_error():
 async def test_overdue_task_triggers_start_task():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
         await _run_loop_once(s)
@@ -263,8 +265,8 @@ async def test_overdue_task_triggers_start_task():
     call = s._server.start_task.call_args
     assert call.args[0]['command'] == 'execute'
     assert call.args[0]['arguments']['pipeline'] == rec.pipeline
-    assert call.kwargs['user_id'] == rec.created_by
-    assert call.kwargs['client_id'] == rec.created_by
+    assert call.kwargs['user_id'] == rec.userId
+    assert call.kwargs['client_id'] == rec.userId
     assert call.kwargs['conn'] is None
 
 
@@ -272,10 +274,10 @@ async def test_overdue_task_triggers_start_task():
 async def test_future_task_not_dispatched():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
         await _run_loop_once(s)
 
     s._server.start_task.assert_not_called()
@@ -285,10 +287,10 @@ async def test_future_task_not_dispatched():
 async def test_loop_skips_when_previous_run_still_active():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
 
     s._active_tokens[rec.pipeline['project_id']] = 'tk_old'
     s._server._task_control['tk_old'] = SimpleNamespace(task=SimpleNamespace(is_task_complete=lambda: False))
@@ -304,10 +306,10 @@ async def test_loop_skips_when_previous_run_still_active():
 async def test_loop_dispatches_when_previous_run_complete():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
 
     s._active_tokens[rec.pipeline['project_id']] = 'tk_old'
     s._server._task_control['tk_old'] = SimpleNamespace(task=SimpleNamespace(is_task_complete=lambda: True))
@@ -323,10 +325,10 @@ async def test_loop_dispatches_when_previous_run_complete():
 async def test_loop_dispatches_when_previous_token_cleaned_up():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
 
     # token present but not in _task_control — already cleaned up
     s._active_tokens[rec.pipeline['project_id']] = 'tk_old'
@@ -342,11 +344,11 @@ async def test_loop_dispatches_when_previous_token_cleaned_up():
 async def test_dispatch_stores_token_from_start_task():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
     s._server.start_task = AsyncMock(return_value={'token': 'tk_abc'})
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
         await _run_loop_once(s)
@@ -359,11 +361,11 @@ async def test_dispatch_stores_token_from_start_task():
 async def test_dispatch_survives_start_task_failure():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
     s._server.start_task = AsyncMock(side_effect=RuntimeError('boom'))
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
         await _run_loop_once(s)  # must not raise
@@ -386,10 +388,10 @@ async def test_dispatch_noop_for_missing_deployment():
 async def test_future_task_not_dispatched_before_due_time():
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)  # next_run = 12:15:00, still future
+        s.schedule(rec.userId, rec)  # next_run = 12:15:00, still future
         await _run_loop_once(s)
 
     s._server.start_task.assert_not_called()
@@ -400,10 +402,10 @@ async def test_task_dispatched_after_time_advances():
     """The main value of time-machine: future task → advance clock → now due."""
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.created_by, rec)  # next_run = 12:15:00
+        s.schedule(rec.userId, rec)  # next_run = 12:15:00
         await _run_loop_once(s)
     s._server.start_task.assert_not_called()
 
@@ -418,13 +420,13 @@ async def test_sleep_delay_matches_time_until_next_task():
     """_loop must request a sleep of ~10 s when the next task is 10 s away."""
     s = _make_scheduler()
     rec = make_record()
-    await s._server.deployments.save(rec.created_by, rec)
+    await s._server.deployments.save(rec.userId, rec)
 
     sleep_calls: list[float] = []
 
     # Frozen at :14:50 — next */15 tick is :15:00, exactly 10 s away.
     with time_machine.travel(datetime(2026, 1, 1, 12, 14, 50), tick=False):
-        s.schedule(rec.created_by, rec)
+        s.schedule(rec.userId, rec)
 
         async def _capture(delay: float) -> None:
             sleep_calls.append(delay)

--- a/packages/ai/tests/ai/modules/task/test_task_scheduler.py
+++ b/packages/ai/tests/ai/modules/task/test_task_scheduler.py
@@ -24,14 +24,17 @@
 Scenario-based tests for ai.modules.task.task_scheduler.TaskScheduler.
 
 Tests exercise combinations of public methods (schedule, unschedule, start,
-stop) and inspect private state only for result assertions. Loop and dispatch
-behaviour is driven via frozen-clock tests that use time_machine so overdue
-conditions are created deterministically without touching the heap directly.
+shutdown) and inspect private state only for result assertions. Loop and
+dispatch behaviour is driven via frozen-clock tests that use time_machine so
+overdue conditions are created deterministically without touching the heap
+directly. The TaskServer interaction is mocked at the start_server_task
+boundary (the facade), so these tests stay focused on scheduling logic.
 """
 
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
 from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -44,6 +47,7 @@ from ai.account.deployment_store import DeploymentStore
 from ai.account.models import DeploymentRecord
 from ai.account.store_providers.memory import MemoryStore
 from ai.modules.task.task_scheduler import TaskScheduler
+from ai.modules.task.task_server_facade import ServerTaskAuthError
 
 
 # =============================================================================
@@ -72,7 +76,6 @@ def make_record(
 def _make_server(task_control=None) -> SimpleNamespace:
     return SimpleNamespace(
         _task_control=task_control if task_control is not None else {},
-        start_task=AsyncMock(return_value={'token': 'tk_new'}),
         deployments=DeploymentStore(MemoryStore()),
     )
 
@@ -83,19 +86,44 @@ def _make_scheduler(task_control=None) -> TaskScheduler:
     s._schedule = []
     s._tasks = {}
     s._active_tokens = {}
-    s._loop_task = None
+    s._scheduling = None
+    s._inflight_starts = set()
     s._server = _make_server(task_control)
     return s
 
 
 async def _run_loop_once(scheduler: TaskScheduler) -> None:
-    """Drive _loop through exactly one iteration, then stop."""
+    """Drive the scheduling loop (_run) through exactly one iteration, then stop."""
 
     async def _cancel(_: float) -> None:
         raise asyncio.CancelledError()
 
     with pytest.raises(asyncio.CancelledError), patch('asyncio.sleep', _cancel):
-        await scheduler._loop()
+        await scheduler._run()
+
+
+async def _drain() -> None:
+    """Yield repeatedly so a background _start_task can run to completion."""
+    for _ in range(50):
+        await asyncio.sleep(0)
+
+
+@contextmanager
+def _patch_start_server_task(*, token='tk_new', exc=None):
+    """Patch start_server_task in the scheduler module; yield the AsyncMock.
+
+    With ``exc`` set, the mock raises it (e.g. ServerTaskAuthError); otherwise it
+    returns ``token`` as the new task token.
+    """
+
+    def impl(server, user_token, pipeline):
+        if exc is not None:
+            raise exc
+        return token
+
+    mock = AsyncMock(side_effect=impl)
+    with patch('ai.modules.task.task_scheduler.start_server_task', mock):
+        yield mock
 
 
 # =============================================================================
@@ -106,7 +134,7 @@ async def _run_loop_once(scheduler: TaskScheduler) -> None:
 def test_scheduling_active_deployment_creates_future_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.userId, rec)
+    s.schedule(rec)
     assert rec.pipeline['project_id'] in s._tasks
     task = s._tasks[rec.pipeline['project_id']]
     assert task.next_run > datetime.now().timestamp()
@@ -116,17 +144,17 @@ def test_scheduling_active_deployment_creates_future_task():
 
 def test_scheduling_manual_deployment_is_ignored():
     s = _make_scheduler()
-    s.schedule('user-1', make_record(schedule='manual'))
+    s.schedule(make_record(schedule='manual'))
     assert 'proj-1' not in s._tasks
 
 
 def test_switching_active_to_manual_cancels_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.userId, rec)
+    s.schedule(rec)
     old_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.userId, make_record(schedule='manual'))
+    s.schedule(make_record(schedule='manual'))
     assert old_task.cancelled
     assert rec.pipeline['project_id'] not in s._tasks
 
@@ -134,10 +162,10 @@ def test_switching_active_to_manual_cancels_task():
 def test_switching_active_to_paused_cancels_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.userId, rec)
+    s.schedule(rec)
     old_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.userId, make_record(state='paused'))
+    s.schedule(make_record(state='paused'))
     assert old_task.cancelled
     assert rec.pipeline['project_id'] not in s._tasks
 
@@ -145,10 +173,10 @@ def test_switching_active_to_paused_cancels_task():
 def test_switching_active_to_errored_cancels_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.userId, rec)
+    s.schedule(rec)
     old_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.userId, make_record(state='errored'))
+    s.schedule(make_record(state='errored'))
     assert old_task.cancelled
     assert rec.pipeline['project_id'] not in s._tasks
 
@@ -156,10 +184,10 @@ def test_switching_active_to_errored_cancels_task():
 def test_rescheduling_replaces_existing_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.userId, rec)
+    s.schedule(rec)
     first_task = s._tasks[rec.pipeline['project_id']]
 
-    s.schedule(rec.userId, rec)
+    s.schedule(rec)
     assert first_task.cancelled
     assert len(s._tasks) == 1
     new_task = s._tasks[rec.pipeline['project_id']]
@@ -175,7 +203,7 @@ def test_rescheduling_replaces_existing_task():
 def test_unschedule_cancels_and_removes_scheduled_task():
     s = _make_scheduler()
     rec = make_record()
-    s.schedule(rec.userId, rec)
+    s.schedule(rec)
     task = s._tasks[rec.pipeline['project_id']]
 
     s.unschedule(rec.pipeline['project_id'])
@@ -196,50 +224,63 @@ def test_unschedule_unknown_deployment_is_noop():
 
 
 # =============================================================================
-# Startup scenarios
+# Load scenarios (startup scan)
 # =============================================================================
 
 
 @pytest.mark.asyncio
-async def test_startup_schedules_active_deployments():
+async def test_load_schedules_active_deployments():
     s = _make_scheduler()
     rec = make_record(schedule='@hourly', state='active')
     await s._server.deployments.save(rec.userId, rec)
-    await s.start()
-    await s.stop()
+    await s._load()
     assert rec.pipeline['project_id'] in s._tasks
 
 
 @pytest.mark.asyncio
-async def test_startup_skips_manual_deployments():
+async def test_load_skips_manual_deployments():
     s = _make_scheduler()
     rec = make_record(schedule='manual')
     await s._server.deployments.save(rec.userId, rec)
-    await s.start()
-    await s.stop()
+    await s._load()
     assert rec.pipeline['project_id'] not in s._tasks
 
 
 @pytest.mark.asyncio
-async def test_startup_loads_multiple_deployments():
+async def test_load_loads_multiple_deployments():
     s = _make_scheduler()
     records = [make_record('proj-1'), make_record('proj-2'), make_record('proj-3')]
     for r in records:
         await s._server.deployments.save(r.userId, r)
-    await s.start()
-    await s.stop()
+    await s._load()
     assert set(s._tasks) == {'proj-1', 'proj-2', 'proj-3'}
 
 
 @pytest.mark.asyncio
-async def test_startup_survives_store_error():
+async def test_load_skips_bad_record_and_continues():
+    """One unschedulable record (e.g. corrupt cron expression on disk) must not
+    abort loading the records after it.
+    """
+    s = _make_scheduler()
+    bad = make_record('proj-bad', schedule='not-a-cron')  # store does not validate cron
+    good = make_record('proj-good')
+    await s._server.deployments.save(bad.userId, bad)
+    await s._server.deployments.save(good.userId, good)
+
+    await s._load()  # must not raise
+
+    assert 'proj-good' in s._tasks
+    assert 'proj-bad' not in s._tasks
+
+
+@pytest.mark.asyncio
+async def test_load_survives_store_error():
     s = _make_scheduler()
     failing_iter = MagicMock()
     failing_iter.__aiter__ = MagicMock(return_value=failing_iter)
     failing_iter.__anext__ = AsyncMock(side_effect=OSError('storage unavailable'))
     with patch.object(s._server.deployments, 'iter_all', return_value=failing_iter):
-        await s.start()
-        await s.stop()
+        await s._load()  # must not raise
     assert s._tasks == {}
 
 
@@ -249,25 +290,21 @@ async def test_startup_survives_store_error():
 
 
 @pytest.mark.asyncio
-async def test_overdue_task_triggers_start_task():
+async def test_overdue_task_triggers_dispatch():
     s = _make_scheduler()
     rec = make_record()
     await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)
+        s.schedule(rec)
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
         await _run_loop_once(s)
-        await asyncio.sleep(0)
+        await _drain()
 
-    s._server.start_task.assert_called_once()
-    call = s._server.start_task.call_args
-    assert call.args[0]['command'] == 'execute'
-    assert call.args[0]['arguments']['pipeline'] == rec.pipeline
-    assert call.kwargs['user_id'] == rec.userId
-    assert call.kwargs['client_id'] == rec.userId
-    assert call.kwargs['conn'] is None
+    start.assert_awaited_once_with(s._server, rec.userToken, rec.pipeline)
+    assert s._active_tokens[rec.pipeline['project_id']] == 'tk_new'
+    assert s._inflight_starts == set()  # completed task starts discard themselves
 
 
 @pytest.mark.asyncio
@@ -276,11 +313,13 @@ async def test_future_task_not_dispatched():
     rec = make_record()
     await s._server.deployments.save(rec.userId, rec)
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
+        s.schedule(rec)
         await _run_loop_once(s)
+        await _drain()
 
-    s._server.start_task.assert_not_called()
+    start.assert_not_awaited()
+    assert s._active_tokens == {}
 
 
 @pytest.mark.asyncio
@@ -290,16 +329,17 @@ async def test_loop_skips_when_previous_run_still_active():
     await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)
+        s.schedule(rec)
 
     s._active_tokens[rec.pipeline['project_id']] = 'tk_old'
     s._server._task_control['tk_old'] = SimpleNamespace(task=SimpleNamespace(is_task_complete=lambda: False))
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
         await _run_loop_once(s)
-        await asyncio.sleep(0)
+        await _drain()
 
-    s._server.start_task.assert_not_called()
+    start.assert_not_awaited()
+    assert s._active_tokens[rec.pipeline['project_id']] == 'tk_old'
 
 
 @pytest.mark.asyncio
@@ -309,16 +349,17 @@ async def test_loop_dispatches_when_previous_run_complete():
     await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)
+        s.schedule(rec)
 
     s._active_tokens[rec.pipeline['project_id']] = 'tk_old'
     s._server._task_control['tk_old'] = SimpleNamespace(task=SimpleNamespace(is_task_complete=lambda: True))
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
         await _run_loop_once(s)
-        await asyncio.sleep(0)
+        await _drain()
 
-    s._server.start_task.assert_called_once()
+    start.assert_awaited_once()
+    assert s._active_tokens[rec.pipeline['project_id']] == 'tk_new'
 
 
 @pytest.mark.asyncio
@@ -328,59 +369,84 @@ async def test_loop_dispatches_when_previous_token_cleaned_up():
     await s._server.deployments.save(rec.userId, rec)
 
     with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)
+        s.schedule(rec)
 
     # token present but not in _task_control — already cleaned up
     s._active_tokens[rec.pipeline['project_id']] = 'tk_old'
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
         await _run_loop_once(s)
-        await asyncio.sleep(0)
+        await _drain()
 
-    s._server.start_task.assert_called_once()
+    start.assert_awaited_once()
+    assert s._active_tokens[rec.pipeline['project_id']] == 'tk_new'
 
 
 @pytest.mark.asyncio
-async def test_dispatch_stores_token_from_start_task():
+async def test_dispatch_calls_start_server_task_and_stores_token():
     s = _make_scheduler()
     rec = make_record()
     await s._server.deployments.save(rec.userId, rec)
-    s._server.start_task = AsyncMock(return_value={'token': 'tk_abc'})
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)
+    with _patch_start_server_task(token='tk_abc') as start:
+        await s._start_task(rec.userId, rec.pipeline['project_id'])
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
-        await _run_loop_once(s)
-        await asyncio.sleep(0)
-
+    start.assert_awaited_once_with(s._server, rec.userToken, rec.pipeline)
     assert s._active_tokens[rec.pipeline['project_id']] == 'tk_abc'
 
 
 @pytest.mark.asyncio
-async def test_dispatch_survives_start_task_failure():
+async def test_dispatch_survives_execute_failure():
     s = _make_scheduler()
     rec = make_record()
     await s._server.deployments.save(rec.userId, rec)
-    s._server.start_task = AsyncMock(side_effect=RuntimeError('boom'))
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)
+    with _patch_start_server_task(exc=RuntimeError('execute failed: boom')):
+        await s._start_task(rec.userId, rec.pipeline['project_id'])  # must not raise
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
-        await _run_loop_once(s)  # must not raise
-        await asyncio.sleep(0)
+    assert rec.pipeline['project_id'] not in s._active_tokens
+
+
+@pytest.mark.asyncio
+async def test_dispatch_auth_failure_marks_errored_and_unschedules():
+    s = _make_scheduler()
+    rec = make_record()
+    await s._server.deployments.save(rec.userId, rec)
+    s.schedule(rec)
+
+    with _patch_start_server_task(exc=ServerTaskAuthError('bad token')):
+        await s._start_task(rec.userId, rec.pipeline['project_id'])
+
+    saved = await s._server.deployments.get(rec.userId, rec.pipeline['project_id'])
+    assert saved.state == 'errored'
+    assert rec.pipeline['project_id'] not in s._active_tokens
+    assert rec.pipeline['project_id'] not in s._tasks
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_when_no_user_token():
+    s = _make_scheduler()
+    rec = make_record(userToken='')
+    await s._server.deployments.save(rec.userId, rec)
+
+    with _patch_start_server_task() as start:
+        await s._start_task(rec.userId, rec.pipeline['project_id'])
+
+    start.assert_not_awaited()
+    assert rec.pipeline['project_id'] not in s._active_tokens
 
 
 @pytest.mark.asyncio
 async def test_dispatch_noop_for_missing_deployment():
     s = _make_scheduler()
-    await s._dispatch('user-1', 'nonexistent')
-    s._server.start_task.assert_not_called()
+    with _patch_start_server_task() as start:
+        await s._start_task('user-1', 'nonexistent')
+    start.assert_not_awaited()
+    assert 'nonexistent' not in s._active_tokens
 
 
 # =============================================================================
-# _loop — time-machine variant
+# _run loop — time-machine variant
 # =============================================================================
 
 
@@ -390,11 +456,12 @@ async def test_future_task_not_dispatched_before_due_time():
     rec = make_record()
     await s._server.deployments.save(rec.userId, rec)
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)  # next_run = 12:15:00, still future
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
+        s.schedule(rec)  # next_run = 12:15:00, still future
         await _run_loop_once(s)
+        await _drain()
 
-    s._server.start_task.assert_not_called()
+    start.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -404,20 +471,23 @@ async def test_task_dispatched_after_time_advances():
     rec = make_record()
     await s._server.deployments.save(rec.userId, rec)
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
-        s.schedule(rec.userId, rec)  # next_run = 12:15:00
-        await _run_loop_once(s)
-    s._server.start_task.assert_not_called()
+    with _patch_start_server_task() as start:
+        with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
+            s.schedule(rec)  # next_run = 12:15:00
+            await _run_loop_once(s)
+            await _drain()
+        start.assert_not_awaited()
 
-    with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
-        await _run_loop_once(s)
-        await asyncio.sleep(0)  # drain background dispatch task
-    s._server.start_task.assert_called_once()
+        with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+            await _run_loop_once(s)
+            await _drain()  # drain background dispatch task
+        start.assert_awaited_once()
+        assert s._active_tokens[rec.pipeline['project_id']] == 'tk_new'
 
 
 @pytest.mark.asyncio
 async def test_sleep_delay_matches_time_until_next_task():
-    """_loop must request a sleep of ~10 s when the next task is 10 s away."""
+    """_run must request a sleep of ~10 s when the next task is 10 s away."""
     s = _make_scheduler()
     rec = make_record()
     await s._server.deployments.save(rec.userId, rec)
@@ -426,13 +496,107 @@ async def test_sleep_delay_matches_time_until_next_task():
 
     # Frozen at :14:50 — next */15 tick is :15:00, exactly 10 s away.
     with time_machine.travel(datetime(2026, 1, 1, 12, 14, 50), tick=False):
-        s.schedule(rec.userId, rec)
+        s.schedule(rec)
 
         async def _capture(delay: float) -> None:
             sleep_calls.append(delay)
             raise asyncio.CancelledError()
 
         with patch('asyncio.sleep', _capture), pytest.raises(asyncio.CancelledError):
-            await s._loop()
+            await s._run()
 
     assert sleep_calls == [pytest.approx(10.0, abs=0.01)]
+
+
+# =============================================================================
+# _run loop — robustness
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_survives_record_deleted_while_due():
+    """deploy_remove deletes the record from the store before calling unschedule;
+    a task due inside that window must not kill the scheduling loop.
+    """
+    s = _make_scheduler()
+    rec = make_record()
+    await s._server.deployments.save(rec.userId, rec)
+
+    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
+        s.schedule(rec)
+
+    await s._server.deployments.delete(rec.userId, rec.pipeline['project_id'])
+
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+        await _run_loop_once(s)  # must not raise
+        await _drain()
+
+    # Dispatch aborted (record gone), but the loop stayed alive and rescheduled
+    # from the in-memory cron expression without touching the store.
+    start.assert_not_awaited()
+    assert rec.pipeline['project_id'] in s._tasks
+    assert rec.pipeline['project_id'] not in s._active_tokens
+
+
+@pytest.mark.asyncio
+async def test_run_survives_tick_error():
+    """An unexpected exception while processing one task is logged and skipped;
+    it must not propagate out of _run and stop scheduling for everyone.
+    """
+    s = _make_scheduler()
+    rec = make_record()
+    await s._server.deployments.save(rec.userId, rec)
+
+    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
+        s.schedule(rec)
+
+    # Poison the overlap guard: the task-control lookup explodes.
+    s._active_tokens[rec.pipeline['project_id']] = 'tk_old'
+    s._server._task_control = MagicMock()
+    s._server._task_control.get.side_effect = RuntimeError('boom')
+
+    with _patch_start_server_task() as start, time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+        await _run_loop_once(s)  # must not raise
+        await _drain()
+
+    start.assert_not_awaited()
+    # Rescheduling happens before the failing guard, so the deployment survives.
+    assert rec.pipeline['project_id'] in s._tasks
+
+
+# =============================================================================
+# Shutdown
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_shutdown_drains_inflight_starts():
+    """shutdown() must wait for task starts that already left the loop, not abandon them."""
+    s = _make_scheduler()
+    rec = make_record()
+    await s._server.deployments.save(rec.userId, rec)
+
+    release = asyncio.Event()
+
+    async def slow_start(server, user_token, pipeline):
+        await release.wait()
+        return 'tk_slow'
+
+    with time_machine.travel(datetime(2026, 1, 1, 12, 0, 0), tick=False):
+        s.schedule(rec)
+
+    with patch('ai.modules.task.task_scheduler.start_server_task', AsyncMock(side_effect=slow_start)):
+        with time_machine.travel(datetime(2026, 1, 1, 12, 16, 0), tick=False):
+            await _run_loop_once(s)
+            await _drain()
+        assert len(s._inflight_starts) == 1
+
+        shutdown = asyncio.create_task(s.shutdown())
+        await _drain()
+        assert not shutdown.done()  # blocked on the in-flight dispatch
+
+        release.set()
+        await asyncio.wait_for(shutdown, timeout=5)
+
+    assert s._inflight_starts == set()
+    assert s._active_tokens[rec.pipeline['project_id']] == 'tk_slow'

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -65,6 +65,7 @@ You build your `.pipe` - and you run it against the fastest AI runtime available
 ## Features
 
 - **Pipeline execution** - Start with `use()`, send data via `send()`, `send_files()`, or `pipe()`
+- **Deployments** - Persist pipelines server-side and run them on a cron schedule via `client.deploy`
 - **Chat** - Conversational AI via `chat()` and `Question`
 - **Event streaming** - Real-time events via `on_event` and `set_events()`
 - **File upload** - `send_files()` with progress; streaming with `pipe()`
@@ -242,6 +243,30 @@ result = await pipe.close()
 
 **How it works:** The client opens a pipe with the question MIME type, writes the serialized `Question`, closes the pipe, and returns the server result. The pipeline must support the chat provider.
 
+### Deploy
+
+Accessed via `client.deploy`. A deployment persists a pipeline on the server and runs it on a cron schedule (or on demand with `"manual"`), outliving the client connection. Each deployment is identified by its pipeline's `project_id`.
+
+| Method          | Signature                                                                                                          | Returns                  | Description                                                                                                                |
+| --------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| `deploy.add`    | `async def add(self, pipeline: PipelineConfig, *, schedule: str \| None = None) -> DeploymentRecord`               | `DeploymentRecord`       | Persists the pipeline as a deployment and activates it. `schedule`: 5-field cron (`"*/15 * * * *"`), preset (`@hourly`, `@daily`, …), or `"manual"` (default). |
+| `deploy.remove` | `async def remove(self, project_id: str) -> None`                                                                  | -                        | Undeploys and removes the deployment.                                                                                        |
+| `deploy.list`   | `async def list(self) -> list[DeploymentRecord]`                                                                   | `list[DeploymentRecord]` | Returns the authenticated user's deployments.                                                                                |
+| `deploy.status` | `async def status(self, project_id: str) -> DeploymentRecord`                                                      | `DeploymentRecord`       | Gets one deployment record.                                                                                                  |
+| `deploy.update` | `async def update(self, project_id: str, *, pipeline: PipelineConfig \| None = None, schedule: str \| None = None) -> None` | -                        | Replaces the pipeline and/or schedule; omitted parameters stay unchanged.                                                    |
+
+**States:** `state` is `'active'` (scheduled runs fire per cron), `'paused'`, or `'errored'` — scheduled runs could no longer authenticate (e.g. the owner's API key was revoked) and have stopped; remove and re-add the deployment to resume. If a scheduled run is still in progress when the next tick comes due, that tick is skipped — runs of the same deployment never overlap.
+
+**Example:**
+
+```python
+record = await client.deploy.add(my_pipeline, schedule="*/15 * * * *")
+for rec in await client.deploy.list():
+    print(rec["pipeline"]["project_id"], rec["schedule"], rec["state"])
+await client.deploy.update(project_id, schedule="manual")  # pause scheduled runs
+await client.deploy.remove(project_id)
+```
+
 ---
 
 ## DataPipe
@@ -315,6 +340,7 @@ From `rocketride.schema`. Used to parse chat response content. The client does n
 - **TASK_STATUS**: Task status with `completedCount`, `totalCount`, `completed`, `state`, `exitCode`, and many more fields.
 - **DAPMessage**: Dict with `type`, `seq`, and optional `command`, `arguments`, `body`, `success`, `message`, `event`, `token`, etc.
 - **PipelineConfig**: Pipeline definition with `name`, `description`, `version`, `components`, `source`, `project_id`.
+- **DeploymentRecord**: TypedDict with `pipeline`, `schedule`, `state` (`'active' | 'paused' | 'errored'`), `userId`, `createdAt`, `updatedAt` (Unix seconds).
 - **QuestionHistory**: `{ 'role': str, 'content': str }`.
 - **QuestionInstruction**: `{ 'subtitle': str, 'instructions': str }`.
 - **QuestionExample**: `{ 'given': str, 'result': str }`.

--- a/packages/client-python/src/rocketride/deploy.py
+++ b/packages/client-python/src/rocketride/deploy.py
@@ -99,9 +99,7 @@ class DeployApi:
 
     async def list(self) -> list[DeploymentRecord]:
         """
-        Return all deployments visible to the caller with their status and schedule config.
-
-        Team members see their team's deployments; org admins see all deployments in the org.
+        Return the authenticated user's deployments with their status and schedule config.
 
         Returns:
             List of deployment summary records.

--- a/packages/client-python/src/rocketride/types/deploy.py
+++ b/packages/client-python/src/rocketride/types/deploy.py
@@ -23,8 +23,6 @@
 """
 Deploy type definitions for the RocketRide Python SDK.
 
-Mirrors the server's ``DeploymentRecord`` model returned by ``rrext_deploy_*`` commands.
-
 Types:
     DeploymentRecord:   Deployment record as returned by add / list / status.
 """
@@ -36,15 +34,16 @@ from .pipeline import PipelineConfig
 
 class DeploymentRecord(TypedDict, total=False):
     """
-    Deployment record returned by ``rrext_deploy_add``, ``rrext_deploy_list``,
-    and ``rrext_deploy_status``.
-
-    Mirrors ``DeploymentRecord.model_dump()`` on the server.
+    Deployment record returned by ``deploy.add``, ``deploy.list``, and
+    ``deploy.status``.
     """
 
     pipeline: PipelineConfig
+    # Cron expression (e.g. '*/15 * * * *') or 'manual' for on-demand only.
     schedule: str
     state: Literal['active', 'paused', 'errored']
-    created_by: str
-    created_at: float
-    updated_at: float
+    # ID of the user who created the deployment.
+    userId: str
+    # Unix timestamps (seconds).
+    createdAt: float
+    updatedAt: float

--- a/packages/client-python/tests/test_deploy.py
+++ b/packages/client-python/tests/test_deploy.py
@@ -105,9 +105,11 @@ class TestDeploy:
             assert rec['pipeline'] == PIPELINE
             assert rec['schedule'] == 'manual'
             assert rec['state'] == 'active'
-            assert rec['created_by']
-            assert rec['created_at'] > 0
-            assert rec['updated_at'] > 0
+            assert rec['userId']
+            # The stored user credential must never be echoed back to clients.
+            assert 'userToken' not in rec
+            assert rec['createdAt'] > 0
+            assert rec['updatedAt'] > 0
         finally:
             await self.client.deploy.remove(rec['pipeline']['project_id'])
 
@@ -195,7 +197,7 @@ class TestDeploy:
         try:
             await self.client.deploy.update(rec['pipeline']['project_id'], schedule='@hourly')
             status = await self.client.deploy.status(rec['pipeline']['project_id'])
-            assert status['updated_at'] >= rec['updated_at']
+            assert status['updatedAt'] >= rec['updatedAt']
         finally:
             await self.client.deploy.remove(rec['pipeline']['project_id'])
 

--- a/packages/client-typescript/docs/guide/methods/deploy.md
+++ b/packages/client-typescript/docs/guide/methods/deploy.md
@@ -1,0 +1,160 @@
+---
+title: "Deploy"
+date: 2026-06-12
+---
+
+- [Overview](#overview)
+- [Methods](#methods)
+- [Schedules](#schedules)
+- [The DeploymentRecord](#the-deploymentrecord)
+- [Usage Examples](#usage-examples)
+- [Deployment States](#deployment-states)
+- [Error Handling](#error-handling)
+- [API Endpoints](#api-endpoints)
+- [Related Methods](#related-methods)
+
+## **Overview**
+
+The `client.deploy` namespace manages **deployments**: pipelines persisted on the server and run on a cron schedule or on demand. Unlike `use()`, which runs a pipeline for the duration of your session, a deployment outlives the connection — the server starts scheduled runs on your behalf under the account that created the deployment.
+
+Each deployment is identified by its pipeline's `project_id`. One deployment exists per project per user.
+
+## **Methods**
+
+| Method | Description |
+| --- | --- |
+| `deploy.add(pipeline, options?)` | Persist a pipeline as a deployment and activate it |
+| `deploy.remove(projectId)` | Undeploy and delete the deployment |
+| `deploy.list()` | List the authenticated user's deployments |
+| `deploy.status(projectId)` | Get one deployment record |
+| `deploy.update(projectId, options?)` | Replace the pipeline and/or schedule |
+
+### Python (async)
+
+```python
+record = await client.deploy.add(pipeline, schedule='*/15 * * * *')
+records = await client.deploy.list()
+record = await client.deploy.status(project_id)
+await client.deploy.update(project_id, schedule='@hourly')
+await client.deploy.remove(project_id)
+```
+
+### TypeScript
+
+```typescript
+const record = await client.deploy.add(pipeline, { schedule: '*/15 * * * *' });
+const records = await client.deploy.list();
+const rec = await client.deploy.status(projectId);
+await client.deploy.update(projectId, { schedule: '@hourly' });
+await client.deploy.remove(projectId);
+```
+
+## **Schedules**
+
+The `schedule` value accepted by `add()` and `update()`:
+
+| Value | Meaning |
+| --- | --- |
+| `"manual"` | No scheduled runs; the deployment only runs when started explicitly. Default. |
+| 5-field cron expression | e.g. `"*/15 * * * *"` — run every 15 minutes |
+| Cron preset | `@hourly`, `@daily`, `@midnight`, `@weekly`, `@monthly`, `@yearly`, `@annually` |
+
+Invalid schedule strings are rejected with an error.
+
+## **The DeploymentRecord**
+
+Returned by `add()`, `status()`, and (as an array) `list()`:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `pipeline` | `PipelineConfig` | The deployed pipeline definition |
+| `schedule` | `str` / `string` | Cron expression or `"manual"` |
+| `state` | `string` | `"active"` \| `"paused"` \| `"errored"` (see [Deployment States](#deployment-states)) |
+| `userId` | `str` / `string` | ID of the user who created the deployment |
+| `createdAt` | `float` / `number` | Creation time (Unix seconds) |
+| `updatedAt` | `float` / `number` | Last modification time (Unix seconds) |
+
+## **Usage Examples**
+
+### Deploy a pipeline on a 15-minute schedule
+
+```python
+import asyncio
+from rocketride import RocketRideClient
+
+async def main():
+    async with RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key") as client:
+        record = await client.deploy.add(my_pipeline, schedule="*/15 * * * *")
+        print(record["pipeline"]["project_id"], record["state"])
+
+asyncio.run(main())
+```
+
+```typescript
+const client = new RocketRideClient({ uri: 'https://cloud.rocketride.ai', auth: 'my-key' });
+await client.connect();
+
+const record = await client.deploy.add(myPipeline, { schedule: '*/15 * * * *' });
+console.log(record.pipeline!.project_id, record.state);
+```
+
+### Pause scheduled runs without deleting
+
+Switch the schedule to `"manual"`; switch back to a cron expression to resume:
+
+```python
+await client.deploy.update(project_id, schedule="manual")
+```
+
+### Inspect and clean up
+
+```python
+for rec in await client.deploy.list():
+    print(rec["pipeline"]["project_id"], rec["schedule"], rec["state"])
+
+await client.deploy.remove(project_id)
+```
+
+## **Deployment States**
+
+| State | Meaning |
+| --- | --- |
+| `active` | Scheduled runs fire per the cron schedule (no runs when schedule is `"manual"`) |
+| `paused` | Deployment is retained but scheduled runs do not fire |
+| `errored` | Scheduled runs could no longer authenticate (e.g. the owner's API key was revoked) and have stopped |
+
+An `errored` deployment is not retried. Remove it and `add()` it again to resume scheduled runs.
+
+If a scheduled run is still in progress when the next tick comes due, that tick is skipped — runs of the same deployment never overlap.
+
+## **Error Handling**
+
+| Error | Cause |
+| --- | --- |
+| `RuntimeError` / `Error` | Duplicate `add()` for an existing `project_id`; unknown `projectId` on `status()` / `update()` / `remove()`; invalid schedule string |
+| Authentication error | Invalid or missing API key, or missing `task.control` permission |
+
+```python
+try:
+    await client.deploy.add(pipeline, schedule="*/15 * * * *")
+except RuntimeError as e:
+    print(f"Deploy failed: {e}")
+```
+
+## **API Endpoints**
+
+These methods communicate via the RocketRide DAP protocol over WebSocket using the `rrext_deploy_*` commands:
+
+| Method | DAP Command |
+| --- | --- |
+| `add()` | `rrext_deploy_add` |
+| `remove()` | `rrext_deploy_remove` |
+| `list()` | `rrext_deploy_list` |
+| `status()` | `rrext_deploy_status` |
+| `update()` | `rrext_deploy_update` |
+
+## **Related Methods**
+
+- [`use()`](./use) - Run a pipeline interactively in the current session
+- [`get_task_status()` / `getTaskStatus()`](./get-task-status) - Monitor a running pipeline
+- [`terminate()`](./terminate) - Stop a running pipeline

--- a/packages/client-typescript/src/client/deploy.ts
+++ b/packages/client-typescript/src/client/deploy.ts
@@ -80,9 +80,7 @@ export class DeployApi {
 	}
 
 	/**
-	 * Returns all deployments visible to the caller with their status and schedule config.
-	 *
-	 * Team members see their team's deployments; org admins see all deployments in the org.
+	 * Returns the authenticated user's deployments with their status and schedule config.
 	 *
 	 * @returns Array of deployment summary records.
 	 */

--- a/packages/client-typescript/src/client/types/deploy.ts
+++ b/packages/client-typescript/src/client/types/deploy.ts
@@ -24,8 +24,6 @@
 
 /**
  * Deploy type definitions for the RocketRide TypeScript SDK.
- *
- * Mirrors the server's `DeploymentRecord` model returned by `rrext_deploy_*` commands.
  */
 
 import type { PipelineConfig } from './pipeline.js';
@@ -35,17 +33,18 @@ export type { PipelineConfig };
 // DEPLOY TYPES
 // =============================================================================
 
-/** Deployment record returned by `rrext_deploy_add`, `rrext_deploy_list`, and `rrext_deploy_status`. */
+/** Deployment record returned by `deploy.add`, `deploy.list`, and `deploy.status`. */
 export interface DeploymentRecord {
 	pipeline?: PipelineConfig;
 	/** Cron expression or `"manual"`. */
 	schedule?: string;
 	state?: 'active' | 'paused' | 'errored';
-	created_by?: string;
+	/** ID of the user who created the deployment. */
+	userId?: string;
 	/** Unix timestamp (seconds). */
-	created_at?: number;
+	createdAt?: number;
 	/** Unix timestamp (seconds). */
-	updated_at?: number;
+	updatedAt?: number;
 }
 
 /** Parameters accepted by `client.deploy.update()`. */

--- a/packages/client-typescript/tests/deploy.test.ts
+++ b/packages/client-typescript/tests/deploy.test.ts
@@ -115,9 +115,11 @@ describe('Deploy API Integration Tests', () => {
 				expect(rec.pipeline).toEqual(PIPELINE);
 				expect(rec.schedule).toBe('manual');
 				expect(rec.state).toBe('active');
-				expect(rec.created_by).toBeTruthy();
-				expect(rec.created_at).toBeGreaterThan(0);
-				expect(rec.updated_at).toBeGreaterThan(0);
+				expect(rec.userId).toBeTruthy();
+				// The stored user credential must never be echoed back to clients.
+				expect(rec).not.toHaveProperty('userToken');
+				expect(rec.createdAt).toBeGreaterThan(0);
+				expect(rec.updatedAt).toBeGreaterThan(0);
 			} finally {
 				await client.deploy.remove(rec.pipeline!.project_id!);
 			}
@@ -244,13 +246,13 @@ describe('Deploy API Integration Tests', () => {
 
 
 	it(
-		'update bumps updated_at',
+		'update bumps updatedAt',
 		async () => {
 			const rec = await client.deploy.add(PIPELINE);
 			try {
 				await client.deploy.update(rec.pipeline!.project_id!, { schedule: '@hourly' });
 				const s = await client.deploy.status(rec.pipeline!.project_id!);
-				expect(s.updated_at!).toBeGreaterThanOrEqual(rec.updated_at!);
+				expect(s.updatedAt!).toBeGreaterThanOrEqual(rec.updatedAt!);
 			} finally {
 				await client.deploy.remove(rec.pipeline!.project_id!);
 			}


### PR DESCRIPTION
## Deploy v2 — scheduled pipeline deployments

Pipelines can now be deployed to the server and run autonomously on a schedule. A deployment persists a pipeline with a cron schedule (`*/15 * * * *`, `@hourly`, … or `manual`); the built-in scheduler fires due runs under the deploying user's account, with the same authentication, permission, and plan checks as an on-demand run.

### Highlights
- Full lifecycle API: `rrext_deploy_add / update / list / status / remove`.
- Scheduler: loads persisted deployments on startup, never overlaps runs of the same deployment, tolerates bad records and transient store errors, drains in-flight runs on graceful shutdown.
- Lost access (e.g. revoked API key) flips the deployment to `errored` and stops scheduling instead of retrying forever.
- The credential stored for scheduled runs is never returned by the API or exposed in client types.

### Clients ready to build on
The Python and TypeScript SDKs ship a complete, typed `client.deploy` namespace (`add` / `remove` / `list` / `status` / `update`) with integration tests and a docs page — fully capable for on-top development (SaaS UI and beyond).

### Not the final version — remaining work
- SaaS UI development, with iterative UI ↔ backend refinement and bug-fixing.
- Deployment history.
- Task run history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deployments can be scheduled and run persistently via the client deploy API; scheduled jobs are started/stopped reliably and removal unschedules them.

* **Bug Fixes**
  * Scheduler more robust: rejects operations without credentials, marks errored deployments to avoid repeated failures, and better handles invalid schedules and runtime errors.

* **Documentation**
  * New user guides and updated client docs with examples for deploy.add/remove/list/status/update.

* **Chores**
  * Deployment record fields standardized to camelCase and client responses now omit sensitive tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->