### PR TITLE
fix(shell-ui): define REACT_APP_OAUTH_ROOT_URL (fixes 'process is not defined' in cloud)

### DIFF
--- a/apps/shell-ui/rsbuild.config.mts
+++ b/apps/shell-ui/rsbuild.config.mts
@@ -191,6 +191,10 @@ export default defineConfig(({ command }) => {
 
 				// Zitadel OAuth2 client ID registered for this SPA.
 				'process.env.RR_ZITADEL_CLIENT_ID': e('RR_ZITADEL_CLIENT_ID'),
+
+				// OAuth broker root URL — read at module load by shared-ui/config/oauth.ts;
+				// shell-ui bundles shared-ui from source so it must define this (like rslib/vscode).
+				'process.env.REACT_APP_OAUTH_ROOT_URL': e('REACT_APP_OAUTH_ROOT_URL'),
 			},
 		},
 		dev: {


### PR DESCRIPTION
Cloud shell-ui throws `Uncaught ReferenceError: process is not defined` on load (Module Federation shared-factory init).

**Root cause:** `packages/shared-ui/src/config/oauth.ts` (added in #1334) reads `process.env.REACT_APP_OAUTH_ROOT_URL` at module top level. The define was added to `apps/vscode/rsbuild.config.mjs` and shared-ui's `rslib.config.ts`, but **shell-ui bundles shared-ui from source** (rsbuild.config.mts imports `packages/shared-ui/src/index.ts` as the eager MF `shared` module), so the rslib define never applies. shell-ui's own define block didn't include the var, so the `process.env` token survived into the browser bundle unreplaced and threw at module load.

**Fix:** add `'process.env.REACT_APP_OAUTH_ROOT_URL': e('REACT_APP_OAUTH_ROOT_URL')` to shell-ui's define block. `e()` = `JSON.stringify(env[key] ?? '')`, so it's not hard-required (oauth.ts keeps its `https://oauth2.rocketride.ai` fallback). Matches vscode/rslib.

Note (per @Rod): longer-term, oauth.ts should receive the URL from the host via formContext (the shared-ui 'no process.env' contract) instead of every host build defining it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading the app’s OAuth broker root URL in the browser at startup, improving sign-in related configuration availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->