### PR TITLE
docs: sync node catalog, services.json model, and missing node READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 </p>
 
 <p>
- RocketRide is an open-source data pipeline builder and runtime built for AI and ML workloads. With 50+ pipeline nodes spanning 13 LLM providers, 8 vector databases, OCR, NER, and more — pipelines are defined as portable JSON, built visually in VS Code, and executed by a multithreaded C++ runtime. From real-time data processing to multimodal AI search, RocketRide runs entirely on your own infrastructure.
+ RocketRide is an open-source data pipeline builder and runtime built for AI and ML workloads. With 85+ pipeline nodes (110+ services) spanning 13 LLM providers, 8 vector databases, OCR, NER, and more — pipelines are defined as portable JSON, built visually in VS Code, and executed by a multithreaded C++ runtime. From real-time data processing to multimodal AI search, RocketRide runs entirely on your own infrastructure.
 </p>
 
 <p>
@@ -50,7 +50,7 @@ _Drop pipelines into any Python or TypeScript app with a few lines of code, no i
 | :-------------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Visual Pipeline Builder**       | Drag, connect, and configure nodes in VS Code — no boilerplate. Real-time observability tracks token usage, LLM calls, latency, and execution. Pipelines are portable JSON — version-controllable, shareable, and runnable anywhere. |
 | **High-Performance C++ Runtime**  | Native multithreading purpose-built for the throughput demands of AI and data workloads. No bottlenecks, no compromises for production scale.                                                                                        |
-| **50+ Pipeline Nodes**            | 13 LLM providers, 8 vector databases, OCR, NER, PII anonymization, chunking strategies, embedding models, and more. All nodes are Python-extensible — build and publish your own.                                                    |
+| **85+ Pipeline Nodes**            | 13 LLM providers, 8 vector databases, OCR, NER, PII anonymization, chunking strategies, embedding models, and more. All nodes are Python-extensible — build and publish your own.                                                    |
 | **Multi-Agent Workflows**         | Built-in CrewAI and LangChain support. Chain agents, share memory across pipeline runs, and manage multi-step reasoning at scale.                                                                                                    |
 | **Coding Agent Ready**            | RocketRide auto-detects your coding agent — Claude, Cursor, and more. Build, modify, and deploy pipelines through natural language.                                                                                                  |
 | **TypeScript, Python & MCP SDKs** | Integrate pipelines into native apps, expose them as callable tools for AI assistants, or build programmatic workflows into your existing codebase.                                                                                  |

--- a/docs/README-node-schema.md
+++ b/docs/README-node-schema.md
@@ -1,7 +1,7 @@
 # Node Service Definitions (`services.json`)
 
-Every pipeline node is declared by one or more **`services*.json`** files in
-`nodes/src/nodes/<node>/`. This single file does three jobs:
+A node lives in `nodes/src/nodes/<node>/` and is defined by one or more
+**`services*.json`** files. That one file pulls triple duty:
 
 1. **Registers** the node with the engine (protocol, class, executable).
 2. **Declares how it connects** to other nodes (`lanes`).

--- a/docs/README-node-schema.md
+++ b/docs/README-node-schema.md
@@ -1,0 +1,158 @@
+# Node Service Definitions (`services.json`)
+
+Every pipeline node is declared by one or more **`services*.json`** files in
+`nodes/src/nodes/<node>/`. This single file does three jobs:
+
+1. **Registers** the node with the engine (protocol, class, executable).
+2. **Declares how it connects** to other nodes (`lanes`).
+3. **Describes its configuration UI**, which the visual canvas renders
+   automatically (`preconfig`, `profiles`, `fields`, `shape`).
+
+A directory may contain several definitions (`services.chat.json`,
+`services.manager.json`, …); each registers a separate service/variant. The files
+are **JSONC** — `//` comments and trailing commas are allowed, so they cannot be
+read with a strict JSON parser.
+
+> For the catalog of all nodes and how they wire together, see
+> [README-nodes.md](README-nodes.md). For testing, see
+> [README-node-testing.md](README-node-testing.md).
+
+---
+
+## Top-level keys
+
+| Key             | Required | Purpose                                                                 |
+| --------------- | :------: | ----------------------------------------------------------------------- |
+| `title`         |    ✓     | Display name shown on the canvas tile.                                   |
+| `protocol`      |    ✓     | Endpoint protocol, e.g. `llm_openai://`.                                 |
+| `classType`     |    ✓     | What the node is, e.g. `["llm"]`, `["tool"]`, `["store"]`. Drives catalog grouping and behavior. |
+| `capabilities`  |    ✓     | Engine behavior flags, e.g. `["invoke"]`.                               |
+| `register`      |          | `filter`, `endpoint`, or omitted. Registers a factory of that type.      |
+| `node` / `path` |          | Runtime (`python`) and module path (`nodes.llm_openai`).                |
+| `prefix`        |    ✓     | Prefix added/removed when converting URLs ⇄ paths.                       |
+| `description`   |          | Array of strings (joined) describing the node.                          |
+| `icon`          |          | SVG filename next to the definition (auto-discovered, auto-themed).     |
+| `tile`          |          | Rendering hints shown on the canvas tile.                               |
+| `lanes`         |          | **Data-flow ports** (see below). Absent for `tool` nodes.              |
+| `preconfig`     |          | Default profile + named `profiles` merged into config.                 |
+| `fields`        |          | Config field schema the canvas renders (RJSF).                         |
+| `shape`         |          | Layout of fields into UI sections.                                     |
+| `test`          |          | Automated test cases (see README-node-testing.md).                     |
+
+---
+
+## `lanes` — how the node connects (data flow)
+
+`lanes` maps each **input** lane to the list of **output** lanes it produces:
+
+```jsonc
+"lanes": {
+  "image": ["text"]   // consumes `image`, produces `text`
+}
+```
+
+Two nodes are wire-compatible when an upstream **output** type matches a
+downstream **input** type. Nodes with **no `lanes`** (most `tool` nodes) do not
+flow data — they **bind to an agent's tool channel** instead. The full lane-type
+ontology and the wire-vs-bind rule live in
+[README-nodes.md → How nodes connect](README-nodes.md#how-nodes-connect).
+
+---
+
+## `preconfig` and `profiles` — preset configurations
+
+`preconfig` holds the default profile name and a map of named **profiles**. A
+profile is a preset bundle of values (model, token limits, etc.) merged into the
+node config unless the profile is `absolute`:
+
+```jsonc
+"preconfig": {
+  "default": "gemini-2.5-flash",
+  "profiles": {
+    "gemini-2.5-flash": { "title": "Gemini 2.5 Flash", "model": "gemini-2.5-flash", "modelTotalTokens": 1048576, "apikey": "" },
+    "gemini-2.5-pro":   { "title": "Gemini 2.5 Pro",   "model": "gemini-2.5-pro",   "modelTotalTokens": 1048576, "apikey": "" }
+  }
+}
+```
+
+---
+
+## `fields` — the configuration schema (rendered by the canvas)
+
+`fields` is a JSON-Schema-flavored description of every configurable value. The
+canvas renders it with **RJSF (React JSON Schema Form)**, so each field becomes a
+form control automatically. Supported per-field keys include `type`, `title`,
+`description`, `default`, `format` (e.g. `textarea`), and `enum`:
+
+```jsonc
+"accessibility.spatialFormat": {
+  "type": "string",
+  "title": "Spatial Format",
+  "default": "clock",
+  "enum": [
+    ["clock", "Clock positions (12 o'clock, 3 o'clock)"],
+    ["relative", "Relative (left, right, ahead, behind)"]
+  ]
+}
+```
+
+Two dynamic features are used heavily:
+
+- **Profile selector** — a field (commonly `<node>.profile`) whose options are
+  generated from the profiles via a reference pattern, and which swaps the visible
+  fields with `conditional`:
+
+  ```jsonc
+  "accessibility_describe.profile": {
+    "title": "Vision Model",
+    "type": "string",
+    "default": "gemini-2.5-flash",
+    "enum": ["*>preconfig.profiles.*.title"],          // options pulled from profiles
+    "conditional": [
+      { "value": "gemini-2.5-flash", "properties": ["accessibility_describe.gemini-2.5-flash"] },
+      { "value": "gemini-2.5-pro",   "properties": ["accessibility_describe.gemini-2.5-pro"] }
+    ]
+  }
+  ```
+
+- **Property groups** — an entry whose `properties` array lists which fields to
+  show together for a given profile/object.
+
+---
+
+## `shape` — UI layout
+
+`shape` arranges fields into labeled sections in the node's config panel:
+
+```jsonc
+"shape": [
+  { "section": "Pipe", "title": "Accessibility Describe", "properties": ["accessibility_describe.profile"] }
+]
+```
+
+---
+
+## How the canvas consumes this
+
+The visual builder (`packages/shared-ui/src/components/canvas/`) turns these
+definitions into the editor:
+
+- The node graph is rendered with **ReactFlow**; config panels with **RJSF**.
+- `NodeConfigPanel` renders `fields`/`shape` into the side panel, wires up custom
+  widgets (API-key, select, OAuth, …) from `canvas/components/rjsf-widgets/`, and
+  validates server-side.
+- Field defaults are resolved from the schema (`getDefaultFormState`) rather than
+  hardcoded, so `default` values in `fields`/`profiles` are what the user starts
+  with.
+
+You do **not** register nodes anywhere central: dropping a `services*.json` (plus
+its SVG) under `nodes/src/nodes/<node>/` is enough for the build to discover it.
+
+---
+
+## Full example
+
+`nodes/src/nodes/accessibility_describe/services.json` is a compact, complete
+example: metadata + `lanes` (`image → text`) + three Gemini `profiles` + `fields`
+with a conditional profile selector + a one-section `shape` + `test` cases. Read
+it alongside this document.

--- a/docs/README-nodes.md
+++ b/docs/README-nodes.md
@@ -1,9 +1,8 @@
 # Pipeline Nodes
 
-Pipeline nodes are modular components that extend the engine's data-processing
-capabilities. Each node handles one task — parsing documents, calling an LLM,
-storing embeddings in a vector database, transcribing audio, and so on — and
-nodes are composed into pipelines through their service definitions.
+A node is the unit you build pipelines from. Each one does a single job — parse a
+document, call an LLM, store embeddings, transcribe audio — and you chain them
+together through their service definitions.
 
 Every node is declared in one or more `services*.json` files under
 `nodes/src/nodes/<node>/`. A single directory may register **several services**
@@ -19,8 +18,9 @@ rather than directories.
 
 ## How nodes connect
 
-There are **two distinct ways** nodes relate to each other. Understanding both is
-essential when assembling a pipeline (and when asking an LLM to assemble one).
+Nodes connect in **two different ways**, and knowing which is which is the
+difference between a pipeline that runs and one that doesn't — whether you wire it
+by hand or hand the job to an LLM.
 
 ### 1. Data flow — typed lanes
 

--- a/docs/README-nodes.md
+++ b/docs/README-nodes.md
@@ -1,172 +1,270 @@
 # Pipeline Nodes
 
-Pipeline nodes are modular Python components that extend the engine's data processing capabilities. Each node handles a specific task -- parsing documents, calling an LLM, storing embeddings in a vector database, etc. -- and nodes are composed into pipelines via JSON configuration.
+Pipeline nodes are modular components that extend the engine's data-processing
+capabilities. Each node handles one task — parsing documents, calling an LLM,
+storing embeddings in a vector database, transcribing audio, and so on — and
+nodes are composed into pipelines through their service definitions.
 
-For information on testing nodes, see [README-node-testing.md](README-node-testing.md).
+Every node is declared in one or more `services*.json` files under
+`nodes/src/nodes/<node>/`. A single directory may register **several services**
+(for example `core`, `webhook`, `remote`, `agent_crewai`, and `index_search`
+each expose multiple variants), which is why the catalog below lists **services**
+rather than directories.
+
+> This catalog is generated from the `services*.json` definitions on `develop`
+> (87 node directories → 117 services). For node testing, see
+> [README-node-testing.md](README-node-testing.md).
 
 ---
 
-## LLM Providers
+## How nodes connect
 
-| Node                 | Description                                | Documentation                                             |
-| -------------------- | ------------------------------------------ | --------------------------------------------------------- |
-| `llm_openai`         | OpenAI GPT models                          |                                                           |
-| `llm_anthropic`      | Anthropic Claude                           |                                                           |
-| `llm_gemini`         | Google Gemini                              |                                                           |
-| `llm_bedrock`        | AWS Bedrock                                |                                                           |
-| `llm_ollama`         | Local Ollama models                        |                                                           |
-| `llm_mistral`        | Mistral AI                                 |                                                           |
-| `llm_perplexity`     | Perplexity AI (Sonar, web search)          | [README](../nodes/src/nodes/llm_perplexity/README.md)     |
-| `llm_deepseek`       | DeepSeek models                            |                                                           |
-| `llm_minimax`        | MiniMax models                             |                                                           |
-| `llm_xai`            | xAI (Grok)                                 |                                                           |
-| `llm_ibm_watson`     | IBM Watson                                 |                                                           |
-| `llm_nebius`         | Nebius AI (preset of `llm_openai_api` — defined via `services.nebius.json`, not a separate directory) | [README](../nodes/src/nodes/llm_openai_api/README.md)      |
-| `llm_gmi_cloud`      | GMI Cloud models                           |                                                           |
-| `llm_qwen`           | Qwen models                                |                                                           |
+There are **two distinct ways** nodes relate to each other. Understanding both is
+essential when assembling a pipeline (and when asking an LLM to assemble one).
 
-## Vision Models
+### 1. Data flow — typed lanes
 
-| Node                  | Description                                      | Documentation                                             |
-| --------------------- | ------------------------------------------------ | --------------------------------------------------------- |
-| `llm_vision_gemini`   | Google Gemini Vision (multimodal, image-to-text)  |                                                           |
-| `llm_vision_ollama`   | Ollama Vision (multimodal, image-to-text)         |                                                           |
-| `llm_vision_openai`   | OpenAI Vision (multimodal, image-to-text)         |                                                           |
-| `llm_vision_mistral`  | Mistral Vision (multimodal, image-to-text)        | [README](../nodes/src/nodes/llm_vision_mistral/README.md) |
+Most nodes exchange data over **lanes**. A lane is a typed port: a node declares
+which lane types it **consumes** (inputs) and which it **produces** (outputs) in
+its `lanes` block. Two nodes are wire-compatible when an **output lane type of
+the upstream node matches an input lane type of the downstream node**.
 
-## Vector Databases
+The complete lane-type ontology and who produces / consumes each type:
 
-| Node                | Description                 |
-| ------------------- | --------------------------- |
-| `chroma`            | Chroma DB                   |
-| `pinecone`          | Pinecone                    |
-| `milvus`            | Milvus                      |
-| `qdrant`            | Qdrant                      |
-| `weaviate`          | Weaviate                    |
-| `astra_db`          | Astra DB (DataStax)         |
-| `vectordb_postgres` | PostgreSQL pgvector         |
-| `atlas`             | MongoDB Atlas Vector Search |
+| Lane type   | Produced by | Consumed by | Meaning                                            |
+| ----------- | :---------: | :---------: | -------------------------------------------------- |
+| `questions` |     17      |     39      | A query/prompt envelope flowing toward a model     |
+| `answers`   |     36      |      6      | A model/agent response                             |
+| `documents` |     29      |     23      | Chunked/embeddable document records                |
+| `text`      |     23      |     15      | Plain text                                         |
+| `table`     |     10      |      5      | Structured/tabular data                            |
+| `image`     |      6      |     10      | Image payloads                                     |
+| `audio`     |      4      |      3      | Audio payloads                                     |
+| `video`     |      3      |      6      | Video payloads                                     |
+| `tags`      |      3      |      3      | Metadata/markers attached to records               |
+| `_source`   |      0      |      5      | Entry lane of **source** nodes (external triggers) |
 
-## Embeddings
+A typical RAG flow chains these types end to end:
+`webhook (_source → questions)` → `embedding_openai (questions → questions)` →
+`pinecone (questions → documents)` → `prompt (documents → questions)` →
+`llm_openai (questions → answers)` → `response (answers → —)`.
 
-| Node                    | Description                  |
-| ----------------------- | ---------------------------- |
-| `embedding_openai`      | OpenAI embeddings            |
-| `embedding_transformer` | Local transformer embeddings |
-| `embedding_image`       | Image embeddings             |
-| `embedding_video`       | Video embeddings             |
+### 2. Tool binding — agents and tools
 
-## Document Processing
+Nodes whose `classType` is `tool` (and a few infrastructure nodes) **have no data
+lanes**. They do not sit in the data flow. Instead they **attach to an agent node's
+tool channel** and are invoked on demand by the agent. A tool is agent-agnostic:
+the same `tool_github` or `tool_tavily` can attach to `agent_deepagent`,
+`agent_langchain`, `agent_crewai`, or `agent_rocketride`.
 
-| Node                     | Description                   | Documentation                                     |
-| ------------------------ | ----------------------------- | ------------------------------------------------- |
-| `llamaparse`             | LlamaParse document parser    | [README](../nodes/src/nodes/llamaparse/README.md) |
-| `reducto`                | Reducto document parser       |                                                   |
-| `ocr`                    | Optical character recognition |                                                   |
-| `preprocessor_langchain` | LangChain text splitters      |                                                   |
-| `preprocessor_llm`       | LLM-based preprocessing       |                                                   |
-| `preprocessor_code`      | Code preprocessing            |                                                   |
-| `extract_data`           | Structured data extraction    |                                                   |
-| `vectorizer`             | Text vectorization            |                                                   |
+> Rule of thumb: if a node has lanes, **wire** it into the flow. If it is a `tool`,
+> **bind** it to an agent. Mixing these up produces an invalid pipeline.
 
-## AI and Analysis
+---
 
-| Node               | Description              | Documentation                              |
-| ------------------ | ------------------------ | ------------------------------------------ |
-| `ner`              | Named Entity Recognition | [README](../nodes/src/nodes/ner/README.md) |
-| `anonymize`        | PII redaction            |                                            |
-| `summarization`    | Text summarization       |                                            |
-| `audio_transcribe` | Audio to text (Whisper)  |                                            |
-| `guardrails`         | Pipeline guardrails and safety checks |                                  |
-| `rerank_cohere`      | Cohere reranking                      |                                  |
-| `accessibility_describe` | Accessibility image descriptions  |                                  |
+## Catalog
 
-## Media
+### LLM Providers
 
-| Node            | Description            |
-| --------------- | ---------------------- |
-| `frame_grabber` | Video frame extraction |
-| `image_cleanup` | Image preprocessing    |
-| `thumbnail`     | Thumbnail generation   |
-| `audio_player`  | Audio playback         |
-| `audio_tts`     | Text-to-speech synthesis |
-| `twelvelabs`    | TwelveLabs video AI      |
+| Service          | Data flow (in → out) | Description                                  |
+| ---------------- | -------------------- | -------------------------------------------- |
+| `llm_openai`     | questions → answers  | OpenAI GPT models                            |
+| `llm_anthropic`  | questions → answers  | Anthropic Claude models                      |
+| `llm_gemini`     | questions → answers  | Google Gemini models                         |
+| `llm_bedrock`    | questions → answers  | Amazon Bedrock foundation models             |
+| `llm_ollama`     | questions → answers  | Locally-hosted models via Ollama             |
+| `llm_mistral`    | questions → answers  | Mistral AI models                            |
+| `llm_deepseek`   | questions → answers  | DeepSeek models                              |
+| `llm_minimax`    | questions → answers  | MiniMax models                               |
+| `llm_qwen`       | questions → answers  | Alibaba Qwen via DashScope                   |
+| `llm_xai`        | questions → answers  | xAI Grok models                              |
+| `llm_perplexity` | questions → answers  | Perplexity Sonar (web-search models)         |
+| `llm_gmi_cloud`  | questions → answers  | GMI Cloud models                             |
+| `llm_openai_api` | questions → answers  | Any OpenAI-compatible endpoint (also ships a Nebius Token Factory preset) |
 
-## Storage and Connectivity
+> `nodes/src/nodes/llm_ibm_watson/` exists but currently ships **no service
+> definition** (`services*.json`); it is not registered in the canvas. See
+> [open items](#open-items).
 
-| Node           | Description               |
-| -------------- | ------------------------- |
-| `remote`       | S3, Azure Blob, GCS       |
-| `db_mysql`     | MySQL database            |
-| `index_search` | Elasticsearch, OpenSearch |
-| `db_clickhouse` | ClickHouse database       |
-| `db_neo4j`      | Neo4j graph database      |
-| `db_postgres`   | PostgreSQL database       |
-| `search_exa`    | Exa search                |
-| `telegram`      | Telegram integration      |
+### Agents
 
-The `core` module provides built-in connectors for OneDrive, SharePoint, Google Drive, Outlook, Confluence, Jira, Slack, SMB, and filesystem sources. These are configured via pipeline JSON rather than as standalone nodes.
+| Service             | Data flow (in → out) | Description                                                |
+| ------------------- | -------------------- | --------------------------------------------------------- |
+| `agent_rocketride`  | questions → answers  | Native wave-planning agent built on the RocketRide engine |
+| `agent_langchain`   | questions → answers  | Single-agent execution using LangChain                    |
+| `agent_crewai`      | questions → answers  | CrewAI agent — standalone, hierarchical manager, and managed sub-agent variants |
+| `agent_deepagent`   | questions → answers  | Deep Agents — single-agent and managed sub-agent variants |
 
-## Pipeline Utilities
+### Agent Tools
 
-| Node                | Description                                                                                 |
-| ------------------- | ------------------------------------------------------------------------------------------- |
-| `question`          | Question routing                                                                            |
-| `response`          | Response formatting (text, documents, answers, audio, image, video, table, classifications) |
-| `prompt`            | Prompt construction                                                                         |
-| `webhook`           | Webhook integration (chat, dropper, ADS)                                                    |
-| `autopipe`          | Automatic pipeline routing                                                                  |
-| `dictionary`        | Dictionary lookups                                                                          |
-| `text_output`       | Text output                                                                                 |
-| `local_text_output` | Local text file output                                                                      |
-| `memory_internal`   | Internal conversation memory                                                                |
-| `memory_persistent` | Persistent conversation memory                                                              |
+Tool nodes (`classType: ["tool"]`) expose capabilities to agents over the tool
+channel; they have no data lanes and **bind to an agent** (see
+[Tool binding](#2-tool-binding--agents-and-tools)).
 
-## Agent Nodes
+| Service             | Description                                                       |
+| ------------------- | ---------------------------------------------------------------- |
+| `tool_tavily`       | Tavily real-time web search                                      |
+| `tool_exa_search`   | Exa semantic web search                                          |
+| `tool_firecrawl`    | Firecrawl web-scraping operations                                |
+| `tool_http_request` | Arbitrary HTTP requests — "curl for agents"                      |
+| `tool_github`       | GitHub repository operations                                     |
+| `tool_git`          | Local Git repository operations                                  |
+| `tool_filesystem`   | File-system access                                               |
+| `tool_python`       | Executes Python in a restricted in-process sandbox               |
+| `tool_pipe`         | Exposes an inline pipeline as a tool                             |
+| `tool_mcp_client`   | Connects to an external (or Butterbase) MCP server's tools       |
+| `tool_chartjs`      | Generates Chart.js v4 chart configs from data via the LLM        |
+| `tool_bland_ai`     | Places and manages AI phone calls via Bland AI                   |
+| `tool_xtrace_memory`| Long-term shared agent memory, backed by xTrace Memory Manager   |
 
-Agent nodes orchestrate multi-step reasoning with tool use.
+### Embeddings
 
-| Node                | Description                              |
-| ------------------- | ---------------------------------------- |
-| `agent_crewai`      | CrewAI multi-agent orchestration         |
-| `agent_deepagent`   | DeepAgent autonomous reasoning           |
-| `agent_langchain`   | LangChain agent framework                |
-| `agent_rocketride`  | Native RocketRide agent                  |
+| Service                 | Data flow (in → out)                         | Description                       |
+| ----------------------- | -------------------------------------------- | --------------------------------- |
+| `embedding_openai`      | documents, questions → documents, questions  | OpenAI text embeddings            |
+| `embedding_transformer` | documents, questions → documents, questions  | Local transformer text embeddings |
+| `embedding_image`       | documents, image → documents                 | Image embeddings                  |
+| `embedding_video`       | video → documents                            | Video embeddings (frame-based)    |
 
-## Agent Tools
+### Vector Databases & Stores
 
-Tool nodes (`classType: ["tool"]`) expose capabilities to agents via the control-plane invoke channel rather than data lanes.
+| Service             | Data flow (in → out)                                | Description                  |
+| ------------------- | --------------------------------------------------- | ---------------------------- |
+| `chroma`            | documents, questions → answers, documents, questions | Chroma DB                    |
+| `pinecone`          | documents, questions → answers, documents, questions | Pinecone                     |
+| `milvus`            | documents, questions → answers, documents, questions | Milvus                       |
+| `qdrant`            | documents, questions → answers, documents, questions | Qdrant                       |
+| `weaviate`          | documents, questions → answers, documents, questions | Weaviate                     |
+| `astra_db`          | documents, questions → answers, documents, questions | Astra DB (DataStax)          |
+| `atlas`             | documents, questions → answers, documents, questions | MongoDB Atlas Vector Search  |
+| `vectordb_postgres` | documents, questions → answers, documents, questions | PostgreSQL pgvector          |
+| `index_search`      | text, documents, questions → answers, documents, questions, text | Elasticsearch and OpenSearch (BM25 + vector) |
 
-| Node                 | Description                             | Documentation                                      |
-| -------------------- | --------------------------------------- | -------------------------------------------------- |
-| `tool_tavily`        | Tavily real-time web search for agents  | [README](../nodes/src/nodes/tool_tavily/README.md) |
-| `tool_bland_ai`      | Bland AI phone call tool                |                                                    |
-| `tool_chartjs`       | Chart.js chart generation               |                                                    |
-| `tool_exa_search`    | Exa search tool for agents              |                                                    |
-| `tool_filesystem`    | Filesystem operations                   |                                                    |
-| `tool_firecrawl`     | FireCrawl web scraping                  |                                                    |
-| `tool_git`           | Git operations                          |                                                    |
-| `tool_github`        | GitHub API operations                   |                                                    |
-| `tool_http_request`  | HTTP request tool                       |                                                    |
-| `tool_mcp_client`    | MCP client tool                         |                                                    |
-| `tool_pipe`          | Pipeline-to-pipeline invocation         |                                                    |
-| `tool_python`        | Python code execution                   |                                                    |
-| `tool_xtrace_memory` | XTrace memory tool                      |                                                    |
+### Databases
 
-Like any tool node, these are agent-agnostic: they attach to any agent node's tool channel (e.g. `agent_deepagent`, `agent_langchain`, `agent_crewai`).
+| Service         | Data flow (in → out)               | Description                                  |
+| --------------- | ---------------------------------- | -------------------------------------------- |
+| `db_postgres`   | answers, questions → answers, table, text | PostgreSQL and Supabase (insert + NL-to-SQL) |
+| `db_mysql`      | answers, questions → answers, table, text | MySQL                                        |
+| `db_clickhouse` | questions → answers, table, text   | ClickHouse (NL-to-SQL)                       |
+| `db_neo4j`      | questions → answers, table, text   | Neo4j graph database                         |
 
-## Internal
+### Document Processing
 
-| Node       | Description                                                           |
-| ---------- | --------------------------------------------------------------------- |
-| `llm_base` | Compatibility wrapper; canonical base is `ai.common.llm_base.LLMBase` |
-| `core`     | Core services (cloud connectors, parsing, etc.)                       |
+| Service                  | Data flow (in → out)   | Description                                  |
+| ------------------------ | ---------------------- | -------------------------------------------- |
+| `llamaparse`             | tags → table, text     | LlamaParse document parser                   |
+| `reducto`                | tags → table, text     | Reducto document parser                      |
+| `preprocessor_langchain` | table, text → documents | LangChain text splitters / chunking          |
+| `preprocessor_llm`       | table, text → documents | LLM-based summarization / key-point chunking |
+| `preprocessor_code`      | text → documents       | Source-code tokenization                     |
+
+> Generic parsing and content hashing are also provided by the **`core`** module
+> (see [Core module](#core-module)).
+
+### Text & Analysis
+
+| Service         | Data flow (in → out)                       | Description                                  |
+| --------------- | ------------------------------------------ | -------------------------------------------- |
+| `question`      | text → questions                           | Wraps input text into a Question envelope    |
+| `prompt`        | documents, text, table, questions → questions | Merges multiple inputs into one question  |
+| `extract_data`  | table, text → answers, documents           | Extracts structured data from text           |
+| `ner`           | text, documents → documents, text          | Named Entity Recognition                     |
+| `anonymize`     | text → text                                | PII detection and redaction                  |
+| `summarization` | text → documents, text                     | Summaries and key points                     |
+| `dictionary`    | text → documents                           | Extracts a dictionary of key terms           |
+
+### Image
+
+| Service                  | Data flow (in → out)        | Description                                  |
+| ------------------------ | --------------------------- | -------------------------------------------- |
+| `llm_vision_openai`      | image, documents → documents, text | OpenAI vision models (analysis, OCR)  |
+| `llm_vision_gemini`      | image, documents → documents, text | Google Gemini vision models           |
+| `llm_vision_mistral`     | image, documents → documents, text | Mistral vision models                 |
+| `llm_vision_ollama`      | image, documents → documents, text | Local vision models via Ollama        |
+| `accessibility_describe` | image → text                | Scene descriptions for accessibility         |
+| `ocr`                    | documents, image → table, text | Optical character recognition             |
+| `image_cleanup`          | image → image               | Image preprocessing (grayscale, denoise) for OCR |
+| `thumbnail`              | image, documents → documents, image | Thumbnail generation                 |
+
+### Audio
+
+| Service            | Data flow (in → out)                        | Description                                  |
+| ------------------ | ------------------------------------------- | -------------------------------------------- |
+| `audio_transcribe` | audio, video → text                         | Speech-to-text transcription                 |
+| `audio_tts`        | text, documents, questions, answers → audio | Text-to-speech (Kokoro-82M)                  |
+| `audio_player`     | audio, video → —                            | Plays audio on the system output device      |
+
+### Video
+
+| Service         | Data flow (in → out)                | Description                          |
+| --------------- | ----------------------------------- | ------------------------------------ |
+| `frame_grabber` | video → documents, image, table     | Extracts frames from video           |
+| `twelvelabs`    | video → text                        | TwelveLabs video understanding       |
+
+### Sources
+
+| Service    | Data flow (in → out)                              | Description                                  |
+| ---------- | ------------------------------------------------- | -------------------------------------------- |
+| `webhook`  | _source → questions / tags / audio, image, text, video … | HTTP intake — chat, dropper, and ADS variants |
+| `telegram` | _source → audio, image, tags, text, video         | Telegram Bot message source                  |
+
+> Filesystem and cloud connector sources (Google Drive, OneDrive, SharePoint,
+> Slack, Confluence, SMB, S3, Azure Blob, GCS, …) are provided by the **`core`**
+> module (see [Core module](#core-module)).
+
+### Memory
+
+| Service             | Data flow (in → out)                 | Description                                  |
+| ------------------- | ------------------------------------ | -------------------------------------------- |
+| `memory_persistent` | questions, answers → answers, questions | Cross-session persistent memory           |
+| `memory_internal`   | — (agent tool)                       | Run-scoped keyed memory exposed as agent tools |
+
+### Safety, Reranking & Search
+
+| Service         | Data flow (in → out)                                  | Description                                  |
+| --------------- | ----------------------------------------------------- | -------------------------------------------- |
+| `guardrails`    | questions, answers, documents → answers, documents, questions | Input/output safety guardrails       |
+| `rerank_cohere` | questions → answers, documents                        | Cohere Rerank for retrieval quality          |
+| `search_exa`    | questions → answers, text                             | Direct Exa web search (non-tool)             |
+
+### Outputs & Routing
+
+| Service             | Data flow (in → out)                                          | Description                                  |
+| ------------------- | ------------------------------------------------------------ | -------------------------------------------- |
+| `response`          | text, table, documents, questions, answers, audio, video, image → — | Returns results to the requesting client (per-type variants) |
+| `text_output`       | text → —                                                     | Writes text to the file system               |
+| `local_text_output` | text → —                                                     | Writes text to a local file                  |
+| `remote`            | — (transport)                                                | Forwards data to a remote machine / node (client + server) |
+| `autopipe`          | — (composite)                                                | Combines parse + preprocess + embed in one node |
+
+---
+
+## Core module
+
+The `core` module (`nodes/src/nodes/core/`) is not a single node — it registers a
+family of built-in services through several `services.common.*.json` files:
+
+- **Sources / connectors:** local filesystem, S3, Azure Blob, Google Drive,
+  OneDrive, SharePoint, Outlook, Gmail, Confluence, Slack, SMB.
+- **Processing:** document parsing, content hashing/fingerprinting, ZIP creation,
+  word indexing, and vectorization helpers.
+
+These are configured through pipeline service definitions rather than as
+standalone catalog nodes.
+
+---
+
+## Open items
+
+- `llm_ibm_watson` ships no `services*.json` and is not registered — confirm
+  whether it is in progress or should be removed.
 
 ---
 
 ## Adding a New Node
 
-1. Create a directory in `nodes/src/nodes/<node_name>/`
+1. Create a directory in `nodes/src/nodes/<node_name>/`.
 2. Implement the required interfaces:
 
    ```python
@@ -186,28 +284,37 @@ Like any tool node, these are agent-agnostic: they attach to any agent node's to
            return output_data
    ```
 
-3. Add `services.json` (or `services.<variant>.json` for branded presets) for the node definition.
+3. Add a `services.json` (or `services.<variant>.json`) node definition. This is
+   where you declare `classType`, `capabilities`, the `lanes` block (which makes
+   the node wire-compatible with others), and the `fields` / `shape` config schema
+   the canvas renders.
 4. Drop the node icon SVG next to `services.json` and reference it by filename:
 
    ```json
    {
-     "icon": "my_node.svg",
-     ...
+     "icon": "my_node.svg"
    }
    ```
 
-   The build pipeline auto-discovers every `nodes/src/nodes/<node>/*.svg` — no central registry to update. It also inspects each SVG and:
+   The build pipeline auto-discovers every `nodes/src/nodes/<node>/*.svg` — no
+   central registry to update. It also inspects each SVG and:
 
-   - If the SVG is **monochrome** (one distinct fill/stroke color), it auto-rewrites the color to `currentColor` so the icon inherits the active light/dark theme color. Author the SVG in whichever single color you like (commonly `#000`); the theme handles re-tinting.
-   - If the SVG is **multicolor** (two or more distinct colors, a gradient, or a pattern), it passes through unchanged and renders in its authored colors. Use this for brand logos.
+   - If the SVG is **monochrome** (one distinct fill/stroke color), it auto-rewrites
+     the color to `currentColor` so the icon inherits the active light/dark theme
+     color. Author the SVG in whichever single color you like (commonly `#000`);
+     the theme handles re-tinting.
+   - If the SVG is **multicolor** (two or more distinct colors, a gradient, or a
+     pattern), it passes through unchanged and renders in its authored colors. Use
+     this for brand logos.
 
    No theme flag, no manifest list to maintain.
 
 5. Add `requirements.txt` for dependencies.
-6. Optionally add a `test` section to `services.json` for automated testing (see [README-node-testing.md](README-node-testing.md)).
+6. Optionally add a `test` section to `services.json` for automated testing (see
+   [README-node-testing.md](README-node-testing.md)).
 
 ---
 
 ## License
 
-MIT License -- see [LICENSE](../LICENSE).
+MIT License — see [LICENSE](../LICENSE).

--- a/docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md
+++ b/docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md
@@ -1,6 +1,6 @@
 # RocketRide Component Reference
 
-**Last Updated:** March 2026
+**Last Updated:** June 2026
 
 ---
 
@@ -20,6 +20,13 @@ When the RocketRide VS Code extension is installed, it populates a `.rocketride/
 ```
 
 **IMPORTANT:** Always read `.rocketride/services-catalog.json` for the current list of available components. The catalog is the single source of truth — it is generated from the connected server and may contain components not listed in this document.
+
+> **Human-readable references (repo docs):**
+> [`docs/README-nodes.md`](../README-nodes.md) is the browsable catalog of every
+> node grouped by category, with each node's data-flow lanes and the wire-vs-bind
+> rule. [`docs/README-node-schema.md`](../README-node-schema.md) explains the
+> `services.json` model (`lanes`, `preconfig`/`profiles`, `fields`, `shape`) that
+> drives both this reference and the canvas UI.
 
 ### Reading the Catalog
 

--- a/docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md
+++ b/docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md
@@ -21,12 +21,11 @@ When the RocketRide VS Code extension is installed, it populates a `.rocketride/
 
 **IMPORTANT:** Always read `.rocketride/services-catalog.json` for the current list of available components. The catalog is the single source of truth — it is generated from the connected server and may contain components not listed in this document.
 
-> **Human-readable references (repo docs):**
-> [`docs/README-nodes.md`](../README-nodes.md) is the browsable catalog of every
-> node grouped by category, with each node's data-flow lanes and the wire-vs-bind
-> rule. [`docs/README-node-schema.md`](../README-node-schema.md) explains the
-> `services.json` model (`lanes`, `preconfig`/`profiles`, `fields`, `shape`) that
-> drives both this reference and the canvas UI.
+> **See also:** [`docs/README-nodes.md`](../README-nodes.md) is the node catalog
+> grouped by category, with each node's lanes and the wire-vs-bind rule.
+> [`docs/README-node-schema.md`](../README-node-schema.md) explains the
+> `services.json` model (`lanes`, `preconfig`/`profiles`, `fields`, `shape`)
+> behind this reference and the canvas UI.
 
 ### Reading the Catalog
 

--- a/nodes/src/nodes/agent_crewai/README.md
+++ b/nodes/src/nodes/agent_crewai/README.md
@@ -1,0 +1,52 @@
+# agent_crewai
+
+CrewAI-backed agent nodes for RocketRide — a standalone agent, a hierarchical manager, and managed sub-agents.
+
+## What it does
+
+Wraps [CrewAI](https://docs.crewai.com) into three node variants that share the same base driver:
+
+- **CrewAI Agent** (`agent_crewai`) — a standalone single agent. It assembles a CrewAI `Agent` + `Task` and runs it to answer the incoming question.
+- **CrewAI Manager** (`agent_crewai_manager`) — a multi-agent orchestrator. It runs CrewAI's hierarchical process: it fans out to the connected CrewAI Subagent nodes, assembles a Crew with the manager as delegator, and synthesizes their outputs into a single answer.
+- **CrewAI Subagent** (`agent_crewai_subagent`) — a managed worker. It is wired into a Manager via the `crewai` channel and is delegated to by name (its `role`); it has no `questions` lane and cannot be invoked directly.
+
+The Agent and Manager are agents in the data-flow sense: they consume `questions` and produce `answers` (`"questions": ["answers"]`). Both also register as tools (`classType: ["agent", "tool"]`) and expose themselves as `<nodeId>.run_agent`, so a parent agent can delegate to them in hierarchical pipelines. Tools are attached through the agent's `tool` invoke channel (control-plane invoke), not through lanes; the Subagent likewise has its own `tool` channel. Each variant requires exactly one `llm` channel (`min: 1`).
+
+## Configuration
+
+### CrewAI Agent
+
+| Field             | Default       | Description                                                                              |
+| ----------------- | ------------- | ---------------------------------------------------------------------------------------- |
+| Agent description | `""`          | What this agent does. Helps parent agents select and invoke it correctly.                |
+| Instructions      | `[]`          | Additional instructions to guide the agent.                                              |
+| Advanced Mode     | `Off`         | When On, exposes the CrewAI Agent and Task config fields below directly.                  |
+| Role              | `"Assistant"` | Agent role name (e.g. "Financial Analyst"). Maps to CrewAI `Agent(role=...)`.            |
+| Goal              | `""`          | What the agent is trying to achieve. Maps to `Agent(goal=...)`.                          |
+| Backstory         | `""`          | Background context for the agent's persona. Maps to `Agent(backstory=...)`.              |
+| Task              | `""`          | What the agent should do. If blank, the incoming question is used. Maps to `Task(description=...)`. |
+| Expected Output   | `""`          | Description of the expected output format. Maps to `Task(expected_output=...)`.          |
+
+### CrewAI Manager
+
+| Field             | Default | Description                                                                                          |
+| ----------------- | ------- | --------------------------------------------------------------------------------------------------- |
+| Agent description | `""`    | What this manager + its sub-agent crew does. Used by parent agents that call it as a tool.           |
+| Instructions      | `[]`    | Additional instructions to guide the manager's delegation strategy.                                  |
+| Advanced Mode     | `Off`   | When On, exposes the manager Agent config fields below directly.                                      |
+| Manager Goal      | `""`    | What the manager is trying to achieve. Maps to `Agent(goal=...)`.                                    |
+| Manager Backstory | `""`    | Background context for the manager's persona. Maps to `Agent(backstory=...)`.                        |
+
+The Manager requires at least one connected CrewAI Subagent on the `crewai` channel (`min: 1`).
+
+### CrewAI Subagent
+
+| Field           | Default          | Description                                                                                       |
+| --------------- | ---------------- | ------------------------------------------------------------------------------------------------ |
+| Instructions    | `[]`             | Additional instructions for this sub-agent when the Manager delegates to it.                     |
+| Advanced Mode   | `Off`            | When On, exposes the CrewAI Agent and Task config fields below directly.                          |
+| Role            | `"Specialist"`   | Sub-agent role name. The Manager uses this name when routing delegation. Maps to `Agent(role=...)`. |
+| Goal            | `""`             | What this sub-agent aims to achieve. Maps to `Agent(goal=...)`.                                   |
+| Backstory       | `""`             | Background context / expertise. Maps to `Agent(backstory=...)`.                                   |
+| Task            | `""`             | What this sub-agent does when delegated to; the request is passed as context. Maps to `Task(description=...)`. |
+| Expected Output | `""`             | Description of the expected output format. Maps to `Task(expected_output=...)`.                   |

--- a/nodes/src/nodes/agent_crewai/README.md
+++ b/nodes/src/nodes/agent_crewai/README.md
@@ -1,16 +1,16 @@
 # agent_crewai
 
-CrewAI-backed agent nodes for RocketRide — a standalone agent, a hierarchical manager, and managed sub-agents.
+Run [CrewAI](https://docs.crewai.com) agents inside RocketRide — solo, as a manager, or as managed workers.
 
 ## What it does
 
-Wraps [CrewAI](https://docs.crewai.com) into three node variants that share the same base driver:
+Three node variants share the same base driver:
 
 - **CrewAI Agent** (`agent_crewai`) — a standalone single agent. It assembles a CrewAI `Agent` + `Task` and runs it to answer the incoming question.
-- **CrewAI Manager** (`agent_crewai_manager`) — a multi-agent orchestrator. It runs CrewAI's hierarchical process: it fans out to the connected CrewAI Subagent nodes, assembles a Crew with the manager as delegator, and synthesizes their outputs into a single answer.
-- **CrewAI Subagent** (`agent_crewai_subagent`) — a managed worker. It is wired into a Manager via the `crewai` channel and is delegated to by name (its `role`); it has no `questions` lane and cannot be invoked directly.
+- **CrewAI Manager** (`agent_crewai_manager`) — orchestrates a crew. It runs CrewAI's hierarchical process: fans out to the connected CrewAI Subagent nodes, assembles a Crew with the manager as delegator, and synthesizes their outputs into one answer.
+- **CrewAI Subagent** (`agent_crewai_subagent`) — a managed worker. Wired into a Manager via the `crewai` channel and delegated to by name (its `role`); it has no `questions` lane and cannot be invoked directly.
 
-The Agent and Manager are agents in the data-flow sense: they consume `questions` and produce `answers` (`"questions": ["answers"]`). Both also register as tools (`classType: ["agent", "tool"]`) and expose themselves as `<nodeId>.run_agent`, so a parent agent can delegate to them in hierarchical pipelines. Tools are attached through the agent's `tool` invoke channel (control-plane invoke), not through lanes; the Subagent likewise has its own `tool` channel. Each variant requires exactly one `llm` channel (`min: 1`).
+In data-flow terms, the Agent and Manager consume `questions` and produce `answers` (`"questions": ["answers"]`). Both also register as tools (`classType: ["agent", "tool"]`) and expose themselves as `<nodeId>.run_agent`, so a parent agent can delegate to them in hierarchical pipelines. Tools attach through the agent's `tool` invoke channel (control-plane invoke), not through lanes; the Subagent has its own `tool` channel too. Each variant requires exactly one `llm` channel (`min: 1`).
 
 ## Configuration
 

--- a/nodes/src/nodes/agent_deepagent/README.md
+++ b/nodes/src/nodes/agent_deepagent/README.md
@@ -1,0 +1,32 @@
+# agent_deepagent
+
+Deep Agents node for RocketRide — a planning-capable agent plus optional managed sub-agents.
+
+## What it does
+
+Wraps [Deep Agents](https://github.com/langchain-ai/deepagents) (built on LangChain/LangGraph) into two node variants:
+
+- **Deep Agent** (`agent_deepagent`) — a single agent that layers strategic planning, persistent state, and long-context management on top of a normal LangChain tool-calling loop. It answers the incoming question via `deepagents.create_deep_agent`.
+- **Deep Agent Subagent** (`agent_deepagent_subagent`) — a managed worker. It is wired into a Deep Agent via the `deepagent` channel and the orchestrator delegates to it based on its `description`; it has no `questions` lane and cannot be invoked directly.
+
+The Deep Agent is an agent in the data-flow sense: it consumes `questions` and produces `answers` (`"questions": ["answers"]`). It also registers as a tool (`classType: ["agent", "tool"]`) and exposes itself as `<nodeId>.run_agent`, so a parent agent can delegate to it in hierarchical pipelines. Connecting Deep Agent Subagent nodes on the optional `deepagent` channel (`min: 0`) turns it into a hierarchical orchestrator that can delegate to those sub-agents. Tools are attached through the `tool` invoke channel (control-plane invoke), not through lanes; the Subagent has its own `tool` channel. Each variant requires exactly one `llm` channel (`min: 1`).
+
+## Configuration
+
+### Deep Agent
+
+| Field             | Default | Description                                                                                    |
+| ----------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| Advanced Mode     | `Off`   | When Off, edit the agent through the Instructions list. When On, expose Agent Description and System Prompt for full control. |
+| Instructions      | `[]`    | Additional instructions to guide the agent. Each line is appended to the system prompt. (Advanced Mode Off) |
+| Agent description | `""`    | What this agent does. Helps parent agents select and invoke it correctly. (Advanced Mode On)   |
+| System prompt     | `""`    | Instructions that define the agent's role and behaviour. Leave blank to use the default. (Advanced Mode On) |
+
+### Deep Agent Subagent
+
+| Field         | Default | Description                                                                                       |
+| ------------- | ------- | ------------------------------------------------------------------------------------------------ |
+| Advanced Mode | `Off`   | When Off, edit through the Instructions list. When On, expose the System Prompt for full control. |
+| Description   | `""`    | The orchestrator reads this to decide when to delegate. Keep it specific and action-oriented — it is the only signal used to pick a sub-agent. |
+| Instructions  | `[]`    | Additional instructions for this sub-agent. Each line is appended to the system prompt. (Advanced Mode Off) |
+| System prompt | `""`    | Instructions that define this sub-agent's role and behaviour. Leave blank to use the default. (Advanced Mode On) |

--- a/nodes/src/nodes/agent_deepagent/README.md
+++ b/nodes/src/nodes/agent_deepagent/README.md
@@ -1,15 +1,15 @@
 # agent_deepagent
 
-Deep Agents node for RocketRide — a planning-capable agent plus optional managed sub-agents.
+A planning-capable agent for RocketRide, with optional managed sub-agents.
 
 ## What it does
 
-Wraps [Deep Agents](https://github.com/langchain-ai/deepagents) (built on LangChain/LangGraph) into two node variants:
+[Deep Agents](https://github.com/langchain-ai/deepagents) (built on LangChain/LangGraph) come in two node variants:
 
-- **Deep Agent** (`agent_deepagent`) — a single agent that layers strategic planning, persistent state, and long-context management on top of a normal LangChain tool-calling loop. It answers the incoming question via `deepagents.create_deep_agent`.
-- **Deep Agent Subagent** (`agent_deepagent_subagent`) — a managed worker. It is wired into a Deep Agent via the `deepagent` channel and the orchestrator delegates to it based on its `description`; it has no `questions` lane and cannot be invoked directly.
+- **Deep Agent** (`agent_deepagent`) — a single agent that adds strategic planning, persistent state, and long-context management on top of a normal LangChain tool-calling loop. It answers the incoming question via `deepagents.create_deep_agent`.
+- **Deep Agent Subagent** (`agent_deepagent_subagent`) — a managed worker. Wired into a Deep Agent via the `deepagent` channel; the orchestrator delegates to it based on its `description`. It has no `questions` lane and cannot be invoked directly.
 
-The Deep Agent is an agent in the data-flow sense: it consumes `questions` and produces `answers` (`"questions": ["answers"]`). It also registers as a tool (`classType: ["agent", "tool"]`) and exposes itself as `<nodeId>.run_agent`, so a parent agent can delegate to it in hierarchical pipelines. Connecting Deep Agent Subagent nodes on the optional `deepagent` channel (`min: 0`) turns it into a hierarchical orchestrator that can delegate to those sub-agents. Tools are attached through the `tool` invoke channel (control-plane invoke), not through lanes; the Subagent has its own `tool` channel. Each variant requires exactly one `llm` channel (`min: 1`).
+In data-flow terms, the Deep Agent consumes `questions` and produces `answers` (`"questions": ["answers"]`). It also registers as a tool (`classType: ["agent", "tool"]`) and exposes itself as `<nodeId>.run_agent`, so a parent agent can delegate to it in hierarchical pipelines. Connect Deep Agent Subagent nodes on the optional `deepagent` channel (`min: 0`) and it becomes a hierarchical orchestrator that delegates to them. Tools attach through the `tool` invoke channel (control-plane invoke), not through lanes; the Subagent has its own `tool` channel. Each variant requires exactly one `llm` channel (`min: 1`).
 
 ## Configuration
 

--- a/nodes/src/nodes/core/README.md
+++ b/nodes/src/nodes/core/README.md
@@ -1,0 +1,30 @@
+# core
+
+## What it does
+
+`core` is not a single pipeline node — it is the module that registers RocketRide's family of common services. These services are defined across the `services.*.json` files in this directory (for example `services.common.aws.json`, `services.common.google.json`, `services.common.vector.json`, `services.parse.json`, `services.hash.json`, `services.indexer.json`, `services.zip.json`, and `services.filesys.json`) and are configured as part of a pipeline rather than added as one standalone node.
+
+## Service families
+
+**Sources / connectors**
+
+- Local File System (`services.filesys.json`) and SMB
+- Amazon S3 and Azure Blob (object storage)
+- Google Drive, OneDrive, SharePoint
+- Outlook and Gmail
+- Confluence and Slack
+
+**Processing**
+
+- Parsing (`services.parse.json`) — content extraction from source objects
+- Hashing / fingerprinting (`services.hash.json`)
+- Zip streaming and creation (`services.zip.json`)
+- Word indexing (`services.indexer.json`)
+- Vectorization, embeddings, and vector stores (`services.common.vector.json`)
+- Anonymization (`services.common.anonymize.json`) and LLM access (`services.common.llm.json`)
+
+Cloud-provider credentials and connection settings are grouped per provider (AWS, Google, etc.). The `services.all.json` aggregate exposes combined selectable types (preprocessor, embedding, vector store, LLM) for pipelines that pick one provider per slot.
+
+## Configuration
+
+Each service exposes its own config fields (credentials, hosts/ports, collection names, processing parameters) through the pipeline builder when the corresponding service is selected. See the individual `services.*.json` files for the exact fields of each provider.

--- a/nodes/src/nodes/core/README.md
+++ b/nodes/src/nodes/core/README.md
@@ -2,7 +2,7 @@
 
 ## What it does
 
-`core` is not a single pipeline node — it is the module that registers RocketRide's family of common services. These services are defined across the `services.*.json` files in this directory (for example `services.common.aws.json`, `services.common.google.json`, `services.common.vector.json`, `services.parse.json`, `services.hash.json`, `services.indexer.json`, `services.zip.json`, and `services.filesys.json`) and are configured as part of a pipeline rather than added as one standalone node.
+`core` isn't one node — it's the module that registers RocketRide's family of shared services. They live in the `services.*.json` files in this directory (for example `services.common.aws.json`, `services.common.google.json`, `services.common.vector.json`, `services.parse.json`, `services.hash.json`, `services.indexer.json`, `services.zip.json`, and `services.filesys.json`), and you configure them inside a pipeline rather than dropping one standalone node on the canvas.
 
 ## Service families
 

--- a/nodes/src/nodes/embedding_video/README.md
+++ b/nodes/src/nodes/embedding_video/README.md
@@ -1,0 +1,35 @@
+# embedding_video
+
+Generates vector embeddings from video by extracting and encoding frames.
+
+## What it does
+
+Extracts frames from a video at a configurable interval and encodes each one with a vision model such as CLIP, turning the video's visual features into numerical representations. The resulting embeddings capture the semantic and structural characteristics of the video, enabling similarity search, clustering, and integration into multimodal RAG workflows. Runs on the model server and is GPU-accelerated when available.
+
+**Lanes:**
+
+| Lane in | Lane out    | Description                                          |
+| ------- | ----------- | --------------------------------------------------- |
+| `video` | `documents` | Embed extracted video frames into document objects  |
+
+Output documents carry an `embedding` vector, ready for ingestion into a vector store.
+
+## Configuration
+
+| Field            | Default | Description                                                       |
+| ---------------- | ------- | ---------------------------------------------------------------- |
+| Model            | *(see profiles)* | Hugging Face vision model used for frame embedding.     |
+| Interval         | `5`     | Seconds between extracted frames.                                |
+| Maximum frames   | `50`    | Cap on total frames extracted (`0` = unlimited).                 |
+| Start time       | `0`     | Start offset in seconds for frame extraction (`0` = beginning).  |
+| Duration         | `0`     | Duration in seconds to extract (`0` = end of video).             |
+| Max video size (MB) | `500`| Reject videos larger than this size.                             |
+
+## Profiles
+
+| Profile                | Model                          | Notes                                 |
+| ---------------------- | ------------------------------ | ------------------------------------- |
+| OpenAI 16×16 _(default)_ | `openai/clip-vit-base-patch16` | Good performance, lower memory        |
+| OpenAI 32×32           | `openai/clip-vit-base-patch32` | Lower performance, better recognition |
+| Google 16×16           | `google/vit-base-patch16-224`  | Fast, accurate, general-purpose       |
+| Custom                 | _(user-specified)_             | Any Hugging Face vision model         |

--- a/nodes/src/nodes/embedding_video/README.md
+++ b/nodes/src/nodes/embedding_video/README.md
@@ -1,10 +1,10 @@
 # embedding_video
 
-Generates vector embeddings from video by extracting and encoding frames.
+Turns video into searchable vectors by sampling and encoding its frames.
 
 ## What it does
 
-Extracts frames from a video at a configurable interval and encodes each one with a vision model such as CLIP, turning the video's visual features into numerical representations. The resulting embeddings capture the semantic and structural characteristics of the video, enabling similarity search, clustering, and integration into multimodal RAG workflows. Runs on the model server and is GPU-accelerated when available.
+It pulls frames from a video at an interval you choose and runs each through a vision model like CLIP, converting what's on screen into numbers. Those embeddings capture the video's semantic and structural features, so you can run similarity search, cluster videos, or feed them into multimodal RAG workflows. It runs on the model server and uses the GPU when one is available.
 
 **Lanes:**
 

--- a/nodes/src/nodes/guardrails/README.md
+++ b/nodes/src/nodes/guardrails/README.md
@@ -1,0 +1,40 @@
+# guardrails
+
+An input/output safety filter for AI pipelines.
+
+## What it does
+
+Checks questions before they reach the LLM and answers after the LLM responds. On the input side it can detect prompt injection attempts, enforce topic restrictions (blocked/allowed keywords), and cap input length or estimated token count. On the output side it can detect hallucinations (grounding answers against source documents), flag unsafe content, detect PII leaks (emails, phones, SSNs, credit cards), and validate the output format.
+
+Each violation is handled according to the **policy mode**: `block` rejects the offending question/answer, `warn` logs the violation and forwards anyway, and `log` records it silently.
+
+**Lanes:**
+
+| Lane in     | Lane out    | Description                                              |
+| ----------- | ----------- | ------------------------------------------------------- |
+| `questions` | `questions` | Apply input checks before forwarding to the LLM         |
+| `answers`   | `answers`   | Apply output checks after the LLM responds              |
+| `documents` | `documents` | Collected as ground-truth context for hallucination checks |
+
+## Configuration
+
+| Field                          | Default | Description                                                              |
+| ------------------------------ | ------- | ------------------------------------------------------------------------ |
+| Policy mode                    | `warn`  | How to handle violations: `block`, `warn`, or `log`.                     |
+| Enable prompt injection        | `true`  | Detect and flag prompt injection attempts in input.                      |
+| Enable content safety check    | `true`  | Detect harmful or unsafe content in output.                              |
+| Enable PII detection           | `true`  | Detect personal identifiable information in output.                      |
+| Enable hallucination check     | `false` | Verify output claims are grounded in source documents.                   |
+| Max input length (chars)       | `0`     | Maximum character count for input text (`0` = no limit).                 |
+| Max tokens (estimate)          | `0`     | Maximum estimated token count for input text (`0` = no limit).           |
+| Expected output format         | *(none)*| Validate output matches a format: `json`, `markdown`, `bullet_list`, `numbered_list`. |
+| Blocked topics                 | *(empty)* | Keywords for topics that should be rejected.                           |
+| Allowed topics                 | *(empty)* | If set, input must contain at least one of these keywords.             |
+
+## Profiles
+
+| Profile             | Notes                                                          |
+| ------------------- | -------------------------------------------------------------- |
+| Basic _(default)_   | Prompt injection + PII detection, `warn` mode                  |
+| Strict              | All checks enabled, `block` on violation                       |
+| Custom              | Configure each check individually                              |

--- a/nodes/src/nodes/guardrails/README.md
+++ b/nodes/src/nodes/guardrails/README.md
@@ -1,12 +1,12 @@
 # guardrails
 
-An input/output safety filter for AI pipelines.
+Stops bad input from reaching your LLM, and bad output from reaching your users.
 
 ## What it does
 
-Checks questions before they reach the LLM and answers after the LLM responds. On the input side it can detect prompt injection attempts, enforce topic restrictions (blocked/allowed keywords), and cap input length or estimated token count. On the output side it can detect hallucinations (grounding answers against source documents), flag unsafe content, detect PII leaks (emails, phones, SSNs, credit cards), and validate the output format.
+It screens questions on the way in and answers on the way out. Going in, it catches prompt injection, enforces topic rules (blocked/allowed keywords), and caps input length or estimated tokens. Coming out, it catches hallucinations (checking answers against source documents), flags unsafe content, spots PII leaks (emails, phones, SSNs, credit cards), and checks the output format.
 
-Each violation is handled according to the **policy mode**: `block` rejects the offending question/answer, `warn` logs the violation and forwards anyway, and `log` records it silently.
+How it reacts is up to the **policy mode**: `block` rejects the offending question/answer, `warn` logs the violation and forwards anyway, and `log` records it silently.
 
 **Lanes:**
 

--- a/nodes/src/nodes/index_search/README.md
+++ b/nodes/src/nodes/index_search/README.md
@@ -1,15 +1,15 @@
 # index_search
 
-Index and search node backed by Elasticsearch or OpenSearch, supporting both classic BM25 text search and vector (semantic) search.
+Store your documents and search them back — by keyword (BM25) or by meaning (vectors). Backed by Elasticsearch or OpenSearch.
 
 ## What it does
 
-A single node implementation with two service variants — **Elasticsearch** and **OpenSearch** — for ingesting documents and retrieving them at query time. Each variant can operate in two modes (controlled by the **Store Mode** toggle):
+One node, two service variants — **Elasticsearch** and **OpenSearch** — that ingest documents and retrieve them at query time. Each variant runs in one of two modes, set by the **Store Mode** toggle:
 
 - **Index mode** — classic BM25 full-text search over the index, with configurable match operator (`or`, `and`, `exact` phrase) and optional contextual snippet highlighting.
 - **Vector store mode** — semantic similarity search over embedded documents, with a minimum retrieval score threshold.
 
-The Elasticsearch variant supports self-managed, Elastic Cloud Hosted, and Elastic Cloud Serverless deployments. The OpenSearch variant works with self-managed OpenSearch.
+Elasticsearch covers self-managed, Elastic Cloud Hosted, and Elastic Cloud Serverless deployments. OpenSearch covers self-managed OpenSearch.
 
 **Lanes:**
 
@@ -19,7 +19,7 @@ The Elasticsearch variant supports self-managed, Elastic Cloud Hosted, and Elast
 | `text`      | —                                       | Ingest raw text                                                  |
 | `questions` | `text`, `documents`, `answers`, `questions` | Search and return matches as text, documents, an answer, or enrich the question for downstream nodes |
 
-(The OpenSearch variant produces `text`, `answers`, `documents` from `questions`.) In vector store mode, documents must be run through an embedding node before reaching this node.
+(The OpenSearch variant produces `text`, `answers`, `documents` from `questions`.) In vector store mode, run documents through an embedding node before they reach this one.
 
 ## Setup
 

--- a/nodes/src/nodes/index_search/README.md
+++ b/nodes/src/nodes/index_search/README.md
@@ -1,0 +1,42 @@
+# index_search
+
+Index and search node backed by Elasticsearch or OpenSearch, supporting both classic BM25 text search and vector (semantic) search.
+
+## What it does
+
+A single node implementation with two service variants — **Elasticsearch** and **OpenSearch** — for ingesting documents and retrieving them at query time. Each variant can operate in two modes (controlled by the **Store Mode** toggle):
+
+- **Index mode** — classic BM25 full-text search over the index, with configurable match operator (`or`, `and`, `exact` phrase) and optional contextual snippet highlighting.
+- **Vector store mode** — semantic similarity search over embedded documents, with a minimum retrieval score threshold.
+
+The Elasticsearch variant supports self-managed, Elastic Cloud Hosted, and Elastic Cloud Serverless deployments. The OpenSearch variant works with self-managed OpenSearch.
+
+**Lanes:**
+
+| Lane in     | Lane out                                | Description                                                       |
+| ----------- | --------------------------------------- | ---------------------------------------------------------------- |
+| `documents` | —                                       | Ingest documents into the index/collection                       |
+| `text`      | —                                       | Ingest raw text                                                  |
+| `questions` | `text`, `documents`, `answers`, `questions` | Search and return matches as text, documents, an answer, or enrich the question for downstream nodes |
+
+(The OpenSearch variant produces `text`, `answers`, `documents` from `questions`.) In vector store mode, documents must be run through an embedding node before reaching this node.
+
+## Setup
+
+| Variant       | Connection                                                                                          |
+| ------------- | --------------------------------------------------------------------------------------------------- |
+| Elasticsearch | Self-managed: `localhost:9200`. Cloud Hosted / Serverless require a host URL and an **API Key**.    |
+| OpenSearch    | Host URL (default `http://localhost:9200`), optional basic auth (username / password).              |
+
+## Configuration
+
+| Field                     | Default        | Description                                                                                  |
+| ------------------------- | -------------- | -------------------------------------------------------------------------------------------- |
+| Deployment Type / Host    | self-managed   | Elasticsearch deployment profile, or OpenSearch host URL                                      |
+| Index Name / Collection   | `rocketride`   | Name of the index / collection (lowercase)                                                    |
+| Store Mode                | varies         | Toggle between index (BM25 text search) and vector store (semantic search)                     |
+| Match Operator            | `or`           | How query terms are matched: `or` (any), `and` (all), `exact` (phrase). `exact` adds **Slop**  |
+| Return contextual snippets| `false`        | Use the unified highlighter to return snippets around matches (configurable snippet size)      |
+| Retrieval Score           | `0.5`          | Minimum similarity threshold in vector store mode (0.0–1.0)                                     |
+| Embedding Dimension       | `768`          | Dimension of embedding vectors (OpenSearch vector store mode)                                  |
+| API Key                   | *(empty)*      | Elastic Cloud API key (Cloud Hosted / Serverless profiles)                                     |

--- a/nodes/src/nodes/memory_persistent/README.md
+++ b/nodes/src/nodes/memory_persistent/README.md
@@ -1,14 +1,14 @@
 # memory_persistent
 
-A persistent, cross-session memory store for pipelines.
+Gives your pipeline a memory that survives across runs, keyed by `session_id`.
 
 ## What it does
 
-Retains data across pipeline invocations, keyed by `session_id`. Unlike [memory_internal](../memory_internal/) — which is run-scoped, wired only to the Wave agent, and cleared at the end of each run — this node persists session state between runs and is wired into the pipeline as a pass-through filter on the `questions` and `answers` lanes.
+Unlike [memory_internal](../memory_internal/) — which is run-scoped, wired only to the Wave agent, and cleared at the end of each run — this node keeps session state between runs and sits in the pipeline as a pass-through filter on the `questions` and `answers` lanes.
 
-When a question carries a `session_id` in its metadata, the node resumes (or creates) that session and attaches its stored keys to the question as memory context before forwarding. Answers for that session are persisted back (e.g. `last_answer`, an `answer_count`) for future retrieval. Questions without a `session_id` pass through unchanged.
+When a question carries a `session_id` in its metadata, the node resumes (or creates) that session and attaches its stored keys to the question as memory context before forwarding. Answers for that session are saved back (e.g. `last_answer`, an `answer_count`) for later. Questions without a `session_id` pass through untouched.
 
-It supports session management, keyed storage, history tracking, and automatic summarization of older history entries once the limit is reached.
+You get session management, keyed storage, history tracking, and automatic summarization of older entries once the limit is hit.
 
 **Lanes:**
 

--- a/nodes/src/nodes/memory_persistent/README.md
+++ b/nodes/src/nodes/memory_persistent/README.md
@@ -1,0 +1,34 @@
+# memory_persistent
+
+A persistent, cross-session memory store for pipelines.
+
+## What it does
+
+Retains data across pipeline invocations, keyed by `session_id`. Unlike [memory_internal](../memory_internal/) — which is run-scoped, wired only to the Wave agent, and cleared at the end of each run — this node persists session state between runs and is wired into the pipeline as a pass-through filter on the `questions` and `answers` lanes.
+
+When a question carries a `session_id` in its metadata, the node resumes (or creates) that session and attaches its stored keys to the question as memory context before forwarding. Answers for that session are persisted back (e.g. `last_answer`, an `answer_count`) for future retrieval. Questions without a `session_id` pass through unchanged.
+
+It supports session management, keyed storage, history tracking, and automatic summarization of older history entries once the limit is reached.
+
+**Lanes:**
+
+| Lane in     | Lane out    | Description                                              |
+| ----------- | ----------- | ------------------------------------------------------- |
+| `questions` | `questions` | Enriched with session memory context in metadata        |
+| `answers`   | `answers`   | Stored in session memory, then passed through           |
+
+## Setup
+
+The default `memory` backend is in-process and needs no setup (intended for testing). For production, select the `redis` backend and point it at a reachable Redis instance via the config fields below.
+
+## Configuration
+
+| Field             | Default     | Description                                                       |
+| ----------------- | ----------- | ---------------------------------------------------------------- |
+| Backend           | `memory`    | Storage backend: `redis` (production) or `memory` (testing).     |
+| Redis Host        | `localhost` | Redis server hostname.                                           |
+| Redis Port        | `6379`      | Redis server port.                                               |
+| Redis Password    | *(empty)*   | Redis password (leave empty for no auth).                        |
+| Session TTL (hours) | `0`       | How long sessions persist before auto-expiry (`0` = no expiry).  |
+| Max History Entries | `100`     | History entries per session before auto-summarization.           |
+| Auto-Summarize    | `true`      | Summarize older history entries when the limit is reached.       |

--- a/nodes/src/nodes/rerank_cohere/README.md
+++ b/nodes/src/nodes/rerank_cohere/README.md
@@ -1,0 +1,33 @@
+# rerank_cohere
+
+Reranks retrieved documents by relevance using [Cohere's Rerank API](https://docs.cohere.com/reference/rerank).
+
+## What it does
+
+Improves search quality by reordering a set of already-retrieved documents based on their relevance to the query. Each document is scored by the Cohere Rerank API, results are sorted by relevance, optionally truncated to the top N, and filtered by a minimum score threshold. Supports the `rerank-english-v3.0` and `rerank-v3.5` models, plus a custom model option.
+
+**Lanes:**
+
+| Lane in     | Lane out    | Description                                                |
+| ----------- | ----------- | ---------------------------------------------------------- |
+| `questions` | `documents` | Produces reranked documents ordered by relevance score     |
+| `questions` | `answers`   | Produces an answer with reranked documents                 |
+
+Place this node downstream of a retrieval/vector-store node so it can rerank the documents attached to each question.
+
+## Setup
+
+Requires a Cohere API key. Provide it via the node config field **API Key**, or via the environment variable:
+
+```bash
+ROCKETRIDE_RERANK_COHERE_KEY=...
+```
+
+## Configuration
+
+| Field     | Default                | Description                                          |
+| --------- | ---------------------- | ---------------------------------------------------- |
+| Model     | `rerank-english-v3.0`  | Cohere rerank model (`rerank-english-v3.0`, `rerank-v3.5`, or custom) |
+| Top N     | `5`                    | Number of top results to return (minimum 1)          |
+| Min Score | `0.0`                  | Minimum relevance score threshold (0.0–1.0); results below it are dropped |
+| API Key   | *(empty)*              | Cohere API key                                       |

--- a/nodes/src/nodes/rerank_cohere/README.md
+++ b/nodes/src/nodes/rerank_cohere/README.md
@@ -1,10 +1,10 @@
 # rerank_cohere
 
-Reranks retrieved documents by relevance using [Cohere's Rerank API](https://docs.cohere.com/reference/rerank).
+Got search results, but not in the right order? This node reranks them by relevance with [Cohere's Rerank API](https://docs.cohere.com/reference/rerank).
 
 ## What it does
 
-Improves search quality by reordering a set of already-retrieved documents based on their relevance to the query. Each document is scored by the Cohere Rerank API, results are sorted by relevance, optionally truncated to the top N, and filtered by a minimum score threshold. Supports the `rerank-english-v3.0` and `rerank-v3.5` models, plus a custom model option.
+Takes documents you've already retrieved and reorders them by how well they match the query. Cohere scores each one, then results are sorted, optionally cut to the top N, and dropped below a minimum score. Works with the `rerank-english-v3.0` and `rerank-v3.5` models, or a custom one.
 
 **Lanes:**
 
@@ -13,11 +13,11 @@ Improves search quality by reordering a set of already-retrieved documents based
 | `questions` | `documents` | Produces reranked documents ordered by relevance score     |
 | `questions` | `answers`   | Produces an answer with reranked documents                 |
 
-Place this node downstream of a retrieval/vector-store node so it can rerank the documents attached to each question.
+Put it downstream of a retrieval or vector-store node so it can rerank the documents attached to each question.
 
 ## Setup
 
-Requires a Cohere API key. Provide it via the node config field **API Key**, or via the environment variable:
+You'll need a Cohere API key. Set it in the node's **API Key** field, or via the environment variable:
 
 ```bash
 ROCKETRIDE_RERANK_COHERE_KEY=...

--- a/nodes/src/nodes/telegram/README.md
+++ b/nodes/src/nodes/telegram/README.md
@@ -1,0 +1,31 @@
+# telegram
+
+A Telegram Bot source node that receives messages from users via the Telegram Bot API and feeds them into a pipeline.
+
+## What it does
+
+This is a `source` node (`telegram://`) that connects to a bot created with @BotFather and listens for incoming messages. It supports text messages and media files — images, audio, voice, video, and documents — downloading each file (up to Telegram's 20 MB bot limit) and routing it to the matching pipeline lane. Pipeline responses are automatically sent back as replies to the originating chat.
+
+It uses `_source` as its internal input and emits to these output lanes:
+
+| Telegram message | Output lane |
+| ---------------- | ----------- |
+| Text             | `text`      |
+| Photo            | `image`     |
+| Audio / voice    | `audio`     |
+| Video            | `video`     |
+| Document (PDF, Word, etc.) | `tags` |
+
+Updates can be delivered by **polling** (works anywhere without a public URL) or **webhook** (requires a public HTTPS endpoint that Telegram POSTs updates to).
+
+## Setup
+
+A Telegram bot token from @BotFather is required (e.g. `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`). It is stored as a secure field. For webhook mode you also need a public HTTPS URL.
+
+## Configuration
+
+| Field                | Default     | Description                                                                                  |
+| -------------------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `telegram.botToken`  | *(required)* | Telegram bot token from @BotFather. Secure / encrypted at rest.                              |
+| `telegram.mode`      | `polling`   | `polling` (no public URL needed) or `webhook` (requires a public HTTPS endpoint).            |
+| `telegram.webhookUrl` | *(optional)* | Public HTTPS URL Telegram POSTs updates to (e.g. `https://your-server.com/telegram/webhook`). Required for `webhook` mode. |

--- a/nodes/src/nodes/telegram/README.md
+++ b/nodes/src/nodes/telegram/README.md
@@ -1,12 +1,12 @@
 # telegram
 
-A Telegram Bot source node that receives messages from users via the Telegram Bot API and feeds them into a pipeline.
+Turn a Telegram bot into the front door of your pipeline. Messages come in, pipeline replies go straight back to the chat.
 
 ## What it does
 
-This is a `source` node (`telegram://`) that connects to a bot created with @BotFather and listens for incoming messages. It supports text messages and media files — images, audio, voice, video, and documents — downloading each file (up to Telegram's 20 MB bot limit) and routing it to the matching pipeline lane. Pipeline responses are automatically sent back as replies to the originating chat.
+A `source` node (`telegram://`) that connects to a bot you create with @BotFather and listens for incoming messages. It handles text and media alike — images, audio, voice, video, and documents — downloading each file (up to Telegram's 20 MB bot limit) and routing it to the matching pipeline lane. Replies go back to the chat that sent them, automatically.
 
-It uses `_source` as its internal input and emits to these output lanes:
+Internally it reads from `_source` and emits to these output lanes:
 
 | Telegram message | Output lane |
 | ---------------- | ----------- |
@@ -16,11 +16,11 @@ It uses `_source` as its internal input and emits to these output lanes:
 | Video            | `video`     |
 | Document (PDF, Word, etc.) | `tags` |
 
-Updates can be delivered by **polling** (works anywhere without a public URL) or **webhook** (requires a public HTTPS endpoint that Telegram POSTs updates to).
+Pick how updates arrive: **polling** (works anywhere, no public URL) or **webhook** (a public HTTPS endpoint that Telegram POSTs updates to).
 
 ## Setup
 
-A Telegram bot token from @BotFather is required (e.g. `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`). It is stored as a secure field. For webhook mode you also need a public HTTPS URL.
+You need a bot token from @BotFather (e.g. `123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11`), stored as a secure field. Webhook mode also needs a public HTTPS URL.
 
 ## Configuration
 

--- a/nodes/src/nodes/text_output/README.md
+++ b/nodes/src/nodes/text_output/README.md
@@ -2,9 +2,9 @@
 
 ## What it does
 
-Writes pipeline text output to the file system over SMB. Receives text from upstream nodes and saves each object as a `.txt` file, preserving the source directory structure under the target path. This is a target (sink) node — it consumes the `text` lane and has no output lane.
+Saves your pipeline's text to disk over SMB. Each upstream object becomes a `.txt` file, mirroring the source directory layout under the target path. It's the end of the line — consumes the `text` lane, emits nothing.
 
-Objects that produce no text are skipped, and objects whose source and target are unchanged since the last run are skipped to avoid redundant writes. Files are written in UTF-8 and target subdirectories are created automatically.
+Empty objects are skipped, and so are objects unchanged since the last run, so you don't rewrite the same file twice. Output is UTF-8, and target subdirectories are created for you.
 
 Requires the `network` capability and is not available in remote (`noremote`) or SaaS (`nosaas`) deployments.
 

--- a/nodes/src/nodes/text_output/README.md
+++ b/nodes/src/nodes/text_output/README.md
@@ -1,0 +1,24 @@
+# text_output
+
+## What it does
+
+Writes pipeline text output to the file system over SMB. Receives text from upstream nodes and saves each object as a `.txt` file, preserving the source directory structure under the target path. This is a target (sink) node — it consumes the `text` lane and has no output lane.
+
+Objects that produce no text are skipped, and objects whose source and target are unchanged since the last run are skipped to avoid redundant writes. Files are written in UTF-8 and target subdirectories are created automatically.
+
+Requires the `network` capability and is not available in remote (`noremote`) or SaaS (`nosaas`) deployments.
+
+**Lanes:**
+
+| Lane in | Description                   |
+| ------- | ----------------------------- |
+| `text`  | Text content to write to disk |
+
+## Configuration
+
+| Field      | Description                                                  |
+| ---------- | ------------------------------------------------------------ |
+| Parameters | Target parameters, including `anonymize` for the written text. |
+| Mode       | Target write mode.                                           |
+
+The source file extension is replaced with `.txt` on output.

--- a/nodes/src/nodes/tool_exa_search/README.md
+++ b/nodes/src/nodes/tool_exa_search/README.md
@@ -1,0 +1,25 @@
+# tool_exa_search
+
+Exposes [Exa](https://exa.ai) semantic web search as an agent tool node.
+
+> Experimental — this node is marked `experimental` and may change.
+
+## What it does
+
+Agents invoke this node via the tool invoke channel. The node performs a real-time web search using the Exa API and returns structured results containing titles, URLs, text content, relevance scores, and dates.
+
+Because `lanes` is empty (`{}`), this node has no pipeline input/output lanes — it is consumed exclusively by agent runtimes through the `invoke` capability.
+
+## Setup
+
+Set your Exa API key via the node config field **API Key** (from https://exa.ai). The field is encrypted at rest and masked in the UI.
+
+## Config fields
+
+| Field                | Default | Description                                                       |
+| -------------------- | ------- | ----------------------------------------------------------------- |
+| API Key              | *(empty)* | Exa API key (from https://exa.ai). Encrypted at rest.           |
+| Number of Results    | `10`    | Maximum number of search results to return (1–50).                |
+| Use Autoprompt       | `Yes`   | Let Exa optimize the query for better results.                    |
+| Search Type          | `Auto`  | `Auto`, `Neural`, or `Keyword`.                                   |
+| Include Text Content | `Yes`   | Include full text content in each result.                         |

--- a/nodes/src/nodes/tool_exa_search/README.md
+++ b/nodes/src/nodes/tool_exa_search/README.md
@@ -1,18 +1,18 @@
 # tool_exa_search
 
-Exposes [Exa](https://exa.ai) semantic web search as an agent tool node.
+Give your agents live web search powered by [Exa](https://exa.ai)'s semantic search.
 
 > Experimental — this node is marked `experimental` and may change.
 
 ## What it does
 
-Agents invoke this node via the tool invoke channel. The node performs a real-time web search using the Exa API and returns structured results containing titles, URLs, text content, relevance scores, and dates.
+When an agent calls this tool, it runs a real-time Exa search and hands back structured results: titles, URLs, text content, relevance scores, and dates.
 
-Because `lanes` is empty (`{}`), this node has no pipeline input/output lanes — it is consumed exclusively by agent runtimes through the `invoke` capability.
+There are no pipeline lanes here (`lanes` is `{}`). Only agent runtimes reach it, through the `invoke` capability.
 
 ## Setup
 
-Set your Exa API key via the node config field **API Key** (from https://exa.ai). The field is encrypted at rest and masked in the UI.
+Drop your Exa API key into the **API Key** config field (grab one at https://exa.ai). It's encrypted at rest and masked in the UI.
 
 ## Config fields
 

--- a/nodes/src/nodes/tool_pipe/README.md
+++ b/nodes/src/nodes/tool_pipe/README.md
@@ -1,12 +1,12 @@
 # tool_pipe
 
-Exposes an inline pipeline as an agent tool node.
+Turn a whole inline pipeline into a single agent tool.
 
 ## What it does
 
-Agents invoke this node via the tool invoke channel. When the agent calls the tool, the input is routed to every connected output lane, the inline pipeline runs, and the configured response value is returned to the agent.
+When the agent calls the tool, its input fans out to every connected output lane, the inline pipeline runs, and the configured response value comes back to the agent.
 
-Unlike the other `tool_*` nodes, `tool_pipe` does have output lanes (`text`, `questions`, `documents`, `table`, `answers`) on its `_source` channel. Connect these to any pipeline nodes on the same canvas to build the tool's behavior. End each connected branch with a response node so results can be returned. The agent binding itself still happens through the `invoke` capability.
+`tool_pipe` is the one `tool_*` node with real output lanes (`text`, `questions`, `documents`, `table`, `answers`) on its `_source` channel. Wire them to other nodes on the same canvas to shape the tool's behavior, and cap each branch with a response node so results can flow back. As always, the agent binds through the `invoke` capability.
 
 ## Config fields
 

--- a/nodes/src/nodes/tool_pipe/README.md
+++ b/nodes/src/nodes/tool_pipe/README.md
@@ -1,0 +1,16 @@
+# tool_pipe
+
+Exposes an inline pipeline as an agent tool node.
+
+## What it does
+
+Agents invoke this node via the tool invoke channel. When the agent calls the tool, the input is routed to every connected output lane, the inline pipeline runs, and the configured response value is returned to the agent.
+
+Unlike the other `tool_*` nodes, `tool_pipe` does have output lanes (`text`, `questions`, `documents`, `table`, `answers`) on its `_source` channel. Connect these to any pipeline nodes on the same canvas to build the tool's behavior. End each connected branch with a response node so results can be returned. The agent binding itself still happens through the `invoke` capability.
+
+## Config fields
+
+| Field            | Default | Description                                                                 |
+| ---------------- | ------- | --------------------------------------------------------------------------- |
+| Tool Description | *(empty)* | Natural-language description the agent uses to decide when to call this tool. |
+| Return Type      | `text`  | Which response lane value to return to the agent: `text`, `answers`, `documents`, or `table`. |

--- a/nodes/src/nodes/vectorizer/README.md
+++ b/nodes/src/nodes/vectorizer/README.md
@@ -1,0 +1,21 @@
+# vectorizer
+
+Internal node that chunks incoming text and tables, computes embeddings, and writes the resulting documents to the configured store.
+
+## What it does
+
+The vectorizer is an internal (`capabilities: ["internal"]`) processing node in the ingestion path. As text and tables flow through it, it:
+
+1. Checks whether the current object is flagged for vectorization (`FLAGS.VECTORIZE`).
+2. Splits the text into chunks using the configured preprocessor.
+3. Builds per-chunk document metadata (chunk id, table id, permission id, etc.).
+4. Computes embeddings for the chunks via the embedding component.
+5. Persists the chunks — either directly to the store (instance mode) or by writing them downstream to the endpoint store driver (transform mode).
+
+On retrieval (`renderObject`), it reads previously vectorized content back out of the store and feeds it to the text writer.
+
+**Lanes:** none. `lanes` is empty (`{}`), `classType` is empty, and the node has no user-facing configuration fields — it is wired internally by the engine rather than placed manually in a pipeline.
+
+## Setup
+
+No configuration. This node has no profiles, no config fields, and no external credentials; it relies on the embedding and store components configured elsewhere in the pipeline.

--- a/nodes/src/nodes/vectorizer/README.md
+++ b/nodes/src/nodes/vectorizer/README.md
@@ -1,10 +1,10 @@
 # vectorizer
 
-Internal node that chunks incoming text and tables, computes embeddings, and writes the resulting documents to the configured store.
+Chunks incoming text and tables, embeds them, and writes the resulting documents to the configured store.
 
 ## What it does
 
-The vectorizer is an internal (`capabilities: ["internal"]`) processing node in the ingestion path. As text and tables flow through it, it:
+The vectorizer is an internal (`capabilities: ["internal"]`) step in the ingestion path. As text and tables flow through, it:
 
 1. Checks whether the current object is flagged for vectorization (`FLAGS.VECTORIZE`).
 2. Splits the text into chunks using the configured preprocessor.
@@ -12,10 +12,10 @@ The vectorizer is an internal (`capabilities: ["internal"]`) processing node in 
 4. Computes embeddings for the chunks via the embedding component.
 5. Persists the chunks — either directly to the store (instance mode) or by writing them downstream to the endpoint store driver (transform mode).
 
-On retrieval (`renderObject`), it reads previously vectorized content back out of the store and feeds it to the text writer.
+On retrieval (`renderObject`), it pulls previously vectorized content back out of the store and feeds it to the text writer.
 
-**Lanes:** none. `lanes` is empty (`{}`), `classType` is empty, and the node has no user-facing configuration fields — it is wired internally by the engine rather than placed manually in a pipeline.
+**Lanes:** none. `lanes` is empty (`{}`), `classType` is empty, and there are no user-facing config fields — the engine wires this one up for you rather than you placing it by hand.
 
 ## Setup
 
-No configuration. This node has no profiles, no config fields, and no external credentials; it relies on the embedding and store components configured elsewhere in the pipeline.
+Nothing to configure. No profiles, no config fields, no credentials; it leans on the embedding and store components set up elsewhere in the pipeline.

--- a/nodes/src/nodes/webhook/README.md
+++ b/nodes/src/nodes/webhook/README.md
@@ -1,16 +1,16 @@
 # webhook
 
-An HTTP source node that feeds external input into a pipeline. It ships in three variants — Chat, Dropper, and Web Hook — all served from a single FastAPI endpoint.
+Let external input reach a pipeline over HTTP. Three variants — Chat, Dropper, and Web Hook — all served from a single FastAPI endpoint.
 
 ## What it does
 
-This is a `source` node: it stands up its own HTTP endpoint (host/port supplied by the engine) and forwards incoming data into the attached pipeline. The three variants share the same code (`nodes.webhook`) but differ by protocol and the surface they expose:
+It's a `source` node: it stands up its own HTTP endpoint (host/port supplied by the engine) and forwards incoming data into the attached pipeline. The three variants share the same code (`nodes.webhook`) but differ by protocol and by the surface they expose:
 
-- **Chat** (`chat://`) — serves a web-based chat UI. Users type questions in the browser, which are routed through the pipeline. Output lane: `questions`.
+- **Chat** (`chat://`) — serves a web-based chat UI. Users type questions in the browser, which flow through the pipeline. Output lane: `questions`.
 - **Dropper** (`dropper://`) — serves a web-based file-drop UI. Users drop files for ingestion and processing. Output lane: `tags`.
-- **Web Hook** (`webhook://`) — exposes a raw HTTP intake (also used for the RocketRide DataToolchain / ADS flow). External systems POST documents, media, or data for the pipeline to process. Output lanes: `tags`, `text`, `audio`, `video`, `image`, `questions`.
+- **Web Hook** (`webhook://`) — a raw HTTP intake (also used for the RocketRide DataToolchain / ADS flow). External systems POST documents, media, or data for the pipeline to process. Output lanes: `tags`, `text`, `audio`, `video`, `image`, `questions`.
 
-Each variant uses `_source` as its internal input and emits to the lanes listed above. On startup the node publishes its interface URL, a public authorization key, and a private token so callers know how to reach the endpoint.
+Each variant uses `_source` as its internal input and emits to the lanes listed above. On startup the node publishes its interface URL, a public authorization key, and a private token so callers know how to reach it.
 
 ## Configuration
 

--- a/nodes/src/nodes/webhook/README.md
+++ b/nodes/src/nodes/webhook/README.md
@@ -1,0 +1,22 @@
+# webhook
+
+An HTTP source node that feeds external input into a pipeline. It ships in three variants — Chat, Dropper, and Web Hook — all served from a single FastAPI endpoint.
+
+## What it does
+
+This is a `source` node: it stands up its own HTTP endpoint (host/port supplied by the engine) and forwards incoming data into the attached pipeline. The three variants share the same code (`nodes.webhook`) but differ by protocol and the surface they expose:
+
+- **Chat** (`chat://`) — serves a web-based chat UI. Users type questions in the browser, which are routed through the pipeline. Output lane: `questions`.
+- **Dropper** (`dropper://`) — serves a web-based file-drop UI. Users drop files for ingestion and processing. Output lane: `tags`.
+- **Web Hook** (`webhook://`) — exposes a raw HTTP intake (also used for the RocketRide DataToolchain / ADS flow). External systems POST documents, media, or data for the pipeline to process. Output lanes: `tags`, `text`, `audio`, `video`, `image`, `questions`.
+
+Each variant uses `_source` as its internal input and emits to the lanes listed above. On startup the node publishes its interface URL, a public authorization key, and a private token so callers know how to reach the endpoint.
+
+## Configuration
+
+The node creates its endpoint from the host and port passed in by the engine (`--data_host`, `--data_port`, defaulting to `localhost:5567`). There are no per-variant config fields beyond the standard source parameters.
+
+| Field          | Default | Description                                                        |
+| -------------- | ------- | ------------------------------------------------------------------ |
+| `source.mode`  | —       | Standard pipeline source mode.                                     |
+| `parameters`   | *(empty)* | Source parameters object; no variant-specific options are defined. |


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- Rewrite `docs/README-nodes.md` into a full 117-service catalog grouped by category, with each node's data-flow lanes and a new "How nodes connect" section (typed lanes + tool binding, i.e. the wire-vs-bind rule for assembling valid pipelines)
- Add `docs/README-node-schema.md` documenting the `services.json` model (`lanes`, `preconfig`/`profiles`, `fields`, `shape`) and how the visual canvas (RJSF) renders it; add `README.md` to 14 nodes that lacked one (`agent_crewai`, `agent_deepagent`, `guardrails`, `webhook`, `index_search`, `memory_persistent`, `telegram`, `rerank_cohere`, `embedding_video`, `tool_exa_search`, `tool_pipe`, `text_output`, `core`, `vectorizer`)
- Bump node count in root `README.md` (50+ → 85+ / 110+ services) and cross-link the new docs from `docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md`. Docs-only — no `services.json` or runtime code touched

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

docs

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #
