### PR TITLE
feat(checkout): round monthly-equivalent plan price up to whole dollars

### DIFF
--- a/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
+++ b/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
@@ -73,7 +73,8 @@ export function planDisplayAmount(plan: CheckoutPlan): string {
 	const cents = (plan.amountCents || 0) / (plan.interval === 'year' ? 12 : 1);
 	const amount = cents / 100;
 	const symbol = (plan as any).currency?.toUpperCase() === 'EUR' ? '\u20AC' : '$';
-	return amount === Math.floor(amount) ? `${symbol}${amount}` : `${symbol}${amount.toFixed(2)}`;
+	// Round up to whole dollars \u2014 the picker shows no cents.
+	return `${symbol}${Math.ceil(amount)}`;
 }
 
 /** Label describing the billing cadence for a plan card, or null when none applies. */


### PR DESCRIPTION
Follow-up to #1305. The annual plan price is shown as a monthly-equivalent (annual ÷ 12); this rounds that figure UP to the nearest whole dollar and drops cents in the plan picker (e.g. $250/yr → $21/mo). Display-only — `planAmount` and the actual annual `stripePriceId` charged at checkout are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pricing display in the plan picker to consistently show prices as whole dollar amounts with values rounded up, rather than displaying inconsistent decimal or integer formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->