### PR TITLE
fix(profiler-ui): rehydrate report on mount so split panes keep the chart

### DIFF
--- a/apps/profiler-ui/src/views/ProfilerView.tsx
+++ b/apps/profiler-ui/src/views/ProfilerView.tsx
@@ -423,6 +423,9 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 	// Guard against stale async responses when target changes mid-flight
 	const fetchIdRef = useRef<number>(0);
 
+	// Guard so an existing server-side report is rehydrated at most once per target
+	const rehydratedTargetRef = useRef<string | null | undefined>(undefined);
+
 	// =========================================================================
 	// STATUS POLLING
 	// =========================================================================
@@ -545,6 +548,22 @@ const ProfilerView: React.FC<ProfilerViewProps> = ({ host, port, name }) => {
 		}
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [showSystemCalls]);
+
+	// Rehydrate an existing report when this view mounts (or re-mounts) without
+	// local data — e.g. after the tab is split, which mounts fresh ProfilerView
+	// instances. Report DATA lives only in local state and is otherwise populated
+	// solely by the live Stop flow, so a fresh instance shows "No profiling data
+	// available" even though the server still holds a report (status.has_report
+	// stays true because it is server-backed). Fetch it once per target.
+	useEffect(() => {
+		if (!isConnected) { rehydratedTargetRef.current = undefined; return; }
+		if (status?.active === true) return;   // a live session owns the data
+		if (!status?.has_report) return;       // nothing on the server to rehydrate
+		if (treeData?.tree != null) return;    // already have data locally
+		if (rehydratedTargetRef.current === target) return; // already attempted for this target
+		rehydratedTargetRef.current = target;
+		fetchReport();
+	}, [isConnected, status?.active, status?.has_report, target, treeData, fetchReport]);
 
 	// =========================================================================
 	// ROOT CHANGE HANDLER


### PR DESCRIPTION
## Problem
Splitting a Profiler tab made both panes show **"No profiling data available"** even though the status line still read **"Idle — report available"**.

## Root cause
Report data (`treeData`/`vizRoot`) lived only in `ProfilerView` local state and was populated solely by the live Stop flow. Splitting (`splitGroupWithDocument`) mounts fresh `ProfilerView` instances with empty state. Meanwhile `status` is server-backed (polled), so `has_report` stayed true — hence the divergence.

## Fix
Add a mount-time effect that calls the existing `fetchReport()` once (guarded per-target) when connected, not actively profiling, `status.has_report` is true, but local `treeData` is empty. This makes report data server-rehydratable like status, so freshly-mounted split panes reload the existing report.

Fixes both the sunburst chart and the stats table (same `treeData` gate).

## Verification
- Builds via rsbuild.
- Manual: load a report → split the view → both panes keep the chart + table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The profiler view now automatically loads previously captured profiling reports when reconnecting to a session, eliminating empty views and eliminating the need to re-run profiling when returning to an existing session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->