### PR TITLE
feat(docs): docs-site star caching & UX robustness (RR-1218)

### DIFF
--- a/packages/client-typescript/src/client/constants.ts
+++ b/packages/client-typescript/src/client/constants.ts
@@ -25,7 +25,7 @@
 /**
  * SDK version — automatically synced from package.json during build.
  */
-export const SDK_VERSION = '1.2.0';
+export const SDK_VERSION = '1.3.0';
 
 /**
  * Default protocol for connections when none is specified.

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -8,7 +8,7 @@
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "clear": "docusaurus clear",
-    "serve": "docusaurus serve",
+    "serve": "docusaurus serve --dir ../../dist/docs",
     "typecheck": "tsc"
   },
   "dependencies": {

--- a/packages/docs/scripts/tasks.js
+++ b/packages/docs/scripts/tasks.js
@@ -79,6 +79,10 @@ function makeDevStartAction(options = {}) {
  * Preview the built static site from SITE_OUT. `docusaurus serve` defaults to
  * packages/docs/build, but the pipeline emits to SITE_OUT (dist/docs), so point
  * --dir there. Fails fast with an actionable message when nothing is built yet.
+ *
+ * The `serve` script in package.json mirrors this with a path relative to
+ * packages/docs (`../../dist/docs`), which resolves to the same repo-root
+ * dist/docs as the absolute SITE_OUT here.
  */
 function makeServeAction() {
 	return {

--- a/packages/docs/scripts/tasks.js
+++ b/packages/docs/scripts/tasks.js
@@ -73,6 +73,17 @@ function makeDevStartAction(options = {}) {
 	};
 }
 
+// Preview the built static site. docusaurus serve defaults to packages/docs/build,
+// but the pipeline emits to SITE_OUT (dist/docs), so point --dir there.
+function makeServeAction() {
+	return {
+		description: 'Serve built docs',
+		run: async (ctx, task) => {
+			await execCommand('pnpm', ['exec', 'docusaurus', 'serve', '--dir', SITE_OUT, '--port', '3000'], { task, cwd: DOCS_DIR, stdio: 'inherit' });
+		}
+	};
+}
+
 function makeCleanAction() {
 	return {
 		description: 'Clean docs',
@@ -114,6 +125,10 @@ module.exports = {
 				description: 'Start docs dev server',
 				steps: ['docs:gather-dev', 'docs:dev-start']
 			})
+		},
+		{
+			name: 'docs:serve',
+			action: makeServeAction
 		},
 		{
 			name: 'docs:clean',

--- a/packages/docs/scripts/tasks.js
+++ b/packages/docs/scripts/tasks.js
@@ -3,10 +3,12 @@
  *
  * Co-located documentation site. Discovered by the build orchestrator at
  * packages/docs/scripts/tasks.js; exposes `docs:build` (gather -> index ->
- * compile), `docs:dev`, and `docs:clean`. Bare `builder build` includes
- * docs:build via global-command expansion because it carries a description.
+ * compile), `docs:dev`, `docs:serve`, `docs:test`, and `docs:clean`. Bare
+ * `builder build` includes docs:build via global-command expansion because it
+ * carries a description.
  */
 const path = require('path');
+const { readdir } = require('node:fs/promises');
 const { execCommand, exists, mkdir, rm, setState, parallel, PROJECT_ROOT, BUILD_ROOT, DIST_ROOT } = require('../../../scripts/lib');
 
 // Light, in-tree reference generators that deposit before gather collects them.
@@ -73,13 +75,50 @@ function makeDevStartAction(options = {}) {
 	};
 }
 
-// Preview the built static site. docusaurus serve defaults to packages/docs/build,
-// but the pipeline emits to SITE_OUT (dist/docs), so point --dir there.
+/**
+ * Preview the built static site from SITE_OUT. `docusaurus serve` defaults to
+ * packages/docs/build, but the pipeline emits to SITE_OUT (dist/docs), so point
+ * --dir there. Fails fast with an actionable message when nothing is built yet.
+ */
 function makeServeAction() {
 	return {
 		description: 'Serve built docs',
 		run: async (ctx, task) => {
+			if (!(await exists(SITE_OUT))) {
+				throw new Error(`No built docs at ${SITE_OUT}. Run 'builder docs:build' first.`);
+			}
 			await execCommand('pnpm', ['exec', 'docusaurus', 'serve', '--dir', SITE_OUT, '--port', '3000'], { task, cwd: DOCS_DIR, stdio: 'inherit' });
+		}
+	};
+}
+
+/** Recursively collect `*.test.mjs` files under `dir` (absolute paths). */
+async function findTestFiles(dir) {
+	const entries = await readdir(dir, { withFileTypes: true });
+	const files = [];
+	for (const entry of entries) {
+		const full = path.join(dir, entry.name);
+		if (entry.isDirectory()) {
+			files.push(...(await findTestFiles(full)));
+		} else if (entry.name.endsWith('.test.mjs')) {
+			files.push(full);
+		}
+	}
+	return files;
+}
+
+/** Run unit tests for the docs site's pure helpers via Node's test runner. */
+function makeTestAction() {
+	return {
+		description: 'Test docs helpers',
+		run: async (ctx, task) => {
+			const srcDir = path.join(DOCS_DIR, 'src');
+			const testFiles = (await findTestFiles(srcDir)).map((f) => path.relative(DOCS_DIR, f));
+			if (testFiles.length === 0) {
+				task.output = 'No test files found under src/';
+				return;
+			}
+			await execCommand('node', ['--test', '--test-reporter=spec', ...testFiles], { task, cwd: DOCS_DIR });
 		}
 	};
 }
@@ -129,6 +168,10 @@ module.exports = {
 		{
 			name: 'docs:serve',
 			action: makeServeAction
+		},
+		{
+			name: 'docs:test',
+			action: makeTestAction
 		},
 		{
 			name: 'docs:clean',

--- a/packages/docs/src/components/githubStarsNavbarItem.tsx
+++ b/packages/docs/src/components/githubStarsNavbarItem.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import clsx from 'clsx';
 import { SiGithub } from 'react-icons/si';
+import { formatStars } from '../lib/format.mjs';
 
 type Props = {
 	href: string;
@@ -46,11 +47,6 @@ function writeCachedStars(count: number | null): void {
 	}
 }
 
-function formatStars(count: number): string {
-	if (count < 1000) return String(count);
-	return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`;
-}
-
 /**
  * Navbar GitHub link that appends the repository's live star count.
  *
@@ -78,7 +74,7 @@ export default function GitHubStarsNavbarItem({ href, label = 'GitHub', classNam
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-		fetch(REPO_API, { signal: controller.signal })
+		fetch(REPO_API, { signal: controller.signal, headers: { Accept: 'application/vnd.github+json' } })
 			.then((res) => (res.ok ? res.json() : null))
 			.then((data) => {
 				if (cancelled) return;
@@ -98,8 +94,12 @@ export default function GitHubStarsNavbarItem({ href, label = 'GitHub', classNam
 		};
 	}, []);
 
+	// The icon is aria-hidden, so fold the count into the accessible name once it
+	// loads — otherwise screen readers announce only "GitHub".
+	const ariaLabel = stars !== null ? `${label}, ${formatStars(stars)} stars` : label;
+
 	return (
-		<a className={clsx('navbar__item', 'navbar__link', 'github-stars', mobile && 'menu__link', className)} href={href} target="_blank" rel="noopener noreferrer" aria-label={label}>
+		<a className={clsx('navbar__item', 'navbar__link', 'github-stars', mobile && 'menu__link', className)} href={href} target="_blank" rel="noopener noreferrer" aria-label={ariaLabel}>
 			<span className="github-stars__count">
 				<SiGithub className="github-stars__icon" aria-hidden="true" />
 				{stars !== null && formatStars(stars)}

--- a/packages/docs/src/components/githubStarsNavbarItem.tsx
+++ b/packages/docs/src/components/githubStarsNavbarItem.tsx
@@ -11,25 +11,33 @@ type Props = {
 
 const REPO_API = 'https://api.github.com/repos/rocketride-org/rocketride-server';
 const CACHE_KEY = 'rr-github-stars';
-const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6h — keep the count fresh without hammering the API.
+// Successful counts stay fresh for 6h. Failures (rate limit, offline, non-OK)
+// are cached as a null count for a shorter window so we back off rather than
+// refetching on every page load — GitHub's unauthenticated API is 60 req/hr/IP.
+const SUCCESS_TTL_MS = 6 * 60 * 60 * 1000; // 6h
+const FAILURE_TTL_MS = 30 * 60 * 1000; // 30m
+const FETCH_TIMEOUT_MS = 6000;
 
-type CacheEntry = { count: number; at: number };
+// A cached count of null is a remembered failure (negative cache), not a miss.
+type CacheEntry = { count: number | null; at: number };
 
-function readCachedStars(): number | null {
+function readCachedStars(): CacheEntry | null {
 	// localStorage may be unavailable (private mode) and a stale entry may be
 	// malformed JSON — treat any failure as a cache miss rather than throwing.
 	try {
 		const raw = localStorage.getItem(CACHE_KEY);
 		if (!raw) return null;
 		const entry = JSON.parse(raw) as CacheEntry;
-		if (typeof entry?.count !== 'number' || Date.now() - entry.at > CACHE_TTL_MS) return null;
-		return entry.count;
+		if (typeof entry?.at !== 'number') return null;
+		const ttl = typeof entry.count === 'number' ? SUCCESS_TTL_MS : FAILURE_TTL_MS;
+		if (Date.now() - entry.at > ttl) return null;
+		return entry;
 	} catch {
 		return null;
 	}
 }
 
-function writeCachedStars(count: number): void {
+function writeCachedStars(count: number | null): void {
 	// Best-effort cache write; ignore unavailable storage or quota errors.
 	try {
 		localStorage.setItem(CACHE_KEY, JSON.stringify({ count, at: Date.now() } satisfies CacheEntry));
@@ -62,21 +70,31 @@ export default function GitHubStarsNavbarItem({ href, label = 'GitHub', classNam
 
 		const cached = readCachedStars();
 		if (cached !== null) {
-			setStars(cached);
+			// Fresh entry (a remembered failure has count null → no badge, no refetch).
+			setStars(cached.count);
 			return;
 		}
 
-		fetch(REPO_API)
+		const controller = new AbortController();
+		const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+		fetch(REPO_API, { signal: controller.signal })
 			.then((res) => (res.ok ? res.json() : null))
 			.then((data) => {
-				if (cancelled || typeof data?.stargazers_count !== 'number') return;
-				setStars(data.stargazers_count);
-				writeCachedStars(data.stargazers_count);
+				if (cancelled) return;
+				const count = typeof data?.stargazers_count === 'number' ? data.stargazers_count : null;
+				setStars(count);
+				writeCachedStars(count); // negative-cache failures so we back off
 			})
-			.catch(() => {});
+			.catch(() => {
+				if (!cancelled) writeCachedStars(null);
+			})
+			.finally(() => clearTimeout(timeout));
 
 		return () => {
 			cancelled = true;
+			clearTimeout(timeout);
+			controller.abort();
 		};
 	}, []);
 

--- a/packages/docs/src/lib/format.mjs
+++ b/packages/docs/src/lib/format.mjs
@@ -1,0 +1,39 @@
+// Pure presentation helpers shared by the docs theme components. Kept as plain
+// ESM (no JSX) so Node's test runner can exercise them directly under docs:test.
+
+/**
+ * Format a star count into a compact label.
+ *
+ * Counts under 1000 render verbatim; larger counts collapse to one decimal of
+ * thousands with a trailing `k` (and a redundant `.0` trimmed). Past ~1M this
+ * yields e.g. `1000k` — acceptable for a repo whose count lives in the low
+ * thousands, so there is deliberately no `M` branch.
+ *
+ * @param {number} count - Raw star count.
+ * @returns {string} Compact display string (e.g. `999`, `1.5k`, `12k`).
+ */
+export function formatStars(count) {
+	if (count < 1000) return String(count);
+	return `${(count / 1000).toFixed(1).replace(/\.0$/, '')}k`;
+}
+
+/**
+ * Map a doc route to its raw `.md` sibling emitted by docs:gather.
+ *
+ * @param {string} pathname - Current route, e.g. `/` or `/nodes/x/`.
+ * @returns {string} Markdown URL, e.g. `/index.md` or `/nodes/x.md`.
+ */
+export function markdownUrl(pathname) {
+	if (pathname === '/') return '/index.md';
+	return `${pathname.replace(/\/$/, '')}.md`;
+}
+
+/**
+ * Whether a footer href points off-site (an absolute http/https URL).
+ *
+ * @param {string} href - Link target.
+ * @returns {boolean} True for absolute external URLs, false for internal routes.
+ */
+export function isExternal(href) {
+	return /^https?:\/\//.test(href);
+}

--- a/packages/docs/src/lib/format.test.mjs
+++ b/packages/docs/src/lib/format.test.mjs
@@ -1,0 +1,40 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatStars, markdownUrl, isExternal } from './format.mjs';
+
+describe('formatStars', () => {
+	it('renders counts under 1000 verbatim', () => {
+		assert.equal(formatStars(999), '999');
+	});
+
+	it('collapses thousands and trims a redundant .0', () => {
+		assert.equal(formatStars(1000), '1k');
+		assert.equal(formatStars(1500), '1.5k');
+		assert.equal(formatStars(12000), '12k');
+	});
+
+	it('keeps the k suffix past 1M (no M branch by design)', () => {
+		assert.equal(formatStars(999999), '1000k');
+	});
+});
+
+describe('markdownUrl', () => {
+	it('maps the root route to index.md', () => {
+		assert.equal(markdownUrl('/'), '/index.md');
+	});
+
+	it('strips a trailing slash before appending .md', () => {
+		assert.equal(markdownUrl('/nodes/x/'), '/nodes/x.md');
+	});
+});
+
+describe('isExternal', () => {
+	it('is true for absolute http/https urls', () => {
+		assert.equal(isExternal('https://example.com'), true);
+		assert.equal(isExternal('http://example.com'), true);
+	});
+
+	it('is false for internal routes', () => {
+		assert.equal(isExternal('/quickstart'), false);
+	});
+});

--- a/packages/docs/src/theme/DocItem/Content/index.tsx
+++ b/packages/docs/src/theme/DocItem/Content/index.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode } from 'react';
+import React, { useState, type ReactNode } from 'react';
 import clsx from 'clsx';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
@@ -29,6 +29,7 @@ export default function DocItemContent({ children }: Props): ReactNode {
 	const { pathname } = useLocation();
 	const showActions = pathname !== '/';
 	const mdUrl = markdownUrl(pathname);
+	const [copied, setCopied] = useState(false);
 
 	const copyMarkdown = async () => {
 		// Best-effort: a failed fetch or a denied clipboard write should be a
@@ -38,6 +39,8 @@ export default function DocItemContent({ children }: Props): ReactNode {
 			if (!res.ok) return;
 			const text = await res.text();
 			await navigator.clipboard.writeText(text);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
 		} catch {
 			/* clipboard unavailable or fetch failed — ignore */
 		}
@@ -54,7 +57,7 @@ export default function DocItemContent({ children }: Props): ReactNode {
 								<SiMarkdown className="docs-md-actions__icon" /> View as Markdown
 							</a>
 							<button type="button" className="button button--secondary button--sm" onClick={copyMarkdown}>
-								<LuClipboard className="docs-md-actions__icon" /> Copy as Markdown
+								<LuClipboard className="docs-md-actions__icon" /> {copied ? 'Copied' : 'Copy as Markdown'}
 							</button>
 						</div>
 					)}

--- a/packages/docs/src/theme/DocItem/Content/index.tsx
+++ b/packages/docs/src/theme/DocItem/Content/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, type ReactNode } from 'react';
+import React, { useEffect, useRef, useState, type ReactNode } from 'react';
 import clsx from 'clsx';
 import { ThemeClassNames } from '@docusaurus/theme-common';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
@@ -8,12 +8,7 @@ import MDXContent from '@theme/MDXContent';
 import type { Props } from '@theme/DocItem/Content';
 import { LuClipboard } from 'react-icons/lu';
 import { SiMarkdown } from 'react-icons/si';
-
-// Map the current route to its raw .md sibling emitted by docs:gather.
-function markdownUrl(pathname: string): string {
-	if (pathname === '/') return '/index.md';
-	return `${pathname.replace(/\/$/, '')}.md`;
-}
+import { markdownUrl } from '../../../lib/format.mjs';
 
 /**
  * Renders the doc title ourselves so the View/Copy-as-Markdown controls can sit
@@ -30,6 +25,16 @@ export default function DocItemContent({ children }: Props): ReactNode {
 	const showActions = pathname !== '/';
 	const mdUrl = markdownUrl(pathname);
 	const [copied, setCopied] = useState(false);
+	const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Clear a pending "Copied" reset if the component unmounts mid-window, so the
+	// timer never fires against an unmounted component.
+	useEffect(
+		() => () => {
+			if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
+		},
+		[]
+	);
 
 	const copyMarkdown = async () => {
 		// Best-effort: a failed fetch or a denied clipboard write should be a
@@ -39,8 +44,10 @@ export default function DocItemContent({ children }: Props): ReactNode {
 			if (!res.ok) return;
 			const text = await res.text();
 			await navigator.clipboard.writeText(text);
+			// Reset any in-flight timer so rapid clicks don't stack timeouts.
+			if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current);
 			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
+			copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
 		} catch {
 			/* clipboard unavailable or fetch failed — ignore */
 		}

--- a/packages/docs/src/theme/Footer/index.tsx
+++ b/packages/docs/src/theme/Footer/index.tsx
@@ -8,6 +8,8 @@ type FooterLink = { label: string; href: string };
 type FooterColumn = { title: string; items: FooterLink[] };
 type SocialLink = { label: string; href: string; icon: React.ReactNode };
 
+const isExternal = (href: string): boolean => /^https?:\/\//.test(href);
+
 // Footer navigation wired to the docs spine (routeBasePath is '/'). Category
 // labels with no landing page point at their first leaf.
 const COLUMNS: FooterColumn[] = [
@@ -107,9 +109,15 @@ export default function Footer(): React.ReactNode {
 							<ul className="rr-footer__list">
 								{column.items.map((item) => (
 									<li key={item.label}>
-										<Link className="rr-footer__link" to={item.href}>
-											{item.label}
-										</Link>
+										{isExternal(item.href) ? (
+											<a className="rr-footer__link" href={item.href} target="_blank" rel="noopener noreferrer">
+												{item.label}
+											</a>
+										) : (
+											<Link className="rr-footer__link" to={item.href}>
+												{item.label}
+											</Link>
+										)}
 									</li>
 								))}
 							</ul>

--- a/packages/docs/src/theme/Footer/index.tsx
+++ b/packages/docs/src/theme/Footer/index.tsx
@@ -3,12 +3,11 @@ import Link from '@docusaurus/Link';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import ThemedImage from '@theme/ThemedImage';
+import { isExternal } from '../../lib/format.mjs';
 
 type FooterLink = { label: string; href: string };
 type FooterColumn = { title: string; items: FooterLink[] };
 type SocialLink = { label: string; href: string; icon: React.ReactNode };
-
-const isExternal = (href: string): boolean => /^https?:\/\//.test(href);
 
 // Footer navigation wired to the docs spine (routeBasePath is '/'). Category
 // labels with no landing page point at their first leaf.
@@ -78,6 +77,7 @@ const SOCIALS: SocialLink[] = [
 	},
 ];
 
+/** Site footer: brand, social links, and the docs navigation spine. */
 export default function Footer(): React.ReactNode {
 	const { siteConfig } = useDocusaurusContext();
 	const logoLight = useBaseUrl('img/rocketride-icon-colored.svg');

--- a/packages/docs/tsconfig.json
+++ b/packages/docs/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "baseUrl": "."
   },
-  "exclude": [".docusaurus", "build"]
+  "exclude": [".docusaurus", "build", "**/*.test.mjs"]
 }


### PR DESCRIPTION
## Summary

- Negative-cache GitHub stars (30m on failure vs 6h success) with a 6s fetch timeout to respect the unauthenticated 60 req/hr/IP limit
- Add copy-button feedback, route external footer links through target=_blank anchors, and add a `docs:serve` task pointing at the SITE_OUT build dir
- Bump TypeScript SDK version to 1.3.0

## Type

feature

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Closes RR-1218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy-as-Markdown button shows "Copied" for 2 seconds after use.
  * Added docs preview action to serve the built site locally.
  * Added docs test action to run documentation tests.

* **Improvements**
  * Footer external links now open in new tabs.
  * GitHub stars display improved with better caching, timeout and error handling.
  * Docs now include utilities for formatting star counts, doc URLs, and external-link detection.
  * SDK version updated to 1.3.0.

* **Tests**
  * Added unit tests for docs formatting utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->