### PR TITLE
feat(depends): add load_depends() helper

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -890,6 +890,23 @@ def depends(requirements: Optional[str] = None):
         _apply_pywin32_hack()
 
 
+def load_depends(current_file: str, requirements_file: str = 'requirements.txt') -> None:
+    """Install a requirements file located alongside the calling module.
+
+    Saves callers the os.path boilerplate of resolving a requirements file next
+    to their own module. Equivalent to ``depends(<dir of current_file>/<requirements_file>)``.
+
+    Args:
+        current_file: The caller's ``__file__``.
+        requirements_file: Requirements filename in that module's directory (default 'requirements.txt').
+
+    Returns:
+        None.
+    """
+    requirements = os.path.join(os.path.dirname(os.path.realpath(current_file)), requirements_file)
+    depends(requirements)
+
+
 # ---------------------------------------------------------------------------
 # Main Mode
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds `load_depends(current_file, requirements_file='requirements.txt')` to the `depends` module.

Resolves a requirements file located next to the caller's module and installs it via `depends()`, replacing the repeated `os.path.join(os.path.dirname(os.path.realpath(__file__)), ...)` + `depends()` boilerplate.

Usage:
```python
from depends import load_depends
load_depends(__file__, 'requirements_vision.txt')
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency management handling in Python library components for more flexible requirements file configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->