### PR TITLE
fix(task): correct organizations= typo that nulled pk_/tk_ account org

### DIFF
--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -543,14 +543,12 @@ class TaskServer(DAPBase):
             phoneNumberVerified=False,
             locale='',
             defaultTeam=control.teamId,
-            organizations=[
-                {
-                    'id': control.orgId,
-                    'name': '',
-                    'permissions': [],
-                    'teams': [{'id': control.teamId, 'name': '', 'permissions': permissions}],
-                }
-            ],
+            organization={
+                'id': control.orgId,
+                'name': '',
+                'permissions': [],
+                'teams': [{'id': control.teamId, 'name': '', 'permissions': permissions}],
+            },
         )
 
     async def authenticate(self, authorization: str) -> Optional[AccountInfo]:

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -628,3 +628,28 @@ async def test_push_account_update_swallows_send_errors(monkeypatch):
     await TaskServer.push_account_update(ts, 'u1')
     target.send_event.assert_not_awaited()
     ts.debug_message.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _build_task_account_info — pk_/tk_ permission resolution
+# ---------------------------------------------------------------------------
+
+
+def test_build_task_account_info_populates_organization():
+    """The synthesized account for pk_/tk_ auth must carry a populated
+    ``organization`` so team permissions resolve. Regression: a plural
+    ``organizations=`` value was silently dropped by pydantic, leaving
+    ``organization`` None and breaking the chat SSE subscribe with
+    'Access denied: no permissions for this task'.
+    """
+    from ai.account.models import resolve_task_permissions
+
+    ts = _make_server()
+    control = SimpleNamespace(userId='user-1', teamId='team-1', orgId='org-1')
+
+    info = ts._build_task_account_info('pk_abc', control, ['task.data'])
+
+    assert info.organization is not None
+    # The task's own team is present with the granted permissions, so a pk_
+    # subscriber resolves to a non-empty permission list for its own task.
+    assert resolve_task_permissions(info, 'team-1') == ['task.data']


### PR DESCRIPTION
## Summary

- **Root cause — a typo that silently broke the account contract.** `AccountInfo` is contractually **single-org** (`organization: Optional[OrgInfo]`, documented as *"single org per user"*; `resolve_task_permissions` reads it as one object via `org.get('teams')`). `_build_task_account_info` (the account synthesized for task-scoped `pk_`/`tk_` auth) instead passed the **non-existent plural** `organizations=[...]`. Pydantic drops unknown keys, so every `pk_`/`tk_` session was built with `organization=None` — the only place in the codebase that violated the single-org contract.
- With `organization=None`, `resolve_task_permissions()` returns `[]` for any team, so the SSE subscribe (`cmd_monitor.py`, no `pk_`/`tk_` bypass) raised `Access denied: no permissions for this task`. The pipe open/write path was unaffected because it bypasses the team check for `pk_`/`tk_` auth (`task_conn.py`) — which is why the pipe ran but the trace showed `missing leave event`.
- **Fix:** pass the singular `organization={...}`, matching the contract every other caller already honors (OSS/SaaS account builders, `resolve_task_permissions`). One-line cause, mechanical fix.
- Added a regression test for the synthesized `pk_` account.

## Why singular, not "support the plural"

This is not a style choice between singular and plural — the model contract is single-org by design (documented in three places; 10 `.organization` readers, zero `AccountInfo.organizations` fields; `resolve_task_permissions` would crash on a list). The plural here was an isolated typo that broke that contract, not an intended multi-org design. Supporting plural would mean changing the model field, `resolve_task_permissions`/`resolve_team_permissions`, the OSS/SaaS builders, and every `.organization` reader — a real multi-org feature, out of scope for this bugfix.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally (chat SSE subscribe works; regression test passes)
- [ ] `./builder test` passes (ran the new test only)

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1315
