### PR TITLE
feat(nodes): add shared Google access/scope resolver (RR-1054)

### DIFF
--- a/nodes/src/nodes/core/google_access.py
+++ b/nodes/src/nodes/core/google_access.py
@@ -43,7 +43,14 @@ class AccessSpec:
     scopes: dict[str, list[str]]  # access tier -> OAuth scopes
     default: str  # tier used when config omits access
     flags: tuple[str, ...] = ()  # config boolean field names honored
-    readonly_tiers: frozenset[str] = frozenset({'readonly'})
+
+    def __post_init__(self) -> None:
+        if not self.scopes:
+            raise GoogleAccessError('AccessSpec.scopes must declare at least one tier')
+        if self.default not in self.scopes:
+            raise GoogleAccessError(
+                f'AccessSpec default tier {self.default!r} is not a defined tier; expected one of {sorted(self.scopes)}'
+            )
 
 
 @dataclass(frozen=True)
@@ -67,16 +74,35 @@ class GoogleAccess:
             )
 
 
+def _resolve_flags(config: dict, spec: AccessSpec) -> dict[str, bool]:
+    # Strict: a destructive gate must fail loud on misconfig, not coerce. Only an
+    # explicit bool True enables; a present non-bool ('false', 1, 'no') is an error.
+    flags: dict[str, bool] = {}
+    for name in spec.flags:
+        if name not in config:
+            flags[name] = False
+            continue
+        value = config[name]
+        if type(value) is not bool:
+            raise GoogleAccessError(f'flag {name!r} must be a boolean, got {value!r} ({type(value).__name__})')
+        flags[name] = value
+    return flags
+
+
 def resolve_google_access(config: dict, spec: AccessSpec) -> GoogleAccess:
     tier = config.get('access') or spec.default
+    if not isinstance(tier, str):
+        raise GoogleAccessError(f'access must be a string tier name, got {type(tier).__name__}')
     if tier not in spec.scopes:
         raise GoogleAccessError(f'unknown access tier {tier!r}; expected one of {sorted(spec.scopes)}')
-    flags = {name: bool(config.get(name, False)) for name in spec.flags}
+    tier_scopes = spec.scopes[tier]
+    # Writable iff at least one granted scope is not a Google read-only scope
+    # (those end in '.readonly'). Derived from scopes so it can't drift from grant.
     return GoogleAccess(
         tier=tier,
-        scopes=list(spec.scopes[tier]),
-        can_write=tier not in spec.readonly_tiers,
-        flags=flags,
+        scopes=list(tier_scopes),
+        can_write=any(not s.endswith('.readonly') for s in tier_scopes),
+        flags=_resolve_flags(config, spec),
     )
 
 
@@ -89,7 +115,8 @@ GMAIL = AccessSpec(
         'send': [f'{_G}/gmail.modify', f'{_G}/gmail.send'],
     },
     default='modify',
-    flags=('allowHardDelete',),
+    # No allowHardDelete: permanent delete (messages.delete) needs the full
+    # https://mail.google.com/ scope, which no tier here grants. gmail.modify only trashes.
 )
 DRIVE = AccessSpec(
     scopes={'readonly': [f'{_G}/drive.readonly'], 'write': [f'{_G}/drive']},

--- a/nodes/src/nodes/core/google_access.py
+++ b/nodes/src/nodes/core/google_access.py
@@ -1,0 +1,123 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Single reader that turns a Google tool node's `access` enum and capability
+toggles into one resolved object: the OAuth scopes to request, plus the
+write/destructive gates the node's tool functions check at invoke time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+class GoogleAccessError(PermissionError):
+    """Raised when a gated operation runs without the config enabling it."""
+
+
+@dataclass(frozen=True)
+class AccessSpec:
+    scopes: dict[str, list[str]]  # access tier -> OAuth scopes
+    default: str  # tier used when config omits access
+    flags: tuple[str, ...] = ()  # config boolean field names honored
+    readonly_tiers: frozenset[str] = frozenset({'readonly'})
+
+
+@dataclass(frozen=True)
+class GoogleAccess:
+    tier: str
+    scopes: list[str]
+    can_write: bool
+    flags: dict[str, bool]
+
+    def require_write(self, op: str) -> None:
+        if not self.can_write:
+            raise GoogleAccessError(
+                f'{op} needs write access, but this node is read-only '
+                f'(access={self.tier!r}). Raise the access level to enable it.'
+            )
+
+    def require_flag(self, name: str, op: str) -> None:
+        if not self.flags.get(name, False):
+            raise GoogleAccessError(
+                f'{op} is gated by {name!r}, which is off by default. Enable {name!r} in the node config to allow it.'
+            )
+
+
+def resolve_google_access(config: dict, spec: AccessSpec) -> GoogleAccess:
+    tier = config.get('access') or spec.default
+    if tier not in spec.scopes:
+        raise GoogleAccessError(f'unknown access tier {tier!r}; expected one of {sorted(spec.scopes)}')
+    flags = {name: bool(config.get(name, False)) for name in spec.flags}
+    return GoogleAccess(
+        tier=tier,
+        scopes=list(spec.scopes[tier]),
+        can_write=tier not in spec.readonly_tiers,
+        flags=flags,
+    )
+
+
+_G = 'https://www.googleapis.com/auth'
+
+GMAIL = AccessSpec(
+    scopes={
+        'readonly': [f'{_G}/gmail.readonly'],
+        'modify': [f'{_G}/gmail.modify'],
+        'send': [f'{_G}/gmail.modify', f'{_G}/gmail.send'],
+    },
+    default='modify',
+    flags=('allowHardDelete',),
+)
+DRIVE = AccessSpec(
+    scopes={'readonly': [f'{_G}/drive.readonly'], 'write': [f'{_G}/drive']},
+    default='write',
+    flags=('allowPublicSharing', 'allowHardDelete'),
+)
+SHEETS = AccessSpec(
+    scopes={'readonly': [f'{_G}/spreadsheets.readonly'], 'write': [f'{_G}/spreadsheets']},
+    default='write',
+)
+DOCS = AccessSpec(
+    scopes={'readonly': [f'{_G}/documents.readonly'], 'write': [f'{_G}/documents']},
+    default='write',
+)
+CALENDAR = AccessSpec(
+    scopes={'readonly': [f'{_G}/calendar.readonly'], 'write': [f'{_G}/calendar']},
+    default='write',
+    flags=('allowDelete',),
+)
+SLIDES = AccessSpec(
+    scopes={'readonly': [f'{_G}/presentations.readonly'], 'write': [f'{_G}/presentations']},
+    default='write',
+)
+PEOPLE = AccessSpec(
+    scopes={
+        'readonly': [f'{_G}/contacts.readonly', f'{_G}/directory.readonly'],
+        'write': [f'{_G}/contacts', f'{_G}/directory.readonly'],
+    },
+    default='write',
+    flags=('allowDelete',),
+)

--- a/nodes/src/nodes/core/google_access.py
+++ b/nodes/src/nodes/core/google_access.py
@@ -40,11 +40,14 @@ class GoogleAccessError(PermissionError):
 
 @dataclass(frozen=True)
 class AccessSpec:
+    """Per-API access contract: tier->scopes, default tier, and honored gate flags."""
+
     scopes: dict[str, list[str]]  # access tier -> OAuth scopes
     default: str  # tier used when config omits access
     flags: tuple[str, ...] = ()  # config boolean field names honored
 
     def __post_init__(self) -> None:
+        """Validate the spec at construction."""
         if not self.scopes:
             raise GoogleAccessError('AccessSpec.scopes must declare at least one tier')
         if self.default not in self.scopes:
@@ -55,12 +58,15 @@ class AccessSpec:
 
 @dataclass(frozen=True)
 class GoogleAccess:
+    """Resolved access for one node: granted scopes, write capability, and gate flags."""
+
     tier: str
     scopes: list[str]
     can_write: bool
     flags: dict[str, bool]
 
     def require_write(self, op: str) -> None:
+        """Raise if the node is read-only."""
         if not self.can_write:
             raise GoogleAccessError(
                 f'{op} needs write access, but this node is read-only '
@@ -68,6 +74,7 @@ class GoogleAccess:
             )
 
     def require_flag(self, name: str, op: str) -> None:
+        """Raise if the named destructive gate is not enabled."""
         if not self.flags.get(name, False):
             raise GoogleAccessError(
                 f'{op} is gated by {name!r}, which is off by default. Enable {name!r} in the node config to allow it.'
@@ -75,6 +82,7 @@ class GoogleAccess:
 
 
 def _resolve_flags(config: dict, spec: AccessSpec) -> dict[str, bool]:
+    """Resolve declared gate flags, rejecting non-bool config values."""
     # Strict: a destructive gate must fail loud on misconfig, not coerce. Only an
     # explicit bool True enables; a present non-bool ('false', 1, 'no') is an error.
     flags: dict[str, bool] = {}
@@ -90,9 +98,17 @@ def _resolve_flags(config: dict, spec: AccessSpec) -> dict[str, bool]:
 
 
 def resolve_google_access(config: dict, spec: AccessSpec) -> GoogleAccess:
-    tier = config.get('access') or spec.default
-    if not isinstance(tier, str):
-        raise GoogleAccessError(f'access must be a string tier name, got {type(tier).__name__}')
+    """Resolve a node's config + AccessSpec into a GoogleAccess (scopes + gates)."""
+    # Blank/omitted access means "use the default tier" (e.g. an empty UI field).
+    # Any other non-string value is malformed config and must raise rather than
+    # silently fall through to the default.
+    raw = config.get('access')
+    if raw is None or raw == '':
+        tier = spec.default
+    elif not isinstance(raw, str):
+        raise GoogleAccessError(f'access must be a string tier name, got {type(raw).__name__}')
+    else:
+        tier = raw
     if tier not in spec.scopes:
         raise GoogleAccessError(f'unknown access tier {tier!r}; expected one of {sorted(spec.scopes)}')
     tier_scopes = spec.scopes[tier]

--- a/nodes/test/core/test_google_access.py
+++ b/nodes/test/core/test_google_access.py
@@ -1,0 +1,186 @@
+"""
+Unit tests for the shared Google access/gate resolver (core/google_access.py).
+
+Pure logic, no server or live API needed:
+
+    pytest nodes/test/core/test_google_access.py -v
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'core'))
+from google_access import (  # noqa: E402
+    CALENDAR,
+    DRIVE,
+    DOCS,
+    GMAIL,
+    PEOPLE,
+    SHEETS,
+    SLIDES,
+    AccessSpec,
+    GoogleAccess,
+    GoogleAccessError,
+    resolve_google_access,
+)
+
+_G = 'https://www.googleapis.com/auth'
+
+# A small spec used for the resolver's own behavior (independent of the per-app specs)
+_FIXTURE = AccessSpec(
+    scopes={'readonly': [f'{_G}/thing.readonly'], 'write': [f'{_G}/thing']},
+    default='write',
+    flags=('allowDelete', 'allowPublic'),
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_google_access: tier -> scopes
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_named_tier_to_its_scopes():
+    access = resolve_google_access({'access': 'readonly'}, _FIXTURE)
+    assert access.tier == 'readonly'
+    assert access.scopes == [f'{_G}/thing.readonly']
+
+
+def test_applies_default_tier_when_access_omitted():
+    access = resolve_google_access({}, _FIXTURE)
+    assert access.tier == 'write'
+    assert access.scopes == [f'{_G}/thing']
+
+
+def test_blank_access_falls_back_to_default():
+    access = resolve_google_access({'access': ''}, _FIXTURE)
+    assert access.tier == 'write'
+
+
+def test_unknown_tier_raises():
+    with pytest.raises(GoogleAccessError):
+        resolve_google_access({'access': 'superuser'}, _FIXTURE)
+
+
+# ---------------------------------------------------------------------------
+# can_write
+# ---------------------------------------------------------------------------
+
+
+def test_write_tier_can_write():
+    assert resolve_google_access({'access': 'write'}, _FIXTURE).can_write is True
+
+
+def test_readonly_tier_cannot_write():
+    assert resolve_google_access({'access': 'readonly'}, _FIXTURE).can_write is False
+
+
+# ---------------------------------------------------------------------------
+# require_write
+# ---------------------------------------------------------------------------
+
+
+def test_require_write_noop_on_write_tier():
+    access = resolve_google_access({'access': 'write'}, _FIXTURE)
+    access.require_write('thing_create')  # must not raise
+
+
+def test_require_write_raises_on_readonly_tier():
+    access = resolve_google_access({'access': 'readonly'}, _FIXTURE)
+    with pytest.raises(GoogleAccessError):
+        access.require_write('thing_create')
+
+
+# ---------------------------------------------------------------------------
+# require_flag
+# ---------------------------------------------------------------------------
+
+
+def test_require_flag_noop_when_flag_true():
+    access = resolve_google_access({'access': 'write', 'allowDelete': True}, _FIXTURE)
+    access.require_flag('allowDelete', 'thing_delete')  # must not raise
+
+
+def test_require_flag_raises_when_flag_false():
+    access = resolve_google_access({'access': 'write', 'allowDelete': False}, _FIXTURE)
+    with pytest.raises(GoogleAccessError):
+        access.require_flag('allowDelete', 'thing_delete')
+
+
+def test_require_flag_raises_when_flag_absent():
+    access = resolve_google_access({'access': 'write'}, _FIXTURE)
+    with pytest.raises(GoogleAccessError):
+        access.require_flag('allowDelete', 'thing_delete')
+
+
+def test_flags_populated_from_config():
+    access = resolve_google_access({'access': 'write', 'allowDelete': True, 'allowPublic': False}, _FIXTURE)
+    assert access.flags == {'allowDelete': True, 'allowPublic': False}
+
+
+def test_only_declared_flags_are_read():
+    # A config boolean not declared in the spec must not leak into flags.
+    access = resolve_google_access({'access': 'write', 'undeclared': True}, _FIXTURE)
+    assert 'undeclared' not in access.flags
+
+
+# ---------------------------------------------------------------------------
+# Per-app specs
+# ---------------------------------------------------------------------------
+
+
+def test_gmail_send_tier_includes_modify_and_send_scopes():
+    access = resolve_google_access({'access': 'send'}, GMAIL)
+    assert f'{_G}/gmail.modify' in access.scopes
+    assert f'{_G}/gmail.send' in access.scopes
+
+
+def test_gmail_default_is_modify():
+    assert resolve_google_access({}, GMAIL).tier == 'modify'
+
+
+def test_gmail_modify_is_writeable():
+    assert resolve_google_access({'access': 'modify'}, GMAIL).can_write is True
+
+
+def test_gmail_declares_allow_hard_delete_flag():
+    assert 'allowHardDelete' in GMAIL.flags
+
+
+def test_drive_declares_public_sharing_and_hard_delete_flags():
+    assert set(DRIVE.flags) == {'allowPublicSharing', 'allowHardDelete'}
+
+
+def test_people_readonly_includes_directory_scope():
+    access = resolve_google_access({'access': 'readonly'}, PEOPLE)
+    assert f'{_G}/directory.readonly' in access.scopes
+
+
+def test_calendar_and_people_declare_allow_delete():
+    assert 'allowDelete' in CALENDAR.flags
+    assert 'allowDelete' in PEOPLE.flags
+
+
+@pytest.mark.parametrize('spec', [SHEETS, DOCS, SLIDES])
+def test_simple_editor_apps_have_no_flags_and_default_write(spec):
+    assert spec.flags == ()
+    assert spec.default == 'write'
+    assert resolve_google_access({}, spec).can_write is True
+
+
+@pytest.mark.parametrize('spec', [GMAIL, DRIVE, SHEETS, DOCS, CALENDAR, SLIDES, PEOPLE])
+def test_every_spec_has_a_readonly_tier_that_cannot_write(spec):
+    access = resolve_google_access({'access': 'readonly'}, spec)
+    assert access.can_write is False
+
+
+@pytest.mark.parametrize('spec', [GMAIL, DRIVE, SHEETS, DOCS, CALENDAR, SLIDES, PEOPLE])
+def test_default_tier_is_a_valid_tier(spec):
+    assert spec.default in spec.scopes
+
+
+def test_resolver_returns_googleaccess_instance():
+    assert isinstance(resolve_google_access({}, GMAIL), GoogleAccess)

--- a/nodes/test/core/test_google_access.py
+++ b/nodes/test/core/test_google_access.py
@@ -13,6 +13,8 @@ from pathlib import Path
 
 import pytest
 
+# core/ is a flat dir of engine-loaded modules (no __init__.py) and nodes/src is
+# not on pytest's pythonpath, so import the module by adding its dir to sys.path.
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'core'))
 from google_access import (  # noqa: E402
     CALENDAR,
@@ -146,8 +148,9 @@ def test_gmail_modify_is_writeable():
     assert resolve_google_access({'access': 'modify'}, GMAIL).can_write is True
 
 
-def test_gmail_declares_allow_hard_delete_flag():
-    assert 'allowHardDelete' in GMAIL.flags
+def test_gmail_declares_no_capability_flags():
+    # Permanent delete needs the full mail scope (no tier grants it), so Gmail has no gates.
+    assert GMAIL.flags == ()
 
 
 def test_drive_declares_public_sharing_and_hard_delete_flags():
@@ -184,3 +187,106 @@ def test_default_tier_is_a_valid_tier(spec):
 
 def test_resolver_returns_googleaccess_instance():
     assert isinstance(resolve_google_access({}, GMAIL), GoogleAccess)
+
+
+# ---------------------------------------------------------------------------
+# Strict-boolean flags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('bad', ['false', 'true', 'no', 1, 0, [], {}])
+def test_flag_non_bool_value_raises(bad):
+    with pytest.raises(GoogleAccessError):
+        resolve_google_access({'access': 'write', 'allowDelete': bad}, _FIXTURE)
+
+
+def test_flag_explicit_true_enables():
+    access = resolve_google_access({'access': 'write', 'allowDelete': True}, _FIXTURE)
+    assert access.flags['allowDelete'] is True
+
+
+def test_flag_explicit_false_disables():
+    access = resolve_google_access({'access': 'write', 'allowDelete': False}, _FIXTURE)
+    assert access.flags['allowDelete'] is False
+
+
+# ---------------------------------------------------------------------------
+# Non-string access guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('bad_access', [['write'], {'tier': 'write'}, 123])
+def test_non_string_access_raises_googleaccesserror(bad_access):
+    with pytest.raises(GoogleAccessError):
+        resolve_google_access({'access': bad_access}, _FIXTURE)
+
+
+# ---------------------------------------------------------------------------
+# AccessSpec construction validation
+# ---------------------------------------------------------------------------
+
+
+def test_accessspec_default_absent_from_scopes_raises():
+    with pytest.raises(GoogleAccessError):
+        AccessSpec(scopes={'readonly': [f'{_G}/thing.readonly']}, default='write')
+
+
+def test_accessspec_empty_scopes_raises():
+    with pytest.raises(GoogleAccessError):
+        AccessSpec(scopes={}, default='write')
+
+
+# ---------------------------------------------------------------------------
+# Scope-derived can_write across every shipped spec/tier
+# ---------------------------------------------------------------------------
+
+_CAN_WRITE_CASES = [
+    (GMAIL, 'readonly', False),
+    (GMAIL, 'modify', True),
+    (GMAIL, 'send', True),
+    (DRIVE, 'readonly', False),
+    (DRIVE, 'write', True),
+    (SHEETS, 'readonly', False),
+    (SHEETS, 'write', True),
+    (DOCS, 'readonly', False),
+    (DOCS, 'write', True),
+    (CALENDAR, 'readonly', False),
+    (CALENDAR, 'write', True),
+    (SLIDES, 'readonly', False),
+    (SLIDES, 'write', True),
+    (PEOPLE, 'readonly', False),
+    (PEOPLE, 'write', True),
+]
+
+
+@pytest.mark.parametrize('spec,tier,expected', _CAN_WRITE_CASES)
+def test_can_write_derived_from_scopes(spec, tier, expected):
+    assert resolve_google_access({'access': tier}, spec).can_write is expected
+
+
+def test_people_write_is_writable_despite_directory_readonly():
+    access = resolve_google_access({'access': 'write'}, PEOPLE)
+    assert f'{_G}/directory.readonly' in access.scopes  # retained
+    assert f'{_G}/contacts' in access.scopes  # writable scope present
+    assert access.can_write is True
+
+
+# ---------------------------------------------------------------------------
+# Exact scope strings for the flag-less editor/calendar specs
+# ---------------------------------------------------------------------------
+
+_EXACT_SCOPES = [
+    (SHEETS, 'readonly', [f'{_G}/spreadsheets.readonly']),
+    (SHEETS, 'write', [f'{_G}/spreadsheets']),
+    (DOCS, 'readonly', [f'{_G}/documents.readonly']),
+    (DOCS, 'write', [f'{_G}/documents']),
+    (SLIDES, 'readonly', [f'{_G}/presentations.readonly']),
+    (SLIDES, 'write', [f'{_G}/presentations']),
+    (CALENDAR, 'readonly', [f'{_G}/calendar.readonly']),
+    (CALENDAR, 'write', [f'{_G}/calendar']),
+]
+
+
+@pytest.mark.parametrize('spec,tier,scopes', _EXACT_SCOPES)
+def test_exact_scope_strings(spec, tier, scopes):
+    assert resolve_google_access({'access': tier}, spec).scopes == scopes

--- a/nodes/test/core/test_google_access.py
+++ b/nodes/test/core/test_google_access.py
@@ -215,10 +215,16 @@ def test_flag_explicit_false_disables():
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize('bad_access', [['write'], {'tier': 'write'}, 123])
+@pytest.mark.parametrize('bad_access', [['write'], {'tier': 'write'}, 123, 0, False, [], {}])
 def test_non_string_access_raises_googleaccesserror(bad_access):
+    # Includes falsey non-strings (0/False/[]/{}) that must NOT silently fall
+    # back to the default tier; only None/'' / a missing key default (see below).
     with pytest.raises(GoogleAccessError):
         resolve_google_access({'access': bad_access}, _FIXTURE)
+
+
+def test_none_access_falls_back_to_default():
+    assert resolve_google_access({'access': None}, _FIXTURE).tier == 'write'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add a single reader that turns a Google tool node's `access` enum and capability toggles into one resolved object: the OAuth scopes to request plus write/destructive gates.
- Define per-app specs (Gmail, Drive, Sheets, Docs, Calendar, Slides, People) with least-privilege defaults — dangerous ops (hard delete, public sharing) gated off unless explicitly enabled.
- Reusable primitive; node wiring lands separately.

## Type

feature

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Closes RR-1054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google OAuth access resolution with selectable access tiers, computed read/write determination, and per-feature gate flags across Gmail, Drive, Sheets, Docs, Calendar, Slides, and People. Includes strict validation of tiers, defaults and flag types and returns an immutable resolved access object for permission checks.

* **Tests**
  * Added comprehensive tests for tier resolution, defaults, read/write behavior, flag handling, validation errors, and per-service expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->