### PR TITLE
fix(vscode): allow GitHub raw host in webview CSP so announcements load

### DIFF
--- a/apps/vscode/src/providers/template.html
+++ b/apps/vscode/src/providers/template.html
@@ -31,7 +31,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' {{cspSource}}; style-src 'unsafe-inline' {{cspSource}}; font-src {{cspSource}} data:; connect-src {{cspSource}}; img-src {{cspSource}} data:;">
+	<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'unsafe-eval' {{cspSource}}; style-src 'unsafe-inline' {{cspSource}}; font-src {{cspSource}} data:; connect-src {{cspSource}} https://raw.githubusercontent.com; img-src {{cspSource}} data: https://raw.githubusercontent.com;">
 	<title>RocketRide</title>
 
 </head>


### PR DESCRIPTION
## Summary

- The sidebar announcements ticker (`SidebarFooter`) fetches from `raw.githubusercontent.com` via `useAnnouncements`, but the webview CSP only allowed the extension's own origin — so the fetch was browser-blocked and the ticker silently rendered empty.
- Adds `https://raw.githubusercontent.com` to `connect-src` (JSON fetch) and `img-src` (announcement icons) in the shared webview template CSP.

## Type

fix

## Testing

- [ ] Tests added or updated <!-- N/A — CSP meta-tag change, no unit-testable surface -->
- [ ] Tested locally
- [ ] `./builder test` passes <!-- run before pushing -->

Steps: rebuild the webview so `page-sidebar.html` regenerates with the new CSP → reload the window → announcements render from `announcements.json`; webview console shows no `Refused to connect` error.

## Linked Issue

Fixes #1130 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security policy to allow external resource requests from GitHub raw content repository. This enables loading of content from this external source while maintaining application security standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->