### PR TITLE
fix(vscode): repoint example links to repo pipelines (#1422)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://docs.rocketride.ai
+    url: https://docs.rocketride.org
     about: Check the docs for guides, API references, and examples.
   - name: Wiki
     url: https://github.com/rocketride-org/rocketride-server/wiki

--- a/apps/vscode/docs/index.md
+++ b/apps/vscode/docs/index.md
@@ -50,7 +50,7 @@ You build your `.pipe` - and you run it against the fastest AI runtime available
 - **Connection manager** - Connect to a local engine (one click, no setup) or your own on-premises server.
 - **SDKs for TypeScript, Python & MCP** - Embed pipelines in your apps or expose them as tools for AI assistants.
 
-Need inspiration? Check out our [example pipelines](https://github.com/rocketride-org/rocketride-server/tree/develop/examples):
+Need inspiration? Check out our [example pipelines](https://github.com/rocketride-org/awesome-rocketride):
 
 - [RAG Pipeline](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/rag-pipeline.pipe)
 - [Document Processor](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/document-processor.pipe)

--- a/apps/vscode/docs/index.md
+++ b/apps/vscode/docs/index.md
@@ -50,11 +50,11 @@ You build your `.pipe` - and you run it against the fastest AI runtime available
 - **Connection manager** - Connect to a local engine (one click, no setup) or your own on-premises server.
 - **SDKs for TypeScript, Python & MCP** - Embed pipelines in your apps or expose them as tools for AI assistants.
 
-Need inspiration? Check out our [example pipelines](https://docs.rocketride.org/):
+Need inspiration? Check out our [example pipelines](https://github.com/rocketride-org/rocketride-server/tree/develop/examples):
 
-- [Advanced RAG](https://docs.rocketride.org/examples/advanced-rag-pipeline/)
-- [Video Frame Grabber](https://docs.rocketride.org/examples/video-key-frame-grabber/)
-- [Audio Transcription](https://docs.rocketride.org/examples/audio-transcription-simple/)
+- [RAG Pipeline](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/rag-pipeline.pipe)
+- [Document Processor](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/document-processor.pipe)
+- [LlamaIndex Agent](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/agent-llamaindex.pipe)
 
 ## Extension Settings
 

--- a/docs/README-vscode.md
+++ b/docs/README-vscode.md
@@ -52,7 +52,7 @@ You build your `.pipe` - and you run it against the fastest AI runtime available
 - **Connection manager** - Connect to a local engine, Docker container, system service, on-premises server, or RocketRide Cloud. Separate development and deployment targets let you build locally and deploy to a different environment.
 - **SDKs for TypeScript, Python & MCP** - Embed pipelines in your apps or expose them as tools for AI assistants.
 
-Need inspiration? Check out our [example pipelines](https://github.com/rocketride-org/rocketride-server/tree/develop/examples):
+Need inspiration? Check out our [example pipelines](https://github.com/rocketride-org/awesome-rocketride):
 
 - [RAG Pipeline](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/rag-pipeline.pipe)
 - [Document Processor](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/document-processor.pipe)

--- a/docs/README-vscode.md
+++ b/docs/README-vscode.md
@@ -52,11 +52,11 @@ You build your `.pipe` - and you run it against the fastest AI runtime available
 - **Connection manager** - Connect to a local engine, Docker container, system service, on-premises server, or RocketRide Cloud. Separate development and deployment targets let you build locally and deploy to a different environment.
 - **SDKs for TypeScript, Python & MCP** - Embed pipelines in your apps or expose them as tools for AI assistants.
 
-Need inspiration? Check out our [example pipelines](https://docs.rocketride.org/):
+Need inspiration? Check out our [example pipelines](https://github.com/rocketride-org/rocketride-server/tree/develop/examples):
 
-- [Advanced RAG](https://docs.rocketride.org/examples/advanced-rag-pipeline/)
-- [Video Frame Grabber](https://docs.rocketride.org/examples/video-key-frame-grabber/)
-- [Audio Transcription](https://docs.rocketride.org/examples/audio-transcription-simple/)
+- [RAG Pipeline](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/rag-pipeline.pipe)
+- [Document Processor](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/document-processor.pipe)
+- [LlamaIndex Agent](https://github.com/rocketride-org/rocketride-server/blob/develop/examples/agent-llamaindex.pipe)
 
 ## Extension Settings
 


### PR DESCRIPTION
Replace broken docs.rocketride.org example URLs with working GitHub links to examples/*.pipe. Align issue template docs URL to .org domain.

## Summary

- Repoint VS Code extension example links from dead docs.rocketride.org/examples/* URLs to working GitHub links for real examples/*.pipe templates (rag-pipeline, document-processor, agent-llamaindex)
- Update both the marketplace README source (docs/README-vscode.md) and co-located extension docs (apps/vscode/docs/index.md)
- Align the GitHub issue template documentation contact link from docs.rocketride.ai to docs.rocketride.org

## Type
- [x]  Bug fix (non-breaking change which fixes an issue)

## Testing

- [ ] Tests added or updated (not needed for docs-only change)
- [x] Tested locally
- [ ] ./builder test passes (not required for markdown/config-only change)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1422 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation support contact link to the new docs domain.
  * Refreshed “Need inspiration?” example pipeline links in the VS Code docs to point to three GitHub-hosted `.pipe` files on the `develop` branch: RAG Pipeline, Document Processor, and LlamaIndex Agent.
  * Replaced the previous external example pipeline links with the repository-based equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->