### PR TITLE
fix(scripts): resolve undefined BUILD_ROOT and DIST_DIR in licenses.js (#1383)

### DIFF
--- a/scripts/licenses.js
+++ b/scripts/licenses.js
@@ -19,7 +19,7 @@ const path = require('path');
 const { execSync } = require('child_process');
 
 // Paths
-const { PROJECT_ROOT, DIST_ROOT } = require('./lib/paths');
+const { PROJECT_ROOT, BUILD_ROOT, DIST_ROOT } = require('./lib/paths');
 const OUTPUT_FILE = path.join(DIST_ROOT, 'THIRD_PARTY_LICENSES.md');
 
 // ============================================================================
@@ -758,7 +758,7 @@ function generateLicenseFile(allLicenses) {
 async function main() {
     console.log('=== License Aggregation ===\n');
     
-    ensureDir(DIST_DIR);
+    ensureDir(DIST_ROOT);
     
     // Collect all licenses
     const projectLicenses = collectProjectLicenses().map(l => ({ ...l, category: 'PROJECT' }));


### PR DESCRIPTION
## Summary

Fixes #1383

`scripts/licenses.js` crashed on every run with `ReferenceError: DIST_DIR is not defined`, and its vcpkg license collector was unreachable due to a second undefined identifier (`BUILD_ROOT`). This fixes both.

- **`BUILD_ROOT`** was used at `scripts/licenses.js:200` (`path.join(BUILD_ROOT, 'vcpkg_installed')`) but never imported. It is added to the `./lib/paths` destructured import.
- **`DIST_DIR`** at `scripts/licenses.js:761` (`ensureDir(DIST_DIR)` in `main()`) was a typo — the exported name is `DIST_ROOT`. Corrected.

`scripts/lib/paths.js` already exports both `BUILD_ROOT` and `DIST_ROOT` (there is no `DIST_DIR`), so these are import/typo fixes only — no path semantics change.

---

## Changes

```diff
-const { PROJECT_ROOT, DIST_ROOT } = require('./lib/paths');
+const { PROJECT_ROOT, BUILD_ROOT, DIST_ROOT } = require('./lib/paths');
...
-    ensureDir(DIST_DIR);
+    ensureDir(DIST_ROOT);
```

---

## Root Cause

`main()` calls `ensureDir(DIST_DIR)` near the top, so the script threw:

```text
ReferenceError: DIST_DIR is not defined
```

immediately on every invocation.

Had that been fixed alone, `collectVcpkgLicenses()` would then have thrown:

```text
ReferenceError: BUILD_ROOT is not defined
```

when reached.

---

## Testing

- `node --check scripts/licenses.js` — passes (no syntax errors).
- Reference audit:
  - `PROJECT_ROOT`
  - `BUILD_ROOT`
  - `DIST_ROOT`

  are all imported and used correctly; no `DIST_DIR` references remain.
- `node scripts/licenses.js` — now runs to completion (exit `0`):
  - Creates the `dist` directory.
  - Writes `dist/THIRD_PARTY_LICENSES.md`.
  - Reaches the vcpkg collector, emitting a graceful `"vcpkg installed directory not found"` warning instead of crashing.

---

## Notes

- Diff is limited to `scripts/licenses.js`.
- The generated `dist/THIRD_PARTY_LICENSES.md` is git-ignored and not included.
- Pre-existing whole-file Prettier style differences were left untouched to avoid a noisy, unrelated diff; the two edited lines conform to the surrounding style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal path handling for generated license output to better match the app’s standard build and distribution directories.
  * Improved directory setup during the release process, helping ensure output files are created in the expected location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->