### PR TITLE
fix(canvas): pipeline render-loop fix + sidebar logo home nav

### DIFF
--- a/apps/shell-ui/src/components/layout/Sidebar.tsx
+++ b/apps/shell-ui/src/components/layout/Sidebar.tsx
@@ -459,14 +459,23 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 					</button>
 				) : (
 					<>
-						<div style={{ display: 'flex', flex: 1, minWidth: 0 }}>
+						<button
+							title="Go to home"
+							aria-label="Go to home"
+							onClick={() => ConnectionManager.getInstance().emit('shell:switchApp', { appId: 'rocketride.home' })}
+							onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--rr-bg-list-hover, var(--rr-bg-surface-alt))'; }}
+							onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+							style={{ display: 'flex', flex: 1, minWidth: 0, alignItems: 'center', padding: '2px 4px', borderRadius: 6, border: 'none', background: 'transparent', cursor: 'pointer', font: 'inherit', color: 'inherit', textAlign: 'left', transition: 'background 120ms ease' }}
+						>
 							<AppSwitcherButton collapsed={collapsed} />
-						</div>
+						</button>
 						<button
 							title="Collapse sidebar"
 							aria-label="Collapse sidebar"
 							onClick={toggleCollapse}
-							style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 28, height: 28, borderRadius: 6, border: 'none', cursor: 'pointer', background: 'transparent', color: 'var(--rr-text-secondary)', flexShrink: 0 }}
+							onMouseEnter={(e) => { e.currentTarget.style.background = 'var(--rr-bg-list-hover, var(--rr-bg-surface-alt))'; }}
+							onMouseLeave={(e) => { e.currentTarget.style.background = 'transparent'; }}
+							style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', width: 28, height: 28, borderRadius: 6, border: 'none', cursor: 'pointer', background: 'transparent', color: 'var(--rr-text-secondary)', flexShrink: 0, transition: 'background 120ms ease' }}
 						>
 							<BxDockLeft size={18} />
 						</button>

--- a/packages/shared-ui/src/components/canvas/components/FlowCanvas.tsx
+++ b/packages/shared-ui/src/components/canvas/components/FlowCanvas.tsx
@@ -34,7 +34,7 @@
  *   - Applies navigation mode (pan vs lasso-select) and lock state
  */
 
-import { ReactElement, useCallback, useEffect, useId, useRef, useState } from 'react';
+import { ReactElement, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { ReactFlow, Background, SelectionMode, useReactFlow } from '@xyflow/react';
 import { Settings } from 'lucide-react';
 import '@xyflow/react/dist/style.css';
@@ -291,6 +291,16 @@ export default function Canvas(): ReactElement {
 	const editable = !isLocked;
 	const isPanMode = navigationMode === NavigationMode.DRAG;
 
+	// Stable snapGrid reference. `projectLayout` can be rebuilt with a fresh
+	// snapGridSize array even when the values are unchanged; passing that array
+	// straight to <ReactFlow> makes StoreUpdater re-sync the store every render →
+	// "Maximum update depth exceeded". Memoizing on the actual numbers keeps the
+	// array reference stable until a value really changes.
+	const snapGrid = useMemo<[number, number]>(
+		() => (projectLayout.snapGridSize as [number, number] | undefined) ?? DEFAULT_SNAP_GRID,
+		[projectLayout.snapGridSize?.[0], projectLayout.snapGridSize?.[1]]
+	);
+
 	// --- Annotation shortcut -----------------------------------------------
 	const addAnnotation = useCallback(() => {
 		addNode(
@@ -447,7 +457,7 @@ export default function Canvas(): ReactElement {
 				defaultViewport={DEFAULT_VIEWPORT}
 				proOptions={PRO_OPTIONS}
 				snapToGrid={projectLayout.snapToGrid ?? true}
-				snapGrid={projectLayout.snapGridSize ?? DEFAULT_SNAP_GRID}
+				snapGrid={snapGrid}
 			>
 				<Background color="var(--rr-text-disabled)" gap={20} style={{ backgroundColor: 'var(--rr-bg-default)' }} />
 			</ReactFlow>

--- a/packages/shared-ui/src/components/canvas/context/FlowGraphContext.tsx
+++ b/packages/shared-ui/src/components/canvas/context/FlowGraphContext.tsx
@@ -271,6 +271,23 @@ export interface IFlowGraphProviderProps {
 }
 
 // =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Stable signature of a project's component content, used to detect echoes of
+ * our own changes independently of docRevision. Two projects with identical
+ * components produce identical signatures regardless of version number.
+ */
+function projectContentSig(project?: { components?: unknown } | null): string {
+	try {
+		return JSON.stringify(project?.components ?? []);
+	} catch {
+		return ' nosig';
+	}
+}
+
+// =============================================================================
 // Provider
 // =============================================================================
 
@@ -305,6 +322,9 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 	const lastSentVersion = useRef(-1);
 	/** The project_id we last loaded — used to bypass echo-detection when project identity changes. */
 	const lastLoadedProjectId = useRef<string | undefined>(undefined);
+	/** Content signature of the components currently on the canvas. Echoes of our
+	 *  own edits share this signature and must NOT trigger a reload. */
+	const loadedContentSig = useRef<string>('');
 
 	// --- Derived state -----------------------------------------------------
 
@@ -383,6 +403,9 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 			// Remove viewport from content — it's a user preference, not document content
 			delete (project as any).viewport;
 			lastSentVersion.current = nextVersion;
+			// Register the content we're about to send so its echo (which round-trips
+			// back as currentProject) is recognized and does NOT trigger a reload.
+			loadedContentSig.current = projectContentSig(project);
 			onContentChanged(project);
 		}, 50);
 	}, [onContentChanged, patchToolchainState]);
@@ -402,7 +425,6 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		(changes: NodeChange<FlowNode>[]) => {
 			if (isLocked) return;
 
-			const types = changes.map((c) => c.type);
 			const structural = changes.some((c) => c.type === 'add' || c.type === 'remove');
 			if (structural) {
 				onContentUpdated();
@@ -960,12 +982,21 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		if (!currentProject) return;
 
 		const projectChanged = incomingProjectId !== lastLoadedProjectId.current;
+		const incomingSig = projectContentSig(currentProject);
 
-		// Skip if this is an echo of our own change — but always load when project identity changes
-		if (!projectChanged && incomingVersion === lastSentVersion.current) {
+		// Skip echoes of our own content. We compare component CONTENT rather than
+		// docRevision: rapid edits produce several in-flight versions whose echoes
+		// arrive with docRevisions that never equal our latest lastSentVersion, so a
+		// version-equality guard re-ran loadData on every stale echo — and each load
+		// re-emitted content, bumping the version again: an infinite reload loop that
+		// wiped node measurements (setFlowReady thrash) and ended in "Maximum update
+		// depth exceeded". Content comparison converges; undo/redo still loads because
+		// its content differs from what's currently on the canvas.
+		if (!projectChanged && incomingSig === loadedContentSig.current) {
 			return;
 		}
 
+		loadedContentSig.current = incomingSig;
 		lastSentVersion.current = incomingVersion;
 		lastLoadedProjectId.current = incomingProjectId;
 		const unconfigured = loadData(currentProject);
@@ -1031,6 +1062,20 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		if (!isFlowReady) return;
 
 		const pending = pendingViewportRef.current;
+
+		// Only do work when a viewport restore is actually queued (loadData sets
+		// pendingViewportRef right after a structural load). Previously
+		// updateNodeInternals + the viewport restore ran on EVERY isFlowReady→true
+		// transition. Because updateNodeInternals perturbs node measurements, that
+		// flipped isFlowReady back to false and re-entered this effect — a feedback
+		// loop that runs away to "Maximum update depth exceeded" once the canvas has
+		// nodes to re-measure (reproducible via add → delete → add). With nothing
+		// pending there is nothing to restore, so we clear the loading guard and bail
+		// instead of needlessly re-scanning every node's internals.
+		if (!pending) {
+			isLoadingRef.current = false;
+			return;
+		}
 		pendingViewportRef.current = null;
 
 		// Force ReactFlow to re-scan all handle positions so edges that loaded
@@ -1040,10 +1085,9 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 			updateNodeInternals(nodeIds);
 		}
 
-
 		if (pending === 'fitView') {
 			fitView({ padding: 0.15, duration: 0 });
-		} else if (pending) {
+		} else {
 			setViewport(pending, { duration: 0 });
 		}
 

--- a/packages/shared-ui/src/components/canvas/context/FlowPreferencesContext.tsx
+++ b/packages/shared-ui/src/components/canvas/context/FlowPreferencesContext.tsx
@@ -38,7 +38,7 @@
  * are not persisted.
  */
 
-import { createContext, ReactElement, ReactNode, useCallback, useContext, useEffect, useState } from 'react';
+import { createContext, ReactElement, ReactNode, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 import { IProjectLayout, ICanvasPreferences } from '../types';
 
@@ -211,19 +211,26 @@ export function FlowPreferencesProvider({ children, projectId, getPreference: ho
 		updateProjectLayout({ isLocked: !internalIsLocked });
 	}, [isReadonly, updateProjectLayout, internalIsLocked]);
 
-	// --- Context value (stable references via useCallback) -----------------
+	// --- Context value -----------------------------------------------------
+	// Memoized so consumers (notably Canvas → <ReactFlow>) don't re-render on
+	// every provider render. An unmemoized value here made the canvas re-render
+	// continuously, feeding React Flow's StoreUpdater and amplifying the
+	// measurement feedback loop into "Maximum update depth exceeded".
 
-	const value: IFlowPreferencesContext = {
-		navigationMode,
-		setNavigationMode,
-		isReadonly,
-		isLocked,
-		toggleLock,
-		projectLayout,
-		updateProjectLayout,
-		getPreference,
-		setPreference,
-	};
+	const value = useMemo<IFlowPreferencesContext>(
+		() => ({
+			navigationMode,
+			setNavigationMode,
+			isReadonly,
+			isLocked,
+			toggleLock,
+			projectLayout,
+			updateProjectLayout,
+			getPreference,
+			setPreference,
+		}),
+		[navigationMode, setNavigationMode, isReadonly, isLocked, toggleLock, projectLayout, updateProjectLayout, getPreference, setPreference]
+	);
 
 	return <FlowPreferencesContext.Provider value={value}>{children}</FlowPreferencesContext.Provider>;
 }


### PR DESCRIPTION
## Summary
Two changes to the shared canvas/shell:

### 1. `fix(canvas)` — break the infinite render loop when editing pipelines
Editing the pipeline canvas (add → delete → add, with multiple pipelines open) could spin into **"Maximum update depth exceeded"**.

**Root cause:** the canvas load effect compared `docRevision` to detect echoes of its own edits. Rapid edits produce several in-flight 50ms saves whose echoes come back with `docRevision`s that never equal the *latest* sent version, so the guard missed them, `loadData` re-ran on every stale echo, each load re-emitted content (bumping the version again) and wiped node measurements — thrashing `isFlowReady` until React's recursion limit.

**Fix:**
- **FlowGraphContext** — detect echoes by **component-content signature** instead of `docRevision` (converges regardless of version races; undo/redo still loads because its content differs). Gate the viewport-restore effect on a *pending* viewport so `updateNodeInternals` no longer re-scans every node on each `isFlowReady` transition.
- **FlowPreferencesContext** — memoize the context value (it was re-rendering the whole canvas every provider render, feeding React Flow's `StoreUpdater`).
- **FlowCanvas** — memoize the `snapGrid` array so an unchanged value doesn't hand `<ReactFlow>` a fresh reference each render.

### 2. `feat(shell-ui)` — sidebar logo navigates home
The RocketRide wordmark in the sidebar header is now a button that switches to the home app, with hover shading on both it and the collapse toggle so each clickable region is distinct.

## Why this never hit the VS Code host
The VS Code extension uses the `TextDocument` as the source of truth and dedups on content-equality before writing, with no `docRevision` echo — so the canvas's version-keyed reload path stays dormant there. This fix lifts that same content-equality guarantee into shared-ui so the canvas is robust under either host.

## Test plan
- Open several pipelines, rapidly add/delete/add nodes, switch files — no crash, no runaway re-renders.
- Undo/redo still reloads correctly.
- Click the sidebar logo → switches to the home app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Go to home" button to the sidebar header for quick navigation.

* **Bug Fixes**
  * Fixed unnecessary project reloads when receiving echoed updates.
  * Resolved infinite loop issue in viewport restoration.

* **Performance**
  * Enhanced rendering efficiency across canvas and preferences components through optimized memoization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->