### PR TITLE
fix(ai): map server RR_* env vars to ROCKETRIDE_* for sys.admin pipelines

### DIFF
--- a/packages/ai/src/ai/modules/task/commands/cmd_misc.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_misc.py
@@ -41,6 +41,7 @@ Architecture:
 - Provides read-only access to service metadata
 """
 
+import os
 import time
 from typing import TYPE_CHECKING, Dict, Any, List
 from rocketride import EVENT_TYPE
@@ -191,10 +192,18 @@ class MiscCommands(DAPConn):
                 org = getattr(self._account_info, 'organization', None)
                 if org:
                     org_id = org.get('id', '') if isinstance(org, dict) else getattr(org, 'id', '')
-                merged_env = await account.get_merged_env(
-                    user_id=self._account_info.userId,
-                    org_id=org_id,
-                    team_id=team_id,
+
+                # sys.admin: seed with server RR_* keys mapped to ROCKETRIDE_*
+                if 'sys.admin' in (self._account_info.sysPermissions or []):
+                    merged_env = {'ROCKETRIDE_' + k[3:]: v for k, v in os.environ.items() if k.startswith('RR_')}
+
+                # Layer org → team → user secrets on top
+                merged_env.update(
+                    await account.get_merged_env(
+                        user_id=self._account_info.userId,
+                        org_id=org_id,
+                        team_id=team_id,
+                    )
                 )
 
             # Resolve ${ROCKETRIDE_*} variables before validation

--- a/packages/ai/src/ai/modules/task/commands/cmd_task.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_task.py
@@ -50,6 +50,7 @@ command processing layer in a task execution and debugging infrastructure.
 The actual task execution and management is delegated to the TaskServer.
 """
 
+import os
 from typing import TYPE_CHECKING, Dict, Any
 from ai.common.dap import DAPConn, TransportBase
 from ai.account import account
@@ -165,10 +166,22 @@ class TaskCommands(DAPConn):
             # Security: only accept ROCKETRIDE_* keys from the caller
             raw_env = args.get('env', {})
             caller_env = {k: v for k, v in raw_env.items() if k.startswith('ROCKETRIDE_')}
-            merged_env = await account.get_merged_env(
-                user_id=self._account_info.userId,
-                org_id=org_id,
-                team_id=team_id,
+
+            # sys.admin: seed with server RR_* keys mapped to ROCKETRIDE_* so
+            # admin pipelines can reference internal secrets via ${ROCKETRIDE_*}.
+            # This is the bottom layer — org/team/user secrets override it.
+            if 'sys.admin' in (self._account_info.sysPermissions or []):
+                merged_env = {'ROCKETRIDE_' + k[3:]: v for k, v in os.environ.items() if k.startswith('RR_')}
+            else:
+                merged_env = {}
+
+            # Layer org → team → user secrets on top
+            merged_env.update(
+                await account.get_merged_env(
+                    user_id=self._account_info.userId,
+                    org_id=org_id,
+                    team_id=team_id,
+                )
             )
             # Caller-supplied env overrides on top
             merged_env.update(caller_env)

--- a/packages/ai/tests/ai/modules/task/commands/test_cmd_task.py
+++ b/packages/ai/tests/ai/modules/task/commands/test_cmd_task.py
@@ -61,6 +61,7 @@ def _account_info(*, user_id='user-1', auth='ak_x', default_team='team-1', organ
         userToken='token-' + user_id,
         defaultTeam=default_team,
         organization=organization,
+        sysPermissions=[],
     )
 
 


### PR DESCRIPTION
## Summary

- **Problem:** sys.admin pipelines (admin-ui Web AI, landing chat warmup) reference `${ROCKETRIDE_*}` placeholders in `.pipe` files, but the server stores secrets as `RR_*` environment variables. Without an explicit mapping layer, `resolve_pipeline_env()` resolves every `${ROCKETRIDE_OPENAI_KEY}`, `${ROCKETRIDE_QDRANT_HOST}`, etc. to empty strings — causing opaque auth and connection failures at the provider level (OpenAI 401s, Qdrant connection refused, etc.).
- **Root cause:** `cmd_misc.py` (handles `misc/use`) and `cmd_task.py` (handles `task/start`) both called `account.get_merged_env()` to resolve pipeline secrets, but that only returns secrets stored in the database per org/team/user. Server-side `RR_*` env vars were never injected into the pipeline env namespace.
- **Fix:** For callers with the `sys.admin` system permission, seed the pipeline environment with every server `RR_*` variable mapped to `ROCKETRIDE_*` (e.g. `RR_OPENAI_KEY` → `ROCKETRIDE_OPENAI_KEY`). This becomes the **bottom layer** — org/team/user database secrets from `get_merged_env()` override on top, followed by any caller-supplied env. The existing override hierarchy is fully preserved.
- **Files changed:**
  - `packages/ai/src/ai/modules/task/commands/cmd_misc.py` — added `import os`, added sys.admin RR_→ROCKETRIDE_ seed block before `get_merged_env()` call
  - `packages/ai/src/ai/modules/task/commands/cmd_task.py` — identical change for the task/start code path

## Test plan
- [ ] Start admin-ui Web AI page → pipeline should resolve all `${ROCKETRIDE_*}` secrets and connect to OpenAI + Qdrant without errors
- [ ] Landing chat warmup (`chat_route.py`) should still work (it has its own RR_ mapping; this fix covers the authenticated `client.use()` path)
- [ ] Non-admin users should NOT receive server RR_* env vars (permission guard)
- [ ] Per-org/team/user secrets in the database should still override server defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

**New Features**
- Improved environment variable handling for task execution and pipeline validation. When permissions allow, system administrators can automatically resolve `${ROCKETRIDE_*}` values by merging server-level settings with organization/team/account secrets. Caller-provided environment variables are filtered to only the supported keys, ensuring consistent and permission-aware configuration layering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->