### PR TITLE
feat(tika): support RAR5 archives via 7-Zip-JBinding

### DIFF
--- a/packages/tika/lib/tika/pom-template.xml
+++ b/packages/tika/lib/tika/pom-template.xml
@@ -79,6 +79,20 @@
 			<artifactId>commons-lang3</artifactId>
 			<version>3.19.0</version>
 		</dependency>
+		<!-- 7-Zip-JBinding: replaces Tika's junrar-based RarParser with a
+			RAR4+RAR5 capable parser. The all-platforms artifact bundles the
+			win/linux/mac native libraries inside the jar; SevenZip extracts
+			and loads the right one at runtime. -->
+		<dependency>
+			<groupId>net.sf.sevenzipjbinding</groupId>
+			<artifactId>sevenzipjbinding</artifactId>
+			<version>16.02-2.01</version>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.sevenzipjbinding</groupId>
+			<artifactId>sevenzipjbinding-all-platforms</artifactId>
+			<version>16.02-2.01</version>
+		</dependency>
 		<!-- log4j jar's are excluded by tika-parser/pom.xml; include 
 			them here (see tika-app/pom.xml for log4j dependencies and tika-parent/pom.xml for versions) -->
 		<dependency>

--- a/packages/tika/lib/tika/pom-template.xml
+++ b/packages/tika/lib/tika/pom-template.xml
@@ -82,7 +82,15 @@
 		<!-- 7-Zip-JBinding: replaces Tika's junrar-based RarParser with a
 			RAR4+RAR5 capable parser. The all-platforms artifact bundles the
 			win/linux/mac native libraries inside the jar; SevenZip extracts
-			and loads the right one at runtime. -->
+			and loads the right one at runtime.
+
+			Security note: 16.02-2.01 is the last published release (2016) and
+			wraps a frozen 7-Zip 16.02 native core that parses untrusted input
+			via JNI, so it will not receive upstream CVE patches. This is the
+			same accept-and-document posture the module already takes for its
+			other native dependencies (bundled JPEG2000, native SQLite, the JNI
+			engine bridge); RAR support is gated behind Tika's media-type
+			detection and runs in the sandboxed Tika worker. -->
 		<dependency>
 			<groupId>net.sf.sevenzipjbinding</groupId>
 			<artifactId>sevenzipjbinding</artifactId>

--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/ConfigBuilder.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/ConfigBuilder.java
@@ -513,6 +513,11 @@ public class ConfigBuilder {
 		excludeExternalParserIfUnavailable(doc, "org.apache.tika.parser.external.CompositeExternalParser");
 		excludeExternalParserIfUnavailable(doc, "org.apache.tika.parser.external.ExternalParser");
 
+		// Replace Tika's junrar-backed RarParser (RAR4-only; throws on RAR5) with our
+		// 7-Zip-JBinding-backed parser, which handles both RAR4 and RAR5.
+		removeParser(doc, "org.apache.tika.parser.pkg.RarParser");
+		findOrAddParser(doc, "com.rocketride.tika_api.parsers.rar.RarSevenZipParser");
+
 		// Output the xml
 		logger.debug(xmlToString(doc, 4));
 

--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/ConfigBuilder.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/ConfigBuilder.java
@@ -515,8 +515,16 @@ public class ConfigBuilder {
 
 		// Replace Tika's junrar-backed RarParser (RAR4-only; throws on RAR5) with our
 		// 7-Zip-JBinding-backed parser, which handles both RAR4 and RAR5.
-		removeParser(doc, "org.apache.tika.parser.pkg.RarParser");
-		findOrAddParser(doc, "com.rocketride.tika_api.parsers.rar.RarSevenZipParser");
+		//
+		// Only when the native library actually loaded. TikaApi.init() logs and carries
+		// on when it does not, and installing a parser that cannot run would leave RAR
+		// with no working parser at all. Keeping junrar preserves RAR4 in that case.
+		if (TikaApi.isSevenZipReady()) {
+			removeParser(doc, "org.apache.tika.parser.pkg.RarParser");
+			findOrAddParser(doc, "com.rocketride.tika_api.parsers.rar.RarSevenZipParser");
+		} else {
+			logger.warn("7-Zip-JBinding unavailable; keeping Tika's RarParser (RAR4 only, RAR5 unsupported)");
+		}
 
 		// Output the xml
 		logger.debug(xmlToString(doc, 4));

--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/TikaApi.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/TikaApi.java
@@ -112,7 +112,17 @@ public final class TikaApi {
 	/**
 	 * Global privates used to control the process
 	 */
-	private static boolean initialized = false;
+	// volatile so a reader outside init()'s monitor cannot observe a stale value.
+	private static volatile boolean initialized = false;
+
+	/**
+	 * Whether 7-Zip-JBinding's native library actually loaded.
+	 *
+	 * ConfigBuilder only swaps Tika's RarParser for RarSevenZipParser when this is
+	 * true, so a failed native load leaves RAR4 handling in place instead of
+	 * removing RAR support altogether.
+	 */
+	private static volatile boolean sevenZipReady = false;
 
 	// private static CompositeEncodingDetector encodingDetector;
 	private static ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
@@ -307,7 +317,10 @@ public final class TikaApi {
 	/**
 	 * Global init/deinit of our tika parsing subsystem
 	 */
-	public static void init() throws Exception {
+	// synchronized so the initialized check and assignment below are one atomic
+	// step. Two threads could otherwise both pass the guard and race into
+	// SevenZip.initSevenZipFromPlatformJAR().
+	public static synchronized void init() throws Exception {
 		// Get the root path
 		logger.log(Level.INFO, "Tika.rootPath (Before set): " + TikaApi.rootPath);
 		rootPath = System.getProperty("java.home") + "/..";
@@ -322,14 +335,21 @@ public final class TikaApi {
 
 		// Initialize 7-Zip-JBinding once for the JVM. Required by RarSevenZipParser;
 		// the call extracts the platform-specific native lib from the bundled jar
-		// and loads it. Failures are logged but not fatal — non-RAR parsing still works.
+		// and loads it. Failures are logged but not fatal: non-RAR parsing still
+		// works, and ConfigBuilder keeps Tika's RAR4 parser when this did not load.
 		try {
 			if (!SevenZip.isInitializedSuccessfully()) {
 				SevenZip.initSevenZipFromPlatformJAR();
 				logger.log(Level.INFO, "7-Zip-JBinding initialized: " + SevenZip.getSevenZipVersion().version);
 			}
-		} catch (Throwable t) {
-			logger.log(Level.WARNING, "Failed to initialize 7-Zip-JBinding; RAR parsing will fail", t);
+			sevenZipReady = true;
+		} catch (Exception | LinkageError t) {
+			// A missing or incompatible native library arrives as UnsatisfiedLinkError,
+			// hence LinkageError. JVM-fatal Errors (OutOfMemoryError, StackOverflowError)
+			// are deliberately not caught: continuing after one of those would leave the
+			// process in a state this method cannot reason about.
+			logger.log(Level.WARNING, "Failed to initialize 7-Zip-JBinding; RAR5 support disabled", t);
+			sevenZipReady = false;
 		}
 
 		// Get a new encoding detector
@@ -343,6 +363,16 @@ public final class TikaApi {
 		// TemporaryResources [APPLAT-265]. This task will run every 5 minutes.
 		executor.scheduleWithFixedDelay(new DeleteTemporaryFilesTask(), 5, 5, TimeUnit.MINUTES);
 		initialized = true;
+	}
+
+	/**
+	 * Whether the 7-Zip-JBinding native library is loaded and RarSevenZipParser can
+	 * run. Consulted by ConfigBuilder before it replaces Tika's RarParser.
+	 *
+	 * @return true when 7-Zip-JBinding initialized successfully
+	 */
+	public static boolean isSevenZipReady() {
+		return sevenZipReady;
 	}
 
 	/**

--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/TikaApi.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/TikaApi.java
@@ -39,6 +39,8 @@ import org.apache.tika.parser.AutoDetectParser;
 import org.apache.tika.parser.pdf.PDFParserConfig;
 import org.apache.tika.extractor.EmbeddedDocumentExtractor;
 
+import net.sf.sevenzipjbinding.SevenZip;
+
 import com.rocketride.tika_api.parsers.email.CustomRFC822Parser;
 import com.rocketride.tika_api.EmbeddedContentExtractor.EmbeddedContentProcessor;
 
@@ -317,6 +319,18 @@ public final class TikaApi {
 
 		logger.log(Level.INFO, "Initializing TikaAPI ...");
 		logger.log(Level.INFO, "Aspose parsers available: " + asposeAvailable);
+
+		// Initialize 7-Zip-JBinding once for the JVM. Required by RarSevenZipParser;
+		// the call extracts the platform-specific native lib from the bundled jar
+		// and loads it. Failures are logged but not fatal — non-RAR parsing still works.
+		try {
+			if (!SevenZip.isInitializedSuccessfully()) {
+				SevenZip.initSevenZipFromPlatformJAR();
+				logger.log(Level.INFO, "7-Zip-JBinding initialized: " + SevenZip.getSevenZipVersion().version);
+			}
+		} catch (Throwable t) {
+			logger.log(Level.WARNING, "Failed to initialize 7-Zip-JBinding; RAR parsing will fail", t);
+		}
 
 		// Get a new encoding detector
 		// encodingDetector = initEncodingDetector();

--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/parsers/rar/RarSevenZipParser.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/parsers/rar/RarSevenZipParser.java
@@ -1,0 +1,214 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+package com.rocketride.tika_api.parsers.rar;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.tika.exception.EncryptedDocumentException;
+import org.apache.tika.exception.TikaException;
+import org.apache.tika.extractor.EmbeddedDocumentExtractor;
+import org.apache.tika.extractor.EmbeddedDocumentUtil;
+import org.apache.tika.io.TemporaryResources;
+import org.apache.tika.io.TikaInputStream;
+import org.apache.tika.metadata.Metadata;
+import org.apache.tika.metadata.TikaCoreProperties;
+import org.apache.tika.mime.MediaType;
+import org.apache.tika.parser.ParseContext;
+import org.apache.tika.parser.Parser;
+import org.apache.tika.sax.XHTMLContentHandler;
+import org.xml.sax.ContentHandler;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
+
+import net.sf.sevenzipjbinding.ExtractOperationResult;
+import net.sf.sevenzipjbinding.IInArchive;
+import net.sf.sevenzipjbinding.ISequentialOutStream;
+import net.sf.sevenzipjbinding.SevenZip;
+import net.sf.sevenzipjbinding.SevenZipException;
+import net.sf.sevenzipjbinding.impl.RandomAccessFileInStream;
+import net.sf.sevenzipjbinding.simple.ISimpleInArchive;
+import net.sf.sevenzipjbinding.simple.ISimpleInArchiveItem;
+
+/**
+ * RAR parser backed by 7-Zip-JBinding. Replaces Tika's built-in
+ * {@code org.apache.tika.parser.pkg.RarParser}, which is JUnRAR-based and
+ * explicitly rejects RAR5 archives.
+ *
+ * The parser spools the input to a temp file, opens it via 7-Zip-JBinding's
+ * auto-detection (handles both RAR4 and RAR5), then iterates entries and
+ * routes each to the {@link EmbeddedDocumentExtractor} on the parse context.
+ */
+public class RarSevenZipParser implements Parser {
+    private static final long serialVersionUID = 1L;
+
+    private static final Logger logger = Logger.getLogger("TikaApi");
+
+    private static final Set<MediaType> SUPPORTED_TYPES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(
+                    MediaType.application("x-rar-compressed"),
+                    MediaType.application("x-rar"),
+                    MediaType.application("vnd.rar"))));
+
+    @Override
+    public Set<MediaType> getSupportedTypes(ParseContext context) {
+        return SUPPORTED_TYPES;
+    }
+
+    @Override
+    public void parse(InputStream stream, ContentHandler handler, Metadata metadata, ParseContext context)
+            throws IOException, SAXException, TikaException {
+        XHTMLContentHandler xhtml = new XHTMLContentHandler(handler, metadata);
+        xhtml.startDocument();
+
+        EmbeddedDocumentExtractor extractor = EmbeddedDocumentUtil.getEmbeddedDocumentExtractor(context);
+
+        try (TemporaryResources tmp = new TemporaryResources();
+                TikaInputStream tis = TikaInputStream.get(stream, tmp, metadata)) {
+            File rarFile = tis.getFile();
+
+            try (RandomAccessFile raf = new RandomAccessFile(rarFile, "r");
+                    RandomAccessFileInStream inStream = new RandomAccessFileInStream(raf);
+                    IInArchive archive = SevenZip.openInArchive(null, inStream)) {
+
+                ISimpleInArchive simple = archive.getSimpleInterface();
+                for (ISimpleInArchiveItem item : simple.getArchiveItems()) {
+                    if (Thread.currentThread().isInterrupted()) {
+                        break;
+                    }
+                    extractItem(item, xhtml, extractor, tmp);
+                }
+            }
+        } catch (SevenZipException e) {
+            throw new TikaException("RarSevenZipParser failed to read RAR archive", e);
+        }
+
+        xhtml.endDocument();
+    }
+
+    private static void extractItem(ISimpleInArchiveItem item, XHTMLContentHandler xhtml,
+            EmbeddedDocumentExtractor extractor, TemporaryResources tmp)
+            throws IOException, SAXException, TikaException {
+        String name;
+        Date ctime;
+        Date mtime;
+        Long size;
+        boolean folder;
+        boolean encrypted;
+        try {
+            folder = item.isFolder();
+            if (folder) {
+                return;
+            }
+            encrypted = item.isEncrypted();
+            name = item.getPath();
+            ctime = item.getCreationTime();
+            mtime = item.getLastWriteTime();
+            size = item.getSize();
+        } catch (SevenZipException e) {
+            // Bad header on this entry — skip it but keep going through the archive.
+            logger.log(Level.WARNING, "Skipping unreadable RAR entry header", e);
+            return;
+        }
+
+        if (encrypted) {
+            // Match Tika's behavior for encrypted archives: surface to the caller.
+            throw new EncryptedDocumentException();
+        }
+
+        Metadata entryMeta = handleEntryMetadata(name, ctime, mtime, size, xhtml);
+        if (!extractor.shouldParseEmbedded(entryMeta)) {
+            return;
+        }
+
+        File entryFile = tmp.createTemporaryFile();
+        try (OutputStream fos = new FileOutputStream(entryFile)) {
+            ExtractOperationResult result = item.extractSlow(new ISequentialOutStream() {
+                @Override
+                public int write(byte[] data) throws SevenZipException {
+                    try {
+                        fos.write(data);
+                    } catch (IOException e) {
+                        throw new SevenZipException(e);
+                    }
+                    return data.length;
+                }
+            });
+            if (result != ExtractOperationResult.OK) {
+                logger.log(Level.WARNING, "RAR entry extraction returned " + result + " for " + name);
+                return;
+            }
+        } catch (SevenZipException e) {
+            logger.log(Level.WARNING, "Failed to extract RAR entry: " + name, e);
+            return;
+        }
+
+        // Hand a TikaInputStream (mark/reset supported, file-backed) to the
+        // embedded extractor — Tika's detectors call mark/reset to sniff bytes
+        // and a plain FileInputStream throws IOException: mark/reset not supported.
+        try (TikaInputStream entryStream = TikaInputStream.get(entryFile.toPath())) {
+            extractor.parseEmbedded(entryStream, xhtml, entryMeta, true);
+        }
+    }
+
+    /**
+     * Mirrors {@code PackageParser.handleEntryMetadata}, which is package/protected
+     * in upstream Tika and not callable from here.
+     */
+    private static Metadata handleEntryMetadata(String name, Date createAt, Date modifiedAt,
+            Long size, XHTMLContentHandler xhtml) throws SAXException {
+        Metadata entrydata = new Metadata();
+        if (createAt != null) {
+            entrydata.set(TikaCoreProperties.CREATED, createAt);
+        }
+        if (modifiedAt != null) {
+            entrydata.set(TikaCoreProperties.MODIFIED, modifiedAt);
+        }
+        if (size != null) {
+            entrydata.set(Metadata.CONTENT_LENGTH, Long.toString(size));
+        }
+        if (name != null && !name.isEmpty()) {
+            name = name.replace('\\', '/');
+            entrydata.set(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+            AttributesImpl attributes = new AttributesImpl();
+            attributes.addAttribute("", "class", "class", "CDATA", "embedded");
+            attributes.addAttribute("", "id", "id", "CDATA", name);
+            xhtml.startElement("div", attributes);
+            xhtml.endElement("div");
+            entrydata.set(TikaCoreProperties.EMBEDDED_RELATIONSHIP_ID, name);
+        }
+        return entrydata;
+    }
+}

--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/parsers/rar/RarSevenZipParser.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/parsers/rar/RarSevenZipParser.java
@@ -1,38 +1,37 @@
-// =============================================================================
-// MIT License
-// Copyright (c) 2026 Aparavi Software AG
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
-// =============================================================================
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.rocketride.tika_api.parsers.rar;
 
+import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -53,7 +52,9 @@ import org.xml.sax.ContentHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
+import net.sf.sevenzipjbinding.ExtractAskMode;
 import net.sf.sevenzipjbinding.ExtractOperationResult;
+import net.sf.sevenzipjbinding.IArchiveExtractCallback;
 import net.sf.sevenzipjbinding.IInArchive;
 import net.sf.sevenzipjbinding.ISequentialOutStream;
 import net.sf.sevenzipjbinding.SevenZip;
@@ -68,8 +69,15 @@ import net.sf.sevenzipjbinding.simple.ISimpleInArchiveItem;
  * explicitly rejects RAR5 archives.
  *
  * The parser spools the input to a temp file, opens it via 7-Zip-JBinding's
- * auto-detection (handles both RAR4 and RAR5), then iterates entries and
- * routes each to the {@link EmbeddedDocumentExtractor} on the parse context.
+ * auto-detection (handles both RAR4 and RAR5), enumerates the entries it can
+ * read, then extracts the selected ones in a single bulk pass and routes each
+ * to the {@link EmbeddedDocumentExtractor} on the parse context.
+ *
+ * <p>Extraction uses {@link IInArchive#extract(int[], boolean, IArchiveExtractCallback)}
+ * rather than per-entry {@code extractSlow}: RAR archives are frequently solid,
+ * where {@code extractSlow} re-decompresses from the start of the archive for
+ * every entry (O(n&sup2;) on an n-entry archive). A single bulk call decompresses
+ * the whole archive once while preserving solid-block ordering.
  */
 public class RarSevenZipParser implements Parser {
     private static final long serialVersionUID = 1L;
@@ -103,12 +111,63 @@ public class RarSevenZipParser implements Parser {
                     RandomAccessFileInStream inStream = new RandomAccessFileInStream(raf);
                     IInArchive archive = SevenZip.openInArchive(null, inStream)) {
 
+                // Pass 1: enumerate entries, emit their XHTML markers, and collect
+                // the indices we actually want to extract (skipping folders,
+                // encrypted entries, and anything the extractor declines).
                 ISimpleInArchive simple = archive.getSimpleInterface();
+                Map<Integer, Metadata> selected = new LinkedHashMap<>();
+                int fileEntries = 0;
+                int encryptedEntries = 0;
+
                 for (ISimpleInArchiveItem item : simple.getArchiveItems()) {
-                    if (Thread.currentThread().isInterrupted()) {
-                        break;
+                    Boolean folder = safeIsFolder(item);
+                    if (folder == null || folder) {
+                        // Unreadable header (logged) or a directory — nothing to extract.
+                        continue;
                     }
-                    extractItem(item, xhtml, extractor, tmp);
+                    fileEntries++;
+
+                    Boolean encrypted = safeIsEncrypted(item);
+                    if (encrypted == null) {
+                        continue;
+                    }
+                    if (encrypted) {
+                        // Per-entry resilience: skip this one but keep reading the rest,
+                        // consistent with how unreadable headers are handled. A blanket
+                        // EncryptedDocumentException is only surfaced below if EVERY entry
+                        // is encrypted (i.e. the archive as a whole is unreadable).
+                        encryptedEntries++;
+                        logger.log(Level.WARNING, "Skipping encrypted RAR entry: " + safePath(item));
+                        continue;
+                    }
+
+                    Metadata entryMeta = handleEntryMetadata(item, xhtml);
+                    if (entryMeta == null || !extractor.shouldParseEmbedded(entryMeta)) {
+                        continue;
+                    }
+                    selected.put(item.getItemIndex(), entryMeta);
+                }
+
+                if (fileEntries > 0 && encryptedEntries == fileEntries) {
+                    // Nothing was readable because the whole archive is encrypted.
+                    throw new EncryptedDocumentException();
+                }
+
+                // Pass 2: extract everything selected in one decompression pass.
+                if (!selected.isEmpty()) {
+                    int[] indices = toSortedIndices(selected.keySet());
+                    ExtractCallback callback = new ExtractCallback(selected, xhtml, extractor, tmp);
+                    try {
+                        archive.extract(indices, false, callback);
+                    } catch (SevenZipException e) {
+                        // A checked failure raised while dispatching an extracted entry to
+                        // the embedded extractor is wrapped by the callback; unwrap and
+                        // rethrow it as its original type so write-limit and I/O semantics
+                        // are preserved. Anything else is a genuine archive read error.
+                        callback.rethrowPending();
+                        throw new TikaException("RarSevenZipParser failed to extract RAR entries", e);
+                    }
+                    callback.rethrowPending();
                 }
             }
         } catch (SevenZipException e) {
@@ -118,77 +177,185 @@ public class RarSevenZipParser implements Parser {
         xhtml.endDocument();
     }
 
-    private static void extractItem(ISimpleInArchiveItem item, XHTMLContentHandler xhtml,
-            EmbeddedDocumentExtractor extractor, TemporaryResources tmp)
-            throws IOException, SAXException, TikaException {
-        String name;
-        Date ctime;
-        Date mtime;
-        Long size;
-        boolean folder;
-        boolean encrypted;
-        try {
-            folder = item.isFolder();
-            if (folder) {
-                return;
+    /**
+     * Receives bulk-extracted entry bytes from 7-Zip-JBinding. For each selected
+     * index it spools the bytes to a temp file, then hands that file to the
+     * embedded extractor as soon as the entry finishes — so only one entry is on
+     * disk at a time. Checked exceptions from the embedded extractor cannot cross
+     * the {@link IArchiveExtractCallback} signature, so the first one is stashed
+     * and re-raised by {@link #rethrowPending()} after extraction unwinds.
+     */
+    private static final class ExtractCallback implements IArchiveExtractCallback {
+        private final Map<Integer, Metadata> selected;
+        private final XHTMLContentHandler xhtml;
+        private final EmbeddedDocumentExtractor extractor;
+        private final TemporaryResources tmp;
+
+        private int currentIndex = -1;
+        private File currentFile;
+        private OutputStream currentOut;
+        private Exception pending;
+
+        ExtractCallback(Map<Integer, Metadata> selected, XHTMLContentHandler xhtml,
+                EmbeddedDocumentExtractor extractor, TemporaryResources tmp) {
+            this.selected = selected;
+            this.xhtml = xhtml;
+            this.extractor = extractor;
+            this.tmp = tmp;
+        }
+
+        @Override
+        public ISequentialOutStream getStream(int index, ExtractAskMode extractAskMode) throws SevenZipException {
+            if (extractAskMode != ExtractAskMode.EXTRACT || !selected.containsKey(index)) {
+                return null;
             }
-            encrypted = item.isEncrypted();
-            name = item.getPath();
-            ctime = item.getCreationTime();
-            mtime = item.getLastWriteTime();
-            size = item.getSize();
-        } catch (SevenZipException e) {
-            // Bad header on this entry — skip it but keep going through the archive.
-            logger.log(Level.WARNING, "Skipping unreadable RAR entry header", e);
-            return;
-        }
-
-        if (encrypted) {
-            // Match Tika's behavior for encrypted archives: surface to the caller.
-            throw new EncryptedDocumentException();
-        }
-
-        Metadata entryMeta = handleEntryMetadata(name, ctime, mtime, size, xhtml);
-        if (!extractor.shouldParseEmbedded(entryMeta)) {
-            return;
-        }
-
-        File entryFile = tmp.createTemporaryFile();
-        try (OutputStream fos = new FileOutputStream(entryFile)) {
-            ExtractOperationResult result = item.extractSlow(new ISequentialOutStream() {
+            try {
+                currentFile = tmp.createTemporaryFile();
+                currentOut = new BufferedOutputStream(new FileOutputStream(currentFile));
+            } catch (IOException e) {
+                throw new SevenZipException("Failed to create temp file for RAR entry", e);
+            }
+            currentIndex = index;
+            final OutputStream out = currentOut;
+            return new ISequentialOutStream() {
                 @Override
                 public int write(byte[] data) throws SevenZipException {
                     try {
-                        fos.write(data);
+                        out.write(data);
                     } catch (IOException e) {
                         throw new SevenZipException(e);
                     }
                     return data.length;
                 }
-            });
-            if (result != ExtractOperationResult.OK) {
-                logger.log(Level.WARNING, "RAR entry extraction returned " + result + " for " + name);
-                return;
-            }
-        } catch (SevenZipException e) {
-            logger.log(Level.WARNING, "Failed to extract RAR entry: " + name, e);
-            return;
+            };
         }
 
-        // Hand a TikaInputStream (mark/reset supported, file-backed) to the
-        // embedded extractor — Tika's detectors call mark/reset to sniff bytes
-        // and a plain FileInputStream throws IOException: mark/reset not supported.
-        try (TikaInputStream entryStream = TikaInputStream.get(entryFile.toPath())) {
-            extractor.parseEmbedded(entryStream, xhtml, entryMeta, true);
+        @Override
+        public void prepareOperation(ExtractAskMode extractAskMode) {
+        }
+
+        @Override
+        public void setOperationResult(ExtractOperationResult extractOperationResult) throws SevenZipException {
+            if (currentIndex < 0) {
+                return;
+            }
+            int index = currentIndex;
+            File file = currentFile;
+            Metadata meta = selected.get(index);
+            // Reset state before doing anything that can throw, so a failure here
+            // never leaves a half-open stream referenced for the next entry.
+            currentIndex = -1;
+            currentFile = null;
+            OutputStream out = currentOut;
+            currentOut = null;
+
+            try {
+                if (out != null) {
+                    out.close();
+                }
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "Failed to close temp stream for RAR entry: " + name(meta), e);
+            }
+
+            try {
+                if (extractOperationResult != ExtractOperationResult.OK) {
+                    logger.log(Level.WARNING,
+                            "RAR entry extraction returned " + extractOperationResult + " for " + name(meta));
+                    return;
+                }
+                // Hand a TikaInputStream (mark/reset supported, file-backed) to the
+                // embedded extractor — Tika's detectors call mark/reset to sniff bytes
+                // and a plain FileInputStream throws IOException: mark/reset not supported.
+                try (TikaInputStream entryStream = TikaInputStream.get(file.toPath())) {
+                    extractor.parseEmbedded(entryStream, xhtml, meta, true);
+                } catch (IOException | SAXException e) {
+                    // Cannot cross this callback's signature; stash and stop extraction.
+                    // Rethrown in original form by rethrowPending() once extract() unwinds.
+                    pending = e;
+                    throw new SevenZipException("Embedded parse failed for RAR entry: " + name(meta), e);
+                }
+            } finally {
+                if (file != null) {
+                    // Keep peak disk usage to a single entry rather than the whole archive.
+                    file.delete();
+                }
+            }
+        }
+
+        @Override
+        public void setTotal(long total) {
+        }
+
+        @Override
+        public void setCompleted(long complete) {
+        }
+
+        /** Re-raise the first checked exception captured during dispatch, if any. */
+        void rethrowPending() throws IOException, SAXException {
+            if (pending instanceof IOException) {
+                throw (IOException) pending;
+            }
+            if (pending instanceof SAXException) {
+                throw (SAXException) pending;
+            }
+        }
+
+        private static String name(Metadata meta) {
+            String n = meta == null ? null : meta.get(TikaCoreProperties.RESOURCE_NAME_KEY);
+            return n == null ? "<unknown>" : n;
+        }
+    }
+
+    private static Boolean safeIsFolder(ISimpleInArchiveItem item) {
+        try {
+            return item.isFolder();
+        } catch (SevenZipException e) {
+            logger.log(Level.WARNING, "Skipping unreadable RAR entry header", e);
+            return null;
+        }
+    }
+
+    private static Boolean safeIsEncrypted(ISimpleInArchiveItem item) {
+        try {
+            return item.isEncrypted();
+        } catch (SevenZipException e) {
+            logger.log(Level.WARNING, "Skipping RAR entry with unreadable encryption flag", e);
+            return null;
+        }
+    }
+
+    private static String safePath(ISimpleInArchiveItem item) {
+        try {
+            return item.getPath();
+        } catch (SevenZipException e) {
+            return "<unknown>";
         }
     }
 
     /**
-     * Mirrors {@code PackageParser.handleEntryMetadata}, which is package/protected
-     * in upstream Tika and not callable from here.
+     * Reads an entry's metadata and emits its XHTML marker. Returns {@code null}
+     * (and logs) if the entry header cannot be read, so the caller can skip it
+     * without aborting the whole archive.
+     *
+     * <p>Mirrors {@code PackageParser.handleEntryMetadata}, which is
+     * package-protected in upstream Tika and not callable from here.
      */
-    private static Metadata handleEntryMetadata(String name, Date createAt, Date modifiedAt,
-            Long size, XHTMLContentHandler xhtml) throws SAXException {
+    private static Metadata handleEntryMetadata(ISimpleInArchiveItem item, XHTMLContentHandler xhtml)
+            throws SAXException {
+        String name;
+        Date createAt;
+        Date modifiedAt;
+        Long size;
+        try {
+            name = item.getPath();
+            createAt = item.getCreationTime();
+            modifiedAt = item.getLastWriteTime();
+            size = item.getSize();
+        } catch (SevenZipException e) {
+            logger.log(Level.WARNING, "Skipping unreadable RAR entry header", e);
+            return null;
+        }
+
         Metadata entrydata = new Metadata();
         if (createAt != null) {
             entrydata.set(TikaCoreProperties.CREATED, createAt);
@@ -210,5 +377,15 @@ public class RarSevenZipParser implements Parser {
             entrydata.set(TikaCoreProperties.EMBEDDED_RELATIONSHIP_ID, name);
         }
         return entrydata;
+    }
+
+    private static int[] toSortedIndices(Set<Integer> keys) {
+        List<Integer> sorted = new ArrayList<>(keys);
+        Collections.sort(sorted);
+        int[] indices = new int[sorted.size()];
+        for (int i = 0; i < indices.length; i++) {
+            indices[i] = sorted.get(i);
+        }
+        return indices;
     }
 }

--- a/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/parsers/rar/RarSevenZipParser.java
+++ b/packages/tika/lib/tika/src/main/java/com/rocketride/tika_api/parsers/rar/RarSevenZipParser.java
@@ -166,6 +166,12 @@ public class RarSevenZipParser implements Parser {
                         // are preserved. Anything else is a genuine archive read error.
                         callback.rethrowPending();
                         throw new TikaException("RarSevenZipParser failed to extract RAR entries", e);
+                    } finally {
+                        // setOperationResult() closes and deletes each entry on the normal
+                        // path, but 7-Zip-JBinding does not promise a matching call once a
+                        // callback throws. This covers the aborted entry so no stream is
+                        // left open on a corrupt archive.
+                        callback.discardActiveEntry();
                     }
                     callback.rethrowPending();
                 }
@@ -279,6 +285,34 @@ public class RarSevenZipParser implements Parser {
                     // Keep peak disk usage to a single entry rather than the whole archive.
                     file.delete();
                 }
+            }
+        }
+
+        /**
+         * Close and drop the entry still in flight, if any.
+         *
+         * On the normal path {@link #setOperationResult} has already cleared this
+         * state, so this is a no-op. It matters when extraction aborts between
+         * {@link #getStream} and {@link #setOperationResult}: the entry's stream
+         * would otherwise stay open, and on Windows that open handle also stops
+         * {@link TemporaryResources} from deleting the file it points at.
+         */
+        void discardActiveEntry() {
+            OutputStream out = currentOut;
+            File file = currentFile;
+            currentOut = null;
+            currentFile = null;
+            currentIndex = -1;
+
+            if (out != null) {
+                try {
+                    out.close();
+                } catch (IOException e) {
+                    logger.log(Level.WARNING, "Failed to close stream for aborted RAR entry", e);
+                }
+            }
+            if (file != null) {
+                file.delete();
             }
         }
 


### PR DESCRIPTION
## Summary

- Tika's junrar-backed `RarParser` throws on RAR v5 (the default WinRAR format since 2013), so modern RAR files fail to parse.
- Add `net.sf.sevenzipjbinding` plus a `RarSevenZipParser` that auto-detects RAR4/RAR5 and routes entries through the configured `EmbeddedDocumentExtractor`; `ConfigBuilder` swaps the parser and `TikaApi` initializes the native binding once per JVM.

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1163


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for parsing RAR4 and RAR5 archives.
  * Archive contents can be extracted and processed as embedded documents.
  * Encrypted archive entries are skipped when possible, with fully encrypted archives reported clearly.

* **Bug Fixes**
  * Improved resilience when archive-processing components fail to initialize, allowing other document processing to continue.
  * RAR processing automatically falls back to the standard parser when enhanced support is unavailable.

* **Chores**
  * Added archive-processing components required for expanded RAR support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->