### PR TITLE
fix(ci): pin cryptography at build + UV_LINK_MODE=copy (Windows nodes:test _rust.pyd lock)

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -238,6 +238,10 @@ jobs:
         # (.env.template, the engine's built-in dev key).
         env:
           ROCKETRIDE_APIKEY: MYAPIKEY
+          # Force uv to copy rather than hardlink when (re)installing node deps at
+          # test time. On Windows a hardlink over an already-loaded native .pyd
+          # (e.g. cryptography's _rust.pyd) fails with a file lock; copy is atomic.
+          UV_LINK_MODE: copy
         # note: Sequential execution should be changed to parallel execution
         #       after the appropriate fixes have been made, see #743 #1048 for details.
         run: ${{ matrix.builder_cmd }} test --verbose --sequential

--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -768,7 +768,7 @@ function makeInstallPipAction() {
             // Bootstrap pip, then install all build, test, and runtime dependencies.
             // uv is left for depends.py at runtime; the builder just uses pip.
             // State key version bumped to force re-run when deps change.
-            const pipInstalled = await getState('server.pipInstalledV8');
+            const pipInstalled = await getState('server.pipInstalledV9');
             if (!pipInstalled) {
                 // Bootstrap pip
                 // Add the engine's Scripts/bin dir to PATH so pip doesn't warn about it
@@ -795,8 +795,16 @@ function makeInstallPipAction() {
                     'mcp>=1.2.0',
                     // Model server
                     'huggingface_hub[hf_xet]',
+                    // Pin cryptography to the node-requirements range so the build
+                    // installs the right version up front. Unconstrained, the build
+                    // pulls the latest (transitively, via mcp/huggingface_hub) and
+                    // depends() then downgrades it during parallel pytest collection;
+                    // on Windows the workers race to overwrite the already-loaded
+                    // cryptography _rust.pyd DLL and the whole suite fails. Keep this
+                    // in lockstep with nodes/src/nodes/requirements.txt.
+                    'cryptography>=46.0.7,<47',
                 );
-                await setState('server.pipInstalledV8', true);
+                await setState('server.pipInstalledV9', true);
             } else {
                 task.output = 'Build and test deps already installed (skipped)';
             }


### PR DESCRIPTION
Fixes the Windows `nodes:test` failure Rod flagged (43 failed / 16 collection errors): uv cannot install cryptography because `_rust.pyd` is locked (Access is denied, os error 5).

**Root cause:** the Windows build installs cryptography unconstrained -> latest (transitively via mcp/huggingface_hub). Then during parallel pytest collection (-n 4) every worker's depends() downgrades cryptography to the node-pinned 46.0.7 in the same shared venv at once; on Windows one worker has _rust.pyd memory-mapped while another overwrites it -> file lock. The install FileLock serializes uv but can't unmap a DLL another live process holds.

**Fix (CI/build-side only, no depends.py/engine change):**
- packages/server/scripts/tasks.js: pin cryptography>=46.0.7,<47 in the build pip install (matches nodes/src/nodes/requirements.txt) so collection finds nothing to downgrade; state key V8->V9.
- .github/workflows/_build.yaml: UV_LINK_MODE=copy on the test step (atomic copy vs hardlink over a loaded .pyd).

Keep the build pin and node-req pin in lockstep (dependabot #1291 -> 48.0.1; bump this to match if it lands first).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability on Windows by avoiding a file-locking issue during dependency setup.
  * Updated Python dependency installation to refresh once and include a required security-related package version, helping prevent setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->