### PR TITLE
fix(ui): address PR #1191 CodeRabbit review comments

### DIFF
--- a/apps/shell-ui/src/views/environment/EnvironmentPage.tsx
+++ b/apps/shell-ui/src/views/environment/EnvironmentPage.tsx
@@ -14,7 +14,7 @@
 
 import React, { useState, useCallback } from 'react';
 import { EnvironmentView } from 'shared/modules/environment';
-import type { EnvironmentSlotConfig } from 'shared/modules/environment';
+import type { EnvironmentSlotConfig, EnvironmentScope } from 'shared/modules/environment';
 import { useShellConnection } from '../../connection/ConnectionContext';
 import { useAuthUser } from '../../hooks/useAuthUser';
 
@@ -67,15 +67,19 @@ const EnvironmentPage: React.FC = () => {
 	 * @param scope - Env scope: 'org', 'team', or 'user'.
 	 * @param scopeId - Required for 'org' and 'team' scopes.
 	 */
-	const handleLoadEnv = useCallback((slotId: string, scope: string, scopeId?: string) => {
+	const handleLoadEnv = useCallback((slotId: string, scope: EnvironmentScope, scopeId?: string) => {
 		if (!client) return;
 		const cacheKey = `${slotId}:${scope}:${scopeId ?? ''}`;
-		client.account.getEnv(scope as 'org' | 'team' | 'user', scopeId)
+		client.account.getEnv(scope, scopeId)
 			.then((env: Record<string, string>) => {
 				setEnvs((prev) => ({ ...prev, [cacheKey]: env }));
 				setError(null);
 			})
-			.catch((err: Error) => setError(err.message));
+			.catch((err: Error) => {
+				// Store empty dict so the card exits the loading state
+				setEnvs((prev) => ({ ...prev, [cacheKey]: prev[cacheKey] ?? {} }));
+				setError(err.message);
+			});
 	}, [client]);
 
 	// ── Save callback ───────────────────────────────────────────────────
@@ -87,9 +91,9 @@ const EnvironmentPage: React.FC = () => {
 	 * @param env - The full env dict to save.
 	 * @param scopeId - Required for 'org' and 'team' scopes.
 	 */
-	const handleSaveEnv = useCallback(async (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => {
+	const handleSaveEnv = useCallback(async (slotId: string, scope: EnvironmentScope, env: Record<string, string>, scopeId?: string) => {
 		if (!client) return;
-		await client.account.setEnv(scope as 'org' | 'team' | 'user', env, scopeId);
+		await client.account.setEnv(scope, env, scopeId);
 		const cacheKey = `${slotId}:${scope}:${scopeId ?? ''}`;
 		setEnvs((prev) => ({ ...prev, [cacheKey]: env }));
 	}, [client]);

--- a/apps/vscode/src/providers/EnvironmentProvider.ts
+++ b/apps/vscode/src/providers/EnvironmentProvider.ts
@@ -173,9 +173,10 @@ export class EnvironmentProvider {
 
 			// -- Load env for a specific slot + scope ----------------------------
 			case 'env:getEnv': {
+				const ctx = { slot: message.slot, scope: message.scope, scopeId: message.scopeId };
 				const resolved = this.resolveSlotClient(message.slot);
 				if (!resolved) {
-					this.postError(panel, `${message.slot} server is not connected`);
+					this.postError(panel, `${message.slot} server is not connected`, ctx);
 					break;
 				}
 				try {
@@ -191,16 +192,17 @@ export class EnvironmentProvider {
 						env,
 					});
 				} catch (err: unknown) {
-					this.postError(panel, err instanceof Error ? err.message : String(err));
+					this.postError(panel, err instanceof Error ? err.message : String(err), ctx);
 				}
 				break;
 			}
 
 			// -- Save env for a specific slot + scope ----------------------------
 			case 'env:saveEnv': {
+				const ctx = { slot: message.slot, scope: message.scope, scopeId: message.scopeId };
 				const resolved = this.resolveSlotClient(message.slot);
 				if (!resolved) {
-					this.postError(panel, `${message.slot} server is not connected`);
+					this.postError(panel, `${message.slot} server is not connected`, ctx);
 					break;
 				}
 				try {
@@ -222,7 +224,7 @@ export class EnvironmentProvider {
 					const manager = message.slot === 'development' ? this.connectionManager : this.deployManager;
 					manager.emit('shell:envKeysChanged');
 				} catch (err: unknown) {
-					this.postError(panel, err instanceof Error ? err.message : String(err));
+					this.postError(panel, err instanceof Error ? err.message : String(err), ctx);
 				}
 				break;
 			}
@@ -406,9 +408,15 @@ export class EnvironmentProvider {
 	 *
 	 * @param panel   - The webview panel.
 	 * @param message - The error description.
+	 * @param context - Optional slot/scope context so the webview can clear
+	 *                  per-card loading state for the specific key that failed.
 	 */
-	private postError(panel: vscode.WebviewPanel, message: string): void {
-		panel.webview.postMessage({ type: 'env:error', error: message }).then(undefined, (err: unknown) => {
+	private postError(
+		panel: vscode.WebviewPanel,
+		message: string,
+		context?: { slot: 'development' | 'deployment'; scope: 'org' | 'team' | 'user'; scopeId?: string },
+	): void {
+		panel.webview.postMessage({ type: 'env:error', error: message, ...context }).then(undefined, (err: unknown) => {
 			console.error(`[EnvironmentProvider] Failed to post error: ${err}`);
 		});
 	}

--- a/apps/vscode/src/providers/views/Environment/EnvironmentWebview.tsx
+++ b/apps/vscode/src/providers/views/Environment/EnvironmentWebview.tsx
@@ -17,7 +17,7 @@
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { EnvironmentView } from 'shared/modules/environment';
-import type { EnvironmentSlotConfig } from 'shared/modules/environment';
+import type { EnvironmentSlotConfig, EnvironmentScope } from 'shared/modules/environment';
 import { useMessaging } from '../hooks/useMessaging';
 import type { EnvironmentHostToWebview, EnvironmentWebviewToHost, EnvironmentSlotState } from '../types';
 
@@ -54,6 +54,12 @@ const EnvironmentWebview: React.FC = () => {
 
 	/** Ref to the latest sendMessage so callbacks don't go stale. */
 	const sendMessageRef = useRef<(msg: EnvironmentWebviewToHost) => void>(() => {});
+
+	/**
+	 * Pending save resolvers keyed by `slot:scope:scopeId`.
+	 * Resolved when env:data arrives for that key, rejected on env:error.
+	 */
+	const pendingSavesRef = useRef<Map<string, { resolve: () => void; reject: (err: Error) => void }>>(new Map());
 
 	// ── Incoming messages ────────────────────────────────────────────────
 	const handleMessage = useCallback((message: EnvironmentHostToWebview) => {
@@ -95,11 +101,28 @@ const EnvironmentWebview: React.FC = () => {
 				}
 				setEnvs((prev) => ({ ...prev, [cacheKey]: env }));
 				setError(null);
+				// Resolve any pending save for this key (host confirmed persistence)
+				pendingSavesRef.current.get(cacheKey)?.resolve();
+				pendingSavesRef.current.delete(cacheKey);
 				break;
 			}
 
 			case 'env:error':
 				setError(message.error);
+				// If the error includes scope context, clear loading state for
+				// the specific cache key so the card doesn't stay stuck
+				if (message.slot && message.scope) {
+					const failedKey = `${message.slot}:${message.scope}:${message.scopeId ?? ''}`;
+					setEnvs((prev) => {
+						if (prev[failedKey] === undefined) {
+							return { ...prev, [failedKey]: {} };
+						}
+						return prev;
+					});
+					// Reject any pending save for this key
+					pendingSavesRef.current.get(failedKey)?.reject(new Error(message.error));
+					pendingSavesRef.current.delete(failedKey);
+				}
 				break;
 
 			case 'env:prefill': {
@@ -128,13 +151,24 @@ const EnvironmentWebview: React.FC = () => {
 	// ── Callbacks for EnvironmentView ────────────────────────────────────
 
 	/** Sends a getEnv request to the extension host. */
-	const handleLoadEnv = useCallback((slotId: string, scope: string, scopeId?: string) => {
+	const handleLoadEnv = useCallback((slotId: string, scope: EnvironmentScope, scopeId?: string) => {
 		sendMessageRef.current({ type: 'env:getEnv', slot: slotId as 'development' | 'deployment', scope, scopeId });
 	}, []);
 
-	/** Sends a saveEnv request to the extension host. */
-	const handleSaveEnv = useCallback(async (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => {
+	/**
+	 * Sends a saveEnv request and waits for the host to confirm persistence.
+	 *
+	 * Resolves when env:data arrives for the same key (host re-fetches and
+	 * sends canonical data after a successful save). Rejects on env:error.
+	 */
+	const handleSaveEnv = useCallback(async (slotId: string, scope: EnvironmentScope, env: Record<string, string>, scopeId?: string) => {
+		const cacheKey = `${slotId}:${scope}:${scopeId ?? ''}`;
+		// Create a promise that resolves when the host confirms
+		const confirmation = new Promise<void>((resolve, reject) => {
+			pendingSavesRef.current.set(cacheKey, { resolve, reject });
+		});
 		sendMessageRef.current({ type: 'env:saveEnv', slot: slotId as 'development' | 'deployment', scope, env, scopeId });
+		await confirmation;
 	}, []);
 
 	// ── Build slot configs for shared EnvironmentView ────────────────────

--- a/apps/vscode/src/providers/views/environmentTypes.ts
+++ b/apps/vscode/src/providers/views/environmentTypes.ts
@@ -80,6 +80,12 @@ export type EnvironmentHostToWebview =
 			type: 'env:error';
 			/** Human-readable error description. */
 			error: string;
+			/** Which connection slot the error belongs to (if known). */
+			slot?: 'development' | 'deployment';
+			/** The scope level that failed (if known). */
+			scope?: 'org' | 'team' | 'user';
+			/** Optional scope identifier for the failed operation. */
+			scopeId?: string;
 	  }
 	| {
 			/** Pre-fill missing env var keys as empty entries in the user scope card. */

--- a/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
+++ b/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
@@ -383,7 +383,7 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 			)}
 
 			{/* ── Trigger row — avatar (signed in) or rocket branding (anonymous) */}
-			<div ref={triggerRef} role="button" tabIndex={0} aria-haspopup="menu" aria-expanded={menuOpen} style={S.avatarRow(hovered, menuOpen, collapsed)} onClick={() => setMenuOpen((v) => !v)} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setMenuOpen((v) => !v); } }} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
+			<div ref={triggerRef} role="button" tabIndex={0} aria-haspopup="menu" aria-expanded={menuOpen} style={S.avatarRow(hovered, menuOpen, collapsed)} onClick={() => { if (menuOpen) handleClose(); else setMenuOpen(true); }} onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); if (menuOpen) handleClose(); else setMenuOpen(true); } }} onMouseEnter={() => setHovered(true)} onMouseLeave={() => setHovered(false)}>
 				{userName ? (
 					<>
 						<div style={S.avatarCircle}>{initials}</div>
@@ -452,8 +452,8 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 														title={isProgressLine ? line : undefined}
 														role={isTeamLine ? 'button' : undefined}
 														tabIndex={isTeamLine ? 0 : undefined}
-														onClick={isTeamLine ? (e) => openFlyout(item.id, item.submenu!, (e.currentTarget.parentElement ?? e.currentTarget) as HTMLElement) : undefined}
-														onKeyDown={isTeamLine ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openFlyout(item.id, item.submenu!, (e.currentTarget.parentElement ?? e.currentTarget) as HTMLElement); } } : undefined}
+														onClick={isTeamLine ? (e) => openFlyout(item.id, item.submenu!, e.currentTarget as HTMLElement) : undefined}
+														onKeyDown={isTeamLine ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openFlyout(item.id, item.submenu!, e.currentTarget as HTMLElement); } } : undefined}
 														style={{
 															paddingLeft: 10,
 															fontSize: isProgressLine ? 10 : 11,

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -74,7 +74,7 @@ export type { IAccountViewProps } from './modules/account/AccountView';
 
 // --- Environment module (pipeline secrets / env vars) -------------------------
 export { EnvironmentView } from './modules/environment';
-export type { EnvironmentViewProps, EnvironmentSlotConfig } from './modules/environment';
+export type { EnvironmentViewProps, EnvironmentSlotConfig, EnvironmentScope } from './modules/environment';
 
 // --- Billing module (subscription management) --------------------------------
 // Types: import directly from 'rocketride' (BillingDetail, CreditBalance, etc.)

--- a/packages/shared-ui/src/modules/environment/EnvironmentView.tsx
+++ b/packages/shared-ui/src/modules/environment/EnvironmentView.tsx
@@ -29,6 +29,9 @@ import { EnvScopeCard } from '../account/components/EnvironmentPanel';
 // TYPES
 // =============================================================================
 
+/** Possible environment scope levels. */
+export type EnvironmentScope = 'org' | 'team' | 'user';
+
 /** Connection state and permissions for a single connection slot. */
 export interface EnvironmentSlotConfig {
 	/** Slot identifier (e.g. 'development', 'deployment', 'default'). */
@@ -61,10 +64,10 @@ export interface EnvironmentViewProps {
 	envs: Record<string, Record<string, string> | undefined>;
 
 	/** Requests the host to load env data for a scope. */
-	onLoadEnv: (slotId: string, scope: string, scopeId?: string) => void;
+	onLoadEnv: (slotId: string, scope: EnvironmentScope, scopeId?: string) => void;
 
 	/** Saves env data for a scope. */
-	onSaveEnv: (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => Promise<void>;
+	onSaveEnv: (slotId: string, scope: EnvironmentScope, env: Record<string, string>, scopeId?: string) => Promise<void>;
 
 	/** Keys that must have non-empty values before save is allowed (user scope only). */
 	requiredKeys?: string[];
@@ -136,9 +139,9 @@ const SlotPanel: React.FC<{
 	/** Loaded env dicts keyed by `slotId:scope:scopeId`. */
 	envs: Record<string, Record<string, string> | undefined>;
 	/** Requests env data load. */
-	onLoadEnv: (slotId: string, scope: string, scopeId?: string) => void;
+	onLoadEnv: (slotId: string, scope: EnvironmentScope, scopeId?: string) => void;
 	/** Saves env data. */
-	onSaveEnv: (slotId: string, scope: string, env: Record<string, string>, scopeId?: string) => Promise<void>;
+	onSaveEnv: (slotId: string, scope: EnvironmentScope, env: Record<string, string>, scopeId?: string) => Promise<void>;
 	/** Required keys for user scope. */
 	requiredKeys?: string[];
 }> = ({ slot, single, envs, onLoadEnv, onSaveEnv, requiredKeys }) => {
@@ -254,6 +257,18 @@ const EnvironmentView: React.FC<EnvironmentViewProps> = ({
 				/>
 			),
 		};
+	}
+
+	// ── Empty guard — nothing to render if no slots provided ──────────
+	if (slots.length === 0) {
+		return (
+			<div style={styles.container}>
+				{error && <div style={styles.errorBanner}>{error}</div>}
+				<div style={{ padding: 16, color: 'var(--rr-text-secondary)', fontFamily: 'var(--rr-font-family)' }}>
+					No connection slots available.
+				</div>
+			</div>
+		);
 	}
 
 	return (

--- a/packages/shared-ui/src/modules/environment/index.ts
+++ b/packages/shared-ui/src/modules/environment/index.ts
@@ -4,4 +4,4 @@
 // =============================================================================
 
 export { default as EnvironmentView } from './EnvironmentView';
-export type { EnvironmentViewProps, EnvironmentSlotConfig } from './EnvironmentView';
+export type { EnvironmentViewProps, EnvironmentSlotConfig, EnvironmentScope } from './EnvironmentView';


### PR DESCRIPTION
## Summary

Follow-up fixes for review comments on #1191 (sidebar footer + environment page).

- **EnvironmentScope type safety** — define `EnvironmentScope = 'org' | 'team' | 'user'` in shared-ui and narrow all callback signatures, removing unsafe `as` casts
- **Stuck loading state** — on env load failure, store empty dict for the cache key so cards exit loading; extend `env:error` protocol with slot/scope/scopeId context for per-card error handling in VSCode
- **Save confirmation** — VSCode `handleSaveEnv` now awaits host confirmation (env:data/env:error) before resolving, so "Saved" only shows after persistence is confirmed
- **Empty slots guard** — early return in EnvironmentView when `slots` is empty to prevent crash on `slots[0]`
- **Flyout reset** — trigger toggle calls `handleClose()` instead of bare `setMenuOpen` toggle, preventing stale flyout state
- **Flyout anchor** — team flyout anchors to `e.currentTarget` instead of `parentElement` for correct positioning

## Test plan
- [ ] Open Environment page in shell-ui — verify scope cards load and save correctly
- [ ] Disconnect server — verify cards show error state, not permanent loading
- [ ] Open Environment page in VSCode — verify save waits for host confirmation
- [ ] Open sidebar footer menu, open team flyout, close menu, reopen — verify no stale flyout
- [ ] Click Team: row — verify flyout anchors to the row, not the header

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment error messages now display context about which configuration failed, aiding troubleshooting.
  * Pending save operations are now tracked and confirmed before completion.

* **Bug Fixes**
  * Fixed loading states not clearing when environment operations fail.
  * Fixed sidebar menu popup closing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->