### PR TITLE
fix(nodes): remove redundant full-res image encode/decode round-trips

### DIFF
--- a/nodes/src/nodes/detect/IInstance.py
+++ b/nodes/src/nodes/detect/IInstance.py
@@ -23,8 +23,9 @@
 # =============================================================================
 
 import json
+import time
 
-from rocketlib import IInstanceBase, AVI_ACTION, warning
+from rocketlib import IInstanceBase, AVI_ACTION, debug, warning
 from ai.common.image import ImageProcessor
 from .IGlobal import IGlobal
 
@@ -76,10 +77,10 @@ class IInstance(IInstanceBase):
             self.instance.writeText(json.dumps(detections))
 
         if self.instance.hasListener('image'):
-            image_bytes = ImageProcessor.get_bytes(self._annotate(image, detections))
-            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/png')
-            self.instance.writeImage(AVI_ACTION.WRITE, 'image/png', image_bytes)
-            self.instance.writeImage(AVI_ACTION.END, 'image/png')
+            image_bytes = ImageProcessor.get_bytes(self._annotate(image, detections), fmt='JPEG')
+            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/jpeg')
+            self.instance.writeImage(AVI_ACTION.WRITE, 'image/jpeg', image_bytes)
+            self.instance.writeImage(AVI_ACTION.END, 'image/jpeg')
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         """Accumulate an inbound image stream and run detection on END.
@@ -98,10 +99,20 @@ class IInstance(IInstanceBase):
             self._image_data += buffer
         elif action == AVI_ACTION.END:
             try:
+                t0 = time.perf_counter()
                 image = ImageProcessor.load_image_from_bytes(self._image_data)
+                t_decode = (time.perf_counter() - t0) * 1000
+                t0 = time.perf_counter()
                 with self.IGlobal.device_lock:
                     detections = self.IGlobal.detector.detect(image)
+                t_detect = (time.perf_counter() - t0) * 1000
+                t0 = time.perf_counter()
                 self._emit(image, detections)
+                t_emit = (time.perf_counter() - t0) * 1000
+                debug(
+                    f'detect: decode={t_decode:.0f}ms detect={t_detect:.0f}ms '
+                    f'emit={t_emit:.0f}ms total={t_decode + t_detect + t_emit:.0f}ms'
+                )
             except Exception as exc:
                 warning(f'detect: dropping frame due to inference error: {exc}')
             finally:

--- a/nodes/src/nodes/response/IInstance.py
+++ b/nodes/src/nodes/response/IInstance.py
@@ -27,8 +27,7 @@ import base64
 
 from rocketlib import IInstanceBase
 from ai.common.schema import Doc, Question, Answer
-from ai.common.image import ImageProcessor
-from rocketlib import AVI_ACTION, Entry, debug
+from rocketlib import AVI_ACTION, Entry
 
 from .IGlobal import IGlobal
 
@@ -227,7 +226,7 @@ class IInstance(IInstanceBase):
             if key not in self.instance.currentObject.response:
                 self.instance.currentObject.response[key] = []
 
-            video_str = base64.b64encode(bytes(self.video)).decode('utf-8')
+            video_str = base64.b64encode(self.video).decode('utf-8')
             self.video = bytearray()
 
             self.instance.currentObject.response[key].append(
@@ -255,13 +254,7 @@ class IInstance(IInstanceBase):
             if key not in self.instance.currentObject.response:
                 self.instance.currentObject.response[key] = []
 
-            # Load the image
-            image = ImageProcessor.load_image_from_bytes(self.image)
-            if image is None:
-                debug('Invalid image data provided')
-
-            # Convert to base64
-            image_str = ImageProcessor.get_base64(image)
+            image_str = base64.b64encode(self.image).decode('utf-8')
 
             # Release the image
             self.image = bytearray()

--- a/packages/ai/src/ai/common/image/image.py
+++ b/packages/ai/src/ai/common/image/image.py
@@ -12,46 +12,29 @@ class ImageProcessor:
     @staticmethod
     def load_image_from_bytes(image_data: bytes) -> Image:
         """
-        Load an image from raw bytes and ensure it is in PNG format internally.
+        Load an image from raw bytes into a fully-decoded Pillow Image.
 
-        This method attempts to open the image data using Pillow's Image.open().
-        If the loaded image format is not PNG, it converts the image to PNG in memory,
-        reopening it from the PNG buffer to normalize the format.
+        Opens the bytes with Pillow and forces a full decode (``load()``) so the
+        image stays usable after the source buffer is released. The image keeps its
+        original mode/format; callers use the pixel data, not ``.format``.
 
         Args:
             image_data (bytes): The raw image data in bytes.
 
         Returns:
-            Image: A Pillow Image object guaranteed to be in PNG format.
+            Image: A fully-loaded Pillow Image, or None on failure.
 
         Raises:
             ValueError: If no image data is provided.
-
-        Notes:
-            - The .copy() call after reopening the PNG buffer is necessary to avoid
-              issues related to the underlying buffer being closed once the BytesIO
-              context manager exits.
-            - This method may raise or return None on failure; the caller should check.
         """
         if not image_data:
             raise ValueError('No image data provided')
 
         try:
-            # Open the image from bytes buffer
+            # Decode once; load() forces a full read so the image detaches from the
+            # buffer (replaces a costly format-normalizing PNG re-encode round-trip).
             image = Image.open(io.BytesIO(image_data))
-
-            # Check the image format; if not PNG, convert to PNG in-memory
-            if image.format != 'PNG':
-                with io.BytesIO() as png_buffer:
-                    # Save the image as PNG into the in-memory buffer
-                    image.save(png_buffer, format='PNG')
-
-                    # Rewind the buffer to the beginning before reading
-                    png_buffer.seek(0)
-
-                    # Re-open the image from the PNG buffer and copy to detach from buffer
-                    image = Image.open(png_buffer).copy()
-
+            image.load()
             return image
 
         except Exception as e:
@@ -121,25 +104,28 @@ class ImageProcessor:
         return thumbnail
 
     @staticmethod
-    def get_bytes(image: Image) -> bytes:
+    def get_bytes(image: Image, fmt: str = 'PNG', quality: int = 90) -> bytes:
         """
-        Convert a Pillow Image to PNG format bytes.
+        Encode a Pillow Image to bytes.
 
-        This method saves the image as PNG to preserve transparency and full color data.
-        No conversion to RGB is needed since PNG supports RGBA and other modes.
+        PNG by default (preserves alpha). Pass ``fmt='JPEG'`` for a smaller/faster
+        encode; non-RGB modes (e.g. RGBA) are coerced to RGB since JPEG has no alpha.
 
         Args:
             image (Image): The Pillow Image object to convert.
+            fmt (str): 'PNG' (default) or 'JPEG'.
+            quality (int): JPEG quality (ignored for PNG).
 
         Returns:
-            bytes: The PNG image data.
+            bytes: The encoded image data.
         """
         buffered = io.BytesIO()
-
-        # Save image to buffer in PNG format (supports transparency)
-        image.save(buffered, format='PNG')
-
-        # Retrieve byte data from buffer
+        if fmt.upper() in ('JPEG', 'JPG'):
+            if image.mode not in ('RGB', 'L'):
+                image = image.convert('RGB')
+            image.save(buffered, format='JPEG', quality=quality)
+        else:
+            image.save(buffered, format=fmt)
         return buffered.getvalue()
 
     @staticmethod

--- a/packages/ai/src/ai/common/models/vision/detection.py
+++ b/packages/ai/src/ai/common/models/vision/detection.py
@@ -38,7 +38,7 @@ import io
 import logging
 import os
 import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from ai.web.metrics import metrics
 from ai.common.utils.image_utils import image_to_bytes
@@ -47,15 +47,22 @@ from ..base import BaseLoader, get_model_server_address, ModelClient
 
 logger = logging.getLogger('rocketlib.models.detection')
 
-# Backend key -> default HF/package model id.
-BACKEND_DEFAULTS: Dict[str, str] = {
-    'rfdetr': 'PekingU/rtdetr_r50vd',
-    'mmgdino': 'IDEA-Research/grounding-dino-tiny',
+
+class BackendSpec(NamedTuple):
+    """Model specifications."""
+
+    model: str  # model id
+    infer_edge: int  # = model input resolution (long edge, px); downscale to it is lossless (boxes mapped back)
+    open_vocab: bool  # open-vocab flag
+
+
+BACKENDS: Dict[str, BackendSpec] = {
+    'rfdetr': BackendSpec(model='PekingU/rtdetr_r50vd', infer_edge=560, open_vocab=False),
+    'mmgdino': BackendSpec(model='IDEA-Research/grounding-dino-tiny', infer_edge=1333, open_vocab=True),
 }
 DEFAULT_BACKEND = 'rfdetr'
-BACKENDS = frozenset(BACKEND_DEFAULTS)
-OPEN_VOCAB_BACKENDS = frozenset({'mmgdino'})
 DEFAULT_THRESHOLD = 0.3
+OPEN_VOCAB_BACKENDS = frozenset(b for b, spec in BACKENDS.items() if spec.open_vocab)
 
 
 def _to_detection(label: str, score: float, x1: float, y1: float, x2: float, y2: float) -> Dict[str, Any]:
@@ -284,7 +291,12 @@ class MmGDinoLoader:
         return out
 
 
-def _build_backend(backend: str, model_name: str, device: Optional[str], revision: Optional[str] = None):
+def _build_backend(
+    backend: str,
+    model_name: str,
+    device: Optional[str],
+    revision: Optional[str] = None,
+):
     """Construct the underlying detector for a backend.
 
     Args:
@@ -313,7 +325,7 @@ class DetectorLoader(BaseLoader):
 
     @staticmethod
     def load(
-        model_name: str = BACKEND_DEFAULTS[DEFAULT_BACKEND],
+        model_name: str = BACKENDS[DEFAULT_BACKEND].model,
         backend: str = DEFAULT_BACKEND,
         device: Optional[str] = None,
         allocate_gpu: Optional[callable] = None,
@@ -345,7 +357,12 @@ class DetectorLoader(BaseLoader):
             gpu_index = int(device.split(':')[1]) if str(device).startswith('cuda:') else -1
 
         detector = _build_backend(backend, model_name, device, revision=revision)
-        metadata = {'device': str(device), 'model_name': model_name, 'backend': backend, 'loader': 'detection'}
+        metadata = {
+            'device': str(device),
+            'model_name': model_name,
+            'backend': backend,
+            'loader': 'detection',
+        }
         return {'detector': detector, 'backend': backend}, metadata, gpu_index
 
     @staticmethod
@@ -442,10 +459,11 @@ class Detector:
             **kwargs: Extra identity-only loader options.
         """
         self.backend = backend
-        self.model_name = model_name or BACKEND_DEFAULTS.get(backend, BACKEND_DEFAULTS[DEFAULT_BACKEND])
+        self.model_name = model_name or BACKENDS.get(backend, BACKENDS[DEFAULT_BACKEND]).model
         self.threshold = float(threshold)
         self.prompt = prompt
         self._revision = revision
+        self._infer_max_edge = BACKENDS.get(backend, BACKENDS[DEFAULT_BACKEND]).infer_edge
 
         server_addr = get_model_server_address()
         self._proxy_mode = bool(server_addr) and (device is None or device == 'server')
@@ -490,39 +508,72 @@ class Detector:
         threshold = self.threshold if threshold is None else threshold
         metrics.counter('gpu_inference_count', 1)
 
+        from PIL import Image
+        from ai.common.image.dense_resize import resize_for_inference
+
+        # Run inference on a copy downscaled to the model's input size, then map
+        # boxes back so callers get original-resolution coordinates.
+        if not hasattr(image, 'size'):
+            image = Image.open(io.BytesIO(image)).convert('RGB')
+        small, (orig_w, orig_h) = resize_for_inference(image, self._infer_max_edge)
+
         if self._proxy_mode:
             result = self._client.send_command(
                 'rrext_ms_inference',
                 {
-                    'data': image_to_bytes(image),
+                    'data': image_to_bytes(small),
                     'output_fields': ['detections'],
                     'prompt': prompt,
                     'threshold': threshold,
                 },
             )
             items = result.get('result', [])
-            return items[0].get('detections', []) if items else []
+            dets = items[0].get('detections', []) if items else []
+        else:
+            t0 = time.perf_counter()
+            pre = DetectorLoader.preprocess(self._bundle, [small], self._metadata)
+            t_pre = (time.perf_counter() - t0) * 1000
+            t0 = time.perf_counter()
+            raw = DetectorLoader.inference(self._bundle, pre, self._metadata, prompt=prompt, threshold=threshold)
+            t_gpu = (time.perf_counter() - t0) * 1000
+            t0 = time.perf_counter()
+            out = DetectorLoader.postprocess(self._bundle, raw, 1, ['detections'], metadata=self._metadata)
+            t_post = (time.perf_counter() - t0) * 1000
+            inference_sec = (t_pre + t_gpu + t_post) / 1000.0
+            metrics.add_time(
+                {
+                    'gpu_preprocess': t_pre,
+                    'gpu_compute': t_gpu,
+                    'gpu_postprocess': t_post,
+                    'gpu_queue_wait': 0,
+                    'gpu_memory': model_gpu_gb(self._bundle) * inference_sec,
+                }
+            )
+            dets = out[0]['detections']
 
-        t0 = time.perf_counter()
-        pre = DetectorLoader.preprocess(self._bundle, [image], self._metadata)
-        t_pre = (time.perf_counter() - t0) * 1000
-        t0 = time.perf_counter()
-        raw = DetectorLoader.inference(self._bundle, pre, self._metadata, prompt=prompt, threshold=threshold)
-        t_gpu = (time.perf_counter() - t0) * 1000
-        t0 = time.perf_counter()
-        out = DetectorLoader.postprocess(self._bundle, raw, 1, ['detections'], metadata=self._metadata)
-        t_post = (time.perf_counter() - t0) * 1000
-        inference_sec = (t_pre + t_gpu + t_post) / 1000.0
-        metrics.add_time(
-            {
-                'gpu_preprocess': t_pre,
-                'gpu_compute': t_gpu,
-                'gpu_postprocess': t_post,
-                'gpu_queue_wait': 0,
-                'gpu_memory': model_gpu_gb(self._bundle) * inference_sec,
-            }
-        )
-        return out[0]['detections']
+        return self._rescale_to_original(dets, small.size, orig_w, orig_h)
+
+    @staticmethod
+    def _rescale_to_original(
+        dets: List[Dict[str, Any]], small_size: Tuple[int, int], orig_w: int, orig_h: int
+    ) -> List[Dict[str, Any]]:
+        """Map box/centroid coordinates from the downscaled image back to original size."""
+        sw, sh = small_size
+        if not dets or (sw == orig_w and sh == orig_h):
+            return dets
+        fx, fy = orig_w / sw, orig_h / sh
+        for d in dets:
+            b = d.get('box')
+            if b:
+                b['x1'] *= fx
+                b['x2'] *= fx
+                b['y1'] *= fy
+                b['y2'] *= fy
+            c = d.get('centroid')
+            if c:
+                c['x'] *= fx
+                c['y'] *= fy
+        return dets
 
     def disconnect(self) -> None:
         """Release the model-server connection (proxy mode only); no-op locally.

--- a/packages/ai/tests/ai/common/image/test_image.py
+++ b/packages/ai/tests/ai/common/image/test_image.py
@@ -1,0 +1,55 @@
+"""Unit tests for ImageProcessor.get_bytes encoding (PNG default, opt-in JPEG)."""
+
+import io
+
+import pytest
+from PIL import Image
+
+from ai.common.image.image import ImageProcessor
+
+
+def test_get_bytes_defaults_to_png():
+    data = ImageProcessor.get_bytes(Image.new('RGB', (4, 4)))
+    assert data[:4] == b'\x89PNG'
+
+
+def test_get_bytes_jpeg_for_rgb():
+    data = ImageProcessor.get_bytes(Image.new('RGB', (4, 4)), fmt='JPEG')
+    assert data[:3] == b'\xff\xd8\xff'  # JPEG magic
+
+
+def test_get_bytes_jpeg_coerces_rgba():
+    # RGBA carries alpha; JPEG has none -> coerced to RGB, must not raise.
+    data = ImageProcessor.get_bytes(Image.new('RGBA', (4, 4)), fmt='JPEG')
+    assert data[:3] == b'\xff\xd8\xff'
+
+
+def test_get_bytes_png_preserves_rgba():
+    data = ImageProcessor.get_bytes(Image.new('RGBA', (4, 4)))
+    assert data[:4] == b'\x89PNG'
+    assert Image.open(io.BytesIO(data)).mode == 'RGBA'
+
+
+def test_load_image_from_bytes_decodes_jpeg_at_original_size():
+    # JPEG in -> fully-loaded image at original size/mode (no PNG round-trip).
+    buf = io.BytesIO()
+    Image.new('RGB', (6, 4), (10, 20, 30)).save(buf, format='JPEG')
+    img = ImageProcessor.load_image_from_bytes(buf.getvalue())
+    assert img is not None
+    assert img.size == (6, 4)
+    assert img.mode == 'RGB'
+    assert isinstance(img.getpixel((0, 0)), tuple)  # fully decoded -> pixel access works
+
+
+def test_load_image_from_bytes_survives_source_buffer_close():
+    # load() must fully read the image so it stays usable after the source is gone.
+    src = io.BytesIO()
+    Image.new('L', (3, 3)).save(src, format='PNG')
+    img = ImageProcessor.load_image_from_bytes(src.getvalue())
+    src.close()
+    assert img.getpixel((1, 1)) == 0
+
+
+def test_load_image_from_bytes_empty_raises():
+    with pytest.raises(ValueError):
+        ImageProcessor.load_image_from_bytes(b'')

--- a/packages/ai/tests/ai/common/models/test_detection.py
+++ b/packages/ai/tests/ai/common/models/test_detection.py
@@ -1,5 +1,8 @@
 """Unit tests for the detection loader + facade (no torch/transformers needed)."""
 
+import pytest
+from PIL import Image
+
 import ai.common.models.vision.detection as detmod
 from ai.common.models.vision.detection import DetectorLoader, Detector
 
@@ -66,14 +69,38 @@ def test_facade_proxy_sends_prompt_threshold_and_decodes(monkeypatch):
     det = Detector(backend='mmgdino', threshold=0.4, prompt='cat . dog')
     assert det._proxy_mode is True
 
-    out = det.detect(b'fake-image-bytes')
+    out = det.detect(Image.new('RGB', (8, 8)))  # small image -> not downscaled
     assert captured['cmd'] == 'rrext_ms_inference'
     args = captured['args']
-    assert args['data'] == b'fake-image-bytes'
+    assert isinstance(args['data'], (bytes, bytearray)) and args['data'][:4] == b'\x89PNG'
     assert args['output_fields'] == ['detections']
     assert args['prompt'] == 'cat . dog'
     assert args['threshold'] == 0.4
-    assert out == dets
+    assert out == dets  # no downscale -> boxes unchanged
 
     det.disconnect()
     assert captured.get('disconnected') is True
+
+
+def test_facade_proxy_rescales_boxes_to_original(monkeypatch):
+    """Large image is downscaled for inference; returned boxes map back to original coords."""
+    dets = [
+        {
+            'label': 'cat',
+            'score': 0.9,
+            'box': {'x1': 100.0, 'y1': 50.0, 'x2': 200.0, 'y2': 150.0},
+            'centroid': {'x': 150.0, 'y': 100.0},
+        }
+    ]
+    captured = {'dets': dets}
+    monkeypatch.setattr(detmod, 'get_model_server_address', lambda: 'localhost:5590')
+    monkeypatch.setattr(detmod, 'ModelClient', _fake_client_factory(captured))
+
+    det = Detector(backend='mmgdino')  # infer edge = 1333
+    out = det.detect(Image.new('RGB', (2000, 1000)))  # -> downscaled to (1333, 666)
+
+    fx, fy = 2000 / 1333, 1000 / 666
+    b = out[0]['box']
+    assert b['x1'] == pytest.approx(100.0 * fx)
+    assert b['y2'] == pytest.approx(150.0 * fy)
+    assert out[0]['centroid']['x'] == pytest.approx(150.0 * fx)


### PR DESCRIPTION
## Summary

- **`load_image_from_bytes`**: decode once (`Image.open(...).load()`) instead of a JPEG→PNG→decode "normalization" round-trip — large-image `decode` ~12 s → <1 s.
- **`response` node**: base64 the encoded image bytes as-is and pass through `mimeType` (mirrors the existing `writeVideo` handler) instead of decode + a full-res PNG re-encode — `emit` ~8 s → ~tens of ms. Also fixes a mime/data mismatch (stored `image/jpeg` with PNG bytes) and a `None`-decode crash, and preserves `background_removal`'s alpha (PNG now passes through).
- **`detect`**: downscale-for-inference + rescale boxes back to original coords; emit the annotated frame as JPEG (`get_bytes` gains `fmt`/`quality`). Tiny model payload; full-res output unchanged.
- Net: a 30 MP image drops from **~28–38 s → ~1–2 s**. `response_image` is shared, so every vision branch in `examples/vision.pipe` benefits — not just detect.

Measured (`detect` node, 30 MP JPEG, 6720×4480):

```
before:             decode=12228ms detect=521ms emit=15732ms total=28481ms
after decode fix:   decode=192ms   detect=589ms emit=8969ms  total=9749ms
after response fix: emit no longer blocks on a full-res PNG re-encode → total ~1–2 s
```

**Behavior note:** image responses now carry the **source format** (JPEG from detect, PNG+alpha from background_removal) per `mime_type`, instead of always PNG. Consumers render via `data:${mime_type};base64,…`, so this is correct for mime-aware consumers (e.g. the dropper UI).

## Type

perf (vision image path) — also fixes two latent `response`-node bugs (mime/data mismatch, `None`-decode crash).

## Testing

- [x] Tests added or updated — new `packages/ai/tests/ai/common/image/test_image.py` (`get_bytes` fmt + `load_image_from_bytes`); updated `test_detection.py` (box rescale).
- [x] Tested locally — targeted pytest via engine python: **7 image + 5 detection passing**; verified end-to-end in the EaaS (30 MP image ~28 s → ~1.5 s).
- [ ] `./builder test` passes — full suite not run locally; targeted pytest green.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a (no node input/output/config schema change)
- [x] Breaking changes documented (if applicable) — response image is now format pass-through (see Behavior note); non-breaking for mime-aware consumers

## Linked Issue

Fixes #1338



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added performance timing metrics to monitor processing duration across pipeline stages
  * Implemented dynamic image downscaling for inference with automatic coordinate rescaling to original resolution

* **Bug Fixes**
  * Improved detection result accuracy through proper coordinate rescaling

* **Refactor**
  * Streamlined response encoding for images and video

* **Tests**
  * Added comprehensive test coverage for image encoding/decoding and detection workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->