### PR TITLE
fix(audio): force docopt/num2words to wheels for Windows engine install (#1358)

### DIFF
--- a/nodes/src/nodes/audio_tts/requirements.txt
+++ b/nodes/src/nodes/audio_tts/requirements.txt
@@ -1,4 +1,10 @@
 numpy
+
+# Resolve docopt and num2words from wheels only, so the embedded engine installs
+# them without building any source distribution.
+--only-binary docopt
+--only-binary num2words
+
 # Kokoro-82M: official inference package (not transformers AutoModel)
 kokoro>=0.9.4
 soundfile>=0.13.1

--- a/packages/ai/src/ai/common/models/audio/requirements_kokoro.txt
+++ b/packages/ai/src/ai/common/models/audio/requirements_kokoro.txt
@@ -1,5 +1,11 @@
 # contract-check: skip-install  reason: ~200 MB of audio-model deps (misaki, librosa, einops) for an opt-in feature. PR lane skips; nightly --install-all installs and verifies.
 # Kokoro-82M inference (model server + local); torch from image
+
+# Resolve docopt and num2words from wheels only, so the embedded engine installs
+# them without building any source distribution.
+--only-binary docopt
+--only-binary num2words
+
 kokoro>=0.9.4
 soundfile>=0.12.0
 # en_core_web_sm is installed dynamically in KokoroLoader._ensure_dependencies()


### PR DESCRIPTION
## Summary

- **What:** Add `--only-binary docopt` / `--only-binary num2words` to the two requirements files that pull Kokoro (`requirements_kokoro.txt` and the `audio_tts` node), so the resolver lands on `num2words 0.5.6` (wheel, no docopt).
- **Why it works:** `docopt 0.6.2` and `num2words 0.5.7` are sdist-only, and the frozen `engine.exe` on Windows can't build sdists (uv can't seed a build venv). Restricting both to wheels makes the resolver pick a wheel-only `num2words` version — nothing gets built, so the failing path never runs.
- **Why it scales (and why it's safe):** It is just a wheel policy in the requirements file — no version pin, no vendored binaries — so any future sdist-only dependency in the chain can be handled the same one-line way, and resolution stays uniform across Windows/macOS/Linux. docopt itself is only a CLI argument-parsing library used by the `num2words` command-line entry point, never by the `num2words` Python API that Kokoro calls.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Tested locally on macOS through the real engine/uv flow (`engine lib/python3.12/depends.py install`): resolves to `num2words 0.5.6` from a wheel, `docopt` not installed, zero sdist builds. Windows uv-flow validation still pending.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1358

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package installation reliability by preferring prebuilt wheels for certain dependencies.
  * Reduced the chance of installation failures during setup on systems without build tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->