### PR TITLE
fix(docs): trigger workflow on README.md changes to keep llms.txt current

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,7 @@ on:
     branches: [develop]
     paths:
       - 'packages/docs/**'
-      - 'nodes/src/nodes/**/doc.md'
+      - 'nodes/src/nodes/**/README.md'
       - 'packages/*/docs/**'
       - 'apps/*/docs/**'
       - '.github/workflows/docs.yml'


### PR DESCRIPTION
## Summary

- Replaces the stale `nodes/src/nodes/**/doc.md` path trigger in `docs.yml` with `nodes/src/nodes/**/README.md` — matching what `gather.js` actually reads.

## Problem

`gather.js` uses `NODES_GLOB = 'nodes/src/nodes/*/README.md'` (and variant sub-pages at `nodes/src/nodes/*/*/README.md`) as its source for all node documentation. The `doc.md` entry in the workflow paths filter never matched any real file, so node doc changes never triggered a docs rebuild — leaving `llms.txt` and `llms-full.txt` out of date on the deployed site.

## Test plan

- [ ] Merge a change that only edits a node `README.md` (e.g. `nodes/src/nodes/webhook/README.md`) and confirm the `Docs` workflow fires.
- [ ] After deploy, verify `llms-full.txt` reflects the updated content.

Closes #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated documentation build workflow to improve inclusion of node-specific documentation files in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->