### PR TITLE
fix(engine): error instead of crashing on unregistered providers 

### DIFF
--- a/nodes/test/conftest.py
+++ b/nodes/test/conftest.py
@@ -222,6 +222,9 @@ def _build_parametrize_list(configs, skip_nodes=None, include_skip=None):
     """
     params = []
     for config in configs:
+        # Release engines don't register "debug" nodes; running one only errors.
+        if 'debug' in config.capabilities:
+            continue
         if skip_nodes and config.node_name in skip_nodes:
             if include_skip is None or config.node_name not in include_skip:
                 continue
@@ -271,8 +274,6 @@ def pytest_generate_tests(metafunc):
             'caption',
             'background_removal',
             'pose_estimation',
-            # Debug-only nodes (capabilities include "debug"): inactive in release
-            # (NDEBUG) builds, so the dynamic engine test cannot load them.
             'face_detection',
             # Temporarily exclude nodes with failing tests until they can be fixed and re-enabled:
             'index_search',

--- a/nodes/test/framework/discovery.py
+++ b/nodes/test/framework/discovery.py
@@ -101,6 +101,7 @@ class NodeTestConfig:
     # Node metadata
     preconfig: Dict[str, Any] = field(default_factory=dict)
     lanes: Dict[str, Any] = field(default_factory=dict)
+    capabilities: List[str] = field(default_factory=list)
     config_id: Optional[str] = None
 
     def get_test_id(self) -> str:
@@ -376,6 +377,7 @@ def _parse_test_config(
                 config=group.get('config') if isinstance(group.get('config'), dict) else {},
                 preconfig=data.get('preconfig', {}),
                 lanes=data.get('lanes', {}),
+                capabilities=_ensure_list_field(data.get('capabilities'), 'capabilities', service_file),
                 config_id=config_id,
             )
         )

--- a/packages/server/engine-lib/engLib/store/pipeline/pipeline_config.cpp
+++ b/packages/server/engine-lib/engLib/store/pipeline/pipeline_config.cpp
@@ -287,6 +287,14 @@ Error PipelineConfig::validate(bool sourceRequired) noexcept {
         for (auto &[id, comp] : comps) {
             for (auto &input : comp.inputs) {
                 for (auto &output : comp.outputs) {
+                    // Unregistered provider (e.g. a debug-only node in a release
+                    // build) — error instead of dereferencing a null def.
+                    if (!comp.def)
+                        return APERR(Ec::InvalidParam, "Component", id,
+                                     "references a provider with no registered "
+                                     "service definition; it is unavailable in "
+                                     "this engine build (e.g. a debug-only node)");
+
                     if (!comp.def->serviceDefinition["lanes"].isMember(
                             input->name))
                         return APERR(Ec::InvalidParam, "Component", id,

--- a/packages/server/engine-lib/test/store/pipeline/pipeline_config.cpp
+++ b/packages/server/engine-lib/test/store/pipeline/pipeline_config.cpp
@@ -508,6 +508,51 @@ TEST_CASE("PipelineConfig") {
         REQUIRE_FALSE(_anyOf(chain, "response_1"));
     }
 
+    SECTION("provider:unregistered") {
+        // A component whose provider has no registered service definition (e.g.
+        // a debug-only node excluded from a release/NDEBUG build) must fail
+        // validation cleanly. Before the guard in PipelineConfig::validate this
+        // dereferenced a null comp.def in the lane-linking loop and crashed with
+        // an SEH access violation (0xc0000005) instead of returning an error.
+        pipeline = R"({
+            "source": "source_1",
+            "components": [
+                {
+                    "id": "source_1",
+                    "provider": "filesys",
+                    "config": {}
+                },
+                {
+                    "id": "ghost_1",
+                    "provider": "this_provider_is_not_registered",
+                    "config": {},
+                    "input": [
+                        {
+                            "from": "source_1",
+                            "lane": "tags"
+                        }
+                    ]
+                },
+                {
+                    "id": "response_1",
+                    "provider": "response",
+                    "config": {},
+                    "input": [
+                        {
+                            "from": "ghost_1",
+                            "lane": "text"
+                        }
+                    ]
+                }
+            ]
+        })"_json;
+
+        REQUIRE_ERROR(config.validate(), Ec::InvalidParam,
+                      "Component ghost_1 references a provider with no "
+                      "registered service definition; it is unavailable in "
+                      "this engine build (e.g. a debug-only node)");
+    }
+
     SECTION("chain") {
         pipeline["components"].append(R"({
             "id": "source_2",


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- Engine: return a clear `InvalidParam` error instead of crashing (`SEH 0xc0000005`) when a pipeline references a provider with no registered service definition — e.g. a `debug`-capability node, which release (`NDEBUG`) builds never register.
- Dynamic node tests: exclude `debug`-capability nodes from both suites (`test_dynamic` + `test_dynamic_full`), regardless of `ROCKETRIDE_INCLUDE_SKIP`; parse `capabilities` onto `NodeTestConfig`.
- Add an `engtest` regression case (`provider:unregistered`) for the unregistered-provider path.

## Type

fix 

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #1353 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline validation to fail fast when a component’s provider/service definition is unavailable in the current engine build, returning a clearer error instead of unexpected failures.
  * Refined dynamic test selection to exclude debug-only node configurations more reliably.
* **Tests**
  * Added a new pipeline validation test to verify failure when an unregistered provider is referenced, including the correct error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->