### PR TITLE
fix(build): restore .config removed in #1113 (unbreaks stage prerelease build)

### DIFF
--- a/.config
+++ b/.config
@@ -1,0 +1,77 @@
+# =============================================================================
+# RocketRide Build Configuration
+#
+# Public infrastructure values baked into app bundles at build time.
+# This file is the single source of truth -- safe to commit to the repo.
+#
+# Load order:  .config (defaults)  ->  .env (overrides)
+#
+# At build time, esbuild / rsbuild reads .config first, then layers .env
+# on top. Any key set in .env takes precedence over the value here.
+# This lets developers override cloud URLs for local testing without
+# modifying committed defaults.
+#
+# SECURITY: Only public values belong here. Never add secrets (API keys,
+# service tokens, database credentials, Stripe secret keys, etc.).
+# =============================================================================
+
+# =============================================================================
+# ZITADEL (OAuth2 / OIDC)
+#
+# All values below are public OAuth2 identifiers -- not secrets.
+# Security comes from PKCE challenge + redirect URI validation,
+# not from hiding these values.
+# =============================================================================
+
+# Zitadel issuer URL -- the OIDC identity provider endpoint.
+# How to get: your Zitadel instance URL from the Zitadel console.
+#   Self-hosted example: http://localhost:8080
+#   Zitadel Cloud example: https://yourinstance.zitadel.cloud
+RR_ZITADEL_URL=https://auth.rocketride.ai
+
+# Zitadel client ID for web applications (SPA / browser client).
+# Used by shell-ui (rsbuild injects it as process.env.RR_ZITADEL_CLIENT_ID).
+# How to get:
+#   1. Zitadel console -> Projects -> your project -> Applications
+#   2. Create a new application (type: User Agent / SPA)
+#   3. Copy the Client ID shown after creation
+RR_ZITADEL_CLIENT_ID=368801673541427525
+
+# Zitadel client ID for the VS Code extension (Native app type).
+# Separate from the web client because Native apps use custom URI schemes
+# (vscode://) for the OAuth redirect, which requires its own registration.
+# How to get: same as above, but create an application of type "Native".
+RR_ZITADEL_VSCODE_CLIENT_ID=369956598501709684
+
+# =============================================================================
+# STRIPE (Payments)
+#
+# The publishable key is a public client-side identifier -- not a secret.
+# Security comes from the server-side secret key (sk_*) which is never
+# included here. The publishable key only allows Stripe.js to render
+# payment elements and confirm payments initiated by the server.
+# =============================================================================
+
+# Stripe publishable key (pk_test_* or pk_live_*).
+# Used by shell-ui and VS Code webviews for Stripe Elements checkout.
+# How to get: Stripe Dashboard -> Developers -> API keys -> Publishable key
+RR_STRIPE_PUBLISHABLE_KEY=pk_test_51TNH9RDH9Dj9FxZRrhpNhVrnG2QfLe1NzLcjnPdPscFsJIAVvsjLsPnTdrAo0onHD6DEimTtb9nsB4oZbmKJuAH600WBYGWRxi
+
+# =============================================================================
+# SERVER CONNECTION (build-time defaults)
+#
+# These are the same defaults documented in .env.template and hardcoded as
+# fallbacks in apps/vscode/src/config.ts. They are required by the rsbuild
+# and esbuild config loaders (scripts/lib/getenv.js#requireKeys) so the
+# build can complete without a per-developer .env file. Local developers
+# can still override either value via .env.
+# =============================================================================
+
+# Default cloud / dev-server URI. Localhost is intentional -- developers
+# point this elsewhere via .env when targeting a remote server.
+ROCKETRIDE_URI=http://localhost:5565
+
+# Engine's built-in development API key -- NOT a secret. It is the public
+# default key the engine recognises in dev mode. Production / on-prem
+# deployments override this via .env with a real key.
+ROCKETRIDE_APIKEY=MYAPIKEY


### PR DESCRIPTION
## Why
Rod's **stage → Nightly prerelease** build (run 26971618302) failed all 3 platforms at the UI build:
```
[chat-ui] Missing required environment variable(s): ROCKETRIDE_URI
  at requireKeys (scripts/lib/getenv.js:108) / apps/chat-ui/rsbuild.config.mts:17
```
**#1113** (billing-3/shell-infra) **deleted the committed `.config`** (the public build-config: `ROCKETRIDE_URI`, `RR_ZITADEL_URL`, `RR_ZITADEL_CLIENT_ID`, …). chat-ui + shell-ui still read those at build time via `requireKeys`/`getenv` — and `getenv` reads `.config`/`.env`, **not** `process.env` — so the UI build aborts. develop still has the full `.config`, which is why develop builds.

## What
Restore `.config` to its pre-#1113 contents (public build defaults only, no secrets).

## Note
If `.config` was removed deliberately (config moving elsewhere in the shell-infra refactor), the proper fix is to repoint the apps' rsbuild `requireKeys` at the new source — but restoring `.config` is the fast unblock so prerelease builds work again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)