### PR TITLE
fix(billing/shell): resilient event bus + plan-aware checkout/upgrade UI

### DIFF
--- a/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
+++ b/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
@@ -113,7 +113,19 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 					priceId,
 				});
 			}}
-			onSuccess={() => { setCheckoutApp(null); setPresetPlan(null); }}
+			onSuccess={() => {
+				// New purchase complete: drop the user into the app they just bought
+				// and confirm briefly, rather than leaving them on the pricing grid.
+				// (Upgrades keep their own inline confirmation in UpgradeModal.)
+				const appId = checkoutApp.id;
+				const appName = checkoutApp.name;
+				setCheckoutApp(null);
+				setPresetPlan(null);
+				cm.emit('shell:switchApp', { appId });
+				cm.emit('shell:statusMessage', { message: `Welcome to ${appName} — your plan is now active.` });
+				// Auto-clear so the confirmation doesn't linger in the status bar.
+				setTimeout(() => cm.emit('shell:statusMessage', { message: null }), 5000);
+			}}
 			onClose={() => { setCheckoutApp(null); setPresetPlan(null); }}
 		/>
 	);

--- a/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
+++ b/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
@@ -24,7 +24,7 @@
 // CHECKOUT FLOW — Stripe subscription checkout wired to shell events
 // =============================================================================
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { CheckoutModal } from 'shared';
 import type { CheckoutPlan } from 'shared';
 import { ConnectionManager } from '../../connection/connection';
@@ -57,6 +57,14 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 	/** Optional plan preselected by the caller (e.g. the web pricing page) to
 	 *  skip the picker and go straight to payment; null = show the picker. */
 	const [presetPlan, setPresetPlan] = useState<CheckoutPlan | null>(null);
+	/** Pending timer that clears the post-purchase welcome status message. */
+	const statusClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	// Cancel the pending status-message clear if we unmount first (e.g. logout
+	// or navigation) so it doesn't emit after the component is gone.
+	useEffect(() => () => {
+		if (statusClearTimer.current) clearTimeout(statusClearTimer.current);
+	}, []);
 
 	// --- Listen for subscribe events -----------------------------------------
 	useEffect(() => {
@@ -124,7 +132,9 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 				cm.emit('shell:switchApp', { appId });
 				cm.emit('shell:statusMessage', { message: `Welcome to ${appName} — your plan is now active.` });
 				// Auto-clear so the confirmation doesn't linger in the status bar.
-				setTimeout(() => cm.emit('shell:statusMessage', { message: null }), 5000);
+				// Tracked in a ref so it's cancelled if we unmount before it fires.
+				if (statusClearTimer.current) clearTimeout(statusClearTimer.current);
+				statusClearTimer.current = setTimeout(() => cm.emit('shell:statusMessage', { message: null }), 5000);
 			}}
 			onClose={() => { setCheckoutApp(null); setPresetPlan(null); }}
 		/>

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -131,14 +131,24 @@ export class ConnectionManager implements IConnectionManager {
 	// SINGLETON
 	// =========================================================================
 
-	private static instance: ConnectionManager;
+	/**
+	 * Global key for the singleton. A plain `private static instance` is NOT a
+	 * true singleton under Module Federation: a remote (e.g. home-ui) that loads
+	 * a duplicated copy of the shell-ui module gets its own class object with its
+	 * own static field, so its emit() lands on a different instance than the one
+	 * the Shell host registered listeners on — events vanish silently. Anchoring
+	 * the instance on globalThis makes getInstance() return the same object
+	 * regardless of how many module copies exist in the page.
+	 */
+	private static readonly GLOBAL_KEY = Symbol.for('rocketride.connectionManager');
 
 	/** Returns the singleton ConnectionManager instance. */
 	public static getInstance(): ConnectionManager {
-		if (!ConnectionManager.instance) {
-			ConnectionManager.instance = new ConnectionManager();
+		const g = globalThis as unknown as Record<symbol, ConnectionManager | undefined>;
+		if (!g[ConnectionManager.GLOBAL_KEY]) {
+			g[ConnectionManager.GLOBAL_KEY] = new ConnectionManager();
 		}
-		return ConnectionManager.instance;
+		return g[ConnectionManager.GLOBAL_KEY]!;
 	}
 
 	private constructor() {}
@@ -181,6 +191,22 @@ export class ConnectionManager implements IConnectionManager {
 	private listeners = new Map<string, Set<Handler>>();
 	private wildcardListeners = new Set<WildcardHandler>();
 	private debugLog: DebugLogEntry[] = [];
+
+	/**
+	 * User-intent control events that must not be silently dropped if emitted
+	 * while no listener is registered (e.g. the Shell listener is mid-remount, or
+	 * a remote emits before the host's listener useEffect has run). These are
+	 * buffered (latest payload wins) and replayed to the first matching handler
+	 * that registers via on(). Status/lifecycle events are intentionally NOT
+	 * replayable — replaying a stale 'shell:disconnected' would be wrong.
+	 */
+	private static readonly REPLAYABLE_EVENTS = new Set<string>([
+		'shell:loginRequest',
+		'shell:subscribe',
+	]);
+
+	/** Latest buffered payload per replayable event, awaiting a listener. */
+	private pendingEvents = new Map<string, unknown>();
 
 	// =========================================================================
 	// INITIALIZATION
@@ -877,9 +903,10 @@ export class ConnectionManager implements IConnectionManager {
 		// Push into debug log
 		this.logDebug(event as string, payload);
 
-		// Dispatch to registered handlers via microtask
+		// Dispatch to registered handlers via microtask. An unsubscribed handler
+		// leaves an empty Set behind, so check size — not just presence.
 		const handlers = this.listeners.get(event as string);
-		if (handlers) {
+		if (handlers && handlers.size > 0) {
 			Promise.resolve().then(() => {
 				for (const fn of handlers) {
 					try {
@@ -889,6 +916,18 @@ export class ConnectionManager implements IConnectionManager {
 					}
 				}
 			});
+			return;
+		}
+
+		// No live listener. For user-intent control events, buffer the payload so
+		// it can be replayed to the next listener that registers (see on()).
+		// Without this, a click whose listener isn't yet/no-longer mounted is
+		// silently swallowed — the prod "Get Started does nothing" symptom.
+		if (ConnectionManager.REPLAYABLE_EVENTS.has(event as string)) {
+			this.pendingEvents.set(event as string, payload);
+			console.warn(
+				`[ConnectionManager] '${event as string}' emitted with no listener — buffered for replay.`,
+			);
 		}
 	}
 
@@ -907,6 +946,20 @@ export class ConnectionManager implements IConnectionManager {
 		if (!this.listeners.has(key)) this.listeners.set(key, new Set());
 		const set = this.listeners.get(key)!;
 		set.add(handler as Handler);
+
+		// Replay a buffered user-intent event to this fresh listener (see emit()).
+		// Delivered once, via microtask to match normal emit() dispatch timing.
+		if (this.pendingEvents.has(key)) {
+			const payload = this.pendingEvents.get(key);
+			this.pendingEvents.delete(key);
+			Promise.resolve().then(() => {
+				try {
+					(handler as Handler)(payload);
+				} catch (err) {
+					console.error(`[ConnectionManager] Replay handler for '${key}' threw:`, err);
+				}
+			});
+		}
 
 		// Warn if a single event has too many listeners — likely a leak
 		if (set.size > 25) {

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -947,16 +947,25 @@ export class ConnectionManager implements IConnectionManager {
 		const set = this.listeners.get(key)!;
 		set.add(handler as Handler);
 
-		// Replay a buffered user-intent event to this fresh listener (see emit()).
-		// Delivered once, via microtask to match normal emit() dispatch timing.
+		// Replay a buffered user-intent event to a fresh listener (see emit()).
+		// Deferred to a microtask AND dispatched to the LIVE listener set at that
+		// time — not the captured handler — because under React StrictMode
+		// (mount→cleanup→mount) or any remount the registering handler may
+		// unsubscribe before the microtask runs. The buffered payload is consumed
+		// only once a live listener actually receives it, so the intent is never
+		// lost to a dead handler.
 		if (this.pendingEvents.has(key)) {
-			const payload = this.pendingEvents.get(key);
-			this.pendingEvents.delete(key);
 			Promise.resolve().then(() => {
-				try {
-					(handler as Handler)(payload);
-				} catch (err) {
-					console.error(`[ConnectionManager] Replay handler for '${key}' threw:`, err);
+				const live = this.listeners.get(key);
+				if (!this.pendingEvents.has(key) || !live || live.size === 0) return;
+				const payload = this.pendingEvents.get(key);
+				this.pendingEvents.delete(key);
+				for (const fn of live) {
+					try {
+						fn(payload);
+					} catch (err) {
+						console.error(`[ConnectionManager] Replay handler for '${key}' threw:`, err);
+					}
 				}
 			});
 		}

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -687,6 +687,9 @@ export class ConnectionManager implements IConnectionManager {
 		this.clearToken();
 		this.clearSessionAppId();
 		this.accountInfo = undefined;
+		// Drop any buffered user-intent events so a stale shell:subscribe /
+		// shell:loginRequest can't replay into the next session.
+		this.pendingEvents.clear();
 
 		// Emit logout before disconnecting so listeners can clean up
 		this.emit('shell:logout', {});
@@ -702,6 +705,7 @@ export class ConnectionManager implements IConnectionManager {
 		await this.disconnect();
 		this.listeners.clear();
 		this.wildcardListeners.clear();
+		this.pendingEvents.clear();
 		this.debugLog.length = 0;
 	}
 

--- a/packages/shared-ui/src/index.ts
+++ b/packages/shared-ui/src/index.ts
@@ -79,7 +79,8 @@ export type { EnvironmentViewProps, EnvironmentSlotConfig, EnvironmentScope } fr
 
 // --- Billing module (subscription management) --------------------------------
 // Types: import directly from 'rocketride' (BillingDetail, CreditBalance, etc.)
-export { CreditsPanel } from './modules/billing';
+export { CreditsPanel, UpgradeModal } from './modules/billing';
+export type { UpgradeModalProps } from './modules/billing';
 
 // --- Checkout module (subscription checkout flow) ----------------------------
 export { CheckoutModal, PlanPicker } from './modules/checkout';

--- a/packages/shared-ui/src/modules/billing/components/UpgradeModal.tsx
+++ b/packages/shared-ui/src/modules/billing/components/UpgradeModal.tsx
@@ -141,6 +141,12 @@ export interface UpgradeModalProps {
 	currentPriceId: string;
 	/** Human-readable name of the current plan (e.g. "Pro Monthly"). */
 	currentPlanName: string | null;
+	/**
+	 * Optional Stripe price_* to preselect on open (e.g. the plan a user clicked
+	 * on the pricing page), so they land on the proration summary ready to
+	 * confirm. Ignored if it equals the current plan. Defaults to no selection.
+	 */
+	preselectedPriceId?: string;
 	/** Called when the user confirms the plan change. */
 	onUpgrade: (newPriceId: string) => Promise<void>;
 	/** Called when the modal is dismissed. */
@@ -162,10 +168,15 @@ export const UpgradeModal: React.FC<UpgradeModalProps> = ({
 	plans,
 	currentPriceId,
 	currentPlanName,
+	preselectedPriceId,
 	onUpgrade,
 	onClose,
 }) => {
-	const [selectedPlan, setSelectedPlan] = useState<CheckoutPlan | null>(null);
+	const [selectedPlan, setSelectedPlan] = useState<CheckoutPlan | null>(
+		() => (preselectedPriceId && preselectedPriceId !== currentPriceId
+			? plans.find((p) => p.stripePriceId === preselectedPriceId) ?? null
+			: null),
+	);
 	const [upgrading, setUpgrading] = useState(false);
 	const [success, setSuccess] = useState(false);
 	const [error, setError] = useState<string | null>(null);
@@ -179,19 +190,25 @@ export const UpgradeModal: React.FC<UpgradeModalProps> = ({
 	/** Whether the selected plan differs from the current plan. */
 	const isValidSelection = selectedPlan && selectedPlan.stripePriceId !== currentPriceId;
 
-	/** Normalize amount to monthly cost for comparison across intervals. */
-	const monthlyAmount = (plan: CheckoutPlan) => {
-		if (plan.interval === 'year') return plan.amountCents / 12;
-		return plan.amountCents;
-	};
+	/**
+	 * When opened with a preselected plan (e.g. from the pricing page), show a
+	 * focused confirmation of that plan instead of the full plan picker.
+	 */
+	const compact = !!preselectedPriceId && isValidSelection;
 
-	/** Determine if the selected plan is an upgrade or downgrade. */
+	/**
+	 * Determine if the selected plan is an upgrade or downgrade. Matches the
+	 * server (change_subscription_plan), which compares RAW price amounts: a
+	 * higher amount is an immediate prorated upgrade, a lower one is scheduled
+	 * for the next renewal. (Comparing normalized monthly cost mislabels
+	 * cross-interval switches, e.g. monthly→annual.)
+	 */
 	const changeDirection = useMemo(() => {
 		if (!selectedPlan) return null;
 		const currentPlan = subscriptionPlans.find((p) => p.stripePriceId === currentPriceId);
 		if (!currentPlan) return 'change';
-		if (monthlyAmount(selectedPlan) > monthlyAmount(currentPlan)) return 'upgrade';
-		if (monthlyAmount(selectedPlan) < monthlyAmount(currentPlan)) return 'downgrade';
+		if (selectedPlan.amountCents > currentPlan.amountCents) return 'upgrade';
+		if (selectedPlan.amountCents < currentPlan.amountCents) return 'downgrade';
 		return 'change';
 	}, [selectedPlan, currentPriceId, subscriptionPlans]);
 
@@ -245,20 +262,34 @@ export const UpgradeModal: React.FC<UpgradeModalProps> = ({
 					</div>
 				) : (
 					<>
-						{/* Current plan info */}
-						<div style={S.currentPlan}>
-							<span style={S.currentLabel}>Current</span>
-							<span style={{ color: 'var(--rr-text-primary)', fontWeight: 600 }}>
-								{currentPlanName ?? 'Unknown plan'}
-							</span>
-						</div>
+						{compact && selectedPlan ? (
+							/* Focused confirmation: caller preselected the plan, so summarise
+							   it instead of re-showing the picker. */
+							<div style={S.currentPlan}>
+								<span style={S.currentLabel}>Switch to</span>
+								<span style={{ color: 'var(--rr-text-primary)', fontWeight: 600 }}>
+									{selectedPlan.nickname} &middot; {planAmount(selectedPlan)}
+								</span>
+							</div>
+						) : (
+							<>
+								{/* Current plan info */}
+								<div style={S.currentPlan}>
+									<span style={S.currentLabel}>Current</span>
+									<span style={{ color: 'var(--rr-text-primary)', fontWeight: 600 }}>
+										{currentPlanName ?? 'Unknown plan'}
+									</span>
+								</div>
 
-						{/* Plan picker -- reuses the same card grid */}
-						<PlanPicker
-							plans={subscriptionPlans}
-							selectedPlan={selectedPlan}
-							onSelectPlan={handleSelect}
-						/>
+								{/* Plan picker -- reuses the same card grid */}
+								<PlanPicker
+									plans={subscriptionPlans}
+									selectedPlan={selectedPlan}
+									onSelectPlan={handleSelect}
+									currentPriceId={currentPriceId}
+								/>
+							</>
+						)}
 
 						{/* Proration info -- explains what happens on upgrade vs downgrade */}
 						{isValidSelection && changeDirection === 'upgrade' && (

--- a/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
+++ b/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
@@ -268,6 +268,21 @@ const S = {
 		transition: 'opacity 0.15s',
 	} as CSSProperties,
 
+	// "Current plan" badge shown on the user's active card (selection mode).
+	currentBadge: {
+		display: 'inline-block',
+		alignSelf: 'center',
+		fontSize: 10,
+		fontWeight: 700,
+		letterSpacing: 0.4,
+		textTransform: 'uppercase' as const,
+		color: 'var(--rr-brand)',
+		border: '1px solid var(--rr-brand)',
+		borderRadius: 999,
+		padding: '1px 8px',
+		marginBottom: 6,
+	} as CSSProperties,
+
 	// ── Loading / empty state ────────────────────────────────────────────
 	status: {
 		textAlign: 'center' as const,
@@ -312,6 +327,23 @@ export interface PlanPickerProps {
 	/** Label for the per-card billable CTA. Default: ``'Get started'``. Only used with ``onPlanCta``. */
 	ctaLabel?: string;
 
+	/**
+	 * Optional per-plan CTA overrides, keyed by ``stripePriceId``. Lets a host
+	 * app render context-aware labels (e.g. "Selected", "Upgrade", "Switch
+	 * plan") and disable a card's CTA — without baking any subscription logic
+	 * into shared-ui (this component ships in the VS Code extension too). A plan
+	 * with no entry falls back to ``ctaLabel``. Only used with ``onPlanCta``.
+	 */
+	ctaConfig?: Record<string, { label?: string; disabled?: boolean }>;
+
+	/**
+	 * Stripe price ID of the user's current plan, in card-selection mode
+	 * (``onSelectPlan``). The matching card shows a "Current" badge and is made
+	 * non-selectable. The host owns what "current" means — no subscription logic
+	 * lives here. Used by the upgrade flow.
+	 */
+	currentPriceId?: string;
+
 	/** Content rendered below the plan cards (e.g. a "Continue" button). */
 	footer?: React.ReactNode;
 
@@ -347,6 +379,8 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 	onActionClick = defaultActionClick,
 	onPlanCta,
 	ctaLabel = 'Get started',
+	ctaConfig,
+	currentPriceId,
 	footer,
 	defaultInterval = 'month',
 	autoSelectDefault = false,
@@ -487,12 +521,16 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 					const action = planAction(plan);
 					const isAction = !!action;
 					const selected = !isAction && selectedPlan?.stripePriceId === plan.stripePriceId;
+					const isCurrent = !isAction && !!currentPriceId && plan.stripePriceId === currentPriceId;
+					const cta = isAction ? undefined : ctaConfig?.[plan.stripePriceId];
+					const ctaDisabled = cta?.disabled ?? false;
 					const desc = planDescription(plan);
 					// Whole-card selection only applies when a selection handler is
 					// wired (the checkout/upgrade modals). On display-only pages
 					// (pricing) the card is static — the CTA button is the action —
 					// so drop the pointer, radio role, focusability and click handlers.
-					const interactive = !isAction && !!onSelectPlan;
+					// The current plan is never selectable (you can't "switch" to it).
+					const interactive = !isAction && !!onSelectPlan && !isCurrent;
 
 					return (
 						<div
@@ -515,6 +553,7 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 						>
 							{/* Card header: tier name, price, interval */}
 							<div style={S.cardHead(selected)}>
+								{isCurrent && <div style={S.currentBadge}>Current plan</div>}
 								<div style={S.cardTier}>{plan.nickname}</div>
 								<div style={S.cardPrice}>{planDisplayAmount(plan)}</div>
 								{planIntervalLabel(plan) && (
@@ -556,17 +595,24 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 								</a>
 							)}
 
-							{/* Primary CTA for billable plans (opt-in via onPlanCta) */}
+							{/* Primary CTA for billable plans (opt-in via onPlanCta). A host
+							    may override label/disabled per plan via ctaConfig (e.g.
+							    "Selected" on the user's current tier). */}
 							{!isAction && onPlanCta && (
 								<button
 									type="button"
-									style={S.cardCta}
+									disabled={ctaDisabled}
+									style={
+										ctaDisabled
+											? { ...S.cardCta, background: 'transparent', color: 'var(--rr-text-secondary)', border: '1px solid var(--rr-border)', cursor: 'default' }
+											: S.cardCta
+									}
 									onClick={(e) => {
 										e.stopPropagation();
-										onPlanCta(plan);
+										if (!ctaDisabled) onPlanCta(plan);
 									}}
 								>
-									{ctaLabel}
+									{cta?.label ?? ctaLabel}
 								</button>
 							)}
 						</div>


### PR DESCRIPTION
Shared-UI / shell-UI half of the Stripe billing + pricing work. The home-ui and `extension/` (backend) changes land in a follow-up **rocketride-saas** PR that bumps this submodule.

## Commits (logical)
1. **fix(shell): resilient ConnectionManager singleton + user-intent event buffer** — anchor the singleton on `globalThis` (Symbol.for) so a Module-Federation-duplicated `shell-ui` copy can't spawn a second instance (the cause of `shell:loginRequest`/`shell:subscribe` landing on a dead instance → "Get Started" doing nothing in prod). Buffer those two user-intent events when emitted with no live listener and replay to the next listener.
2. **feat(checkout): plan-aware PlanPicker** — optional `ctaConfig` (per-plan label/disabled, CTA mode) and `currentPriceId` ("Current plan" badge + non-selectable, selection mode). Both optional/backward-compatible; subscription logic stays in the host (extension-safe).
3. **feat(billing): UpgradeModal preselect + compact confirm, raw-amount direction; export it** — `preselectedPriceId` + compact confirmation (hide picker); `changeDirection` now compares raw `amountCents` to match the server's `change_subscription_plan` (fixes mislabeled cross-interval switches); export `UpgradeModal`. Incorporates the fix from #1344.
4. **feat(checkout): land in the app + confirm after a successful purchase** — switch into the purchased app and show a brief welcome instead of leaving the user on the pricing grid; upgrades keep their inline confirmation.

## Notes
- All four are additive/backward-compatible; existing consumers (CheckoutModal, account-screen UpgradeModal, the VS Code extension) are unchanged.
- Type-checked (no new errors; the one `PlanPicker.tsx` downlevelIteration warning is pre-existing/repo-wide).
- Supersedes #1344 (changeDirection raw-amount), included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Checkout now emits a welcome status message after purchase, automatically clears it, and switches you to the purchased app.
  * Plan selection highlights your current subscription tier and prevents selecting the active plan.
  * Upgrade modal supports a preselected plan flow and adds a compact “switch to” display mode.
  * Plan cards now support per-plan CTA label overrides and disabling.

* **Improvements**
  * Improved cross-instance reliability by sharing a single connection manager and buffering replayable user-intent events until handlers are ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->