### PR TITLE
chore(release): rename nightly.yaml → prerelease.yaml

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -400,7 +400,7 @@ jobs:
           {
             echo "body<<${DELIM}"
             if [ "${{ inputs.prerelease }}" = "true" ]; then
-              echo "_Automated nightly prerelease from \`${{ github.ref_name }}\` — **${{ matrix.name }}** v${{ matrix.version }}._"
+              echo "_Automated prerelease from \`${{ github.ref_name }}\` — **${{ matrix.name }}** v${{ matrix.version }}._"
               echo ""
             fi
             if [ -n "$NOTES" ]; then

--- a/.github/workflows/experimental-release.yaml
+++ b/.github/workflows/experimental-release.yaml
@@ -7,8 +7,8 @@ run-name: Experimental release ${{ inputs.ref }} → -${{ inputs.tag_suffix }}
 # publish a GitHub Release (with binaries attached) under a custom tag
 # suffix so workshop attendees can `gh release download` from it.
 #
-# Distinct from nightly.yaml/release.yaml because:
-#   - nightly.yaml hard-codes the `-prerelease` suffix and its
+# Distinct from prerelease.yaml/release.yaml because:
+#   - prerelease.yaml hard-codes the `-prerelease` suffix and its
 #     `cleanup-prereleases` step would wipe develop's current
 #     prerelease tags if run from another branch.
 #   - release.yaml has no suffix and auto-publishes to

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,12 +1,12 @@
-name: Nightly prerelease
-run-name: Nightly ${{ github.event_name == 'workflow_dispatch' && '(manual)' || '(auto)' }}
+name: Prerelease
+run-name: Prerelease ${{ github.event_name == 'workflow_dispatch' && '(manual)' || '(auto)' }}
 
 # `cancel-in-progress` is what makes the "every green develop commit"
 # cadence safe under load: if 5 PRs land in 30 minutes, only the last
 # one's nightly run completes — the previous 4 are cancelled mid-build.
 # Without this we'd burn ~25 min × 5 = 2 hours of CI minutes per burst.
 concurrency:
-  group: nightly
+  group: prerelease
   cancel-in-progress: true
 
 # Top-level least-privilege. Individual jobs below raise to write only

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,7 +7,7 @@ This document describes the automated release pipeline for the RocketRide Engine
 - [Overview](#overview)
 - [Packages](#packages)
 - [Branching Strategy](#branching-strategy)
-- [Nightly Prereleases](#nightly-prereleases)
+- [Prereleases](#prereleases)
 - [Stable Releases](#stable-releases)
 - [Version Management](#version-management)
 - [Release Notes](#release-notes)
@@ -22,7 +22,7 @@ The release pipeline consists of two workflows:
 
 | Workflow | Trigger | Purpose |
 |----------|---------|---------|
-| **Nightly** (`.github/workflows/nightly.yaml`) | Daily at 02:00 UTC or manual dispatch | Build and publish prereleases from `stage` |
+| **Prerelease** (`.github/workflows/prerelease.yaml`) | On successful `develop` CI (`workflow_run`) or manual dispatch | Build and publish GitHub prereleases (one per package) |
 | **Release** (`.github/workflows/release.yaml`) | Push to `main` | Build, publish to registries, and create stable GitHub Releases |
 
 Both workflows build the full project across three platforms (Linux, Windows, macOS), run tests, and package artifacts. The key difference is that nightly creates prereleases on GitHub only, while the release workflow publishes to external registries (npm, PyPI, VS Code Marketplace) and creates stable GitHub Releases.
@@ -82,11 +82,11 @@ hotfix/*  ──┘                  │         │
 - **`main`** — Stable release branch. When `stage` is merged into `main`, the release workflow triggers automatically.
 - **`feature/*`**, **`bugfix/*`**, **`hotfix/*`** — Short-lived branches that merge into `develop` via pull request.
 
-## Nightly Prereleases
+## Prereleases
 
-**Workflow:** `.github/workflows/nightly.yaml`
+**Workflow:** `.github/workflows/prerelease.yaml`
 
-**Trigger:** Runs automatically every day at 02:00 UTC, or can be triggered manually via GitHub Actions UI (`workflow_dispatch`).
+**Trigger:** Runs automatically on every successful `develop` CI run (`workflow_run` on the CI workflow), or can be triggered manually via the GitHub Actions UI (`workflow_dispatch`). (Formerly named "Nightly"; it is not a daily cron — it fires per green develop commit.)
 
 ### What happens
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -86,7 +86,7 @@ hotfix/*  ──┘                  │         │
 
 **Workflow:** `.github/workflows/prerelease.yaml`
 
-**Trigger:** Runs automatically on every successful `develop` CI run (`workflow_run` on the CI workflow), or can be triggered manually via the GitHub Actions UI (`workflow_dispatch`). (Formerly named "Nightly"; it is not a daily cron — it fires per green develop commit.)
+**Trigger:** Runs automatically on every successful `develop` CI run (`workflow_run` on the CI workflow), or can be triggered manually via the GitHub Actions UI (`workflow_dispatch`).
 
 ### What happens
 


### PR DESCRIPTION
Renames the misnamed `nightly.yaml` workflow → `prerelease.yaml`. It triggers on every successful `develop` CI run (`workflow_run`) + manual dispatch — **not** a 02:00 cron — so "nightly" was a misnomer (caught by Stepan).

- Rename file + workflow `name`/`run-name`/`concurrency` group → **Prerelease**
- RELEASE.md: path, section heading, and the stale "Daily at 02:00 UTC" trigger description (now: on develop CI success)
- experimental-release.yaml comment + the prerelease release-note string

No trigger/behavior change; nothing references the old workflow name via `workflow_run`, and it's post-merge (not a required PR check).

## Reworked from the earlier suffix approach
This PR previously added a `-prerelease.<run_number>` version suffix. **Stepan correctly flagged** that would break `scripts/lib/download.js` (L88), which detects prereleases via `releaseTag.endsWith('-prerelease')` — a `…-prerelease.<run>` tag would no longer match, so prereleases would never refresh. Dropped that approach.

The real "prerelease must be > stable" fix is **base-version bumps** (keeping the existing single force-pushed `-prerelease` tag scheme): server via #1187 (→3.3.0, merged), and the SDKs (typescript/python → 1.3.0) in a follow-up PR. vscode needs its own Marketplace odd-minor prerelease scheme (separate). Tracked in task #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)