### PR TITLE
fix(tool_tavily): backport CodeRabbit hardening to stage (SSRF CGNAT, non-dict guard, 5xx test)

### DIFF
--- a/nodes/src/nodes/tool_tavily/IInstance.py
+++ b/nodes/src/nodes/tool_tavily/IInstance.py
@@ -195,6 +195,8 @@ def _shape_results(query: str, body: Dict[str, Any]) -> Dict[str, Any]:
     """Map a Tavily response body into the tool's output schema, dropping unsafe URLs."""
     results = []
     for item in body.get('results', []) or []:
+        if not isinstance(item, dict):
+            continue
         url = item.get('url', '')
         if not url:
             continue

--- a/nodes/test/test_tool_tavily.py
+++ b/nodes/test/test_tool_tavily.py
@@ -116,3 +116,13 @@ def test_shape_results_maps_tavily_fields():
     assert shaped['results'][0]['score'] == 0.9
     assert shaped['results'][0]['content'] == 'snippet'
     assert shaped['results'][0]['published_date'] is None
+
+
+def test_shape_results_skips_non_dict_items():
+    # A malformed upstream payload may contain scalar/string entries; they must
+    # be skipped rather than raising AttributeError on item.get(...).
+    body = {'results': ['oops', None, 42, {'url': 'https://example.com', 'title': 'T'}]}
+    shaped = mod._shape_results('q', body)
+    assert shaped['success'] is True
+    assert shaped['num_results'] == 1
+    assert shaped['results'][0]['url'] == 'https://example.com'

--- a/packages/ai/src/ai/common/utils/url_utils.py
+++ b/packages/ai/src/ai/common/utils/url_utils.py
@@ -10,9 +10,10 @@ from urllib.parse import urlparse
 def validate_public_url(raw_url: str) -> str:
     """Return ``raw_url`` if it points at a public host; raise ``ValueError`` otherwise.
 
-    Rejects non-http(s) URLs and hosts that resolve to private, loopback,
-    link-local, reserved, multicast, or unspecified addresses. Use this before
-    following or returning URLs supplied by third-party APIs to prevent SSRF.
+    Rejects non-http(s) URLs and hosts that resolve to any non-global address
+    (private, loopback, link-local, reserved, multicast, unspecified, or
+    shared/CGNAT 100.64.0.0/10). Use this before following or returning URLs
+    supplied by third-party APIs to prevent SSRF.
     """
     parsed = urlparse(raw_url)
     if parsed.scheme not in ('http', 'https') or not parsed.hostname:
@@ -23,13 +24,9 @@ def validate_public_url(raw_url: str) -> str:
         raise ValueError(f'Unresolved URL host: {parsed.hostname}') from e
     for _, _, _, _, sockaddr in addrinfo:
         ip = ipaddress.ip_address(sockaddr[0])
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or ip.is_unspecified
-        ):
+        # ``is_global`` is False for every reserved range (private, loopback,
+        # link-local, reserved, multicast, unspecified) *and* shared/CGNAT
+        # space (100.64.0.0/10), which the individual flags miss.
+        if not ip.is_global:
             raise ValueError(f'Blocked non-public URL host: {parsed.hostname}')
     return raw_url

--- a/packages/ai/tests/ai/common/utils/test_http_retry.py
+++ b/packages/ai/tests/ai/common/utils/test_http_retry.py
@@ -74,6 +74,19 @@ def test_retries_429_then_succeeds(monkeypatch):
     assert calls['n'] == 2
 
 
+def test_retries_5xx_then_succeeds(monkeypatch):
+    calls = {'n': 0}
+    ok = _FakeResp(200, {})
+
+    def fake_post(*a, **k):
+        calls['n'] += 1
+        return _FakeResp(500) if calls['n'] == 1 else ok
+
+    _patch_post(monkeypatch, fake_post)
+    assert post_with_retry('https://api.example.com', base_delay=0) is ok
+    assert calls['n'] == 2
+
+
 def test_does_not_retry_4xx(monkeypatch):
     calls = {'n': 0}
 

--- a/packages/ai/tests/ai/common/utils/test_url_utils.py
+++ b/packages/ai/tests/ai/common/utils/test_url_utils.py
@@ -50,6 +50,14 @@ def test_rejects_private_resolved_host(monkeypatch):
         validate_public_url('https://internal.example.com/admin')
 
 
+def test_rejects_cgnat_resolved_host(monkeypatch):
+    # 100.64.0.0/10 is shared/CGNAT space: is_private is False but is_global is
+    # also False, so the old per-flag check let it through. is_global blocks it.
+    _stub_resolve(monkeypatch, '100.64.0.1')
+    with pytest.raises(ValueError):
+        validate_public_url('https://carrier-nat.example.com/internal')
+
+
 def test_rejects_unresolvable_host(monkeypatch):
     def _boom(*a, **k):
         raise socket.gaierror('name resolution failed')


### PR DESCRIPTION
## Why

`tool_tavily` shipped to `stage` via #1072 to make the Nebius event cut. When the same code was opened against `develop` (#1097), CodeRabbit surfaced three latent issues that were therefore **also present on `stage`**:

1. **SSRF gap (security)** — `validate_public_url` checked individual flags (`is_private`, `is_loopback`, …) and missed shared/CGNAT space (`100.64.0.0/10`). Switched to `not ip.is_global`, which covers every reserved range *plus* CGNAT.
2. **Crash on malformed payload** — `_shape_results` assumed every entry in the Tavily `results` array is a dict; a scalar/string entry would raise `AttributeError`. Now skips non-dict items.
3. **Missing test coverage** — no test exercised the 5xx retry branch in `post_with_retry`. Added it, plus CGNAT and non-dict regression tests.

## What

Cherry-pick of the same hardening commit merged-bound for `develop` in #1097, applied cleanly onto `stage` so the event build carries the fixes too — most importantly the SSRF tightening.

No behaviour change for well-formed inputs. Part of #1047. Mirrors #1097.

🤖 Generated with [Claude Code](https://claude.com/claude-code)