### PR TITLE
fix(ai): install AI test deps via depends() so engine constraints apply

### DIFF
--- a/packages/ai/scripts/tasks.js
+++ b/packages/ai/scripts/tasks.js
@@ -66,7 +66,9 @@ function makeRunPytestAction(options = {}) {
         run: async (ctx, task) => {
             const aiTestRequirements = path.join(TESTS_DIR, 'requirements.txt');
             task.output = `Installing AI test requirements (${aiTestRequirements})...`;
-            await execCommand(ENGINE, ['-m', 'pip', 'install', '--quiet', '-r', aiTestRequirements], {
+            // Install via depends() so the engine's constraints apply; plain pip
+            // ignores them and resolves unpinned deps (e.g. pillow) to latest.
+            await execCommand(ENGINE, ['-c', 'import sys; from depends import depends; depends(sys.argv[1])', aiTestRequirements], {
                 task,
                 cwd: SERVER_DIR
             });


### PR DESCRIPTION
## Summary

- `ai:test` installed test requirements with plain `pip`. pip is never handed the engine's compiled constraints file, so unpinned deps (e.g. `pillow`) resolved to the latest version instead of the engine-pinned one.
- On Windows this broke test collection. pillow was pulled to a newer version, then `depends()` tried to downgrade it at import time and could not overwrite the already-loaded `_imaging*.pyd` (file locked). That left a half-written `PIL` package, so tests failed with `ModuleNotFoundError: No module named 'PIL'`.
- Install the test requirements through `depends()` instead of pip. It runs `uv pip install` with the constraints file, so every dep (and each nested `-r` include) resolves to its pinned version. pillow now stays at the pinned 10.4.0.

## Type

fix (test/build tooling)

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

The four previously-failing test files collect and pass (23 tests), and pillow resolves to the pinned 10.4.0. Full `./builder test` not run.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #<!-- add issue number -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the test setup to install Python dependencies through the standard engine-managed flow, helping keep test environments consistent and avoid unexpected dependency upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->