### PR TITLE
fix(build): include shell-ui and apps.json in release packages, fix restart token

### DIFF
--- a/apps/shell-ui/scripts/tasks.js
+++ b/apps/shell-ui/scripts/tasks.js
@@ -136,7 +136,7 @@ function makeCopyAction() {
 		run: async (ctx, task) => {
 			// Exclude apps/ from mirror — app bundles are copied by their own tasks
 			// and must not be deleted when shell-ui syncs its build output.
-			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR, { ignore: ['**/__pycache__/**', 'apps/**'] });
+			const stats = await syncDir(BUILD_DIR, SERVER_STATIC_DIR, { ignore: ['**/__pycache__/**', 'apps/**'], package: true });
 			task.output = formatSyncStats(stats);
 		},
 	};

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -1158,7 +1158,6 @@ export class RocketRideClient extends DAPClient {
 					source: options.source,
 					pipeline: options.pipeline,
 				},
-				{ token: '*' }
 			);
 		} catch (err) {
 			const errorMsg = err instanceof Error ? err.message : String(err);

--- a/scripts/lib/registerApp.js
+++ b/scripts/lib/registerApp.js
@@ -43,7 +43,7 @@
 
 const fs   = require('node:fs');
 const path = require('node:path');
-const { BUILD_ROOT, DIST_ROOT } = require('./index');
+const { BUILD_ROOT, DIST_ROOT, setState } = require('./index');
 
 const BUILD_APPS_JSON = path.join(BUILD_ROOT, 'apps.json');
 const DIST_APPS_JSON  = path.join(DIST_ROOT, 'server', 'static', 'apps.json');
@@ -231,6 +231,9 @@ function registerApp(appRoot) {
 
 			// Upsert into dist/server/static/apps.json (production server)
 			writeManifest(DIST_APPS_JSON, upsert(readManifest(DIST_APPS_JSON), appEntry));
+
+			// Register apps.json for packaging so it's included in release archives
+			await setState(['package', DIST_APPS_JSON], ['static/apps.json']);
 
 			task.output = `Registered "${appEntry.name}" (${appEntry.id}) → ${appEntry.entry}`;
 		},


### PR DESCRIPTION
## Summary
- **shell-ui missing from releases**: `shell-ui:copy` didn't set `package: true`, so the SPA files were never included in CI release archives. Downloaded engines showed "Shell UI not built" on every request.
- **apps.json missing from releases**: `registerApp.js` wrote `apps.json` via raw `fs.writeFileSync`, bypassing the packaging system. Release archives had no app manifest.
- **restart command broken**: `client.restart()` passed `{ token: '*' }` as DAP options, causing `buildRequest()` to overwrite `arguments.token` (the task token) with `'*'`. Server couldn't find the task. Removed the redundant DAP token — session auth handles it.

## Test plan
- [ ] `./builder build --verbose` then `./builder package --verbose` — inspect the zip for `static/shell/index.html`, `static/apps.json`, and `static/apps/`
- [ ] Download a release engine, start it, browse to `http://localhost:5565` — shell should load
- [ ] Run a pipeline, save the .pipe file, click Yes on restart prompt — should restart without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)