### PR TITLE
fix(dap): don't let an oversized subprocess stdout line kill the pipeline task

### DIFF
--- a/packages/ai/src/ai/common/dap/transport_stdio.py
+++ b/packages/ai/src/ai/common/dap/transport_stdio.py
@@ -484,7 +484,13 @@ class TransportStdio(TransportBase):
             self._debug_message(f'Starting to read {stream_name} stream')
 
             while not stream.at_eof():
-                line = await stream.readline()
+                try:
+                    line = await stream.readline()
+                except (ValueError, asyncio.LimitOverrunError) as line_exc:
+                    # Line over the reader limit (readline already dropped it) —
+                    # skip rather than let it kill the whole task.
+                    self._debug_message(f'Skipping oversized line on {stream_name} (exceeds reader limit): {line_exc}')
+                    continue
 
                 if not line:
                     self._debug_message(f'EOF reached on {stream_name} stream')

--- a/packages/ai/tests/ai/common/dap/test_transport_stdio.py
+++ b/packages/ai/tests/ai/common/dap/test_transport_stdio.py
@@ -592,8 +592,7 @@ async def test_read_stream_processes_normal_lines_in_order():
     await TransportStdio._read_stream(stub, reader, 'stderr')
 
     kinds = [e.get('event') for e in stub.events]
-    assert 'apaevt_status_state' in kinds
-    assert 'apaevt_status_message' in kinds
+    assert kinds == ['apaevt_status_state', 'apaevt_status_message']
 
 
 @pytest.mark.asyncio

--- a/packages/ai/tests/ai/common/dap/test_transport_stdio.py
+++ b/packages/ai/tests/ai/common/dap/test_transport_stdio.py
@@ -12,6 +12,7 @@ Each test asserts the **dispatched event payload**, not the internal regex.
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 import pytest
@@ -573,3 +574,39 @@ async def test_disconnect_is_safe_when_already_disconnected():
     transport._connected = False
     await transport.disconnect()  # must not raise
     assert transport._process is None
+
+
+# ---------------------------------------------------------------------------
+# _read_stream — line parsing + oversized-line recovery (crash hardening)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_stream_processes_normal_lines_in_order():
+    """Normal-traffic regression: each newline-delimited message is parsed."""
+    reader = asyncio.StreamReader()
+    reader.feed_data(b'>SVC*1\n>JOB*hello\n')
+    reader.feed_eof()
+
+    stub = _Stub()
+    await TransportStdio._read_stream(stub, reader, 'stderr')
+
+    kinds = [e.get('event') for e in stub.events]
+    assert 'apaevt_status_state' in kinds
+    assert 'apaevt_status_message' in kinds
+
+
+@pytest.mark.asyncio
+async def test_read_stream_skips_oversized_line_and_keeps_going():
+    """Regression: a line over the reader limit is skipped, not fatal to the reader."""
+    reader = asyncio.StreamReader(limit=64)
+    # oversized line + newline, then a normal message
+    reader.feed_data(b'X' * 500 + b'\n' + b'>SVC*1\n')
+    reader.feed_eof()
+
+    stub = _Stub()
+    await TransportStdio._read_stream(stub, reader, 'stderr')
+
+    assert any(e.get('event') == 'apaevt_status_state' for e in stub.events), (
+        f'message after the oversized line was not processed: {stub.events!r}'
+    )


### PR DESCRIPTION

## Summary

- Harden `TransportStdio._read_stream` (the DAP stdout reader) to **skip** a subprocess line that exceeds the 16 MB `StreamReader` limit (`CONST_SUBPROCESS_BUFFER_LIMIT`) instead of letting it crash the whole pipeline task.
- Root cause: `readline()` ran **outside** the per-message `try/except`, so a `LimitOverrunError`/`ValueError` — e.g. a large image inlined into a FLOW/trace event — propagated out of the read loop and tore down the subprocess, killing every node in the pipeline.
- `readline()` already drops the offending bytes, so catch-and-`continue` is safe (no manual drain, no infinite loop); the 16 MB limit is unchanged.

## Type

fix

## Testing

`41 passed` in `test_transport_stdio.py` via engine pytest; full `./builder test` not run.

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1327


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug communication resilience by handling oversized or malformed incoming lines without interrupting processing, ensuring subsequent valid messages continue to be parsed.

* **Tests**
  * Added async regression coverage to confirm correct event parsing for protocol messages and verified continued processing after oversized-line conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->