### PR TITLE
fix(tika): disable external parser startup probes on Windows

### DIFF
--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/ConfigBuilder.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/ConfigBuilder.java
@@ -431,6 +431,7 @@ public class ConfigBuilder {
 			languages = getParam(doc, lang, "languages", "string");
 		
 		removeParser(doc, "org.apache.tika.parser.ocr.TesseractOCRParser"); // Explicitely removed it, otherwise it will throw error
+		removeParser(doc, "org.apache.tika.parser.external.CompositeExternalParser"); // Avoid startup probes for optional tools like sox on clean installs
 
 		// Output the xml
 		logger.debug(xmlToString(doc, 4));

--- a/packages/tika/lib/tika/src/test/java/TestTikaConfig.java
+++ b/packages/tika/lib/tika/src/test/java/TestTikaConfig.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import org.apache.tika.config.TikaConfig;
+import org.apache.tika.parser.CompositeParser;
+import org.apache.tika.parser.Parser;
 
 class TestTikaConfig {
     @Test
@@ -15,5 +17,25 @@ class TestTikaConfig {
         assertNotNull(config, "TikaConfig should not be null");
         assertNotNull(config.getParser(), "Parser should not be null");
         assertNotNull(config.getDetector(), "Detector should not be null");
+    }
+
+    @Test
+    void testCompositeExternalParserExcluded() throws Exception {
+        TikaApi.rootPath = System.getProperty("user.dir");
+
+        TikaConfig config = ConfigBuilder.getConfig();
+        Parser configuredParser = config.getParser();
+
+        assertTrue(configuredParser instanceof CompositeParser,
+                "Configured parser should expose component parsers");
+
+        CompositeParser compositeParser = (CompositeParser) configuredParser;
+        boolean hasExternalComposite = compositeParser.getAllComponentParsers().stream()
+                .map(Parser::getClass)
+                .map(Class::getName)
+                .anyMatch("org.apache.tika.parser.external.CompositeExternalParser"::equals);
+
+        assertFalse(hasExternalComposite,
+                "ConfigBuilder should exclude CompositeExternalParser to avoid probing optional external tools");
     }
 }


### PR DESCRIPTION
## Summary

- Clean Windows installs log missing `sox` executable errors at startup because Tika's `CompositeExternalParser` probes external parsers.
- Exclude `CompositeExternalParser` from the generated config; add a regression test keeping it out of the configured parser tree.

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1158
