### PR TITLE
fix(connectors): fix SharePoint connector authentication

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/msauth.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/msauth.py
@@ -51,7 +51,7 @@ def getClientToken(tenant, region, clientId, clientSecret, scopes):
             client_id=clientId,
             authority='https://login.microsoftonline.com/' + tenant,
             client_credential=clientSecret,
-            azure_region=region,
+            azure_region=region or None,
         )
 
         # Save it
@@ -84,7 +84,7 @@ def getPasswordToken(tenant, region, clientId, username, password, scopes):
     if data['app'] is None:
         # Get a new app
         app = msal.ConfidentialClientApplication(
-            client_id=clientId, authority='https://login.microsoftonline.com/' + tenant, azure_region=region
+            client_id=clientId, authority='https://login.microsoftonline.com/' + tenant, azure_region=region or None
         )
 
         # Save it


### PR DESCRIPTION
## Summary

- The SharePoint connector fails to authenticate due to incorrect Microsoft auth (`msauth`) handling.
- Correct the msauth path so authentication succeeds.

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1160
