### PR TITLE
fix(agent): CrewAI reliability — stop, trace, config shape (RR-1363)

### DIFF
--- a/docs/agents/ROCKETRIDE_OBSERVABILITY.md
+++ b/docs/agents/ROCKETRIDE_OBSERVABILITY.md
@@ -323,6 +323,7 @@ subscription time.
   id: number,                                  // pipe index within the pipeline
   op: "begin" | "enter" | "leave" | "end",
   pipes: string[],                             // current component stack for this pipe
+  component?: string,                          // component this op refers to (on "leave", the leaving one); pair enter/leave by identity, not stack position
   trace: {                                     // shape depends on pipelineTraceLevel
     lane?: string,
     data?: object,                             // input/intermediate data

--- a/nodes/src/nodes/agent_crewai/crewai_agent/IGlobal.py
+++ b/nodes/src/nodes/agent_crewai/crewai_agent/IGlobal.py
@@ -15,7 +15,9 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from rocketlib import IGlobalBase, IJson, OPEN_MODE
+from rocketlib import IGlobalBase, OPEN_MODE
+
+from ai.common.config import Config
 
 
 class IGlobal(IGlobalBase):
@@ -50,7 +52,10 @@ class IGlobal(IGlobalBase):
 
         self.process = Process.sequential
 
-        conn_config = IJson.toDict(self.glb.connConfig) if self.glb.connConfig else {}
+        # Resolve through Config.getNodeConfig so profile defaults are applied and both
+        # the flat and nested-under-default pipe shapes work (same resolver the agent
+        # driver uses for instructions/agent_description).
+        conn_config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
 
         self.role = str(conn_config.get('role') or 'Assistant').strip() or 'Assistant'
         self.task_description = str(conn_config.get('task_description') or '').strip()

--- a/nodes/src/nodes/agent_crewai/crewai_manager/IGlobal.py
+++ b/nodes/src/nodes/agent_crewai/crewai_manager/IGlobal.py
@@ -20,7 +20,9 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from rocketlib import IGlobalBase, IJson, OPEN_MODE
+from rocketlib import IGlobalBase, OPEN_MODE
+
+from ai.common.config import Config
 
 
 class IGlobal(IGlobalBase):
@@ -43,7 +45,9 @@ class IGlobal(IGlobalBase):
         )
         depends(requirements)
 
-        conn_config = IJson.toDict(self.glb.connConfig) if self.glb.connConfig else {}
+        # Resolve through Config.getNodeConfig so profile defaults are applied and both
+        # the flat and nested-under-default pipe shapes work.
+        conn_config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
 
         self.goal = str(conn_config.get('goal') or '').strip()
         self.backstory = str(conn_config.get('backstory') or '').strip()

--- a/nodes/src/nodes/agent_crewai/crewai_subagent/IGlobal.py
+++ b/nodes/src/nodes/agent_crewai/crewai_subagent/IGlobal.py
@@ -18,7 +18,9 @@ from __future__ import annotations
 import os
 from typing import Any
 
-from rocketlib import IGlobalBase, IJson, OPEN_MODE
+from rocketlib import IGlobalBase, OPEN_MODE
+
+from ai.common.config import Config
 
 
 class IGlobal(IGlobalBase):
@@ -44,7 +46,9 @@ class IGlobal(IGlobalBase):
         )
         depends(requirements)
 
-        conn_config = IJson.toDict(self.glb.connConfig) if self.glb.connConfig else {}
+        # Resolve through Config.getNodeConfig so profile defaults are applied and both
+        # the flat and nested-under-default pipe shapes work.
+        conn_config = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
 
         self.role = str(conn_config.get('role') or 'Specialist').strip() or 'Specialist'
         self.task_description = str(conn_config.get('task_description') or '').strip()

--- a/nodes/src/nodes/agent_crewai/services.agent.json
+++ b/nodes/src/nodes/agent_crewai/services.agent.json
@@ -112,17 +112,13 @@
 			"format": "textarea",
 			"title": "Expected Output",
 			"description": "Description of the expected output format. Maps to CrewAI Task(expected_output=...)."
-		},
-		"agent_crewai.default": {
-			"object": "default",
-			"properties": ["agent_description", "instructions", "advanced_mode"]
 		}
 	},
 	"shape": [
 		{
 			"section": "Pipe",
 			"title": "CrewAI Agent",
-			"properties": ["agent_crewai.default"]
+			"properties": ["agent_description", "instructions", "advanced_mode"]
 		}
 	]
 }

--- a/nodes/src/nodes/agent_crewai/services.manager.json
+++ b/nodes/src/nodes/agent_crewai/services.manager.json
@@ -81,17 +81,13 @@
 			"format": "textarea",
 			"title": "Manager Backstory",
 			"description": "Background context for the manager's persona. Maps to CrewAI Agent(backstory=...)."
-		},
-		"agent_crewai_manager.default": {
-			"object": "default",
-			"properties": ["agent_description", "instructions", "advanced_mode"]
 		}
 	},
 	"shape": [
 		{
 			"section": "Pipe",
 			"title": "CrewAI Manager",
-			"properties": ["agent_crewai_manager.default"]
+			"properties": ["agent_description", "instructions", "advanced_mode"]
 		}
 	]
 }

--- a/nodes/src/nodes/agent_crewai/services.subagent.json
+++ b/nodes/src/nodes/agent_crewai/services.subagent.json
@@ -98,17 +98,13 @@
 			"format": "textarea",
 			"title": "Expected Output",
 			"description": "Description of the expected output format. Maps to CrewAI Task(expected_output=...)."
-		},
-		"agent_crewai_subagent.default": {
-			"object": "default",
-			"properties": ["instructions", "advanced_mode"]
 		}
 	},
 	"shape": [
 		{
 			"section": "Pipe",
 			"title": "CrewAI Subagent",
-			"properties": ["agent_crewai_subagent.default"]
+			"properties": ["instructions", "advanced_mode"]
 		}
 	]
 }

--- a/nodes/src/nodes/agent_deepagent/deepagent.py
+++ b/nodes/src/nodes/agent_deepagent/deepagent.py
@@ -271,46 +271,12 @@ class DeepAgentDriver(AgentBase):
         """
         super().__init__(iGlobal)
 
-        # Read user-configured values directly from connConfig so we work with
-        # both pipe shapes:
-        #   * flat:   {"description": "...", "instructions": [...]}
-        #   * nested: {"default": {"description": "...", "instructions": [...]}}
-        # The UI currently writes the nested shape; ``Config.getNodeConfig``
-        # in the no-profile branch does not descend into that wrapper, so we
-        # overlay the resolved values here. We also re-assign the base-class
-        # ``_instructions`` / ``_agent_description`` for the same reason.
-        values = self._read_connconfig_values()
-        self._instructions = values.get('instructions', []) or []
-        self._agent_description = (values.get('agent_description', '') or '').strip()
-        self._description: str = (values.get('description', '') or '').strip()
-        self._system_prompt: str = (values.get('system_prompt', '') or '').strip()
-
-    def _read_connconfig_values(self) -> Dict[str, Any]:
-        """Return the user-configured field values for this node.
-
-        Handles both pipe shapes the engine may deliver:
-
-        * Flat: ``connConfig`` is the value dict itself.
-        * Nested: ``connConfig`` wraps the values under the default-profile key
-          (the shape the UI writes, e.g. ``{"default": {...}}``).
-        """
-        from rocketlib import IJson as _IJson, getServiceDefinition
-
-        raw = self._iGlobal.glb.connConfig
-        conn = _IJson.toDict(raw) if raw else {}
-        if not isinstance(conn, dict):
-            return {}
-
-        # If the UI nested values under the default-profile key, use those.
-        try:
-            service = getServiceDefinition(self._iGlobal.glb.logicalType) or {}
-            default_profile = (service.get('preconfig') or {}).get('default')
-        except Exception:
-            default_profile = None
-
-        if default_profile and isinstance(conn.get(default_profile), dict):
-            return conn[default_profile]
-        return conn
+        # ``_instructions`` / ``_agent_description`` are already loaded by
+        # ``AgentBase.__init__`` from the resolved config (which handles both the
+        # flat and nested-under-default pipe shapes). Read this driver's two extra
+        # fields from the same resolved config.
+        self._description: str = (self._config.get('description', '') or '').strip()
+        self._system_prompt: str = (self._config.get('system_prompt', '') or '').strip()
 
     def _run(self, *, context: AgentContext, question: Question) -> AgentRunResult:
         """Execute the agent using ``deepagents.create_deep_agent``."""

--- a/nodes/test/agent_crewai/test_stop_words.py
+++ b/nodes/test/agent_crewai/test_stop_words.py
@@ -122,6 +122,30 @@ class TestTruncationOutcome:
         assert truncate_at_stop_words(FABRICATED, []) == FABRICATED
 
 
+# Matching is exact (case-sensitive) on purpose: API-level stop is now primary, so the
+# truncation net stays narrow to avoid cutting legitimate answers that merely contain the
+# marker text. Drifted markers are left alone rather than risk an over-match.
+DRIFT_SPACED = FABRICATED.replace('\nObservation:', '\nObservation :')  # spaced colon
+DRIFT_CASE = FABRICATED.replace('\nObservation:', '\nobservation:')  # lowercased
+
+
+class TestTruncationIsExactOnly:
+    def test_drifted_marker_is_not_truncated(self):
+        # "\nObservation :" / "\nobservation:" are not the exact stop word, so the net
+        # leaves them intact (the provider's API stop handles the real case).
+        assert truncate_at_stop_words(DRIFT_SPACED, REACT_STOP) == DRIFT_SPACED
+        assert truncate_at_stop_words(DRIFT_CASE, REACT_STOP) == DRIFT_CASE
+
+    def test_prose_containing_marker_text_is_preserved(self):
+        # A legitimate answer mentioning the marker text must not be cut.
+        prose = 'My key observation: the pipeline is healthy.'
+        assert truncate_at_stop_words(prose, REACT_STOP) == prose
+
+    def test_clean_text_without_marker_is_untouched(self):
+        clean = 'Thought: all done\nFinal Answer: 42 is the answer.'
+        assert truncate_at_stop_words(clean, REACT_STOP) == clean
+
+
 # ---------------------------------------------------------------------------
 # Seam 2 — why the wrapper must read `stop_sequences`, not `stop`
 # Faithful mirror of crewai/llms/base_llm.py:165-214 (stop field + stop_sequences
@@ -183,3 +207,145 @@ class TestStopSequencesContract:
         with call_stop_override(llm, REACT_STOP):
             out = truncate_at_stop_words(FABRICATED, llm.stop_sequences)
         assert 'Observation:' not in out and 'Final Answer' not in out
+
+
+# ---------------------------------------------------------------------------
+# Seam 3 — API-level stop: the native Anthropic payload must carry the stop
+# sequences published on STOP_SEQUENCES_VAR, so the provider stops generating
+# (not just post-hoc truncation). Loads the REAL llm_native_stream with rocketlib
+# stubbed, and fakes the LangChain payload builder + raw stream.
+# ---------------------------------------------------------------------------
+_NATIVE_PATH = (
+    Path(__file__).resolve().parents[3] / 'packages' / 'ai' / 'src' / 'ai' / 'common' / 'llm_native_stream.py'
+)
+
+
+def _load_native_stream():
+    saved_rl = sys.modules.get('rocketlib')
+    rl = types.ModuleType('rocketlib')
+    rl.debug = lambda *a, **k: None
+    rl.warning = lambda *a, **k: None
+    sys.modules['rocketlib'] = rl
+    try:
+        spec = importlib.util.spec_from_file_location('rr_real_native_stream', _NATIVE_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if saved_rl is None:
+            sys.modules.pop('rocketlib', None)
+        else:
+            sys.modules['rocketlib'] = saved_rl
+
+
+def _run_native_capture(ns, stop_value):
+    """Drive _stream_anthropic_messages_api with fakes; return the stop the payload got."""
+    captured: dict = {}
+
+    class _FakeLLM:
+        _client = object()  # non-None so the client guard passes
+
+        def _get_request_payload(self, prompt, stop=None, stream=None):
+            captured['stop'] = stop
+            return {}
+
+    class _FakeChat:
+        _llm = _FakeLLM()
+
+    ns._open_raw_message_stream = lambda client, payload: iter(())  # no events -> no text
+    token = ns.STOP_SEQUENCES_VAR.set(stop_value)
+    try:
+        # Produces no text, so the function raises after building the payload — we only
+        # assert the payload wiring, which happens before any streaming.
+        ns._stream_anthropic_messages_api(_FakeChat(), 'prompt', lambda t: None, None, None)
+    except RuntimeError:
+        pass
+    finally:
+        ns.STOP_SEQUENCES_VAR.reset(token)
+    return captured.get('stop', 'UNSET')
+
+
+class TestNativeStopThreading:
+    def test_payload_carries_contextvar_stop(self):
+        ns = _load_native_stream()
+        assert _run_native_capture(ns, REACT_STOP) == REACT_STOP
+
+    def test_payload_stop_defaults_none(self):
+        ns = _load_native_stream()
+        assert _run_native_capture(ns, None) is None
+
+
+# ---------------------------------------------------------------------------
+# Seam 4 — LLMBase._question must publish the stop list on STOP_SEQUENCES_VAR
+# around chat.chat(...) and ALWAYS reset it afterward, so a stop from one request
+# cannot leak onto the next on a reused chat instance. Loads the REAL llm_base
+# with its deps stubbed, sharing the real STOP_SEQUENCES_VAR object.
+# ---------------------------------------------------------------------------
+_LLM_BASE_PATH = Path(__file__).resolve().parents[3] / 'packages' / 'ai' / 'src' / 'ai' / 'common' / 'llm_base.py'
+
+
+def _load_llm_base(stop_var):
+    saved = {
+        k: sys.modules.get(k)
+        for k in ('rocketlib', 'ai', 'ai.common', 'ai.common.schema', 'ai.common.llm_native_stream')
+    }
+    rl = types.ModuleType('rocketlib')
+    rl.IInstanceBase = object
+    rl.invoke_function = lambda f: f
+    rl.warning = lambda *a, **k: None
+    sys.modules['rocketlib'] = rl
+    sys.modules['ai'] = types.ModuleType('ai')
+    sys.modules['ai.common'] = types.ModuleType('ai.common')
+    schema = types.ModuleType('ai.common.schema')
+    schema.Question = object
+    schema.Answer = object
+    sys.modules['ai.common.schema'] = schema
+    nsmod = types.ModuleType('ai.common.llm_native_stream')
+    nsmod.STOP_SEQUENCES_VAR = stop_var  # share the SAME contextvar the test asserts on
+    sys.modules['ai.common.llm_native_stream'] = nsmod
+    try:
+        spec = importlib.util.spec_from_file_location('rr_real_llm_base', _LLM_BASE_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.LLMBase
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+class TestQuestionContextvar:
+    def _make_self(self, chat):
+        ig = type('IGlobal', (), {'_chat': chat})()
+        return type('Node', (), {'IGlobal': ig})()
+
+    def test_question_sets_stop_during_and_resets_after(self):
+        var = _load_native_stream().STOP_SEQUENCES_VAR
+        LLMBase = _load_llm_base(var)
+        seen = {}
+
+        class _Chat:
+            def chat(self, question, on_chunk=None, on_finish=None, on_reasoning_chunk=None):
+                seen['during'] = var.get()
+                return 'answer'
+
+        assert var.get() is None
+        LLMBase._question(self._make_self(_Chat()), 'q', stop=REACT_STOP)
+        assert seen['during'] == REACT_STOP  # published during the call
+        assert var.get() is None  # reset afterward
+
+    def test_question_resets_stop_even_when_chat_raises(self):
+        var = _load_native_stream().STOP_SEQUENCES_VAR
+        LLMBase = _load_llm_base(var)
+
+        class _Chat:
+            def chat(self, question, on_chunk=None, on_finish=None, on_reasoning_chunk=None):
+                raise RuntimeError('boom')
+
+        try:
+            LLMBase._question(self._make_self(_Chat()), 'q', stop=REACT_STOP)
+        except RuntimeError:
+            pass
+        assert var.get() is None  # reset in finally, no leak onto the next request

--- a/packages/ai/src/ai/common/agent/_internal/utils.py
+++ b/packages/ai/src/ai/common/agent/_internal/utils.py
@@ -79,7 +79,13 @@ def extract_text(result: Any) -> str:
 
 def truncate_at_stop_words(text: str, stop_words: Any) -> str:
     """
-    Truncate `text` at the first occurrence of any stop word.
+    Truncate `text` at the first exact occurrence of any stop word.
+
+    This is the backstop behind API-level `stop_sequences` (now primary): the provider
+    already stops generating at the marker, so this only trims a fabricated ReAct tail on
+    the rare miss. Matching is exact and case-sensitive on purpose — a fuzzy/anchored
+    match would over-truncate legitimate answers that merely contain the marker text
+    (e.g. "My key observation: ...").
 
     Args:
         text: Model output text.

--- a/packages/ai/src/ai/common/agent/agent.py
+++ b/packages/ai/src/ai/common/agent/agent.py
@@ -75,6 +75,10 @@ class AgentBase(ABC):
         # for this node instance.
         config = Config.getNodeConfig(self._iGlobal.glb.logicalType, self._iGlobal.glb.connConfig)
 
+        # Keep the resolved config so subclasses can read their own extra fields
+        # without re-resolving (and without re-implementing shape handling).
+        self._config = config
+
         # And save any specific instructions
         self._instructions = config.get('instructions', [])
         self._agent_description = config.get('agent_description', '') or ''

--- a/packages/ai/src/ai/common/agent/agent.py
+++ b/packages/ai/src/ai/common/agent/agent.py
@@ -306,7 +306,10 @@ class AgentBase(ABC):
             q = Question(role=role or '')
             q.addQuestion(transcript)
 
-        result = context.llm.invoke(IInvokeLLM.Ask(question=q))
+        # Forward stop words to the provider API (via the node's ask handler) so the model
+        # actually stops generating at e.g. "\nObservation:", and keep the post-hoc
+        # truncation below as a defense-in-depth net against any marker drift.
+        result = context.llm.invoke(IInvokeLLM.Ask(question=q, stop=stop_words))
         return truncate_at_stop_words(extract_text(result), stop_words)
 
     def call_llm_json(

--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -19,7 +19,23 @@ from ai.common.schema import Answer, Question
 from ai.common.config import Config
 from ai.common.util import parseJson
 from ai.common.validation import validate_model_name, validate_max_tokens, validate_prompt
-from ai.common.llm_native_stream import dispatch_native_chat_stream
+from ai.common.llm_native_stream import STOP_SEQUENCES_VAR, dispatch_native_chat_stream
+
+
+def _stop_kwargs() -> dict:
+    """Return ``{'stop': [...]}`` only when stop sequences are active for this call.
+
+    Passing ``stop=`` unconditionally (even ``stop=None``) breaks model backends and
+    test mocks whose ``invoke``/``stream`` signature does not accept a ``stop`` kwarg, so
+    the argument is omitted entirely for the common no-stop path.
+
+    INVARIANT: this is read within the synchronous ``ask()`` call, while
+    ``LLMBase._question`` still holds the contextvar (before its ``finally`` reset).
+    Do not defer consumption (e.g. by returning a lazy generator to the caller) —
+    the value would then read ``None`` after the reset and silently send no stop.
+    """
+    stop = STOP_SEQUENCES_VAR.get()
+    return {'stop': stop} if stop else {}
 
 
 def _make_think_tag_splitter():
@@ -222,8 +238,9 @@ class ChatBase:
             Should raise appropriate exceptions for API failures, authentication
             errors, or other provider-specific issues
         """
-        # Ask the LLM
-        results = self._llm.invoke(prompt)
+        # Ask the LLM. The stop kwarg is only added when the agent set stop sequences,
+        # so non-agent callers (and backends/mocks without a stop param) are unaffected.
+        results = self._llm.invoke(prompt, **_stop_kwargs())
 
         # Return the results
         return results.content
@@ -479,7 +496,7 @@ class ChatBase:
             # Only retry non-streaming if nothing has reached the UI; otherwise
             # the full fallback would arrive on top of the partial we already streamed.
             if emitted is None or not emitted['any']:
-                results = self._llm.invoke(prompt)
+                results = self._llm.invoke(prompt, **_stop_kwargs())
                 content = getattr(results, 'content', '') or ''
                 content_text = content if isinstance(content, str) else str(content)
                 text_parts = [content_text]
@@ -580,7 +597,7 @@ class ChatBase:
                 finish_reason: Optional[str] = None
                 _signature_only_note_sent = False
                 _think_split = _make_think_tag_splitter()
-                for piece in _llm.stream(prompt):
+                for piece in _llm.stream(prompt, **_stop_kwargs()):
                     # content: str for OpenAI-style, list of typed blocks for Anthropic.
                     content = piece.content
                     text = ''

--- a/packages/ai/src/ai/common/config.py
+++ b/packages/ai/src/ai/common/config.py
@@ -157,6 +157,22 @@ class Config:
             # Use the connConfig directly as it is not using profiles
             userConfig = connConfig
 
+            # Some UIs nest a node's fields under a sub-object named after the default
+            # profile (e.g. connConfig["default"] = {"instructions": [...]}) instead of at
+            # the top level. That nesting is otherwise invisible here — merge() below never
+            # descends into it — so agent nodes silently lose their instructions. Overlay the
+            # nested object's keys as a lower-priority layer, with real top-level keys still
+            # winning, so both shapes resolve. No-op unless such a sub-object exists.
+            nested = connConfig.get(profile)
+            if isinstance(nested, (dict, IJson)):
+                combined = dict(IJson.toDict(nested) if isinstance(nested, IJson) else nested)
+                for key, value in connConfig.items():
+                    # Only real (non-None) top-level values override the nested block; a
+                    # None placeholder must not clobber a populated nested value.
+                    if key != profile and value is not None:
+                        combined[key] = value
+                userConfig = combined
+
             # Merge it
             config = merge(userConfig, defaultConfig)
 

--- a/packages/ai/src/ai/common/llm_base.py
+++ b/packages/ai/src/ai/common/llm_base.py
@@ -1,10 +1,11 @@
 # Copyright (c) 2026 Aparavi Software AG
 
 import inspect
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from rocketlib import IInstanceBase, invoke_function, warning
 from ai.common.schema import Question, Answer
+from ai.common.llm_native_stream import STOP_SEQUENCES_VAR
 
 
 class LLMBase(IInstanceBase):
@@ -20,21 +21,30 @@ class LLMBase(IInstanceBase):
         on_chunk: Optional[Callable[[str], None]] = None,
         on_finish: Optional[Callable[[Optional[str]], None]] = None,
         on_reasoning_chunk: Optional[Callable[[str], None]] = None,
+        stop: Optional[List[str]] = None,
     ) -> Answer:
         chat = self.IGlobal._chat
-        # Legacy drivers override chat(self, question) without streaming callbacks.
+        # Publish the stop sequences on the per-call contextvar so ChatBase's model sinks
+        # forward them to the provider API. A contextvar (not a chat() kwarg) leaves the
+        # many chat()/_chat() provider overrides untouched. Reset in finally so a stop from
+        # one request never bleeds into the next on a reused chat instance.
+        token = STOP_SEQUENCES_VAR.set(stop or None)
         try:
-            accepts_stream = 'on_chunk' in inspect.signature(chat.chat).parameters
-        except (TypeError, ValueError):
-            accepts_stream = True
-        if not accepts_stream:
-            return chat.chat(question)
-        return chat.chat(
-            question,
-            on_chunk=on_chunk,
-            on_finish=on_finish,
-            on_reasoning_chunk=on_reasoning_chunk,
-        )
+            # Legacy drivers override chat(self, question) without streaming callbacks.
+            try:
+                accepts_stream = 'on_chunk' in inspect.signature(chat.chat).parameters
+            except (TypeError, ValueError):
+                accepts_stream = True
+            if not accepts_stream:
+                return chat.chat(question)
+            return chat.chat(
+                question,
+                on_chunk=on_chunk,
+                on_finish=on_finish,
+                on_reasoning_chunk=on_reasoning_chunk,
+            )
+        finally:
+            STOP_SEQUENCES_VAR.reset(token)
 
     def writeQuestions(self, question: Question):
         # Stream the model's reasoning live, one line at a time, on the chat-ui
@@ -102,4 +112,4 @@ class LLMBase(IInstanceBase):
 
     @invoke_function
     def ask(self, param):
-        return self._question(param.question)
+        return self._question(param.question, stop=getattr(param, 'stop', None))

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -14,9 +14,19 @@ the generic stream.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Optional
+import contextvars
+from typing import Any, Callable, Dict, List, Optional
 
 from rocketlib import debug, warning
+
+# Per-call carrier for API-level stop sequences (e.g. CrewAI's ReAct "\nObservation:").
+# Set on the ask path in llm_base._question and read at every model sink so the stop
+# reaches the provider API instead of relying only on post-hoc text truncation. A
+# contextvar (not a param) keeps the many ChatBase._chat/chat() provider overrides and
+# the fixed-signature native handlers below untouched, and is concurrency-safe.
+STOP_SEQUENCES_VAR: contextvars.ContextVar[Optional[List[str]]] = contextvars.ContextVar(
+    'rocketride_llm_stop_sequences', default=None
+)
 
 # --- Anthropic: model id gates (vendor prefixes) ---
 
@@ -165,7 +175,10 @@ def _stream_anthropic_messages_api(
     on_reasoning_chunk: Optional[Callable[[str], None]],
 ) -> str:
     llm = chat._llm
-    payload: dict[str, Any] = dict(llm._get_request_payload(prompt, stop=None, stream=True))
+    # INVARIANT: read synchronously within the ask() call, while LLMBase._question still
+    # holds the contextvar (before its finally reset). The stream is consumed here, not
+    # deferred to the caller, so this never runs after the reset (which would send None).
+    payload: dict[str, Any] = dict(llm._get_request_payload(prompt, stop=STOP_SEQUENCES_VAR.get() or None, stream=True))
     _raw_client = getattr(llm, '_client', None)
     client = _raw_client() if callable(_raw_client) else _raw_client
     if client is None:

--- a/packages/ai/src/ai/modules/task/pipeflow.py
+++ b/packages/ai/src/ai/modules/task/pipeflow.py
@@ -1,0 +1,52 @@
+"""Pure helpers for reconstructing pipeline trace flow chains.
+
+Kept dependency-free (typing only) so the enter/leave stack logic can be unit
+tested in isolation, without instantiating the full Task engine.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+
+def apply_pipeflow_event(
+    by_pipe: Dict[object, List[str]],
+    pipe_index: object,
+    operation: str,
+    component_name: str,
+) -> List[str]:
+    """Update the per-pipe execution stack for one trace event and return a snapshot.
+
+    `by_pipe` maps a reusable pipe-slot index to the current stack of component
+    names nested under it. Reentrant agent sub-invocations (e.g. an agent calling
+    qdrant -> transformer mid-run) share one `pipe_index` and their enter/leave
+    events can interleave across threads, so:
+
+    - `leave` pops by identity (the leaving component carried in the DBG line),
+      not by position, dropping the last occurrence of `component_name`. A blind
+      top-pop would remove the wrong frame when leaves arrive out of order.
+    - the returned `pipes` is a fresh ``list(...)`` copy, never the live stack —
+      the stack keeps mutating on later events, so emitting it by reference would
+      let queued / later-serialized events reflect a mutated (corrupt) chain.
+
+    Returns the point-in-time snapshot to attach to the emitted flow event.
+    """
+    stack = by_pipe.setdefault(pipe_index, [])
+
+    if operation == 'begin':
+        stack = by_pipe[pipe_index] = [component_name]
+    elif operation == 'enter':
+        stack.append(component_name)
+    elif operation == 'leave':
+        for i in range(len(stack) - 1, -1, -1):
+            if stack[i] == component_name:
+                del stack[i]
+                break
+        else:
+            # Component not found (dropped/duplicate enter) — fall back to a top-pop.
+            if stack:
+                stack.pop()
+    elif operation == 'end':
+        stack = by_pipe[pipe_index] = []
+
+    return list(stack)

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -53,6 +53,7 @@ from ai.constants import (
 )
 from ai import CONST_AI_NODE_SCRIPT
 from ai.common.dap import DAPBase, DAPClient, TransportWebSocket
+from ai.modules.task.pipeflow import apply_pipeflow_event
 from rocketride import TASK_STATUS, TASK_STATUS_FLOW, TASK_STATE, EVENT_TYPE
 from .dbg_debugpy import DbgDebugpy
 from .dbg_stdio import DbgStdio
@@ -1070,25 +1071,21 @@ class Task(DAPBase):
 
             self._status.pipeflow.totalPipes = total_pipes
 
-            if pipe_index not in self._status.pipeflow.byPipe:
-                self._status.pipeflow.byPipe[pipe_index] = []
+            # Update the per-pipe execution stack and get a stable snapshot chain.
+            # See pipeflow.apply_pipeflow_event for why leave pops by identity and the
+            # snapshot is copied (reentrant sub-invocations share one pipe_index and
+            # interleave across threads).
+            pipes = apply_pipeflow_event(self._status.pipeflow.byPipe, pipe_index, operation, component_name)
 
-            # Update execution stack
-            if operation == 'begin':
-                self._status.pipeflow.byPipe[pipe_index] = [component_name]
-            elif operation == 'enter':
-                self._status.pipeflow.byPipe[pipe_index].append(component_name)
-            elif operation == 'leave':
-                if self._status.pipeflow.byPipe[pipe_index]:
-                    self._status.pipeflow.byPipe[pipe_index].pop()
-            elif operation == 'end':
-                self._status.pipeflow.byPipe[pipe_index] = []
-
-            # Build the flow event
+            # Build the flow event. `component` names the component this op refers to
+            # (for 'leave', the leaving one) so consumers can pair enter/leave by identity
+            # rather than assuming strict LIFO order — reentrant agent sub-invocations
+            # interleave under one pipe_index. `pipes` remains the current component stack.
             body = {
                 'id': pipe_index,
                 'op': operation,
-                'pipes': self._status.pipeflow.byPipe[pipe_index],
+                'pipes': pipes,
+                'component': component_name,
                 'trace': trace or {},
                 'project_id': self.project_id,
                 'source': self.source,

--- a/packages/ai/tests/ai/common/test_config_shapes.py
+++ b/packages/ai/tests/ai/common/test_config_shapes.py
@@ -1,0 +1,108 @@
+"""Unit tests for Config.getNodeConfig shape handling.
+
+Pins the fix for the agent config-shape bug: the VS Code form nests a node's
+fields under a sub-object named after the default profile (e.g.
+``connConfig["default"] = {"instructions": [...]}``), but the runtime reads them
+top-level. ``getNodeConfig`` now overlays that nested object so both the flat
+(Shape B) and nested (Shape A) shapes resolve, with real top-level values
+winning over a stale/empty nested block.
+
+Loaded by file path with ``rocketlib``/``json5`` stubbed so no engine runtime is
+needed — run with ``pytest --noconftest``.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_CONFIG_PATH = Path(__file__).resolve().parents[3] / 'src' / 'ai' / 'common' / 'config.py'
+
+# Fake service definition: single "default" profile with empty field defaults.
+_SERVICE = {
+    'preconfig': {
+        'default': 'default',
+        'profiles': {
+            'default': {'instructions': [], 'agent_description': '', 'role': 'Assistant'},
+        },
+    }
+}
+
+
+def _load_config():
+    """Load config.py with rocketlib/json5 stubbed; patch getServiceDefinition."""
+    saved = {k: sys.modules.get(k) for k in ('rocketlib', 'json5')}
+
+    rl = types.ModuleType('rocketlib')
+
+    class _IJson:
+        @staticmethod
+        def toDict(x):
+            return dict(x) if isinstance(x, dict) else x
+
+    rl.IJson = _IJson
+    rl.warning = lambda *a, **k: None
+    rl.getServiceDefinition = lambda logical_type: _SERVICE
+    sys.modules['rocketlib'] = rl
+    sys.modules['json5'] = types.ModuleType('json5')
+
+    try:
+        spec = importlib.util.spec_from_file_location('rr_real_config', _CONFIG_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.Config
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+Config = _load_config()
+
+
+class TestFlatShape:
+    def test_top_level_fields_resolve(self):
+        cfg = Config.getNodeConfig('agent_x', {'instructions': ['a', 'b'], 'agent_description': 'desc'})
+        assert cfg['instructions'] == ['a', 'b']
+        assert cfg['agent_description'] == 'desc'
+
+    def test_empty_conn_config_uses_profile_defaults(self):
+        cfg = Config.getNodeConfig('agent_x', {})
+        assert cfg['instructions'] == []
+        assert cfg['role'] == 'Assistant'
+
+
+class TestNestedShape:
+    def test_nested_under_default_resolves(self):
+        cfg = Config.getNodeConfig('agent_x', {'default': {'instructions': ['a', 'b'], 'agent_description': 'desc'}})
+        assert cfg['instructions'] == ['a', 'b']
+        assert cfg['agent_description'] == 'desc'
+
+    def test_nested_advanced_field_resolves(self):
+        cfg = Config.getNodeConfig('agent_x', {'default': {'role': 'Analyst'}})
+        assert cfg['role'] == 'Analyst'
+
+
+class TestMixedShapePrecedence:
+    def test_real_top_level_beats_empty_nested_default(self):
+        cfg = Config.getNodeConfig('agent_x', {'instructions': ['real'], 'default': {'instructions': []}})
+        assert cfg['instructions'] == ['real']
+
+    def test_top_level_overrides_nested_value(self):
+        cfg = Config.getNodeConfig('agent_x', {'instructions': ['top'], 'default': {'instructions': ['nested']}})
+        assert cfg['instructions'] == ['top']
+
+    def test_explicit_none_top_level_does_not_clobber_nested(self):
+        # A None placeholder at the top level must not override a populated nested value.
+        cfg = Config.getNodeConfig('agent_x', {'role': None, 'default': {'role': 'Analyst'}})
+        assert cfg['role'] == 'Analyst'
+
+
+class TestExplicitProfileBranchUnaffected:
+    def test_explicit_profile_reads_nested(self):
+        cfg = Config.getNodeConfig('agent_x', {'profile': 'default', 'default': {'instructions': ['x']}})
+        assert cfg['instructions'] == ['x']

--- a/packages/ai/tests/ai/modules/task/test_pipeflow.py
+++ b/packages/ai/tests/ai/modules/task/test_pipeflow.py
@@ -1,0 +1,111 @@
+"""Unit tests for ai.modules.task.pipeflow.apply_pipeflow_event.
+
+These pin the two fixes for the agent-trace "missing leave event" / duplicate-span
+bug (reentrant agent sub-invocations share one pipe_index and interleave):
+
+1. Each emitted `pipes` chain is an independent snapshot — mutating the stack via
+   later events must NOT change an already-captured chain (the aliasing bug where
+   the live list was emitted by reference).
+2. `leave` pops by identity (the leaving component), not by position, so an
+   out-of-order leave removes the correct frame rather than the current top.
+
+Loaded by file path (pipeflow.py has no heavy imports) so the test needs no engine
+runtime — run with `pytest --noconftest`.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_PIPEFLOW_PATH = Path(__file__).resolve().parents[4] / 'src' / 'ai' / 'modules' / 'task' / 'pipeflow.py'
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location('rr_real_pipeflow', _PIPEFLOW_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod.apply_pipeflow_event
+
+
+apply_pipeflow_event = _load()
+
+
+class TestStackUpdates:
+    def test_begin_resets_stack(self):
+        by_pipe = {0: ['stale', 'frames']}
+        pipes = apply_pipeflow_event(by_pipe, 0, 'begin', 'ralph')
+        assert pipes == ['ralph']
+        assert by_pipe[0] == ['ralph']
+
+    def test_enter_appends_and_snapshots_self(self):
+        by_pipe = {}
+        apply_pipeflow_event(by_pipe, 0, 'begin', 'ralph')
+        pipes = apply_pipeflow_event(by_pipe, 0, 'enter', 'qdrant')
+        assert pipes == ['ralph', 'qdrant']
+
+    def test_end_clears_stack(self):
+        by_pipe = {0: ['ralph', 'qdrant']}
+        pipes = apply_pipeflow_event(by_pipe, 0, 'end', 'ralph')
+        assert pipes == []
+        assert by_pipe[0] == []
+
+
+class TestSnapshotIndependence:
+    def test_returned_pipes_is_not_the_live_stack(self):
+        by_pipe = {}
+        apply_pipeflow_event(by_pipe, 0, 'begin', 'ralph')
+        captured = apply_pipeflow_event(by_pipe, 0, 'enter', 'qdrant')
+        assert captured == ['ralph', 'qdrant']
+        # Mutating the stack via subsequent events must not alter the captured chain.
+        apply_pipeflow_event(by_pipe, 0, 'enter', 'transformer')
+        apply_pipeflow_event(by_pipe, 0, 'leave', 'transformer')
+        assert captured == ['ralph', 'qdrant']  # would be corrupted if emitted by reference
+
+
+class TestIdentityLeavePop:
+    def test_out_of_order_leave_pops_correct_component(self):
+        by_pipe = {}
+        apply_pipeflow_event(by_pipe, 0, 'begin', 'ralph')
+        apply_pipeflow_event(by_pipe, 0, 'enter', 'qdrant')
+        apply_pipeflow_event(by_pipe, 0, 'enter', 'transformer')
+        # qdrant leaves BEFORE transformer (interleaved). A blind top-pop would drop
+        # transformer; identity-pop must drop qdrant.
+        pipes = apply_pipeflow_event(by_pipe, 0, 'leave', 'qdrant')
+        assert pipes == ['ralph', 'transformer']
+        assert by_pipe[0] == ['ralph', 'transformer']
+
+    def test_leave_removes_last_occurrence(self):
+        by_pipe = {0: ['ralph', 'tool', 'ralph']}
+        pipes = apply_pipeflow_event(by_pipe, 0, 'leave', 'ralph')
+        assert pipes == ['ralph', 'tool']
+
+    def test_leave_of_absent_component_falls_back_to_top_pop(self):
+        by_pipe = {0: ['ralph', 'qdrant']}
+        pipes = apply_pipeflow_event(by_pipe, 0, 'leave', 'ghost')
+        assert pipes == ['ralph']
+
+    def test_leave_on_empty_stack_is_safe(self):
+        by_pipe = {0: []}
+        pipes = apply_pipeflow_event(by_pipe, 0, 'leave', 'ralph')
+        assert pipes == []
+
+
+class TestReentrantSequence:
+    def test_nested_agent_memory_lookup_unwinds_cleanly(self):
+        by_pipe = {}
+        seq = [
+            ('begin', 'ralph'),
+            ('enter', 'qdrant'),
+            ('enter', 'transformer'),
+            ('leave', 'transformer'),
+            ('leave', 'qdrant'),
+            ('end', 'ralph'),
+        ]
+        snapshots = [apply_pipeflow_event(by_pipe, 0, op, name) for op, name in seq]
+        assert snapshots[0] == ['ralph']
+        assert snapshots[1] == ['ralph', 'qdrant']
+        assert snapshots[2] == ['ralph', 'qdrant', 'transformer']
+        assert snapshots[3] == ['ralph', 'qdrant']
+        assert snapshots[4] == ['ralph']
+        assert snapshots[5] == []

--- a/packages/server/docs/observability.md
+++ b/packages/server/docs/observability.md
@@ -156,6 +156,7 @@ component's entry and exit with its lane data and any error.
   id: number,                              // pipe index within the pipeline
   op: "begin" | "enter" | "leave" | "end",
   pipes: string[],                         // current component stack for this pipe
+  component?: string,                      // component this op refers to (on "leave", the leaving one) — pair enter/leave by identity, not stack position
   trace: { lane?: string, data?: object, result?: string, error?: string },
   result?: PIPELINE_RESULT,                // on op === "end", level >= summary
   project_id: string,

--- a/packages/server/engine-lib/rocketlib-python/lib/rocketlib/types.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/rocketlib/types.py
@@ -235,6 +235,7 @@ class IInvokeLLM(IInvoke):
         lane: str = 'llm'
         op: str = Field(default='ask', frozen=True)
         question: Any  # Required — client SDK's Question object
+        stop: Any = None  # Optional stop sequences forwarded to the provider API (e.g. ReAct "\nObservation:")
 
     class GetContextLength(IInvokeOp):
         """Get the maximum context length for the model."""

--- a/packages/shared-ui/src/modules/project/hooks/useTraceState.ts
+++ b/packages/shared-ui/src/modules/project/hooks/useTraceState.ts
@@ -35,6 +35,23 @@ interface TraceDocument {
 	rows: TraceRow[];
 }
 
+/**
+ * An open (entered, not-yet-left) frame awaiting its leave event.
+ *
+ * Reentrant agent sub-invocations (e.g. an agent calling qdrant->transformer
+ * mid-run) share one pipelineId and interleave across threads, so enter/leave
+ * do not arrive in strict LIFO order. We therefore match a leave to an open
+ * frame by the component identity carried on the event, rather than by stack
+ * position, and only flag a frame as "missing leave event" if it is still open
+ * when the pipeline ends.
+ */
+interface PendingFrame {
+	row: TraceRow;
+	component: string;
+	/** Index of `row` within its document's rows array — rows are append-only until 'end', so this stays valid and lets leave/end close a frame in O(1). */
+	index: number;
+}
+
 // =============================================================================
 // Hook
 // =============================================================================
@@ -58,8 +75,8 @@ export function useTraceState(traceEvents: TraceEvent[]): {
 	/** Maps pipeline slot (pipelineId) to the active docId */
 	const slotBindingsRef = useRef<Map<number, number>>(new Map());
 
-	/** Per-pipeline pending call stack used to pair enter/leave events */
-	const pendingStacksRef = useRef<Map<number, TraceRow[]>>(new Map());
+	/** Per-pipeline set of open (entered, not-yet-left) frames used to pair enter/leave events */
+	const pendingStacksRef = useRef<Map<number, PendingFrame[]>>(new Map());
 
 	/** Monotonically increasing row ID counter */
 	const rowCounterRef = useRef<number>(0);
@@ -130,7 +147,7 @@ export function useTraceState(traceEvents: TraceEvent[]): {
 
 		for (let i = start; i < end; i++) {
 			const event = traceEvents[i];
-			const { pipelineId, op, pipes, trace, source: eventSource } = event;
+			const { pipelineId, op, pipes, trace, source: eventSource, component } = event;
 			const lane = trace.lane || op;
 
 			switch (op) {
@@ -158,49 +175,12 @@ export function useTraceState(traceEvents: TraceEvent[]): {
 					const stack = pendingStacksRef.current.get(pipelineId);
 					if (!stack) break;
 
-					// Expected parent chain for this enter:
-					//   pipes = [base, parent..., self]
-					//   parent chain = pipes[1..length-1]  (skip the base/objectName)
-					// The current stack should equal that parent chain.
-					const parentChain = pipes.slice(1, pipes.length - 1);
-
-					// Align the stack to parentChain.
-					// 1. Pop frames that don't match (missed leaves) — mark as orphans.
-					// 2. Push synthetic frames for missing parents (missed enters).
-					while (stack.length > parentChain.length || (stack.length > 0 && stack[stack.length - 1].filterName !== parentChain[stack.length - 1])) {
-						const orphan = stack.pop();
-						if (!orphan) break;
-						const idx = doc.rows.findIndex((r) => r.id === orphan.id);
-						if (idx !== -1) {
-							doc.rows[idx] = {
-								...doc.rows[idx],
-								result: 'error',
-								error: 'missing leave event',
-								endTimestamp: Date.now(),
-							};
-						}
-					}
-
-					// Push synthetic frames for any parents we missed enters for.
-					while (stack.length < parentChain.length) {
-						const missingName = parentChain[stack.length];
-						const synthetic: TraceRow = {
-							id: rowCounterRef.current++,
-							docId,
-							completed: false,
-							lane,
-							filterName: missingName,
-							depth: stack.length,
-							timestamp: Date.now(),
-							objectName: doc.objectName,
-							source: eventSource,
-							error: 'missing enter event',
-							result: 'error',
-						};
-						doc.rows.push(synthetic);
-						stack.push(synthetic);
-					}
-
+					// pipes = [base, parent..., self]; depth comes straight from this event,
+					// so nesting renders correctly regardless of interleaving. We do NOT pop
+					// "orphans" or synthesize missing parents here — under reentrancy the
+					// stack legitimately holds concurrently-open frames, and forcing strict
+					// LIFO here is exactly what produced spurious "missing leave event" errors
+					// and inflated counts. Genuine orphans are flagged only at 'end'.
 					const filterName = pipes[pipes.length - 1] || '';
 					const depth = Math.max(0, pipes.length - 2);
 
@@ -217,8 +197,10 @@ export function useTraceState(traceEvents: TraceEvent[]): {
 						source: eventSource,
 					};
 
-					doc.rows.push(row);
-					stack.push(row);
+					const rowIndex = doc.rows.push(row) - 1;
+					// Fall back to the frame's own name (pipes tail) if the engine did not
+					// send `component` (older engine) so matching still works.
+					stack.push({ row, component: component ?? filterName, index: rowIndex });
 					break;
 				}
 
@@ -231,54 +213,35 @@ export function useTraceState(traceEvents: TraceEvent[]): {
 					const stack = pendingStacksRef.current.get(pipelineId);
 					if (!stack || stack.length === 0) break;
 
-					// Expected parent chain for this leave:
-					//   pipes = [base, parent...]  (the leaving frame's parent path)
-					// The leaving frame's path is parentChain + [leavingFrame.filterName]
-					// So stack length should be parentChain.length + 1 and the
-					// top frame's filterName + parents should match.
-					const parentChain = pipes.slice(1);
-
-					// Pop orphans until top matches expected: stack length === parentChain.length + 1
-					// AND every frame in stack matches parentChain prefix.
-					while (stack.length > parentChain.length + 1) {
-						const orphan = stack.pop();
-						if (!orphan) break;
-						const idx = doc.rows.findIndex((r) => r.id === orphan.id);
-						if (idx !== -1) {
-							doc.rows[idx] = {
-								...doc.rows[idx],
-								result: 'error',
-								error: 'missing leave event',
-								endTimestamp: Date.now(),
-							};
-						}
-					}
-
-					// Validate the parent chain matches the stack below the top frame
-					let aligned = stack.length === parentChain.length + 1;
-					if (aligned) {
-						for (let p = 0; p < parentChain.length; p++) {
-							if (stack[p].filterName !== parentChain[p]) {
-								aligned = false;
+					// Match this leave to the most-recent still-open frame with the same
+					// component identity, instead of assuming it is the top of a strict LIFO
+					// stack (reentrant sub-invocations interleave).
+					let matchIdx = -1;
+					if (component != null) {
+						for (let s = stack.length - 1; s >= 0; s--) {
+							if (stack[s].component === component) {
+								matchIdx = s;
 								break;
 							}
 						}
 					}
+					// No open frame matches (desync, or an engine that sent no component): skip
+					// this leave rather than stamp its result/error onto an unrelated span. The
+					// frame stays open and is correctly flagged "missing leave event" at 'end'.
+					if (matchIdx === -1) break;
 
-					if (!aligned) break; // can't safely match — skip this leave
-
-					const pending = stack.pop();
-					if (pending) {
-						const idx = doc.rows.findIndex((r) => r.id === pending.id);
-						if (idx !== -1) {
-							doc.rows[idx] = {
-								...doc.rows[idx],
-								exitData: trace.data,
-								result: trace.result,
-								error: trace.error,
-								endTimestamp: Date.now(),
-							};
-						}
+					const [pending] = stack.splice(matchIdx, 1);
+					// O(1): rows are append-only until 'end', so the stored index still points
+					// at this frame's row. Guard with the id in case that ever changes.
+					const idx = pending.index;
+					if (doc.rows[idx]?.id === pending.row.id) {
+						doc.rows[idx] = {
+							...doc.rows[idx],
+							exitData: trace.data,
+							result: trace.result,
+							error: trace.error,
+							endTimestamp: Date.now(),
+						};
 					}
 					break;
 				}
@@ -289,6 +252,25 @@ export function useTraceState(traceEvents: TraceEvent[]): {
 						const doc = documentsRef.current.get(docId);
 						if (doc) {
 							doc.completed = true;
+
+							// Any frame still open when the pipeline ends genuinely never
+							// received a leave — this is the ONLY place a "missing leave
+							// event" is real (transient interleaving is resolved by then).
+							const openFrames = pendingStacksRef.current.get(pipelineId);
+							if (openFrames) {
+								for (const frame of openFrames) {
+									const idx = doc.rows.findIndex((r) => r.id === frame.row.id);
+									if (idx !== -1 && doc.rows[idx].endTimestamp == null) {
+										doc.rows[idx] = {
+											...doc.rows[idx],
+											result: 'error',
+											error: 'missing leave event',
+											endTimestamp: Date.now(),
+										};
+									}
+								}
+							}
+
 							const result = (event as any).pipelineResult as Record<string, unknown> | undefined;
 							if (result && Object.keys(result).length > 0) {
 								const resultRow: TraceRow = {

--- a/packages/shared-ui/src/modules/project/types.ts
+++ b/packages/shared-ui/src/modules/project/types.ts
@@ -26,6 +26,8 @@ export interface TraceEvent {
 	pipelineId: number;
 	op: 'begin' | 'enter' | 'leave' | 'end';
 	pipes: string[];
+	/** Component this op refers to (for 'leave', the leaving component). Used to pair enter/leave by identity under reentrancy. */
+	component?: string;
 	trace: {
 		lane?: string;
 		data?: Record<string, unknown>;

--- a/packages/shared-ui/src/modules/project/utils.ts
+++ b/packages/shared-ui/src/modules/project/utils.ts
@@ -54,6 +54,7 @@ export function parseServerEvent(event: unknown, projectId: string): ParsedServe
 			pipelineId: body.id ?? 0,
 			op: body.op || 'enter',
 			pipes: body.pipes || [],
+			component: body.component,
 			trace: body.op === 'end' ? {} : body.trace || {},
 			source: body.source,
 			...(body.op === 'end' && body.trace && Object.keys(body.trace).length > 0 ? { pipelineResult: body.trace } : {}),


### PR DESCRIPTION
## Summary

- **Stop sequences reach the provider API**: the CrewAI text-ReAct agent now sends `stop_sequences` (threaded via the invoke envelope + a per-call contextvar into the LangChain/native model calls) so the model actually stops at `\nObservation:` instead of fabricating the whole trajectory that post-hoc truncation only trimmed. The `truncate_at_stop_words` net is kept as a narrow **exact-match** backstop (added to the model call only when a stop is set), so it never over-truncates a legitimate answer that merely contains the marker text.
- **Trace "missing leave event" fixed**: reentrant agent sub-invocations (tools, RAG memory) share one reusable pipeId and interleave across threads. Added a `component` id to `apaevt_flow` so enter/leave pair by identity; fixed a pipes-list aliasing bug and identity-pop in `task_engine`; the trace viewer now flags a genuine orphan only at pipeline end. A leave with no matching open frame is skipped (not stamped onto an unrelated span).
- **CrewAI config nested-default shape**: the VS Code form nested `instructions`/`agent_description` under `config.default`, which the runtime read top-level → silently dropped. Fixed in the shared `Config.getNodeConfig` (descends into the default-profile object, top-level non-None values win), retired the deepagent local workaround, routed the crewai IGlobals through the resolver, and flattened the crewai schemas to the convention. Existing pipes with the nested shape keep running unchanged (the resolver descends), so no pipe files are edited.

## Also fixes other agent nodes

All three fixes live in shared layers (`AgentBase.call_llm`, `task_engine`/`useTraceState`, `Config.getNodeConfig`), so they remediate more than CrewAI. Verified across every agent node:

- **agent_llamaindex** — also a text-ReAct agent passing `stop_words=['Observation:']` (`llamaindex.py:110`); was post-hoc-truncation-only, now gets API-level stop from the shared `call_llm` change (same class of bug as CrewAI).
- **agent_rocketride** — runs tool+memory sub-invocations concurrently (`ThreadPoolExecutor`), so it hit the same reentrant "missing leave event" trace desync; fixed by the shared component-id pairing.
- **agent_deepagent** — most concurrent (async gather + `to_thread` + subagent fan-out), same trace desync; fixed by the shared change. Its local config-shape workaround is also retired here in favor of the shared resolver fix.
- **agent_langchain** — sequential JSON-envelope protocol; reenters the same way but only nests (never interleaves), so it was low-risk and is trivially covered.

No node-specific fixes were required — the shared changes cover them all.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

RR-1363

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trace/observability flow events now include optional component identity to improve enter/leave pairing in the UI.
  * Stop sequences are now applied consistently during both streaming and native streaming LLM calls.
  * CrewAI configuration options are now exposed more directly in the configuration schemas/UI.
* **Bug Fixes**
  * Improved resolution of nested, profile-based configuration defaults and precedence.
  * Hardened stop-word truncation against minor marker drift.
  * More reliable pipeflow/tracing timeline reconstruction for reentrant and out-of-order events.
* **Documentation**
  * Updated `apaevt_flow` schema docs for the new component field.
* **Tests**
  * Added coverage for stop handling, config shapes, and pipeflow stack semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->