### PR TITLE
VSCode: Free tier "Get Started" button does nothing (should link to self-hosting docs)

### DIFF
--- a/apps/vscode/src/providers/AccountProvider.ts
+++ b/apps/vscode/src/providers/AccountProvider.ts
@@ -25,7 +25,7 @@ import type { ConnectionStatus } from '../shared/types';
 import type { ConnectResult, TeamDetail } from 'rocketride';
 import { CloudAuthProvider } from '../auth/CloudAuthProvider';
 import { PIPE_BUILDER_APP_ID } from '../shared/types';
-import { isAllowedExternalUrl } from '../shared/util/externalUrl';
+import { openExternalUrl } from '../shared/util/externalUrl';
 
 // =============================================================================
 // INTERFACES
@@ -262,11 +262,7 @@ export class AccountProvider {
 
 			// -- External links (Free tier docs, Enterprise mailto, etc.) ---------
 			case 'openExternal':
-				if (message.url && isAllowedExternalUrl(message.url)) {
-					await vscode.env.openExternal(vscode.Uri.parse(message.url));
-				} else if (message.url) {
-					this.postError(panel, 'Unsupported external URL.');
-				}
+				if (message.url) await openExternalUrl(message.url, () => this.postError(panel, 'Unsupported external URL.'));
 				break;
 
 			// Environment variables removed — now handled by EnvironmentProvider.

--- a/apps/vscode/src/providers/AccountProvider.ts
+++ b/apps/vscode/src/providers/AccountProvider.ts
@@ -25,6 +25,7 @@ import type { ConnectionStatus } from '../shared/types';
 import type { ConnectResult, TeamDetail } from 'rocketride';
 import { CloudAuthProvider } from '../auth/CloudAuthProvider';
 import { PIPE_BUILDER_APP_ID } from '../shared/types';
+import { isAllowedExternalUrl } from '../shared/util/externalUrl';
 
 // =============================================================================
 // INTERFACES
@@ -261,8 +262,10 @@ export class AccountProvider {
 
 			// -- External links (Free tier docs, Enterprise mailto, etc.) ---------
 			case 'openExternal':
-				if (message.url) {
+				if (message.url && isAllowedExternalUrl(message.url)) {
 					await vscode.env.openExternal(vscode.Uri.parse(message.url));
+				} else if (message.url) {
+					this.postError(panel, 'Unsupported external URL.');
 				}
 				break;
 

--- a/apps/vscode/src/providers/AccountProvider.ts
+++ b/apps/vscode/src/providers/AccountProvider.ts
@@ -47,6 +47,7 @@ interface AccountWebviewMessage {
 	newPriceId?: string;
 	orgId?: string;
 	subscriptionId?: string;
+	url?: string;
 }
 
 // =============================================================================
@@ -256,6 +257,13 @@ export class AccountProvider {
 
 			case 'checkout:confirmPending':
 				await this.handleCheckoutConfirmPending(panel, message);
+				break;
+
+			// -- External links (Free tier docs, Enterprise mailto, etc.) ---------
+			case 'openExternal':
+				if (message.url) {
+					await vscode.env.openExternal(vscode.Uri.parse(message.url));
+				}
 				break;
 
 			// Environment variables removed — now handled by EnvironmentProvider.

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -470,6 +470,15 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 					break;
 				}
 
+				// External links (Free tier docs link, Enterprise mailto, etc.) —
+				// open in the user's browser/mail client via the extension host.
+				case 'openExternal': {
+					if (data.url) {
+						await vscode.env.openExternal(vscode.Uri.parse(data.url as string));
+					}
+					break;
+				}
+
 				// Trace messages
 				case 'trace:clear':
 					// No-op on host side

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -25,7 +25,7 @@ import { icons } from '../shared/util/icons';
 import { PipelineFileParser } from '../shared/util/pipelineParser';
 import { isSubscribed } from '../shared/util/subscriptionGate';
 import { handleMissingEnvVars } from '../shared/util/envVarCheck';
-import { isAllowedExternalUrl } from '../shared/util/externalUrl';
+import { openExternalUrl } from '../shared/util/externalUrl';
 
 // =============================================================================
 // CONSTANTS
@@ -475,11 +475,7 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 				// open in the user's browser/mail client via the extension host.
 				case 'openExternal': {
 					const url = data.url as string | undefined;
-					if (url && isAllowedExternalUrl(url)) {
-						await vscode.env.openExternal(vscode.Uri.parse(url));
-					} else if (url) {
-						this.logger.error(`Refused to open external URL with unsupported scheme: ${url}`);
-					}
+					if (url) await openExternalUrl(url, (msg) => this.logger.error(msg));
 					break;
 				}
 

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -25,6 +25,7 @@ import { icons } from '../shared/util/icons';
 import { PipelineFileParser } from '../shared/util/pipelineParser';
 import { isSubscribed } from '../shared/util/subscriptionGate';
 import { handleMissingEnvVars } from '../shared/util/envVarCheck';
+import { isAllowedExternalUrl } from '../shared/util/externalUrl';
 
 // =============================================================================
 // CONSTANTS
@@ -473,8 +474,11 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 				// External links (Free tier docs link, Enterprise mailto, etc.) —
 				// open in the user's browser/mail client via the extension host.
 				case 'openExternal': {
-					if (data.url) {
-						await vscode.env.openExternal(vscode.Uri.parse(data.url as string));
+					const url = data.url as string | undefined;
+					if (url && isAllowedExternalUrl(url)) {
+						await vscode.env.openExternal(vscode.Uri.parse(url));
+					} else if (url) {
+						this.logger.error(`Refused to open external URL with unsupported scheme: ${url}`);
 					}
 					break;
 				}

--- a/apps/vscode/src/providers/SettingsProvider.ts
+++ b/apps/vscode/src/providers/SettingsProvider.ts
@@ -213,6 +213,13 @@ export class SettingsProvider {
 						break;
 					}
 
+					// -- External links (Free tier docs link, Enterprise mailto) -----
+					case 'openExternal':
+						if (message.url) {
+							await vscode.env.openExternal(vscode.Uri.parse(message.url as string));
+						}
+						break;
+
 					default: {
 						// Delegate connection messages (cloud, docker, service, test, engine versions, sudo)
 						const handled = await this.connHandler.handleMessage(message, panel.webview);

--- a/apps/vscode/src/providers/SettingsProvider.ts
+++ b/apps/vscode/src/providers/SettingsProvider.ts
@@ -42,7 +42,7 @@ import { ConnectionMessageHandler } from './shared/connection-message-handler';
 import { isSubscribed } from '../shared/util/subscriptionGate';
 import { PIPE_BUILDER_APP_ID } from '../shared/types';
 import { getLogger } from '../shared/util/output';
-import { isAllowedExternalUrl } from '../shared/util/externalUrl';
+import { openExternalUrl } from '../shared/util/externalUrl';
 
 export class SettingsProvider {
 	private disposables: vscode.Disposable[] = [];
@@ -218,11 +218,7 @@ export class SettingsProvider {
 					// -- External links (Free tier docs link, Enterprise mailto) -----
 					case 'openExternal': {
 						const url = message.url as string | undefined;
-						if (url && isAllowedExternalUrl(url)) {
-							await vscode.env.openExternal(vscode.Uri.parse(url));
-						} else if (url) {
-							getLogger().error(`Refused to open external URL with unsupported scheme: ${url}`);
-						}
+						if (url) await openExternalUrl(url, (msg) => getLogger().error(msg));
 						break;
 					}
 

--- a/apps/vscode/src/providers/SettingsProvider.ts
+++ b/apps/vscode/src/providers/SettingsProvider.ts
@@ -41,6 +41,8 @@ import { DeployManager } from '../connection/deploy-manager';
 import { ConnectionMessageHandler } from './shared/connection-message-handler';
 import { isSubscribed } from '../shared/util/subscriptionGate';
 import { PIPE_BUILDER_APP_ID } from '../shared/types';
+import { getLogger } from '../shared/util/output';
+import { isAllowedExternalUrl } from '../shared/util/externalUrl';
 
 export class SettingsProvider {
 	private disposables: vscode.Disposable[] = [];
@@ -214,11 +216,15 @@ export class SettingsProvider {
 					}
 
 					// -- External links (Free tier docs link, Enterprise mailto) -----
-					case 'openExternal':
-						if (message.url) {
-							await vscode.env.openExternal(vscode.Uri.parse(message.url as string));
+					case 'openExternal': {
+						const url = message.url as string | undefined;
+						if (url && isAllowedExternalUrl(url)) {
+							await vscode.env.openExternal(vscode.Uri.parse(url));
+						} else if (url) {
+							getLogger().error(`Refused to open external URL with unsupported scheme: ${url}`);
 						}
 						break;
+					}
 
 					default: {
 						// Delegate connection messages (cloud, docker, service, test, engine versions, sudo)

--- a/apps/vscode/src/providers/WelcomeProvider.ts
+++ b/apps/vscode/src/providers/WelcomeProvider.ts
@@ -38,6 +38,8 @@ import * as vscode from 'vscode';
 import { ConfigManager } from '../config';
 import { getConnectionManager, getEngineRegistry } from '../extension';
 import { ConnectionMessageHandler } from './shared/connection-message-handler';
+import { getLogger } from '../shared/util/output';
+import { isAllowedExternalUrl } from '../shared/util/externalUrl';
 
 const DISMISSED_KEY = 'welcomeDismissed';
 
@@ -108,11 +110,15 @@ export class WelcomeProvider {
 						vscode.commands.executeCommand('rocketride.page.settings.open');
 						break;
 
-					case 'openExternal':
-						if (message.url) {
-							vscode.env.openExternal(vscode.Uri.parse(message.url));
+					case 'openExternal': {
+						const url = message.url;
+						if (url && isAllowedExternalUrl(url)) {
+							vscode.env.openExternal(vscode.Uri.parse(url));
+						} else if (url) {
+							getLogger().error(`Refused to open external URL with unsupported scheme: ${url}`);
 						}
 						break;
+					}
 
 					default: {
 						// Delegate connection messages (cloud, docker, service, test, engine versions, sudo)

--- a/apps/vscode/src/providers/WelcomeProvider.ts
+++ b/apps/vscode/src/providers/WelcomeProvider.ts
@@ -38,8 +38,6 @@ import * as vscode from 'vscode';
 import { ConfigManager } from '../config';
 import { getConnectionManager, getEngineRegistry } from '../extension';
 import { ConnectionMessageHandler } from './shared/connection-message-handler';
-import { getLogger } from '../shared/util/output';
-import { isAllowedExternalUrl } from '../shared/util/externalUrl';
 
 const DISMISSED_KEY = 'welcomeDismissed';
 
@@ -110,15 +108,11 @@ export class WelcomeProvider {
 						vscode.commands.executeCommand('rocketride.page.settings.open');
 						break;
 
-					case 'openExternal': {
-						const url = message.url;
-						if (url && isAllowedExternalUrl(url)) {
-							vscode.env.openExternal(vscode.Uri.parse(url));
-						} else if (url) {
-							getLogger().error(`Refused to open external URL with unsupported scheme: ${url}`);
+					case 'openExternal':
+						if (message.url) {
+							vscode.env.openExternal(vscode.Uri.parse(message.url));
 						}
 						break;
-					}
 
 					default: {
 						// Delegate connection messages (cloud, docker, service, test, engine versions, sudo)

--- a/apps/vscode/src/providers/views/Account/AccountWebview.tsx
+++ b/apps/vscode/src/providers/views/Account/AccountWebview.tsx
@@ -16,8 +16,8 @@
 
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 
-import { AccountView, CheckoutModal } from 'shared';
-import type { ApiKeyRecord, OrgDetail, MemberRecord, TeamRecord, TeamDetail, AccountSection, ProfileUpdate, CheckoutPlan } from 'shared';
+import { AccountView, CheckoutModal, actionHref } from 'shared';
+import type { ApiKeyRecord, OrgDetail, MemberRecord, TeamRecord, TeamDetail, AccountSection, ProfileUpdate, CheckoutPlan, PlanAction } from 'shared';
 import type { ConnectResult } from 'rocketride';
 import { useMessaging } from '../hooks/useMessaging';
 import type { AccountHostToWebview, AccountWebviewToHost } from '../types';
@@ -372,6 +372,17 @@ const AccountWebview: React.FC = () => {
 		});
 	}, []);
 
+	/**
+	 * Opens an action plan's link/mailto via the extension host.
+	 *
+	 * The webview sandbox blocks ``window.open`` / ``window.location``, so the
+	 * Free tier "Get Started" link (and Enterprise mailto) must be routed
+	 * through the host's ``vscode.env.openExternal``.
+	 */
+	const handleActionClick = useCallback((_plan: CheckoutPlan, action: PlanAction): void => {
+		sendMessageRef.current({ type: 'openExternal', url: actionHref(action) } as any);
+	}, []);
+
 	/** Closes the checkout modal and refreshes billing data on success. */
 	const handleCheckoutSuccess = useCallback((): void => {
 		setShowCheckout(false);
@@ -468,6 +479,7 @@ const AccountWebview: React.FC = () => {
 					onConfirmPending={handleConfirmPending}
 					onSuccess={handleCheckoutSuccess}
 					onClose={() => setShowCheckout(false)}
+					onActionClick={handleActionClick}
 				/>
 			)}
 		</>

--- a/apps/vscode/src/providers/views/Account/AccountWebview.tsx
+++ b/apps/vscode/src/providers/views/Account/AccountWebview.tsx
@@ -380,7 +380,7 @@ const AccountWebview: React.FC = () => {
 	 * through the host's ``vscode.env.openExternal``.
 	 */
 	const handleActionClick = useCallback((_plan: CheckoutPlan, action: PlanAction): void => {
-		sendMessageRef.current({ type: 'openExternal', url: actionHref(action) } as any);
+		sendMessageRef.current({ type: 'openExternal', url: actionHref(action) });
 	}, []);
 
 	/** Closes the checkout modal and refreshes billing data on success. */

--- a/apps/vscode/src/providers/views/Account/AccountWebview.tsx
+++ b/apps/vscode/src/providers/views/Account/AccountWebview.tsx
@@ -380,7 +380,7 @@ const AccountWebview: React.FC = () => {
 	 * through the host's ``vscode.env.openExternal``.
 	 */
 	const handleActionClick = useCallback((_plan: CheckoutPlan, action: PlanAction): void => {
-		sendMessageRef.current({ type: 'openExternal', url: actionHref(action) });
+		sendMessageRef.current({ type: 'openExternal', url: actionHref(action) } as any);
 	}, []);
 
 	/** Closes the checkout modal and refreshes billing data on success. */

--- a/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
+++ b/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
@@ -324,7 +324,7 @@ const ProjectWebview: React.FC = () => {
 	 */
 	const handleActionClick = useCallback(
 		(_plan: CheckoutPlan, action: PlanAction) => {
-			sendMessage({ type: 'openExternal', url: actionHref(action) } as any);
+			sendMessage({ type: 'openExternal', url: actionHref(action) });
 		},
 		[sendMessage]
 	);

--- a/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
+++ b/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
@@ -18,8 +18,8 @@ import React, { useState, useCallback, useRef, useEffect } from 'react';
 
 import { applyTheme } from 'shared/themes';
 import type { ThemeTokens } from 'shared/themes/tokens';
-import { ProjectView, parseServerEvent, CheckoutModal } from 'shared';
-import type { TaskStatus, TraceEvent, ViewState, CheckoutPlan } from 'shared';
+import { ProjectView, parseServerEvent, CheckoutModal, actionHref } from 'shared';
+import type { TaskStatus, TraceEvent, ViewState, CheckoutPlan, PlanAction } from 'shared';
 import { useMessaging } from '../hooks/useMessaging';
 import type { ProjectHostToWebview, ProjectWebviewToHost } from '../types';
 
@@ -317,6 +317,18 @@ const ProjectWebview: React.FC = () => {
 		setSubscribed(true);
 	}, []);
 
+	/**
+	 * Opens an action plan's link/mailto via the extension host. The webview
+	 * sandbox blocks ``window.open`` / ``window.location``, so the Free tier
+	 * "Get Started" link must be routed through ``vscode.env.openExternal``.
+	 */
+	const handleActionClick = useCallback(
+		(_plan: CheckoutPlan, action: PlanAction) => {
+			sendMessage({ type: 'openExternal', url: actionHref(action) } as any);
+		},
+		[sendMessage]
+	);
+
 	// --- Wait for initial state from host before rendering -------------------
 
 	if (!viewState || !prefs) return null;
@@ -328,7 +340,7 @@ const ProjectWebview: React.FC = () => {
 	return (
 		<>
 			<ProjectView project={project} servicesJson={servicesJson} isConnected={isConnected} isSubscribed={subscribed} statusMap={statusMap} serverHost={serverHost} isDirty={isDirty} isNew={isNew} initialViewState={viewState} initialPrefs={prefs} traceEvents={traceEvents} onContentChanged={handleContentChanged} onValidate={handleValidate} onPipelineAction={handlePipelineAction} onViewStateChange={handleViewStateChange} onPrefsChange={handlePrefsChange} onOpenLink={handleOpenLink} onSave={handleSave} onTraceClear={handleTraceClear} isReadonly={isReadonly} envKeys={envKeys} onMissingEnvVars={handleMissingEnvVars} />
-			{showCheckout && stripeKey && <CheckoutModal appName="RocketRide" appDescription="Visual AI pipeline editor — run and deploy pipelines on RocketRide Cloud." stripePublishableKey={stripeKey} onFetchPlans={handleFetchPlans} onCreateCheckout={handleCreateCheckout} onConfirmPending={handleConfirmPending} onSuccess={handleCheckoutSuccess} onClose={() => setShowCheckout(false)} />}
+			{showCheckout && stripeKey && <CheckoutModal appName="RocketRide" appDescription="Visual AI pipeline editor — run and deploy pipelines on RocketRide Cloud." stripePublishableKey={stripeKey} onFetchPlans={handleFetchPlans} onCreateCheckout={handleCreateCheckout} onConfirmPending={handleConfirmPending} onSuccess={handleCheckoutSuccess} onClose={() => setShowCheckout(false)} onActionClick={handleActionClick} />}
 		</>
 	);
 };

--- a/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
+++ b/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
@@ -324,7 +324,7 @@ const ProjectWebview: React.FC = () => {
 	 */
 	const handleActionClick = useCallback(
 		(_plan: CheckoutPlan, action: PlanAction) => {
-			sendMessage({ type: 'openExternal', url: actionHref(action) });
+			sendMessage({ type: 'openExternal', url: actionHref(action) } as any);
 		},
 		[sendMessage]
 	);

--- a/apps/vscode/src/providers/views/Settings/ConnectionSettings.tsx
+++ b/apps/vscode/src/providers/views/Settings/ConnectionSettings.tsx
@@ -60,6 +60,8 @@ interface ConnectionSettingsProps {
 	onCreateCheckout?: (priceId: string) => Promise<{ clientSecret: string; subscriptionId: string }>;
 	onConfirmPending?: (subscriptionId: string, priceId: string) => Promise<void>;
 	onCheckoutSuccess?: () => void;
+	/** Called when an action plan's CTA is clicked (e.g. Free tier docs link). */
+	onCheckoutActionClick?: (plan: any, action: any) => void;
 	// -- Docker panel props --
 	dockerStatus: DockerStatus;
 	dockerProgress: string | null;
@@ -192,6 +194,7 @@ export const ConnectionSettings: React.FC<ConnectionSettingsProps> = (props) => 
 						onCreateCheckout={props.onCreateCheckout}
 						onConfirmPending={props.onConfirmPending}
 						onCheckoutSuccess={props.onCheckoutSuccess}
+						onCheckoutActionClick={props.onCheckoutActionClick}
 					/>
 				</div>
 			</div>

--- a/apps/vscode/src/providers/views/Settings/DeploySettings.tsx
+++ b/apps/vscode/src/providers/views/Settings/DeploySettings.tsx
@@ -57,6 +57,8 @@ interface DeploySettingsProps {
 	onCreateCheckout?: (priceId: string) => Promise<{ clientSecret: string; subscriptionId: string }>;
 	onConfirmPending?: (subscriptionId: string, priceId: string) => Promise<void>;
 	onCheckoutSuccess?: () => void;
+	/** Called when an action plan's CTA is clicked (e.g. Free tier docs link). */
+	onCheckoutActionClick?: (plan: any, action: any) => void;
 	// -- Docker panel props --
 	dockerStatus: DockerStatus;
 	dockerProgress: string | null;
@@ -195,6 +197,7 @@ export const DeploySettings: React.FC<DeploySettingsProps> = (props) => {
 							onCreateCheckout={props.onCreateCheckout}
 							onConfirmPending={props.onConfirmPending}
 							onCheckoutSuccess={props.onCheckoutSuccess}
+							onCheckoutActionClick={props.onCheckoutActionClick}
 						/>
 					)}
 				</div>

--- a/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
+++ b/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
@@ -31,7 +31,8 @@ import { IntegrationSettings } from './IntegrationSettings';
 import { DeploySettings } from './DeploySettings';
 import { MessageDisplay } from './MessageDisplay';
 import { commonStyles } from 'shared/themes/styles';
-import type { CheckoutPlan } from 'shared';
+import { actionHref } from 'shared';
+import type { CheckoutPlan, PlanAction } from 'shared';
 import { TabPanel } from 'shared/components/tab-panel/TabPanel';
 import type { ITabPanelTab, ITabPanelPanel } from 'shared/components/tab-panel/TabPanel';
 import type { ServiceStatus, DockerStatus, VersionOption } from '../components/panels/shared';
@@ -827,6 +828,15 @@ export const Settings: React.FC = () => {
 		setSubscribed(true);
 	}, []);
 
+	/**
+	 * Opens an action plan's link/mailto (e.g. the Free tier "Get Started"
+	 * self-hosting docs link) via the extension host. The webview sandbox
+	 * blocks ``window.open``, so it must go through ``vscode.env.openExternal``.
+	 */
+	const handleCheckoutActionClick = useCallback((_plan: CheckoutPlan, action: PlanAction) => {
+		sendMessage({ type: 'openExternal', url: actionHref(action) } as any);
+	}, [sendMessage]);
+
 	const panels: Record<string, ITabPanelPanel> = useMemo(
 		() => ({
 			development: {
@@ -889,6 +899,7 @@ export const Settings: React.FC = () => {
 							onCreateCheckout={handleCreateCheckout}
 							onConfirmPending={handleConfirmPending}
 							onCheckoutSuccess={handleCheckoutSuccess}
+							onCheckoutActionClick={handleCheckoutActionClick}
 						/>
 					</div>
 				),
@@ -953,6 +964,7 @@ export const Settings: React.FC = () => {
 							onCreateCheckout={handleCreateCheckout}
 							onConfirmPending={handleConfirmPending}
 							onCheckoutSuccess={handleCheckoutSuccess}
+							onCheckoutActionClick={handleCheckoutActionClick}
 						/>
 					</div>
 				),

--- a/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
+++ b/apps/vscode/src/providers/views/Settings/SettingsWebview.tsx
@@ -155,6 +155,10 @@ export type SettingsOutgoingMessage =
 	  }
 	| {
 			type: 'openSubscribe';
+	  }
+	| {
+			type: 'openExternal';
+			url: string;
 	  };
 
 // ============================================================================
@@ -834,7 +838,7 @@ export const Settings: React.FC = () => {
 	 * blocks ``window.open``, so it must go through ``vscode.env.openExternal``.
 	 */
 	const handleCheckoutActionClick = useCallback((_plan: CheckoutPlan, action: PlanAction) => {
-		sendMessage({ type: 'openExternal', url: actionHref(action) } as any);
+		sendMessage({ type: 'openExternal', url: actionHref(action) });
 	}, [sendMessage]);
 
 	const panels: Record<string, ITabPanelPanel> = useMemo(

--- a/apps/vscode/src/providers/views/components/panels/CloudPanel.tsx
+++ b/apps/vscode/src/providers/views/components/panels/CloudPanel.tsx
@@ -16,7 +16,7 @@ import cloudLogoLight from '../../../../../rocketride-light-icon.png';
 import { settingsStyles as S } from '../../Settings/SettingsWebview';
 import { useTheme } from '../../hooks/useTheme';
 import { CheckoutModal } from 'shared';
-import type { CheckoutPlan } from 'shared';
+import type { CheckoutPlan, PlanAction } from 'shared';
 
 // =============================================================================
 // TYPES
@@ -55,13 +55,15 @@ export interface CloudPanelProps {
 	onCreateCheckout?: (priceId: string) => Promise<{ clientSecret: string; subscriptionId: string }>;
 	onConfirmPending?: (subscriptionId: string, priceId: string) => Promise<void>;
 	onCheckoutSuccess?: () => void;
+	/** Called when an action plan's CTA is clicked (e.g. Free tier docs link). */
+	onCheckoutActionClick?: (plan: CheckoutPlan, action: PlanAction) => void;
 }
 
 // =============================================================================
 // COMPONENT
 // =============================================================================
 
-export const CloudPanel: React.FC<CloudPanelProps> = ({ cloudSignedIn, cloudUserName, onCloudSignIn, onCloudSignOut, teams, selectedTeamId, onTeamChange, idPrefix, isSaas, onProbeServer, onFetchTeams, isSubscribed, onFetchPlans, onCreateCheckout, onConfirmPending, onCheckoutSuccess }) => {
+export const CloudPanel: React.FC<CloudPanelProps> = ({ cloudSignedIn, cloudUserName, onCloudSignIn, onCloudSignOut, teams, selectedTeamId, onTeamChange, idPrefix, isSaas, onProbeServer, onFetchTeams, isSubscribed, onFetchPlans, onCreateCheckout, onConfirmPending, onCheckoutSuccess, onCheckoutActionClick }) => {
 	const id = (name: string) => `${idPrefix}-${name}`;
 	const theme = useTheme();
 	const [showCheckout, setShowCheckout] = useState(false);
@@ -175,6 +177,7 @@ export const CloudPanel: React.FC<CloudPanelProps> = ({ cloudSignedIn, cloudUser
 					onConfirmPending={onConfirmPending}
 					onSuccess={handleCheckoutSuccess}
 					onClose={() => setShowCheckout(false)}
+					onActionClick={onCheckoutActionClick}
 				/>
 			)}
 

--- a/apps/vscode/src/providers/views/types.ts
+++ b/apps/vscode/src/providers/views/types.ts
@@ -23,7 +23,7 @@ export type ProjectHostToWebview = { type: 'project:load'; project: any; viewSta
 	| { type: 'project:envKeysUpdate'; envKeys: string[] };
 
 /** All messages the ProjectWebview can send to the extension host. */
-export type ProjectWebviewToHost = { type: 'view:ready' } | { type: 'view:initialized' } | { type: 'project:contentChanged'; project: any } | { type: 'project:validate'; requestId: number; pipeline: any } | { type: 'project:requestSave' } | { type: 'project:viewStateChange'; viewState: ViewState } | { type: 'project:prefsChange'; prefs: Record<string, unknown> } | { type: 'project:openLink'; url: string; displayName?: string } | { type: 'status:pipelineAction'; action: 'run' | 'stop' | 'restart'; source?: string } | { type: 'status:missingEnvVars'; keys: string[] } | { type: 'trace:clear' };
+export type ProjectWebviewToHost = { type: 'view:ready' } | { type: 'view:initialized' } | { type: 'project:contentChanged'; project: any } | { type: 'project:validate'; requestId: number; pipeline: any } | { type: 'project:requestSave' } | { type: 'project:viewStateChange'; viewState: ViewState } | { type: 'project:prefsChange'; prefs: Record<string, unknown> } | { type: 'project:openLink'; url: string; displayName?: string } | { type: 'openExternal'; url: string } | { type: 'status:pipelineAction'; action: 'run' | 'stop' | 'restart'; source?: string } | { type: 'status:missingEnvVars'; keys: string[] } | { type: 'trace:clear' };
 
 // =============================================================================
 // SERVER MONITOR PROTOCOL
@@ -61,7 +61,8 @@ export type AccountWebviewToHost =
 	| { type: 'account:addTeamMember'; params: { teamId: string; userId: string; permissions: string[] } }
 	| { type: 'account:editPerms'; params: { teamId: string; userId: string; permissions: string[] } }
 	| { type: 'account:removeTeamMember'; params: { teamId: string; userId: string } }
-	| { type: 'account:sectionChange'; section: string };
+	| { type: 'account:sectionChange'; section: string }
+	| { type: 'openExternal'; url: string };
 
 // =============================================================================
 // ENVIRONMENT PAGE PROTOCOL

--- a/apps/vscode/src/shared/util/externalUrl.ts
+++ b/apps/vscode/src/shared/util/externalUrl.ts
@@ -9,3 +9,23 @@ export function isAllowedExternalUrl(raw: string): boolean {
 		return false;
 	}
 }
+
+/**
+ * Opens an external URL in the user's browser/mail client via the extension
+ * host, gated behind the {@link isAllowedExternalUrl} (https/http/mailto)
+ * allowlist. This is the single place webview ``openExternal`` messages are
+ * funnelled through, so the scheme allowlist lives only here.
+ *
+ * @param url - The URL to open (from a webview message).
+ * @param onReject - Optional callback invoked with a human-readable reason when
+ *   `url` is present but its scheme is not allowlisted. Hosts use this to log or
+ *   surface an error; when omitted the rejection is silently ignored.
+ * @returns A promise that resolves once the URL has been opened (or rejected).
+ */
+export async function openExternalUrl(url: string, onReject?: (msg: string) => void): Promise<void> {
+	if (isAllowedExternalUrl(url)) {
+		await vscode.env.openExternal(vscode.Uri.parse(url));
+	} else {
+		onReject?.(`Refused to open external URL with unsupported scheme: ${url}`);
+	}
+}

--- a/apps/vscode/src/shared/util/externalUrl.ts
+++ b/apps/vscode/src/shared/util/externalUrl.ts
@@ -1,0 +1,11 @@
+import * as vscode from 'vscode';
+
+/** True when `raw` parses to an allowlisted external scheme (https/http/mailto). */
+export function isAllowedExternalUrl(raw: string): boolean {
+	try {
+		const scheme = vscode.Uri.parse(raw).scheme.toLowerCase();
+		return scheme === 'https' || scheme === 'http' || scheme === 'mailto';
+	} catch {
+		return false;
+	}
+}

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -82,7 +82,7 @@ export type { EnvironmentViewProps, EnvironmentSlotConfig, EnvironmentScope } fr
 export { CreditsPanel } from './modules/billing';
 
 // --- Checkout module (subscription checkout flow) ----------------------------
-export { CheckoutModal, PlanPicker } from './modules/checkout';
+export { CheckoutModal, PlanPicker, actionHref } from './modules/checkout';
 export type { CheckoutModalProps, CheckoutPlan, PlanAction, PlanPickerProps } from './modules/checkout';
 
 // --- Chat module (conversational chat surface) --------------------------------

--- a/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
+++ b/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
@@ -251,6 +251,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 	onConfirmPending,
 	onSuccess,
 	onClose,
+	onActionClick,
 }) => {
 	// Initialise Stripe lazily
 	const [stripePromise] = useState(() => loadStripe(stripePublishableKey));
@@ -362,6 +363,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 							loading={plansLoading}
 							selectedPlan={selectedPlan}
 							onSelectPlan={setSelectedPlan}
+							onActionClick={onActionClick}
 							footer={
 								<button
 									style={S.continueBtn(!selectedPlan || !!selectedPlan.metadata?.action)}

--- a/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
+++ b/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
@@ -60,7 +60,7 @@ export function planAmount(plan: CheckoutPlan): string {
  * @param action - The plan action descriptor.
  * @returns A navigable URL string.
  */
-function actionHref(action: PlanAction): string {
+export function actionHref(action: PlanAction): string {
 	if (action.type === 'mailto') {
 		const subject = action.subject ? `?subject=${encodeURIComponent(action.subject)}` : '';
 		return `mailto:${action.url}${subject}`;

--- a/packages/shared-ui/src/modules/checkout/index.ts
+++ b/packages/shared-ui/src/modules/checkout/index.ts
@@ -10,6 +10,6 @@
  */
 
 export { CheckoutModal } from './CheckoutModal';
-export { PlanPicker } from './PlanPicker';
+export { PlanPicker, actionHref } from './PlanPicker';
 export type { PlanPickerProps } from './PlanPicker';
 export type { CheckoutModalProps, CheckoutPlan, PlanAction } from './types';

--- a/packages/shared-ui/src/modules/checkout/types.ts
+++ b/packages/shared-ui/src/modules/checkout/types.ts
@@ -117,4 +117,15 @@ export interface CheckoutModalProps {
 
 	/** Called when the user dismisses the modal without completing checkout. */
 	onClose: () => void;
+
+	/**
+	 * Called when the user clicks an action plan's CTA (e.g. the Free tier
+	 * "Get Started" link, or an Enterprise "Contact us" mailto).
+	 *
+	 * Hosts that run inside a sandboxed webview (the VS Code extension) MUST
+	 * supply this to route the link through the extension host — the webview's
+	 * own ``window.open`` / ``window.location`` are no-ops there. When omitted,
+	 * the plan picker opens the link/mailto natively (browser shell).
+	 */
+	onActionClick?: (plan: CheckoutPlan, action: PlanAction) => void;
 }


### PR DESCRIPTION
Fixes #1302

## Root cause
On the plan-selection cards, the Free tier "Get Started" CTA did nothing in the VS Code extension. `CheckoutModal` never forwarded an `onActionClick` to `PlanPicker`, so action plans (the Free tier `link`, the Enterprise `mailto`) fell back to `PlanPicker.defaultActionClick`, which calls `window.open` / `window.location.href`. Both are no-ops inside the sandboxed VS Code webview, so the click had no effect. (The browser shell, where `window.open` works, was unaffected — which is why "other cards redirect correctly" only there.)

## Fix
- Add an optional `onActionClick` prop to `CheckoutModal` (`packages/shared-ui/src/modules/checkout`) that is forwarded to `PlanPicker`. When omitted, `PlanPicker` keeps its native `defaultActionClick` so the browser shell behavior is unchanged.
- Export the shared `actionHref` helper so hosts can build the link/mailto URL.
- Wire each VS Code webview host (Project, Account, Settings → CloudPanel) to supply `onActionClick`, which posts an `openExternal` message to the extension host. The hosts (`ProjectProvider`, `AccountProvider`, `SettingsProvider`) handle it via `vscode.env.openExternal(vscode.Uri.parse(url))` — the same pattern as `AccountProvider.handleOpenPortal` / `WelcomeProvider`.

The Free tier "Get Started" now opens the self-hosting / open-source setup documentation in the user's browser, and the Enterprise mailto opens the mail client.

## Verification
- `npx tsc --noEmit` in `apps/vscode` — passes.
- `./builder build vscode` — full extension build (rsbuild webview bundling + type-check) succeeds.
- Confirmed the remaining `packages/shared-ui` standalone `tsc` errors are pre-existing on `develop` (that package is type-checked as part of the consuming app build, not standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * External link handling in checkout modals and settings now delegates to the VS Code host environment for improved security and sandbox isolation
  * Plan action links and mailto addresses are properly validated before opening
  * Support for HTTP, HTTPS, and mailto URL schemes with error handling for unsupported protocols
<!-- end of auto-generated comment: release notes by coderabbit.ai -->