### PR TITLE
feat(nodes): emit profile token limits in generated tables, fix Anthropic drift (RR-1220)

### DIFF
--- a/nodes/scripts/gen-node-tables.mjs
+++ b/nodes/scripts/gen-node-tables.mjs
@@ -82,6 +82,15 @@ function esc(v) {
 	return String(v == null ? '' : v).replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').trim();
 }
 
+function fmtTokens(n) {
+	if (n == null || n === '') return '';
+	const num = Number(n);
+	if (!Number.isFinite(num)) return esc(n);
+	if (num >= 1_000_000 && num % 1_000_000 === 0) return `${num / 1_000_000}M`;
+	if (num >= 1000 && num % 1000 === 0) return `${num / 1000}K`;
+	return num.toLocaleString('en-US');
+}
+
 function serviceBlock(svc, label) {
 	const lines = [];
 	if (label) lines.push(`### Service: \`${label}\``, '');
@@ -106,9 +115,18 @@ function serviceBlock(svc, label) {
 
 	const profiles = svc.preconfig?.profiles;
 	if (profiles && Object.keys(profiles).length) {
-		lines.push('**Profiles**', '', '| Profile | Title | Model |', '| --- | --- | --- |');
-		for (const [key, p] of Object.entries(profiles)) {
-			lines.push(`| \`${esc(key)}\` | ${esc(p?.title)} | ${esc(p?.model)} |`);
+		const entries = Object.entries(profiles);
+		const hasTokens = entries.some(([, p]) => p?.modelTotalTokens != null || p?.modelOutputTokens != null);
+		if (hasTokens) {
+			lines.push('**Profiles**', '', '| Profile | Title | Model | Context | Max output |', '| --- | --- | --- | --- | --- |');
+			for (const [key, p] of entries) {
+				lines.push(`| \`${esc(key)}\` | ${esc(p?.title)} | ${esc(p?.model)} | ${fmtTokens(p?.modelTotalTokens)} | ${fmtTokens(p?.modelOutputTokens)} |`);
+			}
+		} else {
+			lines.push('**Profiles**', '', '| Profile | Title | Model |', '| --- | --- | --- |');
+			for (const [key, p] of entries) {
+				lines.push(`| \`${esc(key)}\` | ${esc(p?.title)} | ${esc(p?.model)} |`);
+			}
 		}
 		lines.push('');
 	}

--- a/nodes/src/nodes/accessibility_describe/doc.md
+++ b/nodes/src/nodes/accessibility_describe/doc.md
@@ -67,11 +67,11 @@ Customize the **Analysis Prompt** field to change this structure.
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `gemini-2.5-flash` | Gemini 2.5 Flash - Fast & Efficient (1M tokens) | gemini-2.5-flash |
-| `gemini-2.5-pro` | Gemini 2.5 Pro - High Quality (1M tokens) | gemini-2.5-pro |
-| `gemini-2.0-flash` | Gemini 2.0 Flash - Balanced (1M tokens) | gemini-2.0-flash |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `gemini-2.5-flash` | Gemini 2.5 Flash - Fast & Efficient (1M tokens) | gemini-2.5-flash | 1,048,576 |  |
+| `gemini-2.5-pro` | Gemini 2.5 Pro - High Quality (1M tokens) | gemini-2.5-pro | 1,048,576 |  |
+| `gemini-2.0-flash` | Gemini 2.0 Flash - Balanced (1M tokens) | gemini-2.0-flash | 1,048,576 |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/audio_tts/doc.md
+++ b/nodes/src/nodes/audio_tts/doc.md
@@ -5,7 +5,7 @@ Text-to-speech node using **Kokoro-82M** only. Additional engines (Piper, Bark, 
 ## Behavior (aligned with reference branch for `engine: kokoro`)
 
 - **Input:** `text` lane
-- **Output:** `audio` lane — WAV bytes via `writeAudio` (BEGIN / WRITE / END) with MIME `audio/wav`
+- **Output:** `audio` lane — WAV bytes with MIME `audio/wav`
 - **Local:** `kokoro.KPipeline`, spaCy `en_core_web_sm` via `ensure_spacy_en_model()`
 - **`--modelserver`:** `ModelClient` + `KokoroLoader` on the server
 

--- a/nodes/src/nodes/embedding_openai/doc.md
+++ b/nodes/src/nodes/embedding_openai/doc.md
@@ -10,11 +10,12 @@ Generates text embeddings using OpenAI's embedding API. Requires an OpenAI API k
 
 **Lanes:**
 
-| Lane in     | Lane out    | Description                                         |
-| ----------- | ----------- | --------------------------------------------------- |
-| `documents` | `documents` | Embed document text, attach vector to each document |
+| Lane in     | Lane out    | Description                                            |
+| ----------- | ----------- | ----------------------------------------------------- |
+| `documents` | `documents` | Embed document text, attach vector to each document   |
+| `questions` | `questions` | Embed a query string, attach vector for similarity search |
 
-Output documents have an `embedding` vector attached, ready for ingestion into a vector store.
+Output documents have an `embedding` vector attached, ready for ingestion into a vector store. The `questions` lane embeds a search query with the same model so it can be matched against a stored index.
 
 ## Configuration
 

--- a/nodes/src/nodes/llm_anthropic/doc.md
+++ b/nodes/src/nodes/llm_anthropic/doc.md
@@ -30,6 +30,7 @@ Connects Anthropic's Claude models to your pipeline. Used primarily as an `llm` 
 | Profile                       | Model ID            | Context                          |
 | ----------------------------- | ------------------- | -------------------------------- |
 | Claude Sonnet 4.6 _(default)_ | `claude-sonnet-4-6` | 200K tokens                      |
+| Claude Opus 4.7               | `claude-opus-4-7`   | 200K tokens                      |
 | Claude Opus 4.6               | `claude-opus-4-6`   | 200K tokens                      |
 | Claude Sonnet 4.5             | `claude-sonnet-4-5` | 200K tokens                      |
 | Claude Opus 4.5               | `claude-opus-4-5`   | 200K tokens                      |

--- a/nodes/src/nodes/llm_anthropic/doc.md
+++ b/nodes/src/nodes/llm_anthropic/doc.md
@@ -27,15 +27,17 @@ Connects Anthropic's Claude models to your pipeline. Used primarily as an `llm` 
 
 ## Profiles
 
-| Profile                       | Model ID            | Context                          |
-| ----------------------------- | ------------------- | -------------------------------- |
-| Claude Sonnet 4.6 _(default)_ | `claude-sonnet-4-6` | 1M context, 128K output          |
-| Claude Opus 4.7               | `claude-opus-4-7`   | 1M context, 128K output          |
-| Claude Opus 4.6               | `claude-opus-4-6`   | 1M context, 128K output          |
-| Claude Sonnet 4.5             | `claude-sonnet-4-5` | 1M context, 64K output           |
-| Claude Opus 4.5               | `claude-opus-4-5`   | 200K context, 64K output         |
-| Claude Haiku 4.5              | `claude-haiku-4-5`  | 200K context, 64K output         |
-| Custom                        | _(user-specified)_  | Specify model ID and token limit |
+| Profile                       | Model ID            |
+| ----------------------------- | ------------------- |
+| Claude Sonnet 4.6 _(default)_ | `claude-sonnet-4-6` |
+| Claude Opus 4.7               | `claude-opus-4-7`   |
+| Claude Opus 4.6               | `claude-opus-4-6`   |
+| Claude Sonnet 4.5             | `claude-sonnet-4-5` |
+| Claude Opus 4.5               | `claude-opus-4-5`   |
+| Claude Haiku 4.5              | `claude-haiku-4-5`  |
+| Custom                        | _(user-specified)_  |
+
+Per-profile context and output token limits are in the Reference table below, sourced from the node's `services.json`.
 
 ## Upstream docs
 
@@ -60,15 +62,15 @@ Connects Anthropic's Claude models to your pipeline. Used primarily as an `llm` 
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` |  |  |
-| `claude-sonnet-4-6` | Claude Sonnet 4.6 | claude-sonnet-4-6 |
-| `claude-opus-4-6` | Claude Opus 4.6 | claude-opus-4-6 |
-| `claude-haiku-4-5` | Claude Haiku 4.5 | claude-haiku-4-5 |
-| `claude-sonnet-4-5` | Claude Sonnet 4.5 | claude-sonnet-4-5 |
-| `claude-opus-4-5` | Claude Opus 4.5 | claude-opus-4-5 |
-| `claude-opus-4-7` | Anthropic: Claude Opus 4.7 | claude-opus-4-7 |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` |  |  | 200K |  |
+| `claude-sonnet-4-6` | Claude Sonnet 4.6 | claude-sonnet-4-6 | 1M | 128K |
+| `claude-opus-4-6` | Claude Opus 4.6 | claude-opus-4-6 | 1M | 128K |
+| `claude-haiku-4-5` | Claude Haiku 4.5 | claude-haiku-4-5 | 200K | 64K |
+| `claude-sonnet-4-5` | Claude Sonnet 4.5 | claude-sonnet-4-5 | 1M | 64K |
+| `claude-opus-4-5` | Claude Opus 4.5 | claude-opus-4-5 | 200K | 64K |
+| `claude-opus-4-7` | Anthropic: Claude Opus 4.7 | claude-opus-4-7 | 1M | 128K |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_anthropic/doc.md
+++ b/nodes/src/nodes/llm_anthropic/doc.md
@@ -29,12 +29,12 @@ Connects Anthropic's Claude models to your pipeline. Used primarily as an `llm` 
 
 | Profile                       | Model ID            | Context                          |
 | ----------------------------- | ------------------- | -------------------------------- |
-| Claude Sonnet 4.6 _(default)_ | `claude-sonnet-4-6` | 200K tokens                      |
-| Claude Opus 4.7               | `claude-opus-4-7`   | 200K tokens                      |
-| Claude Opus 4.6               | `claude-opus-4-6`   | 200K tokens                      |
-| Claude Sonnet 4.5             | `claude-sonnet-4-5` | 200K tokens                      |
-| Claude Opus 4.5               | `claude-opus-4-5`   | 200K tokens                      |
-| Claude Haiku 4.5              | `claude-haiku-4-5`  | 200K tokens                      |
+| Claude Sonnet 4.6 _(default)_ | `claude-sonnet-4-6` | 1M context, 128K output          |
+| Claude Opus 4.7               | `claude-opus-4-7`   | 1M context, 128K output          |
+| Claude Opus 4.6               | `claude-opus-4-6`   | 1M context, 128K output          |
+| Claude Sonnet 4.5             | `claude-sonnet-4-5` | 1M context, 64K output           |
+| Claude Opus 4.5               | `claude-opus-4-5`   | 200K context, 64K output         |
+| Claude Haiku 4.5              | `claude-haiku-4-5`  | 200K context, 64K output         |
 | Custom                        | _(user-specified)_  | Specify model ID and token limit |
 
 ## Upstream docs

--- a/nodes/src/nodes/llm_baidu_qianfan/doc.md
+++ b/nodes/src/nodes/llm_baidu_qianfan/doc.md
@@ -31,12 +31,12 @@ Use the Baidu Qianfan node to call ERNIE chat models through Qianfan's OpenAI-co
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `ernie-4-5-turbo-128k` | ERNIE 4.5 Turbo 128K | ernie-4.5-turbo-128k |
-| `ernie-4-5-turbo-32k` | ERNIE 4.5 Turbo 32K | ernie-4.5-turbo-32k |
-| `ernie-5-0-thinking-preview` | ERNIE 5.0 Thinking Preview | ernie-5.0-thinking-preview |
-| `custom` | Custom |  |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `ernie-4-5-turbo-128k` | ERNIE 4.5 Turbo 128K | ernie-4.5-turbo-128k | 128K | 4,096 |
+| `ernie-4-5-turbo-32k` | ERNIE 4.5 Turbo 32K | ernie-4.5-turbo-32k | 32,768 | 4,096 |
+| `ernie-5-0-thinking-preview` | ERNIE 5.0 Thinking Preview | ernie-5.0-thinking-preview | 128K | 8,192 |
+| `custom` | Custom |  | 32,768 | 4,096 |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_bedrock/doc.md
+++ b/nodes/src/nodes/llm_bedrock/doc.md
@@ -101,30 +101,30 @@ Connects Amazon Bedrock-hosted models to your pipeline. Used primarily as an `ll
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` | Custom |  |
-| `ai21_jamba-1_5-large` | Jamba 1.5 Large | ai21.jamba-1-5-large-v1:0 |
-| `ai21_jamba-1_5-mini` | Jamba 1.5 Mini | ai21.jamba-1-5-mini-v1:0 |
-| `amazon_titan-text-express` | Titan Text Express | amazon.titan-text-express-v1 |
-| `amazon_nova-2-lite` | Nova 2 Lite | amazon.nova-2-lite-v1:0 |
-| `anthropic_claude-3_7-sonnet` | Claude Sonnet 3.7 | anthropic.claude-3-7-sonnet-20250219-v1:0 |
-| `anthropic_claude-sonnet-4-5` | Claude Sonnet 4.5 | anthropic.claude-sonnet-4-5-20250929-v1:0 |
-| `anthropic_claude-3_5-haiku` | Claude Haiku 3.5 | anthropic.claude-3-5-haiku-20241022-v1:0 |
-| `anthropic_claude-haiku-4-5` | Claude Haiku 4.5 | anthropic.claude-haiku-4-5-20251001-v1:0 |
-| `anthropic_claude-opus-4` | Claude Opus 4 | anthropic.claude-opus-4-20250514-v1:0 |
-| `anthropic_claude-opus-4-5` | Claude Opus 4.5 | anthropic.claude-opus-4-5-20251101-v1:0 |
-| `cohere_command-r-plus` | Command R+ | cohere.command-r-plus-v1:0 |
-| `cohere_command-r` | Command R | cohere.command-r-v1:0 |
-| `meta_llama3_1-8b` | Llama 3.1 8B Instruct | meta.llama3-1-8b-instruct-v1:0 |
-| `meta_llama3_1-70b` | Llama 3.1 70B Instruct | meta.llama3-1-70b-instruct-v1:0 |
-| `meta_llama3_3-70b` | Llama 3.3 70B Instruct | meta.llama3-3-70b-instruct-v1:0 |
-| `meta_llama3_2-1b` | Llama 3.2 1B Instruct | meta.llama3-2-1b-instruct-v1:0 |
-| `meta_llama3_2-3b` | Llama 3.2 3B Instruct | meta.llama3-2-3b-instruct-v1:0 |
-| `meta_llama3_2-11b` | Llama 3.2 11B Vision Instruct | meta.llama3-2-11b-instruct-v1:0 |
-| `meta_llama3_2-90b` | Llama 3.2 90B Vision Instruct | meta.llama3-2-90b-instruct-v1:0 |
-| `meta_llama4-scout-17b` | Llama 4 Scout 17B Instruct | meta.llama4-scout-17b-instruct-v1:0 |
-| `meta_llama4-maverick-17b` | Llama 4 Maverick 17B Instruct | meta.llama4-maverick-17b-instruct-v1:0 |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` | Custom |  | 256K |  |
+| `ai21_jamba-1_5-large` | Jamba 1.5 Large | ai21.jamba-1-5-large-v1:0 | 256K |  |
+| `ai21_jamba-1_5-mini` | Jamba 1.5 Mini | ai21.jamba-1-5-mini-v1:0 | 256K |  |
+| `amazon_titan-text-express` | Titan Text Express | amazon.titan-text-express-v1 | 8,192 |  |
+| `amazon_nova-2-lite` | Nova 2 Lite | amazon.nova-2-lite-v1:0 | 1M |  |
+| `anthropic_claude-3_7-sonnet` | Claude Sonnet 3.7 | anthropic.claude-3-7-sonnet-20250219-v1:0 | 200K |  |
+| `anthropic_claude-sonnet-4-5` | Claude Sonnet 4.5 | anthropic.claude-sonnet-4-5-20250929-v1:0 | 200K |  |
+| `anthropic_claude-3_5-haiku` | Claude Haiku 3.5 | anthropic.claude-3-5-haiku-20241022-v1:0 | 200K |  |
+| `anthropic_claude-haiku-4-5` | Claude Haiku 4.5 | anthropic.claude-haiku-4-5-20251001-v1:0 | 200K |  |
+| `anthropic_claude-opus-4` | Claude Opus 4 | anthropic.claude-opus-4-20250514-v1:0 | 200K |  |
+| `anthropic_claude-opus-4-5` | Claude Opus 4.5 | anthropic.claude-opus-4-5-20251101-v1:0 | 200K |  |
+| `cohere_command-r-plus` | Command R+ | cohere.command-r-plus-v1:0 | 128K |  |
+| `cohere_command-r` | Command R | cohere.command-r-v1:0 | 128K |  |
+| `meta_llama3_1-8b` | Llama 3.1 8B Instruct | meta.llama3-1-8b-instruct-v1:0 | 128K |  |
+| `meta_llama3_1-70b` | Llama 3.1 70B Instruct | meta.llama3-1-70b-instruct-v1:0 | 128K |  |
+| `meta_llama3_3-70b` | Llama 3.3 70B Instruct | meta.llama3-3-70b-instruct-v1:0 | 128K |  |
+| `meta_llama3_2-1b` | Llama 3.2 1B Instruct | meta.llama3-2-1b-instruct-v1:0 | 128K |  |
+| `meta_llama3_2-3b` | Llama 3.2 3B Instruct | meta.llama3-2-3b-instruct-v1:0 | 128K |  |
+| `meta_llama3_2-11b` | Llama 3.2 11B Vision Instruct | meta.llama3-2-11b-instruct-v1:0 | 128K |  |
+| `meta_llama3_2-90b` | Llama 3.2 90B Vision Instruct | meta.llama3-2-90b-instruct-v1:0 | 128K |  |
+| `meta_llama4-scout-17b` | Llama 4 Scout 17B Instruct | meta.llama4-scout-17b-instruct-v1:0 | 3500K |  |
+| `meta_llama4-maverick-17b` | Llama 4 Maverick 17B Instruct | meta.llama4-maverick-17b-instruct-v1:0 | 1M |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_deepseek/doc.md
+++ b/nodes/src/nodes/llm_deepseek/doc.md
@@ -71,32 +71,32 @@ Connects DeepSeek models to your pipeline — either via the DeepSeek cloud API 
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `cloud-reasoner` | Cloud Reasoner | deepseek-reasoner |
-| `cloud-chat` | Cloud Chat | deepseek-chat |
-| `deepseek-r1-1_5b` |  | deepseek-r1:1.5b |
-| `deepseek-r1-7b` |  | deepseek-r1:7b |
-| `deepseek-r1-8b` |  | deepseek-r1:8b |
-| `deepseek-r1-14b` |  | deepseek-r1:14b |
-| `deepseek-r1-32b` |  | deepseek-r1:32b |
-| `deepseek-r1-70b` |  | deepseek-r1:70b |
-| `deepseek-r1-671b` |  | deepseek-r1:671b |
-| `deepseek-v3` |  | deepseek-v3 |
-| `deepseek-chat-v3-0324` | DeepSeek: DeepSeek V3 0324 | deepseek-chat-v3-0324 |
-| `deepseek-chat-v3-1` | DeepSeek: DeepSeek V3.1 | deepseek-chat-v3.1 |
-| `deepseek-r1` | DeepSeek: R1 | deepseek-r1 |
-| `deepseek-r1-0528` | DeepSeek: R1 0528 | deepseek-r1-0528 |
-| `deepseek-r1-distill-llama-70b` | DeepSeek: R1 Distill Llama 70B | deepseek-r1-distill-llama-70b |
-| `deepseek-r1-distill-qwen-32b` | DeepSeek: R1 Distill Qwen 32B | deepseek-r1-distill-qwen-32b |
-| `deepseek-r1t2-chimera` | TNG: DeepSeek R1T2 Chimera | deepseek-r1t2-chimera |
-| `deepseek-v3-1-nex-n1` | Nex AGI: DeepSeek V3.1 Nex N1 | deepseek-v3.1-nex-n1 |
-| `deepseek-v3-1-terminus` | DeepSeek: DeepSeek V3.1 Terminus | deepseek-v3.1-terminus |
-| `deepseek-v3-2` | DeepSeek: DeepSeek V3.2 | deepseek-v3.2 |
-| `deepseek-v3-2-exp` | DeepSeek: DeepSeek V3.2 Exp | deepseek-v3.2-exp |
-| `deepseek-v3-2-speciale` | DeepSeek: DeepSeek V3.2 Speciale | deepseek-v3.2-speciale |
-| `deepseek-v4-flash` | DeepSeek: DeepSeek V4 Flash | deepseek-v4-flash |
-| `deepseek-v4-pro` | DeepSeek: DeepSeek V4 Pro | deepseek-v4-pro |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `cloud-reasoner` | Cloud Reasoner | deepseek-reasoner | 128K | 4,096 |
+| `cloud-chat` | Cloud Chat | deepseek-chat | 163,840 | 16,384 |
+| `deepseek-r1-1_5b` |  | deepseek-r1:1.5b | 128K | 4,096 |
+| `deepseek-r1-7b` |  | deepseek-r1:7b | 128K | 4,096 |
+| `deepseek-r1-8b` |  | deepseek-r1:8b | 128K | 4,096 |
+| `deepseek-r1-14b` |  | deepseek-r1:14b | 128K | 4,096 |
+| `deepseek-r1-32b` |  | deepseek-r1:32b | 128K | 4,096 |
+| `deepseek-r1-70b` |  | deepseek-r1:70b | 128K | 4,096 |
+| `deepseek-r1-671b` |  | deepseek-r1:671b | 128K | 4,096 |
+| `deepseek-v3` |  | deepseek-v3 | 128K | 4,096 |
+| `deepseek-chat-v3-0324` | DeepSeek: DeepSeek V3 0324 | deepseek-chat-v3-0324 | 163,840 | 16,384 |
+| `deepseek-chat-v3-1` | DeepSeek: DeepSeek V3.1 | deepseek-chat-v3.1 | 32,768 | 7,168 |
+| `deepseek-r1` | DeepSeek: R1 | deepseek-r1 | 64K | 16K |
+| `deepseek-r1-0528` | DeepSeek: R1 0528 | deepseek-r1-0528 | 163,840 | 32,768 |
+| `deepseek-r1-distill-llama-70b` | DeepSeek: R1 Distill Llama 70B | deepseek-r1-distill-llama-70b | 131,072 | 16,384 |
+| `deepseek-r1-distill-qwen-32b` | DeepSeek: R1 Distill Qwen 32B | deepseek-r1-distill-qwen-32b | 32,768 | 32,768 |
+| `deepseek-r1t2-chimera` | TNG: DeepSeek R1T2 Chimera | deepseek-r1t2-chimera | 163,840 | 163,840 |
+| `deepseek-v3-1-nex-n1` | Nex AGI: DeepSeek V3.1 Nex N1 | deepseek-v3.1-nex-n1 | 131,072 | 163,840 |
+| `deepseek-v3-1-terminus` | DeepSeek: DeepSeek V3.1 Terminus | deepseek-v3.1-terminus | 163,840 | 32,768 |
+| `deepseek-v3-2` | DeepSeek: DeepSeek V3.2 | deepseek-v3.2 | 131,072 | 65,536 |
+| `deepseek-v3-2-exp` | DeepSeek: DeepSeek V3.2 Exp | deepseek-v3.2-exp | 163,840 | 65,536 |
+| `deepseek-v3-2-speciale` | DeepSeek: DeepSeek V3.2 Speciale | deepseek-v3.2-speciale | 163,840 | 163,840 |
+| `deepseek-v4-flash` | DeepSeek: DeepSeek V4 Flash | deepseek-v4-flash | 1,048,576 | 384K |
+| `deepseek-v4-pro` | DeepSeek: DeepSeek V4 Pro | deepseek-v4-pro | 1,048,576 | 384K |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_gemini/doc.md
+++ b/nodes/src/nodes/llm_gemini/doc.md
@@ -65,28 +65,28 @@ Profiles marked **Image** support image generation output. Deprecated profiles (
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` |  |  |
-| `gemini-3_1-pro-preview` | Gemini 3.1 Pro | models/gemini-3.1-pro-preview |
-| `gemini-3_1-flash-image-preview` | Gemini 3.1 Flash Image Preview | models/gemini-3.1-flash-image-preview |
-| `gemini-3_1-flash-lite-preview` | Gemini 3.1 Flash Lite | models/gemini-3.1-flash-lite-preview |
-| `gemini-3-flash-preview` | Gemini 3 Flash Preview | models/gemini-3-flash-preview |
-| `gemini-3-pro-image-preview` | Gemini 3 Pro Image Preview | models/gemini-3-pro-image-preview |
-| `gemini-2_5-pro` | Gemini 2.5 Pro | models/gemini-2.5-pro |
-| `gemini-2_5-flash` | Gemini 2.5 Flash | models/gemini-2.5-flash |
-| `gemini-2_5-flash-lite` | Gemini 2.5 Flash Lite | models/gemini-2.5-flash-lite |
-| `gemini-2_5-flash-image` | Gemini 2.5 Flash Image | models/gemini-2.5-flash-image |
-| `gemini-3-pro-preview` | Gemini 3 Pro Preview | models/gemini-3-pro-preview |
-| `gemini-3-pro-image` | Gemini 3 Pro Image | models/gemini-3-pro-image |
-| `gemini-2_0-flash` | Gemini 2.0 Flash | models/gemini-2.0-flash |
-| `gemini-2_0-flash-lite` | Gemini 2.0 Flash Lite | models/gemini-2.0-flash-lite |
-| `models-gemini-2-5-flash-lite-preview-09-2025` | Google: Gemini 2.5 Flash Lite Preview 09-2025 | models/gemini-2.5-flash-lite-preview-09-2025 |
-| `models-gemini-2-5-pro-preview` | Google: Gemini 2.5 Pro Preview 06-05 | models/gemini-2.5-pro-preview |
-| `models-gemini-2-5-pro-preview-05-06` | Google: Gemini 2.5 Pro Preview 05-06 | models/gemini-2.5-pro-preview-05-06 |
-| `models-gemini-3-1-pro-preview-customtools` | Google: Gemini 3.1 Pro Preview Custom Tools | models/gemini-3.1-pro-preview-customtools |
-| `models-gemini-flash-latest` | Google Gemini Flash Latest | models/gemini-flash-latest |
-| `models-gemini-pro-latest` | Google Gemini Pro Latest | models/gemini-pro-latest |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` |  |  | 1,114,112 | 65,536 |
+| `gemini-3_1-pro-preview` | Gemini 3.1 Pro | models/gemini-3.1-pro-preview | 1,048,576 | 65,536 |
+| `gemini-3_1-flash-image-preview` | Gemini 3.1 Flash Image Preview | models/gemini-3.1-flash-image-preview | 131,072 | 65,536 |
+| `gemini-3_1-flash-lite-preview` | Gemini 3.1 Flash Lite | models/gemini-3.1-flash-lite-preview | 1,048,576 | 65,536 |
+| `gemini-3-flash-preview` | Gemini 3 Flash Preview | models/gemini-3-flash-preview | 1,048,576 | 65,536 |
+| `gemini-3-pro-image-preview` | Gemini 3 Pro Image Preview | models/gemini-3-pro-image-preview | 65,536 | 32,768 |
+| `gemini-2_5-pro` | Gemini 2.5 Pro | models/gemini-2.5-pro | 1,048,576 | 65,536 |
+| `gemini-2_5-flash` | Gemini 2.5 Flash | models/gemini-2.5-flash | 1,048,576 | 65,535 |
+| `gemini-2_5-flash-lite` | Gemini 2.5 Flash Lite | models/gemini-2.5-flash-lite | 1,048,576 | 65,535 |
+| `gemini-2_5-flash-image` | Gemini 2.5 Flash Image | models/gemini-2.5-flash-image | 32,768 | 32,768 |
+| `gemini-3-pro-preview` | Gemini 3 Pro Preview | models/gemini-3-pro-preview | 1,048,576 | 65,536 |
+| `gemini-3-pro-image` | Gemini 3 Pro Image | models/gemini-3-pro-image | 98,304 | 32,768 |
+| `gemini-2_0-flash` | Gemini 2.0 Flash | models/gemini-2.0-flash | 1,048,576 | 65,535 |
+| `gemini-2_0-flash-lite` | Gemini 2.0 Flash Lite | models/gemini-2.0-flash-lite |  | 65,536 |
+| `models-gemini-2-5-flash-lite-preview-09-2025` | Google: Gemini 2.5 Flash Lite Preview 09-2025 | models/gemini-2.5-flash-lite-preview-09-2025 | 1,048,576 | 65,535 |
+| `models-gemini-2-5-pro-preview` | Google: Gemini 2.5 Pro Preview 06-05 | models/gemini-2.5-pro-preview | 1,048,576 | 65,536 |
+| `models-gemini-2-5-pro-preview-05-06` | Google: Gemini 2.5 Pro Preview 05-06 | models/gemini-2.5-pro-preview-05-06 | 1,048,576 | 65,535 |
+| `models-gemini-3-1-pro-preview-customtools` | Google: Gemini 3.1 Pro Preview Custom Tools | models/gemini-3.1-pro-preview-customtools | 1,048,576 | 65,536 |
+| `models-gemini-flash-latest` | Google Gemini Flash Latest | models/gemini-flash-latest | 1,048,576 | 65,536 |
+| `models-gemini-pro-latest` | Google Gemini Pro Latest | models/gemini-pro-latest | 1,048,576 | 65,536 |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_gmi_cloud/doc.md
+++ b/nodes/src/nodes/llm_gmi_cloud/doc.md
@@ -87,30 +87,30 @@ GMI Cloud has three tiers:
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` |  |  |
-| `llama-4-scout` | Llama 4 Scout | meta-llama/Llama-4-Scout-17B-16E-Instruct |
-| `llama-4-maverick` | Llama 4 Maverick | meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 |
-| `qwen3-235b` | Qwen3 235B | Qwen/Qwen3-235B-A22B-FP8 |
-| `qwen3-32b` | Qwen3 32B | Qwen/Qwen3-32B-FP8 |
-| `qwen3-30b` | Qwen3 30B | Qwen/Qwen3-30B-A3B |
-| `qwen3-coder-480b` | Qwen3 Coder 480B | Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 |
-| `deepseek-v3-2` | DeepSeek V3.2 | deepseek-ai/DeepSeek-V3.2 |
-| `deepseek-v3` | DeepSeek V3 | deepseek-ai/DeepSeek-V3-0324 |
-| `deepseek-r1` | DeepSeek R1 | deepseek-ai/DeepSeek-R1 |
-| `deepseek-r1-distill-32b` | DeepSeek R1 Distill 32B | deepseek-ai/DeepSeek-R1-Distill-Qwen-32B |
-| `deepseek-r1-distill-1-5b` | DeepSeek R1 Distill 1.5B | deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B |
-| `deepseek-prover-v2` | DeepSeek Prover V2 | deepseek-ai/DeepSeek-Prover-V2-671B |
-| `gpt-5-2` | GPT-5.2 | openai/gpt-5.2 |
-| `gpt-5-1` | GPT-5.1 | openai/gpt-5.1 |
-| `gpt-5` | GPT-5 | openai/gpt-5 |
-| `gpt-4o` | GPT-4o | openai/gpt-4o |
-| `claude-opus-4-5` | Claude Opus 4.5 | anthropic/claude-opus-4.5 |
-| `claude-sonnet-4-5` | Claude Sonnet 4.5 | anthropic/claude-sonnet-4.5 |
-| `gemini-3-pro` | Gemini 3.1 Pro | google/gemini-3.1-pro-preview |
-| `gemini-3-flash` | Gemini 3 Flash | google/gemini-3-flash-preview |
-| `gemini-3-1-flash-lite` | Gemini 3.1 Flash Lite | google/gemini-3.1-flash-lite-preview |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` |  |  | 16,384 |  |
+| `llama-4-scout` | Llama 4 Scout | meta-llama/Llama-4-Scout-17B-16E-Instruct | 1,048,576 |  |
+| `llama-4-maverick` | Llama 4 Maverick | meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8 | 1,048,576 |  |
+| `qwen3-235b` | Qwen3 235B | Qwen/Qwen3-235B-A22B-FP8 | 131,072 |  |
+| `qwen3-32b` | Qwen3 32B | Qwen/Qwen3-32B-FP8 | 131,072 |  |
+| `qwen3-30b` | Qwen3 30B | Qwen/Qwen3-30B-A3B | 131,072 |  |
+| `qwen3-coder-480b` | Qwen3 Coder 480B | Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 | 131,072 |  |
+| `deepseek-v3-2` | DeepSeek V3.2 | deepseek-ai/DeepSeek-V3.2 | 163,840 |  |
+| `deepseek-v3` | DeepSeek V3 | deepseek-ai/DeepSeek-V3-0324 | 163,840 |  |
+| `deepseek-r1` | DeepSeek R1 | deepseek-ai/DeepSeek-R1 | 131,072 |  |
+| `deepseek-r1-distill-32b` | DeepSeek R1 Distill 32B | deepseek-ai/DeepSeek-R1-Distill-Qwen-32B | 131,072 |  |
+| `deepseek-r1-distill-1-5b` | DeepSeek R1 Distill 1.5B | deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B | 131,072 |  |
+| `deepseek-prover-v2` | DeepSeek Prover V2 | deepseek-ai/DeepSeek-Prover-V2-671B | 131,072 |  |
+| `gpt-5-2` | GPT-5.2 | openai/gpt-5.2 | 128K |  |
+| `gpt-5-1` | GPT-5.1 | openai/gpt-5.1 | 128K |  |
+| `gpt-5` | GPT-5 | openai/gpt-5 | 128K |  |
+| `gpt-4o` | GPT-4o | openai/gpt-4o | 128K |  |
+| `claude-opus-4-5` | Claude Opus 4.5 | anthropic/claude-opus-4.5 | 200K |  |
+| `claude-sonnet-4-5` | Claude Sonnet 4.5 | anthropic/claude-sonnet-4.5 | 200K |  |
+| `gemini-3-pro` | Gemini 3.1 Pro | google/gemini-3.1-pro-preview | 128K |  |
+| `gemini-3-flash` | Gemini 3 Flash | google/gemini-3-flash-preview | 128K |  |
+| `gemini-3-1-flash-lite` | Gemini 3.1 Flash Lite | google/gemini-3.1-flash-lite-preview | 128K |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_minimax/doc.md
+++ b/nodes/src/nodes/llm_minimax/doc.md
@@ -89,20 +89,20 @@ These models will not fit on a typical laptop without aggressive quantization. M
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` | Custom Model |  |
-| `minimax-m2` | MiniMax M2 | MiniMax-M2 |
-| `minimax-m2-1` | MiniMax M2.1 | MiniMax-M2.1 |
-| `minimax-m2-1-highspeed` | MiniMax M2.1 Highspeed | MiniMax-M2.1-highspeed |
-| `minimax-m2-5` | MiniMax M2.5 | MiniMax-M2.5 |
-| `minimax-m2-5-highspeed` | MiniMax M2.5 Highspeed | MiniMax-M2.5-highspeed |
-| `minimax-m2-7` | MiniMax M2.7 | MiniMax-M2.7 |
-| `minimax-m2-7-highspeed` | MiniMax M2.7 Highspeed | MiniMax-M2.7-highspeed |
-| `minimax-m2-local` | MiniMax M2 (Local) | MiniMaxAI/MiniMax-M2 |
-| `minimax-m2-5-local` | MiniMax M2.5 (Local) | MiniMaxAI/MiniMax-M2.5 |
-| `minimax-m2-7-local` | MiniMax M2.7 (Local) | MiniMaxAI/MiniMax-M2.7 |
-| `minimax-m3` | MiniMax M3 | MiniMax-M3 |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` | Custom Model |  | 200K | 8,192 |
+| `minimax-m2` | MiniMax M2 | MiniMax-M2 | 204,800 | 65,536 |
+| `minimax-m2-1` | MiniMax M2.1 | MiniMax-M2.1 | 204,800 | 65,536 |
+| `minimax-m2-1-highspeed` | MiniMax M2.1 Highspeed | MiniMax-M2.1-highspeed | 204,800 | 65,536 |
+| `minimax-m2-5` | MiniMax M2.5 | MiniMax-M2.5 | 204,800 | 65,536 |
+| `minimax-m2-5-highspeed` | MiniMax M2.5 Highspeed | MiniMax-M2.5-highspeed | 204,800 | 65,536 |
+| `minimax-m2-7` | MiniMax M2.7 | MiniMax-M2.7 | 204,800 | 65,536 |
+| `minimax-m2-7-highspeed` | MiniMax M2.7 Highspeed | MiniMax-M2.7-highspeed | 204,800 | 65,536 |
+| `minimax-m2-local` | MiniMax M2 (Local) | MiniMaxAI/MiniMax-M2 | 204,800 | 8,192 |
+| `minimax-m2-5-local` | MiniMax M2.5 (Local) | MiniMaxAI/MiniMax-M2.5 | 204,800 | 8,192 |
+| `minimax-m2-7-local` | MiniMax M2.7 (Local) | MiniMaxAI/MiniMax-M2.7 | 204,800 | 8,192 |
+| `minimax-m3` | MiniMax M3 | MiniMax-M3 | 1M | 131,072 |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_mistral/doc.md
+++ b/nodes/src/nodes/llm_mistral/doc.md
@@ -84,44 +84,44 @@ Connects Mistral AI models to your pipeline. Used primarily as an `llm` invoke c
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` | Custom Model |  |
-| `mistral-large` | Mistral Large 3 | mistral-large-2512 |
-| `mistral-medium` | Mistral Medium 3.1 | mistral-medium-2508 |
-| `mistral-small` | Mistral Small 3.2 | mistral-small-2506 |
-| `codestral` | Codestral | codestral-2508 |
-| `magistral-medium` | Magistral Medium 1.2 | magistral-medium-2509 |
-| `magistral-small` | Magistral Small 1.2 | magistral-small-2509 |
-| `devstral-medium` | Devstral Medium 1.0 | devstral-medium-2507 |
-| `devstral-small` | Devstral Small 1.1 | devstral-small-2507 |
-| `ministral-14b` | Ministral 3 14B | ministral-14b-2512 |
-| `ministral-8b` | Ministral 3 8B | ministral-8b-2512 |
-| `ministral-3b` | Ministral 3 3B | ministral-3b-2512 |
-| `codestral-latest` | Codestral-latest | codestral-latest |
-| `devstral-2512` | Mistral: Devstral 2 2512 | devstral-2512 |
-| `devstral-latest` | Devstral-latest | devstral-latest |
-| `devstral-medium-latest` | Devstral-medium-latest | devstral-medium-latest |
-| `magistral-medium-latest` | Magistral-medium-latest | magistral-medium-latest |
-| `magistral-small-latest` | Magistral-small-latest | magistral-small-latest |
-| `ministral-14b-latest` | Ministral-14b-latest | ministral-14b-latest |
-| `ministral-3b-latest` | Ministral-3b-latest | ministral-3b-latest |
-| `ministral-8b-latest` | Ministral-8b-latest | ministral-8b-latest |
-| `mistral-large-2411` | Mistral Large 2411 | mistral-large-2411 |
-| `mistral-large-latest` | Mistral Large Latest | mistral-large-latest |
-| `mistral-medium-2505` | Mistral Medium 2505 | mistral-medium-2505 |
-| `mistral-medium-2604` | Mistral Medium 2604 | mistral-medium-2604 |
-| `mistral-medium-3` | Mistral: Mistral Medium 3 | mistral-medium-3 |
-| `mistral-medium-3-5` | Mistral Medium 3.5 | mistral-medium-3-5 |
-| `mistral-medium-c21211-r0-75` | Mistral Medium C21211 R0 75 | mistral-medium-c21211-r0-75 |
-| `mistral-medium-latest` | Mistral Medium Latest | mistral-medium-latest |
-| `mistral-small-2603` | Mistral: Mistral Small 4 | mistral-small-2603 |
-| `mistral-small-latest` | Mistral Small Latest | mistral-small-latest |
-| `mistral-tiny-2407` | Mistral Tiny 2407 | mistral-tiny-2407 |
-| `mistral-tiny-latest` | Mistral Tiny Latest | mistral-tiny-latest |
-| `mistral-vibe-cli-fast` | Mistral Vibe Cli Fast | mistral-vibe-cli-fast |
-| `mistral-vibe-cli-latest` | Mistral Vibe Cli Latest | mistral-vibe-cli-latest |
-| `mistral-vibe-cli-with-tools` | Mistral Vibe Cli With Tools | mistral-vibe-cli-with-tools |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` | Custom Model |  | 32,768 |  |
+| `mistral-large` | Mistral Large 3 | mistral-large-2512 | 262,144 | 262,144 |
+| `mistral-medium` | Mistral Medium 3.1 | mistral-medium-2508 | 131,072 | 4,096 |
+| `mistral-small` | Mistral Small 3.2 | mistral-small-2506 | 131,072 | 4,096 |
+| `codestral` | Codestral | codestral-2508 | 256K | 256K |
+| `magistral-medium` | Magistral Medium 1.2 | magistral-medium-2509 | 40K | 40K |
+| `magistral-small` | Magistral Small 1.2 | magistral-small-2509 | 40,960 | 4,096 |
+| `devstral-medium` | Devstral Medium 1.0 | devstral-medium-2507 | 128K | 128K |
+| `devstral-small` | Devstral Small 1.1 | devstral-small-2507 | 128K | 128K |
+| `ministral-14b` | Ministral 3 14B | ministral-14b-2512 | 262,144 | 4,096 |
+| `ministral-8b` | Ministral 3 8B | ministral-8b-2512 | 262,144 | 4,096 |
+| `ministral-3b` | Ministral 3 3B | ministral-3b-2512 | 131,072 | 4,096 |
+| `codestral-latest` | Codestral-latest | codestral-latest | 8,191 | 8,191 |
+| `devstral-2512` | Mistral: Devstral 2 2512 | devstral-2512 | 262,144 | 256K |
+| `devstral-latest` | Devstral-latest | devstral-latest | 256K | 256K |
+| `devstral-medium-latest` | Devstral-medium-latest | devstral-medium-latest | 256K | 256K |
+| `magistral-medium-latest` | Magistral-medium-latest | magistral-medium-latest | 40K | 40K |
+| `magistral-small-latest` | Magistral-small-latest | magistral-small-latest | 40K | 40K |
+| `ministral-14b-latest` | Ministral-14b-latest | ministral-14b-latest | 16,384 | 4,096 |
+| `ministral-3b-latest` | Ministral-3b-latest | ministral-3b-latest | 16,384 | 4,096 |
+| `ministral-8b-latest` | Ministral-8b-latest | ministral-8b-latest | 16,384 | 4,096 |
+| `mistral-large-2411` | Mistral Large 2411 | mistral-large-2411 | 131,072 | 128K |
+| `mistral-large-latest` | Mistral Large Latest | mistral-large-latest | 32K | 4,096 |
+| `mistral-medium-2505` | Mistral Medium 2505 | mistral-medium-2505 | 8,191 | 8,191 |
+| `mistral-medium-2604` | Mistral Medium 2604 | mistral-medium-2604 | 16,384 | 4,096 |
+| `mistral-medium-3` | Mistral: Mistral Medium 3 | mistral-medium-3 | 131,072 | 4,096 |
+| `mistral-medium-3-5` | Mistral Medium 3.5 | mistral-medium-3-5 | 16,384 | 4,096 |
+| `mistral-medium-c21211-r0-75` | Mistral Medium C21211 R0 75 | mistral-medium-c21211-r0-75 | 16,384 | 4,096 |
+| `mistral-medium-latest` | Mistral Medium Latest | mistral-medium-latest | 131,072 | 131,072 |
+| `mistral-small-2603` | Mistral: Mistral Small 4 | mistral-small-2603 | 262,144 | 4,096 |
+| `mistral-small-latest` | Mistral Small Latest | mistral-small-latest | 131,072 | 131,072 |
+| `mistral-tiny-2407` | Mistral Tiny 2407 | mistral-tiny-2407 | 16,384 | 4,096 |
+| `mistral-tiny-latest` | Mistral Tiny Latest | mistral-tiny-latest | 16,384 | 4,096 |
+| `mistral-vibe-cli-fast` | Mistral Vibe Cli Fast | mistral-vibe-cli-fast | 16,384 | 4,096 |
+| `mistral-vibe-cli-latest` | Mistral Vibe Cli Latest | mistral-vibe-cli-latest | 16,384 | 4,096 |
+| `mistral-vibe-cli-with-tools` | Mistral Vibe Cli With Tools | mistral-vibe-cli-with-tools | 16,384 | 4,096 |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_ollama/doc.md
+++ b/nodes/src/nodes/llm_ollama/doc.md
@@ -95,31 +95,31 @@ Connects locally-hosted Ollama models to your pipeline. Used primarily as an `ll
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` | Custom |  |
-| `llama3_3` | Llama 3.3 | llama3.3:latest |
-| `llama3_1-8b` | Llama 3.1 8B | llama3.1:8b |
-| `llama3_1-70b` | Llama 3.1 70B | llama3.1:70b |
-| `llama3_1-405b` | Llama 3.1 405B | llama3.1:405b |
-| `phi4-14b` | Phi 4 14B | phi4 |
-| `llama3_2-3b` | Llama 3.2 3B | llama3.2 |
-| `llama3_2-1b` | Llama 3.2 1B | llama3.2:1b |
-| `llama4-latest` | Llama 4 Latest | llama4:latest |
-| `mistral-7b` | Mistral 7B | mistral |
-| `qwen2_5-7b` | Qwen 2.5 7B | qwen2.5 |
-| `qwen2_5-0_5b` | Qwen 2.5 0.5B | qwen2.5:0.5b |
-| `qwen2_5-1_5b` | Qwen 2.5 1.5B | qwen2.5:1.5b |
-| `qwen2_5-3b` | Qwen 2.5 3B | qwen2.5:3b |
-| `qwen2_5-14b` | Qwen 2.5 14B | qwen2.5:14b |
-| `qwen2_5-32b` | Qwen 2.5 32B | qwen2.5:32b |
-| `qwen2_5-72b` | Qwen 2.5 72B | qwen2.5:72b |
-| `qwen3-latest` | Qwen 3 Latest | qwen3:latest |
-| `deepseek-r1-1_5b` | DeepSeek R1 1.5B | deepseek-r1:1.5b |
-| `deepseek-r1-7b` | DeepSeek R1 7B | deepseek-r1:7b |
-| `deepseek-r1-14b` | DeepSeek R1 14B | deepseek-r1:14b |
-| `deepseek-r1-32b` | DeepSeek R1 32B | deepseek-r1:32b |
-| `deepseek-r1-671b` | DeepSeek R1 671B | deepseek-r1:671b |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` | Custom |  | 16,385 |  |
+| `llama3_3` | Llama 3.3 | llama3.3:latest | 128K |  |
+| `llama3_1-8b` | Llama 3.1 8B | llama3.1:8b | 128K |  |
+| `llama3_1-70b` | Llama 3.1 70B | llama3.1:70b | 128K |  |
+| `llama3_1-405b` | Llama 3.1 405B | llama3.1:405b | 128K |  |
+| `phi4-14b` | Phi 4 14B | phi4 | 16K |  |
+| `llama3_2-3b` | Llama 3.2 3B | llama3.2 | 128K |  |
+| `llama3_2-1b` | Llama 3.2 1B | llama3.2:1b | 128K |  |
+| `llama4-latest` | Llama 4 Latest | llama4:latest | 10M |  |
+| `mistral-7b` | Mistral 7B | mistral | 32K |  |
+| `qwen2_5-7b` | Qwen 2.5 7B | qwen2.5 | 128K |  |
+| `qwen2_5-0_5b` | Qwen 2.5 0.5B | qwen2.5:0.5b | 128K |  |
+| `qwen2_5-1_5b` | Qwen 2.5 1.5B | qwen2.5:1.5b | 128K |  |
+| `qwen2_5-3b` | Qwen 2.5 3B | qwen2.5:3b | 128K |  |
+| `qwen2_5-14b` | Qwen 2.5 14B | qwen2.5:14b | 128K |  |
+| `qwen2_5-32b` | Qwen 2.5 32B | qwen2.5:32b | 128K |  |
+| `qwen2_5-72b` | Qwen 2.5 72B | qwen2.5:72b | 128K |  |
+| `qwen3-latest` | Qwen 3 Latest | qwen3:latest | 128K |  |
+| `deepseek-r1-1_5b` | DeepSeek R1 1.5B | deepseek-r1:1.5b | 128K |  |
+| `deepseek-r1-7b` | DeepSeek R1 7B | deepseek-r1:7b | 128K |  |
+| `deepseek-r1-14b` | DeepSeek R1 14B | deepseek-r1:14b | 128K |  |
+| `deepseek-r1-32b` | DeepSeek R1 32B | deepseek-r1:32b | 128K |  |
+| `deepseek-r1-671b` | DeepSeek R1 671B | deepseek-r1:671b | 128K |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_openai/doc.md
+++ b/nodes/src/nodes/llm_openai/doc.md
@@ -61,36 +61,36 @@ Connects OpenAI GPT models to your pipeline. Used primarily as an `llm` invoke c
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` |  |  |
-| `openai-5-4` | GPT-5.4 | gpt-5.4 |
-| `openai-5-4-pro` | GPT-5.4 Pro | gpt-5.4-pro |
-| `openai-5-4-mini` | GPT-5.4-mini | gpt-5.4-mini |
-| `openai-5-4-nano` | GPT-5.4-nano | gpt-5.4-nano |
-| `openai-4o` | GPT-4o | gpt-4o |
-| `openai-4o-mini` | GPT-4o-mini | gpt-4o-mini |
-| `openai-5` | GPT-5 | gpt-5 |
-| `openai-5-1` | GPT-5.1 | gpt-5.1 |
-| `openai-5-2` | GPT-5.2 | gpt-5.2 |
-| `openai-5-mini` | GPT-5-mini | gpt-5-mini |
-| `openai-5-nano` | GPT-5-nano | gpt-5-nano |
-| `gpt-3-5-turbo` | OpenAI: GPT-3.5 Turbo | gpt-3.5-turbo |
-| `gpt-3-5-turbo-16k` | OpenAI: GPT-3.5 Turbo 16k | gpt-3.5-turbo-16k |
-| `gpt-4` | OpenAI: GPT-4 | gpt-4 |
-| `gpt-4-1` | OpenAI: GPT-4.1 | gpt-4.1 |
-| `gpt-4-1-mini` | OpenAI: GPT-4.1 Mini | gpt-4.1-mini |
-| `gpt-4-1-nano` | OpenAI: GPT-4.1 Nano | gpt-4.1-nano |
-| `gpt-4-turbo` | OpenAI: GPT-4 Turbo | gpt-4-turbo |
-| `gpt-5-1-chat-latest` | GPT-5.1 Chat Latest | gpt-5.1-chat-latest |
-| `gpt-5-2-chat-latest` | GPT-5.2 Chat Latest | gpt-5.2-chat-latest |
-| `gpt-5-3-chat-latest` | GPT-5.3 Chat Latest | gpt-5.3-chat-latest |
-| `gpt-5-chat-latest` | GPT-5 Chat Latest | gpt-5-chat-latest |
-| `o1` | OpenAI: o1 | o1 |
-| `o3` | OpenAI: o3 | o3 |
-| `o3-mini` | OpenAI: o3 Mini | o3-mini |
-| `o4-mini` | OpenAI: o4 Mini | o4-mini |
-| `gpt-5-5` | OpenAI: GPT-5.5 | gpt-5.5 |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` |  |  | 16,384 |  |
+| `openai-5-4` | GPT-5.4 | gpt-5.4 | 1050K | 128K |
+| `openai-5-4-pro` | GPT-5.4 Pro | gpt-5.4-pro | 1050K | 128K |
+| `openai-5-4-mini` | GPT-5.4-mini | gpt-5.4-mini | 400K | 128K |
+| `openai-5-4-nano` | GPT-5.4-nano | gpt-5.4-nano | 400K | 128K |
+| `openai-4o` | GPT-4o | gpt-4o | 128K | 16,384 |
+| `openai-4o-mini` | GPT-4o-mini | gpt-4o-mini | 128K | 16,384 |
+| `openai-5` | GPT-5 | gpt-5 | 400K | 128K |
+| `openai-5-1` | GPT-5.1 | gpt-5.1 | 400K | 128K |
+| `openai-5-2` | GPT-5.2 | gpt-5.2 | 400K | 128K |
+| `openai-5-mini` | GPT-5-mini | gpt-5-mini | 400K | 128K |
+| `openai-5-nano` | GPT-5-nano | gpt-5-nano | 400K | 128K |
+| `gpt-3-5-turbo` | OpenAI: GPT-3.5 Turbo | gpt-3.5-turbo | 16,385 | 4,096 |
+| `gpt-3-5-turbo-16k` | OpenAI: GPT-3.5 Turbo 16k | gpt-3.5-turbo-16k | 16,385 | 4,096 |
+| `gpt-4` | OpenAI: GPT-4 | gpt-4 | 8,191 | 4,096 |
+| `gpt-4-1` | OpenAI: GPT-4.1 | gpt-4.1 | 1,047,576 | 32,768 |
+| `gpt-4-1-mini` | OpenAI: GPT-4.1 Mini | gpt-4.1-mini | 1,047,576 | 32,768 |
+| `gpt-4-1-nano` | OpenAI: GPT-4.1 Nano | gpt-4.1-nano | 1,047,576 | 32,768 |
+| `gpt-4-turbo` | OpenAI: GPT-4 Turbo | gpt-4-turbo | 128K | 4,096 |
+| `gpt-5-1-chat-latest` | GPT-5.1 Chat Latest | gpt-5.1-chat-latest | 16,384 | 16,384 |
+| `gpt-5-2-chat-latest` | GPT-5.2 Chat Latest | gpt-5.2-chat-latest | 16,384 | 16,384 |
+| `gpt-5-3-chat-latest` | GPT-5.3 Chat Latest | gpt-5.3-chat-latest | 16,384 | 16,384 |
+| `gpt-5-chat-latest` | GPT-5 Chat Latest | gpt-5-chat-latest | 16,384 | 16,384 |
+| `o1` | OpenAI: o1 | o1 | 200K | 100K |
+| `o3` | OpenAI: o3 | o3 | 200K | 100K |
+| `o3-mini` | OpenAI: o3 Mini | o3-mini | 200K | 100K |
+| `o4-mini` | OpenAI: o4 Mini | o4-mini | 200K | 100K |
+| `gpt-5-5` | OpenAI: GPT-5.5 | gpt-5.5 | 1050K | 128K |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_openai_api/doc.md
+++ b/nodes/src/nodes/llm_openai_api/doc.md
@@ -50,9 +50,9 @@ There are no preset profiles — all fields are specified directly.
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` |  |  |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` |  |  | 32,768 |  |
 
 **Configuration sections**
 
@@ -76,12 +76,12 @@ There are no preset profiles — all fields are specified directly.
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `llama-3-3-70b` | Llama 3.3 70B Instruct | meta-llama/Llama-3.3-70B-Instruct |
-| `qwen3-235b` | Qwen3 235B | Qwen/Qwen3-235B-A22B |
-| `deepseek-v3` | DeepSeek V3 | deepseek-ai/DeepSeek-V3 |
-| `custom` |  |  |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `llama-3-3-70b` | Llama 3.3 70B Instruct | meta-llama/Llama-3.3-70B-Instruct | 131,072 |  |
+| `qwen3-235b` | Qwen3 235B | Qwen/Qwen3-235B-A22B | 131,072 |  |
+| `deepseek-v3` | DeepSeek V3 | deepseek-ai/DeepSeek-V3 | 131,072 |  |
+| `custom` |  |  | 131,072 |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_perplexity/doc.md
+++ b/nodes/src/nodes/llm_perplexity/doc.md
@@ -58,14 +58,14 @@ Connects Perplexity AI Sonar models to your pipeline. Sonar models include real-
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `sonar-pro` | Sonar Pro | sonar-pro |
-| `sonar` | Sonar | sonar |
-| `sonar-reasoning-pro` | Sonar Reasoning Pro | sonar-reasoning-pro |
-| `sonar-reasoning` | Sonar Reasoning | sonar-reasoning |
-| `sonar-deep-research` | Sonar Deep Research | sonar-deep-research |
-| `sonar-pro-search` | Perplexity: Sonar Pro Search | sonar-pro-search |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `sonar-pro` | Sonar Pro | sonar-pro | 200K | 8K |
+| `sonar` | Sonar | sonar | 127,072 | 4,096 |
+| `sonar-reasoning-pro` | Sonar Reasoning Pro | sonar-reasoning-pro | 128K | 4,096 |
+| `sonar-reasoning` | Sonar Reasoning | sonar-reasoning | 128K | 4,096 |
+| `sonar-deep-research` | Sonar Deep Research | sonar-deep-research | 128K | 4,096 |
+| `sonar-pro-search` | Perplexity: Sonar Pro Search | sonar-pro-search | 200K | 8K |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_qwen/doc.md
+++ b/nodes/src/nodes/llm_qwen/doc.md
@@ -70,17 +70,17 @@ US deployments require the `-us` model suffix (e.g., `qwen3.5-flash-us`).
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `qwen-plus` | Qwen Plus | qwen-plus |
-| `qwen-flash` | Qwen Flash | qwen-flash |
-| `qwen-2-5-72b-instruct` | Qwen2.5 72B Instruct | qwen-2.5-72b-instruct |
-| `qwen-2-5-7b-instruct` | Qwen: Qwen2.5 7B Instruct | qwen-2.5-7b-instruct |
-| `qwen-2-5-coder-32b-instruct` | Qwen2.5 Coder 32B Instruct | qwen-2.5-coder-32b-instruct |
-| `qwen-max` | Qwen: Qwen-Max | qwen-max |
-| `qwen-plus-2025-07-28` | Qwen: Qwen Plus 0728 | qwen-plus-2025-07-28 |
-| `qwen-plus-2025-07-28-thinking` | Qwen: Qwen Plus 0728 (thinking) | qwen-plus-2025-07-28:thinking |
-| `qwen-turbo` | Qwen: Qwen-Turbo | qwen-turbo |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `qwen-plus` | Qwen Plus | qwen-plus | 1M | 32,768 |
+| `qwen-flash` | Qwen Flash | qwen-flash | 131,072 | 4,096 |
+| `qwen-2-5-72b-instruct` | Qwen2.5 72B Instruct | qwen-2.5-72b-instruct | 32,768 | 16,384 |
+| `qwen-2-5-7b-instruct` | Qwen: Qwen2.5 7B Instruct | qwen-2.5-7b-instruct | 32,768 | 32,768 |
+| `qwen-2-5-coder-32b-instruct` | Qwen2.5 Coder 32B Instruct | qwen-2.5-coder-32b-instruct | 32,768 | 4,096 |
+| `qwen-max` | Qwen: Qwen-Max | qwen-max | 32,768 | 8,192 |
+| `qwen-plus-2025-07-28` | Qwen: Qwen Plus 0728 | qwen-plus-2025-07-28 | 1M | 32,768 |
+| `qwen-plus-2025-07-28-thinking` | Qwen: Qwen Plus 0728 (thinking) | qwen-plus-2025-07-28:thinking | 1M | 32,768 |
+| `qwen-turbo` | Qwen: Qwen-Turbo | qwen-turbo | 131,072 | 8,192 |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_vision_gemini/doc.md
+++ b/nodes/src/nodes/llm_vision_gemini/doc.md
@@ -86,13 +86,13 @@ Get a key at [aistudio.google.com/apikey](https://aistudio.google.com/apikey). K
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `gemini-2_5-flash` | Gemini 2.5 Flash - Fast Vision (1M tokens) | models/gemini-2.5-flash |
-| `gemini-2_5-pro` | Gemini 2.5 Pro - High Quality Vision (1M tokens) | models/gemini-2.5-pro |
-| `gemini-2_5-flash-lite` | Gemini 2.5 Flash Lite - Fastest & Cheapest (1M tokens) | models/gemini-2.5-flash-lite |
-| `gemini-3_1-pro-preview` | Gemini 3.1 Pro - Latest Vision (1M tokens) | models/gemini-3.1-pro-preview |
-| `gemini-3_1-flash-image-preview` | Gemini 3.1 Flash Image Preview (131k tokens) | models/gemini-3.1-flash-image-preview |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `gemini-2_5-flash` | Gemini 2.5 Flash - Fast Vision (1M tokens) | models/gemini-2.5-flash | 1,048,576 |  |
+| `gemini-2_5-pro` | Gemini 2.5 Pro - High Quality Vision (1M tokens) | models/gemini-2.5-pro | 1,048,576 |  |
+| `gemini-2_5-flash-lite` | Gemini 2.5 Flash Lite - Fastest & Cheapest (1M tokens) | models/gemini-2.5-flash-lite | 1,048,576 |  |
+| `gemini-3_1-pro-preview` | Gemini 3.1 Pro - Latest Vision (1M tokens) | models/gemini-3.1-pro-preview | 1,048,576 |  |
+| `gemini-3_1-flash-image-preview` | Gemini 3.1 Flash Image Preview (131k tokens) | models/gemini-3.1-flash-image-preview | 131,072 |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_vision_mistral/doc.md
+++ b/nodes/src/nodes/llm_vision_mistral/doc.md
@@ -63,14 +63,14 @@ Sends images to Mistral vision-capable models and returns text analysis. Accepts
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `mistral-large-3` | Mistral Large 3 - Premier Vision (256k tokens) | mistral-large-2512 |
-| `mistral-medium-3.1` | Mistral Medium 3.1 - Balanced Vision (128k tokens) | mistral-medium-2508 |
-| `mistral-small-3.2` | Mistral Small 3.2 - Fast & Cheap Vision (128k tokens) | mistral-small-2506 |
-| `ministral-14b-3` | Ministral 3 14B - High Performance Vision (256k tokens) | ministral-14b-2512 |
-| `ministral-8b-3` | Ministral 3 8B - Balanced Vision (256k tokens) | ministral-8b-2512 |
-| `ministral-3b-3` | Ministral 3 3B - Efficient Vision (256k tokens) | ministral-3b-2512 |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `mistral-large-3` | Mistral Large 3 - Premier Vision (256k tokens) | mistral-large-2512 | 256K |  |
+| `mistral-medium-3.1` | Mistral Medium 3.1 - Balanced Vision (128k tokens) | mistral-medium-2508 | 128K |  |
+| `mistral-small-3.2` | Mistral Small 3.2 - Fast & Cheap Vision (128k tokens) | mistral-small-2506 | 128K |  |
+| `ministral-14b-3` | Ministral 3 14B - High Performance Vision (256k tokens) | ministral-14b-2512 | 256K |  |
+| `ministral-8b-3` | Ministral 3 8B - Balanced Vision (256k tokens) | ministral-8b-2512 | 256K |  |
+| `ministral-3b-3` | Ministral 3 3B - Efficient Vision (256k tokens) | ministral-3b-2512 | 256K |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_vision_ollama/doc.md
+++ b/nodes/src/nodes/llm_vision_ollama/doc.md
@@ -63,18 +63,18 @@ Sends images to locally-hosted Ollama vision models and returns text analysis. N
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` | Custom |  |
-| `llama3_2-vision-11b` | Llama 3.2 Vision 11B | llama3.2-vision:11b |
-| `llama3_2-vision-90b` | Llama 3.2 Vision 90B | llama3.2-vision:90b |
-| `llava-7b` | LLaVA 7B | llava:7b |
-| `llava-13b` | LLaVA 13B | llava:13b |
-| `llava-34b` | LLaVA 34B | llava:34b |
-| `moondream` | Moondream 2 | moondream |
-| `minicpm-v` | MiniCPM-V | minicpm-v |
-| `qwen2_5vl-3b` | Qwen 2.5 VL 3B | qwen2.5vl:3b |
-| `qwen2_5vl-7b` | Qwen 2.5 VL 7B | qwen2.5vl:7b |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` | Custom |  | 16,385 |  |
+| `llama3_2-vision-11b` | Llama 3.2 Vision 11B | llama3.2-vision:11b | 128K |  |
+| `llama3_2-vision-90b` | Llama 3.2 Vision 90B | llama3.2-vision:90b | 128K |  |
+| `llava-7b` | LLaVA 7B | llava:7b | 32,768 |  |
+| `llava-13b` | LLaVA 13B | llava:13b | 4,096 |  |
+| `llava-34b` | LLaVA 34B | llava:34b | 4,096 |  |
+| `moondream` | Moondream 2 | moondream | 2,048 |  |
+| `minicpm-v` | MiniCPM-V | minicpm-v | 8,192 |  |
+| `qwen2_5vl-3b` | Qwen 2.5 VL 3B | qwen2.5vl:3b | 128K |  |
+| `qwen2_5vl-7b` | Qwen 2.5 VL 7B | qwen2.5vl:7b | 128K |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_vision_openai/doc.md
+++ b/nodes/src/nodes/llm_vision_openai/doc.md
@@ -59,13 +59,13 @@ Sends images to OpenAI vision-capable models and returns text analysis. Accepts 
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `openai-4-1` | GPT-4.1 | gpt-4.1 |
-| `openai-4-1-mini` | GPT-4.1-mini | gpt-4.1-mini |
-| `openai-4-1-nano` | GPT-4.1-nano | gpt-4.1-nano |
-| `openai-4o` | GPT-4o | gpt-4o |
-| `openai-4o-mini` | GPT-4o-mini | gpt-4o-mini |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `openai-4-1` | GPT-4.1 | gpt-4.1 | 1,047,576 |  |
+| `openai-4-1-mini` | GPT-4.1-mini | gpt-4.1-mini | 1,047,576 |  |
+| `openai-4-1-nano` | GPT-4.1-nano | gpt-4.1-nano | 1,047,576 |  |
+| `openai-4o` | GPT-4o | gpt-4o | 128K |  |
+| `openai-4o-mini` | GPT-4o-mini | gpt-4o-mini | 128K |  |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/llm_xai/doc.md
+++ b/nodes/src/nodes/llm_xai/doc.md
@@ -62,23 +62,23 @@ Connects xAI Grok models to your pipeline. Used primarily as an `llm` invoke con
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `custom` | Custom Model |  |
-| `grok-4-1-fast-reasoning` | Grok 4.1 Fast | grok-4-1-fast-reasoning |
-| `grok-4-1-fast-non-reasoning` | Grok 4.1 Fast Non-Reasoning | grok-4-1-fast-non-reasoning |
-| `grok-code-fast-1` | Grok Code Fast 1 | grok-code-fast-1 |
-| `grok-4-fast-reasoning` | Grok 4 Fast | grok-4-fast-reasoning |
-| `grok-4-fast-non-reasoning` | Grok 4 Fast Non-Reasoning | grok-4-fast-non-reasoning |
-| `grok-4` | Grok 4 | grok-4-0709 |
-| `grok-3-mini` | Grok 3 Mini | grok-3-mini |
-| `grok-3` | Grok 3 | grok-3 |
-| `grok-3-beta` | xAI: Grok 3 Beta | grok-3-beta |
-| `grok-3-mini-beta` | xAI: Grok 3 Mini Beta | grok-3-mini-beta |
-| `grok-4-1-fast` | xAI: Grok 4.1 Fast | grok-4.1-fast |
-| `grok-4-20` | xAI: Grok 4.20 | grok-4.20 |
-| `grok-4-20-multi-agent` | xAI: Grok 4.20 Multi-Agent | grok-4.20-multi-agent |
-| `grok-4-fast` | xAI: Grok 4 Fast | grok-4-fast |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `custom` | Custom Model |  | 131,072 |  |
+| `grok-4-1-fast-reasoning` | Grok 4.1 Fast | grok-4-1-fast-reasoning | 2M | 4,096 |
+| `grok-4-1-fast-non-reasoning` | Grok 4.1 Fast Non-Reasoning | grok-4-1-fast-non-reasoning | 2M | 4,096 |
+| `grok-code-fast-1` | Grok Code Fast 1 | grok-code-fast-1 | 256K | 10K |
+| `grok-4-fast-reasoning` | Grok 4 Fast | grok-4-fast-reasoning | 2M | 4,096 |
+| `grok-4-fast-non-reasoning` | Grok 4 Fast Non-Reasoning | grok-4-fast-non-reasoning | 2M | 4,096 |
+| `grok-4` | Grok 4 | grok-4-0709 | 256K | 256K |
+| `grok-3-mini` | Grok 3 Mini | grok-3-mini | 131,072 | 131,072 |
+| `grok-3` | Grok 3 | grok-3 | 131,072 | 131,072 |
+| `grok-3-beta` | xAI: Grok 3 Beta | grok-3-beta | 131,072 | 131,072 |
+| `grok-3-mini-beta` | xAI: Grok 3 Mini Beta | grok-3-mini-beta | 131,072 | 131,072 |
+| `grok-4-1-fast` | xAI: Grok 4.1 Fast | grok-4.1-fast | 2M | 30K |
+| `grok-4-20` | xAI: Grok 4.20 | grok-4.20 | 2M | 4,096 |
+| `grok-4-20-multi-agent` | xAI: Grok 4.20 Multi-Agent | grok-4.20-multi-agent | 2M | 4,096 |
+| `grok-4-fast` | xAI: Grok 4 Fast | grok-4-fast | 2M | 30K |
 
 **Configuration sections**
 

--- a/nodes/src/nodes/search_exa/doc.md
+++ b/nodes/src/nodes/search_exa/doc.md
@@ -48,9 +48,9 @@ Performs web search using the Exa API. Accepts a question and returns semantic o
 
 **Profiles**
 
-| Profile | Title | Model |
-| --- | --- | --- |
-| `default` |  | exa-search |
+| Profile | Title | Model | Context | Max output |
+| --- | --- | --- | --- | --- |
+| `default` |  | exa-search | 16,384 |  |
 
 **Configuration sections**
 

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -43,6 +43,8 @@ async def main():
 asyncio.run(main())
 ```
 
+**URI scheme:** any scheme works — the client normalizes the `uri` to a WebSocket address before connecting. `https://` and `wss://` both resolve to a secure `wss://` connection; `http://`, `ws://`, and a bare `host:port` resolve to plain `ws://`. For RocketRide Cloud use `https://cloud.rocketride.ai` (or the equivalent `wss://cloud.rocketride.ai`); for a local engine use `ws://localhost:5565`. Examples below mix `https://` and `wss://` interchangeably for this reason.
+
 Don't have a pipeline yet? Visit [RocketRide on GitHub](https://github.com/rocketride-org/rocketride-server) or download the extension directly in your IDE.
 
 <p align="center">

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -43,7 +43,7 @@ async def main():
 asyncio.run(main())
 ```
 
-**URI scheme:** any scheme works — the client normalizes the `uri` to a WebSocket address before connecting. `https://` and `wss://` both resolve to a secure `wss://` connection; `http://`, `ws://`, and a bare `host:port` resolve to plain `ws://`. For RocketRide Cloud use `https://cloud.rocketride.ai` (or the equivalent `wss://cloud.rocketride.ai`); for a local engine use `ws://localhost:5565`. Examples below mix `https://` and `wss://` interchangeably for this reason.
+**URI scheme:** the scheme selects the transport. The client normalizes the `uri` to a WebSocket address before connecting: `https://` and `wss://` both resolve to a secure `wss://` connection, while `http://`, `ws://`, and a bare `host:port` resolve to plain `ws://`. For RocketRide Cloud use `https://cloud.rocketride.ai` (or the equivalent `wss://cloud.rocketride.ai`); for a local engine use `ws://localhost:5565`. **Caution:** against a Cloud endpoint always use `https://` or `wss://`, because an `http://` or `ws://` URI (or a bare `host:port`) silently downgrades to an unencrypted `ws://` connection.
 
 Don't have a pipeline yet? Visit [RocketRide on GitHub](https://github.com/rocketride-org/rocketride-server) or download the extension directly in your IDE.
 


### PR DESCRIPTION
## Summary

- Fill node/SDK reference content gaps deferred from #1213, plus address CodeRabbit review on this PR.
- `embedding_openai`: document the `questions` input lane; `audio_tts`: drop internal BEGIN/WRITE/END detail.
- `client-python`: tighten URI-scheme guidance (https/wss resolve to secure wss; http/ws/bare host:port resolve to plaintext ws) and add a Cloud plaintext-downgrade caution. Behavior described, no internal symbol names.
- `llm_anthropic`: the prose Profiles "Context" column drifted (four rows understated 5x). Fixed the root cause: the node-table generator now emits `modelTotalTokens`/`modelOutputTokens` as "Context" and "Max output" columns in the generated Profiles block, and the hand-maintained Context column is removed so it cannot drift again. Columns appear only for nodes whose profiles carry the token fields; 20 `llm_*` docs regenerated.

## Type

feature

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`builder docs:build` is green. Verified the Anthropic generated block matches `services.json` (e.g. `claude-sonnet-4-6` = 1M / 128K) and that non-token nodes (`db_postgres`, `embedding_openai`) keep the 3-column table.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Closes RR-1220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified audio output now emits WAV bytes with MIME type audio/wav
  * Documented embedding lanes for documents and questions
  * Expanded many generated model profile tables to include Context and Max output, updated token/context values and added Claude Opus 4.7 entry
  * Clarified URI normalization for WebSocket connections in the Python SDK, with examples and security note
<!-- end of auto-generated comment: release notes by coderabbit.ai -->