### PR TITLE
fix(ci): stop Discord notifier from posting blank bot comments

### DIFF
--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -98,7 +98,7 @@ jobs:
             --jq '[.[] | {id: .id, body: .body, author: .user.login}]')
 
           DISCORD_MSG_ID=$(echo "$COMMENTS" | \
-            jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$"))) | .body' | \
+            jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("<!-- discord-msg-id:[0-9]+ -->"))) | .body' | \
             grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2 | head -1)
 
           WEBHOOK_ID=$(echo    "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $(NF-1)}')
@@ -115,7 +115,7 @@ jobs:
 
             if [ "$PATCH_STATUS" = "404" ]; then
               STALE_COMMENT_ID=$(echo "$COMMENTS" | \
-                jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$"))) | .id' | head -1)
+                jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("<!-- discord-msg-id:[0-9]+ -->"))) | .id' | head -1)
               gh api -X DELETE "/repos/$REPO/issues/comments/$STALE_COMMENT_ID"
               DISCORD_MSG_ID=""
             elif [ "$PATCH_STATUS" != "200" ]; then
@@ -136,7 +136,7 @@ jobs:
 
             # ── Race guard: re-check for a comment created by a concurrent run ──
             EXISTING=$(gh api "/repos/$REPO/issues/$NUMBER/comments" \
-              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$")))] | first // empty' 2>/dev/null)
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("<!-- discord-msg-id:[0-9]+ -->")))] | first // empty' 2>/dev/null)
 
             if [ -n "$EXISTING" ]; then
               # Another run won the race — delete our duplicate message, use theirs
@@ -147,8 +147,16 @@ jobs:
                 "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null || true
             else
               DISCORD_MSG_ID="$NEW_MSG_ID"
+              COMMENT_BODY=$(printf '%s\n' \
+                '<details>' \
+                '<summary>🤖 Internal: Discord sync marker</summary>' \
+                '' \
+                'Auto-managed by the Discord notification workflow. Stores the linked Discord message ID. Do not edit or delete.' \
+                '' \
+                "<!-- discord-msg-id:${DISCORD_MSG_ID} -->" \
+                '</details>')
               gh api "/repos/$REPO/issues/$NUMBER/comments" \
                 -X POST \
-                -f body="<!-- discord-msg-id:${DISCORD_MSG_ID} -->"
+                -f body="$COMMENT_BODY"
             fi
           fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -195,7 +195,7 @@ jobs:
             --jq '[.[] | {id: .id, body: .body, author: .user.login}]')
 
           DISCORD_MSG_ID=$(echo "$COMMENTS" | \
-            jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$"))) | .body' | \
+            jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("<!-- discord-msg-id:[0-9]+ -->"))) | .body' | \
             grep -o 'discord-msg-id:[0-9]*' | cut -d':' -f2 | head -1)
 
           WEBHOOK_ID=$(echo    "$DISCORD_WEBHOOK_URL" | awk -F'/' '{print $(NF-1)}')
@@ -212,7 +212,7 @@ jobs:
 
             if [ "$PATCH_STATUS" = "404" ]; then
               STALE_COMMENT_ID=$(echo "$COMMENTS" | \
-                jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$"))) | .id' | head -1)
+                jq -r '.[] | select(.author == "github-actions[bot]" and (.body | test("<!-- discord-msg-id:[0-9]+ -->"))) | .id' | head -1)
               gh api -X DELETE "/repos/$REPO/issues/comments/$STALE_COMMENT_ID"
               DISCORD_MSG_ID=""
             elif [ "$PATCH_STATUS" != "200" ]; then
@@ -233,7 +233,7 @@ jobs:
 
             # ── Race guard: re-check for a comment created by a concurrent run ──
             EXISTING=$(gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
-              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("^<!-- discord-msg-id:[0-9]+ -->\\s*$")))] | first // empty' 2>/dev/null)
+              --jq '[.[] | select(.user.login == "github-actions[bot]" and (.body | test("<!-- discord-msg-id:[0-9]+ -->")))] | first // empty' 2>/dev/null)
 
             if [ -n "$EXISTING" ]; then
               # Another run won the race — delete our duplicate message, use theirs
@@ -244,8 +244,16 @@ jobs:
                 "https://discord.com/api/webhooks/$WEBHOOK_ID/$WEBHOOK_TOKEN/messages/$DISCORD_MSG_ID" > /dev/null || true
             else
               DISCORD_MSG_ID="$NEW_MSG_ID"
+              COMMENT_BODY=$(printf '%s\n' \
+                '<details>' \
+                '<summary>🤖 Internal: Discord sync marker</summary>' \
+                '' \
+                'Auto-managed by the Discord notification workflow. Stores the linked Discord message ID. Do not edit or delete.' \
+                '' \
+                "<!-- discord-msg-id:${DISCORD_MSG_ID} -->" \
+                '</details>')
               gh api "/repos/$REPO/issues/$PR_NUMBER/comments" \
                 -X POST \
-                -f body="<!-- discord-msg-id:${DISCORD_MSG_ID} -->"
+                -f body="$COMMENT_BODY"
             fi
           fi


### PR DESCRIPTION
## Summary

- The Discord notifier workflows stored the `discord-msg-id` tracking marker as a bare HTML comment (`<!-- discord-msg-id:NNN -->`), which GitHub renders as a blank "No description provided" `github-actions[bot]` comment on every PR and issue.
- Wrapped the marker in a collapsible `<details>` block (summary: `🤖 Internal: Discord sync marker`) so the tracking comment is no longer empty/confusing.
- Relaxed the detection regex from a full-body anchor (`^<!-- … -->\s*$`) to a substring match (`<!-- … -->`) so it still finds the ID inside the new block — and remains backward compatible with existing bare-marker comments already on open PRs/issues.

## Type

fix (CI / GitHub Actions)

## Testing

- [ ] Tests added or updated <!-- N/A — workflow YAML change -->
- [ ] Tested locally
- [ ] `./builder test` passes <!-- N/A — no application code changed -->

Validation run locally:
- `actionlint` (with embedded `shellcheck`) on both workflows — no issues
- YAML parse of both workflows — valid
- `gitleaks protect --staged` (repo config) — no leaks
- Detection regex confirmed to match both the new `<details>` body and legacy bare-marker comments

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable) <!-- none -->

## Linked Issue

Fixes #1079


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced Discord message ID tracking logic for GitHub issues and pull requests with improved marker detection
  * Updated linked GitHub comments to display collapsible details blocks containing instructional information and message identifiers
  * Improved synchronization of Discord notification references across concurrent workflow runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->