### PR TITLE
feat(sync): stamp capabilities.reasoning from OpenRouter

### DIFF
--- a/tools/sync_models/scripts/tasks.js
+++ b/tools/sync_models/scripts/tasks.js
@@ -9,6 +9,7 @@ const path = require('path');
 const { execCommand, PROJECT_ROOT, DIST_ROOT } = require('../../../scripts/lib');
 
 const TOOLS_SRC = path.join(__dirname, '..', 'src', 'sync_models.py');
+const STAMP_REASONING_SRC = path.join(__dirname, '..', 'src', 'stamp_reasoning.py');
 
 // Maps provider key → relative path to its services.json from the repo root.
 // Mirrors _SERVICES_JSON_PATHS in tools/sync_models/src/sync_models.py.
@@ -47,7 +48,20 @@ function makeRunSyncModelsAction(options = {}) {
 			await execCommand(ENGINE, [TOOLS_SRC, ...extraArgs], {
 				task,
 				cwd: PROJECT_ROOT,
-				env: { ...process.env },
+				env: { ...process.env, PYTHONIOENCODING: 'utf-8' },
+			});
+		},
+	};
+}
+
+function makeStampReasoningAction() {
+	return {
+		run: async (_ctx, task) => {
+			task.output = 'Stamping capabilities.reasoning for local providers';
+			await execCommand(ENGINE, [STAMP_REASONING_SRC], {
+				task,
+				cwd: PROJECT_ROOT,
+				env: { ...process.env, PYTHONIOENCODING: 'utf-8' },
 			});
 		},
 	};
@@ -100,14 +114,22 @@ module.exports = {
 	actions: [
 		// Internal steps
 		{ name: 'models:run-sync', action: makeRunSyncModelsAction },
+		{ name: 'models:stamp-reasoning', action: makeStampReasoningAction },
 		{ name: 'models:prettier', action: makePrettierAction },
 
-		// Public action
+		// Public actions
 		{
 			name: 'models:update',
 			action: () => ({
 				description: 'Updating models',
 				steps: ['models:run-sync', 'models:prettier'],
+			}),
+		},
+		{
+			name: 'models:stamp-locals',
+			action: () => ({
+				description: 'Stamping reasoning flag for local providers',
+				steps: ['models:stamp-reasoning'],
 			}),
 		},
 	],

--- a/tools/sync_models/src/core/merger.py
+++ b/tools/sync_models/src/core/merger.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+import re
 from typing import Dict, Any, List, NamedTuple, Tuple, Optional
 
 try:
@@ -31,7 +32,7 @@ except ImportError:
 
 # Module-level cache — populated on first use, once per process.
 # None = not yet fetched; {} = fetch attempted but failed (no retry).
-_OPENROUTER_CACHE: Optional[Dict[str, Tuple[Optional[int], Optional[int], Optional[str], Optional[str]]]] = None
+_OPENROUTER_CACHE: Optional[Dict[str, Tuple[Optional[int], Optional[int], Optional[str], Optional[str], bool]]] = None
 _OPENROUTER_AVAILABLE: bool = False
 
 
@@ -62,7 +63,7 @@ def _load_openrouter_cache() -> None:
         with _urllib.urlopen(req, timeout=10) as resp:
             data = _json.loads(resp.read())
 
-        cache: Dict[str, Tuple[Optional[int], Optional[int], Optional[str], Optional[str]]] = {}
+        cache: Dict[str, Tuple[Optional[int], Optional[int], Optional[str], Optional[str], bool]] = {}
         for model in data.get('data', []):
             raw_id = model.get('id', '')
             bare = raw_id.split('/', 1)[1] if '/' in raw_id else raw_id
@@ -73,13 +74,45 @@ def _load_openrouter_cache() -> None:
             exp = model.get('expiration_date') or None
             ctx = int(ctx) if ctx is not None else None
             out = int(out) if out is not None else None
+            sp = model.get('supported_parameters') or []
+            reasoning = 'reasoning' in sp or 'include_reasoning' in sp
             if bare not in cache:  # keep first occurrence per bare ID
-                cache[bare] = (ctx, out, name, exp)
+                cache[bare] = (ctx, out, name, exp, reasoning)
 
         _OPENROUTER_CACHE = cache
         _OPENROUTER_AVAILABLE = True
     except Exception:
         _OPENROUTER_CACHE = {}  # empty sentinel — no retry on subsequent calls
+
+
+# Stable family/product roots whose variants inherit reasoning (covers distills,
+# quantizations, Qwen hybrid-thinking DashScope aliases, and explicit `-thinking` snapshots).
+_REASONING_FAMILIES = (
+    'deepseek-r1',
+    'qwen3',
+    'qwq',
+    'magistral',
+    'qwen-plus',
+    'qwen-flash',
+    'qwen-turbo',
+    'qwen-max',
+    '-thinking',
+)
+
+
+def _is_reasoning_model(bare_id: str) -> bool:
+    """True if the model is in OpenRouter as reasoning, or matches a known family root."""
+    cache = get_openrouter_cache()
+    entry = cache.get(bare_id)
+    if entry is None:
+        # Anthropic profiles store hyphens (claude-opus-4-7) while OR uses dots (claude-opus-4.7).
+        dotted = re.sub(r'(\d)-(\d)', r'\1.\2', bare_id)
+        if dotted != bare_id:
+            entry = cache.get(dotted)
+    if entry is not None and entry[4]:
+        return True
+    low = bare_id.lower()
+    return any(fam in low for fam in _REASONING_FAMILIES)
 
 
 def _source_is_authoritative(source: str, model_source: str) -> bool:
@@ -104,7 +137,7 @@ def _source_is_authoritative(source: str, model_source: str) -> bool:
     return False
 
 
-def get_openrouter_cache() -> Dict[str, Tuple[Optional[int], Optional[int], Optional[str], Optional[str]]]:
+def get_openrouter_cache() -> Dict[str, Tuple[Optional[int], Optional[int], Optional[str], Optional[str], bool]]:
     """
     Return the OpenRouter model cache, loading it on first call.
 
@@ -144,7 +177,8 @@ def _openrouter_info(model_id: str) -> Tuple[Optional[int], Optional[int], Optio
         expiration_date is non-None when OpenRouter has marked the model as deprecated.
     """
     _load_openrouter_cache()
-    return (_OPENROUTER_CACHE or {}).get(model_id, (None, None, None, None))
+    entry = (_OPENROUTER_CACHE or {}).get(model_id)
+    return entry[:4] if entry else (None, None, None, None)
 
 
 def _litellm_info(model_id: str) -> Tuple[Optional[int], Optional[int]]:
@@ -330,6 +364,8 @@ def build_new_profile(
         profile['modelOutputTokens'] = output_tokens
         if output_tokens_source:
             profile['_src_modelOutputTokens'] = output_tokens_source
+    if _is_reasoning_model(model_id):
+        profile['capabilities'] = {'reasoning': True}
     if extra_fields:
         profile.update(extra_fields)
     return profile
@@ -626,6 +662,15 @@ def merge(
             # Existing model — only update token limits when we have authoritative data
             existing = updated_profiles[profile_key]
             changed = False
+
+            # Enrich capabilities.reasoning so the flag tracks OpenRouter over time.
+            existing_cap = existing.get('capabilities') if isinstance(existing.get('capabilities'), dict) else {}
+            should_reason = _is_reasoning_model(model_id)
+            if should_reason and not existing_cap.get('reasoning'):
+                merged_cap = {**existing_cap, 'reasoning': True}
+                updated_profiles[profile_key]['capabilities'] = merged_cap
+                updated_fields.append((profile_key, 'capabilities.reasoning', False, True))
+                changed = True
 
             if authoritative_total_tokens is not None:
                 if existing.get('modelTotalTokens') != authoritative_total_tokens:

--- a/tools/sync_models/src/core/patcher.py
+++ b/tools/sync_models/src/core/patcher.py
@@ -180,7 +180,16 @@ def _inject_source_comments(serialized: str) -> str:
         else:
             result.append(line)
         i += 1
-    return '\n'.join(result)
+    text = '\n'.join(result)
+    # Strip trailing commas before a closing `}` (left behind when a `_src_FIELD`
+    # line that was the object's last entry got dropped above). Preserves any
+    # inline `// comment` between the comma and the newline.
+    text = re.sub(
+        r',(\s*//[^\n]*)?(\s*\n\s*\})',
+        lambda m: (m.group(1) or '') + m.group(2),
+        text,
+    )
+    return text
 
 
 def _serialize_profiles(profiles: Dict[str, Any], indent_level: int = 0) -> str:

--- a/tools/sync_models/src/providers/base.py
+++ b/tools/sync_models/src/providers/base.py
@@ -349,6 +349,19 @@ class CloudProvider(ABC):
         discovery_source: str | None = next((s for s in model_sources if _discovery_available(s)), None)
 
         # --- Fetch api_models from primary_source ---
+        # If the provider SDK isn't bundled (e.g. running through the engine without
+        # `pip install -r tools/requirements.txt`) fall back to the next available source.
+        if primary_source == 'provider':
+            try:
+                self.make_client(api_key)
+            except ImportError as e:
+                report.warning = f'Provider SDK unavailable ({e}); falling back to OpenRouter.'
+                primary_source = next((s for s in model_sources if s != 'provider' and _enrichment_available(s)), None)
+                if primary_source is None:
+                    report.error = f'No fallback source available: {e}'
+                    return report
+                if discovery_source == 'provider':
+                    discovery_source = primary_source if allow_fallback_discovery else None
         try:
             if primary_source == 'provider':
                 client = self.make_client(api_key)
@@ -499,7 +512,7 @@ class CloudProvider(ABC):
         """
         seen: Dict[str, Dict[str, Any]] = {}  # native_id → entry
 
-        for bare_id, (ctx, _out, _name, _exp) in get_openrouter_cache().items():
+        for bare_id, (ctx, _out, _name, _exp, _reasoning) in get_openrouter_cache().items():
             # Apply the same two-step conversion as _fetch_litellm_models():
             # 1. normalize_model_id() — handles raw ID quirks (e.g. dots→hyphens for Anthropic)
             # 2. litellm_to_native_model_id() — converts to the native format stored in

--- a/tools/sync_models/src/stamp_reasoning.py
+++ b/tools/sync_models/src/stamp_reasoning.py
@@ -1,0 +1,45 @@
+"""Stamp `capabilities.reasoning` in services.json files outside the sync registry.
+
+For providers without an API handler (Ollama local, GMI Cloud aggregator) the
+weekly `sync_models.py` cron skips them. This script applies the same OpenRouter
++ family-fallback heuristic used by the merger to keep them in sync.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from core.merger import _is_reasoning_model, _load_openrouter_cache  # noqa: E402
+from core.patcher import get_profiles, patch  # noqa: E402
+
+_PATHS = [
+    'nodes/src/nodes/llm_gmi_cloud/services.json',
+    'nodes/src/nodes/llm_ollama/services.json',
+]
+
+
+def main() -> int:
+    if hasattr(sys.stdout, 'reconfigure'):
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    _load_openrouter_cache()
+    for path in _PATHS:
+        profiles = get_profiles(path)
+        updated, changed = {}, False
+        for key, p in profiles.items():
+            cap = (p.get('capabilities') or {}) if isinstance(p, dict) else {}
+            if isinstance(p, dict) and _is_reasoning_model(p.get('model', '')) and not cap.get('reasoning'):
+                updated[key] = {**p, 'capabilities': {**cap, 'reasoning': True}}
+                changed = True
+                print(f'  {path}: {key} → capabilities.reasoning=true')
+            else:
+                updated[key] = p
+        if changed:
+            patch(path, updated, set(), set(), set(), dry_run=False)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/sync_models/src/sync_models.py
+++ b/tools/sync_models/src/sync_models.py
@@ -247,6 +247,11 @@ def main() -> int:
     Returns:
         Exit code (0 = success, 1 = one or more errors)
     """
+    # The bundled engine runtime ships stdout as ASCII; force UTF-8 so we can print ✓/✗.
+    if hasattr(sys.stdout, 'reconfigure'):
+        sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+        sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+
     parser = argparse.ArgumentParser(
         description='Sync LLM model lists from provider APIs into services.json files.',
     )
@@ -314,8 +319,12 @@ def main() -> int:
     args = parser.parse_args()
 
     # --- Validate / normalise --model-source ---
-    if args.model_sources is None:
-        args.model_sources = ['provider', 'openrouter', 'litellm']
+    explicit_sources = args.model_sources is not None
+    if not explicit_sources:
+        # Defaults degrade gracefully when litellm isn't bundled (engine runtime).
+        args.model_sources = ['provider', 'openrouter']
+        if _LITELLM_AVAILABLE:
+            args.model_sources.append('litellm')
     if len(args.model_sources) != len(set(args.model_sources)):
         print(
             'ERROR: --model-source values must not be repeated.',


### PR DESCRIPTION
## Summary

- Model sync now detects reasoning-capable models from the OpenRouter catalog (+ a family-root fallback for distills/variants) and stamps `capabilities.reasoning` into each provider's `services.json`.
- Adds `models:stamp-reasoning` / `models:stamp-locals` and `stamp_reasoning.py` for providers without an API handler (Ollama, GMI Cloud).
- Includes engine-runtime fixes needed to run the sync: UTF-8 stdout, optional litellm source, provider-SDK fallback to OpenRouter, and a patcher trailing-comma cleanup.


## Type

feat (tooling)

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`python -m py_compile` clean on all changed modules. `./builder models:update --all --apply` verified stamping `capabilities.reasoning: true` on the reasoning models across Anthropic / OpenAI / DeepSeek / xAI / Qwen / Perplexity / Mistral / Kimi (run on the sibling branch with this same tooling). Generated `services.json` are intentionally **not** included — they're regenerated by running the sync.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

No behavior change for consumers — the flag is additive and currently unread.

## Linked Issue

Fixes #1212

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new `models:stamp-locals` action for stamping model capabilities.
  * Implemented automatic detection and tracking of reasoning models across providers.

* **Bug Fixes**
  * Improved UTF-8 encoding consistency for output.
  * Fixed trailing comma formatting in configuration files.
  * Enhanced graceful handling when provider SDKs are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->