### PR TITLE
fix(release): remove orphaned TWINE lines crashing the MCP PyPI publish

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -263,8 +263,6 @@ jobs:
           else
             twine upload release-assets/*.whl release-assets/*.tar.gz
           fi
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
 
       # --- VS Code Marketplace + Open VSX ---
       - name: Set up Node.js for vsce


### PR DESCRIPTION
**Root-causes the red `Release / MCP Client` job from the 2026-06-04 release.**

The `Publish rocketride-mcp to PyPI` step in `_release.yaml` had a leftover **duplicate `TWINE_USERNAME` / `TWINE_PASSWORD` pair *inside* the `run:` block** (after the `fi`), on top of the correct `env:` block. The shell tried to execute `TWINE_USERNAME: __token__` as a command → `command not found`, **exit 127**.

- The MCP **package still reached PyPI** (`rocketride-mcp` 1.2.0 is live) — the step crashed *after* the publish/skip, so it was a cosmetic-but-red failure.
- The neighbouring `Publish rocketride to PyPI` step had no such dupe, which is exactly why the **python client published fine** and only MCP went red.

Fix = delete the two orphaned lines. `python -c yaml.safe_load` passes; diff is `-2 lines`.

> Note: this is on **develop**. The released **stage/main** copy still has the dupe, so it should ride along on the next develop→stage promote (or be cherry-picked) before the next release, else MCP goes red again (harmlessly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)