### PR TITLE
hotfix(3.2.2): deepagent transformers-free token counting + App-token release flow

### DIFF
--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -322,27 +322,10 @@ jobs:
 
       # --- Tag and GitHub Release ---
       #
-      # IMPORTANT: tag push uses WORKFLOW_PAT (a Personal Access Token with
-      # `repo` + `workflow` scopes) instead of the default GITHUB_TOKEN.
-      #
-      # GitHub rejects any tag push from GITHUB_TOKEN whose target commit
-      # modifies files under `.github/workflows/`, with the error:
-      #
-      #   refusing to allow a GitHub App to create or update workflow
-      #   `.github/workflows/<file>` without `workflows` permission
-      #
-      # `workflows` is a token-level scope, not a YAML permission, so the
-      # only fix is to swap to a credential that has it. WORKFLOW_PAT is
-      # that credential. Without this, every nightly that lands on a
-      # workflow-touching commit silently bricks the prerelease pipeline:
-      # the cleanup job runs first and deletes existing -prerelease tags,
-      # then all 5 prerelease creation jobs fail to push the new ones,
-      # leaving the repo with zero prereleases until the next clean
-      # commit.
       # Mint a short-lived GitHub App installation token for the tag push. The
       # tag points at a commit whose tree contains workflow files, so the
       # pushing identity needs Workflows:write — GITHUB_TOKEN can't, and an App
-      # token removes the long-lived PAT that silently expires. The App
+      # token avoids a long-lived PAT that silently expires. The App
       # (RELEASE_BOT_APP_ID) is installed on this repo with Contents:write +
       # Workflows:write; the token lives only for this job.
       - name: Generate release-bot token

--- a/.github/workflows/_release.yaml
+++ b/.github/workflows/_release.yaml
@@ -339,17 +339,30 @@ jobs:
       # then all 5 prerelease creation jobs fail to push the new ones,
       # leaving the repo with zero prereleases until the next clean
       # commit.
+      # Mint a short-lived GitHub App installation token for the tag push. The
+      # tag points at a commit whose tree contains workflow files, so the
+      # pushing identity needs Workflows:write — GITHUB_TOKEN can't, and an App
+      # token removes the long-lived PAT that silently expires. The App
+      # (RELEASE_BOT_APP_ID) is installed on this repo with Contents:write +
+      # Workflows:write; the token lives only for this job.
+      - name: Generate release-bot token
+        id: bot_token
+        if: inputs.prerelease || steps.tag_check.outputs.exists == 'false'
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Create tag
         if: inputs.prerelease || steps.tag_check.outputs.exists == 'false'
         env:
-          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+          BOT_TOKEN: ${{ steps.bot_token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # Swap the remote URL to authenticate with WORKFLOW_PAT for the
-          # push. This affects only this step's git config and goes away
-          # when the runner tears down.
-          git remote set-url origin "https://x-access-token:${WORKFLOW_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+          # Authenticate the push with the App installation token (this step's
+          # git config only; gone when the runner tears down).
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if [ "${{ inputs.prerelease }}" = "true" ]; then
             git tag -f "${{ matrix.tag_name }}"
             git push -f origin "${{ matrix.tag_name }}"

--- a/.github/workflows/experimental-release.yaml
+++ b/.github/workflows/experimental-release.yaml
@@ -138,17 +138,26 @@ jobs:
       - name: List artifacts
         run: find release-assets -type f | sort
 
-      # Tag push goes through WORKFLOW_PAT for the same reason _release.yaml
-      # uses it: GITHUB_TOKEN is refused on tags whose target commits touch
-      # files under .github/workflows/. Force-push so re-running this
-      # workflow on the same branch + tag_suffix replaces cleanly.
+      # Tag push goes through a short-lived GitHub App installation token for
+      # the same reason _release.yaml uses one: GITHUB_TOKEN is refused on
+      # tags whose target commits touch files under .github/workflows/, and
+      # the release-bot App has Contents:write + Workflows:write. Force-push
+      # so re-running this workflow on the same branch + tag_suffix replaces
+      # cleanly.
+      - name: Generate release-bot token
+        id: bot_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
+
       - name: Create / replace tag
         env:
-          WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}
+          BOT_TOKEN: ${{ steps.bot_token.outputs.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${WORKFLOW_PAT}@github.com/${GITHUB_REPOSITORY}.git"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git tag -f "${{ matrix.tag_name }}"
           git push -f origin "${{ matrix.tag_name }}"
 

--- a/nodes/src/nodes/agent_deepagent/deepagent.py
+++ b/nodes/src/nodes/agent_deepagent/deepagent.py
@@ -56,7 +56,8 @@ def _build_deepagent_llm(agent_base: AgentBase, context: AgentContext) -> Any:
     the LLM produces malformed JSON.
     """
     from langchain_core.language_models import BaseChatModel
-    from langchain_core.messages import AIMessage
+    from langchain_core.messages import AIMessage, HumanMessage
+    from langchain_core.messages.utils import count_tokens_approximately
     from langchain_core.outputs import ChatGeneration, ChatResult
 
     class RocketRideToolCallingChatModel(BaseChatModel):
@@ -82,6 +83,21 @@ def _build_deepagent_llm(agent_base: AgentBase, context: AgentContext) -> Any:
             except Exception:
                 self._bound_tools = []
             return self
+
+        # deepagents' middleware asks the model to count tokens; BaseChatModel's
+        # fallback needs `transformers` (not bundled) and only knows GPT-2 anyway.
+        # The host LLM is opaque to us, so approximate counting is both sufficient
+        # and dependency-free.
+        def get_num_tokens(self, text: str) -> int:
+            return count_tokens_approximately([HumanMessage(content=safe_str(text))])
+
+        def get_token_ids(self, text: str) -> List[int]:
+            # No real tokenizer; synthesize an id list of the right length so
+            # len(get_token_ids(text)) == get_num_tokens(text) still holds.
+            return list(range(self.get_num_tokens(text)))
+
+        def get_num_tokens_from_messages(self, messages: Any, tools: Any = None) -> int:
+            return count_tokens_approximately(messages)
 
         def _generate(self, messages: Any, stop: Any = None, run_manager: Any = None, **kwargs: Any) -> Any:
             transcript = langchain_messages_to_transcript(messages)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride-server",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"description": "RocketRide Server - A high-performance data processing engine with modular nodes, AI capabilities, and cross-platform clients",
 	"private": true,
 	"license": "MIT",


### PR DESCRIPTION
Stable hotfix for Josh's tutorial — participants follow the default "Latest" path in the VS Code extension, which resolves the latest stable server release; current 3.2.1 lacks the deepagent fix.

Cherry-picks onto main:
- **#1205** `b1cf42e3` — fix(deepagent): avoid transformers dependency for token counting (the payload)
- **#1203** `7dc41e31` + **#1207** `5e180798` — release tag pushes via the GitHub App token. **Required**: main's release flow still referenced `WORKFLOW_PAT`, which expired and was deleted today — a stable release from main would die at Create tag exactly like the prereleases did. RELEASE_BOT_* secrets are repo-level and work here.
- Version bump 3.2.1 → 3.2.2 (root package.json = server version; SDK/extension versions untouched → their existing tags are skipped by tag_check).

On merge, `release.yaml` publishes `server-v3.2.2` automatically; it becomes the repo's Latest release and the extension's default engine resolution picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)