### PR TITLE
fix(shell-ui): clear pending app on abandoned OAuth back-nav

### DIFF
--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -285,7 +285,15 @@ export class ConnectionManager implements IConnectionManager {
 		// so the button works again without a manual page refresh.
 		if (typeof window !== 'undefined') {
 			window.addEventListener('pageshow', (e) => {
-				if ((e as PageTransitionEvent).persisted) this.oauthStarted = false;
+				if ((e as PageTransitionEvent).persisted) {
+					this.oauthStarted = false;
+					// Back from Zitadel without signing in: if still unauthenticated,
+					// drop any pending app so a later refresh can't re-seed the auth
+					// gate and bounce the user back to login. Guard on token — a
+					// signed-in user's last-active-app restore reuses rr:appId via
+					// persistActiveApp, so it must survive for them.
+					if (!this.loadToken()) this.clearPendingAppId();
+				}
 			});
 		}
 	}
@@ -469,7 +477,13 @@ export class ConnectionManager implements IConnectionManager {
 			}
 		}
 
-		// No token — show shell unauthenticated (transport is attached, public APIs work)
+		// No code, no session lock, no token — an unauthenticated home load. If a
+		// pending app survived an abandoned OAuth round-trip (user pressed Back from
+		// the Zitadel login instead of signing in), drop it now. Otherwise Shell
+		// re-seeds startupAppId from it and the ShellLayout auth gate re-fires
+		// shell:loginRequest → startOAuth, bouncing the user straight back to Zitadel.
+		this.clearPendingAppId();
+		// Show shell unauthenticated (transport is attached, public APIs work)
 		return null;
 	}
 
@@ -768,6 +782,13 @@ export class ConnectionManager implements IConnectionManager {
 	/** Read the pending app ID (set before OAuth redirect). */
 	public getPendingAppId(): string {
 		try { return sessionStorage.getItem(SS_PENDING_APP_ID) ?? ''; } catch { return ''; }
+	}
+
+	/** Clear the pending app ID. Called when an OAuth round-trip is abandoned
+	 *  (user pressed Back from Zitadel) so the stale target can't re-seed the
+	 *  auth gate on the next load and bounce them straight back to login. */
+	public clearPendingAppId(): void {
+		try { sessionStorage.removeItem(SS_PENDING_APP_ID); } catch { /* storage unavailable */ }
 	}
 
 	/** Save pending app ID (for retrieval after OAuth callback). */


### PR DESCRIPTION
## Problem

When an unsigned user clicked an auth-gated app (e.g. **Pipeline Builder**) from `home-ui`:

1. `setPendingAppId(...)` wrote `sessionStorage['rr:appId']` (`SS_PENDING_APP_ID`) and `startOAuth()` redirected to Zitadel.
2. Pressing the browser **Back** button returned to the shell.
3. `Shell` re-seeded `startupAppId` from the stale `rr:appId`, so the gated app became active again with `identity === null`.
4. The `ShellLayout` auth gate saw an auth-required app with no identity and re-fired `shell:loginRequest` → `startOAuth`, **bouncing the user straight back to the Zitadel login** instead of home.

Net effect: Back from the Zitadel login never returned the user to where they came from — it re-entered auth.

## Fix

`apps/shell-ui/src/connection/connection.ts`:

- **`clearPendingAppId()`** — new method mirroring `get/setPendingAppId`.
- **`_bootstrap` terminal branch** — on a genuinely unauthenticated load (no `?code`, no session lock, no token), clear the pending app **before** `return null`, so Back falls through to the default app. This runs during `await cm.bootstrap()`, before `Shell` reads `SS_PENDING_APP_ID` for `startupAppId` (that read is gated behind `renderPhase === 'loading'`).
- **`pageshow` (persisted) handler** — also clear the pending app on bfcache restore, but **only when `!loadToken()`**, so a signed-in user's last-active-app restore (which reuses `rr:appId` via `persistActiveApp`) is preserved.

## Why it's safe

- The clear is only reachable when there is no code **and** no session lock **and** no token — the exact "abandoned auth" state. The `?code=` success path and warm-token paths return earlier and never hit it.
- Deep-link `?appId=` uses a **different** key (`SS_APP_ID`) and is untouched.
- Self-healing: re-clicking the app re-runs `setPendingAppId`.

## Test plan

- [ ] Unsigned: click Pipeline Builder → at Zitadel press **Back** → land on **home** (no re-redirect), nav still works.
- [ ] Sign in for real → still routed to Pipeline Builder after the `?code=` callback.
- [ ] Signed-in user on a non-home app → navigate away and Back (bfcache) → last app still restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth and back-navigation handling to prevent unwanted re-authentication attempts when using the browser back button during authentication flows.
  * Fixed application state management when pages are restored from the browser cache, preventing unnecessary re-triggering of the authentication process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->