### PR TITLE
fix(vscode): bake production server URL and Stripe key into the VSIX

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -145,6 +145,9 @@ jobs:
           FULL_VERSION: ${{ inputs.full_version }}
           BUILD_HASH: ${{ inputs.build_hash }}
           BUILD_STAMP: ${{ inputs.build_stamp }}
+          # Production values baked into the VS Code extension at build time.
+          ROCKETRIDE_URI: ${{ vars.ROCKETRIDE_URI }}
+          RR_STRIPE_PUBLISHABLE_KEY: ${{ vars.RR_STRIPE_PUBLISHABLE_KEY }}
         run: ${{ matrix.builder_cmd }} build --verbose --autoinstall --version="$FULL_VERSION" --hash="$BUILD_HASH" --stamp="$BUILD_STAMP" ${{ inputs.nodownload && '--nodownload' || '' }}
 
       # MinIO for S3Store integration tests (Linux only). Env vars are exported

--- a/scripts/lib/getenv.js
+++ b/scripts/lib/getenv.js
@@ -68,7 +68,7 @@ function parseFile(filePath) {
 // ============================================================================
 
 /**
- * Load merged build environment: .config defaults + .env overrides.
+ * Load merged build environment: .config -> .env -> process.env (real wins).
  *
  * In overlay mode (ROCKETRIDE_BUILD_ROOT is set by build.js when
  * --overlay-root is passed), the .env is read from the overlay root.
@@ -86,8 +86,15 @@ function getenv() {
 	const envRoot = buildRoot ? path.resolve(buildRoot, '..') : SERVER_ROOT;
 	const env = parseFile(path.join(envRoot, '.env'));
 
-	// Step 3: merge — .env values override .config defaults
-	return { ...config, ...env };
+	// Step 3: merge — .env overrides .config defaults
+	const merged = { ...config, ...env };
+
+	// Real env vars win, for known keys only, ignoring empty values.
+	for (const key of Object.keys(merged)) {
+		const real = process.env[key];
+		if (real !== undefined && real !== '') merged[key] = real;
+	}
+	return merged;
 }
 
 // ============================================================================

--- a/scripts/lib/getenv.js
+++ b/scripts/lib/getenv.js
@@ -90,7 +90,7 @@ function getenv() {
 	const merged = { ...config, ...env };
 
 	// Real env vars win, for known keys only, ignoring empty values.
-	for (const key of Object.keys(merged)) {
+	for (const key in merged) {
 		const real = process.env[key];
 		if (real !== undefined && real !== '') merged[key] = real;
 	}


### PR DESCRIPTION

<img width="806" height="686" alt="Captura de pantalla 2026-06-24 a las 10 34 50" src="https://github.com/user-attachments/assets/59121b9a-0994-4b1a-9363-69c48dce1d89" />

## Summary

- The published VS Code extension was baked with the `.config` dev defaults (`ROCKETRIDE_URI=http://localhost:5565`, `RR_STRIPE_PUBLISHABLE_KEY=pk_test_…`) because `getenv()` only read `.config`/`.env` and ignored real environment variables — and CI has no `.env`, so production values could never be injected.
- `getenv()` now honors `process.env` with precedence `.config -> .env -> process.env`, for known keys only and ignoring empty values (a set-but-empty CI secret falls back to the committed default instead of baking an empty string).
- The `Build` step exposes `ROCKETRIDE_URI` and `RR_STRIPE_PUBLISHABLE_KEY` from repo variables, scoped to the step so the `Test` step keeps the localhost defaults and integration tests do not hit production.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Verified `getenv()` precedence locally: dev (no env) → `localhost` / `pk_test`; with real env → `https://api.rocketride.ai` / `pk_live`; set-but-empty → falls back to the `.config` default.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Deployment note

Requires two repo variables to be created (public, non-secret values):

- `ROCKETRIDE_URI=https://api.rocketride.ai`
- `RR_STRIPE_PUBLISHABLE_KEY=pk_live_…`

## Linked Issue

_No linked issue — to be added._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two build-time environment variables to the deployment workflow for app and payment configuration.

* **Bug Fixes**
  * Improved environment resolution so real runtime values take priority over config and local env.
  * Runtime values that are empty strings are now ignored to prevent accidental overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->