### PR TITLE
docs(clients): correct and expand Python & TypeScript client SDK references

### DIFF
--- a/docs/agents/ROCKETRIDE_python_API.md
+++ b/docs/agents/ROCKETRIDE_python_API.md
@@ -295,7 +295,7 @@ client = RocketRideClient(
 await client.connect()
 
 # Manual pipe management
-pipe = await client.pipe(token, mimetype='text/csv')
+pipe = await client.pipe(token, mime_type='text/csv')
 await pipe.open()
 await pipe.write(b'header1,header2\n')
 await pipe.write(b'value1,value2\n')
@@ -364,7 +364,7 @@ await client.disconnect()
 #### Constructor
 
 ```python
-RocketRideClient(uri: str, auth: str, **kwargs)
+RocketRideClient(uri: str = '', auth: str = '', **kwargs)
 ```
 
 **Parameters:**
@@ -381,13 +381,65 @@ RocketRideClient(uri: str, auth: str, **kwargs)
 
 #### Connection Methods
 
-##### `async connect() -> None`
+##### `async connect(credential: Optional[str] = None, *, timeout: Optional[float] = None) -> ConnectResult`
 
-Establish connection to the RocketRide server.
+Establish a connection to the RocketRide server. Optionally pass a `credential` to authenticate; `timeout` bounds the attempt. Internally this wraps the attach + login lifecycle and returns a `ConnectResult` carrying the resolved auth/identity info (most callers can ignore the return value).
 
 ##### `async disconnect() -> None`
 
-Close connection to the RocketRide server and stop automatic reconnection.
+Close the connection to the RocketRide server and stop automatic reconnection. Internally wraps `logout()` + `detach()`.
+
+##### Auth / Connection Lifecycle
+
+`connect()`/`disconnect()` are convenience wrappers over two independent concerns: the WebSocket transport (attach/detach) and the DAP auth handshake (login/logout). Use the primitives below when you need to manage them separately — e.g. attach once, then log in and out under different credentials without reopening the socket.
+
+###### `async attach(uri: Optional[str] = None, *, timeout: Optional[float] = None) -> None`
+
+Open the WebSocket transport without authenticating. If `uri` is provided and differs from the current URI, detaches first; attaching to the same URI is a no-op. `timeout` (seconds) bounds the connect.
+
+###### `async detach() -> None`
+
+Detach from the server: closes the WebSocket and cancels any pending reconnection.
+
+###### `async login(credential: Optional[str] = None, *, uri: Optional[str] = None, timeout: Optional[float] = None) -> ConnectResult`
+
+Authenticate over an attached transport (auto-attaches if not already attached). If `credential` differs from the current one, logs out first (best-effort) before re-authenticating; if already authenticated with the same credential, this is a no-op. Passing `uri` detaches and re-attaches to the new URI first. Returns a `ConnectResult` with the resolved auth/identity info.
+
+###### `async logout() -> None`
+
+Deauthenticate: sends a `deauth` request to the server and clears client-side auth state. The transport stays attached.
+
+###### `def is_attached() -> bool`
+
+`True` when the WebSocket transport is connected, regardless of auth state.
+
+###### `def is_authenticated() -> bool`
+
+`True` when the auth handshake has succeeded on the current connection.
+
+###### `def is_connected() -> bool`
+
+`True` when the client is connected (transport is up). Check before `use()`/`send()` if needed.
+
+###### `def get_account_info() -> Optional[ConnectResult]`
+
+Return the `ConnectResult` from the last successful `login()`, or `None` if not authenticated.
+
+**Example — attach once, log in, run, log out:**
+
+```python
+client = RocketRideClient()  # config from .env
+
+await client.attach()
+await client.login()  # uses ROCKETRIDE_APIKEY
+
+if client.is_authenticated():
+    result = await client.use(filepath='pipeline.pipe')
+    await client.send(result['token'], 'hello')
+
+await client.logout()
+await client.detach()
+```
 
 #### Execution Methods
 
@@ -395,13 +447,15 @@ Close connection to the RocketRide server and stop automatic reconnection.
 
 Start a RocketRide pipeline for processing data. Automatically performs environment variable substitution on the pipeline configuration.
 
+> All `use()` parameters are **keyword-only** — pass them by name (e.g. `use(pipeline=...)`), not positionally.
+
 **Parameters:**
 
 - `pipeline` (dict, optional): Flat pipeline configuration dict (`components`, `source`, `project_id` at top level)
 - `filepath` (str, optional): Path to a `.pipe` or JSON file containing pipeline configuration.
 - `token` (str, optional): Custom token for the pipeline (auto-generated if not provided)
 - `source` (str, optional): Override pipeline source
-- `threads` (int, optional): Number of threads for execution (default: 1)
+- `threads` (int, optional): Number of threads for execution (default: None — the server decides)
 - `use_existing` (bool, optional): Use existing pipeline instance
 - `args` (List[str], optional): Command line arguments to pass to pipeline
 - `ttl` (int, optional): Time-to-live in seconds for idle pipelines (server default if not provided; use 0 for no timeout)
@@ -427,9 +481,43 @@ Get the current status of a running pipeline.
 
 **Returns:** Dictionary containing status information
 
+##### `async restart(*, project_id: str, source: str, pipeline: PipelineConfig, token: Optional[str] = None) -> None`
+
+Restart a running pipeline with a new configuration. Looks up the existing task by project/source, terminates it, and starts a new execution in one server round-trip. All arguments are keyword-only.
+
+**Parameters:**
+
+- `project_id` (str): The project identifier
+- `source` (str): The source component identifier
+- `pipeline` (PipelineConfig): The pipeline configuration to restart with
+- `token` (str, optional): Existing task token; resolved server-side if omitted
+
+**Raises:** `RuntimeError` if the restart fails.
+
+**Example:**
+
+```python
+await client.restart(
+    project_id='my-project',
+    source='webhook',
+    pipeline=updated_pipeline,
+)
+```
+
+##### `async get_task_token(project_id: str, source: str) -> str | None`
+
+Resolve a running task's token from its project ID and source component. The token is required for operations like `terminate()` and `restart()`. Returns `None` if no task is currently running for the given project/source.
+
+**Parameters:**
+
+- `project_id` (str): The project identifier
+- `source` (str): The source component identifier
+
+**Returns:** The task token string, or `None` if no running task was found.
+
 #### Data Methods
 
-##### `async send(token: str, data: Union[str, bytes], objinfo: Dict[str, Any] = {}, mimetype: str = None) -> Dict[str, Any]`
+##### `async send(token: str, data: Union[str, bytes], objinfo: Dict[str, Any] = None, mimetype: str = None, on_sse=None) -> Dict[str, Any]`
 
 Send data directly to a pipeline.
 
@@ -439,6 +527,7 @@ Send data directly to a pipeline.
 - `data` (str or bytes): Data to send
 - `objinfo` (dict, optional): Metadata about the data
 - `mimetype` (str, optional): MIME type of the data
+- `on_sse` (callable, optional): Async callback `on_sse(type, data)` for streamed SSE events (see [Streaming Callback](#streaming-callback-on_sse))
 
 **Returns:** Processing result dictionary
 
@@ -459,7 +548,7 @@ Upload multiple files in parallel.
 
 **Note:** Upload progress events are sent through the event system as `apaevt_status_upload` events.
 
-##### `async pipe(token: str, objinfo: Dict[str, Any] = None, mime_type: str = None, provider: str = None) -> DataPipe`
+##### `async pipe(token: str, objinfo: Dict[str, Any] = None, mime_type: str = None, provider: str = None, on_sse=None) -> DataPipe`
 
 Create a streaming data pipe for sending large datasets.
 
@@ -469,19 +558,49 @@ Create a streaming data pipe for sending large datasets.
 - `objinfo` (dict, optional): Metadata about the data
 - `mime_type` (str, optional): MIME type of the data
 - `provider` (str, optional): Provider name
+- `on_sse` (callable, optional): Async callback `on_sse(type, data)` for streamed SSE events (see [Streaming Callback](#streaming-callback-on_sse))
 
 **Returns:** DataPipe instance
 
+##### Streaming Callback (`on_sse`)
+
+`send()`, `pipe()`, and `chat()` each accept an optional `on_sse` keyword argument: an async callback invoked for every Server-Sent Event emitted by the pipeline node for that specific call. Use it to stream incremental output (e.g. token-by-token LLM responses) before the final result resolves.
+
+**Callback signature:**
+
+```python
+async def on_sse(type: str, data: dict) -> None:
+    ...
+```
+
+- `type` (str): The SSE event type
+- `data` (dict): The event payload
+
+**Example — streaming a chat response:**
+
+```python
+from rocketride.schema import Question
+
+async def handle_sse(type: str, data: dict) -> None:
+    print(f'[{type}] {data}')
+
+question = Question()
+question.addQuestion('Summarize the document.')
+
+response = await client.chat(token=token, question=question, on_sse=handle_sse)
+```
+
 #### Chat Methods
 
-##### `async chat(token: str, question: Question) -> Dict[str, Any]`
+##### `async chat(*, token: str, question: Question, on_sse=None) -> Dict[str, Any]`
 
-Ask a question to RocketRide's AI and get an intelligent response.
+Ask a question to RocketRide's AI and get an intelligent response. All arguments are keyword-only.
 
 **Parameters:**
 
 - `token` (str): Task token of the chat pipeline
 - `question` (Question): Question object containing the query
+- `on_sse` (callable, optional): Async callback `on_sse(type, data)` for streamed SSE events (see [Streaming Callback](#streaming-callback-on_sse))
 
 **Returns:** Response dictionary containing answers
 
@@ -563,7 +682,7 @@ Question(expectJson: bool = False)
 
 Add the main question text.
 
-##### `addInstruction(subtitle: str, instructions: str) -> Question`
+##### `addInstruction(title: str, instruction: str) -> Question`
 
 Add specific instructions to guide the AI's response.
 
@@ -674,7 +793,6 @@ The SDK supports automatic MIME type detection for common file extensions:
 
 For data pipes, MIME types determine processing lanes:
 
-- `application/rocketride-tag` → RocketRide tag stream format
 - `application/rocketride-question` → AI chat question format
 - `text/*` → Text lane
 - `image/*` → Image lane
@@ -809,7 +927,7 @@ async def stream_sensor_data(data_generator):
         token = result['token']
 
         # Stream data using pipe
-        async with await client.pipe(token, mimetype='application/json') as pipe:
+        async with await client.pipe(token, mime_type='application/json') as pipe:
             async for sensor_reading in data_generator:
                 data = {
                     'timestamp': sensor_reading.timestamp,
@@ -946,6 +1064,51 @@ Common error scenarios:
 - **Pipeline errors**: Invalid pipeline configuration
 - **Execution errors**: Pipeline execution failures
 - **Upload errors**: File upload failures
+
+### Exception Hierarchy
+
+All SDK exceptions derive from `DAPException`, which wraps the raw DAP error result (exposed via `.dap_result`). Catch from broad to narrow:
+
+```text
+DAPException                      (base; wraps DAP error responses)
+└── RocketRideException           (catch-all for any RocketRide error)
+    ├── ConnectionException       (server unreachable, network, connection lost)
+    │   └── AuthenticationException   (bad API key / credentials)
+    ├── PipeException             (data-transfer failures; also a RuntimeError)
+    ├── ExecutionException        (pipeline execution failures)
+    └── ValidationException       (invalid input / pipeline configuration)
+```
+
+Which methods raise what:
+
+- `connect()` / `attach()` / `login()` — `ConnectionException`, or `AuthenticationException` on bad credentials
+- `use()` — `ValidationException` for a bad config, `ExecutionException` if the pipeline fails to start
+- `send()` / `send_files()` / `pipe()` writes — `PipeException` on transfer failure (also catchable as `RuntimeError`)
+- `terminate()` / `restart()` — raise `RuntimeError` on failure
+
+Catching `RocketRideException` handles every SDK-originated error while still giving you `.dap_result` for context.
+
+```python
+from rocketride import RocketRideException, AuthenticationException
+
+try:
+    await client.connect()
+    result = await client.use(filepath='pipeline.pipe')
+except AuthenticationException as e:
+    print(f'Bad credentials: {e}')
+except RocketRideException as e:
+    print(f'RocketRide error: {e} (raw: {e.dap_result})')
+```
+
+### Importing Schema Types
+
+Schema models can be imported directly from the top-level `rocketride` package (they are re-exported via `__all__`), not only from `rocketride.schema`:
+
+```python
+from rocketride import Question, Doc, DocGroup, DocFilter
+```
+
+Both import paths work; the top-level form is convenient when you also import `RocketRideClient` from `rocketride`.
 
 ## Performance Considerations
 

--- a/docs/agents/ROCKETRIDE_typescript_API.md
+++ b/docs/agents/ROCKETRIDE_typescript_API.md
@@ -370,14 +370,14 @@ new RocketRideClient(config?: RocketRideClientConfig)
 - `onDisconnected?: (reason?: string, hasError?: boolean) => Promise<void>` - Connection lost callback
 - `persist?: boolean` - Enable automatic reconnection with exponential backoff (default: false)
 - `maxRetryTime?: number` - Maximum total time in milliseconds to keep retrying connections (default: undefined, retry indefinitely)
-- `onConnectError?: (error?: string) => Promise<void>` - Called on each failed connection attempt in persist mode
+- `onConnectError?: (error: ConnectionException) => void | Promise<void>` - Called on each failed connection attempt in persist mode (the argument is a `ConnectionException`)
 - `module?: string` - Module name for client identification
 
 #### Connection Methods
 
-##### `connect(): Promise<void>`
+##### `connect(credential?: string | { code: string; verifier: string; redirectUri: string }, options?: { uri?: string; timeout?: number }): Promise<ConnectResult>`
 
-Establish connection to the RocketRide server.
+Establish a connection to the RocketRide server. The optional `credential` may be either an API-key/token string or an OAuth PKCE object (`{ code, verifier, redirectUri }`); `options` (`uri`, `timeout`) override config per call. Returns a `ConnectResult` carrying the resolved auth/identity info (most callers can ignore the return value).
 
 ##### `disconnect(): Promise<void>`
 
@@ -386,6 +386,38 @@ Close connection to the RocketRide server and stop automatic reconnection.
 ##### `isConnected(): boolean`
 
 Check if the client is currently connected to the server.
+
+#### Auth & Connection Lifecycle
+
+Lower-level lifecycle primitives that `connect()`/`disconnect()` build on: open a transport, authenticate, and tear down independently. `connect()` itself is the high-level convenience — it attaches and logs in for you, and its `credential` may be either an API key/token string or an OAuth PKCE object `{ code, verifier, redirectUri }`.
+
+##### `attach(uri?: string, options?: { timeout?: number }): Promise<void>`
+
+Open the WebSocket transport without authenticating. If `uri` differs from the current one, the client detaches first. After attach, public (`rrext_public_*`) APIs are available. No-op if already attached to the same URI.
+
+##### `login(credential?: string | { code: string; verifier: string; redirectUri: string }, options?: { uri?: string; timeout?: number }): Promise<ConnectResult>`
+
+Authenticate over an already-attached transport. Accepts an API key, an `rr_` token, or a PKCE code object. If `options.uri` differs, it detaches and re-attaches first. Returns a `ConnectResult` with user identity. Throws `AuthenticationException` on failure (the transport stays attached).
+
+##### `logout(): Promise<void>`
+
+Deauthenticate (sends `deauth`) and clear client auth state. The transport stays attached, so public APIs keep working.
+
+##### `detach(): Promise<void>`
+
+Close the WebSocket transport entirely.
+
+**Example — manual attach/login/logout/detach:**
+
+```typescript
+const client = new RocketRideClient({ uri: 'https://api.rocketride.ai' });
+
+await client.attach(); // transport only — public APIs now available
+await client.login('your-api-key'); // authenticate
+// ... do authenticated work ...
+await client.logout(); // drop auth, keep transport
+await client.detach(); // close transport
+```
 
 #### Execution Methods
 
@@ -413,9 +445,46 @@ Terminate a running pipeline.
 
 Get the current status of a running pipeline.
 
+##### `validate(options: { pipeline: PipelineConfig | Record<string, unknown>; source?: string }): Promise<ValidationResult>`
+
+Validate a pipeline configuration without starting it — a pre-flight check before `use()`. Returns a `ValidationResult` with `errors` and `warnings` arrays (plus any extra engine fields). A pipeline will not execute while it has `errors`; `warnings` are non-fatal.
+
+```typescript
+const result = await client.validate({ pipeline });
+if (result.errors.length > 0) {
+	console.error('Pipeline invalid:', result.errors);
+} else {
+	const { token } = await client.use({ pipeline });
+}
+```
+
+##### `restart(options: { token?: string; projectId: string; source: string; pipeline: Record<string, unknown> }): Promise<void>`
+
+Restart a running pipeline with a new configuration. Looks up the existing task by project/source, terminates it, and starts a new execution in one server round-trip. `token` is optional and resolved server-side if omitted.
+
+```typescript
+await client.restart({ projectId: 'proj-123', source: 'input', pipeline });
+```
+
+##### `getTaskToken(options: { projectId: string; source: string }): Promise<string | undefined>`
+
+Resolve a running task's token from its project ID and source component. The token is required for operations like `terminate()` and `restart()`. Returns `undefined` if no task is currently running for that project/source.
+
+```typescript
+const token = await client.getTaskToken({ projectId: 'proj-123', source: 'input' });
+```
+
+##### `getTaskPipeline(token: string): Promise<Record<string, unknown> | undefined>`
+
+Return the unresolved pipeline configuration for a running task. The pipeline is returned exactly as stored — `${ROCKETRIDE_*}` placeholders are **not** substituted, so no secrets are included. Returns `undefined` if the task is not found.
+
+```typescript
+const pipeline = await client.getTaskPipeline(token);
+```
+
 #### Data Methods
 
-##### `send(token: string, data: string | Uint8Array, objinfo?: Record<string, any>, mimetype?: string): Promise<PIPELINE_RESULT>`
+##### `send(token: string, data: string | Uint8Array, objinfo?: Record<string, any>, mimetype?: string): Promise<PIPELINE_RESULT | undefined>`
 
 Send data directly to a pipeline.
 
@@ -443,6 +512,33 @@ Upload multiple files in parallel.
 
 Create a streaming data pipe for sending large datasets.
 
+##### Streaming callback (`onSSE`)
+
+`pipe()`, `send()`, and `chat()` accept a trailing `onSSE` callback that fires for each server-sent event (e.g. token-by-token AI output) while the request is in flight. The callback signature is the same in every case:
+
+```typescript
+onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>
+```
+
+It is the last positional parameter on `pipe()` and `send()`, and a field on the `chat()` options object:
+
+- `send(token, data, objinfo?, mimetype?, onSSE?)`
+- `pipe(token, objinfo?, mimeType?, provider?, onSSE?)`
+- `chat({ token, question, onSSE? })`
+
+**Example — stream a chat answer:**
+
+```typescript
+const response = await client.chat({
+	token,
+	question,
+	onSSE: async (type, data) => {
+		// `type` is the SSE event name; `data` is the event payload.
+		console.log('sse', type, data);
+	},
+});
+```
+
 #### Chat Methods
 
 ##### `chat(options: { token: string, question: Question }): Promise<PIPELINE_RESULT>`
@@ -464,14 +560,32 @@ const response = await client.chat({ token: 'chat-token', question });
 
 #### Event Methods
 
-##### `setEvents(token: string, eventTypes: string[]): Promise<void>`
+##### `setEvents(token: string, eventTypes: string[], pipeId?: number): Promise<void>`
 
-Subscribe to specific types of events from the server.
+Subscribe to specific types of events from the server. The optional `pipeId` scopes the subscription to a single pipe within the task.
 
 **Example:**
 
 ```typescript
 await client.setEvents('task-token', ['apaevt_status_upload', 'apaevt_status_processing']);
+```
+
+##### `addMonitor(key: MonitorKey, types: string[]): Promise<void>`
+
+Add a reference-counted monitor subscription. If the key already exists, the new `types` are merged with the existing set and the merged set is sent to the server. `MonitorKey` is either `{ token: string }` for a running task or `{ projectId: string; source: string; pipeId?: number }` for a project/source.
+
+```typescript
+await client.addMonitor({ token }, ['summary', 'flow']);
+// or, before the task is running, by project/source:
+await client.addMonitor({ projectId: 'proj-123', source: 'input' }, ['summary']);
+```
+
+##### `removeMonitor(key: MonitorKey, types: string[]): Promise<void>`
+
+Remove a monitor subscription. Decrements the reference counts for the given `types`; a type is only unsubscribed from the server once its count reaches zero. The `key` must match the one passed to `addMonitor()`.
+
+```typescript
+await client.removeMonitor({ token }, ['flow']);
 ```
 
 #### Connectivity Methods
@@ -504,23 +618,25 @@ Question builder for AI chat operations.
 
 #### Methods
 
-##### `addQuestion(text: string): Question`
+> The `add*` builder methods mutate the `Question` in place and return `void` — they do **not** support chaining (e.g. `q.addQuestion(...).addContext(...)` will not compile).
+
+##### `addQuestion(text: string): void`
 
 Add the main question text.
 
-##### `addInstruction(subtitle: string, instructions: string): Question`
+##### `addInstruction(title: string, instruction: string): void`
 
 Add specific instructions to guide the AI's response.
 
-##### `addExample(given: string, result: any): Question`
+##### `addExample(given: string, result: any): void`
 
 Provide an example of the desired response format.
 
-##### `addContext(context: string | Record<string, any>): Question`
+##### `addContext(context: string | Record<string, any>): void`
 
 Add contextual information for the AI.
 
-##### `addHistory(history: QuestionHistory): Question`
+##### `addHistory(history: QuestionHistory): void`
 
 Add conversation history for context.
 
@@ -533,11 +649,11 @@ Add conversation history for context.
 }
 ```
 
-##### `addGoal(goal: string): Question`
+##### `addGoal(goal: string): void`
 
 Add a goal to guide the AI's response.
 
-##### `addDocuments(documents: Doc | Doc[]): Question`
+##### `addDocuments(documents: Doc | Doc[]): void`
 
 Add one or more documents to the question context.
 
@@ -596,7 +712,8 @@ interface PIPELINE_RESULT {
 
 ```typescript
 interface TASK_STATUS {
-	state: 'running' | 'completed' | 'failed' | 'terminated';
+	state: number; // TASK_STATE enum: 0 NONE, 1 STARTING, 2 INITIALIZING, 3 RUNNING, 4 STOPPING, 5 COMPLETED, 6 CANCELLED
+	completed: boolean; // true once the task has finished (prefer this over comparing `state`)
 	progress?: number; // Progress percentage (0-100)
 	message?: string; // Status message
 	[key: string]: any; // Additional status fields
@@ -619,7 +736,6 @@ The SDK supports automatic MIME type detection for common file extensions:
 
 For data pipes, MIME types determine processing lanes:
 
-- `application/rocketride-tag` → RocketRide tag stream format
 - `application/rocketride-question` → AI chat question format
 - `text/*` → Text lane
 - `image/*` → Image lane
@@ -653,7 +769,7 @@ async function myChat(myQuestion: string): Promise<string> {
 	// Issue the chat request
 	const response = await client.chat({ token, question });
 
-	// Check if we got answers
+	// `answers` is a dynamic field — present only when the pipeline's result_types maps it. Treat it as optional.
 	if (!response.answers || response.answers.length === 0) {
 		return 'No answer received';
 	}
@@ -846,12 +962,12 @@ const client = new RocketRideClient({
 ```typescript
 // Request status
 const status = await client.getTaskStatus(token);
-const state = status.state; // 'running', 'completed', 'failed', etc.
+const numericState = status.state; // number from the TASK_STATE enum (e.g. 3 = RUNNING, 5 = COMPLETED)
 
-// Poll for progress
+// Poll for progress — `completed` is a boolean that flips true once the task finishes
 while (true) {
 	const status = await client.getTaskStatus(token);
-	if (['completed', 'failed', 'terminated'].includes(status.state)) {
+	if (status.completed) {
 		break;
 	}
 	await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -912,6 +1028,57 @@ Common error scenarios:
 - **Execution errors**: Pipeline execution failures
 - **Upload errors**: File upload failures
 
+### Exception Classes
+
+The SDK exports a typed exception hierarchy so you can catch errors at the right level of specificity. All extend the base `DAPException`, which carries the raw server response on a `dapResult: Record<string, unknown>` property.
+
+```
+DAPException                      // base — wraps any DAP error response (.dapResult)
+└─ RocketRideException            // root of all RocketRide-specific errors
+   ├─ ConnectionException         // connect/transport problems, dropped connections
+   │  └─ AuthenticationException  // bad API key / credentials
+   ├─ PipeException               // data pipe / upload / streaming failures
+   ├─ ExecutionException          // pipeline start/run/management failures
+   └─ ValidationException         // invalid pipeline configuration
+```
+
+All are importable from the package root:
+
+```typescript
+import {
+	DAPException,
+	RocketRideException,
+	ConnectionException,
+	AuthenticationException,
+	PipeException,
+	ExecutionException,
+	ValidationException,
+} from 'rocketride';
+```
+
+**Which methods throw what:**
+
+- `AuthenticationException` — thrown by `login()` (and therefore `connect()`) on auth failure. In persist mode the client catches it, calls `onConnectError`, and does **not** retry, so the app can fix credentials and reconnect.
+- `ConnectionException` — `attach()`/`connect()` transport failures; also delivered to the `onConnectError` constructor callback (whose argument is typed `ConnectionException`).
+
+Catch the most specific type first, then fall back to a broader one:
+
+```typescript
+import { AuthenticationException, RocketRideException } from 'rocketride';
+
+try {
+	await client.connect('your-api-key');
+} catch (err) {
+	if (err instanceof AuthenticationException) {
+		console.error('Bad credentials:', err.message);
+	} else if (err instanceof RocketRideException) {
+		console.error('RocketRide error:', err.message, err.dapResult);
+	} else {
+		throw err;
+	}
+}
+```
+
 ## Performance Considerations
 
 - File uploads are parallelized (all files uploaded concurrently)
@@ -922,7 +1089,7 @@ Common error scenarios:
 
 ## Requirements
 
-- Node.js 16.0.0 or higher
+- Node.js 18+ recommended. The package declares no hard `engines` floor; the `await using` / `Symbol.asyncDispose` examples require Node 20+ and TypeScript 5.2+.
 - WebSocket connection to RocketRide DAP server
 - Valid API key for authentication
 


### PR DESCRIPTION
## Summary

Audit-driven fixes and additions to the client SDK reference docs (`docs/agents/ROCKETRIDE_{python,typescript}_API.md`), every claim verified against `packages/client-{python,typescript}/src`. **Docs-only — no code changes.**

Prompted by Ariel's review note that the client docs were likely outdated. They were: several documented examples would break on copy-paste, and large parts of the current API surface were undocumented.

## Corrections (would break copy-pasted code)

**Python**
- `pipe()` `mimetype=` → `mime_type=` (the real kwarg)
- Constructor defaults `(uri='', auth='')`; `connect()` real signature returning `ConnectResult`
- `use()` `threads` default `None` (server decides) + keyword-only note; `send()` `objinfo` default `None`
- `addInstruction(title, instruction)`

**TypeScript**
- `Question.add*` return `void` (not `Question` — no chaining)
- `TASK_STATUS.state` is a numeric `TASK_STATE` enum + `completed: boolean`; polling uses `status.completed`
- `send(): Promise<PIPELINE_RESULT | undefined>`; `connect()` real PKCE signature
- `onConnectError` arg is a `ConnectionException`; `setEvents` gains `pipeId?`

**Both**
- Removed phantom `application/rocketride-tag` MIME type (absent from the codebase)
- Replaced the unsubstantiated "Node 16+" requirement (no `engines` field; `await using` needs Node 20+/TS 5.2+)

## Additions (verified API surface that was undocumented)

- **Python:** auth/connection lifecycle (`attach/detach/login/logout/is_*`), `restart()`, `get_task_token()`, streaming `on_sse`, exception hierarchy, top-level schema imports
- **TypeScript:** auth/connection lifecycle, `validate()`, `restart()`, `getTaskToken()`, `getTaskPipeline()`, streaming `onSSE`, `add/removeMonitor`, exception classes

## Verification

- Every documented signature grep-checked against client source; an independent adversarial review pass caught and fixed 2 inaccuracies (invented `ConnectOptions` type, TS `addInstruction` params).
- `docs/agents/` is the canonical source; `build/vscode/docs/` regenerates from it on `./builder vscode:build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Python and TypeScript API reference documentation with revised method signatures and parameters
  * Added streaming callback support for incremental output during requests
  * Introduced new connection lifecycle and pipeline execution methods
  * Added comprehensive exception hierarchy documentation with method-specific error guidance
  * Clarified parameter defaults and keyword-only arguments across core APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->