### PR TITLE
fix(shell-ui): only show Aparavi AQL Settings in sidebar when the AQL app is installed

### DIFF
--- a/apps/shell-ui/src/components/layout/Sidebar.tsx
+++ b/apps/shell-ui/src/components/layout/Sidebar.tsx
@@ -372,12 +372,14 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 
 	const showAppSwitcher = !hideAppSwitcher && appManifest.length > 1;
 
+	// The "Settings" overlay is Aparavi-AQL-specific; only surface it when that app is installed.
+	const aparaviInstalled = appManifest.some((a) => a.id === 'rocketride.aparavi');
+
 	const footerMenuItems: SidebarFooterMenuItem[] = useMemo(() => {
 		const items: SidebarFooterMenuItem[] = [
 			{ id: 'home', label: 'Home', icon: BxHome, onClick: () => ConnectionManager.getInstance().emit('shell:switchApp', { appId: 'rocketride.home' }) },
 			{ id: 'account', label: 'Account', icon: BxUser, dividerBefore: true, onClick: () => onOverlay('account') },
 			{ id: 'environment', label: 'Variables', icon: BxLock, onClick: () => onOverlay('environment') },
-			{ id: 'settings', label: 'Settings', icon: BxCog, onClick: () => onOverlay('settings') },
 			{
 				id: 'theme', label: 'Theme', icon: BxPalette, dividerBefore: true,
 				submenu: themeOptions.map((t) => ({
@@ -386,6 +388,10 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 				})),
 			},
 		];
+
+		if (aparaviInstalled) {
+			items.splice(3, 0, { id: 'settings', label: 'Settings', icon: BxCog, onClick: () => onOverlay('settings') });
+		}
 
 		if (showAppSwitcher) {
 			/**
@@ -415,7 +421,7 @@ const Sidebar: React.FC<SidebarProps> = ({ themeConfig, account, hideAppSwitcher
 		items.push({ id: 'logout', label: 'Log out', icon: BxExport, dividerBefore: true, onClick: () => account.onLogout?.() });
 
 		return items;
-	}, [themeOptions, prefs.theme, showAppSwitcher, appManifest, activeAppId, isOnDesktop, account, handleThemeSelect, onOverlay]);
+	}, [themeOptions, prefs.theme, showAppSwitcher, aparaviInstalled, appManifest, activeAppId, isOnDesktop, account, handleThemeSelect, onOverlay]);
 
 	// --- Don't render sidebar when not authenticated -------------------------
 


### PR DESCRIPTION
The shared app sidebar footer rendered a "Settings" entry unconditionally. That settings overlay is Aparavi-AQL-specific, so it appeared in every app even when the Aparavi AQL app was not installed.

This gates the footer "Settings" menu item on the Aparavi AQL app (`rocketride.aparavi`) being present in `appManifest` (from `useWorkspace()`). When the app is not installed the item is simply omitted; all other footer items are unchanged, and the item keeps its original position (after Variables, before Theme) when it is shown.

Refs rocketride-ai/rocketride-saas#240

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings option in the sidebar footer is now only visible when the Aparavi app is installed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->