### PR TITLE
fix(release): cut CHANGELOG at version bump + scope stable release notes (#56)

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -349,8 +349,10 @@ jobs:
           SERVER_VERSION: ${{ inputs.server_version }}
         run: |
           # Source GitHub Release notes from CHANGELOG.md so releases show the
-          # curated, human-written change list — not the squashed stage->main
-          # merge PR that generate_release_notes would otherwise emit.
+          # curated, human-written change list. The "Create GitHub release"
+          # step below keeps generate_release_notes OFF, so this body is the
+          # ENTIRE published notes — no appended, squashed stage->main merge-PR
+          # list (which is all GitHub's auto-notes would add under squash-merge).
           #
           #   Prerelease (nightly): emit the current [Unreleased] section — the
           #     "what's cooking on stage" view a prerelease should expose.
@@ -360,11 +362,21 @@ jobs:
           #     scripts/release/cut-changelog.mjs, so the notes are scoped to
           #     this release instead of re-emitting the whole growing
           #     [Unreleased] blob on every release. See RELEASE.md.
+          #
+          # Both extractors are fenced-code aware: a "## [" line inside a ```
+          # (or ~~~) block is body text, not a section header, so it must not
+          # split sections.
           if [ "${{ inputs.prerelease }}" = "true" ]; then
-            NOTES="$(awk '/^## \[/{c++} c==1{print} c==2{exit}' CHANGELOG.md | sed '1d')"
+            NOTES="$(awk '
+              /^(```|~~~)/        { fence = !fence }
+              !fence && /^## \[/  { c++ }
+              c == 1              { print }
+              c == 2              { exit }
+            ' CHANGELOG.md | sed '1d')"
           else
             NOTES="$(awk '
-              /^## \[/ {
+              /^(```|~~~)/ { fence = !fence }
+              !fence && /^## \[/ {
                 if (cap) exit                       # next header after capture -> done
                 if ($0 ~ /^## \[Unreleased/) next   # skip the [Unreleased] header and its body
                 cap = 1; next                        # first released header -> capture its body
@@ -374,15 +386,19 @@ jobs:
             # Warn (do NOT fail) if the top released section is not this
             # release — the usual cause is a version bump that forgot to run
             # scripts/release/cut-changelog.mjs. A stale-but-real body beats
-            # bricking the release, so this is a warning, not an error.
-            TOP="$(awk '/^## \[Unreleased/{next} /^## \[/{print; exit}' CHANGELOG.md)"
+            # bricking the release, so this is a warning, not an error. Match
+            # the bracketed "[x.y.z]" form so 3.2.0 does not match [13.2.0].
+            TOP="$(awk '/^(```|~~~)/{fence=!fence; next} fence{next} /^## \[Unreleased/{next} /^## \[/{print; exit}' CHANGELOG.md)"
             case "$TOP" in
-              *"$SERVER_VERSION"*) : ;;
-              *) echo "::warning::Top released CHANGELOG section ($TOP) does not mention v$SERVER_VERSION — did the version-bump PR run scripts/release/cut-changelog.mjs?" ;;
+              *"[$SERVER_VERSION]"*) : ;;
+              *) echo "::warning::Top released CHANGELOG section ($TOP) does not mention [$SERVER_VERSION] — did the version-bump PR run scripts/release/cut-changelog.mjs?" ;;
             esac
           fi
+          # Run-unique heredoc delimiter so free-form CHANGELOG content can
+          # never collide with it and truncate/corrupt $GITHUB_OUTPUT.
+          DELIM="RR_RELEASE_BODY_${GITHUB_RUN_ID:-0}_${GITHUB_RUN_ATTEMPT:-0}_${RANDOM}${RANDOM}"
           {
-            echo 'body<<RELEASE_BODY'
+            echo "body<<${DELIM}"
             if [ "${{ inputs.prerelease }}" = "true" ]; then
               echo "_Automated nightly prerelease from \`${{ github.ref_name }}\` — **${{ matrix.name }}** v${{ matrix.version }}._"
               echo ""
@@ -392,7 +408,7 @@ jobs:
             else
               echo "**${{ matrix.name }}** v${{ matrix.version }}"
             fi
-            echo 'RELEASE_BODY'
+            echo "${DELIM}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
@@ -402,7 +418,11 @@ jobs:
           tag_name: ${{ matrix.tag_name }}
           name: RocketRide ${{ matrix.name }} v${{ matrix.version }}${{ inputs.prerelease && ' (prerelease)' || '' }}
           prerelease: ${{ inputs.prerelease }}
-          generate_release_notes: ${{ inputs.prerelease == false }}
+          # Keep OFF. softprops/action-gh-release APPENDS GitHub's auto-notes
+          # to `body` when this is true — under squash-merge stage->main that
+          # is just the one batched merge PR, which is exactly the noise the
+          # curated CHANGELOG body (Set release body step) replaces.
+          generate_release_notes: false
           body: ${{ steps.release_body.outputs.body }}
           files: release-assets/*
         env:

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -345,12 +345,42 @@ jobs:
 
       - name: Set release body
         id: release_body
+        env:
+          SERVER_VERSION: ${{ inputs.server_version }}
         run: |
-          # Pull the top CHANGELOG section (everything from the first "## ["
-          # header to the next one) so the GitHub Release shows the real,
-          # human-written change list instead of just the batched stage->main
+          # Source GitHub Release notes from CHANGELOG.md so releases show the
+          # curated, human-written change list — not the squashed stage->main
           # merge PR that generate_release_notes would otherwise emit.
-          NOTES="$(awk '/^## \[/{c++} c==1{print} c==2{exit}' CHANGELOG.md | sed '1d')"
+          #
+          #   Prerelease (nightly): emit the current [Unreleased] section — the
+          #     "what's cooking on stage" view a prerelease should expose.
+          #   Stable: emit the most recent *released* section (the first "## ["
+          #     that is NOT [Unreleased]). The version-bump PR archives
+          #     [Unreleased] into that dated, versioned section via
+          #     scripts/release/cut-changelog.mjs, so the notes are scoped to
+          #     this release instead of re-emitting the whole growing
+          #     [Unreleased] blob on every release. See RELEASE.md.
+          if [ "${{ inputs.prerelease }}" = "true" ]; then
+            NOTES="$(awk '/^## \[/{c++} c==1{print} c==2{exit}' CHANGELOG.md | sed '1d')"
+          else
+            NOTES="$(awk '
+              /^## \[/ {
+                if (cap) exit                       # next header after capture -> done
+                if ($0 ~ /^## \[Unreleased/) next   # skip the [Unreleased] header and its body
+                cap = 1; next                        # first released header -> capture its body
+              }
+              cap { print }
+            ' CHANGELOG.md)"
+            # Warn (do NOT fail) if the top released section is not this
+            # release — the usual cause is a version bump that forgot to run
+            # scripts/release/cut-changelog.mjs. A stale-but-real body beats
+            # bricking the release, so this is a warning, not an error.
+            TOP="$(awk '/^## \[Unreleased/{next} /^## \[/{print; exit}' CHANGELOG.md)"
+            case "$TOP" in
+              *"$SERVER_VERSION"*) : ;;
+              *) echo "::warning::Top released CHANGELOG section ($TOP) does not mention v$SERVER_VERSION — did the version-bump PR run scripts/release/cut-changelog.mjs?" ;;
+            esac
+          fi
           {
             echo 'body<<RELEASE_BODY'
             if [ "${{ inputs.prerelease }}" = "true" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — since 2026-03-29
+## [Unreleased] — since 2026-06-05
+
+## [3.2.0] - 2026-06-05
+
+_RocketRide 1.2.0 release train — Server **3.2.0**; Python / TypeScript / MCP clients and VS Code extension **1.2.0**. Consolidates everything since 1.0.3, including the 1.1.0 → 1.2.0 client SDK migration._
 
 ### ⚠ Breaking Changes — Client SDKs (`rocketride` / `rocketride-python`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — since 2026-06-05
-
-## [3.2.0] - 2026-06-05
-
-_RocketRide 1.2.0 release train — Server **3.2.0**; Python / TypeScript / MCP clients and VS Code extension **1.2.0**. Consolidates everything since 1.0.3, including the 1.1.0 → 1.2.0 client SDK migration._
+## [Unreleased] — since 2026-03-29
 
 ### ⚠ Breaking Changes — Client SDKs (`rocketride` / `rocketride-python`)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@ This document describes the automated release pipeline for the RocketRide Engine
 - [Nightly Prereleases](#nightly-prereleases)
 - [Stable Releases](#stable-releases)
 - [Version Management](#version-management)
+- [Release Notes](#release-notes)
 - [Tags and GitHub Releases](#tags-and-github-releases)
 - [Registry Publishing](#registry-publishing)
 - [Build Matrix](#build-matrix)
@@ -142,7 +143,7 @@ Visit the [Releases page](https://github.com/rocketride-org/rocketride-server/re
 
    c. **Create git tag** — Tag the commit (e.g., `server-v1.0.3`).
 
-   d. **Create GitHub Release** — Create a GitHub Release with the tag, auto-generated release notes, and the package artifacts attached.
+   d. **Create GitHub Release** — Create a GitHub Release with the tag, release notes sourced from `CHANGELOG.md` (see [Release Notes](#release-notes)), and the package artifacts attached.
 
 ### Idempotency
 
@@ -174,21 +175,28 @@ Each package is published independently:
 ### How to release a new version
 
 1. **Bump the version** in the appropriate file(s) on the `develop` branch.
-2. **Commit and push** to `develop`, then **merge `develop` into `stage`** once the change is ready to be validated:
+2. **Cut the changelog** in the *same* pull request, so the cut rides the normal `develop → stage → main` promotion:
+   ```bash
+   # Archive [Unreleased] -> [<server-version>] - <today> and open a fresh [Unreleased].
+   node scripts/release/cut-changelog.mjs            # uses the root package.json version + today
+   # or pin explicitly:  node scripts/release/cut-changelog.mjs 3.2.0 2026-06-05
+   ```
+   This is what makes the stable GitHub Release notes scoped to the release (see [Release Notes](#release-notes)). Do this in the version-bump PR — **never** auto-commit a cut to `main` from CI (it would re-trigger the release workflow and diverge `main`'s changelog from `develop`).
+3. **Commit and push** to `develop`, then **merge `develop` into `stage`** once the change is ready to be validated:
    ```bash
    git checkout stage
    git merge develop
    git push origin stage
    ```
    The next nightly build will create a prerelease with the new version from `stage`.
-3. **Verify the prerelease** by downloading artifacts from the GitHub Releases page.
-4. **Merge `stage` into `main`**:
+4. **Verify the prerelease** by downloading artifacts from the GitHub Releases page.
+5. **Merge `stage` into `main`**:
    ```bash
    git checkout main
    git merge stage
    git push origin main
    ```
-5. The release workflow triggers automatically and publishes all packages with new versions.
+6. The release workflow triggers automatically and publishes all packages with new versions.
 
 ### Releasing a single package
 
@@ -204,6 +212,23 @@ Because each package is versioned independently, you can release a single packag
 - Bump MAJOR for breaking API changes.
 - Bump MINOR for new features that are backward compatible.
 - Bump PATCH for backward-compatible bug fixes.
+
+## Release Notes
+
+GitHub Release bodies are sourced from `CHANGELOG.md` by the **Set release body** step in `.github/workflows/_release.yaml` — not from GitHub's `generate_release_notes`, which under the squash-merge `stage → main` flow would only show the single batched merge PR. The same notes are used for all five packages, because they ship as one synchronized release train sharing this changelog.
+
+| Build | Notes shown |
+|-------|-------------|
+| **Prerelease** (nightly) | The current `## [Unreleased]` section — the "what's cooking on `stage`" view. |
+| **Stable** (push to `main`) | The most recent *released* section — the first `## [` heading that is **not** `[Unreleased]`. |
+
+This is why the changelog must be **cut at version-bump time** (step 2 of [How to release a new version](#how-to-release-a-new-version)):
+
+- `scripts/release/cut-changelog.mjs` archives `[Unreleased]` into a dated, versioned section (labelled with the **server** version, e.g. `## [3.2.0] - 2026-06-05`) and opens a fresh, empty `[Unreleased]`.
+- At release time the stable build emits that newly-cut section, so the notes are scoped to the release instead of re-emitting the entire growing `[Unreleased]` blob on every release.
+- If a version bump forgets to cut, the release does **not** fail — it emits the previous section and logs a `::warning::` that the top section does not mention the release version. Fix it by running the cut and re-running the release.
+
+Keep `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) form (`### Added` / `### Changed` / `### Fixed` / etc. under `[Unreleased]`) so each cut section reads as clean release notes.
 
 ## Tags and GitHub Releases
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -215,7 +215,7 @@ Because each package is versioned independently, you can release a single packag
 
 ## Release Notes
 
-GitHub Release bodies are sourced from `CHANGELOG.md` by the **Set release body** step in `.github/workflows/_release.yaml` — not from GitHub's `generate_release_notes`, which under the squash-merge `stage → main` flow would only show the single batched merge PR. The same notes are used for all five packages, because they ship as one synchronized release train sharing this changelog.
+GitHub Release bodies are sourced from `CHANGELOG.md` by the **Set release body** step in `.github/workflows/_release.yaml`. The **Create GitHub release** step keeps `generate_release_notes: false`, so the curated CHANGELOG section is the *entire* published body — GitHub's auto-generated notes (under squash-merge `stage → main` that is just the single batched merge PR) are **not** appended. The same notes are used for all five packages, because they ship as one synchronized release train sharing this changelog.
 
 | Build | Notes shown |
 |-------|-------------|
@@ -224,9 +224,9 @@ GitHub Release bodies are sourced from `CHANGELOG.md` by the **Set release body*
 
 This is why the changelog must be **cut at version-bump time** (step 2 of [How to release a new version](#how-to-release-a-new-version)):
 
-- `scripts/release/cut-changelog.mjs` archives `[Unreleased]` into a dated, versioned section (labelled with the **server** version, e.g. `## [3.2.0] - 2026-06-05`) and opens a fresh, empty `[Unreleased]`.
+- `scripts/release/cut-changelog.mjs` archives `[Unreleased]` into a dated, versioned section (labelled with the **server** version, e.g. `## [3.2.2] - 2026-06-10`) and opens a fresh, empty `[Unreleased]`.
 - At release time the stable build emits that newly-cut section, so the notes are scoped to the release instead of re-emitting the entire growing `[Unreleased]` blob on every release.
-- If a version bump forgets to cut, the release does **not** fail — it emits the previous section and logs a `::warning::` that the top section does not mention the release version. Fix it by running the cut and re-running the release.
+- If a version bump forgets to cut, the release does **not** fail — it emits the previous released section and logs a `::warning::` that the top section does not mention `[<release-version>]`. **Re-running the workflow will NOT fix the already-published body**: once the tag exists, the tag-skip idempotency skips the "Create GitHub release" step (see [Idempotency](#idempotency)). To correct it, either edit the GitHub Release body by hand, or run the cut and then delete the stale tag **and** its GitHub Release before re-running (see ["A git tag exists but there is no GitHub Release"](#a-git-tag-exists-but-there-is-no-github-release)).
 
 Keep `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) form (`### Added` / `### Changed` / `### Fixed` / etc. under `[Unreleased]`) so each cut section reads as clean release notes.
 

--- a/scripts/release/cut-changelog.mjs
+++ b/scripts/release/cut-changelog.mjs
@@ -83,8 +83,17 @@ if (typeof version !== 'string' || !/^\d+\.\d+\.\d+([-+].+)?$/.test(version)) {
 }
 
 const date = argv[1] ?? new Date().toISOString().slice(0, 10);
-if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-  fail(2, `Invalid date "${date}" — expected ISO YYYY-MM-DD.`);
+// Shape AND validity: reject impossible dates like 2026-13-40 or 2026-02-30.
+// For ISO-8601 strings JS yields an Invalid Date (NaN) on out-of-range parts;
+// the round-trip also catches any silent normalization. `||` short-circuits,
+// so toISOString() never runs on a NaN date.
+const parsedDate = new Date(`${date}T00:00:00Z`);
+if (
+  !/^\d{4}-\d{2}-\d{2}$/.test(date) ||
+  Number.isNaN(parsedDate.getTime()) ||
+  parsedDate.toISOString().slice(0, 10) !== date
+) {
+  fail(2, `Invalid date "${date}" — expected a real ISO date (YYYY-MM-DD).`);
 }
 
 const original = readFileSync(changelogPath, 'utf8');

--- a/scripts/release/cut-changelog.mjs
+++ b/scripts/release/cut-changelog.mjs
@@ -1,0 +1,116 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+/**
+ * Cut the CHANGELOG "[Unreleased]" section into a dated, versioned section and
+ * open a fresh, empty "[Unreleased]" above it.
+ *
+ * Run this in the version-bump pull request (the same PR that bumps
+ * package.json / pyproject.toml versions) so the cut rides the normal
+ * develop -> stage -> main promotion. Do NOT auto-commit a cut to `main` from
+ * CI: the release workflow triggers on push-to-main and would re-fire, and
+ * main's CHANGELOG would diverge from develop and conflict on the next merge.
+ *
+ * The version label is the **server** (root package.json) version, since this
+ * is the rocketride-server monorepo and all five packages ship as one
+ * synchronized release train sharing this CHANGELOG. The release workflow's
+ * "Set release body" step emits this section as the GitHub Release notes for
+ * every package in the train (see .github/workflows/_release.yaml and
+ * RELEASE.md -> "Release Notes").
+ *
+ * Usage:
+ *   node scripts/release/cut-changelog.mjs [version] [date]
+ *
+ *   version  semver to label the cut section (default: root package.json .version)
+ *   date     ISO date YYYY-MM-DD for the section header (default: today, UTC)
+ *
+ * Examples:
+ *   node scripts/release/cut-changelog.mjs            # cut at the current root version, today
+ *   node scripts/release/cut-changelog.mjs 3.2.0      # cut as [3.2.0] - <today>
+ *   node scripts/release/cut-changelog.mjs 3.2.0 2026-06-05
+ *
+ * Exit codes: 0 ok, 1 nothing to cut / already cut / bad version, 2 bad usage.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
+const changelogPath = resolve(repoRoot, 'CHANGELOG.md');
+
+function fail(code, message) {
+  console.error(message);
+  process.exit(code);
+}
+
+const argv = process.argv.slice(2);
+if (argv.includes('-h') || argv.includes('--help')) {
+  // Print the leading JSDoc usage block and exit cleanly.
+  console.log(
+    'Usage: node scripts/release/cut-changelog.mjs [version] [date]\n' +
+      '  Archive [Unreleased] as a dated, versioned CHANGELOG section and open a fresh [Unreleased].\n' +
+      '  version  semver label (default: root package.json .version)\n' +
+      '  date     ISO YYYY-MM-DD (default: today, UTC)',
+  );
+  process.exit(0);
+}
+
+const version =
+  argv[0] ?? JSON.parse(readFileSync(resolve(repoRoot, 'package.json'), 'utf8')).version;
+if (typeof version !== 'string' || !/^\d+\.\d+\.\d+([-+].+)?$/.test(version)) {
+  fail(1, `Refusing to cut: "${version}" is not a semver version.`);
+}
+
+const date = argv[1] ?? new Date().toISOString().slice(0, 10);
+if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+  fail(2, `Invalid date "${date}" — expected ISO YYYY-MM-DD.`);
+}
+
+const original = readFileSync(changelogPath, 'utf8');
+const lines = original.split('\n');
+
+const unreleasedIdx = lines.findIndex((line) => /^## \[Unreleased\b/.test(line));
+if (unreleasedIdx === -1) {
+  fail(1, 'No "## [Unreleased]" section found in CHANGELOG.md — nothing to cut.');
+}
+
+const versionHeader = new RegExp(`^## \\[${version.replace(/[.+]/g, '\\$&')}\\]`);
+if (lines.some((line) => versionHeader.test(line))) {
+  fail(1, `CHANGELOG.md already has a "## [${version}]" section — already cut for this version?`);
+}
+
+// Replace the single "## [Unreleased] ..." header line with a fresh empty
+// Unreleased header, a blank line, then the dated version header. Everything
+// that followed the old Unreleased header stays put — it becomes the body of
+// the newly-dated version section.
+lines.splice(
+  unreleasedIdx,
+  1,
+  `## [Unreleased] — since ${date}`,
+  '',
+  `## [${version}] - ${date}`,
+);
+
+writeFileSync(changelogPath, lines.join('\n'));
+console.log(`Cut [Unreleased] -> [${version}] - ${date}; opened a fresh [Unreleased].`);


### PR DESCRIPTION
## Problem (#56)

GitHub Release notes have been empty / unscoped. `#1086` made the release-body step extract the *top* CHANGELOG section, but the top section is the single `## [Unreleased]` blob (since 2026-03-29, ~350 lines) that is **never cut** into per-version sections — so every release re-emits everything since March. Additionally, stable releases set `generate_release_notes: true`, which (per softprops/action-gh-release, verified against the pinned action's compiled `dist/index.js`) **appends** GitHub's auto-notes — the batched squash-merge PR — below the body, re-introducing exactly the noise the curated notes are meant to replace.

## Approach (mechanism, not a one-off)

Releases fire on push to `main` (when root `package.json`'s version has no tag); the flow is `develop → stage → main`. So the changelog **cut belongs in the version-bump PR on `develop`**, riding the normal promotion — never an auto-commit to `main` from CI (would re-trigger Release + diverge main's changelog).

- **`scripts/release/cut-changelog.mjs`** — archives `[Unreleased]` → a dated `## [<server-version>] - <date>` section and opens a fresh `[Unreleased]`. Idempotent; validates semver **and** real calendar dates.
- **`_release.yaml` "Set release body"** — **Stable** emits the first *released* (non-`[Unreleased]`) section; **Prerelease** emits `[Unreleased]`. Extractors are **fence-aware** (a `## [` inside a ``` block is body text, not a header) across stable, prerelease, and the version-warning TOP detector; the version-mention warning is anchored to `[x.y.z]`; the `$GITHUB_OUTPUT` heredoc uses a **run-unique delimiter**.
- **`generate_release_notes: false`** — so the curated CHANGELOG section is the *entire* published body, with no appended squash-merge auto-notes.
- **`RELEASE.md`** — documents the cut step + a "Release Notes" section, including the correct forgot-to-cut recovery (tag idempotency means a plain re-run won't fix an already-published body).

## Adversarial review applied before merge

A multi-lens review (shell/awk, GHA release-flow, cut-script, branch-model, docs) with per-finding skeptic verification ran against this PR. Outcome folded in:
- **Fixed:** `generate_release_notes` append (would have defeated the PR's purpose); fence-awareness; anchored warning glob; run-unique heredoc delimiter; date round-trip validation; corrected the RELEASE.md recovery instruction.
- **Dropped:** the original retroactive `[Unreleased] → [3.2.0]` cut. `server-v3.2.0` (05-22) and `server-v3.2.1` (05-29) already shipped, and **develop's `package.json` (3.2.0) trails main (3.2.1)** — so no single version label for the multi-release blob is correct. The first real cut should accompany the next bump. (Reverting also removed a transient "next nightly shows empty notes" effect.)

## Verified locally (CI can't exercise the release path)

Stable extraction (incl. fence fixtures both directions) emits the correct scoped section and stops at the next real header; prerelease emits full `[Unreleased]`; anchored warning fires on `[13.2.0]` vs `3.2.0`; heredoc safe against a literal `RELEASE_BODY` content line; cut-script rejects `2026-13-40`/`2026-02-30`, honors idempotency + no-arg `package.json` read; `_release.yaml` parses (PyYAML) and `bash -n` clean.

## Follow-ups (out of scope, for the team)

- **develop's version (3.2.0) trails main (3.2.1)** — needs a deliberate bump; the first changelog cut should land in that PR.
- The historical `[Unreleased]` blob spans several already-shipped releases (server 3.2.0/3.2.1, clients 1.2.0); splitting it into accurate per-version sections is editorial.
- `RELEASE.md` still lists `NPM_TOKEN`; npm moved to OIDC trusted publishing (#1077/#54) — separate doc cleanup.

Closes #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
