### PR TITLE
ci(release): push tags via GitHub App token (drop expiring WORKFLOW_PAT)

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -324,17 +324,30 @@ jobs:
       # then all 5 prerelease creation jobs fail to push the new ones,
       # leaving the repo with zero prereleases until the next clean
       # commit.
+      # Mint a short-lived GitHub App installation token for the tag push. The
+      # tag points at a commit whose tree contains workflow files, so the
+      # pushing identity needs Workflows:write — GITHUB_TOKEN can't, and an App
+      # token removes the long-lived PAT that silently expires. The App
+      # (RELEASE_BOT_APP_ID) is installed on this repo with Contents:write +
+      # Workflows:write; the token lives only for this job.
+      - name: Generate release-bot token
+        id: bot_token
+        if: inputs.prerelease || steps.tag_check.outputs.exists == 'false'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Create tag
         if: inputs.prerelease || steps.tag_check.outputs.exists == 'false'
         env:
-          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+          BOT_TOKEN: ${{ steps.bot_token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # Swap the remote URL to authenticate with WORKFLOW_PAT for the
-          # push. This affects only this step's git config and goes away
-          # when the runner tears down.
-          git remote set-url origin "https://x-access-token:${WORKFLOW_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+          # Authenticate the push with the App installation token (this step's
+          # git config only; gone when the runner tears down).
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if [ "${{ inputs.prerelease }}" = "true" ]; then
             git tag -f "${{ matrix.tag_name }}"
             git push -f origin "${{ matrix.tag_name }}"


### PR DESCRIPTION
## Why
The release pipeline's **Create tag** step pushes `<pkg>-v<version>[-prerelease]` tags. That push needs **Workflows: write** (the tag's tree contains `.github/workflows/*`) and must **trigger the downstream tag-triggered release workflow** — so `GITHUB_TOKEN` can't do it. We used a long-lived **`WORKFLOW_PAT`**, which **silently expired (~Jun 6)** and stopped all prerelease publishing (no `server-v3.3.0-prerelease`).

## What
Swap the PAT for a **per-job GitHub App installation token** (`actions/create-github-app-token@v3.2.0`, SHA-pinned). The token is minted at job start, scoped to this repo, and expires when the job ends — **nothing to rotate, nothing to expire**.

## One-time setup (org owner) — required before merge
1. **Create a GitHub App** under `rocketride-org` (Settings → Developer settings → GitHub Apps → New).
   - Repository permissions: **Contents: Read and write**, **Workflows: Read and write**. No webhook needed.
2. **Install** the App on `rocketride-server`.
3. **Generate a private key** (.pem) for the App.
4. Add repo (or org) secrets:
   - `RELEASE_BOT_APP_ID` = the App's numeric ID
   - `RELEASE_BOT_PRIVATE_KEY` = the full .pem contents
5. Mark this PR ready + merge. Then the next develop CI publishes `server-v3.3.0-prerelease` via the App token. **Delete `WORKFLOW_PAT`** afterward.

Kept as **draft** — merging before the App secrets exist would fail the new step. The `cleanup-prereleases` job stays on `GITHUB_TOKEN` (tag deletes don't need Workflows:write).