### PR TITLE
fix(vscode): show actionable message when cloud sign-in has no linked account (#1299)

### DIFF
--- a/apps/vscode/src/auth/CloudAuthProvider.ts
+++ b/apps/vscode/src/auth/CloudAuthProvider.ts
@@ -22,6 +22,7 @@
 
 import * as vscode from 'vscode';
 import { RocketRideClient } from 'rocketride';
+import type { ConnectResult } from 'rocketride';
 import { generatePkce, buildAuthUrl } from './pkce';
 
 import { EventEmitter } from 'events';
@@ -33,6 +34,26 @@ import { EventEmitter } from 'events';
 const SECRET_KEY_TOKEN = 'rocketride.cloudToken';
 const SECRET_KEY_NAME = 'rocketride.cloudUserName';
 const REDIRECT_URI = `${vscode.env.uriScheme}://rocketride.rocketride/auth/callback`;
+
+/**
+ * Resolve the Cloud web app URL for the same environment as the API endpoint
+ * used for token exchange (`ROCKETRIDE_URI`). Maps `api.*` hosts to `cloud.*`
+ * so staging/dev builds do not open production.
+ */
+function resolveCloudAppUrl(cloudApiUrl: string): string {
+	try {
+		const url = new URL(RocketRideClient.normalizeUri(cloudApiUrl));
+		if (url.hostname.startsWith('api.')) {
+			url.hostname = `cloud.${url.hostname.slice('api.'.length)}`;
+		}
+		url.pathname = '/';
+		url.search = '';
+		url.hash = '';
+		return url.toString();
+	} catch {
+		return 'https://cloud.rocketride.ai/';
+	}
+}
 
 // =============================================================================
 // CLASS
@@ -189,35 +210,61 @@ export class CloudAuthProvider implements vscode.UriHandler, vscode.Disposable {
 
 		// Exchange the code for a persistent rr_* token using a temporary
 		// client connection. This is auth only — not a persistent connection.
+		// Always use the cloud URI for token exchange -- the OAuth code must
+		// be exchanged against the cloud server regardless of the current
+		// connection mode (local, docker, etc.).
+		const cloudUrl = process.env.ROCKETRIDE_URI;
+		if (!cloudUrl) {
+			vscode.window.showErrorMessage('RocketRide Cloud sign-in failed: cloud endpoint is not configured (ROCKETRIDE_URI).');
+			return;
+		}
+
+		let result: ConnectResult;
 		try {
-			// Always use the cloud URI for token exchange -- the OAuth code must
-			// be exchanged against the cloud server regardless of the current
-			// connection mode (local, docker, etc.).
-			const cloudUrl = process.env.ROCKETRIDE_URI;
-			if (!cloudUrl) {
-				vscode.window.showErrorMessage('RocketRide Cloud sign-in failed: cloud endpoint is not configured (ROCKETRIDE_URI).');
-				return;
-			}
 			const tempClient = new RocketRideClient({ persist: false });
-			const result = await tempClient.connect({ code, verifier, redirectUri: REDIRECT_URI }, { uri: cloudUrl });
+			result = await tempClient.connect({ code, verifier, redirectUri: REDIRECT_URI }, { uri: cloudUrl });
 
-			const token = (result as any)?.userToken || '';
-			const displayName = (result as any)?.displayName || '';
-
-			// Disconnect immediately — we only needed the token
+			// Disconnect immediately — we only needed the auth result
 			await tempClient.disconnect();
-
-			if (token) {
-				await this.storeToken(token);
-				await this.storeUserName(displayName);
-				this._onDidChange.emit('changed');
-				vscode.window.showInformationMessage(`Signed in to RocketRide Cloud as ${displayName || 'user'}`);
-			} else {
-				vscode.window.showErrorMessage('RocketRide Cloud sign-in failed: no token received.');
-			}
 		} catch (error) {
 			const msg = error instanceof Error ? error.message : String(error);
 			vscode.window.showErrorMessage(`RocketRide Cloud sign-in failed: ${msg}`);
+			return;
+		}
+
+		const token = result.userToken || '';
+		const displayName = result.displayName || '';
+
+		if (token) {
+			await this.storeToken(token);
+			await this.storeUserName(displayName);
+			this._onDidChange.emit('changed');
+			vscode.window.showInformationMessage(`Signed in to RocketRide Cloud as ${displayName || 'user'}`);
+			return;
+		}
+
+		// A resolved (non-throwing) connect() with an empty userToken is not
+		// "no account" — cloud PKCE auto-provisions users. The server returns
+		// waitlisted:true for pending access (empty token by design), or an
+		// empty token for an enabled user whose rr_* API keys are all inactive.
+		if (result.waitlisted) {
+			vscode.window.showInformationMessage(
+				"Your RocketRide account is pending access approval. You'll be able to sign in once access is granted."
+			);
+			return;
+		}
+
+		const selection = await vscode.window.showErrorMessage(
+			'No active API key was found for this RocketRide account. Open RocketRide Cloud to create or reactivate a key, then sign in again.',
+			'Open RocketRide Cloud'
+		);
+		if (selection === 'Open RocketRide Cloud') {
+			try {
+				await vscode.env.openExternal(vscode.Uri.parse(resolveCloudAppUrl(cloudUrl)));
+			} catch (error) {
+				const msg = error instanceof Error ? error.message : String(error);
+				vscode.window.showErrorMessage(`Failed to open RocketRide Cloud: ${msg}`);
+			}
 		}
 	}
 

--- a/apps/vscode/src/auth/CloudAuthProvider.ts
+++ b/apps/vscode/src/auth/CloudAuthProvider.ts
@@ -24,6 +24,7 @@ import * as vscode from 'vscode';
 import { RocketRideClient } from 'rocketride';
 import type { ConnectResult } from 'rocketride';
 import { generatePkce, buildAuthUrl } from './pkce';
+import { resolveCloudAppUrl } from './resolveCloudAppUrl';
 
 import { EventEmitter } from 'events';
 
@@ -34,26 +35,6 @@ import { EventEmitter } from 'events';
 const SECRET_KEY_TOKEN = 'rocketride.cloudToken';
 const SECRET_KEY_NAME = 'rocketride.cloudUserName';
 const REDIRECT_URI = `${vscode.env.uriScheme}://rocketride.rocketride/auth/callback`;
-
-/**
- * Resolve the Cloud web app URL for the same environment as the API endpoint
- * used for token exchange (`ROCKETRIDE_URI`). Maps `api.*` hosts to `cloud.*`
- * so staging/dev builds do not open production.
- */
-function resolveCloudAppUrl(cloudApiUrl: string): string {
-	try {
-		const url = new URL(RocketRideClient.normalizeUri(cloudApiUrl));
-		if (url.hostname.startsWith('api.')) {
-			url.hostname = `cloud.${url.hostname.slice('api.'.length)}`;
-		}
-		url.pathname = '/';
-		url.search = '';
-		url.hash = '';
-		return url.toString();
-	} catch {
-		return 'https://cloud.rocketride.ai/';
-	}
-}
 
 // =============================================================================
 // CLASS

--- a/apps/vscode/src/auth/CloudAuthProvider.ts
+++ b/apps/vscode/src/auth/CloudAuthProvider.ts
@@ -21,7 +21,7 @@
  */
 
 import * as vscode from 'vscode';
-import { RocketRideClient } from 'rocketride';
+import { RocketRideClient, CONST_DEFAULT_WEB_CLOUD } from 'rocketride';
 import type { ConnectResult } from 'rocketride';
 import { generatePkce, buildAuthUrl } from './pkce';
 import { resolveCloudAppUrl } from './resolveCloudAppUrl';
@@ -194,11 +194,7 @@ export class CloudAuthProvider implements vscode.UriHandler, vscode.Disposable {
 		// Always use the cloud URI for token exchange -- the OAuth code must
 		// be exchanged against the cloud server regardless of the current
 		// connection mode (local, docker, etc.).
-		const cloudUrl = process.env.ROCKETRIDE_URI;
-		if (!cloudUrl) {
-			vscode.window.showErrorMessage('RocketRide Cloud sign-in failed: cloud endpoint is not configured (ROCKETRIDE_URI).');
-			return;
-		}
+		const cloudUrl = CONST_DEFAULT_WEB_CLOUD;
 
 		let result: ConnectResult;
 		try {
@@ -241,7 +237,13 @@ export class CloudAuthProvider implements vscode.UriHandler, vscode.Disposable {
 		);
 		if (selection === 'Open RocketRide Cloud') {
 			try {
-				await vscode.env.openExternal(vscode.Uri.parse(resolveCloudAppUrl(cloudUrl)));
+				const opened = await vscode.env.openExternal(
+					vscode.Uri.parse(resolveCloudAppUrl(cloudUrl))
+				);
+
+				if (!opened) {
+					vscode.window.showErrorMessage('Failed to open RocketRide Cloud.');
+				}
 			} catch (error) {
 				const msg = error instanceof Error ? error.message : String(error);
 				vscode.window.showErrorMessage(`Failed to open RocketRide Cloud: ${msg}`);

--- a/apps/vscode/src/auth/resolveCloudAppUrl.ts
+++ b/apps/vscode/src/auth/resolveCloudAppUrl.ts
@@ -1,0 +1,36 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * Resolve the Cloud web app URL for the same environment as the API endpoint
+ * used for token exchange (`ROCKETRIDE_URI`).
+ *
+ * Only `api.*` hosts have a known `cloud.*` counterpart. Anything else
+ * (localhost, custom deployments, unparseable input) falls back to production
+ * cloud — `normalizeUri` is an API-URL normalizer (may preserve wss: and add
+ * engine port 5565), so non-api hosts cannot be mapped to a usable web URL.
+ */
+
+import { RocketRideClient } from 'rocketride';
+
+const FALLBACK = 'https://cloud.rocketride.ai/';
+
+export function resolveCloudAppUrl(cloudApiUrl: string): string {
+	try {
+		const url = new URL(RocketRideClient.normalizeUri(cloudApiUrl));
+		// Only an api.* host has a known cloud.* counterpart; anything else
+		// (localhost, custom deployments) has no derivable web app URL.
+		if (!url.hostname.startsWith('api.')) return FALLBACK;
+		url.hostname = `cloud.${url.hostname.slice('api.'.length)}`;
+		url.protocol = 'https:'; // normalizeUri preserves ws/wss; openExternal needs http(s)
+		url.port = ''; // normalizeUri may have added the engine port (5565)
+		url.pathname = '/';
+		url.search = '';
+		url.hash = '';
+		return url.toString();
+	} catch {
+		return FALLBACK;
+	}
+}

--- a/apps/vscode/src/test/resolveCloudAppUrl.test.ts
+++ b/apps/vscode/src/test/resolveCloudAppUrl.test.ts
@@ -1,0 +1,49 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveCloudAppUrl } from '../auth/resolveCloudAppUrl';
+
+const FALLBACK = 'https://cloud.rocketride.ai/';
+
+const cases: Array<{ name: string; input: string; expected: string }> = [
+	{
+		name: 'maps production api host to cloud host',
+		input: 'https://api.rocketride.ai',
+		expected: 'https://cloud.rocketride.ai/',
+	},
+	{
+		name: 'maps staging api host and strips engine port / forces https',
+		input: 'https://api.staging.example.com',
+		expected: 'https://cloud.staging.example.com/',
+	},
+	{
+		name: 'maps wss api host to https cloud host (openExternal-safe)',
+		input: 'wss://api.rocketride.ai',
+		expected: 'https://cloud.rocketride.ai/',
+	},
+	{
+		name: 'falls back for localhost (no derivable web app URL)',
+		input: 'http://localhost:5565',
+		expected: FALLBACK,
+	},
+	{
+		name: 'falls back for non-api host',
+		input: 'https://engine.example.com',
+		expected: FALLBACK,
+	},
+	{
+		name: 'falls back for unparseable input',
+		input: 'not a url',
+		expected: FALLBACK,
+	},
+];
+
+for (const { name, input, expected } of cases) {
+	test(name, () => {
+		assert.equal(resolveCloudAppUrl(input), expected);
+	});
+}


### PR DESCRIPTION
## Summary

VS Code cloud sign-in showed a cryptic "no token received" error when OAuth succeeded but returned an empty `userToken`.
Cloud PKCE auto-provisions users, so an empty token is **not** "no account". This change branches on `ConnectResult.waitlisted` and improves the empty-token UX:
- **Waitlisted** -> pending-access information message (no misleading signup CTA)
- **Empty token, not waitlisted** -> actionable message about no active API key, with an **Open RocketRide Cloud** button
- Cloud web URL is derived via `resolveCloudAppUrl` from `ROCKETRIDE_URI` (`api.*` -> `https://cloud.*`), falling back to production cloud for localhost/custom hosts so `openExternal` never gets `wss:` or engine port `5565`
- `openExternal` failures are reported separately from authentication failures
- Uses typed `ConnectResult` instead of `(result as any)`
Genuine auth failures still throw and are handled in the existing catch path.


## Type

- [x] Fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Unit tests: `npx tsx --test src/test/resolveCloudAppUrl.test.ts` (from `apps/vscode`)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1299 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced sign-in recovery with clearer guidance when authentication completes without an account token.
  * Sign-in can open the appropriate cloud page, including account creation, when needed.
* **Bug Fixes**
  * Improved OAuth callback handling by distinguishing pending access from missing or inactive API keys.
  * Improved cloud-page navigation across production, staging, and supported WebSocket environments.
  * Added safer fallback behavior for local, custom, or invalid endpoints.
* **Tests**
  * Added coverage for cloud URL resolution and fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->