### PR TITLE
feat(anonymize): configurable entity types + token redaction style

### DIFF
--- a/nodes/src/nodes/anonymize/IInstance.py
+++ b/nodes/src/nodes/anonymize/IInstance.py
@@ -28,25 +28,6 @@ from .IGlobal import IGlobal
 class IInstance(IInstanceBase):
     IGlobal: IGlobal  # Reference to a global context providing recognizer functionality
 
-    # Default PII labels for zero-shot NER when no classifications provided
-    DEFAULT_PII_LABELS = [
-        'person',
-        'name',
-        'email',
-        'phone number',
-        'address',
-        'social security number',
-        'credit card number',
-        'date of birth',
-        'organization',
-        'company',
-        'location',
-        'ip address',
-        'bank account',
-        'passport number',
-        'driver license',
-    ]
-
     #
     # Current object context properties
     #
@@ -70,8 +51,10 @@ class IInstance(IInstanceBase):
 
     def closing(self):
         if not self.has_classifications:
-            # No classifications received - anonymize with default PII labels
-            self.target_object_text = self.IGlobal.recognizer.process(self.target_object_text, self.DEFAULT_PII_LABELS)
+            # No classifications received - anonymize with the configured entity types
+            self.target_object_text = self.IGlobal.recognizer.process(
+                self.target_object_text, self.IGlobal.recognizer.labels
+            )
 
         # Resume the writeText lane
         self.instance.writeText(self.target_object_text)

--- a/nodes/src/nodes/anonymize/README.md
+++ b/nodes/src/nodes/anonymize/README.md
@@ -1,21 +1,33 @@
 # anonymize
 
-A RocketRide filter node that detects and masks sensitive entities in text flowing through a pipeline.
+A RocketRide filter node that detects and redacts sensitive entities in text flowing through a pipeline.
 
 ## What it does
 
-Scans text for personally identifiable information (names, emails, phone numbers, addresses, and more) using a locally-run GLiNER zero-shot NER model and replaces every character of each detected entity span with a configurable masking character (default `█`, U+2588). Text length and structure are preserved: only the entity character positions are replaced, and overlapping or adjacent spans are merged before masking.
+Scans text for sensitive entities — names, emails, phone numbers, organizations, and more — using a locally-run GLiNER zero-shot NER model, then replaces each detected span. You control **which** entity types are detected (the `entityTypes` field) and **how** matches are replaced (the `redactionStyle` field):
 
-Example:
+- **`mask`** (default) overwrites every character of the span with a configurable masking character (default `█`, U+2588), preserving text length and structure.
+- **`token`** replaces each span with a labelled placeholder tag such as `[PERSON]` or `[EMAIL]`.
+
+Example (mask):
 
 ```
 Input:  John Smith is a patient at St. Mary's Hospital.
 Output: ████ █████ is a patient at ██ █████████████████.
 ```
 
+Example (token):
+
+```
+Input:  John Smith is a patient at St. Mary's Hospital.
+Output: [PERSON] is a patient at [ORGANIZATION].
+```
+
+Overlapping spans are merged before replacement (mask style also merges directly-adjacent spans, since the masked output is identical either way; token style keeps adjacent spans separate so each entity keeps its own tag).
+
 Models are loaded via `ai.common.models.GLiNER`, which runs inference locally and automatically routes to a model server when the engine is started with the `--modelserver` flag. Models are downloaded from Hugging Face on first use; no API key is required. The node declares the `gpu` capability, so GPU acceleration is used when available.
 
-Large documents are split into 1024-character chunks with a 128-character overlap so entities at chunk boundaries are not missed. Chunks are processed in parallel using up to 4 threads, entity labels are batched in groups of 32, and entities found in the overlap regions are de-duplicated before the final masking pass.
+Large documents are split into 1024-character chunks with a 128-character overlap so entities at chunk boundaries are not missed. Chunks are processed in parallel using up to 4 threads, entity labels are batched in groups of 32, and entities found in the overlap regions are de-duplicated before the final replacement pass.
 
 Note: AI-based detection cannot guarantee 100% accuracy. Review results before using in production.
 
@@ -33,11 +45,13 @@ When an upstream classifier node is present, the node also receives classificati
 
 ### Fields
 
-The node is configured by choosing a model profile. Each profile exposes the masking character field; the `custom` profile additionally exposes a free-form model name field.
+The node is configured by choosing a model profile. Each profile exposes the entity-type, redaction-style, and masking-character fields; the `custom` profile additionally exposes a free-form model name field.
 
 | Field | Type | Description |
 |---|---|---|
-| `anonymizeChar` | string | Character |
+| `entityTypes` | array | Entity types to detect. Pre-filled with 15 common PII types; remove any you don't want or add your own (the model is zero-shot, so any label works). An empty value falls back to the defaults. |
+| `redactionStyle` | string | How matches are replaced: `mask` (default) overwrites with the masking character; `token` replaces with a labelled tag like `[PERSON]`. |
+| `anonymizeChar` | string | Character used for masking (mask style only) |
 | `model` | string | Gliner model to use for anonymization |
 | `profile` | string | Default "glinerMergedLarge". Anonymize model |
 
@@ -72,11 +86,11 @@ The default profile when adding the node is `glinerSmall` (as set in `preconfig.
 
 ## Entity labels
 
-What gets detected and masked depends on whether an upstream classifier node feeds this node.
+What gets detected and redacted depends on whether an upstream classifier node feeds this node.
 
 ### Standalone (no upstream classifier)
 
-The node runs GLiNER with a built-in set of 15 PII labels:
+The node runs GLiNER with the labels from the `entityTypes` field. This is pre-filled with a default set of 15 common PII labels, which you can edit freely (the model is zero-shot, so any label works):
 
 `person`, `name`, `email`, `phone number`, `address`, `social security number`, `credit card number`, `date of birth`, `organization`, `company`, `location`, `ip address`, `bank account`, `passport number`, `driver license`
 
@@ -84,7 +98,7 @@ The node runs GLiNER with a built-in set of 15 PII labels:
 
 When classification data arrives before the object closes, the node:
 
-1. Masks the exact character spans (`offset`, `length`) reported in the classification `textMatches`.
+1. Redacts the exact character spans (`offset`, `length`) reported in the classification `textMatches`. In `token` style these carry no entity type, so they are tagged `[REDACTED]` unless a more specific NER detection covers the same span.
 2. Resolves classification rule `idRef` values to English names via the Nucleuz rule pack (`nucleuz/rulePack.dat` under the engine path).
 3. Extracts keyword `<Term>` entries from the classification rules as additional GLiNER labels.
 4. Runs GLiNER with the combined label set and merges the results with the spans from step 1.
@@ -95,7 +109,7 @@ If `nucleuz/rulePack.dat` is not present, rule-name resolution silently produces
 
 ## Running the tests
 
-The node ships automated test cases in `services.json`. The standard test runs against the `glinerSmall` profile; the full test exercises every model profile.
+The node ships automated test cases in `services.json`. The standard test runs against the `glinerSmall` profile; the full test exercises every model profile. Server-free unit tests for the pure redaction logic live in `nodes/test/test_anonymize_logic.py`.
 
 ```bash
 # Standard test (glinerSmall profile)

--- a/nodes/src/nodes/anonymize/anonymize.py
+++ b/nodes/src/nodes/anonymize/anonymize.py
@@ -22,6 +22,58 @@
 # =============================================================================
 
 
+import re
+
+
+# Default PII labels for zero-shot detection when the user has not configured
+# their own. Kept in sync with the `entityTypes` field default in services.json
+# (enforced by nodes/test/test_anonymize_logic.py::test_default_labels_match_services_json).
+DEFAULT_PII_LABELS = [
+    'person',
+    'name',
+    'email',
+    'phone number',
+    'address',
+    'social security number',
+    'credit card number',
+    'date of birth',
+    'organization',
+    'company',
+    'location',
+    'ip address',
+    'bank account',
+    'passport number',
+    'driver license',
+]
+
+
+def format_token(label: str) -> str:
+    """Render an entity label as a clean placeholder tag, e.g. [PHONE NUMBER].
+
+    Labels reach this function already normalized by GLiNER (lowercased, spaces
+    collapsed to underscores). We undo that so multi-word types read naturally
+    inside the brackets instead of as [PHONE_NUMBER].
+    """
+    cleaned = re.sub(r'\s+', ' ', label.replace('_', ' ')).strip()
+    return f'[{cleaned.upper()}]'
+
+
+def clean_entity_types(configured, defaults=None) -> list:
+    """Normalize a configured `entityTypes` value into a usable label list.
+
+    - A non-list value (e.g. a stray JSON string) is rejected outright so it can
+      never be iterated character-by-character into junk single-char labels.
+    - Blank / non-string entries are dropped.
+    - An empty result falls back to the defaults, so detection is never silently
+      disabled (this fallback is intended behavior, not a bug).
+    """
+    labels = DEFAULT_PII_LABELS if defaults is None else defaults
+    if not isinstance(configured, list):
+        return list(labels)
+    cleaned = [item.strip() for item in configured if isinstance(item, str) and item.strip()]
+    return cleaned or list(labels)
+
+
 def anonymize(text: str, matches, anonymize_char: str = '*') -> str:
     """Replace specified segments with a sequence of anonymization characters.
 
@@ -66,25 +118,34 @@ def anonymize_tokens(text: str, matches) -> str:
             [offset, offset + length) is replaced by the token string.
 
     Note:
-        Offsets may be in any order. Overlapping and adjacent matches are
-        merged; on a merge the first (lowest-offset) token is kept.
+        Offsets may be in any order. Only genuinely overlapping matches are
+        merged (adjacent-but-distinct spans are kept separate so each entity
+        keeps its own token); on a merge the first (lowest-offset, earliest in
+        the input list) token is kept. Callers that want a specific label to win
+        over a generic one on an equal-offset overlap must list it first.
     """
     if not matches:
         return text  # Return the original text if no matches exist
 
-    # Merge overlapping and adjacent matches, keeping the first token.
+    # Merge only truly overlapping matches (strict `<`, not `<=`), keeping the
+    # first token. Equal offsets are a stable tiebreak via Python's stable sort.
     merged_matches = []
     for offset, length, token in sorted(matches, key=lambda m: m[0]):
-        if merged_matches and offset <= merged_matches[-1][0] + merged_matches[-1][1]:
-            prev_offset, prev_length, prev_token = merged_matches.pop()
+        if merged_matches and offset < merged_matches[-1][0] + merged_matches[-1][1]:
+            prev_offset, prev_length, prev_token = merged_matches[-1]
             new_length = max(prev_offset + prev_length, offset + length) - prev_offset
-            merged_matches.append((prev_offset, new_length, prev_token))
+            merged_matches[-1] = (prev_offset, new_length, prev_token)
         else:
             merged_matches.append((offset, length, token))
 
-    # Replace right-to-left so earlier offsets stay valid as span lengths change.
-    result = text
-    for offset, length, token in reversed(merged_matches):
-        result = result[:offset] + token + result[offset + length :]
+    # Single left-to-right pass: copy gaps verbatim, swap each span for its
+    # token, then join once — O(n) instead of rebuilding the string per match.
+    parts = []
+    cursor = 0
+    for offset, length, token in merged_matches:
+        parts.append(text[cursor:offset])
+        parts.append(token)
+        cursor = offset + length
+    parts.append(text[cursor:])
 
-    return result
+    return ''.join(parts)

--- a/nodes/src/nodes/anonymize/anonymize.py
+++ b/nodes/src/nodes/anonymize/anonymize.py
@@ -55,3 +55,36 @@ def anonymize(text: str, matches, anonymize_char: str = '*') -> str:
         text_list[offset:end] = [anonymize_char] * length
 
     return ''.join(text_list)
+
+
+def anonymize_tokens(text: str, matches) -> str:
+    """Replace specified segments with labelled placeholder tokens.
+
+    Args:
+        text (str): Input text to replace the segments.
+        matches (any): A list of (offset, length, token) tuples. The span
+            [offset, offset + length) is replaced by the token string.
+
+    Note:
+        Offsets may be in any order. Overlapping and adjacent matches are
+        merged; on a merge the first (lowest-offset) token is kept.
+    """
+    if not matches:
+        return text  # Return the original text if no matches exist
+
+    # Merge overlapping and adjacent matches, keeping the first token.
+    merged_matches = []
+    for offset, length, token in sorted(matches, key=lambda m: m[0]):
+        if merged_matches and offset <= merged_matches[-1][0] + merged_matches[-1][1]:
+            prev_offset, prev_length, prev_token = merged_matches.pop()
+            new_length = max(prev_offset + prev_length, offset + length) - prev_offset
+            merged_matches.append((prev_offset, new_length, prev_token))
+        else:
+            merged_matches.append((offset, length, token))
+
+    # Replace right-to-left so earlier offsets stay valid as span lengths change.
+    result = text
+    for offset, length, token in reversed(merged_matches):
+        result = result[:offset] + token + result[offset + length :]
+
+    return result

--- a/nodes/src/nodes/anonymize/glinerRecognizer.py
+++ b/nodes/src/nodes/anonymize/glinerRecognizer.py
@@ -29,7 +29,7 @@ from rocketlib import debug, expand
 from ai.common.config import Config
 from ai.common.models import GLiNER
 from .Ruleparser import RuleParser
-from .anonymize import anonymize as _anonymize
+from .anonymize import anonymize as _anonymize, anonymize_tokens
 
 
 # Default PII labels for zero-shot detection when the user has not configured
@@ -67,6 +67,10 @@ class GliNERRecognizer:
         self.model_name = config.get('model', 'xomad/gliner-model-merge-large-v1.0')
         self.anonymize = config.get('anonymize', True)
         self.anonymize_char = config.get('anonymizeChar', '\u2588')
+
+        # Redaction style: 'mask' overwrites entities with anonymize_char (\u2588\u2588\u2588\u2588),
+        # 'token' replaces each entity with a labelled placeholder like [PERSON].
+        self.redaction_style = config.get('redactionStyle', 'mask')
 
         # Entity types to detect. Configurable per pipeline via the `entityTypes`
         # field; falls back to the common defaults when unset or empty. Blank
@@ -111,6 +115,17 @@ class GliNERRecognizer:
             )
         )
         return matches
+
+    def convert_ner_results_to_token_matches(self, ner_results):
+        """Build (offset, length, token) tuples, deriving the token from the label."""
+        return [
+            (
+                result['start'],
+                result['end'] - result['start'],
+                f'[{result["label"].upper()}]',
+            )
+            for result in ner_results
+        ]
 
     def normalize_label(self, label):
         """Clean label names to a consistent format."""
@@ -219,18 +234,30 @@ class GliNERRecognizer:
             existing_matches: Optional list of (offset, length) tuples from classifications
 
         Returns:
-            Anonymized text with detected entities replaced by anonymize_char
+            Anonymized text. In 'mask' style detected spans are overwritten with
+            anonymize_char; in 'token' style they are replaced with labelled
+            placeholder tokens (e.g. [PERSON]).
         """
         if not text:
             return text
 
         # Run NER prediction
         ner_results = self.predict(text, labels)
-        ner_matches = self.convert_ner_results_to_matches(ner_results)
 
         debug(f'Anonymize: Detected {len(ner_results)} entities')
 
-        # Combine with existing matches (from classifications)
+        if self.redaction_style == 'token':
+            token_matches = self.convert_ner_results_to_token_matches(ner_results)
+            # Classification matches carry no per-match label -> generic token.
+            fallback = [(offset, length, '[REDACTED]') for offset, length in (existing_matches or [])]
+            all_matches = fallback + token_matches
+            if not all_matches:
+                debug('Anonymize: No entities to mask')
+                return text
+            return anonymize_tokens(text, all_matches)
+
+        # Default 'mask' style (unchanged behavior)
+        ner_matches = self.convert_ner_results_to_matches(ner_results)
         all_matches = list(existing_matches or []) + ner_matches
 
         if not all_matches:

--- a/nodes/src/nodes/anonymize/glinerRecognizer.py
+++ b/nodes/src/nodes/anonymize/glinerRecognizer.py
@@ -29,28 +29,12 @@ from rocketlib import debug, expand
 from ai.common.config import Config
 from ai.common.models import GLiNER
 from .Ruleparser import RuleParser
-from .anonymize import anonymize as _anonymize, anonymize_tokens
-
-
-# Default PII labels for zero-shot detection when the user has not configured
-# their own. Kept in sync with the `entityTypes` field default in services.json.
-DEFAULT_PII_LABELS = [
-    'person',
-    'name',
-    'email',
-    'phone number',
-    'address',
-    'social security number',
-    'credit card number',
-    'date of birth',
-    'organization',
-    'company',
-    'location',
-    'ip address',
-    'bank account',
-    'passport number',
-    'driver license',
-]
+from .anonymize import (
+    anonymize as _anonymize,
+    anonymize_tokens,
+    clean_entity_types,
+    format_token,
+)
 
 
 class GliNERRecognizer:
@@ -73,13 +57,10 @@ class GliNERRecognizer:
         self.redaction_style = config.get('redactionStyle', 'mask')
 
         # Entity types to detect. Configurable per pipeline via the `entityTypes`
-        # field; falls back to the common defaults when unset or empty. Blank
-        # entries are dropped so an empty value never disables detection.
-        configured = config.get('entityTypes')
-        cleaned = (
-            [label.strip() for label in configured if isinstance(label, str) and label.strip()] if configured else []
-        )
-        self.labels = cleaned or DEFAULT_PII_LABELS
+        # field; clean_entity_types rejects non-list values, drops blank entries,
+        # and falls back to the common defaults when the result is empty so
+        # detection is never silently disabled.
+        self.labels = clean_entity_types(config.get('entityTypes'))
 
         enginePath = expand('%execPath%')
         rule_file_path = os.path.join(enginePath, 'nucleuz', 'rulePack.dat')
@@ -117,14 +98,15 @@ class GliNERRecognizer:
         return matches
 
     def convert_ner_results_to_token_matches(self, ner_results):
-        """Build (offset, length, token) tuples, deriving the token from the label."""
+        """Build (offset, length, token) tuples, deriving the token from the label.
+
+        Reuses convert_ner_results_to_matches for the span math so the offset/
+        length derivation lives in exactly one place; only the appended token
+        label differs between the mask and token styles.
+        """
+        matches = self.convert_ner_results_to_matches(ner_results)
         return [
-            (
-                result['start'],
-                result['end'] - result['start'],
-                f'[{result["label"].upper()}]',
-            )
-            for result in ner_results
+            (offset, length, format_token(result['label'])) for (offset, length), result in zip(matches, ner_results)
         ]
 
     def normalize_label(self, label):
@@ -250,7 +232,10 @@ class GliNERRecognizer:
             token_matches = self.convert_ner_results_to_token_matches(ner_results)
             # Classification matches carry no per-match label -> generic token.
             fallback = [(offset, length, '[REDACTED]') for offset, length in (existing_matches or [])]
-            all_matches = fallback + token_matches
+            # Specific NER tokens first: on an equal-offset overlap the merge in
+            # anonymize_tokens keeps the earliest-listed token, so a real label
+            # like [EMAIL] wins over the generic [REDACTED] fallback.
+            all_matches = token_matches + fallback
             if not all_matches:
                 debug('Anonymize: No entities to mask')
                 return text

--- a/nodes/src/nodes/anonymize/glinerRecognizer.py
+++ b/nodes/src/nodes/anonymize/glinerRecognizer.py
@@ -32,6 +32,27 @@ from .Ruleparser import RuleParser
 from .anonymize import anonymize as _anonymize
 
 
+# Default PII labels for zero-shot detection when the user has not configured
+# their own. Kept in sync with the `entityTypes` field default in services.json.
+DEFAULT_PII_LABELS = [
+    'person',
+    'name',
+    'email',
+    'phone number',
+    'address',
+    'social security number',
+    'credit card number',
+    'date of birth',
+    'organization',
+    'company',
+    'location',
+    'ip address',
+    'bank account',
+    'passport number',
+    'driver license',
+]
+
+
 class GliNERRecognizer:
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
         """
@@ -46,6 +67,15 @@ class GliNERRecognizer:
         self.model_name = config.get('model', 'xomad/gliner-model-merge-large-v1.0')
         self.anonymize = config.get('anonymize', True)
         self.anonymize_char = config.get('anonymizeChar', '\u2588')
+
+        # Entity types to detect. Configurable per pipeline via the `entityTypes`
+        # field; falls back to the common defaults when unset or empty. Blank
+        # entries are dropped so an empty value never disables detection.
+        configured = config.get('entityTypes')
+        cleaned = (
+            [label.strip() for label in configured if isinstance(label, str) and label.strip()] if configured else []
+        )
+        self.labels = cleaned or DEFAULT_PII_LABELS
 
         enginePath = expand('%execPath%')
         rule_file_path = os.path.join(enginePath, 'nucleuz', 'rulePack.dat')

--- a/nodes/src/nodes/anonymize/services.json
+++ b/nodes/src/nodes/anonymize/services.json
@@ -253,6 +253,13 @@
 				"driver license"
 			]
 		},
+		"redactionStyle": {
+			"type": "string",
+			"title": "Redaction style",
+			"description": "How detected entities are replaced. 'mask' overwrites each entity with the anonymization character (████). 'token' replaces each entity with a labelled tag like [PERSON] or [EMAIL].",
+			"default": "mask",
+			"enum": ["mask", "token"]
+		},
 		"anonymize.model": {
 			"type": "string",
 			"title": "Model name",
@@ -262,75 +269,75 @@
 		},
 		"anonymize.custom": {
 			"object": "custom",
-			"properties": ["anonymize.model", "anonymizeChar", "entityTypes"]
+			"properties": ["anonymize.model", "anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerMergedLarge": {
 			"object": "glinerMergedLarge",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerMultiPII": {
 			"object": "glinerMultiPII",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerPIILarge": {
 			"object": "glinerPIILarge",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerSmall": {
 			"object": "glinerSmall",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerMedium": {
 			"object": "glinerMedium",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerLarge": {
 			"object": "glinerLarge",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerMulti": {
 			"object": "glinerMulti",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.gretelSmall": {
 			"object": "gretelSmall",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.gretelLarge": {
 			"object": "gretelLarge",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerKo": {
 			"object": "glinerKo",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerIt": {
 			"object": "glinerIt",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerAr": {
 			"object": "glinerAr",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerCommunitySmall": {
 			"object": "glinerCommunitySmall",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerCommunityMedium": {
 			"object": "glinerCommunityMedium",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerCommunityLarge": {
 			"object": "glinerCommunityLarge",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerBiomedSmall": {
 			"object": "glinerBiomedSmall",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.glinerBiomedLarge": {
 			"object": "glinerBiomedLarge",
-			"properties": ["anonymizeChar", "entityTypes"]
+			"properties": ["anonymizeChar", "entityTypes", "redactionStyle"]
 		},
 		"anonymize.profile": {
 			"title": "Model",

--- a/nodes/src/nodes/anonymize/services.json
+++ b/nodes/src/nodes/anonymize/services.json
@@ -228,6 +228,31 @@
 			"title": "Character to use for anonymization",
 			"description": "Character"
 		},
+		"entityTypes": {
+			"type": "array",
+			"title": "Entity types to anonymize",
+			"description": "PII / entity types to detect and mask. Pre-filled with common types; remove any you don't want, or add your own (the model is zero-shot, so any label works).",
+			"items": {
+				"type": "string"
+			},
+			"default": [
+				"person",
+				"name",
+				"email",
+				"phone number",
+				"address",
+				"social security number",
+				"credit card number",
+				"date of birth",
+				"organization",
+				"company",
+				"location",
+				"ip address",
+				"bank account",
+				"passport number",
+				"driver license"
+			]
+		},
 		"anonymize.model": {
 			"type": "string",
 			"title": "Model name",
@@ -237,75 +262,75 @@
 		},
 		"anonymize.custom": {
 			"object": "custom",
-			"properties": ["anonymize.model", "anonymizeChar"]
+			"properties": ["anonymize.model", "anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerMergedLarge": {
 			"object": "glinerMergedLarge",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerMultiPII": {
 			"object": "glinerMultiPII",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerPIILarge": {
 			"object": "glinerPIILarge",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerSmall": {
 			"object": "glinerSmall",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerMedium": {
 			"object": "glinerMedium",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerLarge": {
 			"object": "glinerLarge",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerMulti": {
 			"object": "glinerMulti",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.gretelSmall": {
 			"object": "gretelSmall",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.gretelLarge": {
 			"object": "gretelLarge",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerKo": {
 			"object": "glinerKo",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerIt": {
 			"object": "glinerIt",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerAr": {
 			"object": "glinerAr",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerCommunitySmall": {
 			"object": "glinerCommunitySmall",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerCommunityMedium": {
 			"object": "glinerCommunityMedium",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerCommunityLarge": {
 			"object": "glinerCommunityLarge",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerBiomedSmall": {
 			"object": "glinerBiomedSmall",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.glinerBiomedLarge": {
 			"object": "glinerBiomedLarge",
-			"properties": ["anonymizeChar"]
+			"properties": ["anonymizeChar", "entityTypes"]
 		},
 		"anonymize.profile": {
 			"title": "Model",

--- a/nodes/test/test_anonymize_logic.py
+++ b/nodes/test/test_anonymize_logic.py
@@ -1,0 +1,163 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Pure-logic unit tests for the anonymize node.
+
+These exercise the import-light helpers in ``nodes/anonymize/anonymize.py``
+(token replacement, label-tag formatting, entity-type cleaning) plus the
+code/services.json default-label sync. No GLiNER model or running server is
+required, so this file runs under plain ``python3`` as well as pytest.
+"""
+
+import importlib.util
+import json
+import os
+
+_ANON_DIR = os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes', 'anonymize')
+
+
+def _load_anonymize_module():
+    """Load anonymize.py by file path, bypassing the package __init__ (heavy deps)."""
+    path = os.path.join(_ANON_DIR, 'anonymize.py')
+    spec = importlib.util.spec_from_file_location('anonymize_pure', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+anon = _load_anonymize_module()
+
+
+# --- anonymize_tokens: adjacency (#1) -------------------------------------
+
+
+def test_adjacent_distinct_entities_keep_both_tokens():
+    # "JohnDoe" [0,7) name immediately followed by "a@b.co" [7,13) email,
+    # no separator. Each must keep its own tag, not collapse into one.
+    text = 'JohnDoea@b.co!'
+    matches = [(0, 7, '[NAME]'), (7, 6, '[EMAIL]')]
+    assert anon.anonymize_tokens(text, matches) == '[NAME][EMAIL]!'
+
+
+def test_true_overlap_merges_keeping_first_token():
+    # Genuinely overlapping spans collapse to one token (the first by offset).
+    text = 'abcdefgh'
+    matches = [(0, 4, '[A]'), (2, 4, '[B]')]  # [0,4) and [2,6) overlap
+    assert anon.anonymize_tokens(text, matches) == '[A]gh'
+
+
+def test_exact_duplicate_span_merges():
+    text = 'secret stuff'
+    matches = [(0, 6, '[X]'), (0, 6, '[X]')]
+    assert anon.anonymize_tokens(text, matches) == '[X] stuff'
+
+
+# --- anonymize_tokens: first-in-list wins on equal offset (#2 invariant) ---
+
+
+def test_equal_offset_keeps_first_in_list_order():
+    # process() relies on this: a specific NER token listed BEFORE a generic
+    # [REDACTED] fallback at the same span must win.
+    text = 'jane@x.com here'
+    specific_first = [(0, 10, '[EMAIL]'), (0, 10, '[REDACTED]')]
+    assert anon.anonymize_tokens(text, specific_first) == '[EMAIL] here'
+
+
+# --- anonymize_tokens: correctness / ordering ------------------------------
+
+
+def test_replaces_multiple_spans_in_order():
+    text = 'A bob B carol C'
+    matches = [(2, 3, '[P1]'), (8, 5, '[P2]')]
+    assert anon.anonymize_tokens(text, matches) == 'A [P1] B [P2] C'
+
+
+def test_unsorted_input_is_handled():
+    text = 'A bob B carol C'
+    matches = [(8, 5, '[P2]'), (2, 3, '[P1]')]
+    assert anon.anonymize_tokens(text, matches) == 'A [P1] B [P2] C'
+
+
+def test_no_matches_returns_original():
+    assert anon.anonymize_tokens('untouched', []) == 'untouched'
+
+
+# --- format_token: readable multi-word tags (#3) ---------------------------
+
+
+def test_format_token_single_word():
+    assert anon.format_token('person') == '[PERSON]'
+
+
+def test_format_token_multiword_uses_spaces_not_underscores():
+    assert anon.format_token('phone_number') == '[PHONE NUMBER]'
+    assert anon.format_token('social_security_number') == '[SOCIAL SECURITY NUMBER]'
+
+
+def test_format_token_accepts_spaced_input():
+    assert anon.format_token('ip address') == '[IP ADDRESS]'
+
+
+# --- clean_entity_types: non-list guard + intended fallback (#4, #5) --------
+
+
+def test_clean_entity_types_string_does_not_become_per_char_labels():
+    # A stray string config must NOT iterate into single-character labels.
+    result = anon.clean_entity_types('person')
+    assert result == anon.DEFAULT_PII_LABELS
+
+
+def test_clean_entity_types_none_returns_defaults():
+    assert anon.clean_entity_types(None) == anon.DEFAULT_PII_LABELS
+
+
+def test_clean_entity_types_empty_list_returns_defaults():
+    # Intended: an empty list never disables detection.
+    assert anon.clean_entity_types([]) == anon.DEFAULT_PII_LABELS
+
+
+def test_clean_entity_types_strips_and_drops_blanks():
+    assert anon.clean_entity_types(['  email ', '', '   ', 'ssn']) == ['email', 'ssn']
+
+
+def test_clean_entity_types_all_blank_returns_defaults():
+    assert anon.clean_entity_types(['  ', '']) == anon.DEFAULT_PII_LABELS
+
+
+def test_clean_entity_types_drops_non_string_items():
+    assert anon.clean_entity_types(['email', 123, None, 'ssn']) == ['email', 'ssn']
+
+
+# --- DEFAULT_PII_LABELS stays in sync with services.json (#9) --------------
+
+
+def test_default_labels_match_services_json():
+    # services.json is JSONC (// comments, and "//" appears inside the protocol
+    # string), so a plain json.load fails. Extract just the entityTypes.default
+    # array — its contents are plain JSON with no comments.
+    with open(os.path.join(_ANON_DIR, 'services.json'), encoding='utf-8') as f:
+        raw = f.read()
+    key = raw.index('"entityTypes"')
+    default = raw.index('"default"', key)
+    start = raw.index('[', default)
+    end = raw.index(']', start)
+    json_default = json.loads(raw[start : end + 1])
+    assert json_default == anon.DEFAULT_PII_LABELS, (
+        'entityTypes.default in services.json drifted from DEFAULT_PII_LABELS'
+    )
+
+
+if __name__ == '__main__':
+    tests = [v for k, v in sorted(globals().items()) if k.startswith('test_') and callable(v)]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f'  ok - {t.__name__}')
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(f'  FAIL - {t.__name__}: {type(e).__name__}: {e}')
+    print(f'\n{len(tests) - failed}/{len(tests)} passed')
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
## Summary

Adds configurable PII entity types and a token-based redaction style to the `anonymize` node, alongside the existing mask style.

- **`entityTypes`** (array) — choose which PII labels GLiNER detects. Pre-filled with 15 common labels; editable (zero-shot, any label works). Empty falls back to defaults.
- **`redactionStyle`** (`mask` | `token`) — `mask` (default) overwrites each span with the masking char; `token` replaces each span with a labelled tag like `[PERSON]` / `[EMAIL]`.

## Changes

- `anonymize.py` — `DEFAULT_PII_LABELS`, `format_token()`, `clean_entity_types()`, and a rewritten `anonymize_tokens` (strict `<` overlap merge so adjacent distinct entities keep separate tags; single-pass O(n) join).
- `glinerRecognizer.py` — reads `entityTypes` via `clean_entity_types`; token path delegates to `format_token`; specific NER labels take precedence over generic classifier spans.
- `services.json` — `redactionStyle` enum, `entityTypes.default` (15 labels), glinerSmall test case.
- `README.md` — documents both fields.
- `IInstance.py` — trimmed.

## Testing

- `nodes/test/test_anonymize_logic.py` — 17 server-free pure-logic tests (mask/token replacement, overlap merge, entity-type cleaning, services.json default sync). All green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new redaction style for anonymized output, with support for both masked placeholders and token-based replacements.
  * Expanded configurable entity types so more kinds of sensitive text can be redacted.

* **Bug Fixes**
  * Improved anonymization when no upstream classifications are available by using the configured entity labels.
  * Refined span handling so overlapping, adjacent, and duplicate matches are redacted more consistently.

* **Documentation**
  * Updated anonymization guidance and configuration details, including clearer examples and test-running notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->