### PR TITLE
ci(release): npm OIDC trusted publishing (drop expiring NPM_TOKEN)

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -192,6 +192,13 @@ jobs:
       - name: Publish to npm
         if: inputs.prerelease == false && steps.tag_check.outputs.exists == 'false' && matrix.type == 'client-typescript'
         run: |
+          # OIDC trusted publishing — no NPM_TOKEN. Auth uses this job's
+          # id-token (already granted for --provenance). Requires npm >= 11.5.1;
+          # Node 20 ships npm 10.x, so upgrade in place. The trusted publisher
+          # must be configured on npmjs.com against the CALLER workflow
+          # (release.yaml) + environment "release" — not this reusable child.
+          npm install -g npm@latest
+          npm --version
           VERSION="${{ matrix.version }}"
           if npm view "rocketride@${VERSION}" version 2>/dev/null; then
             echo "rocketride@${VERSION} already exists on npm — skipping"
@@ -200,8 +207,6 @@ jobs:
             echo "Publishing ${TARBALL}"
             npm publish "./${TARBALL}" --access public --provenance
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       # --- PyPI ---
       - name: Set up Python


### PR DESCRIPTION
## Why
The granular `NPM_TOKEN` used to publish `rocketride` to npm expires periodically (**next expiry: June 3, 2026**), which recurringly breaks the npm publish on a real release. npm is also phasing out long-lived automation tokens. The fix is to stop using a token at all.

The publish job in `_release.yaml` already has `id-token: write` (granted for `--provenance`), so the OIDC identity needed for **npm Trusted Publishing** is already flowing — no new secret required.

## What this PR changes
- Upgrade npm to `>= 11.5.1` in the npm publish step (Node 20 ships npm 10.x, which predates OIDC trusted-publishing support).
- Remove the `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` env from the publish step.

No change to the `prerelease == false` gating — nightly prereleases still never publish.

## ⚠️ DO NOT MERGE until npmjs.com is configured
Trusted publishing must be set up on npm **before** this merges, or the next real release will fail to authenticate. On npmjs.com → package **`rocketride`** → Settings → **Trusted Publisher** → add a GitHub Actions publisher:

| Field | Value |
|---|---|
| Organization / repository | `rocketride-org/rocketride-server` |
| Workflow filename | **`release.yaml`** |
| Environment | `release` |

> **Trap:** npm validates the OIDC token's top-level `workflow_ref`, which is the **caller** (`release.yaml`), **not** the reusable child (`_release.yaml`) that contains the actual `npm publish`. Configuring it against `_release.yaml` silently 404s as "package not found." Use `release.yaml`.

Once that's saved, mark this PR ready and merge. First real release on `main` validates it end-to-end (provenance + OIDC). The `NPM_TOKEN` secret can be deleted after a successful release.

## Bridge option
If a real release is needed before this is verified, the zero-risk fallback is to re-mint a granular `NPM_TOKEN` and update the repo secret — keeps the current path working. This PR makes that the last time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)