### PR TITLE
feat(ui): unify sidebar footer, add engine progress log

### DIFF
--- a/apps/shell-ui/src/components/layout/OverlayManager.tsx
+++ b/apps/shell-ui/src/components/layout/OverlayManager.tsx
@@ -29,13 +29,14 @@ import type { CSSProperties } from 'react';
 import { commonStyles } from 'shared/themes/styles';
 import AccountPage from '../../views/account/AccountPage';
 import SettingsPage from '../../views/settings/SettingsPage';
+import EnvironmentPage from '../../views/environment/EnvironmentPage';
 
 // =============================================================================
 // TYPES
 // =============================================================================
 
 /** Shell overlay pages that render as modal dialogs over the client area. */
-export type ShellOverlay = 'account' | 'settings' | null;
+export type ShellOverlay = 'account' | 'settings' | 'environment' | null;
 
 // =============================================================================
 // STYLES
@@ -124,6 +125,7 @@ export const OverlayManager: React.FC<OverlayManagerProps> = ({ children }) => {
 						<button style={styles.dialogClose} onClick={closeOverlay}>✕</button>
 						{overlay === 'account' && <AccountPage />}
 						{overlay === 'settings' && <SettingsPage />}
+						{overlay === 'environment' && <EnvironmentPage />}
 					</div>
 				</div>
 			)}

--- a/apps/shell-ui/src/components/layout/Sidebar.tsx
+++ b/apps/shell-ui/src/components/layout/Sidebar.tsx
@@ -327,15 +327,15 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 
 	const footerMenuItems: SidebarFooterMenuItem[] = useMemo(() => {
 		const items: SidebarFooterMenuItem[] = [
+			{ id: 'account', label: 'Account', icon: BxUser, onClick: () => onOverlay('account') },
+			{ id: 'settings', label: 'Settings', icon: BxCog, onClick: () => onOverlay('settings') },
 			{
-				id: 'theme', label: 'Theme', icon: BxPalette,
+				id: 'theme', label: 'Theme', icon: BxPalette, dividerBefore: true,
 				submenu: themeOptions.map((t) => ({
 					id: t.id, label: t.name, checked: prefs.theme === t.id,
 					onClick: () => handleThemeSelect(t.id),
 				})),
 			},
-			{ id: 'account', label: 'Account', icon: BxUser, onClick: () => onOverlay('account') },
-			{ id: 'settings', label: 'Settings', icon: BxCog, onClick: () => onOverlay('settings') },
 		];
 
 		if (showAppSwitcher) {
@@ -350,7 +350,7 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 			};
 
 			items.push({
-				id: 'apps', label: 'Switch App', icon: BxGridAlt, dividerBefore: true,
+				id: 'apps', label: 'Switch App', icon: BxGridAlt,
 				submenu: appManifest
 					.filter((a) => a.id !== 'rocketride.home' && a.id !== 'rocketride.hello')
 					.filter((a) => isOnDesktop(a.id))
@@ -362,7 +362,7 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 			});
 		}
 
-		items.push({ id: 'logout', label: 'Log out', icon: BxExport, dividerBefore: !showAppSwitcher, onClick: () => account.onLogout?.() });
+		items.push({ id: 'logout', label: 'Log out', icon: BxExport, dividerBefore: true, onClick: () => account.onLogout?.() });
 
 		return items;
 	}, [themeOptions, prefs.theme, showAppSwitcher, appManifest, activeAppId, isOnDesktop, account, handleThemeSelect, onOverlay]);

--- a/apps/shell-ui/src/components/layout/Sidebar.tsx
+++ b/apps/shell-ui/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ShellIdentityContext } from '../../hooks/useAuthUser';
 import {
-	BxCog, BxPalette, BxUser, BxExport, BxGridAlt, BxHome,
+	BxCog, BxLock, BxPalette, BxUser, BxExport, BxGridAlt, BxHome,
 } from '../../icons/BoxIcon';
 import { ConnectionManager } from '../../connection/connection';
 import type { IconComponent } from '../../icons/BoxIcon';
@@ -71,8 +71,8 @@ export interface SidebarProps {
 	account: ShellAccountConfig;
 	/** When true, the app switcher submenu in the footer is hidden. */
 	hideAppSwitcher?: boolean;
-	/** Callback to open a shell overlay (account, billing, settings). */
-	onOverlay: (overlay: 'account' | 'settings') => void;
+	/** Callback to open a shell overlay (account, settings, environment). */
+	onOverlay: (overlay: 'account' | 'settings' | 'environment') => void;
 }
 
 // =============================================================================
@@ -328,6 +328,7 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 	const footerMenuItems: SidebarFooterMenuItem[] = useMemo(() => {
 		const items: SidebarFooterMenuItem[] = [
 			{ id: 'account', label: 'Account', icon: BxUser, onClick: () => onOverlay('account') },
+			{ id: 'environment', label: 'Variables', icon: BxLock, onClick: () => onOverlay('environment') },
 			{ id: 'settings', label: 'Settings', icon: BxCog, onClick: () => onOverlay('settings') },
 			{
 				id: 'theme', label: 'Theme', icon: BxPalette, dividerBefore: true,

--- a/apps/shell-ui/src/views/environment/EnvironmentPage.tsx
+++ b/apps/shell-ui/src/views/environment/EnvironmentPage.tsx
@@ -1,0 +1,109 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * EnvironmentPage — thin shell-ui wrapper around shared-ui EnvironmentView.
+ *
+ * Owns all DAP fetching and auth wiring. Passes pure data and async
+ * callbacks down to the host-agnostic EnvironmentView. Unlike the VS Code
+ * wrapper, this page has direct access to the RocketRide client — no
+ * postMessage bridge required.
+ */
+
+import React, { useState, useCallback } from 'react';
+import { EnvironmentView } from 'shared/modules/environment';
+import type { EnvironmentSlotConfig } from 'shared/modules/environment';
+import { useShellConnection } from '../../connection/ConnectionContext';
+import { useAuthUser } from '../../hooks/useAuthUser';
+
+// =============================================================================
+// COMPONENT
+// =============================================================================
+
+/**
+ * Cloud-UI EnvironmentView wrapper.
+ *
+ * Fetches env data via the RocketRide client and delegates all rendering
+ * to the shared-ui EnvironmentView. Shell-UI always has a single SaaS
+ * connection, so a single slot is passed.
+ */
+const EnvironmentPage: React.FC = () => {
+	const { client, isConnected } = useShellConnection();
+	const authUser = useAuthUser();
+
+	// ── Error state ─────────────────────────────────────────────────────
+	const [error, setError] = useState<string | null>(null);
+
+	// ── Loaded env dicts keyed by `slotId:scope:scopeId` ────────────────
+	const [envs, setEnvs] = useState<Record<string, Record<string, string> | undefined>>({});
+
+	// ── Permission flags ────────────────────────────────────────────────
+	const orgId = authUser?.organizations?.[0]?.id;
+	const teamId = (authUser as any)?.defaultTeamId ?? authUser?.organizations?.[0]?.teams?.[0]?.id;
+	const isOrgAdmin = authUser?.organizations?.[0]?.permissions?.includes('org.admin') ?? false;
+	const isTeamAdmin = teamId
+		? (authUser?.organizations?.[0]?.teams?.find((t: any) => t.id === teamId)?.permissions?.includes('team.admin') ?? false)
+		: false;
+
+	// ── Single slot config ──────────────────────────────────────────────
+	const slots: EnvironmentSlotConfig[] = [{
+		id: 'default',
+		label: 'Environment',
+		isConnected,
+		isSaas: true,
+		isOrgAdmin,
+		isTeamAdmin,
+		orgId,
+		teamId,
+	}];
+
+	// ── Load callback ───────────────────────────────────────────────────
+	/**
+	 * Fetches env data for a scope and stores it in the envs dict.
+	 *
+	 * @param slotId - Slot identifier (always 'default' in shell-ui).
+	 * @param scope - Env scope: 'org', 'team', or 'user'.
+	 * @param scopeId - Required for 'org' and 'team' scopes.
+	 */
+	const handleLoadEnv = useCallback((slotId: string, scope: string, scopeId?: string) => {
+		if (!client) return;
+		const cacheKey = `${slotId}:${scope}:${scopeId ?? ''}`;
+		client.account.getEnv(scope as 'org' | 'team' | 'user', scopeId)
+			.then((env: Record<string, string>) => {
+				setEnvs((prev) => ({ ...prev, [cacheKey]: env }));
+				setError(null);
+			})
+			.catch((err: Error) => setError(err.message));
+	}, [client]);
+
+	// ── Save callback ───────────────────────────────────────────────────
+	/**
+	 * Persists env data for a scope and updates the local cache.
+	 *
+	 * @param slotId - Slot identifier (always 'default' in shell-ui).
+	 * @param scope - Env scope: 'org', 'team', or 'user'.
+	 * @param env - The full env dict to save.
+	 * @param scopeId - Required for 'org' and 'team' scopes.
+	 */
+	const handleSaveEnv = useCallback(async (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => {
+		if (!client) return;
+		await client.account.setEnv(scope as 'org' | 'team' | 'user', env, scopeId);
+		const cacheKey = `${slotId}:${scope}:${scopeId ?? ''}`;
+		setEnvs((prev) => ({ ...prev, [cacheKey]: env }));
+	}, [client]);
+
+	// ── Render ───────────────────────────────────────────────────────────
+	return (
+		<EnvironmentView
+			slots={slots}
+			envs={envs}
+			onLoadEnv={handleLoadEnv}
+			onSaveEnv={handleSaveEnv}
+			error={error}
+		/>
+	);
+};
+
+export default EnvironmentPage;

--- a/apps/vscode/src/connection/connection.ts
+++ b/apps/vscode/src/connection/connection.ts
@@ -183,10 +183,12 @@ export class ConnectionManager extends EventEmitter {
 					this.updateConnectionStatus({
 						state: ConnectionState.DISCONNECTED,
 						lastError: event.error ?? event.message,
+						progressLogLine: undefined,
 					});
 				} else {
 					this.updateConnectionStatus({
 						state: ConnectionState.DISCONNECTED,
+						progressLogLine: undefined,
 					});
 				}
 				break;
@@ -420,6 +422,7 @@ export class ConnectionManager extends EventEmitter {
 					lastError: undefined,
 					retryAttempt: 0,
 					progressMessage: undefined,
+					progressLogLine: undefined,
 				});
 				this.logger.output(`${icons.success} Connected to RocketRide server`);
 				this.emit('shell:connected');
@@ -462,6 +465,7 @@ export class ConnectionManager extends EventEmitter {
 						state: ConnectionState.AUTH_FAILED,
 						lastError: error.message,
 						progressMessage: undefined,
+						progressLogLine: undefined,
 					});
 
 					// Open the settings page focused on the failing group so the user can fix credentials
@@ -511,6 +515,7 @@ export class ConnectionManager extends EventEmitter {
 		this.updateConnectionStatus({
 			state: ConnectionState.DISCONNECTED,
 			progressMessage: undefined,
+			progressLogLine: undefined,
 		});
 	}
 

--- a/apps/vscode/src/connection/connection.ts
+++ b/apps/vscode/src/connection/connection.ts
@@ -162,6 +162,7 @@ export class ConnectionManager extends EventEmitter {
 					this.updateConnectionStatus({
 						state: ConnectionState.CONNECTING,
 						progressMessage: event.message,
+						progressLogLine: event.logLine,
 					});
 				}
 				break;

--- a/apps/vscode/src/engine/engine-backend.ts
+++ b/apps/vscode/src/engine/engine-backend.ts
@@ -34,6 +34,8 @@ export interface EngineStatusEvent {
 	version?: string;
 	/** Error description when phase is `error`. */
 	error?: string;
+	/** Optional engine log line (e.g. "Installing wheel...") shown in the sidebar progress log. */
+	logLine?: string;
 }
 
 /** Callback signature for emitting status events from a backend to its owner. */

--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -357,13 +357,19 @@ export class EngineLocal extends EngineBackend {
 				}
 			};
 
-			// Monitor stdout and stderr for the readiness message
+			// Monitor stdout and stderr for the readiness message.
+			// Lines starting with "[nnnn]" are engine progress — forward
+			// them to the sidebar via emitStatus during startup.
+			const engineLineRegex = /^\[\d+\w*\]\s*/;
 			const handleOutput = (data: Buffer): void => {
 				for (const line of data.toString().split('\n')) {
 					const msg = line.trim();
 					if (msg) {
 						this.logger.console(msg);
 						if (msg.includes('Uvicorn running')) tryResolveReady(msg);
+						else if (!processReady && engineLineRegex.test(msg)) {
+							this.emitStatus({ phase: 'working', message: 'Starting server...', logLine: msg.replace(engineLineRegex, '') });
+						}
 					}
 				}
 			};

--- a/apps/vscode/src/providers/BarStatusProvider.ts
+++ b/apps/vscode/src/providers/BarStatusProvider.ts
@@ -126,7 +126,7 @@ export class BarStatus {
 	 */
 	private handleConnectionStatusChange(status: ConnectionStatus): void {
 		if (status.state === ConnectionState.CONNECTED) {
-			const modeLabel: Record<string, string> = { cloud: 'Cloud', docker: 'Docker', service: 'Service', onprem: 'On-prem', local: 'Local' };
+			const modeLabel: Record<string, string> = { cloud: 'Cloud', docker: 'Docker', service: 'Service', onprem: 'Direct', local: 'Local' };
 			this.statusBarItem.text = `$(debug-console) RocketRide: Connected (${modeLabel[status.connectionMode] || status.connectionMode})`;
 			this.statusBarItem.command = 'rocketride.sidebar.connection.disconnect';
 			this.statusBarItem.tooltip = 'Connected - Click to disconnect';

--- a/apps/vscode/src/providers/SidebarProvider.ts
+++ b/apps/vscode/src/providers/SidebarProvider.ts
@@ -400,11 +400,13 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 				connectionMode: config.development.connectionMode,
 				developmentTeamId: config.development.teamId,
 				devProgressMessage: status.progressMessage,
+				devProgressLogLine: status.progressLogLine,
 				// Deploy connection
 				deployConnectionState: deployStatus.state,
 				deployConnectionMode: config.deployment.connectionMode,
 				deployTargetTeamId: config.deployment.teamId,
 				deployProgressMessage: deployStatus.progressMessage,
+				deployProgressLogLine: deployStatus.progressLogLine,
 				// Teams (from respective servers)
 				teams: this.getTeamsFromClient(this.connectionManager.getClient()),
 				deployTeams: this.getTeamsFromClient(this.deployManager.getClient()),

--- a/apps/vscode/src/providers/views/Environment/EnvironmentWebview.tsx
+++ b/apps/vscode/src/providers/views/Environment/EnvironmentWebview.tsx
@@ -1,267 +1,51 @@
 // =============================================================================
 // MIT License
 // Copyright (c) 2026 Aparavi Software AG
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
 // =============================================================================
 
 /**
- * EnvironmentWebview — VS Code webview bridge for environment variable management.
+ * EnvironmentWebview — VS Code messaging bridge for the shared EnvironmentView.
  *
- * Receives `env:*` messages from EnvironmentProvider via useMessaging, manages
- * local state for both connection slots, and renders EnvScopeCard components
- * for each accessible scope.
- *
- * The page adapts to the connection state:
- *   - Shared mode (deploy shares dev target): no pill bar, single panel
- *   - Independent mode: TabPanel with Development / Deployment pills
- *   - Per slot: OSS → single "Environment" card; SaaS → Org/Team/User cards
- *   - Disconnected slot → empty state message
+ * Translates `env:*` postMessage events from EnvironmentProvider into pure
+ * props for the host-agnostic EnvironmentView component. All rendering is
+ * delegated to shared-ui; this file only manages messaging state.
  *
  * Architecture:
- *   EnvironmentProvider (Node.js) ↔ postMessage ↔ EnvironmentWebview (browser)
+ *   EnvironmentProvider (Node.js) <-> postMessage <-> EnvironmentWebview (browser)
+ *     -> EnvironmentView (shared-ui)
  */
 
-import React, { useState, useCallback, useRef, useEffect, type CSSProperties } from 'react';
-import { EnvScopeCard } from 'shared/modules/account/components/EnvironmentPanel';
-import { TabPanel } from 'shared/components/tab-panel/TabPanel';
-import type { ITabPanelTab, ITabPanelPanel } from 'shared/components/tab-panel/TabPanel';
-import { commonStyles } from 'shared/themes/styles';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { EnvironmentView } from 'shared/modules/environment';
+import type { EnvironmentSlotConfig } from 'shared/modules/environment';
 import { useMessaging } from '../hooks/useMessaging';
 import type { EnvironmentHostToWebview, EnvironmentWebviewToHost, EnvironmentSlotState } from '../types';
 
 // =============================================================================
-// STYLES
-// =============================================================================
-
-/** Styles specific to the Environment page layout. */
-const styles = {
-	/** Outer container — fills the available space with a column layout. */
-	container: {
-		...commonStyles.columnFill,
-	} as CSSProperties,
-
-	/**
-	 * Content area when inside a TabPanel — identical to
-	 * commonStyles.tabContent used by Settings, Account, Monitor, etc.
-	 */
-	content: {
-		...commonStyles.tabContent,
-	} as CSSProperties,
-
-	/**
-	 * Content area in shared mode (no TabPanel / no pill bar).
-	 * Same layout as tabContent but 30px top since there's no
-	 * overlay pill bar to clear.
-	 */
-	contentShared: {
-		...commonStyles.tabContent,
-		paddingTop: 30,
-	} as CSSProperties,
-
-	/** Empty-state message shown when a slot is not connected. */
-	emptyState: {
-		display: 'flex',
-		alignItems: 'center',
-		justifyContent: 'center',
-		padding: '60px 24px',
-		color: 'var(--rr-text-disabled)',
-		fontSize: 13,
-		textAlign: 'center',
-	} as CSSProperties,
-
-	/** Page-level error banner. */
-	errorBanner: {
-		padding: '8px 16px',
-		margin: '0 24px 12px',
-		background: 'var(--rr-color-error-bg, rgba(244, 67, 54, 0.1))',
-		color: 'var(--rr-color-error)',
-		borderRadius: 4,
-		fontSize: 12,
-	} as CSSProperties,
-};
-
-// =============================================================================
-// SLOT PANEL — renders env cards for a single connection slot
+// COMPONENT
 // =============================================================================
 
 /**
- * Props for the EnvironmentSlotPanel sub-component.
- */
-interface SlotPanelProps {
-	/** Which connection slot this panel represents. */
-	slot: 'development' | 'deployment';
-
-	/** True when rendering without a TabPanel (shared mode). */
-	shared?: boolean;
-
-	/** Live connection state for this slot (undefined while init hasn't arrived). */
-	state: EnvironmentSlotState | undefined;
-
-	/** Loaded env dicts keyed by `slot:scope:scopeId`. */
-	envs: Record<string, Record<string, string> | undefined>;
-
-	/**
-	 * Sends a message to the extension host.
-	 * Stored in a ref so callbacks don't go stale.
-	 */
-	sendMessage: (msg: EnvironmentWebviewToHost) => void;
-
-	/** Keys that must have non-empty values before save is allowed (user scope only). */
-	requiredKeys?: string[];
-}
-
-/**
- * Renders the env scope cards for a single connection slot.
+ * VS Code webview entry point for the Environment page.
  *
- * - If the slot is not connected, shows an empty-state message.
- * - If the server is OSS (not SaaS), shows a single "Environment" card
- *   that maps to the org-level API call on the server.
- * - If the server is SaaS, shows up to three cards (Organization, Team, User)
- *   gated by the user's permissions.
- */
-const EnvironmentSlotPanel: React.FC<SlotPanelProps> = ({ slot, shared: isShared, state, envs, sendMessage, requiredKeys }) => {
-	/** Pick the right content padding based on whether we're inside a TabPanel. */
-	const contentStyle = isShared ? styles.contentShared : styles.content;
-	/**
-	 * Builds a unique cache key for an env dict entry.
-	 * Format: `development:org:abc123` or `deployment:user:`.
-	 */
-	const envKey = useCallback(
-		(scope: string, scopeId?: string) => `${slot}:${scope}:${scopeId ?? ''}`,
-		[slot]
-	);
-
-	// ── Not connected — empty state ─────────────────────────────────────
-	if (!state || !state.isConnected) {
-		const label = slot === 'development' ? 'Development' : 'Deployment';
-		return (
-			<div style={styles.emptyState}>
-				{label} server is not connected.
-				<br />
-				Connect in Settings to manage environment variables.
-			</div>
-		);
-	}
-
-	// ── OSS server — single flat card ───────────────────────────────────
-	// OSS has no org/team/user hierarchy; the entire .env file is
-	// accessed via the 'user' scope (rrext_account_me) on the server.
-	if (!state.isSaas) {
-		return (
-			<div style={contentStyle}>
-				<EnvScopeCard
-					label="Server"
-					env={envs[envKey('user')]}
-					onRequestLoad={() => sendMessage({ type: 'env:getEnv', slot, scope: 'user' })}
-					onSave={async (env) => {
-						sendMessage({ type: 'env:saveEnv', slot, scope: 'user', env });
-					}}
-					requiredKeys={requiredKeys}
-				/>
-			</div>
-		);
-	}
-
-	// ── SaaS server — scoped cards gated by permissions ─────────────────
-	return (
-		<div style={contentStyle}>
-			{/* Organization scope — only visible to org admins */}
-			{state.isOrgAdmin && state.orgId && (
-				<EnvScopeCard
-					label="Organization"
-					env={envs[envKey('org', state.orgId)]}
-					onRequestLoad={() => sendMessage({ type: 'env:getEnv', slot, scope: 'org', scopeId: state.orgId })}
-					onSave={async (env) => {
-						sendMessage({ type: 'env:saveEnv', slot, scope: 'org', env, scopeId: state.orgId });
-					}}
-				/>
-			)}
-
-			{/* Team scope — only visible to team admins */}
-			{state.isTeamAdmin && state.teamId && (
-				<EnvScopeCard
-					label="Team"
-					env={envs[envKey('team', state.teamId)]}
-					onRequestLoad={() => sendMessage({ type: 'env:getEnv', slot, scope: 'team', scopeId: state.teamId })}
-					onSave={async (env) => {
-						sendMessage({ type: 'env:saveEnv', slot, scope: 'team', env, scopeId: state.teamId });
-					}}
-				/>
-			)}
-
-			{/* User scope — always visible when connected to SaaS */}
-			<EnvScopeCard
-				label="User"
-				env={envs[envKey('user')]}
-				onRequestLoad={() => sendMessage({ type: 'env:getEnv', slot, scope: 'user' })}
-				onSave={async (env) => {
-					sendMessage({ type: 'env:saveEnv', slot, scope: 'user', env });
-				}}
-				requiredKeys={requiredKeys}
-			/>
-		</div>
-	);
-};
-
-// =============================================================================
-// MAIN COMPONENT
-// =============================================================================
-
-/**
- * EnvironmentWebview is the top-level React component for the Environment page.
- *
- * It manages the messaging bridge to EnvironmentProvider, holds state for
- * both connection slots, and renders either a single panel (shared mode) or
- * a TabPanel with dev/deploy pills (independent mode).
+ * Receives env:* messages from EnvironmentProvider, maintains local state,
+ * and passes pure props to the shared EnvironmentView.
  */
 const EnvironmentWebview: React.FC = () => {
-	// =========================================================================
-	// STATE
-	// =========================================================================
-
+	// ── State ────────────────────────────────────────────────────────────
 	/** Whether the init message has been received. */
 	const [ready, setReady] = useState(false);
 
-	/**
-	 * Whether deployment shares the development target.
-	 * When true, the pill bar is hidden and only the dev slot is shown.
-	 */
+	/** Whether deployment shares the development target. */
 	const [shared, setShared] = useState(false);
 
-	/** Currently active pill in the dev/deploy TabPanel. */
-	const [activeSlot, setActiveSlot] = useState<'development' | 'deployment'>('development');
-
-	/**
-	 * Per-slot connection state received from the extension host.
-	 * Keyed by slot name ('development' | 'deployment').
-	 */
+	/** Per-slot connection state keyed by slot name. */
 	const [slots, setSlots] = useState<Record<string, EnvironmentSlotState>>({});
 
-	/**
-	 * Loaded env dicts keyed by `slot:scope:scopeId`.
-	 * A key being present with `undefined` means the load hasn't completed;
-	 * a missing key means no load has been requested yet.
-	 */
+	/** Loaded env dicts keyed by `slotId:scope:scopeId`. */
 	const [envs, setEnvs] = useState<Record<string, Record<string, string> | undefined>>({});
 
-	/** Page-level error message (cleared on next successful operation). */
+	/** Page-level error message. */
 	const [error, setError] = useState<string | null>(null);
 
 	/** Keys that must have non-empty values before save is allowed. */
@@ -271,62 +55,42 @@ const EnvironmentWebview: React.FC = () => {
 	/** Ref to the latest sendMessage so callbacks don't go stale. */
 	const sendMessageRef = useRef<(msg: EnvironmentWebviewToHost) => void>(() => {});
 
-	// =========================================================================
-	// INCOMING MESSAGES
-	// =========================================================================
-
-	/**
-	 * Handles every message type the extension host can send to this webview.
-	 * Updates the corresponding React state slices.
-	 */
+	// ── Incoming messages ────────────────────────────────────────────────
 	const handleMessage = useCallback((message: EnvironmentHostToWebview) => {
 		switch (message.type) {
-			// -- Full initialisation (sent once on view:ready, and on reconnects) --
 			case 'env:init':
 				setShared(message.shared);
-				// Build a slot-keyed map from the array
 				setSlots(() => {
 					const map: Record<string, EnvironmentSlotState> = {};
-					for (const s of message.slots) {
-						map[s.slot] = s;
-					}
+					for (const s of message.slots) map[s.slot] = s;
 					return map;
 				});
-				// Clear cached env data — connection state may have changed
 				setEnvs({});
 				setError(null);
 				setReady(true);
 				break;
 
-			// -- Single slot update (connection change, permission change) ---------
 			case 'env:slotUpdate':
 				setSlots((prev) => ({ ...prev, [message.slot.slot]: message.slot }));
-				// If the slot disconnected, clear its cached env data
 				if (!message.slot.isConnected) {
 					setEnvs((prev) => {
 						const next: Record<string, Record<string, string> | undefined> = {};
 						for (const [key, val] of Object.entries(prev)) {
-							// Only keep entries that don't belong to the disconnected slot
-							if (!key.startsWith(`${message.slot.slot}:`)) {
-								next[key] = val;
-							}
+							if (!key.startsWith(`${message.slot.slot}:`)) next[key] = val;
 						}
 						return next;
 					});
 				}
 				break;
 
-			// -- Env data response (from getEnv or refreshed after saveEnv) --------
 			case 'env:data': {
 				const cacheKey = `${message.slot}:${message.scope}:${message.scopeId ?? ''}`;
 				let env = message.env;
-				// Only merge required keys into the development user scope
+				// Merge required keys into the development user scope
 				if (message.slot === 'development' && message.scope === 'user' && requiredKeysRef.current.length > 0) {
 					env = { ...env };
 					for (const key of requiredKeysRef.current) {
-						if (!(key in env)) {
-							env[key] = '';
-						}
+						if (!(key in env)) env[key] = '';
 					}
 				}
 				setEnvs((prev) => ({ ...prev, [cacheKey]: env }));
@@ -334,22 +98,17 @@ const EnvironmentWebview: React.FC = () => {
 				break;
 			}
 
-			// -- Error from the host ----------------------------------------------
 			case 'env:error':
 				setError(message.error);
 				break;
 
-			// -- Pre-fill missing env var keys into the user scope card ----------
 			case 'env:prefill': {
-				// Merge missing keys (with empty values) into the development user-scope env
 				const userKey = 'development:user:';
 				setEnvs((prev) => {
 					const existing = prev[userKey] ?? {};
 					const merged = { ...existing };
 					for (const key of message.keys) {
-						if (!(key in merged)) {
-							merged[key] = '';
-						}
+						if (!(key in merged)) merged[key] = '';
 					}
 					return { ...prev, [userKey]: merged };
 				});
@@ -360,92 +119,59 @@ const EnvironmentWebview: React.FC = () => {
 		}
 	}, []);
 
-	// =========================================================================
-	// MESSAGING HOOK
-	// =========================================================================
-
 	const { sendMessage } = useMessaging<EnvironmentWebviewToHost, EnvironmentHostToWebview>({
 		onMessage: handleMessage,
 	});
 
-	// Keep the ref in sync so callbacks created with useCallback don't go stale
-	useEffect(() => {
-		sendMessageRef.current = sendMessage;
-	}, [sendMessage]);
+	useEffect(() => { sendMessageRef.current = sendMessage; }, [sendMessage]);
 
-	/** Stable reference for child components to send messages. */
-	const stableSendMessage = useCallback(
-		(msg: EnvironmentWebviewToHost) => sendMessageRef.current(msg),
-		[]
-	);
+	// ── Callbacks for EnvironmentView ────────────────────────────────────
 
-	// =========================================================================
-	// TAB DEFINITIONS
-	// =========================================================================
+	/** Sends a getEnv request to the extension host. */
+	const handleLoadEnv = useCallback((slotId: string, scope: string, scopeId?: string) => {
+		sendMessageRef.current({ type: 'env:getEnv', slot: slotId as 'development' | 'deployment', scope, scopeId });
+	}, []);
 
-	/** Pills for the dev/deploy selector (only shown in independent mode). */
-	const tabs: ITabPanelTab[] = [
-		{ id: 'development', label: 'Development' },
-		{ id: 'deployment', label: 'Deployment' },
-	];
+	/** Sends a saveEnv request to the extension host. */
+	const handleSaveEnv = useCallback(async (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => {
+		sendMessageRef.current({ type: 'env:saveEnv', slot: slotId as 'development' | 'deployment', scope, env, scopeId });
+	}, []);
 
-	/** Panel content for each tab — renders an EnvironmentSlotPanel. */
-	const panels: Record<string, ITabPanelPanel> = {
-		development: {
-			content: (
-				<EnvironmentSlotPanel
-					slot="development"
-					state={slots['development']}
-					envs={envs}
-					sendMessage={stableSendMessage}
-					requiredKeys={requiredKeys}
-				/>
-			),
-		},
-		deployment: {
-			content: (
-				<EnvironmentSlotPanel
-					slot="deployment"
-					state={slots['deployment']}
-					envs={envs}
-					sendMessage={stableSendMessage}
-				/>
-			),
-		},
+	// ── Build slot configs for shared EnvironmentView ────────────────────
+
+	/** Converts an EnvironmentSlotState to an EnvironmentSlotConfig. */
+	const buildSlotConfigs = (): EnvironmentSlotConfig[] => {
+		const slotIds = shared ? ['development'] : ['development', 'deployment'];
+		return slotIds
+			.filter((id) => slots[id])
+			.map((id) => {
+				const s = slots[id];
+				return {
+					id,
+					label: id === 'development' ? 'Development' : 'Deployment',
+					isConnected: s.isConnected,
+					isSaas: s.isSaas,
+					isOrgAdmin: s.isOrgAdmin,
+					isTeamAdmin: s.isTeamAdmin,
+					orgId: s.orgId,
+					teamId: s.teamId,
+				};
+			});
 	};
 
-	// =========================================================================
-	// RENDER
-	// =========================================================================
+	// ── Render ───────────────────────────────────────────────────────────
 
-	// Don't render until the first env:init arrives
 	if (!ready) return null;
 
 	return (
-		<div style={styles.container}>
-			{/* Page-level error banner */}
-			{error && <div style={styles.errorBanner}>{error}</div>}
-
-			{shared ? (
-				// ── Shared mode — no pill bar, single dev panel ──────────────
-				<EnvironmentSlotPanel
-					slot="development"
-					shared
-					state={slots['development']}
-					envs={envs}
-					sendMessage={stableSendMessage}
-					requiredKeys={requiredKeys}
-				/>
-			) : (
-				// ── Independent mode — dev/deploy pill bar ───────────────────
-				<TabPanel
-					tabs={tabs}
-					activeTab={activeSlot}
-					onTabChange={(id) => setActiveSlot(id as 'development' | 'deployment')}
-					panels={panels}
-				/>
-			)}
-		</div>
+		<EnvironmentView
+			slots={buildSlotConfigs()}
+			envs={envs}
+			onLoadEnv={handleLoadEnv}
+			onSaveEnv={handleSaveEnv}
+			requiredKeys={requiredKeys}
+			error={error}
+		/>
 	);
 };
 

--- a/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
+++ b/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
@@ -78,11 +78,13 @@ type IncomingMessage =
 				connectionMode: string;
 				developmentTeamId?: string;
 				devProgressMessage?: string;
+				devProgressLogLine?: string;
 				// Deploy connection
 				deployConnectionState?: string;
 				deployConnectionMode?: string | null;
 				deployTargetTeamId?: string;
 				deployProgressMessage?: string;
+				deployProgressLogLine?: string;
 				// Teams (from respective servers)
 				teams?: TeamDTO[];
 				deployTeams?: TeamDTO[];
@@ -126,6 +128,11 @@ const SidebarViewWebview: React.FC = () => {
 	const [entries, setEntries] = useState<ProjectEntry[]>([]);
 	const [activeTasks, setActiveTasks] = useState<Map<string, ActiveTaskState>>(new Map());
 	const [unknownTasks, setUnknownTasks] = useState<UnknownTask[]>([]);
+
+	// ── Engine progress log (last N lines for popup display) ───────────────
+	const MAX_PROGRESS_LINES = 15;
+	const [devProgressLog, setDevProgressLog] = useState<string[]>([]);
+	const [deployProgressLog, setDeployProgressLog] = useState<string[]>([]);
 
 	// ── Shared auth + identity ──────────────────────────────────────────────
 	const [userName, setUserName] = useState<string | undefined>();
@@ -249,12 +256,26 @@ const SidebarViewWebview: React.FC = () => {
 					if (msg.data.developmentTeamId !== undefined) setDevelopmentTeamId(msg.data.developmentTeamId);
 					setDevProgressMessage(msg.data.devProgressMessage);
 
+					// Accumulate dev engine log lines; clear on connect
+					if (msg.data.connectionState === 'connected') {
+						setDevProgressLog([]);
+					} else if (msg.data.devProgressLogLine && msg.data.devProgressLogLine !== devProgressLog[devProgressLog.length - 1]) {
+						setDevProgressLog((prev) => prev[prev.length - 1] === msg.data.devProgressLogLine ? prev : [...prev.slice(-(MAX_PROGRESS_LINES - 1)), msg.data.devProgressLogLine!]);
+					}
+
 					// Deploy connection state
 					if (msg.data.deployConnectionState) setDeployConnectionState(msg.data.deployConnectionState);
 					if (msg.data.deployTeams) setDeployTeams(msg.data.deployTeams);
 					if (msg.data.deployConnectionMode !== undefined) setDeployTargetMode(msg.data.deployConnectionMode ?? null);
 					if (msg.data.deployTargetTeamId !== undefined) setDeployTargetTeamId(msg.data.deployTargetTeamId);
 					setDeployProgressMessage(msg.data.deployProgressMessage);
+
+					// Accumulate deploy engine log lines; clear on connect
+					if (msg.data.deployConnectionState === 'connected') {
+						setDeployProgressLog([]);
+					} else if (msg.data.deployProgressLogLine) {
+						setDeployProgressLog((prev) => prev[prev.length - 1] === msg.data.deployProgressLogLine ? prev : [...prev.slice(-(MAX_PROGRESS_LINES - 1)), msg.data.deployProgressLogLine!]);
+					}
 					// Subscription status
 					if ((msg.data as any).isSubscribed !== undefined) setSubscribed((msg.data as any).isSubscribed);
 					break;
@@ -391,25 +412,21 @@ const SidebarViewWebview: React.FC = () => {
 		}
 	};
 
-	// ── Flat vs popup mode ──────────────────────────────────────────────────
-	// Flat: shared connection + no cloud account → show status inline, no popup.
-	// Popup: independent deploy target OR cloud account → full popup menu.
+	// ── Footer menu items ───────────────────────────────────────────────────
 	const anyConnected = connection.state === 'connected' || deployConnectionState === 'connected';
-	const useFlatFooter = !deployTargetMode && !cloudConnected;
 
 	const footerMenuItems: SidebarFooterMenuItem[] = useMemo(() => {
-		if (useFlatFooter) return [];
-
 		const items: SidebarFooterMenuItem[] = [];
 
 		// ── Development section ─────────────────────────────────────────────
 		const devStatus = connectionStatusText(connection.state, developmentMode, devProgressMessage);
 		const devTeamLine = developmentMode === 'cloud' && devTeamName ? `Team: ${devTeamName}` : undefined;
+		const devLines = [devStatus, ...(devTeamLine ? [devTeamLine] : []), ...devProgressLog];
 		items.push({
 			id: 'dev-header',
 			label: 'Development',
 			header: true,
-			statusText: devTeamLine ? `${devStatus}\n${devTeamLine}` : devStatus,
+			statusText: devLines.join('\n'),
 			statusState: connection.state === 'connected' ? 'connected' : connection.state === 'connecting' ? 'connecting' : 'disconnected',
 			onClick: () => sendMessage({ type: 'command', command: 'rocketride.page.settings.open', args: ['development'] }),
 			submenu: developmentMode === 'cloud' && teams.length > 0 ? [...teams].sort((a, b) => a.name.localeCompare(b.name)).map((t: TeamDTO) => ({ id: `dev-${t.id}`, label: t.name, checked: developmentTeamId === t.id, onClick: () => sendMessage({ type: 'setDevelopmentTeam', teamId: t.id }) })) : undefined,
@@ -419,11 +436,12 @@ const SidebarViewWebview: React.FC = () => {
 		if (deployTargetMode) {
 			const deployStatus = connectionStatusText(deployConnectionState, deployTargetMode, deployProgressMessage);
 			const deployTeamLine = deployTargetMode === 'cloud' && deployTeamName ? `Team: ${deployTeamName}` : undefined;
+			const deployLines = [deployStatus, ...(deployTeamLine ? [deployTeamLine] : []), ...deployProgressLog];
 			items.push({
 				id: 'deploy-header',
 				label: 'Deployment',
 				header: true,
-				statusText: deployTeamLine ? `${deployStatus}\n${deployTeamLine}` : deployStatus,
+				statusText: deployLines.join('\n'),
 				statusState: deployConnectionState === 'connected' ? 'connected' : deployConnectionState === 'connecting' ? 'connecting' : 'disconnected',
 				onClick: () => sendMessage({ type: 'command', command: 'rocketride.page.settings.open', args: ['deployment'] }),
 				submenu: deployTargetMode === 'cloud' && deployTeams.length > 0 ? [...deployTeams].sort((a, b) => a.name.localeCompare(b.name)).map((t: TeamDTO) => ({ id: `deploy-${t.id}`, label: t.name, checked: deployTargetTeamId === t.id, onClick: () => sendMessage({ type: 'setDeployTargetTeam', teamId: t.id }) })) : undefined,
@@ -455,24 +473,10 @@ const SidebarViewWebview: React.FC = () => {
 		}
 
 		return items;
-	}, [sendMessage, cloudConnected, useFlatFooter, connection.state, teams, deployTeams, developmentMode, developmentTeamId, devTeamName, devProgressMessage, deployConnectionState, deployTargetMode, deployTargetTeamId, deployTeamName, deployProgressMessage, subscribed]);
-
-	// ── Flat-mode connection status ─────────────────────────────────────────
-	const flatConnectionStatus = useMemo(() => {
-		if (!useFlatFooter) return undefined;
-		const state = connection.state === 'connected' ? 'connected' as const : connection.state === 'connecting' ? 'connecting' as const : 'disconnected' as const;
-		// Line 1: connection state label (never the progress message).
-		// Line 2: progress/action message when the engine is doing something.
-		const modeStr = modeLabel(developmentMode);
-		const stateLabel = connection.state === 'connected' ? `Connected (${modeStr})` : connection.state === 'connecting' ? 'Connecting...' : connection.state === 'downloading-engine' ? 'Downloading engine...' : connection.state === 'starting-engine' ? 'Starting engine...' : connection.state === 'stopping-engine' ? 'Stopping engine...' : connection.state === 'auth-failed' ? 'Sign-in required' : 'Disconnected';
-		return { state, text: stateLabel, message: devProgressMessage };
-	}, [useFlatFooter, connection.state, developmentMode, devProgressMessage]);
-
-	const handleSettingsClick = useCallback(() => sendMessage({ type: 'command', command: 'rocketride.page.settings.open' }), [sendMessage]);
-	const handleEnvironmentClick = useCallback(() => sendMessage({ type: 'command', command: 'rocketride.page.environment.open' }), [sendMessage]);
+	}, [sendMessage, cloudConnected, connection.state, teams, deployTeams, developmentMode, developmentTeamId, devTeamName, devProgressMessage, devProgressLog, deployConnectionState, deployTargetMode, deployTargetTeamId, deployTeamName, deployProgressMessage, deployProgressLog, subscribed, anyConnected]);
 
 	// ── Footer slot ─────────────────────────────────────────────────────────
-	const footerSlot = <SidebarFooter collapsed={false} userName={userName} userEmail={userEmail} onOpenDocs={onOpenDocs} onEnvironmentClick={anyConnected ? handleEnvironmentClick : undefined} onSettingsClick={handleSettingsClick} connectionStatus={flatConnectionStatus} menuItems={footerMenuItems} />;
+	const footerSlot = <SidebarFooter collapsed={false} userName={userName} userEmail={userEmail} onOpenDocs={onOpenDocs} menuItems={footerMenuItems} />;
 
 	// ── Render ───────────────────────────────────────────────────────────────
 

--- a/apps/vscode/src/shared/types/connection.ts
+++ b/apps/vscode/src/shared/types/connection.ts
@@ -93,4 +93,7 @@ export interface ConnectionStatus {
 
 	/** Detailed progress message (e.g. download progress) shown during connecting states */
 	progressMessage?: string;
+
+	/** Engine log line for sidebar progress display (e.g. "Installing wheel..."). */
+	progressLogLine?: string;
 }

--- a/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
+++ b/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
@@ -383,7 +383,7 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 			)}
 
 			{/* ── Trigger row — avatar (signed in) or rocket branding (anonymous) */}
-			<div ref={triggerRef} style={S.avatarRow(hovered, menuOpen, collapsed)} onClick={() => setMenuOpen((v) => !v)} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+			<div ref={triggerRef} role="button" tabIndex={0} aria-haspopup="menu" aria-expanded={menuOpen} style={S.avatarRow(hovered, menuOpen, collapsed)} onClick={() => setMenuOpen((v) => !v)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setMenuOpen((v) => !v); } }} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
 				{userName ? (
 					<>
 						<div style={S.avatarCircle}>{initials}</div>
@@ -450,7 +450,10 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 													<div
 														key={i}
 														title={isProgressLine ? line : undefined}
+														role={isTeamLine ? 'button' : undefined}
+														tabIndex={isTeamLine ? 0 : undefined}
 														onClick={isTeamLine ? (e) => openFlyout(item.id, item.submenu!, (e.currentTarget.parentElement ?? e.currentTarget) as HTMLElement) : undefined}
+														onKeyDown={isTeamLine ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openFlyout(item.id, item.submenu!, (e.currentTarget.parentElement ?? e.currentTarget) as HTMLElement); } } : undefined}
 														style={{
 															paddingLeft: 10,
 															fontSize: isProgressLine ? 10 : 11,

--- a/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
+++ b/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
@@ -34,7 +34,7 @@ import { commonStyles } from '../../themes/styles';
 import { useFixedPopupPosition } from '../../hooks/useFixedPopupPosition';
 import { useAnnouncements } from '../../hooks/useAnnouncements';
 import { PopupRow } from '../PopupRow';
-import { BxBookOpen, BxChevronRight, BxCheck } from '../BoxIcon';
+import { BxBookOpen, BxChevronRight, BxCheck, BxCog } from '../BoxIcon';
 import type { IconComponent } from '../BoxIcon';
 
 // =============================================================================
@@ -388,7 +388,7 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 					<>
 						<div style={S.avatarCircle}>{initials}</div>
 						{!collapsed && (
-							<div style={S.nameBlock}>
+							<div style={{ ...S.nameBlock, flex: 1 }}>
 								<div style={S.nameText}>{userName}</div>
 								{userEmail && <div style={S.emailText}>{userEmail}</div>}
 							</div>
@@ -398,12 +398,13 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 					<>
 						<div style={S.rocketCircle}><RocketRideMark size={18} /></div>
 						{!collapsed && (
-							<div style={S.nameBlock}>
+							<div style={{ ...S.nameBlock, flex: 1 }}>
 								<div style={S.nameText}>RocketRide</div>
 							</div>
 						)}
 					</>
 				)}
+				{!collapsed && <BxCog size={16} color="var(--rr-text-secondary)" />}
 			</div>
 
 			{/* ── Popup menu (portalled to document.body to escape overflow:hidden) */}

--- a/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
+++ b/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
@@ -7,10 +7,14 @@
  * SidebarFooter — unified footer for both shell-ui and VS Code sidebars.
  *
  * Renders (top to bottom):
- *   1. Documentation button (optional, driven by onOpenDocs)
- *   2. Avatar trigger row (when userName is provided) OR gear icon fallback
- *      (when no userName but menuItems exist) — both open the popup menu
- *   3. Connection status row (optional, driven by connection prop)
+ *   1. Announcements ticker (when expanded and announcements are available)
+ *   2. Documentation button (optional, driven by onOpenDocs)
+ *   3. Trigger row — always present, whole row opens the popup menu:
+ *      - When userName is provided: avatar circle + name/email
+ *      - When anonymous: rocket icon + "RocketRide" branding
+ *   4. Connection status line(s) below the trigger row (optional):
+ *      - If one connection or both identical: single line
+ *      - If two different connections: two labelled lines
  *
  * Popup menu:
  *   - Main popup is 2/3 of sidebar width, inset by POPUP_MARGIN on each side.
@@ -19,11 +23,6 @@
  *     the VS Code webview bounds (popups cannot escape the webview iframe).
  *   - Selecting a flyout item closes only the flyout, keeping the main popup.
  *   - Click-outside dismisses everything (no hover timers).
- *
- * Three distinct footer states (driven by host):
- *   - Anonymous + engine:   gear icon trigger, Settings + Development Mode
- *   - Cloud identity + engine: avatar trigger, full menu
- *   - Cloud-UI (always cloud):  avatar trigger, Theme/Account/Billing/etc.
  */
 
 import React, { CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -35,7 +34,7 @@ import { commonStyles } from '../../themes/styles';
 import { useFixedPopupPosition } from '../../hooks/useFixedPopupPosition';
 import { useAnnouncements } from '../../hooks/useAnnouncements';
 import { PopupRow } from '../PopupRow';
-import { BxBookOpen, BxCog, BxChevronRight, BxCheck, BxLock } from '../BoxIcon';
+import { BxBookOpen, BxChevronRight, BxCheck } from '../BoxIcon';
 import type { IconComponent } from '../BoxIcon';
 
 // =============================================================================
@@ -51,6 +50,18 @@ const annMarkdownComponents = {
 		<span {...props} style={{ display: 'block', margin: 0, fontSize: 10 }} />
 	),
 };
+
+// =============================================================================
+// ROCKETRIDE MARK — branded rocket icon for anonymous trigger row
+// =============================================================================
+
+/** RocketRide rocket mark (icon only, no logotype). */
+const RocketRideMark: React.FC<{ size?: number }> = ({ size = 16 }) => (
+	<svg width={size} height={size} viewBox="0 0 211 211" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<path d="M159.501 180.6L153.701 186.4C151.901 188.2 148.901 188.2 147.001 186.4L126.601 166C115.601 155 115.601 137.2 126.601 126.2C138.101 114.7 138.101 96.1 126.601 84.6L125.101 83.1C113.601 71.6 95.0006 71.6 83.5006 83.1C72.5006 94.1 54.6006 94.1 43.6006 83.1L23.2006 62.7C21.4006 60.9 21.4006 57.9 23.2006 56L29.0006 50.2C37.0006 42.2 49.1006 39.7 59.6006 44.1L87.5006 55.5C97.3006 59.3 108.401 57.2 116.301 50.3L137.001 29.6C138.601 28.1 140.401 26.6 142.501 25.4C146.201 23.3 150.301 22.2 154.501 21.8L185.401 19.2C188.301 18.9 190.801 21.4 190.501 24.3L187.801 55.6C187.301 62 184.501 68 180.101 72.7L160.501 92.3C152.501 100.4 150.101 112.5 154.501 123L155.501 125.4L161.201 139.2L165.601 150.1C169.901 160.6 167.501 172.7 159.501 180.7V180.6Z" fill="currentColor"/>
+		<path d="M0.800333 209.5C-0.199667 208.5 -0.299667 206.8 0.600333 205.6L21.1003 181.2C31.1003 169.2 37.9003 156.9 41.3003 144.5C43.6003 135.8 44.6003 127.7 44.1003 120.4C44.1003 119.5 44.4003 118.6 45.1003 118C45.8003 117.4 46.8003 117.1 47.7003 117.3C65.0003 120.8 83.5003 117.5 98.5003 108.1C99.6003 107.4 101.1 107.6 102 108.5C102.9 109.4 103.1 110.9 102.4 112C93.0003 127 89.7003 145.5 93.2003 162.7C93.4003 163.5 93.2003 164.4 92.6003 165.1C92.0003 165.8 91.0003 166.4 90.1003 166.3C82.8003 165.8 74.6003 166.7 66.0003 169.1C53.6003 172.4 41.2003 179.2 29.3003 189.3L4.90033 209.8C3.80033 210.7 2.10033 210.7 1.00033 209.6H0.800333V209.5Z" fill="#F93822"/>
+	</svg>
+);
 
 // =============================================================================
 // TYPES
@@ -93,24 +104,9 @@ export interface SidebarFooterProps {
 	// ── Fixed footer buttons ────────────────────────────────────────────────
 	/** Show a Documentation link. */
 	onOpenDocs?: () => void;
-	/** Opens the Environment page (shown in flat mode when connected). */
-	onEnvironmentClick?: () => void;
-	/** Opens the Settings page directly (used in both flat and popup modes). */
-	onSettingsClick?: () => void;
-
-	// ── Inline connection status (flat mode) ────────────────────────────────
-	/**
-	 * When provided, the footer renders in "flat" mode: Documentation,
-	 * Settings, and connection status are shown directly — no popup.
-	 */
-	connectionStatus?: {
-		state: 'connected' | 'connecting' | 'disconnected';
-		text: string;
-		message?: string;
-	};
 
 	// ── Popup menu items ────────────────────────────────────────────────────
-	/** Host-specific menu items shown in the avatar popup. */
+	/** Host-specific menu items shown in the popup. */
 	menuItems?: SidebarFooterMenuItem[];
 }
 
@@ -192,23 +188,17 @@ const S = {
 		lineHeight: 1.3,
 	} as CSSProperties,
 
-	// ── Gear trigger (fallback when no user identity) ────────────────────────
-	gearTrigger: (hovered: boolean, menuOpen: boolean, collapsed: boolean): CSSProperties => ({
+	// ── Rocket icon circle (anonymous trigger) ──────────────────────────────
+	rocketCircle: {
+		width: 32,
+		height: 32,
+		borderRadius: '50%',
+		background: 'var(--rr-bg-surface-alt)',
 		display: 'flex',
 		alignItems: 'center',
-		gap: 8,
-		padding: collapsed ? '4px 0' : '6px 10px',
-		justifyContent: collapsed ? 'center' : 'flex-start',
-		borderRadius: 8,
-		cursor: 'pointer',
-		fontSize: 13,
-		color: 'var(--rr-text-secondary)',
-		border: 'none',
-		background: hovered || menuOpen ? 'var(--rr-bg-surface-alt)' : 'transparent',
-		transition: 'background 100ms ease',
-		width: '100%',
-		textAlign: 'left' as const,
-	}),
+		justifyContent: 'center',
+		flexShrink: 0,
+	} as CSSProperties,
 
 	// ── Popup divider ───────────────────────────────────────────────────────
 	divider: commonStyles.divider,
@@ -225,10 +215,10 @@ const S = {
 // COMPONENT
 // =============================================================================
 
-export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userName, userEmail, onOpenDocs, onEnvironmentClick, onSettingsClick, connectionStatus, menuItems }) => {
+export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userName, userEmail, onOpenDocs, menuItems }) => {
 	// ── Avatar initials ─────────────────────────────────────────────────────
 	const initials = useMemo(() => {
-		if (!userName) return 'U';
+		if (!userName) return '';
 		return userName
 			.split(' ')
 			.filter(Boolean)
@@ -242,7 +232,6 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 	const [menuOpen, setMenuOpen] = useState(false);
 	const [hovered, setHovered] = useState(false);
 	const [docsHovered, setDocsHovered] = useState(false);
-	const [envHovered, setEnvHovered] = useState(false);
 	const triggerRef = useRef<HTMLDivElement>(null);
 	const popupRef = useRef<HTMLDivElement>(null);
 	const [triggerWidth, setTriggerWidth] = useState(200);
@@ -332,9 +321,8 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 	}, [menuOpen]);
 
 	const topLevelItems = menuItems ?? [];
-	const flatMode = !!connectionStatus;
 
-	// ── Announcements ticker (flat mode) ────────────────────────────────────
+	// ── Announcements ticker ────────────────────────────────────────────────
 	const announcements = useAnnouncements();
 	const [tickerIndex, setTickerIndex] = useState(0);
 	const [tickerFade, setTickerFade] = useState(true);
@@ -352,86 +340,6 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 	}, [announcements.length]);
 
 	// ── Render ──────────────────────────────────────────────────────────────
-
-	// ── Flat mode: no popup, render items directly in the footer ────────
-	if (flatMode) {
-		const current = announcements[tickerIndex % Math.max(announcements.length, 1)];
-		return (
-			<div style={S.wrapper}>
-				{/* Announcements ticker */}
-				{current && (
-					<>
-						<div style={S.fullDivider} />
-						<div style={{ padding: '10px 12px', overflow: 'hidden' }}>
-							<div
-								style={{
-									opacity: tickerFade ? 1 : 0,
-									transition: 'opacity 300ms ease',
-								}}
-							>
-								<div style={{ fontSize: 13, fontWeight: 600, color: 'var(--rr-text-primary)', marginBottom: 4 }}>
-									<ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} components={annMarkdownComponents}>{current.title}</ReactMarkdown>
-								</div>
-								<div style={{ fontSize: 12, color: 'var(--rr-text-secondary)', lineHeight: 1.4, marginBottom: 6 }}>
-									<ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]} components={annMarkdownComponents}>{current.body}</ReactMarkdown>
-								</div>
-								<div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-									{current.link && /^https?:\/\//i.test(current.link) ? (
-										<a href={current.link} target="_blank" rel="noopener noreferrer" style={{ fontSize: 11, color: 'var(--rr-brand)', textDecoration: 'none', cursor: 'pointer' }}>Learn more &rarr;</a>
-									) : <span />}
-									{announcements.length > 1 && (
-										<div style={{ display: 'flex', gap: 2 }}>
-											<button type="button" aria-label="Previous announcement" onClick={() => { setTickerFade(false); setTimeout(() => { setTickerIndex((i) => (i - 1 + announcements.length) % announcements.length); setTickerFade(true); }, 150); }} style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontSize: 11, color: 'var(--rr-text-secondary)', lineHeight: 1 }}>&lsaquo;</button>
-											<button type="button" aria-label="Next announcement" onClick={() => { setTickerFade(false); setTimeout(() => { setTickerIndex((i) => (i + 1) % announcements.length); setTickerFade(true); }, 150); }} style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer', fontSize: 11, color: 'var(--rr-text-secondary)', lineHeight: 1 }}>&rsaquo;</button>
-										</div>
-									)}
-								</div>
-							</div>
-						</div>
-					</>
-				)}
-				{onOpenDocs && (
-					<button style={{ ...S.docsBtn, background: docsHovered ? 'var(--rr-bg-surface-alt)' : 'none' }} onMouseEnter={() => setDocsHovered(true)} onMouseLeave={() => setDocsHovered(false)} onClick={onOpenDocs}>
-						<BxBookOpen size={16} />
-						{!collapsed && 'Documentation'}
-					</button>
-				)}
-				{onEnvironmentClick && (
-					<button style={{ ...S.docsBtn, background: envHovered ? 'var(--rr-bg-surface-alt)' : 'none' }} onMouseEnter={() => setEnvHovered(true)} onMouseLeave={() => setEnvHovered(false)} onClick={onEnvironmentClick}>
-						<BxLock size={16} />
-						{!collapsed && 'Variables'}
-					</button>
-				)}
-				{onSettingsClick && (
-					<button style={S.gearTrigger(hovered, false, collapsed)} onClick={onSettingsClick} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
-						<BxCog size={20} />
-						{!collapsed && <span>Settings</span>}
-					</button>
-				)}
-				{/* Separator under Settings, above connection info */}
-				<div style={S.fullDivider} />
-				{!collapsed && (
-					<div style={{ padding: '4px 15px', fontSize: 11, color: 'var(--rr-text-secondary)' }}>
-						<div style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-							<span
-								style={{
-									width: 8,
-									height: 8,
-									borderRadius: '50%',
-									flexShrink: 0,
-									backgroundColor: connectionStatus.state === 'connected' ? 'var(--rr-color-success)' : 'var(--rr-text-secondary)',
-								}}
-							/>
-							<span>{connectionStatus.text}</span>
-						</div>
-						{connectionStatus.message && <div style={{ paddingLeft: 13, marginTop: 2, fontSize: 11, color: 'var(--rr-text-secondary)' }}>{connectionStatus.message}</div>}
-					</div>
-				)}
-			</div>
-		);
-	}
-
-	// ── Popup mode ──────────────────────────────────────────────────────
 
 	return (
 		<div style={S.wrapper}>
@@ -474,26 +382,29 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 				</button>
 			)}
 
-			{/* ── Avatar trigger row (when user identity is available) ── */}
-			{userName && (
-				<div ref={triggerRef} style={S.avatarRow(hovered, menuOpen, collapsed)} onClick={() => setMenuOpen((v) => !v)} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
-					<div style={S.avatarCircle}>{initials}</div>
-					{!collapsed && (
-						<div style={S.nameBlock}>
-							<div style={S.nameText}>{userName}</div>
-							{userEmail && <div style={S.emailText}>{userEmail}</div>}
-						</div>
-					)}
-				</div>
-			)}
-
-			{/* ── Gear trigger fallback (no identity, popup mode) ──────── */}
-			{!userName && menuItems && menuItems.length > 0 && (
-				<button ref={triggerRef as React.RefObject<HTMLButtonElement>} style={S.gearTrigger(hovered, menuOpen, collapsed)} onClick={() => setMenuOpen((v) => !v)} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
-					<BxCog size={20} />
-					{!collapsed && <span>Settings</span>}
-				</button>
-			)}
+			{/* ── Trigger row — avatar (signed in) or rocket branding (anonymous) */}
+			<div ref={triggerRef} style={S.avatarRow(hovered, menuOpen, collapsed)} onClick={() => setMenuOpen((v) => !v)} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+				{userName ? (
+					<>
+						<div style={S.avatarCircle}>{initials}</div>
+						{!collapsed && (
+							<div style={S.nameBlock}>
+								<div style={S.nameText}>{userName}</div>
+								{userEmail && <div style={S.emailText}>{userEmail}</div>}
+							</div>
+						)}
+					</>
+				) : (
+					<>
+						<div style={S.rocketCircle}><RocketRideMark size={18} /></div>
+						{!collapsed && (
+							<div style={S.nameBlock}>
+								<div style={S.nameText}>RocketRide</div>
+							</div>
+						)}
+					</>
+				)}
+			</div>
 
 			{/* ── Popup menu (portalled to document.body to escape overflow:hidden) */}
 			{menuOpen &&
@@ -530,15 +441,18 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 										{/* Status lines (e.g. "Connected (Local)" + "Team: Dev") */}
 										{item.statusText &&
 											item.statusText.split('\n').map((line, i) => {
-												// Last line with a submenu → clickable to open team flyout
-												const isTeamLine = i > 0 && item.submenu;
+												// Line 0 = connection status, line 1 with submenu = team selector,
+												// remaining lines = engine progress log (truncated with hover tooltip)
+												const isTeamLine = i > 0 && item.submenu && line.startsWith('Team:');
+												const isProgressLine = i > 0 && !isTeamLine;
 												return (
 													<div
 														key={i}
+														title={isProgressLine ? line : undefined}
 														onClick={isTeamLine ? (e) => openFlyout(item.id, item.submenu!, (e.currentTarget.parentElement ?? e.currentTarget) as HTMLElement) : undefined}
 														style={{
 															paddingLeft: 10,
-															fontSize: 11,
+															fontSize: isProgressLine ? 10 : 11,
 															fontWeight: 400,
 															textTransform: 'none',
 															letterSpacing: 'normal',
@@ -547,9 +461,12 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 															cursor: isTeamLine ? 'pointer' : 'default',
 															display: 'flex',
 															alignItems: 'center',
+															overflow: 'hidden',
+															textOverflow: 'ellipsis',
+															whiteSpace: 'nowrap',
 														}}
 													>
-														{/* Green/gray dot on the connection status line */}
+														{/* Colored dot on the connection status line */}
 														{i === 0 && item.statusState && (
 															<span
 																style={{
@@ -562,7 +479,7 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 																}}
 															/>
 														)}
-														<span style={{ flex: 1 }}>{line}</span>
+														<span style={{ flex: 1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{line}</span>
 														{isTeamLine && <BxChevronRight size={12} />}
 													</div>
 												);

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -72,6 +72,10 @@ export type { SidebarFooterProps, SidebarFooterMenuItem } from './components/sid
 export { default as AccountView } from './modules/account/AccountView';
 export type { IAccountViewProps } from './modules/account/AccountView';
 
+// --- Environment module (pipeline secrets / env vars) -------------------------
+export { EnvironmentView } from './modules/environment';
+export type { EnvironmentViewProps, EnvironmentSlotConfig } from './modules/environment';
+
 // --- Billing module (subscription management) --------------------------------
 // Types: import directly from 'rocketride' (BillingDetail, CreditBalance, etc.)
 export { BillingView } from './modules/billing';

--- a/packages/shared-ui/src/modules/environment/EnvironmentView.tsx
+++ b/packages/shared-ui/src/modules/environment/EnvironmentView.tsx
@@ -1,0 +1,287 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * EnvironmentView — host-agnostic environment variable management page.
+ *
+ * Pure component that receives all data as props and delegates server
+ * mutations to async callback props. The host application is responsible
+ * for fetching/saving env data via whatever transport it uses (direct
+ * client calls in shell-ui, postMessage bridge in VS Code).
+ *
+ * Rendering modes:
+ *   - Single slot: no tab bar, renders scope cards directly
+ *   - Multiple slots: TabPanel with a pill per slot (e.g. Development / Deployment)
+ *   - Per slot: OSS server → single "Server" card; SaaS → Org/Team/User cards
+ *   - Disconnected slot → empty-state message
+ */
+
+import React, { useCallback, useState } from 'react';
+import type { CSSProperties } from 'react';
+import { TabPanel } from '../../components/tab-panel/TabPanel';
+import type { ITabPanelTab, ITabPanelPanel } from '../../components/tab-panel/TabPanel';
+import { commonStyles } from '../../themes/styles';
+import { EnvScopeCard } from '../account/components/EnvironmentPanel';
+
+// =============================================================================
+// TYPES
+// =============================================================================
+
+/** Connection state and permissions for a single connection slot. */
+export interface EnvironmentSlotConfig {
+	/** Slot identifier (e.g. 'development', 'deployment', 'default'). */
+	id: string;
+	/** Display label for the tab (e.g. "Development", "Deployment"). */
+	label: string;
+	/** Whether this slot's server is connected. */
+	isConnected: boolean;
+	/** Whether the server is SaaS (true) or OSS (false). */
+	isSaas: boolean;
+	/** Whether the current user is an org admin on this slot. */
+	isOrgAdmin: boolean;
+	/** Whether the current user is a team admin on this slot. */
+	isTeamAdmin: boolean;
+	/** Organization ID (SaaS only). */
+	orgId?: string;
+	/** Team ID (SaaS only). */
+	teamId?: string;
+}
+
+/** Props for the host-agnostic EnvironmentView component. */
+export interface EnvironmentViewProps {
+	/** Connection slots to display. Single slot = no tabs, multiple = tab panel. */
+	slots: EnvironmentSlotConfig[];
+
+	/**
+	 * Loaded env dicts keyed by `slotId:scope:scopeId`.
+	 * A key with `undefined` means loading; missing key means not yet requested.
+	 */
+	envs: Record<string, Record<string, string> | undefined>;
+
+	/** Requests the host to load env data for a scope. */
+	onLoadEnv: (slotId: string, scope: string, scopeId?: string) => void;
+
+	/** Saves env data for a scope. */
+	onSaveEnv: (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => Promise<void>;
+
+	/** Keys that must have non-empty values before save is allowed (user scope only). */
+	requiredKeys?: string[];
+
+	/** Page-level error message. */
+	error?: string | null;
+}
+
+// =============================================================================
+// STYLES
+// =============================================================================
+
+const styles = {
+	/** Outer container — fills the available space with a column layout. */
+	container: {
+		...commonStyles.columnFill,
+	} as CSSProperties,
+
+	/** Content area when inside a TabPanel. */
+	content: {
+		...commonStyles.tabContent,
+	} as CSSProperties,
+
+	/** Content area in single-slot mode (no TabPanel / no pill bar). */
+	contentSingle: {
+		...commonStyles.tabContent,
+		paddingTop: 30,
+	} as CSSProperties,
+
+	/** Empty-state message shown when a slot is not connected. */
+	emptyState: {
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: '60px 24px',
+		color: 'var(--rr-text-disabled)',
+		fontSize: 13,
+		textAlign: 'center',
+	} as CSSProperties,
+
+	/** Page-level error banner. */
+	errorBanner: {
+		padding: '8px 16px',
+		margin: '0 24px 12px',
+		background: 'var(--rr-color-error-bg, rgba(244, 67, 54, 0.1))',
+		color: 'var(--rr-color-error)',
+		borderRadius: 4,
+		fontSize: 12,
+	} as CSSProperties,
+};
+
+// =============================================================================
+// SLOT PANEL — renders env cards for a single connection slot
+// =============================================================================
+
+/**
+ * Renders the env scope cards for a single connection slot.
+ *
+ * - Disconnected slot → empty-state message
+ * - OSS server → single "Server" card (user scope on the server)
+ * - SaaS server → up to three cards (Organization, Team, User)
+ *   gated by the user's permissions
+ */
+const SlotPanel: React.FC<{
+	/** Slot configuration. */
+	slot: EnvironmentSlotConfig;
+	/** Whether this is the only slot (no tab panel). */
+	single: boolean;
+	/** Loaded env dicts keyed by `slotId:scope:scopeId`. */
+	envs: Record<string, Record<string, string> | undefined>;
+	/** Requests env data load. */
+	onLoadEnv: (slotId: string, scope: string, scopeId?: string) => void;
+	/** Saves env data. */
+	onSaveEnv: (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => Promise<void>;
+	/** Required keys for user scope. */
+	requiredKeys?: string[];
+}> = ({ slot, single, envs, onLoadEnv, onSaveEnv, requiredKeys }) => {
+	/** Builds a cache key for an env dict entry. */
+	const envKey = useCallback(
+		(scope: string, scopeId?: string) => `${slot.id}:${scope}:${scopeId ?? ''}`,
+		[slot.id]
+	);
+
+	const contentStyle = single ? styles.contentSingle : styles.content;
+
+	// ── Not connected — empty state ─────────────────────────────────────
+	if (!slot.isConnected) {
+		return (
+			<div style={styles.emptyState}>
+				{slot.label} server is not connected.
+				<br />
+				Connect in Settings to manage environment variables.
+			</div>
+		);
+	}
+
+	// ── OSS server — single flat card ───────────────────────────────────
+	if (!slot.isSaas) {
+		return (
+			<div style={contentStyle}>
+				<EnvScopeCard
+					label="Server"
+					env={envs[envKey('user')]}
+					onRequestLoad={() => onLoadEnv(slot.id, 'user')}
+					onSave={async (env) => { await onSaveEnv(slot.id, 'user', env); }}
+					requiredKeys={requiredKeys}
+				/>
+			</div>
+		);
+	}
+
+	// ── SaaS server — scoped cards gated by permissions ─────────────────
+	return (
+		<div style={contentStyle}>
+			{/* Organization scope — only visible to org admins */}
+			{slot.isOrgAdmin && slot.orgId && (
+				<EnvScopeCard
+					label="Organization"
+					env={envs[envKey('org', slot.orgId)]}
+					onRequestLoad={() => onLoadEnv(slot.id, 'org', slot.orgId)}
+					onSave={async (env) => { await onSaveEnv(slot.id, 'org', env, slot.orgId); }}
+				/>
+			)}
+
+			{/* Team scope — only visible to team admins */}
+			{slot.isTeamAdmin && slot.teamId && (
+				<EnvScopeCard
+					label="Team"
+					env={envs[envKey('team', slot.teamId)]}
+					onRequestLoad={() => onLoadEnv(slot.id, 'team', slot.teamId)}
+					onSave={async (env) => { await onSaveEnv(slot.id, 'team', env, slot.teamId); }}
+				/>
+			)}
+
+			{/* User scope — always visible when connected to SaaS */}
+			<EnvScopeCard
+				label="User"
+				env={envs[envKey('user')]}
+				onRequestLoad={() => onLoadEnv(slot.id, 'user')}
+				onSave={async (env) => { await onSaveEnv(slot.id, 'user', env); }}
+				requiredKeys={requiredKeys}
+			/>
+		</div>
+	);
+};
+
+// =============================================================================
+// MAIN COMPONENT
+// =============================================================================
+
+/**
+ * EnvironmentView — host-agnostic environment variable management page.
+ *
+ * Renders env scope cards for one or more connection slots. When there
+ * is a single slot, cards render directly. When there are multiple
+ * slots, a TabPanel provides a pill bar to switch between them.
+ *
+ * @param props - Environment view configuration and callbacks.
+ */
+const EnvironmentView: React.FC<EnvironmentViewProps> = ({
+	slots,
+	envs,
+	onLoadEnv,
+	onSaveEnv,
+	requiredKeys,
+	error,
+}) => {
+	// ── Tab state (only used when multiple slots) ───────────────────────
+	const [activeTab, setActiveTab] = useState(slots[0]?.id ?? '');
+
+	const isSingle = slots.length <= 1;
+
+	// ── Build tab definitions ──────────────────────────────────────────
+	const tabs: ITabPanelTab[] = slots.map((s) => ({ id: s.id, label: s.label }));
+
+	const panels: Record<string, ITabPanelPanel> = {};
+	for (const slot of slots) {
+		panels[slot.id] = {
+			content: (
+				<SlotPanel
+					slot={slot}
+					single={isSingle}
+					envs={envs}
+					onLoadEnv={onLoadEnv}
+					onSaveEnv={onSaveEnv}
+					requiredKeys={requiredKeys}
+				/>
+			),
+		};
+	}
+
+	return (
+		<div style={styles.container}>
+			{/* Page-level error banner */}
+			{error && <div style={styles.errorBanner}>{error}</div>}
+
+			{isSingle ? (
+				// ── Single slot — no tab bar ────────────────────────────────
+				<SlotPanel
+					slot={slots[0]}
+					single
+					envs={envs}
+					onLoadEnv={onLoadEnv}
+					onSaveEnv={onSaveEnv}
+					requiredKeys={requiredKeys}
+				/>
+			) : (
+				// ── Multiple slots — tab bar ────────────────────────────────
+				<TabPanel
+					tabs={tabs}
+					activeTab={activeTab}
+					onTabChange={setActiveTab}
+					panels={panels}
+				/>
+			)}
+		</div>
+	);
+};
+
+export default EnvironmentView;

--- a/packages/shared-ui/src/modules/environment/index.ts
+++ b/packages/shared-ui/src/modules/environment/index.ts
@@ -1,0 +1,7 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+export { default as EnvironmentView } from './EnvironmentView';
+export type { EnvironmentViewProps, EnvironmentSlotConfig } from './EnvironmentView';


### PR DESCRIPTION
## Summary

- **Remove flat/popup mode split** in SidebarFooter — one consistent UX regardless of cloud auth or deploy target state
- **Always show identity row**: avatar + name when signed in, branded RocketRide mark when anonymous
- **Remove connection dots** from the footer (redundant with VS Code status bar); keep them inside the popup menu headers
- **Add engine progress log**: engine stdout lines starting with `[number]` are forwarded via a new `logLine` field through `EngineStatusEvent` -> `ConnectionStatus` -> `SidebarProvider` -> webview, which accumulates the last 15 unique lines under the connection header in the popup
- **Reorder shell-ui menu**: Account, Settings, ---, Theme, Switch App, ---, Log out
- **Fix status bar label**: "On-prem" -> "Direct" to match sidebar terminology

## Files changed

| File | Change |
|------|--------|
| `packages/shared-ui/.../SidebarFooter.tsx` | Remove flat mode branch, add RocketRide mark for anonymous, update popup rendering with progress lines |
| `apps/vscode/.../SidebarWebview.tsx` | Remove flat footer logic, always build menu items, accumulate engine log lines |
| `apps/vscode/.../engine-local.ts` | Emit `[number]`-prefixed stdout lines as `logLine` on status events |
| `apps/vscode/.../engine-backend.ts` | Add `logLine` to `EngineStatusEvent` interface |
| `apps/vscode/.../connection.ts` | Forward `logLine` to `progressLogLine` on `ConnectionStatus` |
| `apps/vscode/.../connection.ts` (types) | Add `progressLogLine` to `ConnectionStatus` |
| `apps/vscode/.../SidebarProvider.ts` | Send `devProgressLogLine` / `deployProgressLogLine` to webview |
| `apps/vscode/.../BarStatusProvider.ts` | Fix "On-prem" -> "Direct" label |
| `apps/shell-ui/.../Sidebar.tsx` | Reorder footer menu items |

## Test plan

- [ ] VSCode: verify anonymous footer shows rocket mark + "RocketRide" text
- [ ] VSCode: verify signed-in footer shows avatar + name/email
- [ ] VSCode: click trigger row opens popup menu in all states (local, cloud, deploy configured)
- [ ] VSCode: configure a local deploy target, trigger engine start, verify progress lines appear in popup under DEPLOYMENT header
- [ ] VSCode: verify duplicate consecutive lines are suppressed
- [ ] VSCode: verify progress log clears when connection reaches "connected"
- [ ] VSCode: verify status bar shows "Direct" instead of "On-prem"
- [ ] Shell-UI: verify menu order is Account, Settings, ---, Theme, (Switch App), ---, Log out

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment management view added to shell and VS Code sidebars with load/save actions and per-slot scope cards.
  * Engine progress log lines are now captured and shown in sidebar footers with short per-connection histories.

* **UI Improvements**
  * Sidebar footer consolidated to a single popup layout with clearer anonymous/user trigger and multiline status handling.
  * Connection label "On-prem" renamed to "Direct".
  * Footer menu order and dividers adjusted: environment/variables placed before theme; app switch divider removed; logout now has a divider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->