### PR TITLE
fix(shell-ui): force prompt=login on web sign-in so users can switch accounts

### DIFF
--- a/apps/shell-ui/src/util/pkce.ts
+++ b/apps/shell-ui/src/util/pkce.ts
@@ -184,9 +184,10 @@ export function buildAuthUrl(
         code_challenge_method: 'S256',
     });
 
-    // When the caller requests registration mode, set the `prompt=create` hint
-    // so Zitadel presents the sign-up form rather than the sign-in form.
+    // register -> sign-up form; otherwise force the login UI (prompt=login) so
+    // Zitadel never silently reuses its SSO session and blocks switching accounts.
     if (register) params.set('prompt', 'create');
+    else params.set('prompt', 'login');
 
     // Strip any trailing slash from the base URL before appending the path
     // to avoid a double-slash in the resulting URL.


### PR DESCRIPTION
## Summary

- `buildAuthUrl` (`apps/shell-ui/src/util/pkce.ts`) now sends `prompt=login` for normal web sign-in (registration still uses `prompt=create`).
- Without a `prompt`, Zitadel silently reused its SSO cookie and returned a code without showing the login UI, locking the browser to one account — clearing site data did not help (the IdP cookie lives on the `auth.rocketride.ai` domain, not the app origin).
- With `prompt=login` the Zitadel login screen (`/ui/v2/login/loginname`) always appears, so a different account can sign in.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

> Manual: sign in as account A → sign out / clear site data → sign in again now lands on the Zitadel login UI and allows selecting a different account B (previously auto-returned as A). Registration flow (`prompt=create`) unchanged.

## Risks & compatibility

- Trade-off: web sign-in no longer relies on silent SSO, so users authenticate through the Zitadel login screen each sign-in (no impact during an active session — only at sign-in). This is the intended behavior to unblock account switching.
- Scope limited to the web flow. The backend DAP/VS Code authorize (`extension/saas/zitadel_auth.py:build_auth_url`) is intentionally left unchanged to avoid forcing re-auth on VS Code connects; tracked as a follow-up in #1281.
- No fallback/migration concerns: pure client-side OAuth request param, no persisted state or schema change.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1281

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth authentication now explicitly specifies the authentication action required. When signing up, users are prompted to create a new account. When logging in, users are prompted to authenticate with an existing account. This provides clearer guidance and ensures consistent behavior across both authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->