### PR TITLE
feat(tool): add DAP tool subcommand for direct @tool_function invocation

### DIFF
--- a/nodes/scripts/gen-node-tables.mjs
+++ b/nodes/scripts/gen-node-tables.mjs
@@ -205,6 +205,14 @@ function resolveDocPath(dir) {
 }
 
 function main() {
+	// Only regenerate docs on the develop branch to avoid polluting feature
+	// branch diffs with source-link changes (branch name is in the URL).
+	const branch = git(['rev-parse', '--abbrev-ref', 'HEAD'], '');
+	if (branch && branch !== 'develop') {
+		console.log(`nodes:docs-generate skipped (branch: ${branch}, only runs on develop)`);
+		return;
+	}
+
 	// Optional CLI args restrict generation to the named node(s); no args = all.
 	const only = new Set(process.argv.slice(2));
 	let updated = 0;

--- a/nodes/test/test_vectordb_tool_mixin.py
+++ b/nodes/test/test_vectordb_tool_mixin.py
@@ -377,7 +377,7 @@ def test_collect_tool_methods_namespaces_with_server_name() -> None:
     instance = FakeIInstance(FakeIGlobal(store=FakeStore(), server_name='myvdb'))
     methods = instance._collect_tool_methods()
 
-    assert set(methods.keys()) == {'myvdb.search', 'myvdb.upsert', 'myvdb.delete'}
+    assert set(methods.keys()) == {'myvdb.search', 'myvdb.upsert', 'myvdb.delete', 'myvdb.list', 'myvdb.stats'}
     # Each value is a callable bound to the fake instance
     for bound in methods.values():
         assert callable(bound)
@@ -390,6 +390,8 @@ def test_collect_tool_methods_uses_provider_fallback() -> None:
     assert 'chroma.search' in methods
     assert 'chroma.upsert' in methods
     assert 'chroma.delete' in methods
+    assert 'chroma.list' in methods
+    assert 'chroma.stats' in methods
 
 
 def test_collect_tool_methods_default_when_no_globals() -> None:
@@ -400,7 +402,13 @@ def test_collect_tool_methods_default_when_no_globals() -> None:
     orphan.IGlobal = None
     methods = orphan._collect_tool_methods()
     # Falls all the way back to 'vectordb'
-    assert set(methods.keys()) == {'vectordb.search', 'vectordb.upsert', 'vectordb.delete'}
+    assert set(methods.keys()) == {
+        'vectordb.search',
+        'vectordb.upsert',
+        'vectordb.delete',
+        'vectordb.list',
+        'vectordb.stats',
+    }
 
 
 def test_two_instances_different_server_names_do_not_collide() -> None:

--- a/packages/ai/src/ai/common/database/db_global_base.py
+++ b/packages/ai/src/ai/common/database/db_global_base.py
@@ -447,10 +447,10 @@ class DatabaseGlobalBase(IGlobalBase, ABC):
         self.max_validation_attempts = max(1, self._max_validation_attempts(raw))
         self.db_description = (self._db_description(raw) or '').strip()
 
-        # EXECUTE path is opt-in: a caller passing QuestionType.EXECUTE bypasses
-        # the LLM translation + is_sql_safe gate, so the node owner must
-        # explicitly enable the capability. Strings like 'false' / '0' must
-        # not be truthy here, so don't use bool() directly.
+        # The execute tool is opt-in: callers invoking the 'execute' tool
+        # function bypass the LLM translation + is_sql_safe gate, so the node
+        # owner must explicitly enable the capability. Strings like 'false' /
+        # '0' must not be truthy here, so don't use bool() directly.
         allow_execute = raw.get('allow_execute', False)
         if isinstance(allow_execute, str):
             self.allow_execute = allow_execute.strip().lower() in {'1', 'true', 'yes', 'on'}

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -74,8 +74,8 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
     def _db_dialect(self) -> str:
         """Return the machine-readable dialect identifier (e.g. 'mysql', 'postgres').
 
-        Surfaced to SDK callers via ``QuestionType.DIALECT`` so applications can
-        branch on the underlying engine (dialect-specific SQL, type coercion, etc.).
+        Surfaced to SDK callers via the ``dialect`` tool function so applications
+        can branch on the underlying engine (dialect-specific SQL, type coercion, etc.).
         """
 
     # ------------------------------------------------------------------
@@ -246,6 +246,62 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             return {'error': 'Generated query contains unsafe SQL', 'sql': sql_query, 'valid': False}
         else:
             return {'answer': sql_query, 'valid': False}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['sql'],
+            'properties': {
+                'sql': {'type': 'string', 'description': 'Raw SQL statement to execute.'},
+            },
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'rows': {'type': 'array', 'items': {'type': 'object'}},
+                'affected_rows': {'type': 'integer'},
+            },
+        },
+        description=lambda self: (
+            f'Execute a raw SQL statement against this {self._db_display_name()} database. '
+            f'Bypasses LLM translation and SQL safety checks.'
+        ),
+    )
+    def execute(self, args):
+        """Execute a raw SQL statement against this database."""
+        if not isinstance(args, dict):
+            raise ValueError('Tool input must be a JSON object')
+        sql = args.get('sql')
+        if not sql or not isinstance(sql, str) or not sql.strip():
+            raise ValueError('"sql" is required and must be a non-empty string')
+
+        if not self.IGlobal.allow_execute:
+            raise ValueError('execute tool is disabled for this node (set allow_execute=true)')
+
+        result = self._executeRawQuery(sql.strip())
+        if result is None:
+            return {'rows': [], 'affected_rows': 0}
+
+        # Sanitize rows for JSON serialization
+        rows = [self._sanitize_row(row) for row in result['rows']]
+        return {'rows': rows, 'affected_rows': result['affected_rows']}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {},
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'dialect': {'type': 'string', 'description': 'Database engine identifier.'},
+            },
+        },
+        description='Return the database engine dialect (e.g. postgres, mysql, neo4j).',
+    )
+    def dialect(self, args):
+        """Return the database engine dialect."""
+        return {'dialect': self._db_dialect()}
 
     # ------------------------------------------------------------------
     # Sanitization helpers
@@ -504,46 +560,6 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             return
 
         lanes = self.instance.getListeners()
-
-        # DIALECT: dialect-discovery request — emit {'dialect': '...'} on the
-        # answers lane so the SDK can branch on the engine. No gate needed:
-        # the value is metadata, not data, and the node already exposed itself
-        # by being connected.
-        if question.type == QuestionType.DIALECT:
-            if 'answers' in lanes:
-                answer = Answer()
-                answer.setAnswer(json.dumps({'dialect': self._db_dialect()}))
-                self.instance.writeAnswers(answer)
-            return
-
-        # EXECUTE: caller passes raw SQL; bypass LLM translation + safety check.
-        if question.type == QuestionType.EXECUTE:
-            if not self.IGlobal.allow_execute:
-                warning('QuestionType.EXECUTE is disabled for this node (set allow_execute=true to enable).')
-                return
-            try:
-                execute_result = self._executeRawQuery(question_text)
-                if execute_result is None:
-                    return
-
-                rows = [self._sanitize_row(row) for row in execute_result['rows']]
-                affected = execute_result['affected_rows']
-                payload = {'rows': rows, 'affected_rows': affected}
-                markdown = self._formatResultAsMarkdown(rows) if rows else None
-
-                if 'text' in lanes:
-                    self.instance.writeText(markdown if markdown else f'{affected} rows affected')
-
-                if 'table' in lanes and rows:
-                    self.instance.writeTable(markdown)
-
-                if 'answers' in lanes:
-                    answer = Answer()
-                    answer.setAnswer(json.dumps(payload, default=str))
-                    self.instance.writeAnswers(answer)
-            except Exception as e:
-                error(f'Error handling execute question: {e}')
-            return
 
         try:
             # Ask the LLM to translate the natural-language question into SQL.

--- a/packages/ai/src/ai/common/store.py
+++ b/packages/ai/src/ai/common/store.py
@@ -1111,8 +1111,11 @@ class VectorStoreToolMixin:
         store = self._vectordb_store()
 
         parent = args.get('parent', None)
-        offset = int(args.get('offset', 0))
-        limit = int(args.get('limit', 1000))
+        try:
+            offset = int(args.get('offset', 0))
+            limit = int(args.get('limit', 1000))
+        except (TypeError, ValueError):
+            return {'success': False, 'error': 'offset and limit must be valid integers'}
 
         paths = store.getPaths(parent=parent, offset=offset, limit=limit)
         return {'success': True, 'paths': paths}

--- a/packages/ai/src/ai/common/store.py
+++ b/packages/ai/src/ai/common/store.py
@@ -1074,3 +1074,72 @@ class VectorStoreToolMixin:
 
         store.remove(clean_ids)
         return {'success': True, 'deleted_count': len(clean_ids)}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'parent': {
+                    'type': 'string',
+                    'description': 'Optional parent path filter. Only return paths under this parent.',
+                },
+                'offset': {
+                    'type': 'integer',
+                    'description': 'Number of results to skip (default 0).',
+                },
+                'limit': {
+                    'type': 'integer',
+                    'description': 'Maximum number of results to return (default 1000).',
+                },
+            },
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'paths': {
+                    'type': 'object',
+                    'description': 'Map of unique parent paths to their object IDs.',
+                },
+                'success': {'type': 'boolean'},
+            },
+        },
+        description='List unique document paths stored in this vector database.',
+    )
+    def list(self, args):
+        """List unique document paths in this vector store."""
+        args = _normalize_vectordb_tool_input(args)
+        store = self._vectordb_store()
+
+        parent = args.get('parent', None)
+        offset = int(args.get('offset', 0))
+        limit = int(args.get('limit', 1000))
+
+        paths = store.getPaths(parent=parent, offset=offset, limit=limit)
+        return {'success': True, 'paths': paths}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {},
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'count': {'type': 'integer', 'description': 'Total number of documents.'},
+                'model': {'type': 'string', 'description': 'Embedding model name.'},
+                'vector_size': {'type': 'integer', 'description': 'Embedding vector dimension.'},
+                'success': {'type': 'boolean'},
+            },
+        },
+        description='Return statistics about this vector store collection.',
+    )
+    def stats(self, args):
+        """Return collection statistics for this vector store."""
+        store = self._vectordb_store()
+
+        return {
+            'success': True,
+            'count': store.count_documents(),
+            'model': store.modelName,
+            'vector_size': store.vectorSize,
+        }

--- a/packages/ai/src/ai/modules/data/data_conn.py
+++ b/packages/ai/src/ai/modules/data/data_conn.py
@@ -28,11 +28,14 @@ from ai.common.dap import DAPConn
 from ai.common.cprofile_manager import profiler
 from ai.common.schema import Question, Doc, Answer
 from rocketlib import (
+    APERR,
+    AVI_ACTION,
+    Ec,
+    Entry,
+    IInvokeTool,
     IServiceEndpoint,
     IServiceFilterPipe,
     getObject,
-    Entry,
-    AVI_ACTION,
     monitorCompleted,
     monitorFailed,
 )
@@ -414,6 +417,7 @@ class DataConn(DAPConn):
         - open: Initialize a new data pipe for processing
         - write: Write data to a specific lane of an active pipe (resets activity timer)
         - close: Close and finalize a pipe, returning processing results (resets activity timer)
+        - tool: Invoke a @tool_function on a pipeline node (optionally using an open pipe)
 
         Args:
             request (Dict[str, Any]): The extended command request containing:
@@ -442,6 +446,8 @@ class DataConn(DAPConn):
             return await self._write(request, args)
         elif subcmd == 'close':
             return await self._close(request, args)
+        elif subcmd == 'tool':
+            return await self._tool(request, args)
         else:
             raise ValueError(f'Invalid subcommand {subcmd}')
 
@@ -746,6 +752,85 @@ class DataConn(DAPConn):
             if conn_pipe.semaphore_acquired:
                 self._pipe_sem.release()
                 self.debug_message(f'Released semaphore for pipe {pipe_id}')
+
+    async def _tool(self, request: Dict[str, Any], args: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Invoke a @tool_function on a pipeline node.
+
+        Dispatches an IInvokeTool.Invoke through the control plane, bypassing
+        the Question/Answer data lane entirely.  If ``pipe_id`` is provided the
+        caller's already-open pipe is reused; otherwise a pipe is borrowed from
+        the endpoint pool for the duration of the call.
+
+        Args:
+            request: The DAP request envelope.
+            args: Parsed arguments containing:
+                - tool (str, required): Name of the @tool_function to invoke.
+                - nodeId (str, optional): Target node ID.  When empty the
+                  control plane broadcasts to all tool-lane nodes; the first
+                  node that owns the tool handles the call.
+                - input (dict, optional): Arguments forwarded to the tool.
+                - pipe_id (int, optional): Pipe ID of an already-open pipe.
+
+        Returns:
+            DAP response with ``body.result`` set to the tool's return value.
+
+        Raises:
+            ValueError: If ``tool`` is missing, ``pipe_id`` is invalid, or no
+                node handles the requested tool.
+        """
+        tool_name = args.get('tool')
+        if not tool_name:
+            raise ValueError('tool is required')
+
+        node_id = args.get('nodeId', '')
+        tool_input = args.get('input', {})
+        pipe_id = args.get('pipe_id', None)
+
+        def tool_sync():
+            # Use caller's open pipe if provided, otherwise borrow one
+            if pipe_id is not None:
+                conn_pipe = self._pipe_map.get(pipe_id)
+                if not conn_pipe or not conn_pipe.is_open:
+                    raise ValueError(f'Pipe {pipe_id} is not open')
+                pipe = conn_pipe.pipe
+                borrowed = False
+            else:
+                pipe = self._target.getPipe()
+                borrowed = True
+
+            try:
+                # Walk the filter chain (pipe.next) to find the target node
+                # by its component ID.  Each node in the chain is an
+                # IFilterInstance with invoke() available.
+                node = pipe
+                while node is not None:
+                    if node.pipeType.id == node_id:
+                        break
+                    node = node.next
+                else:
+                    raise ValueError(f'Node "{node_id}" not found in pipeline')
+
+                # Get the Python IInstance from the C++ filter and call
+                # invoke() directly — bypasses the C++ control dispatcher
+                # which requires controller map entries.
+                py_instance = node.pyInstance
+                param = IInvokeTool.Invoke(tool_name=tool_name, input=tool_input)
+                try:
+                    py_instance.invoke(param)
+                except APERR as e:
+                    if e.ec == Ec.PreventDefault:
+                        raise ValueError(f'No handler found for tool "{tool_name}" on node "{node_id}"')
+                    raise
+
+                return param.output
+
+            finally:
+                if borrowed:
+                    self._target.putPipe(pipe)
+
+        result = await asyncio.to_thread(tool_sync)
+        return self.build_response(request, body={'result': result})
 
     # =========================================================================
     # CPROFILE COMMANDS

--- a/packages/ai/src/ai/modules/data/data_conn.py
+++ b/packages/ai/src/ai/modules/data/data_conn.py
@@ -787,12 +787,20 @@ class DataConn(DAPConn):
         tool_input = args.get('input', {})
         pipe_id = args.get('pipe_id', None)
 
+        # Resolve conn_pipe in async scope so we can set in_use before
+        # dispatching to the thread (mirrors _write pattern).
+        conn_pipe = None
+        if pipe_id is not None:
+            conn_pipe = self._pipe_map.get(pipe_id)
+            if not conn_pipe or not conn_pipe.is_open:
+                raise ValueError(f'Pipe {pipe_id} is not open')
+            if conn_pipe.has_failed:
+                raise ValueError(f'Pipe {pipe_id} has failed')
+            self._reset_pipe_activity(conn_pipe)
+
         def tool_sync():
             # Use caller's open pipe if provided, otherwise borrow one
-            if pipe_id is not None:
-                conn_pipe = self._pipe_map.get(pipe_id)
-                if not conn_pipe or not conn_pipe.is_open:
-                    raise ValueError(f'Pipe {pipe_id} is not open')
+            if conn_pipe is not None:
                 pipe = conn_pipe.pipe
                 borrowed = False
             else:
@@ -800,37 +808,55 @@ class DataConn(DAPConn):
                 borrowed = True
 
             try:
-                # Walk the filter chain (pipe.next) to find the target node
-                # by its component ID.  Each node in the chain is an
-                # IFilterInstance with invoke() available.
-                node = pipe
-                while node is not None:
-                    if node.pipeType.id == node_id:
-                        break
-                    node = node.next
+                # Walk the filter chain to find candidate node(s).
+                # When node_id is provided, match exactly.
+                # When empty, broadcast to all nodes — first handler wins.
+                if node_id:
+                    node = pipe
+                    while node is not None:
+                        if node.pipeType.id == node_id:
+                            break
+                        node = node.next
+                    else:
+                        raise ValueError(f'Node "{node_id}" not found in pipeline')
+                    candidates = [node]
                 else:
-                    raise ValueError(f'Node "{node_id}" not found in pipeline')
+                    candidates = []
+                    node = pipe
+                    while node is not None:
+                        candidates.append(node)
+                        node = node.next
 
-                # Get the Python IInstance from the C++ filter and call
-                # invoke() directly — bypasses the C++ control dispatcher
-                # which requires controller map entries.
-                py_instance = node.pyInstance
-                param = IInvokeTool.Invoke(tool_name=tool_name, input=tool_input)
-                try:
-                    py_instance.invoke(param)
-                except APERR as e:
-                    if e.ec == Ec.PreventDefault:
-                        raise ValueError(f'No handler found for tool "{tool_name}" on node "{node_id}"')
-                    raise
+                # Invoke the tool on the first node that handles it.
+                for node in candidates:
+                    py_instance = getattr(node, 'pyInstance', None)
+                    if py_instance is None:
+                        continue
+                    param = IInvokeTool.Invoke(tool_name=tool_name, input=tool_input)
+                    try:
+                        py_instance.invoke(param)
+                        return param.output
+                    except APERR as e:
+                        if e.ec == Ec.PreventDefault:
+                            continue
+                        raise
 
-                return param.output
+                raise ValueError(f'No handler found for tool "{tool_name}" on node "{node_id}"')
 
             finally:
                 if borrowed:
                     self._target.putPipe(pipe)
 
-        result = await asyncio.to_thread(tool_sync)
-        return self.build_response(request, body={'result': result})
+        # Execute in thread, marking pipe as in-use so the zombie detector skips it
+        if conn_pipe is not None:
+            conn_pipe.in_use = True
+        try:
+            result = await asyncio.to_thread(tool_sync)
+            return self.build_response(request, body={'result': result})
+        finally:
+            if conn_pipe is not None:
+                conn_pipe.in_use = False
+                self._reset_pipe_activity(conn_pipe)
 
     # =========================================================================
     # CPROFILE COMMANDS

--- a/packages/ai/src/ai/modules/task/commands/cmd_data.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_data.py
@@ -151,6 +151,7 @@ class DataCommands(DAPConn):
             # build_response constructs a fresh envelope keyed off the inbound
             # request so request_seq matches what the chat client sent.  Mirrors
             # the same pattern task_conn.request uses for the debug channel.
+
             return self.build_response(
                 request,
                 body=subprocess_response.get('body'),

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -551,6 +551,12 @@ class Task(DAPBase):
             arguments=args,
             token=args.get('token'),
         )
+
+        # Propagate subprocess failures so callers don't silently
+        # receive success for a failed operation.
+        if self._data_client.did_fail(response):
+            raise RuntimeError(response.get('message', 'Data request failed'))
+
         return response
 
     async def _terminated(self) -> None:

--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -58,7 +58,7 @@ from .mixins.services import ServicesMixin
 from .mixins.dashboard import DashboardMixin
 from .mixins.cprofile import CProfileMixin
 from .mixins.store import StoreMixin
-from typing import Callable, TYPE_CHECKING
+from typing import Any, Callable, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .types.client import DAPMessage, ServerInfoResult
@@ -305,6 +305,42 @@ class RocketRideClient(
             self._on_trace(self.TRACE_SUCCESS, response)
 
         return response.get('body') or {}
+
+    async def tool(self, *, token: str, tool: str, node_id: str = '', input: dict = None, timeout: float = None) -> Any:
+        """
+        Invoke a @tool_function on a pipeline node.
+
+        Sends a ``tool`` subcommand through the DAP data connection.  The
+        server borrows a pipeline instance from the pool, dispatches the tool
+        call through the control plane, and returns the result directly -- no
+        Question, Answer, or SSE overhead.
+
+        Args:
+            token: Pipeline token for authentication and resource access.
+            tool: Name of the @tool_function to invoke (e.g. ``'search'``,
+                ``'list'``, ``'execute'``).
+            node_id: Target node ID.  When empty the call broadcasts to all
+                tool-lane nodes; the first node that owns the tool handles it.
+            input: Arguments forwarded to the tool function.
+            timeout: Optional per-request timeout in ms.
+
+        Returns:
+            The tool's return value (typically a dict).
+
+        Raises:
+            RuntimeError: If the server signals failure or no node handles the
+                requested tool.
+        """
+        result = await self.call(
+            'rrext_process',
+            token=token,
+            timeout=timeout,
+            subcommand='tool',
+            tool=tool,
+            nodeId=node_id,
+            input=input or {},
+        )
+        return result.get('result')
 
     # =========================================================================
     # NAMESPACED API ACCESSORS

--- a/packages/client-python/src/rocketride/database.py
+++ b/packages/client-python/src/rocketride/database.py
@@ -24,21 +24,17 @@
 Database API namespace for the RocketRide Python SDK.
 
 Exposes ``client.database.query(...)`` for issuing raw SQL or Cypher directly
-against a database pipeline, bypassing the LLM translation layer that the
-default ``client.chat(...)`` flow uses.
+against a database pipeline node via the ``execute`` tool function, bypassing
+the LLM translation layer that the default ``client.chat(...)`` flow uses.
 
 Usage:
-    rows = await client.database.query(token=t, sql='SELECT 1 AS one')
+    result = await client.database.query(token=t, sql='SELECT 1 AS one')
 """
 
 from __future__ import annotations
 
-import json
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
-
-from .schema.question import Question, QuestionType
-from .types.data import PIPELINE_RESULT
+from typing import TYPE_CHECKING, Any, Dict
 
 if TYPE_CHECKING:
     from .client import RocketRideClient
@@ -75,68 +71,69 @@ class DatabaseApi:
         *,
         token: str,
         sql: str,
-        on_sse: Optional[object] = None,
-    ) -> PIPELINE_RESULT:
+        node_id: str = '',
+    ) -> Dict[str, Any]:
         """
-        Execute a raw SQL or Cypher statement against a database pipeline.
+        Execute a raw SQL or Cypher statement against a database pipeline node.
 
-        Sends a Question with ``type=QuestionType.EXECUTE`` so the database
-        node treats ``sql`` as the literal statement to run -- no LLM call,
-        no ``is_sql_safe`` / ``_is_cypher_safe`` gating.
+        Invokes the ``execute`` tool function on the target database node,
+        bypassing LLM translation and SQL safety checks.
 
         Args:
             token: Pipeline token for authentication and resource access.
             sql: Raw SQL or Cypher statement to execute.
-            on_sse: Optional callback for streaming events (matches ``chat``).
+            node_id: Target database node ID.  When empty the call broadcasts
+                to all tool-lane nodes; the first database node handles it.
 
         Returns:
-            PIPELINE_RESULT: The pipeline response. The ``answers`` lane carries
-            a JSON-encoded payload of shape ``{"rows": [...], "affected_rows": N}``.
+            Dict with ``rows`` (list of row dicts) and ``affected_rows`` (int).
 
         Raises:
             ValueError: If ``token`` or ``sql`` is empty or whitespace-only.
+            RuntimeError: If the server signals failure.
         """
         if not isinstance(token, str) or not token.strip():
             raise ValueError('token must be a non-empty string')
         if not isinstance(sql, str) or not sql.strip():
             raise ValueError('sql must be a non-empty string')
 
-        question = Question(type=QuestionType.EXECUTE)
-        question.addQuestion(sql)
-        return await self._client.chat(token=token, question=question, on_sse=on_sse)
+        return await self._client.tool(
+            token=token,
+            tool='execute',
+            node_id=node_id,
+            input={'sql': sql},
+        )
 
-    async def dialect(self, *, token: str) -> DatabaseDialect:
+    async def dialect(self, *, token: str, node_id: str = '') -> DatabaseDialect:
         """
-        Discover the underlying database engine for a pipeline.
+        Discover the underlying database engine for a pipeline node.
 
-        Sends a ``Question(type=DIALECT)``; the database node replies on the
-        ``answers`` lane with ``{"dialect": "<engine>"}``. Use this to branch
-        on dialect-specific SQL or to assert you're not pointed at the wrong
-        kind of database (e.g. Neo4j when you expected Postgres).
+        Invokes the ``dialect`` tool function on the target database node.
 
         Args:
             token: Pipeline token for authentication and resource access.
+            node_id: Target database node ID.  When empty the call broadcasts
+                to all tool-lane nodes; the first database node handles it.
 
         Returns:
             DatabaseDialect: The dialect reported by the node.
 
         Raises:
-            ValueError: If ``token`` is empty/whitespace, the pipeline returns
-                no answer, or the response is not a recognized dialect.
+            ValueError: If ``token`` is empty/whitespace or the response is not
+                a recognized dialect.
+            RuntimeError: If the server signals failure.
         """
         if not isinstance(token, str) or not token.strip():
             raise ValueError('token must be a non-empty string')
 
-        question = Question(type=QuestionType.DIALECT)
-        question.addQuestion('dialect')
-        result = await self._client.chat(token=token, question=question)
+        result = await self._client.tool(
+            token=token,
+            tool='dialect',
+            node_id=node_id,
+        )
 
-        answers = result.get('answers') if isinstance(result, dict) else None
-        if not answers:
-            raise ValueError('Pipeline returned no dialect answer; is the endpoint a database node?')
+        dialect_str = result.get('dialect') if isinstance(result, dict) else None
+        if not dialect_str:
+            raise ValueError('Pipeline returned no dialect; is the endpoint a database node?')
 
-        try:
-            payload = json.loads(answers[0])
-            return DatabaseDialect(payload['dialect'])
-        except (TypeError, KeyError, ValueError, json.JSONDecodeError) as e:
-            raise ValueError(f'Unexpected dialect response from pipeline: {answers[0]!r}') from e
+        return DatabaseDialect(dialect_str)

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -56,7 +56,7 @@ import time
 import asyncio
 import mimetypes
 from pathlib import Path
-from typing import Dict, Any, List, Union, Tuple, Optional
+from typing import Any, Dict, List, Optional, Tuple, Union
 from ..core import DAPClient, PipeException
 from ..types import PIPELINE_RESULT, UPLOAD_RESULT
 
@@ -302,6 +302,49 @@ class DataMixin(DAPClient):
                         await self._client.set_events(self._token, [], pipe_id=self._pipe_id)
                     except Exception:
                         pass  # Best-effort cleanup
+
+        async def tool(self, *, tool: str, node_id: str = '', input: dict = None) -> Any:
+            """
+            Invoke a @tool_function on a pipeline node using this pipe.
+
+            The call reuses this pipe's existing pipeline instance, avoiding the
+            overhead of borrowing a new one from the pool.
+
+            Args:
+                tool: Name of the @tool_function to invoke.
+                node_id: Target node ID.  When empty the call broadcasts to all
+                    tool-lane nodes; the first node that owns the tool handles it.
+                input: Arguments forwarded to the tool function.
+
+            Returns:
+                The tool's return value (typically a dict).
+
+            Raises:
+                RuntimeError: If the pipe is not open.
+            """
+            if not self._opened:
+                raise RuntimeError('Pipe is not open')
+
+            request = self._client.build_request(
+                'rrext_process',
+                arguments={
+                    'subcommand': 'tool',
+                    'tool': tool,
+                    'nodeId': node_id,
+                    'input': input or {},
+                    'pipe_id': self._pipe_id,
+                },
+                token=self._token,
+            )
+
+            response = await self._client.request(request)
+
+            if self._client.did_fail(response):
+                msg = response.get('message') or f'Tool "{tool}" invocation failed.'
+                raise RuntimeError(msg)
+
+            body = response.get('body', {})
+            return body.get('result')
 
         async def __aenter__(self):
             """Enter async context manager - automatically opens pipe."""

--- a/packages/client-python/src/rocketride/schema/question.py
+++ b/packages/client-python/src/rocketride/schema/question.py
@@ -294,8 +294,6 @@ class QuestionType(str, Enum):
         KEYWORD: Uses keyword matching and text search
         GET: Retrieves specific information or data
         PROMPT: Raw prompt without additional processing
-        EXECUTE: Direct query execution against database nodes (bypasses LLM + safety checks)
-        DIALECT: Database-dialect discovery (node responds with its engine name)
     """
 
     QUESTION = 'question'  # Basic question-answering
@@ -303,8 +301,6 @@ class QuestionType(str, Enum):
     KEYWORD = 'keyword'  # Keyword-based search
     GET = 'get'  # Information retrieval
     PROMPT = 'prompt'  # Raw prompt processing
-    EXECUTE = 'execute'  # Direct DB query execution (no LLM, no safety check)
-    DIALECT = 'dialect'  # Ask a database node which engine it is connected to
 
 
 class Question(BaseModel):

--- a/packages/client-python/tests/conftest.py
+++ b/packages/client-python/tests/conftest.py
@@ -1,3 +1,32 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Pytest configuration and shared fixtures for client-python tests.
+
+Provides TEST_CONFIG, ensure_clean_pipeline, and a connected client fixture
+following the same patterns as client-mcp/tests/conftest.py.
+"""
+
 # Configure Python path for tests to import rocketride from source
 import sys
 from pathlib import Path
@@ -5,3 +34,46 @@ from pathlib import Path
 src_path = Path(__file__).parent.parent / 'src'
 if str(src_path) not in sys.path:
     sys.path.insert(0, str(src_path))
+
+import os
+from typing import Any, AsyncGenerator, Dict
+
+import pytest_asyncio
+
+from rocketride import RocketRideClient
+
+
+# =========================================================================
+# TEST CONFIGURATION
+# =========================================================================
+
+TEST_CONFIG: Dict[str, Any] = {
+    'uri': os.getenv('ROCKETRIDE_URI', 'http://localhost:5565'),
+    'auth': os.getenv('ROCKETRIDE_APIKEY', 'MYAPIKEY'),
+    'timeout': 30.0,
+}
+
+
+async def ensure_clean_pipeline(client: RocketRideClient, token: str) -> None:
+    """Clean up pipeline if it exists, ignoring errors."""
+    try:
+        await client.terminate(token)
+    except Exception:
+        pass
+
+
+# =========================================================================
+# FIXTURES
+# =========================================================================
+
+
+@pytest_asyncio.fixture
+async def client() -> AsyncGenerator[RocketRideClient, None]:
+    """Provide a connected RocketRideClient, disconnecting on teardown."""
+    _client = RocketRideClient(uri=TEST_CONFIG['uri'], auth=TEST_CONFIG['auth'])
+    await _client.connect()
+    try:
+        yield _client
+    finally:
+        if _client.is_connected():
+            await _client.disconnect()

--- a/packages/client-python/tests/test_tool.py
+++ b/packages/client-python/tests/test_tool.py
@@ -1,0 +1,140 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Integration tests for ``client.tool()`` and ``DataPipe.tool()``.
+
+Starts a pipeline with a tool_python node and invokes its ``execute`` tool
+via the new DAP ``tool`` subcommand -- both standalone (borrowed pipe) and
+pipe-bound paths.
+"""
+
+import pytest
+import pytest_asyncio
+
+from rocketride import RocketRideClient
+from conftest import ensure_clean_pipeline
+from tool_pipeline import get_tool_pipeline
+
+
+# =========================================================================
+# FIXTURES
+# =========================================================================
+
+TOOL_TOKEN = 'PY-TOOL'
+
+
+@pytest_asyncio.fixture
+async def tool_pipeline(client: RocketRideClient):
+    """Start a tool_python pipeline, yield its token, terminate on teardown."""
+    await ensure_clean_pipeline(client, TOOL_TOKEN)
+
+    result = await client.use(pipeline=get_tool_pipeline(), token=TOOL_TOKEN)
+    pipeline_token = result['token']
+    try:
+        yield pipeline_token
+    finally:
+        await ensure_clean_pipeline(client, pipeline_token)
+
+
+# =========================================================================
+# STANDALONE client.tool() -- borrows a pipe from the pool
+# =========================================================================
+
+
+class TestStandaloneTool:
+    """Tests for client.tool() which borrows a pipe for each call."""
+
+    @pytest.mark.asyncio
+    async def test_executes_python_and_returns_result(self, client: RocketRideClient, tool_pipeline: str):
+        """client.tool() invokes execute on tool_python_1 and returns the result dict."""
+        result = await client.tool(
+            token=tool_pipeline,
+            tool='execute',
+            node_id='tool_python_1',
+            input={'code': 'result = {"answer": 2 + 2}'},
+        )
+
+        assert result is not None
+        assert isinstance(result, dict)
+        assert result.get('exit_code') == 0
+        assert result.get('result') == {'answer': 4}
+
+    @pytest.mark.asyncio
+    async def test_stdout_capture(self, client: RocketRideClient, tool_pipeline: str):
+        """client.tool() captures stdout from the sandboxed script."""
+        result = await client.tool(
+            token=tool_pipeline,
+            tool='execute',
+            node_id='tool_python_1',
+            input={'code': 'print("hello")'},
+        )
+
+        assert result is not None
+        assert result.get('exit_code') == 0
+        assert 'hello' in result.get('stdout', '')
+
+    @pytest.mark.asyncio
+    async def test_invalid_tool_name_raises(self, client: RocketRideClient, tool_pipeline: str):
+        """client.tool() raises when the node doesn't own the tool."""
+        with pytest.raises(RuntimeError):
+            await client.tool(
+                token=tool_pipeline,
+                tool='nonexistent_tool',
+                node_id='tool_python_1',
+                input={},
+            )
+
+
+# =========================================================================
+# PIPE-BOUND DataPipe.tool() -- reuses an already-open pipe
+# =========================================================================
+
+
+class TestPipeBoundTool:
+    """Tests for DataPipe.tool() which reuses the caller's open pipe."""
+
+    @pytest.mark.asyncio
+    async def test_executes_python_through_open_pipe(self, client: RocketRideClient, tool_pipeline: str):
+        """DataPipe.tool() invokes a tool using the pipe's pipeline instance."""
+        pipe = await client.pipe(tool_pipeline, {}, 'text/plain')
+        await pipe.open()
+
+        result = await pipe.tool(
+            tool='execute',
+            node_id='tool_python_1',
+            input={'code': 'result = list(range(5))'},
+        )
+
+        assert result is not None
+        assert result.get('exit_code') == 0
+        assert result.get('result') == [0, 1, 2, 3, 4]
+
+        await pipe.close()
+
+    @pytest.mark.asyncio
+    async def test_before_open_raises(self, client: RocketRideClient, tool_pipeline: str):
+        """DataPipe.tool() raises RuntimeError if the pipe is not open."""
+        pipe = await client.pipe(tool_pipeline, {}, 'text/plain')
+
+        with pytest.raises(RuntimeError, match='not open'):
+            await pipe.tool(tool='execute', node_id='tool_python_1', input={'code': 'pass'})

--- a/packages/client-python/tests/tool_pipeline.py
+++ b/packages/client-python/tests/tool_pipeline.py
@@ -1,0 +1,63 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Tool pipeline fixture for integration tests.
+
+Provides a minimal pipeline with a tool_python node whose ``execute`` tool
+can be invoked via ``client.tool()`` without any external API keys or services.
+"""
+
+from typing import Any, Dict
+
+
+def get_tool_pipeline(project_id: str = 'a1b2c3d4-tool-test-0000-000000000001') -> Dict[str, Any]:
+    """
+    Get a pipeline with a tool_python node for testing client.tool().
+
+    The pipeline has a webhook source feeding into a tool_python node. The
+    tool_python node exposes a ``python.execute`` tool that runs Python code
+    in a sandbox -- no external dependencies required.
+    """
+    return {
+        'components': [
+            {
+                'id': 'webhook_1',
+                'provider': 'webhook',
+                'config': {'hideForm': True, 'mode': 'Source', 'type': 'webhook'},
+            },
+            {
+                'id': 'tool_python_1',
+                'provider': 'tool_python',
+                'config': {},
+                'input': [{'lane': 'text', 'from': 'webhook_1'}],
+            },
+            {
+                'id': 'response_1',
+                'provider': 'response',
+                'config': {'lanes': []},
+                'input': [{'lane': 'text', 'from': 'webhook_1'}],
+            },
+        ],
+        'source': 'webhook_1',
+        'project_id': project_id,
+    }

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -256,6 +256,45 @@ export class DataPipe {
 			}
 		}
 	}
+
+	/**
+	 * Invoke a @tool_function on a pipeline node using this pipe.
+	 *
+	 * The call reuses this pipe's existing pipeline instance, avoiding the
+	 * overhead of borrowing a new one from the pool.
+	 *
+	 * @param tool - Name of the @tool_function to invoke
+	 * @param nodeId - Target node ID.  When empty the call broadcasts to all
+	 *                 tool-lane nodes; the first node that owns the tool handles it.
+	 * @param input - Arguments forwarded to the tool function
+	 * @returns The tool's return value (typically a record/object)
+	 * @throws Error if the pipe is not open or no node handles the tool
+	 */
+	async tool<T = any>(tool: string, nodeId = '', input: Record<string, unknown> = {}): Promise<T> {
+		if (!this._opened) {
+			throw new Error('Pipe is not open');
+		}
+
+		const request = this._client.buildRequest('rrext_process', {
+			arguments: {
+				subcommand: 'tool',
+				tool,
+				nodeId,
+				input,
+				pipe_id: this._pipeId,
+			},
+			token: this._token,
+		});
+
+		const response = await this._client.request(request);
+
+		if (this._client.didFail(response)) {
+			const msg = response.message || `Tool "${tool}" invocation failed.`;
+			throw new Error(msg);
+		}
+
+		return (response.body as any)?.result as T;
+	}
 }
 
 /**
@@ -2629,6 +2668,42 @@ export class RocketRideClient extends DAPClient {
 
 		// Unwrap the body envelope
 		return (response.body ?? response) as T;
+	}
+
+	/**
+	 * Invoke a @tool_function on a pipeline node.
+	 *
+	 * Sends a `tool` subcommand through the DAP data connection.  The server
+	 * borrows a pipeline instance from the pool, dispatches the tool call
+	 * through the control plane, and returns the result directly — no
+	 * Question, Answer, or SSE overhead.
+	 *
+	 * @param options.token - Pipeline token for authentication and resource access
+	 * @param options.tool - Name of the @tool_function to invoke (e.g. 'search', 'list', 'execute')
+	 * @param options.nodeId - Target node ID.  When empty the call broadcasts to all
+	 *                         tool-lane nodes; the first node that owns the tool handles it.
+	 * @param options.input - Arguments forwarded to the tool function
+	 * @param options.timeout - Optional per-request timeout in ms
+	 * @returns The tool's return value (typically a record/object)
+	 * @throws Error if the server signals failure or no node handles the requested tool
+	 */
+	async tool<T = any>(options: {
+		token: string;
+		tool: string;
+		nodeId?: string;
+		input?: Record<string, unknown>;
+		timeout?: number;
+	}): Promise<T> {
+		const result = await this.call<{ result: T }>('rrext_process', {
+			subcommand: 'tool',
+			tool: options.tool,
+			nodeId: options.nodeId ?? '',
+			input: options.input ?? {},
+		}, {
+			token: options.token,
+			timeout: options.timeout,
+		});
+		return result.result;
 	}
 }
 

--- a/packages/client-typescript/src/client/database.ts
+++ b/packages/client-typescript/src/client/database.ts
@@ -26,13 +26,11 @@
  * Database API namespace for the RocketRide TypeScript SDK.
  *
  * Exposes `client.database.query(...)` for issuing raw SQL or Cypher directly
- * against a database pipeline, bypassing the LLM translation layer that the
- * default `client.chat(...)` flow uses.
+ * against a database pipeline node via the `execute` tool function, bypassing
+ * the LLM translation layer that the default `client.chat(...)` flow uses.
  */
 
 import type { RocketRideClient } from './client.js';
-import type { PIPELINE_RESULT } from './types/index.js';
-import { Question, QuestionType } from './schema/Question.js';
 
 // =============================================================================
 // DIALECT ENUM
@@ -66,23 +64,22 @@ export class DatabaseApi {
 	constructor(private readonly client: RocketRideClient) {}
 
 	/**
-	 * Execute a raw SQL or Cypher statement against a database pipeline.
+	 * Execute a raw SQL or Cypher statement against a database pipeline node.
 	 *
-	 * Sends a Question with `type=QuestionType.EXECUTE` so the database node
-	 * treats `sql` as the literal statement to run — no LLM call, no
-	 * `is_sql_safe` / `_is_cypher_safe` gating.
+	 * Invokes the `execute` tool function on the target database node,
+	 * bypassing LLM translation and SQL safety checks.
 	 *
 	 * @param options.token - Pipeline token for authentication and resource access.
 	 * @param options.sql - Raw SQL or Cypher statement to execute.
-	 * @param options.onSSE - Optional streaming callback (matches `chat`).
-	 * @returns The pipeline response. The `answers` lane carries a JSON-encoded
-	 *   payload of shape `{"rows": [...], "affected_rows": N}`.
+	 * @param options.nodeId - Target database node ID.  When empty the call
+	 *   broadcasts to all tool-lane nodes; the first database node handles it.
+	 * @returns Object with `rows` (array of row objects) and `affected_rows` (number).
 	 */
 	async query(options: {
 		token: string;
 		sql: string;
-		onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>;
-	}): Promise<PIPELINE_RESULT> {
+		nodeId?: string;
+	}): Promise<{ rows: Record<string, unknown>[]; affected_rows: number }> {
 		if (typeof options.token !== 'string' || options.token.trim() === '') {
 			throw new Error('token must be a non-empty string');
 		}
@@ -90,49 +87,40 @@ export class DatabaseApi {
 			throw new Error('sql must be a non-empty string');
 		}
 
-		const question = new Question({ type: QuestionType.EXECUTE });
-		question.addQuestion(options.sql);
-		return this.client.chat({ token: options.token, question, onSSE: options.onSSE });
+		return this.client.tool({
+			token: options.token,
+			tool: 'execute',
+			nodeId: options.nodeId,
+			input: { sql: options.sql },
+		});
 	}
 
 	/**
-	 * Discover the underlying database engine for a pipeline.
+	 * Discover the underlying database engine for a pipeline node.
 	 *
-	 * Sends a `Question(type=DIALECT)`; the database node replies on the
-	 * `answers` lane with `{"dialect": "<engine>"}`. Use this to branch on
-	 * dialect-specific SQL or to assert you're not pointed at the wrong kind
-	 * of database (e.g. Neo4j when you expected Postgres).
+	 * Invokes the `dialect` tool function on the target database node.
 	 *
 	 * @param options.token - Pipeline token for authentication and resource access.
+	 * @param options.nodeId - Target database node ID.  When empty the call
+	 *   broadcasts to all tool-lane nodes; the first database node handles it.
 	 * @returns The dialect reported by the node.
-	 * @throws If `token` is empty, the pipeline returns no answer, or the
-	 *   response is not a recognized dialect.
+	 * @throws If `token` is empty or the response is not a recognized dialect.
 	 */
-	async dialect(options: { token: string }): Promise<DatabaseDialect> {
+	async dialect(options: { token: string; nodeId?: string }): Promise<DatabaseDialect> {
 		if (typeof options.token !== 'string' || options.token.trim() === '') {
 			throw new Error('token must be a non-empty string');
 		}
 
-		const question = new Question({ type: QuestionType.DIALECT });
-		question.addQuestion('dialect');
-		const result = await this.client.chat({ token: options.token, question });
-
-		const answers = (result as { answers?: string[] })?.answers;
-		if (!answers || answers.length === 0) {
-			throw new Error('Pipeline returned no dialect answer; is the endpoint a database node?');
-		}
-
-		let payload: { dialect?: string };
-		try {
-			payload = JSON.parse(answers[0]);
-		} catch {
-			throw new Error(`Unexpected dialect response from pipeline: ${answers[0]}`);
-		}
+		const result = await this.client.tool<{ dialect?: string }>({
+			token: options.token,
+			tool: 'dialect',
+			nodeId: options.nodeId,
+		});
 
 		const known = Object.values(DatabaseDialect) as string[];
-		if (!payload.dialect || !known.includes(payload.dialect)) {
-			throw new Error(`Unexpected dialect response from pipeline: ${answers[0]}`);
+		if (!result?.dialect || !known.includes(result.dialect)) {
+			throw new Error(`Unexpected dialect response from pipeline: ${JSON.stringify(result)}`);
 		}
-		return payload.dialect as DatabaseDialect;
+		return result.dialect as DatabaseDialect;
 	}
 }

--- a/packages/client-typescript/src/client/schema/Question.ts
+++ b/packages/client-typescript/src/client/schema/Question.ts
@@ -34,8 +34,6 @@ export enum QuestionType {
 	KEYWORD = 'keyword',
 	GET = 'get',
 	PROMPT = 'prompt',
-	EXECUTE = 'execute',
-	DIALECT = 'dialect'
 }
 
 /**

--- a/packages/client-typescript/tests/tool.pipeline.ts
+++ b/packages/client-typescript/tests/tool.pipeline.ts
@@ -1,0 +1,56 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Tool pipeline fixture for integration tests.
+ *
+ * Provides a minimal pipeline with a tool_python node whose `execute` tool
+ * can be invoked via `client.tool()` without any external API keys or services.
+ */
+
+export function getToolPipeline(projectId = 'a1b2c3d4-tool-test-0000-000000000001') {
+	return {
+		components: [
+			{
+				id: 'webhook_1',
+				provider: 'webhook',
+				config: { hideForm: true, mode: 'Source', type: 'webhook' },
+			},
+			{
+				id: 'tool_python_1',
+				provider: 'tool_python',
+				config: {},
+				input: [{ lane: 'text', from: 'webhook_1' }],
+			},
+			{
+				id: 'response_1',
+				provider: 'response',
+				config: { lanes: [] },
+				input: [{ lane: 'text', from: 'webhook_1' }],
+			},
+		],
+		source: 'webhook_1',
+		project_id: projectId,
+	};
+}

--- a/packages/client-typescript/tests/tool.test.ts
+++ b/packages/client-typescript/tests/tool.test.ts
@@ -1,0 +1,167 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Integration tests for `client.tool()` and `DataPipe.tool()`.
+ *
+ * Starts a pipeline with a tool_python node and invokes its `execute` tool
+ * via the new DAP `tool` subcommand -- both standalone (borrowed pipe) and
+ * pipe-bound paths.
+ */
+
+import { RocketRideClient } from '../src/client';
+import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { getToolPipeline } from './tool.pipeline';
+
+const TEST_CONFIG = {
+	uri: process.env.ROCKETRIDE_URI || 'http://localhost:5565',
+	auth: process.env.ROCKETRIDE_APIKEY || 'MYAPIKEY',
+	timeout: 120000,
+};
+
+const TOOL_TOKEN = 'TS-TOOL';
+
+async function ensureCleanPipeline(client: RocketRideClient, token: string): Promise<void> {
+	try {
+		await client.terminate(token);
+	} catch {
+		// Ignore errors - pipeline might not be running
+	}
+}
+
+describe('Tool Operations', () => {
+	let client: RocketRideClient;
+	let pipelineToken: string;
+
+	beforeEach(async () => {
+		client = new RocketRideClient({
+			auth: TEST_CONFIG.auth,
+			uri: TEST_CONFIG.uri,
+		});
+		await client.connect();
+		await ensureCleanPipeline(client, TOOL_TOKEN);
+
+		const result = await client.use({
+			pipeline: getToolPipeline(),
+			token: TOOL_TOKEN,
+		});
+		pipelineToken = result.token;
+	});
+
+	afterEach(async () => {
+		if (pipelineToken) {
+			try {
+				await client.terminate(pipelineToken);
+			} catch {
+				// Ignore cleanup errors
+			}
+		}
+		await ensureCleanPipeline(client, TOOL_TOKEN);
+		if (client.isConnected()) {
+			await Promise.race([
+				client.disconnect(),
+				new Promise<void>((resolve) => setTimeout(resolve, 10000)),
+			]);
+		}
+	});
+
+	// ------------------------------------------------------------------
+	// Standalone client.tool() -- borrows a pipe from the pool
+	// ------------------------------------------------------------------
+
+	describe('standalone client.tool()', () => {
+		it('executes python and returns result', async () => {
+			const result = await client.tool<{
+				exit_code: number;
+				result: { answer: number };
+			}>({
+				token: pipelineToken,
+				tool: 'execute',
+				nodeId: 'tool_python_1',
+				input: { code: 'result = {"answer": 2 + 2}' },
+			});
+
+			expect(result).toBeDefined();
+			expect(result.exit_code).toBe(0);
+			expect(result.result).toEqual({ answer: 4 });
+		}, TEST_CONFIG.timeout);
+
+		it('captures stdout from sandboxed script', async () => {
+			const result = await client.tool<{
+				exit_code: number;
+				stdout: string;
+			}>({
+				token: pipelineToken,
+				tool: 'execute',
+				nodeId: 'tool_python_1',
+				input: { code: 'print("hello")' },
+			});
+
+			expect(result).toBeDefined();
+			expect(result.exit_code).toBe(0);
+			expect(result.stdout).toContain('hello');
+		}, TEST_CONFIG.timeout);
+
+		it('invalid tool name throws', async () => {
+			await expect(
+				client.tool({
+					token: pipelineToken,
+					tool: 'nonexistent_tool',
+					nodeId: 'tool_python_1',
+					input: {},
+				}),
+			).rejects.toThrow();
+		}, TEST_CONFIG.timeout);
+	});
+
+	// ------------------------------------------------------------------
+	// DataPipe.tool() -- reuses an already-open pipe
+	// ------------------------------------------------------------------
+
+	describe('pipe-bound DataPipe.tool()', () => {
+		it('executes python using open pipe', async () => {
+			const pipe = await client.pipe(pipelineToken, {}, 'text/plain');
+			await pipe.open();
+
+			const result = await pipe.tool<{
+				exit_code: number;
+				result: number[];
+			}>('execute', 'tool_python_1', { code: 'result = list(range(5))' });
+
+			expect(result).toBeDefined();
+			expect(result.exit_code).toBe(0);
+			expect(result.result).toEqual([0, 1, 2, 3, 4]);
+
+			await pipe.close();
+		}, TEST_CONFIG.timeout);
+
+		it('before open throws', async () => {
+			const pipe = await client.pipe(pipelineToken, {}, 'text/plain');
+
+			await expect(
+				pipe.tool('execute', 'tool_python_1', { code: 'pass' }),
+			).rejects.toThrow('not open');
+		}, TEST_CONFIG.timeout);
+	});
+});


### PR DESCRIPTION
## Summary

- Add a `tool` DAP subcommand to `rrext_process` that lets SDK callers invoke any `@tool_function` on any node in a running pipeline directly -- no Question/Answer/SSE overhead
- Remove `QuestionType.EXECUTE` and `DIALECT`, replace with `@tool_function` methods (`execute`, `dialect`) on database nodes
- Add `list` and `stats` tools to vector store nodes
- Add `client.tool()` and `DataPipe.tool()` to both Python and TypeScript SDKs
- Fix pre-existing bug where the mid-tier DAP proxy silently swallowed subprocess errors
- Skip `nodes:docs-generate` on non-develop branches to prevent 100+ README file changes in diffs

## Usage example

```python
# Start a pipeline with a vector store node
result = await client.use(pipeline=my_rag_pipeline, token='my-token')
token = result['token']

# Get document count and collection stats
stats = await client.tool(token=token, tool='stats', node_id='qdrant_1')
print(f"Documents: {stats['count']}, Model: {stats['model']}, Dimensions: {stats['vector_size']}")

# List stored document paths
paths = await client.tool(token=token, tool='list', node_id='qdrant_1')
print(f"Paths: {paths['paths']}")

# Search directly
results = await client.tool(
    token=token,
    tool='search',
    node_id='qdrant_1',
    input={'query': 'revenue growth', 'top_k': 5},
)

# Execute SQL on a database node
rows = await client.tool(
    token=token,
    tool='execute',
    node_id='postgres_1',
    input={'sql': 'SELECT count(*) FROM users'},
)

# Same thing via the DatabaseApi convenience wrapper
rows = await client.database.query(token=token, sql='SELECT count(*) FROM users')
```

```typescript
// TypeScript equivalent
const stats = await client.tool<{ count: number; model: string; vector_size: number }>({
    token,
    tool: 'stats',
    nodeId: 'qdrant_1',
});
console.log(`Documents: ${stats.count}, Model: ${stats.model}`);

// Pipe-bound: reuse an open pipe for multiple tool calls
const pipe = await client.pipe(token, {}, 'text/plain');
await pipe.open();

const paths = await pipe.tool('list', 'qdrant_1');
const searchResults = await pipe.tool('search', 'qdrant_1', { query: 'revenue', top_k: 5 });

await pipe.close();
```

## Architecture

The `tool` subcommand walks the pipe's filter chain via `IServiceFilterInstance.next` to locate the target node by component ID, then calls `node.pyInstance.invoke(param)` directly. This bypasses the C++ `cb_control` dispatcher (which requires controller map entries that are scoped to control bindings, not available from the data connection layer) and instead invokes `IInstanceBase.invoke()` -> `_dispatch_tool()` -- the same code path agents use internally.

Two SDK entry points:
- **Standalone** `client.tool(token, tool, node_id, input)` -- server borrows a pipe from the pool
- **Pipe-bound** `pipe.tool(tool, node_id, input)` -- reuses the caller's open pipe via `pipe_id`

## Files changed

| Area | Files | What |
|------|-------|------|
| Server | `data_conn.py` | `tool` subcommand + `_tool()` handler |
| Server | `task_engine.py` | `_send_data()` now raises on subprocess `success: False` |
| Server | `cmd_data.py` | Comment update (error propagation now handled by `_send_data`) |
| Server | `cmd_cprofile.py` | Same |
| Server | `store.py` | `list` + `stats` `@tool_function` on VectorStoreToolMixin |
| Server | `db_instance_base.py` | `execute` + `dialect` `@tool_function`, removed EXECUTE/DIALECT from writeQuestions |
| Server | `db_global_base.py` | Comment update |
| Python SDK | `client.py` | Standalone `tool()` method |
| Python SDK | `data.py` | `DataPipe.tool()` pipe-bound method |
| Python SDK | `database.py` | Rewritten to use `client.tool()` internally |
| Python SDK | `question.py` | Removed EXECUTE/DIALECT from QuestionType enum |
| TS SDK | `client.ts` | Standalone `tool()` + `DataPipe.tool()` |
| TS SDK | `database.ts` | Rewritten to use `client.tool()` internally |
| TS SDK | `Question.ts` | Removed EXECUTE/DIALECT from QuestionType enum |
| Tests | `test_tool.py`, `tool.test.ts` | Integration tests (Python + TS) |
| Tests | `tool_pipeline.py`, `tool.pipeline.ts` | Pipeline fixtures |
| Tests | `conftest.py` | Shared test config + fixtures |
| Tests | `test_vectordb_tool_mixin.py` | Updated assertions for new list/stats tools |
| Build | `gen-node-tables.mjs` | Skip on non-develop branches |

## Test plan

- [x] Python: `builder client-python:test` -- 83 passed
- [x] TypeScript: `builder client-typescript:test` -- all passed
- [x] Nodes: `builder nodes:test --pytest="-k test_collect_tool_methods"` -- 3 passed
- [ ] Full CI

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direct tool invocation APIs (`tool()`), including pipeline-bound tool execution.
  * Enabled tool routing via the data connection using a `tool` subcommand.
  * Added vectordb controls: `list` (with pagination) and `stats` (collection stats).
  * Updated database operations to run raw SQL/Cypher and fetch dialect via tool calls.

* **Bug Fixes**
  * Improved error propagation for failed data-channel requests.

* **Tests**
  * Added integration coverage for `tool()` and tool-bound pipe behavior.

* **Breaking Changes**
  * Removed `EXECUTE` and `DIALECT` question types; use tool-based database APIs instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->