### PR TITLE
fix(build): make cc/c++ symlinking idempotent and fail gracefully without sudo

### DIFF
--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -438,6 +438,46 @@ dep_install_hint() {
     esac
 }
 
+# Run a command that needs root, prefixing sudo when we're not already root
+# ($SUDO is "" under root, unquoted so it disappears cleanly). The build harness
+# spawns this script with stdio captured and no controlling terminal for the
+# child, so a sudo that needs a password can't prompt and dies with
+# "sudo: a password is required". Rather than let `set -e` abort with that bare,
+# contextless error, catch the failure and tell the user exactly how to recover:
+# run this script standalone in a real terminal where sudo CAN prompt. This is
+# what keeps a privileged step (e.g. the cc/c++ symlinks below) from failing the
+# whole build with an unexplained exit 1. $*: the command to run (without sudo).
+run_privileged() {
+    if $SUDO "$@"; then
+        return 0
+    fi
+    echo ""
+    echo "=========================================="
+    echo "ERROR: a required privileged step failed:"
+    echo "    $SUDO $*"
+    if [ -n "$SUDO" ]; then
+        echo ""
+        echo "sudo could not obtain credentials. When the build runs this check it"
+        echo "captures output, so sudo has no terminal to prompt for a password."
+        echo ""
+        echo "Run the prerequisite setup once, directly in your terminal:"
+        echo "    ./scripts/compiler-unix.sh --autoinstall"
+        echo ""
+        echo "then re-run the build. Alternatives: pre-authenticate with 'sudo -v'"
+        echo "before building, or grant passwordless sudo for this command."
+    fi
+    echo "=========================================="
+    exit 1
+}
+
+# True when path $1 exists and resolves to the same file as $2. Used to make the
+# cc/c++ -> clang symlinking idempotent, so a fully-provisioned machine doesn't
+# invoke sudo just to recreate links that are already correct.
+link_points_to() {
+    [ -e "$1" ] || return 1
+    [ "$(readlink -f "$1" 2>/dev/null)" = "$(readlink -f "$2" 2>/dev/null)" ]
+}
+
 # Point the default cc/c++ at clang so vcpkg's compiler detection doesn't pick
 # gcc (which rejects the triplet's -stdlib=libc++). $1 = apt|dnf, $2 = run|print.
 # apt uses update-alternatives; Fedora symlinks into /usr/local/bin (ahead of
@@ -445,10 +485,13 @@ dep_install_hint() {
 setup_cc_alternatives() {
     case "$1" in
         apt)
+            # apt already guards on NEED_CC_ALTERNATIVES (set only when cc/c++
+            # don't already resolve to clang), so the run path is reached only
+            # when a change is genuinely needed — no extra idempotency check here.
             [ "$NEED_CC_ALTERNATIVES" = "1" ] || return 0
             if [ "$2" = "run" ]; then
-                $SUDO update-alternatives --install /usr/bin/cc cc "$CC_PATH" 100
-                $SUDO update-alternatives --install /usr/bin/c++ c++ "$CXX_PATH" 100
+                run_privileged update-alternatives --install /usr/bin/cc cc "$CC_PATH" 100
+                run_privileged update-alternatives --install /usr/bin/c++ c++ "$CXX_PATH" 100
                 echo "✓ cc/c++ -> $CC/$CXX"
             else
                 echo "    # Set default cc/c++ to $CC and $CXX"
@@ -458,9 +501,19 @@ setup_cc_alternatives() {
             ;;
         dnf)
             if [ "$2" = "run" ] && command_exists clang && command_exists clang++; then
-                $SUDO ln -sf "$(command -v clang)" /usr/local/bin/cc
-                $SUDO ln -sf "$(command -v clang++)" /usr/local/bin/c++
-                echo "✓ cc/c++ -> clang (/usr/local/bin)"
+                local clang_path clangxx_path
+                clang_path=$(command -v clang)
+                clangxx_path=$(command -v clang++)
+                # Already pointing at clang? Skip — never invoke sudo on a box
+                # whose symlinks are already correct (the common re-run case).
+                if link_points_to /usr/local/bin/cc "$clang_path" && \
+                   link_points_to /usr/local/bin/c++ "$clangxx_path"; then
+                    echo "✓ cc/c++ already -> clang (/usr/local/bin)"
+                else
+                    run_privileged ln -sf "$clang_path" /usr/local/bin/cc
+                    run_privileged ln -sf "$clangxx_path" /usr/local/bin/c++
+                    echo "✓ cc/c++ -> clang (/usr/local/bin)"
+                fi
             elif [ "$2" = "print" ]; then
                 # Fedora's cc defaults to gcc; point it at clang (ahead of /usr/bin
                 # in PATH) so vcpkg's compiler detection doesn't choke on -stdlib=libc++.


### PR DESCRIPTION
## Summary

- On Fedora, the `--autoinstall` path unconditionally ran `sudo ln -sf` to point `cc`/`c++` at clang **even when the symlinks were already correct**. The builder spawns `compiler-unix.sh` with stdio captured and no controlling terminal, so `sudo` can't prompt for a password — it timed out and aborted an otherwise fully-provisioned build with a bare `sudo: a password is required`.
- Add `link_points_to()` and guard the dnf symlinking so a machine whose `cc`/`c++` already resolve to clang skips the privileged step entirely (no `sudo` at all).
- Add `run_privileged()` wrapping the cc/c++ symlink (dnf) and `update-alternatives` (apt) calls: uses `sudo` only when not root, and on failure prints how to recover (run `./scripts/compiler-unix.sh --autoinstall` standalone in a terminal, pre-auth with `sudo -v`, or grant passwordless sudo) instead of dying on sudo's raw error.
- `apt` already guarded this via `NEED_CC_ALTERNATIVES`, so its behavior is unchanged aside from the friendlier failure message.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Verified on Fedora 44 (clang 22) under the exact failing condition (captured stdio, no TTY):
- All deps present + symlinks already correct → prints `✓ cc/c++ already -> clang (/usr/local/bin)`, **no sudo prompt**, exits 0.
- Simulated sudo failure → prints the standalone-script recovery guidance and exits 1 (no bare error).
- apt `run`/`print`/already-correct paths verified via simulation; root case (`SUDO=""`) runs the command directly.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #<!-- add issue number -->
