### PR TITLE
fix(#1459): make GPU import guard forward-compatible with Python 3.12+

### DIFF
--- a/packages/ai/src/ai/common/models/gpu_guard.py
+++ b/packages/ai/src/ai/common/models/gpu_guard.py
@@ -76,10 +76,13 @@ class _GPUImportBlocker:
     """
     ``sys.meta_path`` finder that blocks GPU library imports.
 
-    When Python's import machinery encounters a module name, it calls
-    ``find_module`` on each entry in ``sys.meta_path``.  This class
-    intercepts blocked module names and raises ``ImportError`` before
-    the real finder can load them.
+    Implements ``MetaPathFinder.find_spec`` (PEP 451), the protocol
+    Python's import machinery has used since 3.4. The legacy
+    ``find_module``/``load_module`` pair this class used to implement was
+    deprecated in 3.4 and removed entirely in 3.12 — on 3.12+ the import
+    system never calls those methods, so a finder implementing only them
+    silently stops blocking anything. ``find_spec`` has no such removal
+    and works unchanged across 3.4 through current versions.
 
     Attributes:
         _blocked: Frozenset of top-level module names to block.
@@ -94,51 +97,38 @@ class _GPUImportBlocker:
         """
         self._blocked = blocked
 
-    def find_module(self, fullname: str, path: Optional[str] = None):
+    def find_spec(self, fullname: str, path: Optional[str] = None, target=None):
         """
-        Check if the requested module should be blocked.
+        Block blocked modules; defer everything else to later finders.
 
-        Called by Python's import machinery for every import.  Returns
-        ``self`` (the loader) if the module is blocked, signalling that
-        this finder will handle it.  Returns ``None`` to let the next
-        finder in ``sys.meta_path`` handle it.
+        Called by Python's import machinery for every import. For a
+        blocked module this raises ``ImportError`` directly — the import
+        system does not catch exceptions raised here, so it propagates
+        straight out of the ``import`` statement. For anything else it
+        returns ``None`` so the next finder in ``sys.meta_path`` handles
+        it normally (including modules that genuinely don't exist, which
+        still raise the standard ``ModuleNotFoundError``).
 
         Args:
             fullname: Fully qualified module name (e.g. ``'torch.nn'``).
-            path: Module search path (unused).
+            path: Parent package's ``__path__`` (unused).
+            target: Existing module used as a hint on reload (unused).
 
-        Returns:
-            ``self`` if blocked, ``None`` otherwise.
+        Raises:
+            ImportError: If the module's top-level package is blocked.
         """
         # Extract the top-level package name (e.g. 'torch' from 'torch.nn.functional')
         top_level = fullname.split('.')[0]
 
-        # Check if this top-level package is in our blocked set
         if top_level in self._blocked:
-            return self
+            raise ImportError(
+                f'Direct import of "{fullname}" is blocked in model server mode. '
+                f'GPU inference runs on the model server via ai.common.models. '
+                f'Do not import GPU libraries directly in nodes.'
+            )
 
         # Not blocked — let the normal import machinery handle it
         return None
-
-    def load_module(self, fullname: str):
-        """
-        Raise ImportError for blocked modules.
-
-        Called by Python after ``find_module`` returns ``self``.  Always
-        raises ``ImportError`` with a descriptive message explaining why
-        the import is blocked and what to use instead.
-
-        Args:
-            fullname: Fully qualified module name being imported.
-
-        Raises:
-            ImportError: Always — this is the whole point of the guard.
-        """
-        raise ImportError(
-            f'Direct import of "{fullname}" is blocked in model server mode. '
-            f'GPU inference runs on the model server via ai.common.models. '
-            f'Do not import GPU libraries directly in nodes.'
-        )
 
 
 # ============================================================================

--- a/packages/ai/tests/ai/web/metrics/test_gpu_guard.py
+++ b/packages/ai/tests/ai/web/metrics/test_gpu_guard.py
@@ -29,10 +29,11 @@ Tests verify that:
 - When --modelserver is NOT set, no hook is installed.
 - Submodules of blocked libraries are also blocked.
 - The hook is idempotent (safe to call multiple times).
+- The finder uses the find_spec protocol (Python 3.12+ compatible) rather
+  than the legacy find_module/load_module pair removed in 3.12.
 """
 
 import sys
-from unittest.mock import patch
 
 import pytest
 
@@ -47,45 +48,73 @@ from ai.common.models.gpu_guard import _GPUImportBlocker, install_gpu_guard, _BL
 class TestGPUImportBlocker:
     """Tests for the _GPUImportBlocker import hook class."""
 
-    def test_find_module_blocks_torch(self):
-        """find_module should return self for blocked top-level modules."""
+    def test_does_not_implement_legacy_protocol(self):
+        """
+        Regression test for the reported bug: find_module/load_module were
+        removed from the import machinery in Python 3.12, so a finder that
+        only implements them silently stops blocking anything. Guard
+        against reintroducing that dead protocol instead of find_spec.
+        """
         blocker = _GPUImportBlocker(_BLOCKED_MODULES)
 
-        # Should return self (the loader) for blocked modules
-        assert blocker.find_module('torch') is blocker
-        assert blocker.find_module('tensorflow') is blocker
-        assert blocker.find_module('onnxruntime') is blocker
-        assert blocker.find_module('cupy') is blocker
+        assert not hasattr(blocker, 'find_module')
+        assert not hasattr(blocker, 'load_module')
+        assert hasattr(blocker, 'find_spec')
 
-    def test_find_module_blocks_submodules(self):
-        """find_module should block submodules of blocked packages."""
+    def test_find_spec_blocks_torch(self):
+        """find_spec should raise ImportError for blocked top-level modules."""
         blocker = _GPUImportBlocker(_BLOCKED_MODULES)
 
-        # Submodules should also be caught (top-level extracted from dotted name)
-        assert blocker.find_module('torch.nn') is blocker
-        assert blocker.find_module('torch.nn.functional') is blocker
-        assert blocker.find_module('tensorflow.keras') is blocker
-        assert blocker.find_module('onnxruntime.transformers') is blocker
+        for name in ('torch', 'tensorflow', 'onnxruntime', 'cupy'):
+            with pytest.raises(ImportError, match=f'Direct import of "{name}" is blocked'):
+                blocker.find_spec(name)
 
-    def test_find_module_allows_other(self):
-        """find_module should return None for non-blocked modules."""
+    def test_find_spec_blocks_submodules(self):
+        """find_spec should block submodules of blocked packages too."""
         blocker = _GPUImportBlocker(_BLOCKED_MODULES)
-
-        # Non-blocked modules should pass through
-        assert blocker.find_module('os') is None
-        assert blocker.find_module('json') is None
-        assert blocker.find_module('numpy') is None
-        assert blocker.find_module('ai.web.metrics') is None
-
-    def test_load_module_raises_import_error(self):
-        """load_module should raise ImportError with descriptive message."""
-        blocker = _GPUImportBlocker(_BLOCKED_MODULES)
-
-        with pytest.raises(ImportError, match='Direct import of "torch" is blocked'):
-            blocker.load_module('torch')
 
         with pytest.raises(ImportError, match='Direct import of "torch.nn" is blocked'):
-            blocker.load_module('torch.nn')
+            blocker.find_spec('torch.nn')
+        with pytest.raises(ImportError, match='Direct import of "torch.nn.functional" is blocked'):
+            blocker.find_spec('torch.nn.functional')
+        with pytest.raises(ImportError, match='Direct import of "tensorflow.keras" is blocked'):
+            blocker.find_spec('tensorflow.keras')
+        with pytest.raises(ImportError, match='Direct import of "onnxruntime.transformers" is blocked'):
+            blocker.find_spec('onnxruntime.transformers')
+
+    def test_find_spec_allows_other(self):
+        """find_spec should return None (defer to other finders) for non-blocked modules."""
+        blocker = _GPUImportBlocker(_BLOCKED_MODULES)
+
+        assert blocker.find_spec('os') is None
+        assert blocker.find_spec('json') is None
+        assert blocker.find_spec('numpy') is None
+        assert blocker.find_spec('ai.web.metrics') is None
+
+    def test_real_import_statement_is_blocked(self):
+        """
+        End-to-end regression test using the actual import machinery
+        (not a direct find_spec() call) — this is what actually failed
+        silently on Python 3.12+ before the fix, since the bug was that
+        the real import system stopped calling into the finder at all.
+        """
+        blocker = _GPUImportBlocker(frozenset({'this_is_a_fake_blocked_pkg'}))
+        sys.meta_path.insert(0, blocker)
+        try:
+            with pytest.raises(ImportError, match='Direct import of "this_is_a_fake_blocked_pkg" is blocked'):
+                __import__('this_is_a_fake_blocked_pkg')
+
+            with pytest.raises(
+                ImportError, match='Direct import of "this_is_a_fake_blocked_pkg.sub" is blocked'
+            ):
+                __import__('this_is_a_fake_blocked_pkg.sub')
+
+            # A genuinely missing, non-blocked module must still raise the
+            # normal error, proving the finder doesn't swallow unrelated imports.
+            with pytest.raises(ModuleNotFoundError):
+                __import__('this_module_genuinely_does_not_exist_xyz')
+        finally:
+            sys.meta_path.remove(blocker)
 
 
 # ============================================================================


### PR DESCRIPTION
Fixes #1459.

## What & Why

`_GPUImportBlocker` (`packages/ai/src/ai/common/models/gpu_guard.py`) implemented
the legacy `find_module`/`load_module` meta_path finder protocol. Python
deprecated that protocol in 3.4 and **removed it entirely in 3.12** — on 3.12+
the import system never calls those methods, so the finder installed at
`sys.meta_path[0]` becomes a silent no-op. GPU libraries (`torch`, `tensorflow`,
`onnxruntime`, `cupy`) can then be imported directly inside subprocess nodes
even in `--modelserver` mode, with no error at all.

## Fix

Switch `_GPUImportBlocker` to implement `find_spec` (PEP 451) instead — the
protocol import machinery has used since 3.4, and the only one still supported
on 3.12+. A blocked top-level module now raises `ImportError` directly from
`find_spec`; the import system does not catch exceptions there, so it
propagates straight out of the `import` statement, same as before. Anything
not blocked returns `None` so later finders (and genuinely missing modules)
behave exactly as before — this isn't a behavior change for the non-blocked path.

## Verification

Ran this end-to-end against the real Python import machinery on Python 3.13
(a 3.12+ interpreter), using the actual file content from both before and
after the fix (not just a hand-written repro):

- **Before the fix** (`develop`'s current `gpu_guard.py`): installing the guard
  in simulated `--modelserver` mode, then importing a module added to
  `_blocked` — the import **succeeds**, reproducing the reported bug exactly.
- **After the fix**: the same setup correctly raises `ImportError` with the
  expected message for the blocked module and its submodules, while an
  unrelated real module still imports normally and a genuinely missing module
  still raises the standard `ModuleNotFoundError` (proving the finder doesn't
  swallow unrelated imports).

I couldn't run the full `pytest` suite for this file in my sandbox — `ai/__init__.py`
eagerly imports `depends`, which imports `engLib`, a module that's "built into
engine.exe" (per `depends.py`'s own comment) and only exists inside the actual
compiled engine, not in a source-only checkout. This is unrelated to this fix;
the same wall would block running the *original* test file in this environment too.
To work around it for verification, I imported the real `gpu_guard.py` (byte-for-byte,
via a stub sibling `base` module providing `get_model_server_address`) directly,
bypassing only the unrelated `ai` package `__init__` chain — the class and its
logic under test are unmodified from what's in this PR.

## Test changes

Updated `packages/ai/tests/ai/web/metrics/test_gpu_guard.py`:
- Replaced the old `find_module`/`load_module` unit tests with `find_spec` equivalents.
- Added a regression test asserting the class no longer exposes `find_module`/`load_module`
  at all, to guard against reintroducing the dead protocol.
- Added an end-to-end test that installs the blocker into `sys.meta_path` and
  performs a real `__import__()` call (rather than calling `find_spec()` directly) —
  this is what actually failed silently before the fix, since the bug was that the
  real import system stopped calling into the finder at all, not that the finder's
  own logic was wrong.

## Files Changed

| File | Change |
|------|--------|
| `packages/ai/src/ai/common/models/gpu_guard.py` | Replace `find_module`/`load_module` with `find_spec` |
| `packages/ai/tests/ai/web/metrics/test_gpu_guard.py` | Update tests for the new API + add a real-import regression test |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blocking of GPU-related imports so affected modules are reliably prevented from loading on newer Python versions.
  * Blocked imports now fail immediately for both top-level modules and submodules, while unrelated imports continue normally.
  * Added end-to-end coverage to confirm import blocking behaves correctly in real import scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->