### PR TITLE
chore(deps): update dependencies flagged by security scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"overrides": {
 			"@remix-run/router": ">=1.23.2 <2",
 			"ajv@8": ">=8.18.0 <9",
+			"brace-expansion": ">=5.0.5 <6",
 			"cross-spawn": ">=6.0.6",
 			"diff@7": ">=8.0.3 <9",
 			"dompurify": ">=3.4.0 <3.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@remix-run/router': '>=1.23.2 <2'
   ajv@8: '>=8.18.0 <9'
+  brace-expansion: '>=5.0.5 <6'
   cross-spawn: '>=6.0.6'
   diff@7: '>=8.0.3 <9'
   dompurify: '>=3.4.0 <3.5.0'


### PR DESCRIPTION
## Summary

- Bump dependencies flagged by a security/SOC scan to patched versions (`package.json` + lockfile).

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1159
