### PR TITLE
fix(canvas): forward drag events through CreateNodePanel backdrop

### DIFF
--- a/packages/shared-ui/src/components/canvas/components/panels/create-node/CreateNodePanel.tsx
+++ b/packages/shared-ui/src/components/canvas/components/panels/create-node/CreateNodePanel.tsx
@@ -229,7 +229,7 @@ interface ICreateNodePanelProps {
 
 export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): ReactElement {
 	const { inventory } = useFlowProject();
-	const { addNode, setTempNode } = useFlowGraph();
+	const { addNode, setTempNode, onDrop, onDragOver } = useFlowGraph();
 	const { getPreference, setPreference } = useFlowPreferences();
 
 	const [search, setSearch] = useState('');
@@ -381,7 +381,7 @@ export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): Rea
 
 	return (
 		<>
-			<div style={styles.backdrop} onClick={onClose} />
+			<div style={styles.backdrop} onClick={onClose} onDragOver={onDragOver} onDrop={onDrop} />
 			<div className="nopan nodrag" style={{ ...styles.container, width: `${width}px`, userSelect: isResizing ? 'none' : 'auto' }}>
 				{/* Resize handle */}
 				<div style={styles.resizeHitArea} onMouseDown={onResizeMouseDown} onMouseEnter={() => setHandleHover(true)} onMouseLeave={() => setHandleHover(false)}>


### PR DESCRIPTION
## Summary

- The backdrop div introduced in c5cde38f sits at `z-index: 29` over the entire canvas with `position: absolute; inset: 0`
- HTML5 drag-and-drop requires `preventDefault()` in `onDragOver` to allow a drop — the backdrop had no drag handlers, so the browser blocked all drops silently
- ReactFlow's `onDrop` never fired, so nodes dragged from the Add Node panel were never placed

**Fix:** forward `onDragOver` and `onDrop` from `FlowGraphContext` to the backdrop div so drops land at the correct canvas position while the backdrop still closes the panel on click.

## Test plan

- [ ] Open the Add Node panel
- [ ] Drag a node type from the panel onto the canvas — verify it places at the drop location
- [ ] Click outside the panel (on the canvas backdrop) — verify the panel still closes
- [ ] Click-to-add still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added drag-and-drop support to the Create Node Panel. Users can now drop items directly onto the panel area while retaining the existing close-on-click functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->