### PR TITLE
feat(profiler): replace cProfile with yappi, snakeviz-style UI

### DIFF
--- a/apps/profiler-ui/src/views/ProfilerView.tsx
+++ b/apps/profiler-ui/src/views/ProfilerView.tsx
@@ -21,21 +21,23 @@
 // SOFTWARE.
 
 // =============================================================================
-// PROFILER VIEW — Profiling controls, status, and tabbed visualisations
+// PROFILER VIEW — SnakeViz-style stacked layout
 // =============================================================================
 //
-// Connects to a server via the shell's RocketRide client. Provides:
-// - Target selector (Server Process or running pipeline)
-// - Start/Stop profiling controls
-// - Status display with owner and runtime
-// - Tabbed visualisation area: Flame Graph | Sunburst | Table | Text
+// Layout matches snakeviz:
+//   Controls → Viz Controls → Sunburst/Icicle → Call Stack → Stats Table
+//
+// No tabs — viz on top, table always visible below.
+// Style dropdown switches between sunburst and icicle.
+// Depth + Cutoff dropdowns filter client-side (not server params).
+// Table row click and viz arc click both re-root the visualisation.
 // =============================================================================
 
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import type { CSSProperties } from 'react';
 import { useShellConnection, getClient } from 'shell-ui';
 import { commonStyles } from 'shared/themes/styles';
-import type { ProfileTreeNode, ProfileTreeResponse, ProfilerTab } from './visualizations/types';
+import type { ProfileTreeNode, ProfileTreeResponse, VizStyle } from './visualizations/types';
 import ReportText from './visualizations/ReportText';
 import FlameGraph from './visualizations/FlameGraph';
 import SunburstChart from './visualizations/SunburstChart';
@@ -71,12 +73,14 @@ const STATUS_POLL_MS = 3000;
 /** Task list refresh interval in milliseconds. */
 const TASKS_POLL_MS = 10000;
 
-/** Tab definitions for the visualisation switcher. */
-const TABS: { key: ProfilerTab; label: string }[] = [
-	{ key: 'flame', label: 'Flame Graph' },
-	{ key: 'sunburst', label: 'Sunburst' },
-	{ key: 'table', label: 'Table' },
-	{ key: 'text', label: 'Text' },
+/** Available depth options for the viz depth dropdown (matches snakeviz). */
+const DEPTH_OPTIONS = [3, 5, 10, 15, 20];
+
+/** Available cutoff options for the viz cutoff dropdown (matches snakeviz). */
+const CUTOFF_OPTIONS = [
+	{ value: 0.001, label: '1/1000' },
+	{ value: 0.01, label: '1/100' },
+	{ value: 0, label: 'None' },
 ];
 
 // =============================================================================
@@ -110,6 +114,17 @@ const styles = {
 		fontSize: 13,
 		fontFamily: 'var(--rr-font-family)',
 		minWidth: 200,
+	} as CSSProperties,
+
+	/** Smaller dropdown for viz controls. */
+	smallSelect: {
+		padding: '4px 8px',
+		border: '1px solid var(--rr-border)',
+		background: 'var(--rr-bg-input)',
+		color: 'var(--rr-text-primary)',
+		borderRadius: 4,
+		fontSize: 12,
+		fontFamily: 'var(--rr-font-family)',
 	} as CSSProperties,
 
 	/** Session name text input. */
@@ -190,42 +205,138 @@ const styles = {
 	} as CSSProperties,
 
 	// =========================================================================
-	// TAB BAR
+	// VIZ CONTROLS ROW
 	// =========================================================================
 
-	/** Horizontal tab bar container. */
-	tabBar: {
+	/** Viz controls bar — style, depth, cutoff, reset buttons. */
+	vizControls: {
 		display: 'flex',
-		gap: 0,
-		borderBottom: '1px solid var(--rr-border)',
+		alignItems: 'center',
+		gap: 12,
+		flexWrap: 'wrap',
+		fontSize: 12,
+		color: 'var(--rr-text-secondary)',
 	} as CSSProperties,
 
-	/** Individual tab button (inactive). */
-	tab: {
-		padding: '8px 16px',
-		border: 'none',
-		borderBottom: '2px solid transparent',
-		background: 'transparent',
-		color: 'var(--rr-text-secondary)',
-		fontSize: 13,
-		fontWeight: 500,
+	/** Label within viz controls. */
+	vizLabel: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: 4,
+	} as CSSProperties,
+
+	/** Small button for Reset Zoom / Reset Root. */
+	smallButton: {
+		padding: '4px 10px',
+		border: '1px solid var(--rr-border)',
+		borderRadius: 4,
+		fontSize: 12,
 		cursor: 'pointer',
 		fontFamily: 'var(--rr-font-family)',
-		transition: 'color 0.15s, border-color 0.15s',
+		background: 'var(--rr-bg-input)',
+		color: 'var(--rr-text-primary)',
 	} as CSSProperties,
 
-	/** Active tab button override. */
-	tabActive: {
-		color: 'var(--rr-brand)',
-		borderBottomColor: 'var(--rr-brand)',
+	// =========================================================================
+	// CALL STACK
+	// =========================================================================
+
+	/** Call stack breadcrumb bar. */
+	callStack: {
+		display: 'flex',
+		alignItems: 'center',
+		gap: 4,
+		padding: '6px 8px',
+		fontSize: 12,
+		fontFamily: 'var(--rr-font-mono, monospace)',
+		color: 'var(--rr-text-secondary)',
+		borderTop: '1px solid var(--rr-border)',
+		borderBottom: '1px solid var(--rr-border)',
+		flexWrap: 'wrap',
 	} as CSSProperties,
 
-	/** Content area below the tab bar — fills remaining space. */
-	tabContent: {
+	/** Clickable call stack entry. */
+	callStackLink: {
+		color: 'var(--rr-text-link)',
+		cursor: 'pointer',
+		background: 'none',
+		border: 'none',
+		padding: 0,
+		fontFamily: 'inherit',
+		fontSize: 12,
+	} as CSSProperties,
+
+	/** Call stack separator arrow. */
+	callStackSep: {
+		color: 'var(--rr-text-disabled)',
+	} as CSSProperties,
+
+	// =========================================================================
+	// LAYOUT SECTIONS
+	// =========================================================================
+
+	/** Visualisation area — takes available space. */
+	vizArea: {
 		flex: 1,
 		display: 'flex',
 		flexDirection: 'column',
-		minHeight: 0,
+		minHeight: 200,
+		overflow: 'hidden',
+	} as CSSProperties,
+
+	/** Table area — takes remaining space. */
+	tableArea: {
+		flex: 1,
+		display: 'flex',
+		flexDirection: 'column',
+		minHeight: 150,
+		overflow: 'hidden',
+	} as CSSProperties,
+
+	// =========================================================================
+	// REPORT MODAL
+	// =========================================================================
+
+	/** Modal backdrop. */
+	modalBackdrop: {
+		position: 'fixed',
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 0,
+		background: 'rgba(0, 0, 0, 0.5)',
+		zIndex: 9000,
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+	} as CSSProperties,
+
+	/** Modal dialog. */
+	modalDialog: {
+		background: 'var(--rr-bg-paper)',
+		borderRadius: 8,
+		width: '80%',
+		maxWidth: 900,
+		maxHeight: '80vh',
+		display: 'flex',
+		flexDirection: 'column',
+		overflow: 'hidden',
+		border: '1px solid var(--rr-border)',
+		boxShadow: '0 8px 32px rgba(0, 0, 0, 0.3)',
+	} as CSSProperties,
+
+	/** Modal header. */
+	modalHeader: {
+		display: 'flex',
+		justifyContent: 'space-between',
+		alignItems: 'center',
+		padding: '12px 16px',
+		borderBottom: '1px solid var(--rr-border)',
+	} as CSSProperties,
+
+	/** Modal body. */
+	modalBody: {
+		flex: 1,
 		overflow: 'hidden',
 	} as CSSProperties,
 };
@@ -244,15 +355,36 @@ interface ProfilerViewProps {
 }
 
 // =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Find a node in the tree by identity (file + line + name).
+ * Returns the path (ancestor chain) from root to the found node.
+ */
+function findNodePath(
+	root: ProfileTreeNode,
+	target: ProfileTreeNode,
+): ProfileTreeNode[] | null {
+	if (root.name === target.name && root.file === target.file && root.line === target.line) {
+		return [root];
+	}
+	for (const child of root.children) {
+		const path = findNodePath(child, target);
+		if (path) return [root, ...path];
+	}
+	return null;
+}
+
+// =============================================================================
 // COMPONENT
 // =============================================================================
 
 /**
- * Profiler view for a single server connection.
+ * SnakeViz-style profiler view for a single server connection.
  *
- * Provides a target selector (Server Process or running pipelines),
- * start/stop controls, status display, and tabbed visualisation area
- * with flame graph, sunburst, sortable table, and raw text views.
+ * Stacked layout: controls → viz controls → sunburst/icicle → call stack → table.
+ * No tabs — visualisation and table are always visible simultaneously.
  */
 const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 	const { isConnected } = useShellConnection();
@@ -261,34 +393,30 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 	// STATE
 	// =========================================================================
 
-	// Current profiling status from the server
+	// Server state
 	const [status, setStatus] = useState<CProfileStatus | null>(null);
-
-	// Full pstats report text (for the Text tab)
-	const [report, setReport] = useState<string>('');
-
-	// Structured call tree data (for Flame Graph, Sunburst, Table tabs)
 	const [treeData, setTreeData] = useState<ProfileTreeResponse | null>(null);
-
-	// Available pipeline targets (from rrext_get_tasks)
+	const [report, setReport] = useState<string>('');
 	const [tasks, setTasks] = useState<TaskEntry[]>([]);
-
-	// Selected target: null = Server Process, string = task token
 	const [target, setTarget] = useState<string | null>(null);
-
-	// Optional session name for the profiling session
 	const [sessionName, setSessionName] = useState<string>('');
-
-	// Error message to display
 	const [error, setError] = useState<string>('');
 
-	// Active visualisation tab
-	const [activeTab, setActiveTab] = useState<ProfilerTab>('flame');
+	// Viz state — snakeviz controls
+	const [vizStyle, setVizStyle] = useState<VizStyle>('sunburst');
+	const [vizDepth, setVizDepth] = useState<number>(10);
+	const [vizCutoff, setVizCutoff] = useState<number>(0.001);
+	const [showSystemCalls, setShowSystemCalls] = useState<boolean>(false);
 
-	// Selected node for cross-highlighting between visualisations
-	const [selectedNode, setSelectedNode] = useState<ProfileTreeNode | null>(null);
+	// Root tracking — distinct from tree root
+	const [vizRoot, setVizRoot] = useState<ProfileTreeNode | null>(null);
+	const [originalRoot, setOriginalRoot] = useState<ProfileTreeNode | null>(null);
+	const [callStack, setCallStack] = useState<ProfileTreeNode[]>([]);
 
-	// Refs for polling intervals
+	// Report modal
+	const [showReportModal, setShowReportModal] = useState(false);
+
+	// Polling refs
 	const statusIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 	const tasksIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -299,15 +427,13 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 	// STATUS POLLING
 	// =========================================================================
 
-	/** Fetch cProfile status for the selected target. */
+	/** Fetch profiling status for the selected target. */
 	const fetchStatus = useCallback(async () => {
 		const client = getClient();
 		if (!client || !client.isConnected()) return;
 		try {
-			// Build arguments — include target if profiling a pipeline
 			const args: Record<string, unknown> = {};
 			if (target) args.target = target;
-
 			const result = await client.call<CProfileStatus>('rrext_cprofile_status', args);
 			setStatus(result);
 		} catch (err) {
@@ -321,11 +447,8 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 			if (statusIntervalRef.current) { clearInterval(statusIntervalRef.current); statusIntervalRef.current = null; }
 			return;
 		}
-
-		// Initial fetch then poll
 		fetchStatus();
 		statusIntervalRef.current = setInterval(fetchStatus, STATUS_POLL_MS);
-
 		return () => {
 			if (statusIntervalRef.current) { clearInterval(statusIntervalRef.current); statusIntervalRef.current = null; }
 		};
@@ -343,7 +466,6 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 			const result = await client.call<{ tasks: TaskEntry[] }>('rrext_get_tasks', {});
 			setTasks(result.tasks || []);
 		} catch {
-			// Task list may fail on model servers (no tasks) — that's fine
 			setTasks([]);
 		}
 	}, []);
@@ -354,11 +476,8 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 			if (tasksIntervalRef.current) { clearInterval(tasksIntervalRef.current); tasksIntervalRef.current = null; }
 			return;
 		}
-
-		// Initial fetch then poll less frequently
 		fetchTasks();
 		tasksIntervalRef.current = setInterval(fetchTasks, TASKS_POLL_MS);
-
 		return () => {
 			if (tasksIntervalRef.current) { clearInterval(tasksIntervalRef.current); tasksIntervalRef.current = null; }
 		};
@@ -368,19 +487,18 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 	// REPORT FETCHING
 	// =========================================================================
 
-	/** Fetch the text report and the structured tree independently. */
-	const fetchReport = useCallback(async () => {
+	/** Fetch both the text report and structured tree data. */
+	const fetchReport = useCallback(async (systemCalls?: boolean) => {
 		const client = getClient();
 		if (!client) return;
 
 		// Increment fetch ID so stale responses from a previous target are ignored
 		const id = ++fetchIdRef.current;
 
-		// Build shared arguments
 		const args: Record<string, unknown> = {};
 		if (target) args.target = target;
 
-		// Fetch text report — always available
+		// Fetch text report
 		try {
 			const textResult = await client.call<{ report: string }>('rrext_cprofile_report', args);
 			if (fetchIdRef.current !== id) return; // stale response
@@ -388,22 +506,66 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		} catch (err) {
 			console.log('[ProfilerView] Text report fetch failed:', err);
 			if (fetchIdRef.current !== id) return;
-			// Clear stale report so the UI doesn't show outdated results
 			setReport('');
 		}
 
-		// Fetch tree data — may not be available on older servers
+		// Fetch tree data — pass include_system flag to server
+		const treeArgs: Record<string, unknown> = { ...args };
+		const includeSystem = systemCalls ?? showSystemCalls;
+		treeArgs.include_system = includeSystem;
 		try {
-			const treeResult = await client.call<ProfileTreeResponse>('rrext_cprofile_report_tree', args);
+			const treeResult = await client.call<ProfileTreeResponse>('rrext_cprofile_report_tree', treeArgs);
 			if (fetchIdRef.current !== id) return; // stale response
 			setTreeData(treeResult);
+			// Set the original root and initial viz root
+			if (treeResult.tree) {
+				setOriginalRoot(treeResult.tree);
+				setVizRoot(treeResult.tree);
+				setCallStack([treeResult.tree]);
+			}
 		} catch (err) {
 			console.log('[ProfilerView] Tree report fetch failed:', err);
 			if (fetchIdRef.current !== id) return;
-			// Clear stale tree data so visualisations don't show outdated results
 			setTreeData(null);
+			setOriginalRoot(null);
+			setVizRoot(null);
+			setCallStack([]);
 		}
-	}, [target]);
+	}, [target, showSystemCalls]);
+
+	// Re-fetch tree when system calls toggle changes (if we have data)
+	useEffect(() => {
+		if (treeData?.tree) {
+			fetchReport();
+		}
+	// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [showSystemCalls]);
+
+	// =========================================================================
+	// ROOT CHANGE HANDLER
+	// =========================================================================
+
+	/**
+	 * Handle re-rooting the visualisation (from viz click or table row click).
+	 * Builds the call stack by finding the path from the original root.
+	 */
+	const handleRootChange = useCallback((node: ProfileTreeNode) => {
+		// Find the matching node in the ORIGINAL tree (not a pruned/copied node
+		// from d3 — those lose their full subtree after limitDepth/pruneTree)
+		if (originalRoot) {
+			const path = findNodePath(originalRoot, node);
+			if (path) {
+				// Use the last element of the path — that's the node from the
+				// original tree with its full subtree intact
+				setVizRoot(path[path.length - 1]);
+				setCallStack(path);
+				return;
+			}
+		}
+		// Fallback: use the clicked node directly
+		setVizRoot(node);
+		setCallStack([node]);
+	}, [originalRoot]);
 
 	// =========================================================================
 	// ACTIONS
@@ -414,7 +576,6 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		const client = getClient();
 		if (!client) return;
 		try {
-			// Build arguments
 			const args: Record<string, unknown> = {};
 			if (target) args.target = target;
 			if (sessionName.trim()) args.session = sessionName.trim();
@@ -427,9 +588,10 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 				// Clear stale data
 				setReport('');
 				setTreeData(null);
-				setSelectedNode(null);
+				setOriginalRoot(null);
+				setVizRoot(null);
+				setCallStack([]);
 			}
-			// Refresh status immediately
 			await fetchStatus();
 		} catch (err: unknown) {
 			setError(err instanceof Error ? err.message : 'Failed to start profiling');
@@ -441,7 +603,6 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		const client = getClient();
 		if (!client) return;
 		try {
-			// Build arguments
 			const args: Record<string, unknown> = {};
 			if (target) args.target = target;
 
@@ -450,7 +611,6 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 				setError(result.message || 'Failed to stop profiling');
 			} else {
 				setError('');
-				// Fetch both report types after stopping
 				await fetchReport();
 			}
 			await fetchStatus();
@@ -459,16 +619,26 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		}
 	};
 
+	/** Reset Zoom — go back to original root. */
+	const handleResetRoot = useCallback(() => {
+		if (originalRoot) {
+			setVizRoot(originalRoot);
+			setCallStack([originalRoot]);
+		}
+	}, [originalRoot]);
+
 	// =========================================================================
 	// RENDER
 	// =========================================================================
 
-	// Show disconnected state
+	// Disconnected state
 	if (!isConnected) {
 		return <div style={styles.disconnected}>Connecting to {name} ({host}:{port})...</div>;
 	}
 
 	const isActive = status?.active === true;
+	const hasData = treeData?.tree != null;
+	const totalTime = treeData?.total_time ?? 0;
 
 	return (
 		<div style={styles.container}>
@@ -477,7 +647,7 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 
 			{/* Controls row */}
 			<div style={styles.controls}>
-				{/* Target selector — Server Process + running pipelines */}
+				{/* Target selector */}
 				<select
 					style={styles.select}
 					value={target || ''}
@@ -513,10 +683,13 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 					</button>
 				)}
 
-				{/* View Report button — only when not actively profiling */}
+				{/* View Report button — available whenever not actively profiling */}
 				<button
 					style={styles.button}
-					onClick={fetchReport}
+					onClick={() => {
+						if (!report) fetchReport();
+						setShowReportModal(true);
+					}}
 					disabled={isActive}
 				>
 					View Report
@@ -538,46 +711,145 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 				</div>
 			)}
 
-			{/* Visualisation tab bar */}
-			<div style={styles.tabBar}>
-				{TABS.map((tab) => (
+			{/* Viz controls row — only shown when data is available */}
+			{hasData && (
+				<div style={styles.vizControls}>
+					{/* Style dropdown */}
+					<span style={styles.vizLabel}>
+						Style:
+						<select
+							style={styles.smallSelect}
+							value={vizStyle}
+							onChange={(e) => setVizStyle(e.target.value as VizStyle)}
+						>
+							<option value="sunburst">Sunburst</option>
+							<option value="icicle">Icicle</option>
+						</select>
+					</span>
+
+					{/* Depth dropdown */}
+					<span style={styles.vizLabel}>
+						Depth:
+						<select
+							style={styles.smallSelect}
+							value={vizDepth}
+							onChange={(e) => setVizDepth(Number(e.target.value))}
+						>
+							{DEPTH_OPTIONS.map((d) => (
+								<option key={d} value={d}>{d}</option>
+							))}
+						</select>
+					</span>
+
+					{/* Cutoff dropdown */}
+					<span style={styles.vizLabel}>
+						Cutoff:
+						<select
+							style={styles.smallSelect}
+							value={vizCutoff}
+							onChange={(e) => setVizCutoff(Number(e.target.value))}
+						>
+							{CUTOFF_OPTIONS.map((opt) => (
+								<option key={opt.label} value={opt.value}>{opt.label}</option>
+							))}
+						</select>
+					</span>
+
+					{/* System calls checkbox — off by default, only show project code */}
+					<label style={{ ...styles.vizLabel, cursor: 'pointer' }}>
+						<input
+							type="checkbox"
+							checked={showSystemCalls}
+							onChange={(e) => setShowSystemCalls(e.target.checked)}
+						/>
+						System calls
+					</label>
+
+					{/* Reset Root button */}
 					<button
-						key={tab.key}
-						style={{ ...styles.tab, ...(activeTab === tab.key ? styles.tabActive : {}) }}
-						onClick={() => setActiveTab(tab.key)}
+						style={styles.smallButton}
+						onClick={handleResetRoot}
+						disabled={vizRoot === originalRoot}
 					>
-						{tab.label}
+						Reset Root
 					</button>
-				))}
+				</div>
+			)}
+
+			{/* Visualisation area */}
+			<div style={styles.vizArea}>
+				{vizStyle === 'sunburst' ? (
+					<SunburstChart
+						root={vizRoot}
+						totalTime={totalTime}
+						maxDepth={vizDepth}
+						cutoff={vizCutoff}
+						onRootChange={handleRootChange}
+					/>
+				) : (
+					<FlameGraph
+						root={vizRoot}
+						totalTime={totalTime}
+						maxDepth={vizDepth}
+						cutoff={vizCutoff}
+						onRootChange={handleRootChange}
+					/>
+				)}
 			</div>
 
-			{/* Visualisation content area */}
-			<div style={styles.tabContent}>
-				{activeTab === 'flame' && (
-					<FlameGraph
-						treeData={treeData}
-						selectedNode={selectedNode}
-						onNodeSelect={setSelectedNode}
-					/>
-				)}
-				{activeTab === 'sunburst' && (
-					<SunburstChart
-						treeData={treeData}
-						selectedNode={selectedNode}
-						onNodeSelect={setSelectedNode}
-					/>
-				)}
-				{activeTab === 'table' && (
-					<StatsTable
-						treeData={treeData}
-						selectedNode={selectedNode}
-						onNodeSelect={setSelectedNode}
-					/>
-				)}
-				{activeTab === 'text' && (
-					<ReportText report={report} />
-				)}
+			{/* Call stack — shows path from root to current viz root */}
+			{hasData && callStack.length > 1 && (
+				<div style={styles.callStack}>
+					<span>Call Stack:</span>
+					{callStack.map((node, i) => (
+						<React.Fragment key={i}>
+							{i > 0 && <span style={styles.callStackSep}>{'\u2192'}</span>}
+							<button
+								style={styles.callStackLink}
+								onClick={() => handleRootChange(node)}
+							>
+								{node.name === '<root>' ? 'All' : node.name}
+							</button>
+						</React.Fragment>
+					))}
+				</div>
+			)}
+
+			{/* Stats table — always visible below the viz */}
+			<div style={styles.tableArea}>
+				<StatsTable
+					treeData={treeData}
+					vizRoot={vizRoot}
+					onRootChange={handleRootChange}
+					showSystemCalls={showSystemCalls}
+				/>
 			</div>
+
+			{/* Report modal */}
+			{showReportModal && (
+				<div
+					style={styles.modalBackdrop}
+					onClick={() => setShowReportModal(false)}
+				>
+					<div
+						style={styles.modalDialog}
+						onClick={(e) => e.stopPropagation()}
+					>
+						<div style={styles.modalHeader}>
+							<h3 style={{ margin: 0, fontSize: 14 }}>Raw Profile Report</h3>
+							<button
+								style={styles.button}
+								onClick={() => setShowReportModal(false)}
+							>
+								Close
+							</button>
+						</div>
+						<div style={styles.modalBody}>
+							<ReportText report={report} />
+						</div>
+					</div>
+				</div>
+			)}
 		</div>
 	);
 };

--- a/apps/profiler-ui/src/views/ProfilerView.tsx
+++ b/apps/profiler-ui/src/views/ProfilerView.tsx
@@ -522,6 +522,11 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 				setOriginalRoot(treeResult.tree);
 				setVizRoot(treeResult.tree);
 				setCallStack([treeResult.tree]);
+			} else {
+				// Clear stale roots when tree response is empty
+				setOriginalRoot(null);
+				setVizRoot(null);
+				setCallStack([]);
 			}
 		} catch (err) {
 			console.log('[ProfilerView] Tree report fetch failed:', err);

--- a/apps/profiler-ui/src/views/visualizations/FlameGraph.tsx
+++ b/apps/profiler-ui/src/views/visualizations/FlameGraph.tsx
@@ -21,15 +21,21 @@
 // SOFTWARE.
 
 // =============================================================================
-// FLAME GRAPH — Interactive icicle chart with d3.partition
+// FLAME GRAPH (ICICLE) — SnakeViz-style rectangular partition visualisation
+// =============================================================================
+//
+// SnakeViz icicle mode: top-down stacked rectangles.
+// Width = cumulative time.  Color = D3 ordinal scale by function name.
+// Hover = magenta highlight + all same-name rects highlighted.
+// Click rect = re-root to that function.
 // =============================================================================
 
-import React, { useRef, useEffect, useCallback, useState } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import type { CSSProperties } from 'react';
 import * as d3 from 'd3';
 import type { HierarchyRectangularNode } from 'd3';
 import { commonStyles } from 'shared/themes/styles';
-import type { ProfileTreeNode, ProfileTreeResponse, BreadcrumbEntry, OnNodeSelect } from './types';
+import type { ProfileTreeNode, OnRootChange } from './types';
 
 // =============================================================================
 // CONSTANTS
@@ -47,66 +53,20 @@ const MIN_RENDER_WIDTH = 2;
 /** Padding inside each rect for the label text. */
 const TEXT_PADDING = 4;
 
-// =============================================================================
-// COLOUR PALETTE
-// =============================================================================
+/** Magenta highlight colour for hovered nodes (same as sunburst). */
+const HOVER_COLOR = '#ff00ff';
 
 /**
- * CSS variable names for the chart colour palette.
- * Resolved at render time via getComputedStyle because d3 `.attr('fill')`
- * uses setAttribute which cannot resolve CSS `var()` references.
+ * D3 category20c palette — same 20-colour ordinal scale as snakeviz.
+ * Hardcoded to avoid dependency on d3-scale-chromatic type exports.
  */
-const PALETTE_VARS = [
-	'--rr-chart-blue',
-	'--rr-chart-purple',
-	'--rr-chart-green',
-	'--rr-chart-yellow',
-	'--rr-chart-orange',
-	'--rr-chart-red',
+const CATEGORY20C = [
+	'#3182bd', '#6baed6', '#9ecae1', '#c6dbef',
+	'#e6550d', '#fd8d3c', '#fdae6b', '#fdd0a2',
+	'#31a354', '#74c476', '#a1d99b', '#c7e9c0',
+	'#756bb1', '#9e9ac8', '#bcbddc', '#dadaeb',
+	'#636363', '#969696', '#bdbdbd', '#d9d9d9',
 ];
-
-/** Fallback hex values if CSS variables cannot be resolved. */
-const PALETTE_FALLBACK = ['#4263eb', '#7048e8', '#2b8a3e', '#e67700', '#e67a2e', '#c92a2a'];
-
-/**
- * Resolve the chart palette from CSS custom properties on a DOM element.
- *
- * @param el - DOM element to read computed styles from.
- * @returns Array of resolved hex colour strings.
- */
-function resolvePalette(el: Element): string[] {
-	const cs = getComputedStyle(el);
-	return PALETTE_VARS.map((v, i) => cs.getPropertyValue(v).trim() || PALETTE_FALLBACK[i]);
-}
-
-/**
- * Simple string hash for distributing colours across function names.
- *
- * @param s - String to hash.
- * @returns Positive integer hash.
- */
-function hashStr(s: string): number {
-	let h = 0;
-	for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
-	return Math.abs(h);
-}
-
-/**
- * Map a node to a resolved colour string.
- *
- * @param palette - Resolved colour array from resolvePalette().
- * @param name    - Function name (for hash distribution).
- * @param tottime - Self-time.
- * @param cumtime - Cumulative time.
- * @returns Resolved hex colour string.
- */
-function nodeColour(palette: string[], name: string, tottime: number, cumtime: number): string {
-	const base = hashStr(name) % palette.length;
-	const ratio = cumtime > 0 ? tottime / cumtime : 0;
-	const shift = Math.floor(ratio * 2);
-	const idx = Math.min(base + shift, palette.length - 1);
-	return palette[idx];
-}
 
 // =============================================================================
 // STYLES
@@ -117,52 +77,6 @@ const styles = {
 	container: {
 		...commonStyles.columnFill,
 		overflow: 'hidden',
-	} as CSSProperties,
-
-	/** Toolbar row with search and breadcrumbs. */
-	toolbar: {
-		display: 'flex',
-		alignItems: 'center',
-		gap: 8,
-		padding: '6px 8px',
-		borderBottom: '1px solid var(--rr-border)',
-		flexWrap: 'wrap',
-	} as CSSProperties,
-
-	/** Search input. */
-	searchInput: {
-		...commonStyles.inputField,
-		width: 220,
-		padding: '4px 8px',
-		fontSize: 12,
-	} as CSSProperties,
-
-	/** Breadcrumb trail container. */
-	breadcrumbs: {
-		display: 'flex',
-		alignItems: 'center',
-		gap: 4,
-		fontSize: 12,
-		color: 'var(--rr-text-secondary)',
-		overflow: 'hidden',
-	} as CSSProperties,
-
-	/** Clickable breadcrumb link. */
-	breadcrumbLink: {
-		color: 'var(--rr-text-link)',
-		cursor: 'pointer',
-		textDecoration: 'none',
-		whiteSpace: 'nowrap',
-		background: 'none',
-		border: 'none',
-		padding: 0,
-		fontFamily: 'inherit',
-		fontSize: 12,
-	} as CSSProperties,
-
-	/** Breadcrumb separator. */
-	breadcrumbSep: {
-		color: 'var(--rr-text-disabled)',
 	} as CSSProperties,
 
 	/** Scrollable SVG container. */
@@ -192,16 +106,48 @@ const styles = {
 };
 
 // =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Apply cutoff pruning to a tree node.
+ * Children whose cumtime is less than cutoff * parent.cumtime are removed.
+ */
+function pruneTree(node: ProfileTreeNode, cutoff: number): ProfileTreeNode {
+	if (cutoff <= 0 || !node.children.length) return node;
+	const threshold = cutoff * node.cumtime;
+	const prunedChildren = node.children
+		.filter((c) => c.cumtime >= threshold)
+		.map((c) => pruneTree(c, cutoff));
+	return { ...node, children: prunedChildren };
+}
+
+/**
+ * Limit tree depth to maxDepth levels.
+ */
+function limitDepth(node: ProfileTreeNode, maxDepth: number, depth: number = 0): ProfileTreeNode {
+	if (depth >= maxDepth) return { ...node, children: [] };
+	return {
+		...node,
+		children: node.children.map((c) => limitDepth(c, maxDepth, depth + 1)),
+	};
+}
+
+// =============================================================================
 // PROPS
 // =============================================================================
 
 interface FlameGraphProps {
-	/** Structured call tree from the server. */
-	treeData: ProfileTreeResponse | null;
-	/** Currently selected node for cross-highlighting. */
-	selectedNode: ProfileTreeNode | null;
-	/** Callback when a node is selected. */
-	onNodeSelect: OnNodeSelect;
+	/** Root node to visualise (the current viz root). */
+	root: ProfileTreeNode | null;
+	/** Total cumulative time of the full profile (for percentage display). */
+	totalTime: number;
+	/** Maximum depth levels to render. */
+	maxDepth: number;
+	/** Cutoff fraction — prune children with cumtime < cutoff * parent.cumtime. */
+	cutoff: number;
+	/** Callback when user clicks a rect to re-root the visualisation. */
+	onRootChange: OnRootChange;
 }
 
 // =============================================================================
@@ -209,23 +155,22 @@ interface FlameGraphProps {
 // =============================================================================
 
 /**
- * Interactive icicle / flame graph visualisation.
+ * SnakeViz-style icicle chart visualisation.
  *
- * Renders a top-down icicle chart using d3.hierarchy + d3.partition in SVG.
- * Click any block to zoom into that subtree; breadcrumbs at top for
- * navigating back. Hover shows a tooltip with function details. Search
- * input highlights matching nodes and dims the rest.
- *
- * @param props.treeData     - Tree data from the server.
- * @param props.selectedNode - Currently highlighted node (cross-vis).
- * @param props.onNodeSelect - Callback for node selection.
+ * Renders a top-down rectangular partition layout using d3.partition.
+ * Width = cumulative time.  Same colour scheme and hover behaviour as
+ * the sunburst chart.
  */
-const FlameGraph: React.FC<FlameGraphProps> = ({ treeData, selectedNode, onNodeSelect }) => {
+const FlameGraph: React.FC<FlameGraphProps> = ({
+	root: vizRoot,
+	totalTime,
+	maxDepth: maxDepthProp,
+	cutoff,
+	onRootChange,
+}) => {
 	const svgRef = useRef<SVGSVGElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const [width, setWidth] = useState(800);
-	const [breadcrumbs, setBreadcrumbs] = useState<BreadcrumbEntry[]>([]);
-	const [search, setSearch] = useState('');
 	const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
 
 	// =========================================================================
@@ -248,28 +193,26 @@ const FlameGraph: React.FC<FlameGraphProps> = ({ treeData, selectedNode, onNodeS
 
 	useEffect(() => {
 		const svg = svgRef.current;
-		if (!svg || !treeData?.tree) return;
+		if (!svg || !vizRoot) return;
 
-		// Determine the zoom root
-		const zoomRoot = breadcrumbs.length > 0
-			? breadcrumbs[breadcrumbs.length - 1].node
-			: treeData.tree;
+		// Apply client-side depth limiting and cutoff pruning
+		const processedRoot = pruneTree(limitDepth(vizRoot, maxDepthProp), cutoff);
 
-		// Build d3 hierarchy — use self-time for partition widths
-		const root = d3.hierarchy(zoomRoot, (d) => d.children)
+		// D3 ordinal colour scale by function name (matches sunburst)
+		const color = d3.scaleOrdinal(CATEGORY20C);
+
+		// Build d3 hierarchy — partition value = cumtime (snakeviz icicle mode)
+		const root = d3.hierarchy(processedRoot, (d) => d.children)
 			.sum((d) => {
 				if (!d.children || d.children.length === 0) return Math.max(d.cumtime, 0.000001);
 				const childCum = d.children.reduce((s, c) => s + c.cumtime, 0);
-				return Math.max(d.cumtime - childCum, 0);
+				return Math.max(d.cumtime - childCum, 0.000001);
 			})
 			.sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
 
-		// Resolve theme colours from CSS custom properties (d3 .attr() can't use var())
-		const palette = resolvePalette(svg);
-
 		// Compute partition layout
-		const maxDepth = Math.min(root.height + 1, MAX_VISIBLE_DEPTH);
-		const height = maxDepth * ROW_HEIGHT;
+		const depthLimit = Math.min(root.height + 1, MAX_VISIBLE_DEPTH);
+		const height = depthLimit * ROW_HEIGHT;
 		const partition = d3.partition<ProfileTreeNode>()
 			.size([width, height])
 			.padding(1);
@@ -280,45 +223,28 @@ const FlameGraph: React.FC<FlameGraphProps> = ({ treeData, selectedNode, onNodeS
 		d3.select(svg).selectAll('*').remove();
 
 		// Flatten visible nodes
-		const nodes = root.descendants() as HierarchyRectangularNode<ProfileTreeNode>[];
-		const searchLower = search.toLowerCase().trim();
-
-		// Resolve theme colours from CSS custom properties
-		const computedStyle = getComputedStyle(svg);
-		const brandColor = computedStyle.getPropertyValue('--rr-brand').trim() || '#f7901f';
+		const nodes = (root.descendants() as HierarchyRectangularNode<ProfileTreeNode>[])
+			.filter((d) => (d.x1 - d.x0) >= MIN_RENDER_WIDTH);
 
 		// Create node groups
 		const g = d3.select(svg)
 			.selectAll<SVGGElement, HierarchyRectangularNode<ProfileTreeNode>>('g.node')
-			.data(nodes.filter((d) => (d.x1 - d.x0) >= MIN_RENDER_WIDTH))
+			.data(nodes)
 			.join('g')
 			.attr('class', 'node')
 			.attr('transform', (d) => `translate(${d.x0},${d.y0})`);
 
 		// Rectangles
-		g.append('rect')
+		const rects = g.append('rect')
 			.attr('width', (d) => Math.max(0, d.x1 - d.x0))
 			.attr('height', (d) => Math.max(0, d.y1 - d.y0 - 1))
 			.attr('rx', 2)
-			.attr('fill', (d) => nodeColour(palette, d.data.name, d.data.tottime, d.data.cumtime))
-			.attr('opacity', (d) => {
-				if (!searchLower) return 0.85;
-				const matches = d.data.name.toLowerCase().includes(searchLower)
-					|| d.data.file.toLowerCase().includes(searchLower);
-				return matches ? 1 : 0.2;
-			})
-			.attr('stroke', (d) => {
-				if (selectedNode && d.data.name === selectedNode.name
-					&& d.data.file === selectedNode.file
-					&& d.data.line === selectedNode.line) {
-					return brandColor;
-				}
-				return 'none';
-			})
-			.attr('stroke-width', 2)
+			.attr('fill', (d) => color(d.data.name))
+			.attr('opacity', 0.85)
+			.attr('stroke', 'none')
 			.style('cursor', 'pointer');
 
-		// Labels — use theme text colour for readability
+		// Labels
 		g.append('text')
 			.attr('x', TEXT_PADDING)
 			.attr('y', ROW_HEIGHT / 2 + 1)
@@ -336,90 +262,68 @@ const FlameGraph: React.FC<FlameGraphProps> = ({ treeData, selectedNode, onNodeS
 			});
 
 		// =====================================================================
-		// INTERACTION
+		// CLICK — Re-root to that function
 		// =====================================================================
 
-		// Click to zoom
+		// Click any block to re-root the visualisation to that function
+		// (no children guard — ProfilerView resolves the full subtree from the original tree)
 		g.on('click', (_event, d) => {
 			if (d.depth === 0) return;
-			const ancestors: BreadcrumbEntry[] = [];
-			let current: HierarchyRectangularNode<ProfileTreeNode> | null = d;
-			while (current && current.depth > 0) {
-				ancestors.unshift({ label: current.data.name, node: current.data });
-				current = current.parent;
-			}
-			setBreadcrumbs([...breadcrumbs, ...ancestors]);
-			onNodeSelect(d.data);
+			onRootChange(d.data);
 		});
 
-		// Tooltip
+		// =====================================================================
+		// HOVER — Magenta highlight + same-function highlighting (snakeviz)
+		// =====================================================================
+
 		g.on('mouseenter', (event, d) => {
+			const hoveredName = d.data.name;
+
+			// Highlight all rects with the same function name
+			rects.each(function (dd) {
+				const el = d3.select(this);
+				if (dd.data.name === hoveredName) {
+					el.attr('fill', HOVER_COLOR).attr('opacity', 1);
+				} else {
+					el.attr('opacity', 0.4);
+				}
+			});
+
+			// Tooltip with cumtime percentage
+			const pct = totalTime > 0 ? (d.data.cumtime / totalTime * 100).toFixed(1) : '0.0';
 			const lines = [
 				d.data.name,
+				`${d.data.cumtime.toFixed(4)}s (${pct}%)`,
 				`${d.data.file}:${d.data.line}`,
-				`Calls: ${d.data.ncalls}`,
-				`Total: ${d.data.tottime.toFixed(4)}s`,
-				`Cumulative: ${d.data.cumtime.toFixed(4)}s`,
 			];
 			setTooltip({ x: event.clientX + 12, y: event.clientY + 12, text: lines.join('\n') });
 		});
+
 		g.on('mousemove', (event) => {
 			setTooltip((prev) => prev ? { ...prev, x: event.clientX + 12, y: event.clientY + 12 } : null);
 		});
-		g.on('mouseleave', () => setTooltip(null));
 
-	}, [treeData, width, breadcrumbs, search, selectedNode, onNodeSelect]);
+		g.on('mouseleave', () => {
+			// Restore original colours
+			rects.attr('fill', (d) => color(d.data.name)).attr('opacity', 0.85);
+			setTooltip(null);
+		});
 
-	// =========================================================================
-	// BREADCRUMB NAVIGATION
-	// =========================================================================
-
-	const handleBreadcrumbClick = useCallback((index: number) => {
-		if (index < 0) {
-			setBreadcrumbs([]);
-			onNodeSelect(null);
-		} else {
-			setBreadcrumbs((prev) => prev.slice(0, index + 1));
-			onNodeSelect(null);
-		}
-	}, [onNodeSelect]);
+	}, [vizRoot, width, maxDepthProp, cutoff, onRootChange, totalTime]);
 
 	// =========================================================================
 	// RENDER
 	// =========================================================================
 
-	if (!treeData?.tree) {
+	if (!vizRoot) {
 		return <div style={commonStyles.empty}>No profiling data available. Start and stop a session to generate a flame graph.</div>;
 	}
 
 	return (
 		<div style={styles.container}>
-			{/* Toolbar */}
-			<div style={styles.toolbar}>
-				<input
-					type="text"
-					placeholder="Search functions..."
-					value={search}
-					onChange={(e) => setSearch(e.target.value)}
-					style={styles.searchInput}
-				/>
-				<div style={styles.breadcrumbs}>
-					<button style={styles.breadcrumbLink} onClick={() => handleBreadcrumbClick(-1)}>root</button>
-					{breadcrumbs.map((crumb, i) => (
-						<React.Fragment key={i}>
-							<span style={styles.breadcrumbSep}>&gt;</span>
-							<button style={styles.breadcrumbLink} onClick={() => handleBreadcrumbClick(i)}>{crumb.label}</button>
-						</React.Fragment>
-					))}
-				</div>
-			</div>
-
-			{/* SVG */}
 			<div ref={containerRef} style={styles.svgContainer}>
 				<svg ref={svgRef} />
 			</div>
-
-			{/* Tooltip */}
 			{tooltip && (
 				<div style={{ ...styles.tooltip, left: tooltip.x, top: tooltip.y }}>{tooltip.text}</div>
 			)}

--- a/apps/profiler-ui/src/views/visualizations/StatsTable.tsx
+++ b/apps/profiler-ui/src/views/visualizations/StatsTable.tsx
@@ -21,13 +21,20 @@
 // SOFTWARE.
 
 // =============================================================================
-// STATS TABLE — Sortable flat function table
+// STATS TABLE — SnakeViz-style sortable flat function table
+// =============================================================================
+//
+// Column order matches snakeviz / pstats output:
+//   ncalls | tottime | percall | cumtime | percall | filename:lineno(function)
+//
+// Row click = re-root the visualisation (not just cross-highlight).
+// Table always shows ALL functions regardless of current viz root.
 // =============================================================================
 
 import React, { useMemo, useState, useCallback, useRef, useEffect } from 'react';
 import type { CSSProperties } from 'react';
 import { commonStyles } from 'shared/themes/styles';
-import type { ProfileTreeNode, ProfileTreeResponse, OnNodeSelect } from './types';
+import type { ProfileTreeNode, ProfileTreeResponse, OnRootChange } from './types';
 
 // =============================================================================
 // TYPES
@@ -35,19 +42,30 @@ import type { ProfileTreeNode, ProfileTreeResponse, OnNodeSelect } from './types
 
 /** Aggregated stats for one unique function across all call sites. */
 interface FlatRow {
+	/** Function name. */
 	name: string;
+	/** Source filename. */
 	file: string;
+	/** Source line number. */
 	line: number;
+	/** Total call count. */
 	ncalls: number;
+	/** Self time (excludes sub-calls). */
 	tottime: number;
-	cumtime: number;
+	/** tottime / ncalls. */
 	percall: number;
+	/** Cumulative time (includes sub-calls). */
+	cumtime: number;
+	/** cumtime / ncalls. */
 	cumpercall: number;
+	/** Combined pstats-style location string. */
+	location: string;
+	/** Reference to the original tree node (for re-rooting). */
 	refNode: ProfileTreeNode;
 }
 
 /** Sortable column identifiers. */
-type SortColumn = 'name' | 'file' | 'ncalls' | 'tottime' | 'cumtime' | 'percall' | 'cumpercall';
+type SortColumn = 'ncalls' | 'tottime' | 'percall' | 'cumtime' | 'cumpercall' | 'location';
 
 /** Sort direction. */
 type SortDir = 'asc' | 'desc';
@@ -59,15 +77,14 @@ type SortDir = 'asc' | 'desc';
 /** Number of rows to render per chunk for windowed rendering. */
 const CHUNK_SIZE = 200;
 
-/** Column definitions. */
+/** Column definitions — matches snakeviz / pstats output order. */
 const COLUMNS: { key: SortColumn; label: string; align: 'left' | 'right' }[] = [
-	{ key: 'name', label: 'Function', align: 'left' },
-	{ key: 'file', label: 'File:Line', align: 'left' },
-	{ key: 'ncalls', label: 'Calls', align: 'right' },
-	{ key: 'tottime', label: 'Total Time', align: 'right' },
-	{ key: 'cumtime', label: 'Cum Time', align: 'right' },
-	{ key: 'percall', label: 'Time/Call', align: 'right' },
-	{ key: 'cumpercall', label: 'Cum/Call', align: 'right' },
+	{ key: 'ncalls', label: 'ncalls', align: 'right' },
+	{ key: 'tottime', label: 'tottime', align: 'right' },
+	{ key: 'percall', label: 'percall', align: 'right' },
+	{ key: 'cumtime', label: 'cumtime', align: 'right' },
+	{ key: 'cumpercall', label: 'percall', align: 'right' },
+	{ key: 'location', label: 'filename:lineno(function)', align: 'left' },
 ];
 
 // =============================================================================
@@ -118,7 +135,7 @@ const styles = {
 		fontFamily: 'var(--rr-font-mono, monospace)',
 	} as CSSProperties,
 
-	/** Header cell — extends commonStyles.tableHeader with sort cursor. */
+	/** Header cell. */
 	th: {
 		...commonStyles.tableHeader,
 		position: 'sticky',
@@ -145,19 +162,19 @@ const styles = {
 		background: 'var(--rr-bg-list-hover)',
 	} as CSSProperties,
 
-	/** Selected row. */
+	/** Selected row (current viz root). */
 	trSelected: {
 		background: 'var(--rr-bg-list-active)',
 		color: 'var(--rr-fg-list-active)',
 	} as CSSProperties,
 
-	/** Table body cell — extends commonStyles.tableCell. */
+	/** Table body cell. */
 	td: {
 		...commonStyles.tableCell,
 		whiteSpace: 'nowrap',
 		overflow: 'hidden',
 		textOverflow: 'ellipsis',
-		maxWidth: 300,
+		maxWidth: 400,
 		fontSize: 12,
 	} as CSSProperties,
 };
@@ -168,6 +185,7 @@ const styles = {
 
 /**
  * Flatten a call tree into a deduplicated list of unique functions.
+ * Matches snakeviz's behaviour: aggregate all occurrences of the same function.
  *
  * @param tree - Root of the call tree.
  * @returns Array of aggregated flat rows.
@@ -175,12 +193,13 @@ const styles = {
 function flattenTree(tree: ProfileTreeNode): FlatRow[] {
 	const map = new Map<string, FlatRow>();
 
-	/** Recursively walk the tree, aggregating stats. */
+	/** Recursively walk the tree, aggregating stats by function identity. */
 	function walk(node: ProfileTreeNode): void {
 		if (node.name !== '<root>') {
 			const key = `${node.file}:${node.line}:${node.name}`;
 			const existing = map.get(key);
 			if (existing) {
+				// Aggregate calls and times across all call sites
 				existing.ncalls += node.ncalls;
 				existing.tottime += node.tottime;
 				existing.cumtime += node.cumtime;
@@ -194,6 +213,7 @@ function flattenTree(tree: ProfileTreeNode): FlatRow[] {
 					cumtime: node.cumtime,
 					percall: 0,
 					cumpercall: 0,
+					location: `${node.file}:${node.line}(${node.name})`,
 					refNode: node,
 				});
 			}
@@ -203,7 +223,7 @@ function flattenTree(tree: ProfileTreeNode): FlatRow[] {
 
 	walk(tree);
 
-	// Compute per-call values
+	// Compute per-call values after aggregation
 	const rows = Array.from(map.values());
 	for (const row of rows) {
 		row.percall = row.ncalls > 0 ? row.tottime / row.ncalls : 0;
@@ -217,20 +237,38 @@ function flattenTree(tree: ProfileTreeNode): FlatRow[] {
 // =============================================================================
 
 /**
- * Sortable flat statistics table.
+ * SnakeViz-style sortable flat statistics table.
  *
- * Flattens the call tree, provides column sorting, search filtering,
- * and click-to-select for cross-highlighting.
+ * Column order matches pstats output: ncalls, tottime, percall, cumtime, percall,
+ * filename:lineno(function).
  *
- * @param props.treeData     - Tree data from the server.
- * @param props.selectedNode - Currently highlighted node (cross-vis).
- * @param props.onNodeSelect - Callback for node selection.
+ * Row click re-roots the visualisation to that function (not just cross-highlight).
+ * Table always shows all functions regardless of current viz root.
  */
+/**
+ * Path prefixes that identify project code.
+ * Used to filter rows when showSystemCalls is false.
+ */
+const PROJECT_PREFIXES = [
+	'./nodes/', './ai/', './lib/', './libs/', './rocketlib/', 'engLib:',
+];
+
+/** Check whether a file path belongs to project code. */
+function isProjectCode(file: string): boolean {
+	if (!file) return false;
+	return PROJECT_PREFIXES.some((p) => file.startsWith(p));
+}
+
 const StatsTable: React.FC<{
+	/** Full tree data from the server (always shows all functions). */
 	treeData: ProfileTreeResponse | null;
-	selectedNode: ProfileTreeNode | null;
-	onNodeSelect: OnNodeSelect;
-}> = ({ treeData, selectedNode, onNodeSelect }) => {
+	/** Current visualisation root node (for highlighting active row). */
+	vizRoot: ProfileTreeNode | null;
+	/** Callback to re-root the visualisation to a clicked function. */
+	onRootChange: OnRootChange;
+	/** Whether to show system/stdlib calls in the table. */
+	showSystemCalls: boolean;
+}> = ({ treeData, vizRoot, onRootChange, showSystemCalls }) => {
 	const [sortCol, setSortCol] = useState<SortColumn>('tottime');
 	const [sortDir, setSortDir] = useState<SortDir>('desc');
 	const [search, setSearch] = useState('');
@@ -242,17 +280,23 @@ const StatsTable: React.FC<{
 	// DATA PROCESSING
 	// =========================================================================
 
+	/** Flatten tree into deduplicated function list, optionally filtering system calls. */
 	const allRows = useMemo(() => {
 		if (!treeData?.tree) return [];
-		return flattenTree(treeData.tree);
-	}, [treeData]);
+		const rows = flattenTree(treeData.tree);
+		if (showSystemCalls) return rows;
+		// Filter to only project code when system calls is unchecked
+		return rows.filter((r) => isProjectCode(r.file));
+	}, [treeData, showSystemCalls]);
 
+	/** Apply search filter (matches snakeviz: filters by the location string). */
 	const filteredRows = useMemo(() => {
 		if (!search.trim()) return allRows;
 		const q = search.toLowerCase().trim();
-		return allRows.filter((r) => r.name.toLowerCase().includes(q) || r.file.toLowerCase().includes(q));
+		return allRows.filter((r) => r.location.toLowerCase().includes(q));
 	}, [allRows, search]);
 
+	/** Sort by selected column. */
 	const sortedRows = useMemo(() => {
 		const sorted = [...filteredRows];
 		const dir = sortDir === 'asc' ? 1 : -1;
@@ -265,6 +309,7 @@ const StatsTable: React.FC<{
 		return sorted;
 	}, [filteredRows, sortCol, sortDir]);
 
+	// Reset visible count when data changes
 	useEffect(() => { setVisibleCount(CHUNK_SIZE); }, [sortedRows]);
 
 	// =========================================================================
@@ -284,22 +329,25 @@ const StatsTable: React.FC<{
 	// HANDLERS
 	// =========================================================================
 
+	/** Toggle sort column/direction. */
 	const handleSort = useCallback((col: SortColumn) => {
 		setSortCol((prev) => {
 			if (prev === col) {
 				setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
 				return col;
 			}
-			setSortDir(col === 'name' || col === 'file' ? 'asc' : 'desc');
+			// Default to desc for numeric columns, asc for text
+			setSortDir(col === 'location' ? 'asc' : 'desc');
 			return col;
 		});
 	}, []);
 
+	/** Row click — re-root the visualisation (snakeviz behaviour). */
 	const handleRowClick = useCallback((row: FlatRow) => {
-		onNodeSelect(row.refNode);
-	}, [onNodeSelect]);
+		onRootChange(row.refNode);
+	}, [onRootChange]);
 
-	/** Handle keyboard activation (Enter/Space) on a sortable column header. */
+	/** Handle keyboard activation on a sortable column header. */
 	const handleThKeyDown = useCallback((e: React.KeyboardEvent, col: SortColumn) => {
 		if (e.key === 'Enter' || e.key === ' ') {
 			e.preventDefault();
@@ -307,7 +355,7 @@ const StatsTable: React.FC<{
 		}
 	}, [handleSort]);
 
-	/** Handle keyboard activation (Enter/Space) on a selectable row. */
+	/** Handle keyboard activation on a selectable row. */
 	const handleRowKeyDown = useCallback((e: React.KeyboardEvent, row: FlatRow) => {
 		if (e.key === 'Enter' || e.key === ' ') {
 			e.preventDefault();
@@ -385,10 +433,11 @@ const StatsTable: React.FC<{
 					</thead>
 					<tbody>
 						{visibleRows.map((row, i) => {
-							const isSelected = selectedNode
-								&& row.name === selectedNode.name
-								&& row.file === selectedNode.file
-								&& row.line === selectedNode.line;
+							// Highlight the row that matches the current viz root
+							const isSelected = vizRoot
+								&& row.name === vizRoot.name
+								&& row.file === vizRoot.file
+								&& row.line === vizRoot.line;
 
 							return (
 								<tr
@@ -405,13 +454,12 @@ const StatsTable: React.FC<{
 									onMouseEnter={() => setHoveredIdx(i)}
 									onMouseLeave={() => setHoveredIdx(-1)}
 								>
-									<td style={{ ...styles.td, textAlign: 'left' }}>{row.name}</td>
-									<td style={{ ...styles.td, textAlign: 'left' }}>{row.file}:{row.line}</td>
 									<td style={{ ...styles.td, textAlign: 'right' }}>{row.ncalls.toLocaleString()}</td>
 									<td style={{ ...styles.td, textAlign: 'right' }}>{fmtTime(row.tottime)}</td>
-									<td style={{ ...styles.td, textAlign: 'right' }}>{fmtTime(row.cumtime)}</td>
 									<td style={{ ...styles.td, textAlign: 'right' }}>{fmtTime(row.percall)}</td>
+									<td style={{ ...styles.td, textAlign: 'right' }}>{fmtTime(row.cumtime)}</td>
 									<td style={{ ...styles.td, textAlign: 'right' }}>{fmtTime(row.cumpercall)}</td>
+									<td style={{ ...styles.td, textAlign: 'left' }}>{row.location}</td>
 								</tr>
 							);
 						})}

--- a/apps/profiler-ui/src/views/visualizations/SunburstChart.tsx
+++ b/apps/profiler-ui/src/views/visualizations/SunburstChart.tsx
@@ -21,7 +21,13 @@
 // SOFTWARE.
 
 // =============================================================================
-// SUNBURST CHART — Radial partition visualisation with d3
+// SUNBURST CHART — SnakeViz-style radial partition visualisation
+// =============================================================================
+//
+// Arc width = cumulative time (matching snakeviz).
+// Color = D3 ordinal scale by function name (consistent per function).
+// Hover = magenta highlight + all same-name arcs highlighted.
+// Click arc = re-root to that function.  Click center = zoom out one level.
 // =============================================================================
 
 import React, { useRef, useEffect, useState } from 'react';
@@ -29,71 +35,53 @@ import type { CSSProperties } from 'react';
 import * as d3 from 'd3';
 import type { HierarchyRectangularNode } from 'd3';
 import { commonStyles } from 'shared/themes/styles';
-import type { ProfileTreeNode, ProfileTreeResponse, OnNodeSelect } from './types';
+import type { ProfileTreeNode, OnRootChange } from './types';
 
 // =============================================================================
 // CONSTANTS
 // =============================================================================
 
-/** Maximum visible depth rings. */
-const MAX_DEPTH = 10;
-
 /** Minimum arc angle (radians) for a node to be rendered. */
 const MIN_ARC_ANGLE = 0.005;
 
-// =============================================================================
-// COLOUR PALETTE (same as FlameGraph)
-// =============================================================================
+/** Magenta highlight colour for hovered arcs. */
+const HOVER_COLOR = '#ff00ff';
 
-/** CSS variable names for chart colours. */
-const PALETTE_VARS = [
-	'--rr-chart-blue', '--rr-chart-purple', '--rr-chart-green',
-	'--rr-chart-yellow', '--rr-chart-orange', '--rr-chart-red',
+/**
+ * D3 category20c palette — the same 20-colour ordinal scale that snakeviz uses.
+ * Hardcoded to avoid dependency on d3-scale-chromatic type exports.
+ */
+const CATEGORY20C = [
+	'#3182bd', '#6baed6', '#9ecae1', '#c6dbef',
+	'#e6550d', '#fd8d3c', '#fdae6b', '#fdd0a2',
+	'#31a354', '#74c476', '#a1d99b', '#c7e9c0',
+	'#756bb1', '#9e9ac8', '#bcbddc', '#dadaeb',
+	'#636363', '#969696', '#bdbdbd', '#d9d9d9',
 ];
-
-/** Fallback hex values. */
-const PALETTE_FALLBACK = ['#4263eb', '#7048e8', '#2b8a3e', '#e67700', '#e67a2e', '#c92a2a'];
-
-/** Resolve palette from CSS custom properties on a DOM element. */
-function resolvePalette(el: Element): string[] {
-	const cs = getComputedStyle(el);
-	return PALETTE_VARS.map((v, i) => cs.getPropertyValue(v).trim() || PALETTE_FALLBACK[i]);
-}
-
-/** Simple string hash for distributing colours. */
-function hashStr(s: string): number {
-	let h = 0;
-	for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
-	return Math.abs(h);
-}
-
-/** Map a node to a resolved colour string. */
-function nodeColour(palette: string[], name: string, tottime: number, cumtime: number): string {
-	const base = hashStr(name) % palette.length;
-	const ratio = cumtime > 0 ? tottime / cumtime : 0;
-	const shift = Math.floor(ratio * 2);
-	const idx = Math.min(base + shift, palette.length - 1);
-	return palette[idx];
-}
 
 // =============================================================================
 // STYLES
 // =============================================================================
 
 const styles = {
-	/** Outer container. */
+	/** Outer container — centers the SVG using flexbox. */
 	container: {
 		...commonStyles.columnFill,
-		alignItems: 'center',
 		overflow: 'auto',
 		background: 'var(--rr-bg-surface-alt)',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
 	} as CSSProperties,
 
-	/** SVG wrapper. */
+	/** SVG wrapper — constrains the SVG size. */
 	svgWrapper: {
 		display: 'flex',
+		alignItems: 'center',
 		justifyContent: 'center',
-		padding: 20,
+		padding: 10,
+		width: '100%',
+		height: '100%',
 	} as CSSProperties,
 
 	/** Tooltip overlay. */
@@ -120,12 +108,46 @@ const styles = {
 // =============================================================================
 
 interface SunburstChartProps {
-	/** Structured call tree from the server. */
-	treeData: ProfileTreeResponse | null;
-	/** Currently selected node for cross-highlighting. */
-	selectedNode: ProfileTreeNode | null;
-	/** Callback when a node is selected. */
-	onNodeSelect: OnNodeSelect;
+	/** Root node to visualise (the current viz root, not necessarily the tree root). */
+	root: ProfileTreeNode | null;
+	/** Total cumulative time of the full profile (for percentage display). */
+	totalTime: number;
+	/** Maximum depth rings to render. */
+	maxDepth: number;
+	/** Cutoff fraction — prune children with cumtime < cutoff * parent.cumtime. */
+	cutoff: number;
+	/** Callback when user clicks an arc to re-root the visualisation. */
+	onRootChange: OnRootChange;
+}
+
+// =============================================================================
+// HELPERS
+// =============================================================================
+
+/**
+ * Apply cutoff pruning to a tree node.
+ * Returns a new node with children filtered by the cutoff threshold.
+ * Children whose cumtime is less than cutoff * parent.cumtime are removed.
+ */
+function pruneTree(node: ProfileTreeNode, cutoff: number): ProfileTreeNode {
+	if (cutoff <= 0 || !node.children.length) return node;
+	const threshold = cutoff * node.cumtime;
+	const prunedChildren = node.children
+		.filter((c) => c.cumtime >= threshold)
+		.map((c) => pruneTree(c, cutoff));
+	return { ...node, children: prunedChildren };
+}
+
+/**
+ * Limit tree depth to maxDepth levels.
+ * Returns a new tree with children beyond maxDepth removed.
+ */
+function limitDepth(node: ProfileTreeNode, maxDepth: number, depth: number = 0): ProfileTreeNode {
+	if (depth >= maxDepth) return { ...node, children: [] };
+	return {
+		...node,
+		children: node.children.map((c) => limitDepth(c, maxDepth, depth + 1)),
+	};
 }
 
 // =============================================================================
@@ -133,26 +155,26 @@ interface SunburstChartProps {
 // =============================================================================
 
 /**
- * Radial sunburst chart visualisation.
+ * SnakeViz-style radial sunburst chart.
  *
- * Renders a radial partition layout using d3.partition + d3.arc.
- * Click to zoom into a subtree; click centre to zoom back out.
- *
- * @param props.treeData     - Tree data from the server.
- * @param props.selectedNode - Currently highlighted node (cross-vis).
- * @param props.onNodeSelect - Callback for node selection.
+ * - Arc width proportional to cumulative time (not self-time)
+ * - D3 ordinal colour scale by function name (consistent per function)
+ * - Hover highlights all same-name arcs in magenta
+ * - Click arc = re-root, click center = zoom out one level
  */
-const SunburstChart: React.FC<SunburstChartProps> = ({ treeData, selectedNode, onNodeSelect }) => {
+/** Fixed internal coordinate size for the SVG viewBox. */
+const SVG_SIZE = 600;
+const SVG_RADIUS = SVG_SIZE / 2;
+
+const SunburstChart: React.FC<SunburstChartProps> = ({
+	root: vizRoot,
+	totalTime,
+	maxDepth,
+	cutoff,
+	onRootChange,
+}) => {
 	const svgRef = useRef<SVGSVGElement>(null);
-	const [zoomNode, setZoomNode] = useState<ProfileTreeNode | null>(null);
 	const [tooltip, setTooltip] = useState<{ x: number; y: number; text: string } | null>(null);
-
-	// Current root for rendering
-	const currentRoot = zoomNode || treeData?.tree || null;
-
-	// Chart dimensions
-	const size = 600;
-	const radius = size / 2;
 
 	// =========================================================================
 	// D3 RENDER
@@ -160,34 +182,42 @@ const SunburstChart: React.FC<SunburstChartProps> = ({ treeData, selectedNode, o
 
 	useEffect(() => {
 		const svg = svgRef.current;
-		if (!svg || !currentRoot) return;
+		if (!svg || !vizRoot) return;
 
-		// Resolve theme colours (d3 .attr() can't use CSS var() references)
+		// Apply client-side depth limiting and cutoff pruning
+		const processedRoot = pruneTree(limitDepth(vizRoot, maxDepth), cutoff);
+
+		// Resolve theme colours
 		const cs = getComputedStyle(svg);
-		const palette = resolvePalette(svg);
 		const textPrimary = cs.getPropertyValue('--rr-text-primary').trim() || '#1a1a1a';
 		const textSecondary = cs.getPropertyValue('--rr-text-secondary').trim() || '#666';
-		const brandColor = cs.getPropertyValue('--rr-brand').trim() || '#f7901f';
 		const bgPaper = cs.getPropertyValue('--rr-bg-paper').trim() || '#ffffff';
 
-		// Build hierarchy with self-time partitioning
-		const root = d3.hierarchy(currentRoot, (d) => d.children)
+		// D3 ordinal colour scale by function name (snakeviz: category20c)
+		const color = d3.scaleOrdinal(CATEGORY20C);
+
+		// Build hierarchy — partition value = cumtime (snakeviz behaviour)
+		const root = d3.hierarchy(processedRoot, (d) => d.children)
 			.sum((d) => {
+				// Use cumtime for partition sizing (snakeviz style)
 				if (!d.children || d.children.length === 0) return Math.max(d.cumtime, 0.000001);
+				// For parent nodes: cumtime minus children to avoid double-counting
 				const childCum = d.children.reduce((s, c) => s + c.cumtime, 0);
-				return Math.max(d.cumtime - childCum, 0);
+				return Math.max(d.cumtime - childCum, 0.000001);
 			})
 			.sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
 
 		// Radial partition layout
-		const partition = d3.partition<ProfileTreeNode>().size([2 * Math.PI, radius]);
+		const partition = d3.partition<ProfileTreeNode>().size([2 * Math.PI, SVG_RADIUS]);
 		partition(root);
 
-		// Setup SVG
+		// Setup SVG — fixed viewBox, scales to fill container via CSS
 		const svgSel = d3.select(svg)
-			.attr('width', size)
-			.attr('height', size)
-			.attr('viewBox', `${-radius} ${-radius} ${size} ${size}`);
+			.attr('viewBox', `${-SVG_RADIUS} ${-SVG_RADIUS} ${SVG_SIZE} ${SVG_SIZE}`)
+			.style('width', '100%')
+			.style('height', '100%')
+			.style('max-width', `${SVG_SIZE}px`)
+			.style('max-height', `${SVG_SIZE}px`);
 		svgSel.selectAll('*').remove();
 
 		// Arc generator
@@ -197,103 +227,92 @@ const SunburstChart: React.FC<SunburstChartProps> = ({ treeData, selectedNode, o
 			.innerRadius((d) => d.y0)
 			.outerRadius((d) => d.y1 - 1)
 			.padAngle(0.002)
-			.padRadius(radius / 2);
+			.padRadius(SVG_RADIUS / 2);
 
-		// Filter visible nodes
+		// Filter visible nodes (depth > 0, min arc angle)
 		const nodes = root.descendants()
-			.filter((d) => d.depth > 0 && d.depth <= MAX_DEPTH && (d.x1 - d.x0) > MIN_ARC_ANGLE) as HierarchyRectangularNode<ProfileTreeNode>[];
+			.filter((d) => d.depth > 0 && (d.x1 - d.x0) > MIN_ARC_ANGLE) as HierarchyRectangularNode<ProfileTreeNode>[];
 
 		// Draw arcs
-		const paths = svgSel.selectAll<SVGPathElement, HierarchyRectangularNode<ProfileTreeNode>>('path')
+		const paths = svgSel.selectAll<SVGPathElement, HierarchyRectangularNode<ProfileTreeNode>>('path.arc')
 			.data(nodes)
 			.join('path')
+			.attr('class', 'arc')
 			.attr('d', arc)
-			.attr('fill', (d) => nodeColour(palette, d.data.name, d.data.tottime, d.data.cumtime))
+			.attr('fill', (d) => color(d.data.name))
 			.attr('opacity', 0.85)
-			.attr('stroke', (d) => {
-				if (selectedNode && d.data.name === selectedNode.name
-					&& d.data.file === selectedNode.file
-					&& d.data.line === selectedNode.line) {
-					return brandColor;
-				}
-				return bgPaper;
-			})
-			.attr('stroke-width', (d) => {
-				if (selectedNode && d.data.name === selectedNode.name
-					&& d.data.file === selectedNode.file
-					&& d.data.line === selectedNode.line) return 2;
-				return 0.5;
-			})
+			.attr('stroke', bgPaper)
+			.attr('stroke-width', 0.5)
 			.style('cursor', 'pointer');
 
-		// Centre label — current root name
+		// Center label — current root name
 		svgSel.append('text')
 			.attr('text-anchor', 'middle')
 			.attr('dy', '-0.3em')
 			.attr('fill', textPrimary)
 			.attr('font-size', 13)
 			.attr('font-family', 'var(--rr-font-mono, monospace)')
-			.text(currentRoot.name === '<root>' ? 'All' : currentRoot.name);
+			.text(vizRoot.name === '<root>' ? 'All' : vizRoot.name);
 
-		// Centre subtitle — cumtime
+		// Center subtitle — cumtime
 		svgSel.append('text')
 			.attr('text-anchor', 'middle')
 			.attr('dy', '1.2em')
 			.attr('fill', textSecondary)
 			.attr('font-size', 11)
 			.attr('font-family', 'var(--rr-font-mono, monospace)')
-			.text(`${currentRoot.cumtime.toFixed(3)}s`);
+			.text(`${vizRoot.cumtime.toFixed(3)}s`);
 
-		// Click centre circle to zoom out
-		const innerRadius = (root.children?.[0] as HierarchyRectangularNode<ProfileTreeNode>)?.y0 || 40;
-		svgSel.append('circle')
-			.attr('r', innerRadius)
-			.attr('fill', 'transparent')
-			.style('cursor', zoomNode ? 'pointer' : 'default')
-			.on('click', () => {
-				if (zoomNode) {
-					setZoomNode(null);
-					onNodeSelect(null);
+		// Click any arc to re-root the visualisation to that function
+		// (no children guard — ProfilerView resolves the full subtree from the original tree)
+		paths.on('click', (_event, d) => {
+			onRootChange(d.data);
+		});
+
+		// =====================================================================
+		// HOVER — Magenta highlight + same-function highlighting (snakeviz)
+		// =====================================================================
+
+		paths.on('mouseenter', (event, d) => {
+			const hoveredName = d.data.name;
+
+			// Highlight all arcs with the same function name
+			paths.each(function (dd) {
+				const el = d3.select(this);
+				if (dd.data.name === hoveredName) {
+					el.attr('fill', HOVER_COLOR).attr('opacity', 1);
+				} else {
+					el.attr('opacity', 0.4);
 				}
 			});
 
-		// Click arc to select and optionally zoom into subtree
-		paths.on('click', (_event, d) => {
-			// Always select the clicked node (enables leaf-arc selection)
-			onNodeSelect(d.data);
-
-			// Zoom into subtree only if the node has children
-			if (d.children && d.children.length > 0) {
-				setZoomNode(d.data);
-			}
-		});
-
-		// Tooltip
-		paths.on('mouseenter', (event, d) => {
+			// Tooltip with cumtime percentage
+			const pct = totalTime > 0 ? (d.data.cumtime / totalTime * 100).toFixed(1) : '0.0';
 			const lines = [
 				d.data.name,
+				`${d.data.cumtime.toFixed(4)}s (${pct}%)`,
 				`${d.data.file}:${d.data.line}`,
-				`Calls: ${d.data.ncalls}`,
-				`Total: ${d.data.tottime.toFixed(4)}s`,
-				`Cumulative: ${d.data.cumtime.toFixed(4)}s`,
 			];
 			setTooltip({ x: event.clientX + 12, y: event.clientY + 12, text: lines.join('\n') });
 		});
+
 		paths.on('mousemove', (event) => {
 			setTooltip((prev) => prev ? { ...prev, x: event.clientX + 12, y: event.clientY + 12 } : null);
 		});
-		paths.on('mouseleave', () => setTooltip(null));
 
-	}, [currentRoot, selectedNode, zoomNode, onNodeSelect, radius, size]);
+		paths.on('mouseleave', () => {
+			// Restore original colours
+			paths.attr('fill', (d) => color(d.data.name)).attr('opacity', 0.85);
+			setTooltip(null);
+		});
 
-	// Reset zoom when tree data changes
-	useEffect(() => { setZoomNode(null); }, [treeData]);
+	}, [vizRoot, maxDepth, cutoff, onRootChange, totalTime]);
 
 	// =========================================================================
 	// RENDER
 	// =========================================================================
 
-	if (!treeData?.tree) {
+	if (!vizRoot) {
 		return <div style={commonStyles.empty}>No profiling data available. Start and stop a session to generate a sunburst chart.</div>;
 	}
 

--- a/apps/profiler-ui/src/views/visualizations/types.ts
+++ b/apps/profiler-ui/src/views/visualizations/types.ts
@@ -24,8 +24,8 @@
 // PROFILER VISUALIZATION — Shared Types
 // =============================================================================
 //
-// Types used across all profiler visualization components (FlameGraph,
-// SunburstChart, StatsTable, ReportText).
+// Types used across all profiler visualization components (SunburstChart,
+// FlameGraph/Icicle, StatsTable, ReportText).
 // =============================================================================
 
 // =============================================================================
@@ -75,8 +75,8 @@ export interface ProfileTreeResponse {
 // UI STATE
 // =============================================================================
 
-/** Active visualisation tab. */
-export type ProfilerTab = 'flame' | 'sunburst' | 'table' | 'text';
+/** Visualisation style — sunburst (radial) or icicle (rectangular). */
+export type VizStyle = 'sunburst' | 'icicle';
 
 /**
  * Breadcrumb entry for flame graph / sunburst drill-down navigation.
@@ -91,6 +91,12 @@ export interface BreadcrumbEntry {
 
 /**
  * Callback signature for when the user selects a node in any visualisation.
- * Used for cross-highlighting between flame graph, sunburst, and table.
+ * Used for cross-highlighting between visualisations.
  */
 export type OnNodeSelect = (node: ProfileTreeNode | null) => void;
+
+/**
+ * Callback signature for when a viz or table re-roots the visualisation
+ * (e.g. clicking a table row makes that function the sunburst center).
+ */
+export type OnRootChange = (node: ProfileTreeNode) => void;

--- a/apps/vscode/src/providers/AccountProvider.ts
+++ b/apps/vscode/src/providers/AccountProvider.ts
@@ -867,7 +867,7 @@ export class AccountProvider {
 	 *
 	 * @param panel - The webview panel (used to post error messages if needed).
 	 */
-	private async handleSubscribe(panel: vscode.WebviewPanel): Promise<void> {
+	private async handleSubscribe(_panel: vscode.WebviewPanel): Promise<void> {
 		try {
 			// Open or focus the pipeline editor — its webview renders the
 			// embedded Stripe checkout flow for new subscriptions

--- a/apps/vscode/src/providers/SettingsProvider.ts
+++ b/apps/vscode/src/providers/SettingsProvider.ts
@@ -157,7 +157,7 @@ export class SettingsProvider {
 
 					case 'openSubscribe':
 						// Open the Account page billing tab to start the subscribe flow
-						vscode.commands.executeCommand('rocketride.page.account.open', 'billing');
+						await vscode.commands.executeCommand('rocketride.page.account.open', 'billing');
 						break;
 
 					default: {

--- a/packages/ai/src/ai/common/cprofile_manager.py
+++ b/packages/ai/src/ai/common/cprofile_manager.py
@@ -21,9 +21,12 @@
 # SOFTWARE.
 
 """
-CProfileManager: Process-Level cProfile Singleton.
+CProfileManager: Process-Level yappi Profiler Singleton.
 
-Provides a single, thread-safe cProfile session per Python process.
+Provides a single, thread-safe profiling session per Python process using
+yappi, which profiles all threads (unlike cProfile which only profiles
+the calling thread).
+
 Any DAP connection handler can import the module-level ``profiler``
 instance and call start/stop/status/report.
 
@@ -35,17 +38,85 @@ Usage:
     from ai.common.cprofile_manager import profiler
 
     result = profiler.start('task:42', session='my_test')
-    # ... server handles requests ...
+    # ... server handles requests across all threads ...
     result = profiler.stop('task:42')
     report = profiler.report()
 """
 
-import cProfile
 import io
-import pstats
+import os
+import sys
 import threading
 import time
 from typing import Dict, Any, List, Optional, Tuple
+
+import yappi
+
+
+# =============================================================================
+# PATH RELATIVIZATION (strip absolute paths from profiler output)
+# =============================================================================
+
+# Derive the dist server root from sys.executable
+# e.g. C:\Projects\saas\dist\server\engine.exe → C:\Projects\saas\dist\server
+_SERVER_ROOT = os.path.dirname(sys.executable).replace('\\', '/').rstrip('/') + '/'
+
+# Source-tree markers — when running in dev mode, yappi reports paths from
+# the source tree (e.g. .../rocketride-server/packages/ai/src/ai/common/foo.py).
+# We strip everything up to and including the marker so the result is ./ai/common/foo.py.
+_SOURCE_MARKERS = [
+    '/packages/ai/src/',  # .../packages/ai/src/ai/...         → ./ai/...
+    '/nodes/src/',  # .../nodes/src/nodes/...            → ./nodes/...
+    '/engine-lib/rocketlib-python/lib/',  # .../engine-lib/.../lib/rocketlib/  → ./rocketlib/...
+]
+
+
+def _relativize_path(path: str) -> str:
+    """
+    Strip absolute prefixes from a module path, returning a relative './...' path.
+
+    Handles two cases:
+    1. Dist paths:   C:/Projects/saas/dist/server/Lib/...  → ./Lib/...
+    2. Source paths:  .../rocketride-server/packages/ai/src/ai/common/foo.py → ./ai/common/foo.py
+                      .../rocketride-server/nodes/src/nodes/agent/foo.py    → ./nodes/agent/foo.py
+
+    Args:
+        path: Absolute or relative module file path from yappi.
+
+    Returns:
+        Relative path prefixed with './', or the original if no prefix matched.
+    """
+    normalised = path.replace('\\', '/')
+
+    # Case 1: dist server root
+    if normalised.startswith(_SERVER_ROOT):
+        return './' + normalised[len(_SERVER_ROOT) :]
+
+    # Case 2: source tree dev-mode paths
+    for marker in _SOURCE_MARKERS:
+        idx = normalised.find(marker)
+        if idx >= 0:
+            # Strip up to and including the marker
+            return './' + normalised[idx + len(marker) :]
+
+    return normalised
+
+
+# Prefixes that identify project code (not system/stdlib).
+# Used by report_tree() to filter when include_system=False.
+_PROJECT_PREFIXES = (
+    './nodes/',  # pipeline node implementations
+    './ai/',  # AI server code
+    './lib/',  # engine native library wrappers
+    './libs/',  # additional native libraries
+    './rocketlib/',  # engine rocketlib Python wrappers
+    'engLib:',  # engine C library functions
+)
+
+
+def _is_project_code(path: str) -> bool:
+    """Check whether a relativized module path belongs to project code."""
+    return path.startswith(_PROJECT_PREFIXES)
 
 
 # =============================================================================
@@ -55,24 +126,28 @@ from typing import Dict, Any, List, Optional, Tuple
 
 class CProfileManager:
     """
-    Process-level singleton managing a single cProfile session.
+    Process-level singleton managing a single yappi profiling session.
 
     Thread-safe via a threading.Lock — safe to call from asyncio handlers
     and from worker threads in the model server.
 
+    yappi is process-global (start/stop are module-level), so this manager
+    provides ownership tracking and prevents concurrent sessions.
+
     Attributes:
-        _profiler: The active cProfile.Profile instance, or None.
+        _active: Whether a profiling session is currently running.
         _owner_id: Identifier of the connection that started the session.
         _session_name: Human-readable name for the session.
         _start_time: Unix timestamp when profiling started.
-        _last_report: Text of the most recently completed pstats report.
+        _last_report: Text of the most recently completed report.
+        _last_stats_data: Structured stats from the last session for report_tree().
         _lock: Guards all mutable state.
     """
 
     def __init__(self) -> None:
         """Initialize an idle CProfileManager with no active session."""
-        # Active profiler instance (None when not profiling)
-        self._profiler: Optional[cProfile.Profile] = None
+        # Whether profiling is currently active
+        self._active: bool = False
 
         # Connection that owns the current session
         self._owner_id: Optional[str] = None
@@ -86,27 +161,37 @@ class CProfileManager:
         # Most recent completed report text
         self._last_report: Optional[str] = None
 
-        # Raw pstats data from the last completed session, used by report_tree().
-        # Stored as the pstats.Stats.stats dict — keys are (filename, lineno, funcname)
-        # tuples, values are (cc, nc, tt, ct, callers) where callers maps caller
-        # tuples to (cc, nc, tt, ct).
-        self._last_stats_data: Optional[Dict] = None
+        # Structured stats from the last completed session for report_tree().
+        # Stored as a list of dicts, each with:
+        #   key: (module, lineno, name)
+        #   ncall: int
+        #   ttot: float (cumulative time)
+        #   tsub: float (self time)
+        #   children: list of (child_key, ncall, ttot, tsub)
+        self._last_stats_data: Optional[List[Dict]] = None
 
         # Thread lock protecting all mutable state
         self._lock = threading.Lock()
 
-    def start(self, owner_id: str, session: Optional[str] = None) -> Dict[str, Any]:
+    def start(
+        self,
+        owner_id: str,
+        session: Optional[str] = None,
+        clock_type: str = 'wall',
+    ) -> Dict[str, Any]:
         """
-        Start a new cProfile profiling session.
+        Start a new yappi profiling session across all threads.
 
-        Creates a fresh cProfile.Profile, enables it, and records the owner.
-        Returns an error dict if a session is already active.
+        Creates a fresh profiling session, clears any prior data, and begins
+        profiling.  Returns an error dict if a session is already active.
 
         Args:
             owner_id: Identifier for the connection claiming ownership
                       (e.g. "task:42", "model:3").
             session: Optional human-readable name for the session.
                      Defaults to "session_{timestamp}" if not provided.
+            clock_type: Clock type for timing — 'wall' (default) for
+                        wall-clock time or 'cpu' for CPU time.
 
         Returns:
             Dict with status, session name, owner, and start_time on success,
@@ -114,7 +199,7 @@ class CProfileManager:
         """
         with self._lock:
             # Reject if a session is already running
-            if self._profiler is not None:
+            if self._active:
                 return {
                     'status': 'error',
                     'message': f'Profiling already active (owned by {self._owner_id})',
@@ -126,9 +211,16 @@ class CProfileManager:
             self._owner_id = owner_id
             self._start_time = time.time()
 
-            # Create and enable the profiler
-            self._profiler = cProfile.Profile()
-            self._profiler.enable()
+            # Clear any stale data from prior sessions
+            yappi.clear_stats()
+
+            # Set clock type — 'wall' for wall-clock, 'cpu' for CPU time
+            valid_clock = clock_type if clock_type in ('wall', 'cpu') else 'wall'
+            yappi.set_clock_type(valid_clock)
+
+            # Start profiling all threads (including builtins)
+            yappi.start(builtins=True)
+            self._active = True
 
             return {
                 'status': 'started',
@@ -139,21 +231,21 @@ class CProfileManager:
 
     def stop(self, owner_id: str) -> Dict[str, Any]:
         """
-        Stop the active profiling session and generate a pstats report.
+        Stop the active profiling session and generate reports.
 
         Only the owning connection may stop the session.  The generated
-        report is stored in ``_last_report`` for later retrieval.
+        report and structured stats are stored for later retrieval.
 
         Args:
             owner_id: Must match the owner that started the session.
 
         Returns:
-            Dict with status, session name, runtime, and a summary of the
-            top functions on success, or status='error' on failure.
+            Dict with status, session name, and runtime on success,
+            or status='error' on failure.
         """
         with self._lock:
             # Reject if nothing is running
-            if self._profiler is None:
+            if not self._active:
                 return {
                     'status': 'error',
                     'message': 'No active profiling session',
@@ -167,52 +259,33 @@ class CProfileManager:
                     'owner': self._owner_id,
                 }
 
-            # Disable the profiler
-            self._profiler.disable()
+            # Stop profiling
+            yappi.stop()
             end_time = time.time()
             runtime = end_time - self._start_time
 
-            # Generate the pstats report into a string buffer
-            report_buf = io.StringIO()
-            report_buf.write(f'Session: {self._session_name}\n')
-            report_buf.write(f'Owner: {self._owner_id}\n')
-            report_buf.write(f'Duration: {runtime:.2f}s\n')
-            report_buf.write('=' * 80 + '\n\n')
+            # Capture function stats before clearing
+            func_stats = yappi.get_func_stats()
 
-            # Build Stats object once, reuse for both text reports and raw data
-            stats = pstats.Stats(self._profiler, stream=io.StringIO())
+            # Generate text report
+            self._last_report = self._build_text_report(
+                func_stats,
+                self._session_name,
+                self._owner_id,
+                runtime,
+            )
 
-            # Save raw stats dict for report_tree() — must copy before Profile
-            # is released, as pstats.Stats references the Profile internally
-            self._last_stats_data = dict(stats.stats)
+            # Build structured stats data for report_tree()
+            self._last_stats_data = self._capture_stats_data(func_stats)
 
-            # Cumulative time sort — full stats
-            stats_buf = io.StringIO()
-            stats.stream = stats_buf
-            stats.sort_stats('cumulative')
-            stats.print_stats()
-            report_buf.write('FUNCTIONS BY CUMULATIVE TIME:\n')
-            report_buf.write('-' * 50 + '\n')
-            report_buf.write(stats_buf.getvalue())
-            report_buf.write('\n')
+            # Clear yappi's internal data to free memory
+            yappi.clear_stats()
 
-            # Total time sort — top 30
-            stats_buf = io.StringIO()
-            stats.stream = stats_buf
-            stats.sort_stats('tottime')
-            stats.print_stats(30)
-            report_buf.write('TOP 30 BY TOTAL TIME:\n')
-            report_buf.write('-' * 50 + '\n')
-            report_buf.write(stats_buf.getvalue())
-
-            # Store the report
-            self._last_report = report_buf.getvalue()
-
-            # Capture session info before clearing
+            # Capture session info before clearing ownership
             session_name = self._session_name
 
             # Reset state
-            self._profiler = None
+            self._active = False
             self._owner_id = None
             self._session_name = None
             self._start_time = None
@@ -234,7 +307,7 @@ class CProfileManager:
             (if active), or history info (if inactive).
         """
         with self._lock:
-            if self._profiler is not None:
+            if self._active:
                 # Active session
                 runtime = time.time() - self._start_time if self._start_time else 0
                 return {
@@ -260,7 +333,7 @@ class CProfileManager:
         Anyone can call this — no ownership check.
 
         Returns:
-            Dict with 'report' key containing the full pstats text,
+            Dict with 'report' key containing the full report text,
             or a placeholder message if no report is available.
         """
         with self._lock:
@@ -272,32 +345,35 @@ class CProfileManager:
         self,
         max_depth: int = 50,
         min_pct: float = 0.1,
+        include_system: bool = True,
     ) -> Dict[str, Any]:
         """
         Build a hierarchical call-tree from the last completed profiling session.
 
-        Inverts the pstats callers dict to produce a parent→children tree
-        suitable for flame graph / sunburst / icicle visualisations.
-        Functions appearing in multiple call paths are duplicated (each parent
-        gets its own copy with caller-specific timing from the callers dict).
+        Uses yappi's callee data to produce a parent→children tree suitable
+        for flame graph / sunburst / icicle visualisations.
 
         Args:
             max_depth: Maximum tree depth before pruning (default 50).
             min_pct:   Minimum percentage of total cumtime a node must have
                        to be included in the tree (default 0.1).
+            include_system: If False, filter out system/stdlib functions and
+                            only return project code (./ai/, ./nodes/, etc.).
+                            System nodes are collapsed — their project-code
+                            children are promoted to the nearest project ancestor.
 
         Returns:
             Dict with 'tree' (root node), 'total_time', and 'total_calls',
             or an error message if no stats data is available.
         """
-        # Validate and clamp max_depth to a reasonable integer range
+        # Validate and clamp max_depth
         try:
             max_depth = int(max_depth)
         except (TypeError, ValueError):
             max_depth = 50
         max_depth = max(1, min(max_depth, 500))
 
-        # Validate and clamp min_pct to a reasonable float range
+        # Validate and clamp min_pct
         try:
             min_pct = float(min_pct)
         except (TypeError, ValueError):
@@ -313,110 +389,242 @@ class CProfileManager:
                     'error': 'No profiling data available. Run a session first.',
                 }
 
-            # Copy the stats data while under the lock so we can process
-            # outside of it without holding it for the tree-building work
-            stats_data = dict(self._last_stats_data)
+            # Copy data under lock, process outside
+            stats_data = list(self._last_stats_data)
 
-        # --- Build the tree outside the lock (read-only on stats_data) ---
-        return self._build_tree(stats_data, max_depth, min_pct)
+        # Build the tree outside the lock (read-only on stats_data)
+        result = self._build_tree(stats_data, max_depth, min_pct)
+
+        # Filter out system calls if requested
+        if not include_system and result.get('tree'):
+            result['tree'] = self._filter_system_calls(result['tree'])
+
+        return result
+
+    @staticmethod
+    def _filter_system_calls(node: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Filter a tree node to only include project code.
+
+        System nodes are collapsed out — their project-code children are
+        promoted up to the nearest project-code ancestor.
+
+        Args:
+            node: A tree node dict with name, file, children, etc.
+
+        Returns:
+            A new tree node with only project-code descendants.
+        """
+
+        def collect_project_children(n: Dict[str, Any]) -> List[Dict[str, Any]]:
+            """Recursively collect project-code descendants, skipping system nodes."""
+            result = []
+            for child in n.get('children', []):
+                if _is_project_code(child.get('file', '')):
+                    # Keep this child, recursively filter its children
+                    filtered = dict(child)
+                    filtered['children'] = collect_project_children(child)
+                    result.append(filtered)
+                else:
+                    # Skip this system node, promote its project-code descendants
+                    result.extend(collect_project_children(child))
+            return result
+
+        filtered = dict(node)
+        filtered['children'] = collect_project_children(node)
+        return filtered
+
+    def release(self, owner_id: str) -> None:
+        """
+        Release ownership if this connection owns the active session.
+
+        Called on connection disconnect to auto-stop an abandoned session.
+        If the owner_id doesn't match, this is a silent no-op.
+
+        Args:
+            owner_id: The disconnecting connection's identifier.
+        """
+        with self._lock:
+            # Only release if this connection owns the session
+            if self._active and self._owner_id == owner_id:
+                # Stop yappi and clear without generating a report
+                yappi.stop()
+                yappi.clear_stats()
+                self._active = False
+                self._owner_id = None
+                self._session_name = None
+                self._start_time = None
+
+    # =========================================================================
+    # PRIVATE HELPERS
+    # =========================================================================
+
+    @staticmethod
+    def _build_text_report(
+        func_stats: yappi.YFuncStats,
+        session_name: str,
+        owner_id: str,
+        runtime: float,
+    ) -> str:
+        """
+        Generate a pstats-style text report from yappi function stats.
+
+        Args:
+            func_stats: yappi's function statistics object.
+            session_name: Human-readable session name.
+            owner_id: Connection that owned the session.
+            runtime: Total profiling duration in seconds.
+
+        Returns:
+            Formatted report string.
+        """
+        report_buf = io.StringIO()
+
+        # Header
+        report_buf.write(f'Session: {session_name}\n')
+        report_buf.write(f'Owner: {owner_id}\n')
+        report_buf.write(f'Duration: {runtime:.2f}s\n')
+        report_buf.write('=' * 80 + '\n\n')
+
+        # Cumulative time sort — full stats
+        report_buf.write('FUNCTIONS BY CUMULATIVE TIME:\n')
+        report_buf.write('-' * 50 + '\n')
+        stat_buf = io.StringIO()
+        func_stats.sort('ttot', 'desc')
+        func_stats.print_all(out=stat_buf)
+        report_buf.write(stat_buf.getvalue())
+        report_buf.write('\n')
+
+        # Total (self) time sort — top 30
+        report_buf.write('TOP 30 BY TOTAL TIME:\n')
+        report_buf.write('-' * 50 + '\n')
+        stat_buf = io.StringIO()
+        func_stats.sort('tsub', 'desc')
+        func_stats.print_all(out=stat_buf, limit=30)
+        report_buf.write(stat_buf.getvalue())
+
+        # Strip absolute paths from the report text — both dist and source tree
+        report_text = report_buf.getvalue()
+        # Dist root (both slash styles)
+        report_text = report_text.replace(_SERVER_ROOT.replace('/', '\\'), './')
+        report_text = report_text.replace(_SERVER_ROOT, './')
+        return report_text
+
+    @staticmethod
+    def _capture_stats_data(func_stats: yappi.YFuncStats) -> List[Dict]:
+        """
+        Capture yappi function stats into a serializable structure.
+
+        Iterates all profiled functions and their callees to build a
+        list of dicts that report_tree() can use to construct the
+        call-tree hierarchy.
+
+        Args:
+            func_stats: yappi's function statistics object.
+
+        Returns:
+            List of dicts, each with key, ncall, ttot, tsub, and children.
+        """
+        stats_list = []
+        for stat in func_stats:
+            # Build the unique key — relativize module path to strip server root
+            func_key = (_relativize_path(stat.module), stat.lineno, stat.name)
+
+            # Capture children (callees) with their timing.
+            # NOTE: stat.children is a PROPERTY (YChildFuncStats), not a method.
+            children = []
+            for child in stat.children:
+                child_key = (_relativize_path(child.module), child.lineno, child.name)
+                children.append(
+                    {
+                        'key': child_key,
+                        'ncall': child.ncall,
+                        'ttot': child.ttot,
+                        'tsub': child.tsub,
+                    }
+                )
+
+            stats_list.append(
+                {
+                    'key': func_key,
+                    'ncall': stat.ncall,
+                    'ttot': stat.ttot,
+                    'tsub': stat.tsub,
+                    'children': children,
+                }
+            )
+
+        return stats_list
 
     @staticmethod
     def _build_tree(
-        stats_data: Dict,
+        stats_data: List[Dict],
         max_depth: int,
         min_pct: float,
     ) -> Dict[str, Any]:
         """
-        Transform raw pstats stats dict into a JSON-serializable call tree.
+        Transform captured yappi stats into a JSON-serializable call tree.
 
-        The pstats dict is keyed by (filename, lineno, funcname) tuples.
-        Each value is (primitive_calls, total_calls, tottime, cumtime, callers)
-        where callers maps caller-key → (cc, nc, tt, ct).
-
-        This method inverts the callers relationships to build a top-down tree:
-        for each function, every key in its callers dict becomes a parent, and
-        the function becomes a child of that parent with the timing data from
-        the caller relationship.
+        Uses the children (callee) relationships directly provided by yappi
+        to build a top-down tree.
 
         Args:
-            stats_data: Raw pstats.Stats.stats dict.
+            stats_data: List of stat dicts from _capture_stats_data().
             max_depth: Maximum recursion depth for tree building.
             min_pct: Minimum cumtime percentage threshold for inclusion.
 
         Returns:
             Dict with 'tree', 'total_time', and 'total_calls'.
         """
-        # Step 1: Compute total cumtime across all functions for the min_pct
-        # threshold calculation (sum, not max — max would skew to one hotspot)
+        # Step 1: Build lookup from key → stat entry
+        lookup: Dict[Tuple[str, int, str], Dict] = {}
+        for entry in stats_data:
+            lookup[entry['key']] = entry
+
+        # Step 2: Compute totals for threshold calculation
+        # (sum, not max — max would skew to one hotspot)
         total_time = 0.0
         total_calls = 0
-        for _key, (cc, nc, tt, ct, _callers) in stats_data.items():
-            total_time += ct
-            total_calls += nc
+        for entry in stats_data:
+            total_time += entry['ttot']
+            total_calls += entry['ncall']
 
-        # Minimum absolute time threshold (convert percentage to seconds)
+        # Minimum absolute time threshold
         min_time = total_time * (min_pct / 100.0) if total_time > 0 else 0
 
-        # Step 2: Build parent→children adjacency map.
-        # For each function, iterate its callers and record the function as
-        # a child of each caller with the caller-specific timing.
-        #
-        # children_map[parent_key] = list of (child_key, cc, nc, tt, ct)
-        children_map: Dict[
-            Tuple[str, int, str],
-            List[Tuple[Tuple[str, int, str], int, int, float, float]],
-        ] = {}
+        # Step 3: Identify root nodes — functions not appearing as anyone's child
+        all_child_keys: set = set()
+        for entry in stats_data:
+            for child in entry['children']:
+                all_child_keys.add(child['key'])
 
-        # Track which functions have callers (non-roots)
-        has_caller: set = set()
+        root_keys = [e['key'] for e in stats_data if e['key'] not in all_child_keys]
 
-        for func_key, (cc, nc, tt, ct, callers) in stats_data.items():
-            if callers:
-                for caller_key, caller_timing in callers.items():
-                    has_caller.add(func_key)
-                    # caller_timing can be (nc, nc, tt, ct) or (cc, nc, tt, ct)
-                    c_cc, c_nc, c_tt, c_ct = caller_timing
-                    if caller_key not in children_map:
-                        children_map[caller_key] = []
-                    children_map[caller_key].append((func_key, c_cc, c_nc, c_tt, c_ct))
-
-        # Step 3: Identify root nodes — functions that have no callers
-        root_keys = [k for k in stats_data if k not in has_caller]
-
-        # When profiling an already-running process (e.g. asyncio event loop),
-        # all recorded functions may have callers because the calling functions
-        # were already on the stack when profiling started.  These "phantom
-        # callers" appear in children_map but not in stats_data.
-        # Promote children of phantom callers to roots — these are entry
-        # points whose callers were already on the stack when profiling started.
-        # Always promote (not just when root_keys is empty), otherwise
-        # phantom-rooted branches are silently dropped.
-        phantom_callers = set(children_map.keys()) - set(stats_data.keys())
-        if phantom_callers:
+        # When profiling a running process, all functions may have callers
+        # because the calling functions were on the stack when profiling started.
+        # Always promote phantom-caller children (not just when root_keys is
+        # empty), otherwise phantom-rooted branches are silently dropped.
+        all_keys = set(lookup.keys())
+        phantom_parent_keys = all_child_keys - all_keys
+        if phantom_parent_keys:
             promoted: set = set()
-            for pc in phantom_callers:
-                for child_key, _c_cc, _c_nc, _c_tt, _c_ct in children_map[pc]:
-                    promoted.add(child_key)
+            for entry in stats_data:
+                for child in entry['children']:
+                    if entry['key'] not in all_keys:
+                        promoted.add(child['key'])
             root_keys = list(set(root_keys) | promoted)
 
-        # Last resort fallback — pick the highest-cumtime functions
+        # Last resort — pick highest cumtime functions
         if not root_keys:
-            root_keys = sorted(
-                stats_data.keys(),
-                key=lambda k: stats_data[k][3],  # index 3 = cumtime
-                reverse=True,
-            )[:5]
+            sorted_entries = sorted(stats_data, key=lambda e: e['ttot'], reverse=True)
+            root_keys = [e['key'] for e in sorted_entries[:5]]
 
-        # Step 4: Recursively build the tree with cycle detection.
-        # In asyncio servers, _run_once → handlers → callbacks → _run_once
-        # creates cycles.  We track the ancestor path and emit a leaf node
-        # tagged "[cycle]" when a function is encountered that already
-        # appears in the current call path.
+        # Step 4: Recursively build tree with cycle detection
         def build_node(
             func_key: Tuple[str, int, str],
-            nc: int,
-            tt: float,
-            ct: float,
+            ncall: int,
+            ttot: float,
+            tsub: float,
             depth: int,
             ancestors: Optional[set] = None,
         ) -> Optional[Dict[str, Any]]:
@@ -424,82 +632,82 @@ class CProfileManager:
             Recursively build a tree node for a single function.
 
             Args:
-                func_key: (filename, lineno, funcname) tuple.
-                nc: Number of calls from the parent context.
-                tt: Total time from the parent context.
-                ct: Cumulative time from the parent context.
+                func_key: (module, lineno, name) tuple.
+                ncall: Number of calls from the parent context.
+                ttot: Cumulative time from the parent context.
+                tsub: Self time from the parent context.
                 depth: Current recursion depth.
-                ancestors: Set of func_keys on the current call path (cycle detection).
+                ancestors: Set of func_keys on the current path (cycle detection).
 
             Returns:
                 A dict representing the node, or None if pruned.
             """
-            # Prune nodes below the minimum time threshold
-            if ct < min_time and depth > 1:
+            # Prune below minimum time threshold
+            if ttot < min_time and depth > 1:
                 return None
 
-            filename, lineno, funcname = func_key
+            module, lineno, name = func_key
 
-            # Initialise ancestor tracking on first call
+            # Initialise ancestor tracking
             if ancestors is None:
                 ancestors = set()
 
-            # Cycle detection — if this function is already on the current
-            # call path, emit a leaf node tagged "[cycle]" instead of recursing
+            # Cycle detection — emit a tagged leaf instead of recursing
             if func_key in ancestors:
                 return {
-                    'name': f'{funcname} [cycle]',
-                    'file': filename,
+                    'name': f'{name} [cycle]',
+                    'file': module,
                     'line': lineno,
-                    'ncalls': nc,
-                    'tottime': round(tt, 6),
-                    'cumtime': round(ct, 6),
+                    'ncalls': ncall,
+                    'tottime': round(tsub, 6),
+                    'cumtime': round(ttot, 6),
                     'children': [],
                 }
 
-            # Add this function to the ancestor path
+            # Add to ancestor path
             path = ancestors | {func_key}
 
-            # Build child nodes if within depth limit
+            # Build children from the lookup
             children: List[Dict[str, Any]] = []
-            if depth < max_depth and func_key in children_map:
-                for child_key, c_cc, c_nc, c_tt, c_ct in children_map[func_key]:
+            if depth < max_depth and func_key in lookup:
+                for child_info in lookup[func_key]['children']:
                     child_node = build_node(
-                        child_key,
-                        c_nc,
-                        c_tt,
-                        c_ct,
+                        child_info['key'],
+                        child_info['ncall'],
+                        child_info['ttot'],
+                        child_info['tsub'],
                         depth + 1,
                         path,
                     )
                     if child_node is not None:
                         children.append(child_node)
 
-                # Sort children by cumulative time descending for consistent layout
+                # Sort by cumulative time descending
                 children.sort(key=lambda n: n['cumtime'], reverse=True)
 
             return {
-                'name': funcname,
-                'file': filename,
+                'name': name,
+                'file': module,
                 'line': lineno,
-                'ncalls': nc,
-                'tottime': round(tt, 6),
-                'cumtime': round(ct, 6),
+                'ncalls': ncall,
+                'tottime': round(tsub, 6),
+                'cumtime': round(ttot, 6),
                 'children': children,
             }
 
-        # Step 5: Build root children from the identified root functions
+        # Step 5: Build root children
         root_children: List[Dict[str, Any]] = []
         for rk in root_keys:
-            cc, nc, tt, ct, _callers = stats_data[rk]
-            node = build_node(rk, nc, tt, ct, depth=0)
-            if node is not None:
-                root_children.append(node)
+            if rk in lookup:
+                entry = lookup[rk]
+                node = build_node(rk, entry['ncall'], entry['ttot'], entry['tsub'], depth=0)
+                if node is not None:
+                    root_children.append(node)
 
-        # Sort root children by cumulative time descending
+        # Sort by cumulative time descending
         root_children.sort(key=lambda n: n['cumtime'], reverse=True)
 
-        # Step 6: Wrap in a synthetic root node
+        # Step 6: Wrap in synthetic root node
         root = {
             'name': '<root>',
             'file': '',
@@ -515,26 +723,6 @@ class CProfileManager:
             'total_time': round(total_time, 6),
             'total_calls': total_calls,
         }
-
-    def release(self, owner_id: str) -> None:
-        """
-        Release ownership if this connection owns the active session.
-
-        Called on connection disconnect to auto-stop an abandoned session.
-        If the owner_id doesn't match, this is a silent no-op.
-
-        Args:
-            owner_id: The disconnecting connection's identifier.
-        """
-        with self._lock:
-            # Only release if this connection owns the session
-            if self._profiler is not None and self._owner_id == owner_id:
-                # Disable without generating a report (session was abandoned)
-                self._profiler.disable()
-                self._profiler = None
-                self._owner_id = None
-                self._session_name = None
-                self._start_time = None
 
 
 # =============================================================================

--- a/packages/ai/src/ai/common/cprofile_manager.py
+++ b/packages/ai/src/ai/common/cprofile_manager.py
@@ -99,6 +99,9 @@ def _relativize_path(path: str) -> str:
             # Strip up to and including the marker
             return './' + normalised[idx + len(marker) :]
 
+    # Final guard: never expose absolute host paths
+    if normalised.startswith('/') or (len(normalised) >= 2 and normalised[1] == ':'):
+        return './<system>'
     return normalised
 
 
@@ -215,8 +218,12 @@ class CProfileManager:
             yappi.clear_stats()
 
             # Set clock type — 'wall' for wall-clock, 'cpu' for CPU time
-            valid_clock = clock_type if clock_type in ('wall', 'cpu') else 'wall'
-            yappi.set_clock_type(valid_clock)
+            if clock_type not in ('wall', 'cpu'):
+                return {
+                    'status': 'error',
+                    'message': f"Invalid clock_type '{clock_type}': must be 'wall' or 'cpu'",
+                }
+            yappi.set_clock_type(clock_type)
 
             # Start profiling all threads (including builtins)
             yappi.start(builtins=True)

--- a/packages/ai/src/ai/common/requirements.txt
+++ b/packages/ai/src/ai/common/requirements.txt
@@ -5,3 +5,4 @@ rank_bm25
 json5
 RestrictedPython
 SQLAlchemy>=2.0,<2.1
+yappi

--- a/packages/ai/src/ai/modules/data/data_conn.py
+++ b/packages/ai/src/ai/modules/data/data_conn.py
@@ -811,3 +811,29 @@ class DataConn(DAPConn):
         """
         result = profiler.report()
         return self.build_response(request, body=result)
+
+    async def on_rrext_cprofile_report_tree(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Get a structured call tree from the last completed profiling session.
+
+        Returns a hierarchical JSON tree suitable for flame graph, sunburst,
+        and icicle visualisations.
+
+        Args:
+            request (Dict[str, Any]): DAP request containing:
+                - arguments.max_depth (int, optional): Max tree depth (default 50)
+                - arguments.min_pct (float, optional): Min cumtime % threshold (default 0.1)
+
+        Returns:
+            Dict[str, Any]: DAP response with tree, total_time, total_calls
+        """
+        args = request.get('arguments', {})
+        max_depth = args.get('max_depth', 50)
+        min_pct = args.get('min_pct', 0.1)
+        include_system = args.get('include_system', True)
+        result = profiler.report_tree(
+            max_depth=max_depth,
+            min_pct=min_pct,
+            include_system=include_system,
+        )
+        return self.build_response(request, body=result)

--- a/packages/ai/src/ai/modules/task/commands/cmd_cprofile.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_cprofile.py
@@ -284,7 +284,12 @@ class CProfileCommands(DAPConn):
         # Direct mode — build the tree from the local profiler's stored stats
         max_depth = args.get('max_depth', 50)
         min_pct = args.get('min_pct', 0.1)
-        result = profiler.report_tree(max_depth=max_depth, min_pct=min_pct)
+        include_system = args.get('include_system', True)
+        result = profiler.report_tree(
+            max_depth=max_depth,
+            min_pct=min_pct,
+            include_system=include_system,
+        )
         return self.build_response(request, body=result)
 
     def release_profiler(self) -> None:

--- a/packages/client-python/src/rocketride/mixins/cprofile.py
+++ b/packages/client-python/src/rocketride/mixins/cprofile.py
@@ -157,6 +157,7 @@ class CProfileMixin(DAPClient):
         target: Optional[str] = None,
         max_depth: int = 50,
         min_pct: float = 0.1,
+        include_system: bool = True,
     ) -> Dict[str, Any]:
         """
         Get a structured call tree from the last completed profiling session.
@@ -169,6 +170,9 @@ class CProfileMixin(DAPClient):
             target: Task token if querying a pipeline, or None for server.
             max_depth: Maximum tree depth before pruning (default 50).
             min_pct: Minimum cumtime percentage threshold for inclusion (default 0.1).
+            include_system: Include stdlib/system functions in the tree (default True).
+                When False, the server filters out system nodes and promotes
+                project-code children.
 
         Returns:
             Dict with 'tree' (root node), 'total_time', and 'total_calls'.
@@ -182,6 +186,7 @@ class CProfileMixin(DAPClient):
         args: Dict[str, Any] = {
             'max_depth': max_depth,
             'min_pct': min_pct,
+            'include_system': include_system,
         }
         if target:
             args['target'] = target

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -2345,11 +2345,17 @@ export class RocketRideClient extends DAPClient {
 	 * @param minPct   - Minimum cumtime percentage threshold (default 0.1).
 	 * @returns Object containing the tree root, total_time, and total_calls.
 	 */
-	async cprofileReportTree(target?: string | null, maxDepth?: number, minPct?: number): Promise<CProfileReportTreeResponse> {
+	async cprofileReportTree(
+		target?: string | null,
+		maxDepth?: number,
+		minPct?: number,
+		includeSystem?: boolean,
+	): Promise<CProfileReportTreeResponse> {
 		const args: Record<string, unknown> = {};
 		if (target) args.target = target;
 		if (maxDepth !== undefined) args.max_depth = maxDepth;
 		if (minPct !== undefined) args.min_pct = minPct;
+		if (includeSystem !== undefined) args.include_system = includeSystem;
 		return this.call<CProfileReportTreeResponse>('rrext_cprofile_report_tree', args);
 	}
 

--- a/scripts/lib/registerApp.js
+++ b/scripts/lib/registerApp.js
@@ -225,7 +225,9 @@ function registerApp(appRoot) {
 				// Include billing section (plans array) for seed_apps to provision Stripe products
 				...(appManifest.billing ? { billing: appManifest.billing } : {}),
 				// Permission-gated apps — user must hold ALL listed sysPermissions to see the app
-				...(appManifest.requiredPermissions?.length
+				...(Array.isArray(appManifest.requiredPermissions)
+					&& appManifest.requiredPermissions.length
+					&& appManifest.requiredPermissions.every((p) => typeof p === 'string' && p.length > 0)
 					? { requiredPermissions: appManifest.requiredPermissions }
 					: {}),
 			};


### PR DESCRIPTION
## Summary

- **Replace cProfile with yappi** for thread-safe profiling across all threads. cProfile only profiles the calling thread, missing asyncio event loops and ThreadPoolExecutor workers entirely. yappi profiles all threads with both wall-clock and CPU-clock support.

- **Rewrite profiler-ui to match snakeviz behaviour** — the standard Python profiler visualization that developers expect. Stacked layout (viz + table always visible), cumtime-based arc sizing, D3 category20c colours, magenta hover highlighting, depth/cutoff client-side controls, call stack breadcrumbs, and click-to-reroot from both the viz and table.

- **Server-side path sanitization and system-call filtering** — all module paths are relativized (stripping the server root or source-tree prefix so the UI never leaks filesystem layout). A new `include_system` parameter on `report_tree()` lets the server filter out stdlib/system functions before sending, collapsing system nodes and promoting project-code children.

## Changes

### Server (`packages/ai/src/ai/common/cprofile_manager.py`)
- Replace `cProfile.Profile` with `yappi.start/stop/get_func_stats`
- yappi is process-global — `_active` boolean replaces `_profiler` instance reference; ownership model (start/stop/release/disconnect) unchanged
- **Critical fix**: yappi's `stat.children` is a property, not a method — the old `stat.children()` call raised `TypeError` silently caught by `except Exception: pass`, producing flat 2-level trees with no call depth
- `_relativize_path()` strips absolute paths via `sys.executable` (dist) and source-tree markers (dev mode) → `./ai/...`, `./nodes/...`, `./rocketlib/...`
- `_is_project_code()` / `_filter_system_calls()` for server-side filtering: when `include_system=False`, system nodes are collapsed and their project-code children promoted to the nearest project ancestor
- `report_tree()` accepts `include_system` param

### DAP Handlers
- `cmd_cprofile.py`: pass `include_system` from request args to `profiler.report_tree()`
- `data_conn.py`: **add missing `on_rrext_cprofile_report_tree` handler** — this was never implemented on the engine subprocess, causing "no data" when profiling pipeline tasks via proxy. Also passes `include_system` through.

### Profiler-UI (`apps/profiler-ui/`)
- **Layout**: Replace 4-tab layout (flame/sunburst/table/text) with snakeviz stacked layout — controls → viz controls → sunburst or icicle → call stack → stats table (always visible)
- **Viz controls**: Style dropdown (sunburst/icicle), Depth dropdown (3/5/10/15/20), Cutoff dropdown (1/1000, 1/100, None), System calls checkbox, Reset Root button
- **SunburstChart**: arc width = cumtime (not self-time), D3 category20c ordinal palette by function name, magenta hover with same-function highlighting across all arcs, fixed 600px viewBox scaling responsively via CSS
- **FlameGraph**: same cumtime/palette/hover as sunburst, icicle-style top-down rectangles
- **StatsTable**: columns match pstats order (`ncalls | tottime | percall | cumtime | percall | filename:lineno(function)`); row click re-roots the visualization; row-level `isProjectCode` filter as safety net
- **Call stack**: breadcrumb bar showing ancestor chain from root → current viz root, each entry clickable
- **System calls checkbox**: default off, passes `include_system` to server on each toggle, re-fetches tree
- **ReportText**: moved from tab to modal overlay via "View Report" button
- **Re-root fix**: `handleRootChange` finds the clicked node in the original tree by name/file/line so `vizRoot` always has its full subtree intact (pruned d3 copies lost children)
- **types.ts**: add `VizStyle`, `OnRootChange`; remove `ProfilerTab`

### Dependencies
- Add `yappi` to `packages/ai/src/ai/common/requirements.txt`

## Test plan

- [ ] Profile **server process**: start/stop, verify sunburst and icicle render with multi-level depth
- [ ] Profile **pipeline task**: start/stop, verify data appears (was broken before due to missing `report_tree` handler)
- [ ] **System calls toggle**: unchecked shows only project code (./ai/, ./nodes/, ./lib/); checked shows everything including stdlib
- [ ] **Click to re-root**: click sunburst arc or table row → viz re-renders with that function as root, call stack updates
- [ ] **Reset Root**: returns to full tree view
- [ ] **Depth/Cutoff**: changing dropdowns filters the viz client-side without re-fetching
- [ ] **Disconnect cleanup**: start profiling, kill client connection → profiler is released (not stuck active)
- [ ] **Path sanitization**: no absolute filesystem paths visible in UI (neither dist nor source-tree paths)
- [ ] **View Report modal**: opens with raw text report, copy-to-clipboard works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redesigned profiler UI with SnakeViz-style stacked layout featuring sunburst and icicle chart visualizations
  * Added visualization controls: chart style selection, depth limiting, cutoff filtering, and system calls toggle
  * Implemented on-demand "View Report" modal for raw profiling results
  * Enhanced interaction: click charts to re-root visualization; hover highlights matching functions with timing tooltips
  * Added subscription-gating in Settings UI

* **Refactor**
  * Migrated profiler backend from cProfile to yappi for improved multi-threaded profiling
  * Restructured stats table as flattened function rows with sortable columns and system call filtering
  * Rewrote visualization components with tree pruning and depth clamping

* **Chores**
  * Added yappi dependency to profiling system
  * Improved validation of permissions configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->