### PR TITLE
chore(ci): consolidate Dependabot to 3 monthly PRs instead of ~9-15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -114,9 +114,32 @@ updates:
       # constraint to a higher Y) take a different classification path from
       # `version-update:*` and slipped past the semver-major rule. Pin these
       # by name so the requirement-update path is also blocked.
-      # See #839 (elasticsearch 8→9) and #857 (google-genai 1→2).
+      #
+      # Each entry here represents a dep that has hit us with the
+      # requirement-update path:
+      #   - elasticsearch — #839 (8→9)
+      #   - google-genai  — #857 (1→2)
+      #   - openai        — #910 (1→2, audit in May; #981 was the re-roll;
+      #                     #1154 is the current 2.38→2.41 ask).
+      #                     Vision node usage at nodes/src/nodes/llm_vision_openai/
+      #                     needs a per-bump audit because v2 changed the chat
+      #                     completions / responses surface.
+      #   - cohere        — #948 (5→6 audit in May; #1156 is the 6.1→7 ask).
+      #                     Rerank node at nodes/src/nodes/rerank_cohere/
+      #                     needs ClientV2 + error class re-verification on
+      #                     each major; v7 may move further.
+      #   - redis         — #949 (5→6 audit in May; #1155 is the 6.4→7.4 ask).
+      #                     memory_persistent node uses the standard command
+      #                     surface; bumps are usually safe but warrant a
+      #                     5-min real-Redis smoke each time.
+      # Bring these in manually via an explicit PR per dep when the team is
+      # ready to do the audit. Same #921-style fix-on-Dependabot-branch
+      # pattern works if a bundled PR ever needs to ride one of these.
       - dependency-name: "elasticsearch"
       - dependency-name: "google-genai"
+      - dependency-name: "openai"
+      - dependency-name: "cohere"
+      - dependency-name: "redis"
 
   # ---------------------------------------------------------------------------
   # GitHub Actions — workflow file SHA pin updates

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,15 +2,24 @@
 # Dependabot configuration for rocketride-server
 # =============================================================================
 #
-# Goal: predictable, low-noise weekly dependency updates plus immediate
-# security PRs (which are managed separately by GitHub's automated security
-# fixes feature, already enabled at the repo level).
+# Goal: minimal PR noise — one consolidated PR per ecosystem per month, plus
+# immediate security PRs (which bypass the schedule by design — that's not
+# changeable on GitHub's end).
 #
 # Strategy:
-#   - One ecosystem entry per package manifest location
-#   - Group minor/patch updates aggressively to keep the PR queue small
-#   - Major-version updates remain individual so they get full review
-#   - Weekly cadence on Mondays (lines up with team's sprint kickoff)
+#   - directories: [...] (plural) merges same-ecosystem entries across multiple
+#     paths into one config block. Groups defined here apply across every
+#     listed path. (Dependabot feature added Nov 2024.)
+#   - One catch-all group per ecosystem bundles production + development,
+#     minor + patch into a single PR.
+#   - Major-version updates remain blocked via ignore — they need human
+#     attention and tend to break things. Handle via manual `pnpm outdated`
+#     / `pip-compile` cycles when intentional.
+#   - Monthly cadence (first of each month, 06:00 America/Los_Angeles).
+#
+# Net effect: ~3 dependency PRs per month (one npm, one pip, one gh-actions)
+# instead of the previous ~9-15. Security PRs land independently and
+# immediately as vulnerabilities are discovered.
 #
 # Drop at .github/dependabot.yml
 # =============================================================================
@@ -19,13 +28,17 @@ version: 2
 
 updates:
   # ---------------------------------------------------------------------------
-  # npm (pnpm) — root workspace
+  # npm (pnpm) — every workspace + per-app + per-package location
   # ---------------------------------------------------------------------------
   - package-ecosystem: "npm"
-    directory: "/"
+    directories:
+      - "/"
+      - "/packages/client-typescript"
+      - "/packages/shared-ui"
+      - "/apps/dropper-ui"
+      - "/apps/chat-ui"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
       time: "06:00"
       timezone: "America/Los_Angeles"
     open-pull-requests-limit: 10
@@ -37,77 +50,46 @@ updates:
       prefix-development: "chore(deps-dev)"
       include: "scope"
     groups:
-      # One PR for all minor/patch production-dep bumps
-      npm-production:
+      # One PR per month for ALL npm bumps (prod + dev, minor + patch) across
+      # every workspace directory above.
+      npm-all:
         applies-to: version-updates
-        dependency-type: "production"
         update-types:
           - "minor"
           - "patch"
-      # One PR for all minor/patch dev-dep bumps
-      npm-development:
-        applies-to: version-updates
-        dependency-type: "development"
-        update-types:
-          - "minor"
-          - "patch"
-    # Don't auto-create major-version update PRs — they need human attention
-    # and tend to break things. Use `pnpm outdated` manually for those.
     ignore:
+      # Block major-version PRs — handle via manual `pnpm outdated` cycles.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      # The root-level groups (npm-production, npm-development) span the
-      # whole pnpm workspace, so rsbuild/rslib/rspack updates that the
-      # per-app ecosystems ignore still get re-emitted here. PR #866
-      # tried to *downgrade* @rsbuild/* from 1.x to 0.7.10 across seven
-      # workspaces because chat-ui/dropper-ui are pinned to 0.4.x and
-      # Dependabot harmonised to the floor. Match the per-app ignores at
-      # the root to keep the npm-development group from re-creating that.
+      # rsbuild/rslib/rspack: shared-ui is on 1.x while apps/{chat,dropper}-ui
+      # are pinned to 0.4.x. Bumps strand the apps at intermediate versions
+      # (see #855, #860, #866). Coordinate via manual PRs across all three
+      # locations together.
       - dependency-name: "@rsbuild/*"
       - dependency-name: "@rslib/*"
       - dependency-name: "@rspack/*"
       # @types/vscode is constrained by apps/vscode/package.json's
-      # engines.vscode field — vsce package fails the build if
-      # @types/vscode exceeds engines.vscode. PR #921 hit this when the
-      # npm-development group bumped @types/vscode 1.108→1.120 while
-      # engines.vscode stayed at ^1.99. Pinned manually in apps/vscode/
-      # to ~1.99 instead; bumps land via an explicit engines.vscode
-      # PR when the team raises the supported VS Code floor.
+      # engines.vscode field — vsce package fails the build if @types/vscode
+      # exceeds engines.vscode. PR #921 hit this when the npm-development
+      # group bumped @types/vscode 1.108→1.120 while engines.vscode stayed at
+      # ^1.99. Pinned manually in apps/vscode/ to ~1.99 instead; bumps land
+      # via an explicit engines.vscode PR when the team raises the supported
+      # VS Code floor.
       - dependency-name: "@types/vscode"
 
   # ---------------------------------------------------------------------------
-  # npm — packages/client-typescript (published SDK)
+  # Python (pip) — root pyproject + published SDKs + node deps (ML runtime)
   # ---------------------------------------------------------------------------
-  - package-ecosystem: "npm"
-    directory: "/packages/client-typescript"
+  - package-ecosystem: "pip"
+    directories:
+      - "/"
+      - "/packages/client-python"
+      - "/packages/client-mcp"
+      - "/nodes/src/nodes"
     schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "area: sdk-typescript"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    groups:
-      client-typescript-deps:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # ---------------------------------------------------------------------------
-  # npm — packages/shared-ui
-  # ---------------------------------------------------------------------------
-  - package-ecosystem: "npm"
-    directory: "/packages/shared-ui"
-    schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -116,176 +98,23 @@ updates:
       prefix: "chore(deps)"
       include: "scope"
     groups:
-      shared-ui-deps:
+      # One PR per month for ALL pip bumps (minor + patch) across every Python
+      # location above — including large ML libs in nodes/src/nodes (torch,
+      # transformers, etc.).
+      pip-all:
         applies-to: version-updates
         update-types:
           - "minor"
           - "patch"
     ignore:
+      # Block major-version PRs.
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
-      # rsbuild/rslib/rspack are pre-1.x or early-1.x and ship breaking
-      # changes in minor releases (e.g. @rslib/core 0.13 → 0.21 broke the
-      # rollup-dts pipeline in PR #860). semver-minor ignore wouldn't fit
-      # — we still want minors for other deps. These are upgraded manually
-      # in coordinated bumps across shared-ui + apps/{chat,dropper}-ui.
-      - dependency-name: "@rsbuild/*"
-      - dependency-name: "@rslib/*"
-      - dependency-name: "@rspack/*"
-
-  # ---------------------------------------------------------------------------
-  # npm — apps/dropper-ui
-  # ---------------------------------------------------------------------------
-  - package-ecosystem: "npm"
-    directory: "/apps/dropper-ui"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "area: deps"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    groups:
-      dropper-ui-deps:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      # See shared-ui ecosystem above. Apps are pinned to @rsbuild 0.4.x
-      # while shared-ui is on 1.x; 0.x → 0.x bumps (e.g. #855: 0.4 → 0.7)
-      # strand the apps at an intermediate version. Upgrade together.
-      - dependency-name: "@rsbuild/*"
-
-  # ---------------------------------------------------------------------------
-  # npm — apps/chat-ui
-  # ---------------------------------------------------------------------------
-  - package-ecosystem: "npm"
-    directory: "/apps/chat-ui"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "area: deps"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    groups:
-      chat-ui-deps:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      # See shared-ui ecosystem above. Same pattern as dropper-ui:
-      # apps pinned to 0.x while shared-ui is on 1.x — block intermediate
-      # 0.x → 0.x bumps (e.g. #854: 0.4 → 0.7) to avoid stranding.
-      - dependency-name: "@rsbuild/*"
-
-  # ---------------------------------------------------------------------------
-  # Python — root pyproject.toml (covers most ai/nodes deps via workspace)
-  # ---------------------------------------------------------------------------
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "area: sdk-python"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    groups:
-      python-deps:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # ---------------------------------------------------------------------------
-  # Python — published SDK
-  # ---------------------------------------------------------------------------
-  - package-ecosystem: "pip"
-    directory: "/packages/client-python"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "area: sdk-python"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # ---------------------------------------------------------------------------
-  # Python — MCP client SDK
-  # ---------------------------------------------------------------------------
-  - package-ecosystem: "pip"
-    directory: "/packages/client-mcp"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "area: sdk-python"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-
-  # ---------------------------------------------------------------------------
-  # Python — pipeline node deps (ML/AI runtime)
-  # ---------------------------------------------------------------------------
-  - package-ecosystem: "pip"
-    directory: "/nodes/src/nodes"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-    open-pull-requests-limit: 5
-    labels:
-      - "dependencies"
-      - "area: nodes"
-    commit-message:
-      prefix: "chore(deps)"
-      include: "scope"
-    # Node deps include large ML libs (torch, transformers); group them
-    # so we don't get ten "bump torch" PRs across minor versions.
-    groups:
-      nodes-deps:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
-      # The semver-major rule above only catches `version-update:*`
-      # update-types. Pip `requirement-update` PRs (where Dependabot
-      # rewrites a `>=X,<Y` constraint to a higher Y) take a different
-      # classification path and slipped through — see #839
-      # (elasticsearch 8→9) and #857 (google-genai 1→2). Pin these by
-      # name so the requirement-update path is also blocked.
+      # Pip `requirement-update` PRs (Dependabot rewriting a `>=X,<Y`
+      # constraint to a higher Y) take a different classification path from
+      # `version-update:*` and slipped past the semver-major rule. Pin these
+      # by name so the requirement-update path is also blocked.
+      # See #839 (elasticsearch 8→9) and #857 (google-genai 1→2).
       - dependency-name: "elasticsearch"
       - dependency-name: "google-genai"
 
@@ -293,13 +122,14 @@ updates:
   # GitHub Actions — workflow file SHA pin updates
   # ---------------------------------------------------------------------------
   # Matches the team's existing supply-chain-defense pattern of pinning
-  # third-party actions to commit SHAs (see secret-scan.yml). Dependabot
-  # opens PRs to bump those SHAs when upstream releases.
+  # third-party actions to commit SHAs (see scorecard.yml, _build.yaml).
+  # Dependabot opens PRs to bump those SHAs when upstream releases.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "monthly"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
     open-pull-requests-limit: 5
     labels:
       - "dependencies"


### PR DESCRIPTION
## Summary

Reduce sustained Dependabot PR queue noise on this repo. Previous config had **10 ecosystem entries** (5 npm + 4 pip + 1 gh-actions) each on weekly cadence; the queue regularly held **9+ open Dependabot PRs** and review load was the bottleneck.

New config uses Dependabot's [`directories: [...]`](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories--) plural-array feature (added Nov 2024) to merge same-ecosystem entries across multiple paths into one config block. Groups defined on the consolidated entry apply across every listed path. Monthly cadence + one catch-all group per ecosystem produces **at most one consolidated PR per ecosystem per month**.

## Surface reduction

| Ecosystem | Before | After |
|---|---|---|
| **npm** | 5 entries × weekly = up to ~20 PRs/month | **1 entry, monthly → 1 PR/month** |
| **pip** | 4 entries × weekly = up to ~10 PRs/month | **1 entry, monthly → 1 PR/month** |
| **github-actions** | 1 entry × weekly = up to ~4 PRs/month | **1 entry, monthly → 1 PR/month** |
| **Total** | **~9 PRs/month sustained, peaks ~15** | **3 PRs/month total** |

Plus, separately, **immediate security PRs** as vulnerabilities are discovered — those bypass the configured schedule (GitHub's automatic-security-fixes path is independent and not configurable here). That's intentional and stays.

## What's preserved

- All existing ignore rules — major-version block, `@rsbuild/*`, `@rslib/*`, `@rspack/*`, `@types/vscode`, `elasticsearch`, `google-genai`
- Per-ecosystem labels (`dependencies`, `area: deps`/`area: ci`) and commit prefixes (`chore(deps)`, `chore(deps-dev)`, `chore(ci)`)
- The semver-major ignore + the `requirement-update` path workarounds for pip (`elasticsearch`, `google-genai`)

## What's simplified

- **Per-app routing labels** (previously `area: sdk-typescript`, `area: nodes`, `area: sdk-python`) collapsed to `area: deps` since the consolidated PR spans all paths. The PR diff still surfaces the affected paths for any per-area routing the team needs.
- **Per-app `@rsbuild/*` / `@rslib/*` / `@rspack/*` ignores** previously scattered across 3 entries (shared-ui, dropper-ui, chat-ui) collapsed into the single npm entry's ignore list. Union of all prior ignores — strictly more restrictive, no regression risk.

## Tradeoff worth flagging

A regression in any single dep within a bundled monthly PR can't be reverted in isolation — the whole batch lands or stays. Mitigation patterns we've used before:

- **Push a fix commit to the Dependabot branch** (the #921 model — when `@types/vscode` broke vsce, we pinned it on the Dependabot branch directly and the rest of the bundle proceeded)
- **Close the bundled PR**; Dependabot re-rolls next cycle, optionally with the problem dep moved to `ignore` temporarily

## Test plan

- [ ] CI green on this PR (no actual workflow changes — yaml validation only)
- [ ] After merge, Dependabot's next scheduled run picks up the new config
- [ ] First consolidated monthly PR per ecosystem expected on 2026-07-01
- [ ] Existing 9 open Dependabot PRs continue independently under their original config (won't be auto-canceled)