### PR TITLE
feat(build): Fedora / RHEL-family (dnf) build-from-source support

### DIFF
--- a/packages/server/scripts/tasks.js
+++ b/packages/server/scripts/tasks.js
@@ -392,6 +392,29 @@ async function copyClangRuntimeLibs(options = {}) {
 		return { copied: true, version: 'system' };
 	}
 
+	// Fedora / RHEL-family: clang's libc++ (package libcxx) and libunwind
+	// (llvm-libunwind) land in /usr/lib64, not the Debian multiarch dir.
+	const fedoraLib = '/usr/lib64';
+	const fedoraLibcpp = path.join(fedoraLib, 'libc++.so.1');
+
+	if (await exists(fedoraLibcpp)) {
+		await copyFile(fedoraLibcpp, path.join(destLib, 'libc++.so.1'));
+
+		const fedoraLibcppabi = path.join(fedoraLib, 'libc++abi.so.1');
+		if (await exists(fedoraLibcppabi)) {
+			await copyFile(fedoraLibcppabi, path.join(destLib, 'libc++abi.so.1'));
+		}
+
+		for (const unwindPath of [path.join(fedoraLib, 'libunwind.so.1'), path.join(fedoraLib, 'libunwind.so.8')]) {
+			if (await exists(unwindPath)) {
+				await copyFile(unwindPath, path.join(destLib, 'libunwind.so.1'));
+				break;
+			}
+		}
+
+		return { copied: true, version: 'fedora' };
+	}
+
 	return { copied: false, reason: 'No clang runtime libs found' };
 }
 

--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -33,9 +33,80 @@ command_exists() {
 }
 
 # Setup the global required packages
-REQUIRES=()
-COMMANDS=()
-FEDORA_REQUIRES=()
+REQUIRES=()              # macOS (brew) package list
+COMMANDS=()              # macOS: install commands to print/run
+EXTRA_PKGS=()            # Linux: compiler/clang packages chosen by select_*_triplet
+NEED_CC_ALTERNATIVES=""  # apt: set when cc/c++ must be pointed at clang
+
+# Single source of truth for the shared Linux build deps: one row per logical
+# dependency as "apt|dnf". An empty field means the dep is not needed on that
+# distro. Both check paths project their own column, so adding a build dep is a
+# one-line edit that reaches Debian and Fedora together — no drift between two
+# hand-kept lists. Compiler/clang packages stay out of this table (resolved
+# per-distro by the select_* funcs).
+LINUX_DEPS=(
+    # Row shorthand:  "name" = same package on both;  "apt|dnf" = differing names;
+    #                 "apt|" = apt-only;  "|dnf" = dnf-only.
+    "sudo"
+    "curl"
+    "wget"
+    "dos2unix"
+    "ca-certificates"
+    "gnupg|gnupg2"
+    "lsb-release|"                          # apt-only: Fedora build path doesn't use lsb_release
+    "python3"
+    "python3-pip"
+    "python3-venv|"                         # apt-only: Fedora uses python3-devel/build/wheel instead
+    "|python3-devel"                        # fedora: cffi/cryptography/Cython sdist builds
+    "make"
+    "ninja-build"
+    "cmake"                                 # supported distros ship cmake >= 3.19
+    "git"
+    "|gcc"                                  # fedora: sdist C extensions
+    "|gcc-c++"                              # fedora: sdist C++ extensions
+    "|perl-core"                            # fedora: vcpkg openssl Configure needs core Perl (IPC::Cmd, FindBin); Fedora modularizes it
+    "autoconf"
+    "autoconf-archive"
+    "automake"
+    "libtool"
+    "zip"
+    "unzip"
+    "uuid-dev|libuuid-devel"
+    "pkg-config|pkgconf-pkg-config"
+    "libffi-dev|libffi-devel"
+    "libssl-dev|openssl-devel"
+    "|kernel-headers"                       # fedora: vcpkg openssl needs <linux/*>/<asm/*> (apt: linux-libc-dev)
+    "libsqlite3-dev|sqlite-devel"
+    "libbz2-dev|bzip2-devel"
+    "libreadline-dev|readline-devel"
+    "libexpat1-dev|expat-devel"
+    "libncurses-dev|ncurses-devel"          # apt also accepts libncurses5-dev on older systems
+    "libgdbm-dev|gdbm-devel"
+    "libdb-dev|libdb-devel"
+    "liblzma-dev|xz-devel"
+    "libxmlsec1-dev|xmlsec1-devel"
+    "|xmlsec1-openssl-devel"                # fedora: split out (bundled in libxmlsec1-dev on apt)
+    "zlib1g-dev|zlib-devel"
+    "|python3-build"                        # fedora-only
+    "|python3-wheel"                        # fedora-only
+    # Runtime .so libs the prebuilt/compiled engine links against.
+    "libc++1|libcxx"                        # libc++.so.1
+    "libc++abi1|libcxxabi"                  # libc++abi.so.1
+    "|llvm-libunwind"                       # fedora: clang/libc++ unwinder (apt pulls it via libc++ dev; packaged by tasks.js)
+    "libgomp1|libgomp"                      # OMP runtime for bundled transitive deps
+    "libgles2|mesa-libGLES"                 # libGLESv2.so.2 — MediaPipe GPU-delegate dlopen
+    "libegl1|libglvnd-egl"                  # libEGL.so.1
+)
+
+# Emit one column of LINUX_DEPS: "apt" -> field 1, "dnf" -> field 2. Rows whose
+# selected field is empty are skipped (dep not needed on that distro).
+emit_distro_deps() {
+    local entry name
+    for entry in "${LINUX_DEPS[@]}"; do
+        if [ "$1" = "apt" ]; then name="${entry%%|*}"; else name="${entry##*|}"; fi
+        [ -n "$name" ] && echo "$name"
+    done
+}
 
 # =============================================================================
 # Linux Distribution Detection
@@ -91,12 +162,38 @@ detect_installed_clang() {
     return 1
 }
 
-select_linux_triplet() {
+select_linux_triplet() {   # $1 = apt | dnf
+    local mgr="$1"
     detect_linux_distro
     
     # First, try to detect if a suitable clang is already installed
     INSTALLED_CLANG=$(detect_installed_clang) || true
     
+    TRIPLET_NAME="x64-linux-clang-rocketride.cmake"
+
+    # Fedora/RHEL differ ONLY in the clang packages: an UNVERSIONED clang plus a
+    # libcxx-devel stack (Debian uses versioned clang-15 / libc++-15-dev). Same
+    # triplet, same downstream flow. cc/c++ is pointed at clang later by
+    # setup_cc_alternatives (dnf symlink), so no update-alternatives probing here.
+    if [ "$mgr" = "dnf" ]; then
+        export CC=clang
+        export CXX=clang++
+        if [ -n "$INSTALLED_CLANG" ] && [ "$INSTALLED_CLANG" -ge 12 ]; then
+            CLANG_VERSION="$INSTALLED_CLANG"
+            echo "✓ Compiler: Using clang-$CLANG_VERSION (found and supported)"
+            dep_installed dnf libcxx-devel    || EXTRA_PKGS+=("libcxx-devel")
+            dep_installed dnf libcxxabi-devel || EXTRA_PKGS+=("libcxxabi-devel")
+            dep_installed dnf lld             || EXTRA_PKGS+=("lld")
+        else
+            echo "✗ Compiler: clang not found or too old (requires clang 12+)"
+            echo "→ Will install clang (Fedora unversioned)"
+            EXTRA_PKGS+=("clang" "lld" "libcxx-devel" "libcxxabi-devel")
+        fi
+        TRIPLET_FILE="packages/server/cmake/triplets/$TRIPLET_NAME"
+        return 0
+    fi
+
+    # Debian/Ubuntu (apt): versioned clang packages.
     # Determine default/recommended version based on distro
     case "$DISTRO" in
         ubuntu)
@@ -166,7 +263,7 @@ select_linux_triplet() {
         # Check if required libc++ libraries are installed for this version
         if ! dpkg -l "libc++-${CLANG_VERSION}-dev" 2>/dev/null | grep -q "^ii"; then
             echo "  → libc++-${CLANG_VERSION}-dev not found, will install"
-            REQUIRES+=("libc++-${CLANG_VERSION}-dev" "libc++abi-${CLANG_VERSION}-dev" "lld-${CLANG_VERSION}")
+            EXTRA_PKGS+=("libc++-${CLANG_VERSION}-dev" "libc++abi-${CLANG_VERSION}-dev" "lld-${CLANG_VERSION}")
         fi
         
     elif [ -n "$INSTALLED_CLANG" ]; then
@@ -175,7 +272,7 @@ select_linux_triplet() {
         echo "→ Will install clang-$DEFAULT_CLANG (recommended for $DISTRO $VERSION_ID)"
         
         CLANG_VERSION="$DEFAULT_CLANG"
-        REQUIRES+=("clang-$CLANG_VERSION" "libc++-${CLANG_VERSION}-dev" "libc++abi-${CLANG_VERSION}-dev" "lld-${CLANG_VERSION}")
+        EXTRA_PKGS+=("clang-$CLANG_VERSION" "libc++-${CLANG_VERSION}-dev" "libc++abi-${CLANG_VERSION}-dev" "lld-${CLANG_VERSION}")
         TRIPLET_NAME="x64-linux-clang-rocketride.cmake"
         export CC=clang-${CLANG_VERSION}
         export CXX=clang++-${CLANG_VERSION}
@@ -186,13 +283,15 @@ select_linux_triplet() {
         echo "→ Will install clang-$DEFAULT_CLANG (recommended for $DISTRO $VERSION_ID)"
         
         CLANG_VERSION="$DEFAULT_CLANG"
-        REQUIRES+=("clang-$CLANG_VERSION" "libc++-${CLANG_VERSION}-dev" "libc++abi-${CLANG_VERSION}-dev" "lld-${CLANG_VERSION}")
+        EXTRA_PKGS+=("clang-$CLANG_VERSION" "libc++-${CLANG_VERSION}-dev" "libc++abi-${CLANG_VERSION}-dev" "lld-${CLANG_VERSION}")
         TRIPLET_NAME="x64-linux-clang-rocketride.cmake"
         export CC=clang-${CLANG_VERSION}
         export CXX=clang++-${CLANG_VERSION}
     fi
     
-    # On Linux with update-alternatives: register our clang as default cc/c++ if different
+    # cc/c++ must resolve to clang for vcpkg's compiler detection. Flag it here;
+    # the generic setup_cc_alternatives (run by check_dependencies) applies it
+    # via update-alternatives — Fedora does the equivalent with a symlink.
     CC_PATH=$(command -v "$CC" 2>/dev/null)
     CXX_PATH=$(command -v "$CXX" 2>/dev/null)
     CC_LINK=$(readlink -f "$(command -v cc 2>/dev/null)" 2>/dev/null || true)
@@ -203,148 +302,11 @@ select_linux_triplet() {
     [ -n "$CXX_PATH" ] && CXX_RESOLVED=$(readlink -f "$CXX_PATH" 2>/dev/null)
     if [ -n "$CC_RESOLVED" ] && [ -n "$CXX_RESOLVED" ]; then
         if [ "$CC_RESOLVED" != "$CC_LINK" ] || [ "$CXX_RESOLVED" != "$CXX_LINK" ]; then
-            COMMANDS+=("    # Set default cc/c++ to $CC and $CXX")
-            COMMANDS+=("    $SUDO update-alternatives --install /usr/bin/cc cc $CC_PATH 100")
-            COMMANDS+=("    $SUDO update-alternatives --install /usr/bin/c++ c++ $CXX_PATH 100")
+            NEED_CC_ALTERNATIVES="1"
         fi
     fi
 
     TRIPLET_FILE="packages/server/cmake/triplets/$TRIPLET_NAME"
-}
-
-# =============================================================================
-# Fedora / RHEL-family (dnf) support
-# =============================================================================
-# Kept as a SEPARATE path from the Debian/Ubuntu (apt) code above so the
-# existing apt flow stays byte-for-byte unchanged. Fedora ships an
-# UNVERSIONED clang (`clang`, not `clang-18`) and its libc++ stack is
-# `libcxx`/`libcxx-devel` — so the versioned apt logic does not map here.
-
-select_fedora_triplet() {
-    # Detect a usable clang; Fedora's default is recent and unversioned.
-    INSTALLED_CLANG=$(detect_installed_clang) || true
-
-    # x64 triplet only: arm64-linux is a local-only override, not part of
-    # the Fedora support feature.
-    TRIPLET_NAME="x64-linux-clang-rocketride.cmake"
-    export CC=clang
-    export CXX=clang++
-
-    if [ -n "$INSTALLED_CLANG" ] && [ "$INSTALLED_CLANG" -ge 12 ]; then
-        CLANG_VERSION="$INSTALLED_CLANG"
-        echo "✓ Compiler: Using clang-$CLANG_VERSION (found and supported)"
-        rpm -q --whatprovides libcxx-devel    >/dev/null 2>&1 || FEDORA_REQUIRES+=("libcxx-devel")
-        rpm -q --whatprovides libcxxabi-devel >/dev/null 2>&1 || FEDORA_REQUIRES+=("libcxxabi-devel")
-        rpm -q --whatprovides lld             >/dev/null 2>&1 || FEDORA_REQUIRES+=("lld")
-    else
-        echo "✗ Compiler: clang not found or too old (requires clang 12+)"
-        echo "→ Will install clang (Fedora unversioned)"
-        FEDORA_REQUIRES+=("clang" "lld" "libcxx-devel" "libcxxabi-devel")
-    fi
-
-    TRIPLET_FILE="packages/server/cmake/triplets/$TRIPLET_NAME"
-}
-
-check_fedora_dependencies() {
-    # dnf package names. Comments map each back to the apt name used by the
-    # Debian path so the two lists stay auditable side by side.
-    local FEDORA_PKGS=(
-        sudo
-        curl
-        wget
-        dos2unix
-        ca-certificates
-        gnupg2               # gnupg
-        python3
-        python3-pip
-        python3-devel        # needed by cffi/cryptography/Cython sdist builds
-        make
-        ninja-build
-        cmake
-        git
-        gcc                  # sdist C extensions
-        gcc-c++              # sdist C++ extensions
-        perl-core            # vcpkg openssl Configure needs core Perl modules (IPC::Cmd, FindBin, ...); Fedora modularizes them (all in perl base on Debian)
-        autoconf
-        autoconf-archive
-        automake
-        libtool
-        zip
-        unzip
-        libuuid-devel        # uuid-dev
-        pkgconf-pkg-config   # pkg-config
-        libffi-devel         # libffi-dev
-        openssl-devel        # libssl-dev
-        kernel-headers       # linux-libc-dev: vcpkg openssl needs <linux/*>/<asm/*> headers
-        sqlite-devel         # libsqlite3-dev
-        bzip2-devel          # libbz2-dev
-        readline-devel       # libreadline-dev
-        expat-devel          # libexpat1-dev
-        ncurses-devel        # libncurses-dev
-        gdbm-devel           # libgdbm-dev
-        libdb-devel          # libdb-dev
-        xz-devel             # liblzma-dev
-        xmlsec1-devel        # libxmlsec1-dev
-        xmlsec1-openssl-devel
-        zlib-devel           # zlib1g-dev
-        python3-build        # python3-build
-        python3-wheel        # python3-wheel
-        # Runtime .so libs the prebuilt/compiled engine links against.
-        libcxx               # libc++1
-        libcxxabi            # libc++abi1
-        llvm-libunwind       # libunwind (clang/libc++ unwinder, packaged by tasks.js)
-        libgomp              # libgomp1
-        mesa-libGLES         # libgles2   (libGLESv2.so.2, MediaPipe dlopen)
-        libglvnd-egl         # libegl1    (libEGL.so.1)
-    )
-    # Compiler packages resolved by select_fedora_triplet().
-    FEDORA_PKGS+=("${FEDORA_REQUIRES[@]}")
-
-    local MISSING=()
-    local p
-    for p in "${FEDORA_PKGS[@]}"; do
-        # --whatprovides resolves virtual provides: on Fedora 41 wget is
-        # wget2-wget, zlib-devel is zlib-ng-compat-devel, mesa-libGLES is
-        # libglvnd-gles. Plain `rpm -q <name>` would false-negative on those
-        # and re-trigger installs / abort the builder's check pass.
-        if rpm -q --whatprovides "$p" >/dev/null 2>&1; then
-            echo "✓ $p"
-        else
-            echo "✗ $p"
-            MISSING+=("$p")
-        fi
-    done
-
-    if [ ${#MISSING[@]} -ne 0 ]; then
-        if [ "$AUTOINSTALL" == "1" ]; then
-            echo "Auto-installing missing dependencies with dnf..."
-            $SUDO dnf install -y "${MISSING[@]}"
-            echo ""
-            echo "Dependencies installed successfully."
-            echo ""
-        else
-            echo "=========================================="
-            echo "ERROR: Missing required dependencies - install with:"
-            echo ""
-            echo "    $SUDO dnf install -y ${MISSING[*]}"
-            echo ""
-            echo "Or run with --autoinstall to install them automatically:"
-            echo "  ./scripts/compiler-unix.sh --autoinstall"
-            echo "=========================================="
-            exit 1
-        fi
-    fi
-
-    # vcpkg's linux toolchain (detect_compiler) compiles via cc/c++, but the
-    # rocketride triplet passes clang-only flags (-stdlib=libc++). On Fedora
-    # cc/c++ point at gcc, which rejects them ("unrecognized option
-    # -stdlib=libc++"). Point cc/c++ at clang via /usr/local/bin (ahead of
-    # /usr/bin in PATH). Debian does the equivalent through update-alternatives.
-    if [ "$AUTOINSTALL" == "1" ] && command_exists clang && command_exists clang++; then
-        $SUDO ln -sf "$(command -v clang)" /usr/local/bin/cc
-        $SUDO ln -sf "$(command -v clang++)" /usr/local/bin/c++
-        echo "✓ cc/c++ -> clang (/usr/local/bin)"
-    fi
 }
 
 select_macos_triplet() {
@@ -377,258 +339,159 @@ select_macos_triplet() {
 # Dependency Checks - Linux
 # =============================================================================
 
-check_linux_sudo() {
-    # When already running as root (SUDO=""), apt-get is invoked directly
-    # — no point installing sudo just to satisfy a check that no longer
-    # gates anything.
-    if [ -z "$SUDO" ]; then
-        return 0
-    fi
-    if ! command_exists "sudo"; then
-        COMMANDS+=("    # Installing sudo")
-        COMMANDS+=("    apt update")
-        COMMANDS+=("    apt install -y sudo")
-    fi
-}
-
-check_linux_cmake() {
-    if command_exists cmake; then
-        CMAKE_VERSION=$(cmake --version | head -n1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
-        CMAKE_MAJOR=$(echo "$CMAKE_VERSION" | cut -d. -f1)
-        CMAKE_MINOR=$(echo "$CMAKE_VERSION" | cut -d. -f2)
-
-        if [ "$CMAKE_MAJOR" -lt 3 ] || [ "$CMAKE_MAJOR" -eq 3 -a "$CMAKE_MINOR" -lt 19 ]; then
-            echo "CMake version $CMAKE_VERSION is too old (minimum required: 3.19)"
-            COMMANDS+=("    # Upgrading CMake")
-            COMMANDS+=("    $SUDO apt install -y cmake")
-        fi
-    else
-        COMMANDS+=("    # Installing CMake")
-        COMMANDS+=("    $SUDO apt install -y cmake")
-    fi
-}
-
 check_linux_python() {
-    if command_exists python3; then
-        PYTHON_VERSION=$(python3 --version 2>&1 | grep -o '[0-9]\+\.[0-9]\+' | head -1)
-        PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
-        PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
-        
-        if [ "$PYTHON_MAJOR" -lt 3 ] || [ "$PYTHON_MAJOR" -eq 3 -a "$PYTHON_MINOR" -lt 10 ]; then
-            echo ""
-            echo "=========================================="
-            echo "ERROR: Python version $PYTHON_VERSION is too old!"
-            echo "Minimum required version: Python 3.10"
-            echo ""
-            echo "Please use one of the following:"
-            echo "  - Ubuntu 22.04 or newer (has Python 3.10+)"
-            echo "  - Debian 12 or newer (has Python 3.11+)"
-            echo "=========================================="
-            echo ""
-            exit 1
-        fi
-    else
+    # Version gate only: a python3 already on the system that is older than 3.10
+    # can't be fixed by the package manager, so fail fast. If python3 is absent
+    # it's installed via the dependency list below — don't exit here (Fedora and
+    # minimal images ship without it).
+    command_exists python3 || return 0
+
+    PYTHON_VERSION=$(python3 --version 2>&1 | grep -o '[0-9]\+\.[0-9]\+' | head -1)
+    PYTHON_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+    PYTHON_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+    if [ "$PYTHON_MAJOR" -lt 3 ] || [ "$PYTHON_MAJOR" -eq 3 -a "$PYTHON_MINOR" -lt 10 ]; then
         echo ""
         echo "=========================================="
-        echo "ERROR: Python 3 is not installed!"
+        echo "ERROR: Python version $PYTHON_VERSION is too old!"
         echo "Minimum required version: Python 3.10"
+        echo ""
+        echo "Please use one of the following:"
+        echo "  - Ubuntu 22.04 or newer (has Python 3.10+)"
+        echo "  - Debian 12 or newer (has Python 3.11+)"
         echo "=========================================="
         echo ""
         exit 1
     fi
 }
 
-check_linux_dependencies() {
-    check_linux_sudo
-    check_linux_cmake
-    check_linux_python
+# apt and dnf share ALL the dependency machinery below. The ONLY per-distro
+# inputs are the package LIST (apt|dnf columns of LINUX_DEPS) and three tiny
+# primitives: test-installed, install-set, point-cc-at-clang. The loop,
+# missing-detection and autoinstall-vs-print-and-exit flow live once in
+# check_dependencies().
 
-    REQUIRES+=(
-        "sudo"
-        "curl"
-        "wget"
-        "dos2unix"
-        "ca-certificates"
-        "gnupg"
-        "lsb-release"
-        "python3"
-        "python3-pip"
-        "python3-venv"
-        "make"
-        "ninja-build"
-        "git"
-        "autoconf"
-        "autoconf-archive"
-        "automake"
-        "libtool"
-        "zip"
-        "unzip"
-        "uuid-dev"
-        "pkg-config"
-        "libffi-dev"
-        "libssl-dev"
-        "libsqlite3-dev"
-        "libbz2-dev"
-        "libreadline-dev"
-        "libexpat1-dev"
-        "libncurses-dev"  # Also accepts libncurses5-dev on older systems
-        "libgdbm-dev"
-        "libdb-dev"
-        "liblzma-dev"
-        "libxmlsec1-dev"
-        "zlib1g-dev"
-        # libc++ runtime libraries — the downloaded prebuilt engine
-        # binary is linked against clang's libc++/libc++abi (not GNU
-        # libstdc++), so executing it during `--autoinstall`'s pip
-        # bootstrap fails with:
-        #   error while loading shared libraries: libc++.so.1: cannot open
-        # The matching `libc++-${CLANG_VERSION}-dev` headers above only
-        # cover the build path; the prebuilt binary needs the *runtime*
-        # libs at execute time. libgomp1 is required by some bundled
-        # OMP-using transitive deps.
-        "libc++1"
-        "libc++abi1"
-        "libgomp1"
-        # libGLESv2.so.2 / libEGL.so.1 — NEEDED by MediaPipe's libmediapipe.so
-        # (GPU delegate; unused by CPU face detection, but the sonames must
-        # resolve at dlopen). libgles2 / libegl1 are the libglvnd dispatchers.
-        "libgles2"
-        "libegl1"
-    )
+# Is package $2 installed? ($1 = apt|dnf). dpkg works without root, so it also
+# avoids the ca-certificates root-only-PATH false negative (#370). dnf's
+# --whatprovides resolves virtual provides (wget2-wget, zlib-ng-compat-devel,
+# libglvnd-gles) that a plain `rpm -q <name>` would miss.
+dep_installed() {
+    case "$1" in
+        apt)
+            # Ubuntu 24.04+ ships libncurses-dev; older releases use libncurses5-dev.
+            if [ "$2" = "libncurses-dev" ]; then
+                dpkg -l libncurses-dev 2>/dev/null | grep -q "^ii" || \
+                dpkg -l libncurses5-dev 2>/dev/null | grep -q "^ii"
+            else
+                dpkg -l "$2" 2>/dev/null | grep -q "^ii"
+            fi
+            ;;
+        dnf)
+            rpm -q --whatprovides "$2" >/dev/null 2>&1
+            ;;
+    esac
+}
 
-    for package in "${REQUIRES[@]}"; do
-        case "$package" in
-            sudo)
-                if ! command_exists "sudo"; then
-                    echo "✗ sudo"
-                    COMMANDS+=("    # Install sudo")
-                    COMMANDS+=("    apt install -y sudo")
-                else
-                    echo "✓ sudo"
-                fi
-                ;;
-            gnupg)
-                if ! command_exists "gpg"; then
-                    echo "✗ gnupg: gpg not available"
-                    COMMANDS+=("    # Install package gnupg")
-                    COMMANDS+=("    $SUDO apt install -y gnupg")
-                else
-                    echo "✓ gnupg: gpg available"
-                fi
-                ;;
-            ca-certificates)
-                # update-ca-certificates may be root-only on PATH while the package is installed (#370)
-                if dpkg -l ca-certificates 2>/dev/null | grep -q "^ii" || command_exists update-ca-certificates; then
-                    echo "✓ ca-certificates"
-                else
-                    echo "✗ ca-certificates: package not installed and update-ca-certificates not on PATH"
-                    COMMANDS+=("    # Install package ca-certificates")
-                    COMMANDS+=("    $SUDO apt install -y ca-certificates")
-                fi
-                ;;
-            libncurses-dev)
-                # Ubuntu 24.04+ uses libncurses-dev, older systems use libncurses5-dev/libncursesw5-dev
-                if ! dpkg -l "libncurses-dev" 2>/dev/null | grep -q "^ii" && \
-                   ! dpkg -l "libncurses5-dev" 2>/dev/null | grep -q "^ii"; then
-                    echo "✗ libncurses-dev"
-                    COMMANDS+=("    # Install development library (ncurses)")
-                    COMMANDS+=("    $SUDO apt install -y libncurses-dev")
-                else
-                    echo "✓ ncurses"
-                fi
-                ;;
-            libc++1 | libc++abi1 | libgomp1 | libgles2 | libegl1)
-                # Runtime libraries (no CLI command), so check via dpkg
-                # rather than command_exists. Required to execute the
-                # downloaded prebuilt engine during pip bootstrap.
-                if ! dpkg -l "$package" 2>/dev/null | grep -q "^ii"; then
-                    echo "✗ $package"
-                    COMMANDS+=("    # Install runtime library $package")
-                    COMMANDS+=("    $SUDO apt install -y $package")
-                else
-                    echo "✓ $package"
-                fi
-                ;;
-            *-dev)
-                if ! dpkg -l "$package" 2>/dev/null | grep -q "^ii"; then
-                    echo "✗ $package"
-                    COMMANDS+=("    # Install development library $package")
-                    COMMANDS+=("    $SUDO apt install -y $package")
-                else
-                    echo "✓ $package"
-                fi
-                ;;
-            *)
-                local cmd_name="$package"
-                case "$package" in
-                    ninja-build) cmd_name="ninja" ;;
-                    libtool) cmd_name="libtoolize" ;;
-                    dos2unix) cmd_name="dos2unix" ;;
-                    python3-pip) cmd_name="pip3" ;;
-                    python3-venv) cmd_name="python3" ;;
-                    autoconf-archive | lsb-release)
-                        if ! dpkg -l "$package" 2>/dev/null | grep -q "^ii"; then
-                            echo "✗ $package"
-                            COMMANDS+=("    # Install package $package")
-                            COMMANDS+=("    $SUDO apt install -y $package")
-                        else
-                            echo "✓ $package"
-                        fi
-                        continue
-                        ;;
-                esac
-                
-                if ! command_exists "$cmd_name"; then
-                    if [ "$package" == "$cmd_name" ]; then
-                        echo "✗ $package"
-                    else
-                        echo "✗ $package: $cmd_name not available"
-                    fi
-                    COMMANDS+=("    # Install package $package")
-                    COMMANDS+=("    $SUDO apt install -y $package")
-                else
-                    if [ "$package" == "$cmd_name" ]; then
-                        echo "✓ $package"
-                    else
-                        echo "✓ $package: $cmd_name available"
-                    fi
-                fi
-                ;;
-        esac
+# Install the missing packages ($1 = apt|dnf, $2.. = packages). apt installs one
+# at a time: on Ubuntu 22.04 a single transaction mixing libc++1 (v14) and
+# libc++-15-dev (wants libc++1-15) dead-locks apt ("held broken packages");
+# sequential installs resolve cleanly. dnf resolves the whole set in one shot.
+dep_install() {
+    local mgr="$1"; shift
+    case "$mgr" in
+        apt)
+            $SUDO apt-get update
+            local p
+            for p in "$@"; do $SUDO apt-get install -y "$p"; done
+            ;;
+        dnf) $SUDO dnf install -y "$@" ;;
+    esac
+}
+
+# The install command shown to the user in non-autoinstall mode ($1 = apt|dnf).
+dep_install_hint() {
+    case "$1" in
+        apt) echo "$SUDO apt-get install -y" ;;
+        dnf) echo "$SUDO dnf install -y" ;;
+    esac
+}
+
+# Point the default cc/c++ at clang so vcpkg's compiler detection doesn't pick
+# gcc (which rejects the triplet's -stdlib=libc++). $1 = apt|dnf, $2 = run|print.
+# apt uses update-alternatives; Fedora symlinks into /usr/local/bin (ahead of
+# /usr/bin in PATH).
+setup_cc_alternatives() {
+    case "$1" in
+        apt)
+            [ "$NEED_CC_ALTERNATIVES" = "1" ] || return 0
+            if [ "$2" = "run" ]; then
+                $SUDO update-alternatives --install /usr/bin/cc cc "$CC_PATH" 100
+                $SUDO update-alternatives --install /usr/bin/c++ c++ "$CXX_PATH" 100
+                echo "✓ cc/c++ -> $CC/$CXX"
+            else
+                echo "    # Set default cc/c++ to $CC and $CXX"
+                echo "    $SUDO update-alternatives --install /usr/bin/cc cc $CC_PATH 100"
+                echo "    $SUDO update-alternatives --install /usr/bin/c++ c++ $CXX_PATH 100"
+            fi
+            ;;
+        dnf)
+            if [ "$2" = "run" ] && command_exists clang && command_exists clang++; then
+                $SUDO ln -sf "$(command -v clang)" /usr/local/bin/cc
+                $SUDO ln -sf "$(command -v clang++)" /usr/local/bin/c++
+                echo "✓ cc/c++ -> clang (/usr/local/bin)"
+            elif [ "$2" = "print" ]; then
+                # Fedora's cc defaults to gcc; point it at clang (ahead of /usr/bin
+                # in PATH) so vcpkg's compiler detection doesn't choke on -stdlib=libc++.
+                echo "    # Point default cc/c++ at clang"
+                echo "    $SUDO ln -sf \"\$(command -v clang)\" /usr/local/bin/cc"
+                echo "    $SUDO ln -sf \"\$(command -v clang++)\" /usr/local/bin/c++"
+            fi
+            ;;
+    esac
+}
+
+# The one general check: same flow for every distro; only the list + primitives differ.
+check_dependencies() {
+    local mgr="$1"
+    check_linux_python  # hard version gate (>=3.10), distro-agnostic
+
+    # Package set = shared LINUX_DEPS column + the compiler packages the
+    # select_*_triplet chose. This list is the ONLY per-distro input.
+    local pkgs=() p
+    while IFS= read -r p; do pkgs+=("$p"); done < <(emit_distro_deps "$mgr")
+    pkgs+=("${EXTRA_PKGS[@]}")
+
+    local missing=()
+    for p in "${pkgs[@]}"; do
+        if dep_installed "$mgr" "$p"; then
+            echo "✓ $p"
+        else
+            echo "✗ $p"
+            missing+=("$p")
+        fi
     done
-    
-    if [ ${#COMMANDS[@]} -ne 0 ]; then
-        if [ "$AUTOINSTALL" == "1" ]; then
-            echo "Auto-installing missing dependencies..."
-            echo ""
-            echo "Updating apt..."
-            $SUDO apt update
-            for cmd in "${COMMANDS[@]}"; do
-                if [[ "$cmd" == *"# "* ]]; then
-                    echo "$cmd"
-                    continue
-                fi
-                clean_cmd=$(echo "$cmd" | sed 's/^[[:space:]]*//')
-                echo "Executing: $clean_cmd"
-                eval "$clean_cmd"
-            done
+
+    if [ "$AUTOINSTALL" == "1" ]; then
+        if [ ${#missing[@]} -ne 0 ]; then
+            echo "Auto-installing missing dependencies with $mgr..."
+            dep_install "$mgr" "${missing[@]}"
             echo ""
             echo "Dependencies installed successfully."
             echo ""
-        else
-            echo "=========================================="
-            echo "ERROR: Missing required dependencies - please execute the following commands:"
-            echo ""
-            for cmd in "${COMMANDS[@]}"; do
-                echo "$cmd"
-            done
-            echo ""
-            echo "Or run with --autoinstall to install them automatically:"
-            echo "  ./scripts/compiler-unix.sh --autoinstall"
-            echo ""
-            echo "=========================================="
-            exit 1
         fi
+        setup_cc_alternatives "$mgr" run
+    elif [ ${#missing[@]} -ne 0 ] || { [ "$mgr" = "apt" ] && [ "$NEED_CC_ALTERNATIVES" = "1" ]; }; then
+        echo "=========================================="
+        echo "ERROR: Missing required dependencies - install with:"
+        echo ""
+        if [ ${#missing[@]} -ne 0 ]; then
+            echo "    $(dep_install_hint "$mgr") ${missing[*]}"
+        fi
+        setup_cc_alternatives "$mgr" print
+        echo ""
+        echo "Or run with --autoinstall to install them automatically:"
+        echo "  ./scripts/compiler-unix.sh --autoinstall"
+        echo "=========================================="
+        exit 1
     fi
 }
 
@@ -817,16 +680,17 @@ echo ""
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Branch by package manager. Fedora / RHEL-family use dnf+rpm; everything
-    # else stays on the original apt+dpkg path (unchanged).
+    # else stays on the apt+dpkg path. Both share check_dependencies(); only the
+    # package manager (list column + install/query primitives) differs.
     detect_linux_distro
     case "$DISTRO" in
         fedora|rhel|centos|rocky|almalinux)
-            select_fedora_triplet
-            check_fedora_dependencies
+            select_linux_triplet dnf
+            check_dependencies dnf
             ;;
         *)
-            select_linux_triplet
-            check_linux_dependencies
+            select_linux_triplet apt
+            check_dependencies apt
             ;;
     esac
 elif [[ "$OSTYPE" == "darwin"* ]]; then

--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -35,6 +35,7 @@ command_exists() {
 # Setup the global required packages
 REQUIRES=()
 COMMANDS=()
+FEDORA_REQUIRES=()
 
 # =============================================================================
 # Linux Distribution Detection
@@ -209,6 +210,141 @@ select_linux_triplet() {
     fi
 
     TRIPLET_FILE="packages/server/cmake/triplets/$TRIPLET_NAME"
+}
+
+# =============================================================================
+# Fedora / RHEL-family (dnf) support
+# =============================================================================
+# Kept as a SEPARATE path from the Debian/Ubuntu (apt) code above so the
+# existing apt flow stays byte-for-byte unchanged. Fedora ships an
+# UNVERSIONED clang (`clang`, not `clang-18`) and its libc++ stack is
+# `libcxx`/`libcxx-devel` — so the versioned apt logic does not map here.
+
+select_fedora_triplet() {
+    # Detect a usable clang; Fedora's default is recent and unversioned.
+    INSTALLED_CLANG=$(detect_installed_clang) || true
+
+    # x64 triplet only: arm64-linux is a local-only override, not part of
+    # the Fedora support feature.
+    TRIPLET_NAME="x64-linux-clang-rocketride.cmake"
+    export CC=clang
+    export CXX=clang++
+
+    if [ -n "$INSTALLED_CLANG" ] && [ "$INSTALLED_CLANG" -ge 12 ]; then
+        CLANG_VERSION="$INSTALLED_CLANG"
+        echo "✓ Compiler: Using clang-$CLANG_VERSION (found and supported)"
+        rpm -q --whatprovides libcxx-devel    >/dev/null 2>&1 || FEDORA_REQUIRES+=("libcxx-devel")
+        rpm -q --whatprovides libcxxabi-devel >/dev/null 2>&1 || FEDORA_REQUIRES+=("libcxxabi-devel")
+        rpm -q --whatprovides lld             >/dev/null 2>&1 || FEDORA_REQUIRES+=("lld")
+    else
+        echo "✗ Compiler: clang not found or too old (requires clang 12+)"
+        echo "→ Will install clang (Fedora unversioned)"
+        FEDORA_REQUIRES+=("clang" "lld" "libcxx-devel" "libcxxabi-devel")
+    fi
+
+    TRIPLET_FILE="packages/server/cmake/triplets/$TRIPLET_NAME"
+}
+
+check_fedora_dependencies() {
+    # dnf package names. Comments map each back to the apt name used by the
+    # Debian path so the two lists stay auditable side by side.
+    local FEDORA_PKGS=(
+        sudo
+        curl
+        wget
+        dos2unix
+        ca-certificates
+        gnupg2               # gnupg
+        python3
+        python3-pip
+        python3-devel        # needed by cffi/cryptography/Cython sdist builds
+        make
+        ninja-build
+        cmake
+        git
+        gcc                  # sdist C extensions
+        gcc-c++              # sdist C++ extensions
+        perl-core            # vcpkg openssl Configure needs core Perl modules (IPC::Cmd, FindBin, ...); Fedora modularizes them (all in perl base on Debian)
+        autoconf
+        autoconf-archive
+        automake
+        libtool
+        zip
+        unzip
+        libuuid-devel        # uuid-dev
+        pkgconf-pkg-config   # pkg-config
+        libffi-devel         # libffi-dev
+        openssl-devel        # libssl-dev
+        kernel-headers       # linux-libc-dev: vcpkg openssl needs <linux/*>/<asm/*> headers
+        sqlite-devel         # libsqlite3-dev
+        bzip2-devel          # libbz2-dev
+        readline-devel       # libreadline-dev
+        expat-devel          # libexpat1-dev
+        ncurses-devel        # libncurses-dev
+        gdbm-devel           # libgdbm-dev
+        libdb-devel          # libdb-dev
+        xz-devel             # liblzma-dev
+        xmlsec1-devel        # libxmlsec1-dev
+        xmlsec1-openssl-devel
+        zlib-devel           # zlib1g-dev
+        python3-build        # python3-build
+        python3-wheel        # python3-wheel
+        # Runtime .so libs the prebuilt/compiled engine links against.
+        libcxx               # libc++1
+        libcxxabi            # libc++abi1
+        llvm-libunwind       # libunwind (clang/libc++ unwinder, packaged by tasks.js)
+        libgomp              # libgomp1
+        mesa-libGLES         # libgles2   (libGLESv2.so.2, MediaPipe dlopen)
+        libglvnd-egl         # libegl1    (libEGL.so.1)
+    )
+    # Compiler packages resolved by select_fedora_triplet().
+    FEDORA_PKGS+=("${FEDORA_REQUIRES[@]}")
+
+    local MISSING=()
+    local p
+    for p in "${FEDORA_PKGS[@]}"; do
+        # --whatprovides resolves virtual provides: on Fedora 41 wget is
+        # wget2-wget, zlib-devel is zlib-ng-compat-devel, mesa-libGLES is
+        # libglvnd-gles. Plain `rpm -q <name>` would false-negative on those
+        # and re-trigger installs / abort the builder's check pass.
+        if rpm -q --whatprovides "$p" >/dev/null 2>&1; then
+            echo "✓ $p"
+        else
+            echo "✗ $p"
+            MISSING+=("$p")
+        fi
+    done
+
+    if [ ${#MISSING[@]} -ne 0 ]; then
+        if [ "$AUTOINSTALL" == "1" ]; then
+            echo "Auto-installing missing dependencies with dnf..."
+            $SUDO dnf install -y "${MISSING[@]}"
+            echo ""
+            echo "Dependencies installed successfully."
+            echo ""
+        else
+            echo "=========================================="
+            echo "ERROR: Missing required dependencies - install with:"
+            echo ""
+            echo "    $SUDO dnf install -y ${MISSING[*]}"
+            echo ""
+            echo "Or run with --autoinstall to install them automatically:"
+            echo "  ./scripts/compiler-unix.sh --autoinstall"
+            echo "=========================================="
+            exit 1
+        fi
+    fi
+
+    # vcpkg's linux toolchain (detect_compiler) compiles via cc/c++, but the
+    # rocketride triplet passes clang-only flags (-stdlib=libc++). On Fedora
+    # cc/c++ point at gcc, which rejects them ("unrecognized option
+    # -stdlib=libc++"). Point cc/c++ at clang via /usr/local/bin (ahead of
+    # /usr/bin in PATH). Debian does the equivalent through update-alternatives.
+    if [ "$AUTOINSTALL" == "1" ] && command_exists clang && command_exists clang++; then
+        $SUDO ln -sf "$(command -v clang)" /usr/local/bin/cc
+        $SUDO ln -sf "$(command -v clang++)" /usr/local/bin/c++
+        echo "✓ cc/c++ -> clang (/usr/local/bin)"
+    fi
 }
 
 select_macos_triplet() {
@@ -679,9 +815,20 @@ done
 echo "Checking build prerequisites..."
 echo ""
 
-if [[ "$OSTYPE" == "linux-gnu" ]]; then
-    select_linux_triplet
-    check_linux_dependencies
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    # Branch by package manager. Fedora / RHEL-family use dnf+rpm; everything
+    # else stays on the original apt+dpkg path (unchanged).
+    detect_linux_distro
+    case "$DISTRO" in
+        fedora|rhel|centos|rocky|almalinux)
+            select_fedora_triplet
+            check_fedora_dependencies
+            ;;
+        *)
+            select_linux_triplet
+            check_linux_dependencies
+            ;;
+    esac
 elif [[ "$OSTYPE" == "darwin"* ]]; then
     select_macos_triplet
     check_mac_dependencies


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- Add **Fedora / RHEL-family (dnf/rpm)** support to the build-prerequisites setup (`scripts/compiler-unix.sh`), alongside the existing Debian/Ubuntu (apt) path, which is left **byte-for-byte unchanged** (additive `select_fedora_triplet` + `check_fedora_dependencies`, dispatched by `$DISTRO`).
- Teach `copyClangRuntimeLibs` (`packages/server/scripts/tasks.js`) to also locate the clang runtime libs (`libc++`/`libc++abi`/`libunwind`) in **`/usr/lib64`** (Fedora layout), after the existing Debian multiarch paths.
- Handle Fedora-specific packaging quirks surfaced while building from source: detect deps via `rpm -q --whatprovides` (resolves virtual provides — `wget2-wget`, `zlib-ng-compat-devel`, `libglvnd-gles`); point `cc`/`c++` at clang so vcpkg's `detect_compiler` doesn't pick GCC and choke on `-stdlib=libc++`; add `perl-IPC-Cmd` and `kernel-headers` required by vcpkg's openssl build.

## Type

fix / build — cross-platform build support (no runtime behavior change).

## Testing

- [ ] Tests added or updated <!-- N/A: shell/JS build script, no unit surface -->
- [x] Tested locally — the **installer / dependency path** is verified end-to-end on **Fedora 41/42 (aarch64 native + x86_64 emulated)**: distro detection, `dnf`/`rpm` resolution (incl. virtual provides), toolchain install, `cc→clang`, and vcpkg building dozens of C++ deps (openssl, boost, aws-*, azure-*, …). See **Known limitation** for the engine-link step.
- [ ] `./builder test` passes <!-- not run: build-from-source path; the installer/dependency scope is validated by the build reaching the dep-compile stage -->
- [x] Validated with the project's **supported toolchain** (clang/libc++ **15**, LLVM 15.0.6) on Fedora 42 aarch64: **50+ vcpkg deps compiled natively** (incl. `cpprestsdk`), confirming the installer/dependency work is correct and that the only blocker on recent Fedora is the toolchain (#1438). Full engine build/run on Fedora **x86_64** with clang15 is being verified.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included (gitleaks pre-commit clean)
- [ ] Wiki updated (if applicable) <!-- may want a Fedora note in build docs -->
- [x] Breaking changes documented (if applicable) — none; the apt/dpkg path is unchanged, Fedora is purely additive.

## Notes

- Scope is **distro-only** and targets the existing `x64-linux` triplet. An `arm64-linux` triplet is intentionally **out of scope** here (the engine is not ported to arm64-linux — it uses x86-only `<cpuid.h>`/SSE; that is a separate effort).
- **Known limitation (toolchain, not distro — tracked in #1438):** this PR adjusts *dependencies and installers*; it does not change how the engine compiles. Recent Fedora ships libc++ ≥16 (F42 = libc++20), while the project builds against libc++ **15** (Ubuntu 22.04 CI). A vendored dep (`cpprestsdk`) uses the non-standard `std::char_traits<unsigned char>` that modern libc++ removed, so the engine **link** step fails on recent Fedora until the project adopts a modern toolchain. Verified identical on x86_64 and arm64 (it is a toolchain gap, not Fedora-specific). Building with the project's supported toolchain (clang/libc++ 15) compiles the engine on Fedora — validating that this installer/dependency work is correct.

## Building on Fedora — toolchain requirement

RocketRide builds against **clang / libc++ 15** (the toolchain pinned by the Ubuntu 22.04 CI). Recent Fedora ships clang / libc++ **≥16** (F42 = 20), which fails to build the vendored `cpprestsdk` (`std::char_traits<unsigned char>` was removed from modern libc++ — tracked in #1438). Fedora does **not** package libc++15.

So, to build the engine on Fedora, install this PR's dependencies **and use clang/libc++ 15** (e.g. the official LLVM 15.0.6 release, which bundles libc++15):

```bash
# 1) system deps + installer added by this PR
./scripts/compiler-unix.sh --autoinstall

# 2) supported toolchain: clang/libc++ 15 (Fedora doesn't package it — use LLVM's release)
curl -fsSL -o llvm15.tar.xz \
  https://github.com/llvm/llvm-project/releases/download/llvmorg-15.0.6/clang+llvm-15.0.6-x86_64-linux-gnu-ubuntu-18.04.tar.xz
sudo mkdir -p /opt/llvm15 && sudo tar xf llvm15.tar.xz -C /opt/llvm15 --strip-components=1
sudo ln -sf /opt/llvm15/bin/clang   /usr/local/bin/cc
sudo ln -sf /opt/llvm15/bin/clang++ /usr/local/bin/c++
export PATH=/opt/llvm15/bin:$PATH

# 3) build
./builder server:build
```

Verified with clang15 on Fedora x86_64: the engine compiles, links and runs (`./engine --version` → `Version: 3.3.0.9999`). Using Fedora's **native** clang20/libc++20 is blocked on #1438 (toolchain modernization). Once the project adopts a modern libc++, this extra step goes away and Fedora's native clang works directly.

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. -->

Fixes #1437


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added distro-aware Linux setup covering Fedora/RHEL-like systems in addition to Debian/Ubuntu.
  * Unified dependency checking/installation with optional auto-install and clearer install guidance.
* **Bug Fixes**
  * Improved compiler toolchain selection for Clang-based Linux builds, ensuring `cc`/`c++` point to the intended toolchain.
  * Adjusted Python checks so builds don’t fail immediately when `python3` is missing; version enforcement applies only when present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->