### PR TITLE
chore(release): bump TS + Python SDKs to 1.3.0 (prerelease > stable)

### DIFF
--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride"
-version = "1.2.0"
+version = "1.3.0"
 description = "RocketRide Pipeline Python Client SDK"
 readme = "README.md"
 authors = [

--- a/packages/client-typescript/package.json
+++ b/packages/client-typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"author": "RocketRide, Inc.",
 	"license": "MIT",
 	"description": "TypeScript client for RocketRide data processing and AI services",


### PR DESCRIPTION
Follow-up to Stepan's review of #1188. The TS + Python client SDKs sit at **1.2.0 for both stable and prerelease** — the prerelease isn't ahead of stable. Bumping the base on `develop` to **1.3.0** fixes that: next prerelease tags become `client-{typescript,python}-v1.3.0-prerelease` (> stable `v1.2.0`), using the **existing** single force-pushed `-prerelease` tag scheme.

This is the correct "prerelease > stable" mechanism (base bump), as opposed to the run-number suffix originally in #1188 — which Stepan correctly noted would break `scripts/lib/download.js` (`releaseTag.endsWith('-prerelease')`). #1188 is now reduced to the workflow rename only.

## Scope
- ✅ **TS** (`rocketride` npm) 1.2.0 → 1.3.0
- ✅ **Python** (`rocketride` PyPI) 1.2.0 → 1.3.0
- ⏸️ **MCP** — already correct (stable 1.1.1 / prerelease 1.2.0), left as-is
- ⏸️ **vscode** — left out: Marketplace uses the odd-minor prerelease convention (stable even / prerelease odd), so a flat 1.3.0 bump is wrong for it; needs separate handling (task #70)
- Server already bumped to 3.3.0 (#1187, merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)