### PR TITLE
fix(build): add missing libuuid vcpkg config template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ CPackSourceConfig.cmake
 install_manifest.txt
 Makefile
 *.cmake.in
+!packages/server/cmake/ports/**/*.cmake.in
 
 # -----------------------------------------------------------------------------
 # Visual Studio Artifacts


### PR DESCRIPTION
## Summary

- A repo-wide `*.cmake.in` gitignore rule excluded `unofficial-libuuid-config.cmake.in`, breaking the Linux vcpkg build with "No such file or directory".
- Add a gitignore negation so the overlay port config is tracked, and drop the unnecessary `check_required_components` from the template.

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1157
