### PR TITLE
fix(docker): provision /opt/data and use /version for healthcheck

### DIFF
--- a/docker/Dockerfile.engine
+++ b/docker/Dockerfile.engine
@@ -22,13 +22,19 @@ RUN apt-get update \
 
 COPY --chown=rocketride:rocketride dist/server/ /opt/rocketride/
 
+# Engine writes runtime data to /opt/data; create it writable for the
+# non-root user (root owns /opt) and persist it. See #1295.
+RUN mkdir -p /opt/data && chown -R rocketride:rocketride /opt/data
+VOLUME /opt/data
+
 WORKDIR /opt/rocketride
 
 USER rocketride
 
 EXPOSE 5565
 
+# /version is public; /ping returns 401 behind the auth gate. See #1295.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-    CMD curl -f http://localhost:5565/ping || exit 1
+    CMD curl -f http://localhost:5565/version || exit 1
 
 ENTRYPOINT ["./engine", "./ai/eaas.py", "--host=0.0.0.0"]


### PR DESCRIPTION
## Summary

- Create `/opt/data` owned by the non-root `rocketride` user (and declare it a `VOLUME`) so the engine can write runtime/task data there — pipeline runs were failing with `[Errno 13] Permission denied: '/opt/data'`.
- Switch the container healthcheck from `/ping` (returns `401` behind the auth gate → container stuck `unhealthy` even while serving) to the public `/version` endpoint.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Verified on a fresh container built from `…:3.3.0-prerelease` with both changes applied: `/opt/data` is writable by `rocketride`, pipeline runs get past the permission error, `/version` returns `200`, and the container transitions to `healthy`. (Image-only Dockerfile change; no engine/Python/TS code touched, so `./builder test` is N/A.)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none

## Linked Issue

Fixes #1295

---

Follow-ups tracked in #1295 (out of scope here): the engine-side reason `/ping` (`public=True`) still returns `401`, and the transient `download.pytorch.org` `503` crashing the dependency bootstrap on boot.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Data persistence: Runtime/task data is now stored in a dedicated writable directory and persisted across container recreation.
  * Health monitoring: Updated the container health check to use the unauthenticated version endpoint, improving status detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->