### PR TITLE
fix: prevent application crash on restricted sessionStorage access

### DIFF
--- a/apps/chat-ui/src/App.tsx
+++ b/apps/chat-ui/src/App.tsx
@@ -99,7 +99,7 @@ const App: React.FC = () => {
 			window.history.replaceState({}, '', window.location.pathname);
 		} else if (!isVSCode) {
 			// Fall back to session storage (skip in VSCode webview - shared storage would mix auth across tabs)
-			token = sessionStorage.getItem('auth') || '';
+			try { token = sessionStorage.getItem('auth') || ''; } catch { token = ''; }
 		}
 		if (!token && API_CONFIG.devMode && API_CONFIG.ROCKETRIDE_APIKEY) {
 			token = API_CONFIG.ROCKETRIDE_APIKEY;
@@ -126,7 +126,7 @@ const App: React.FC = () => {
 
 		// Save the token in session storage (skip in VSCode) and our state
 		if (!isVSCode) {
-			sessionStorage.setItem('auth', token);
+			try { sessionStorage.setItem('auth', token); } catch {}
 		}
 		setAuthToken(token);
 

--- a/apps/dropper-ui/src/App.tsx
+++ b/apps/dropper-ui/src/App.tsx
@@ -71,7 +71,7 @@ const App: React.FC = () => {
 		if (token) {
 			window.history.replaceState({}, '', window.location.pathname);
 		} else if (!isVSCode) {
-			token = sessionStorage.getItem('auth') || '';
+			try { token = sessionStorage.getItem('auth') || ''; } catch { token = ''; }
 		}
 		if (!token && API_CONFIG.devMode && API_CONFIG.ROCKETRIDE_APIKEY) {
 			token = API_CONFIG.ROCKETRIDE_APIKEY;
@@ -94,7 +94,7 @@ const App: React.FC = () => {
 		});
 
 		if (!isVSCode) {
-			sessionStorage.setItem('auth', token);
+			try { sessionStorage.setItem('auth', token); } catch {}
 		}
 		setAuthToken(token);
 

--- a/apps/dropper-ui/src/hooks/clientSingleton.ts
+++ b/apps/dropper-ui/src/hooks/clientSingleton.ts
@@ -120,7 +120,8 @@ let lastConnectionError: { reason: string; hasError: boolean } | null = null;
  */
 async function getAuthToken(): Promise<string | null> {
 	// Check session storage first for cached token
-	let auth = sessionStorage.getItem('auth');
+	let auth: string | null = null;
+	try { auth = sessionStorage.getItem('auth'); } catch {}
 	if (auth) return auth;
 
 	if (API_CONFIG.devMode) {
@@ -150,7 +151,7 @@ async function getAuthToken(): Promise<string | null> {
 	}
 
 	// Cache token in session storage for subsequent requests
-	if (auth) sessionStorage.setItem('auth', auth);
+	if (auth) { try { sessionStorage.setItem('auth', auth); } catch {} }
 	return auth;
 }
 

--- a/apps/shell-ui/src/util/pkce.ts
+++ b/apps/shell-ui/src/util/pkce.ts
@@ -114,7 +114,7 @@ export async function generatePkce(): Promise<PkceChallenge> {
 
     // Persist the verifier in sessionStorage so it survives the browser
     // redirect to the Zitadel authorization endpoint and back.
-    sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier);
+    try { sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier); } catch {}
 
     return { verifier, challenge };
 }
@@ -132,7 +132,7 @@ export function getStoredVerifier(): string | null {
     // Read the previously stored verifier from sessionStorage.
     // Returns null if the key does not exist (e.g., the tab was closed
     // between the initial navigation and the redirect callback).
-    return sessionStorage.getItem(PKCE_VERIFIER_KEY);
+    try { return sessionStorage.getItem(PKCE_VERIFIER_KEY); } catch { return null; }
 }
 
 /**
@@ -143,7 +143,7 @@ export function getStoredVerifier(): string | null {
  */
 export function clearStoredVerifier(): void {
     // Remove the verifier entry from sessionStorage so it cannot be reused.
-    sessionStorage.removeItem(PKCE_VERIFIER_KEY);
+    try { sessionStorage.removeItem(PKCE_VERIFIER_KEY); } catch {}
 }
 
 // =============================================================================


### PR DESCRIPTION
## Description of changes
This PR fixes a critical Denial of Service (DoS) bug where unprotected `sessionStorage` access causes the application to crash completely when run in strict privacy modes (e.g., Safari Private Browsing or Chrome with third-party cookies blocked).

All bare `sessionStorage.getItem()` and `sessionStorage.setItem()` calls across the frontend apps have been safely wrapped in `try/catch` blocks, allowing the app to gracefully fall back to in-memory state or limited functionality when storage is restricted.

Affected files:
- `apps/chat-ui/src/App.tsx`
- `apps/dropper-ui/src/App.tsx`
- `apps/dropper-ui/src/hooks/clientSingleton.ts`
- `apps/shell-ui/src/util/pkce.ts`

Fixes #1453

## Testing performed
- Verified syntax correctness.
- Safely swallows `SecurityError` and `QuotaExceededError` exceptions raised by the browser when access to `window.sessionStorage` is denied.

## Breaking changes
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in and token handling so the app no longer crashes when browser storage is unavailable or restricted.
  * Made authentication and PKCE data persistence more resilient by safely handling storage read/write failures.
  * Reduced the chance of runtime errors during login flows across the chat, dropper, and shell experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->