### PR TITLE
fix(cli): catch ValueError from json5.loads, not non-existent json5.JSONError (#1379)

### DIFF
--- a/packages/client-python/src/rocketride/cli/utils/config.py
+++ b/packages/client-python/src/rocketride/cli/utils/config.py
@@ -106,7 +106,7 @@ def load_pipeline_config(pipeline_file: str) -> Dict[str, Any]:
                 try:
                     return json5.loads(content)
                 except ValueError as e:
-                    raise ValueError(f'Invalid JSON5 format in {pipeline_file}: {e}')
+                    raise ValueError(f'Invalid JSON5 format in {pipeline_file}: {e}') from e
             else:
                 try:
                     return json.loads(content)

--- a/packages/client-python/src/rocketride/cli/utils/config.py
+++ b/packages/client-python/src/rocketride/cli/utils/config.py
@@ -105,7 +105,7 @@ def load_pipeline_config(pipeline_file: str) -> Dict[str, Any]:
             if json5:
                 try:
                     return json5.loads(content)
-                except json5.JSONError as e:
+                except ValueError as e:
                     raise ValueError(f'Invalid JSON5 format in {pipeline_file}: {e}')
             else:
                 try:


### PR DESCRIPTION
## Summary

Fixes #1379.

`load_pipeline_config()` in `packages/client-python/src/rocketride/cli/utils/config.py`
catches `json5.JSONError` when parsing a `.pipe` file. The dpranke `json5` package
(imported at line 54) exposes **no** `JSONError` attribute — it raises `ValueError`
on parse failures.

Because the `except` expression is only evaluated when the `try` body raises, the
bug is dormant until a malformed file is loaded. At that point Python evaluates
`json5.JSONError` to test the match and raises:

```text
AttributeError: module 'json5' has no attribute 'JSONError'
```

That `AttributeError` is then swallowed by the outer `except Exception` and
re-wrapped as:

```text
ValueError: Error reading <file>: module 'json5' has no attribute 'JSONError'
```

The intended `Invalid JSON5 format in <file>: <details>` branch is unreachable, so
users see a confusing message instead of the real syntax error and location.

---

## Fix

```diff
-                except json5.JSONError as e:
+                except ValueError as e:
                     raise ValueError(f'Invalid JSON5 format in {pipeline_file}: {e}')
```

Catch the exception `json5` actually raises (`ValueError`). The re-raised
`ValueError` still passes cleanly through the outer handler thanks to the existing
`isinstance(e, (FileNotFoundError, ValueError))` re-raise guard.

---

## Reproduction

`broken.pipe` contains:

```json5
{ "a": }
```

```python
load_pipeline_config("broken.pipe")
```

### Before

```text
ValueError: Error reading broken.pipe: module 'json5' has no attribute 'JSONError'
```

### After

```text
ValueError: Invalid JSON5 format in broken.pipe: <details>
```

---

## Notes

- Requires the optional `json5` package to be installed to trigger (the `else`
  branch already correctly catches `json.JSONDecodeError`).
- Scope limited to the single `except` clause; no behavior change on the success path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pipeline configuration parsing for invalid JSON5 by handling parsing failures more consistently.
  * On malformed configuration files, the app now surfaces the same “Invalid JSON5 format in {pipeline_file}” error reliably to simplify troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->