### PR TITLE
fix(deepagent): avoid transformers dependency for token counting

### DIFF
--- a/nodes/src/nodes/agent_deepagent/deepagent.py
+++ b/nodes/src/nodes/agent_deepagent/deepagent.py
@@ -56,7 +56,8 @@ def _build_deepagent_llm(agent_base: AgentBase, context: AgentContext) -> Any:
     the LLM produces malformed JSON.
     """
     from langchain_core.language_models import BaseChatModel
-    from langchain_core.messages import AIMessage
+    from langchain_core.messages import AIMessage, HumanMessage
+    from langchain_core.messages.utils import count_tokens_approximately
     from langchain_core.outputs import ChatGeneration, ChatResult
 
     class RocketRideToolCallingChatModel(BaseChatModel):
@@ -82,6 +83,21 @@ def _build_deepagent_llm(agent_base: AgentBase, context: AgentContext) -> Any:
             except Exception:
                 self._bound_tools = []
             return self
+
+        # deepagents' middleware asks the model to count tokens; BaseChatModel's
+        # fallback needs `transformers` (not bundled) and only knows GPT-2 anyway.
+        # The host LLM is opaque to us, so approximate counting is both sufficient
+        # and dependency-free.
+        def get_num_tokens(self, text: str) -> int:
+            return count_tokens_approximately([HumanMessage(content=safe_str(text))])
+
+        def get_token_ids(self, text: str) -> List[int]:
+            # No real tokenizer; synthesize an id list of the right length so
+            # len(get_token_ids(text)) == get_num_tokens(text) still holds.
+            return list(range(self.get_num_tokens(text)))
+
+        def get_num_tokens_from_messages(self, messages: Any, tools: Any = None) -> int:
+            return count_tokens_approximately(messages)
 
         def _generate(self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any) -> Any:
             transcript = langchain_messages_to_transcript(messages)


### PR DESCRIPTION
## Summary

- Override token-counting on the Deep Agent's `RocketRideToolCallingChatModel` wrapper so the `deepagents` middleware no longer triggers LangChain's GPT-2 fallback, which imports `transformers` (not bundled in the engine Python) and aborted every run.
- Route `get_num_tokens` / `get_num_tokens_from_messages` through `langchain_core`'s char-based `count_tokens_approximately`; `get_token_ids` derives from it, preserving `len(get_token_ids(x)) == get_num_tokens(x)`.
- Chose the code-level override over adding `transformers` to `requirements.txt` — the fallback tokenizer is hardcoded GPT-2 and wouldn't match the opaque host model, so the dependency would buy a heavy install plus a runtime HuggingFace download for no better accuracy.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1204


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token-counting callback support to the DeepAgent chat model, enabling approximate token counting without requiring additional tokenizer dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->