### PR TITLE
Fix/rr #1352 GitHub client 404 and rate limit

### DIFF
--- a/nodes/src/nodes/tool_github/IInstance.py
+++ b/nodes/src/nodes/tool_github/IInstance.py
@@ -211,7 +211,7 @@ class IInstance(IInstanceBase):
             data = call(self._token(), 'GET', f'/repos/{repo}/contents/{path.lstrip("/")}', params=params)
         except ValueError as e:
             if '404' in str(e):
-                return {'found': False, 'message': f'File path "{path}" does not exist.'}
+                return {'found': False, 'message': str(e)}
             raise
         if isinstance(data, list):
             raise ValueError(f'Path "{path}" is a directory — use file_list instead')

--- a/nodes/src/nodes/tool_github/IInstance.py
+++ b/nodes/src/nodes/tool_github/IInstance.py
@@ -219,6 +219,7 @@ class IInstance(IInstanceBase):
         content_b64 = data.get('content', '')
         content = base64.b64decode(content_b64).decode('utf-8', errors='replace')
         return {
+            'found': True,
             'path': data.get('path'),
             'name': data.get('name'),
             'sha': data.get('sha'),

--- a/nodes/src/nodes/tool_github/IInstance.py
+++ b/nodes/src/nodes/tool_github/IInstance.py
@@ -202,11 +202,17 @@ class IInstance(IInstanceBase):
         description='Get the decoded content and metadata of a single file from a GitHub repository.',
     )
     def file_get(self, args):
+        """Get the decoded content and metadata of a single file from a GitHub repository."""
         args = normalize_tool_input(args, tool_name='tool_github')
         repo = self._repo(args)
         path = require_str(args, 'path', tool_name='file_get')
         params = {'ref': args['ref']} if args.get('ref') else None
-        data = call(self._token(), 'GET', f'/repos/{repo}/contents/{path.lstrip("/")}', params=params)
+        try:
+            data = call(self._token(), 'GET', f'/repos/{repo}/contents/{path.lstrip("/")}', params=params)
+        except ValueError as e:
+            if '404' in str(e):
+                return {'found': False, 'message': f'File path "{path}" does not exist.'}
+            raise
         if isinstance(data, list):
             raise ValueError(f'Path "{path}" is a directory — use file_list instead')
         content_b64 = data.get('content', '')
@@ -233,6 +239,7 @@ class IInstance(IInstanceBase):
         description='List files and directories at a path in a GitHub repository.',
     )
     def file_list(self, args):
+        """List files and directories at a path in a GitHub repository."""
         args = normalize_tool_input(args, tool_name='tool_github')
         repo = self._repo(args)
         path = (args.get('path') or '').strip().lstrip('/')

--- a/nodes/src/nodes/tool_github/IInstance.py
+++ b/nodes/src/nodes/tool_github/IInstance.py
@@ -40,6 +40,7 @@ from rocketlib import IInstanceBase, tool_function
 from ai.common.utils import normalize_tool_input, require_int, require_str
 
 from .github_client import (
+    GitHubAPIError,
     call,
     clean_commit,
     clean_file_entry,
@@ -209,8 +210,8 @@ class IInstance(IInstanceBase):
         params = {'ref': args['ref']} if args.get('ref') else None
         try:
             data = call(self._token(), 'GET', f'/repos/{repo}/contents/{path.lstrip("/")}', params=params)
-        except ValueError as e:
-            if '404' in str(e):
+        except GitHubAPIError as e:
+            if e.status_code == 404:
                 return {'found': False, 'message': str(e)}
             raise
         if isinstance(data, list):

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -55,6 +55,21 @@ class RateLimitError(Exception):
         self.response = response
 
 
+def _rate_limit_hint(headers) -> str:
+    """Human-readable retry hint from rate-limit headers, or '' if none present."""
+    retry_after = headers.get('Retry-After')
+    if retry_after:
+        return f'retry after {retry_after}s'
+    reset = headers.get('X-RateLimit-Reset')
+    if reset:
+        try:
+            secs = max(0, int(float(reset) - time.time()))
+            return f'rate limit resets in ~{secs}s'
+        except ValueError:
+            return f'rate limit resets at epoch {reset}'
+    return ''
+
+
 def _raise_github_error(resp: requests.Response) -> None:
     """Parse GitHub error response and raise GitHubAPIError."""
     try:
@@ -65,6 +80,9 @@ def _raise_github_error(resp: requests.Response) -> None:
             msg += ' — ' + '; '.join(e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in errors)
     except Exception:
         msg = resp.text or resp.reason or 'unknown error'
+    hint = _rate_limit_hint(resp.headers)
+    if hint:
+        msg += f' ({hint})'
     raise GitHubAPIError(resp.status_code, msg)
 
 
@@ -111,10 +129,11 @@ def call(
 
         if not resp.ok:
             is_rate_limit = resp.status_code == 429 or (
-                resp.status_code == 403 and (
-                    'Retry-After' in resp.headers or
-                    resp.headers.get('X-RateLimit-Remaining') == '0' or
-                    'rate limit' in resp.text.lower()
+                resp.status_code == 403
+                and (
+                    'Retry-After' in resp.headers
+                    or resp.headers.get('X-RateLimit-Remaining') == '0'
+                    or 'rate limit' in resp.text.lower()
                 )
             )
             if is_rate_limit:
@@ -131,6 +150,7 @@ def call(
 
             def _check_and_cap(w: float) -> float:
                 import math
+
                 if not math.isfinite(w) or w < 0:
                     raise ValueError()
                 if w > DEFAULT_TIMEOUT:
@@ -144,7 +164,7 @@ def call(
                     return _check_and_cap(float(hdrs['Retry-After']))
                 except ValueError:
                     pass
-            
+
             # 2. X-RateLimit-Reset provides epoch timestamp of reset
             if 'X-RateLimit-Reset' in hdrs:
                 try:

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -128,10 +128,20 @@ def call(
         exc = retry_state.outcome.exception()
         if isinstance(exc, RateLimitError):
             hdrs = exc.response.headers
+
+            def _check_and_cap(w: float) -> float:
+                import math
+                if not math.isfinite(w) or w < 0:
+                    raise ValueError()
+                if w > DEFAULT_TIMEOUT:
+                    # Fail fast if server requires waiting longer than local cap
+                    raise exc
+                return w
+
             # 1. Retry-After provides exactly how many seconds to wait
             if 'Retry-After' in hdrs:
                 try:
-                    return min(float(DEFAULT_TIMEOUT), float(hdrs['Retry-After']))
+                    return _check_and_cap(float(hdrs['Retry-After']))
                 except ValueError:
                     pass
             
@@ -140,7 +150,7 @@ def call(
                 try:
                     reset_epoch = float(hdrs['X-RateLimit-Reset'])
                     sleep_time = reset_epoch - time.time()
-                    return min(float(DEFAULT_TIMEOUT), max(1.0, sleep_time))
+                    return _check_and_cap(max(1.0, sleep_time))
                 except ValueError:
                     pass
         return float(wait_exponential(multiplier=2, min=2, max=DEFAULT_TIMEOUT)(retry_state))

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -36,10 +36,12 @@ from typing import Any
 import time
 
 import requests
+from tenacity import RetryCallState, Retrying, retry_if_exception_type, stop_after_attempt, wait_exponential
 
 
-class GitHubAPIError(Exception):
+class GitHubAPIError(ValueError):
     """Raised when the GitHub API returns an error response."""
+
     def __init__(self, status_code: int, message: str):
         super().__init__(f'GitHub API {status_code}: {message}')
         self.status_code = status_code
@@ -48,6 +50,7 @@ class GitHubAPIError(Exception):
 
 class RateLimitError(Exception):
     """Raised when GitHub signals a rate limit (429 or 403 secondary limit)."""
+
     def __init__(self, response: requests.Response):
         self.response = response
 
@@ -64,8 +67,6 @@ def _raise_github_error(resp: requests.Response) -> None:
         msg = resp.text or resp.reason or 'unknown error'
     raise GitHubAPIError(resp.status_code, msg)
 
-
-from tenacity import RetryCallState, Retrying, retry_if_exception, stop_after_attempt
 
 BASE_URL = 'https://api.github.com'
 DEFAULT_TIMEOUT = 30
@@ -130,7 +131,7 @@ def call(
             # 1. Retry-After provides exactly how many seconds to wait
             if 'Retry-After' in hdrs:
                 try:
-                    return float(hdrs['Retry-After'])
+                    return min(float(DEFAULT_TIMEOUT), float(hdrs['Retry-After']))
                 except ValueError:
                     pass
             
@@ -139,16 +140,16 @@ def call(
                 try:
                     reset_epoch = float(hdrs['X-RateLimit-Reset'])
                     sleep_time = reset_epoch - time.time()
-                    return max(1.0, sleep_time)
+                    return min(float(DEFAULT_TIMEOUT), max(1.0, sleep_time))
                 except ValueError:
                     pass
-        return 2.0
+        return float(wait_exponential(multiplier=2, min=2, max=DEFAULT_TIMEOUT)(retry_state))
 
     try:
         return Retrying(
             stop=stop_after_attempt(3),
             wait=github_rate_limit_wait,
-            retry=retry_if_exception(lambda e: isinstance(e, RateLimitError)),
+            retry=retry_if_exception_type(RateLimitError),
             reraise=True,
         )(_attempt)
     except RateLimitError as exc:

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -94,8 +94,9 @@ def call(
                 else:
                     sleep_time = 2.0 ** attempt  # Exponential backoff fallback
 
-            # Bound the sleep time to prevent blocking the pipeline indefinitely
-            sleep_time = min(sleep_time, DEFAULT_TIMEOUT)
+            # Clamp the sleep time to [0, DEFAULT_TIMEOUT] and handle NaN gracefully
+            if not (0.0 <= sleep_time <= DEFAULT_TIMEOUT):
+                sleep_time = DEFAULT_TIMEOUT if sleep_time > DEFAULT_TIMEOUT else 1.0
             time.sleep(sleep_time)
             continue
 

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -77,7 +77,14 @@ def call(
             raise ValueError(f'GitHub request failed: {exc}') from exc
 
         # Handle Rate Limiting (403 or 429)
-        if resp.status_code in (403, 429) and attempt < max_retries - 1:
+        is_rate_limit = resp.status_code == 429 or (
+            resp.status_code == 403 and (
+                'Retry-After' in resp.headers or
+                resp.headers.get('X-RateLimit-Remaining') == '0' or
+                'rate limit' in resp.text.lower()
+            )
+        )
+        if is_rate_limit and attempt < max_retries - 1:
             retry_after = resp.headers.get('Retry-After')
             if retry_after:
                 try:
@@ -95,8 +102,13 @@ def call(
                     sleep_time = 2.0 ** attempt  # Exponential backoff fallback
 
             # Clamp the sleep time to [0, DEFAULT_TIMEOUT] and handle NaN gracefully
-            if not (0.0 <= sleep_time <= DEFAULT_TIMEOUT):
-                sleep_time = DEFAULT_TIMEOUT if sleep_time > DEFAULT_TIMEOUT else 1.0
+            if sleep_time != sleep_time:
+                sleep_time = 1.0
+            elif sleep_time < 0.0:
+                sleep_time = 0.0
+            elif sleep_time > DEFAULT_TIMEOUT:
+                sleep_time = DEFAULT_TIMEOUT
+
             time.sleep(sleep_time)
             continue
 

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -33,6 +33,7 @@ and response normalisation. All tool methods in IInstance call through here.
 from __future__ import annotations
 
 from typing import Any
+import time
 
 import requests
 
@@ -60,31 +61,57 @@ def call(
     }
 
     url = BASE_URL + path
-    try:
-        resp = requests.request(
-            method.upper(),
-            url,
-            headers=headers,
-            params={k: v for k, v in (params or {}).items() if v is not None},
-            json=body,
-            timeout=DEFAULT_TIMEOUT,
-        )
-    except requests.RequestException as exc:
-        raise ValueError(f'GitHub request failed: {exc}') from exc
+    max_retries = 3
 
-    if resp.status_code == 204:
-        return {}
-
-    if not resp.ok:
+    for attempt in range(max_retries):
         try:
-            err = resp.json()
-            msg = err.get('message', resp.text)
-            errors = err.get('errors')
-            if errors:
-                msg += ' — ' + '; '.join(e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in errors)
-        except Exception:
-            msg = resp.text or resp.reason or 'unknown error'
-        raise ValueError(f'GitHub API {resp.status_code}: {msg}')
+            resp = requests.request(
+                method.upper(),
+                url,
+                headers=headers,
+                params={k: v for k, v in (params or {}).items() if v is not None},
+                json=body,
+                timeout=DEFAULT_TIMEOUT,
+            )
+        except requests.RequestException as exc:
+            raise ValueError(f'GitHub request failed: {exc}') from exc
+
+        # Handle Rate Limiting (403 or 429)
+        if resp.status_code in (403, 429) and attempt < max_retries - 1:
+            retry_after = resp.headers.get('Retry-After')
+            if retry_after:
+                try:
+                    sleep_time = float(retry_after)
+                except ValueError:
+                    sleep_time = 1.0
+            else:
+                reset_time = resp.headers.get('X-RateLimit-Reset')
+                if reset_time:
+                    try:
+                        sleep_time = max(0, float(reset_time) - time.time())
+                    except ValueError:
+                        sleep_time = 1.0
+                else:
+                    sleep_time = 2.0 ** attempt  # Exponential backoff fallback
+
+            time.sleep(sleep_time)
+            continue
+
+        if resp.status_code == 204:
+            return {}
+
+        if not resp.ok:
+            try:
+                err = resp.json()
+                msg = err.get('message', resp.text)
+                errors = err.get('errors')
+                if errors:
+                    msg += ' — ' + '; '.join(e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in errors)
+            except Exception:
+                msg = resp.text or resp.reason or 'unknown error'
+            raise ValueError(f'GitHub API {resp.status_code}: {msg}')
+
+        return resp.json()
 
     return resp.json()
 

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -94,6 +94,8 @@ def call(
                 else:
                     sleep_time = 2.0 ** attempt  # Exponential backoff fallback
 
+            # Bound the sleep time to prevent blocking the pipeline indefinitely
+            sleep_time = min(sleep_time, DEFAULT_TIMEOUT)
             time.sleep(sleep_time)
             continue
 

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -36,7 +36,36 @@ from typing import Any
 import time
 
 import requests
-from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_exponential
+
+
+class GitHubAPIError(Exception):
+    """Raised when the GitHub API returns an error response."""
+    def __init__(self, status_code: int, message: str):
+        super().__init__(f'GitHub API {status_code}: {message}')
+        self.status_code = status_code
+        self.message = message
+
+
+class RateLimitError(Exception):
+    """Raised when GitHub signals a rate limit (429 or 403 secondary limit)."""
+    def __init__(self, response: requests.Response):
+        self.response = response
+
+
+def _raise_github_error(resp: requests.Response) -> None:
+    """Parse GitHub error response and raise GitHubAPIError."""
+    try:
+        err = resp.json()
+        msg = err.get('message', resp.text)
+        errors = err.get('errors')
+        if errors:
+            msg += ' — ' + '; '.join(e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in errors)
+    except Exception:
+        msg = resp.text or resp.reason or 'unknown error'
+    raise GitHubAPIError(resp.status_code, msg)
+
+
+from tenacity import RetryCallState, Retrying, retry_if_exception, stop_after_attempt
 
 BASE_URL = 'https://api.github.com'
 DEFAULT_TIMEOUT = 30
@@ -60,10 +89,6 @@ def call(
         'Accept': 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
     }
-
-    class RateLimitError(Exception):
-        def __init__(self, response: requests.Response):
-            self.response = response
 
     url = BASE_URL + path
 
@@ -94,36 +119,40 @@ def call(
             if is_rate_limit:
                 raise RateLimitError(resp)
 
-            try:
-                err = resp.json()
-                msg = err.get('message', resp.text)
-                errors = err.get('errors')
-                if errors:
-                    msg += ' — ' + '; '.join(e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in errors)
-            except Exception:
-                msg = resp.text or resp.reason or 'unknown error'
-            raise ValueError(f'GitHub API {resp.status_code}: {msg}')
+            _raise_github_error(resp)
 
         return resp.json()
+
+    def github_rate_limit_wait(retry_state: RetryCallState) -> float:
+        exc = retry_state.outcome.exception()
+        if isinstance(exc, RateLimitError):
+            hdrs = exc.response.headers
+            # 1. Retry-After provides exactly how many seconds to wait
+            if 'Retry-After' in hdrs:
+                try:
+                    return float(hdrs['Retry-After'])
+                except ValueError:
+                    pass
+            
+            # 2. X-RateLimit-Reset provides epoch timestamp of reset
+            if 'X-RateLimit-Reset' in hdrs:
+                try:
+                    reset_epoch = float(hdrs['X-RateLimit-Reset'])
+                    sleep_time = reset_epoch - time.time()
+                    return max(1.0, sleep_time)
+                except ValueError:
+                    pass
+        return 2.0
 
     try:
         return Retrying(
             stop=stop_after_attempt(3),
-            wait=wait_exponential(multiplier=1, min=1, max=10),
+            wait=github_rate_limit_wait,
             retry=retry_if_exception(lambda e: isinstance(e, RateLimitError)),
             reraise=True,
         )(_attempt)
     except RateLimitError as exc:
-        resp = exc.response
-        try:
-            err = resp.json()
-            msg = err.get('message', resp.text)
-            errors = err.get('errors')
-            if errors:
-                msg += ' — ' + '; '.join(e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in errors)
-        except Exception:
-            msg = resp.text or resp.reason or 'unknown error'
-        raise ValueError(f'GitHub API {resp.status_code}: {msg}')
+        _raise_github_error(exc.response)
 
 
 # ---------------------------------------------------------------------------

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -36,6 +36,7 @@ from typing import Any
 import time
 
 import requests
+from tenacity import Retrying, retry_if_exception, stop_after_attempt, wait_exponential
 
 BASE_URL = 'https://api.github.com'
 DEFAULT_TIMEOUT = 30
@@ -60,10 +61,13 @@ def call(
         'X-GitHub-Api-Version': '2022-11-28',
     }
 
-    url = BASE_URL + path
-    max_retries = 3
+    class RateLimitError(Exception):
+        def __init__(self, response: requests.Response):
+            self.response = response
 
-    for attempt in range(max_retries):
+    url = BASE_URL + path
+
+    def _attempt() -> Any:
         try:
             resp = requests.request(
                 method.upper(),
@@ -76,46 +80,20 @@ def call(
         except requests.RequestException as exc:
             raise ValueError(f'GitHub request failed: {exc}') from exc
 
-        # Handle Rate Limiting (403 or 429)
-        is_rate_limit = resp.status_code == 429 or (
-            resp.status_code == 403 and (
-                'Retry-After' in resp.headers or
-                resp.headers.get('X-RateLimit-Remaining') == '0' or
-                'rate limit' in resp.text.lower()
-            )
-        )
-        if is_rate_limit and attempt < max_retries - 1:
-            retry_after = resp.headers.get('Retry-After')
-            if retry_after:
-                try:
-                    sleep_time = float(retry_after)
-                except ValueError:
-                    sleep_time = 1.0
-            else:
-                reset_time = resp.headers.get('X-RateLimit-Reset')
-                if reset_time:
-                    try:
-                        sleep_time = max(0, float(reset_time) - time.time())
-                    except ValueError:
-                        sleep_time = 1.0
-                else:
-                    sleep_time = 2.0 ** attempt  # Exponential backoff fallback
-
-            # Clamp the sleep time to [0, DEFAULT_TIMEOUT] and handle NaN gracefully
-            if sleep_time != sleep_time:
-                sleep_time = 1.0
-            elif sleep_time < 0.0:
-                sleep_time = 0.0
-            elif sleep_time > DEFAULT_TIMEOUT:
-                sleep_time = DEFAULT_TIMEOUT
-
-            time.sleep(sleep_time)
-            continue
-
         if resp.status_code == 204:
             return {}
 
         if not resp.ok:
+            is_rate_limit = resp.status_code == 429 or (
+                resp.status_code == 403 and (
+                    'Retry-After' in resp.headers or
+                    resp.headers.get('X-RateLimit-Remaining') == '0' or
+                    'rate limit' in resp.text.lower()
+                )
+            )
+            if is_rate_limit:
+                raise RateLimitError(resp)
+
             try:
                 err = resp.json()
                 msg = err.get('message', resp.text)
@@ -128,7 +106,24 @@ def call(
 
         return resp.json()
 
-    return resp.json()
+    try:
+        return Retrying(
+            stop=stop_after_attempt(3),
+            wait=wait_exponential(multiplier=1, min=1, max=10),
+            retry=retry_if_exception(lambda e: isinstance(e, RateLimitError)),
+            reraise=True,
+        )(_attempt)
+    except RateLimitError as exc:
+        resp = exc.response
+        try:
+            err = resp.json()
+            msg = err.get('message', resp.text)
+            errors = err.get('errors')
+            if errors:
+                msg += ' — ' + '; '.join(e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in errors)
+        except Exception:
+            msg = resp.text or resp.reason or 'unknown error'
+        raise ValueError(f'GitHub API {resp.status_code}: {msg}')
 
 
 # ---------------------------------------------------------------------------

--- a/nodes/src/nodes/tool_github/requirements.txt
+++ b/nodes/src/nodes/tool_github/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.34.2
+tenacity

--- a/nodes/src/nodes/tool_github/requirements.txt
+++ b/nodes/src/nodes/tool_github/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.34.2
-tenacity>=8.4.0
+tenacity

--- a/nodes/src/nodes/tool_github/requirements.txt
+++ b/nodes/src/nodes/tool_github/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.34.2
-tenacity
+tenacity>=8.4.0

--- a/nodes/test/tool_github/test_github_client.py
+++ b/nodes/test/tool_github/test_github_client.py
@@ -68,16 +68,42 @@ with _scoped_stubs():
     from tool_github.IInstance import IInstance
 
 
-def test_file_get_404():
-    """Test that a 404 response in file_get returns a structured dict instead of raising."""
+def test_file_get_404_ambiguous():
+    """Test that ambiguous 404s (missing file, invalid ref, inaccessible repo) return a structured dict."""
     inst = Mock()
     inst._token.return_value = 'token'
     inst._repo.return_value = 'owner/repo'
     
     with patch('tool_github.IInstance.call') as mock_call:
+        # 1. Missing file or inaccessible repository
         mock_call.side_effect = GitHubAPIError(404, 'Not Found')
         result = IInstance.file_get(inst, {'path': 'missing.txt'})
         assert result == {'found': False, 'message': 'GitHub API 404: Not Found'}
+
+        # 2. Invalid ref
+        mock_call.side_effect = GitHubAPIError(404, 'No commit found for the ref X')
+        result = IInstance.file_get(inst, {'path': 'file.txt', 'ref': 'X'})
+        assert result == {'found': False, 'message': 'GitHub API 404: No commit found for the ref X'}
+
+
+@patch('tool_github.github_client.requests.request')
+def test_non_rate_limit_403(mock_request):
+    """Test that a 403 that is not a rate limit raises GitHubAPIError immediately."""
+    resp_403 = Mock(spec=requests.Response)
+    resp_403.ok = False
+    resp_403.status_code = 403
+    resp_403.headers = {}
+    resp_403.json.return_value = {'message': 'Resource not accessible by integration'}
+    resp_403.text = 'Resource not accessible by integration'
+    
+    mock_request.return_value = resp_403
+    
+    with pytest.raises(GitHubAPIError) as exc_info:
+        call('token', 'GET', '/test')
+        
+    assert exc_info.value.status_code == 403
+    assert 'Resource not accessible' in exc_info.value.message
+    assert mock_request.call_count == 1  # No retries
 
 
 @patch('tool_github.github_client.time.time', return_value=1000.0)
@@ -88,7 +114,7 @@ def test_rate_limit_429_retry_after(mock_request, mock_sleep, mock_time):
     resp_429 = Mock(spec=requests.Response)
     resp_429.ok = False
     resp_429.status_code = 429
-    resp_429.headers = {'Retry-After': '60'}
+    resp_429.headers = {'Retry-After': '5'}
     resp_429.json.return_value = {'message': 'rate limit'}
     resp_429.text = 'rate limit'
     
@@ -104,7 +130,7 @@ def test_rate_limit_429_retry_after(mock_request, mock_sleep, mock_time):
     assert result == {'success': True}
     assert mock_request.call_count == 3
     assert mock_sleep.call_count == 2
-    mock_sleep.assert_called_with(30.0)
+    mock_sleep.assert_called_with(5.0)
 
 
 @patch('tool_github.github_client.time.time', return_value=1000.0)
@@ -115,7 +141,7 @@ def test_rate_limit_403_reset(mock_request, mock_sleep, mock_time):
     resp_403 = Mock(spec=requests.Response)
     resp_403.ok = False
     resp_403.status_code = 403
-    resp_403.headers = {'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1045.0'}
+    resp_403.headers = {'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1010.0'}
     resp_403.json.return_value = {'message': 'rate limit'}
     resp_403.text = 'rate limit'
     
@@ -127,4 +153,58 @@ def test_rate_limit_403_reset(mock_request, mock_sleep, mock_time):
     assert exc_info.value.status_code == 403
     assert mock_request.call_count == 3
     assert mock_sleep.call_count == 2
-    mock_sleep.assert_called_with(30.0)
+    mock_sleep.assert_called_with(10.0)
+
+
+@patch('tool_github.github_client.time.time', return_value=1000.0)
+@patch('time.sleep')
+@patch('tool_github.github_client.requests.request')
+@pytest.mark.parametrize('bad_value', ['malformed', '-5', 'NaN', 'Inf'])
+def test_rate_limit_retry_after_malformed(mock_request, mock_sleep, mock_time, bad_value):
+    """Test that malformed/negative/non-finite Retry-After falls back to exponential backoff."""
+    resp_429 = Mock(spec=requests.Response)
+    resp_429.ok = False
+    resp_429.status_code = 429
+    resp_429.headers = {'Retry-After': bad_value}
+    resp_429.json.return_value = {'message': 'rate limit'}
+    resp_429.text = 'rate limit'
+    
+    resp_success = Mock(spec=requests.Response)
+    resp_success.ok = True
+    resp_success.status_code = 200
+    resp_success.json.return_value = {'success': True}
+    
+    mock_request.side_effect = [resp_429, resp_success]
+    
+    result = call('token', 'GET', '/test')
+    
+    assert result == {'success': True}
+    assert mock_request.call_count == 2
+    assert mock_sleep.call_count == 1
+    # Should fall back to wait_exponential (first wait is usually 2s with multiplier=2, min=2)
+    # Actually wait_exponential without attempt context just evaluates to a power of 2, 2.0s
+    assert mock_sleep.call_args[0][0] >= 2.0
+
+
+@patch('tool_github.github_client.time.time', return_value=1000.0)
+@patch('time.sleep')
+@patch('tool_github.github_client.requests.request')
+def test_rate_limit_excessive_wait_fails_fast(mock_request, mock_sleep, mock_time):
+    """Test that an excessive server-provided wait > DEFAULT_TIMEOUT fails fast."""
+    resp_429 = Mock(spec=requests.Response)
+    resp_429.ok = False
+    resp_429.status_code = 429
+    resp_429.headers = {'Retry-After': '3600'}  # 1 hour
+    resp_429.json.return_value = {'message': 'rate limit'}
+    resp_429.text = 'rate limit'
+    
+    mock_request.return_value = resp_429
+    
+    with pytest.raises(GitHubAPIError) as exc_info:
+        call('token', 'GET', '/test')
+        
+    assert exc_info.value.status_code == 429
+    assert 'rate limit' in exc_info.value.message
+    assert mock_request.call_count == 1  # Failed fast on first attempt
+    assert mock_sleep.call_count == 0  # No sleep
+

--- a/nodes/test/tool_github/test_github_client.py
+++ b/nodes/test/tool_github/test_github_client.py
@@ -1,0 +1,94 @@
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
+
+rl = Mock()
+def mock_tool_function(*args, **kwargs):
+    return lambda f: f
+rl.tool_function = mock_tool_function
+class IInstanceBase:
+    pass
+rl.IInstanceBase = IInstanceBase
+sys.modules['rocketlib'] = rl
+
+utils = Mock()
+utils.normalize_tool_input = lambda x, **kwargs: x
+utils.require_str = lambda x, k, **kwargs: x.get(k)
+
+sys.modules['ai'] = Mock()
+sys.modules['ai.common'] = Mock()
+sys.modules['ai.common.config'] = Mock()
+sys.modules['ai.common.utils'] = utils
+
+from tool_github.github_client import call, GitHubAPIError, RateLimitError
+from tool_github.IInstance import IInstance
+
+
+def test_file_get_404():
+    """Test that a 404 response in file_get returns a structured dict instead of raising."""
+    inst = Mock()
+    inst._token.return_value = 'token'
+    inst._repo.return_value = 'owner/repo'
+    
+    with patch('tool_github.IInstance.call') as mock_call:
+        mock_call.side_effect = GitHubAPIError(404, 'Not Found')
+        result = IInstance.file_get(inst, {'path': 'missing.txt'})
+        assert result == {'found': False, 'message': 'GitHub API 404: Not Found'}
+
+
+@patch('tool_github.github_client.time.time', return_value=1000.0)
+@patch('time.sleep')
+@patch('tool_github.github_client.requests.request')
+def test_rate_limit_429_retry_after(mock_request, mock_sleep, mock_time):
+    """Test that a 429 response with Retry-After header correctly sleeps and retries."""
+    
+    resp_429 = Mock(spec=requests.Response)
+    resp_429.ok = False
+    resp_429.status_code = 429
+    resp_429.headers = {'Retry-After': '60'}
+    resp_429.json.return_value = {'message': 'rate limit'}
+    resp_429.text = 'rate limit'
+    
+    resp_success = Mock(spec=requests.Response)
+    resp_success.ok = True
+    resp_success.status_code = 200
+    resp_success.json.return_value = {'success': True}
+    
+    mock_request.side_effect = [resp_429, resp_429, resp_success]
+    
+    result = call('token', 'GET', '/test')
+    
+    assert result == {'success': True}
+    assert mock_request.call_count == 3
+    assert mock_sleep.call_count == 2
+    mock_sleep.assert_called_with(60.0)
+
+
+@patch('tool_github.github_client.time.time', return_value=1000.0)
+@patch('time.sleep')
+@patch('tool_github.github_client.requests.request')
+def test_rate_limit_403_reset(mock_request, mock_sleep, mock_time):
+    """Test that a 403 secondary rate limit with X-RateLimit-Reset correctly sleeps and retries."""
+    
+    resp_403 = Mock(spec=requests.Response)
+    resp_403.ok = False
+    resp_403.status_code = 403
+    resp_403.headers = {'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1045.0'}
+    resp_403.json.return_value = {'message': 'rate limit'}
+    resp_403.text = 'rate limit'
+    
+    mock_request.side_effect = [resp_403, resp_403, resp_403, resp_403]
+    
+    with pytest.raises(GitHubAPIError) as exc_info:
+        call('token', 'GET', '/test')
+        
+    assert exc_info.value.status_code == 403
+    assert mock_request.call_count == 3
+    assert mock_sleep.call_count == 2
+    mock_sleep.assert_called_with(45.0)

--- a/nodes/test/tool_github/test_github_client.py
+++ b/nodes/test/tool_github/test_github_client.py
@@ -15,18 +15,18 @@ _STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.co
 
 def _install_stubs() -> None:
     mod_rl = types.ModuleType('rocketlib')
-    
+
     def mock_tool_function(*args, **kwargs):
         return lambda f: f
-    
+
     mod_rl.tool_function = mock_tool_function
-    
+
     class IInstanceBase:
         pass
-        
+
     class IGlobalBase:
         pass
-        
+
     mod_rl.IInstanceBase = IInstanceBase
     mod_rl.IGlobalBase = IGlobalBase
     mod_rl.OPEN_MODE = Mock()
@@ -35,10 +35,12 @@ def _install_stubs() -> None:
 
     sys.modules['ai'] = types.ModuleType('ai')
     sys.modules['ai.common'] = types.ModuleType('ai.common')
-    
+
     mod_ai_common_config = types.ModuleType('ai.common.config')
+
     class Config:
         pass
+
     mod_ai_common_config.Config = Config
     sys.modules['ai.common.config'] = mod_ai_common_config
 
@@ -73,7 +75,7 @@ def test_file_get_404_ambiguous():
     inst = Mock()
     inst._token.return_value = 'token'
     inst._repo.return_value = 'owner/repo'
-    
+
     with patch('tool_github.IInstance.call') as mock_call:
         # 1. Missing file or inaccessible repository
         mock_call.side_effect = GitHubAPIError(404, 'Not Found')
@@ -95,12 +97,12 @@ def test_non_rate_limit_403(mock_request):
     resp_403.headers = {}
     resp_403.json.return_value = {'message': 'Resource not accessible by integration'}
     resp_403.text = 'Resource not accessible by integration'
-    
+
     mock_request.return_value = resp_403
-    
+
     with pytest.raises(GitHubAPIError) as exc_info:
         call('token', 'GET', '/test')
-        
+
     assert exc_info.value.status_code == 403
     assert 'Resource not accessible' in exc_info.value.message
     assert mock_request.call_count == 1  # No retries
@@ -117,16 +119,16 @@ def test_rate_limit_429_retry_after(mock_request, mock_sleep, mock_time):
     resp_429.headers = {'Retry-After': '5'}
     resp_429.json.return_value = {'message': 'rate limit'}
     resp_429.text = 'rate limit'
-    
+
     resp_success = Mock(spec=requests.Response)
     resp_success.ok = True
     resp_success.status_code = 200
     resp_success.json.return_value = {'success': True}
-    
+
     mock_request.side_effect = [resp_429, resp_429, resp_success]
-    
+
     result = call('token', 'GET', '/test')
-    
+
     assert result == {'success': True}
     assert mock_request.call_count == 3
     assert mock_sleep.call_count == 2
@@ -144,12 +146,12 @@ def test_rate_limit_403_reset(mock_request, mock_sleep, mock_time):
     resp_403.headers = {'X-RateLimit-Remaining': '0', 'X-RateLimit-Reset': '1010.0'}
     resp_403.json.return_value = {'message': 'rate limit'}
     resp_403.text = 'rate limit'
-    
+
     mock_request.side_effect = [resp_403, resp_403, resp_403, resp_403]
-    
+
     with pytest.raises(GitHubAPIError) as exc_info:
         call('token', 'GET', '/test')
-        
+
     assert exc_info.value.status_code == 403
     assert mock_request.call_count == 3
     assert mock_sleep.call_count == 2
@@ -168,16 +170,16 @@ def test_rate_limit_retry_after_malformed(mock_request, mock_sleep, mock_time, b
     resp_429.headers = {'Retry-After': bad_value}
     resp_429.json.return_value = {'message': 'rate limit'}
     resp_429.text = 'rate limit'
-    
+
     resp_success = Mock(spec=requests.Response)
     resp_success.ok = True
     resp_success.status_code = 200
     resp_success.json.return_value = {'success': True}
-    
+
     mock_request.side_effect = [resp_429, resp_success]
-    
+
     result = call('token', 'GET', '/test')
-    
+
     assert result == {'success': True}
     assert mock_request.call_count == 2
     assert mock_sleep.call_count == 1
@@ -197,14 +199,14 @@ def test_rate_limit_excessive_wait_fails_fast(mock_request, mock_sleep, mock_tim
     resp_429.headers = {'Retry-After': '3600'}  # 1 hour
     resp_429.json.return_value = {'message': 'rate limit'}
     resp_429.text = 'rate limit'
-    
+
     mock_request.return_value = resp_429
-    
+
     with pytest.raises(GitHubAPIError) as exc_info:
         call('token', 'GET', '/test')
-        
+
     assert exc_info.value.status_code == 429
     assert 'rate limit' in exc_info.value.message
+    assert 'retry after 3600s' in exc_info.value.message  # reset hint tells caller when to retry
     assert mock_request.call_count == 1  # Failed fast on first attempt
     assert mock_sleep.call_count == 0  # No sleep
-

--- a/nodes/test/tool_github/test_github_client.py
+++ b/nodes/test/tool_github/test_github_client.py
@@ -1,5 +1,7 @@
 import sys
-import time
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch, Mock
 
@@ -8,26 +10,62 @@ import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
 
-rl = Mock()
-def mock_tool_function(*args, **kwargs):
-    return lambda f: f
-rl.tool_function = mock_tool_function
-class IInstanceBase:
-    pass
-rl.IInstanceBase = IInstanceBase
-sys.modules['rocketlib'] = rl
+_STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
 
-utils = Mock()
-utils.normalize_tool_input = lambda x, **kwargs: x
-utils.require_str = lambda x, k, **kwargs: x.get(k)
 
-sys.modules['ai'] = Mock()
-sys.modules['ai.common'] = Mock()
-sys.modules['ai.common.config'] = Mock()
-sys.modules['ai.common.utils'] = utils
+def _install_stubs() -> None:
+    mod_rl = types.ModuleType('rocketlib')
+    
+    def mock_tool_function(*args, **kwargs):
+        return lambda f: f
+    
+    mod_rl.tool_function = mock_tool_function
+    
+    class IInstanceBase:
+        pass
+        
+    class IGlobalBase:
+        pass
+        
+    mod_rl.IInstanceBase = IInstanceBase
+    mod_rl.IGlobalBase = IGlobalBase
+    mod_rl.OPEN_MODE = Mock()
+    mod_rl.warning = Mock()
+    sys.modules['rocketlib'] = mod_rl
 
-from tool_github.github_client import call, GitHubAPIError, RateLimitError
-from tool_github.IInstance import IInstance
+    sys.modules['ai'] = types.ModuleType('ai')
+    sys.modules['ai.common'] = types.ModuleType('ai.common')
+    
+    mod_ai_common_config = types.ModuleType('ai.common.config')
+    class Config:
+        pass
+    mod_ai_common_config.Config = Config
+    sys.modules['ai.common.config'] = mod_ai_common_config
+
+    mod_ai_common_utils = types.ModuleType('ai.common.utils')
+    mod_ai_common_utils.normalize_tool_input = lambda x, **kwargs: x
+    mod_ai_common_utils.require_str = lambda x, k, **kwargs: x.get(k)
+    mod_ai_common_utils.require_int = lambda x, k, **kwargs: x.get(k)
+    sys.modules['ai.common.utils'] = mod_ai_common_utils
+
+
+@contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    original_modules = {module_name: sys.modules.get(module_name) for module_name in _STUB_MODULE_NAMES}
+    _install_stubs()
+    try:
+        yield
+    finally:
+        for module_name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+
+with _scoped_stubs():
+    from tool_github.github_client import call, GitHubAPIError
+    from tool_github.IInstance import IInstance
 
 
 def test_file_get_404():
@@ -47,7 +85,6 @@ def test_file_get_404():
 @patch('tool_github.github_client.requests.request')
 def test_rate_limit_429_retry_after(mock_request, mock_sleep, mock_time):
     """Test that a 429 response with Retry-After header correctly sleeps and retries."""
-    
     resp_429 = Mock(spec=requests.Response)
     resp_429.ok = False
     resp_429.status_code = 429
@@ -67,7 +104,7 @@ def test_rate_limit_429_retry_after(mock_request, mock_sleep, mock_time):
     assert result == {'success': True}
     assert mock_request.call_count == 3
     assert mock_sleep.call_count == 2
-    mock_sleep.assert_called_with(60.0)
+    mock_sleep.assert_called_with(30.0)
 
 
 @patch('tool_github.github_client.time.time', return_value=1000.0)
@@ -75,7 +112,6 @@ def test_rate_limit_429_retry_after(mock_request, mock_sleep, mock_time):
 @patch('tool_github.github_client.requests.request')
 def test_rate_limit_403_reset(mock_request, mock_sleep, mock_time):
     """Test that a 403 secondary rate limit with X-RateLimit-Reset correctly sleeps and retries."""
-    
     resp_403 = Mock(spec=requests.Response)
     resp_403.ok = False
     resp_403.status_code = 403
@@ -91,4 +127,4 @@ def test_rate_limit_403_reset(mock_request, mock_sleep, mock_time):
     assert exc_info.value.status_code == 403
     assert mock_request.call_count == 3
     assert mock_sleep.call_count == 2
-    mock_sleep.assert_called_with(45.0)
+    mock_sleep.assert_called_with(30.0)


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- I wrapped the API call in `IInstance.py` in a try-except block so it safely catches 404 and returns `{"found": false}` instead of crashing.
- I added a retry loop in `github_client.py` for 403 and 429 (Rate Limits).
- The client now accurately parses the `Retry-After` and `X-RateLimit-Reset` headers to sleep for the recommended duration, with an exponential backoff fallback.

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
fix
## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #1352 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Missing GitHub file paths are now handled gracefully, returning a clear “not found” result instead of erroring.
  * GitHub API calls now automatically retry when requests are rate-limited (e.g., throttling), improving reliability during temporary limits.
  * Retry behavior uses server-provided timing when available, with safe fallback backoff to prevent excessive delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->