### PR TITLE
fix: fix vs code checkout button not opening external links (#1302, #1303)

### DIFF
--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -72,9 +72,12 @@
 		"@rsbuild/plugin-sass": "~1.5.3",
 		"@rsbuild/plugin-svgr": "^2.0.3",
 		"@rslib/core": "~0.22.0",
+		"@testing-library/jest-dom": "^6.4.2",
+		"@testing-library/react": "^14.2.2",
 		"@types/react": "~18.3.29",
 		"@types/react-dom": "~18.3.7",
 		"@types/react-syntax-highlighter": "^15.5.13",
+		"jsdom": "^24.0.0",
 		"rollup": "~4.60.4",
 		"rollup-plugin-dts": "~6.4.1",
 		"rollup-plugin-peer-deps-external": "~2.2.4",
@@ -82,7 +85,11 @@
 		"run-script-os": "^1.1.6",
 		"svgo": "^3.3.3",
 		"tsx": "~4.23.1",
-		"typescript": "^5.6.3"
+		"typescript": "^5.6.3",
+		"vitest": "^1.4.0"
+	},
+	"scripts": {
+		"test": "vitest run"
 	},
 	"exports": {
 		".": "./index.ts",

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/field-label-with-info/FieldLabelWithInfo.test.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/field-label-with-info/FieldLabelWithInfo.test.tsx
@@ -22,7 +22,7 @@
 // =============================================================================
 
 import assert from 'node:assert/strict';
-import { test } from 'node:test';
+import { test } from 'vitest';
 import React, { Children, type ComponentType, type ReactElement } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 

--- a/packages/shared-ui/src/modules/checkout/PlanPicker.test.tsx
+++ b/packages/shared-ui/src/modules/checkout/PlanPicker.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { PlanPicker } from './PlanPicker';
+import type { CheckoutPlan } from './types';
+
+describe('PlanPicker', () => {
+	it('renders an action plan as a native <a> tag with target="_blank" and rel="noopener noreferrer"', () => {
+		const mockActionPlan: CheckoutPlan = {
+			id: 'price_free',
+			stripePriceId: 'price_free',
+			nickname: 'Free',
+			amountCents: 0,
+			interval: 'month',
+			metadata: {
+				action: {
+					type: 'link',
+					label: 'Get started',
+					url: 'https://rocketride.org/docs',
+				},
+			},
+		};
+
+		render(<PlanPicker plans={[mockActionPlan]} />);
+
+		const link = screen.getByRole('link', { name: 'Get started' });
+		expect(link).toBeInTheDocument();
+		// Asserting native navigation works via the href
+		expect(link).toHaveAttribute('href', 'https://rocketride.org/docs');
+		// Asserting security regression fix
+		expect(link).toHaveAttribute('target', '_blank');
+		expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+	});
+
+	it('prevents default native navigation when onActionClick is provided', async () => {
+		const mockActionPlan: CheckoutPlan = {
+			id: 'price_enterprise',
+			stripePriceId: 'price_enterprise',
+			nickname: 'Enterprise',
+			amountCents: 0,
+			interval: 'month',
+			metadata: {
+				action: {
+					type: 'link',
+					label: 'Contact us',
+					url: 'https://rocketride.org/contact',
+				},
+			},
+		};
+
+		const onActionClick = vi.fn();
+		render(<PlanPicker plans={[mockActionPlan]} onActionClick={onActionClick} />);
+
+		const link = screen.getByRole('link', { name: 'Contact us' });
+		
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+		const defaultPrevented = !link.dispatchEvent(event);
+		
+		// The custom handler should be called instead of native navigation
+		expect(defaultPrevented).toBe(true);
+		expect(onActionClick).toHaveBeenCalledWith(mockActionPlan, mockActionPlan.metadata.action);
+	});
+
+	it('renders a mailto action with no target or rel, and handles default navigation if no onActionClick', () => {
+		const mockMailtoPlan: CheckoutPlan = {
+			id: 'price_contact',
+			stripePriceId: 'price_contact',
+			nickname: 'Contact',
+			amountCents: 0,
+			interval: 'month',
+			metadata: {
+				action: {
+					type: 'mailto',
+					label: 'Email us',
+					url: 'hello@rocketride.org',
+					subject: 'Enterprise Plan',
+				},
+			},
+		};
+
+		render(<PlanPicker plans={[mockMailtoPlan]} />);
+
+		const link = screen.getByRole('link', { name: 'Email us' });
+		expect(link).toHaveAttribute('href', 'mailto:hello@rocketride.org?subject=Enterprise%20Plan');
+		expect(link).not.toHaveAttribute('target');
+		expect(link).not.toHaveAttribute('rel');
+
+		const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+		const defaultPrevented = !link.dispatchEvent(event);
+		
+		// Native navigation should happen (default not prevented)
+		expect(defaultPrevented).toBe(false);
+	});
+});

--- a/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
+++ b/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
@@ -98,20 +98,7 @@ function actionHref(action: PlanAction): string {
 	return action.url;
 }
 
-/**
- * Default handler for action plan clicks -- opens link in new tab or mailto.
- *
- * @param _plan  - The plan that was clicked (unused, kept for signature).
- * @param action - The action descriptor with type and url.
- */
-function defaultActionClick(_plan: CheckoutPlan, action: PlanAction): void {
-	const href = actionHref(action);
-	if (action.type === 'link') {
-		window.open(href, '_blank', 'noopener,noreferrer');
-	} else {
-		window.location.href = href;
-	}
-}
+
 
 /** True when an action link points at GitHub (drives the GitHub glyph on the CTA). */
 function isGithubAction(action: PlanAction | null): boolean {
@@ -376,7 +363,7 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 	loading = false,
 	selectedPlan = null,
 	onSelectPlan,
-	onActionClick = defaultActionClick,
+	onActionClick,
 	onPlanCta,
 	ctaLabel = 'Get started',
 	ctaConfig,
@@ -586,8 +573,10 @@ export const PlanPicker: React.FC<PlanPickerProps> = ({
 									}
 									onClick={(e) => {
 										e.stopPropagation();
-										e.preventDefault();
-										onActionClick(plan, action);
+										if (onActionClick) {
+											e.preventDefault();
+											onActionClick(plan, action);
+										}
 									}}
 								>
 									{action.label}

--- a/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
+++ b/packages/shared-ui/src/modules/checkout/PlanPicker.tsx
@@ -98,8 +98,6 @@ function actionHref(action: PlanAction): string {
 	return action.url;
 }
 
-
-
 /** True when an action link points at GitHub (drives the GitHub glyph on the CTA). */
 function isGithubAction(action: PlanAction | null): boolean {
 	return !!action && action.type === 'link' && /github\.com/i.test(action.url);

--- a/packages/shared-ui/vitest.config.ts
+++ b/packages/shared-ui/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: {
+		environment: 'jsdom',
+		setupFiles: ['./vitest.setup.ts'],
+		include: ['src/**/*.test.{ts,tsx}'],
+	},
+});

--- a/packages/shared-ui/vitest.setup.ts
+++ b/packages/shared-ui/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->
- I removed the `defaultActionClick` handler from `PlanPicker.tsx` which was attempting to use `window.open()` and `window.location.href` to handle link clicks.
- Then made `e.preventDefault()` conditional so it only runs if a custom `onActionClick` handler is actively provided.
- Fixes a bug in the VS Code extension where the "Get Started" and "Contact us" buttons did nothing or hung the view because VS Code's webview sandbox blocks `window.open()` and internal navigation. It now successfully relies on native HTML `<a>` navigation, which VS Code natively intercepts and opens in an external browser.


## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
fix
## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #1302, #1303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated plan selection CTA handling so link/mailto actions use native browser navigation when no custom click handler is provided.
  * Ensured custom click callbacks only intercept the click when explicitly supplied, preserving expected `target`/`rel` behavior.

* **New Features**
  * Added automated test coverage for link action rendering and callback behavior in `PlanPicker`.

* **Tests**
  * Introduced Vitest + jsdom-based test setup and configuration for the shared UI package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->