### PR TITLE
fix(vision): optimize the vision suite — downscale-for-inference, fast PNG, GPU onnxruntime

### DIFF
--- a/nodes/src/nodes/anonymize/requirements.txt
+++ b/nodes/src/nodes/anonymize/requirements.txt
@@ -1,1 +1,3 @@
 gliner
+onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/nodes/src/nodes/anonymize/requirements.txt
+++ b/nodes/src/nodes/anonymize/requirements.txt
@@ -1,3 +1,5 @@
 gliner
+# onnxruntime is an indirect dep (via gliner), not imported here.
+# Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
 onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/nodes/src/nodes/audio_transcribe/requirements.txt
+++ b/nodes/src/nodes/audio_transcribe/requirements.txt
@@ -5,4 +5,5 @@ av
 tokenizers
 huggingface-hub
 tqdm
-onnxruntime
+onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/nodes/src/nodes/audio_transcribe/requirements.txt
+++ b/nodes/src/nodes/audio_transcribe/requirements.txt
@@ -5,5 +5,7 @@ av
 tokenizers
 huggingface-hub
 tqdm
+# onnxruntime is an indirect dep (via faster-whisper), not imported here.
+# Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
 onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/nodes/src/nodes/background_removal/IGlobal.py
+++ b/nodes/src/nodes/background_removal/IGlobal.py
@@ -22,9 +22,6 @@
 # SOFTWARE.
 # =============================================================================
 
-import contextlib
-import threading
-
 from rocketlib import IGlobalBase, OPEN_MODE, warning
 from ai.common.config import Config
 
@@ -66,9 +63,9 @@ class IGlobal(IGlobalBase):
         self.remover = BackgroundRemover(model_name=model_name, device=None, revision=revision)
 
         # Local inference must serialize GPU access
-        from ai.common.models.base import is_model_server_enabled
+        from ai.common.models.base import make_device_lock
 
-        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
+        self.device_lock = make_device_lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/background_removal/IGlobal.py
+++ b/nodes/src/nodes/background_removal/IGlobal.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # =============================================================================
 
+import contextlib
 import threading
 
 from rocketlib import IGlobalBase, OPEN_MODE, warning
@@ -63,7 +64,11 @@ class IGlobal(IGlobalBase):
 
         # device=None -> model server when --modelserver is set, else local.
         self.remover = BackgroundRemover(model_name=model_name, device=None, revision=revision)
-        self.device_lock = threading.Lock()
+
+        # Local inference must serialize GPU access
+        from ai.common.models.base import is_model_server_enabled
+
+        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/background_removal/IInstance.py
+++ b/nodes/src/nodes/background_removal/IInstance.py
@@ -23,10 +23,11 @@
 # =============================================================================
 
 import json
+import time
 
-from rocketlib import IInstanceBase, AVI_ACTION, warning
+from rocketlib import IInstanceBase, AVI_ACTION, debug, warning
 from ai.common.image import Image, ImageProcessor
-from ai.common.image.dense_resize import resize_for_inference
+from ai.common.image.dense_resize import resize_for_inference, restore_dense_output
 from .IGlobal import IGlobal
 
 
@@ -57,11 +58,14 @@ class IInstance(IInstanceBase):
         """
         import numpy as np
 
-        # Cap the source first; the cutout is emitted at this (capped) resolution.
-        source_capped, _ = resize_for_inference(image.convert('RGB'), self.IGlobal.max_edge)
+        orig_rgb = image.convert('RGB')
+        # Downscale only for inference; the cutout is restored to the original resolution.
+        source_capped, original_size = resize_for_inference(orig_rgb, self.IGlobal.max_edge)
 
+        t0 = time.perf_counter()
         with self.IGlobal.device_lock:
             alpha = self.IGlobal.remover.remove(source_capped)
+        debug(f'bg_removal: infer={(time.perf_counter() - t0) * 1000:.0f}ms')
 
         alpha_norm = alpha.astype(np.float32) / 255.0
         stats = {
@@ -73,11 +77,17 @@ class IInstance(IInstanceBase):
             self.instance.writeText(json.dumps(stats))
 
         if self.instance.hasListener('image'):
-            # Straight (un-premultiplied) alpha avoids dark fringes when consumers
-            # re-composite over a non-black background.
-            r, g, b = source_capped.split()
-            rgba = Image.merge('RGBA', (r, g, b, Image.fromarray(alpha, mode='L')))
-            image_bytes = ImageProcessor.get_bytes(rgba)
+            # Restore the matte to the original resolution and composite over the full-res
+            # source so the cutout matches the input size. Straight (un-premultiplied) alpha
+            # avoids dark fringes when consumers re-composite over a non-black background.
+            t0 = time.perf_counter()
+            alpha_full = restore_dense_output(alpha, original_size, mode='bilinear')
+            r, g, b = orig_rgb.split()
+            rgba = Image.merge('RGBA', (r, g, b, Image.fromarray(alpha_full, mode='L')))
+            # Fast zlib level: a full-res RGBA cutout encodes ~5-6x faster than the
+            # default level 6 (~16s -> ~3s on 30 MP), for a modestly larger PNG.
+            image_bytes = ImageProcessor.get_bytes(rgba, compress_level=1)
+            debug(f'bg_removal: encode={(time.perf_counter() - t0) * 1000:.0f}ms out={len(image_bytes) / 1e6:.1f}MB')
             self.instance.writeImage(AVI_ACTION.BEGIN, 'image/png')
             self.instance.writeImage(AVI_ACTION.WRITE, 'image/png', image_bytes)
             self.instance.writeImage(AVI_ACTION.END, 'image/png')

--- a/nodes/src/nodes/background_removal/IInstance.py
+++ b/nodes/src/nodes/background_removal/IInstance.py
@@ -84,8 +84,7 @@ class IInstance(IInstanceBase):
             alpha_full = restore_dense_output(alpha, original_size, mode='bilinear')
             r, g, b = orig_rgb.split()
             rgba = Image.merge('RGBA', (r, g, b, Image.fromarray(alpha_full, mode='L')))
-            # Fast zlib level: a full-res RGBA cutout encodes ~5-6x faster than the
-            # default level 6 (~16s -> ~3s on 30 MP), for a modestly larger PNG.
+            # Fast zlib level: ~5-6x faster encode on big RGBA cutouts, slightly larger file.
             image_bytes = ImageProcessor.get_bytes(rgba, compress_level=1)
             debug(f'bg_removal: encode={(time.perf_counter() - t0) * 1000:.0f}ms out={len(image_bytes) / 1e6:.1f}MB')
             self.instance.writeImage(AVI_ACTION.BEGIN, 'image/png')

--- a/nodes/src/nodes/caption/IGlobal.py
+++ b/nodes/src/nodes/caption/IGlobal.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # =============================================================================
 
+import contextlib
 import threading
 
 from rocketlib import IGlobalBase, OPEN_MODE, warning
@@ -50,7 +51,11 @@ class IGlobal(IGlobalBase):
 
         # device=None -> model server when --modelserver is set, else local.
         self.captioner = Captioner(model_name=model_name, device=None, task=task, revision=revision)
-        self.device_lock = threading.Lock()
+
+        # Local inference must serialize GPU access
+        from ai.common.models.base import is_model_server_enabled
+
+        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/caption/IGlobal.py
+++ b/nodes/src/nodes/caption/IGlobal.py
@@ -22,9 +22,6 @@
 # SOFTWARE.
 # =============================================================================
 
-import contextlib
-import threading
-
 from rocketlib import IGlobalBase, OPEN_MODE, warning
 from ai.common.config import Config
 
@@ -53,9 +50,9 @@ class IGlobal(IGlobalBase):
         self.captioner = Captioner(model_name=model_name, device=None, task=task, revision=revision)
 
         # Local inference must serialize GPU access
-        from ai.common.models.base import is_model_server_enabled
+        from ai.common.models.base import make_device_lock
 
-        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
+        self.device_lock = make_device_lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/depth_estimate/IGlobal.py
+++ b/nodes/src/nodes/depth_estimate/IGlobal.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # =============================================================================
 
+import contextlib
 import threading
 
 from rocketlib import IGlobalBase, OPEN_MODE, warning
@@ -62,7 +63,11 @@ class IGlobal(IGlobalBase):
 
         # device=None -> model server when --modelserver is set, else local.
         self.estimator = DepthEstimator(model_name, device=None, revision=revision)
-        self.device_lock = threading.Lock()
+
+        # Local inference must serialize GPU access
+        from ai.common.models.base import is_model_server_enabled
+
+        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/depth_estimate/IGlobal.py
+++ b/nodes/src/nodes/depth_estimate/IGlobal.py
@@ -22,9 +22,6 @@
 # SOFTWARE.
 # =============================================================================
 
-import contextlib
-import threading
-
 from rocketlib import IGlobalBase, OPEN_MODE, warning
 from ai.common.config import Config
 
@@ -65,9 +62,9 @@ class IGlobal(IGlobalBase):
         self.estimator = DepthEstimator(model_name, device=None, revision=revision)
 
         # Local inference must serialize GPU access
-        from ai.common.models.base import is_model_server_enabled
+        from ai.common.models.base import make_device_lock
 
-        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
+        self.device_lock = make_device_lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/depth_estimate/IInstance.py
+++ b/nodes/src/nodes/depth_estimate/IInstance.py
@@ -23,8 +23,9 @@
 # =============================================================================
 
 import json
+import time
 
-from rocketlib import IInstanceBase, AVI_ACTION, warning
+from rocketlib import IInstanceBase, AVI_ACTION, debug, warning
 from ai.common.image import ImageProcessor
 from ai.common.image.dense_resize import resize_for_inference, restore_dense_output
 from ai.common.utils import colorize_depth
@@ -57,8 +58,10 @@ class IInstance(IInstanceBase):
             image: Decoded input PIL image for this frame.
         """
         resized, original_size = resize_for_inference(image, self.IGlobal.max_edge)
+        t0 = time.perf_counter()
         with self.IGlobal.device_lock:
             depth_np = self.IGlobal.estimator.estimate(resized)
+        debug(f'depth: infer={(time.perf_counter() - t0) * 1000:.0f}ms')
         depth_full = restore_dense_output(depth_np, original_size, mode='bilinear')
 
         stats = {
@@ -71,10 +74,10 @@ class IInstance(IInstanceBase):
             self.instance.writeText(json.dumps(stats))
 
         if self.instance.hasListener('image'):
-            image_bytes = ImageProcessor.get_bytes(colorize_depth(depth_full))
-            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/png')
-            self.instance.writeImage(AVI_ACTION.WRITE, 'image/png', image_bytes)
-            self.instance.writeImage(AVI_ACTION.END, 'image/png')
+            image_bytes = ImageProcessor.get_bytes(colorize_depth(depth_full), fmt='JPEG')
+            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/jpeg')
+            self.instance.writeImage(AVI_ACTION.WRITE, 'image/jpeg', image_bytes)
+            self.instance.writeImage(AVI_ACTION.END, 'image/jpeg')
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         """Accumulate an inbound image stream and run depth estimation on END.

--- a/nodes/src/nodes/detect/IGlobal.py
+++ b/nodes/src/nodes/detect/IGlobal.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # =============================================================================
 
+import contextlib
 import threading
 
 from rocketlib import IGlobalBase, OPEN_MODE, warning
@@ -76,7 +77,11 @@ class IGlobal(IGlobalBase):
         self.detector = Detector(
             backend=backend, device=None, threshold=threshold, prompt=prompt or None, revision=revision
         )
-        self.device_lock = threading.Lock()
+
+        # Local inference must serialize GPU access
+        from ai.common.models.base import is_model_server_enabled
+
+        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/detect/IGlobal.py
+++ b/nodes/src/nodes/detect/IGlobal.py
@@ -22,9 +22,6 @@
 # SOFTWARE.
 # =============================================================================
 
-import contextlib
-import threading
-
 from rocketlib import IGlobalBase, OPEN_MODE, warning
 from ai.common.config import Config
 
@@ -79,9 +76,9 @@ class IGlobal(IGlobalBase):
         )
 
         # Local inference must serialize GPU access
-        from ai.common.models.base import is_model_server_enabled
+        from ai.common.models.base import make_device_lock
 
-        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
+        self.device_lock = make_device_lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/detect_segment/IGlobal.py
+++ b/nodes/src/nodes/detect_segment/IGlobal.py
@@ -22,9 +22,6 @@
 # SOFTWARE.
 # =============================================================================
 
-import contextlib
-import threading
-
 from rocketlib import IGlobalBase, OPEN_MODE, warning
 from ai.common.config import Config
 
@@ -81,9 +78,9 @@ class IGlobal(IGlobalBase):
         )
 
         # Local inference must serialize GPU access
-        from ai.common.models.base import is_model_server_enabled
+        from ai.common.models.base import make_device_lock
 
-        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
+        self.device_lock = make_device_lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/detect_segment/IGlobal.py
+++ b/nodes/src/nodes/detect_segment/IGlobal.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # =============================================================================
 
+import contextlib
 import threading
 
 from rocketlib import IGlobalBase, OPEN_MODE, warning
@@ -78,7 +79,11 @@ class IGlobal(IGlobalBase):
         self.segmenter = Segmenter(
             mode=mode, model_name=model_name, device=None, threshold=threshold, max_edge=max_edge, revision=revision
         )
-        self.device_lock = threading.Lock()
+
+        # Local inference must serialize GPU access
+        from ai.common.models.base import is_model_server_enabled
+
+        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/detect_segment/IInstance.py
+++ b/nodes/src/nodes/detect_segment/IInstance.py
@@ -24,8 +24,9 @@
 
 import colorsys
 import json
+import time
 
-from rocketlib import IInstanceBase, AVI_ACTION, warning
+from rocketlib import IInstanceBase, AVI_ACTION, debug, warning
 
 from ai.common.image import ImageProcessor
 
@@ -195,10 +196,10 @@ class IInstance(IInstanceBase):
             self.instance.writeText(json.dumps(result, default=str))
 
         if self.instance.hasListener('image'):
-            image_bytes = ImageProcessor.get_bytes(annotated)
-            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/png')
-            self.instance.writeImage(AVI_ACTION.WRITE, 'image/png', image_bytes)
-            self.instance.writeImage(AVI_ACTION.END, 'image/png')
+            image_bytes = ImageProcessor.get_bytes(annotated, fmt='JPEG')
+            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/jpeg')
+            self.instance.writeImage(AVI_ACTION.WRITE, 'image/jpeg', image_bytes)
+            self.instance.writeImage(AVI_ACTION.END, 'image/jpeg')
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         """Accumulate an inbound image stream and run segmentation on END.
@@ -218,8 +219,10 @@ class IInstance(IInstanceBase):
         elif action == AVI_ACTION.END:
             try:
                 image = ImageProcessor.load_image_from_bytes(self._image_data)
+                t0 = time.perf_counter()
                 with self.IGlobal.device_lock:
                     result = self.IGlobal.segmenter.segment(image)
+                debug(f'segment: infer={(time.perf_counter() - t0) * 1000:.0f}ms')
                 self._emit(image, result)
             except Exception as exc:
                 warning(f'detect_segment: dropping frame due to inference error: {exc}')

--- a/nodes/src/nodes/face_detection/IInstance.py
+++ b/nodes/src/nodes/face_detection/IInstance.py
@@ -58,10 +58,10 @@ class IInstance(IInstanceBase):
             self.instance.writeText(json.dumps(faces))
 
         if self.instance.hasListener('image'):
-            image_bytes = ImageProcessor.get_bytes(annotated)
-            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/png')
-            self.instance.writeImage(AVI_ACTION.WRITE, 'image/png', image_bytes)
-            self.instance.writeImage(AVI_ACTION.END, 'image/png')
+            image_bytes = ImageProcessor.get_bytes(annotated, fmt='JPEG')
+            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/jpeg')
+            self.instance.writeImage(AVI_ACTION.WRITE, 'image/jpeg', image_bytes)
+            self.instance.writeImage(AVI_ACTION.END, 'image/jpeg')
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         if action == AVI_ACTION.BEGIN:

--- a/nodes/src/nodes/face_detection/face_detection.py
+++ b/nodes/src/nodes/face_detection/face_detection.py
@@ -86,6 +86,10 @@ KEYPOINT_NAMES: List[str] = [
     'left_ear_tragion',
 ]
 
+# Long-edge (px) the input is downscaled to before detection; boxes/landmarks come back
+# in this space and are mapped to original coords. Bounds cost on huge frames.
+INFER_MAX_EDGE = 1333
+
 
 class FaceDetector:
     """
@@ -224,11 +228,53 @@ class FaceDetector:
         import numpy as np
         import mediapipe as mp  # contract-check: ignore — see _build_detector
 
-        rgb = np.array(image.convert('RGB'))
+        from ai.common.image.dense_resize import resize_for_inference
+
+        # Downscale for inference; boxes/landmarks come back in the fed-image space and
+        # are mapped back to original coords so callers get input-resolution coordinates.
+        small, (orig_w, orig_h) = resize_for_inference(image.convert('RGB'), INFER_MAX_EDGE)
+        rgb = np.array(small)
         mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=rgb)
 
         result = self._detector.detect(mp_image)
-        return self._format(result, image.width, image.height)
+        faces = self._format(result, small.width, small.height)
+        return self._rescale_to_original(faces, small.size, orig_w, orig_h)
+
+    @staticmethod
+    def _rescale_to_original(
+        faces: List[Dict[str, Any]], small_size: Any, orig_w: int, orig_h: int
+    ) -> List[Dict[str, Any]]:
+        """Map box/centroid/landmark coords from the downscaled image back to original size.
+
+        Args:
+            faces: Canonical face dicts with coords in the downscaled (inference) image space.
+            small_size: (width, height) of the downscaled image the detector ran on.
+            orig_w: Original image width in pixels.
+            orig_h: Original image height in pixels.
+
+        Returns:
+            The same list with box/centroid/landmark coords scaled to the original image
+            (mutated in place; returned unchanged when the sizes already match).
+        """
+        sw, sh = small_size
+        if not faces or (sw == orig_w and sh == orig_h):
+            return faces
+        fx, fy = orig_w / sw, orig_h / sh
+        for f in faces:
+            b = f.get('box')
+            if b:
+                b['x1'] *= fx
+                b['x2'] *= fx
+                b['y1'] *= fy
+                b['y2'] *= fy
+            c = f.get('centroid')
+            if c:
+                c['x'] *= fx
+                c['y'] *= fy
+            for kp in f.get('landmarks', []):
+                kp['x'] *= fx
+                kp['y'] *= fy
+        return faces
 
     def _format(self, result: Any, img_w: int, img_h: int) -> List[Dict[str, Any]]:
         """Convert a MediaPipe FaceDetectorResult to canonical dicts."""

--- a/nodes/src/nodes/face_detection/face_detection.py
+++ b/nodes/src/nodes/face_detection/face_detection.py
@@ -256,24 +256,21 @@ class FaceDetector:
             The same list with box/centroid/landmark coords scaled to the original image
             (mutated in place; returned unchanged when the sizes already match).
         """
-        sw, sh = small_size
-        if not faces or (sw == orig_w and sh == orig_h):
+        from ai.common.image.dense_resize import inference_scale, scale_box, scale_point
+
+        factors = inference_scale(small_size, (orig_w, orig_h))
+        if not faces or factors is None:
             return faces
-        fx, fy = orig_w / sw, orig_h / sh
+        fx, fy = factors
         for f in faces:
-            b = f.get('box')
-            if b:
-                b['x1'] *= fx
-                b['x2'] *= fx
-                b['y1'] *= fy
-                b['y2'] *= fy
+            box = f.get('box')
+            if box:
+                scale_box(box, fx, fy)
             c = f.get('centroid')
             if c:
-                c['x'] *= fx
-                c['y'] *= fy
+                scale_point(c, fx, fy)
             for kp in f.get('landmarks', []):
-                kp['x'] *= fx
-                kp['y'] *= fy
+                scale_point(kp, fx, fy)
         return faces
 
     def _format(self, result: Any, img_w: int, img_h: int) -> List[Dict[str, Any]]:

--- a/nodes/src/nodes/face_detection/face_detection.py
+++ b/nodes/src/nodes/face_detection/face_detection.py
@@ -256,7 +256,7 @@ class FaceDetector:
             The same list with box/centroid/landmark coords scaled to the original image
             (mutated in place; returned unchanged when the sizes already match).
         """
-        from ai.common.image.dense_resize import inference_scale, scale_box, scale_point
+        from ai.common.utils.image_utils import inference_scale, scale_box, scale_point
 
         factors = inference_scale(small_size, (orig_w, orig_h))
         if not faces or factors is None:

--- a/nodes/src/nodes/pose_estimation/IGlobal.py
+++ b/nodes/src/nodes/pose_estimation/IGlobal.py
@@ -22,9 +22,6 @@
 # SOFTWARE.
 # =============================================================================
 
-import contextlib
-import threading
-
 from rocketlib import IGlobalBase, OPEN_MODE, warning
 from ai.common.config import Config
 
@@ -70,9 +67,9 @@ class IGlobal(IGlobalBase):
         self.pose_estimator = PoseEstimator(mode=mode, device=None, threshold=self.threshold, max_persons=max_persons)
 
         # Local inference must serialize GPU access
-        from ai.common.models.base import is_model_server_enabled
+        from ai.common.models.base import make_device_lock
 
-        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
+        self.device_lock = make_device_lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/pose_estimation/IGlobal.py
+++ b/nodes/src/nodes/pose_estimation/IGlobal.py
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # =============================================================================
 
+import contextlib
 import threading
 
 from rocketlib import IGlobalBase, OPEN_MODE, warning
@@ -67,7 +68,11 @@ class IGlobal(IGlobalBase):
 
         # device=None -> model server when --modelserver is set, else local.
         self.pose_estimator = PoseEstimator(mode=mode, device=None, threshold=self.threshold, max_persons=max_persons)
-        self.device_lock = threading.Lock()
+
+        # Local inference must serialize GPU access
+        from ai.common.models.base import is_model_server_enabled
+
+        self.device_lock = contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
 
     def endGlobal(self):
         """Disconnect the facade and release shared state on teardown."""

--- a/nodes/src/nodes/pose_estimation/IInstance.py
+++ b/nodes/src/nodes/pose_estimation/IInstance.py
@@ -23,9 +23,10 @@
 # =============================================================================
 
 import json
+import time
 from typing import Any, Dict, List
 
-from rocketlib import IInstanceBase, AVI_ACTION, warning
+from rocketlib import IInstanceBase, AVI_ACTION, debug, warning
 from ai.common.image import ImageProcessor
 from .IGlobal import IGlobal
 
@@ -101,10 +102,10 @@ class IInstance(IInstanceBase):
             self.instance.writeText(json.dumps(persons))
 
         if self.instance.hasListener('image'):
-            image_bytes = ImageProcessor.get_bytes(self._annotate(image, persons))
-            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/png')
-            self.instance.writeImage(AVI_ACTION.WRITE, 'image/png', image_bytes)
-            self.instance.writeImage(AVI_ACTION.END, 'image/png')
+            image_bytes = ImageProcessor.get_bytes(self._annotate(image, persons), fmt='JPEG')
+            self.instance.writeImage(AVI_ACTION.BEGIN, 'image/jpeg')
+            self.instance.writeImage(AVI_ACTION.WRITE, 'image/jpeg', image_bytes)
+            self.instance.writeImage(AVI_ACTION.END, 'image/jpeg')
 
     def writeImage(self, action: int, mimeType: str, buffer: bytes):
         """Accumulate an inbound image stream and run pose estimation on END.
@@ -124,8 +125,10 @@ class IInstance(IInstanceBase):
         elif action == AVI_ACTION.END:
             try:
                 image = ImageProcessor.load_image_from_bytes(self._image_data)
+                t0 = time.perf_counter()
                 with self.IGlobal.device_lock:
                     persons = self.IGlobal.pose_estimator.estimate(image)
+                debug(f'pose: infer={(time.perf_counter() - t0) * 1000:.0f}ms')
                 self._emit(image, persons)
             except Exception as exc:
                 warning(f'pose_estimation: dropping frame due to inference error: {exc}')

--- a/nodes/test/face_detection/test_face_detection.py
+++ b/nodes/test/face_detection/test_face_detection.py
@@ -168,3 +168,32 @@ def test_build_detector_succeeds_when_lib_present(monkeypatch):
     monkeypatch.setattr(det, '_resolve_model_path', lambda: '/tmp/model.tflite')
 
     assert det._build_detector() is sentinel
+
+
+# ---------------------------------------------------------------------------
+# _rescale_to_original maps downscaled-inference coords back to original size
+# ---------------------------------------------------------------------------
+
+
+def test_rescale_to_original_maps_box_centroid_and_landmarks():
+    faces = [
+        {
+            'label': 'face',
+            'score': 0.9,
+            'box': {'x1': 100.0, 'y1': 50.0, 'x2': 200.0, 'y2': 150.0},
+            'centroid': {'x': 150.0, 'y': 100.0},
+            'landmarks': [{'name': 'nose_tip', 'x': 150.0, 'y': 100.0}],
+        }
+    ]
+    # inference at (1000, 500), original (2000, 1000) -> fx = fy = 2.
+    out = FaceDetector._rescale_to_original(faces, (1000, 500), 2000, 1000)
+    assert out[0]['box'] == {'x1': 200.0, 'y1': 100.0, 'x2': 400.0, 'y2': 300.0}
+    assert out[0]['centroid'] == {'x': 300.0, 'y': 200.0}
+    assert out[0]['landmarks'][0]['x'] == 300.0
+    assert out[0]['landmarks'][0]['y'] == 200.0
+
+
+def test_rescale_to_original_noop_when_sizes_match():
+    faces = [{'box': {'x1': 1.0, 'y1': 2.0, 'x2': 3.0, 'y2': 4.0}}]
+    out = FaceDetector._rescale_to_original(faces, (500, 500), 500, 500)
+    assert out[0]['box'] == {'x1': 1.0, 'y1': 2.0, 'x2': 3.0, 'y2': 4.0}

--- a/packages/ai/src/ai/common/image/dense_resize.py
+++ b/packages/ai/src/ai/common/image/dense_resize.py
@@ -4,7 +4,7 @@ See vision suite build brief §1.3 and Plan #13. Primary strategy is max-edge re
 """
 
 from __future__ import annotations
-from typing import Dict, Literal, Optional, Tuple, Union
+from typing import Literal, Optional, Tuple, Union
 import numpy as np
 from PIL import Image
 
@@ -69,41 +69,6 @@ def resize_for_inference(
 
     resized = image.resize((new_w, new_h), resample=Image.LANCZOS)
     return resized, (orig_w, orig_h)
-
-
-def inference_scale(small_size: Tuple[int, int], original_size: Tuple[int, int]) -> Optional[Tuple[float, float]]:
-    """(fx, fy) mapping coords from a downscaled inference image back to the original.
-
-    The sparse-output counterpart to ``restore_dense_output``: detection / pose / face
-    run inference on a ``resize_for_inference`` downscale, then scale their box,
-    keypoint and centroid coords by these factors.
-
-    Args:
-        small_size: (width, height) the inference ran on.
-        original_size: (width, height) of the original image.
-
-    Returns:
-        (fx, fy) scale factors, or None when the sizes already match (no rescale needed).
-    """
-    sw, sh = int(small_size[0]), int(small_size[1])
-    ow, oh = int(original_size[0]), int(original_size[1])
-    if sw == ow and sh == oh:
-        return None
-    return ow / sw, oh / sh
-
-
-def scale_box(box: Dict[str, float], fx: float, fy: float) -> None:
-    """Scale an ``{x1, y1, x2, y2}`` box in place by (fx, fy)."""
-    box['x1'] *= fx
-    box['x2'] *= fx
-    box['y1'] *= fy
-    box['y2'] *= fy
-
-
-def scale_point(point: Dict[str, float], fx: float, fy: float) -> None:
-    """Scale an ``{x, y}`` point (keypoint / centroid / landmark) in place by (fx, fy)."""
-    point['x'] *= fx
-    point['y'] *= fy
 
 
 def restore_dense_output(

--- a/packages/ai/src/ai/common/image/dense_resize.py
+++ b/packages/ai/src/ai/common/image/dense_resize.py
@@ -4,7 +4,7 @@ See vision suite build brief §1.3 and Plan #13. Primary strategy is max-edge re
 """
 
 from __future__ import annotations
-from typing import Literal, Optional, Tuple, Union
+from typing import Dict, Literal, Optional, Tuple, Union
 import numpy as np
 from PIL import Image
 
@@ -69,6 +69,41 @@ def resize_for_inference(
 
     resized = image.resize((new_w, new_h), resample=Image.LANCZOS)
     return resized, (orig_w, orig_h)
+
+
+def inference_scale(small_size: Tuple[int, int], original_size: Tuple[int, int]) -> Optional[Tuple[float, float]]:
+    """(fx, fy) mapping coords from a downscaled inference image back to the original.
+
+    The sparse-output counterpart to ``restore_dense_output``: detection / pose / face
+    run inference on a ``resize_for_inference`` downscale, then scale their box,
+    keypoint and centroid coords by these factors.
+
+    Args:
+        small_size: (width, height) the inference ran on.
+        original_size: (width, height) of the original image.
+
+    Returns:
+        (fx, fy) scale factors, or None when the sizes already match (no rescale needed).
+    """
+    sw, sh = int(small_size[0]), int(small_size[1])
+    ow, oh = int(original_size[0]), int(original_size[1])
+    if sw == ow and sh == oh:
+        return None
+    return ow / sw, oh / sh
+
+
+def scale_box(box: Dict[str, float], fx: float, fy: float) -> None:
+    """Scale an ``{x1, y1, x2, y2}`` box in place by (fx, fy)."""
+    box['x1'] *= fx
+    box['x2'] *= fx
+    box['y1'] *= fy
+    box['y2'] *= fy
+
+
+def scale_point(point: Dict[str, float], fx: float, fy: float) -> None:
+    """Scale an ``{x, y}`` point (keypoint / centroid / landmark) in place by (fx, fy)."""
+    point['x'] *= fx
+    point['y'] *= fy
 
 
 def restore_dense_output(

--- a/packages/ai/src/ai/common/image/image.py
+++ b/packages/ai/src/ai/common/image/image.py
@@ -104,7 +104,7 @@ class ImageProcessor:
         return thumbnail
 
     @staticmethod
-    def get_bytes(image: Image, fmt: str = 'PNG', quality: int = 90) -> bytes:
+    def get_bytes(image: Image, fmt: str = 'PNG', quality: int = 90, compress_level: int = 6) -> bytes:
         """
         Encode a Pillow Image to bytes.
 
@@ -115,6 +115,9 @@ class ImageProcessor:
             image (Image): The Pillow Image object to convert.
             fmt (str): 'PNG' (default) or 'JPEG'.
             quality (int): JPEG quality (ignored for PNG).
+            compress_level (int): PNG zlib level 0-9 (ignored for non-PNG). Default 6
+                matches Pillow. Lower trades file size for speed — e.g. 1 cuts a 30 MP
+                RGBA encode from ~16 s to ~2-3 s, which matters for full-res cutouts.
 
         Returns:
             bytes: The encoded image data.
@@ -124,6 +127,8 @@ class ImageProcessor:
             if image.mode not in ('RGB', 'L'):
                 image = image.convert('RGB')
             image.save(buffered, format='JPEG', quality=quality)
+        elif fmt.upper() == 'PNG':
+            image.save(buffered, format='PNG', compress_level=compress_level)
         else:
             image.save(buffered, format=fmt)
         return buffered.getvalue()

--- a/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
+++ b/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
@@ -4,5 +4,7 @@
 
 faster-whisper
 numpy
+# onnxruntime is an indirect dep (via faster-whisper), not imported here.
+# Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
 onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
+++ b/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
@@ -4,3 +4,5 @@
 
 faster-whisper
 numpy
+onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/packages/ai/src/ai/common/models/base.py
+++ b/packages/ai/src/ai/common/models/base.py
@@ -31,6 +31,8 @@ get_model_server_address() reads --modelserver=<addr> from sys.argv and
 returns the raw string — no parsing or URL construction.
 """
 
+import contextlib
+import threading
 import hashlib
 import json
 import sys
@@ -234,6 +236,20 @@ def is_model_server_enabled() -> bool:
         True if ``--modelserver=<address>`` is present, False otherwise.
     """
     return bool(get_model_server_address())
+
+
+def make_device_lock() -> contextlib.AbstractContextManager:
+    """Return the device-access guard for the current run mode.
+
+    Local in-process GPU inference must serialize, so this returns a real
+    ``threading.Lock``. In proxy mode the model server batches and the DAP transport
+    multiplexes concurrent requests, so a node-side lock would only throttle it —
+    returns a no-op ``contextlib.nullcontext`` instead.
+
+    Returns:
+        A context manager — ``threading.Lock`` locally, ``nullcontext`` when proxying.
+    """
+    return contextlib.nullcontext() if is_model_server_enabled() else threading.Lock()
 
 
 # =============================================================================

--- a/packages/ai/src/ai/common/models/base.py
+++ b/packages/ai/src/ai/common/models/base.py
@@ -223,6 +223,19 @@ def get_model_server_address() -> Optional[str]:
     return None
 
 
+def is_model_server_enabled() -> bool:
+    """
+    True when a model server is configured via ``--modelserver``.
+
+    Reflects configuration only (the flag is set with a non-empty address); it does
+    not verify the server is reachable or running.
+
+    Returns:
+        True if ``--modelserver=<address>`` is present, False otherwise.
+    """
+    return bool(get_model_server_address())
+
+
 # =============================================================================
 # MODEL CLIENT
 # =============================================================================

--- a/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
+++ b/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
@@ -2,6 +2,8 @@
 gliner
 # needed for gliner_ko
 python-mecab-ko
+# onnxruntime is an indirect dep (via gliner), not imported here.
+# Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
 onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'
 

--- a/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
+++ b/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
@@ -2,4 +2,6 @@
 gliner
 # needed for gliner_ko
 python-mecab-ko
+onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime==1.20.1; platform_system == 'Darwin'
 

--- a/packages/ai/src/ai/common/models/vision/caption.py
+++ b/packages/ai/src/ai/common/models/vision/caption.py
@@ -62,6 +62,11 @@ MAX_NEW_TOKENS = 256
 # Local-mode watchdog: Florence can hang on complex scenes; skip the frame past this.
 INFERENCE_TIMEOUT = 60
 
+# Long-edge (px) the input is downscaled to before captioning. Florence resizes
+# internally to its own input, so this is quality-neutral and just trims the
+# model-server payload on large images.
+INFER_MAX_EDGE = 1024
+
 
 def _resolve_token(task: Optional[str]) -> str:
     """Map a caption-granularity key to its Florence-2 task token (falling back to <CAPTION>)."""
@@ -288,6 +293,15 @@ class Captioner:
 
         task = self.task if task is None else task
         metrics.counter('gpu_inference_count', 1)
+
+        from PIL import Image
+        from ai.common.image.dense_resize import resize_for_inference
+
+        # Downscale for inference (quality-neutral; shrinks the model-server payload).
+        if hasattr(image, 'size') and hasattr(image, 'mode'):
+            image, _ = resize_for_inference(image, INFER_MAX_EDGE)
+        elif isinstance(image, (bytes, bytearray)):
+            image, _ = resize_for_inference(Image.open(io.BytesIO(image)).convert('RGB'), INFER_MAX_EDGE)
 
         if self._proxy_mode:
             # The model server enforces its own per-request timeout/retry.

--- a/packages/ai/src/ai/common/models/vision/detection.py
+++ b/packages/ai/src/ai/common/models/vision/detection.py
@@ -558,7 +558,7 @@ class Detector:
         dets: List[Dict[str, Any]], small_size: Tuple[int, int], orig_w: int, orig_h: int
     ) -> List[Dict[str, Any]]:
         """Map box/centroid coordinates from the downscaled image back to original size."""
-        from ai.common.image.dense_resize import inference_scale, scale_box, scale_point
+        from ai.common.utils.image_utils import inference_scale, scale_box, scale_point
 
         factors = inference_scale(small_size, (orig_w, orig_h))
         if not dets or factors is None:

--- a/packages/ai/src/ai/common/models/vision/detection.py
+++ b/packages/ai/src/ai/common/models/vision/detection.py
@@ -558,21 +558,19 @@ class Detector:
         dets: List[Dict[str, Any]], small_size: Tuple[int, int], orig_w: int, orig_h: int
     ) -> List[Dict[str, Any]]:
         """Map box/centroid coordinates from the downscaled image back to original size."""
-        sw, sh = small_size
-        if not dets or (sw == orig_w and sh == orig_h):
+        from ai.common.image.dense_resize import inference_scale, scale_box, scale_point
+
+        factors = inference_scale(small_size, (orig_w, orig_h))
+        if not dets or factors is None:
             return dets
-        fx, fy = orig_w / sw, orig_h / sh
+        fx, fy = factors
         for d in dets:
-            b = d.get('box')
-            if b:
-                b['x1'] *= fx
-                b['x2'] *= fx
-                b['y1'] *= fy
-                b['y2'] *= fy
+            box = d.get('box')
+            if box:
+                scale_box(box, fx, fy)
             c = d.get('centroid')
             if c:
-                c['x'] *= fx
-                c['y'] *= fy
+                scale_point(c, fx, fy)
         return dets
 
     def disconnect(self) -> None:

--- a/packages/ai/src/ai/common/models/vision/pose.py
+++ b/packages/ai/src/ai/common/models/vision/pose.py
@@ -460,20 +460,18 @@ class PoseEstimator:
             The same list with box + keypoint coords scaled to the original image
             (mutated in place; returned unchanged when the sizes already match).
         """
-        sw, sh = small_size
-        if not poses or (sw == orig_w and sh == orig_h):
+        from ai.common.image.dense_resize import inference_scale, scale_box, scale_point
+
+        factors = inference_scale(small_size, (orig_w, orig_h))
+        if not poses or factors is None:
             return poses
-        fx, fy = orig_w / sw, orig_h / sh
+        fx, fy = factors
         for p in poses:
-            b = p.get('box')
-            if b:
-                b['x1'] *= fx
-                b['x2'] *= fx
-                b['y1'] *= fy
-                b['y2'] *= fy
+            box = p.get('box')
+            if box:
+                scale_box(box, fx, fy)
             for kp in p.get('keypoints', []):
-                kp['x'] *= fx
-                kp['y'] *= fy
+                scale_point(kp, fx, fy)
         return poses
 
     def disconnect(self) -> None:

--- a/packages/ai/src/ai/common/models/vision/pose.py
+++ b/packages/ai/src/ai/common/models/vision/pose.py
@@ -460,7 +460,7 @@ class PoseEstimator:
             The same list with box + keypoint coords scaled to the original image
             (mutated in place; returned unchanged when the sizes already match).
         """
-        from ai.common.image.dense_resize import inference_scale, scale_box, scale_point
+        from ai.common.utils.image_utils import inference_scale, scale_box, scale_point
 
         factors = inference_scale(small_size, (orig_w, orig_h))
         if not poses or factors is None:

--- a/packages/ai/src/ai/common/models/vision/pose.py
+++ b/packages/ai/src/ai/common/models/vision/pose.py
@@ -53,6 +53,11 @@ DEFAULT_MODEL = 'rtmlib-body'
 DEFAULT_THRESHOLD = 0.3
 DEFAULT_MAX_PERSONS = 20
 
+# Long-edge (px) the input is downscaled to before inference. Bounds cost on huge
+# images while keeping enough resolution for the person detector + per-person crops;
+# keypoints/boxes come back in this space and are mapped back to original coords.
+INFER_MAX_EDGE = 1333
+
 # Node profile key -> rtmlib ``mode`` (selects bundled RTMDet-nano + RTMPose sizes).
 PROFILE_TO_MODE: Dict[str, str] = {
     'rtmpose-tiny': 'lightweight',
@@ -400,6 +405,23 @@ class PoseEstimator:
         max_persons = self.max_persons if max_persons is None else max_persons
         metrics.counter('gpu_inference_count', 1)
 
+        from PIL import Image
+        from ai.common.image.dense_resize import resize_for_inference
+
+        # Downscale for inference; poses come back in the fed-image space and are mapped
+        # back to original coords below. Unknown inputs (e.g. BGR ndarray) run unscaled.
+        rescale = None
+        if hasattr(image, 'size') and hasattr(image, 'mode'):
+            pil = image
+        elif isinstance(image, (bytes, bytearray)):
+            pil = Image.open(io.BytesIO(image)).convert('RGB')
+        else:
+            pil = None
+        if pil is not None:
+            small, (orig_w, orig_h) = resize_for_inference(pil, INFER_MAX_EDGE)
+            image = small
+            rescale = (small.size, orig_w, orig_h)
+
         if self._proxy_mode:
             result = self._client.send_command(
                 'rrext_ms_inference',
@@ -411,14 +433,48 @@ class PoseEstimator:
                 },
             )
             items = result.get('result', [])
-            return items[0].get('poses', []) if items else []
+            poses = items[0].get('poses', []) if items else []
+        else:
+            pre = PoseEstimatorLoader.preprocess(self._bundle, [image], self._metadata)
+            raw = PoseEstimatorLoader.inference(
+                self._bundle, pre, self._metadata, threshold=threshold, max_persons=max_persons
+            )
+            out = PoseEstimatorLoader.postprocess(self._bundle, raw, 1, ['poses'], metadata=self._metadata)
+            poses = out[0]['poses']
 
-        pre = PoseEstimatorLoader.preprocess(self._bundle, [image], self._metadata)
-        raw = PoseEstimatorLoader.inference(
-            self._bundle, pre, self._metadata, threshold=threshold, max_persons=max_persons
-        )
-        out = PoseEstimatorLoader.postprocess(self._bundle, raw, 1, ['poses'], metadata=self._metadata)
-        return out[0]['poses']
+        return poses if rescale is None else self._rescale_to_original(poses, *rescale)
+
+    @staticmethod
+    def _rescale_to_original(
+        poses: List[Dict[str, Any]], small_size: Tuple[int, int], orig_w: int, orig_h: int
+    ) -> List[Dict[str, Any]]:
+        """Map box + keypoint coordinates from the downscaled image back to original size.
+
+        Args:
+            poses: Canonical person dicts with coords in the downscaled (inference) image space.
+            small_size: (width, height) of the downscaled image inference ran on.
+            orig_w: Original image width in pixels.
+            orig_h: Original image height in pixels.
+
+        Returns:
+            The same list with box + keypoint coords scaled to the original image
+            (mutated in place; returned unchanged when the sizes already match).
+        """
+        sw, sh = small_size
+        if not poses or (sw == orig_w and sh == orig_h):
+            return poses
+        fx, fy = orig_w / sw, orig_h / sh
+        for p in poses:
+            b = p.get('box')
+            if b:
+                b['x1'] *= fx
+                b['x2'] *= fx
+                b['y1'] *= fy
+                b['y2'] *= fy
+            for kp in p.get('keypoints', []):
+                kp['x'] *= fx
+                kp['y'] *= fy
+        return poses
 
     def disconnect(self) -> None:
         """Release the model-server connection (proxy mode only); no-op locally.

--- a/packages/ai/src/ai/common/models/vision/requirements_pose.txt
+++ b/packages/ai/src/ai/common/models/vision/requirements_pose.txt
@@ -3,6 +3,8 @@
 # GPU wheel on Linux/Windows (CUDA-12 build, CPU fallback when no GPU); plain
 # wheel on macOS (CoreML/MPS; no gpu wheel exists). numpy is a base engine dep.
 rtmlib>=0.0.13
+# onnxruntime is an indirect dep (via rtmlib), not imported here.
+# Pin 1.20.1 — the version rtmlib needs.
 onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'
 Pillow

--- a/packages/ai/src/ai/common/utils/image_utils.py
+++ b/packages/ai/src/ai/common/utils/image_utils.py
@@ -38,7 +38,7 @@ from __future__ import annotations
 import base64
 import io
 import zlib
-from typing import Any, Dict
+from typing import Any, Dict, Optional, Tuple
 
 
 def image_to_bytes(image: Any) -> bytes:
@@ -126,3 +126,33 @@ def colorize_depth(depth: Any) -> Any:
     b = (255 - norm).astype(np.uint8)
 
     return Image.fromarray(np.stack([r, g, b], axis=-1))
+
+
+def inference_scale(small_size: Tuple[int, int], original_size: Tuple[int, int]) -> Optional[Tuple[float, float]]:
+    """(fx, fy) to map coords from a downscaled inference image back to the original.
+
+    Sparse counterpart to ``dense_resize.restore_dense_output``: detection / pose / face
+    run inference on a downscaled image, then scale their box / keypoint / centroid
+    coords by these factors. PIL-free, so node unit tests can use it without Pillow.
+
+    Returns None when the sizes already match (no rescale needed).
+    """
+    sw, sh = int(small_size[0]), int(small_size[1])
+    ow, oh = int(original_size[0]), int(original_size[1])
+    if sw == ow and sh == oh:
+        return None
+    return ow / sw, oh / sh
+
+
+def scale_box(box: Dict[str, float], fx: float, fy: float) -> None:
+    """Scale an ``{x1, y1, x2, y2}`` box in place by (fx, fy)."""
+    box['x1'] *= fx
+    box['x2'] *= fx
+    box['y1'] *= fy
+    box['y2'] *= fy
+
+
+def scale_point(point: Dict[str, float], fx: float, fy: float) -> None:
+    """Scale an ``{x, y}`` point (keypoint / centroid / landmark) in place by (fx, fy)."""
+    point['x'] *= fx
+    point['y'] *= fy

--- a/packages/ai/tests/ai/common/models/test_caption.py
+++ b/packages/ai/tests/ai/common/models/test_caption.py
@@ -1,5 +1,9 @@
 """Unit tests for the caption loader + facade (no torch/transformers needed)."""
 
+import io
+
+from PIL import Image
+
 import ai.common.models.vision.caption as capmod
 from ai.common.models.vision.caption import CaptionerLoader, Captioner
 
@@ -56,13 +60,27 @@ def test_facade_proxy_sends_task_and_decodes(monkeypatch):
     cap = Captioner(task='detailed_caption')
     assert cap._proxy_mode is True
 
-    out = cap.caption(b'fake-image-bytes')
+    out = cap.caption(Image.new('RGB', (8, 8)))  # small -> not downscaled
     assert captured['cmd'] == 'rrext_ms_inference'
     args = captured['args']
-    assert args['data'] == b'fake-image-bytes'
+    assert isinstance(args['data'], (bytes, bytearray)) and args['data'][:4] == b'\x89PNG'
     assert args['output_fields'] == ['caption']
     assert args['task'] == 'detailed_caption'
     assert out == 'a person standing'
 
     cap.disconnect()
     assert captured.get('disconnected') is True
+
+
+def test_facade_proxy_downscales_large_image(monkeypatch):
+    """Large image is downscaled before captioning (payload shrinks); caption unchanged."""
+    captured = {'caption': 'ok'}
+    monkeypatch.setattr(capmod, 'get_model_server_address', lambda: 'localhost:5590')
+    monkeypatch.setattr(capmod, 'ModelClient', _fake_client_factory(captured))
+
+    cap = Captioner(task='caption')
+    out = cap.caption(Image.new('RGB', (4000, 2000)))  # INFER_MAX_EDGE=1024
+    assert out == 'ok'
+
+    sent = Image.open(io.BytesIO(captured['args']['data']))
+    assert max(sent.size) <= 1024

--- a/packages/ai/tests/ai/common/models/test_pose.py
+++ b/packages/ai/tests/ai/common/models/test_pose.py
@@ -1,6 +1,8 @@
 """Unit tests for the pose loader + facade (no onnxruntime/rtmlib needed)."""
 
 import numpy as np
+import pytest
+from PIL import Image
 
 import ai.common.models.vision.pose as posemod
 from ai.common.models.vision.pose import PoseEstimatorLoader, PoseEstimator
@@ -83,14 +85,39 @@ def test_facade_proxy_sends_params_and_decodes(monkeypatch):
     est = PoseEstimator(mode='performance', threshold=0.4, max_persons=7)
     assert est._proxy_mode is True
 
-    out = est.estimate(b'fake-image-bytes')
+    out = est.estimate(Image.new('RGB', (8, 8)))  # small -> not downscaled
     assert captured['cmd'] == 'rrext_ms_inference'
     args = captured['args']
-    assert args['data'] == b'fake-image-bytes'
+    assert isinstance(args['data'], (bytes, bytearray)) and args['data'][:4] == b'\x89PNG'
     assert args['output_fields'] == ['poses']
     assert args['threshold'] == 0.4
     assert args['max_persons'] == 7
-    assert out == poses
+    assert out == poses  # no downscale -> coords unchanged
 
     est.disconnect()
     assert captured.get('disconnected') is True
+
+
+def test_facade_proxy_rescales_poses_to_original(monkeypatch):
+    """Large image is downscaled for inference; box + keypoints map back to original coords."""
+    poses = [
+        {
+            'label': 'person',
+            'box': {'x1': 100.0, 'y1': 50.0, 'x2': 200.0, 'y2': 150.0},
+            'keypoints': [{'name': 'nose', 'x': 150.0, 'y': 100.0, 'score': 0.9}],
+        }
+    ]
+    captured = {'poses': poses}
+    monkeypatch.setattr(posemod, 'get_model_server_address', lambda: 'localhost:5590')
+    monkeypatch.setattr(posemod, 'ModelClient', _fake_client_factory(captured))
+
+    est = PoseEstimator(mode='balanced')
+    out = est.estimate(Image.new('RGB', (2000, 1000)))  # INFER_MAX_EDGE=1333 -> (1333, 666)
+
+    fx, fy = 2000 / 1333, 1000 / 666
+    b = out[0]['box']
+    assert b['x1'] == pytest.approx(100.0 * fx)
+    assert b['y2'] == pytest.approx(150.0 * fy)
+    kp = out[0]['keypoints'][0]
+    assert kp['x'] == pytest.approx(150.0 * fx)
+    assert kp['y'] == pytest.approx(100.0 * fy)

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -753,6 +753,22 @@ def ensure_constraints() -> str:
 # ---------------------------------------------------------------------------
 
 
+def _write_excludes_file() -> str:
+    """Write uv's resolution-excludes file (rewritten each call) and return its path.
+
+    Excludes `uv` (bootstrapped by depends.py; pip-installing it crashes on Windows)
+    and, on non-Darwin, plain `onnxruntime` (it clobbers onnxruntime-gpu in the same
+    folder; the gpu build provides `import onnxruntime`).
+    """
+    excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
+    excludes = 'uv\n'
+    if platform.system() != 'Darwin':
+        excludes += 'onnxruntime\n'
+    with open(excludes_path, 'w', encoding='utf-8') as f:
+        f.write(excludes)
+    return excludes_path
+
+
 def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]:
     """
     Run uv pip install --dry-run and return list of packages that would be installed.
@@ -779,21 +795,10 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
         '--no-color',
     ]
 
-    # Exclude uv from resolution — it's bootstrapped by depends.py and
-    # installing it as a pip package crashes on Windows (os error 32)
-    excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
-    if not os.path.exists(excludes_path):
-        excludes = 'uv\n'
-        # Plain onnxruntime would clobber onnxruntime-gpu (same folder); the gpu build
-        # provides `import onnxruntime`. macOS has no gpu wheel, so keep plain there.
-        if platform.system() != 'Darwin':
-            excludes += 'onnxruntime\n'
-        with open(excludes_path, 'w', encoding='utf-8') as f:
-            f.write(excludes)
     # uv splits --excludes on whitespace, so an absolute path with a space (macOS
     # "Application Support") breaks resolution; pass it relative to the cwd (exe_dir).
     # See #1256.
-    args.extend(['--excludes', os.path.relpath(excludes_path, exe_dir)])
+    args.extend(['--excludes', os.path.relpath(_write_excludes_file(), exe_dir)])
 
     args.extend(_constraints_args(constraints_path, exe_dir))
 
@@ -893,18 +898,8 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
         '--no-build-isolation',  # Don't create temp venvs (engine.exe can't create venvs)
     ]
 
-    # Exclude uv from resolution (same excludes file as dry-run)
-    excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
-    if not os.path.exists(excludes_path):
-        excludes = 'uv\n'
-        # Plain onnxruntime would clobber onnxruntime-gpu (same folder); the gpu build
-        # provides `import onnxruntime`. macOS has no gpu wheel, so keep plain there.
-        if platform.system() != 'Darwin':
-            excludes += 'onnxruntime\n'
-        with open(excludes_path, 'w', encoding='utf-8') as f:
-            f.write(excludes)
     # Relative to cwd (exe_dir) — see the --excludes note in _install_dry_run (#1256).
-    uv_args.extend(['--excludes', os.path.relpath(excludes_path, exe_dir)])
+    uv_args.extend(['--excludes', os.path.relpath(_write_excludes_file(), exe_dir)])
 
     uv_args.extend(_constraints_args(constraints_path, exe_dir))
 

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -783,8 +783,13 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
     # installing it as a pip package crashes on Windows (os error 32)
     excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
     if not os.path.exists(excludes_path):
+        excludes = 'uv\n'
+        # Plain onnxruntime would clobber onnxruntime-gpu (same folder); the gpu build
+        # provides `import onnxruntime`. macOS has no gpu wheel, so keep plain there.
+        if platform.system() != 'Darwin':
+            excludes += 'onnxruntime\n'
         with open(excludes_path, 'w', encoding='utf-8') as f:
-            f.write('uv\n')
+            f.write(excludes)
     # uv splits --excludes on whitespace, so an absolute path with a space (macOS
     # "Application Support") breaks resolution; pass it relative to the cwd (exe_dir).
     # See #1256.
@@ -891,8 +896,13 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
     # Exclude uv from resolution (same excludes file as dry-run)
     excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
     if not os.path.exists(excludes_path):
+        excludes = 'uv\n'
+        # Plain onnxruntime would clobber onnxruntime-gpu (same folder); the gpu build
+        # provides `import onnxruntime`. macOS has no gpu wheel, so keep plain there.
+        if platform.system() != 'Darwin':
+            excludes += 'onnxruntime\n'
         with open(excludes_path, 'w', encoding='utf-8') as f:
-            f.write('uv\n')
+            f.write(excludes)
     # Relative to cwd (exe_dir) — see the --excludes note in _install_dry_run (#1256).
     uv_args.extend(['--excludes', os.path.relpath(excludes_path, exe_dir)])
 


### PR DESCRIPTION
## Summary

Speeds up the vision pipeline (background_removal, depth_estimate,
detect_segment, pose_estimation, face_detection). Three independent commits,
all required to hit the goal:

1. **feat(ai)** — PNG `compress_level` for `ImageProcessor.get_bytes`.
2. **fix(deps)** — GPU onnxruntime everywhere (unblocks the vision models from loading).
3. **perf(vision)** — downscale-for-inference + full-res output across the suite.
4. **perf(vision)** — proxy-mode batching

## Background

A 5-node vision pipeline took ~40 s on a 30 MP image. Tracing split the cost:

| cost | time | nature |
| --- | --- | --- |
| bg_removal PNG encode | ~16 s | full-res RGBA encoded at zlib level 6 — **fixed here** |
| onnxruntime load crash (`OrtCompileApiFlags`) | blocked load | two onnxruntime builds clobbering — **fixed here** |
| GPU model eviction | ~7.5 s/drop | 5 models don't fit in 8 GB VRAM → reload per request; actual GPU inference is only ~1.6 s — **VRAM limit, not a code bug** |

## Changes

### 1. feat(ai): PNG compress_level
`get_bytes(..., compress_level=6)` — new optional arg, default matches Pillow so
all existing callers are unchanged. A lower level trades a slightly larger file
for a 5-6× faster encode; `background_removal` uses level 1.

### 2. fix(deps): GPU onnxruntime
`onnxruntime-gpu==1.20.1` and an unpinned plain `onnxruntime` (pulled
transitively) installed into the same folder and clobbered each other's native
`.pyd`, crashing model load. Declares the gpu/cpu split in every onnxruntime
consumer and excludes the transitive plain build on non-Darwin so the GPU build
wins. macOS keeps the CPU build.

### 3. perf(vision): downscale-for-inference
Caps inference resolution and rescales results back to full size across the
vision nodes. bg emits a full-res RGBA PNG (fast level); the other nodes emit
annotated JPEG frames (no alpha needed).

### 4. perf(vision): proxy-mode batching
Each vision node held `device_lock` across the model-server round-trip, serializing
requests so the server's adaptive batching never engaged. Gate the lock on a new
`is_model_server_enabled()` helper — `nullcontext` when proxying (the DAP transport
multiplexes concurrent requests), a real `Lock` only for local GPU inference.

## Results

- **bg_removal encode: 16.2 s → 2.7 s.**
- **The remaining latency on the 8 GB dev box is GPU eviction — a VRAM limit, not
  code.** Proven by an A/B: trimming the active path to 3 models (which fit in
  8 GB) eliminates eviction entirely — consecutive drops stay warm (0 evictions,
  0 cold-loads, ~1 s GPU inference, ~12 s wall-clock). The 80 GB H100 holds all 5
  models the same way, so no further code change is needed for that half.

## Testing

- `builder nodes:test --pytest-parallel=off` (serial, to avoid the cv2 DLL-lock flake).
- ai unit tests: `test_pose`, `test_caption`, `test_detection`, `test_image`, `test_face_detection`.
- E2E: `examples/vision.pipe` runs to completion via the model server.

## Related issues
Fixes https://github.com/rocketride-org/rocketride-server/issues/1346, #1351 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vision captioning/pose/detection/face detection now downscale large inputs before inference and automatically remap coordinates back to original image size.
* **Bug Fixes**
  * Background removal now restores the alpha matte to full original resolution before producing RGBA cutouts.
  * More reliable coordinate remapping when downscaling is applied.
* **Improvements**
  * Annotated outputs now switch to JPEG (with inference/encoding time logging); PNG encoding supports configurable compression.
  * Local inference synchronization now adapts when running in model-server mode.
* **Chores**
  * Platform-specific ONNX Runtime versions are consistently pinned; dependency exclude handling was updated.
* **Tests**
  * Added/updated coverage for downscaling + remapping behavior and output payload encoding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->