### PR TITLE
fix(vscode): bake dedicated NATIVE Zitadel app client_id for cloud login (#89)

### DIFF
--- a/.config
+++ b/.config
@@ -41,7 +41,7 @@ RR_ZITADEL_CLIENT_ID=368801673541427525
 # Separate from the web client because Native apps use custom URI schemes
 # (vscode://) for the OAuth redirect, which requires its own registration.
 # How to get: same as above, but create an application of type "Native".
-RR_ZITADEL_VSCODE_CLIENT_ID=369956598501709684
+RR_ZITADEL_VSCODE_CLIENT_ID=377584852486102870
 
 # =============================================================================
 # STRIPE (Payments)


### PR DESCRIPTION
## What
`.config`: `RR_ZITADEL_VSCODE_CLIENT_ID` `369956598501709684` → **`377584852486102870`**.

## Why
The prior client (`369956598501709684`) is a **Login V1** app — it completes `vscode://` but forces the passkey screen with no password fallback, so users without a passkey are locked out (the same trap that hit web). `377584852486102870` is a **dedicated NATIVE app on Login V2** with the `vscode://` / `vscode-insiders://` / `cursor://` / `windsurf://` redirect schemes registered (terraform `saas/04-addons/zitadel-app-vscode.tf`).

## Verified
End-to-end: a Cursor build using this client_id signs into RocketRide Cloud successfully (Ariel, 2026-06-15). Authorize for all four editor schemes returns 302 → V2 login.

Once merged, this flows through `_build` (esbuild bakes the value) → `_release` (`vsce publish` + `ovsx publish`) so the published extension carries the fix — no `.env` override needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated authentication configuration for the VS Code extension to maintain service compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->