### PR TITLE
fix(tests): make test_tool_v0 mock import-order independent

### DIFF
--- a/nodes/test/test_tool_v0.py
+++ b/nodes/test/test_tool_v0.py
@@ -168,10 +168,16 @@ def _load_iinstance():
 
 
 _mod = _load_iinstance()
-# Bind the module's `warning` reference to our stub (see tavily test rationale:
-# `from rocketlib import warning` binds at import time, so under the engine's
-# pytest runner the real logger would otherwise be used).
+# Rebind the names the v0 module imported into its own namespace at import time
+# (`from rocketlib import warning`, `from ai.common.utils import post_with_retry,
+# normalize_tool_input`). The import-time sys.modules stubs in _load_iinstance only
+# take effect when those modules weren't already imported — so when a prior test on
+# the same pytest worker imported the REAL `ai.common.utils`/`rocketlib`, the real
+# implementations leak in and `post_with_retry` makes a live network call (HTTP 401).
+# Rebinding here makes the stubbing robust regardless of import order.
 _mod.warning = _stub_warning
+_mod.post_with_retry = _stub_post_with_retry
+_mod.normalize_tool_input = lambda args, **_kw: args if isinstance(args, dict) else {}
 
 _shape_chat = _mod._shape_chat
 IInstance = _mod.IInstance


### PR DESCRIPTION
## Summary

`test_tool_v0.py` only installed its `post_with_retry` stub when `ai.common.utils` wasn't already imported. When a prior test on the same pytest worker imported the real module first, `tool_v0` kept the real `post_with_retry` and made live `api.v0.dev` calls → `401`, failing 7 `TestGenerateUi` tests under the full suite (passes in isolation).

Rebind `post_with_retry` and `normalize_tool_input` on the loaded module after import — same pattern the test already uses for `warning` — so the stubbing is robust regardless of import order.

## Testing

- Repro (`test_config_utils.py` then `test_tool_v0.py`): 7 failed → all pass.
- `test_tool_v0` in isolation: still passes.
- Full `./builder test`: green.

Closes #1268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test mocking consistency to ensure reliable behavior across the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->