### PR TITLE
fix(shell-ui): logout flow + guest overlays, monitor branding

### DIFF
--- a/apps/monitor-ui/src/AppDescriptor.ts
+++ b/apps/monitor-ui/src/AppDescriptor.ts
@@ -24,9 +24,11 @@
 // MONITOR-UI — App Descriptor
 // =============================================================================
 
+import React from 'react';
 import type { AppDescriptor } from 'shell-ui';
 import MonitorApp from './MonitorApp';
 import MonitorSidebar from './MonitorSidebar';
+import RocketRideMark from './RocketRideMark';
 
 /**
  * AppDescriptor for the Server Monitor app.
@@ -39,6 +41,8 @@ const MONITOR_APP: AppDescriptor = {
 	name: 'Server Monitor',
 	branding: {
 		appName: 'Server Monitor',
+		iconDark: React.createElement(RocketRideMark, { bodyColor: '#E0DDF0' }),
+		iconLight: React.createElement(RocketRideMark, { bodyColor: '#1E1A34' }),
 	},
 	components: {
 		App: MonitorApp,

--- a/apps/monitor-ui/src/RocketRideMark.tsx
+++ b/apps/monitor-ui/src/RocketRideMark.tsx
@@ -1,0 +1,46 @@
+// MIT License
+//
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// =============================================================================
+// ROCKETRIDE MARK — branded sidebar logo for the Server Monitor app
+// =============================================================================
+
+import React from 'react';
+
+/**
+ * The RocketRide brand mark, rendered inline so it keeps its authored colors
+ * (the shared `*.svg` pipeline rewrites monochrome marks to `currentColor`,
+ * which would drop the brand fills). Used for the sidebar's collapsed icon via
+ * the AppDescriptor `branding.iconDark` / `iconLight` slots.
+ *
+ * @param props.bodyColor - Fill for the rocket body: pale lavender (#E0DDF0)
+ *   on dark surfaces, deep ink (#1E1A34) on light surfaces. The exhaust swoosh
+ *   is always RocketRide red (#F93822).
+ */
+const RocketRideMark: React.FC<{ bodyColor: string; style?: React.CSSProperties }> = ({ bodyColor, style }) => (
+	<svg viewBox="0 0 191 192" fill="none" xmlns="http://www.w3.org/2000/svg" style={{ width: '100%', height: '100%', ...style }}>
+		<path d="M159.5 161.424L153.7 167.224C151.9 169.024 148.9 169.024 147 167.224L126.6 146.824C115.6 135.824 115.6 118.024 126.6 107.024C138.1 95.5245 138.1 76.9245 126.6 65.4245L125.1 63.9245C113.6 52.4245 95 52.4245 83.5 63.9245C72.5 74.9245 54.6 74.9245 43.6 63.9245L23.2 43.5245C21.4 41.7245 21.4 38.7245 23.2 36.8245L29 31.0245C37 23.0245 49.1 20.5245 59.6 24.9245L87.5 36.3245C97.3 40.1245 108.4 38.0245 116.3 31.1245L137 10.4245C138.6 8.92449 140.4 7.42449 142.5 6.22449C146.2 4.12449 150.3 3.02449 154.5 2.62449L185.4 0.0244895C188.3 -0.275511 190.8 2.22449 190.5 5.12449L187.8 36.4245C187.3 42.8245 184.5 48.8245 180.1 53.5245L160.5 73.1245C152.5 81.2245 150.1 93.3245 154.5 103.824L155.5 106.224L161.2 120.024L165.6 130.924C169.9 141.424 167.5 153.524 159.5 161.524V161.424Z" fill={bodyColor}/>
+		<path d="M0.799997 190.325C-0.200003 189.325 -0.300003 187.625 0.599997 186.425L21.1 162.024C31.1 150.024 37.9 137.725 41.3 125.325C43.6 116.625 44.6 108.525 44.1 101.225C44.1 100.325 44.4 99.4245 45.1 98.8245C45.8 98.2245 46.8 97.9245 47.7 98.1245C65 101.625 83.5 98.3245 98.5 88.9245C99.6 88.2245 101.1 88.4245 102 89.3245C102.9 90.2245 103.1 91.7245 102.4 92.8245C93 107.825 89.7 126.325 93.2 143.525C93.4 144.325 93.2 145.225 92.6 145.925C92 146.625 91 147.225 90.1 147.125C82.8 146.625 74.6 147.525 66 149.925C53.6 153.225 41.2 160.025 29.3 170.125L4.9 190.625C3.8 191.525 2.1 191.525 0.999997 190.425H0.799997V190.325Z" fill="#F93822"/>
+	</svg>
+);
+
+export default RocketRideMark;

--- a/apps/shell-ui/src/components/layout/OverlayManager.tsx
+++ b/apps/shell-ui/src/components/layout/OverlayManager.tsx
@@ -39,6 +39,13 @@ import EnvironmentPage from '../../views/environment/EnvironmentPage';
 /** Shell overlay pages that render as modal dialogs over the client area. */
 export type ShellOverlay = 'account' | 'settings' | 'environment' | null;
 
+/** Opaque overlay ids a guest app is allowed to request via `shell:openOverlay`. */
+const OPENABLE_OVERLAYS = ['account', 'settings', 'environment'] as const;
+
+/** Type guard: is `id` a valid openable overlay id (not null/unknown)? */
+const isOpenableOverlay = (id: unknown): id is Exclude<ShellOverlay, null> =>
+	typeof id === 'string' && (OPENABLE_OVERLAYS as readonly string[]).includes(id);
+
 // =============================================================================
 // STYLES
 // =============================================================================
@@ -108,7 +115,9 @@ export const OverlayManager: React.FC<OverlayManagerProps> = ({ children }) => {
 	// shell routes it into the same overlay state the sidebar uses.
 	useEffect(() => {
 		return ConnectionManager.getInstance().on('shell:openOverlay', ({ id }: { id: ShellOverlay }) => {
-			if (id) setOverlay(id);
+			// Gate to the contracted ids so a stray runtime value can't open a
+			// blank modal shell with no page content.
+			if (isOpenableOverlay(id)) setOverlay(id);
 		});
 	}, []);
 

--- a/apps/shell-ui/src/components/layout/OverlayManager.tsx
+++ b/apps/shell-ui/src/components/layout/OverlayManager.tsx
@@ -27,6 +27,7 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import type { CSSProperties } from 'react';
 import { commonStyles } from 'shared/themes/styles';
+import { ConnectionManager } from '../../connection/connection';
 import AccountPage from '../../views/account/AccountPage';
 import SettingsPage from '../../views/settings/SettingsPage';
 import EnvironmentPage from '../../views/environment/EnvironmentPage';
@@ -100,6 +101,16 @@ export const OverlayManager: React.FC<OverlayManagerProps> = ({ children }) => {
 
 	/** Closes the currently open overlay. */
 	const closeOverlay = useCallback(() => setOverlay(null), []);
+
+	// --- Open-overlay requests from guest apps -------------------------------
+	// Guest apps (e.g. home-ui's profile menu) can't reach `setOverlay`
+	// directly, so they emit `shell:openOverlay` over the event bus and the
+	// shell routes it into the same overlay state the sidebar uses.
+	useEffect(() => {
+		return ConnectionManager.getInstance().on('shell:openOverlay', ({ id }: { id: ShellOverlay }) => {
+			if (id) setOverlay(id);
+		});
+	}, []);
 
 	// --- Escape key handler --------------------------------------------------
 	useEffect(() => {

--- a/apps/shell-ui/src/components/layout/Shell.tsx
+++ b/apps/shell-ui/src/components/layout/Shell.tsx
@@ -317,11 +317,20 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 				if (mountedRef.current) setRenderPhase('goodbye');
 			});
 		} else {
+			// Return to the home app before the auth gate re-runs. Otherwise
+			// ShellLayout still sees an auth-required app (e.g. Pipeline Builder)
+			// active with identity===null and emits shell:loginRequest →
+			// startOAuth, bouncing the signing-out user to the Zitadel login
+			// screen instead of the logged-out home. switchApp updates the live
+			// workspace (and clears the persisted rr:appId via persistActiveApp);
+			// setActiveAppId keeps the startup seed in sync for any later remount.
+			setActiveAppId(defaultAppId);
+			cm.emit('shell:switchApp', { appId: defaultAppId });
 			cm.logout().finally(() => {
 				if (mountedRef.current) setRenderPhase('shell');
 			});
 		}
-	}, [cm, sessionAppId]);
+	}, [cm, sessionAppId, defaultAppId]);
 
 	useEffect(() => {
 		return cm.on('shell:logoutRequest', () => handleLogout());

--- a/apps/shell-ui/src/components/layout/ShellLayout.tsx
+++ b/apps/shell-ui/src/components/layout/ShellLayout.tsx
@@ -219,11 +219,26 @@ export const ShellLayout: React.FC<ShellLayoutProps> = ({
 	// --- Auth gate: auto-trigger login for authenticated apps ----------------
 	const activeManifest = appManifest.find((m) => m.id === activeAppId);
 	const authGateTriggeredRef = useRef<string | null>(null);
+	const prevIdentityRef = useRef(identity);
+	const suppressGateRef = useRef(false);
 
 	useEffect(() => {
+		// Detect a logout transition (had an identity, now none). On logout the
+		// shell switches the active app back to home via shell:switchApp, but that
+		// event is delivered on a microtask, so the workspace's activeAppId flips a
+		// tick AFTER identity clears. During that gap the check below would see
+		// "no identity + auth-required app still active" and fire shell:loginRequest
+		// → startOAuth, bouncing a signing-out user to the Zitadel login screen
+		// instead of leaving them on the logged-out home. Suppress the gate from the
+		// moment identity drops until the active app settles back on the default.
+		const wasLoggedIn = !!prevIdentityRef.current;
+		prevIdentityRef.current = identity;
+		if (wasLoggedIn && !identity) suppressGateRef.current = true;
+		if (identity || activeAppId === defaultAppId) suppressGateRef.current = false;
+
 		// Only gate when the manifest is loaded and explicitly requires auth.
 		// Skip for the default app (home/hello) — it must always be accessible.
-		if (!identity && activeManifest && activeManifest.authenticated !== false && activeAppId !== defaultAppId) {
+		if (!suppressGateRef.current && !identity && activeManifest && activeManifest.authenticated !== false && activeAppId !== defaultAppId) {
 			if (authGateTriggeredRef.current === activeAppId) return;
 			authGateTriggeredRef.current = activeAppId;
 			ConnectionManager.getInstance().emit('shell:loginRequest', { appId: activeAppId });

--- a/packages/shared-ui/src/types/shell.ts
+++ b/packages/shared-ui/src/types/shell.ts
@@ -188,6 +188,13 @@ export interface ShellConnectionEventMap {
 	/** Navigate back to the My Apps launcher screen. */
 	'shell:myApps': Record<string, never>;
 
+	/**
+	 * Request the shell open a built-in overlay (e.g. from a guest app's
+	 * profile/account menu, which can't render the shell's overlays directly).
+	 * The `id` selects which overlay to show.
+	 */
+	'shell:openOverlay': { id: 'account' | 'settings' | 'environment' };
+
 	/** Sidebar is starting to collapse — dependent UI can prepare. */
 	'shell:sidebarCollapsing': Record<string, never>;
 


### PR DESCRIPTION
Shell/monitor changes supporting the home-ui v7 update. Split into three logical commits.

## Changes

**feat(shell-ui): guest apps can request shell overlays** — Adds a `shell:openOverlay` event to `ShellConnectionEventMap` so guest apps (e.g. home-ui's profile menu) can ask the shell to open a built-in account/settings/environment overlay. `OverlayManager` listens and drives overlay state from the requested id.

**fix(shell-ui): prevent auth-gate bounce to login during logout** — On logout, switch the active app back to home before `cm.logout()` so the auth gate doesn't see an auth-required app with a null identity and fire a premature `shell:loginRequest`. `ShellLayout` suppresses the gate from the moment identity clears until the active app settles back to default, covering the microtask race where `activeAppId` updates after identity.

**feat(monitor-ui): branded RocketRideMark sidebar icon** — New `RocketRideMark` component renders the RocketRide logo inline with a parameterized body fill (preserving brand colors vs. the monochrome shared SVG pipeline). Wired into the Server Monitor descriptor as theme-aware collapsed-sidebar icons.

## Notes
Branched from current `develop` tip. No overlap with other in-flight changes. Once merged, the `rocketride-saas` submodule pointer will be bumped to include these commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a RocketRide branded sidebar logo component with customizable color and styling.
  * Enabled guest applications to request shell overlay pages (account, settings, environment) via a new shell coordination event.

* **Bug Fixes**
  * Improved logout behavior by switching the active app back to the default before logging out.
  * Prevented authentication prompts from triggering during logout transitions and related auth-gating timing windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->