### PR TITLE
fix(text-output): correct text output handling

### DIFF
--- a/nodes/src/nodes/text_output/endpoint.py
+++ b/nodes/src/nodes/text_output/endpoint.py
@@ -23,8 +23,6 @@
 
 import errno
 import re
-import smbclient
-from smbprotocol.exceptions import SMBOSError
 from threading import Lock
 from typing import Any
 from zlib import crc32
@@ -105,6 +103,9 @@ class Endpoint:
         Raise:
             An exception if connection failed.
         """
+        import smbclient
+        from smbprotocol.exceptions import SMBOSError
+
         # Setup user name and password
         if self.username and self.password:
             smbclient.ClientConfig(username=self.username, password=self.password)
@@ -232,6 +233,8 @@ class Endpoint:
     username = property(lambda self: self.endpoint.parameters.get('username'))
     password = property(lambda self: self.endpoint.parameters.get('password'))
     anonymize = property(lambda self: self.endpoint.parameters.get('anonymize', False))
+    anonymize_char = property(lambda self: self.endpoint.parameters.get('anonymizeChar', '\u2588'))
+    anonymize_all = property(lambda self: self.endpoint.parameters.get('anonymizeAll', False))
     store_path = property(lambda self: self.endpoint.parameters.get('storePath'))
 
     settings_changed: bool = property(lambda self: self._settings_changed())

--- a/nodes/src/nodes/text_output/instance.py
+++ b/nodes/src/nodes/text_output/instance.py
@@ -23,8 +23,6 @@
 
 import errno
 from os.path import dirname
-import smbclient
-from smbprotocol.exceptions import SMBOSError
 
 import engLib
 from engLib import Entry
@@ -81,6 +79,8 @@ class Instance:
 
     def close(self):
         """Call from engLib, process object complete."""
+        import smbclient
+
         if not self.current_object.objectFailed:
             try:
                 # Write only non-empty file
@@ -117,6 +117,9 @@ class Instance:
 
     def get_transform_key(self) -> str:
         """Build transform key for current object."""
+        import smbclient
+        from smbprotocol.exceptions import SMBOSError
+
         source_change_key = (
             self.current_object.changeKey or f'{self.current_object.modifyTime};{self.current_object.size}'
         )


### PR DESCRIPTION
## Summary

- Correct the `text_output` node's output handling (endpoint + instance).

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1166
