### PR TITLE
chore(security): port .gitleaksignore Exa allowlist to develop (stage↔develop reconcile)

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,2 +1,8 @@
 # Stripe publishable key (pk_test_*) is a public client-side key, not a secret.
 .config:generic-api-key:58
+
+# False positive: placeholder API key in node test config template.
+# Comment on line 137 of services.json: "apikey" is intentionally set to a placeholder.
+# Originally added in #509 (Exa search node, April 21); orphaned SHA after develop
+# force-push at end of April resurfaced the finding on this dot release PR.
+fd6b61d56b0671f7a3d24d0314d060a3d0d61b8c:nodes/src/nodes/tool_exa_search/services.json:pipe-file-api-key:138


### PR DESCRIPTION
Cherry-picks the `.gitleaksignore` Exa-search test-config allowlist (commit 51e814f1) from **stage** onto **develop** — part of the stage↔develop reconcile.

Develop didn't carry this suppression, so gitleaks CI flags the `tool_exa_search/services.json` placeholder as a false positive. This kills it. develop had no unique changes to `.gitleaksignore`, so the cherry-pick is clean (1 file, +6 lines).

**Not included here** (from Rod's reconcile list):
- **Item 1 (npm OIDC `_release.yaml`)** — turns out develop *also* has OIDC, just a different partial (develop still has `registry-url` set / missing #977's removal; stage removed it). It's a genuine bidirectional divergence, not a one-way port — handling it as a careful merge separately. The **release branch (stage) is correct**, so this isn't release-blocking.
- **Item 2 (Discord regex)** — anchored-vs-unanchored reconcile, separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security scanning configuration to refine false positive handling for known placeholder references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->