### PR TITLE
fix(build): restore cmake >= 3.19 version gate (follow-up to #1436)

### DIFF
--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -60,7 +60,7 @@ LINUX_DEPS=(
     "|python3-devel"                        # fedora: cffi/cryptography/Cython sdist builds
     "make"
     "ninja-build"
-    "cmake"                                 # supported distros ship cmake >= 3.19
+    "cmake"                                 # version gated (>= 3.19) by check_linux_cmake
     "git"
     "|gcc"                                  # fedora: sdist C extensions
     "|gcc-c++"                              # fedora: sdist C++ extensions
@@ -364,6 +364,29 @@ check_linux_python() {
     fi
 }
 
+check_linux_cmake() {
+    # Version gate only (mirrors check_linux_python): a cmake already on the
+    # system that is older than 3.19 can't be upgraded by the package manager on
+    # older distros (Ubuntu 20.04 ships 3.16), so fail fast with a clear message
+    # instead of a confusing configure-time error. If cmake is absent it's
+    # installed via the dependency list.
+    command_exists cmake || return 0
+
+    local CMAKE_VERSION CMAKE_MAJOR CMAKE_MINOR
+    CMAKE_VERSION=$(cmake --version | head -n1 | grep -o '[0-9]\+\.[0-9]\+\.[0-9]\+' | head -1)
+    CMAKE_MAJOR=$(echo "$CMAKE_VERSION" | cut -d. -f1)
+    CMAKE_MINOR=$(echo "$CMAKE_VERSION" | cut -d. -f2)
+    if [ "$CMAKE_MAJOR" -lt 3 ] || [ "$CMAKE_MAJOR" -eq 3 -a "$CMAKE_MINOR" -lt 19 ]; then
+        echo ""
+        echo "=========================================="
+        echo "ERROR: CMake version $CMAKE_VERSION is too old!"
+        echo "Minimum required version: CMake 3.19"
+        echo "=========================================="
+        echo ""
+        exit 1
+    fi
+}
+
 # apt and dnf share ALL the dependency machinery below. The ONLY per-distro
 # inputs are the package LIST (apt|dnf columns of LINUX_DEPS) and three tiny
 # primitives: test-installed, install-set, point-cc-at-clang. The loop,
@@ -452,7 +475,8 @@ setup_cc_alternatives() {
 # The one general check: same flow for every distro; only the list + primitives differ.
 check_dependencies() {
     local mgr="$1"
-    check_linux_python  # hard version gate (>=3.10), distro-agnostic
+    check_linux_python  # hard version gate (python >= 3.10), distro-agnostic
+    check_linux_cmake   # hard version gate (cmake >= 3.19), distro-agnostic
 
     # Package set = shared LINUX_DEPS column + the compiler packages the
     # select_*_triplet chose. This list is the ONLY per-distro input.


### PR DESCRIPTION
## Summary

- Follow-up to #1436. That refactor unified the apt/dnf dependency handling and dropped `check_linux_cmake`, so `cmake` became **presence-only** (a `LINUX_DEPS` row). On a distro that ships cmake `< 3.19` (e.g. Ubuntu 20.04 = 3.16) the check printed `✓ cmake` and the build would fail later at the cmake *configure* step instead of failing fast with a clear message.
- Restores `check_linux_cmake` as a **distro-agnostic version gate**, mirroring the `check_linux_python` gate that was kept, and calls it from `check_dependencies`. `cmake` stays in `LINUX_DEPS` (installed if absent); if it's present but `< 3.19` it now fails fast with `CMake version X is too old! Minimum required version: CMake 3.19`.

Addresses @asclearuc's review note on #1436 (`scripts/compiler-unix.sh` cmake row).

## Type

fix / build — restores a version check; no behaviour change on distros that already ship cmake ≥ 3.19.

## Impact

Low in practice: on the affected older distros the Python `>= 3.10` gate already fires first (Ubuntu 20.04 ships Python 3.8), so users still get a clear error today. This just restores the specific, early **cmake** message for the "new-enough python + old cmake" case.

## Testing

- [x] Validated in podman — **Ubuntu 20.04** (cmake 3.16 → clear `CMake too old, minimum 3.19` error, exit 1) and **Ubuntu 22.04** (cmake 3.22 → passes, `[OK] All build prerequisites satisfied`).
- [x] `bash -n scripts/compiler-unix.sh` clean.

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included (gitleaks pre-commit clean)
- [x] No breaking changes — additive version gate, mirrors the existing python gate


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Linux setup now verifies that CMake meets the required minimum version before continuing, helping prevent build and dependency issues.
  * If CMake is already installed but too old, the process now stops with a clear error instead of proceeding.
  * Systems without CMake can still use the existing automatic install flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->