### PR TITLE
SaaS fixes v1: checkout preselect/CTA, canvas loop fix, cloud delete fix, settings copy

### DIFF
--- a/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
+++ b/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
@@ -26,6 +26,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { CheckoutModal } from 'shared';
+import type { CheckoutPlan } from 'shared';
 import { ConnectionManager } from '../../connection/connection';
 import type { AppManifestEntry } from '../../workspace/types';
 
@@ -53,12 +54,19 @@ export interface CheckoutFlowProps {
 export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) => {
 	/** App the user wants to subscribe to; null when modal is closed. */
 	const [checkoutApp, setCheckoutApp] = useState<AppManifestEntry | null>(null);
+	/** Optional plan preselected by the caller (e.g. the web pricing page) to
+	 *  skip the picker and go straight to payment; null = show the picker. */
+	const [presetPlan, setPresetPlan] = useState<CheckoutPlan | null>(null);
 
 	// --- Listen for subscribe events -----------------------------------------
 	useEffect(() => {
-		return ConnectionManager.getInstance().on('shell:subscribe', ({ app }: { app: unknown }) => {
-			setCheckoutApp(app as AppManifestEntry);
-		});
+		return ConnectionManager.getInstance().on(
+			'shell:subscribe',
+			({ app, plan }: { app: unknown; plan?: CheckoutPlan }) => {
+				setCheckoutApp(app as AppManifestEntry);
+				setPresetPlan(plan ?? null);
+			},
+		);
 	}, []);
 
 	// --- Listen for unsubscribe events ---------------------------------------
@@ -84,6 +92,7 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 			appName={checkoutApp.name}
 			appDescription={checkoutApp.description}
 			stripePublishableKey={stripeKey}
+			preselectedPlan={presetPlan ?? undefined}
 			onFetchPlans={async () => {
 				const c = cm.getClient();
 				if (!c) throw new Error('Not connected');
@@ -104,8 +113,8 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 					priceId,
 				});
 			}}
-			onSuccess={() => setCheckoutApp(null)}
-			onClose={() => setCheckoutApp(null)}
+			onSuccess={() => { setCheckoutApp(null); setPresetPlan(null); }}
+			onClose={() => { setCheckoutApp(null); setPresetPlan(null); }}
 		/>
 	);
 };

--- a/apps/shell-ui/src/views/settings/SettingsPage.tsx
+++ b/apps/shell-ui/src/views/settings/SettingsPage.tsx
@@ -600,7 +600,7 @@ const SettingsPage: React.FC = () => {
 									Subscribe to unlock pipeline execution and deployment.
 								</span>
 								<button onClick={handleSubscribe} style={{ ...commonStyles.buttonPrimary, fontFamily: 'var(--rr-font-family)', fontWeight: 600, whiteSpace: 'nowrap' } as CSSProperties}>
-									Subscribe to Pipe Builder
+									Subscribe to RocketRide
 								</button>
 							</div>
 						)}

--- a/docs/README-apps.md
+++ b/docs/README-apps.md
@@ -672,7 +672,7 @@ useEffect(() => {
 | `shell:loginRequest` | `{ appId?: string }` | Apps → Shell | Request OAuth login (optionally targeting an app) |
 | `shell:logoutRequest` | `{}` | Apps → Shell | Request logout |
 | `shell:switchApp` | `{ appId: string }` | Apps → Shell | Switch the active app |
-| `shell:subscribe` | `{ app: AppManifestEntry }` | Apps → Shell | Open subscription checkout for an app |
+| `shell:subscribe` | `{ app: AppManifestEntry, plan?: CheckoutPlan }` | Apps → Shell | Open subscription checkout for an app; optional `plan` preselects a tier and skips the picker (straight to payment) |
 | `shell:myApps` | `{}` | Apps → Shell | Navigate to My Apps |
 | `shell:accountUpdate` | `ConnectResult` | Server → Shell | Server-pushed account/subscription change |
 | `shell:servicesUpdated` | `{ services: Record<string, unknown>; servicesError?: string }` | Shell → Apps | Service catalog fetch completed |

--- a/packages/ai/src/ai/account/store_providers/azure/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure/azure.py
@@ -233,12 +233,12 @@ class AzureBlobStore(IStore):
                 properties = await asyncio.to_thread(blob_client.get_blob_properties)
                 current_etag = properties.etag.strip('"')
 
-                # expected_version is REQUIRED for delete operations
-                if expected_version is None:
-                    raise StorageError(f'Expected version is required when deleting file: {filename}')
-
-                # Verify version matches
-                if current_etag != expected_version:
+                # Optimistic-concurrency check only when a version is supplied.
+                # With no version we fall through to an unconditional delete,
+                # matching the filesystem/memory backends so deleting your own
+                # file always works (cloud backends previously rejected this,
+                # breaking deletes in prod while local worked).
+                if expected_version is not None and current_etag != expected_version:
                     raise VersionMismatchError(
                         filename=filename,
                         expected_version=expected_version,

--- a/packages/ai/src/ai/account/store_providers/s3/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3/s3.py
@@ -245,12 +245,12 @@ class S3Store(IStore):
                 head_response = await asyncio.to_thread(client.head_object, Bucket=self._bucket, Key=key)
                 current_etag = head_response.get('ETag', '').strip('"')
 
-                # expected_version is REQUIRED for delete operations
-                if expected_version is None:
-                    raise StorageError(f'Expected version is required when deleting file: {filename}')
-
-                # Verify version matches
-                if current_etag != expected_version:
+                # Optimistic-concurrency check only when a version is supplied.
+                # With no version we fall through to an unconditional delete,
+                # matching the filesystem/memory backends so deleting your own
+                # file always works (cloud backends previously rejected this,
+                # breaking deletes in prod while local worked).
+                if expected_version is not None and current_etag != expected_version:
                     raise VersionMismatchError(
                         filename=filename,
                         expected_version=expected_version,

--- a/packages/client-typescript/src/app-sdk/types.ts
+++ b/packages/client-typescript/src/app-sdk/types.ts
@@ -431,7 +431,7 @@ export interface ShellEventMap {
 	'shell:loginRequest': { appId?: string };
 	'shell:logoutRequest': Record<string, never>;
 	'shell:switchApp': { appId: string };
-	'shell:subscribe': { app: AppManifestEntry };
+	'shell:subscribe': { app: AppManifestEntry; plan?: unknown };
 	'shell:myApps': Record<string, never>;
 	'shell:accountUpdate': ConnectResult;
 	'shell:sidebarCollapsing': Record<string, never>;

--- a/packages/client-typescript/src/app-sdk/types.ts
+++ b/packages/client-typescript/src/app-sdk/types.ts
@@ -422,6 +422,34 @@ export interface DocumentsState {
  * }
  * ```
  */
+/**
+ * Plan payload for the `shell:subscribe` event. Mirrors the `AppPrice` row from
+ * the `app_prices` table (see the client billing types) so the preselected-plan
+ * checkout flow is type-checked end to end rather than passing an opaque value.
+ */
+export interface CheckoutPlan {
+	/** Internal price UUID. */
+	id: string;
+	/** App identifier. */
+	appId: string;
+	/** Stripe price_* identifier. */
+	stripePriceId: string;
+	/** Human-readable tier label (e.g. "Starter", "Pro"). */
+	nickname: string;
+	/** Price in smallest currency unit (e.g. cents for USD). */
+	amountCents: number;
+	/** ISO 4217 currency code. */
+	currency: string;
+	/** Billing interval. */
+	interval: 'month' | 'year' | 'one_time' | '';
+	/** Full plan metadata (description, action, order, kind, credits, etc.). */
+	metadata?: Record<string, unknown> | null;
+	/** Whether the price is active. */
+	isActive: boolean;
+	/** ISO 8601 creation timestamp. */
+	createdAt: string | null;
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ShellEventMap {
 	'shell:connected': Record<string, never>;
@@ -431,7 +459,7 @@ export interface ShellEventMap {
 	'shell:loginRequest': { appId?: string };
 	'shell:logoutRequest': Record<string, never>;
 	'shell:switchApp': { appId: string };
-	'shell:subscribe': { app: AppManifestEntry; plan?: unknown };
+	'shell:subscribe': { app: AppManifestEntry; plan?: CheckoutPlan };
 	'shell:myApps': Record<string, never>;
 	'shell:accountUpdate': ConnectResult;
 	'shell:sidebarCollapsing': Record<string, never>;

--- a/packages/shared-ui/src/components/canvas/context/FlowGraphContext.tsx
+++ b/packages/shared-ui/src/components/canvas/context/FlowGraphContext.tsx
@@ -325,6 +325,13 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 	/** Content signature of the components currently on the canvas. Echoes of our
 	 *  own edits share this signature and must NOT trigger a reload. */
 	const loadedContentSig = useRef<string>('');
+	/** Circuit breaker for the reload effect: if the content signature never
+	 *  converges (a non-idempotent load round-trip), the effect re-enters
+	 *  hundreds of times/sec and crashes with "Maximum update depth exceeded".
+	 *  We cap reloads within a short window as a backstop to the signature guard.
+	 *  Bailing also stops our re-emit, so the runaway terminates instead of
+	 *  churning. Counts in normal use stay far below the cap. */
+	const reloadGuardRef = useRef<{ t: number; n: number }>({ t: 0, n: 0 });
 
 	// --- Derived state -----------------------------------------------------
 
@@ -993,6 +1000,24 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 		// depth exceeded". Content comparison converges; undo/redo still loads because
 		// its content differs from what's currently on the canvas.
 		if (!projectChanged && incomingSig === loadedContentSig.current) {
+			return;
+		}
+
+		// Backstop circuit breaker: if signature comparison fails to converge for
+		// some project, this effect re-enters in a tight reload loop. Cap reloads
+		// within a short window (well above any human-driven undo/redo/open rate,
+		// far below React's nested-update crash threshold). Bailing skips loadData,
+		// which stops the re-emit that drives the loop, so it self-terminates.
+		const now = performance.now();
+		const guard = reloadGuardRef.current;
+		if (now - guard.t > 250) {
+			guard.t = now;
+			guard.n = 0;
+		}
+		guard.n += 1;
+		if (guard.n > 30) {
+			// eslint-disable-next-line no-console
+			console.warn('[FlowGraph] Suppressed runaway canvas reload — project content is not converging on load. Canvas left in its last-loaded state.');
 			return;
 		}
 

--- a/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
+++ b/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
@@ -13,7 +13,7 @@
  * All server communication flows through callback props — no SDK imports.
  */
 
-import React, { useEffect, useState, useCallback, useMemo, type CSSProperties } from 'react';
+import React, { useEffect, useState, useCallback, useMemo, useRef, type CSSProperties } from 'react';
 import { loadStripe } from '@stripe/stripe-js';
 import { Elements, PaymentElement, useStripe, useElements } from '@stripe/react-stripe-js';
 import { commonStyles } from '../../themes/styles';
@@ -246,6 +246,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 	appName,
 	appDescription,
 	stripePublishableKey,
+	preselectedPlan,
 	onFetchPlans,
 	onCreateCheckout,
 	onConfirmPending,
@@ -258,7 +259,10 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 	// ── State ────────────────────────────────────────────────────────────
 	const [plans, setPlans] = useState<CheckoutPlan[]>([]);
 	const [plansLoading, setPlansLoading] = useState(true);
-	const [selectedPlan, setSelectedPlan] = useState<CheckoutPlan | null>(null);
+	// Seed the selection from a preselected plan so the payment step can render
+	// its recap immediately (and the picker is skipped — see the auto-advance
+	// effect below).
+	const [selectedPlan, setSelectedPlan] = useState<CheckoutPlan | null>(preselectedPlan ?? null);
 
 	const [clientSecret, setClientSecret] = useState<string | null>(null);
 	const [subscriptionId, setSubscriptionId] = useState<string>('');
@@ -303,6 +307,19 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 		setClientSecret(null);
 		setError(null);
 	}, []);
+
+	// When a plan is preselected (web pricing page), skip the picker entirely:
+	// create the subscription immediately so the user lands on the payment step.
+	// At mount ``plans`` is still empty, so the PlanPicker cannot re-select a
+	// default over our seeded selection before this fires. Runs once.
+	const autoStartedRef = useRef(false);
+	useEffect(() => {
+		if (!preselectedPlan || autoStartedRef.current) return;
+		if (!clientSecret && !loadingSecret) {
+			autoStartedRef.current = true;
+			void handleContinue();
+		}
+	}, [preselectedPlan, clientSecret, loadingSecret, handleContinue]);
 
 	// Stripe Elements appearance
 	const appearance = useMemo(() => {

--- a/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
+++ b/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
@@ -113,6 +113,18 @@ function defaultActionClick(_plan: CheckoutPlan, action: PlanAction): void {
 	}
 }
 
+/** True when an action link points at GitHub (drives the GitHub glyph on the CTA). */
+function isGithubAction(action: PlanAction | null): boolean {
+	return !!action && action.type === 'link' && /github\.com/i.test(action.url);
+}
+
+/** Inline GitHub mark, shown on action links that point at github.com. */
+const GitHubMark: React.FC = () => (
+	<svg width={13} height={13} viewBox="0 0 16 16" fill="currentColor" aria-hidden="true" style={{ flexShrink: 0 }}>
+		<path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.65 7.65 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+	</svg>
+);
+
 // =============================================================================
 // STYLES
 // =============================================================================
@@ -155,13 +167,16 @@ const S = {
 		marginBottom: 16,
 	}),
 
-	planCard: (selected: boolean): CSSProperties => ({
+	planCard: (selected: boolean, interactive: boolean): CSSProperties => ({
 		display: 'flex',
 		flexDirection: 'column',
 		borderRadius: 10,
 		border: `2px solid ${selected ? 'var(--rr-brand)' : 'var(--rr-border)'}`,
 		background: 'var(--rr-bg-paper)',
-		cursor: 'pointer',
+		// Only show the pointer when the whole card selects a plan (the modal).
+		// On display-only pages (pricing) the card isn't clickable — the CTA
+		// button is — so a pointer here is misleading.
+		cursor: interactive ? 'pointer' : 'default',
 		transition: 'border-color 0.15s, box-shadow 0.15s',
 		boxShadow: selected ? '0 0 0 1px var(--rr-brand)' : 'none',
 		overflow: 'hidden',
@@ -236,6 +251,23 @@ const S = {
 		transition: 'background 0.15s',
 	} as CSSProperties,
 
+	// ── Primary CTA button inside a billable card (opt-in via onPlanCta) ──
+	cardCta: {
+		display: 'block',
+		width: 'calc(100% - 24px)',
+		margin: '6px 12px 12px',
+		padding: '8px 0',
+		borderRadius: 6,
+		border: 'none',
+		background: 'var(--rr-brand)',
+		color: 'var(--rr-fg-button)',
+		fontSize: 12,
+		fontWeight: 700,
+		textAlign: 'center' as const,
+		cursor: 'pointer',
+		transition: 'opacity 0.15s',
+	} as CSSProperties,
+
 	// ── Loading / empty state ────────────────────────────────────────────
 	status: {
 		textAlign: 'center' as const,
@@ -267,6 +299,18 @@ export interface PlanPickerProps {
 
 	/** Called when the user clicks an action plan's CTA. Defaults to opening the link/mailto natively. */
 	onActionClick?: (plan: CheckoutPlan, action: PlanAction) => void;
+
+	/**
+	 * When provided, each billable plan card renders a primary CTA button
+	 * (labelled by ``ctaLabel``) that calls this with the plan. The caller
+	 * owns what the click does (e.g. start checkout, or prompt sign-up first).
+	 * When omitted, billable cards have no CTA button — selection is via the
+	 * card click / ``onSelectPlan`` (the CheckoutModal flow).
+	 */
+	onPlanCta?: (plan: CheckoutPlan) => void;
+
+	/** Label for the per-card billable CTA. Default: ``'Get started'``. Only used with ``onPlanCta``. */
+	ctaLabel?: string;
 
 	/** Content rendered below the plan cards (e.g. a "Continue" button). */
 	footer?: React.ReactNode;
@@ -301,6 +345,8 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 	selectedPlan = null,
 	onSelectPlan,
 	onActionClick = defaultActionClick,
+	onPlanCta,
+	ctaLabel = 'Get started',
 	footer,
 	defaultInterval = 'month',
 	autoSelectDefault = false,
@@ -430,30 +476,42 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 				</div>
 			)}
 
-			{/* Plan cards grid */}
-			<div style={S.planGrid(visiblePlans.length)} role="radiogroup" aria-label="Subscription plans">
+			{/* Plan cards grid. Only a radiogroup when cards are selectable
+			    (modal); on display-only pages it's a plain container. */}
+			<div
+				style={S.planGrid(visiblePlans.length)}
+				role={onSelectPlan ? 'radiogroup' : undefined}
+				aria-label={onSelectPlan ? 'Subscription plans' : undefined}
+			>
 				{visiblePlans.map((plan) => {
 					const action = planAction(plan);
 					const isAction = !!action;
 					const selected = !isAction && selectedPlan?.stripePriceId === plan.stripePriceId;
 					const desc = planDescription(plan);
+					// Whole-card selection only applies when a selection handler is
+					// wired (the checkout/upgrade modals). On display-only pages
+					// (pricing) the card is static — the CTA button is the action —
+					// so drop the pointer, radio role, focusability and click handlers.
+					const interactive = !isAction && !!onSelectPlan;
 
 					return (
 						<div
 							key={plan.stripePriceId || plan.id}
-							style={S.planCard(selected)}
-							onClick={() => {
-								if (!isAction && onSelectPlan) onSelectPlan(plan);
-							}}
-							onKeyDown={(e) => {
-								if (e.key === 'Enter' || e.key === ' ') {
-									e.preventDefault();
-									if (!isAction && onSelectPlan) onSelectPlan(plan);
-								}
-							}}
-							role={isAction ? undefined : 'radio'}
-							tabIndex={0}
-							aria-checked={isAction ? undefined : selected}
+							style={S.planCard(selected, interactive)}
+							onClick={interactive ? () => onSelectPlan!(plan) : undefined}
+							onKeyDown={
+								interactive
+									? (e) => {
+										if (e.key === 'Enter' || e.key === ' ') {
+											e.preventDefault();
+											onSelectPlan!(plan);
+										}
+									}
+									: undefined
+							}
+							role={interactive ? 'radio' : undefined}
+							tabIndex={interactive ? 0 : undefined}
+							aria-checked={interactive ? selected : undefined}
 						>
 							{/* Card header: tier name, price, interval */}
 							<div style={S.cardHead(selected)}>
@@ -476,13 +534,17 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 								</div>
 							)}
 
-							{/* Action button for link/mailto plans */}
+							{/* Action button for link/mailto plans (Free, Enterprise) */}
 							{action && (
 								<a
 									href={actionHref(action)}
 									target={action.type === 'link' ? '_blank' : undefined}
 									rel={action.type === 'link' ? 'noopener noreferrer' : undefined}
-									style={S.cardAction}
+									style={
+										isGithubAction(action)
+											? { ...S.cardAction, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }
+											: S.cardAction
+									}
 									onClick={(e) => {
 										e.stopPropagation();
 										e.preventDefault();
@@ -490,7 +552,22 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 									}}
 								>
 									{action.label}
+									{isGithubAction(action) && <GitHubMark />}
 								</a>
+							)}
+
+							{/* Primary CTA for billable plans (opt-in via onPlanCta) */}
+							{!isAction && onPlanCta && (
+								<button
+									type="button"
+									style={S.cardCta}
+									onClick={(e) => {
+										e.stopPropagation();
+										onPlanCta(plan);
+									}}
+								>
+									{ctaLabel}
+								</button>
 							)}
 						</div>
 					);

--- a/packages/shared-ui/src/modules/checkout/types.ts
+++ b/packages/shared-ui/src/modules/checkout/types.ts
@@ -97,6 +97,15 @@ export interface CheckoutModalProps {
 	/** Stripe publishable key (pk_test_* or pk_live_*). */
 	stripePublishableKey: string;
 
+	/**
+	 * When set, the modal skips the plan-picker step and goes straight to the
+	 * payment step for this plan (creating the subscription immediately). Omit
+	 * (the default) to show the picker first. Only the web pricing page sets
+	 * this; the in-app and VS Code extension flows leave it undefined and keep
+	 * the pick-a-plan → Continue UX.
+	 */
+	preselectedPlan?: CheckoutPlan;
+
 	/** Fetches available subscription plans from the server. */
 	onFetchPlans: () => Promise<CheckoutPlan[]>;
 

--- a/packages/shared-ui/src/modules/project/ProjectView.tsx
+++ b/packages/shared-ui/src/modules/project/ProjectView.tsx
@@ -345,9 +345,12 @@ const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isCon
 
 	// --- Viewport change -----------------------------------------------------
 
-	const handleViewportChange = (viewport: { x: number; y: number; zoom: number }) => {
+	// Memoized so ReactFlow's onMoveEnd handler keeps a stable identity — an
+	// inline function here gives <ReactFlow> a new onMoveEnd every render, which
+	// makes its StoreUpdater re-sync endlessly ("Maximum update depth exceeded").
+	const handleViewportChange = useCallback((viewport: { x: number; y: number; zoom: number }) => {
 		updateViewState({ viewport });
-	};
+	}, [updateViewState]);
 
 	const panels = {
 		design: {

--- a/packages/shared-ui/src/types/shell.ts
+++ b/packages/shared-ui/src/types/shell.ts
@@ -34,6 +34,7 @@
 
 import type { ConnectResult, DAPMessage } from 'rocketride';
 import type { ConnectionStatus } from './connection';
+import type { CheckoutPlan } from '../modules/checkout/types';
 
 // =============================================================================
 // APP ENTRY — minimal shape for app catalog events
@@ -181,9 +182,11 @@ export interface ShellConnectionEventMap {
 	/**
 	 * User clicked "Subscribe" on a paid app in the marketplace.
 	 *
-	 * Opens the CheckoutModal. The `app` field is the manifest entry.
+	 * Opens the CheckoutModal. The `app` field is the manifest entry. The
+	 * optional `plan` preselects a tier and skips the picker — going straight
+	 * to payment (used by the web pricing page); omit it to show the picker.
 	 */
-	'shell:subscribe': { app: ShellAppEntry };
+	'shell:subscribe': { app: ShellAppEntry; plan?: CheckoutPlan };
 
 	/** Navigate back to the My Apps launcher screen. */
 	'shell:myApps': Record<string, never>;


### PR DESCRIPTION
## Summary

A bundle of SaaS-facing fixes and features surfaced during the rocketride-saas product work. A companion **rocketride-saas** PR will bump the submodule pointer to this branch's merge commit once it lands on `develop`.

## Changes

**Checkout / pricing**
- Support preselecting a plan via an optional `plan` field on the `shell:subscribe` event; `CheckoutModal` seeds the selection and auto-advances straight to the payment step (skipping the picker). Threaded through `CheckoutFlow`, mirrored in the app-sdk event map, and documented.
- `PlanPicker`: opt-in per-plan CTA (`onPlanCta` / `ctaLabel`), a GitHub icon on `github.com` action links, and cards that are only interactive (pointer / radio role / keyboard) when a selection handler is wired — so display-only pages (e.g. the public pricing page) render static cards.
- Settings copy: subscribe CTA now reads "Subscribe to RocketRide".

**Canvas**
- Fix the "Maximum update depth exceeded" crash in the pipeline canvas: memoize `ProjectView`'s viewport handler so ReactFlow's `onMoveEnd` keeps a stable identity (an inline handler made `StoreUpdater` re-sync every render), plus a reload circuit breaker in `FlowGraphContext` as a backstop against non-converging content reloads.

**Storage**
- Cloud (`S3`/`Azure`) `delete_file` now enforces the `expected_version` match only when one is supplied, matching the `filesystem`/`memory` backends. Fixes file deletes failing in prod (cloud backends) while working locally.

## Testing

- UI changes verified locally via `saas:dev` (shell-ui + rocket-ui).
- The storage delete fix is prod-only (local uses the filesystem backend, which already worked) and will be validated on deploy.

## Follow-up

- A rocketride-saas PR will bump the submodule to this branch's merge commit. The saas-side consumers (home-ui pricing page, rocket-ui run-button subscription gate) depend on these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Checkout flows now support an optional preselected subscription plan, letting customers skip the plan picker and go straight to payment.
  * Plan selection cards can display a primary call-to-action button for billable plans.
  * GitHub links in plan actions are now marked with a GitHub icon.
* **Bug Fixes**
  * Prevented infinite reload behavior in the project canvas to avoid React update loops.
  * Storage file deletes now succeed even when no version is provided.
* **Chores**
  * Updated subscription wording in Settings branding to RocketRide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->