### PR TITLE
fix(engine): forward --node_path to task subprocess so workspace-local nodes load

### DIFF
--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1543,6 +1543,14 @@ class Task(DAPBase):
                         child_args.append(arg)
                         break
 
+            # Inherit parent engine's --node_path so workspace-local nodes load
+            # in the task subprocess too (Opt reads argv only, not the env).
+            if not any(a.startswith('--node_path=') for a in child_args):
+                for arg in startup_args():
+                    if arg.startswith('--node_path='):
+                        child_args.append(arg)
+                        break
+
             await self._send_status_update()
 
             # Launch subprocess - pass environment with account context for store access


### PR DESCRIPTION
## Summary

Workspace-local nodes loaded via `--node_path` (#1037) register in the `eaas` **server** process but fail at execution with `The service <node> was not found`, because each pipeline runs in a **per-task engine subprocess** that never receives `--node_path`.

`task_engine.py` builds the child's `child_args` and already forwards the parent's `--trace` (so tracing works in the child). It did not forward `--node_path`; and because `application::Opt` reads **argv only, not the environment**, the inherited environment cannot supply it. The child therefore skips the `<dir>/local_nodes/` scan and its service registry lacks the node.

## Fix

Forward the parent's `--node_path` to the per-task subprocess, mirroring the existing `--trace` forwarding (same idiom, same place):

```python
# Inherit parent engine's --node_path so workspace-local nodes load
# in the task subprocess too (Opt reads argv only, not the env).
if not any(a.startswith('--node_path=') for a in child_args):
    for arg in startup_args():
        if arg.startswith('--node_path='):
            child_args.append(arg)
            break
```

## Verification

- Reproduced: a `.pipe` referencing a workspace-local node failed with `The service <node> was not found`.
- Confirmed the parent server registers the node (`--trace=Services`: `Loading workspace-local nodes from …/local_nodes` → `Logical type: <node>`).
- Confirmed the failure originates in the per-task subprocess (`getServiceDefinition`), whose `child_args` lacked `--node_path`.
- Injecting `--node_path` into the child through the same `child_args` path (`use(args=["--node_path=<dir>"])`) makes an end-to-end pipeline that uses the local node succeed. This change makes that forwarding automatic, so no per-call workaround is needed.

## Scope / Compatibility

- Single, minimal change; mirrors the existing `--trace` forwarding.
- No behavior change when `--node_path` is not set on the parent.
- Platform-independent (subprocess argument forwarding).

Fixes #1433.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task startup so child tasks inherit the parent environment’s Node path when one isn’t explicitly set.
  * This helps tasks run with the correct workspace-local Node setup and makes task execution more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->