### PR TITLE
fix(engine): pass uv -c constraints relative to cwd so spaced install paths resolve

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -306,6 +306,16 @@ def _get_constraints_path() -> str:
     return os.path.join(engine_cache_dir(), 'constraints.txt')
 
 
+def _constraints_args(constraints_path: str, exe_dir: str) -> list[str]:
+    """Return uv ``-c`` args if the constraints file exists and is non-empty, else ``[]``.
+
+    Relative to exe_dir (the subprocess cwd) — uv splits the value on whitespace.
+    """
+    if os.path.exists(constraints_path) and os.path.getsize(constraints_path) > 0:
+        return ['-c', os.path.relpath(constraints_path, exe_dir)]
+    return []
+
+
 def _run(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
     """
     Run a subprocess command, keeping stdin open until process exits.
@@ -777,12 +787,10 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
             f.write('uv\n')
     # uv splits --excludes on whitespace, so an absolute path with a space (macOS
     # "Application Support") breaks resolution; pass it relative to the cwd (exe_dir).
-    # -c is parsed as a single value and is unaffected. See #1256.
+    # See #1256.
     args.extend(['--excludes', os.path.relpath(excludes_path, exe_dir)])
 
-    # Only add constraints if the file exists and has content
-    if os.path.exists(constraints_path) and os.path.getsize(constraints_path) > 0:
-        args.extend(['-c', _get_constraints_path()])
+    args.extend(_constraints_args(constraints_path, exe_dir))
 
     debug(f'Dry-run: {args}')
     result = subprocess.run(
@@ -888,8 +896,7 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
     # Relative to cwd (exe_dir) — see the --excludes note in _install_dry_run (#1256).
     uv_args.extend(['--excludes', os.path.relpath(excludes_path, exe_dir)])
 
-    if os.path.exists(constraints_path) and os.path.getsize(constraints_path) > 0:
-        uv_args.extend(['-c', _get_constraints_path()])
+    uv_args.extend(_constraints_args(constraints_path, exe_dir))
 
     # Run uv and stream output (heartbeat is already running from the caller)
     debug(f'Install: {uv_args}')
@@ -1038,10 +1045,8 @@ def main():
                 uv_args += ['--index-strategy', 'unsafe-best-match']
 
             # For install/sync commands, add constraints file if available
-            constraints_path = _get_constraints_path()
             if sys.argv[1] in ('install', 'sync'):
-                if os.path.exists(constraints_path) and os.path.getsize(constraints_path) > 0:
-                    uv_args.extend(['-c', _get_constraints_path()])
+                uv_args.extend(_constraints_args(_get_constraints_path(), exe_dir))
 
             # Run uv
             result = subprocess.run(uv_args, cwd=exe_dir)


### PR DESCRIPTION
## Summary

- `depends.py` passed the uv constraints file as an **absolute** path (`-c <abs>`). uv splits the `-c` value on whitespace, so an absolute cache path containing a space (the macOS default `~/Library/Application Support/RocketRide/...`) is truncated at the space and dependency resolution fails — crash-looping local mode at `init.cpp:536`.
- This is the **same class of bug** that #1256 / #1279 fixed for `--excludes`; that fix's comment wrongly claimed `-c` was unaffected, so `-c` was left absolute and still broke.
- Pass `-c` relative to `exe_dir` in all three call sites (`_install_dry_run`, `_install_requirements_inner`, the `uv` CLI passthrough) — every one already runs with `cwd=exe_dir` and the constraints file is always `<exe_dir>/cache/constraints.txt`, so the relative path never contains a space. Corrected the misleading comment. `-r` is left absolute (empirically safe).

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Isolated reproduction against the installed prerelease engine's `uv` (0.11.21), command otherwise identical to what `depends.py` builds (`cwd = engine dir`):

| Test | `-r` | `-c` | Result |
|------|------|------|--------|
| A | relative | **absolute** (spaced) | ❌ `error: File not found: /tmp/sp` |
| B | relative | relative | ✅ resolves |
| C | absolute (spaced) | relative | ✅ resolves |

A vs B isolates the cause to `-c`. `py_compile` passes; lint/format clean via pre-commit (ruff). Not run: full packaged engine end-to-end (needs a server rebuild).

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none

## Linked Issue

Fixes #1308


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency installation to apply the constraints file only when it’s present and contains entries, ensuring it’s resolved relative to the running executable.
  * Standardized constraints handling across install and sync flows, including dry-run scenarios, to prevent differences in how constraints were interpreted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->