### PR TITLE
chore(release): bump server to 3.3.0 + cut CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — since 2026-03-29
+## [Unreleased] — since 2026-06-08
+
+## [3.3.0] - 2026-06-08
 
 ### ⚠ Breaking Changes — Client SDKs (`rocketride` / `rocketride-python`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride-server",
-	"version": "3.2.0",
+	"version": "3.3.0",
 	"description": "RocketRide Server - A high-performance data processing engine with modular nodes, AI capabilities, and cross-platform clients",
 	"private": true,
 	"license": "MIT",


### PR DESCRIPTION
Closes the "develop version trails main" gap (#66) and performs the **first real CHANGELOG cut** now that the mechanism (#1141) is in place.

## Changes
- **`package.json`**: server version `3.2.0` → **`3.3.0`** (minor — the accumulated `[Unreleased]` includes new features + the client-SDK layered-connection API rewrite). develop had trailed main's `3.2.1`.
- **`CHANGELOG.md`**: ran `scripts/release/cut-changelog.mjs 3.3.0 2026-06-08` → moved `[Unreleased]` into a dated `## [3.3.0] - 2026-06-08` section and opened a fresh empty `[Unreleased] — since 2026-06-08`.

Rides the normal develop → stage → main promotion, so the next stable release gets scoped GitHub Release notes (the gap behind #56).

## Scope / open question
- **Server only.** The client SDKs (`rocketride`, `rocketride-python`, `rocketride-mcp`, vscode) are independently versioned and currently **1.2.0** — left untouched.
- ⚠️ The `[3.3.0]` notes describe **breaking SDK changes** (layered `connect()`/`attach()`/`login()` API). If those ship in this train, the SDK packages likely need a coordinated bump (e.g. `1.2.0` → `1.3.0`) — **flagging for a maintainer call**, not done here.
- Historical note: `[3.3.0]` sits directly above `[1.0.3]` because the 3.2.x server versions were never cut into the CHANGELOG (the gap this mechanism fixes); reconciling the old headers is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)