### PR TITLE
test(nodes): pin heavy model tests to one xdist worker to prevent OOM

### DIFF
--- a/nodes/scripts/tasks.js
+++ b/nodes/scripts/tasks.js
@@ -206,11 +206,13 @@ function makeRunPytestAction(options = {}) {
             const parallelVal = String(parallelRaw).trim().toLowerCase();
             if (parallelVal && parallelVal !== 'off' && parallelVal !== '0') {
                 extraArgs.push('-n', parallelVal);
-                // Honor @pytest.mark.xdist_group: same-group tests run on one worker, so
-                // heavy GPU/model node tests serialize and don't OOM-crash workers (see
-                // conftest.pytest_collection_modifyitems). The marker is ignored under the
-                // default --dist load. Skip if the caller already set --dist via --pytest.
-                if (!extraArgs.includes('--dist')) {
+                // Honor @pytest.mark.xdist_group (set in conftest._build_parametrize_list):
+                // same-group tests run on one worker, so heavy GPU/model node tests serialize
+                // and don't OOM-crash workers. The marker is ignored under the default
+                // --dist load. Skip if the caller already chose a distribution mode via
+                // --pytest, in either `--dist <mode>` or `--dist=<mode>` form.
+                const hasDistOverride = extraArgs.some((a) => a === '--dist' || a.startsWith('--dist='));
+                if (!hasDistOverride) {
                     extraArgs.push('--dist', 'loadgroup');
                 }
             }

--- a/nodes/scripts/tasks.js
+++ b/nodes/scripts/tasks.js
@@ -206,6 +206,13 @@ function makeRunPytestAction(options = {}) {
             const parallelVal = String(parallelRaw).trim().toLowerCase();
             if (parallelVal && parallelVal !== 'off' && parallelVal !== '0') {
                 extraArgs.push('-n', parallelVal);
+                // Honor @pytest.mark.xdist_group: same-group tests run on one worker, so
+                // heavy GPU/model node tests serialize and don't OOM-crash workers (see
+                // conftest.pytest_collection_modifyitems). The marker is ignored under the
+                // default --dist load. Skip if the caller already set --dist via --pytest.
+                if (!extraArgs.includes('--dist')) {
+                    extraArgs.push('--dist', 'loadgroup');
+                }
             }
 
             await runPytest({

--- a/nodes/test/conftest.py
+++ b/nodes/test/conftest.py
@@ -215,10 +215,30 @@ def _missing_libs_skip_mark(config):
     )
 
 
+# Nodes that load a heavy model in-process but carry no 'gpu' capability tag
+# (CPU model-download nodes). Supplements the capability signal — keep small.
+_HEAVY_TEST_NODES = {'audio_transcribe', 'audio_tts'}
+
+
+def _is_heavy_node(config) -> bool:
+    """Whether a node loads a heavy model in-process.
+
+    True for the 'gpu' capability (mirrors the existing `'debug' in capabilities`
+    check) or a known CPU heavy-model node. Such tests are pinned to one xdist
+    worker so their model loads run serially instead of exhausting RAM/VRAM.
+    """
+    return 'gpu' in config.capabilities or config.node_name in _HEAVY_TEST_NODES
+
+
 def _build_parametrize_list(configs, skip_nodes=None, include_skip=None):
     """Build pytest.param entries for (config, profile) pairs, applying skip_nodes.
 
     A config with missing `requiresLibs` is still emitted, but marked skip.
+    Heavy (model-loading) configs also get an `xdist_group('gpu')` mark so that,
+    under `--dist loadgroup`, all their tests run on one worker (serially) and don't
+    OOM-crash workers. The mark is applied here at parametrize time — not in
+    `pytest_collection_modifyitems` — because xdist reads the group during its own
+    collection pass and would miss a marker added by a later hook.
     """
     params = []
     for config in configs:
@@ -231,8 +251,13 @@ def _build_parametrize_list(configs, skip_nodes=None, include_skip=None):
         if not config.has_required_env_vars():
             continue
 
+        marks = []
         skip_mark = _missing_libs_skip_mark(config)
-        marks = (skip_mark,) if skip_mark else ()
+        if skip_mark:
+            marks.append(skip_mark)
+        if _is_heavy_node(config):
+            marks.append(pytest.mark.xdist_group('gpu'))
+        marks = tuple(marks)
 
         if not config.profiles:
             params.append(pytest.param((config, None), id=config.get_test_id(), marks=marks))


### PR DESCRIPTION
## Summary

- Pin heavy (model-loading) node tests to a single `pytest-xdist` worker via an `xdist_group('gpu')` mark so they run serially instead of OOM-crashing workers under `-n`.
- `nodes:test` now emits `--dist loadgroup` alongside `-n` so the mark is honored; light tests still fan out across the other workers.
- "Heavy" = node's `services.json` declares the `gpu` capability, plus a small supplement for CPU model-download nodes (`audio_transcribe`, `audio_tts`).

## Type

fix (test infrastructure)

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Verified under `-n2 --dist loadgroup`: both gpu tests co-locate on one worker (shown as `...@gpu`) while non-gpu tests spread; `embedding_transformer` / `embedding_video` dynamic tests pin to `gw0` and pass (~60s, models actually loaded). Only `nodes:test` was run locally, not the full `./builder test`.

> Heads-up for reviewers: dynamic node tests need `ROCKETRIDE_APIKEY` unset (defaults to `MYAPIKEY`). A set-but-empty value (`ROCKETRIDE_APIKEY=` in a local `.env`) makes the client auth empty → server rejects → all dynamic tests silently SKIP behind a green build.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pytest parallel execution so test grouping is respected when running with pytest-xdist.
  * CPU-intensive test nodes are now automatically assigned to a serial-friendly xdist group, helping reduce overloaded or flaky runs.
  * Existing behavior that skips tests when required libraries are missing remains unchanged, with grouping applied only as needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->