### PR TITLE
chore(release): bump remaining products to 1.3.0 (v3.3.0 cut)

### DIFF
--- a/apps/hello-ui/package.json
+++ b/apps/hello-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketride/hello-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "RocketRide Hello — OSS landing page and dashboard",
   "license": "MIT",

--- a/apps/monitor-ui/package.json
+++ b/apps/monitor-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketride/monitor-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Server monitoring dashboard — connections, tasks, activity",
   "license": "MIT",

--- a/apps/profiler-ui/package.json
+++ b/apps/profiler-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketride/profiler-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "cProfile process profiler — start/stop sessions, view reports",
   "license": "MIT",

--- a/apps/shell-ui/package.json
+++ b/apps/shell-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shell-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "main": "./src/index.ts",
   "types": "./src/index.ts",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "rocketride",
 	"displayName": "RocketRide",
 	"description": "RocketRide extension for Visual Studio Code",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"publisher": "rocketride",
 	"repository": {
 		"type": "git",

--- a/apps/world-ui/package.json
+++ b/apps/world-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocketride/world-ui",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Hello World demo application — reference MF remote app",
   "license": "MIT",

--- a/packages/client-mcp/pyproject.toml
+++ b/packages/client-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride-mcp"
-version = "1.2.0"
+version = "1.3.0"
 description = "RocketRide MCP stdio server that streams local files to RocketRide EaaS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/shared-ui/package.json
+++ b/packages/shared-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "shared",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"private": true,
 	"main": "./index.ts",
 	"module": "./index.ts",


### PR DESCRIPTION
Rod asked whether all product versions are bumped for v3.3.0. Root was already 3.3.0 and client-typescript/client-python 1.3.0, but **8 products were still on 1.2.0**: shared-ui, shell-ui, vscode, world-ui, profiler-ui, hello-ui, monitor-ui, client-mcp. This aligns them all to **1.3.0** so the release is consistent. Internal deps are workspace:* (no ref churn).