### PR TITLE
fix(ai): migrate GPU import guard to find_spec/exec_module (Python 3.12+)

### DIFF
--- a/packages/ai/src/ai/common/models/gpu_guard.py
+++ b/packages/ai/src/ai/common/models/gpu_guard.py
@@ -29,7 +29,8 @@ via RPC (``ModelClient``).  Subprocess nodes should never load GPU
 libraries directly — doing so wastes VRAM, bypasses billing, and risks
 CUDA context conflicts.
 
-This module installs a ``sys.meta_path`` import hook that blocks
+This module installs a ``sys.meta_path`` import hook (using the modern
+:pep:`451` ``find_spec`` / ``exec_module`` protocol) that blocks
 ``torch``, ``tensorflow``, ``onnxruntime``, ``cupy``, and their
 submodules.  Any ``import torch`` in a node will raise ``ImportError``
 with a clear message directing the developer to use ``ai.common.models``.
@@ -45,7 +46,7 @@ a non-None value — in local mode, GPU libraries load normally.
 """
 
 import sys
-from typing import Optional
+from importlib.machinery import ModuleSpec
 
 from .base import get_model_server_address
 
@@ -77,9 +78,16 @@ class _GPUImportBlocker:
     ``sys.meta_path`` finder that blocks GPU library imports.
 
     When Python's import machinery encounters a module name, it calls
-    ``find_module`` on each entry in ``sys.meta_path``.  This class
-    intercepts blocked module names and raises ``ImportError`` before
-    the real finder can load them.
+    ``find_spec`` on each entry in ``sys.meta_path``.  For a blocked
+    module this class returns a spec pointing at itself as the loader;
+    the loader's ``exec_module`` then raises ``ImportError`` before the
+    real module can be executed.
+
+    This uses the modern :pep:`451` finder/loader protocol
+    (``find_spec`` + ``create_module`` / ``exec_module``).  The legacy
+    ``find_module`` / ``load_module`` protocol it replaced was removed
+    from the import system in Python 3.12, where it would have silently
+    become a no-op.
 
     Attributes:
         _blocked: Frozenset of top-level module names to block.
@@ -94,48 +102,68 @@ class _GPUImportBlocker:
         """
         self._blocked = blocked
 
-    def find_module(self, fullname: str, path: Optional[str] = None):
+    def find_spec(self, fullname: str, path=None, target=None):
         """
-        Check if the requested module should be blocked.
+        Return a blocking spec if the requested module should be blocked.
 
-        Called by Python's import machinery for every import.  Returns
-        ``self`` (the loader) if the module is blocked, signalling that
-        this finder will handle it.  Returns ``None`` to let the next
+        Called by Python's import machinery for every import.  Returns a
+        ``ModuleSpec`` whose loader is ``self`` when the module is
+        blocked, signalling that this finder will handle it (and its
+        ``exec_module`` will raise).  Returns ``None`` to let the next
         finder in ``sys.meta_path`` handle it.
 
         Args:
             fullname: Fully qualified module name (e.g. ``'torch.nn'``).
-            path: Module search path (unused).
+            path: Parent package ``__path__`` (unused).
+            target: Module being reloaded, if any (unused).
 
         Returns:
-            ``self`` if blocked, ``None`` otherwise.
+            A ``ModuleSpec`` if blocked, ``None`` otherwise.
         """
         # Extract the top-level package name (e.g. 'torch' from 'torch.nn.functional')
         top_level = fullname.split('.')[0]
 
         # Check if this top-level package is in our blocked set
         if top_level in self._blocked:
-            return self
+            return ModuleSpec(fullname, self)
 
         # Not blocked — let the normal import machinery handle it
         return None
 
-    def load_module(self, fullname: str):
+    def create_module(self, spec):
+        """
+        Use default module creation semantics.
+
+        Required so ``self`` is a valid loader.  Returning ``None`` tells
+        the import system to create the module the default way — though
+        control never gets that far in practice, because ``exec_module``
+        raises first.
+
+        Args:
+            spec: The ``ModuleSpec`` produced by ``find_spec`` (unused).
+
+        Returns:
+            ``None`` — use default module creation.
+        """
+        return None
+
+    def exec_module(self, module):
         """
         Raise ImportError for blocked modules.
 
-        Called by Python after ``find_module`` returns ``self``.  Always
-        raises ``ImportError`` with a descriptive message explaining why
-        the import is blocked and what to use instead.
+        Called by Python after ``find_spec`` returns a blocking spec.
+        Always raises ``ImportError`` with a descriptive message
+        explaining why the import is blocked and what to use instead.
 
         Args:
-            fullname: Fully qualified module name being imported.
+            module: The module object being executed; ``module.__name__``
+                is the fully qualified name from the blocking spec.
 
         Raises:
             ImportError: Always — this is the whole point of the guard.
         """
         raise ImportError(
-            f'Direct import of "{fullname}" is blocked in model server mode. '
+            f'Direct import of "{module.__name__}" is blocked in model server mode. '
             f'GPU inference runs on the model server via ai.common.models. '
             f'Do not import GPU libraries directly in nodes.'
         )

--- a/packages/ai/tests/ai/common/models/test_gpu_guard.py
+++ b/packages/ai/tests/ai/common/models/test_gpu_guard.py
@@ -31,6 +31,8 @@ Tests verify that:
 - The hook is idempotent (safe to call multiple times).
 """
 
+import importlib
+import importlib.util
 import sys
 from unittest.mock import patch
 
@@ -47,45 +49,64 @@ from ai.common.models.gpu_guard import _GPUImportBlocker, install_gpu_guard, _BL
 class TestGPUImportBlocker:
     """Tests for the _GPUImportBlocker import hook class."""
 
-    def test_find_module_blocks_torch(self):
-        """find_module should return self for blocked top-level modules."""
+    def test_find_spec_blocks_torch(self):
+        """find_spec should return a blocking spec for blocked top-level modules."""
         blocker = _GPUImportBlocker(_BLOCKED_MODULES)
 
-        # Should return self (the loader) for blocked modules
-        assert blocker.find_module('torch') is blocker
-        assert blocker.find_module('tensorflow') is blocker
-        assert blocker.find_module('onnxruntime') is blocker
-        assert blocker.find_module('cupy') is blocker
+        # Should return a ModuleSpec whose loader is the blocker itself
+        for name in ('torch', 'tensorflow', 'onnxruntime', 'cupy'):
+            spec = blocker.find_spec(name)
+            assert spec is not None
+            assert spec.name == name
+            assert spec.loader is blocker
 
-    def test_find_module_blocks_submodules(self):
-        """find_module should block submodules of blocked packages."""
+    def test_find_spec_blocks_submodules(self):
+        """find_spec should block submodules of blocked packages."""
         blocker = _GPUImportBlocker(_BLOCKED_MODULES)
 
         # Submodules should also be caught (top-level extracted from dotted name)
-        assert blocker.find_module('torch.nn') is blocker
-        assert blocker.find_module('torch.nn.functional') is blocker
-        assert blocker.find_module('tensorflow.keras') is blocker
-        assert blocker.find_module('onnxruntime.transformers') is blocker
+        for name in ('torch.nn', 'torch.nn.functional', 'tensorflow.keras', 'onnxruntime.transformers'):
+            spec = blocker.find_spec(name)
+            assert spec is not None
+            assert spec.name == name
+            assert spec.loader is blocker
 
-    def test_find_module_allows_other(self):
-        """find_module should return None for non-blocked modules."""
+    def test_find_spec_allows_other(self):
+        """find_spec should return None for non-blocked modules."""
         blocker = _GPUImportBlocker(_BLOCKED_MODULES)
 
-        # Non-blocked modules should pass through
-        assert blocker.find_module('os') is None
-        assert blocker.find_module('json') is None
-        assert blocker.find_module('numpy') is None
-        assert blocker.find_module('ai.web.metrics') is None
+        # Non-blocked modules should pass through to the next finder
+        assert blocker.find_spec('os') is None
+        assert blocker.find_spec('json') is None
+        assert blocker.find_spec('numpy') is None
+        assert blocker.find_spec('ai.common.models') is None
 
-    def test_load_module_raises_import_error(self):
-        """load_module should raise ImportError with descriptive message."""
+    def test_exec_module_raises_import_error(self):
+        """exec_module should raise ImportError with descriptive message."""
         blocker = _GPUImportBlocker(_BLOCKED_MODULES)
 
-        with pytest.raises(ImportError, match='Direct import of "torch" is blocked'):
-            blocker.load_module('torch')
+        for name in ('torch', 'torch.nn'):
+            module = importlib.util.module_from_spec(blocker.find_spec(name))
+            with pytest.raises(ImportError, match=f'Direct import of "{name}" is blocked'):
+                blocker.exec_module(module)
 
-        with pytest.raises(ImportError, match='Direct import of "torch.nn" is blocked'):
-            blocker.load_module('torch.nn')
+    def test_blocked_import_raises_end_to_end(self):
+        """A real import of a blocked module through the machinery must raise.
+
+        This drives find_spec -> create_module -> exec_module via the real
+        import system, so it fails if the finder ever stops blocking (e.g. a
+        regression back to the removed find_module/load_module protocol).
+        """
+        blocker = _GPUImportBlocker(_BLOCKED_MODULES)
+        sys.meta_path.insert(0, blocker)
+        try:
+            # Ensure a fresh import so the guard (not a cached module) is hit.
+            sys.modules.pop('cupy', None)
+            with pytest.raises(ImportError, match='blocked in model server mode'):
+                importlib.import_module('cupy')
+        finally:
+            sys.meta_path.remove(blocker)
+            sys.modules.pop('cupy', None)
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Migrate `ai.common.models.gpu_guard._GPUImportBlocker` from the legacy import-hook protocol (`find_module`/`load_module`, **removed in Python 3.12**) to the modern PEP 451 protocol (`find_spec` + `create_module`/`exec_module`).
- Without this, on Python 3.12+ the hook silently becomes a no-op and `--modelserver` mode stops blocking direct `torch`/`tensorflow`/`onnxruntime`/`cupy` imports — a fail-open isolation/billing regression with no error.
- Relocate the test to the mirrored path (`tests/ai/common/models/`), rewrite it for the new protocol, and add an end-to-end regression test that drives a real `import` through the machinery so a future silent no-op is caught.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes <!-- ran targeted `ai:run-pytest` equivalent: 8 passed on Python 3.12.13 via the engine interpreter; full ./builder test not yet run -->

Verification detail:
- `ruff check` + `ruff format --check` clean on both changed files.
- `engine.exe -m pytest tests/ai/common/models/test_gpu_guard.py` → **8 passed** on Python 3.12.13 (the version where the old protocol silently failed).
- Repo-wide audit confirmed `gpu_guard.py` is the only hard 3.12 break in first-party code.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) <!-- CHANGELOG.md → Unreleased → Fixed -->

## Linked Issue

Fixes #1459

## Summary

<!-- Describe your changes in 1-3 bullet points -->

-

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU import blocking to work with Python’s modern import system.
  * Blocked GPU libraries now consistently raise clearer import errors, including for direct imports and submodules.
  * End-to-end import behavior is now verified to ensure blocked modules cannot be loaded unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->