### PR TITLE
fix(shell-ui): surface MF app load failures instead of hanging on "Loading..."

### DIFF
--- a/apps/shell-ui/src/components/layout/ShellLayout.tsx
+++ b/apps/shell-ui/src/components/layout/ShellLayout.tsx
@@ -47,6 +47,7 @@ import Sidebar from './Sidebar';
 import StatusBar from './StatusBar';
 import DebugPanel from './DebugPanel';
 import type { ShellConfig } from '../../workspace/types';
+import { commonStyles } from 'shared/themes/styles';
 
 // =============================================================================
 // STYLES
@@ -78,6 +79,39 @@ const styles = {
 		color: 'var(--rr-text-secondary)',
 		fontFamily: 'var(--rr-font-family)',
 		fontSize: 13,
+	} as CSSProperties,
+	// Load-failure state — fills the same client-area slot as appLoading but
+	// stacks a title/message/Retry, mirroring AppErrorBoundary's error screen.
+	appLoadError: {
+		display: 'flex',
+		flex: 1,
+		flexDirection: 'column',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: 16,
+		padding: 40,
+		fontFamily: 'var(--rr-font-family)',
+		color: 'var(--rr-text-primary)',
+		backgroundColor: 'var(--rr-bg-default)',
+		textAlign: 'center',
+	} as CSSProperties,
+	appLoadErrorTitle: {
+		fontSize: 18,
+		fontWeight: 700,
+		color: 'var(--rr-color-error, #ef4444)',
+	} as CSSProperties,
+	appLoadErrorMessage: {
+		fontSize: 13,
+		color: 'var(--rr-text-secondary)',
+		maxWidth: 480,
+		lineHeight: 1.6,
+		wordBreak: 'break-word',
+	} as CSSProperties,
+	appLoadErrorButton: {
+		...commonStyles.buttonPrimary,
+		padding: '8px 20px',
+		fontWeight: 600,
+		marginTop: 8,
 	} as CSSProperties,
 	overlayContainer: {
 		position: 'relative',
@@ -122,7 +156,7 @@ export interface ShellLayoutProps {
 export const ShellLayout: React.FC<ShellLayoutProps> = ({
 	config, isConnected, statusMessage, hideAppSwitcher, defaultAppId,
 }) => {
-	const { loaded, seeded, appLoading, prefs, activeAppId, loadedApps, settings, appManifest } = useWorkspace();
+	const { loaded, seeded, appLoading, prefs, activeAppId, loadedApps, settings, appManifest, appLoadErrors, retryApp } = useWorkspace();
 
 	// --- Merge API config: build-time -> setting defaults -> user settings ----
 	const mergedApiConfig = useMemo(() => {
@@ -231,6 +265,16 @@ export const ShellLayout: React.FC<ShellLayoutProps> = ({
 									identity={identity}
 								/>
 							</AppErrorBoundary>
+						) : appLoadErrors[activeAppId] ? (
+							<div style={styles.appLoadError}>
+								<div style={styles.appLoadErrorTitle}>Could not load {activeManifest?.name ?? activeAppId}</div>
+								<div style={styles.appLoadErrorMessage} role="alert">
+									{appLoadErrors[activeAppId]}
+								</div>
+								<button type="button" style={styles.appLoadErrorButton} onClick={() => retryApp(activeAppId)}>
+									Retry
+								</button>
+							</div>
 						) : appLoading || !activeApp ? (
 							<div style={styles.appLoading}>Loading...</div>
 						) : null}

--- a/apps/shell-ui/src/workspace/WorkspaceContext.tsx
+++ b/apps/shell-ui/src/workspace/WorkspaceContext.tsx
@@ -101,6 +101,10 @@ export interface IWorkspaceContext {
 	loadedApps: Record<string, AppDescriptor>;
 	/** Triggers a lazy load of an app's descriptor if not already loaded. */
 	loadApp: (appId: string) => void;
+	/** Per-app descriptor load-failure messages, keyed by appId. Absent ⇒ no error. */
+	appLoadErrors: Record<string, string>;
+	/** Clears the recorded load error for an app and re-attempts its descriptor load. */
+	retryApp: (appId: string) => void;
 	/** Persisted settings — keyed by setting key (e.g. 'ROCKETRIDE_OPENAI_KEY'). */
 	settings: Record<string, string>;
 	/** Persist a single setting value. */
@@ -174,6 +178,12 @@ export const WorkspaceProvider: React.FC<{
 	const loadedAppsRef = useRef<Record<string, AppDescriptor>>({});
 	// Tracks which appIds currently have an in-flight load
 	const loadingSetRef = useRef<Set<string>>(new Set());
+	// Tracks appIds whose load has FAILED so the auto-load effect won't silently
+	// re-attempt them (only retryApp clears this). Directly mutated, like loadingSetRef.
+	const failedSetRef = useRef<Set<string>>(new Set());
+	// Per-app descriptor load-failure messages, keyed by appId (surfaced to the UI
+	// so a failed remote shows an error + Retry instead of an indefinite "Loading…")
+	const [appLoadErrors, setAppLoadErrors] = useState<Record<string, string>>({});
 
 	// Keep the ref mirror up to date
 	useEffect(() => { loadedAppsRef.current = loadedApps; }, [loadedApps]);
@@ -191,6 +201,9 @@ export const WorkspaceProvider: React.FC<{
 		if (loadedAppsRef.current[appId]) { return; }
 		// Skip if a load is already in flight
 		if (loadingSetRef.current.has(appId)) { return; }
+		// Skip if this app already failed — only retryApp re-attempts it (it clears
+		// failedSetRef first), so the auto-load effect can't silently re-arm the load.
+		if (failedSetRef.current.has(appId)) { return; }
 		// Find the manifest entry
 		const entry = apps.find((a) => a.id === appId);
 		if (!entry) return;
@@ -198,6 +211,8 @@ export const WorkspaceProvider: React.FC<{
 		// Mark as in-flight and raise loading flag
 		loadingSetRef.current.add(appId);
 		setAppLoading(true);
+		// A fresh (re)attempt clears any stale error recorded for this app
+		setAppLoadErrors((prev) => { if (!prev[appId]) return prev; const next = { ...prev }; delete next[appId]; return next; });
 		try {
 			// Load with timeout to avoid indefinite hangs on unreachable remotes
 			const APP_LOAD_TIMEOUT = 15000;
@@ -211,17 +226,32 @@ export const WorkspaceProvider: React.FC<{
 			// Validate the descriptor has the minimum required shape
 			if (!descriptor || !descriptor.components?.App) {
 				console.error(`[WorkspaceContext] Invalid AppDescriptor for "${appId}": missing components.App`);
+				failedSetRef.current.add(appId);
+				setAppLoadErrors((prev) => ({ ...prev, [appId]: `App "${appId}" loaded but is missing its UI (components.App) — the bundle may be stale or only partially deployed.` }));
 				return;
 			}
 
 			setLoadedApps((prev) => ({ ...prev, [appId]: descriptor }));
 		} catch (e) {
 			console.error(`[WorkspaceContext] Failed to load AppDescriptor for "${appId}":`, e);
+			failedSetRef.current.add(appId);
+			setAppLoadErrors((prev) => ({ ...prev, [appId]: (e instanceof Error ? e.message : String(e)) || `App "${appId}" failed to load.` }));
 		} finally {
 			loadingSetRef.current.delete(appId);
 			if (loadingSetRef.current.size === 0) setAppLoading(false);
 		}
 	}, [apps]);
+
+	/**
+	 * Re-attempts an app's descriptor load after a failure. Clears the failure
+	 * marker synchronously (failedSetRef is what stops the auto-load effect from
+	 * silently re-trying a down app, so an explicit retry must clear it first);
+	 * loadDescriptor itself clears the displayed error when the attempt starts.
+	 */
+	const retryApp = useCallback((appId: string) => {
+		failedSetRef.current.delete(appId);
+		loadDescriptor(appId);
+	}, [loadDescriptor]);
 
 	// Load the active app's descriptor once workspace state is ready
 	// (seeded is enough — don't wait for the full disk load)
@@ -320,6 +350,7 @@ export const WorkspaceProvider: React.FC<{
 			appManifest: apps,
 			loadedApps,
 			loadApp: loadDescriptor,
+			appLoadErrors, retryApp,
 			settings, updateSetting,
 			updatePrefs, themeOptions, setTheme, dispatch, emit, on,
 		}}>


### PR DESCRIPTION
## Problem

When a Module-Federation remote fails to load — a timeout, a network/parse error (the `Uncaught SyntaxError: Unexpected token '<'` you get when a remote 404s to the SPA HTML fallback and the browser parses HTML as JS), or a descriptor missing `components.App` — `loadDescriptor` only `console.error`'d the failure. There was **no error state**, and `ShellLayout` treated "no descriptor yet" identically to "still loading":

```tsx
activeApp ? <App/> : (appLoading || !activeApp) ? "Loading..." : null
```

On failure `activeApp` is `undefined` and `appLoading` is `false`, so `false || true` → **"Loading…" forever.** This is the exact silent failure mode behind the **2026-06-02 cloud.rocketride.ai outage** — neither users nor we had any signal which remote broke or why.

## Fix

**`WorkspaceContext.tsx`**
- Add `appLoadErrors: Record<appId, string>` + `retryApp(appId)` to the workspace context.
- Record the failure (guaranteed non-empty message) in **both** failure paths — the `catch` and the invalid-descriptor branch.
- A `failedSetRef` guard makes "failed" a **stable** state: the auto-load `useEffect` (which re-fires on the `seeded→loaded` transition and on app-switch) won't silently re-attempt a down remote and re-arm the 15s timeout. Only `retryApp` clears the marker, so retry is explicit. (A `failedSetRef` *ref* — not a state mirror — is required so `retryApp` can clear it synchronously before calling `loadDescriptor`; a state mirror would lag a render and block the retry.)

**`ShellLayout.tsx`**
- Render an error card **before** the loading branch when `appLoadErrors[activeAppId]` is set: a title naming the failed app (from its **manifest** entry — the descriptor is gone on failure, so `activeManifest.name`), the error detail (`role="alert"`), and a **Retry** button. Styling mirrors `AppErrorBoundary` so the load-error and runtime-crash screens read as one design.

## Three-state model

The render chain becomes `loaded → error → loading → null`. Ordering is load-bearing: the error arm must sit **above** `appLoading || !activeApp`, because `!activeApp` is still `true` on failure.

## Coordination

- **Standalone, develop-based.** Touches `WorkspaceContext.tsx` (which #1078 / `feat/billing-3` does **not** open) and one ternary in `ShellLayout.tsx`.
- **#1078 adjacency:** #1078 prepends a `subGateActive` arm to the same `ShellLayout` ternary head. Whichever lands second resolves to:
  ```tsx
  subGateActive ? <SubGate>
    : activeApp?.components?.App ? <App>
    : appLoadErrors[activeAppId] ? <LoadError>
    : (appLoading || !activeApp) ? <Loading>
    : null
  ```
  ~30s rebase; semantically independent (subGate is an outer guard).
- **Ryan / Rod** — this is in shell-ui (Ryan's domain) and Rod scoped the MF error-display as joint work. I diagnosed + drafted it as a concrete starting point; happy for you to take it, tweak, or fold into #1078.

## Verification

Static reasoning + a 3-lens adversarial review (React-correctness, TypeScript/lint-strict, conventions/a11y) — the wrong-app-name bug and a silent auto-retry were caught in review and fixed here. No local build (deps aren't installed in my checkout), so **CI is the authoritative typecheck/lint.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and display when applications fail to load, providing users with informative feedback instead of generic loading indicators.

* **New Features**
  * Added a "Retry" button that enables users to attempt reloading failed applications without leaving the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->