### PR TITLE
fix(engine): pass uv --excludes relative to cwd so spaced install paths resolve

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -775,7 +775,10 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
     if not os.path.exists(excludes_path):
         with open(excludes_path, 'w', encoding='utf-8') as f:
             f.write('uv\n')
-    args.extend(['--excludes', excludes_path])
+    # uv splits --excludes on whitespace, so an absolute path with a space (macOS
+    # "Application Support") breaks resolution; pass it relative to the cwd (exe_dir).
+    # -c is parsed as a single value and is unaffected. See #1256.
+    args.extend(['--excludes', os.path.relpath(excludes_path, exe_dir)])
 
     # Only add constraints if the file exists and has content
     if os.path.exists(constraints_path) and os.path.getsize(constraints_path) > 0:
@@ -882,7 +885,8 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
     if not os.path.exists(excludes_path):
         with open(excludes_path, 'w', encoding='utf-8') as f:
             f.write('uv\n')
-    uv_args.extend(['--excludes', excludes_path])
+    # Relative to cwd (exe_dir) — see the --excludes note in _install_dry_run (#1256).
+    uv_args.extend(['--excludes', os.path.relpath(excludes_path, exe_dir)])
 
     if os.path.exists(constraints_path) and os.path.getsize(constraints_path) > 0:
         uv_args.extend(['-c', _get_constraints_path()])


### PR DESCRIPTION
## Summary

- `uv` parses `--excludes` as a whitespace-separated list of files, so the absolute
  cache path passed to it (`~/Library/Application Support/RocketRide/engine/cache/excludes.txt`)
  is split at the space in "Application Support" and resolution fails with
  `error: File not found: /Users/$USER/Library/Application`. This crash-loops local mode
  on macOS on the v3.3.0-prerelease engine (the `--excludes` flag was added in #1196).
- Both bootstrap subprocesses (`_install_dry_run`, `_install_requirements_inner`) already
  run with `cwd=exe_dir`, and `engine_cache_dir()` is always `exe_dir/cache`, so the
  excludes file is now passed **relative to the cwd** (`cache/excludes.txt`) — no absolute
  path, no space for uv to split.
- The `-c` constraints arg uses the same absolute path but uv parses it as a single value
  (not whitespace-split), so it works as-is and is left unchanged.

## Type

fix

## Testing

- [ ] Tests added or updated — `depends.py` has no unit harness in `rocketlib-python`;
      happy to add a regression test if you can point me at the right place for bootstrap tests.
- [ ] Tested locally
- [ ] `./builder test` passes

Verification:
- `python -m py_compile` clean.
- Confirmed root cause + fix by simulation against the reported macOS path:
  - old: `…/Library/Application Support/…/cache/excludes.txt` -> uv splits ->
    `['…/Library/Application', 'Support/…/excludes.txt']` (the reported `File not found: …/Application`).
  - new: `os.path.relpath(excludes_path, exe_dir)` -> `cache/excludes.txt` -> single token, no space.
- Matches the fix @charliegillet verified locally in #1256; implemented via `os.path.relpath`
  off `engine_cache_dir()` rather than a hardcoded string, so it stays correct if the cache
  layout changes and on Windows (`cache\excludes.txt`).

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — N/A
- [x] Breaking changes documented (if applicable) — none (bootstrap arg fix only)

## Linked Issue

Fixes #1256