### PR TITLE
fix(tool_http_request): insert path-param values literally (#1369)

### DIFF
--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import re
 import time
 from typing import Any, Dict, Optional
+from urllib.parse import quote
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -101,10 +102,11 @@ def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str
         return url
     resolved = url
     for key, value in path_params.items():
-        # Use a function replacement so the value is inserted literally. Passing the
-        # value as a plain string would let re.sub interpret backslash escapes and
-        # group references in it (e.g. '\1' -> re.error, '\t' -> a tab character).
-        replacement = str(value)
+        # Encode (safe='') so the value stays one path segment and cannot slip
+        # past the URL allowlist, which is checked against the unresolved
+        # template. The function replacement keeps it literal (no re.sub
+        # backslash/group-ref interpretation, e.g. '\1' -> re.error).
+        replacement = quote(str(value), safe='')
         resolved = re.sub(rf':{re.escape(key)}\b', lambda _m, r=replacement: r, resolved)
     return resolved
 

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -101,7 +101,11 @@ def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str
         return url
     resolved = url
     for key, value in path_params.items():
-        resolved = re.sub(rf':{re.escape(key)}\b', str(value), resolved)
+        # Use a function replacement so the value is inserted literally. Passing the
+        # value as a plain string would let re.sub interpret backslash escapes and
+        # group references in it (e.g. '\1' -> re.error, '\t' -> a tab character).
+        replacement = str(value)
+        resolved = re.sub(rf':{re.escape(key)}\b', lambda _m, r=replacement: r, resolved)
     return resolved
 
 

--- a/nodes/test/tool_http_request/test_resolve_path_params.py
+++ b/nodes/test/tool_http_request/test_resolve_path_params.py
@@ -5,10 +5,11 @@
 
 """Regression tests for _resolve_path_params (issue #1369).
 
-Path-param values must be inserted literally. A value used as a plain re.sub
-replacement string would be interpreted as a template, so backslash escapes and
-group references in caller-supplied values would crash (``\\1`` ->
-``re.error``) or be silently mangled (``\\t`` -> a tab character).
+Path-param values are percent-encoded and inserted via a re.sub callback. This
+keeps each value as a single, literal path segment: a value used as a plain
+re.sub replacement string would be interpreted as a template (``\\1`` ->
+``re.error``, ``\\t`` -> a tab character), and an unencoded value could contain
+``/`` or ``..`` and alter the URL structure past the allowlist.
 """
 
 from __future__ import annotations
@@ -31,20 +32,27 @@ from http_client import _resolve_path_params  # noqa: E402
 
 
 def test_group_reference_value_is_literal():
-    """A value of '\\1' must be inserted verbatim, not treated as a backref."""
+    """A value of '\\1' must not be treated as a backref; the backslash is encoded."""
     out = _resolve_path_params('https://api/x/:id', {'id': r'\1'})
-    assert out == r'https://api/x/\1'
+    assert out == 'https://api/x/%5C1'
 
 
 def test_backslash_escape_value_is_literal():
-    """'\\t' and '\\n' must stay literal, not become control characters."""
+    """'\\t' and '\\n' must stay literal (backslash encoded), not become control chars."""
     out_tab = _resolve_path_params('https://api/x/:id', {'id': r'a\tb'})
-    assert out_tab == r'https://api/x/a\tb'
+    assert out_tab == 'https://api/x/a%5Ctb'
     assert '\t' not in out_tab
 
     out_newline = _resolve_path_params('https://api/x/:id', {'id': r'a\nb'})
-    assert out_newline == r'https://api/x/a\nb'
+    assert out_newline == 'https://api/x/a%5Cnb'
     assert '\n' not in out_newline
+
+
+def test_reserved_chars_are_encoded_to_stay_one_segment():
+    """A value with '/', '..' or '?' is encoded so it cannot escape its path segment."""
+    out = _resolve_path_params('https://api/public/:id', {'id': '../admin?x=1'})
+    assert out == 'https://api/public/..%2Fadmin%3Fx%3D1'
+    assert '/admin' not in out
 
 
 def test_plain_value_substitution():

--- a/nodes/test/tool_http_request/test_resolve_path_params.py
+++ b/nodes/test/tool_http_request/test_resolve_path_params.py
@@ -1,0 +1,64 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2024 RocketRide Inc.
+# =============================================================================
+
+"""Regression tests for _resolve_path_params (issue #1369).
+
+Path-param values must be inserted literally. A value used as a plain re.sub
+replacement string would be interpreted as a template, so backslash escapes and
+group references in caller-supplied values would crash (``\\1`` ->
+``re.error``) or be silently mangled (``\\t`` -> a tab character).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# requests is imported at module import time by http_client; skip cleanly if
+# it is not installed in this environment.
+pytest.importorskip('requests')
+
+# Add the node source directory to sys.path so we can import the module
+# without triggering the top-level nodes/__init__.py (which requires the
+# engine runtime). Mirrors test_rate_limiter.py.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 'tool_http_request'))
+
+from http_client import _resolve_path_params  # noqa: E402
+
+
+def test_group_reference_value_is_literal():
+    """A value of '\\1' must be inserted verbatim, not treated as a backref."""
+    out = _resolve_path_params('https://api/x/:id', {'id': r'\1'})
+    assert out == r'https://api/x/\1'
+
+
+def test_backslash_escape_value_is_literal():
+    """'\\t' / '\\n' must stay literal, not become control characters."""
+    out = _resolve_path_params('https://api/x/:id', {'id': r'a\tb'})
+    assert out == r'https://api/x/a\tb'
+    assert '\t' not in out
+
+
+def test_plain_value_substitution():
+    out = _resolve_path_params('https://api/users/:id/posts/:postId', {'id': '42', 'postId': '7'})
+    assert out == 'https://api/users/42/posts/7'
+
+
+def test_non_string_value_is_stringified():
+    out = _resolve_path_params('https://api/x/:id', {'id': 123})
+    assert out == 'https://api/x/123'
+
+
+def test_no_params_returns_url_unchanged():
+    assert _resolve_path_params('https://api/x/:id', None) == 'https://api/x/:id'
+    assert _resolve_path_params('https://api/x/:id', {}) == 'https://api/x/:id'
+
+
+def test_word_boundary_prevents_partial_key_match():
+    """':id' must not match the ':identifier' placeholder prefix."""
+    out = _resolve_path_params('https://api/:identifier', {'id': 'X'})
+    assert out == 'https://api/:identifier'

--- a/nodes/test/tool_http_request/test_resolve_path_params.py
+++ b/nodes/test/tool_http_request/test_resolve_path_params.py
@@ -37,23 +37,30 @@ def test_group_reference_value_is_literal():
 
 
 def test_backslash_escape_value_is_literal():
-    """'\\t' / '\\n' must stay literal, not become control characters."""
-    out = _resolve_path_params('https://api/x/:id', {'id': r'a\tb'})
-    assert out == r'https://api/x/a\tb'
-    assert '\t' not in out
+    """'\\t' and '\\n' must stay literal, not become control characters."""
+    out_tab = _resolve_path_params('https://api/x/:id', {'id': r'a\tb'})
+    assert out_tab == r'https://api/x/a\tb'
+    assert '\t' not in out_tab
+
+    out_newline = _resolve_path_params('https://api/x/:id', {'id': r'a\nb'})
+    assert out_newline == r'https://api/x/a\nb'
+    assert '\n' not in out_newline
 
 
 def test_plain_value_substitution():
+    """Ordinary values replace every matching ':name' placeholder."""
     out = _resolve_path_params('https://api/users/:id/posts/:postId', {'id': '42', 'postId': '7'})
     assert out == 'https://api/users/42/posts/7'
 
 
 def test_non_string_value_is_stringified():
+    """Non-string values are coerced via str() before substitution."""
     out = _resolve_path_params('https://api/x/:id', {'id': 123})
     assert out == 'https://api/x/123'
 
 
 def test_no_params_returns_url_unchanged():
+    """An empty or None mapping leaves the URL untouched."""
     assert _resolve_path_params('https://api/x/:id', None) == 'https://api/x/:id'
     assert _resolve_path_params('https://api/x/:id', {}) == 'https://api/x/:id'
 


### PR DESCRIPTION
## Summary

`_resolve_path_params` in `nodes/src/nodes/tool_http_request/http_client.py` substituted `:name` URL placeholders using the path-param **value as the `re.sub` replacement string**. `re.sub` treats its replacement argument as a *template*, not a literal, so backslash sequences and group references in caller-supplied values were interpreted instead of inserted verbatim.

Fixes #1369

## Root cause

```python
# before
resolved = re.sub(rf':{re.escape(key)}\b', str(value), resolved)
```

`re.escape(key)` correctly escapes the pattern, but the replacement (`str(value)`) flows in unescaped. Since `path_params` is caller/tool-controlled:

- a value of `\1` → `re.error: invalid group reference 1` (crash)
- a value containing `\t` / `\n` → silently converted to real tab/newline characters, corrupting the resolved URL

## Fix

Use a function replacement, which `re.sub` inserts literally (no template interpretation):

```python
# after
replacement = str(value)
resolved = re.sub(rf':{re.escape(key)}\b', lambda _m, r=replacement: r, resolved)
```

(The value is bound as a default arg to avoid late-binding over the loop variable.)

## Before / After

| Input `path_params` | URL | Before | After |
|---------------------|-----|--------|-------|
| `{'id': r'\1'}` | `https://api/x/:id` | `re.error: invalid group reference 1` | `https://api/x/\1` |
| `{'id': r'a\tb'}` | `https://api/x/:id` | `https://api/x/a<TAB>b` | `https://api/x/a\tb` |
| `{'id': '42'}` | `https://api/x/:id` | `https://api/x/42` | `https://api/x/42` (unchanged) |

## Test plan

Adds `nodes/test/tool_http_request/test_resolve_path_params.py` covering:

- group-reference value (`\1`) stays literal (previously crashed)
- backslash-escape value (`\t`) stays literal, no control char injected
- plain / multi-param substitution
- non-string value stringified
- `None` / empty params return the URL unchanged
- word-boundary guard (`:id` does not match `:identifier`)

```bash
python -m pytest nodes/test/tool_http_request/test_resolve_path_params.py -v
```

All cases pass; the two prior failure modes are now asserted to be literal.

## Scope / risk

- Behavior change only for values containing backslashes (previously crashed or corrupted); normal values are unaffected.
- `_resolve_path_params` is a private helper — no public contract/doc change (per `AGENTS.md`), so no co-located docs update required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL path parameter substitution by percent-encoding each segment and inserting values literally to prevent accidental interpretation of backslashes or replacement-style sequences.
  * Enhanced placeholder replacement to avoid partial matches and to keep URLs unchanged when no path parameters are provided.
* **Tests**
  * Added regression coverage for path parameter substitution, including string, non-string, empty, reserved character encoding, and boundary-matching cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->