### PR TITLE
feat(registerApp): pass requiredPermissions to apps.json

### DIFF
--- a/apps/profiler-ui/src/views/ProfilerView.tsx
+++ b/apps/profiler-ui/src/views/ProfilerView.tsx
@@ -292,6 +292,9 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 	const statusIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const tasksIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+	// Guard against stale async responses when target changes mid-flight
+	const fetchIdRef = useRef<number>(0);
+
 	// =========================================================================
 	// STATUS POLLING
 	// =========================================================================
@@ -370,6 +373,9 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		const client = getClient();
 		if (!client) return;
 
+		// Increment fetch ID so stale responses from a previous target are ignored
+		const id = ++fetchIdRef.current;
+
 		// Build shared arguments
 		const args: Record<string, unknown> = {};
 		if (target) args.target = target;
@@ -377,9 +383,11 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		// Fetch text report — always available
 		try {
 			const textResult = await client.call<{ report: string }>('rrext_cprofile_report', args);
+			if (fetchIdRef.current !== id) return; // stale response
 			setReport(textResult.report || 'No report available.');
 		} catch (err) {
 			console.log('[ProfilerView] Text report fetch failed:', err);
+			if (fetchIdRef.current !== id) return;
 			// Clear stale report so the UI doesn't show outdated results
 			setReport('');
 		}
@@ -387,9 +395,11 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		// Fetch tree data — may not be available on older servers
 		try {
 			const treeResult = await client.call<ProfileTreeResponse>('rrext_cprofile_report_tree', args);
+			if (fetchIdRef.current !== id) return; // stale response
 			setTreeData(treeResult);
 		} catch (err) {
 			console.log('[ProfilerView] Tree report fetch failed:', err);
+			if (fetchIdRef.current !== id) return;
 			// Clear stale tree data so visualisations don't show outdated results
 			setTreeData(null);
 		}

--- a/apps/profiler-ui/src/views/visualizations/ReportText.tsx
+++ b/apps/profiler-ui/src/views/visualizations/ReportText.tsx
@@ -98,10 +98,12 @@ function copyViaExecCommand(text: string, setCopied: (v: boolean) => void): void
 		textarea.style.left = '-9999px';
 		document.body.appendChild(textarea);
 		textarea.select();
-		document.execCommand('copy');
+		const ok = document.execCommand('copy');
 		document.body.removeChild(textarea);
-		setCopied(true);
-		setTimeout(() => setCopied(false), 2000);
+		if (ok) {
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		}
 	} catch (err) {
 		console.log('[ReportText] Fallback clipboard copy failed:', err);
 	}

--- a/apps/shell-ui/src/components/layout/Shell.tsx
+++ b/apps/shell-ui/src/components/layout/Shell.tsx
@@ -246,7 +246,7 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 			if (mountedRef.current) {
 				setIdentity(result);
 				// Auto-transition off waitlist when an admin grants access
-				if (renderPhase === 'waitlisted' && !result.waitlisted) {
+				if (renderPhase === 'waitlisted' && result.waitlisted === false) {
 					setRenderPhase('shell');
 				}
 			}

--- a/apps/vscode/src/providers/AccountProvider.ts
+++ b/apps/vscode/src/providers/AccountProvider.ts
@@ -877,7 +877,7 @@ export class AccountProvider {
 		} catch {
 			// Fallback: inform the user to open a pipeline file manually
 			vscode.window.showInformationMessage(
-				'To subscribe, open a .rrpipe file. The pipeline editor includes the checkout flow.'
+				'To subscribe, create or open a pipeline file. The pipeline editor includes the checkout flow.'
 			);
 		}
 	}

--- a/packages/ai/src/ai/common/cprofile_manager.py
+++ b/packages/ai/src/ai/common/cprofile_manager.py
@@ -346,12 +346,12 @@ class CProfileManager:
         Returns:
             Dict with 'tree', 'total_time', and 'total_calls'.
         """
-        # Step 1: Compute total cumtime across all root-level functions for
-        # the min_pct threshold calculation
+        # Step 1: Compute total cumtime across all functions for the min_pct
+        # threshold calculation (sum, not max — max would skew to one hotspot)
         total_time = 0.0
         total_calls = 0
         for _key, (cc, nc, tt, ct, _callers) in stats_data.items():
-            total_time = max(total_time, ct)
+            total_time += ct
             total_calls += nc
 
         # Minimum absolute time threshold (convert percentage to seconds)
@@ -387,15 +387,17 @@ class CProfileManager:
         # all recorded functions may have callers because the calling functions
         # were already on the stack when profiling started.  These "phantom
         # callers" appear in children_map but not in stats_data.
-        if not root_keys:
-            # Promote children of phantom callers to roots — these are the
-            # real entry points of the profiled portion
-            phantom_callers = set(children_map.keys()) - set(stats_data.keys())
+        # Promote children of phantom callers to roots — these are entry
+        # points whose callers were already on the stack when profiling started.
+        # Always promote (not just when root_keys is empty), otherwise
+        # phantom-rooted branches are silently dropped.
+        phantom_callers = set(children_map.keys()) - set(stats_data.keys())
+        if phantom_callers:
             promoted: set = set()
             for pc in phantom_callers:
                 for child_key, _c_cc, _c_nc, _c_tt, _c_ct in children_map[pc]:
                     promoted.add(child_key)
-            root_keys = list(promoted)
+            root_keys = list(set(root_keys) | promoted)
 
         # Last resort fallback — pick the highest-cumtime functions
         if not root_keys:

--- a/packages/shared-ui/src/components/canvas/components/node/node-component/run-button/RunButton.tsx
+++ b/packages/shared-ui/src/components/canvas/components/node/node-component/run-button/RunButton.tsx
@@ -73,7 +73,6 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 	const handleRun = useCallback(
 		(e?: React.MouseEvent) => {
 			e?.stopPropagation();
-			console.log(`[RunButton] clicked nodeId=${nodeId} isRunning=${isRunning} isSubscribed=${isSubscribed} onRunPipeline=${!!onRunPipeline}`);
 			if (isRunning || !onRunPipeline) return;
 
 			const components = getProjectComponents(nodes as INode[], edges);
@@ -83,7 +82,6 @@ export default function RunButton({ nodeId }: IRunButtonProps): ReactElement {
 				version: PIPELINE_SCHEMA_VERSION,
 			};
 
-			console.log('[RunButton] calling onRunPipeline');
 			onRunPipeline(nodeId, project);
 		},
 		[isRunning, onRunPipeline, nodeId, nodes, edges, currentProject, isSubscribed]

--- a/packages/shared-ui/src/components/canvas/context/FlowGraphContext.tsx
+++ b/packages/shared-ui/src/components/canvas/context/FlowGraphContext.tsx
@@ -562,10 +562,6 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		(changes: EdgeChange[]) => {
 			if (isLocked) return;
 
-			const removes = changes.filter((c) => c.type === 'remove');
-			if (removes.length > 0) {
-			}
-
 			// ReactFlow owns edges — pass all changes through directly
 			onEdgesChangeInternal(changes);
 
@@ -686,12 +682,6 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 	const addNode = useCallback(
 		(data: INodeData, position?: { x: number; y: number }, type: INodeType = INodeType.Default): string => {
 			if (isLocked) return '';
-			// Log connection data on existing nodes to verify it's preserved
-			for (const n of nodes) {
-				const nd = n.data as any;
-				if (nd.input?.length || nd.control?.length) {
-				}
-			}
 			const id = generateNodeId(nodes, data.provider);
 
 			// Default to center of viewport if no position given, then search
@@ -849,8 +839,12 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 			const connectedSet = new Set(connected.map((e) => e.id));
 			const remaining = edges.filter((e) => !connectedSet.has(e.id));
 			setEdges(remaining);
+			// Notify host so project state stays in sync
+			if (connected.length > 0) {
+				onContentUpdated();
+			}
 		},
-		[edges, setEdges]
+		[edges, setEdges, onContentUpdated]
 	);
 
 	// =====================================================================
@@ -1013,7 +1007,6 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 			setNodes(updated as FlowNode[]);
 			// Recount after update
 			unconfigured = updated.filter((n) => (n.data as any)?.formDataValid === false).length;
-		} else {
 		}
 
 		if (unconfigured > 0) {
@@ -1093,12 +1086,12 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		configSnackbar,
 		setConfigSnackbar,
 	}), [
-		canvasRef, nodes, edges, nodeMap, setNodes, setEdges,
+		nodes, edges, nodeMap, setNodes, setEdges,
 		onNodesChange, onEdgesChange, onEdgeConnect, isValidConnection,
 		onDragOver, onDrop, onNodeDragStop, addNode, updateNode, deleteNode,
-		onNodesDelete, tempNode, setTempNode, focusOnNode, editingNodeId,
-		setEditingNodeId, onContentUpdated, loadData, loadCanvas, isFlowReady,
-		quickAddState, setQuickAddState, configSnackbar, setConfigSnackbar,
+		onNodesDelete, tempNode, focusOnNode, editingNodeId,
+		onContentUpdated, loadData, loadCanvas, isFlowReady,
+		quickAddState, configSnackbar,
 	]);
 
 	return <FlowGraphContext.Provider value={value}>{children}</FlowGraphContext.Provider>;

--- a/packages/shared-ui/src/components/canvas/hooks/useTemplateInstantiator.ts
+++ b/packages/shared-ui/src/components/canvas/hooks/useTemplateInstantiator.ts
@@ -101,7 +101,6 @@ export function useTemplateInstantiator() {
 			};
 			// Remove viewport from content — it's a user preference, not document content
 			delete (project as any).viewport;
-			console.log('[TemplateInstantiator] post-ready: notifying host, nodes=%d, edges=%d, components=%d, docRevision=%d', nodes.length, edges.length, components.length, nextRevision);
 			onContentChanged(project);
 		}
 		fitView({ padding: 0.15, duration: 300 });
@@ -193,7 +192,6 @@ export function useTemplateInstantiator() {
 			const templateEdges = getEdgesFromNodes(newNodes as unknown as INode[]);
 			const currentEdges = [...edges];
 			const mergedEdges = [...currentEdges, ...templateEdges];
-			console.log('[TemplateInstantiator] loading: nodes=%d (+%d new), edges=%d (existing=%d, template=%d)', allNodes.length, newNodes.length, mergedEdges.length, currentEdges.length, templateEdges.length);
 			loadCanvas(allNodes, mergedEdges);
 
 			// Track new IDs so the post-ready effect can update internals + fitView

--- a/packages/shared-ui/src/components/canvas/util/graph.ts
+++ b/packages/shared-ui/src/components/canvas/util/graph.ts
@@ -243,7 +243,7 @@ export const getEdgesFromNodes = (nodes: INodeLike[]): Edge[] => {
 	const edges: Edge[] = [];
 	const nodesWithConnections = nodes.filter((n) => n.data.control?.length || n.data.input?.length);
 
-	for (const node of nodes) {
+	for (const node of nodesWithConnections) {
 		const { data } = node;
 
 		// -----------------------------------------------------------------
@@ -327,11 +327,11 @@ export const getComponentFromNode = (node: INode, edges?: Edge[]): IProjectCompo
 		for (const edge of incomingEdges) {
 			if (edge.sourceHandle?.startsWith('invoke-source')) {
 				// Invoke edge — classType is the part after "invoke-source."
-				const classType = edge.sourceHandle.split('.').at(1) ?? '';
+				const classType = edge.sourceHandle.replace(/^invoke-source\./, '');
 				control.push({ classType, from: edge.source });
 			} else {
 				// Lane edge — lane is the part after "source-"
-				const lane = edge.sourceHandle?.split('-')?.at(1) ?? '';
+				const lane = edge.sourceHandle?.substring(edge.sourceHandle.indexOf('-') + 1) ?? '';
 				input.push({ lane, from: edge.source });
 			}
 		}

--- a/scripts/lib/registerApp.js
+++ b/scripts/lib/registerApp.js
@@ -224,6 +224,10 @@ function registerApp(appRoot) {
 				...(appManifest.public === false ? { public: false } : {}),
 				// Include billing section (plans array) for seed_apps to provision Stripe products
 				...(appManifest.billing ? { billing: appManifest.billing } : {}),
+				// Permission-gated apps — user must hold ALL listed sysPermissions to see the app
+				...(appManifest.requiredPermissions?.length
+					? { requiredPermissions: appManifest.requiredPermissions }
+					: {}),
 			};
 
 			// Upsert into build/apps.json (dev server publicDir)


### PR DESCRIPTION
## Summary
- Forwards the new `requiredPermissions` manifest field from app `package.json` through `registerApp.js` into `apps.json` entries
- Enables server-side permission gating: apps declaring this field will only be visible to users who hold ALL listed sysPermission strings
- No-op for apps without the field (backward compatible)
- Addresses CodeRabbit review comments on code merged in #1138: stale-response race guard in ProfilerView, explicit waitlist boolean check, empty-block cleanup, debug log removal, fragile handle parsing fixes

## Test plan
- [ ] Build an app with `requiredPermissions: ["sys.admin"]` in its manifest
- [ ] Verify `apps.json` contains the field after `./builder <app>:build`
- [ ] Verify apps without the field still build and register correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profiler UI redesigned with tabbed visualization views—Flame Graph, Sunburst, Table, and Text—for comprehensive performance analysis
  * Added waitlist screen for users pending access approval
  * Integrated subscription checkout flow for pipeline editor

* **Improvements**
  * Enhanced copy-to-clipboard feedback with success validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->