### PR TITLE
fix(client-python): bound truncate_filename for small widths (#1385)

### DIFF
--- a/packages/client-python/src/rocketride/cli/utils/formatters.py
+++ b/packages/client-python/src/rocketride/cli/utils/formatters.py
@@ -185,6 +185,11 @@ def truncate_filename(filename: str, max_length: int) -> str:
     if len(filename) <= max_length:
         return filename
 
+    # Widths too small to hold the '...' indicator cannot be truncated with an
+    # ellipsis without overrunning max_length, so hard-truncate instead.
+    if max_length <= 3:
+        return filename[:max(max_length, 0)]
+
     path = Path(filename)
     name = path.stem
     ext = path.suffix

--- a/packages/client-python/src/rocketride/cli/utils/formatters.py
+++ b/packages/client-python/src/rocketride/cli/utils/formatters.py
@@ -188,7 +188,7 @@ def truncate_filename(filename: str, max_length: int) -> str:
     # Widths too small to hold the '...' indicator cannot be truncated with an
     # ellipsis without overrunning max_length, so hard-truncate instead.
     if max_length <= 3:
-        return filename[:max(max_length, 0)]
+        return filename[: max(max_length, 0)]
 
     path = Path(filename)
     name = path.stem

--- a/packages/client-python/tests/test_formatters_truncate.py
+++ b/packages/client-python/tests/test_formatters_truncate.py
@@ -44,6 +44,7 @@ class TestTruncateFilename(unittest.TestCase):
         self.assertEqual(truncate_filename('abcdef', 2), 'ab')
         self.assertEqual(truncate_filename('report.txt', 1), 'r')
         self.assertEqual(truncate_filename('abcdef', 3), 'abc')
+        self.assertEqual(truncate_filename('abcdef', -1), '')
 
     def test_returns_filename_when_it_fits(self) -> None:
         self.assertEqual(truncate_filename('a.txt', 10), 'a.txt')

--- a/packages/client-python/tests/test_formatters_truncate.py
+++ b/packages/client-python/tests/test_formatters_truncate.py
@@ -1,0 +1,59 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression tests for truncate_filename (RR-1385)."""
+
+import unittest
+
+from rocketride.cli.utils.formatters import truncate_filename
+
+
+class TestTruncateFilename(unittest.TestCase):
+    def test_never_exceeds_max_length_for_small_widths(self) -> None:
+        """Small widths must not overrun max_length by appending an ellipsis."""
+        for max_length in range(0, 8):
+            for filename in ('abcdef', 'report.txt', 'a.very_long_extension'):
+                result = truncate_filename(filename, max_length)
+                self.assertLessEqual(
+                    len(result),
+                    max_length,
+                    f'{filename!r} @ {max_length} -> {result!r}',
+                )
+
+    def test_small_width_has_no_stray_ellipsis(self) -> None:
+        """Widths below the ellipsis width should hard-truncate without '...'."""
+        self.assertEqual(truncate_filename('abcdef', 2), 'ab')
+        self.assertEqual(truncate_filename('report.txt', 1), 'r')
+        self.assertEqual(truncate_filename('abcdef', 3), 'abc')
+
+    def test_returns_filename_when_it_fits(self) -> None:
+        self.assertEqual(truncate_filename('a.txt', 10), 'a.txt')
+
+    def test_preserves_extension_when_room_allows(self) -> None:
+        result = truncate_filename('very_long_document_name.pdf', 20)
+        self.assertLessEqual(len(result), 20)
+        self.assertTrue(result.endswith('.pdf'))
+        self.assertIn('...', result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Problem

`truncate_filename()` returns a string **longer** than `max_length` when `max_length < 3`.

The negative `max_length - 3` slice drops trailing characters and then appends `'...'`, overrunning the width and breaking fixed-width CLI layouts.

```python
truncate_filename('abcdef', 2)  # 'abcde...' (len 8 > 2)
```

---

## Fix

Guard small widths before slicing — when `max_length <= 3`, hard-truncate without an ellipsis (`max(..., 0)` also handles negative values).

```python
truncate_filename('abcdef', 2)  # 'ab'
```

Larger widths are unchanged.

---

## Tests

Added `tests/test_formatters_truncate.py`:

- Asserts `len(result) <= max_length` across widths `0–7`.
- No stray `...` at small widths.
- Fits-unchanged behavior.
- Extension preserved.

---

Closes #1385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename truncation for very small `max_length` values, ensuring output never exceeds the requested length.
  * Prevented stray ellipsis output when width is too small to support standard truncation.
  * Kept filenames unchanged when they already fit, and preserved file extensions when truncation allows.
* **Tests**
  * Added regression tests covering small-width truncation edge cases, extension preservation, and “no ellipsis” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->