### PR TITLE
fix(checkout): open plan CTA links externally in the VS Code extension

### DIFF
--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -752,7 +752,14 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 	 */
 	private openLink(url: string, displayName?: string, browser = false): void {
 		if (browser) {
-			void vscode.env.openExternal(vscode.Uri.parse(url));
+			// URL comes from a webview message; allowlist schemes before opening.
+			const uri = vscode.Uri.parse(url);
+			const scheme = uri.scheme.toLowerCase();
+			if (!['https', 'http', 'mailto'].includes(scheme)) {
+				this.logger.error(`[ProjectProvider] Blocked external URL scheme: ${scheme}`);
+				return;
+			}
+			void vscode.env.openExternal(uri);
 			return;
 		}
 		const panel = vscode.window.createWebviewPanel('externalContent', displayName || 'Pipeline', vscode.ViewColumn.One, {

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -471,7 +471,7 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 				// Link opening
 				case 'project:openLink': {
 					if (data.url) {
-						this.openLink(data.url as string, data.displayName as string | undefined);
+						this.openLink(data.url as string, data.displayName as string | undefined, data.browser as boolean | undefined);
 					}
 					break;
 				}
@@ -745,10 +745,16 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 	// =========================================================================
 
 	/**
-	 * Opens a URL in an embedded VS Code WebviewPanel with an iframe.
-	 * Bridges theme colors, env vars, clipboard, and drag-and-drop to the iframe.
+	 * Opens a URL. With `browser`, opens it in the system browser via the VS Code
+	 * shell (used by sandboxed CTAs like the Free/Enterprise plan links). Otherwise
+	 * opens it in an embedded WebviewPanel with an iframe, bridging theme colors,
+	 * env vars, clipboard, and drag-and-drop to the iframe.
 	 */
-	private openLink(url: string, displayName?: string): void {
+	private openLink(url: string, displayName?: string, browser = false): void {
+		if (browser) {
+			void vscode.env.openExternal(vscode.Uri.parse(url));
+			return;
+		}
 		const panel = vscode.window.createWebviewPanel('externalContent', displayName || 'Pipeline', vscode.ViewColumn.One, {
 			enableScripts: true,
 			retainContextWhenHidden: true,

--- a/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
+++ b/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
@@ -19,7 +19,7 @@ import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { applyTheme } from 'shared/themes';
 import type { ThemeTokens } from 'shared/themes/tokens';
 import { ProjectView, parseServerEvent, CheckoutModal } from 'shared';
-import type { TaskStatus, TraceEvent, ViewState, CheckoutPlan } from 'shared';
+import type { TaskStatus, TraceEvent, ViewState, CheckoutPlan, PlanAction } from 'shared';
 import { useMessaging } from '../hooks/useMessaging';
 import type { ProjectHostToWebview, ProjectWebviewToHost } from '../types';
 
@@ -332,7 +332,7 @@ const ProjectWebview: React.FC = () => {
 	return (
 		<>
 			<ProjectView project={project} servicesJson={servicesJson} isConnected={isConnected} isSubscribed={subscribed} statusMap={statusMap} serverHost={serverHost} isDirty={isDirty} isNew={isNew} initialViewState={viewState} initialPrefs={prefs} traceEvents={traceEvents} onContentChanged={handleContentChanged} onValidate={handleValidate} onPipelineAction={handlePipelineAction} onViewStateChange={handleViewStateChange} onPrefsChange={handlePrefsChange} onOpenLink={handleOpenLink} onSave={handleSave} onTraceClear={handleTraceClear} isReadonly={isReadonly} envKeys={envKeys} onMissingEnvVars={handleMissingEnvVars} />
-			{showCheckout && stripeKey && <CheckoutModal appName="RocketRide" appDescription="Visual AI pipeline editor — run and deploy pipelines on RocketRide Cloud." stripePublishableKey={stripeKey} onFetchPlans={handleFetchPlans} onCreateCheckout={handleCreateCheckout} onConfirmPending={handleConfirmPending} onSuccess={handleCheckoutSuccess} onClose={() => setShowCheckout(false)} />}
+			{showCheckout && stripeKey && <CheckoutModal appName="RocketRide" appDescription="Visual AI pipeline editor — run and deploy pipelines on RocketRide Cloud." stripePublishableKey={stripeKey} onFetchPlans={handleFetchPlans} onCreateCheckout={handleCreateCheckout} onConfirmPending={handleConfirmPending} onSuccess={handleCheckoutSuccess} onClose={() => setShowCheckout(false)} onActionClick={(_plan: CheckoutPlan, action: PlanAction) => sendMessageRef.current({ type: 'project:openLink', url: action.type === 'mailto' ? `mailto:${action.url}${action.subject ? `?subject=${encodeURIComponent(action.subject)}` : ''}` : action.url, browser: true })} />}
 		</>
 	);
 };

--- a/apps/vscode/src/providers/views/types.ts
+++ b/apps/vscode/src/providers/views/types.ts
@@ -23,7 +23,7 @@ export type ProjectHostToWebview = { type: 'project:load'; project: any; viewSta
 	| { type: 'project:envKeysUpdate'; envKeys: string[] };
 
 /** All messages the ProjectWebview can send to the extension host. */
-export type ProjectWebviewToHost = { type: 'view:ready' } | { type: 'view:initialized' } | { type: 'project:contentChanged'; project: any } | { type: 'project:validate'; requestId: number; pipeline: any } | { type: 'project:requestSave' } | { type: 'project:viewStateChange'; viewState: ViewState } | { type: 'project:prefsChange'; prefs: Record<string, unknown> } | { type: 'project:openLink'; url: string; displayName?: string } | { type: 'status:pipelineAction'; action: 'run' | 'stop' | 'restart'; source?: string; pipelineTraceLevel?: TraceLevel } | { type: 'status:missingEnvVars'; keys: string[] } | { type: 'trace:clear' };
+export type ProjectWebviewToHost = { type: 'view:ready' } | { type: 'view:initialized' } | { type: 'project:contentChanged'; project: any } | { type: 'project:validate'; requestId: number; pipeline: any } | { type: 'project:requestSave' } | { type: 'project:viewStateChange'; viewState: ViewState } | { type: 'project:prefsChange'; prefs: Record<string, unknown> } | { type: 'project:openLink'; url: string; displayName?: string; browser?: boolean } | { type: 'status:pipelineAction'; action: 'run' | 'stop' | 'restart'; source?: string; pipelineTraceLevel?: TraceLevel } | { type: 'status:missingEnvVars'; keys: string[] } | { type: 'trace:clear' };
 
 // =============================================================================
 // SERVER MONITOR PROTOCOL

--- a/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
+++ b/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
@@ -252,6 +252,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 	onConfirmPending,
 	onSuccess,
 	onClose,
+	onActionClick,
 }) => {
 	// Initialise Stripe lazily
 	const [stripePromise] = useState(() => loadStripe(stripePublishableKey));
@@ -380,6 +381,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 							loading={plansLoading}
 							selectedPlan={selectedPlan}
 							onSelectPlan={setSelectedPlan}
+							onActionClick={onActionClick}
 							autoSelectDefault
 							footer={
 								<button

--- a/packages/shared-ui/src/modules/checkout/types.ts
+++ b/packages/shared-ui/src/modules/checkout/types.ts
@@ -126,4 +126,12 @@ export interface CheckoutModalProps {
 
 	/** Called when the user dismisses the modal without completing checkout. */
 	onClose: () => void;
+
+	/**
+	 * Overrides how a plan's action CTA (Free → link, Enterprise → mailto) is
+	 * opened. The browser default (window.open / mailto) works in the SaaS web
+	 * app; the VS Code extension passes a handler that routes through the host,
+	 * since webview navigation is sandboxed.
+	 */
+	onActionClick?: (plan: CheckoutPlan, action: PlanAction) => void;
 }


### PR DESCRIPTION
## Summary

- The Free (**"Visit Github"** link) and Enterprise (**"Contact us"** mailto) plan CTAs did nothing in the VS Code extension's checkout — VS Code webviews sandbox navigation, so `PlanPicker`'s default `window.open` / `mailto` silently no-op.
- Fixed by **reusing the existing `project:openLink` message** with one optional `browser` flag — no new message type, no new helper, no global, fully compatible with the existing messaging infrastructure.

## Change (5 files)

- `views/types.ts` — add optional `browser?: boolean` to the existing `project:openLink` message.
- `ProjectProvider.ts` — `openLink()` opens via `vscode.env.openExternal` when `browser` is set (inline, early-return); the existing `project:openLink` handler passes the flag through.
- `checkout/types.ts` + `CheckoutModal.tsx` — one optional `onActionClick` prop, forwarded to `PlanPicker` (which already supports it).
- `ProjectWebview.tsx` — supplies `onActionClick` → `sendMessage({ type: 'project:openLink', url, browser: true })` via the existing `useMessaging`.

The SaaS web app is unchanged: when no `onActionClick` is supplied, `PlanPicker` keeps its native `window.open` behavior.

## Type

Fix.

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Built the vsix, installed locally, ran a pipeline without a subscription to trigger the paywall: **Visit Github** opens the browser, **Contact us** opens the mail client.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1322

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for opening checkout/plan actions in the system browser (instead of only within the embedded view) when available.
  * Improved mail action handling by constructing `mailto:` links and including a subject when provided.
  * Enabled plan action CTA clicks to be handled by the host via a new action callback, allowing custom link-opening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->