### PR TITLE
fix(home-ui): SaaS pipeline export, host-slot sidebar refactor & shell/canvas polish

### DIFF
--- a/apps/shell-ui/src/components/layout/LoadingScreen.tsx
+++ b/apps/shell-ui/src/components/layout/LoadingScreen.tsx
@@ -10,7 +10,7 @@
 // Theme-aware via the same CSS custom properties the rest of the shell uses.
 // =============================================================================
 
-import React, { type CSSProperties } from 'react';
+import React, { useState, type CSSProperties } from 'react';
 import RocketRideMark from '../../icons/RocketRideMark';
 
 const container: CSSProperties = {
@@ -29,13 +29,19 @@ const KEYFRAMES = `@keyframes rr-loading-float {
 	50%       { transform: translateY(-8px); }
 }`;
 
-const LoadingScreen: React.FC = () => (
-	<div style={container}>
-		<style>{KEYFRAMES}</style>
-		<div style={logoWrapper}>
-			<RocketRideMark size={56} color="var(--rr-text-primary)" />
+const LoadingScreen: React.FC = () => {
+	// Phase-anchor the float bob to a shared clock (epoch, realm-independent) so home-ui's
+	// AuthTransitionPage picks up exactly where this leaves off — both use the same 2.4s
+	// cycle. Computed once on mount so re-renders don't restart the animation.
+	const [floatDelay] = useState(() => `${-(Date.now() % 2400)}ms`);
+	return (
+		<div style={container}>
+			<style>{KEYFRAMES}</style>
+			<div style={{ ...logoWrapper, animationDelay: floatDelay }}>
+				<RocketRideMark size={56} color="var(--rr-text-primary)" />
+			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 export default LoadingScreen;

--- a/apps/shell-ui/src/components/layout/ShellLayout.tsx
+++ b/apps/shell-ui/src/components/layout/ShellLayout.tsx
@@ -45,6 +45,7 @@ import { AppErrorBoundary } from './AppErrorBoundary';
 import { OverlayManager, useOverlay } from './OverlayManager';
 import Sidebar from './Sidebar';
 import StatusBar from './StatusBar';
+import LoadingScreen from './LoadingScreen';
 import DebugPanel from './DebugPanel';
 import type { ShellConfig } from '../../workspace/types';
 import { commonStyles } from 'shared/themes/styles';
@@ -256,7 +257,11 @@ export const ShellLayout: React.FC<ShellLayoutProps> = ({
 	// --- Derived layout info -------------------------------------------------
 	const hasSidebar = !!activeApp?.components?.Sidebar;
 	const appName = activeApp?.branding?.appName ?? config.apps[0]?.name ?? 'RocketRide';
-	const showStatusBar = activeManifest?.showStatusBar !== false;
+	// Only show the status bar once the app has actually loaded. During the app-load gap the
+	// client area shows the boot rocket (LoadingScreen); rendering the StatusBar there made it
+	// blink in and then get covered by home-ui's AuthTransitionPage overlay — a one-frame
+	// "flash" between the otherwise-identical loading/transition screens.
+	const showStatusBar = activeManifest?.showStatusBar !== false && !!activeApp?.components?.App;
 
 	// --- Render --------------------------------------------------------------
 	return (
@@ -297,7 +302,11 @@ export const ShellLayout: React.FC<ShellLayoutProps> = ({
 								</button>
 							</div>
 						) : appLoading || !activeApp ? (
-							<div style={styles.appLoading}>Loading...</div>
+							// Same bobbing rocket as the boot LoadingScreen and home-ui's
+							// AuthTransitionPage (all phase-anchored) so the post-login
+							// boot → app-load → transition handoff is one continuous animation
+							// with no "Loading…" text frame flashing between them.
+							<LoadingScreen />
 						) : null}
 					</div>
 				</div>

--- a/apps/shell-ui/src/components/layout/Sidebar.tsx
+++ b/apps/shell-ui/src/components/layout/Sidebar.tsx
@@ -221,6 +221,52 @@ const AppSwitcherButton: React.FC<{ collapsed: boolean }> = ({ collapsed }) => {
 // =============================================================================
 
 /**
+ * App-switcher icon: renders the app's logo when available, otherwise a
+ * two-letter monogram fallback (initials of the first two words, or the
+ * first two characters of a single-word name).
+ *
+ * Defined at module scope so it keeps a stable component identity across
+ * renders instead of being recreated inline per menu item.
+ */
+const AppIcon: React.FC<{ name: string; iconUrl?: string; size?: number }> = ({ name, iconUrl, size = 16 }) => {
+	if (iconUrl) {
+		return (
+			<img
+				src={iconUrl}
+				alt=""
+				width={size}
+				height={size}
+				style={{ borderRadius: 4, objectFit: 'cover', flexShrink: 0, display: 'block' }}
+			/>
+		);
+	}
+
+	const words = name.trim().split(/\s+/).filter(Boolean);
+	const monogram = (words.length > 1 ? words.slice(0, 2).map((w) => w[0]).join('') : name.slice(0, 2)).toUpperCase();
+
+	return (
+		<span
+			style={{
+				width: size,
+				height: size,
+				flexShrink: 0,
+				borderRadius: 4,
+				display: 'flex',
+				alignItems: 'center',
+				justifyContent: 'center',
+				background: 'var(--rr-bg-surface-alt)',
+				color: 'var(--rr-text-secondary)',
+				fontSize: Math.round(size * 0.5),
+				fontWeight: 700,
+				lineHeight: 1,
+			}}
+		>
+			{monogram}
+		</span>
+	);
+};
+
+/**
  * Collapsible, resizable sidebar that renders the active app's sidebar
  * component and a footer with theme picker, account/billing nav, app
  * switcher, and logout.
@@ -360,7 +406,8 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 					.sort((a, b) => a.name.localeCompare(b.name))
 					.map((app) => ({
 						id: app.id, label: app.name, checked: activeAppId === app.id,
-						icon: app.icon ? (({ size = 16 }) => <img src={app.icon} alt="" width={size} height={size} style={{ borderRadius: 4, objectFit: 'cover', flexShrink: 0, display: 'block' }} />) : (({ size = 16 }) => { const w = app.name.trim().split(/\s+/).filter(Boolean); const mono = (w.length > 1 ? w.slice(0, 2).map((s) => s[0]).join('') : app.name.slice(0, 2)).toUpperCase(); return <span style={{ width: size, height: size, flexShrink: 0, borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--rr-bg-surface-alt)', color: 'var(--rr-text-secondary)', fontSize: Math.round(size * 0.5), fontWeight: 700, lineHeight: 1 }}>{mono}</span>; }), onClick: () => handleSwitchApp(app.id),
+						icon: ({ size }: { size?: number }) => <AppIcon name={app.name} iconUrl={app.icon} size={size} />,
+						onClick: () => handleSwitchApp(app.id),
 					})),
 			});
 		}

--- a/apps/shell-ui/src/components/layout/Sidebar.tsx
+++ b/apps/shell-ui/src/components/layout/Sidebar.tsx
@@ -32,7 +32,7 @@
 import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { ShellIdentityContext } from '../../hooks/useAuthUser';
 import {
-	BxCog, BxLock, BxPalette, BxUser, BxExport, BxGridAlt, BxDockLeft,
+	BxCog, BxLock, BxPalette, BxUser, BxExport, BxGridAlt, BxDockLeft, BxHome,
 } from '../../icons/BoxIcon';
 import { ConnectionManager } from '../../connection/connection';
 import type { IconComponent } from '../../icons/BoxIcon';
@@ -328,7 +328,8 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 
 	const footerMenuItems: SidebarFooterMenuItem[] = useMemo(() => {
 		const items: SidebarFooterMenuItem[] = [
-			{ id: 'account', label: 'Account', icon: BxUser, onClick: () => onOverlay('account') },
+			{ id: 'home', label: 'Home', icon: BxHome, onClick: () => ConnectionManager.getInstance().emit('shell:switchApp', { appId: 'rocketride.home' }) },
+			{ id: 'account', label: 'Account', icon: BxUser, dividerBefore: true, onClick: () => onOverlay('account') },
 			{ id: 'environment', label: 'Variables', icon: BxLock, onClick: () => onOverlay('environment') },
 			{ id: 'settings', label: 'Settings', icon: BxCog, onClick: () => onOverlay('settings') },
 			{
@@ -359,7 +360,7 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 					.sort((a, b) => a.name.localeCompare(b.name))
 					.map((app) => ({
 						id: app.id, label: app.name, checked: activeAppId === app.id,
-						onClick: () => handleSwitchApp(app.id),
+						icon: app.icon ? (({ size = 16 }) => <img src={app.icon} alt="" width={size} height={size} style={{ borderRadius: 4, objectFit: 'cover', flexShrink: 0, display: 'block' }} />) : (({ size = 16 }) => { const w = app.name.trim().split(/\s+/).filter(Boolean); const mono = (w.length > 1 ? w.slice(0, 2).map((s) => s[0]).join('') : app.name.slice(0, 2)).toUpperCase(); return <span style={{ width: size, height: size, flexShrink: 0, borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'var(--rr-bg-surface-alt)', color: 'var(--rr-text-secondary)', fontSize: Math.round(size * 0.5), fontWeight: 700, lineHeight: 1 }}>{mono}</span>; }), onClick: () => handleSwitchApp(app.id),
 					})),
 			});
 		}

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -309,8 +309,10 @@ export class ConnectionManager implements IConnectionManager {
 	/** @deprecated Legacy Zitadel config — use authProvider instead. */
 	private zitadelClientId = '';
 
-	/** Module-level flag to prevent double bootstrap under React StrictMode. */
-	private bootStarted = false;
+	/** Cached in-flight/settled bootstrap promise — dedupes repeat bootstrap() calls
+	 *  (StrictMode double-invoke in dev, a Shell remount, MF host re-init) so every caller
+	 *  gets the SAME result instead of a null that the shell would misread as "logged out". */
+	private bootPromise: Promise<{ result: ConnectResult; appId: string } | null> | null = null;
 
 	/** One-shot guard: startOAuth always ends in a full-page redirect, so it must
 	 *  never run twice in one page load (double authorize → Zitadel invalidates the
@@ -375,10 +377,22 @@ export class ConnectionManager implements IConnectionManager {
 		workspaceDir?: string;
 		onThemeChange?: (theme: string) => void;
 	}): Promise<{ result: ConnectResult; appId: string } | null> {
-		// Guard against double-execution (React StrictMode dev double-mount)
-		if (this.bootStarted) return null;
-		this.bootStarted = true;
+		// Dedupe: bootstrap can be invoked more than once per page load (StrictMode
+		// double-invoke in dev, a Shell remount, or MF host re-init). Returning null on
+		// the 2nd call made the shell flip to renderPhase='shell' with a null identity —
+		// flashing the logged-out landing page until the real (in-flight) bootstrap
+		// resolved. Hand every caller the SAME promise so they all settle on the real
+		// authenticated result and the shell never sees a spurious null.
+		if (this.bootPromise) return this.bootPromise;
+		this.bootPromise = this._bootstrap(config);
+		return this.bootPromise;
+	}
 
+	private async _bootstrap(config?: {
+		apps?: Array<{ id: string }>;
+		workspaceDir?: string;
+		onThemeChange?: (theme: string) => void;
+	}): Promise<{ result: ConnectResult; appId: string } | null> {
 		if (!this.client) throw new Error('Client not initialized — call init() first.');
 
 		// Ensure the transport is attached before any login attempt

--- a/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
+++ b/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
@@ -480,9 +480,10 @@ const SidebarViewWebview: React.FC = () => {
 
 	// ── Render ───────────────────────────────────────────────────────────────
 
-	// showDashboard={false}: the VS Code host has no home-app destination, so the
-	// Dashboard nav action (onNavigate('dashboard')) is unhandled here. Hide it.
-	return <SidebarView connection={connection} isSubscribed={subscribed} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} showDashboard={false} onNavigate={onNavigate} onOpenFile={onOpenFile} onSourceAction={onSourceAction} onRefresh={onRefresh} footerSlot={footerSlot} onOpenUnknownTask={onOpenUnknownTask} />;
+	// No headerSlot: the VS Code host has no home-app destination, so it injects no
+	// host-specific top nav. The "Home" button is a SaaS-shell concept owned by the
+	// web host (rocket-ui), intentionally absent from shared-ui / this extension.
+	return <SidebarView connection={connection} isSubscribed={subscribed} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} onNavigate={onNavigate} onOpenFile={onOpenFile} onSourceAction={onSourceAction} onRefresh={onRefresh} footerSlot={footerSlot} onOpenUnknownTask={onOpenUnknownTask} />;
 };
 
 export default SidebarViewWebview;

--- a/packages/shared-ui/src/components/canvas/Canvas.tsx
+++ b/packages/shared-ui/src/components/canvas/Canvas.tsx
@@ -125,6 +125,8 @@ export interface IFlowProps {
 
 	/** Called when the user triggers save from the canvas toolbar. */
 	onSave?: () => void;
+	/** SaaS-only: export/download the current pipeline. Omitted hosts (VS Code) hide the button. */
+	onExport?: () => void;
 
 	/** When true, the canvas is fully read-only: no editing, no adding nodes, no run/stop. */
 	isReadonly?: boolean;
@@ -137,7 +139,7 @@ export interface IFlowProps {
 // Component
 // =============================================================================
 
-export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, getPreference, setPreference, onContentChanged, onViewportChange, onUndo, onRedo, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, isReadonly = false, envKeys }: IFlowProps) {
+export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, getPreference, setPreference, onContentChanged, onViewportChange, onUndo, onRedo, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, isReadonly = false, envKeys }: IFlowProps) {
 	// --- Build inventory from service catalog --------------------------------
 	const inventory = buildInventory(servicesJson);
 
@@ -196,7 +198,7 @@ export default function Flow({ oauth2RootUrl, project, servicesJson, taskStatuse
 					overflow: 'hidden',
 				}}
 			>
-				<FlowContainer oauth2RootUrl={oauth2RootUrl} project={project} servicesJson={servicesJson} inventory={inventory} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} handleValidatePipeline={handleValidatePipeline} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} isReadonly={isReadonly} envKeys={envKeys}>
+				<FlowContainer oauth2RootUrl={oauth2RootUrl} project={project} servicesJson={servicesJson} inventory={inventory} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} handleValidatePipeline={handleValidatePipeline} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} onExport={onExport} isReadonly={isReadonly} envKeys={envKeys}>
 					<FlowCanvas />
 				</FlowContainer>
 			</div>

--- a/packages/shared-ui/src/components/canvas/components/FlowCanvas.tsx
+++ b/packages/shared-ui/src/components/canvas/components/FlowCanvas.tsx
@@ -98,6 +98,18 @@ const edgeTypes = {
 
 const DEFAULT_ZOOM = 0.75;
 
+// Stable references for ReactFlow props. ReactFlow's <StoreUpdater> syncs reactive
+// props into its zustand store via `useEffect(() => setState(prop), [prop])` — passing
+// a fresh object/array literal every render makes that effect fire on every render →
+// store update → re-render → new literal → "Maximum update depth exceeded". Hoisting
+// these to module scope (and using the const fallback below) keeps the references stable.
+// `snapGrid` in particular was undefined for brand-new pipelines, so the inline `[10,10]`
+// fallback was a new array every render — which is why only NEW pipelines crashed.
+const DEFAULT_VIEWPORT = { x: 0, y: 0, zoom: DEFAULT_ZOOM };
+const PRO_OPTIONS = { hideAttribution: true };
+const DEFAULT_SNAP_GRID: [number, number] = [10, 10];
+const DELETE_KEY_CODES = ['Backspace', 'Delete'];
+
 // =============================================================================
 // INLINE ICON HELPERS
 // =============================================================================
@@ -113,6 +125,7 @@ const BX_UNDO = 'M9 10h6c1.654 0 3 1.346 3 3s-1.346 3-3 3h-3v2h3c2.757 0 5-2.243
 const BX_REDO = 'M9 18h3v-2H9c-1.654 0-3-1.346-3-3s1.346-3 3-3h6v3l5-4-5-4v3H9c-2.757 0-5 2.243-5 5s2.243 5 5 5z';
 const BX_POINTER = 'M20.978 13.21a1 1 0 0 0-.396-1.024l-14-10a.999.999 0 0 0-1.575.931l2 17a1 1 0 0 0 1.767.516l3.612-4.416 3.377 5.46 1.701-1.052-3.357-5.428 6.089-1.218a.995.995 0 0 0 .782-.769zm-8.674.31a1 1 0 0 0-.578.347l-3.008 3.677L7.257 5.127l10.283 7.345-5.236 1.048z';
 const BX_SAVE = 'M17 3H5c-1.11 0-2 .9-2 2v14c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V7l-4-4zm-5 16c-1.66 0-3-1.34-3-3s1.34-3 3-3 3 1.34 3 3-1.34 3-3 3zm3-10H5V5h10v4z';
+const BX_EXPORT = 'M11 16h2V7h3l-4-5-4 5h3z M5 22h14c1.103 0 2-.897 2-2v-9c0-1.103-.897-2-2-2h-4v2h4v9H5v-9h4V9H5c-1.103 0-2 .897-2 2v9c0 1.103.897 2 2 2z';
 
 const HandIcon = ({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) => (
 	<svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
@@ -201,7 +214,7 @@ export default function Canvas(): ReactElement {
 		[setPreference]
 	);
 
-	const { onUndo, onRedo, onViewportChange, isDirty, isNew, onSave, initialViewport } = useFlowProject();
+	const { onUndo, onRedo, onViewportChange, isDirty, isNew, onSave, onExport, initialViewport } = useFlowProject();
 	const { fitView, zoomIn, zoomOut, setViewport } = useReactFlow();
 
 	// Keep a ref so the restore handler always sees the latest viewport value
@@ -227,6 +240,12 @@ export default function Canvas(): ReactElement {
 			setViewport(initialViewportRef.current, { duration: 0 });
 		}
 	}, [setViewport]);
+
+	// Stable handler so ReactFlow doesn't see a new onMoveEnd reference every render.
+	const handleMoveEnd = useCallback(
+		(_event: unknown, viewport: { x: number; y: number; zoom: number }) => onViewportChange?.(viewport),
+		[onViewportChange],
+	);
 
 	// Restore viewport when the shell activates this tab (canvas:restoreViewport
 	// is dispatched by ProjectView when it receives shell:viewActivated).
@@ -383,6 +402,11 @@ export default function Canvas(): ReactElement {
 					</ToolbarButton>
 				</>
 			)}
+			{onExport && !isLocked && (
+				<ToolbarButton title="Export" onClick={onExport}>
+					<BxIcon d={BX_EXPORT} size={16} />
+				</ToolbarButton>
+			)}
 		</>
 	);
 
@@ -402,12 +426,12 @@ export default function Canvas(): ReactElement {
 				onConnect={onEdgeConnect}
 				isValidConnection={isValidConnection}
 				onNodesDelete={onNodesDelete}
-				deleteKeyCode={['Backspace', 'Delete']}
+				deleteKeyCode={DELETE_KEY_CODES}
 				onDragOver={onDragOver}
 				onDrop={onDrop}
 				onNodeDragStop={onNodeDragStop}
 				onInit={handleInit}
-				onMoveEnd={(_event, viewport) => onViewportChange?.(viewport)}
+				onMoveEnd={handleMoveEnd}
 				/* Navigation mode: pan on drag vs lasso-select on drag */
 				selectionMode={SelectionMode.Partial}
 				panOnScroll={!isPanMode}
@@ -420,10 +444,10 @@ export default function Canvas(): ReactElement {
 				edgesFocusable={editable}
 				elementsSelectable={editable}
 				/* Viewport defaults — fitView is handled programmatically in loadData */
-				defaultViewport={{ x: 0, y: 0, zoom: DEFAULT_ZOOM }}
-				proOptions={{ hideAttribution: true }}
+				defaultViewport={DEFAULT_VIEWPORT}
+				proOptions={PRO_OPTIONS}
 				snapToGrid={projectLayout.snapToGrid ?? true}
-				snapGrid={projectLayout.snapGridSize ?? [10, 10]}
+				snapGrid={projectLayout.snapGridSize ?? DEFAULT_SNAP_GRID}
 			>
 				<Background color="var(--rr-text-disabled)" gap={20} style={{ backgroundColor: 'var(--rr-bg-default)' }} />
 			</ReactFlow>

--- a/packages/shared-ui/src/components/canvas/components/FlowContainer.tsx
+++ b/packages/shared-ui/src/components/canvas/components/FlowContainer.tsx
@@ -134,6 +134,7 @@ export interface IFlowContainerProps {
 	isNew?: boolean;
 	/** Called when the user triggers save from the canvas toolbar. */
 	onSave?: () => void;
+	onExport?: () => void;
 
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
@@ -152,12 +153,12 @@ export interface IFlowContainerProps {
  * Uses `key` on the outer Box to force a clean re-mount when the project
  * ID changes, ensuring no stale graph state leaks between projects.
  */
-export default function FlowContainer({ project, oauth2RootUrl, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, onOpenLink, getPreference, setPreference, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, envKeys, children }: IFlowContainerProps): ReactElement {
+export default function FlowContainer({ project, oauth2RootUrl, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, onOpenLink, getPreference, setPreference, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys, children }: IFlowContainerProps): ReactElement {
 	return (
 		<ReactFlowProvider>
 			{/* Re-key on project ID to force clean re-mount between projects */}
 			<div style={{ position: 'relative', width: '100%', height: '100%' }} key={`${project.project_id ?? 'new'}-${project.name}`}>
-				<FlowProvider project={project} projectId={project.project_id ?? ''} isReadonly={isReadonly} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} envKeys={envKeys}>
+				<FlowProvider project={project} projectId={project.project_id ?? ''} isReadonly={isReadonly} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} getPreference={getPreference} setPreference={setPreference} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} onExport={onExport} envKeys={envKeys}>
 					{children}
 				</FlowProvider>
 			</div>

--- a/packages/shared-ui/src/components/canvas/components/edge/FlowEdge.tsx
+++ b/packages/shared-ui/src/components/canvas/components/edge/FlowEdge.tsx
@@ -54,6 +54,14 @@ export default function FlowEdge({ id, sourceX, sourceY, targetX, targetY, sourc
 	const [hovered, setHovered] = useState(false);
 	const { setEdges } = useReactFlow();
 
+	// ReactFlow can render an edge for a frame before its connected nodes have been
+	// measured — at which point sourceX/Y and targetX/Y are NaN, and getBezierPath
+	// produces an invalid `<path d="MNaN,NaN…">` (a console error every frame). Bail
+	// until the endpoints are real numbers; ReactFlow re-renders the edge once the
+	// nodes report their measured size. (Hooks above run unconditionally — this early
+	// return is after them, so rules-of-hooks are respected.)
+	if (![sourceX, sourceY, targetX, targetY].every(Number.isFinite)) return null;
+
 	// Invoke edges run vertically (top-to-bottom) so the offset is applied
 	// to Y instead of X. Detect by checking the source handle ID.
 	const isInvokeEdge = sourceHandleId?.toLowerCase().includes('invoke');

--- a/packages/shared-ui/src/components/canvas/components/node/node-component/lanes/InsideLines.tsx
+++ b/packages/shared-ui/src/components/canvas/components/node/node-component/lanes/InsideLines.tsx
@@ -129,6 +129,11 @@ export default function InsideLines({ parentEl, inputConnected, inputLanes = [],
 				const inputPos = getLanePosition(inputHandleId, true);
 				const outputPos = getLanePosition(outputHandleId, false);
 				if (!inputPos || !outputPos) continue;
+				// Skip until the lane handles have finite coordinates. Before the node/handles
+				// are measured (or the flow transform isn't ready) getLanePosition can return
+				// NaN — and feeding NaN to d3.curveBasis emits an invalid `<path d="MNaN,NaN…">`
+				// (a console error every frame). The lines re-render once the handles measure.
+				if (![inputPos.x, inputPos.y, outputPos.x, outputPos.y].every(Number.isFinite)) continue;
 
 				const controlOffset = 15;
 				linesList.push({

--- a/packages/shared-ui/src/components/canvas/context/FlowProjectContext.tsx
+++ b/packages/shared-ui/src/components/canvas/context/FlowProjectContext.tsx
@@ -159,6 +159,7 @@ export interface IFlowProjectContext {
 
 	/** Called when the user requests a save from within the canvas. */
 	onSave?: () => void;
+	onExport?: () => void;
 
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
@@ -217,6 +218,7 @@ export interface IFlowProjectProviderProps {
 	isNew?: boolean;
 	/** Called when the user triggers save from the canvas toolbar. */
 	onSave?: () => void;
+	onExport?: () => void;
 
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
@@ -233,7 +235,7 @@ export interface IFlowProjectProviderProps {
  * The host application passes props that are tunneled through this context
  * so deeply nested components can access them without prop drilling.
  */
-export function FlowProjectProvider({ children, project: currentProject, isReadonly = false, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, envKeys }: IFlowProjectProviderProps): ReactElement {
+export function FlowProjectProvider({ children, project: currentProject, isReadonly = false, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys }: IFlowProjectProviderProps): ReactElement {
 	// --- Toolchain state ---------------------------------------------------
 
 	const [toolchainState, setToolchainState] = useState<IToolchainState>(DEFAULT_TOOLCHAIN_STATE);
@@ -289,6 +291,7 @@ export function FlowProjectProvider({ children, project: currentProject, isReado
 		isDirty,
 		isNew,
 		onSave,
+		onExport,
 		envKeys,
 	}), [
 		currentProject, toolchainState, patchToolchainState, toggleDevMode,
@@ -297,7 +300,7 @@ export function FlowProjectProvider({ children, project: currentProject, isReado
 		handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo,
 		oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId,
 		onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected,
-		isSubscribed, initialViewport, isDirty, isNew, onSave, envKeys,
+		isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys,
 	]);
 
 	return <FlowProjectContext.Provider value={value}>{children}</FlowProjectContext.Provider>;

--- a/packages/shared-ui/src/components/canvas/context/FlowProvider.tsx
+++ b/packages/shared-ui/src/components/canvas/context/FlowProvider.tsx
@@ -116,6 +116,7 @@ export interface IFlowProviderProps {
 	isDirty?: boolean;
 	isNew?: boolean;
 	onSave?: () => void;
+	onExport?: () => void;
 
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
@@ -137,10 +138,10 @@ export interface IFlowProviderProps {
  * </ReactFlowProvider>
  * ```
  */
-export function FlowProvider({ children, project, projectId, getPreference, setPreference, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, envKeys }: IFlowProviderProps): ReactElement {
+export function FlowProvider({ children, project, projectId, getPreference, setPreference, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys }: IFlowProviderProps): ReactElement {
 	return (
 		<FlowPreferencesProvider projectId={projectId} getPreference={getPreference} setPreference={setPreference} isReadonly={isReadonly}>
-			<FlowProjectProvider project={project} isReadonly={isReadonly} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} envKeys={envKeys}>
+			<FlowProjectProvider project={project} isReadonly={isReadonly} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} servicesJson={servicesJson} servicesJsonError={servicesJsonError} inventory={inventory} inventoryConnectorTitleMap={inventoryConnectorTitleMap} handleValidatePipeline={handleValidatePipeline} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} oauth2RootUrl={oauth2RootUrl} onOpenLink={onOpenLink} googlePickerDeveloperKey={googlePickerDeveloperKey} googlePickerClientId={googlePickerClientId} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} onExport={onExport} envKeys={envKeys}>
 				<FlowGraphProvider>{children}</FlowGraphProvider>
 			</FlowProjectProvider>
 		</FlowPreferencesProvider>

--- a/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
+++ b/packages/shared-ui/src/components/sidebar-footer/SidebarFooter.tsx
@@ -535,8 +535,12 @@ export const SidebarFooter: React.FC<SidebarFooterProps> = ({ collapsed, userNam
 							position: 'fixed',
 							top: flyoutPos.top,
 							left: flyoutPos.left,
-							width: Math.round(((triggerWidth - 2 * POPUP_MARGIN) * 2) / 3),
-							minWidth: 140,
+							// Content-driven width so long app names + logos aren't cramped. Grows
+							// to fit the widest row, floored at 160px and capped to the viewport
+							// (the flyout opens rightward from flyoutPos.left, so cap on the right edge).
+							width: 'max-content',
+							minWidth: 160,
+							maxWidth: `calc(100vw - ${flyoutPos.left + 8}px)`,
 							maxHeight: `calc(100vh - ${flyoutPos.top + 8}px)`,
 							overflowY: 'auto',
 							scrollbarWidth: 'thin',

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -47,7 +47,7 @@ export type { ISidebarViewProps, ProjectEntry, ProjectSource, DirEntry, ActiveTa
 
 // --- Explorer module (generic file tree panel) -------------------------------
 export { Explorer } from './modules/explorer';
-export type { IVirtualFileSystem, IExplorerProps, ExplorerConfig, ExplorerEntry, ExplorerChild, ExplorerStatus } from './modules/explorer';
+export type { IVirtualFileSystem, IExplorerProps, ExplorerFileAction, ExplorerConfig, ExplorerEntry, ExplorerChild, ExplorerStatus } from './modules/explorer';
 
 // --- Shared types ------------------------------------------------------------
 export type { IProject, IValidateResponse, IServiceCatalog } from './types/project';

--- a/packages/shared-ui/src/modules/explorer/Explorer.tsx
+++ b/packages/shared-ui/src/modules/explorer/Explorer.tsx
@@ -323,7 +323,7 @@ function childTooltip(child: { id: string; name: string; provider?: string }, ta
  * sources, or any app-specific concepts.  The hosting container provides
  * entries, statuses, and callbacks.
  */
-export const Explorer: React.FC<IExplorerProps> = ({ vfs, config, entries, statuses = new Map(), isConnected, showChildActions = true, activeFilePath, onOpenFile, onFileManage, onChildAction, onRefresh }) => {
+export const Explorer: React.FC<IExplorerProps> = ({ vfs, config, entries, statuses = new Map(), isConnected, showChildActions = true, activeFilePath, onOpenFile, onFileManage, onChildAction, fileActions, onRefresh }) => {
 	const [viewMode, setViewMode] = useState<'tree' | 'flat'>('tree');
 	const [expandedDirs, setExpandedDirs] = useState<Set<string>>(new Set());
 	const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set());
@@ -612,7 +612,7 @@ export const Explorer: React.FC<IExplorerProps> = ({ vfs, config, entries, statu
 							{dotColor && <div style={S.dot(dotColor)} />}
 							{hasFileManage && hoveredRow === rowKey && !isRenaming && (
 								<button
-									style={S.menuBtn}
+									style={{ ...S.menuBtn, ...(isFileSelected ? { color: 'var(--rr-fg-list-active)' } : {}) }}
 									onClick={(e) => {
 										e.stopPropagation();
 										setMenuPath(menuPath === file.path ? null : file.path);
@@ -646,6 +646,21 @@ export const Explorer: React.FC<IExplorerProps> = ({ vfs, config, entries, statu
 									>
 										<BxTrash size={16} /> Delete
 									</button>
+									{fileActions?.map((a) => (
+										<button
+											key={a.id}
+											style={S.popupRow}
+											onMouseEnter={(e) => ((e.target as HTMLElement).style.background = HOVER_BG)}
+											onMouseLeave={(e) => ((e.target as HTMLElement).style.background = 'none')}
+											onClick={(e) => {
+												e.stopPropagation();
+												setMenuPath(null);
+												a.onSelect(file.path);
+											}}
+										>
+											{a.icon} {a.label}
+										</button>
+									))}
 								</div>
 							)}
 						</div>

--- a/packages/shared-ui/src/modules/explorer/index.ts
+++ b/packages/shared-ui/src/modules/explorer/index.ts
@@ -4,4 +4,4 @@
 // =============================================================================
 
 export { Explorer } from './Explorer';
-export type { IVirtualFileSystem, IExplorerProps, ExplorerConfig, ExplorerEntry, ExplorerChild, ExplorerStatus, DirNode } from './types';
+export type { IVirtualFileSystem, IExplorerProps, ExplorerFileAction, ExplorerConfig, ExplorerEntry, ExplorerChild, ExplorerStatus, DirNode } from './types';

--- a/packages/shared-ui/src/modules/explorer/types.ts
+++ b/packages/shared-ui/src/modules/explorer/types.ts
@@ -12,6 +12,8 @@
  * as one prop.
  */
 
+import type { ReactNode } from 'react';
+
 // =============================================================================
 // VIRTUAL FILE SYSTEM
 // =============================================================================
@@ -174,6 +176,25 @@ export interface ExplorerConfig {
 // =============================================================================
 
 /**
+ * A custom action injected by the host into a file row's kebab menu.
+ *
+ * The Explorer is action-agnostic: it renders whatever actions the host
+ * supplies and calls `onSelect(path)` when one is chosen. SaaS hosts use this
+ * for features (e.g. Export/Download) that must stay out of the VS Code
+ * bundle — hosts that omit `fileActions` show only the built-in rename/delete.
+ */
+export interface ExplorerFileAction {
+	/** Stable identifier; also used as the React key. */
+	id: string;
+	/** Menu item label. */
+	label: string;
+	/** Optional leading icon node. */
+	icon?: ReactNode;
+	/** Invoked with the row's file path when the item is chosen. */
+	onSelect: (path: string) => void;
+}
+
+/**
  * Props for the Explorer component.
  */
 export interface IExplorerProps {
@@ -212,6 +233,12 @@ export interface IExplorerProps {
 	 * Optional — when absent, no action buttons are shown on children.
 	 */
 	onChildAction?: (action: 'run' | 'stop', filePath: string, childId: string, documentId?: string) => void;
+
+	/**
+	 * Host-injected extra actions appended to each file row's kebab menu
+	 * (e.g. Export). Optional — omitted hosts (VS Code) show only rename/delete.
+	 */
+	fileActions?: ExplorerFileAction[];
 
 	/** Called when the user clicks the refresh button. */
 	onRefresh: () => void;

--- a/packages/shared-ui/src/modules/project/ProjectView.tsx
+++ b/packages/shared-ui/src/modules/project/ProjectView.tsx
@@ -79,6 +79,8 @@ export interface IProjectViewProps {
 	onOpenLink?: (url: string, displayName?: string) => void;
 	/** Called when the user requests a save (Ctrl+S or menu). */
 	onSave?: () => void;
+	/** SaaS-only: export/download the current pipeline. Forwarded to the canvas. */
+	onExport?: () => void;
 	/** Called when the user clears the trace log. */
 	onTraceClear?: () => void;
 	/** When true, the canvas is fully read-only: editing, saving, and run/stop are disabled. */
@@ -172,7 +174,7 @@ interface SourceInfo {
 // COMPONENT
 // =============================================================================
 
-const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isConnected, isSubscribed = true, statusMap, serverHost = '', isDirty = false, isNew = false, initialViewState, initialPrefs, traceEvents = [], onContentChanged, onValidate, onPipelineAction, onViewStateChange, onPrefsChange, onOpenLink, onSave, onTraceClear, isReadonly = false, envKeys, onMissingEnvVars }) => {
+const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isConnected, isSubscribed = true, statusMap, serverHost = '', isDirty = false, isNew = false, initialViewState, initialPrefs, traceEvents = [], onContentChanged, onValidate, onPipelineAction, onViewStateChange, onPrefsChange, onOpenLink, onSave, onExport, onTraceClear, isReadonly = false, envKeys, onMissingEnvVars }) => {
 	// --- Local view state (initialized from props, managed locally) -----------
 
 	const [viewState, setViewState] = useState<ViewState>(() => ({
@@ -349,7 +351,7 @@ const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isCon
 
 	const panels = {
 		design: {
-			content: <div style={styles.canvasPadding}>{project && <Canvas oauth2RootUrl="" project={project} servicesJson={servicesJson} taskStatuses={statusMap} handleValidatePipeline={handleValidate} onContentChanged={isReadonly ? undefined : handleContentChanged} onViewportChange={handleViewportChange} onRunPipeline={isReadonly ? undefined : handleRunPipeline} onStopPipeline={isReadonly ? undefined : handleStopPipeline} onOpenLink={handleOpenLink} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} getPreference={getPreference} setPreference={setPreference} initialViewport={viewState.viewport} isDirty={isReadonly ? false : isDirty} isNew={isReadonly ? false : isNew} onSave={isReadonly ? undefined : handleSave} isReadonly={isReadonly} envKeys={envKeys} />}</div>,
+			content: <div style={styles.canvasPadding}>{project && <Canvas oauth2RootUrl="" project={project} servicesJson={servicesJson} taskStatuses={statusMap} handleValidatePipeline={handleValidate} onContentChanged={isReadonly ? undefined : handleContentChanged} onViewportChange={handleViewportChange} onRunPipeline={isReadonly ? undefined : handleRunPipeline} onStopPipeline={isReadonly ? undefined : handleStopPipeline} onOpenLink={handleOpenLink} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} getPreference={getPreference} setPreference={setPreference} initialViewport={viewState.viewport} isDirty={isReadonly ? false : isDirty} isNew={isReadonly ? false : isNew} onSave={isReadonly ? undefined : handleSave} onExport={isReadonly ? undefined : onExport} isReadonly={isReadonly} envKeys={envKeys} />}</div>,
 		},
 		status: {
 			content: <div style={commonStyles.tabContent}>{sources.length > 0 ? sources.map((src) => <SourceStatusPane key={src.id} source={src} taskStatus={statusMap[src.id]} isConnected={isConnected} isSubscribed={isSubscribed} onPipelineAction={isReadonly ? undefined : handlePipelineAction} onOpenLink={handleOpenLink} serverHost={serverHost} />) : <div style={commonStyles.empty}>No source components found</div>}</div>,

--- a/packages/shared-ui/src/modules/sidebar/SidebarView.tsx
+++ b/packages/shared-ui/src/modules/sidebar/SidebarView.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState, useCallback, CSSProperties } from 'react';
 import { commonStyles } from '../../themes/styles';
-import { BxHome, BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop } from '../../components/BoxIcon';
+import { BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop } from '../../components/BoxIcon';
 import { Explorer } from '../explorer';
 import type { ISidebarViewProps } from './types';
 import type { ExplorerEntry, ExplorerStatus, ExplorerConfig } from '../explorer';
@@ -121,7 +121,7 @@ const PIPELINE_CONFIG: ExplorerConfig = {
  * Maps ISidebarViewProps (pipeline-specific) to IExplorerProps (generic).
  * The Explorer component handles all file tree rendering internally.
  */
-export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscribed = true, entries, activeTasks, unknownTasks, showDashboard = true, onNavigate, onOpenFile, onFileManage, onSourceAction, onRefresh, footerSlot, onOpenUnknownTask, activeFilePath }) => {
+export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscribed = true, entries, activeTasks, unknownTasks, headerSlot, onNavigate, onOpenFile, onFileManage, fileActions, onSourceAction, onRefresh, footerSlot, onOpenUnknownTask, activeFilePath }) => {
 	const [hoveredNav, setHoveredNav] = useState<string | null>(null);
 	const [hoveredRow, setHoveredRow] = useState<string | null>(null);
 	const [unknownExpanded, setUnknownExpanded] = useState(true);
@@ -162,11 +162,9 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 		<div style={S.container}>
 			{/* ── Navigation ──────────────────────────────────────────── */}
 			<div style={S.navSection}>
-				{showDashboard && (
-						<button style={{ ...S.navBtn, ...navHoverBg('dashboard') }} onMouseEnter={() => setHoveredNav('dashboard')} onMouseLeave={() => setHoveredNav(null)} onClick={() => onNavigate('dashboard')}>
-							<BxHome size={16} /> Dashboard
-						</button>
-					)}
+				{/* Host-injected nav (e.g. rocket-ui's Home button). Bare render so an
+				    omitted slot adds zero DOM/spacing — VS Code passes nothing. */}
+				{headerSlot}
 				<button style={{ ...S.navBtn, ...navHoverBg('new') }} onMouseEnter={() => setHoveredNav('new')} onMouseLeave={() => setHoveredNav(null)} onClick={() => onNavigate('new')}>
 					<BxPlus size={16} /> New pipeline
 				</button>
@@ -176,7 +174,7 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 			</div>
 
 			{/* ── Explorer (file tree) ────────────────────────────────── */}
-			<Explorer vfs={null as any} config={PIPELINE_CONFIG} entries={explorerEntries} statuses={explorerStatuses} isConnected={isConnected} showChildActions={isSubscribed} activeFilePath={activeFilePath} onOpenFile={onOpenFile} onFileManage={onFileManage} onChildAction={handleChildAction} onRefresh={onRefresh} />
+			<Explorer vfs={null as any} config={PIPELINE_CONFIG} entries={explorerEntries} statuses={explorerStatuses} isConnected={isConnected} showChildActions={isSubscribed} activeFilePath={activeFilePath} onOpenFile={onOpenFile} onFileManage={onFileManage} fileActions={fileActions} onChildAction={handleChildAction} onRefresh={onRefresh} />
 
 			{/* ── Unknown tasks (Other) ───────────────────────────────── */}
 			{hasUnknown && (

--- a/packages/shared-ui/src/modules/sidebar/types.ts
+++ b/packages/shared-ui/src/modules/sidebar/types.ts
@@ -12,6 +12,7 @@
  */
 
 import type { ReactNode } from 'react';
+import type { ExplorerFileAction } from '../explorer/types';
 
 // =============================================================================
 // DATA TYPES
@@ -102,15 +103,17 @@ export interface ISidebarViewProps {
 
 	// ── Capabilities ────────────────────────────────────────────────────────
 	/**
-	 * Show the Dashboard nav button. Only hosts that can switch to the home app
-	 * (the web shell) handle `onNavigate('dashboard')`; hosts without that
-	 * destination (e.g. the VS Code extension) should pass `false` to avoid a
-	 * dead button. Defaults to `true`.
+	 * Host-injected content rendered at the TOP of the nav section (above
+	 * "New pipeline"). Renders nothing — and adds no spacing — when omitted.
+	 * Hosts use this for host-specific nav (e.g. rocket-ui's "Home" button which
+	 * switches to the home app). The shared component intentionally knows nothing
+	 * about home/dashboard routing, keeping SaaS-shell concepts out of the
+	 * VS Code extension bundle.
 	 */
-	showDashboard?: boolean;
+	headerSlot?: ReactNode;
 
 	// ── Actions ─────────────────────────────────────────────────────────────
-	onNavigate: (target: 'dashboard' | 'new' | 'monitor' | 'deploy' | 'templates') => void;
+	onNavigate: (target: 'new' | 'monitor' | 'deploy' | 'templates') => void;
 	/** Open a file in the editor. */
 	onOpenFile: (path: string) => void;
 	/**
@@ -119,6 +122,11 @@ export interface ISidebarViewProps {
 	 * header buttons.  When absent, the sidebar is display-only.
 	 */
 	onFileManage?: (action: 'rename' | 'delete' | 'createFolder' | 'createFile', path: string, newName?: string) => void;
+	/**
+	 * Host-injected extra kebab-menu actions per file row (e.g. Export).
+	 * Forwarded to the Explorer. Omitted hosts (VS Code) show none.
+	 */
+	fileActions?: ExplorerFileAction[];
 	onSourceAction: (action: 'run' | 'stop', filePath: string, sourceId: string, projectId?: string) => void;
 	onRefresh: () => void;
 


### PR DESCRIPTION
## Summary

Shared-UI / shell-ui groundwork for the home-ui v4 SaaS changes. Introduces the host-injectable extension points (export callback, file actions, header slot) that rocket-ui will consume, plus rendering and loading-flow fixes. No behavior change for the VS Code host (all new SaaS hooks are optional/omitted there).

## Commits

- **fix(canvas): guard against NaN coordinates during ReactFlow measurement** — stop `d="MNaN,NaN…"` SVG errors when edges/lanes render before node measurement completes (`FlowEdge`, `InsideLines`).
- **feat(shared-ui): thread `onExport` pipeline-export callback through canvas** — optional SaaS-only export handler across `Canvas`/`FlowContainer`/`FlowProjectContext`/`FlowProvider`/`ProjectView` + a toolbar export button; also hoists ReactFlow constants and memoizes `onMoveEnd` to fix a new-pipeline re-render crash.
- **feat(explorer): add `fileActions` API for host-injected file menu actions** — `ExplorerFileAction` type + `fileActions` prop so hosts add kebab-menu actions (e.g. Export) without modifying Explorer.
- **refactor(sidebar): replace `showDashboard` with host-injected `headerSlot`** — decouples Home/Dashboard nav from shared-ui; rocket-ui injects Home, VS Code passes nothing; drops the now-redundant `showDashboard` prop from the VS Code webview.
- **feat(shell-ui): add Home nav item and app icons to sidebar** — Home menu item + per-app icons in the app switcher.
- **fix(shell-ui): sync loading animation and prevent status-bar flash** — phase-anchored rocket bob locked with home-ui's auth transition; gate status bar on app load.
- **fix(shell-ui): dedupe bootstrap via promise caching** — concurrent `bootstrap()` calls (StrictMode/remounts/MF re-init) share one promise instead of an early `null` that flashed a logged-out state.
- **fix(sidebar-footer): use content-driven width for app-switcher flyout** — `max-content` sizing capped to viewport so long app names/logos aren't cramped.

## Test plan

- [ ] VS Code extension sidebar renders unchanged (no Home button, no export action)
- [ ] Pipeline canvas opens without console NaN-path errors / re-render crash on new pipelines
- [ ] Shell loading → auth transition animation stays phase-locked; no status-bar or logged-out flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Canvas export action and host-provided export hook
  * Custom per-file actions in the explorer
  * Sidebar Home shortcut and app icon/monogram in app switcher

* **Bug Fixes**
  * Guarded canvas rendering against invalid coordinates to stop SVG/console errors
  * Prevented brief null/flash during startup and status-bar transition

* **Improvements**
  * Loading animation phase-aligned across load/auth transitions
  * Flyout/app-switcher sizing and header slot support for hosts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->