### PR TITLE
fix(nodes): bootstrap deps in agent_rocketride and drop transformers from llm_anthropic

### DIFF
--- a/nodes/src/nodes/agent_rocketride/IGlobal.py
+++ b/nodes/src/nodes/agent_rocketride/IGlobal.py
@@ -14,9 +14,10 @@ stateless across runs and safe to share.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
-from rocketlib import IGlobalBase
+from rocketlib import IGlobalBase, OPEN_MODE
 
 
 class IGlobal(IGlobalBase):
@@ -41,6 +42,17 @@ class IGlobal(IGlobalBase):
         ``AgentBase.__init__`` via ``Config.getNodeConfig``, so no
         config handling is needed here.
         """
+        # In CONFIG mode the driver is never used, so skip the dependency
+        # install (and its side effects) — same guard as the other nodes.
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            return
+
+        # Install dependencies
+        from depends import depends  # type: ignore
+
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
         from .rocketride_agent import RocketRideDriver
 
         self.agent = RocketRideDriver(self)

--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -30,53 +30,10 @@ from ai.common.chat import ChatBase
 from ai.common.config import Config
 from langchain_anthropic import ChatAnthropic
 
-# --- ANTI-SIGBUS PATCH: disable fast tokenizers and Claude-specific token counting ---
-# 1) Disable tokenizer parallelism
-import os
 
-os.environ.setdefault('TOKENIZERS_PARALLELISM', 'false')
-
-# 2) Force AutoTokenizer to use the slow (Python) version to avoid Rust binary crashes
-try:
-    import transformers as _tf  # type: ignore
-
-    _orig_from_pretrained = _tf.AutoTokenizer.from_pretrained
-
-    def _patched_from_pretrained(*args, **kwargs):
-        kwargs.setdefault('use_fast', False)
-        return _orig_from_pretrained(*args, **kwargs)
-
-    _tf.AutoTokenizer.from_pretrained = _patched_from_pretrained
-except Exception:
-    # If transformers is not installed or fails, just skip
-    pass
-
-# 3) Disable real token counting ONLY for Claude models to avoid transformer usage
-try:
-    # tokenization is optional, ignore it contract-check
-    import langchain_core.utils.tokenization as _tok  # type: ignore  # contract-check: ignore
-
-    _orig_get_token_ids = _tok.get_token_ids
-
-    def _patched_get_token_ids(*args, **kwargs):
-        # Compatible with both positional and keyword arguments
-        text = kwargs.get('text', args[0] if args else '')
-        model_name = kwargs.get('model_name')
-        if model_name is None and len(args) >= 2:
-            model_name = args[1]
-
-        if model_name and 'claude' in str(model_name).lower():
-            # Simple estimate: ~4 chars/token; LC only needs len(ids)
-            n = max(1, (len(text) + 3) // 4)
-            return [0] * n
-
-        return _orig_get_token_ids(*args, **kwargs)
-
-    _tok.get_token_ids = _patched_get_token_ids
-except Exception:
-    # If LC is not imported yet, step 2 already avoids crashes
-    pass
-# --- END PATCH ---
+def _estimate_token_ids(text: str) -> list:
+    """Estimate token ids at ~4 chars/token."""
+    return [0] * max(1, (len(text) + 3) // 4)
 
 
 class Chat(ChatBase):
@@ -108,7 +65,13 @@ class Chat(ChatBase):
         super().__init__(provider, connConfig, bag)
 
         # Get the LLM
-        self._llm = ChatAnthropic(model=model, api_key=apikey, temperature=0, max_tokens=self._modelOutputTokens)
+        self._llm = ChatAnthropic(
+            model=model,
+            api_key=apikey,
+            temperature=0,
+            max_tokens=self._modelOutputTokens,
+            custom_get_token_ids=_estimate_token_ids,
+        )
 
         # Save our chat class into the bag
         bag['chat'] = self


### PR DESCRIPTION
## Summary

- Add the missing `depends(requirements.txt)` bootstrap in the `agent_rocketride` node so its `jmespath` dependency is installed before the executor module that imports it.
- Replace `llm_anthropic`'s dead anti-SIGBUS monkeypatch (it patched a non-existent `langchain_core.utils.tokenization` module, so the real count fell through to the GPT-2 tokenizer) with `ChatAnthropic`'s public `custom_get_token_ids` hook (a ~4 chars/token estimate), which every token-counting path routes through.
- Drop `llm_anthropic`'s reliance on the `transformers` GPT-2 tokenizer fallback, removing the Rust `tokenizers` build/SIGBUS failures on platforms without a prebuilt wheel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Install required third-party packages early to avoid startup failures when the driver initializes, with configuration mode skipping installation.

* **Refactor**
  * Replaced fragile tokenization monkeypatching with a lightweight token-estimation approach for more stable, predictable token counting and improved reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->