### PR TITLE
chore(deps): pin qdrant_client to a known-good version

### DIFF
--- a/nodes/src/nodes/qdrant/requirements.txt
+++ b/nodes/src/nodes/qdrant/requirements.txt
@@ -4,5 +4,5 @@ portalocker
 pydantic
 urllib3
 httpx
-qdrant_client
+qdrant_client==1.17.1
 numpy


### PR DESCRIPTION
## Summary

- Pin `qdrant_client` (1.17.1) so the qdrant node installs a known-good version.

## Testing

- [ ] CI (`./builder test`) — relying on GitHub Actions; not runnable in the contributor's local shell (engine build / Maven / torch unavailable). Static checks (compile, no conflict markers) pass.

## Linked Issue

Fixes #1167
