### PR TITLE
feat(vscode): ETag-based conditional requests for GitHub releases API

### DIFF
--- a/apps/vscode/src/engine/shared/engine-installer.ts
+++ b/apps/vscode/src/engine/shared/engine-installer.ts
@@ -63,6 +63,15 @@ export interface ReleaseListItem {
 	prerelease: boolean;
 }
 
+/**
+ * Result of a conditional GitHub API call using ETags.
+ * - `data`: fresh data returned (HTTP 200); includes the new ETag for future requests.
+ * - `notModified`: server confirmed cached version is still current (HTTP 304, free — no rate limit hit).
+ */
+export type ConditionalResult<T> =
+	| { status: 'data'; data: T; etag: string | undefined }
+	| { status: 'notModified' };
+
 /** Platform-specific archive naming. */
 interface PlatformInfo {
 	name: string;
@@ -419,24 +428,49 @@ export class EngineInstaller {
 	/**
 	 * Fetches all available releases for the version dropdown.
 	 * Returns server-tagged releases with assets, sorted newest first.
+	 *
+	 * Supports ETag-based conditional requests: pass the ETag from a previous
+	 * response to get a free HTTP 304 (not counted against GitHub rate limit)
+	 * when releases haven't changed.
 	 */
 	public async getReleases(
 		token?: vscode.CancellationToken,
-		githubToken?: string
-	): Promise<ReleaseListItem[]> {
+		githubToken?: string,
+		etag?: string
+	): Promise<ConditionalResult<ReleaseListItem[]>> {
 		this.throwIfCancelled(token);
 		const octokit = await this.createOctokit(githubToken);
-		const { data } = await octokit.repos.listReleases({
-			owner: EngineInstaller.GITHUB_OWNER,
-			repo: EngineInstaller.GITHUB_REPO,
-			per_page: 100
-		});
-		return data
-			.filter(r => r.tag_name?.startsWith('server-') && !r.prerelease && r.assets && r.assets.length > 0)
-			.map(r => ({
-				tag_name: r.tag_name,
-				prerelease: r.prerelease
-			}));
+
+		// Build conditional request headers
+		const headers: Record<string, string> = {};
+		if (etag) {
+			headers['if-none-match'] = etag;
+		}
+
+		try {
+			const response = await octokit.repos.listReleases({
+				owner: EngineInstaller.GITHUB_OWNER,
+				repo: EngineInstaller.GITHUB_REPO,
+				per_page: 100,
+				headers,
+			});
+
+			// HTTP 200 — fresh data
+			const data = response.data
+				.filter(r => r.tag_name?.startsWith('server-') && !r.prerelease && r.assets && r.assets.length > 0)
+				.map(r => ({
+					tag_name: r.tag_name,
+					prerelease: r.prerelease
+				}));
+
+			return { status: 'data', data, etag: response.headers.etag };
+		} catch (error: unknown) {
+			// Octokit throws RequestError with status 304 for Not Modified
+			if (this.isNotModifiedError(error)) {
+				return { status: 'notModified' };
+			}
+			throw error;
+		}
 	}
 
 	/** Creates an authenticated (or anonymous) Octokit instance. */
@@ -446,6 +480,19 @@ export class EngineInstaller {
 			auth: githubToken,
 			userAgent: 'RocketRide-VSCode'
 		});
+	}
+
+	/**
+	 * Checks if an error is an Octokit RequestError with HTTP 304 status.
+	 * Octokit throws rather than returning a response for 304s.
+	 * Duck-types the check to avoid importing @octokit/request-error.
+	 */
+	private isNotModifiedError(error: unknown): boolean {
+		return (
+			error instanceof Error &&
+			'status' in error &&
+			(error as { status: number }).status === 304
+		);
 	}
 
 	/**

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -55,6 +55,9 @@ import { AgentManager } from './agents/agent-manager';
 import { syncServiceCatalog } from './agents/services';
 import { CloudAuthProvider } from './auth/CloudAuthProvider';
 
+// Extension context — set once in activate(), available via getExtensionContext()
+let extensionContext: vscode.ExtensionContext;
+
 // Core managers
 let connectionManager: ConnectionManager | undefined;
 let engineRegistry: EngineRegistry | undefined;
@@ -178,6 +181,7 @@ async function runMigrations(context: vscode.ExtensionContext): Promise<void> {
  * @param context VS Code extension context
  */
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
+	extensionContext = context;
 	const logger = getLogger();
 	logger.output(`${icons.begin} Activating RocketRide extension...`);
 
@@ -608,6 +612,7 @@ export let cachedDockerTags: string[] = [];
 export const setCachedDockerTags = (t: string[]) => { cachedDockerTags = t; };
 
 // Export getters for provider access
+export const getExtensionContext = () => extensionContext;
 export const getConnectionManager = () => connectionManager;
 export const getEngineRegistry = () => engineRegistry;
 export const getSettingsProvider = () => settings;

--- a/apps/vscode/src/providers/shared/connection-message-handler.ts
+++ b/apps/vscode/src/providers/shared/connection-message-handler.ts
@@ -21,7 +21,9 @@ import { IMAGE_BASE } from '../../engine/docker/docker-manager';
 import { ConnectionManager } from '../../connection/connection';
 import { type ConnectionMode } from '../../config';
 import { CloudAuthProvider } from '../../auth/CloudAuthProvider';
-import { setCachedEngineVersions, setCachedDockerTags } from '../../extension';
+import { setCachedEngineVersions, setCachedDockerTags, getExtensionContext } from '../../extension';
+import { getLogger } from '../../shared/util/output';
+import { icons } from '../../shared/util/icons';
 
 // =============================================================================
 // TYPES
@@ -55,6 +57,8 @@ interface VersionCache {
 	versions: Array<{ tag_name: string; prerelease: boolean }>;
 	/** When the cache was populated (Date.now()). */
 	fetchedAt: number;
+	/** ETag from the last successful GitHub API response (persisted to globalState). */
+	etag?: string;
 	/** True if the fetch is currently in flight (dedup concurrent callers). */
 	fetching: boolean;
 	/** Promise that concurrent callers can await while a fetch is in flight. */
@@ -85,6 +89,17 @@ export class ConnectionMessageHandler {
 
 	constructor(private readonly opts: ConnectionMessageHandlerOptions) {
 		this.engineInstaller = new EngineInstaller(opts.extensionFsPath);
+
+		// Hydrate version cache from persistent storage so the first fetch after
+		// a restart can send the saved ETag and get a free 304 (no rate limit hit).
+		const persisted = getExtensionContext().globalState
+			.get<{ etag: string; versions: Array<{ tag_name: string; prerelease: boolean }> }>('versionCache');
+		if (persisted) {
+			this.versionCache.etag = persisted.etag;
+			this.versionCache.versions = persisted.versions;
+			// fetchedAt stays 0 — TTL check still triggers a fetch, but with the
+			// saved ETag the response is a free 304 when releases haven't changed.
+		}
 	}
 
 
@@ -374,6 +389,8 @@ export class ConnectionMessageHandler {
 	 * Populates the version cache on success or failure.
 	 */
 	private async doFetchVersions(): Promise<void> {
+		const logger = getLogger();
+
 		// Get GitHub token if available (raises rate limit from 60/hr to 5000/hr)
 		let githubToken: string | undefined;
 		try {
@@ -383,20 +400,61 @@ export class ConnectionMessageHandler {
 			/* proceed without token */
 		}
 
+		const authMode = githubToken ? 'authenticated' : 'unauthenticated';
+		const hasEtag = !!this.versionCache.etag;
+		logger.output(`${icons.info} Fetching engine versions (${authMode}, etag=${hasEtag ? 'cached' : 'none'})...`);
+
 		for (let attempt = 1; attempt <= MAX_FETCH_ATTEMPTS; attempt++) {
 			try {
-				const versions = await this.engineInstaller.getReleases(undefined, githubToken);
-				this.versionCache.versions = versions;
+				const result = await this.engineInstaller.getReleases(
+					undefined,
+					githubToken,
+					this.versionCache.etag
+				);
+
+				if (result.status === 'notModified') {
+					// Data hasn't changed — just refresh the TTL timestamp.
+					// Versions are already correct (hydrated from globalState or previous fetch).
+					logger.output(`${icons.success} Engine versions unchanged (304 Not Modified, no rate limit used)`);
+					this.versionCache.fetchedAt = Date.now();
+					return;
+				}
+
+				// Fresh data received — update cache, global state, and persistent storage
+				logger.output(`${icons.success} Engine versions fetched: ${result.data.length} releases found`);
+				this.versionCache.versions = result.data;
 				this.versionCache.fetchedAt = Date.now();
-				setCachedEngineVersions(versions);
+				this.versionCache.etag = result.etag;
+				setCachedEngineVersions(result.data);
+				getExtensionContext().globalState.update('versionCache', {
+					etag: result.etag,
+					versions: result.data
+				});
 				return;
 			} catch (error) {
-				console.error(`[ConnectionMessageHandler] Version fetch attempt ${attempt}/${MAX_FETCH_ATTEMPTS} failed:`, error);
+				logger.output(`${icons.warning} Version fetch attempt ${attempt}/${MAX_FETCH_ATTEMPTS} failed: ${error}`);
+
+				// If rate-limited, extract reset time from GitHub response headers
+				const rateLimitReset = (error as { response?: { headers?: Record<string, string> } })
+					?.response?.headers?.['x-ratelimit-reset'];
+				if (rateLimitReset) {
+					const resetDate = new Date(Number(rateLimitReset) * 1000);
+					const minutesLeft = Math.max(1, Math.ceil((resetDate.getTime() - Date.now()) / 60000));
+					logger.output(`${icons.info} GitHub rate limit resets in ~${minutesLeft} minute${minutesLeft === 1 ? '' : 's'} (${resetDate.toLocaleTimeString()})`);
+				}
+
 				if (attempt === MAX_FETCH_ATTEMPTS) {
-					// Cache the failure so we don't retry immediately
-					this.versionCache.versions = [];
+					// All attempts failed. If we have cached versions (from
+					// globalState or a prior fetch), serve those instead of
+					// clearing the list — the data is still valid.
 					this.versionCache.fetchedAt = Date.now();
-					setCachedEngineVersions([]);
+					if (this.versionCache.versions.length > 0) {
+						logger.output(`${icons.info} Serving ${this.versionCache.versions.length} cached versions`);
+						setCachedEngineVersions(this.versionCache.versions);
+					} else {
+						logger.output(`${icons.error} All version fetch attempts failed — no cached data available`);
+						setCachedEngineVersions([]);
+					}
 				}
 			}
 		}

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -490,7 +490,11 @@ function makeDownloadAction(options = {}) {
 
 			task.output = `Downloading ${distFilename} from ${matchedTag}...`;
 			const distPath = await downloadGitHubFile(matchedTag, distFilename, task);
-			if (!distPath) throw new Error(`Dist file ${distFilename} not found`);
+			if (!distPath) {
+				task.output = `Dist file ${distFilename} not found in ${matchedTag} — will compile`;
+				await setState('server.downloadHash', null);
+				return;
+			}
 			task.output = `Downloaded ${distFilename}`;
 
 			let symDistPath = null;


### PR DESCRIPTION
## Summary

- Add HTTP ETag conditional requests (`If-None-Match` header) to the GitHub releases API calls so that 304 Not Modified responses (which are free and don't count against the rate limit) are used instead of unconditional requests on every 5-minute TTL expiry
- Persist the ETag + cached version list to VSCode's `globalState` so the cache survives extension restarts — the first fetch after a restart sends the saved ETag and gets a free 304 instead of burning a rate-limited request
- When rate-limited and cached versions exist, serve cached data instead of clearing the version list
- Extract `X-RateLimit-Reset` from GitHub 403 responses and log when the limit will reset
- Add structured logging (icons) for all version fetch outcomes
- Fix server build task to fall through to compilation when a release exists but the platform dist zip is missing from its assets

**Net result: ~1 rate-limited request per actual release published, regardless of restart frequency or TTL polling.**

## Context

Alexandru hit GitHub API rate limiting (60 req/hr unauthenticated) because every TTL cache expiry made an unconditional API call, and the in-memory cache reset on every extension restart. With ETags + globalState persistence, virtually all subsequent fetches are free 304s.

## Test plan

- [ ] Build: `./builder vscode:clean vscode:build`
- [ ] First launch with no prior globalState: unconditional fetch, versions populate, ETag saved
- [ ] Wait >5 min, trigger version fetch: should log "304 Not Modified, no rate limit used"
- [ ] Restart VSCode, trigger version fetch: should log "etag=cached" then "304 Not Modified"
- [ ] Disconnect network, trigger version fetch: should log "Serving N cached versions"
- [ ] Verify rate limit reset message appears when hitting 403
- [ ] Run `saas:build` when release binary is missing: should fall through to compile, not throw

🤖 Generated with [Claude Code](https://claude.com/claude-code)