### PR TITLE
feat: per-object node parameters (object property bag) — POC

### DIFF
--- a/nodes/src/nodes/frame_grabber/IInstance.py
+++ b/nodes/src/nodes/frame_grabber/IInstance.py
@@ -50,7 +50,25 @@ class IInstance(IInstanceBase):
         # Reset the start times
         self._startTimes = []
 
+        interval = self.params.get('interval')
+        if interval is not None:
+            if interval <= 0:
+                raise ValueError(f'interval must be positive, got {interval}')
+            fps = 1.0 / interval
+            if fps != self.IGlobal.config.get('fps'):
+                from ai.common.avi.frame import VideoFrameExtractor
+
+                config = dict(self.IGlobal.config)
+                config['fps'] = fps
+                self._reader = VideoFrameExtractor(
+                    frame_callback=self._frame_callback, name='FrameGrabber', config=config
+                )
+        else:
+            raise RuntimeError('No interval')
+
     def close(self):
+        super().close()
+
         # If we are listening on tables
         if self.instance.hasListener('table') and len(self._startTimes) > 0:
             # Generate the table

--- a/packages/ai/src/ai/modules/data/data_conn.py
+++ b/packages/ai/src/ai/modules/data/data_conn.py
@@ -477,6 +477,8 @@ class DataConn(DAPConn):
         if mime_type is None:
             raise ValueError('No mimeType specified')
 
+        parameters = args.get('parameters', None)
+
         # Acquire semaphore in async context (non-blocking for event loop)
         self.debug_message(f'Waiting for semaphore slot (max: {self._thread_count})...')
         await self._pipe_sem.acquire()
@@ -491,6 +493,9 @@ class DataConn(DAPConn):
                 try:
                     # Create an entry object from the provided object metadata
                     entry = getObject(obj=obj)
+
+                    if parameters:
+                        entry.setParameters(parameters)
 
                     # Get a pipe from the target endpoint
                     pipe_instance = self._target.getPipe()

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -113,6 +113,7 @@ class DataMixin(DAPClient):
             objinfo: Dict[str, Any] = None,
             mime_type: str = None,
             provider: str = None,
+            parameters: Dict[str, Any] = None,
             on_sse=None,
         ):
             """
@@ -124,6 +125,8 @@ class DataMixin(DAPClient):
                 objinfo: Optional metadata about the data
                 mime_type: MIME type of data (e.g., "text/csv", "application/json")
                 provider: Optional provider specification
+                parameters: Optional per-object node parameters, namespaced by
+                            component id, e.g. {"frame_grabber_1": {"interval": 10}}
                 on_sse: Optional async callback(type: str, data: dict) called for each SSE
                         event emitted by the pipeline node for this specific pipe
             """
@@ -132,6 +135,7 @@ class DataMixin(DAPClient):
             self._objinfo = objinfo or {}
             self._mime_type = mime_type or 'application/octet-stream'
             self._provider = provider
+            self._parameters = parameters or {}
             self._pipe_id = None
             self._opened = False
             self._closed = False
@@ -176,6 +180,7 @@ class DataMixin(DAPClient):
                     'object': self._objinfo,
                     'mimeType': self._mime_type,
                     'provider': self._provider,
+                    'parameters': self._parameters,
                 },
                 token=self._token,
             )
@@ -366,7 +371,13 @@ class DataMixin(DAPClient):
         return out
 
     async def pipe(
-        self, token: str, objinfo: Dict[str, Any] = None, mime_type: str = None, provider: str = None, on_sse=None
+        self,
+        token: str,
+        objinfo: Dict[str, Any] = None,
+        mime_type: str = None,
+        provider: str = None,
+        parameters: Dict[str, Any] = None,
+        on_sse=None,
     ) -> DataPipe:
         r"""
         Create a data pipe for streaming operations.
@@ -400,7 +411,15 @@ class DataMixin(DAPClient):
                 results = await pipe.close()
             # Results available after context exits
         """
-        return self.DataPipe(self, token=token, objinfo=objinfo, mime_type=mime_type, provider=provider, on_sse=on_sse)
+        return self.DataPipe(
+            self,
+            token=token,
+            objinfo=objinfo,
+            mime_type=mime_type,
+            provider=provider,
+            parameters=parameters,
+            on_sse=on_sse,
+        )
 
     async def send(
         self,
@@ -487,6 +506,7 @@ class DataMixin(DAPClient):
             ]
         ],
         token: str,
+        parameters: Dict[str, Any] = None,
     ) -> UPLOAD_RESULT:
         """
         Upload multiple files to a pipeline with progress tracking.
@@ -633,7 +653,9 @@ class DataMixin(DAPClient):
                 file_size = os.path.getsize(filepath)
 
                 # Step 1: Create and open pipe (waits for server to allocate)
-                pipe = await self.pipe(token, self._objinfo_with_size(objinfo, file_size), mimetype)
+                pipe = await self.pipe(
+                    token, self._objinfo_with_size(objinfo, file_size), mimetype, parameters=parameters
+                )
                 self.debug_message(f'Opening pipe for {filepath}')
                 await pipe.open()
                 self.debug_message(f'Pipe {pipe.pipe_id} opened for {filepath}')

--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -93,6 +93,7 @@ from rocketride.mixins.connection import ConnectionMixin
 # Import pipelines - using absolute imports since they're in the same directory
 from echo_pipeline import get_echo_pipeline
 from chat_pipeline import get_chat_pipeline
+from grabber_pipeline import get_grabber_pipeline
 
 # Define type aliases for the types that may not be exported directly
 UPLOAD_RESULT = Dict[str, Any]
@@ -617,6 +618,45 @@ class TestDataOperations:
         finally:
             if pipeline_token:
                 await ensure_clean_pipeline(client, pipeline_token)
+            if client.is_connected():
+                await client.disconnect()
+
+
+class TestFrameGrabber:
+    """Test per-object node parameters via the frame_grabber pipeline."""
+
+    VIDEO_PATH = PROJECT_ROOT / 'testdata' / 'video' / 'BBC - Tear down this wall.mp4'
+    GRAB_TOKEN = 'PY-GRAB'
+    GRAB_TOKEN_LARGE = 'PY-GRAB-L'
+
+    async def _grab_frame_count(self, client, parameters, token):
+        await ensure_clean_pipeline(client, token)
+        result = await client.use(pipeline=get_grabber_pipeline(), token=token)
+        pipeline_token = result['token']
+        try:
+            results = await client.send_files([str(self.VIDEO_PATH)], pipeline_token, parameters=parameters)
+            assert isinstance(results, list) and len(results) == 1
+            upload = results[0]
+            assert upload['action'] == 'complete', f'upload failed: {upload.get("error")}'
+            return len((upload.get('result') or {}).get('image', []))
+        finally:
+            await ensure_clean_pipeline(client, pipeline_token)
+
+    @pytest.mark.asyncio
+    async def test_grabber_with_object_parameters(self):
+        """A per-object interval of 10s extracts fewer frames than the 5s default."""
+        client = RocketRideClient(auth=TEST_CONFIG['auth'], uri=TEST_CONFIG['uri'])
+        try:
+            await client.connect()
+            default_count = await self._grab_frame_count(client, None, self.GRAB_TOKEN)
+            larger_count = await self._grab_frame_count(
+                client, {'frame_grabber_1': {'interval': 10}}, self.GRAB_TOKEN_LARGE
+            )
+            assert default_count > 0
+            assert larger_count > 0
+            # 10s between frames yields fewer frames than the 5s default for the same video.
+            assert larger_count < default_count
+        finally:
             if client.is_connected():
                 await client.disconnect()
 

--- a/packages/client-python/tests/grabber_pipeline.py
+++ b/packages/client-python/tests/grabber_pipeline.py
@@ -1,0 +1,88 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Frame Grabber Pipeline Configuration for Testing.
+
+Builds a pipeline that extracts frames from an uploaded video and returns them
+on the ``image`` lane: ``webhook -> frame_grabber -> response_image``.
+
+Used to exercise per-object node parameters: the client can pass
+``parameters={'frame_grabber_1': {'interval': <seconds>}}`` to vary how many
+frames the frame_grabber node extracts for a given object.
+
+Usage:
+    from grabber_pipeline import get_grabber_pipeline
+
+    token = await client.use(pipeline=get_grabber_pipeline())
+"""
+
+from typing import Dict, Any
+
+
+def get_grabber_pipeline(project_id: str = 'a7c3e8d1-4b2f-4e6a-9c5d-3f8b1e2a6d40') -> Dict[str, Any]:
+    """
+    Get the frame-grabber pipeline configuration.
+
+    The frame_grabber node is configured with its default ``interval`` profile
+    (5 seconds between frames). Per-object overrides addressed to
+    ``frame_grabber_1`` take precedence at runtime.
+
+    Args:
+        project_id: Unique project identifier. Concurrent pipelines must use
+            distinct project_ids to avoid server-side contention during startup.
+
+    Returns:
+        Frame-grabber pipeline configuration.
+    """
+    return {
+        'components': [
+            {
+                'id': 'webhook_1',
+                'provider': 'webhook',
+                'name': 'My webhook',
+                'description': 'A webhook to receive video data',
+                'config': {
+                    'hideForm': True,
+                    'mode': 'Source',
+                    'type': 'webhook',
+                },
+            },
+            {
+                'id': 'frame_grabber_1',
+                'provider': 'frame_grabber',
+                'config': {
+                    'profile': 'interval',
+                    'interval': {'duration': 0, 'interval': 5, 'start_time': 0},
+                },
+                'input': [{'lane': 'video', 'from': 'webhook_1'}],
+            },
+            {
+                'id': 'response_image_1',
+                'provider': 'response_image',
+                'config': {'laneName': 'image'},
+                'input': [{'lane': 'image', 'from': 'frame_grabber_1'}],
+            },
+        ],
+        'source': 'webhook_1',
+        'project_id': project_id,
+    }

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -64,6 +64,7 @@ export class DataPipe {
 	private _objinfo: Record<string, unknown>;
 	private _mimeType: string;
 	private _provider?: string;
+	private _parameters: Record<string, unknown>;
 	private _pipeId?: number;
 	private _opened = false;
 	private _closed = false;
@@ -77,15 +78,17 @@ export class DataPipe {
 	 * @param objinfo - Metadata about the object being sent (e.g., filename, size)
 	 * @param mimeType - MIME type of the data being sent (default: 'application/octet-stream')
 	 * @param provider - Optional provider name for the data source
+	 * @param parameters - Optional per-object node parameters, namespaced by component id, e.g. { frame_grabber_1: { interval: 10 } }
 	 * @param onSSE - Optional async callback invoked for each SSE event emitted by
 	 *                the pipeline node for this specific pipe
 	 */
-	constructor(client: RocketRideClient, token: string, objinfo: Record<string, unknown> = {}, mimeType = 'application/octet-stream', provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>) {
+	constructor(client: RocketRideClient, token: string, objinfo: Record<string, unknown> = {}, mimeType = 'application/octet-stream', provider?: string, parameters: Record<string, unknown> = {}, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>) {
 		this._client = client;
 		this._token = token;
 		this._objinfo = objinfo;
 		this._mimeType = mimeType;
 		this._provider = provider;
+		this._parameters = parameters;
 		this._onSSE = onSSE;
 	}
 
@@ -132,6 +135,7 @@ export class DataPipe {
 				object: this._objinfo,
 				mimeType: this._mimeType,
 				provider: this._provider,
+				parameters: this._parameters,
 			},
 			token: this._token,
 		});
@@ -1284,8 +1288,8 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Create a data pipe for streaming operations.
 	 */
-	async pipe(token: string, objinfo: Record<string, unknown> = {}, mimeType?: string, provider?: string, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<DataPipe> {
-		return new DataPipe(this, token, objinfo, mimeType, provider, onSSE);
+	async pipe(token: string, objinfo: Record<string, unknown> = {}, mimeType?: string, provider?: string, parameters: Record<string, unknown> = {}, onSSE?: (type: string, data: Record<string, unknown>) => Promise<void>): Promise<DataPipe> {
+		return new DataPipe(this, token, objinfo, mimeType, provider, parameters, onSSE);
 	}
 
 	/**
@@ -1303,7 +1307,7 @@ export class RocketRideClient extends DAPClient {
 		}
 
 		// Create and use a temporary pipe for the data
-		const pipe = await this.pipe(token, this._objinfoWithSize(objinfo, buffer.length), mimetype, undefined, onSSE);
+		const pipe = await this.pipe(token, this._objinfoWithSize(objinfo, buffer.length), mimetype, undefined, undefined, onSSE);
 
 		try {
 			await pipe.open();
@@ -1363,7 +1367,8 @@ export class RocketRideClient extends DAPClient {
 			objinfo?: Record<string, unknown>;
 			mimetype?: string;
 		}>,
-		token: string
+		token: string,
+		parameters: Record<string, unknown> = {}
 	): Promise<UPLOAD_RESULT[]> {
 		const results: UPLOAD_RESULT[] = new Array(files.length);
 
@@ -1410,7 +1415,7 @@ export class RocketRideClient extends DAPClient {
 
 			try {
 				// Step 1: Create and open pipe (waits for server to allocate)
-				pipe = await this.pipe(token, this._objinfoWithSize({ name: file.name, ...objinfo }, fileSize), finalMimetype);
+				pipe = await this.pipe(token, this._objinfoWithSize({ name: file.name, ...objinfo }, fileSize), finalMimetype, undefined, parameters);
 				await pipe.open();
 
 				// Step 2: Send status update AFTER we have the pipe
@@ -1511,7 +1516,7 @@ export class RocketRideClient extends DAPClient {
 
 			// Create pipe instance — no provider filter so chat() works with chat, webhook,
 			// and dropper sources. The rocketride-question MIME type routes to the 'questions' lane.
-			const pipe = await this.pipe(token, objinfo, 'application/rocketride-question', undefined, onSSE);
+			const pipe = await this.pipe(token, objinfo, 'application/rocketride-question', undefined, undefined, onSSE);
 
 			try {
 				// Open the communication channel to the AI

--- a/packages/server/engine-lib/engLib/headers/entry.hpp
+++ b/packages/server/engine-lib/engLib/headers/entry.hpp
@@ -570,6 +570,7 @@ public:
     EntryTime docModifyTime;
     EntryJson objectTags;
     EntryJson instanceTags;
+    EntryJson parameters;
 
     EntryJson response;
 
@@ -627,6 +628,7 @@ public:
         docModifyTime.reset();
         objectTags.reset();
         instanceTags.reset();
+        parameters.reset();
     }
 
     //-----------------------------------------------------------------
@@ -761,6 +763,7 @@ public:
             entry.permissionId(value->asUInt());
         if (auto value = val.getKey("objectTags")) entry.objectTags(*value);
         if (auto value = val.getKey("instanceTags")) entry.instanceTags(*value);
+        if (auto value = val.getKey("parameters")) entry.parameters(*value);
         if (auto value = val.getKey("isContainer"))
             entry.isContainer(value->asBool());
 
@@ -851,6 +854,7 @@ public:
 #endif
         if (objectTags) val["objectTags"] = objectTags();
         if (instanceTags) val["instanceTags"] = instanceTags();
+        if (parameters) val["parameters"] = parameters();
 
         if (response) val["response"] = response();
 

--- a/packages/server/engine-lib/engLib/store/python/bindings.cpp
+++ b/packages/server/engine-lib/engLib/store/python/bindings.cpp
@@ -637,6 +637,7 @@ PYBIND11_EMBEDDED_MODULE(engLib, engLib) {
 
         .PYBIND_ENTRY_PROP_READONLY(IJson, metadata, hasMetadata)
         .PYBIND_ENTRY_PROP_READONLY(IJson, response, hasResponse)
+        .PYBIND_ENTRY_PROP_READONLY(IJson, parameters, hasParameters)
 
         .PYBIND_PROP_READONLY_CUSTOM(
             objectFailed,
@@ -696,6 +697,11 @@ PYBIND11_EMBEDDED_MODULE(engLib, engLib) {
                          [](Entry &entry, py::object &msg) {
                              auto changeMsg = py::cast<std::string>(msg);
                              entry.markChanged(changeMsg);
+                         })
+
+        .PYBIND_FUNCTION(setParameters,
+                         [](Entry &entry, py::dict values) {
+                             entry.parameters(pyjson::dictToJson(values));
                          })
 
         .PYBIND_FUNCTION(toDict,

--- a/packages/server/engine-lib/rocketlib-python/lib/rocketlib/filters.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/rocketlib/filters.py
@@ -611,11 +611,30 @@ class IInstanceBase:
     IEndpoint: IEndpointBase = None  #: Endpoint instance for communication.
     IGlobal: IGlobalBase = None  #: Global instance for shared data.
     instance: IFilterInstance = None  #: Instance data reference.
+    _params: Dict[str, Any] = None  #: Cached effective params for the current object (reset in close()).
 
     """
     These are all the overrides to provide
     the driver funtionality.
     """
+
+    @property
+    def params(self) -> Dict[str, Any]:
+        # Import locally to avoid load-time dep on ai
+        from ai.common.config import Config
+
+        if self._params is None:
+            # TODO: this global/object config stuff needs refactoring
+            glb = self.IGlobal.glb
+            self._params = Config.getNodeConfig(glb.logicalType, glb.connConfig)
+
+            obj = self.instance.currentObject
+            if obj.hasParameters:
+                objParams = IJson.toDict(obj.parameters).get(self.instance.pipeType.id)
+                if objParams:
+                    self._params = {**self._params, **objParams}
+
+        return self._params
 
     def preventDefault(self) -> None:
         """Prevent the default action from occurring."""
@@ -1005,7 +1024,7 @@ class IInstanceBase:
 
     def close(self) -> None:
         """Close the instance."""
-        pass
+        self._params = None
 
 
 class ILoader(Protocol):


### PR DESCRIPTION
> ⚠️ **POC / proof-of-concept** — opened for design review, not merge-ready.

Adds **per-object node parameters**: a client can attach parameters to an individual object that override a node's startup configuration *for that object only*, addressed by pipeline component id.

## Flow

```
client.send_files(..., parameters={'<nodeId>': {...}})
  → rrext_process "open"
  → seeded onto the shared Entry (entry.setParameters)
  → node reads its OWN slice via self.params
```

## Changes

- **engine (C++)** — `Entry.parameters` transport bag (namespaced by component id) + `entry.setParameters()` binding (`entry.hpp`, `bindings.cpp`).
- **rocketlib** — `IInstanceBase.params`: lazy, per-object accessor that merges the node's resolved config (`Config.getNodeConfig`) with the object's own slice (per-object overrides win); cached and reset on `close()` (`filters.py`).
- **ai** — `data_conn` open handler seeds the source `Entry` from the `parameters` argument.
- **client SDKs** — `parameters=` added to `send_files` / `pipe` / `DataPipe` (Python **and** TypeScript).
- **frame_grabber** — reads `self.params['interval']` to vary frame-extraction rate per object (rebuilds the reader since fps is baked at construction).

## Isolation

`self.params` exposes only the processing node's own slice (`entry.parameters[selfId]`); other nodes' parameters are not reachable through it.

## Open items / known rough edges (POC)

- rocketlib → ai runtime dependency (local import) for `getNodeConfig`.
- Shallow merge of object slice over node config.
- UI declaration (`Object` section in `services.json`) and the engine-side `rrext_process` HTTP path are **not** included — this PR is the runtime/SDK path only.
- POC demo test (client-python frame_grabber interval comparison).

Design discussion: #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)
