### PR TITLE
fix(billing): use raw charge amount for upgrade/downgrade comparison

### DIFF
--- a/packages/shared-ui/src/modules/billing/components/UpgradeModal.tsx
+++ b/packages/shared-ui/src/modules/billing/components/UpgradeModal.tsx
@@ -180,18 +180,17 @@ export const UpgradeModal: React.FC<UpgradeModalProps> = ({
 	const isValidSelection = selectedPlan && selectedPlan.stripePriceId !== currentPriceId;
 
 	/** Normalize amount to monthly cost for comparison across intervals. */
-	const monthlyAmount = (plan: CheckoutPlan) => {
-		if (plan.interval === 'year') return plan.amountCents / 12;
-		return plan.amountCents;
-	};
-
 	/** Determine if the selected plan is an upgrade or downgrade. */
 	const changeDirection = useMemo(() => {
 		if (!selectedPlan) return null;
 		const currentPlan = subscriptionPlans.find((p) => p.stripePriceId === currentPriceId);
 		if (!currentPlan) return 'change';
-		if (monthlyAmount(selectedPlan) > monthlyAmount(currentPlan)) return 'upgrade';
-		if (monthlyAmount(selectedPlan) < monthlyAmount(currentPlan)) return 'downgrade';
+
+		// Compare raw charge amounts — matches the server-side logic in
+		// apps.py which uses unit_amount directly to decide immediate
+		// proration (upgrade) vs deferred schedule (downgrade).
+		if (selectedPlan.amountCents > currentPlan.amountCents) return 'upgrade';
+		if (selectedPlan.amountCents < currentPlan.amountCents) return 'downgrade';
 		return 'change';
 	}, [selectedPlan, currentPriceId, subscriptionPlans]);
 


### PR DESCRIPTION
## Summary
- Fix UpgradeModal using per-month normalized amounts to determine upgrade vs downgrade direction
- Monthly-to-annual changes at the same tier were incorrectly labeled "Downgrade" because the per-month rate is lower
- Changed to compare raw `amountCents` directly, matching the server-side logic in `apps.py`

## Test plan
- [ ] Open billing page, switch from Monthly to Annual on same tier — should show "Upgrade"
- [ ] Switch from Annual to Monthly on same tier — should show "Downgrade"
- [ ] Switch from Starter Monthly to Pro Monthly — should show "Upgrade"
- [ ] Switch from Pro Monthly to Starter Monthly — should show "Downgrade"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plan change classification logic to accurately determine whether plan modifications are upgrades, downgrades, or changes, ensuring correct labeling and messaging in the upgrade flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->