### PR TITLE
feat(shared-ui): add variable picker affordance to config fields

### DIFF
--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/api-key-widget/ApiKeyWidget.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/api-key-widget/ApiKeyWidget.tsx
@@ -23,7 +23,7 @@
 
 import { useEffect, useRef, useState, useCallback, KeyboardEvent, FC } from 'react';
 import { WidgetProps } from '@rjsf/utils';
-import { InputAdornment, TextField, Tooltip } from '@mui/material';
+import { IconButton, InputAdornment, TextField, Tooltip } from '@mui/material';
 import { Delete } from '@mui/icons-material';
 import { useTranslation } from 'react-i18next';
 
@@ -110,6 +110,18 @@ const ApiKeyWidget: FC<WidgetProps> = ({ id, value, label, required, autofocus, 
 		[autocomplete, onEnvVarSelect],
 	);
 
+	// Open the full variable list from the picker button (no `${` typing needed).
+	const handleOpenPicker = useCallback(() => {
+		const el = inputRef.current;
+		if (!el) return;
+		el.focus();
+		autocomplete.openAll(el, el.selectionStart ?? String(tempValue ?? '').length);
+	}, [autocomplete, tempValue]);
+
+	// Only offer the picker while the field is editable (an existing key is masked
+	// + read-only; the user clears it via the trash button before entering a new one).
+	const showVarPicker = envKeys.length > 0 && !disabled && !readonly && !maskApiKey;
+
 	// When in masked mode, scroll the input to the end so the visible trailing characters are shown
 	useEffect(() => {
 		if (inputRef.current && maskApiKey) {
@@ -147,7 +159,7 @@ const ApiKeyWidget: FC<WidgetProps> = ({ id, value, label, required, autofocus, 
 				slotProps={{
 					input: {
 						readOnly: maskApiKey || readonly,
-						endAdornment: maskApiKey && !readonly && (
+						endAdornment: maskApiKey && !readonly ? (
 							<InputAdornment position="end">
 								<Tooltip title={t('form.apiKeyRemoveTooltip')}>
 									<Delete
@@ -167,7 +179,21 @@ const ApiKeyWidget: FC<WidgetProps> = ({ id, value, label, required, autofocus, 
 									/>
 								</Tooltip>
 							</InputAdornment>
-						),
+						) : showVarPicker ? (
+							<InputAdornment position="end">
+								<IconButton
+									size="small"
+									edge="end"
+									tabIndex={-1}
+									aria-label="Insert variable"
+									title="Insert variable"
+									onClick={handleOpenPicker}
+									sx={{ fontSize: 13, fontFamily: 'var(--rr-font-family-widget, monospace)', color: 'var(--rr-text-secondary)', px: 0.5 }}
+								>
+									{'${}'}
+								</IconButton>
+							</InputAdornment>
+						) : undefined,
 					},
 				}}
 			/>

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/base-input-template/BaseInputTemplate.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/base-input-template/BaseInputTemplate.tsx
@@ -23,6 +23,8 @@
 
 import { ChangeEvent, FocusEvent, useState, useEffect, useCallback, useRef, KeyboardEvent } from 'react';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
 import { ariaDescribedByIds, BaseInputTemplateProps, examplesId, getInputProps, labelValue, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 
 import { useEnvVarAutocomplete } from '../hooks/useEnvVarAutocomplete';
@@ -125,6 +127,16 @@ export default function BaseInputTemplate<
 		[autocomplete, onEnvVarSelect],
 	);
 
+	// Open the full variable list from the picker button (no `${` typing needed).
+	const handleOpenPicker = useCallback(() => {
+		const el = inputRef.current;
+		if (!el) return;
+		el.focus();
+		autocomplete.openAll(el, el.selectionStart ?? String(controlledValue ?? '').length);
+	}, [autocomplete, controlledValue]);
+
+	const showVarPicker = envKeys.length > 0 && !disabled && !readonly;
+
 	// Sync controlled value when the form re-renders with a new prop value (e.g., reset or external update)
 	useEffect(() => {
 		if (value !== undefined && value !== null) {
@@ -195,6 +207,27 @@ export default function BaseInputTemplate<
 				inputRef={inputRef}
 				InputLabelProps={DisplayInputLabelProps}
 				{...(textFieldProps as TextFieldProps)}
+				InputProps={{
+					...(textFieldProps as TextFieldProps).InputProps,
+					endAdornment: showVarPicker ? (
+						<InputAdornment position="end">
+							<IconButton
+								size="small"
+								edge="end"
+								tabIndex={-1}
+								aria-label="Insert variable"
+								title="Insert variable"
+								onClick={handleOpenPicker}
+								sx={{ fontSize: 13, fontFamily: 'var(--rr-font-family-widget, monospace)', color: 'var(--rr-text-secondary)', px: 0.5 }}
+							>
+								{'${}'}
+							</IconButton>
+							{(textFieldProps as TextFieldProps).InputProps?.endAdornment}
+						</InputAdornment>
+					) : (
+						(textFieldProps as TextFieldProps).InputProps?.endAdornment
+					),
+				}}
 				sx={{
 					...sx,
 					'& input[type="number"]::-webkit-outer-spin-button, & input[type="number"]::-webkit-inner-spin-button': {

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.ts
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.ts
@@ -19,6 +19,8 @@ export interface UseEnvVarAutocompleteResult {
 	anchorEl: HTMLElement | null;
 	/** Called on every input change to detect the `${` trigger. Pass the value and cursor position directly from the event target. */
 	handleInputChange: (value: string, cursorPos: number, anchorElement: HTMLElement | null) => void;
+	/** Opens the full list of available keys (no `${` needed), inserting at `cursorPos` on select. Used by the explicit picker button. */
+	openAll: (anchorElement: HTMLElement | null, cursorPos: number) => void;
 	/** Called when the user selects a suggestion. Returns the new field value. */
 	handleSelect: (key: string, currentValue: string, inputEl: HTMLInputElement | HTMLTextAreaElement | null) => string;
 	/** Dismisses the popover. */
@@ -110,6 +112,21 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 		[],
 	);
 
+	const openAll = useCallback(
+		(anchorElement: HTMLElement | null, cursorPos: number) => {
+			if (!anchorElement || !envKeys.length) return;
+			// No `${` was typed — insert at the current cursor position. handleSelect
+			// replaces from triggerStart to the cursor, so a zero-width range there
+			// just inserts `${KEY}` without clobbering surrounding text.
+			triggerStartRef.current = cursorPos;
+			setSuggestions(envKeys);
+			setAnchorEl(anchorElement);
+			setHighlightedIndex(0);
+			setIsOpen(true);
+		},
+		[envKeys],
+	);
+
 	const handleDismiss = useCallback(() => {
 		setIsOpen(false);
 	}, []);
@@ -124,5 +141,5 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 		[suggestions.length],
 	);
 
-	return { isOpen, suggestions, anchorEl, handleInputChange, handleSelect, handleDismiss, highlightedIndex, moveHighlight };
+	return { isOpen, suggestions, anchorEl, handleInputChange, openAll, handleSelect, handleDismiss, highlightedIndex, moveHighlight };
 }

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/textarea-widget/TextareaWidget.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/textarea-widget/TextareaWidget.tsx
@@ -6,6 +6,8 @@
 
 import { ChangeEvent, FocusEvent, useState, useEffect, useCallback, useRef, KeyboardEvent, FC } from 'react';
 import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
 import { WidgetProps } from '@rjsf/utils';
 
 import { useEnvVarAutocomplete } from '../hooks/useEnvVarAutocomplete';
@@ -40,6 +42,16 @@ const TextareaWidget: FC<WidgetProps> = ({ id, value, label, required, autofocus
 		},
 		[autocomplete, controlledValue, onChange, options.emptyValue],
 	);
+
+	// Open the full variable list from the picker button (no `${` typing needed).
+	const handleOpenPicker = useCallback(() => {
+		const el = inputRef.current;
+		if (!el) return;
+		el.focus();
+		autocomplete.openAll(el, el.selectionStart ?? String(controlledValue ?? '').length);
+	}, [autocomplete, controlledValue]);
+
+	const showVarPicker = envKeys.length > 0 && !disabled && !readonly;
 
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -90,6 +102,27 @@ const TextareaWidget: FC<WidgetProps> = ({ id, value, label, required, autofocus
 				disabled={disabled || readonly}
 				error={!!rawErrors?.length}
 				variant="outlined"
+				InputProps={
+					showVarPicker
+						? {
+								endAdornment: (
+									<InputAdornment position="end" sx={{ alignItems: 'flex-start', mt: 1 }}>
+										<IconButton
+											size="small"
+											edge="end"
+											tabIndex={-1}
+											aria-label="Insert variable"
+											title="Insert variable"
+											onClick={handleOpenPicker}
+											sx={{ fontSize: 13, fontFamily: 'var(--rr-font-family-widget, monospace)', color: 'var(--rr-text-secondary)', px: 0.5 }}
+										>
+											{'${}'}
+										</IconButton>
+									</InputAdornment>
+								),
+							}
+						: undefined
+				}
 				InputLabelProps={{ shrink: true }}
 				helperText={typeof options?.description === 'string' ? options.description : schema?.description}
 			/>


### PR DESCRIPTION
## Summary

- Make Variables discoverable: add a small `${}` button to the config field widgets (`BaseInputTemplate`, `TextareaWidget`) that opens the list of saved variables — no need to know the `${...}` syntax or `ROCKETRIDE_` prefix.
- Selecting one inserts `${ROCKETRIDE_NAME}` at the cursor, reusing the existing suggestion list and insert logic (new `openAll` on `useEnvVarAutocomplete`).
- Shown only when variables exist (`envKeys`) and the field is editable. Works in web and VS Code (shared widgets).

## Type

feat

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

<!-- TSX syntax validated; needs a visual check: open a component config, click the ${} button, pick a variable, confirm ${ROCKETRIDE_NAME} is inserted. -->

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1275

<!-- Follow-up (separate PR): inline "save new variable" from the field (mini-modal, User/Team scope, prefix hidden) — needs host wiring of client.account.setEnv in rocket-ui and the VS Code provider. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added environment variable picker buttons to text input and textarea fields. Users can now quickly access the full list of available variables with a single click when the fields are editable and variables are configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->