### PR TITLE
feat(vscode): add Parameters tab to set pipeline trace level

### DIFF
--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -51,6 +51,12 @@ The visual editor provides:
 - **Properties panel**: Configure selected component settings (API keys, models, connection strings, etc.).
 - **Lane connections**: Draw lines between component output and input lanes to define data flow.
 
+## Pipeline Parameters
+
+The **Parameters** tab (next to **Design**) holds run-time settings for the open pipeline:
+
+- **Trace level**: how much execution-trace data the engine emits — `full`, `summary` (default), `metadata`, or `none`. Higher levels populate the **Flow** and **Trace** tabs, but `full` inlines entire payloads (including images), which can noticeably slow runs that process large images. The selected level is saved per pipeline and applied on the next run.
+
 ## Monitoring Execution
 
 The **Status** page shows:

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -37,7 +37,9 @@ const LAYOUTS_KEY = 'rocketride.layouts';
 // TYPES
 // =============================================================================
 
-/** Pipeline trace level (mirrors the shared-ui `TraceLevel` and the SDK `client.use` option). */
+// Defined locally on purpose: the host tsconfig excludes `src/providers/views/**`
+// and does not map the `shared/*` path alias, so it cannot import the canonical
+// TraceLevel from the webview/shared-ui layer. Keep in sync with that union.
 type TraceLevel = 'none' | 'metadata' | 'summary' | 'full';
 
 interface EditorState {

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -37,6 +37,9 @@ const LAYOUTS_KEY = 'rocketride.layouts';
 // TYPES
 // =============================================================================
 
+/** Pipeline trace level (mirrors the shared-ui `TraceLevel` and the SDK `client.use` option). */
+type TraceLevel = 'none' | 'metadata' | 'summary' | 'full';
+
 interface EditorState {
 	document: vscode.TextDocument;
 	webviewPanel: vscode.WebviewPanel;
@@ -420,6 +423,7 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 				case 'status:pipelineAction': {
 					const action = data.action as 'run' | 'stop' | 'restart';
 					const source = data.source as string | undefined;
+					const traceLevel = data.pipelineTraceLevel as TraceLevel | undefined;
 					if (action === 'run' || action === 'restart') {
 						// Gate: check connection before running
 						const runClient = this.connectionManager.getClient();
@@ -439,7 +443,7 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 							await this.saveDocument(document, document.getText());
 							const parsed = JSON.parse(document.getText());
 							const pipeName = path.basename(document.uri.fsPath, '.pipe');
-							await this.runPipeline({ pipeline: { ...parsed, source: source ?? parsed.source } }, pipeName);
+							await this.runPipeline({ pipeline: { ...parsed, source: source ?? parsed.source } }, pipeName, traceLevel);
 						} catch (error: unknown) {
 							const message = error instanceof Error ? error.message : String(error);
 							vscode.window.showErrorMessage(`Failed to run pipeline: ${message}`);
@@ -684,7 +688,7 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 	// PIPELINE EXECUTION
 	// =========================================================================
 
-	private async runPipeline(document: { pipeline: PipelineConfig }, name?: string): Promise<void> {
+	private async runPipeline(document: { pipeline: PipelineConfig }, name?: string, pipelineTraceLevel?: TraceLevel): Promise<void> {
 		try {
 			const client = this.connectionManager.getClient();
 			if (!client) throw new Error('Not connected to server');
@@ -694,7 +698,7 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 			await client.use({
 				pipeline: project,
 				source: project.source,
-				pipelineTraceLevel: 'full',
+				pipelineTraceLevel: pipelineTraceLevel ?? 'summary',
 				args: ConfigManager.getInstance().getEngineArgs('development'),
 				name,
 			});
@@ -703,8 +707,6 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 			vscode.window.showErrorMessage(`Failed to run pipeline: ${message}`);
 		}
 	}
-
-
 
 	private async stopPipeline(componentId: string, document: vscode.TextDocument): Promise<void> {
 		try {

--- a/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
+++ b/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
@@ -238,9 +238,9 @@ const ProjectWebview: React.FC = () => {
 
 	const handlePipelineAction = useCallback(
 		(action: 'run' | 'stop' | 'restart', source?: string) => {
-			sendMessage({ type: 'status:pipelineAction', action, source });
+			sendMessage({ type: 'status:pipelineAction', action, source, pipelineTraceLevel: viewState?.pipelineTraceLevel ?? 'summary' });
 		},
-		[sendMessage]
+		[sendMessage, viewState]
 	);
 
 	const handleMissingEnvVars = useCallback(
@@ -252,6 +252,8 @@ const ProjectWebview: React.FC = () => {
 
 	const handleViewStateChange = useCallback(
 		(vs: ViewState) => {
+			// Keep local state current so the next run message carries the latest trace level
+			setViewState(vs);
 			// Persist to VS Code webview state (survives tab switches)
 			const current = getState() ?? ({} as ViewState);
 			setState({ ...current, ...vs });

--- a/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
+++ b/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
@@ -89,6 +89,7 @@ const ProjectWebview: React.FC = () => {
 					mode: vs?.mode ?? 'design',
 					flowViewMode: vs?.flowViewMode ?? 'pipeline',
 					viewport: vs?.viewport,
+					pipelineTraceLevel: vs?.pipelineTraceLevel,
 				});
 				setPrefs(msg.prefs ?? {});
 				setTraceEvents([]);
@@ -186,6 +187,7 @@ const ProjectWebview: React.FC = () => {
 					mode: msg.state?.mode ?? 'design',
 					flowViewMode: msg.state?.flowViewMode ?? 'pipeline',
 					viewport: msg.state?.viewport,
+					pipelineTraceLevel: msg.state?.pipelineTraceLevel,
 				});
 				break;
 			case 'project:initialPrefs':

--- a/apps/vscode/src/providers/views/types.ts
+++ b/apps/vscode/src/providers/views/types.ts
@@ -10,7 +10,7 @@
  * webview (browser) for the project editor and server monitor views.
  */
 
-import type { ViewState, TaskStatus } from 'shared/modules/project';
+import type { ViewState, TaskStatus, TraceLevel } from 'shared/modules/project';
 import type { DashboardResponse } from 'shared/modules/server';
 import type { ConnectResult, ApiKeyRecord, OrgDetail, MemberRecord, TeamRecord, TeamDetail, ProfileUpdate } from 'rocketride';
 
@@ -23,7 +23,7 @@ export type ProjectHostToWebview = { type: 'project:load'; project: any; viewSta
 	| { type: 'project:envKeysUpdate'; envKeys: string[] };
 
 /** All messages the ProjectWebview can send to the extension host. */
-export type ProjectWebviewToHost = { type: 'view:ready' } | { type: 'view:initialized' } | { type: 'project:contentChanged'; project: any } | { type: 'project:validate'; requestId: number; pipeline: any } | { type: 'project:requestSave' } | { type: 'project:viewStateChange'; viewState: ViewState } | { type: 'project:prefsChange'; prefs: Record<string, unknown> } | { type: 'project:openLink'; url: string; displayName?: string } | { type: 'status:pipelineAction'; action: 'run' | 'stop' | 'restart'; source?: string } | { type: 'status:missingEnvVars'; keys: string[] } | { type: 'trace:clear' };
+export type ProjectWebviewToHost = { type: 'view:ready' } | { type: 'view:initialized' } | { type: 'project:contentChanged'; project: any } | { type: 'project:validate'; requestId: number; pipeline: any } | { type: 'project:requestSave' } | { type: 'project:viewStateChange'; viewState: ViewState } | { type: 'project:prefsChange'; prefs: Record<string, unknown> } | { type: 'project:openLink'; url: string; displayName?: string } | { type: 'status:pipelineAction'; action: 'run' | 'stop' | 'restart'; source?: string; pipelineTraceLevel?: TraceLevel } | { type: 'status:missingEnvVars'; keys: string[] } | { type: 'trace:clear' };
 
 // =============================================================================
 // SERVER MONITOR PROTOCOL

--- a/packages/shared-ui/src/modules/project/ProjectView.tsx
+++ b/packages/shared-ui/src/modules/project/ProjectView.tsx
@@ -31,7 +31,7 @@ import { commonStyles } from '../../themes/styles';
 
 import PipelineActions from '../../components/pipeline-actions/PipelineActions';
 import { extractPipelineEnvVars } from '../../components/canvas/util/extractEnvVars';
-import type { ProjectViewMode, ViewState, TaskStatus, TraceEvent, TraceRow } from './types';
+import type { ProjectViewMode, ViewState, TaskStatus, TraceEvent, TraceRow, TraceLevel } from './types';
 
 // =============================================================================
 // PROPS
@@ -322,6 +322,7 @@ const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isCon
 
 	const allTabs = [
 		{ id: 'design', label: isReadonly ? 'Design (Readonly)' : 'Design' },
+		{ id: 'parameters', label: 'Parameters' },
 		{ id: 'status', label: 'Status' },
 		{ id: 'tokens', label: 'Tokens' },
 		{ id: 'flow', label: 'Flow' },
@@ -352,6 +353,13 @@ const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isCon
 	const panels = {
 		design: {
 			content: <div style={styles.canvasPadding}>{project && <Canvas oauth2RootUrl="" project={project} servicesJson={servicesJson} taskStatuses={statusMap} handleValidatePipeline={handleValidate} onContentChanged={isReadonly ? undefined : handleContentChanged} onViewportChange={handleViewportChange} onRunPipeline={isReadonly ? undefined : handleRunPipeline} onStopPipeline={isReadonly ? undefined : handleStopPipeline} onOpenLink={handleOpenLink} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} getPreference={getPreference} setPreference={setPreference} initialViewport={viewState.viewport} isDirty={isReadonly ? false : isDirty} isNew={isReadonly ? false : isNew} onSave={isReadonly ? undefined : handleSave} onExport={isReadonly ? undefined : onExport} isReadonly={isReadonly} envKeys={envKeys} />}</div>,
+		},
+		parameters: {
+			content: (
+				<div style={commonStyles.tabContent}>
+					<ParametersPane value={viewState.pipelineTraceLevel ?? 'summary'} onChange={(level) => updateViewState({ pipelineTraceLevel: level })} disabled={isReadonly} />
+				</div>
+			),
 		},
 		status: {
 			content: <div style={commonStyles.tabContent}>{sources.length > 0 ? sources.map((src) => <SourceStatusPane key={src.id} source={src} taskStatus={statusMap[src.id]} isConnected={isConnected} isSubscribed={isSubscribed} onPipelineAction={isReadonly ? undefined : handlePipelineAction} onOpenLink={handleOpenLink} serverHost={serverHost} />) : <div style={commonStyles.empty}>No source components found</div>}</div>,
@@ -420,6 +428,44 @@ const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isCon
 };
 
 ProjectView.displayName = 'ProjectView';
+
+// =============================================================================
+// PARAMETERS PANE
+// =============================================================================
+
+const TRACE_LEVELS: { value: TraceLevel; label: string }[] = [
+	{ value: 'full', label: 'Full — every lane write & invoke, including full payload data' },
+	{ value: 'summary', label: 'Summary — structure + result summaries (no large/binary payloads)' },
+	{ value: 'metadata', label: 'Metadata — lane/node structure only' },
+	{ value: 'none', label: 'None — tracing disabled' },
+];
+
+const ParametersPane: React.FC<{
+	value: TraceLevel;
+	onChange: (value: TraceLevel) => void;
+	disabled?: boolean;
+}> = ({ value, onChange, disabled }) => {
+	return (
+		<div style={{ ...commonStyles.card, borderRadius: 6, maxWidth: 640 }}>
+			<div style={commonStyles.cardHeader}>
+				<span style={styles.sourceName}>Pipeline parameters</span>
+			</div>
+			<div style={commonStyles.cardBody}>
+				<label htmlFor="rr-trace-level" style={{ display: 'block', fontSize: 12, color: 'var(--rr-text-secondary)', marginBottom: 6 }}>
+					Trace level
+				</label>
+				<select id="rr-trace-level" style={commonStyles.inputField} value={value} disabled={disabled} onChange={(e) => onChange(e.target.value as TraceLevel)}>
+					{TRACE_LEVELS.map((lvl) => (
+						<option key={lvl.value} value={lvl.value}>
+							{lvl.label}
+						</option>
+					))}
+				</select>
+				<div style={{ fontSize: 12, color: 'var(--rr-text-secondary)', marginTop: 8 }}>Controls how much trace data the engine emits for this pipeline. Higher levels feed the Flow and Trace tabs, but Full inlines entire payloads (including images) and can stall large-image runs. Defaults to Summary.</div>
+			</div>
+		</div>
+	);
+};
 
 // =============================================================================
 // SOURCE STATUS PANE

--- a/packages/shared-ui/src/modules/project/ProjectView.tsx
+++ b/packages/shared-ui/src/modules/project/ProjectView.tsx
@@ -181,6 +181,7 @@ const ProjectView: React.FC<IProjectViewProps> = ({ project, servicesJson, isCon
 		mode: initialViewState?.mode ?? 'design',
 		flowViewMode: initialViewState?.flowViewMode ?? 'pipeline',
 		viewport: initialViewState?.viewport,
+		pipelineTraceLevel: initialViewState?.pipelineTraceLevel,
 	}));
 
 	const [prefs, setPrefs] = useState<Record<string, unknown>>(() => initialPrefs ?? {});

--- a/packages/shared-ui/src/modules/project/index.tsx
+++ b/packages/shared-ui/src/modules/project/index.tsx
@@ -9,6 +9,6 @@
 
 export { default as ProjectView } from './ProjectView';
 export type { IProjectViewProps } from './ProjectView';
-export type { IViewProps, ProjectViewMode, ViewState, TaskStatus, TraceEvent, TraceRow } from './types';
+export type { IViewProps, ProjectViewMode, ViewState, TaskStatus, TraceEvent, TraceRow, TraceLevel } from './types';
 export { parseServerEvent } from './utils';
 export type { ParsedServerEvent } from './utils';

--- a/packages/shared-ui/src/modules/project/types.ts
+++ b/packages/shared-ui/src/modules/project/types.ts
@@ -63,14 +63,19 @@ export interface TraceRow {
 // VIEW TYPES
 // =============================================================================
 
-/** View state — per-view UI state (mode, flowViewMode, viewport). */
+/** Pipeline trace level passed to the engine on run (matches the SDK `client.use` option). */
+export type TraceLevel = 'none' | 'metadata' | 'summary' | 'full';
+
+/** View state — per-view UI state (mode, flowViewMode, viewport, trace level). */
 export interface ViewState {
 	mode: ProjectViewMode;
 	flowViewMode?: 'pipeline' | 'component';
 	viewport?: { x: number; y: number; zoom: number };
+	/** Pipeline trace level for the next run. Persisted per-document; defaults to 'summary' when unset. */
+	pipelineTraceLevel?: TraceLevel;
 }
 
-export type ProjectViewMode = 'design' | 'status' | 'tokens' | 'flow' | 'trace' | 'errors';
+export type ProjectViewMode = 'design' | 'parameters' | 'status' | 'tokens' | 'flow' | 'trace' | 'errors';
 
 /** Base view props (for ServerView, WelcomeView, etc.). */
 export interface IViewProps {


### PR DESCRIPTION
## Summary

- Add a "Parameters" tab to the pipeline editor with a trace-level dropdown (full / summary / metadata / none), defaulting to `summary`
- Persist the choice per-pipeline (viewState → `LAYOUTS_KEY`) and pass it to `client.use()` on run, replacing the hardcoded `'full'`
- Fixes the ~13-18s large-image stall caused by `'full'` inlining full node payloads into the FLOW trace (debug-only data; no SDK/engine change needed)

## Type

feature

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1337 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a **Parameters** tab in the pipeline editor with a **Trace level** selector.
  * Choose **full**, **summary** (default), **metadata**, or **none** to control detail shown in **Flow** and **Trace**.
  * Higher levels include more data (with **full** inlining payloads/images and may slow runs).
  * The selected level is saved per pipeline and applied on the next run/restart.

* **Documentation**
  * Updated usage docs to explain the new **Parameters** tab and **Trace level** behavior, defaults, and trade-offs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->