### PR TITLE
fix: style hello-ui theme select for dark color scheme (#1396)

### DIFF
--- a/apps/hello-ui/src/HomeApp.tsx
+++ b/apps/hello-ui/src/HomeApp.tsx
@@ -241,14 +241,6 @@ const styles = {
 	} as CSSProperties,
 };
 
-/** Light themes for native control color-scheme (select popup). */
-function themeColorScheme(themeId: string): 'light' | 'dark' {
-	if (themeId === 'light' || themeId === 'rocketride-light' || themeId === 'visual-studio') {
-		return 'light';
-	}
-	return 'dark';
-}
-
 /** Accent colors cycled across app cards. */
 const CARD_COLORS = [
 	'var(--rr-brand)',
@@ -272,6 +264,11 @@ const CARD_COLORS = [
 const HomeApp: React.FC<ShellAppProps> = ({ identity }) => {
 	const cm = ConnectionManager.getInstance();
 	const { appManifest, prefs, themeOptions, setTheme } = useWorkspace();
+
+	const activeTheme = useMemo(
+		() => themeOptions.find((t) => t.id === prefs.theme),
+		[themeOptions, prefs.theme],
+	);
 
 	// Filter out this app from the list — don't show ourselves
 	const apps = useMemo(
@@ -324,7 +321,7 @@ const HomeApp: React.FC<ShellAppProps> = ({ identity }) => {
 					<select
 						style={{
 							...styles.themeSelect,
-							colorScheme: themeColorScheme(prefs.theme),
+							colorScheme: activeTheme?.isDark ? 'dark' : 'light',
 						}}
 						value={prefs.theme}
 						onChange={(e) => setTheme(e.target.value)}

--- a/apps/hello-ui/src/HomeApp.tsx
+++ b/apps/hello-ui/src/HomeApp.tsx
@@ -226,14 +226,28 @@ const styles = {
 		padding: '7px 10px',
 		borderRadius: 6,
 		border: '1px solid var(--rr-border)',
-		backgroundColor: 'transparent',
-		color: 'var(--rr-text-secondary)',
+		backgroundColor: 'var(--rr-bg-input)',
+		color: 'var(--rr-text-primary)',
 		fontSize: 13,
 		fontFamily: 'var(--rr-font-family)',
 		cursor: 'pointer',
 		outline: 'none',
 	} as CSSProperties,
+
+	/** Theme option — match shell tokens so the native popup isn't white-on-dark. */
+	themeOption: {
+		backgroundColor: 'var(--rr-bg-paper)',
+		color: 'var(--rr-text-primary)',
+	} as CSSProperties,
 };
+
+/** Light themes for native control color-scheme (select popup). */
+function themeColorScheme(themeId: string): 'light' | 'dark' {
+	if (themeId === 'light' || themeId === 'rocketride-light' || themeId === 'visual-studio') {
+		return 'light';
+	}
+	return 'dark';
+}
 
 /** Accent colors cycled across app cards. */
 const CARD_COLORS = [
@@ -308,12 +322,15 @@ const HomeApp: React.FC<ShellAppProps> = ({ identity }) => {
 				{/* Theme picker */}
 				{themeOptions.length > 0 && (
 					<select
-						style={styles.themeSelect}
+						style={{
+							...styles.themeSelect,
+							colorScheme: themeColorScheme(prefs.theme),
+						}}
 						value={prefs.theme}
 						onChange={(e) => setTheme(e.target.value)}
 					>
 						{themeOptions.map((t) => (
-							<option key={t.id} value={t.id}>{t.name}</option>
+							<option key={t.id} value={t.id} style={styles.themeOption}>{t.name}</option>
 						))}
 					</select>
 				)}

--- a/apps/shell-ui/src/createShellConfig.ts
+++ b/apps/shell-ui/src/createShellConfig.ts
@@ -25,8 +25,13 @@
 // =============================================================================
 
 import { fetchAndApplyTheme } from 'shared/themes';
-import type { ShellConfig, ShellApiConfig, AppManifestEntry } from 'shell-ui';
+import type { ShellConfig, ShellApiConfig, AppManifestEntry, ShellThemeOption } from './workspace/types';
 import { ConnectionManager } from './connection/connection';
+import darkTokens from '../public/themes/dark.json';
+import grayTokens from '../public/themes/gray.json';
+import lightTokens from '../public/themes/light.json';
+import rocketrideTokens from '../public/themes/rocketride.json';
+import rocketrideLightTokens from '../public/themes/rocketride-light.json';
 
 // =============================================================================
 // API CONFIG — read from RR_* process.env defines (cloud only)
@@ -61,15 +66,24 @@ const API_CONFIG: ShellApiConfig = {
  * Ordered list of theme choices surfaced in the Shell's theme picker.
  *
  * Each entry maps a CSS theme bundle identifier (`id`) to a human-readable
- * display name (`name`).  The first entry (`rocketride-light`) is applied
- * as the default theme via `onInit`.
+ * display name (`name`). `isDark` is derived from the theme token file's
+ * `--rr-palette-mode` so new themes do not need hardcoded ID lists elsewhere.
+ * The first entry (`rocketride-light`) is applied as the default via `onInit`.
  */
-const THEME_OPTIONS = [
-	{ id: 'rocketride-light', name: 'RocketRide Light' },
-	{ id: 'light', name: 'Light' },
-	{ id: 'dark', name: 'Dark' },
-	{ id: 'gray', name: 'Gray' },
-	{ id: 'rocketride', name: 'RocketRide Dark' },
+function shellThemeOption(id: string, name: string, tokens: Record<string, string>): ShellThemeOption {
+	return {
+		id,
+		name,
+		isDark: tokens['--rr-palette-mode'] === 'dark',
+	};
+}
+
+const THEME_OPTIONS: ShellThemeOption[] = [
+	shellThemeOption('rocketride-light', 'RocketRide Light', rocketrideLightTokens),
+	shellThemeOption('light', 'Light', lightTokens),
+	shellThemeOption('dark', 'Dark', darkTokens),
+	shellThemeOption('gray', 'Gray', grayTokens),
+	shellThemeOption('rocketride', 'RocketRide Dark', rocketrideTokens),
 ];
 
 // =============================================================================

--- a/apps/shell-ui/src/workspace/WorkspaceContext.tsx
+++ b/apps/shell-ui/src/workspace/WorkspaceContext.tsx
@@ -27,7 +27,7 @@
 import React, { createContext, useContext, useCallback, useRef, useState, useEffect } from 'react';
 import { RocketRideClient } from 'rocketride';
 import { useWorkspaceState } from './useWorkspaceState';
-import type { WorkspacePrefs, AppDescriptor, AppManifestEntry } from './types';
+import type { WorkspacePrefs, AppDescriptor, AppManifestEntry, ShellThemeOption } from './types';
 import type { ShellConnectionEventMap } from 'shared';
 import { ConnectionManager } from '../connection/connection';
 
@@ -111,8 +111,8 @@ export interface IWorkspaceContext {
 	updateSetting: (key: string, value: string) => void;
 	/** Update the active app's workspace preferences. */
 	updatePrefs: (patch: Partial<WorkspacePrefs>) => void;
-	/** Available theme options (id + display name). */
-	themeOptions: { id: string; name: string }[];
+	/** Available theme options (id, display name, and palette mode). */
+	themeOptions: ShellThemeOption[];
 	/** Switch the active theme (updates prefs and applies CSS). */
 	setTheme: (themeId: string) => void;
 	/** @deprecated Use `updatePrefs` for prefs, `ConnectionManager.getInstance().emit('shell:switchApp')` for app switches. */
@@ -156,7 +156,7 @@ export const WorkspaceProvider: React.FC<{
 	startupAppId?: string;
 	children: React.ReactNode;
 	defaultAppId?: string;
-	themeOptions?: { id: string; name: string }[];
+	themeOptions?: ShellThemeOption[];
 	onThemeChange?: (themeId: string) => void;
 }> = ({ client, isConnected, apps, workspaceDir, startupAppId, defaultAppId: defaultAppIdProp, themeOptions: themeOptionsProp, onThemeChange, children }) => {
 	// Default app ID — use the prop from Shell (mode-aware), or fall back to hello.

--- a/apps/shell-ui/src/workspace/types.ts
+++ b/apps/shell-ui/src/workspace/types.ts
@@ -308,6 +308,8 @@ export interface ShellThemeOption {
 	id: string;
 	/** Human-readable display name (e.g. 'RocketRide Light'). */
 	name: string;
+	/** Whether the theme uses a dark palette (`--rr-palette-mode: dark`). */
+	isDark: boolean;
 }
 
 /**

--- a/packages/client-typescript/src/app-sdk/types.ts
+++ b/packages/client-typescript/src/app-sdk/types.ts
@@ -233,6 +233,8 @@ export interface ShellThemeOption {
 	id: string;
 	/** Human-readable display name. */
 	name: string;
+	/** Whether the theme uses a dark palette (`--rr-palette-mode: dark`). */
+	isDark: boolean;
 }
 
 /** Theme configuration supplied by the host app. */


### PR DESCRIPTION
## Summary

- Theme `<select>` on the OSS home page (`hello-ui`) now uses `--rr-bg-input` / `--rr-text-primary` instead of a transparent background.
- Sets `color-scheme` from the active theme so the native dropdown popup matches dark/light mode.
- Styles `<option>` elements with shell tokens so options are readable on dark themes.

## Type

- [x] Bug fix

## Testing

- [x] Tested locally, open http://localhost:5565, switch to RocketRide Dark, theme dropdown no longer shows a white popup
- [x] `./builder hello-ui:build --force` passes
- [ ] Tests added or updated

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1396 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved the theme picker to better reflect light and dark palette behavior, including more accurate active theme detection.
* **Bug Fixes**
  * Ensured the theme dropdown renders with consistent native styling, including correct light/dark color handling.
* **UI Improvements**
  * Added dedicated styling for individual theme options in the dropdown for a more consistent look across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->