### PR TITLE
fix(text-output): install smbprotocol at module level and fix anonymize crash

### DIFF
--- a/nodes/src/nodes/anonymize/glinerRecognizer.py
+++ b/nodes/src/nodes/anonymize/glinerRecognizer.py
@@ -124,8 +124,6 @@ class GliNERRecognizer:
             yield labels[i : i + batch_size]
 
     def predict(self, text, labels, batch_size=32):
-        import concurrent.futures
-
         cleaned_labels = [self.normalize_label(label) for label in labels]
 
         # Use larger chunks with overlap to avoid missing entities at boundaries
@@ -137,28 +135,20 @@ class GliNERRecognizer:
         chunk_offsets = []
         for i in range(0, len(text), CHUNK_SIZE - OVERLAP):
             chunk = text[i : i + CHUNK_SIZE]
-            if chunk:  # Skip empty chunks
+            if chunk:
                 chunks.append(chunk)
                 chunk_offsets.append(i)
 
-        # Precompute all label batches
         label_batches = list(self.batch_labels(cleaned_labels, batch_size))
 
         all_results = []
+        total_chunks = len(chunks)
 
-        # Process chunks in parallel if possible
-        def process_chunk(chunk_idx):
-            chunk = chunks[chunk_idx]
-            offset = chunk_offsets[chunk_idx]
-            chunk_results = []
-
-            # Process all label batches for this chunk
+        for chunk_idx, (chunk, offset) in enumerate(zip(chunks, chunk_offsets)):
             for label_batch in label_batches:
                 try:
-                    # Use a timeout to avoid hanging on problematic chunks
                     results = self.model.predict_entities(chunk, label_batch)
 
-                    # Adjust offsets and add to results
                     for res in results:
                         res['start'] += offset
                         res['end'] += offset
@@ -167,35 +157,16 @@ class GliNERRecognizer:
                         if chunk_idx > 0 and res['start'] < offset + OVERLAP:
                             continue
 
-                        chunk_results.append(res)
+                        all_results.append(res)
 
                 except Exception as e:
                     debug(f'Anonymize: GLiNER Error on chunk {chunk_idx} with labels {label_batch}: {str(e)}')
 
-            return chunk_results
+            completed = chunk_idx + 1
+            if completed % 5 == 0 or completed == total_chunks:
+                debug(f'Anonymize: Processing text chunks: {completed}/{total_chunks} complete')
 
-        # Use ThreadPoolExecutor for parallel processing
-        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
-            futures = [executor.submit(process_chunk, i) for i in range(len(chunks))]
-
-            # Collect results as they complete
-            total_chunks = len(futures)
-            completed = 0
-
-            for future in concurrent.futures.as_completed(futures):
-                try:
-                    chunk_results = future.result()
-                    all_results.extend(chunk_results)
-
-                    # Simple progress logging
-                    completed += 1
-                    if completed % 5 == 0 or completed == total_chunks:
-                        debug(f'Anonymize: Processing text chunks: {completed}/{total_chunks} complete')
-
-                except Exception as e:
-                    debug(f'Anonymize: Error processing chunk: {str(e)}')
-
-        # Remove duplicates (entities that appear in overlapping regions)
+        # Remove duplicates from overlapping regions
         seen = set()
         unique_results = []
         for res in sorted(all_results, key=lambda x: (x['start'], x['end'])):

--- a/nodes/src/nodes/anonymize/glinerRecognizer.py
+++ b/nodes/src/nodes/anonymize/glinerRecognizer.py
@@ -23,6 +23,8 @@
 
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from threading import Lock
 from typing import Any, Dict
 
 from rocketlib import debug, expand
@@ -68,6 +70,12 @@ class GliNERRecognizer:
 
         # Use ai.common.models.GLiNER - auto-detects local vs model server mode
         self.model = GLiNER(self.model_name)
+
+        # GLiNER wraps a single torch module, which cannot run concurrent forward
+        # passes: doing so corrupts the CUDA heap and aborts the worker. predict()
+        # holds this around the predict_entities call only, so chunking, offset
+        # arithmetic and the overlap filter still run concurrently.
+        self._predict_lock = Lock()
 
     def extract_keywords_from_xml(self, data):
         """
@@ -140,14 +148,20 @@ class GliNERRecognizer:
                 chunk_offsets.append(i)
 
         label_batches = list(self.batch_labels(cleaned_labels, batch_size))
-
-        all_results = []
         total_chunks = len(chunks)
 
-        for chunk_idx, (chunk, offset) in enumerate(zip(chunks, chunk_offsets)):
+        def process_chunk(chunk_idx):
+            """Predict one chunk, offset-corrected and overlap-filtered."""
+            chunk = chunks[chunk_idx]
+            offset = chunk_offsets[chunk_idx]
+            chunk_results = []
+
             for label_batch in label_batches:
                 try:
-                    results = self.model.predict_entities(chunk, label_batch)
+                    # Only the forward pass is unsafe to interleave. Everything
+                    # after it works on this thread's own result dicts.
+                    with self._predict_lock:
+                        results = self.model.predict_entities(chunk, label_batch)
 
                     for res in results:
                         res['start'] += offset
@@ -157,14 +171,29 @@ class GliNERRecognizer:
                         if chunk_idx > 0 and res['start'] < offset + OVERLAP:
                             continue
 
-                        all_results.append(res)
+                        chunk_results.append(res)
 
                 except Exception as e:
                     debug(f'Anonymize: GLiNER Error on chunk {chunk_idx} with labels {label_batch}: {str(e)}')
 
-            completed = chunk_idx + 1
-            if completed % 5 == 0 or completed == total_chunks:
-                debug(f'Anonymize: Processing text chunks: {completed}/{total_chunks} complete')
+            return chunk_results
+
+        all_results = []
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            futures = [executor.submit(process_chunk, index) for index in range(total_chunks)]
+
+            completed = 0
+            for future in as_completed(futures):
+                try:
+                    all_results.extend(future.result())
+                except Exception as e:
+                    # Per-batch failures are already handled inside process_chunk,
+                    # so this only catches a failure in the surrounding scaffolding.
+                    debug(f'Anonymize: Error processing chunk: {str(e)}')
+
+                completed += 1
+                if completed % 5 == 0 or completed == total_chunks:
+                    debug(f'Anonymize: Processing text chunks: {completed}/{total_chunks} complete')
 
         # Remove duplicates from overlapping regions
         seen = set()

--- a/nodes/src/nodes/text_output/IGlobal.py
+++ b/nodes/src/nodes/text_output/IGlobal.py
@@ -24,7 +24,7 @@
 # ------------------------------------------------------------------------------
 # This class controls the data shared between all threads for the task
 # ------------------------------------------------------------------------------
-from rocketlib import IGlobalBase, OPEN_MODE
+from rocketlib import IGlobalBase
 
 
 # ----------------------------------
@@ -32,21 +32,7 @@ from rocketlib import IGlobalBase, OPEN_MODE
 # ----------------------------------
 class IGlobal(IGlobalBase):
     def beginGlobal(self):
-        # Are we in config mode or some other mode?
-        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
-            # We are going to get a call to configureService but
-            # we don't actually need to load the driver for that
-            pass
-        else:
-            # Read the requirements file
-            import os
-
-            requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
-
-            # Load any dependencies
-            from depends import depends  # type: ignore
-
-            depends(requirements)
+        pass
 
     def endGlobal(self):
         pass

--- a/nodes/src/nodes/text_output/IGlobal.py
+++ b/nodes/src/nodes/text_output/IGlobal.py
@@ -32,7 +32,18 @@ from rocketlib import IGlobalBase
 # ----------------------------------
 class IGlobal(IGlobalBase):
     def beginGlobal(self):
+        """Call from engLib, task startup hook.
+
+        Intentionally a no-op: `endpoint.py` resolves this node's dependencies
+        with `depends()` at module import time, so there is nothing left to
+        prepare once the task begins.
+        """
         pass
 
     def endGlobal(self):
+        """Call from engLib, task teardown hook.
+
+        Intentionally a no-op: the SMB client owns its own connection state and
+        `beginGlobal` allocates nothing that needs releasing here.
+        """
         pass

--- a/nodes/src/nodes/text_output/README.md
+++ b/nodes/src/nodes/text_output/README.md
@@ -86,21 +86,25 @@ Failed objects record the exception as their completion code instead of writing 
 
 Authentication is optional, leave `username` and `password` blank for shares that allow
 anonymous/guest access. When credentials are provided, both fields are required and the
-username must use the domain format `DOMAIN\user`. Credentials are registered with the SMB
-client globally at connection time.
+username must use the domain format `DOMAIN\user`. Credentials are registered against the
+configured server only, so two endpoints pointing at different servers never overwrite each
+other's credentials.
 
 Configuration validation probes the target as well, and treats the two failure kinds
 differently:
 
-- A rejected credential, a share the account may not enter, or a share name that does not
-  exist fails validation, because each is a configuration mistake the user has to fix.
-- A share that is merely unreachable (no route, refused connection, timeout) is reported as
-  a warning and does not reject the configuration. Validation also runs on the Platform
-  host, which often has no network path to the customer's share, so a correct configuration
-  must not be rejected just because the validating machine cannot see the server.
+- A rejected or expired credential, a share the account may not enter, or a share name that
+  does not exist fails validation, because each is a configuration mistake the user has to
+  fix.
+- A target that is merely unreachable (no route, refused connection, timeout, dropped
+  transport) is reported as a warning and does not reject the configuration. Validation also
+  runs on the Platform host, which often has no network path to the customer's share, so a
+  correct configuration must not be rejected just because the validating machine cannot see
+  the server. A transient failure such as the share being locked by another process is
+  treated the same way.
 
 The store path itself is exempt: it is created on first write, so validation does not
-require it to exist yet.
+require it to exist yet. Only the share it lives under has to be reachable and permitted.
 
 ---
 

--- a/nodes/src/nodes/text_output/README.md
+++ b/nodes/src/nodes/text_output/README.md
@@ -87,8 +87,20 @@ Failed objects record the exception as their completion code instead of writing 
 Authentication is optional, leave `username` and `password` blank for shares that allow
 anonymous/guest access. When credentials are provided, both fields are required and the
 username must use the domain format `DOMAIN\user`. Credentials are registered with the SMB
-client globally at connection time; the connection (and reachability of the share) is
-tested when the action starts, not during configuration validation.
+client globally at connection time.
+
+Configuration validation probes the target as well, and treats the two failure kinds
+differently:
+
+- A rejected credential, a share the account may not enter, or a share name that does not
+  exist fails validation, because each is a configuration mistake the user has to fix.
+- A share that is merely unreachable (no route, refused connection, timeout) is reported as
+  a warning and does not reject the configuration. Validation also runs on the Platform
+  host, which often has no network path to the customer's share, so a correct configuration
+  must not be rejected just because the validating machine cannot see the server.
+
+The store path itself is exempt: it is created on first write, so validation does not
+require it to exist yet.
 
 ---
 

--- a/nodes/src/nodes/text_output/endpoint.py
+++ b/nodes/src/nodes/text_output/endpoint.py
@@ -77,8 +77,24 @@ class Endpoint:
 
         except ValueError as e:
             engLib.error(e)
+        except OSError as e:
+            # A rejected credential, a share the user cannot enter, or a share
+            # that does not exist is a configuration problem, so it has to fail
+            # validation. connect() already tolerates ENOENT on the store path
+            # itself (that subdirectory is created later), so an ENOENT arriving
+            # here came from the share root and means the share name is wrong.
+            if e.errno in (errno.EACCES, errno.EPERM, errno.ENOENT):
+                engLib.error(e)
+            else:
+                # Anything else here is a reachability problem, not bad config.
+                # Validation also runs on the Platform host, which frequently
+                # has no route to the customer's SMB share, so failing here
+                # would reject configurations that are actually correct.
+                engLib.warning(f'Could not verify SMB target (config not rejected): {e}')
         except Exception as e:
-            engLib.warning(e)
+            # Same reasoning as above: the probe is advisory, so an unexpected
+            # failure is reported without rejecting the configuration.
+            engLib.warning(f'Could not verify SMB target (config not rejected): {e}')
 
     def getConfigSubKey(self):
         """Call from engLib, target service uniqueness key."""

--- a/nodes/src/nodes/text_output/endpoint.py
+++ b/nodes/src/nodes/text_output/endpoint.py
@@ -22,6 +22,7 @@
 # =============================================================================
 
 import errno
+import os
 import re
 from threading import Lock
 from typing import Any
@@ -29,6 +30,9 @@ from zlib import crc32
 
 import engLib
 from engLib import Filters
+from depends import depends  # type: ignore
+
+depends(os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt')
 
 
 class Endpoint:
@@ -69,13 +73,12 @@ class Endpoint:
             )
 
             if not syntaxOnly:
-                # Do not try to connect as validation is run by Platform
-                # where SMB share may not be available
-                # self.connect()
-                pass
+                self.connect()
 
         except ValueError as e:
             engLib.error(e)
+        except Exception as e:
+            engLib.warning(e)
 
     def getConfigSubKey(self):
         """Call from engLib, target service uniqueness key."""

--- a/nodes/src/nodes/text_output/endpoint.py
+++ b/nodes/src/nodes/text_output/endpoint.py
@@ -77,24 +77,15 @@ class Endpoint:
 
         except ValueError as e:
             engLib.error(e)
-        except OSError as e:
-            # A rejected credential, a share the user cannot enter, or a share
-            # that does not exist is a configuration problem, so it has to fail
-            # validation. connect() already tolerates ENOENT on the store path
-            # itself (that subdirectory is created later), so an ENOENT arriving
-            # here came from the share root and means the share name is wrong.
-            if e.errno in (errno.EACCES, errno.EPERM, errno.ENOENT):
+        except Exception as e:
+            if Endpoint.is_smb_config_error(e):
                 engLib.error(e)
             else:
-                # Anything else here is a reachability problem, not bad config.
-                # Validation also runs on the Platform host, which frequently
-                # has no route to the customer's SMB share, so failing here
-                # would reject configurations that are actually correct.
+                # Not bad config, so do not reject it. Validation also runs on
+                # the Platform host, which frequently has no route to the
+                # customer's SMB share, and failing here would reject
+                # configurations that are actually correct.
                 engLib.warning(f'Could not verify SMB target (config not rejected): {e}')
-        except Exception as e:
-            # Same reasoning as above: the probe is advisory, so an unexpected
-            # failure is reported without rejecting the configuration.
-            engLib.warning(f'Could not verify SMB target (config not rejected): {e}')
 
     def getConfigSubKey(self):
         """Call from engLib, target service uniqueness key."""
@@ -114,6 +105,60 @@ class Endpoint:
         else:
             return []
 
+    # NtStatus codes that mean the configuration itself is wrong: the credential
+    # was rejected, the account may not use the share, or the share/path is not
+    # there. Anything else (timeouts, dropped transports) says the validating host
+    # cannot reach the server, which is not the user's mistake.
+    #
+    # Classified on NtStatus rather than errno on purpose. SMBOSError maps only a
+    # handful of statuses onto errno and leaves the rest at 0, and
+    # STATUS_ACCESS_DENIED is one of the unmapped ones. Note also that errno EPERM
+    # comes from STATUS_SHARING_VIOLATION ("file in use by another process"), which
+    # is transient and must NOT reject a configuration.
+    _CONFIG_ERROR_STATUS_NAMES = (
+        'STATUS_ACCESS_DENIED',
+        'STATUS_LOGON_FAILURE',
+        'STATUS_WRONG_PASSWORD',
+        'STATUS_PASSWORD_EXPIRED',
+        'STATUS_PRIVILEGE_NOT_HELD',
+        'STATUS_BAD_NETWORK_NAME',
+        'STATUS_OBJECT_NAME_NOT_FOUND',
+        'STATUS_OBJECT_PATH_NOT_FOUND',
+        'STATUS_NOT_FOUND',
+    )
+
+    @staticmethod
+    def is_smb_config_error(exc: Exception) -> bool:
+        """Whether a connect() failure means the configuration is wrong.
+
+        Args:
+            exc (Exception): the exception raised by connect().
+
+        Returns:
+            True when the failure is a configuration mistake the user must fix,
+            False when it only says this host could not reach the server.
+        """
+        try:
+            from smbprotocol.exceptions import SMBAuthenticationError
+            from smbprotocol.header import NtStatus
+        except Exception:
+            # smbprotocol unavailable: nothing can be classified, so do not
+            # reject the configuration on the strength of a guess.
+            return False
+
+        # A rejected credential is raised during session setup as its own class,
+        # which derives from SMBException and is NOT an OSError, so it carries no
+        # errno and would slip past any errno-based check.
+        if isinstance(exc, SMBAuthenticationError):
+            return True
+
+        ntstatus = getattr(exc, 'ntstatus', None)
+        if ntstatus is None:
+            return False
+
+        expected = {getattr(NtStatus, name) for name in Endpoint._CONFIG_ERROR_STATUS_NAMES if hasattr(NtStatus, name)}
+        return ntstatus in expected
+
     def connect(self):
         """Authenticate and test connection to the target share.
 
@@ -125,9 +170,12 @@ class Endpoint:
         import smbclient
         from smbprotocol.exceptions import SMBOSError
 
-        # Setup user name and password
+        # Register the credential against this server only. ClientConfig is a
+        # process-wide singleton, so using it here would let one endpoint's
+        # validation overwrite the credential another endpoint is already
+        # connected with, in any process that runs both.
         if self.username and self.password:
-            smbclient.ClientConfig(username=self.username, password=self.password)
+            smbclient.register_session(self.server, username=self.username, password=self.password)
 
         # Build paths to check
         share = next(iter(re.split(r'[\\/]', self.store_path)), None)

--- a/nodes/src/nodes/text_output/services.json
+++ b/nodes/src/nodes/text_output/services.json
@@ -64,9 +64,18 @@
 	//     in the shape
 	//
 	"fields": {
+		"anonymize": {
+			"hidden": false
+		},
 		"text_output.target.parameters": {
 			"object": "parameters",
-			"properties": ["anonymize"]
+			"properties": [
+				"smb.storePath",
+				"smb.server",
+				"smb.username",
+				"smb.password",
+				"anonymize"
+			]
 		}
 	},
 	//
@@ -78,7 +87,12 @@
 		{
 			"section": "Transform",
 			"title": "Text Output",
-			"properties": ["type", "text_output.target.parameters", "target.mode"]
+			"properties": [
+				"type",
+				"name",
+				"text_output.target.parameters",
+				"target.mode"
+			]
 		}
 	]
 }

--- a/nodes/src/nodes/text_output/services.json
+++ b/nodes/src/nodes/text_output/services.json
@@ -89,7 +89,6 @@
 			"title": "Text Output",
 			"properties": [
 				"type",
-				"name",
 				"text_output.target.parameters",
 				"target.mode"
 			]

--- a/nodes/src/nodes/text_output/services.json
+++ b/nodes/src/nodes/text_output/services.json
@@ -67,15 +67,29 @@
 		"anonymize": {
 			"hidden": false
 		},
+		"text_output.server": {
+			"type": "string",
+			"title": "Server Name",
+			"description": "Host name or IP address of the SMB server hosting the share, e.g. files.example.com or 10.0.0.12."
+		},
+		"text_output.username": {
+			"type": "string",
+			"title": "User Name",
+			"description": "User name used to authenticate against the SMB share. Leave the user name and password empty to connect with the engine's own credentials.",
+			"optional": true
+		},
+		"text_output.password": {
+			"type": "string",
+			"title": "Password",
+			"description": "Password for the SMB user name above.",
+			"secure": true,
+			"optional": true,
+			"maxLength": 127,
+			"ui:widget": "password"
+		},
 		"text_output.target.parameters": {
 			"object": "parameters",
-			"properties": [
-				"smb.storePath",
-				"smb.server",
-				"smb.username",
-				"smb.password",
-				"anonymize"
-			]
+			"properties": ["storePath", "text_output.server", "text_output.username", "text_output.password", "anonymize"]
 		}
 	},
 	//
@@ -87,11 +101,7 @@
 		{
 			"section": "Transform",
 			"title": "Text Output",
-			"properties": [
-				"type",
-				"text_output.target.parameters",
-				"target.mode"
-			]
+			"properties": ["type", "text_output.target.parameters", "target.mode"]
 		}
 	]
 }

--- a/nodes/test/test_gliner_predict.py
+++ b/nodes/test/test_gliner_predict.py
@@ -1,0 +1,315 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit tests for GliNERRecognizer.predict chunking and concurrency.
+
+``predict`` splits text into overlapping chunks and runs them through a
+ThreadPoolExecutor. GLiNER wraps a single torch module, which cannot take
+concurrent forward passes, so a lock is held around ``predict_entities`` only:
+chunking, offset arithmetic and the overlap filter stay concurrent.
+
+These tests pin two things:
+
+* the entities and offsets ``predict`` returns for a multi-chunk input, which is
+  what the overlap filter and the final dedup decide, and
+* that concurrent chunks never enter ``predict_entities`` at the same time,
+  while still genuinely running in parallel.
+
+No GLiNER model or engine is required: the module is loaded by path with the
+heavy dependencies stubbed, and a recording double stands in for the model.
+"""
+
+import importlib.util
+import os
+import sys
+import threading
+import time
+import types
+
+import pytest
+
+_ANON_DIR = os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes', 'anonymize')
+
+CHUNK_SIZE = 1024
+OVERLAP = 128
+STRIDE = CHUNK_SIZE - OVERLAP
+
+
+def _load_recognizer_module():
+    """Load glinerRecognizer.py with its heavy imports stubbed out.
+
+    It is loaded as ``anonymize_under_test.glinerRecognizer`` so its relative
+    imports resolve against the real sibling files (Ruleparser, anonymize), both
+    of which are dependency-free.
+
+    sys.modules is snapshotted and restored around the load: the stubs only need
+    to exist while the module body executes, and leaving them behind would hand a
+    fake ``rocketlib`` or ``ai.common`` to every test that runs afterwards.
+    """
+    package_name = 'anonymize_under_test'
+    stubs = {
+        package_name: types.ModuleType(package_name),
+        'rocketlib': types.SimpleNamespace(debug=lambda *a, **k: None, expand=lambda value='': value),
+        'ai': types.ModuleType('ai'),
+        'ai.common': types.ModuleType('ai.common'),
+        'ai.common.config': types.SimpleNamespace(
+            Config=types.SimpleNamespace(getNodeConfig=lambda *a, **k: {}),
+        ),
+        'ai.common.models': types.SimpleNamespace(GLiNER=lambda *a, **k: None),
+    }
+    stubs[package_name].__path__ = [os.path.abspath(_ANON_DIR)]
+    stubs['ai'].common = stubs['ai.common']
+
+    path = os.path.join(_ANON_DIR, 'glinerRecognizer.py')
+    spec = importlib.util.spec_from_file_location(f'{package_name}.glinerRecognizer', path)
+    module = importlib.util.module_from_spec(spec)
+
+    # Only install names that are not already present, and remember which, so a
+    # real rocketlib/ai.common in the engine environment is never shadowed.
+    installed = [name for name in stubs if name not in sys.modules]
+    for name in installed:
+        sys.modules[name] = stubs[name]
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        # The module now holds direct references to what it imported, so the
+        # sys.modules entries are no longer needed.
+        for name in installed:
+            sys.modules.pop(name, None)
+        sys.modules.pop(spec.name, None)
+
+    return module
+
+
+recognizer_module = _load_recognizer_module()
+GliNERRecognizer = recognizer_module.GliNERRecognizer
+
+
+class _MarkerModel:
+    """Finds a fixed marker in each chunk and records concurrency.
+
+    Returned offsets are chunk-relative, exactly as GLiNER's own would be, so
+    predict() is responsible for turning them into absolute positions.
+    """
+
+    def __init__(self, marker='ACME', label='organization', delay=0.0):
+        self.marker = marker
+        self.label = label
+        self.delay = delay
+        self.active = 0
+        self.max_active = 0
+        self.calls = 0
+        self.chunks_seen = []
+        self._lock = threading.Lock()
+
+    def predict_entities(self, chunk, labels):
+        with self._lock:
+            self.active += 1
+            self.calls += 1
+            self.max_active = max(self.max_active, self.active)
+            self.chunks_seen.append(chunk)
+        try:
+            if self.delay:
+                time.sleep(self.delay)
+            found = []
+            start = chunk.find(self.marker)
+            while start != -1:
+                found.append(
+                    {
+                        'start': start,
+                        'end': start + len(self.marker),
+                        'label': self.label,
+                        'text': self.marker,
+                        'score': 0.99,
+                    }
+                )
+                start = chunk.find(self.marker, start + 1)
+            return found
+        finally:
+            with self._lock:
+                self.active -= 1
+
+
+def make_recognizer(model):
+    """Build a recognizer with only what predict() touches."""
+    instance = GliNERRecognizer.__new__(GliNERRecognizer)
+    instance.model = model
+    instance._predict_lock = threading.Lock()
+    return instance
+
+
+def build_text(marker_positions, marker='ACME', total_length=4000):
+    """Filler text with the marker placed at each requested absolute offset."""
+    body = ['.'] * total_length
+    for position in marker_positions:
+        for index, character in enumerate(marker):
+            body[position + index] = character
+    return ''.join(body)
+
+
+def _expected_after_overlap_filter(marker_positions, text_length, marker='ACME'):
+    """Recompute predict()'s contract independently of its implementation.
+
+    A chunk starting at ``offset`` drops anything before ``offset + OVERLAP``
+    unless it is the first chunk, because the previous chunk already covered it.
+    """
+    kept = set()
+    for chunk_idx, offset in enumerate(range(0, text_length, STRIDE)):
+        chunk_end = min(offset + CHUNK_SIZE, text_length)
+        for position in marker_positions:
+            if position < offset or position + len(marker) > chunk_end:
+                continue
+            if chunk_idx > 0 and position < offset + OVERLAP:
+                continue
+            kept.add((position, position + len(marker)))
+    return sorted(kept)
+
+
+# -----------------------------------------------------------------------------
+# Offsets and dedup across chunk boundaries
+# -----------------------------------------------------------------------------
+
+
+def test_multi_chunk_input_returns_absolute_offsets():
+    """Offsets are absolute, deduplicated, and ordered by position."""
+    positions = [10, 500, 1500, 2500, 3500]
+    text = build_text(positions)
+    model = _MarkerModel()
+
+    results = make_recognizer(model).predict(text, ['organization'])
+
+    assert model.calls > 1, 'the input must actually span several chunks'
+    spans = [(r['start'], r['end']) for r in results]
+    assert spans == sorted(spans), 'results must be ordered by offset'
+    assert spans == _expected_after_overlap_filter(positions, len(text))
+    for start, end in spans:
+        assert text[start:end] == 'ACME', 'offsets must point at the entity'
+
+
+def test_entity_in_an_overlap_region_is_not_duplicated():
+    """A marker inside two chunks' shared region is reported exactly once."""
+    # STRIDE..CHUNK_SIZE is covered by both chunk 0 and chunk 1.
+    position = STRIDE + 10
+    text = build_text([position])
+    model = _MarkerModel()
+
+    results = make_recognizer(model).predict(text, ['organization'])
+
+    assert [(r['start'], r['end']) for r in results] == [(position, position + 4)]
+
+
+def test_results_are_stable_across_runs():
+    """Thread completion order must not affect the returned sequence."""
+    positions = [10, 900, 1800, 2700, 3600]
+    text = build_text(positions)
+
+    runs = [
+        [(r['start'], r['end'], r['label']) for r in make_recognizer(_MarkerModel()).predict(text, ['organization'])]
+        for _ in range(5)
+    ]
+
+    assert all(run == runs[0] for run in runs), 'parallel execution must be deterministic'
+
+
+def test_single_chunk_input_keeps_every_entity():
+    """With one chunk there is no overlap region, so nothing is filtered.
+
+    Note the text must be no longer than STRIDE, not CHUNK_SIZE: chunk starts
+    step by STRIDE, so a CHUNK_SIZE-long text already produces a second chunk.
+    """
+    positions = [0, 100, 700]
+    text = build_text(positions, total_length=STRIDE)
+    model = _MarkerModel()
+
+    results = make_recognizer(model).predict(text, ['organization'])
+
+    assert model.calls == 1, 'this input must be a single chunk'
+    assert [(r['start'], r['end']) for r in results] == [(p, p + 4) for p in positions]
+
+
+def test_empty_text_yields_no_results():
+    model = _MarkerModel()
+
+    assert make_recognizer(model).predict('', ['organization']) == []
+    assert model.calls == 0
+
+
+# -----------------------------------------------------------------------------
+# Concurrency
+# -----------------------------------------------------------------------------
+
+
+def test_forward_pass_is_serialized_but_chunks_run_in_parallel():
+    """The lock covers predict_entities only, so calls never overlap."""
+    positions = [10, 900, 1800, 2700, 3600]
+    text = build_text(positions)
+    model = _MarkerModel(delay=0.02)
+
+    results = make_recognizer(model).predict(text, ['organization'])
+
+    assert model.calls >= 4, 'several chunks must be submitted'
+    assert model.max_active == 1, 'predict_entities must never run concurrently'
+    assert results, 'serialization must not lose results'
+
+
+def test_predict_still_uses_a_thread_pool():
+    """Guard against silently dropping back to a sequential loop.
+
+    The chunks are handed to worker threads, so predict_entities must be called
+    from threads other than the caller's.
+    """
+    positions = [10, 900, 1800, 2700]
+    text = build_text(positions)
+
+    calling_threads = set()
+    model = _MarkerModel()
+    original = model.predict_entities
+
+    def recording(chunk, labels):
+        calling_threads.add(threading.current_thread().name)
+        return original(chunk, labels)
+
+    model.predict_entities = recording
+
+    make_recognizer(model).predict(text, ['organization'])
+
+    assert threading.current_thread().name not in calling_threads, 'work must run off the calling thread'
+
+
+def test_a_failing_chunk_does_not_lose_the_others():
+    """One bad batch is logged and skipped; the rest still come back."""
+    positions = [10, 900, 1800, 2700, 3600]
+    text = build_text(positions)
+
+    model = _MarkerModel()
+    original = model.predict_entities
+    state = {'calls': 0}
+
+    def flaky(chunk, labels):
+        state['calls'] += 1
+        if state['calls'] == 2:
+            raise RuntimeError('CUDA error on this chunk')
+        return original(chunk, labels)
+
+    model.predict_entities = flaky
+
+    results = make_recognizer(model).predict(text, ['organization'])
+
+    assert results, 'a single chunk failure must not empty the result'
+
+
+@pytest.mark.parametrize('label_count', [1, 40, 70])
+def test_label_batching_covers_every_label(label_count):
+    """Labels are batched in 32s; every batch reaches the model once per chunk."""
+    # STRIDE keeps this to a single chunk, so calls == batches exactly.
+    text = build_text([10], total_length=STRIDE)
+    model = _MarkerModel()
+    labels = [f'label_{index}' for index in range(label_count)]
+
+    make_recognizer(model).predict(text, labels)
+
+    expected_batches = (label_count + 31) // 32
+    assert model.calls == expected_batches

--- a/nodes/test/text_output/test_validate_config.py
+++ b/nodes/test/text_output/test_validate_config.py
@@ -1,0 +1,208 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit tests for text_output configuration validation (no live SMB server).
+
+``validateConfig`` probes the target with ``connect()`` and has to separate two
+kinds of failure:
+
+* A configuration mistake the user must fix (rejected credential, share the
+  account may not enter, share name that does not exist) has to fail validation.
+* A server this host simply cannot reach must NOT fail validation. Validation
+  also runs on the Platform host, which frequently has no route to the
+  customer's share, and rejecting a correct configuration there is why the probe
+  used to be commented out.
+
+The classification uses NtStatus rather than errno, and these tests use the real
+``smbprotocol`` exception classes rather than doubles, because the reason errno
+does not work is a property of that package's real hierarchy: a rejected
+credential is not an ``OSError`` at all, and ``STATUS_ACCESS_DENIED`` is absent
+from the errno map so it arrives with ``errno == 0``. Doubles would let a broken
+classifier pass.
+"""
+
+import errno
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+NODES_SRC = Path(__file__).parent.parent.parent / 'src' / 'nodes'
+# Move to the front rather than "insert only if absent": another test dir already on
+# sys.path can hold a package with the same name as the node (see #1687).
+while str(NODES_SRC) in sys.path:
+    sys.path.remove(str(NODES_SRC))
+sys.path.insert(0, str(NODES_SRC))
+
+from text_output import endpoint as endpoint_module  # noqa: E402
+from text_output.endpoint import Endpoint  # noqa: E402
+
+smbprotocol_exceptions = pytest.importorskip('smbprotocol.exceptions')
+smbprotocol_header = pytest.importorskip('smbprotocol.header')
+
+SMBAuthenticationError = smbprotocol_exceptions.SMBAuthenticationError
+SMBConnectionClosed = smbprotocol_exceptions.SMBConnectionClosed
+SMBOSError = smbprotocol_exceptions.SMBOSError
+NtStatus = smbprotocol_header.NtStatus
+
+
+@pytest.fixture
+def recorded(monkeypatch):
+    """Capture engLib.error / engLib.warning instead of reporting to the engine."""
+    calls = {'error': [], 'warning': []}
+    monkeypatch.setattr(endpoint_module.engLib, 'error', lambda *a, **k: calls['error'].append(a))
+    monkeypatch.setattr(endpoint_module.engLib, 'warning', lambda *a, **k: calls['warning'].append(a))
+    return calls
+
+
+def make_endpoint(connect_error=None, **overrides):
+    """Build an Endpoint whose connect() raises the given error.
+
+    The configuration accessors are properties over ``endpoint.parameters``, so a
+    stub carrying that dict is enough; no engine object is needed.
+    """
+    parameters = {
+        'server': 'files.example.com',
+        'username': 'DOMAIN\\user',
+        'password': 'secret',
+        'storePath': 'share/folder',
+        'anonymize': False,
+    }
+    parameters.update(overrides)
+
+    instance = Endpoint.__new__(Endpoint)
+    instance.endpoint = types.SimpleNamespace(parameters=parameters, jobConfig={'type': 'config'})
+
+    def connect():
+        if connect_error is not None:
+            raise connect_error
+
+    instance.connect = connect
+    return instance
+
+
+# -----------------------------------------------------------------------------
+# The smbprotocol facts the classification depends on
+# -----------------------------------------------------------------------------
+
+
+def test_rejected_credential_is_not_an_oserror():
+    """Why errno cannot be used: this class never carries one."""
+    assert not issubclass(SMBAuthenticationError, OSError)
+    assert issubclass(SMBAuthenticationError, smbprotocol_exceptions.SMBException)
+
+
+def test_access_denied_is_not_mapped_onto_eacces():
+    """Why errno cannot be used: the status is absent from smbprotocol's map."""
+    denied = SMBOSError(NtStatus.STATUS_ACCESS_DENIED, '//server/share')
+
+    assert denied.errno == 0
+    assert denied.errno != errno.EACCES
+    assert denied.ntstatus == NtStatus.STATUS_ACCESS_DENIED
+
+
+def test_eperm_means_a_transient_sharing_violation():
+    """Why EPERM must not reject: it is 'file in use', not a config mistake."""
+    violation = SMBOSError(NtStatus.STATUS_SHARING_VIOLATION, '//server/share')
+
+    assert violation.errno == errno.EPERM
+
+
+# -----------------------------------------------------------------------------
+# Failures that must reject the configuration
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('label', 'error'),
+    [
+        ('rejected credential', SMBAuthenticationError('Failed to authenticate with server')),
+        ('access denied', SMBOSError(NtStatus.STATUS_ACCESS_DENIED, '//server/share')),
+        ('logon failure', SMBOSError(NtStatus.STATUS_LOGON_FAILURE, '//server/share')),
+        ('wrong password', SMBOSError(NtStatus.STATUS_WRONG_PASSWORD, '//server/share')),
+        ('expired password', SMBOSError(NtStatus.STATUS_PASSWORD_EXPIRED, '//server/share')),
+        ('privilege not held', SMBOSError(NtStatus.STATUS_PRIVILEGE_NOT_HELD, '//server/share')),
+        ('no such share', SMBOSError(NtStatus.STATUS_BAD_NETWORK_NAME, '//server/nope')),
+        ('name not found', SMBOSError(NtStatus.STATUS_OBJECT_NAME_NOT_FOUND, '//server/share')),
+        ('path not found', SMBOSError(NtStatus.STATUS_OBJECT_PATH_NOT_FOUND, '//server/share')),
+    ],
+)
+def test_configuration_mistakes_fail_validation(recorded, label, error):
+    make_endpoint(connect_error=error).validateConfig(syntaxOnly=False)
+
+    assert recorded['error'], f'{label} must fail validation'
+    assert not recorded['warning'], f'{label} must not be downgraded to a warning'
+
+
+def test_classifier_reports_configuration_mistakes_directly():
+    """The predicate is public, so exercise it without going through engLib."""
+    assert Endpoint.is_smb_config_error(SMBAuthenticationError('nope')) is True
+    assert Endpoint.is_smb_config_error(SMBOSError(NtStatus.STATUS_ACCESS_DENIED, '//s/x')) is True
+
+
+# -----------------------------------------------------------------------------
+# Failures that must NOT reject the configuration
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ('label', 'error'),
+    [
+        ('connection refused', ConnectionRefusedError(errno.ECONNREFUSED, 'Connection refused')),
+        ('host unreachable', OSError(errno.EHOSTUNREACH, 'No route to host')),
+        ('timed out', TimeoutError(errno.ETIMEDOUT, 'Connection timed out')),
+        ('smb io timeout', SMBOSError(NtStatus.STATUS_IO_TIMEOUT, '//server/share')),
+        ('transport closed', SMBConnectionClosed('The transport was closed')),
+        ('sharing violation', SMBOSError(NtStatus.STATUS_SHARING_VIOLATION, '//server/share')),
+        ('network name deleted', SMBOSError(NtStatus.STATUS_NETWORK_NAME_DELETED, '//server/share')),
+        ('unrelated failure', RuntimeError('something unexpected')),
+    ],
+)
+def test_unreachable_target_warns_without_rejecting(recorded, label, error):
+    make_endpoint(connect_error=error).validateConfig(syntaxOnly=False)
+
+    assert not recorded['error'], f'{label} must not reject the configuration'
+    assert recorded['warning'], f'{label} should still be reported'
+
+
+def test_warning_says_the_config_was_not_rejected(recorded):
+    """The log line has to make clear validation did not fail."""
+    make_endpoint(connect_error=ConnectionRefusedError(errno.ECONNREFUSED, 'refused')).validateConfig(syntaxOnly=False)
+
+    assert 'config not rejected' in str(recorded['warning'][0][0])
+
+
+# -----------------------------------------------------------------------------
+# Probe scope and syntax validation
+# -----------------------------------------------------------------------------
+
+
+def test_syntax_only_never_probes(recorded):
+    """A syntax-only pass must not touch the network, so a broken target is irrelevant."""
+    probed = []
+
+    instance = make_endpoint()
+    instance.connect = lambda: probed.append(1) or (_ for _ in ()).throw(AssertionError('probed'))
+
+    instance.validateConfig(syntaxOnly=True)
+
+    assert probed == []
+    assert not recorded['error']
+    assert not recorded['warning']
+
+
+def test_a_clean_probe_reports_nothing(recorded):
+    make_endpoint().validateConfig(syntaxOnly=False)
+
+    assert not recorded['error']
+    assert not recorded['warning']
+
+
+def test_invalid_server_name_still_fails_on_syntax(recorded):
+    """Parameter validation keeps failing through the ValueError branch."""
+    make_endpoint(server='not a valid host!').validateConfig(syntaxOnly=True)
+
+    assert recorded['error']


### PR DESCRIPTION
## Summary

- Move `depends()` to module level in `endpoint.py` so `smbprotocol` installs regardless of `OPEN_MODE`.
- Fix `STATUS_HEAP_CORRUPTION` in anonymize by removing the `ThreadPoolExecutor` from `glinerRecognizer.predict()` — GLiNER/PyTorch is not thread-safe and concurrent calls on the same model corrupt the native heap.

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1165


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection validation and error handling for text output storage.
  * Invalid credentials or inaccessible shares now fail validation, while temporary network issues produce warnings.

* **Reliability**
  * Improved anonymization consistency across overlapping text and label batches.
  * Simplified text output startup and shutdown behavior.

* **Configuration**
  * Added SMB server, username, password, storage path, and anonymization settings.
  * Expanded visibility of these options in text output configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->