### PR TITLE
fix(llm_anthropic): drop temperature, removed on Opus 4.7+

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -68,7 +68,6 @@ class Chat(ChatBase):
         self._llm = ChatAnthropic(
             model=model,
             api_key=apikey,
-            temperature=0,
             max_tokens=self._modelOutputTokens,
             custom_get_token_ids=_estimate_token_ids,
         )


### PR DESCRIPTION
## Summary

- Remove the unconditional `temperature=0` from the Anthropic node's `ChatAnthropic` constructor.
- Opus 4.7 and 4.8 removed the sampling parameters (`temperature`/`top_p`/`top_k`); sending any returns HTTP 400 (`'temperature' is deprecated for this model`), so every chat using `claude-opus-4-7` failed.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`./builder nodes:test llm_anthropic` passes locally. Full `./builder test` not run.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

**Behavior change:** models that still accept `temperature` (Opus 4.6, Opus 4.5, Sonnet 4.6) move from deterministic (`0`) to their default (`1.0`) → slightly more variable output. Acceptable for conversational chat.

## Linked Issue

Fixes #1194