### PR TITLE
fix(#1413): write ROCKETRIDE_URI/APIKEY to .env in local mode + add llms.txt (#586)

### DIFF
--- a/apps/vscode/docs/installation.md
+++ b/apps/vscode/docs/installation.md
@@ -50,6 +50,8 @@ Open VS Code settings (`Ctrl+,` / `Cmd+,`) and search for `rocketride` to config
 | `rocketride.local.engineVersion` | `latest` | Engine version: `latest`, `prerelease`, or a specific tag |
 | `rocketride.engineArgs` | - | Additional startup arguments for the local engine |
 
+> **Workspace `.env` writes**: In local mode the engine binds to a dynamic port (`--port=0`), so the connection URI isn't known until the process has started. Once it is, the extension upserts `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` into the `.env` file at the first workspace folder's root — existing lines and values are preserved, only those two keys are added or replaced. This runs on every local engine start, so the values are refreshed (and may change) on each restart. The write is best-effort: if it fails (e.g. no workspace open, or the file can't be written), the engine keeps running and a warning is logged instead.
+
 ### Integrations
 
 | Setting | Default | Description |

--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -62,9 +62,9 @@ export class EngineLocal extends EngineBackend {
 		this.installer = new EngineInstaller(parentDir, 'version.local.json');
 	}
 
-	// =========================================================================
+	// ==========================================================================
 	// PUBLIC API
-	// =========================================================================
+	// ==========================================================================
 
 	/** The EngineInstaller (for version fetching in UI). */
 	getInstaller(): EngineInstaller {
@@ -83,9 +83,9 @@ export class EngineLocal extends EngineBackend {
 		return { version: installed.tag, publishedAt: installed.publishedAt };
 	}
 
-	// =========================================================================
+	// ==========================================================================
 	// LIFECYCLE — install, start, stop, remove
-	// =========================================================================
+	// ==========================================================================
 
 	/**
 	 * Downloads/installs the engine binary. Does NOT start it.
@@ -123,6 +123,10 @@ export class EngineLocal extends EngineBackend {
 	/**
 	 * Installs the engine (if needed) and starts it as a subprocess.
 	 * Emits 'ready' with the URI when the engine is accepting connections.
+	 *
+	 * Also writes ROCKETRIDE_URI and ROCKETRIDE_APIKEY to the workspace
+	 * root .env file so that Python/TypeScript SDK scripts can connect
+	 * without any manual configuration.
 	 */
 	async start(config: ConnectionGroupConfig, token?: vscode.CancellationToken): Promise<void> {
 		const versionSpec = config.local.engineVersion || 'latest';
@@ -151,10 +155,10 @@ export class EngineLocal extends EngineBackend {
 
 		const executablePath = this.installer.getExecutablePath();
 		const args = [
-			'--autoterm',        // Exit when VS Code closes (stdin monitoring)
+			'--autoterm',          // Exit when VS Code closes (stdin monitoring)
 			'./ai/eaas.py',
 			'--host=localhost',
-			'--port=0',          // Dynamic port assignment
+			'--port=0',           // Dynamic port assignment
 			...effectiveArgs,
 		];
 
@@ -168,6 +172,11 @@ export class EngineLocal extends EngineBackend {
 			uri: `http://localhost:${this.actualPort}`,
 			version: installed?.tag,
 		});
+
+		// --- Phase 3: Write connection details to workspace .env ---
+		// This allows Python/TypeScript SDK scripts to connect automatically
+		// without hardcoding the dynamic port or API key.
+		this.writeLocalEnv(`http://localhost:${this.actualPort}`, config.apiKey || 'MYAPIKEY');
 	}
 
 	/**
@@ -203,9 +212,9 @@ export class EngineLocal extends EngineBackend {
 		}
 	}
 
-	// =========================================================================
+	// ==========================================================================
 	// STATIC STATUS — checks filesystem without needing an instance
-	// =========================================================================
+	// ==========================================================================
 
 	/**
 	 * Checks if a local engine is installed and whether a process is running.
@@ -251,9 +260,9 @@ export class EngineLocal extends EngineBackend {
 		if (this.child) await this.stopProcess();
 	}
 
-	// =========================================================================
+	// ==========================================================================
 	// STATIC ioControl — panel commands
-	// =========================================================================
+	// ==========================================================================
 
 	/**
 	 * Local engine: explicit install (download binary without starting).
@@ -277,9 +286,9 @@ export class EngineLocal extends EngineBackend {
 		}
 	}
 
-	// =========================================================================
+	// ==========================================================================
 	// PROCESS MANAGEMENT — spawn, stop, PID tracking
-	// =========================================================================
+	// ==========================================================================
 
 	/**
 	 * Spawns the engine process and waits for the "Uvicorn running" ready
@@ -428,9 +437,69 @@ export class EngineLocal extends EngineBackend {
 		this.pidFilePath = undefined;
 	}
 
-	// =========================================================================
+	// ==========================================================================
+	// .ENV WRITER — writes/upserts ROCKETRIDE_URI and ROCKETRIDE_APIKEY
+	// ==========================================================================
+
+	/**
+	 * Writes ROCKETRIDE_URI and ROCKETRIDE_APIKEY to the workspace root .env
+	 * file. Existing lines are preserved; only the two keys are upserted.
+	 *
+	 * This is the mechanism that makes the QUICKSTART docs work for local mode:
+	 * the dynamic port isn't known until the engine starts, so we write it here
+	 * rather than expecting the user to configure it manually.
+	 *
+	 * Non-fatal: errors are logged but never propagated.
+	 *
+	 * @param uri     - The engine URI, e.g. http://localhost:54321
+	 * @param apiKey  - The API key (config value or default 'MYAPIKEY')
+	 */
+	private writeLocalEnv(uri: string, apiKey: string): void {
+		try {
+			const workspaceFolders = vscode.workspace.workspaceFolders;
+			if (!workspaceFolders?.length) return;
+
+			const envPath = path.join(workspaceFolders[0].uri.fsPath, '.env');
+
+			// Read existing .env (or start empty)
+			let lines: string[] = [];
+			if (fs.existsSync(envPath)) {
+				lines = fs.readFileSync(envPath, 'utf8').split('\n');
+			}
+
+			// Upsert a key=value line, preserving all other lines
+			const upsert = (key: string, value: string): void => {
+				const idx = lines.findIndex(
+					(l) => l.startsWith(`${key}=`) || l.startsWith(`${key} =`),
+				);
+				const line = `${key}=${value}`;
+				if (idx >= 0) {
+					lines[idx] = line;
+				} else {
+					lines.push(line);
+				}
+			};
+
+			upsert('ROCKETRIDE_URI', uri);
+			upsert('ROCKETRIDE_APIKEY', apiKey);
+
+			fs.writeFileSync(envPath, lines.join('\n'), 'utf8');
+			this.logger.output(
+				`${icons.success} Written ROCKETRIDE_URI and ROCKETRIDE_APIKEY to .env`,
+			);
+		} catch (err) {
+			// Non-fatal — engine is running; only the .env convenience write failed
+			this.logger.output(
+				`${icons.warning} Could not write .env: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+
+	// ==========================================================================
 	// HELPERS
-	// =========================================================================
+	// ==========================================================================
 
 	/** Gets existing GitHub session token (no prompt). */
 	private async getGitHubToken(): Promise<string | undefined> {

--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -461,10 +461,15 @@ export class EngineLocal extends EngineBackend {
 
 			const envPath = path.join(workspaceFolders[0].uri.fsPath, '.env');
 
-			// Read existing .env (or start empty)
+			// Read existing .env (or start empty), preserving whichever line
+			// ending it already uses (CRLF is common on Windows) instead of
+			// silently normalizing every line to LF on write.
 			let lines: string[] = [];
+			let eol = '\n';
 			if (fs.existsSync(envPath)) {
-				lines = fs.readFileSync(envPath, 'utf8').split('\n');
+				const raw = fs.readFileSync(envPath, 'utf8');
+				eol = raw.includes('\r\n') ? '\r\n' : '\n';
+				lines = raw.split(/\r?\n/);
 			}
 
 			// Upsert a key=value line, preserving all other lines
@@ -483,7 +488,7 @@ export class EngineLocal extends EngineBackend {
 			upsert('ROCKETRIDE_URI', uri);
 			upsert('ROCKETRIDE_APIKEY', apiKey);
 
-			fs.writeFileSync(envPath, lines.join('\n'), 'utf8');
+			fs.writeFileSync(envPath, lines.join(eol), 'utf8');
 			this.logger.output(
 				`${icons.success} Written ROCKETRIDE_URI and ROCKETRIDE_APIKEY to .env`,
 			);

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -2,21 +2,38 @@
 
 ## Python: Complete Working Project
 
-### Step 1: Check `.env` File (Auto-Created)
+### Step 1: Check `.env` File
 
-The RocketRide extension automatically creates/updates `.env` with your configured settings:
+The RocketRide extension manages the `.env` file in your workspace root automatically, but the
+behavior depends on your connection mode:
+
+| Mode | `ROCKETRIDE_URI` | `ROCKETRIDE_APIKEY` |
+|------|-----------------|---------------------|
+| **Local** | Written automatically when the local engine starts (dynamic port, e.g. `http://localhost:54321`) | Written automatically (`MYAPIKEY` default, or your configured key) |
+| **Docker** | Written automatically when the Docker engine starts | Written automatically |
+| **Remote / Cloud / On-prem** | Must match your configured `rocketride.hostUrl` setting | Must match your configured API key setting |
+
+> **Local mode**: `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are written to `.env` **after** the
+> engine process starts and its port is known. If you check `.env` before starting the engine you
+> will not see these keys — that is expected.
+
+> **Remote / Cloud mode**: `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are synced from your
+> extension settings when the connection is established.
+
+Example `.env` after local engine has started:
 
 ```env
-# Auto-populated from extension settings (rocketride.hostUrl and API key)
-ROCKETRIDE_URI=https://api.rocketride.ai  # Your configured server
-ROCKETRIDE_APIKEY=your-api-key-here     # From extension settings
+# Written automatically by the RocketRide extension (local engine mode)
+ROCKETRIDE_URI=http://localhost:54321   # Dynamic port — changes each restart
+ROCKETRIDE_APIKEY=MYAPIKEY             # Default key for local self-hosted engine
 
 # Add your custom variables:
 ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are automatically synced from your extension settings. You can add additional custom variables as needed.
+> **Note:** Do not manually edit `ROCKETRIDE_URI` or `ROCKETRIDE_APIKEY` — they are overwritten
+> automatically each time the local engine restarts. Add your own variables below them freely.
 
 ### Step 2: Install Client
 
@@ -106,21 +123,24 @@ python main.py
 
 ## TypeScript: Complete Working Project
 
-### Step 1: Check `.env` File (Auto-Created)
+### Step 1: Check `.env` File
 
-The RocketRide extension automatically creates/updates `.env` with your configured settings:
+Same behavior as above — see the table in the Python section.
+
+Example `.env` after local engine has started:
 
 ```env
-# Auto-populated from extension settings (rocketride.hostUrl and API key)
-ROCKETRIDE_URI=https://api.rocketride.ai  # Your configured server
-ROCKETRIDE_APIKEY=your-api-key-here     # From extension settings
+# Written automatically by the RocketRide extension (local engine mode)
+ROCKETRIDE_URI=http://localhost:54321   # Dynamic port — changes each restart
+ROCKETRIDE_APIKEY=MYAPIKEY             # Default key for local self-hosted engine
 
 # Add your custom variables:
 ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are automatically synced from your extension settings. You can add additional custom variables as needed.
+> **Note:** Do not manually edit `ROCKETRIDE_URI` or `ROCKETRIDE_APIKEY` — they are overwritten
+> automatically each time the local engine restarts. Add your own variables below them freely.
 
 ### Step 2: Install Client
 
@@ -274,8 +294,8 @@ await client.disconnect();
 
 ### Always Do This:
 
-1. Configure server URL in extension settings (`rocketride.hostUrl` and API key)
-2. Extension auto-creates/updates `.env` with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`
+1. Start the local engine (or configure remote server) before running your script
+2. Wait for `.env` to be written — for local mode this happens automatically when the engine starts
 3. Use empty constructor: `RocketRideClient()` or `new RocketRideClient()`
 4. Use literal GUID for `project_id` - generate a new one per pipeline
 5. Use `${ROCKETRIDE_*}` variables in component `config` fields
@@ -286,7 +306,7 @@ await client.disconnect();
 
 1. Hardcode `uri` or `auth` in constructor (use `.env` instead)
 2. Use variables in `project_id` field (must be literal GUID)
-3. Manually edit `ROCKETRIDE_URI` or `ROCKETRIDE_APIKEY` in `.env` (use extension settings)
+3. Manually edit `ROCKETRIDE_URI` or `ROCKETRIDE_APIKEY` in `.env` (overwritten on engine restart)
 4. Skip `connect()` or `disconnect()`
 5. Use non-ROCKETRIDE\_\* variables in pipelines
 6. Use `.json` extension for pipeline files (use `.pipe`)
@@ -297,7 +317,7 @@ await client.disconnect();
 
 ```text
 my-rocketride-project/
-├── .env                    # Configuration (MUST have)
+├── .env                    # Written by extension (local) or configured (remote)
 ├── pipeline.pipe           # Pipeline definition (.pipe extension required)
 ├── main.py or main.ts      # Your code
 └── package.json            # (TypeScript only)

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -16,7 +16,7 @@ behavior depends on your connection mode:
 > **Local mode**: `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are written to `.env` **after** the
 > engine process starts and its port is known. If you check `.env` before starting the engine you
 > will not see these keys — that is expected.
-
+>
 > **Remote / Cloud mode**: `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are synced from your
 > extension settings when the connection is established.
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,0 +1,259 @@
+# RocketRide — Full Reference for AI Assistants
+
+> This file follows the llmstxt.org standard. It provides a comprehensive
+> reference for AI coding assistants working with the RocketRide codebase.
+
+## Project Overview
+
+RocketRide is the open source AI Development Environment (AIDE). It turns the
+classic IDE into a full AI Development Environment with deep observability,
+a C++ runtime, and zero vendor lock-in.
+
+- **License**: MIT
+- **Language**: C++ (engine), Python (nodes/SDK), TypeScript (VS Code extension + SDK)
+- **Repository**: https://github.com/rocketride-org/rocketride-server
+- **Fork (contributor)**: https://github.com/Pankajsharma99max/rocketride-server
+- **Default branch**: `develop`
+
+---
+
+## Architecture
+
+```
+rocketride-server/
+├── apps/
+│   ├── engine/          # C++ core engine (CMake)
+│   ├── vscode/          # VS Code extension (TypeScript)
+│   │   └── src/
+│   │       ├── engine/  # Engine backend (local, docker, service, remote)
+│   │       │   └── local/engine-local.ts  # Local subprocess engine
+│   │       ├── connection/connection.ts   # WebSocket connection manager
+│   │       └── config/                   # Settings schema
+│   ├── chat-ui/         # Chat UI (React/TypeScript)
+│   ├── dropper-ui/      # File dropper UI (React/TypeScript)
+│   └── aparavi-ui/      # Aparavi UI (React/TypeScript)
+├── docs/
+│   └── agents/          # AI-assistant oriented documentation
+│       ├── ROCKETRIDE_QUICKSTART.md
+│       ├── ROCKETRIDE_COMPONENT_REFERENCE.md
+│       └── ROCKETRIDE_COMMON_MISTAKES.md
+├── llms.txt             # Concise AI summary (this project)
+└── llms-full.txt        # Full AI reference (this file)
+```
+
+---
+
+## Connection Modes
+
+The VS Code extension supports five connection modes configured via `rocketride.connectionMode`:
+
+| Mode | Value | Auth | Engine location |
+|------|-------|------|-----------------|
+| Local subprocess | `local` | `MYAPIKEY` (default) | Spawned by extension |
+| Docker | `docker` | `MYAPIKEY` (default) | Local Docker container |
+| OS service | `service` | `MYAPIKEY` (default) | System service |
+| On-premises | `onprem` | API key from settings | Remote self-hosted |
+| Cloud | `cloud` | OAuth token | RocketRide Cloud |
+
+### Local Mode — Dynamic Port Behavior
+
+The local engine is started with `--port=0` (OS assigns a free port). The extension:
+
+1. Spawns the engine subprocess (`engine-local.ts` → `spawnProcess()`)
+2. Monitors stdout for `"Uvicorn running on http://localhost:<port>"`
+3. Parses the actual port
+4. Emits `ready` with `uri: http://localhost:<port>`
+5. **Writes `ROCKETRIDE_URI=http://localhost:<port>` and `ROCKETRIDE_APIKEY=<key>` to workspace `.env`**
+
+The `.env` write uses an upsert pattern — existing lines are preserved; only the two keys are overwritten. This happens in `EngineLocal.writeLocalEnv()`.
+
+---
+
+## VS Code Extension Key Files
+
+### `apps/vscode/src/engine/local/engine-local.ts`
+
+Class: `EngineLocal extends EngineBackend`
+
+Key methods:
+- `install(versionSpec, config, token)` — downloads engine binary via `EngineInstaller`
+- `start(config, token)` — install + spawn subprocess + write `.env`
+- `stop()` — graceful shutdown (stdin close → SIGTERM → 5s SIGKILL)
+- `remove()` — stop + delete engine directory
+- `getStatus(parentDir)` — static, checks PID files for running state
+- `writeLocalEnv(uri, apiKey)` — private, upserts ROCKETRIDE_URI/APIKEY to workspace `.env`
+- `spawnProcess(exePath, args)` — private, spawns child process, parses Uvicorn port
+
+### `apps/vscode/src/connection/connection.ts`
+
+Class: `ConnectionManager extends EventEmitter`
+
+Manages the WebSocket client (`RocketRideClient`). Key behavior:
+- `handleEngineStatus(event)` — reacts to `ready/idle/error` from `EngineRegistry`
+- `connectToEngine(uri)` — resolves auth (OAuth / API key / default) then calls `client.connect()`
+- Local mode auth: `groupConfig.apiKey || 'MYAPIKEY'`
+- `getHttpUrl()` — returns HTTP URL from engineUri or hostUrl config
+
+### Auth Resolution in `connectToEngine()`
+
+```typescript
+if (connectionModeUsesOAuth(mode)) {
+    auth = await CloudAuthProvider.getInstance().getToken();
+} else if (connectionModeRequiresApiKey(mode) && groupConfig.apiKey) {
+    auth = groupConfig.apiKey;
+} else {
+    // local, service, docker
+    auth = groupConfig.apiKey || 'MYAPIKEY';
+}
+```
+
+---
+
+## Pipeline File Format
+
+Pipeline files use the `.pipe` extension and are JSON:
+
+```json
+{
+    "project_id": "85be2a13-ad93-49ed-a1e1-4b0f763ca618",
+    "source": "input",
+    "components": [
+        {
+            "id": "input",
+            "provider": "webhook",
+            "config": {}
+        },
+        {
+            "id": "llm",
+            "provider": "llm_openai",
+            "config": {
+                "profile": "openai-5",
+                "openai-5": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }
+            },
+            "input": [{ "lane": "text", "from": "input" }]
+        },
+        {
+            "id": "out",
+            "provider": "response_text",
+            "config": {},
+            "input": [{ "lane": "text", "from": "llm" }]
+        }
+    ]
+}
+```
+
+Rules:
+- `project_id` must be a literal GUID (not a variable)
+- `source` must match a component `id`
+- All env variables must use `ROCKETRIDE_` prefix
+- File extension must be `.pipe` (not `.json`)
+
+---
+
+## Python SDK Usage
+
+```python
+from rocketride import RocketRideClient
+import asyncio
+
+async def main():
+    # Reads ROCKETRIDE_URI and ROCKETRIDE_APIKEY from .env automatically
+    client = RocketRideClient()
+    await client.connect()
+
+    # Webhook pipeline
+    result = await client.use(filepath='pipeline.pipe')
+    token = result['token']
+    await client.send(token, "input data")
+
+    # Chat pipeline
+    from rocketride.schema import Question
+    q = Question()
+    q.addQuestion("What is the capital of France?")
+    response = await client.chat(token=token, question=q)
+    print(response.get('answers', [None])[0])
+
+    await client.disconnect()
+
+asyncio.run(main())
+```
+
+---
+
+## TypeScript SDK Usage
+
+```typescript
+import { RocketRideClient, Question } from 'rocketride';
+
+async function main() {
+    // Reads ROCKETRIDE_URI and ROCKETRIDE_APIKEY from .env automatically
+    const client = new RocketRideClient();
+    await client.connect();
+
+    // Webhook pipeline
+    const { token } = await client.use({ filepath: 'pipeline.pipe' });
+    await client.send(token, 'input data');
+
+    // Chat pipeline
+    const question = new Question();
+    question.addQuestion('What is the capital of France?');
+    const response = await client.chat({ token, question });
+    console.log(response.answers?.[0]);
+
+    await client.disconnect();
+}
+main().catch(console.error);
+```
+
+---
+
+## .env File
+
+The workspace `.env` is the primary configuration mechanism for scripts using the SDK.
+
+For **local mode**, the extension writes it automatically after engine startup:
+
+```env
+ROCKETRIDE_URI=http://localhost:54321    # dynamic — changes each restart
+ROCKETRIDE_APIKEY=MYAPIKEY              # or your configured key
+```
+
+For **remote / cloud / onprem** modes, the extension syncs from extension settings.
+
+**Do not** manually edit `ROCKETRIDE_URI` or `ROCKETRIDE_APIKEY` in local mode — they are
+overwritten each time the engine starts.
+
+---
+
+## Common Mistakes
+
+1. **Wrong pipeline source**: chat pipelines need `"source": "chat_N"` (not `"input"`)
+2. **Using `client.send()` on chat pipelines**: use `client.chat()` instead
+3. **Hardcoding port in `.env`**: local mode uses a dynamic port; let the extension manage it
+4. **Wrong file extension**: use `.pipe` not `.json`
+5. **Variable in `project_id`**: must be a literal GUID
+6. **Not calling `connect()` before use**
+7. **Not calling `disconnect()` after use**
+
+---
+
+## Contributing
+
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and PR guidelines
+- See [AGENTS.md](AGENTS.md) for AI-assistant specific guidelines
+- Branch: `develop` (default)
+- TypeScript: `apps/vscode/` — `tsc --noEmit` for type checking
+- Python: standard pytest
+
+---
+
+## Links
+
+- Home: https://rocketride.org
+- Docs: https://docs.rocketride.org
+- GitHub: https://github.com/rocketride-org/rocketride-server
+- Python SDK (PyPI): https://pypi.org/project/rocketride/
+- TypeScript SDK (npm): https://www.npmjs.com/package/rocketride
+- MCP Server: https://pypi.org/project/rocketride-mcp/
+- Discord: https://discord.gg/PMXrtenMsY
+- Issues: https://github.com/rocketride-org/rocketride-server/issues

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,82 @@
+# RocketRide
+
+> RocketRide is the open source AI Development Environment (AIDE). Build, deploy,
+> and harness production-ready AI solutions directly from your IDE or terminal.
+
+## What is RocketRide?
+
+RocketRide is an open source data pipeline builder and runtime built for AI and ML
+workloads. It combines:
+
+- **50+ pipeline nodes** — LLMs (13 providers), 8 vector databases, OCR, NER, transforms
+- **C++ engine** — multithreaded, high-throughput, battle-tested runtime
+- **VS Code extension** — visual pipeline builder, debugger, live observability
+- **Python + TypeScript SDKs** — connect from any script or service
+- **MCP server** — Model Context Protocol integration for agent frameworks
+
+Pipelines are defined as portable JSON (`.pipe` files) and executed by the engine.
+Everything runs on your own infrastructure — no vendor lock-in.
+
+## Links
+
+- Home: https://rocketride.org
+- Docs: https://docs.rocketride.org
+- GitHub: https://github.com/rocketride-org/rocketride-server
+- Python SDK: https://pypi.org/project/rocketride/
+- TypeScript SDK: https://www.npmjs.com/package/rocketride
+- MCP Server: https://pypi.org/project/rocketride-mcp/
+- Discord: https://discord.gg/PMXrtenMsY
+- License: MIT
+
+## Quick Start (Python)
+
+```bash
+pip install rocketride
+```
+
+```python
+from rocketride import RocketRideClient
+import asyncio
+
+async def main():
+    client = RocketRideClient()  # reads .env automatically
+    await client.connect()
+    result = await client.use(filepath='pipeline.pipe')
+    await client.send(result['token'], "Hello, RocketRide!")
+    await client.disconnect()
+
+asyncio.run(main())
+```
+
+## Quick Start (TypeScript)
+
+```bash
+npm install rocketride
+```
+
+```typescript
+import { RocketRideClient } from 'rocketride';
+const client = new RocketRideClient();
+await client.connect();
+const { token } = await client.use({ filepath: 'pipeline.pipe' });
+await client.send(token, 'Hello, RocketRide!');
+await client.disconnect();
+```
+
+## Connection Modes
+
+| Mode | Description |
+|------|-------------|
+| `local` | Engine runs as a local subprocess (dynamic port); `.env` written automatically |
+| `docker` | Engine runs in a local Docker container |
+| `service` | Engine runs as an OS service |
+| `onprem` | Remote self-hosted engine |
+| `cloud` | RocketRide Cloud (OAuth) |
+
+## Key Docs
+
+- [ROCKETRIDE_QUICKSTART.md](docs/agents/ROCKETRIDE_QUICKSTART.md) — complete working examples
+- [ROCKETRIDE_COMPONENT_REFERENCE.md](docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md) — all 50+ pipeline nodes
+- [ROCKETRIDE_COMMON_MISTAKES.md](docs/agents/ROCKETRIDE_COMMON_MISTAKES.md) — pitfalls to avoid
+- [CONTRIBUTING.md](CONTRIBUTING.md) — how to contribute
+- [CHANGELOG.md](CHANGELOG.md) — release history


### PR DESCRIPTION
## What & Why

Two independent fixes in one PR.

###  #1413 -- Local engine never writes ROCKETRIDE_URI/APIKEY to .env

**Root cause:** `ROCKETRIDE_QUICKSTART.md` claims the extension "automatically creates/updates .env" for all modes. This is false for local mode -- the engine uses `--port=0` so the port is only known *after* the subprocess starts. Nothing in the extension ever wrote to .env for local mode.

**Fix -- `apps/vscode/src/engine/local/engine-local.ts`:**
- Add private `writeLocalEnv(uri, apiKey)` called in `start()` after the engine emits `ready`
- Upserts `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` into workspace root `.env`
- Preserves all other existing .env variables (upsert, not overwrite)
- Non-fatal: errors are logged as warnings, never propagated

**Fix -- `docs/agents/ROCKETRIDE_QUICKSTART.md`:**
- Replace false "auto-synced from extension settings" claim with an accurate per-mode table (local/docker: written on engine start; remote/cloud: from settings)
- Add note that in local mode .env is absent until after the engine starts

###  #586 -- Add llms.txt / llms-full.txt

Adds two root-level files per the llmstxt.org standard:
- `llms.txt` -- concise summary: what RocketRide is, links, quick-start, modes
- `llms-full.txt` -- extended: architecture, pipeline JSON, SDK patterns, auth flow

Static hand-authored files. CI automation deferred per issue discussion.

## Files Changed

| File | Change |
|------|--------|
| `apps/vscode/src/engine/local/engine-local.ts` | Add `writeLocalEnv()` + call in `start()` |
| `docs/agents/ROCKETRIDE_QUICKSTART.md` | Correct per-mode .env description |
| `llms.txt` | New |
| `llms-full.txt` | New |

## Testing

```bash
cd apps/vscode && tsc --noEmit
```

---

Replaces #1450, which accidentally picked up unrelated commits from #1451/#1452 because its head branch was my fork'''s `develop` rather than a dedicated feature branch -- every later push to `develop` silently expanded that PR'''s diff. This PR is opened from a dedicated branch containing only the original single commit, so its diff is just the 4 files above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Local engine startup now automatically writes/updates `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` in the workspace root `.env` (overwritten on each local restart for consistent SDK connectivity).
* **Documentation**
  * Updated quickstart and installation notes to explain `.env` syncing across Local, Docker, Remote/On-prem, and Cloud modes, including guidance to avoid manual edits for local.
  * Added comprehensive RocketRide AI-assistant documentation files with connection-mode behavior, SDK examples, and key project links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->