### PR TITLE
fix(build): gate server:compile-tests on persisted download state

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -972,7 +972,15 @@ function makeTestAction() {
 			'server:build',
 			whenNot({
 				name: 'downloaded',
-				condition: (ctx) => ctx.serverDownloaded,
+				// `ctx.serverDownloaded` only reflects a download that happened in THIS
+				// process. In CI the engine is downloaded during the `build` step and
+				// the `test` step is a separate invocation where `server:build` is
+				// skipped, so the flag is lost and we'd fall through to compiling tests
+				// against a downloaded engine that has no configured CMake build dir
+				// (server:compile-tests -> "not a CMake build directory"). Fall back to
+				// the persisted download marker so a downloaded (non-compiled) engine
+				// still skips the test-compile block across step boundaries.
+				condition: async (ctx) => ctx.serverDownloaded || Boolean(await getState('server.downloadHash')),
 				then: [
 					// Build modules needed for tests
 					parallel(['nodes:build', 'ai:build', 'client-python:build'], 'Build modules'),

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -700,6 +700,10 @@ function makeCompileEngineAction(options = {}) {
 
 			// Save content hash after successful compilation
 			await setState('server.buildHash', ctx.serverSourceHash);
+			// A local compile supersedes any prior downloaded-engine marker;
+			// clear it so `server:test` doesn't read a stale `downloadHash` and
+			// wrongly skip the test block for a freshly-compiled engine.
+			await setState('server.downloadHash', null);
 
 			task.output = `Compiled v${version}`;
 		},


### PR DESCRIPTION
## Problem
CI is **red repo-wide** — `develop` itself (CI #907) plus every open PR (#1138 `feat/billing-4`, `feat/deploy-v2`) fail on **all three platforms** at `server:compile-tests`:

- Ubuntu / macOS: `cmake --build … --target aptest` → `could not load cache` / `not a CMake build directory (missing CMakeCache.txt)`
- Windows: `Visual Studio environment not in state. Run server:setup-tools first`

## Root cause
`makeTestAction` gates the test-compile block with `whenNot({name:'downloaded', condition: (ctx) => ctx.serverDownloaded})`. `ctx.serverDownloaded` is only set when `server:download` runs **in the current process**. In CI the engine is downloaded during the **build** step; the **test** step is a separate `builder` invocation where `server:build` is skipped, so the flag is never restored. The block then runs `server:compile-tests` against a **downloaded** engine that was never CMake-configured → no `CMakeCache.txt`.

This surfaced today once a nightly prerelease matched develop's source hash, flipping CI from the compile path (CMake configured → green) to the download path.

> Note: #1128's `server.buildHash = releaseHash` on the download path is an intentional packaging fix (store the engine hash for downloaded engines). This PR **keeps that** and fixes the test gate instead of touching the hash.

## Fix
Make the `downloaded` gate consult the **persisted** `server.downloadHash` marker in addition to the ephemeral `ctx.serverDownloaded`, so a downloaded (non-compiled) engine skips the test-compile block across the build→test step boundary:

```js
condition: async (ctx) => ctx.serverDownloaded || Boolean(await getState('server.downloadHash'))
```

(`whenNot` already awaits its condition, so the async form is supported.) `server.downloadHash` is set to the release hash on download and cleared to `null` on the compile path, so it cleanly distinguishes downloaded vs built-from-source.

Unblocks `develop`, #1138, and `feat/deploy-v2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant server test compilations by ensuring a previously downloaded engine is recognized across separate CI steps, preserving "downloaded engine → skip compile-tests" behavior and speeding up CI runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->