### PR TITLE
release: v3.3.1 — stage → main (shell-ui oauth hotfix)

### DIFF
--- a/apps/shell-ui/rsbuild.config.mts
+++ b/apps/shell-ui/rsbuild.config.mts
@@ -191,6 +191,10 @@ export default defineConfig(({ command }) => {
 
 				// Zitadel OAuth2 client ID registered for this SPA.
 				'process.env.RR_ZITADEL_CLIENT_ID': e('RR_ZITADEL_CLIENT_ID'),
+
+				// OAuth broker root URL — read at module load by shared-ui/config/oauth.ts;
+				// shell-ui bundles shared-ui from source so it must define this (like rslib/vscode).
+				'process.env.REACT_APP_OAUTH_ROOT_URL': e('REACT_APP_OAUTH_ROOT_URL'),
 			},
 		},
 		dev: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride-server",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"description": "RocketRide Server - A high-performance data processing engine with modular nodes, AI capabilities, and cross-platform clients",
 	"private": true,
 	"license": "MIT",


### PR DESCRIPTION
3.3.1 hotfix: shell-ui REACT_APP_OAUTH_ROOT_URL define (#1486) fixes the cloud `process is not defined`. Clean snapshot of stage (engine 3.3.1). Merging → release.yaml builds engine 3.3.1 → build-saas-engine overlay → prod. SDKs unchanged (idempotent).