### PR TITLE
fix(test): skip HF-downloading embedding nodes in default CI lane

### DIFF
--- a/nodes/test/conftest.py
+++ b/nodes/test/conftest.py
@@ -230,12 +230,17 @@ def pytest_generate_tests(metafunc):
         # excluded because they pull large libraries, use heavy models, or depend on local
         # services, which would cause CI timeouts or OOM. Opt-in via ROCKETRIDE_INCLUDE_SKIP:
         #   ROCKETRIDE_INCLUDE_SKIP=embedding_image pytest nodes/test/test_dynamic.py -v -k embedding_image
-        # Groups: ML/heavy (anonymize, ocr, ner, embedding_image); image/video (image_cleanup, frame_grabber); LLM/local (llm_anthropic, llm_ollama); audio/TTS (audio_tts).
+        # Groups: ML/heavy (anonymize, ocr, ner, embedding_image, embedding_transformer, embedding_video); image/video (image_cleanup, frame_grabber); LLM/local (llm_anthropic, llm_ollama); audio/TTS (audio_tts).
         skip_nodes = {
             'anonymize',
             'ocr',
             'ner',
             'embedding_image',
+            # Download model weights from huggingface.co at test time, so they turn the
+            # required CI check red whenever the HF hub is unreachable/rate-limited — on
+            # PRs unrelated to embeddings (RR-1120). Same class as embedding_image above.
+            'embedding_transformer',  # sentence-transformers (miniLM)
+            'embedding_video',  # CLIP (openai-patch16)
             'image_cleanup',
             'frame_grabber',
             'audio_transcribe',  # it downloads faster-whisper model (1.5GB)


### PR DESCRIPTION
## Summary

Two `test/test_dynamic.py::TestDynamicNodes::test_node_cases` parametrizations download model weights from **huggingface.co at test time**:

- `embedding_video:services:openai-patch16` (CLIP)
- `embedding_transformer:services:miniLM` (sentence-transformers)

When the HF hub is unreachable or rate-limited they raise `RuntimeError: We couldn't connect to 'https://huggingface.co' ...` and turn the **only required check (`ci-ok`)** red — on PRs that have nothing to do with embeddings. Per #1120 this has hit a docs-only PR, the Baidu Qianfan #1006 run, and the 2026-06-04 release prep, and it also blocks develop→stage promotion and the nightly prerelease gate.

## Fix

`conftest.py` already maintains a `skip_nodes` set that excludes heavy / model-downloading nodes from the default dynamic-test lane — including `embedding_image`, which is the exact same category. `embedding_transformer` and `embedding_video` were simply missing from it. This adds them, with a comment explaining why.

```python
'embedding_image',
# Download model weights from huggingface.co at test time ... (RR-1120)
'embedding_transformer',  # sentence-transformers (miniLM)
'embedding_video',        # CLIP (openai-patch16)
```

This is the issue's option 3 (gate so they don't run in the default lane), implemented via the mechanism the repo already uses — no new markers, no CI-image changes.

## Behavior

- Default lane (what CI runs via `./builder test`) no longer touches the network for these nodes → `ci-ok` becomes deterministic.
- They remain runnable on demand, exactly like the other skipped nodes:
  ```
  ROCKETRIDE_INCLUDE_SKIP=embedding_transformer,embedding_video pytest nodes/test/test_dynamic.py -v -k 'embedding_transformer or embedding_video'
  ```
- Contract tests and every other node's tests are unaffected.

## Trade-off

Like the existing skipped nodes (`embedding_image`, `ocr`, `anonymize`, …), these two are no longer smoke-tested in CI — a deliberate, precedent-matching trade of a small coverage loss for a non-flaky required check. A heavier alternative (pre-cache weights + `HF_HUB_OFFLINE=1`) would keep coverage but needs CI-runner-image changes; out of scope here.

## Verification

`python -m py_compile nodes/test/conftest.py` passes; the two skipped node names match the failing parametrizations named in the issue (`embedding_video` → `openai-patch16`, `embedding_transformer` → `miniLM`), each of whose default `test` block runs only that single network-dependent profile.

Closes #1120

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration to skip certain embedding-related nodes during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->