### PR TITLE
feat(shell): branded waitlist button, loading screen, OAuth-loop guard

### DIFF
--- a/apps/shell-ui/rsbuild.config.mts
+++ b/apps/shell-ui/rsbuild.config.mts
@@ -194,6 +194,15 @@ export default defineConfig(({ command }) => {
 			},
 		},
 		dev: {
+			// Disable lazy compilation. It's incompatible with this dev setup
+			// (custom assetPrefix '/shell/' + writeToDisk + Module Federation): the
+			// on-demand `*_lazy-compilation-proxy` chunk for the async bootstrap
+			// boundary (index.tsx -> import('./bootstrap')) fails to load after a
+			// full-page navigation such as the OAuth redirect round-trip, throwing
+			// ChunkLoadError and triggering an HMR reload loop. Compiling everything
+			// up front keeps the bootstrap chunk always available.
+			lazyCompilation: false,
+
 			// Write built assets to disk during development so that the static file
 			// server (and other processes) can read the latest MF remote entries.
 			writeToDisk: true,

--- a/apps/shell-ui/src/components/layout/LoadingScreen.tsx
+++ b/apps/shell-ui/src/components/layout/LoadingScreen.tsx
@@ -1,0 +1,41 @@
+// MIT License — Copyright (c) 2026 Aparavi Software AG
+
+// =============================================================================
+// LOADING SCREEN — animated rocket mark shown during the boot/auth bootstrap
+// =============================================================================
+//
+// Replaces the plain "Loading..." text with the brand rocket mark gently
+// bobbing up and down, mirroring home-ui's AuthTransitionPage so the shell's
+// initial load and the post-OAuth transition read as one continuous animation.
+// Theme-aware via the same CSS custom properties the rest of the shell uses.
+// =============================================================================
+
+import React, { type CSSProperties } from 'react';
+import RocketRideMark from '../../icons/RocketRideMark';
+
+const container: CSSProperties = {
+	display: 'flex',
+	height: '100vh',
+	alignItems: 'center',
+	justifyContent: 'center',
+};
+
+const logoWrapper: CSSProperties = {
+	animation: 'rr-loading-float 2.4s ease-in-out infinite',
+};
+
+const KEYFRAMES = `@keyframes rr-loading-float {
+	0%, 100% { transform: translateY(0); }
+	50%       { transform: translateY(-8px); }
+}`;
+
+const LoadingScreen: React.FC = () => (
+	<div style={container}>
+		<style>{KEYFRAMES}</style>
+		<div style={logoWrapper}>
+			<RocketRideMark size={56} color="var(--rr-text-primary)" />
+		</div>
+	</div>
+);
+
+export default LoadingScreen;

--- a/apps/shell-ui/src/components/layout/Shell.tsx
+++ b/apps/shell-ui/src/components/layout/Shell.tsx
@@ -48,6 +48,7 @@ import type { ShellConfig } from '../../workspace/types';
 import { ShellLayout } from './ShellLayout';
 import { CheckoutFlow } from './CheckoutFlow';
 import { ApiKeyLogin } from './ApiKeyLogin';
+import LoadingScreen from './LoadingScreen';
 import { SS_PENDING_APP_ID } from '../../constants';
 
 // =============================================================================
@@ -71,6 +72,24 @@ const styles = {
 		color: 'var(--rr-fg-button)',
 		fontSize: 13,
 		cursor: 'pointer',
+	} as CSSProperties,
+	// Matches the landing page's "elevated" 3D button — brand fill with a colored
+	// bottom shadow that presses down on hover (see LandingNav.tsx).
+	elevatedButton: {
+		display: 'inline-flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: '7px 18px',
+		borderRadius: 6,
+		border: 'none',
+		backgroundColor: '#00b9ec',
+		color: '#ffffff',
+		fontSize: 14,
+		fontWeight: 600,
+		cursor: 'pointer',
+		boxShadow: '0 3px 0 0 #00708f',
+		transform: 'translateY(0)',
+		transition: 'background-color 0.1s ease, box-shadow 0.1s ease, transform 0.1s ease',
 	} as CSSProperties,
 	goodbyeContainer: {
 		display: 'flex',
@@ -292,6 +311,22 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 		return cm.on('shell:logoutRequest', () => handleLogout());
 	}, [cm, handleLogout]);
 
+	// "Back to Home" on the waitlist screen must LEAVE the session-locked app —
+	// not just sign out in place. A session-locked app (e.g. Canvas) is launched
+	// via the ?appId= URL param, which Shell reads on mount. logout() clears the
+	// token and SS_APP_ID but does NOT strip the URL, so a state-only logout
+	// leaves ?appId= in place; any re-init re-seeds the session lock and bootstrap
+	// fires OAuth again, dropping a still-waitlisted user right back on this screen
+	// (the infinite re-auth loop). Hard-navigate to the clean origin so ?appId= is
+	// gone and the next load starts fresh on the home experience. logout() clears
+	// the token + session app ids synchronously before its async disconnect, so
+	// those are wiped before the navigation unloads the page.
+	const handleBackToHome = useCallback(() => {
+		try { sessionStorage.removeItem('rr:auth:pending'); } catch { /* noop */ }
+		cm.logout();
+		window.location.href = window.location.origin + window.location.pathname;
+	}, [cm]);
+
 	// =====================================================================
 	// SIGN-IN HELPERS
 	// =====================================================================
@@ -396,7 +431,22 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 						you&apos;re in the queue. We&apos;ll send you an email as soon as
 						your account is activated &mdash; it shouldn&apos;t be long!
 					</div>
-					<button onClick={handleLogout} style={styles.signInButton}>Back to Home</button>
+					<button
+						onClick={handleBackToHome}
+						style={styles.elevatedButton}
+						onMouseEnter={(e) => {
+							e.currentTarget.style.backgroundColor = '#0099cc';
+							e.currentTarget.style.transform       = 'translateY(3px)';
+							e.currentTarget.style.boxShadow        = '0 1px 0 0 #00708f';
+						}}
+						onMouseLeave={(e) => {
+							e.currentTarget.style.backgroundColor = '#00b9ec';
+							e.currentTarget.style.transform       = 'translateY(0)';
+							e.currentTarget.style.boxShadow        = '0 3px 0 0 #00708f';
+						}}
+					>
+						Back to Home
+					</button>
 				</div>
 			</div>
 		);
@@ -404,7 +454,7 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 
 	// Loading
 	if (renderPhase === 'loading') {
-		return <div style={styles.statusScreen}>Loading...</div>;
+		return <LoadingScreen />;
 	}
 
 	// =====================================================================

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -301,6 +301,11 @@ export class ConnectionManager implements IConnectionManager {
 	/** Module-level flag to prevent double bootstrap under React StrictMode. */
 	private bootStarted = false;
 
+	/** One-shot guard: startOAuth always ends in a full-page redirect, so it must
+	 *  never run twice in one page load (double authorize → Zitadel invalidates the
+	 *  first code → PKCE 400 → re-auth loop). */
+	private oauthStarted = false;
+
 	/**
 	 * Redirect the browser to the OAuth provider for authorization.
 	 *
@@ -308,6 +313,10 @@ export class ConnectionManager implements IConnectionManager {
 	 * the legacy PKCE flow if no auth provider is configured.
 	 */
 	public async startOAuth(): Promise<void> {
+		// One-shot: a redirect is coming; never start a second authorize in the
+		// same page load (that invalidates the first code and 400s the exchange).
+		if (this.oauthStarted) return;
+		this.oauthStarted = true;
 		if (this.authProvider) {
 			await this.authProvider.signIn();
 			return;

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -315,22 +315,32 @@ export class ConnectionManager implements IConnectionManager {
 	public async startOAuth(): Promise<void> {
 		// One-shot: a redirect is coming; never start a second authorize in the
 		// same page load (that invalidates the first code and 400s the exchange).
+		// The guard is released on any path that does NOT actually navigate, so a
+		// failed initiation can still be retried within the same page load.
 		if (this.oauthStarted) return;
 		this.oauthStarted = true;
-		if (this.authProvider) {
-			await this.authProvider.signIn();
-			return;
+		try {
+			if (this.authProvider) {
+				await this.authProvider.signIn();
+				return;
+			}
+			// Legacy fallback — remove once all callers pass authProvider
+			if (!this.zitadelUrl || !this.zitadelClientId) {
+				console.error('[ConnectionManager] Zitadel not configured');
+				this.emit('shell:error', { error: new Error('Zitadel not configured') });
+				this.oauthStarted = false; // no redirect happened — allow a retry
+				return;
+			}
+			const { generatePkce, buildAuthUrl } = await import('../util/pkce');
+			const { challenge } = await generatePkce();
+			const url = buildAuthUrl(this.zitadelUrl, this.zitadelClientId, window.location.origin, challenge);
+			window.location.replace(url);
+		} catch (err) {
+			// Initiation threw before any redirect (signIn rejected, PKCE/crypto
+			// failure, etc.) — release the guard so a later attempt can retry.
+			this.oauthStarted = false;
+			throw err;
 		}
-		// Legacy fallback — remove once all callers pass authProvider
-		if (!this.zitadelUrl || !this.zitadelClientId) {
-			console.error('[ConnectionManager] Zitadel not configured');
-			this.emit('shell:error', { error: new Error('Zitadel not configured') });
-			return;
-		}
-		const { generatePkce, buildAuthUrl } = await import('../util/pkce');
-		const { challenge } = await generatePkce();
-		const url = buildAuthUrl(this.zitadelUrl, this.zitadelClientId, window.location.origin, challenge);
-		window.location.replace(url);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
Hardens the Shell auth flow against OAuth loops and adds branded loading/escape UX so waitlisted users return to a clean origin instead of being trapped in re-authorization.

## What changed
- Shell.tsx: branded elevatedButton + handleBackToHome (hard-nav to clean origin, escapes the ?appId= re-auth loop); new LoadingScreen component.
- connection.ts: oauthStarted one-shot guard fixes double-authorize → PKCE 400 loop.
- rsbuild.config.mts: lazyCompilation:false resolves OAuth-redirect ChunkLoadError with Module Federation + custom assetPrefix.

Note: an earlier static-asset cache-control change was intentionally cut.

## Test plan
- [ ] Cold load → OAuth redirect, no ChunkLoadError.
- [ ] Rapid re-entry fires only one /authorize (no PKCE 400).
- [ ] Waitlisted user → Back to Home lands on clean origin, no ?appId= loop.
- [ ] LoadingScreen renders during redirect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animated loading screen with a centered visual indicator during app initialization.

* **Bug Fixes**
  * Improved OAuth flow stability to prevent duplicate/startup retries and related navigation errors.
  * Fixed waitlist "Back to Home" behavior to clear pending session state and return users cleanly.
  * Development build config updated to avoid dev-time chunk-loading/HMR issues that could break redirects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->