### PR TITLE
fix(guardrails): reject '|' in email TLD char class (#1371)

### DIFF
--- a/nodes/src/nodes/guardrails/guardrails_engine.py
+++ b/nodes/src/nodes/guardrails/guardrails_engine.py
@@ -190,7 +190,7 @@ class GuardrailsEngine:
     # PII detection patterns
     # -------------------------------------------------------------------------
     PII_PATTERNS: Dict[str, re.Pattern] = {
-        'email': re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'),
+        'email': re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b'),
         'phone_us': re.compile(r'\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b'),
         'ssn': re.compile(r'\b(?!000|666|9\d{2})\d{3}[-\s]?(?!00)\d{2}[-\s]?(?!0000)\d{4}\b'),
         'credit_card': re.compile(

--- a/nodes/test/guardrails/test_all.py
+++ b/nodes/test/guardrails/test_all.py
@@ -368,6 +368,26 @@ class TestPIILeak:
         result = engine.check_pii_leak('The weather is nice today. No personal data here.')
         assert result['passed']
 
+    def test_email_rejects_pipe_in_tld(self):
+        """A pipe '|' must not be accepted as a TLD character (issue #1370).
+
+        The TLD char class was [A-Z|a-z], which matched a literal '|'. With the
+        old pattern, pipe-containing non-emails that end in a word char (so the
+        trailing \\b still holds) — e.g. 'user@example.c|m' or 'a@b.c|d' — were
+        wrongly flagged as PII.
+        """
+        engine = _make_engine()
+        for text in ('Contact user@example.c|m please.', 'See a@b.c|d here.'):
+            result = engine.check_pii_leak(text)
+            assert result['passed'], f'Pipe in TLD must not be detected as email: {text!r}'
+
+    def test_valid_email_with_two_letter_tld_still_detected(self):
+        """Guard against over-fixing: real emails must still be detected."""
+        engine = _make_engine()
+        result = engine.check_pii_leak('Ping me at jane@example.io today.')
+        assert not result['passed']
+        assert 'email' in result['details']
+
     def test_ssn_rejects_invalid_prefix(self):
         """SSN regex should reject prefixes starting with 000, 666, or 9xx."""
         engine = _make_engine()


### PR DESCRIPTION
## Summary

The guardrails PII email pattern used `[A-Z|a-z]` for the TLD. Inside a character class, `|` is a literal, so the TLD accepted a pipe and flagged pipe-containing non-emails as PII in the redaction/compliance path.

Fixes #1371

## Root Cause

```python
# before
'email': re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b'),
```

`[A-Z|a-z]` is the set `{A–Z, a–z, |}`. Because the pattern ends in `\b`, the match must end on a word character, so the following invalid addresses are incorrectly matched:

* `user@example.c|m`
* `a@b.c|d`

## Fix

```python
# after
'email': re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b'),
```

## Test Plan

Adds two tests to `TestPIILeak` in `nodes/test/guardrails/test_all.py`:

* `test_email_rejects_pipe_in_tld` — verifies that `user@example.c|m` and `a@b.c|d` are **not** detected as emails (fails on the old code, passes after the fix).
* `test_valid_email_with_two_letter_tld_still_detected` — verifies that `jane@example.io` is still detected correctly (guards against over-fixing).

```bash
python -m pytest nodes/test/guardrails/test_all.py -k pii -v
```

Verified locally: the old regex matches the invalid examples, while the updated regex rejects them. Valid emails such as `jane@example.io` and `john.doe@example.com` continue to match.

## Scope / Risk

One-character change to a private class attribute; only affects strings where a `|` previously slipped into the TLD. No public contract or documentation changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email address detection in PII checks so valid emails are recognized more reliably.
  * Reduced false positives when certain characters appear in the email domain/TLD portion.

* **Tests**
  * Added coverage for email detection edge cases.
  * Verified that valid short TLDs like `.io` are still flagged correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->