### PR TITLE
fix(vscode): repoint dead example links to awesome-rocketride (#1422)

### DIFF
--- a/apps/vscode/docs/index.md
+++ b/apps/vscode/docs/index.md
@@ -50,11 +50,7 @@ You build your `.pipe` - and you run it against the fastest AI runtime available
 - **Connection manager** - Connect to a local engine (one click, no setup) or your own on-premises server.
 - **SDKs for TypeScript, Python & MCP** - Embed pipelines in your apps or expose them as tools for AI assistants.
 
-Need inspiration? Check out our [example pipelines](https://docs.rocketride.org/):
-
-- [Advanced RAG](https://docs.rocketride.org/examples/advanced-rag-pipeline/)
-- [Video Frame Grabber](https://docs.rocketride.org/examples/video-key-frame-grabber/)
-- [Audio Transcription](https://docs.rocketride.org/examples/audio-transcription-simple/)
+Need inspiration? Check out [awesome-rocketride](https://github.com/rocketride-org/awesome-rocketride#demos--examples), a collection of example projects built on RocketRide.
 
 ## Extension Settings
 

--- a/docs/README-vscode.md
+++ b/docs/README-vscode.md
@@ -52,11 +52,7 @@ You build your `.pipe` - and you run it against the fastest AI runtime available
 - **Connection manager** - Connect to a local engine, Docker container, system service, on-premises server, or RocketRide Cloud. Separate development and deployment targets let you build locally and deploy to a different environment.
 - **SDKs for TypeScript, Python & MCP** - Embed pipelines in your apps or expose them as tools for AI assistants.
 
-Need inspiration? Check out our [example pipelines](https://docs.rocketride.org/):
-
-- [Advanced RAG](https://docs.rocketride.org/examples/advanced-rag-pipeline/)
-- [Video Frame Grabber](https://docs.rocketride.org/examples/video-key-frame-grabber/)
-- [Audio Transcription](https://docs.rocketride.org/examples/audio-transcription-simple/)
+Need inspiration? Check out [awesome-rocketride](https://github.com/rocketride-org/awesome-rocketride#demos--examples), a collection of example projects built on RocketRide.
 
 ## Extension Settings
 


### PR DESCRIPTION
## What

The VS Code extension's "Need inspiration?" block linked to `docs.rocketride.org/examples/{advanced-rag-pipeline, video-key-frame-grabber, audio-transcription-simple}`. Those specific pages no longer resolve (the live docs `llms.txt` now lists `document-extraction`, `rag-pipeline`, `webhook-pipeline` instead), so a new builder hits a dead end on the first click.

This repoints the block to the [awesome-rocketride](https://github.com/rocketride-org/awesome-rocketride#demos--examples) demos-and-examples collection:

> Need inspiration? Check out [awesome-rocketride](https://github.com/rocketride-org/awesome-rocketride#demos--examples), a collection of example projects built on RocketRide.

## Where

Both **tracked** sources carried the block:
- `apps/vscode/docs/index.md` — the docs-site surface for the extension
- `docs/README-vscode.md` — the source that build copies to the (gitignored, generated) marketplace `apps/vscode/README.md`

Verified the `awesome-rocketride` repo is public and the `#demos--examples` anchor resolves to its `## Demos & Examples` heading.

## Note on approach

This differs from the issue's suggested fix (repoint to repo-root `examples/*.pipe`). Per verbal confirmation from Josh, linking to the curated `awesome-rocketride` collection is the intended direction.

Out of scope for this PR (left for a follow-up): the remaining `docs.rocketride.org` "Documentation" links (still live) and the `.org` vs `.ai` domain drift called out in the issue.

Closes #1422

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Need inspiration?” section to point to a new demos/examples collection.
  * Removed the previous list of example pipeline links and replaced it with a single, more focused resource link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->