### PR TITLE
fix: open file picker when Browse files is clicked in Dropper (#1261)

### DIFF
--- a/apps/dropper-ui/src/components/DropZone.tsx
+++ b/apps/dropper-ui/src/components/DropZone.tsx
@@ -25,8 +25,8 @@ interface DropZoneProps {
 	onDrop: (e: React.DragEvent) => void;
 	/** Whether the drop zone is disabled (e.g., during connection) */
 	disabled?: boolean;
-	/** Optional callback to open VS Code's native file dialog (fallback for Cursor/macOS) */
-	onBrowse?: (() => void) | undefined;
+	/** Show an explicit Browse files button (e.g. in the VS Code webview) */
+	showBrowseButton?: boolean;
 }
 
 /**
@@ -79,7 +79,7 @@ export const DropZone: React.FC<DropZoneProps> = ({
 	onDragLeave,
 	onDrop,
 	disabled = false,
-	onBrowse
+	showBrowseButton = false
 }) => {
 	// Reference to hidden file input element
 	const fileInputRef = useRef<HTMLInputElement>(null);
@@ -157,9 +157,9 @@ export const DropZone: React.FC<DropZoneProps> = ({
 					// Default/drag-over state: Show upload icon and instructions
 					<>
 						<Upload className="w-8 h-8 text-gray-400" />
-						<h4>{isDragOver ? 'Drop files here' : (onBrowse ? 'Drop files, click, or browse' : 'Drop files or click')}</h4>
+						<h4>{isDragOver ? 'Drop files here' : (showBrowseButton ? 'Drop files, click, or browse' : 'Drop files or click')}</h4>
 						<p>Documents, images, etc.</p>
-						{onBrowse && (
+						{showBrowseButton && (
 							<button
 								type="button"
 								className="browse-files-btn"

--- a/apps/dropper-ui/src/components/DropZone.tsx
+++ b/apps/dropper-ui/src/components/DropZone.tsx
@@ -163,7 +163,7 @@ export const DropZone: React.FC<DropZoneProps> = ({
 							<button
 								type="button"
 								className="browse-files-btn"
-								onClick={(e) => { e.stopPropagation(); onBrowse(); }}
+								onClick={(e) => { e.stopPropagation(); openFilePicker(); }}
 							>
 								Browse files
 							</button>

--- a/apps/dropper-ui/src/components/DropperContainer.tsx
+++ b/apps/dropper-ui/src/components/DropperContainer.tsx
@@ -252,17 +252,6 @@ export const DropperContainer: React.FC<{ authToken: string | null }> = ({ authT
 	}, [addFiles, isConnected]);
 
 	/**
-	 * Opens VS Code's native file dialog via the extension host.
-	 * Primary upload method for Cursor on macOS where drag-and-drop
-	 * is intercepted by the Cocoa layer before reaching the webview.
-	 */
-	const isVSCode = window.parent !== window;
-	const requestNativeFileDialog = useCallback(() => {
-		if (!isVSCode) return;
-		window.parent.postMessage({ type: 'requestFileDialog' }, '*');
-	}, [isVSCode]);
-
-	/**
 	 * Clears all uploaded files and resets state
 	 * Returns to default results tab and disables compare mode
 	 */
@@ -318,7 +307,7 @@ export const DropperContainer: React.FC<{ authToken: string | null }> = ({ authT
 								onDragLeave={handleDragLeave}
 								onDrop={handleDrop}
 								disabled={!isConnected}
-								onBrowse={isVSCode ? requestNativeFileDialog : undefined}
+								showBrowseButton={window.parent !== window}
 							/>
 
 							{/* List of uploaded files */}


### PR DESCRIPTION
Browse files stopped propagation and called onBrowse(), which is a no-op outside a wired VS Code host. Use openFilePicker() instead so the button matches click-to-upload on the drop zone.

## Summary
- Browse files in DropZone called `onBrowse()`
- which is a no-op in iframe/VS Code contexts.
- It now calls `openFilePicker()` so the button opens the same native file picker as clicking the drop zone.

## Type

- [x] Bug fix

## Testing

- [x] Reproduced via iframe test (`/tmp/dropper-iframe.html`), Browse files now opens picker
- [x] Clicking drop zone still opens picker (no double-fire)
- [x] `./builder dropper-ui:build --force` passes

## Checklist

- [x] PR targets `develop`
- [x] Linked to an issue
- [x] Conventional commit message

## Linked Issue

Fixes #1261 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the “Browse files” button so it now opens the file picker reliably when clicked.
  * Updated the drag-and-drop area to render the “Browse files” button only when enabled by configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->