### PR TITLE
chore(nodes): classify FalkorDB as store (classType)

### DIFF
--- a/nodes/src/nodes/tool_falkordb/services.json
+++ b/nodes/src/nodes/tool_falkordb/services.json
@@ -1,7 +1,7 @@
 {
 	"title": "FalkorDB",
 	"protocol": "tool_falkordb://",
-	"classType": ["tool"],
+	"classType": ["store", "tool"],
 	"capabilities": ["invoke", "experimental"],
 	"register": "filter",
 	"node": "python",


### PR DESCRIPTION
Per Rod's call in dev-sync ("Add store to classType. What it is named in the source code is not relevant").

FalkorDB was the only DB/store node still tagged `classType: ["tool"]`, while:
- vector stores (chroma, qdrant, pinecone, milvus, weaviate, vectordb_postgres) use `["store"]` / `["store","tool"]`
- SQL/graph DBs (db_arango, db_clickhouse, db_mysql, db_neo4j, db_postgres) use `["database","tool"]`

This makes FalkorDB `["store","tool"]` so it categorizes correctly in the canvas (addresses Joe's point that a dev looking for it under a DB category wouldn't find it). Folder name `tool_falkordb` left as-is per Rod.

**Open question for the team:** should the 5 `["database","tool"]` nodes also unify to `store`, or is `database` an intentional separate taxonomy from `store` (vector)? Left untouched here pending that call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The FalkorDB tool is now also recognized as a store, improving how it appears and behaves in workflows that support storage components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->