### PR TITLE
fix(ai): stub matplotlib.pyplot before rfdetr import (ft2font aborts engine; supersedes #1312 cap)

### DIFF
--- a/packages/ai/src/ai/common/models/vision/detection.py
+++ b/packages/ai/src/ai/common/models/vision/detection.py
@@ -108,6 +108,17 @@ class RFDetrLoader:
 
         try:
             import contextlib
+            import sys
+            import types
+
+            # supervision (pulled by rfdetr) imports matplotlib.pyplot at module load.
+            # matplotlib >= 3.10 ships ft2font as a pybind11 extension whose attribute
+            # probe aborts the embedded engine (SIGABRT, "module 'matplotlib.ft2font'
+            # has no attribute '__path__'") — a C++ terminate the except below can't
+            # catch, so it kills the whole model server. pyplot is only used by
+            # supervision plotting helpers we never call, so stub it before importing
+            # rfdetr. Mirrors nodes/face_detection.py.
+            sys.modules.setdefault('matplotlib.pyplot', types.ModuleType('matplotlib.pyplot'))
 
             from rfdetr import RFDETRBase  # type: ignore
 

--- a/packages/ai/src/ai/common/models/vision/requirements_detection.txt
+++ b/packages/ai/src/ai/common/models/vision/requirements_detection.txt
@@ -2,9 +2,3 @@
 # Detection-specific extras, installed after the shared requirements_vision.txt base.
 timm
 rfdetr; python_version >= "3.10"
-# Cap matplotlib below 3.11: 3.11.0's pybind11 ft2font extension aborts the embedded
-# engine (SIGABRT, "module 'matplotlib.ft2font' has no attribute '__path__'") when
-# supervision (pulled by rfdetr) imports matplotlib.pyplot at load time. The abort is a
-# C++ terminate, not a Python exception, so the rtdetr fallback in detection.py can't
-# catch it — one detection request takes down the whole model server.
-matplotlib<3.11


### PR DESCRIPTION
## Correction to #1312
The `matplotlib<3.11` cap merged in #1312 **does not fix** the model-server crash. Verified in a throwaway container off the deployed image: with the cap, matplotlib resolves to **3.10.9** and object detection **still aborts**:

```
libc++abi: terminating due to uncaught exception of type pybind11::attribute_error:
module 'matplotlib.ft2font' has no attribute '__path__'
```

The real boundary is **matplotlib 3.10.0**, which rewrote `ft2font` as a **pybind11** extension. The embedded engine's import system probes `__path__`; on a pybind11 module that raises a **C++ `attribute_error` that escapes as SIGABRT** instead of a catchable Python `AttributeError`. So *any* matplotlib ≥ 3.10 aborts — a version cap can't help, and the `except Exception` rtdetr fallback at `detection.py:124` can't catch a C++ terminate, so one detection request kills the whole GPU server.

## Fix
Stub `matplotlib.pyplot` in `sys.modules` before importing rfdetr, so the real `pyplot → ft2font` never loads. `supervision` (pulled by rfdetr) only imports pyplot for plotting helpers we never call — `detect()` reads `preds.xyxy/confidence/class_id` only. **This mirrors the existing guard in `nodes/face_detection.py`** (same engine/matplotlib abort). Also reverts the ineffective `requirements_detection.txt` cap.

## Verification
Throwaway container off `ghcr.io/rocketride-ai/model-server:develop`, running the real `DetectorLoader._ensure_dependencies()` + stub + `from rfdetr import RFDETRBase`: **clean import, no SIGABRT/minidump** (matplotlib 3.10.9, supervision 0.29.0.post0). Post-merge: saas submodule bump → build → deploy → re-verify on the H100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of vision detection model initialization

* **Chores**
  * Updated vision detection model dependencies: added `timm` and conditional `rfdetr` support for Python 3.10+

<!-- end of auto-generated comment: release notes by coderabbit.ai -->