### PR TITLE
feat(node): add Supabase as a branded preset of db_postgres

### DIFF
--- a/nodes/src/nodes/db_postgres/services.supabase.json
+++ b/nodes/src/nodes/db_postgres/services.supabase.json
@@ -1,0 +1,186 @@
+{
+	//
+	// Required:
+	//		The displayable name of this node
+	//
+	"title": "Supabase",
+	//
+	// Required:
+	//		The protocol is the endpoint protocol
+	//
+	"protocol": "db_supabase://",
+	//
+	// Required:
+	//		Class type of the node - what it does
+	//
+	"classType": ["database", "tool"],
+	//
+	// Required:
+	//		Capabilities are flags that change the behavior of the underlying
+	//		engine
+	//
+	"capabilities": ["noremote", "invoke"],
+	//
+	// Optional:
+	//		Register is either filter, endpoint or ignored if not specified. If the
+	//		type is specified, a factory is registered of that given type
+	//
+	"register": "filter",
+	//
+	// Optional:
+	//		The node is the actual physical node to instantiate - if
+	//		not specified, the protocol will be used
+	//
+	"node": "python",
+	//
+	// Optional:
+	//		Reuses the PostgreSQL implementation — Supabase is managed Postgres,
+	//		so this is a branded preset, not a separate node (no duplicated code).
+	//
+	"path": "nodes.db_postgres",
+	//
+	// Required:
+	//		The prefix map when added/removed when converting URLs <=> paths
+	//
+	"prefix": "supabase",
+	//
+	// Optional:
+	//		Description of this driver
+	//
+	"description": ["A processing component that takes structured table data and inserts it ", "into a Supabase (PostgreSQL) database. Designed for straightforward data ingestion, it ", "supports field mapping and basic configuration of connection credentials ", "and target tables. Use the Supavisor pooler from your Supabase dashboard (works over IPv4); ", "the direct connection is IPv6-only. The connection is encrypted over TLS."],
+	//
+	// Optional:
+	//	  The icon is the icon to display in the UI for this node
+	//
+	"icon": "supabase.svg",
+	"documentation": "https://docs.rocketride.org",
+	//
+	// Optional:
+	//		Defines the invoke connections that may/must be connected
+	// 		which are utilized by this driver
+	//
+	"invoke": {
+		"llm": {
+			"description": "LLM to use to craft SQL queries from question",
+			"min": 1
+		}
+	},
+	//
+	//	Optional:
+	//		As a pipe component, define what this pipe component takes
+	//		and what it produces
+	//
+	"lanes": {
+		"answers": [],
+		"questions": ["table", "text", "answers"]
+	},
+	//
+	//	Optional:
+	//		Profile section are configuration options used by the driver
+	//		itself
+	//
+	"preconfig": {
+		// Define the values that will be merged into any profile configuration
+		// specified, unless the profile is 'absolute'
+		"default": "default",
+		// Defines profiles used with the "profile": key
+		"profiles": {
+			"default": {
+				"database": "postgres"
+			}
+		}
+	},
+	//
+	// Optional:
+	//		Local fields definitions - these define fields only for the
+	//		current service. You may specify them here, or directly
+	//		in the shape
+	//
+	"fields": {
+		"postgresdb.host": {
+			"type": "string",
+			"title": "Supabase host",
+			"description": "From the Supabase dashboard (Connect button), including the port. Recommended: the Supavisor pooler (works over IPv4) -> aws-0-<region>.pooler.supabase.com:6543 (transaction) or :5432 (session). The Direct connection (db.<project-ref>.supabase.co:5432) is IPv6-only and will fail to resolve on networks without IPv6."
+		},
+		"postgresdb.user": {
+			"type": "string",
+			"title": "User",
+			"default": "postgres",
+			"description": "Database user. For the pooler (recommended) it MUST include your project ref: postgres.<project-ref> — without the .<project-ref> suffix the pooler returns 'no tenant identifier'. For the direct connection it is just: postgres"
+		},
+		"postgresdb.password": {
+			"type": "string",
+			"title": "Password",
+			"description": "Database password from your Supabase project (Project Settings -> Database)",
+			"secure": true,
+			"ui": {
+				"ui:widget": "password"
+			}
+		},
+		"postgresdb.database": {
+			"type": "string",
+			"title": "Database name",
+			"default": "postgres",
+			"minLength": 2,
+			"maxLength": 63,
+			"description": "Name of database (Supabase default is 'postgres')"
+		},
+		"postgresdb.table": {
+			"type": "string",
+			"title": "Table name",
+			"default": "table",
+			"description": "Name of table"
+		},
+		"postgresdb.db_description": {
+			"type": "string",
+			"title": "Database description",
+			"default": "",
+			"description": "What is this database used for? Describe its content and purpose — this helps the LLM generate more accurate queries.",
+			"ui": {
+				"ui:widget": "textarea"
+			}
+		},
+		"postgresdb.max_attempts": {
+			"type": "integer",
+			"title": "Max validation attempts",
+			"default": 5,
+			"minimum": 1,
+			"maximum": 20,
+			"description": "Maximum number of times to re-ask the LLM if EXPLAIN rejects the generated SQL"
+		},
+		"postgresdb.allow_execute": {
+			"type": "boolean",
+			"title": "Allow direct query execution",
+			"default": false,
+			"description": "Permit QuestionType.EXECUTE callers to run raw SQL without LLM translation or safety checks. Leave OFF unless a trusted application explicitly needs to issue SQL directly."
+		},
+		"postgresdb.default": {
+			"object": "default",
+			"properties": ["postgresdb.db_description", "postgresdb.host", "postgresdb.user", "postgresdb.password", "postgresdb.database", "postgresdb.table", "postgresdb.max_attempts", "postgresdb.allow_execute"]
+		},
+		"postgresdb.profile": {
+			"hidden": true,
+			"type": "string",
+			"default": "default",
+			"enum": [["default", "Default"]],
+			"conditional": [
+				{
+					"value": "default",
+					"properties": ["postgresdb.default"]
+				}
+			]
+		}
+	},
+	//
+	// Required:
+	//		Defines the fields (shape) of the service. Either source or target
+	//		may be specified, or both, but at least one is required
+	//
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Supabase",
+			"properties": ["postgresdb.profile"]
+		}
+	]
+}

--- a/nodes/src/nodes/db_postgres/supabase.svg
+++ b/nodes/src/nodes/db_postgres/supabase.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none">
+  <!-- Supabase bolt/lightning mark — simplified clean path, official brand color #3ECF8E -->
+  <path
+    d="M13.5 2.5L4 14h8l-1.5 7.5L20 10h-8l1.5-7.5z"
+    fill="#3ECF8E"
+    stroke="none"
+  />
+</svg>


### PR DESCRIPTION
## Summary

- Add Supabase as a branded preset of `db_postgres` (a `services.supabase.json` catalog entry + icon, reusing the PostgreSQL implementation — no new code).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Supabase and PostgreSQL database integration node. Users can now connect to Supabase instances with configurable connection parameters (host, credentials, database, table selection), manage connection retry attempts, and control query execution behavior. Includes complete node documentation and configuration support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->