### PR TITLE
fix(vscode): wire native file dialog for embedded-app Browse button

### DIFF
--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -858,6 +858,28 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 				panel.webview.postMessage({ type: 'pasteContent', text });
 			} else if (msg?.type === 'copyText' && typeof msg.text === 'string') {
 				await vscode.env.clipboard.writeText(msg.text);
+			} else if (msg?.type === 'requestFileDialog') {
+				// The embedded app's "Browse" button can't open an OS file picker from
+				// inside the sandboxed iframe, so it posts {type:'requestFileDialog'} up to
+				// the bridge, which forwards it here. Open the native dialog on the host,
+				// read the chosen files, and post them back as {type:'nativeFilesSelected'};
+				// the bridge relays that into the iframe. Buffers go as number[] so they
+				// survive webview message serialization.
+				try {
+					const uris = await vscode.window.showOpenDialog({ canSelectMany: true, openLabel: 'Select' });
+					if (!uris || uris.length === 0) return;
+					const files = await Promise.all(
+						uris.map(async (uri) => ({
+							name: uri.path.split('/').pop() || 'file',
+							type: '',
+							lastModified: Date.now(),
+							buffer: Array.from(await vscode.workspace.fs.readFile(uri)),
+						}))
+					);
+					panel.webview.postMessage({ type: 'nativeFilesSelected', files });
+				} catch (error) {
+					this.logger.error(`[ProjectProvider] Native file dialog failed: ${error}`);
+				}
 			}
 		});
 	}


### PR DESCRIPTION
## Summary

In the Dropper node UI, the **Browse** button inside the drop area did nothing — clicking anywhere *else* in the drop zone opened the picker, but the button itself was dead (#1011).

## Root cause

The "Browse" button can't open an OS file picker from inside the sandboxed webview iframe, so it uses a host round-trip:

1. `DropZone` Browse button → `window.parent.postMessage({type:'requestFileDialog'})` (`apps/dropper-ui/.../DropperContainer.tsx`)
2. The `openLink` webview bridge forwards it to the extension host: `if (event.data.type === 'requestFileDialog') vscode.postMessage({type:'requestFileDialog'})` (`ProjectProvider.ts:837`)
3. The bridge is ready to relay the response back to the iframe (`ProjectProvider.ts:842`)
4. `DropperContainer` listens for `nativeFilesSelected` and adds the files

**The host-side handler was the missing link.** `panel.webview.onDidReceiveMessage` in `openLink()` only implemented `requestPaste`/`copyText` — there was **no `requestFileDialog` case**, and `vscode.window.showOpenDialog` is never called anywhere in the extension. So the forwarded request was received and silently dropped: no dialog, no `nativeFilesSelected`. Drag-and-drop and the drop-zone click kept working because those don't need the host (the drop bridge reads files in-browser; the click uses the in-iframe `<input type=file>`).

## Fix

Add the missing `requestFileDialog` case to the host handler — open the native dialog, read the selected files, and post them back as `nativeFilesSelected`. It mirrors the existing clipboard and drag-drop bridges in the same place.

```ts
} else if (msg?.type === 'requestFileDialog') {
    const uris = await vscode.window.showOpenDialog({ canSelectMany: true, openLabel: 'Select' });
    if (!uris || uris.length === 0) return;
    const files = await Promise.all(uris.map(async (uri) => ({
        name: uri.path.split('/').pop() || 'file',
        type: '',
        lastModified: Date.now(),
        buffer: Array.from(await vscode.workspace.fs.readFile(uri)),
    })));
    panel.webview.postMessage({ type: 'nativeFilesSelected', files });
}
```

`buffer` is sent as `number[]` to survive webview message serialization; the shape (`{name, type, lastModified, buffer}`) matches exactly what the `nativeFilesSelected` listener consumes (`new Uint8Array(f.buffer)`).

## Verification

- Static trace confirms the full round-trip now completes end-to-end; the posted file shape matches the dropper-ui consumer exactly.
- This completes a half-wired feature (the iframe request, the bridge forward, the bridge relay-back, and the iframe listener already existed — only the host handler was absent).
- **Not runtime-verified in-PR:** building/running the VS Code extension wasn't possible in my environment, and there's no existing unit-test harness for `ProjectProvider`. A maintainer clicking **Browse** in the Dropper is the final check; CI covers TypeScript compilation.

Closes #1011

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native file picker integration allowing users to select and import multiple files directly from VS Code at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->