### PR TITLE
fix(ai): cap matplotlib<3.11 — 3.11.0 ft2font aborts model server on detection load

### DIFF
--- a/packages/ai/src/ai/common/models/vision/requirements_detection.txt
+++ b/packages/ai/src/ai/common/models/vision/requirements_detection.txt
@@ -2,3 +2,9 @@
 # Detection-specific extras, installed after the shared requirements_vision.txt base.
 timm
 rfdetr; python_version >= "3.10"
+# Cap matplotlib below 3.11: 3.11.0's pybind11 ft2font extension aborts the embedded
+# engine (SIGABRT, "module 'matplotlib.ft2font' has no attribute '__path__'") when
+# supervision (pulled by rfdetr) imports matplotlib.pyplot at load time. The abort is a
+# C++ terminate, not a Python exception, so the rtdetr fallback in detection.py can't
+# catch it — one detection request takes down the whole model server.
+matplotlib<3.11


### PR DESCRIPTION
## Problem
Object detection (`rfdetr` backend in `packages/ai/.../vision/detection.py`) aborts the **entire H100 model server** (SIGABRT/134) on detector load:

```
libc++abi: terminating due to uncaught exception of type pybind11::attribute_error:
module 'matplotlib.ft2font' has no attribute '__path__'
```

**Root cause:** matplotlib **3.11.0** (released 2026-06-12) ships `ft2font` as a pybind11 extension that aborts when `supervision` (pulled transitively by `rfdetr`) imports `matplotlib.pyplot` at load time. Model-server deps are runtime `uv`-solved and matplotlib was **unpinned** (transitive), so the new release was pulled on the next solve — the dist-info on the live box is dated 2026-06-17T16:19Z — with **no deploy on our side**. Rolling back the image does **not** help (the unpinned solve re-pulls 3.11.0 regardless).

The abort is a **C++ terminate, not a Python exception**, so the `except Exception` rtdetr fallback at `detection.py:124` never runs — one detection request takes down the whole GPU server, disconnecting all sessions.

## Fix
Cap `matplotlib<3.11` in `requirements_detection.txt` (where matplotlib is pulled, via rfdetr→supervision). Mirrors the existing `matplotlib.pyplot` guard in `nodes/face_detection`.

## Ship path
Reaches the live model server via the saas `Dockerfile.model-server` overlay (`COPY rocketride-server/packages/ai/src/ai → /app/ai`); a saas submodule bump + `build-model-server` + `deploy-model-server` follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a dependency compatibility issue to improve system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->