### PR TITLE
ci(release): populate GitHub Release notes from CHANGELOG

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -319,15 +319,25 @@ jobs:
 
       - name: Set release body
         id: release_body
-        if: inputs.prerelease
         run: |
+          # Pull the top CHANGELOG section (everything from the first "## ["
+          # header to the next one) so the GitHub Release shows the real,
+          # human-written change list instead of just the batched stage->main
+          # merge PR that generate_release_notes would otherwise emit.
+          NOTES="$(awk '/^## \[/{c++} c==1{print} c==2{exit}' CHANGELOG.md | sed '1d')"
           {
             echo 'body<<RELEASE_BODY'
-            echo "Automated nightly prerelease from \`${{ github.ref_name }}\`."
-            echo ""
-            echo "**${{ matrix.name }}** v${{ matrix.version }}"
+            if [ "${{ inputs.prerelease }}" = "true" ]; then
+              echo "_Automated nightly prerelease from \`${{ github.ref_name }}\` — **${{ matrix.name }}** v${{ matrix.version }}._"
+              echo ""
+            fi
+            if [ -n "$NOTES" ]; then
+              echo "$NOTES"
+            else
+              echo "**${{ matrix.name }}** v${{ matrix.version }}"
+            fi
             echo 'RELEASE_BODY'
-          } >> $GITHUB_OUTPUT
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
         if: inputs.prerelease || steps.tag_check.outputs.exists == 'false'


### PR DESCRIPTION
## Why
Real-release GitHub Releases have **empty/useless notes**: we batch everything through one stage→main PR, so `generate_release_notes` only emits that single merge-PR title (e.g. `server-v3.2.1` = *"release: stage → main (#1014)"*). The rich content lives in `CHANGELOG.md`. Po-Hsu (AI Growth) had to ask Engineering manually for newsletter content (2026-06-03).

## What
- The `Set release body` step was gated to **prereleases only** (`if: inputs.prerelease`) — so real releases got an empty body. Dropped that gate.
- It now extracts the **top CHANGELOG section** (first `## [` block → next `## [`) and uses it as the release body, for both prereleases and real releases.
- `generate_release_notes` still appends GitHub's auto compare-link/PR list below the real notes.

Validated the `awk` extraction against the current CHANGELOG: pulls the full `[Unreleased]` section (349 lines), stops correctly before `[1.0.3]`.

## Follow-up
Version-stamp the `[Unreleased]` header on release (release-please style) so each release shows only its delta rather than the cumulative Unreleased set. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)