### PR TITLE
fix(store/services): respect explicit default in combo field provider resolution

### DIFF
--- a/packages/server/engine-lib/engLib/store/services/services.cpp
+++ b/packages/server/engine-lib/engLib/store/services/services.cpp
@@ -1085,8 +1085,9 @@ ErrorOr<IServices::ServiceSchema> IServices::getField(
             info.ui["ui:order"].append(logicalType);
         }
 
-        // Setup the default
-        field["properties"]["provider"]["default"] = defaultProvider;
+        // Setup the default - respect explicit default from combo field definition if provided
+        Text explicitDefault = fieldInfo.lookup<Text>("default", "");
+        field["properties"]["provider"]["default"] = explicitDefault ? explicitDefault : defaultProvider;
 
         // Set the enum values
         field["properties"]["provider"]["enum"] = enumValues;


### PR DESCRIPTION
## Summary

- Combo-field provider resolution ignored an explicitly configured default.
- Honor the explicit default during resolution.

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1164
