### PR TITLE
feat(nodes): add Rime cloud TTS on the shared cloud_tts engine (tts_rime)

### DIFF
--- a/nodes/src/nodes/cloud_tts/IGlobal.py
+++ b/nodes/src/nodes/cloud_tts/IGlobal.py
@@ -11,7 +11,7 @@ from typing import Any, Tuple
 from rocketlib import IGlobalBase, OPEN_MODE
 from ai.common.config import Config
 
-from . import elevenlabs_tts, openai_tts
+from . import elevenlabs_tts, openai_tts, rime_tts
 
 _MP3_MIME = 'audio/mpeg'
 
@@ -32,6 +32,15 @@ _ENGINES = {
         'default_voice': 'EXAVITQu4vr4xnSDxMaL',
         'env_key': 'ELEVENLABS_API_KEY',
         'label': 'ElevenLabs',
+    },
+    # Rime speakers are model-specific; the services.tts_rime.json profile
+    # conditional renders one speaker enum per model, all merged under `voice`.
+    'rime': {
+        'synthesize': rime_tts.synthesize,
+        'default_model': 'coda',
+        'default_voice': 'astra',
+        'env_key': 'RIME_API_KEY',
+        'label': 'Rime',
     },
 }
 

--- a/nodes/src/nodes/cloud_tts/IGlobal.py
+++ b/nodes/src/nodes/cloud_tts/IGlobal.py
@@ -100,7 +100,11 @@ class IGlobal(IGlobalBase):
         handed straight to the caller — no temp file round-trip.
         """
         synth = _ENGINES[self._engine]['synthesize']
-        return synth(text, self._model, self._voice, self._api_key), _MP3_MIME
+        audio = synth(text, self._model, self._voice, self._api_key)
+        if not audio:
+            # A 200 with an empty body would otherwise become a zero-byte clip.
+            raise Exception(f'{_ENGINES[self._engine]["label"]} returned no audio for the request')
+        return audio, _MP3_MIME
 
     def endGlobal(self):
         """Nothing to release — the HTTP client is created per request."""

--- a/nodes/src/nodes/cloud_tts/IGlobal.py
+++ b/nodes/src/nodes/cloud_tts/IGlobal.py
@@ -45,6 +45,26 @@ _ENGINES = {
 }
 
 
+#: Vendor cap on the text of ONE request, in characters. The vendor answers a
+#: 400 when it is exceeded, and the body does not survive raise_for_status, so
+#: the caller would otherwise get a bare "400 Client Error" with nothing to act
+#: on. None means the vendor documents no cap.
+#:
+#: Rime's is per-model and four to five times lower than the others, which is
+#: how a pipeline that worked on OpenAI breaks by switching vendor.
+_INPUT_LIMITS = {
+    'openai': {None: 4096},
+    'elevenlabs': {None: 5000},
+    'rime': {'arcana': None, None: 1000},
+}
+
+
+def _input_limit(engine: str, model: str) -> Any:
+    """The character cap for this vendor/model pair, or None when uncapped."""
+    limits = _INPUT_LIMITS.get(engine) or {}
+    return limits[model] if model in limits else limits.get(None)
+
+
 def _resolve_engine(logical_type: Any) -> str:
     """Pick the vendor whose id appears in the node logicalType.
 
@@ -99,11 +119,25 @@ class IGlobal(IGlobalBase):
         The cloud vendors return the whole clip in one response, so the bytes are
         handed straight to the caller — no temp file round-trip.
         """
+        label = _ENGINES[self._engine]['label']
+        limit = _input_limit(self._engine, self._model)
+        if limit is not None and len(text) > limit:
+            # Caught here rather than at the vendor: the 400 that comes back
+            # says nothing about length, and on Rime the cap depends on the
+            # model, so name the way out too.
+            detail = ''
+            if self._engine == 'rime':
+                detail = ' The arcana model has no cap.'
+            raise Exception(
+                f'{label} accepts {limit} characters per request and this record has {len(text)}. '
+                f'Split the text upstream (a chunker node) before this one.{detail}'
+            )
+
         synth = _ENGINES[self._engine]['synthesize']
         audio = synth(text, self._model, self._voice, self._api_key)
         if not audio:
             # A 200 with an empty body would otherwise become a zero-byte clip.
-            raise Exception(f'{_ENGINES[self._engine]["label"]} returned no audio for the request')
+            raise Exception(f'{label} returned no audio for the request')
         return audio, _MP3_MIME
 
     def endGlobal(self):

--- a/nodes/src/nodes/cloud_tts/README.md
+++ b/nodes/src/nodes/cloud_tts/README.md
@@ -28,9 +28,9 @@ the model server.
 
 Each record is sent to the vendor in a single request — there is no chunking.
 The vendor caps per-request input length (OpenAI rejects text over ~4096
-characters with a 400; ElevenLabs ~5000; Rime ~500, model-dependent), so split
-long inputs upstream (e.g. a chunker node) before this node. One record over the
-cap fails that record.
+characters with a 400; ElevenLabs ~5000; Rime 1,000 for coda/mistv2/mistv3 and
+unlimited for arcana), so split long inputs upstream (e.g. a chunker node)
+before this node. One record over the cap fails that record.
 
 ## Code layout
 

--- a/nodes/src/nodes/cloud_tts/README.md
+++ b/nodes/src/nodes/cloud_tts/README.md
@@ -1,22 +1,23 @@
 # Cloud Text To Speech (`cloud_tts`)
 
-One node directory that backs two cloud TTS vendor registrations sharing a single
-`requests`-only engine. The vendor is resolved from the node `logicalType` at
-runtime (same pattern as `index_search`). Audio is emitted as MP3 on the `audio`
-lane; calls go directly from the engine host over HTTPS, **not** through the
-model server.
+One node directory that backs several cloud TTS vendor registrations sharing a
+single `requests`-only engine. The vendor is resolved from the node `logicalType`
+at runtime (same pattern as `index_search`). Audio is emitted as MP3 on the
+`audio` lane; calls go directly from the engine host over HTTPS, **not** through
+the model server.
 
 | Registration                  | Node              | Endpoint                                          | Key env             |
 | ----------------------------- | ----------------- | ------------------------------------------------- | ------------------- |
 | `services.tts_openai.json`     | OpenAI TTS        | `api.openai.com/v1/audio/speech`                  | `OPENAI_API_KEY`    |
 | `services.tts_elevenlabs.json` | ElevenLabs TTS    | `api.elevenlabs.io/v1/text-to-speech/{voice}`     | `ELEVENLABS_API_KEY`|
+| `services.tts_rime.json`       | Rime TTS          | `users.rime.ai/v1/rime-tts`                       | `RIME_API_KEY`      |
 
 ## Configuration
 
 | Field   | Source            | Notes                                                              |
 | ------- | ----------------- | ------------------------------------------------------------------ |
 | Model   | profile           | One profile per model. Model lists maintained manually.            |
-| Voice   | `<prefix>.voice`  | Static per-vendor list.                                            |
+| Voice   | `<prefix>.voice`  | Static per-vendor list. Rime speakers are model-specific, so each Rime profile carries its own `tts_rime.<model>.voice` enum, all merged under `voice`. |
 | API key | `apikey` / env    | Falls back to the vendor environment variable when blank.         |
 
 ## Lanes
@@ -27,13 +28,14 @@ model server.
 
 Each record is sent to the vendor in a single request — there is no chunking.
 The vendor caps per-request input length (OpenAI rejects text over ~4096
-characters with a 400; ElevenLabs ~5000), so split long inputs upstream (e.g. a
-chunker node) before this node. One record over the cap fails that record.
+characters with a 400; ElevenLabs ~5000; Rime ~500, model-dependent), so split
+long inputs upstream (e.g. a chunker node) before this node. One record over the
+cap fails that record.
 
 ## Code layout
 
 - `IGlobal.py` — resolves the vendor from `logicalType`, holds model/voice/key, dispatches `synthesize`.
-- `openai_tts.py` / `elevenlabs_tts.py` — the per-vendor HTTPS call (returns MP3 bytes).
+- `openai_tts.py` / `elevenlabs_tts.py` / `rime_tts.py` — the per-vendor HTTPS call (returns MP3 bytes).
 - `IInstance.py` — shared lane plumbing (text/documents/questions/answers → audio).
 
 ## Adding a vendor

--- a/nodes/src/nodes/cloud_tts/README.md
+++ b/nodes/src/nodes/cloud_tts/README.md
@@ -27,10 +27,15 @@ the model server.
 ## Limits
 
 Each record is sent to the vendor in a single request — there is no chunking.
-The vendor caps per-request input length (OpenAI rejects text over ~4096
-characters with a 400; ElevenLabs ~5000; Rime 1,000 for coda/mistv2/mistv3 and
-unlimited for arcana), so split long inputs upstream (e.g. a chunker node)
-before this node. One record over the cap fails that record.
+The vendor caps per-request input length (OpenAI ~4096 characters; ElevenLabs
+~5000; Rime 1,000 for coda/mistv2/mistv3 and unlimited for arcana), so split
+long inputs upstream (e.g. a chunker node) before this node.
+
+The node checks the cap itself and fails the record with the count, the limit
+and what to do about it. Left to the vendor it comes back as a bare `400`
+that never mentions length — and Rime's cap is four to five times lower than
+the others, so a pipeline that worked on OpenAI hits it simply by switching
+vendor.
 
 ## Code layout
 

--- a/nodes/src/nodes/cloud_tts/__init__.py
+++ b/nodes/src/nodes/cloud_tts/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2026 Aparavi Software AG
 # =============================================================================
 
-"""cloud_tts node: shared engine for the OpenAI and ElevenLabs cloud TTS vendors."""
+"""cloud_tts node: shared engine for the OpenAI, ElevenLabs and Rime cloud TTS vendors."""
 
 from .IGlobal import IGlobal
 from .IInstance import IInstance

--- a/nodes/src/nodes/cloud_tts/requirements.txt
+++ b/nodes/src/nodes/cloud_tts/requirements.txt
@@ -1,3 +1,3 @@
-# Cloud TTS (OpenAI / ElevenLabs): direct HTTPS calls to the vendor endpoints.
+# Cloud TTS (OpenAI / ElevenLabs / Rime): direct HTTPS calls to the vendor endpoints.
 # Declares the dependency only; uses the requests already present in the project.
 requests

--- a/nodes/src/nodes/cloud_tts/requirements.txt
+++ b/nodes/src/nodes/cloud_tts/requirements.txt
@@ -1,3 +1,3 @@
 # Cloud TTS (OpenAI / ElevenLabs / Rime): direct HTTPS calls to the vendor endpoints.
 # Declares the dependency only; uses the requests already present in the project.
-requests
+requests>=2.34.2

--- a/nodes/src/nodes/cloud_tts/rime.svg
+++ b/nodes/src/nodes/cloud_tts/rime.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" role="img" aria-label="Rime">
+  <title>Rime</title>
+  <path d="M12 2a3 3 0 0 1 3 3v6a3 3 0 0 1-6 0V5a3 3 0 0 1 3-3z"/>
+  <path d="M6 11a1 1 0 0 1 1 1 5 5 0 0 0 10 0 1 1 0 1 1 2 0 7 7 0 0 1-6 6.93V22a1 1 0 1 1-2 0v-3.07A7 7 0 0 1 5 12a1 1 0 0 1 1-1z"/>
+</svg>

--- a/nodes/src/nodes/cloud_tts/rime_tts.py
+++ b/nodes/src/nodes/cloud_tts/rime_tts.py
@@ -1,0 +1,26 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Rime TTS HTTPS call. Returns MP3 bytes; raises on a non-2xx response."""
+
+_RIME_TTS_URL = 'https://users.rime.ai/v1/rime-tts'
+_HTTP_TIMEOUT_SEC = 120
+
+
+def synthesize(text: str, model: str, voice: str, api_key: str) -> bytes:
+    """POST text to the Rime endpoint and return MP3 bytes.
+
+    ``voice`` is the Rime speaker and ``model`` the Rime ``modelId``; Rime
+    speakers are model-specific, so the caller must pass a speaker valid for the
+    model. Output format is selected by the ``Accept`` header (Rime has no body
+    format field), so this always requests MP3.
+    """
+    import requests  # lazy
+
+    payload = {'text': text, 'speaker': voice, 'modelId': model}
+    headers = {'Authorization': f'Bearer {api_key}', 'Content-Type': 'application/json', 'Accept': 'audio/mpeg'}
+    response = requests.post(_RIME_TTS_URL, json=payload, headers=headers, timeout=_HTTP_TIMEOUT_SEC)
+    response.raise_for_status()
+    return response.content

--- a/nodes/src/nodes/cloud_tts/services.tts_rime.json
+++ b/nodes/src/nodes/cloud_tts/services.tts_rime.json
@@ -1,0 +1,269 @@
+{
+	//
+	// Required:
+	//		The displayable name of this node
+	//
+	"title": "Text To Speech (Rime)",
+	//
+	// Required:
+	//		The protocol is the endpoint protocol
+	//
+	"protocol": "tts_rime://",
+	//
+	// Required:
+	//		Class type of the node - what it does
+	//
+	"classType": ["audio"],
+	//
+	// Required:
+	//		Capabilities are flags that change the behavior of the underlying
+	//		engine. "experimental" marks this node as not yet production-ready.
+	//
+	"capabilities": ["experimental"],
+	//
+	// Optional:
+	//		Register is either filter, endpoint or ignored if not specified. If the
+	//		type is specified, a factory is registered of that given type
+	//
+	"register": "filter",
+	//
+	// Optional:
+	//		The node is the actual physical node to instantiate - if
+	//		not specified, the protocol will be used
+	//
+	"node": "python",
+	//
+	// Optional:
+	//		The path is the executable/script code. Shared with the OpenAI and
+	//		ElevenLabs registrations: all cloud TTS vendors run the same engine
+	//		code in nodes/cloud_tts and are dispatched by logicalType at runtime.
+	//
+	"path": "nodes.cloud_tts",
+	//
+	// Required:
+	//		The prefix map when added/removed when converting URLs <=> paths
+	//
+	"prefix": "tts_rime",
+	//
+	// Optional:
+	//		Description of this driver
+	//
+	"description": ["Converts incoming text into speech using the Rime text-to-speech API.", "Calls the vendor API directly from the engine host over HTTPS and emits MP3 bytes on the audio lane.", "Rime speakers are model-specific, so each model exposes its own curated speaker list; the API key falls back to the RIME_API_KEY environment variable when blank."],
+	//
+	// Optional:
+	//	  The icon to display in the UI for this node
+	//
+	"icon": "rime.svg",
+	"documentation": "https://docs.rocketride.org",
+	//
+	//	Optional:
+	//		As a pipe component, define what this pipe component takes
+	//		and what it produces
+	//
+	"lanes": {
+		"text": ["audio"],
+		"documents": ["audio"],
+		"questions": ["audio"],
+		"answers": ["audio"]
+	},
+	//
+	//	Optional:
+	//		Profile section are configuration options used by the driver
+	//		itself. One profile per model (maintained manually).
+	//
+	"preconfig": {
+		// Define the values that will be merged into any profile configuration
+		// specified, unless the profile is 'absolute'
+		"default": "coda",
+		// Defines profiles used with the "profile": key. model + voice live here so
+		// Config.getNodeConfig merges them under the selected profile. `voice` is the
+		// Rime speaker; the shared cloud_tts engine reads it as cfg['voice']. astra is
+		// valid across all four shipped models and is the default.
+		"profiles": {
+			"coda": {
+				"title": "Coda    - Flagship, best quality",
+				"model": "coda",
+				"voice": "astra",
+				"apikey": ""
+			},
+			"arcana": {
+				"title": "Arcana  - Expressive, multilingual",
+				"model": "arcana",
+				"voice": "astra",
+				"apikey": ""
+			},
+			"mistv3": {
+				"title": "Mist v3 - Lowest latency",
+				"model": "mistv3",
+				"voice": "astra",
+				"apikey": ""
+			},
+			"mistv2": {
+				"title": "Mist v2 - Pronunciation control",
+				"model": "mistv2",
+				"voice": "astra",
+				"apikey": ""
+			}
+		}
+	},
+	//
+	// Optional:
+	//		Local field definitions - these define fields only for the
+	//		current service. You may specify them here, or directly
+	//		in the shape
+	//
+	"fields": {
+		// ── Form objects (one per model profile; api key + model-specific voice) ──
+		// The voice field MUST live inside the form-object so it is merged under the
+		// selected profile; in the top-level shape it would be silently dropped by
+		// getNodeConfig. Each profile references its OWN voice field
+		// (tts_rime.<model>.voice) whose leaf key is `voice`, so the shared engine
+		// reads cfg['voice'] regardless of the model — matching how vendor voices
+		// merge for OpenAI/ElevenLabs, but with a model-scoped speaker enum.
+		"tts_rime.coda": {
+			"object": "coda",
+			"properties": ["llm.cloud.apikey", "tts_rime.coda.voice"]
+		},
+		"tts_rime.arcana": {
+			"object": "arcana",
+			"properties": ["llm.cloud.apikey", "tts_rime.arcana.voice"]
+		},
+		"tts_rime.mistv3": {
+			"object": "mistv3",
+			"properties": ["llm.cloud.apikey", "tts_rime.mistv3.voice"]
+		},
+		"tts_rime.mistv2": {
+			"object": "mistv2",
+			"properties": ["llm.cloud.apikey", "tts_rime.mistv2.voice"]
+		},
+		// ── Speaker (model-specific; one curated enum per model). Rime rejects an
+		//    out-of-model speaker at request time, so the list is scoped per model.
+		//    Each field's leaf key is `voice`, delivered to the shared engine as
+		//    cfg['voice']. Sourced from the live catalog; maintained manually. ──────
+		"tts_rime.coda.voice": {
+			"type": "string",
+			"title": "Speaker",
+			"description": "Rime voice for the Coda model.",
+			"default": "astra",
+			"enum": [
+				["astra", "Astra"],
+				["andromeda", "Andromeda"],
+				["arcade", "Arcade"],
+				["aurelio", "Aurelio"],
+				["bancroft", "Bancroft"],
+				["adeline", "Adeline"],
+				["alma", "Alma"],
+				["azura", "Azura"]
+			]
+		},
+		"tts_rime.arcana.voice": {
+			"type": "string",
+			"title": "Speaker",
+			"description": "Rime voice for the Arcana model.",
+			"default": "astra",
+			"enum": [
+				["astra", "Astra"],
+				["andromeda", "Andromeda"],
+				["arcade", "Arcade"],
+				["albion", "Albion"],
+				["andersen_johan", "Andersen Johan"],
+				["anderson_emily", "Anderson Emily"]
+			]
+		},
+		"tts_rime.mistv3.voice": {
+			"type": "string",
+			"title": "Speaker",
+			"description": "Rime voice for the Mist v3 model.",
+			"default": "astra",
+			"enum": [
+				["astra", "Astra"],
+				["alpine", "Alpine"],
+				["cove", "Cove"],
+				["cedar", "Cedar"],
+				["breeze", "Breeze"],
+				["blossom", "Blossom"],
+				["boulder", "Boulder"],
+				["brook", "Brook"]
+			]
+		},
+		"tts_rime.mistv2.voice": {
+			"type": "string",
+			"title": "Speaker",
+			"description": "Rime voice for the Mist v2 model.",
+			"default": "astra",
+			"enum": [
+				["astra", "Astra"],
+				["alpine", "Alpine"],
+				["abbie", "Abbie"],
+				["allison", "Allison"],
+				["amber", "Amber"],
+				["antoine", "Antoine"],
+				["bayou", "Bayou"],
+				["blaze", "Blaze"]
+			]
+		},
+		// ── Profile selector (drives conditional form rendering) ───────────────
+		"tts_rime.profile": {
+			"title": "Model",
+			"description": "Rime TTS model",
+			"type": "string",
+			"default": "coda",
+			"enum": ["*>preconfig.profiles.*.title"],
+			"conditional": [
+				{
+					"value": "coda",
+					"properties": ["tts_rime.coda"]
+				},
+				{
+					"value": "arcana",
+					"properties": ["tts_rime.arcana"]
+				},
+				{
+					"value": "mistv3",
+					"properties": ["tts_rime.mistv3"]
+				},
+				{
+					"value": "mistv2",
+					"properties": ["tts_rime.mistv2"]
+				}
+			]
+		}
+	},
+	//
+	// Required:
+	//		Defines the fields (shape) of the service. Either source or target
+	//		may be specified, or both, but at least one is required
+	//
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Rime Text To Speech",
+			"properties": ["tts_rime.profile"]
+		}
+	],
+	//
+	// Optional:
+	//		Test configuration for automated node testing
+	//
+	"test": [
+		{
+			// No audio mock exists, so this runs only when a real key is present
+			// (ROCKETRIDE_TTS_RIME_KEY) and is skipped in CI otherwise.
+			"requires": ["ROCKETRIDE_TTS_RIME_KEY"],
+			"avoidMocks": true,
+			"profiles": ["coda"],
+			"outputs": ["audio"],
+			"cases": [
+				{
+					"name": "Rime TTS returns audio",
+					"text": "Hello from RocketRide",
+					"expect": {
+						"audio": {
+							"notEmpty": true
+						}
+					}
+				}
+			]
+		}
+	]
+}

--- a/nodes/test/cloud_tts/test_cloud_tts.py
+++ b/nodes/test/cloud_tts/test_cloud_tts.py
@@ -57,7 +57,7 @@ def _load_iglobal():
     pkg.__path__ = [str(_DIR)]
     sys.modules['cloud_tts'] = pkg
     try:
-        for name in ('openai_tts', 'elevenlabs_tts', 'IGlobal'):
+        for name in ('openai_tts', 'elevenlabs_tts', 'rime_tts', 'IGlobal'):
             spec = importlib.util.spec_from_file_location(f'cloud_tts.{name}', _DIR / f'{name}.py')
             module = importlib.util.module_from_spec(spec)
             sys.modules[f'cloud_tts.{name}'] = module
@@ -125,3 +125,191 @@ class TestVoiceWiredUnderProfile:
         for profile_key in data['preconfig']['profiles']:
             form = data['fields'][f'{prefix}.{profile_key}']
             assert voice in form['properties'], f'{profile_key} form-object missing {voice}'
+
+
+# --------------------------------------------------------------------------- #
+# Rime — the third vendor registration (services.tts_rime.json + rime_tts).
+# Rime speakers are MODEL-SPECIFIC, so it does not share the single-global-voice
+# enum the OpenAI/ElevenLabs registrations use: each profile carries its own
+# `tts_rime.<model>.voice` enum (leaf key `voice`) inside the profile form-object.
+# --------------------------------------------------------------------------- #
+
+_RIME_URL = 'https://users.rime.ai/v1/rime-tts'
+_RIME_MODELS = ['coda', 'arcana', 'mistv3', 'mistv2']
+
+
+class _FakeResponse:
+    def __init__(self, content=b'MP3BYTES', raise_exc=None):
+        self.content = content
+        self._raise = raise_exc
+
+    def raise_for_status(self):
+        if self._raise is not None:
+            raise self._raise
+
+
+class _FakeRequests:
+    """Captures the outgoing request and replays a configurable response."""
+
+    def __init__(self):
+        self.last = None
+        self.response = _FakeResponse()
+
+    def post(self, url, json=None, headers=None, timeout=None, **kw):
+        self.last = types.SimpleNamespace(url=url, json=json, headers=headers, timeout=timeout)
+        return self.response
+
+
+@pytest.fixture
+def fake_requests():
+    """Install a stub `requests` (lazily imported inside rime_tts.synthesize)."""
+    fake = _FakeRequests()
+    req_mod = types.ModuleType('requests')
+    req_mod.post = fake.post
+    saved = sys.modules.get('requests')
+    sys.modules['requests'] = req_mod
+    try:
+        yield fake
+    finally:
+        if saved is None:
+            sys.modules.pop('requests', None)
+        else:
+            sys.modules['requests'] = saved
+
+
+class TestRimeVendorContract:
+    """rime_tts.synthesize — Rime's HTTP shape, discriminating an OpenAI/ElevenLabs
+    copy-paste left unadapted (Rime uses modelId/speaker + Bearer + Accept, no
+    response_format and no xi-api-key).
+    """
+
+    def test_posts_to_rime_endpoint(self, fake_requests):
+        from cloud_tts import rime_tts
+
+        rime_tts.synthesize('Hello from RocketRide', 'coda', 'astra', 'rk_test')
+        assert fake_requests.last.url == _RIME_URL
+        assert fake_requests.last.timeout == 120
+
+    def test_body_uses_rime_field_names(self, fake_requests):
+        from cloud_tts import rime_tts
+
+        rime_tts.synthesize('hi', 'mistv3', 'cove', 'rk_test')
+        body = fake_requests.last.json
+        assert body == {'text': 'hi', 'speaker': 'cove', 'modelId': 'mistv3'}
+        assert 'response_format' not in body  # OpenAI leftover would break Rime
+        assert 'model' not in body and 'model_id' not in body and 'voice' not in body
+
+    def test_bearer_auth_and_mpeg_accept(self, fake_requests):
+        from cloud_tts import rime_tts
+
+        rime_tts.synthesize('hi', 'coda', 'astra', 'secret-key')
+        headers = fake_requests.last.headers
+        assert headers['Authorization'] == 'Bearer secret-key'
+        assert headers['Content-Type'] == 'application/json'
+        assert headers['Accept'] == 'audio/mpeg'
+        assert 'xi-api-key' not in headers  # ElevenLabs leftover
+
+    def test_returns_response_bytes(self, fake_requests):
+        from cloud_tts import rime_tts
+
+        fake_requests.response = _FakeResponse(content=b'REALMP3')
+        assert rime_tts.synthesize('hi', 'coda', 'astra', 'k') == b'REALMP3'
+
+    def test_raises_on_http_error(self, fake_requests):
+        from cloud_tts import rime_tts
+
+        fake_requests.response = _FakeResponse(raise_exc=RuntimeError('boom'))
+        with pytest.raises(RuntimeError):
+            rime_tts.synthesize('hi', 'coda', 'astra', 'k')
+
+    def test_text_passed_verbatim_as_json(self, fake_requests):
+        from cloud_tts import rime_tts
+
+        rime_tts.synthesize('Hello from RocketRide', 'coda', 'astra', 'k')
+        assert fake_requests.last.json['text'] == 'Hello from RocketRide'
+        assert isinstance(fake_requests.last.json, dict)  # json=, not data=
+
+
+class TestRimeDispatch:
+    def test_logical_type_resolves_to_rime(self):
+        assert _ig._resolve_engine('tts_rime://node/1') == 'rime'
+        assert _ig._resolve_engine('TTS_RIME://X') == 'rime'
+
+    def test_registry_entry_wired_to_rime_synth(self):
+        from cloud_tts import rime_tts
+
+        spec = _ig._ENGINES['rime']
+        assert spec['synthesize'] is rime_tts.synthesize
+        assert spec['default_model'] == 'coda'
+        assert spec['default_voice'] == 'astra'
+        assert spec['env_key'] == 'RIME_API_KEY'
+        assert spec['label']
+
+    def test_synthesize_dispatches_model_scoped_speaker(self, fake_requests):
+        """Shared engine → rime_tts: the model-scoped speaker (held as `_voice`)
+        must reach Rime as `speaker`, and synthesize returns (mp3 bytes, audio/mpeg)
+        with no temp file. Guards the old always-`astra` bug at the dispatch layer.
+        """
+        fake_requests.response = _FakeResponse(content=b'AUDIO')
+        g = _ig.IGlobal()
+        g._engine, g._model, g._voice, g._api_key = 'rime', 'mistv3', 'cove', 'k'
+        raw, mime = g.synthesize('speak this')
+        assert (raw, mime) == (b'AUDIO', 'audio/mpeg')
+        assert fake_requests.last.json == {'text': 'speak this', 'speaker': 'cove', 'modelId': 'mistv3'}
+
+
+class TestRimeSchema:
+    """services.tts_rime.json — model-scoped speaker enums must merge under `voice`.
+
+    A speaker field left bare in a conditional branch (or in the top-level shape) is a
+    sibling of the profile selector and is silently dropped by getNodeConfig — the exact
+    trap that made the old standalone node always synthesize with the default speaker.
+    """
+
+    _SVC = 'services.tts_rime.json'
+
+    def _data(self):
+        return parse_service_json(_DIR / self._SVC)
+
+    def test_shares_cloud_tts_engine(self):
+        data = self._data()
+        assert data['path'] == 'nodes.cloud_tts'
+        assert data['prefix'] == 'tts_rime'
+        assert data['classType'] == ['audio']
+        assert 'experimental' in data['capabilities']
+
+    def test_profiles_carry_model_and_voice(self):
+        profiles = self._data()['preconfig']['profiles']
+        assert set(profiles) == set(_RIME_MODELS)
+        for name, prof in profiles.items():
+            assert prof['model'] == name
+            assert prof['voice']  # default speaker the shared engine reads as cfg['voice']
+            assert 'apikey' in prof
+
+    def test_each_form_object_carries_its_model_voice_field(self):
+        data = self._data()
+        for model in _RIME_MODELS:
+            form = data['fields'][f'tts_rime.{model}']
+            assert form['object'] == model  # object must equal the profile name to merge
+            assert f'tts_rime.{model}.voice' in form['properties']
+
+    def test_voice_fields_absent_from_top_level_shape(self):
+        data = self._data()
+        shape_props = [p for section in data['shape'] for p in section['properties']]
+        for model in _RIME_MODELS:
+            assert f'tts_rime.{model}.voice' not in shape_props
+        assert 'tts_rime.voice' not in shape_props
+
+    def test_voice_defaults_are_in_enum(self):
+        data = self._data()
+        for model in _RIME_MODELS:
+            field = data['fields'][f'tts_rime.{model}.voice']
+            values = [row[0] for row in field['enum']]
+            assert field['default'] in values, f'{model} default {field["default"]} not in enum'
+
+    def test_conditional_covers_every_model(self):
+        data = self._data()
+        cond = {c['value']: c['properties'] for c in data['fields']['tts_rime.profile']['conditional']}
+        assert set(cond) == set(_RIME_MODELS)
+        for model in _RIME_MODELS:
+            assert f'tts_rime.{model}' in cond[model]

--- a/nodes/test/cloud_tts/test_cloud_tts.py
+++ b/nodes/test/cloud_tts/test_cloud_tts.py
@@ -257,6 +257,14 @@ class TestRimeDispatch:
         assert (raw, mime) == (b'AUDIO', 'audio/mpeg')
         assert fake_requests.last.json == {'text': 'speak this', 'speaker': 'cove', 'modelId': 'mistv3'}
 
+    def test_synthesize_rejects_empty_audio(self, fake_requests):
+        """A 200 with an empty body must raise, not hand back a zero-byte clip."""
+        fake_requests.response = _FakeResponse(content=b'')
+        g = _ig.IGlobal()
+        g._engine, g._model, g._voice, g._api_key = 'rime', 'mistv3', 'cove', 'k'
+        with pytest.raises(Exception, match='no audio'):
+            g.synthesize('speak this')
+
 
 class TestRimeSchema:
     """services.tts_rime.json — model-scoped speaker enums must merge under `voice`.

--- a/nodes/test/cloud_tts/test_cloud_tts.py
+++ b/nodes/test/cloud_tts/test_cloud_tts.py
@@ -321,3 +321,57 @@ class TestRimeSchema:
         assert set(cond) == set(_RIME_MODELS)
         for model in _RIME_MODELS:
             assert f'tts_rime.{model}' in cond[model]
+
+
+class TestInputLimit:
+    """The cap is checked here because the vendor's 400 never explains itself.
+
+    Rime's is per-model and four to five times lower than OpenAI's or
+    ElevenLabs', so it is the cap a working pipeline hits simply by switching
+    vendor — and `raise_for_status` drops the body that would have said so.
+    """
+
+    @staticmethod
+    def _global(engine: str, model: str, voice: str = 'astra'):
+        g = _ig.IGlobal()
+        g._engine, g._model, g._voice, g._api_key = engine, model, voice, 'k'
+        return g
+
+    def test_text_at_the_cap_still_reaches_the_vendor(self, fake_requests):
+        fake_requests.response = _FakeResponse(content=b'AUDIO')
+        self._global('rime', 'coda').synthesize('a' * 1000)
+        assert fake_requests.last is not None, 'a record at the cap must still be sent'
+
+    def test_text_over_the_cap_never_reaches_the_vendor(self, fake_requests):
+        fake_requests.response = _FakeResponse(content=b'AUDIO')
+        with pytest.raises(Exception) as raised:
+            self._global('rime', 'coda').synthesize('a' * 1001)
+        assert fake_requests.last is None, 'the request must not be sent'
+        assert '1000' in str(raised.value) and '1001' in str(raised.value)
+
+    def test_the_error_names_the_way_out(self, fake_requests):
+        with pytest.raises(Exception) as raised:
+            self._global('rime', 'coda').synthesize('a' * 1001)
+        message = str(raised.value)
+        assert 'chunker' in message, 'say how to split the text'
+        assert 'arcana' in message, 'name the model that has no cap'
+
+    def test_arcana_is_uncapped(self, fake_requests):
+        fake_requests.response = _FakeResponse(content=b'AUDIO')
+        self._global('rime', 'arcana').synthesize('a' * 50000)
+        assert fake_requests.last is not None, 'arcana is documented as uncapped'
+
+    def test_every_other_rime_model_carries_the_cap(self, fake_requests):
+        for model in ('mistv2', 'mistv3'):
+            fake_requests.last = None
+            with pytest.raises(Exception, match='1000 characters'):
+                self._global('rime', model).synthesize('a' * 1001)
+            assert fake_requests.last is None
+
+    def test_openai_keeps_its_own_cap(self, fake_requests):
+        with pytest.raises(Exception, match='4096 characters'):
+            self._global('openai', 'gpt-4o-mini-tts', 'alloy').synthesize('a' * 4097)
+
+    def test_elevenlabs_keeps_its_own_cap(self, fake_requests):
+        with pytest.raises(Exception, match='5000 characters'):
+            self._global('elevenlabs', 'eleven_multilingual_v2', 'x').synthesize('a' * 5001)

--- a/packages/ai/src/ai/modules/mcp/credentials.json
+++ b/packages/ai/src/ai/modules/mcp/credentials.json
@@ -1325,6 +1325,19 @@
     ],
     "docs": "https://platform.openai.com/docs/guides/text-to-speech"
   },
+  "tts_rime": {
+    "title": "Rime Text to Speech",
+    "fields": [
+      {
+        "path": "tts_rime.apikey",
+        "title": "Rime API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TTS_RIME_KEY"
+      }
+    ],
+    "docs": "https://docs.rime.ai/api-reference/coda/http"
+  },
   "twelvelabs": {
     "title": "twelvelabs",
     "fields": [


### PR DESCRIPTION
## Summary

Adds **Rime** as a third cloud TTS vendor on the shared `cloud_tts` node (from #927), alongside OpenAI and ElevenLabs. Rime is a thin `services.tts_rime.json` registration (`path: nodes.cloud_tts`) plus a `rime_tts.py` engine call and one `_ENGINES` entry: it stays a separate node in the palette while sharing the one `requests`-only engine, which resolves the vendor from `logicalType` at runtime (same pattern as `index_search`).

Synthesizes speech via `POST users.rime.ai/v1/rime-tts` (`Authorization: Bearer`, body `{text, speaker, modelId}`, `Accept: audio/mpeg`), emitting MP3 on the `audio` lane. Key from config (`secure` + ApiKeyWidget via the shared `llm.cloud.apikey`) or the `RIME_API_KEY` env var.

4 model profiles (`coda` default, `arcana`, `mistv3`, `mistv2`). Rime speakers are **model-specific**, so each profile carries its own curated speaker enum as `tts_rime.<model>.voice` (leaf key `voice`) **inside** the profile form-object; the shared engine reads the resolved speaker as `cfg['voice']` with no Rime-specific branching.

> **History:** this PR originally shipped a standalone `nodes/src/nodes/tts_rime/` directory, cloning the then-unmerged `tts_openai`/`tts_elevenlabs`. #927 was reworked before merge to a single shared `cloud_tts` node, so per review this PR now folds Rime into it. The standalone directory is removed.

## Type

- [x] Feature (new node registration)

## What changed

| File | Change |
|---|---|
| `nodes/src/nodes/cloud_tts/services.tts_rime.json` | New Rime registration: `audio` classType, `experimental`, 4 model profiles, per-model speaker enum inside each profile form-object, secure key field, declarative `test` block |
| `nodes/src/nodes/cloud_tts/rime_tts.py` | New Rime HTTPS call: `synthesize(text, model, voice, api_key) -> bytes` (Bearer, `{text, speaker, modelId}`, `Accept: audio/mpeg`) |
| `nodes/src/nodes/cloud_tts/IGlobal.py` | `'rime'` entry in `_ENGINES` (`default_model: coda`, `default_voice: astra`, `env_key: RIME_API_KEY`) + import |
| `nodes/src/nodes/cloud_tts/README.md`, `__init__.py`, `requirements.txt`, `rime.svg` | Vendor row, model-specific-speaker note, docstring, moved icon |
| `nodes/test/cloud_tts/test_cloud_tts.py` | Rime HTTP contract, dispatch, and schema-wiring tests folded in (network-free; shares the siblings' hermetic loader) |
| `nodes/src/nodes/tts_rime/**`, `nodes/test/test_tts_rime.py` | Removed (standalone layout) |

## Validation

- [x] `nodes/test/cloud_tts/` green (26 passed): Rime request shaping, auth header, model-scoped speaker resolution, dispatch, and the schema guard that keeps each speaker enum under its profile form-object
- [x] `./builder nodes:test` passes locally (1240 passed, 123 skipped); one unrelated local failure (`test_embedding_image`) from a missing Pillow in the local engine env
- [x] `ruff check` + `ruff format --check` clean on all new/changed files
- [x] Rime API facts (endpoint, auth, body, model IDs, model-scoped speakers, Accept-header output) verified against docs.rime.ai + the live voice catalog, not memory
- [ ] No live Rime API call made (no key); live-key smoke test of the exact `modelId` strings + per-model speaker lists not yet claimed

## How this could be extended

- Per-request `samplingRate` / `lang` / `speedAlpha` config (Rime accepts them; omitted for a minimal first registration)
- Chunking for inputs over Rime's ~500-char per-request cap (matches the sibling behavior today)
- A refresh handler to sync the model + per-model speaker lists from Rime's live catalog (currently maintained manually, like the siblings)

Closes #1287


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rime as a cloud text-to-speech provider with configurable models, voices, defaults, and API key support.
  * Added the `tts_rime://` service for converting supported text-based inputs into audio.
* **Bug Fixes**
  * Improved model-specific voice selection and rejected empty audio responses.
* **Documentation**
  * Updated cloud TTS documentation with Rime setup details, supported models, voices, and input limits.
* **Tests**
  * Added coverage for Rime requests, configuration, dispatch, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->