### PR TITLE
feat(llm): stream model reasoning over the 'thinking' SSE lane

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -23,11 +23,16 @@
 
 """
 Anthropic binding for the ChatLLM.
+
+Extended-thinking streaming is handled globally via
+``ai.common.llm_native_stream`` (``_native_stream_provider = 'anthropic'``).
 """
 
 from typing import Any, Dict
+
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.llm_native_stream import build_anthropic_thinking_kwargs, gate_model_name
 from langchain_anthropic import ChatAnthropic
 
 
@@ -52,6 +57,7 @@ class Chat(ChatBase):
 
         # Get the model
         model = config.get('model')
+        model_gate = gate_model_name(str(model) if model is not None else '')
 
         # Get the API key, don't save it
         apikey = (config.get('apikey') or '').strip()
@@ -65,12 +71,22 @@ class Chat(ChatBase):
         super().__init__(provider, connConfig, bag)
 
         # Get the LLM
-        self._llm = ChatAnthropic(
-            model=model,
-            api_key=apikey,
-            max_tokens=self._modelOutputTokens,
-            custom_get_token_ids=_estimate_token_ids,
-        )
+        kwargs: Dict[str, Any] = {
+            'model': model,
+            'api_key': apikey,
+            'max_tokens': self._modelOutputTokens,
+            'custom_get_token_ids': _estimate_token_ids,
+        }
+        if self._is_reasoning:
+            kwargs.update(build_anthropic_thinking_kwargs(model_gate, self._modelOutputTokens))
+
+        self._extended_thinking = bool(kwargs.get('thinking'))
+        # Only route through the native handler when thinking is actually on;
+        # non-reasoning models stay on the default LangChain path.
+        if self._extended_thinking:
+            self._native_stream_provider = 'anthropic'
+
+        self._llm = ChatAnthropic(**kwargs)
 
         # Save our chat class into the bag
         bag['chat'] = self

--- a/nodes/src/nodes/llm_openai/openai_client.py
+++ b/nodes/src/nodes/llm_openai/openai_client.py
@@ -29,13 +29,17 @@ from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
 from langchain_openai import ChatOpenAI
-from openai import APIError, AuthenticationError, RateLimitError, APIConnectionError
+from openai import OpenAI, APIError, AuthenticationError, RateLimitError, APIConnectionError
 
 
 class Chat(ChatBase):
     """
     Create an OpenAI chat bot.
     """
+
+    # Reasoning-capable models route through the OpenAI Responses API so we can
+    # stream the reasoning summary as well as the answer.
+    SUPPORTS_REASONING_STREAMING = True
 
     _llm: ChatOpenAI
 
@@ -51,9 +55,25 @@ class Chat(ChatBase):
 
         # Get the api key, don't save it
         apikey = config.get('apikey')
+        self._apikey = apikey
 
-        # Get the llm
-        self._llm = ChatOpenAI(model=self._model, api_key=apikey, temperature=0, max_tokens=self._modelOutputTokens)
+        # Reasoning models stream via the Responses API + max_completion_tokens.
+        if self._is_reasoning:
+            # Raw client for the Responses API path (reasoning models).
+            self._raw_client = OpenAI(api_key=apikey)
+            self._llm = ChatOpenAI(
+                model=self._model,
+                api_key=apikey,
+                model_kwargs={'max_completion_tokens': self._modelOutputTokens},
+            )
+        else:
+            self._raw_client = None
+            self._llm = ChatOpenAI(
+                model=self._model,
+                api_key=apikey,
+                temperature=0,
+                max_tokens=self._modelOutputTokens,
+            )
 
         # Save our chat class into the bag
         bag['chat'] = self

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -13,12 +13,68 @@ communication with their respective APIs.
 import time
 import json
 import importlib
-from typing import Dict, Any
-from rocketlib import debug
+from typing import Dict, Any, Callable, Optional
+from rocketlib import debug, warning
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
 from ai.common.util import parseJson
 from ai.common.validation import validate_model_name, validate_max_tokens, validate_prompt
+from ai.common.llm_native_stream import dispatch_native_chat_stream
+
+
+def _make_think_tag_splitter():
+    """Split ``<think>...</think>`` CoT out of the content stream (Ollama, Perplexity).
+
+    Returns a ``feed(text) -> (visible, reasoning)`` closure; tags may span deltas.
+    """
+    OPEN, CLOSE = '<think>', '</think>'
+    state = {'mode': 'visible', 'buf': ''}
+
+    def feed(text: str):
+        if not text:
+            return '', ''
+        buf = state['buf'] + text
+        visible_parts: list = []
+        reasoning_parts: list = []
+        while buf:
+            if state['mode'] == 'visible':
+                idx = buf.find(OPEN)
+                if idx < 0:
+                    # Hold back trailing chars that could be a partial '<think>'.
+                    safe = len(buf) - (len(OPEN) - 1)
+                    if safe > 0:
+                        visible_parts.append(buf[:safe])
+                        buf = buf[safe:]
+                    break
+                if idx:
+                    visible_parts.append(buf[:idx])
+                buf = buf[idx + len(OPEN) :]
+                state['mode'] = 'thinking'
+            else:
+                idx = buf.find(CLOSE)
+                if idx < 0:
+                    safe = len(buf) - (len(CLOSE) - 1)
+                    if safe > 0:
+                        reasoning_parts.append(buf[:safe])
+                        buf = buf[safe:]
+                    break
+                if idx:
+                    reasoning_parts.append(buf[:idx])
+                buf = buf[idx + len(CLOSE) :]
+                state['mode'] = 'visible'
+        state['buf'] = buf
+        return ''.join(visible_parts), ''.join(reasoning_parts)
+
+    def flush():
+        """Emit anything buffered at end-of-stream (e.g. an unterminated tag)."""
+        tail = state['buf']
+        state['buf'] = ''
+        if state['mode'] == 'thinking':
+            return '', tail
+        return tail, ''
+
+    feed.flush = flush  # type: ignore[attr-defined]
+    return feed
 
 
 class ChatBase:
@@ -39,6 +95,20 @@ class ChatBase:
         _model (str): The model identifier/name being used
         _modelTotalTokens (int): Maximum tokens the model can handle in total
     """
+
+    # Reasoning capability from services.json (capabilities.reasoning), stamped by
+    # the model sync. Read once in __init__ so no driver has to.
+    _is_reasoning: bool = False
+    # Opt-in: subclass sets True + sets self._raw_client to route through the
+    # OpenAI Responses API for reasoning-summary streaming.
+    SUPPORTS_REASONING_STREAMING: bool = False
+    _raw_client = None
+
+    # Native stream handler key, set by non-OpenAI drivers (e.g. Anthropic);
+    # left empty for OpenAI-compatible drivers, which ChatBase auto-wires.
+    _native_stream_provider: str = ''
+    # Raw openai SDK client for the generic reasoning handler; built lazily by ChatBase.
+    _raw_openai_client = None
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
         """
@@ -79,6 +149,31 @@ class ChatBase:
         debug(f'    Model                    : {self._model}')
         debug(f'    Total tokens             : {self._modelTotalTokens}')
         debug(f'    Output tokens            : {self._modelOutputTokens}')
+
+        # Reasoning capability comes from services.json (stamped by the model sync).
+        self._is_reasoning = bool((config.get('capabilities') or {}).get('reasoning'))
+
+    def _ensure_openai_compat_reasoning_stream(self) -> None:
+        """Lazily build the raw openai client used to stream reasoning for
+        OpenAI-compatible drivers (built here, since _llm exists after super().__init__).
+        """
+        if self._native_stream_provider or self._raw_openai_client is not None:
+            return
+        if not self._is_reasoning:
+            return
+        llm = getattr(self, '_llm', None)
+        base_url = getattr(llm, 'openai_api_base', None)
+        if llm is None or not base_url:
+            return  # not an OpenAI-compatible driver (e.g. plain OpenAI, Anthropic)
+        key = getattr(llm, 'openai_api_key', None)
+        api_key = key.get_secret_value() if hasattr(key, 'get_secret_value') else key
+        try:
+            from openai import OpenAI
+
+            self._raw_openai_client = OpenAI(api_key=api_key, base_url=str(base_url))
+            self._native_stream_provider = 'openai_compat_reasoning'
+        except Exception as e:  # openai SDK missing / bad client → fall back to generic stream
+            debug(f'    Native reasoning stream unavailable: {type(e).__name__}: {e}')
 
     def getTotalTokens(self) -> int:
         """
@@ -310,6 +405,10 @@ class ChatBase:
                     # Non-retryable error or max retries reached
                     debug(f'Chat failed after {attempt + 1} attempts: {str(e)}')
 
+                    # Surface the raw provider message in the UI Errors tab
+                    # before map_exception() collapses it into a vaguer ValueError.
+                    warning(f'Chat failed for model={self._model} ({type(e).__name__}): {e}')
+
                     # Map to a friendlier exception if possible
                     raise self.map_exception(e)
 
@@ -326,35 +425,86 @@ class ChatBase:
         # This should never be reached due to the raise in the loop
         raise Exception('Unexpected exit from retry loop')
 
-    def chat_string(self, prompt: str) -> str:
+    def _chat_string_responses(
+        self,
+        prompt: str,
+        on_chunk: Optional[Callable[[str], None]] = None,
+        on_finish: Optional[Callable[[Optional[str]], None]] = None,
+        on_reasoning_chunk: Optional[Callable[[str], None]] = None,
+        emitted: Optional[Dict[str, bool]] = None,
+    ) -> str:
+        """Stream the answer and reasoning summary via the OpenAI Responses API,
+        falling back to non-streaming invoke() only if nothing reached the UI yet.
         """
-        Invoke the chat interface with string input, token management, and network retry handling.
+        prompt = validate_prompt(prompt, self._modelTotalTokens, self.getTokens)
 
-        This is the main entry point for chat operations using raw string prompts.
-        It handles token counting, limit checking, network retries, and provides
-        warnings for potential issues like truncation.
+        text_parts: list = []
+        finish_reason: Optional[str] = None
+        try:
+            stream = self._raw_client.responses.create(
+                model=self._model,
+                input=prompt,
+                reasoning={'summary': 'auto'},
+                max_output_tokens=self._modelOutputTokens,
+                stream=True,
+            )
+            for event in stream:
+                etype = getattr(event, 'type', '') or ''
+                if etype == 'response.reasoning_summary_text.delta':
+                    delta = getattr(event, 'delta', '') or ''
+                    if delta and on_reasoning_chunk is not None:
+                        on_reasoning_chunk(delta)
+                elif etype == 'response.output_text.delta':
+                    delta = getattr(event, 'delta', '') or ''
+                    if delta:
+                        text_parts.append(delta)
+                        if on_chunk is not None:
+                            on_chunk(delta)
+                elif etype == 'response.completed':
+                    resp = getattr(event, 'response', None)
+                    if resp is not None:
+                        status = getattr(resp, 'status', None)
+                        if status == 'completed':
+                            finish_reason = 'stop'
+                        elif status == 'incomplete':
+                            details = getattr(resp, 'incomplete_details', None)
+                            reason = getattr(details, 'reason', None) if details else None
+                            finish_reason = reason or 'length'
+                        else:
+                            finish_reason = status or 'stop'
+                elif etype in ('response.failed', 'response.error'):
+                    finish_reason = 'error'
+        except Exception as e:
+            warning(f'Reasoning streaming disabled for model={self._model} ({type(e).__name__}): {e}.')
+            # Only retry non-streaming if nothing has reached the UI; otherwise
+            # the full fallback would arrive on top of the partial we already streamed.
+            if emitted is None or not emitted['any']:
+                results = self._llm.invoke(prompt)
+                content = getattr(results, 'content', '') or ''
+                content_text = content if isinstance(content, str) else str(content)
+                text_parts = [content_text]
+                # Push the fallback answer through on_chunk so the open UI bubble
+                # gets the visible text (the caller dedupes the final pipeline result).
+                if content_text and on_chunk is not None:
+                    on_chunk(content_text)
+                finish_reason = 'stop'
+            else:
+                finish_reason = 'error'
 
-        The method performs the following steps:
-        1. Count tokens in the input prompt
-        2. Check if prompt exceeds safe limits
-        3. Call the provider-specific chat implementation with retry logic
-        4. Count tokens in the response
-        5. Check for potential truncation
-        6. Return the result
+        if on_finish is not None:
+            on_finish(finish_reason)
 
-        Args:
-            prompt (str): The complete prompt to send to the model
+        return ''.join(text_parts)
 
-        Returns:
-            str: The model's response
-
-        Warnings:
-            - Issues debug warning if prompt is too long
-            - Issues debug warning if response appears truncated
-
-        Raises:
-            Exception: If network/API retries are exhausted or non-retryable
-                      errors occur
+    def chat_string(
+        self,
+        prompt: str,
+        on_chunk: Optional[Callable[[str], None]] = None,
+        on_finish: Optional[Callable[[Optional[str]], None]] = None,
+        on_reasoning_chunk: Optional[Callable[[str], None]] = None,
+    ) -> str:
+        """Run a string prompt with token checks and retry; when callbacks are given,
+        stream visible/reasoning deltas as they arrive. Returns the full answer.
         """
         # Validate and sanitize the prompt before processing
         prompt = validate_prompt(prompt, self._modelTotalTokens, self.getTokens)
@@ -371,9 +521,133 @@ class ChatBase:
                 f'Warning: Prompt ({prompt_tokens} tokens) exceeds input allocation ({self._modelTotalTokens} tokens)'
             )
 
+        # True once visible text reached the UI; fallback then skips the non-stream
+        # retry to avoid duplication. Only on_chunk flips it (not reasoning).
+        emitted = {'any': False}
+
+        if on_chunk is None:
+            on_chunk_w = None
+        else:
+
+            def on_chunk_w(t):
+                emitted['any'] = True
+                on_chunk(t)
+
+        on_reasoning_chunk_w = on_reasoning_chunk
+
+        # Responses API path for opt-in reasoning models (OpenAI o-series / gpt-5).
+        if (
+            self.SUPPORTS_REASONING_STREAMING
+            and self._is_reasoning
+            and self._raw_client is not None
+            and hasattr(self._raw_client, 'responses')
+        ):
+            return self._chat_string_responses(
+                prompt,
+                on_chunk=on_chunk_w,
+                on_finish=on_finish,
+                on_reasoning_chunk=on_reasoning_chunk_w,
+                emitted=emitted,
+            )
+
+        # Provider-native streaming (generic openai_compat reasoning, Anthropic extended thinking).
+        if on_chunk is not None:
+            # Auto-wire the generic OpenAI-compatible reasoning stream from config
+            # (no per-provider code). Special-case drivers already set their handler.
+            self._ensure_openai_compat_reasoning_stream()
+            native_text = dispatch_native_chat_stream(self, prompt, on_chunk_w, on_finish, on_reasoning_chunk_w)
+            if native_text is not None:
+                result_tokens = self.getTokens(native_text)
+                if prompt_tokens + result_tokens >= self._modelTotalTokens - 5:
+                    debug(f'Warning: Result ({result_tokens} tokens) was probably truncated')
+                return native_text
+            # Native handler returned None after emitting chunks: don't restart
+            # the request through a different path, just close with an error.
+            if emitted['any']:
+                if on_finish is not None:
+                    on_finish('error')
+                return ''
+
+        _llm = getattr(self, '_llm', None)
+
         # Call the chat implementation with network retry logic
         # This is where the real communication with the AI provider happens
-        result = self._chat_with_retries(prompt)
+        # Use chat_string when a per-token callback is provided; .stream() if available, else fall back.
+        result = None
+        if on_chunk_w is not None and _llm is not None and hasattr(_llm, 'stream'):
+            try:
+                parts = []
+                finish_reason: Optional[str] = None
+                _signature_only_note_sent = False
+                _think_split = _make_think_tag_splitter()
+                for piece in _llm.stream(prompt):
+                    # content: str for OpenAI-style, list of typed blocks for Anthropic.
+                    content = piece.content
+                    text = ''
+                    thinking_delta = ''
+                    if isinstance(content, list):
+                        for b in content:
+                            if not isinstance(b, dict):
+                                continue
+                            btype = b.get('type', '')
+                            if btype == 'thinking':
+                                # carries either text deltas or a signature-only final delta.
+                                piece_text = b.get('thinking') or b.get('text') or ''
+                                if piece_text:
+                                    thinking_delta += piece_text
+                                elif b.get('signature') and not _signature_only_note_sent:
+                                    if on_reasoning_chunk_w is not None:
+                                        thinking_delta += (
+                                            '_Extended thinking ran, but this stream only delivered the '
+                                            'block verification signature, not the readable chain-of-thought '
+                                            'text. The answer below still reflects internal reasoning._\n\n'
+                                        )
+                                        _signature_only_note_sent = True
+                            elif btype == 'reasoning':
+                                # LangChain v1 standard block (thinking → reasoning).
+                                piece_text = b.get('reasoning') or b.get('text') or ''
+                                if piece_text:
+                                    thinking_delta += piece_text
+                            elif btype == 'text' or not btype:
+                                text += b.get('text', '')
+                    elif isinstance(content, str):
+                        # Strip inline `<think>...</think>` (Perplexity sonar-reasoning fallback).
+                        text, _thinking_inline = _think_split(content)
+                        if _thinking_inline:
+                            thinking_delta += _thinking_inline
+                    if thinking_delta and on_reasoning_chunk_w is not None:
+                        on_reasoning_chunk_w(thinking_delta)
+                    if text:
+                        on_chunk_w(text)
+                        parts.append(text)
+                    reason = (piece.response_metadata or {}).get('finish_reason')
+                    if reason:
+                        finish_reason = reason
+                # Drain chars buffered by the <think> splitter (partial-tag tail).
+                tail_visible, tail_reasoning = _think_split.flush()
+                if tail_visible:
+                    on_chunk_w(tail_visible)
+                    parts.append(tail_visible)
+                if tail_reasoning and on_reasoning_chunk_w is not None:
+                    on_reasoning_chunk_w(tail_reasoning)
+                if parts:
+                    result = ''.join(parts)
+                    if on_finish is not None:
+                        on_finish(finish_reason)
+            except Exception as e:
+                warning(
+                    f'Streaming disabled for model={self._model} '
+                    f'({type(e).__name__}): {e}. Falling back to non-streaming response.'
+                )
+        if result is None:
+            # If anything already reached the UI we can't restart the request
+            # (would duplicate content); close with an error and return partials.
+            if emitted['any']:
+                if on_finish is not None:
+                    on_finish('error')
+                result = ''
+            else:
+                result = self._chat_with_retries(prompt)
 
         # Count tokens in the response to check for potential truncation
         # This helps identify cases where the model's response was cut off
@@ -388,33 +662,26 @@ class ChatBase:
         # Return the model's response
         return result
 
-    def chat(self, question: Question) -> Answer:
+    def chat(
+        self,
+        question: Question,
+        on_chunk: Optional[Callable[[str], None]] = None,
+        on_finish: Optional[Callable[[Optional[str]], None]] = None,
+        on_reasoning_chunk: Optional[Callable[[str], None]] = None,
+    ) -> Answer:
+        """Chat with Question/Answer objects (JSON validation + retry); forwards the
+        streaming callbacks unless expectJson, which needs the validated final answer.
         """
-        Chat using structured Question/Answer objects with JSON validation and network retry handling.
+        # No streaming for expectJson: repair retries would paint a bad first attempt.
+        stream_cbs = (None, None, None) if question.expectJson else (on_chunk, on_finish, on_reasoning_chunk)
 
-        This method provides a robust interface that works with the application's
-        schema objects. It handles network failures, rate limits, and other
-        transient errors by retrying the request with exponential backoff.
-
-        If the question expects JSON output, this method will also validate the
-        response and retry with additional instructions if the JSON is invalid.
-
-        Args:
-            question (Question): A Question object containing the prompt and
-                               metadata (e.g., whether JSON output is expected)
-
-        Returns:
-            Answer: An Answer object containing the response and preserving
-                   the original question's metadata
-
-        Raises:
-            ValueError: If expectJson is True and valid JSON cannot be obtained
-                       after multiple retry attempts
-            Exception: If network/API retries are exhausted or non-retryable
-                      errors occur
-        """
         # Use chat_string which already handles network retries and token management
-        response = self.chat_string(question.getPrompt())
+        response = self.chat_string(
+            question.getPrompt(),
+            on_chunk=stream_cbs[0],
+            on_finish=stream_cbs[1],
+            on_reasoning_chunk=stream_cbs[2],
+        )
 
         # If JSON output is expected, validate the response and retry if needed.
         # Store the parsed result so setAnswer receives a dict/list directly —

--- a/packages/ai/src/ai/common/llm_base.py
+++ b/packages/ai/src/ai/common/llm_base.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2026 Aparavi Software AG
 
-from rocketlib import IInstanceBase, invoke_function
+import inspect
+from typing import Callable, Optional
+
+from rocketlib import IInstanceBase, invoke_function, warning
 from ai.common.schema import Question, Answer
 
 
@@ -11,11 +14,78 @@ class LLMBase(IInstanceBase):
     Provider-specific request/retry behavior remains in ai.common.chat.ChatBase.
     """
 
-    def _question(self, question: Question) -> Answer:
-        return self.IGlobal._chat.chat(question)
+    def _question(
+        self,
+        question: Question,
+        on_chunk: Optional[Callable[[str], None]] = None,
+        on_finish: Optional[Callable[[Optional[str]], None]] = None,
+        on_reasoning_chunk: Optional[Callable[[str], None]] = None,
+    ) -> Answer:
+        chat = self.IGlobal._chat
+        # Legacy drivers override chat(self, question) without streaming callbacks.
+        try:
+            accepts_stream = 'on_chunk' in inspect.signature(chat.chat).parameters
+        except (TypeError, ValueError):
+            accepts_stream = True
+        if not accepts_stream:
+            return chat.chat(question)
+        return chat.chat(
+            question,
+            on_chunk=on_chunk,
+            on_finish=on_finish,
+            on_reasoning_chunk=on_reasoning_chunk,
+        )
 
     def writeQuestions(self, question: Question):
-        answer = self._question(question)
+        # Stream the model's reasoning live, one line at a time, on the chat-ui
+        # 'thinking' lane (same channel as agents). The answer is written normally.
+        buf: list = []
+
+        def _noop(_text: str) -> None:
+            pass
+
+        def _emit_thinking(message: str) -> None:
+            if message:
+                try:
+                    self.instance.sendSSE('thinking', message=message)
+                except Exception:
+                    pass
+
+        def _flush_reasoning(force: bool = False) -> None:
+            # Emit complete lines; keep the trailing partial in buf so the next
+            # delta can continue it — unless forced (long paragraph or stream end).
+            lines = ''.join(buf).splitlines(keepends=True)
+            remainder = lines.pop() if (lines and not force and not lines[-1].endswith('\n')) else ''
+            buf[:] = [remainder] if remainder else []
+            for line in lines:
+                _emit_thinking(line.strip())
+
+        def on_reasoning_chunk(text: str) -> None:
+            if not text:
+                return
+            buf.append(text)
+            # Stream live: emit complete lines, or force a flush once a newline-less
+            # paragraph grows enough to show progress.
+            if '\n' in text:
+                _flush_reasoning()
+            elif sum(len(p) for p in buf) >= 120:
+                _flush_reasoning(force=True)
+
+        try:
+            answer = self._question(
+                question,
+                on_chunk=_noop,
+                on_reasoning_chunk=on_reasoning_chunk,
+            )
+        except Exception as e:
+            err_msg = f'**LLM error** — {type(e).__name__}: {e}'
+            warning(f'writeQuestions: LLM call failed: {type(e).__name__}: {e}')
+            answer = Answer()
+            answer.setAnswer(err_msg)
+            self.instance.writeAnswers(answer)
+            return
+
+        _flush_reasoning(force=True)  # emit any trailing partial line
         self.instance.writeAnswers(answer)
 
     @invoke_function

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -1,0 +1,335 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Central registry for LLM streaming paths that bypass or augment LangChain's
+# aggregated .stream() when a provider drops reasoning deltas on the wire.
+# =============================================================================
+
+"""Provider-specific streaming handlers that preserve reasoning deltas LangChain drops.
+
+Drivers opt in via ``self._native_stream_provider``; ChatBase dispatches here before
+the generic stream.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Optional
+
+from rocketlib import debug, warning
+
+# --- Anthropic: model id gates (vendor prefixes) ---
+
+_VENDOR_MODEL_PREFIXES = (
+    'openrouter/',
+    'openai/',
+    'anthropic/',
+    'vertex_ai/',
+    'google/',
+)
+
+
+def gate_model_name(model: str) -> str:
+    """Strip routing prefixes so ``openrouter/anthropic/claude-opus-4-7`` matches Claude gates."""
+    m = (model or '').strip().lower()
+    for _ in range(8):
+        stripped = False
+        for p in _VENDOR_MODEL_PREFIXES:
+            if m.startswith(p):
+                m = m[len(p) :]
+                stripped = True
+                break
+        if not stripped:
+            break
+    return m
+
+
+def build_anthropic_thinking_kwargs(model_gate: str, model_output_tokens: int) -> Dict[str, Any]:
+    """Return ``ChatAnthropic`` thinking kwargs by model name, or ``{}`` if unsupported."""
+    if 'haiku' in model_gate:
+        return {}  # Haiku has no extended thinking — sending it 400s.
+    out: Dict[str, Any] = {}
+    if model_gate.startswith('claude-opus-4-7') or model_gate.startswith('claude-opus-4-8'):
+        out['thinking'] = {'type': 'adaptive', 'display': 'summarized'}
+    else:
+        budget = max(2048, model_output_tokens // 2)
+        if budget >= model_output_tokens:
+            budget = model_output_tokens - 1024
+        if budget < 1024:
+            return {}  # output window too small for a valid thinking budget
+        out['betas'] = ['interleaved-thinking-2025-05-14']
+        out['thinking'] = {'type': 'enabled', 'budget_tokens': budget}
+    return out
+
+
+# --- Anthropic native Messages API stream ---
+
+_NATIVE_CREATE_KEYS = frozenset(
+    {
+        'model',
+        'messages',
+        'max_tokens',
+        'system',
+        'temperature',
+        'top_p',
+        'top_k',
+        'stop_sequences',
+        'stream',
+        'metadata',
+        'thinking',
+        'tools',
+        'tool_choice',
+        'betas',
+        'service_tier',
+        'container',
+        'output_config',
+        'inference_geo',
+        'cache_control',
+    }
+)
+
+
+def _map_claude_stop_reason(stop_reason: Any) -> Optional[str]:
+    if stop_reason is None:
+        return None
+    s = str(stop_reason).lower()
+    if s in ('end_turn', 'stop_sequence'):
+        return 'stop'
+    if s in ('max_tokens', 'model_context_window_exceeded', 'length'):
+        return 'length'
+    if 'error' in s:
+        return 'error'
+    return 'stop'
+
+
+def _delta_type_name(delta: Any) -> str:
+    if delta is None:
+        return ''
+    t = getattr(delta, 'type', None)
+    if t is None:
+        return ''
+    v = getattr(t, 'value', t)
+    return str(v)
+
+
+def _event_type_name(event: Any) -> str:
+    if event is None:
+        return ''
+    t = getattr(event, 'type', None)
+    if t is None:
+        return ''
+    v = getattr(t, 'value', t)
+    return str(v)
+
+
+def _payload_for_native_create(payload: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in payload.items() if k in _NATIVE_CREATE_KEYS and v is not None}
+
+
+def _open_raw_message_stream(client: Any, payload: dict[str, Any]):
+    safe = _payload_for_native_create(payload)
+    try:
+        if safe.get('betas'):
+            return client.beta.messages.create(**safe)
+        return client.messages.create(**safe)
+    except TypeError as first_err:
+        minimal = {
+            k: safe[k]
+            for k in ('model', 'messages', 'max_tokens', 'stream', 'thinking', 'temperature', 'system')
+            if k in safe
+        }
+        debug(f'llm_native_stream: anthropic create TypeError ({first_err!r}); retrying minimal keys {list(minimal)}')
+        if safe.get('betas'):
+            minimal['betas'] = safe['betas']
+            return client.beta.messages.create(**minimal)
+        return client.messages.create(**minimal)
+
+
+def anthropic_extended_thinking_active(chat: Any) -> bool:
+    if getattr(chat, '_extended_thinking', False):
+        return True
+    llm = getattr(chat, '_llm', None)
+    if llm is None:
+        return False
+    if getattr(llm, 'thinking', None):
+        return True
+    mk = getattr(llm, 'model_kwargs', None) or {}
+    return bool(mk.get('thinking'))
+
+
+def _stream_anthropic_messages_api(
+    chat: Any,
+    prompt: str,
+    on_chunk: Callable[[str], None],
+    on_finish: Optional[Callable[[Optional[str]], None]],
+    on_reasoning_chunk: Optional[Callable[[str], None]],
+) -> str:
+    llm = chat._llm
+    payload: dict[str, Any] = dict(llm._get_request_payload(prompt, stop=None, stream=True))
+    _raw_client = getattr(llm, '_client', None)
+    client = _raw_client() if callable(_raw_client) else _raw_client
+    if client is None:
+        raise RuntimeError('ChatAnthropic has no _client for native streaming')
+
+    parts: list[str] = []
+    finish_reason: Optional[str] = None
+    reasoning_deltas = 0
+    raw_stream = _open_raw_message_stream(client, payload)
+
+    try:
+        for event in raw_stream:
+            et = _event_type_name(event)
+            if et == 'content_block_delta':
+                delta = getattr(event, 'delta', None)
+                if delta is None:
+                    continue
+                dt = _delta_type_name(delta)
+                if dt == 'thinking_delta' and on_reasoning_chunk is not None:
+                    piece = getattr(delta, 'thinking', None) or ''
+                    if piece:
+                        on_reasoning_chunk(piece)
+                        reasoning_deltas += 1
+                elif dt == 'text_delta' and on_chunk is not None:
+                    piece = getattr(delta, 'text', None) or ''
+                    if piece:
+                        on_chunk(piece)
+                        parts.append(piece)
+            elif et == 'message_delta':
+                md = getattr(event, 'delta', None)
+                if md is not None:
+                    sr = getattr(md, 'stop_reason', None)
+                    if sr is not None:
+                        finish_reason = _map_claude_stop_reason(sr)
+    finally:
+        closer = getattr(raw_stream, 'close', None)
+        if callable(closer):
+            try:
+                closer()
+            except Exception:
+                pass
+
+    if not parts:
+        raise RuntimeError('Anthropic SDK stream produced no text')
+
+    if on_finish is not None:
+        on_finish(finish_reason)
+
+    return ''.join(parts)
+
+
+def try_anthropic_native_chat_stream(
+    chat: Any,
+    prompt: str,
+    on_chunk: Callable[[str], None],
+    on_finish: Optional[Callable[[Optional[str]], None]],
+    on_reasoning_chunk: Optional[Callable[[str], None]],
+) -> Optional[str]:
+    """Return full assistant text if native Anthropic streaming handled the call."""
+    if not anthropic_extended_thinking_active(chat):
+        return None
+
+    try:
+        text = _stream_anthropic_messages_api(chat, prompt, on_chunk, on_finish, on_reasoning_chunk)
+        return text
+    except Exception as e:
+        warning(
+            f'llm_native_stream anthropic: native stream failed ({type(e).__name__}): {e} '
+            '(falling back to LangChain; thinking text may be missing).'
+        )
+        return None
+
+
+# --- OpenAI-compatible Chat Completions with reasoning_content ---
+# langchain-openai drops delta.reasoning_content, so we stream via the raw openai
+# SDK (DeepSeek, Qwen, xAI, GMI, Ollama, …). ChatBase auto-wires this in chat_string.
+
+
+def try_openai_compat_reasoning_stream(
+    chat: Any,
+    prompt: str,
+    on_chunk: Callable[[str], None],
+    on_finish: Optional[Callable[[Optional[str]], None]],
+    on_reasoning_chunk: Optional[Callable[[str], None]],
+) -> Optional[str]:
+    """Stream via the raw ``openai`` SDK to preserve ``delta.reasoning_content``."""
+    client = getattr(chat, '_raw_openai_client', None)
+    if client is None:
+        return None
+    kwargs: Dict[str, Any] = {
+        'model': chat._model,
+        'messages': [{'role': 'user', 'content': prompt}],
+        'stream': True,
+        'max_tokens': chat._modelOutputTokens,
+    }
+    kwargs.update(getattr(chat, '_reasoning_kwargs', {}))
+
+    parts: list[str] = []
+    finish_reason: Optional[str] = None
+    try:
+        for chunk in client.chat.completions.create(**kwargs):
+            if not chunk.choices:
+                continue
+            ch = chunk.choices[0]
+            delta = ch.delta
+            rc = getattr(delta, 'reasoning_content', None)
+            if rc and on_reasoning_chunk is not None:
+                on_reasoning_chunk(rc)
+            if delta.content:
+                on_chunk(delta.content)
+                parts.append(delta.content)
+            if ch.finish_reason:
+                finish_reason = ch.finish_reason
+    except Exception as e:
+        warning(
+            f'llm_native_stream openai_compat_reasoning: stream failed ({type(e).__name__}): {e} '
+            '(falling back to non-streaming chat).'
+        )
+        return None
+
+    if not parts:
+        return None
+    if on_finish is not None:
+        on_finish(finish_reason or 'stop')
+    return ''.join(parts)
+
+
+# --- registry ---
+
+NativeStreamFn = Callable[
+    [Any, str, Callable[[str], None], Optional[Callable[[Optional[str]], None]], Optional[Callable[[str], None]]],
+    Optional[str],
+]
+
+_NATIVE_STREAM_REGISTRY: dict[str, NativeStreamFn] = {}
+
+
+def register_native_stream_handler(name: str, fn: NativeStreamFn) -> None:
+    """Register a provider-specific streaming handler (tests may replace)."""
+    _NATIVE_STREAM_REGISTRY[name] = fn
+
+
+def dispatch_native_chat_stream(
+    chat: Any,
+    prompt: str,
+    on_chunk: Optional[Callable[[str], None]],
+    on_finish: Optional[Callable[[Optional[str]], None]],
+    on_reasoning_chunk: Optional[Callable[[str], None]],
+) -> Optional[str]:
+    """If a registered handler fully serves the stream, return the answer string."""
+    if on_chunk is None:
+        return None
+    key = getattr(chat, '_native_stream_provider', None)
+    if not key:
+        return None
+    fn = _NATIVE_STREAM_REGISTRY.get(str(key))
+    if fn is None:
+        return None
+    return fn(chat, prompt, on_chunk, on_finish, on_reasoning_chunk)
+
+
+def _register_builtin_handlers() -> None:
+    register_native_stream_handler('anthropic', try_anthropic_native_chat_stream)
+    register_native_stream_handler('openai_compat_reasoning', try_openai_compat_reasoning_stream)
+
+
+_register_builtin_handlers()


### PR DESCRIPTION
## Summary


<img width="990" height="436" alt="Captura de pantalla 2026-06-10 a las 21 25 52" src="https://github.com/user-attachments/assets/a2f422e8-7cf1-4741-ab5d-80f989493115" />

- Surface model chain-of-thought in chat through the existing `thinking` SSE lane (the one the UI already renders) — **no UI changes**.
- `ChatBase` reads `capabilities.reasoning` (stamped by the sync, #1214) and centralizes the reasoning paths: generic OpenAI-compatible (`reasoning_content`), Anthropic extended thinking, OpenAI o-series/gpt-5 (Responses API).
- Captured reasoning is emitted as a `thinking` message; the answer is written normally.

## Type

feat

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`py_compile` clean; `./builder nodes:test llm_anthropic llm_openai llm_deepseek` green. Verified live (Anthropic) that reasoning streams into the Thinking panel once the model is stamped reasoning.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

**Safe fallback:** without the `capabilities.reasoning` flag (e.g. before the weekly sync runs) reasoning is off and every model behaves exactly as on develop. `services.json` are intentionally not included (generated by the sync). Mistral/Perplexity keep working via the compat shim and gain reasoning in follow-up per-provider PRs.

## Linked Issue

Fixes #1216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visible output is streamed separately from hidden reasoning/thinking, including unterminated-tag flushes.
  * Native streaming handlers for Anthropic and an OpenAI-compatible reasoning path added and auto-routed.
  * Chat APIs now accept on_chunk, on_reasoning_chunk, and on_finish callbacks for richer incremental UI updates.
  * Reasoning-capable models use a dedicated streaming path with improved finish-reason reporting.

* **Bug Fixes**
  * Retry path surfaces raw provider error details as user-facing warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->