### PR TITLE
fix(llm_ollama): auto-configure reasoning models (temperature + reasoning_effort)

### DIFF
--- a/nodes/src/nodes/llm_ollama/README.md
+++ b/nodes/src/nodes/llm_ollama/README.md
@@ -6,7 +6,7 @@ A RocketRide LLM node that routes pipeline traffic through a locally-hosted Olla
 
 Provides text generation against an Ollama server running on your own hardware. The node acts as an `llm` invoke connection for agents and other nodes that need an LLM, and can also be driven directly via its `questions` / `answers` lane pair. Because all inference happens on-premise, no external API key is required, making it a natural fit for privacy-sensitive or air-gapped deployments.
 
-Internally, the node talks to Ollama through its **OpenAI-compatible `/v1` endpoint** using **langchain-openai** (`ChatOpenAI`), with temperature fixed at `0`. If the configured `serverbase` URL does not end in `/v1`, the node appends it automatically, so both `http://localhost:11434` and `http://localhost:11434/v1` are accepted. The OpenAI client requires a non-empty API key field; the node sends the placeholder string `dummy-key`, which Ollama ignores.
+Internally, the node talks to Ollama through its **OpenAI-compatible `/v1` endpoint** using **langchain-openai** (`ChatOpenAI`). `temperature` is configurable (default `0`; reasoning models such as `gpt-oss` auto-use `1.0` when it is left unset), and `reasoning_effort` can be set for reasoning models. If the configured `serverbase` URL does not end in `/v1`, the node appends it automatically, so both `http://localhost:11434` and `http://localhost:11434/v1` are accepted. The OpenAI client requires a non-empty API key field; the node sends the placeholder string `dummy-key`, which Ollama ignores.
 
 ---
 

--- a/nodes/src/nodes/llm_ollama/README.md
+++ b/nodes/src/nodes/llm_ollama/README.md
@@ -95,6 +95,8 @@ Pick a profile from the dropdown; the profile pre-fills `model`, `serverbase`, a
 | `model` | `string` | **Model**<br/>Ollama model |  |
 | `modelTotalTokens` | `number` | **Tokens**<br/>Total Tokens |  |
 | `ollama.profile` | `string` | **Model**<br/>LLM model | `"llama3_3"` |
+| `reasoning_effort` | `string` | **Reasoning Effort**<br/>Optional reasoning budget for reasoning models: low, medium, or high. Leave unset to let reasoning models auto-use 'low'; a value set here always wins. Ignored by non-reasoning models. |  |
+| `temperature` | `number` | **Temperature**<br/>Sampling temperature. Defaults to 0 for standard models; reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) auto-use 1.0 when this is left unset so they emit a final answer instead of looping on empty output. Set an explicit value here to override the auto behavior. | `0` |
 
 ## Dependencies
 

--- a/nodes/src/nodes/llm_ollama/README.md
+++ b/nodes/src/nodes/llm_ollama/README.md
@@ -96,7 +96,7 @@ Pick a profile from the dropdown; the profile pre-fills `model`, `serverbase`, a
 | `modelTotalTokens` | `number` | **Tokens**<br/>Total Tokens |  |
 | `ollama.profile` | `string` | **Model**<br/>LLM model | `"llama3_3"` |
 | `reasoning_effort` | `string` | **Reasoning Effort**<br/>Optional reasoning budget for reasoning models: low, medium, or high. Leave unset to let reasoning models auto-use 'low'; a value set here always wins. Ignored by non-reasoning models. |  |
-| `temperature` | `number` | **Temperature**<br/>Sampling temperature. Defaults to 0 for standard models; reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) auto-use 1.0 when this is left unset so they emit a final answer instead of looping on empty output. Set an explicit value here to override the auto behavior. | `0` |
+| `temperature` | `number` | **Temperature**<br/>Sampling temperature. Left unset by default so ollama.py can choose: 0 for standard models, and 1.0 for reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) so they emit a final answer instead of looping on empty output. Set an explicit value here to override the auto behavior. |  |
 
 ## Dependencies
 

--- a/nodes/src/nodes/llm_ollama/ollama.py
+++ b/nodes/src/nodes/llm_ollama/ollama.py
@@ -38,6 +38,10 @@ class Chat(ChatBase):
 
     _llm: ChatOpenAI
 
+    # Ollama reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) detected by name.
+    # They need a non-zero temperature so they emit a final answer instead of empty content.
+    REASONING_HINTS = ('gpt-oss', 'deepseek-r1', 'qwen3', 'qwq', 'magistral', '-thinking')
+
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
         """
         Initialize the ollama chat bot.
@@ -63,9 +67,8 @@ class Chat(ChatBase):
         # the model name, then default to a non-zero temperature + low reasoning_effort so they
         # emit the final answer. Both are overridable from the pipe config; non-reasoning models
         # (llama/qwen2.5/mistral) keep temperature 0 and send no reasoning_effort.
-        reasoning_hints = ('gpt-oss', 'deepseek-r1', 'qwen3', 'qwq', 'magistral', '-thinking')
         model_name = (self._model or '').lower()
-        is_reasoning = bool(self._is_reasoning) or any(hint in model_name for hint in reasoning_hints)
+        is_reasoning = bool(self._is_reasoning) or any(hint in model_name for hint in self.REASONING_HINTS)
 
         temperature = config['temperature'] if 'temperature' in config else (1.0 if is_reasoning else 0)
         if 'reasoning_effort' in config:

--- a/nodes/src/nodes/llm_ollama/ollama.py
+++ b/nodes/src/nodes/llm_ollama/ollama.py
@@ -57,9 +57,31 @@ class Chat(ChatBase):
         if not serverbase.rstrip('/').endswith('/v1'):
             serverbase = serverbase.rstrip('/') + '/v1'
 
+        # Reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) loop at temperature 0 and
+        # spend the whole output budget on hidden reasoning, returning empty content — which
+        # breaks expectJson agent steps. Detect them via the stamped reasoning capability or
+        # the model name, then default to a non-zero temperature + low reasoning_effort so they
+        # emit the final answer. Both are overridable from the pipe config; non-reasoning models
+        # (llama/qwen2.5/mistral) keep temperature 0 and send no reasoning_effort.
+        reasoning_hints = ('gpt-oss', 'deepseek-r1', 'qwen3', 'qwq', 'magistral', '-thinking')
+        model_name = (self._model or '').lower()
+        is_reasoning = bool(self._is_reasoning) or any(hint in model_name for hint in reasoning_hints)
+
+        temperature = config['temperature'] if 'temperature' in config else (1.0 if is_reasoning else 0)
+        if 'reasoning_effort' in config:
+            reasoning_effort = config.get('reasoning_effort')
+        else:
+            reasoning_effort = 'low' if is_reasoning else None
+        model_kwargs = {'reasoning_effort': reasoning_effort} if reasoning_effort else {}
+
         # Get the llm
         self._llm = ChatOpenAI(
-            model=self._model, base_url=serverbase, api_key=apikey, temperature=0, max_tokens=self._modelOutputTokens
+            model=self._model,
+            base_url=serverbase,
+            api_key=apikey,
+            temperature=temperature,
+            max_tokens=self._modelOutputTokens,
+            model_kwargs=model_kwargs,
         )
 
         # Save our chat class into the bag

--- a/nodes/src/nodes/llm_ollama/services.json
+++ b/nodes/src/nodes/llm_ollama/services.json
@@ -237,9 +237,21 @@
 			"title": "Tokens",
 			"description": "Total Tokens"
 		},
+		"temperature": {
+			"type": "number",
+			"title": "Temperature",
+			"description": "Sampling temperature. Defaults to 0 for standard models; reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) auto-use 1.0 when this is left unset so they emit a final answer instead of looping on empty output. Set an explicit value here to override the auto behavior.",
+			"default": 0
+		},
+		"reasoning_effort": {
+			"type": "string",
+			"title": "Reasoning Effort",
+			"description": "Optional reasoning budget for reasoning models: low, medium, or high. Leave unset to let reasoning models auto-use 'low'; a value set here always wins. Ignored by non-reasoning models.",
+			"enum": ["low", "medium", "high"]
+		},
 		"ollama.custom": {
 			"object": "custom",
-			"properties": ["model", "modelTotalTokens", "llm.local.serverbase"]
+			"properties": ["model", "modelTotalTokens", "temperature", "reasoning_effort", "llm.local.serverbase"]
 		},
 		"ollama.llama3_3": {
 			"object": "llama3_3",

--- a/nodes/src/nodes/llm_ollama/services.json
+++ b/nodes/src/nodes/llm_ollama/services.json
@@ -240,8 +240,7 @@
 		"temperature": {
 			"type": "number",
 			"title": "Temperature",
-			"description": "Sampling temperature. Defaults to 0 for standard models; reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) auto-use 1.0 when this is left unset so they emit a final answer instead of looping on empty output. Set an explicit value here to override the auto behavior.",
-			"default": 0
+			"description": "Sampling temperature. Left unset by default so ollama.py can choose: 0 for standard models, and 1.0 for reasoning models (gpt-oss, deepseek-r1, qwen3, qwq, ...) so they emit a final answer instead of looping on empty output. Set an explicit value here to override the auto behavior."
 		},
 		"reasoning_effort": {
 			"type": "string",


### PR DESCRIPTION
## Summary

- `llm_ollama` hardcoded `temperature=0`, which makes Ollama **reasoning** models (`gpt-oss`, `deepseek-r1`, `qwen3`, `qwq`, …) loop and return **empty `content`**, breaking any `expectJson`/agent step with `Failed to get valid JSON response`.
- Auto-detect reasoning models — via the existing `capabilities.reasoning` flag or a model-name heuristic — and default them to `temperature=1.0` + `reasoning_effort=low` so they emit their final answer.
- Both `temperature` and `reasoning_effort` are now overridable from config. **Non-reasoning models (llama, qwen2.5, mistral) are unchanged** (temperature 0, no `reasoning_effort`).

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Tested locally against Ollama `gpt-oss:20b` via the raw `/v1` endpoint and an engine agent wave: the reasoning model went from empty content (`finish=length`, 0/4 JSON) to valid JSON (`finish=stop`, 4/4). Deterministic checks of the connector logic: `gpt-oss`/`deepseek-r1`/`qwen3` → auto `temperature=1.0` + `reasoning_effort=low`; `llama3.3`/`qwen2.5` → unchanged (`temperature=0`, no effort); explicit `temperature`/`reasoning_effort` in config override the auto defaults. No unit test added (thin connector config change); the full `./builder test` suite was not run.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — N/A
- [x] Breaking changes documented (if applicable) — none; defaults preserve existing behavior for non-reasoning models

## Linked Issue

Fixes #1439


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved llm_ollama initialization for reasoning-focused model variants, including smarter default generation settings.
  * Added generation controls: `temperature` is now configurable; if left unset, reasoning models use `1.0` while standard models default to `0`.
  * Added `reasoning_effort` to control reasoning behavior for compatible models.
* **Documentation**
  * Updated llm_ollama README and schema to document `temperature` and `reasoning_effort`, including defaults and precedence.
* **Configuration**
  * Exposed `temperature` and `reasoning_effort` in the llm_ollama service profile/schema (including the custom profile).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->