### PR TITLE
feat(telemetry): shared report() for shell + VS Code (rocketride client)

### DIFF
--- a/apps/shell-ui/TELEMETRY.md
+++ b/apps/shell-ui/TELEMETRY.md
@@ -1,12 +1,17 @@
 # RocketRide Product Telemetry — What We Collect
 
-We use [PostHog](https://posthog.com) (Cloud) to understand how RocketRide apps are
-used so we can improve the product — e.g. see which nodes people run and invest
+We use [PostHog](https://posthog.com) (Cloud, US) to understand how RocketRide apps
+are used so we can improve the product — e.g. see which nodes people run and invest
 accordingly. This documents **exactly** what is and isn't collected (per the
-2026-07-01 telemetry review). Keep it in sync with `src/lib/telemetry.ts`.
+2026-07-01 telemetry review).
+
+The reporting logic is shared: it lives in the `rocketride` client
+(`packages/client-typescript/src/client/telemetry.ts`) so the **web shell** and the
+**VS Code extension** send events through the exact same path. This file documents
+the shell's use of it; keep the two in sync.
 
 ## What we collect
-- **Events** — explicit `report()` calls only (no autocapture). Product actions such as:
+- **Events** — explicit `report()` calls only. Product actions such as:
   - `pipeline:run` — a pipeline/canvas was run (the headline event).
   - `pipeline:node_add` / `pipeline:node_remove`, `app:open`, `auth:sign_in`.
 - **Structural metadata** on those events:
@@ -14,24 +19,26 @@ accordingly. This documents **exactly** what is and isn't collected (per the
     `http_request`), so we can see which nodes are popular. **Not** their configuration.
   - `node_count`, `duration_ms`, `status`, `surface` (`home_ui` / `vscode`).
 - **App context** (attached to every event): `app_id`, `app_name`, `app_version`.
-- **User identity** (signed-in users only): a stable user id from our IdP and,
-  minimally, `org_id`. `person_profiles: 'identified_only'` — anonymous visitors get
-  no profile.
+- **User identity**: a per-browser random `distinct_id`; once signed in, a stable
+  user id from our IdP and, minimally, `org_id`.
 
 ## What we do NOT collect
 - ❌ Pipeline configuration, node inputs/outputs, prompts, or any user content.
 - ❌ Files or data flowing through pipelines; credentials, API keys, tokens.
-- ❌ Session recordings / replays (`disable_session_recording: true`).
-- ❌ Autocaptured DOM text or form inputs (`autocapture: false`).
-- A client-side `before_send` sanitizer drops known PII / content property keys as a
-  backstop, even if one is passed by mistake.
+- ❌ **No autocapture and no session replay** — the transport only ever sends the
+  explicit events above (there is nothing that scrapes the DOM or records the screen).
+- A `sanitize()` step drops known PII / content property keys before send, as a
+  backstop even if one is passed by mistake.
 
 ## Opt-out
-Users can opt out of all telemetry; when opted out, PostHog stops all capture.
-`optOut()` / `optIn()` persist the choice per browser. **TODO (with Ryan):** surface a
-toggle in settings.
+- **Web shell**: `optOut()` / `optIn()` persist the choice per browser; when opted
+  out, nothing is sent.
+- **VS Code**: the extension wires the shared telemetry's `enabled` gate to
+  `vscode.env.isTelemetryEnabled`, so it follows the editor's telemetry setting.
 
 ## Ingestion
-Events are sent first-party through `https://e.rocketride.ai` — a CloudFront reverse
-proxy to PostHog Cloud — so they aren't blocked by ad-blockers and no third-party
-analytics domain is exposed. (Proxy: terraform `management/posthog-proxy.tf`.)
+Events are a direct HTTPS `POST` to `https://e.rocketride.ai/i/v0/e/` — a CloudFront
+reverse proxy to PostHog Cloud (terraform `management/posthog-proxy.tf`) — so they're
+first-party (ad-blocker-resistant) and no third-party analytics domain is exposed.
+The public project key (`phc_…`) is injected at build time via
+`ROCKETRIDE_POSTHOG_KEY`; unset (OSS/local) → telemetry is disabled.

--- a/apps/shell-ui/TELEMETRY.md
+++ b/apps/shell-ui/TELEMETRY.md
@@ -1,0 +1,37 @@
+# RocketRide Product Telemetry — What We Collect
+
+We use [PostHog](https://posthog.com) (Cloud) to understand how RocketRide apps are
+used so we can improve the product — e.g. see which nodes people run and invest
+accordingly. This documents **exactly** what is and isn't collected (per the
+2026-07-01 telemetry review). Keep it in sync with `src/lib/telemetry.ts`.
+
+## What we collect
+- **Events** — explicit `report()` calls only (no autocapture). Product actions such as:
+  - `pipeline:run` — a pipeline/canvas was run (the headline event).
+  - `pipeline:node_add` / `pipeline:node_remove`, `app:open`, `auth:sign_in`.
+- **Structural metadata** on those events:
+  - `node_types` — the **types** of nodes/providers used in a run (e.g. `llm_anthropic`,
+    `http_request`), so we can see which nodes are popular. **Not** their configuration.
+  - `node_count`, `duration_ms`, `status`, `surface` (`home_ui` / `vscode`).
+- **App context** (attached to every event): `app_id`, `app_name`, `app_version`.
+- **User identity** (signed-in users only): a stable user id from our IdP and,
+  minimally, `org_id`. `person_profiles: 'identified_only'` — anonymous visitors get
+  no profile.
+
+## What we do NOT collect
+- ❌ Pipeline configuration, node inputs/outputs, prompts, or any user content.
+- ❌ Files or data flowing through pipelines; credentials, API keys, tokens.
+- ❌ Session recordings / replays (`disable_session_recording: true`).
+- ❌ Autocaptured DOM text or form inputs (`autocapture: false`).
+- A client-side `before_send` sanitizer drops known PII / content property keys as a
+  backstop, even if one is passed by mistake.
+
+## Opt-out
+Users can opt out of all telemetry; when opted out, PostHog stops all capture.
+`optOut()` / `optIn()` persist the choice per browser. **TODO (with Ryan):** surface a
+toggle in settings.
+
+## Ingestion
+Events are sent first-party through `https://e.rocketride.ai` — a CloudFront reverse
+proxy to PostHog Cloud — so they aren't blocked by ad-blockers and no third-party
+analytics domain is exposed. (Proxy: terraform `management/posthog-proxy.tf`.)

--- a/apps/shell-ui/package.json
+++ b/apps/shell-ui/package.json
@@ -19,7 +19,6 @@
     "@stripe/stripe-js": "^5.5.0",
     "allotment": "^1.20.5",
     "lucide-react": "~0.460.0",
-    "posthog-js": "^1.190.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rocketride": "workspace:*",

--- a/apps/shell-ui/package.json
+++ b/apps/shell-ui/package.json
@@ -19,6 +19,7 @@
     "@stripe/stripe-js": "^5.5.0",
     "allotment": "^1.20.5",
     "lucide-react": "~0.460.0",
+    "posthog-js": "^1.190.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "rocketride": "workspace:*",

--- a/apps/shell-ui/src/bootstrap.tsx
+++ b/apps/shell-ui/src/bootstrap.tsx
@@ -25,6 +25,7 @@ import Shell from './components/layout/Shell';
 import type { AppManifestEntry } from './workspace/types';
 import { buildShellConfig } from './createShellConfig';
 import { registerAndMapApps } from './lib/appLoader';
+import { initTelemetry } from './lib/telemetry';
 
 // =============================================================================
 // BOOTSTRAP
@@ -40,6 +41,10 @@ import { registerAndMapApps } from './lib/appLoader';
  * 5. Renders the Shell React tree.
  */
 async function main() {
+	// Initialise product telemetry early. No-op unless the public PostHog project
+	// key is provided via the build env (unset for OSS/local builds → disabled).
+	initTelemetry(process.env.ROCKETRIDE_POSTHOG_KEY);
+
 	// Read the server URI from the build-time env define
 	const serverUri = process.env.ROCKETRIDE_URI || 'localhost:5565';
 

--- a/apps/shell-ui/src/lib/telemetry.ts
+++ b/apps/shell-ui/src/lib/telemetry.ts
@@ -1,123 +1,93 @@
-// RocketRide product telemetry — the shared "report" function.
-//
-// The shell initialises PostHog once; every micro-frontend app and the VS Code
-// extension call report() so we can see how our apps + nodes are actually used
-// (which nodes to drop vs beef up, run counts, etc.). Privacy-first: explicit
-// events only (no autocapture, no session replay), PII/content stripped before
-// send, honours opt-out. Exactly what is / isn't collected is documented in
+// Shell wrapper over the shared telemetry that lives in the `rocketride` client
+// (packages/client-typescript/src/client/telemetry.ts). All transport + privacy
+// logic lives in the shared module so the VS Code extension uses the exact same
+// report(); the shell just supplies a browser-persisted distinct id and a
+// localStorage-backed opt-out. What is / isn't collected is documented in
 // apps/shell-ui/TELEMETRY.md — keep the two in sync.
-//
-// Ingestion goes first-party through https://e.rocketride.ai (a CloudFront
-// reverse proxy to PostHog Cloud) so ad-blockers don't drop events.
 
-import posthog from 'posthog-js'
+import { telemetry, report } from 'rocketride'
 
-export type Surface = 'home_ui' | 'vscode' | (string & {})
+export { report }
+export { telemetryEvents as events } from 'rocketride'
 
-let started = false
+const DISTINCT_ID_KEY = 'rr_telemetry_id'
+const OPT_OUT_KEY = 'rr_telemetry_optout'
 
-// Backstop to the "only structural metadata, never config/content" rule: property
-// keys we never let leave the browser. Extend as the event schema grows.
-const PII_KEYS = new Set([
-  'email', 'name', 'first_name', 'last_name', 'phone', 'password', 'token',
-  'api_key', 'apikey', 'secret', 'authorization', 'content', 'config', 'value',
-  'input', 'output', 'prompt', 'text', 'body',
-])
-
-// before_send hook: drop known PII / free-content property keys before the event
-// leaves the client. We only ever want structural metadata (node types, counts…).
-function sanitize<T extends { properties?: Record<string, unknown> } | null>(payload: T): T {
-  const props = payload?.properties
-  if (props && typeof props === 'object') {
-    for (const k of Object.keys(props)) {
-      if (PII_KEYS.has(k.toLowerCase())) delete props[k]
+function browserDistinctId(): string {
+  try {
+    let id = localStorage.getItem(DISTINCT_ID_KEY)
+    if (!id) {
+      id = crypto.randomUUID()
+      localStorage.setItem(DISTINCT_ID_KEY, id)
     }
+    return id
+  } catch {
+    return crypto.randomUUID()
   }
-  return payload
+}
+
+/** Opt the current browser out of all telemetry (persists locally). */
+export function optOut(): void {
+  try {
+    localStorage.setItem(OPT_OUT_KEY, '1')
+  } catch {
+    /* ignore */
+  }
+}
+
+/** Opt back in. */
+export function optIn(): void {
+  try {
+    localStorage.removeItem(OPT_OUT_KEY)
+  } catch {
+    /* ignore */
+  }
+}
+
+export function hasOptedOut(): boolean {
+  try {
+    return localStorage.getItem(OPT_OUT_KEY) === '1'
+  } catch {
+    return false
+  }
 }
 
 /**
- * Initialise telemetry once, from the shell. No-op if already started, if no key
- * is configured (OSS / local), or on the server.
+ * Initialise telemetry once, from the shell. No-op unless the public PostHog
+ * project key is provided (unset for OSS/local builds → disabled). Honours the
+ * per-browser opt-out.
  *
- * @param apiKey  PostHog project API key (public — safe in the bundle).
- * @param apiHost first-party proxy; defaults to the CloudFront reverse proxy.
+ * @param apiKey  PostHog public project key (`phc_…`), injected at build time.
+ * @param apiHost first-party proxy; defaults to the CloudFront proxy.
  */
-export function initTelemetry(apiKey: string | undefined, apiHost = 'https://e.rocketride.ai'): void {
-  if (started || !apiKey || typeof window === 'undefined') return
-  posthog.init(apiKey, {
-    api_host: apiHost,
-    person_profiles: 'identified_only', // no profile for anonymous visitors
-    autocapture: false,                 // explicit report() events only — the canvas holds user data
-    disable_session_recording: true,    // never record pipelines / user content
-    capture_pageview: true,
-    before_send: sanitize,
-    // opt_out_capturing_by_default: true, // flip on if we require opt-in consent
+export function initTelemetry(apiKey: string | undefined, apiHost?: string): void {
+  if (typeof window === 'undefined') return
+  telemetry.configure({
+    apiKey,
+    apiHost,
+    distinctId: browserDistinctId(),
+    enabled: () => !hasOptedOut(),
   })
-  started = true
 }
 
 /** Attach app context so every event carries it (no need to pass the app each call). */
 export function registerApp(ctx: {
   appId: string
   appName?: string
-  surface?: Surface
+  surface?: string
   appVersion?: string
 }): void {
-  if (!started) return
-  posthog.register({
+  telemetry.register({
     app_id: ctx.appId,
     app_name: ctx.appName,
-    surface: ctx.surface,
+    surface: ctx.surface ?? 'home_ui',
     app_version: ctx.appVersion,
   })
 }
 
-/** Tie events to the signed-in user (id from our IdP). Keep person properties minimal. */
-export function identifyUser(userId: string, props?: { org_id?: string; plan?: string }): void {
-  if (!started || !userId) return
-  posthog.identify(userId, props)
-}
-
-/** Clear identity on sign-out. */
-export function resetTelemetry(): void {
-  if (started) posthog.reset()
-}
-
-/**
- * Report a product event. App context is added automatically (see registerApp).
- * Use PostHog `category:object_action` naming, e.g. 'pipeline:run'. Send ONLY
- * structural metadata (node types, counts, durations) — never node config,
- * pipeline content, or user data.
- */
-export function report(event: string, properties: Record<string, unknown> = {}): void {
-  if (!started) return
-  posthog.capture(event, properties)
-}
-
-/** Opt the current user out of all capture (required). Persists per browser. */
-export function optOut(): void {
-  if (started) posthog.opt_out_capturing()
-}
-
-/** Opt back in. */
-export function optIn(): void {
-  if (started) posthog.opt_in_capturing()
-}
-
-export function hasOptedOut(): boolean {
-  return started ? posthog.has_opted_out_capturing() : false
-}
-
-// -----------------------------------------------------------------------------
-// Canonical events (the ones called out in the 2026-07-01 telemetry review).
-// Ryan wires these into the canvas / node ops / app lifecycle. `node_types` is
-// the headline metric ("who uses which nodes") — TYPES ONLY, never config.
-// -----------------------------------------------------------------------------
-export const events = {
-  pipelineRun: (p: { node_types: string[]; node_count?: number; duration_ms?: number; status?: string }) =>
-    report('pipeline:run', p),
-  nodeAdd: (p: { node_type: string }) => report('pipeline:node_add', p),
-  nodeRemove: (p: { node_type: string }) => report('pipeline:node_remove', p),
-  appOpen: () => report('app:open'),
+/** Tie events to the signed-in user (id from our IdP). Keep person data minimal. */
+export function identifyUser(userId: string, props?: { org_id?: string }): void {
+  if (!userId) return
+  telemetry.identify(userId)
+  if (props?.org_id) telemetry.register({ org_id: props.org_id })
 }

--- a/apps/shell-ui/src/lib/telemetry.ts
+++ b/apps/shell-ui/src/lib/telemetry.ts
@@ -1,0 +1,123 @@
+// RocketRide product telemetry — the shared "report" function.
+//
+// The shell initialises PostHog once; every micro-frontend app and the VS Code
+// extension call report() so we can see how our apps + nodes are actually used
+// (which nodes to drop vs beef up, run counts, etc.). Privacy-first: explicit
+// events only (no autocapture, no session replay), PII/content stripped before
+// send, honours opt-out. Exactly what is / isn't collected is documented in
+// apps/shell-ui/TELEMETRY.md — keep the two in sync.
+//
+// Ingestion goes first-party through https://e.rocketride.ai (a CloudFront
+// reverse proxy to PostHog Cloud) so ad-blockers don't drop events.
+
+import posthog from 'posthog-js'
+
+export type Surface = 'home_ui' | 'vscode' | (string & {})
+
+let started = false
+
+// Backstop to the "only structural metadata, never config/content" rule: property
+// keys we never let leave the browser. Extend as the event schema grows.
+const PII_KEYS = new Set([
+  'email', 'name', 'first_name', 'last_name', 'phone', 'password', 'token',
+  'api_key', 'apikey', 'secret', 'authorization', 'content', 'config', 'value',
+  'input', 'output', 'prompt', 'text', 'body',
+])
+
+// before_send hook: drop known PII / free-content property keys before the event
+// leaves the client. We only ever want structural metadata (node types, counts…).
+function sanitize<T extends { properties?: Record<string, unknown> } | null>(payload: T): T {
+  const props = payload?.properties
+  if (props && typeof props === 'object') {
+    for (const k of Object.keys(props)) {
+      if (PII_KEYS.has(k.toLowerCase())) delete props[k]
+    }
+  }
+  return payload
+}
+
+/**
+ * Initialise telemetry once, from the shell. No-op if already started, if no key
+ * is configured (OSS / local), or on the server.
+ *
+ * @param apiKey  PostHog project API key (public — safe in the bundle).
+ * @param apiHost first-party proxy; defaults to the CloudFront reverse proxy.
+ */
+export function initTelemetry(apiKey: string | undefined, apiHost = 'https://e.rocketride.ai'): void {
+  if (started || !apiKey || typeof window === 'undefined') return
+  posthog.init(apiKey, {
+    api_host: apiHost,
+    person_profiles: 'identified_only', // no profile for anonymous visitors
+    autocapture: false,                 // explicit report() events only — the canvas holds user data
+    disable_session_recording: true,    // never record pipelines / user content
+    capture_pageview: true,
+    before_send: sanitize,
+    // opt_out_capturing_by_default: true, // flip on if we require opt-in consent
+  })
+  started = true
+}
+
+/** Attach app context so every event carries it (no need to pass the app each call). */
+export function registerApp(ctx: {
+  appId: string
+  appName?: string
+  surface?: Surface
+  appVersion?: string
+}): void {
+  if (!started) return
+  posthog.register({
+    app_id: ctx.appId,
+    app_name: ctx.appName,
+    surface: ctx.surface,
+    app_version: ctx.appVersion,
+  })
+}
+
+/** Tie events to the signed-in user (id from our IdP). Keep person properties minimal. */
+export function identifyUser(userId: string, props?: { org_id?: string; plan?: string }): void {
+  if (!started || !userId) return
+  posthog.identify(userId, props)
+}
+
+/** Clear identity on sign-out. */
+export function resetTelemetry(): void {
+  if (started) posthog.reset()
+}
+
+/**
+ * Report a product event. App context is added automatically (see registerApp).
+ * Use PostHog `category:object_action` naming, e.g. 'pipeline:run'. Send ONLY
+ * structural metadata (node types, counts, durations) — never node config,
+ * pipeline content, or user data.
+ */
+export function report(event: string, properties: Record<string, unknown> = {}): void {
+  if (!started) return
+  posthog.capture(event, properties)
+}
+
+/** Opt the current user out of all capture (required). Persists per browser. */
+export function optOut(): void {
+  if (started) posthog.opt_out_capturing()
+}
+
+/** Opt back in. */
+export function optIn(): void {
+  if (started) posthog.opt_in_capturing()
+}
+
+export function hasOptedOut(): boolean {
+  return started ? posthog.has_opted_out_capturing() : false
+}
+
+// -----------------------------------------------------------------------------
+// Canonical events (the ones called out in the 2026-07-01 telemetry review).
+// Ryan wires these into the canvas / node ops / app lifecycle. `node_types` is
+// the headline metric ("who uses which nodes") — TYPES ONLY, never config.
+// -----------------------------------------------------------------------------
+export const events = {
+  pipelineRun: (p: { node_types: string[]; node_count?: number; duration_ms?: number; status?: string }) =>
+    report('pipeline:run', p),
+  nodeAdd: (p: { node_type: string }) => report('pipeline:node_add', p),
+  nodeRemove: (p: { node_type: string }) => report('pipeline:node_remove', p),
+  appOpen: () => report('app:open'),
+}

--- a/packages/client-typescript/src/client/index.ts
+++ b/packages/client-typescript/src/client/index.ts
@@ -48,3 +48,7 @@ export * from './client.js';
 
 // Export the database API namespace (DatabaseApi class, DatabaseDialect enum)
 export * from './database.js';
+
+// Export shared product telemetry — report(), the `telemetry` singleton, and
+// canonical events. Used by both the web shell and the VS Code extension.
+export * from './telemetry.js';

--- a/packages/client-typescript/src/client/telemetry.ts
+++ b/packages/client-typescript/src/client/telemetry.ts
@@ -1,0 +1,174 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Shared product telemetry for RocketRide.
+ *
+ * Lives in the client SDK so BOTH the web shell and the VS Code extension use
+ * the exact same reporting path (per the 2026-07-01 telemetry review). Transport
+ * is a plain HTTPS POST to our first-party PostHog proxy (e.rocketride.ai), so it
+ * has no browser-only or Node-only dependency and behaves identically in the
+ * browser and in the extension host.
+ *
+ * Privacy-first: explicit events only (there is no autocapture or session
+ * replay by construction — we only ever send what a call site passes), PII /
+ * free-content property keys are stripped before send, and an `enabled` gate the
+ * host controls suppresses all capture when the user has opted out (the VS Code
+ * extension wires this to `vscode.env.isTelemetryEnabled`).
+ *
+ * Send ONLY structural metadata (node types, counts, durations) — never node
+ * config, pipeline content, or user data.
+ */
+
+export interface TelemetryConfig {
+	/** PostHog public project key (`phc_…`). Telemetry is a no-op without it. */
+	apiKey?: string;
+	/** First-party ingest host. Defaults to the CloudFront proxy. */
+	apiHost?: string;
+	/** Stable id for this user/device; the host supplies one it can persist. */
+	distinctId?: string;
+	/**
+	 * Gate the host controls — return `false` to suppress all capture. The VS
+	 * Code extension passes `() => vscode.env.isTelemetryEnabled`. Defaults to on.
+	 */
+	enabled?: () => boolean;
+}
+
+type Props = Record<string, unknown>;
+
+// Minimal local fetch typing so this compiles regardless of the SDK's tsconfig
+// `lib` (no dependency on the DOM lib). `fetch` is a runtime global in browsers
+// and in Node 18+ / the VS Code extension host.
+type FetchInit = {
+	method?: string;
+	headers?: Record<string, string>;
+	body?: string;
+	keepalive?: boolean;
+};
+type FetchFn = (input: string, init?: FetchInit) => Promise<unknown>;
+
+// Property keys we never let leave the process — a backstop to the
+// "structural metadata only, never config/content" rule.
+const PII_KEYS = new Set([
+	'email', 'name', 'first_name', 'last_name', 'phone', 'password', 'token',
+	'api_key', 'apikey', 'secret', 'authorization', 'content', 'config', 'value',
+	'input', 'output', 'prompt', 'text', 'body',
+]);
+
+function sanitize(props: Props): Props {
+	const out: Props = {};
+	for (const [k, v] of Object.entries(props)) {
+		if (!PII_KEYS.has(k.toLowerCase())) out[k] = v;
+	}
+	return out;
+}
+
+/**
+ * Framework-agnostic telemetry client. Hosts call {@link Telemetry.configure}
+ * once at startup, then {@link Telemetry.report} anywhere. A shared singleton
+ * ({@link telemetry}) and a free {@link report} function are exported below.
+ */
+export class Telemetry {
+	private apiKey?: string;
+	private apiHost = 'https://e.rocketride.ai';
+	private distinctId = 'anonymous';
+	private isEnabled: () => boolean = () => true;
+	private superProps: Props = {};
+	private ready = false;
+
+	/** Configure once per host. No-op (stays disabled) when no key is provided. */
+	configure(cfg: TelemetryConfig): void {
+		if (!cfg.apiKey) return;
+		this.apiKey = cfg.apiKey;
+		if (cfg.apiHost) this.apiHost = cfg.apiHost.replace(/\/+$/, '');
+		if (cfg.distinctId) this.distinctId = cfg.distinctId;
+		if (cfg.enabled) this.isEnabled = cfg.enabled;
+		this.ready = true;
+	}
+
+	/** Context sent with every event (app id/name, surface, version, org). */
+	register(props: Props): void {
+		this.superProps = { ...this.superProps, ...props };
+	}
+
+	/** Tie subsequent events to a signed-in user. */
+	identify(distinctId: string): void {
+		if (distinctId) this.distinctId = distinctId;
+	}
+
+	/**
+	 * Report a product event. Use PostHog `category:object_action` naming, e.g.
+	 * `pipeline:run`. Fire-and-forget; never throws and never blocks the app.
+	 */
+	report(event: string, properties: Props = {}): void {
+		if (!this.ready || !this.apiKey || !this.isEnabled()) return;
+		const f = (globalThis as { fetch?: FetchFn }).fetch;
+		if (!f) return;
+		const payload = {
+			api_key: this.apiKey,
+			event,
+			distinct_id: this.distinctId,
+			properties: { ...this.superProps, ...sanitize(properties) },
+			timestamp: new Date().toISOString(),
+		};
+		void f(`${this.apiHost}/i/v0/e/`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(payload),
+			keepalive: true,
+		}).catch(() => {
+			/* telemetry must never disrupt the app */
+		});
+	}
+
+	/** Whether capture is currently active (configured + keyed + not opted out). */
+	get active(): boolean {
+		return this.ready && !!this.apiKey && this.isEnabled();
+	}
+}
+
+/** Shared instance — configure once per host, then report from anywhere. */
+export const telemetry = new Telemetry();
+
+/** Convenience free function bound to the shared {@link telemetry} instance. */
+export function report(event: string, properties?: Props): void {
+	telemetry.report(event, properties);
+}
+
+/**
+ * Canonical events from the telemetry review. `node_types` is the headline
+ * node-usage metric — TYPES ONLY, never config.
+ */
+export const telemetryEvents = {
+	pipelineRun: (p: {
+		node_types: string[];
+		node_count?: number;
+		duration_ms?: number;
+		status?: string;
+		surface?: string;
+	}) => report('pipeline:run', p),
+	nodeAdd: (p: { node_type: string }) => report('pipeline:node_add', p),
+	nodeRemove: (p: { node_type: string }) => report('pipeline:node_remove', p),
+	appOpen: () => report('app:open'),
+};


### PR DESCRIPTION
**Shared telemetry `report()` for the web shell + VS Code extension** (Rod's 2026-07-01 telemetry review). Draft.

**What's here:**
- `packages/client-typescript/src/client/telemetry.ts` — a framework-agnostic `Telemetry` (configure / register / identify / report), a shared `telemetry` singleton, a free `report()`, and canonical `events` (`pipeline:run` with `node_types` — the headline node-usage metric). Transport is a direct HTTPS `POST` to `https://e.rocketride.ai/i/v0/e/` (the first-party PostHog proxy) — **no posthog-js**, so it runs identically in the browser and the Node extension host. Explicit events only (no autocapture / no session replay by construction); PII/content keys stripped before send; an `enabled()` gate the host controls.
- `apps/shell-ui/src/lib/telemetry.ts` — now a thin wrapper over the shared module: browser-persisted `distinct_id` + localStorage `optOut()/optIn()` wired to the gate. Bootstrap init unchanged. **posthog-js removed** from shell deps.
- `TELEMETRY.md` updated.

**For instrumentation (@Ryan):**
- Anywhere: `import { report } from 'rocketride'; report('pipeline:run', { node_types: [...] })`. Call `registerApp(...)` per app.
- **VS Code**: once, `telemetry.configure({ apiKey, distinctId: vscode.env.machineId, enabled: () => vscode.env.isTelemetryEnabled })` — this satisfies Rod's `isTelemetryEnabled` requirement.
- Deploy: set build env `ROCKETRIDE_POSTHOG_KEY=phc_…` (public project key; unset = disabled for OSS/local).

**Notes:** priority is the home UI (Rod). A `client.report()` convenience method on `RocketRideClient` (one-line delegate to the singleton) can be added if we prefer that call surface. Proxy is live (`e.rocketride.ai`). Before merge: `pnpm install` (lockfile) since posthog-js was dropped.