### PR TITLE
ci(release): finish App-token migration (experimental-release + stale comment)

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -307,27 +307,10 @@ jobs:
 
       # --- Tag and GitHub Release ---
       #
-      # IMPORTANT: tag push uses WORKFLOW_PAT (a Personal Access Token with
-      # `repo` + `workflow` scopes) instead of the default GITHUB_TOKEN.
-      #
-      # GitHub rejects any tag push from GITHUB_TOKEN whose target commit
-      # modifies files under `.github/workflows/`, with the error:
-      #
-      #   refusing to allow a GitHub App to create or update workflow
-      #   `.github/workflows/<file>` without `workflows` permission
-      #
-      # `workflows` is a token-level scope, not a YAML permission, so the
-      # only fix is to swap to a credential that has it. WORKFLOW_PAT is
-      # that credential. Without this, every nightly that lands on a
-      # workflow-touching commit silently bricks the prerelease pipeline:
-      # the cleanup job runs first and deletes existing -prerelease tags,
-      # then all 5 prerelease creation jobs fail to push the new ones,
-      # leaving the repo with zero prereleases until the next clean
-      # commit.
       # Mint a short-lived GitHub App installation token for the tag push. The
       # tag points at a commit whose tree contains workflow files, so the
       # pushing identity needs Workflows:write — GITHUB_TOKEN can't, and an App
-      # token removes the long-lived PAT that silently expires. The App
+      # token avoids a long-lived PAT that silently expires. The App
       # (RELEASE_BOT_APP_ID) is installed on this repo with Contents:write +
       # Workflows:write; the token lives only for this job.
       - name: Generate release-bot token

--- a/.github/workflows/experimental-release.yaml
+++ b/.github/workflows/experimental-release.yaml
@@ -138,17 +138,26 @@ jobs:
       - name: List artifacts
         run: find release-assets -type f | sort
 
-      # Tag push goes through WORKFLOW_PAT for the same reason _release.yaml
-      # uses it: GITHUB_TOKEN is refused on tags whose target commits touch
-      # files under .github/workflows/. Force-push so re-running this
-      # workflow on the same branch + tag_suffix replaces cleanly.
+      # Tag push goes through a short-lived GitHub App installation token for
+      # the same reason _release.yaml uses one: GITHUB_TOKEN is refused on
+      # tags whose target commits touch files under .github/workflows/, and
+      # the release-bot App has Contents:write + Workflows:write. Force-push
+      # so re-running this workflow on the same branch + tag_suffix replaces
+      # cleanly.
+      - name: Generate release-bot token
+        id: bot_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Create / replace tag
         env:
-          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+          BOT_TOKEN: ${{ steps.bot_token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${WORKFLOW_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git tag -f "${{ matrix.tag_name }}"
           git push -f origin "${{ matrix.tag_name }}"
 


### PR DESCRIPTION
Follow-up to #1203.

- **experimental-release.yaml**: tag push still used the expired `WORKFLOW_PAT` — swapped to the same short-lived release-bot App installation token (`RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY`) that `_release.yaml` uses since #1203.
- **_release.yaml**: dropped the stale comment block still describing the WORKFLOW_PAT approach; the App-token comment above the step is the current-state description.

After this lands, `WORKFLOW_PAT` is unreferenced across all workflows and the repo secret can be deleted.

Verified tonight on run 27248696885: App-token tag push published `server-v3.3.0-prerelease` + all 4 SDK prereleases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)