### PR TITLE
fix(nodes): agent keyword search returns nothing (RR-1363)

### DIFF
--- a/nodes/src/nodes/agent_crewai/crewai_base.py
+++ b/nodes/src/nodes/agent_crewai/crewai_base.py
@@ -260,7 +260,7 @@ class CrewBase(AgentBase):
                 # CrewAI injects the ReAct stop list ("\nObservation:") per-call via a
                 # contextvar override that is ONLY visible through the `stop_sequences`
                 # property (crewai/llms/base_llm.py) — NOT the raw `self.stop` field.
-                # Reading `self.stop` got None, so call_llm's post-hoc truncation no-oped
+                # Reading `self.stop` returned an empty list, so call_llm's post-hoc truncation no-oped
                 # and the model's fabricated Observation/Final Answer survived, skipping the
                 # real tool call. Read the property so truncation trims at "\nObservation:".
                 stop_words = self.stop_sequences

--- a/nodes/src/nodes/agent_crewai/crewai_base.py
+++ b/nodes/src/nodes/agent_crewai/crewai_base.py
@@ -257,7 +257,13 @@ class CrewBase(AgentBase):
                 available_functions: Optional[Dict[str, Any]] = None,
                 **kwargs: Any,
             ) -> Union[str, Any]:
-                stop_words = getattr(self, 'stop', None)
+                # CrewAI injects the ReAct stop list ("\nObservation:") per-call via a
+                # contextvar override that is ONLY visible through the `stop_sequences`
+                # property (crewai/llms/base_llm.py) — NOT the raw `self.stop` field.
+                # Reading `self.stop` got None, so call_llm's post-hoc truncation no-oped
+                # and the model's fabricated Observation/Final Answer survived, skipping the
+                # real tool call. Read the property so truncation trims at "\nObservation:".
+                stop_words = self.stop_sequences
                 return outer_self.call_llm(
                     outer_context,
                     messages,

--- a/nodes/src/nodes/tool_github/IInstance.py
+++ b/nodes/src/nodes/tool_github/IInstance.py
@@ -57,6 +57,87 @@ from .IGlobal import IGlobal
 _REPO_DESC = 'Repository in "owner/repo" format (e.g. "acme/myapp"). Omit to use the configured default.'
 _PER_PAGE_DESC = 'Results per page (1–100, default 30).'
 _PAGE_DESC = 'Page number for pagination (default 1).'
+_SEARCH_QUERY_DESC = (
+    'Search keywords — use 2–5 distinct terms, NOT a full sentence. GitHub ANDs every word, so '
+    'long natural-language queries match nothing. Supports GitHub qualifiers like "is:issue", '
+    '"label:bug", "in:title". Example: "dropper browse button".'
+)
+
+# Words stripped from a query before the OR-relax fallback so the relaxed query keeps only
+# meaningful terms (and stays under GitHub's 5 AND/OR/NOT operator limit).
+_SEARCH_STOPWORDS = frozenset(
+    {
+        'a',
+        'an',
+        'the',
+        'is',
+        'are',
+        'was',
+        'were',
+        'be',
+        'been',
+        'being',
+        'i',
+        'im',
+        "i'm",
+        'it',
+        'its',
+        "it's",
+        'this',
+        'that',
+        'to',
+        'of',
+        'in',
+        'on',
+        'for',
+        'with',
+        'and',
+        'or',
+        'but',
+        'if',
+        'when',
+        'my',
+        'me',
+        'you',
+        'having',
+        'issue',
+        'problem',
+        'not',
+        'no',
+        'works',
+        'working',
+        'work',
+        'click',
+        'clicking',
+    }
+)
+
+
+def _relax_query(q: str, *, max_terms: int = 5) -> str | None:
+    """Build an OR-relaxed variant of a free-text-heavy query.
+
+    GitHub free-text search ANDs every term, so a verbose natural-language query matches
+    nothing. This keeps GitHub qualifiers (tokens like ``repo:x``/``is:issue``) intact and
+    OR-joins the remaining keywords. Returns ``None`` when not relaxable (fewer than two
+    usable free-text terms). Caps keywords to ``max_terms`` to stay under GitHub's limit of
+    five AND/OR/NOT operators.
+    """
+    qualifiers: list[str] = []
+    terms: list[str] = []
+    for tok in q.split():
+        if ':' in tok and tok.split(':', 1)[0].isalnum():  # repo:, is:, label:, in:, ...
+            qualifiers.append(tok)
+            continue
+        word = tok.strip('\'".,!?')
+        if len(word) > 1 and word.lower() not in _SEARCH_STOPWORDS:
+            terms.append(word)
+    # de-dup case-insensitively, preserve order
+    seen: set[str] = set()
+    uniq = [t for t in terms if not (t.lower() in seen or seen.add(t.lower()))]
+    if len(uniq) < 2:
+        return None
+    or_clause = ' OR '.join(uniq[:max_terms])
+    return ' '.join([or_clause, *qualifiers]).strip()
 
 
 class IInstance(IInstanceBase):
@@ -992,7 +1073,7 @@ class IInstance(IInstanceBase):
             'properties': {
                 'query': {
                     'type': 'string',
-                    'description': 'Search query. Supports GitHub code search syntax (e.g. "mcp_client transport extension:py")',
+                    'description': _SEARCH_QUERY_DESC,
                 },
                 'repo': {
                     'type': 'string',
@@ -1016,6 +1097,11 @@ class IInstance(IInstanceBase):
             'page': max(1, int(args.get('page') or 1)),
         }
         data = call(self._token(), 'GET', '/search/code', params=params)
+        if not data.get('items'):
+            relaxed = _relax_query(q)
+            if relaxed and relaxed != q:
+                params['q'] = relaxed
+                data = call(self._token(), 'GET', '/search/code', params=params)
         return [
             {
                 'name': item.get('name'),
@@ -1033,7 +1119,7 @@ class IInstance(IInstanceBase):
             'properties': {
                 'query': {
                     'type': 'string',
-                    'description': 'Search query. Supports GitHub issue search syntax (e.g. "mcp timeout is:issue is:open")',
+                    'description': _SEARCH_QUERY_DESC,
                 },
                 'repo': {
                     'type': 'string',
@@ -1060,6 +1146,11 @@ class IInstance(IInstanceBase):
             'page': max(1, int(args.get('page') or 1)),
         }
         data = call(self._token(), 'GET', '/search/issues', params=params)
+        if not data.get('items'):
+            relaxed = _relax_query(q)
+            if relaxed and relaxed != q:
+                params['q'] = relaxed
+                data = call(self._token(), 'GET', '/search/issues', params=params)
         results = []
         for i in data.get('items') or []:
             cleaned = clean_issue(i)

--- a/nodes/src/nodes/tool_github/IInstance.py
+++ b/nodes/src/nodes/tool_github/IInstance.py
@@ -33,6 +33,7 @@ requests, reviews, releases, workflows, orgs, users, and code search.
 from __future__ import annotations
 
 import base64
+import re
 
 from rocketlib import IInstanceBase, tool_function
 
@@ -57,10 +58,18 @@ from .IGlobal import IGlobal
 _REPO_DESC = 'Repository in "owner/repo" format (e.g. "acme/myapp"). Omit to use the configured default.'
 _PER_PAGE_DESC = 'Results per page (1–100, default 30).'
 _PAGE_DESC = 'Page number for pagination (default 1).'
-_SEARCH_QUERY_DESC = (
+# Code search and issue search use DIFFERENT GitHub query syntaxes: issue-only qualifiers
+# (is:issue, label:bug, in:title) are not valid for code search, so the two tools advertise
+# different examples.
+_SEARCH_CODE_QUERY_DESC = (
     'Search keywords — use 2–5 distinct terms, NOT a full sentence. GitHub ANDs every word, so '
-    'long natural-language queries match nothing. Supports GitHub qualifiers like "is:issue", '
-    '"label:bug", "in:title". Example: "dropper browse button".'
+    'long natural-language queries match nothing. Supports code-search qualifiers like '
+    '"language:python", "path:src", "extension:py". Example: "mcp_client transport extension:py".'
+)
+_SEARCH_ISSUES_QUERY_DESC = (
+    'Search keywords — use 2–5 distinct terms, NOT a full sentence. GitHub ANDs every word, so '
+    'long natural-language queries match nothing. Supports issue-search qualifiers like '
+    '"is:issue", "label:bug", "in:title". Example: "dropper browse button is:open".'
 )
 
 # Words stripped from a query before the OR-relax fallback so the relaxed query keeps only
@@ -113,30 +122,40 @@ _SEARCH_STOPWORDS = frozenset(
 )
 
 
+# One search token, keeping quoted qualifier values and quoted phrases whole so a space inside
+# quotes does not split them: -label:"good first issue" | repo:acme/app | "exact phrase" | word
+_QUERY_TOKEN_RE = re.compile(r'-?\w+:"[^"]*"|-?\w+:\S+|"[^"]*"|\S+')
+
+
 def _relax_query(q: str, *, max_terms: int = 5) -> str | None:
     """Build an OR-relaxed variant of a free-text-heavy query.
 
     GitHub free-text search ANDs every term, so a verbose natural-language query matches
-    nothing. This keeps GitHub qualifiers (tokens like ``repo:x``/``is:issue``) intact and
-    OR-joins the remaining keywords. Returns ``None`` when not relaxable (fewer than two
-    usable free-text terms). Caps keywords to ``max_terms`` to stay under GitHub's limit of
-    five AND/OR/NOT operators.
+    nothing. This keeps GitHub qualifiers (``repo:x``, ``is:issue``, negated ``-label:bug``,
+    and quoted values like ``label:"good first issue"``) intact and OR-joins the remaining
+    keywords. Returns ``None`` when not relaxable (fewer than two usable free-text terms).
+
+    Caps the relaxed query to stay under GitHub's limit of five AND/OR/NOT operators: each
+    OR keyword after the first costs one operator and each qualifier costs one implicit AND,
+    so the keyword count is trimmed to leave room for the qualifiers (never below two).
     """
     qualifiers: list[str] = []
     terms: list[str] = []
-    for tok in q.split():
-        if ':' in tok and tok.split(':', 1)[0].isalnum():  # repo:, is:, label:, in:, ...
+    for tok in _QUERY_TOKEN_RE.findall(q):
+        key = tok.split(':', 1)[0].lstrip('-')
+        if ':' in tok and key and key.isalnum():  # repo:, is:, label:, in:, -label:, ...
             qualifiers.append(tok)
             continue
         word = tok.strip('\'".,!?')
         if len(word) > 1 and word.lower() not in _SEARCH_STOPWORDS:
-            terms.append(word)
+            terms.append(f'"{word}"' if ' ' in word else word)  # re-quote multi-word phrases
     # de-dup case-insensitively, preserve order
     seen: set[str] = set()
     uniq = [t for t in terms if not (t.lower() in seen or seen.add(t.lower()))]
     if len(uniq) < 2:
         return None
-    or_clause = ' OR '.join(uniq[:max_terms])
+    budget = max(2, 6 - len(qualifiers))
+    or_clause = ' OR '.join(uniq[: min(max_terms, budget)])
     return ' '.join([or_clause, *qualifiers]).strip()
 
 
@@ -1073,7 +1092,7 @@ class IInstance(IInstanceBase):
             'properties': {
                 'query': {
                     'type': 'string',
-                    'description': _SEARCH_QUERY_DESC,
+                    'description': _SEARCH_CODE_QUERY_DESC,
                 },
                 'repo': {
                     'type': 'string',
@@ -1119,7 +1138,7 @@ class IInstance(IInstanceBase):
             'properties': {
                 'query': {
                     'type': 'string',
-                    'description': _SEARCH_QUERY_DESC,
+                    'description': _SEARCH_ISSUES_QUERY_DESC,
                 },
                 'repo': {
                     'type': 'string',

--- a/nodes/test/agent_crewai/test_stop_words.py
+++ b/nodes/test/agent_crewai/test_stop_words.py
@@ -1,0 +1,185 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Network-free unit tests for the agent_crewai ReAct stop-sequence fix (#1363, Part B).
+
+Bug: the CrewAI ReAct agent (Rocket Ralph) emitted the whole Thought/Action/
+Observation/.../Final Answer transcript in ONE completion, fabricating the
+Observation lines, so the real GitHub tool was never invoked and the agent
+answered from an invented issue.
+
+Root cause: `nodes/src/nodes/agent_crewai/crewai_base.py` `HostInvokeLLM.call`
+read the raw `self.stop` field instead of CrewAI's `self.stop_sequences` property.
+CrewAI injects the ReAct stop list (``"\nObservation:"``) per-call via a contextvar
+override that is ONLY visible through `stop_sequences` (crewai/llms/base_llm.py:99,201).
+Reading `self.stop` returned an empty list, so `AgentBase.call_llm`'s post-hoc
+`truncate_at_stop_words` no-oped and the fabricated tail survived.
+
+The wrapper itself (`crewai_base.HostInvokeLLM`) cannot be imported in a plain
+interpreter — it pulls `rocketlib` (engine-only) and `crewai` (needs pywin32). So
+these tests pin the fix at the two seams that ARE importable here:
+
+1. The REAL `truncate_at_stop_words` (the function the fix feeds) — proving that with
+   the correct stop list the fabricated transcript is trimmed back to a clean Action,
+   and with ``None`` (the old behaviour) it is not.
+2. A faithful mirror of CrewAI's `BaseLLM.stop`/`stop_sequences`/`call_stop_override`
+   contract (semantics copied from crewai/llms/base_llm.py:165-214) — proving exactly
+   why the wrapper must read `stop_sequences`, not `stop`: only the property reflects
+   the per-call override.
+
+End-to-end verification (real wrapper) requires the engine runtime — re-run the
+Rocket Ralph pipeline and confirm the agent invokes search_issues and cites a real
+issue rather than a fabricated one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Load the REAL truncate_at_stop_words from packages/ai, stubbing only its one
+# dependency (ai.common.utils.safe_str) so no engine modules are required.
+# ---------------------------------------------------------------------------
+_UTILS_PATH = (
+    Path(__file__).resolve().parents[3]
+    / 'packages'
+    / 'ai'
+    / 'src'
+    / 'ai'
+    / 'common'
+    / 'agent'
+    / '_internal'
+    / 'utils.py'
+)
+
+
+def _load_real_truncate():
+    saved = {k: sys.modules.get(k) for k in ('ai', 'ai.common', 'ai.common.utils')}
+    acu = types.ModuleType('ai.common.utils')
+    acu.safe_str = lambda x: '' if x is None else str(x)
+    sys.modules['ai'] = types.ModuleType('ai')
+    sys.modules['ai.common'] = types.ModuleType('ai.common')
+    sys.modules['ai.common.utils'] = acu
+    try:
+        spec = importlib.util.spec_from_file_location('rr_real_agent_utils', _UTILS_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.truncate_at_stop_words
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+truncate_at_stop_words = _load_real_truncate()
+
+# The exact failure shape from the pasted repro: a full ReAct transcript with a
+# fabricated Observation and a fabricated Final Answer, emitted in one completion.
+FABRICATED = (
+    'Thought: The user reported a bug, I should search existing issues.\n'
+    'Action: tool_github_1_search_issues\n'
+    'Action Input: {"query": "dropper browse button", "state": "open"}\n'
+    'Observation: [{"number": 42, "title": "Dropper node: Browse button..."}]\n'
+    'Thought: I now know the final answer\n'
+    'Final Answer: There is already an open issue #42 that matches.'
+)
+
+# CrewAI's ReAct stop list (crewai/agent/core.py:1062 -> i18n "observation" slice).
+REACT_STOP = ['\nObservation:']
+
+
+# ---------------------------------------------------------------------------
+# Seam 1 — the real truncation the fix feeds
+# ---------------------------------------------------------------------------
+
+
+class TestTruncationOutcome:
+    def test_correct_stop_list_trims_to_clean_action(self):
+        out = truncate_at_stop_words(FABRICATED, REACT_STOP)
+        # Only Thought/Action/Action Input survive — a clean Action for CrewAI to execute.
+        assert out.strip().endswith('}')
+        assert 'Observation:' not in out
+        assert 'Final Answer' not in out
+        assert 'Action: tool_github_1_search_issues' in out
+
+    def test_none_stop_list_is_the_bug(self):
+        # Old behaviour: self.stop -> empty -> None reaches truncate -> no-op -> the
+        # fabricated Observation + Final Answer survive (tool never runs).
+        assert truncate_at_stop_words(FABRICATED, None) == FABRICATED
+
+    def test_empty_stop_list_also_no_ops(self):
+        assert truncate_at_stop_words(FABRICATED, []) == FABRICATED
+
+
+# ---------------------------------------------------------------------------
+# Seam 2 — why the wrapper must read `stop_sequences`, not `stop`
+# Faithful mirror of crewai/llms/base_llm.py:165-214 (stop field + stop_sequences
+# property + call_stop_override contextvar). If CrewAI changes this contract, the
+# real engine-gated e2e is the backstop.
+# ---------------------------------------------------------------------------
+
+_override_var: contextvars.ContextVar = contextvars.ContextVar('_override_var', default=None)
+
+
+@contextlib.contextmanager
+def call_stop_override(llm, stop):
+    current = _override_var.get() or {}
+    new = dict(current)
+    new[id(llm)] = stop
+    token = _override_var.set(new)
+    try:
+        yield
+    finally:
+        _override_var.reset(token)
+
+
+class _MirrorBaseLLM:
+    """Mirrors CrewAI BaseLLM's stop/stop_sequences semantics."""
+
+    def __init__(self):
+        self.stop: list[str] = []  # raw field — default empty
+
+    @property
+    def stop_sequences(self) -> list[str]:
+        overrides = _override_var.get()
+        if overrides is not None:
+            ov = overrides.get(id(self))
+            if ov is not None:
+                return ov
+        return self.stop
+
+
+class TestStopSequencesContract:
+    def test_raw_stop_misses_override(self):
+        llm = _MirrorBaseLLM()
+        with call_stop_override(llm, REACT_STOP):
+            # The OLD wrapper read this -> empty -> bug.
+            assert getattr(llm, 'stop', None) == []
+
+    def test_stop_sequences_reflects_override(self):
+        llm = _MirrorBaseLLM()
+        with call_stop_override(llm, REACT_STOP):
+            # The FIXED wrapper reads this -> the active ReAct stop list.
+            assert llm.stop_sequences == REACT_STOP
+
+    def test_stop_sequences_falls_back_outside_override(self):
+        llm = _MirrorBaseLLM()
+        assert llm.stop_sequences == []  # no override active -> raw field
+
+    def test_property_feeds_truncation_end_to_end(self):
+        # The composed fix: read stop_sequences under the override, feed truncate.
+        llm = _MirrorBaseLLM()
+        with call_stop_override(llm, REACT_STOP):
+            out = truncate_at_stop_words(FABRICATED, llm.stop_sequences)
+        assert 'Observation:' not in out and 'Final Answer' not in out

--- a/nodes/test/tool_github/test_search_relax.py
+++ b/nodes/test/tool_github/test_search_relax.py
@@ -1,0 +1,208 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Network-free unit tests for tool_github keyword-search relax fallback (#1363).
+
+GitHub free-text search ANDs every term, so a verbose natural-language query
+(what agents tend to pass) matches nothing. ``_relax_query`` rebuilds such a
+query as an OR of its keywords — preserving GitHub qualifiers (``repo:``/
+``is:``) and capping terms so the query stays under GitHub's five-operator
+limit. ``search_issues``/``search_code`` retry once with the relaxed query when
+the first pass returns no items.
+
+These tests stub the node's heavy imports (``rocketlib``, ``ai.common.*``) and
+monkeypatch ``mod.call`` so nothing touches the network.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_NODES_SRC = Path(__file__).resolve().parents[2] / 'src'
+if str(_NODES_SRC) not in sys.path:
+    sys.path.insert(0, str(_NODES_SRC))
+
+
+def _build_import_stubs():
+    """Stub exactly the deps tool_github's IInstance/IGlobal import."""
+    rocketlib = MagicMock()
+    rocketlib.IInstanceBase = object
+    rocketlib.IGlobalBase = object
+    rocketlib.tool_function = lambda **kwargs: lambda f: f  # pass-through decorator
+    rocketlib.OPEN_MODE = MagicMock()
+    rocketlib.warning = lambda *a, **kw: None
+
+    ai_common_utils = MagicMock()
+    ai_common_utils.normalize_tool_input = lambda args, **kw: args if isinstance(args, dict) else {}
+    ai_common_utils.require_str = lambda args, key, **kw: (args.get(key) or '').strip()
+    ai_common_utils.require_int = lambda args, key, **kw: int(args.get(key))
+
+    depends = MagicMock()
+    depends.depends = lambda *a, **kw: None
+
+    return {
+        'rocketlib': rocketlib,
+        'depends': depends,
+        'ai': MagicMock(),
+        'ai.common': MagicMock(),
+        'ai.common.utils': ai_common_utils,
+        'ai.common.config': MagicMock(),
+        'requests': MagicMock(),
+    }
+
+
+# Import nodes.tool_github.IInstance under controlled stubs, then restore
+# sys.modules exactly (same isolation discipline as test_tool_deepl.py).
+_GH_MODULES = ('nodes.tool_github.IInstance', 'nodes.tool_github.IGlobal', 'nodes.tool_github')
+_stubs = _build_import_stubs()
+_touched = list(_stubs) + list(_GH_MODULES)
+_ABSENT = object()
+_saved = {name: sys.modules.get(name, _ABSENT) for name in _touched}
+
+try:
+    for _name, _stub in _stubs.items():
+        sys.modules[_name] = _stub
+    for _name in _GH_MODULES:
+        sys.modules.pop(_name, None)
+    mod = importlib.import_module('nodes.tool_github.IInstance')
+finally:
+    for _name in _touched:
+        _prev = _saved[_name]
+        if _prev is _ABSENT:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _prev
+
+
+_VERBOSE = (
+    "i'm having an issue with the dropper Browse file buttons it's not working "
+    'when i click it but if i click the surrounding box it works'
+)
+
+
+# ---------------------------------------------------------------------------
+# _relax_query — pure string transform
+# ---------------------------------------------------------------------------
+
+
+class TestRelaxQuery:
+    def test_verbose_query_relaxes_to_capped_or_clause(self):
+        q = f'{_VERBOSE} repo:rocketride-org/rocketride-server is:open'
+        relaxed = mod._relax_query(q)
+        assert relaxed is not None
+        # qualifiers preserved verbatim
+        assert 'repo:rocketride-org/rocketride-server' in relaxed
+        assert 'is:open' in relaxed
+        # OR clause present, capped to <= 5 terms => <= 4 OR operators (GitHub caps at 5)
+        assert ' OR ' in relaxed
+        assert relaxed.count(' OR ') <= 4
+        or_clause = relaxed.split(' repo:')[0]
+        assert len(or_clause.split(' OR ')) <= 5
+        # stopwords dropped
+        assert 'OR having' not in relaxed and 'OR the ' not in relaxed
+
+    def test_single_term_not_relaxable(self):
+        assert mod._relax_query('dropper repo:acme/app') is None
+
+    def test_qualifiers_only_not_relaxable(self):
+        assert mod._relax_query('repo:acme/app is:issue') is None
+
+    def test_all_stopwords_not_relaxable(self):
+        assert mod._relax_query('it is the my me when') is None
+
+    def test_two_terms_relax_and_dedup_case_insensitive(self):
+        relaxed = mod._relax_query('Dropper dropper browse repo:acme/app')
+        # 'Dropper'/'dropper' collapse to one term; two distinct terms remain
+        assert relaxed == 'Dropper OR browse repo:acme/app'
+
+    def test_max_terms_respected(self):
+        relaxed = mod._relax_query('alpha beta gamma delta epsilon zeta eta', max_terms=3)
+        or_clause = relaxed
+        assert or_clause == 'alpha OR beta OR gamma'
+
+
+# ---------------------------------------------------------------------------
+# Fallback wiring in search_issues / search_code
+# ---------------------------------------------------------------------------
+
+
+class _Cfg:
+    def __init__(self, token='tok', default_repo='', read_only=False):
+        self.token = token
+        self.default_repo = default_repo
+        self.read_only = read_only
+
+
+def _make_instance(cfg=None):
+    inst = mod.IInstance()
+    inst.IGlobal = cfg or _Cfg()
+    return inst
+
+
+def _queue_calls(monkeypatch, responses):
+    """Patch mod.call to return queued responses in order, recording each query."""
+    calls = []
+    seq = list(responses)
+
+    def _fake(token, method, path, *, params=None, body=None, **kwargs):
+        calls.append({'path': path, 'q': (params or {}).get('q')})
+        return seq.pop(0)
+
+    monkeypatch.setattr(mod, 'call', _fake)
+    return calls
+
+
+_ISSUE_ITEM = {
+    'number': 1335,
+    'title': 'Dropper Browse files button not responding',
+    'repository_url': 'https://api.github.com/repos/acme/app',
+}
+
+
+class TestSearchIssuesFallback:
+    def test_empty_first_pass_retries_with_relaxed_query(self, monkeypatch):
+        calls = _queue_calls(monkeypatch, [{'items': []}, {'items': [_ISSUE_ITEM]}])
+        inst = _make_instance(_Cfg(default_repo='acme/app'))
+        out = inst.search_issues({'query': _VERBOSE})
+        assert len(calls) == 2
+        assert ' OR ' in calls[1]['q']  # second pass used the relaxed query
+        assert calls[1]['q'] != calls[0]['q']
+        assert out and out[0]['number'] == 1335
+
+    def test_non_empty_first_pass_does_not_retry(self, monkeypatch):
+        calls = _queue_calls(monkeypatch, [{'items': [_ISSUE_ITEM]}])
+        inst = _make_instance(_Cfg(default_repo='acme/app'))
+        out = inst.search_issues({'query': 'dropper browse'})
+        assert len(calls) == 1
+        assert out and out[0]['number'] == 1335
+
+    def test_unrelaxable_empty_query_does_not_retry(self, monkeypatch):
+        # single keyword -> _relax_query returns None -> no second call
+        calls = _queue_calls(monkeypatch, [{'items': []}])
+        inst = _make_instance(_Cfg(default_repo='acme/app'))
+        out = inst.search_issues({'query': 'dropper'})
+        assert len(calls) == 1
+        assert out == []
+
+
+class TestSearchCodeFallback:
+    def test_empty_first_pass_retries_with_relaxed_query(self, monkeypatch):
+        code_item = {
+            'name': 'd.tsx',
+            'path': 'src/d.tsx',
+            'repository': {'full_name': 'acme/app'},
+            'html_url': 'http://x',
+        }
+        calls = _queue_calls(monkeypatch, [{'items': []}, {'items': [code_item]}])
+        inst = _make_instance(_Cfg(default_repo='acme/app'))
+        out = inst.search_code({'query': _VERBOSE})
+        assert len(calls) == 2
+        assert ' OR ' in calls[1]['q']
+        assert out and out[0]['path'] == 'src/d.tsx'

--- a/nodes/test/tool_github/test_search_relax.py
+++ b/nodes/test/tool_github/test_search_relax.py
@@ -127,6 +127,27 @@ class TestRelaxQuery:
         or_clause = relaxed
         assert or_clause == 'alpha OR beta OR gamma'
 
+    def test_quoted_qualifier_value_stays_atomic(self):
+        # The space inside label:"good first issue" must not split the qualifier.
+        relaxed = mod._relax_query('dropper browse label:"good first issue"')
+        assert relaxed == 'dropper OR browse label:"good first issue"'
+
+    def test_negated_qualifier_preserved_as_filter(self):
+        # -label:bug is a filter, not a free-text term, so it must not join the OR clause.
+        relaxed = mod._relax_query('dropper browse -label:bug')
+        assert relaxed == 'dropper OR browse -label:bug'
+
+    def test_quoted_phrase_term_kept_quoted(self):
+        relaxed = mod._relax_query('"browse button" dropper repo:acme/app')
+        assert relaxed == '"browse button" OR dropper repo:acme/app'
+
+    def test_keyword_count_trimmed_to_leave_room_for_qualifiers(self):
+        # 5 keywords + 3 qualifiers would exceed GitHub's 5 AND/OR/NOT operator limit;
+        # the keyword count is trimmed so (OR ops) + (qualifiers) stays within budget.
+        relaxed = mod._relax_query('alpha beta gamma delta epsilon repo:a/b is:open in:title')
+        or_clause = relaxed.split(' repo:')[0]
+        assert or_clause == 'alpha OR beta OR gamma'  # 6 - 3 qualifiers = 3 keywords
+
 
 # ---------------------------------------------------------------------------
 # Fallback wiring in search_issues / search_code


### PR DESCRIPTION
Fixes #1363.

Two root causes behind "agent search finds nothing / cites the wrong issue".

## Part A — tool_github: verbose queries match nothing
GitHub free-text search ANDs every term, so the verbose natural-language query an agent tends to pass (e.g. a user's full bug complaint) matches no single issue → empty results, while a short keyword query finds it. By-id lookup always worked, which is why it looked like "search only" was broken.

- Add a bounded OR-relax fallback (`_relax_query`) to `search_issues`/`search_code`: when the first pass returns no items, retry **once** with the keywords OR-joined — GitHub qualifiers (`repo:`/`is:`) preserved, capped under GitHub's 5 AND/OR/NOT operator limit.
- Sharpen the `query` schema descriptions to steer agents toward 2–5 keywords instead of sentences.

## Part B — agent_crewai: model fabricates tool results
`HostInvokeLLM.call` read the raw `self.stop` field instead of CrewAI's `self.stop_sequences` property. CrewAI injects the ReAct stop (`"\nObservation:"`) per-call via a contextvar override visible **only** through `stop_sequences`, so the empty `stop` made `call_llm`'s post-hoc `truncate_at_stop_words` a no-op. The model then emitted the whole `Thought/Action/Observation/…/Final Answer` in one completion — fabricating the Observations and skipping the real tool call (it cited an invented issue). Reading the property restores truncation at `"\nObservation:"`, so a clean `Action` reaches CrewAI and the real tool runs.

## Tests
New network-free unit tests:
- `nodes/test/tool_github/test_search_relax.py` — `_relax_query` + fallback wiring (10).
- `nodes/test/agent_crewai/test_stop_words.py` — real `truncate_at_stop_words` + a faithful mirror of CrewAI's stop/stop_sequences/override contract (7).

17/17 pass · ruff clean. The real CrewAI wrapper can't be imported outside the engine runtime (needs `rocketlib`/`pywin32`); definitive e2e = re-run the Rocket Ralph pipeline and confirm it invokes `search_issues` and cites a real issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed AI tool-call stop-sequence handling to correctly truncate ReAct transcripts at the intended boundary, preventing fabricated “Observation/Final Answer” leakage.
  * Improved GitHub code and issue search by retrying with a relaxed query when the initial search returns no results.

* **Tests**
  * Added network-free tests to verify ReAct stop-sequence truncation behavior.
  * Added network-free tests to validate relaxed GitHub search retry logic and query cleanup rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->