### PR TITLE
fix(tool_mcp_client): stop reasoning-model agents dropping zero-argument MCP tools

### DIFF
--- a/nodes/src/nodes/tool_mcp_client/IGlobal.py
+++ b/nodes/src/nodes/tool_mcp_client/IGlobal.py
@@ -228,7 +228,7 @@ class IGlobal(IGlobalBase):
     def list_namespaced_tools(self) -> List[Dict[str, Any]]:
         out: List[Dict[str, Any]] = []
         for namespaced, tool in (self._tools_by_namespaced or {}).items():
-            out.append({'name': namespaced, 'description': tool.description, 'input_schema': tool.inputSchema})
+            out.append({'name': namespaced, 'description': tool.description, 'inputSchema': tool.inputSchema})
         return out
 
     def get_tool(self, *, server_name: str, tool_name: str) -> Optional[McpToolDef]:

--- a/nodes/src/nodes/tool_mcp_client/IInstance.py
+++ b/nodes/src/nodes/tool_mcp_client/IInstance.py
@@ -37,6 +37,7 @@ from typing import Any, Dict
 from rocketlib import IInstanceBase
 
 from .IGlobal import IGlobal
+from .mcp_schema import strip_synthesized_args
 
 _FRAMEWORK_KEYS = frozenset({'security_context'})
 
@@ -54,7 +55,11 @@ class IInstance(IInstanceBase):
         if input_obj is None:
             arguments: Dict[str, Any] = {}
         elif isinstance(input_obj, dict):
+            # Drop framework-injected keys, then strip the synthesized no-op
+            # placeholder (see mcp_schema.normalize_tool_input_schema) so the MCP
+            # server only ever receives the tool's real arguments.
             arguments = {k: v for k, v in input_obj.items() if k not in _FRAMEWORK_KEYS}
+            arguments = strip_synthesized_args(arguments)
         else:
             raise ValueError('Tool input must be a JSON object (dict)')
         return self.IGlobal.call_tool(server_name=server_name, tool_name=bare_tool, arguments=arguments)

--- a/nodes/src/nodes/tool_mcp_client/IInstance.py
+++ b/nodes/src/nodes/tool_mcp_client/IInstance.py
@@ -55,11 +55,13 @@ class IInstance(IInstanceBase):
         if input_obj is None:
             arguments: Dict[str, Any] = {}
         elif isinstance(input_obj, dict):
-            # Drop framework-injected keys, then strip the synthesized no-op
-            # placeholder (see mcp_schema.normalize_tool_input_schema) so the MCP
-            # server only ever receives the tool's real arguments.
+            # Drop framework-injected keys. A placeholder is removed only for a
+            # cached tool whose schema normalization actually synthesized it;
+            # ``rr_no_args`` remains a valid real MCP argument otherwise.
             arguments = {k: v for k, v in input_obj.items() if k not in _FRAMEWORK_KEYS}
-            arguments = strip_synthesized_args(arguments)
+            tool = self.IGlobal.get_tool(server_name=server_name, tool_name=bare_tool)
+            if tool is not None and getattr(tool, 'has_synthesized_noop_arg', False):
+                arguments = strip_synthesized_args(arguments)
         else:
             raise ValueError('Tool input must be a JSON object (dict)')
         return self.IGlobal.call_tool(server_name=server_name, tool_name=bare_tool, arguments=arguments)

--- a/nodes/src/nodes/tool_mcp_client/README.md
+++ b/nodes/src/nodes/tool_mcp_client/README.md
@@ -94,6 +94,12 @@ The STDIO transport has no authentication fields: the subprocess runs locally wi
 
 ---
 
+## Zero-argument tools
+
+Some MCP tools take no arguments (their input schema is empty). Strict reasoning-model agents can silently drop such a tool from their catalog when it is advertised with an empty JSON Schema. To keep these tools usable everywhere, the client normalizes an empty input schema to carry a single optional placeholder argument (`rr_no_args`) before presenting the tool to an agent. The placeholder is stripped again before the tool is actually called, so the MCP server never receives it — no changes are required on the server side.
+
+---
+
 ## Upstream docs
 
 - [Model Context Protocol specification](https://modelcontextprotocol.io/)

--- a/nodes/src/nodes/tool_mcp_client/README.md
+++ b/nodes/src/nodes/tool_mcp_client/README.md
@@ -96,7 +96,7 @@ The STDIO transport has no authentication fields: the subprocess runs locally wi
 
 ## Zero-argument tools
 
-Some MCP tools take no arguments (their input schema is empty). Strict reasoning-model agents can silently drop such a tool from their catalog when it is advertised with an empty JSON Schema. To keep these tools usable everywhere, the client normalizes an empty input schema to carry a single optional placeholder argument (`rr_no_args`) before presenting the tool to an agent. The placeholder is stripped again before the tool is actually called, so the MCP server never receives it — no changes are required on the server side.
+Some MCP tools take no arguments (their input schema is empty). Strict reasoning-model agents can silently drop such a tool from their catalog when it is advertised with an empty JSON Schema. To keep these tools usable everywhere, the client normalizes an empty input schema to carry a single optional placeholder argument (`rr_no_args`) before presenting the tool to an agent. RocketRide records which cached tools received that synthesized placeholder and strips it only for those tools before the call, so the MCP server never receives it. A tool that genuinely declares an argument named `rr_no_args` continues to receive that argument unchanged.
 
 ---
 

--- a/nodes/src/nodes/tool_mcp_client/mcp_schema.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_schema.py
@@ -1,0 +1,95 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Shared JSON-Schema normalization for MCP tool descriptors.
+
+Reasoning-model agents (e.g. ``qwen`` on Groq) silently drop a tool from their
+usable catalog when its input schema has no ``properties`` — a zero-argument
+tool reaches the model as a degenerate ``{'type': 'object'}``. More forgiving
+models (e.g. ``llama-3.3-70b``) tolerate it. The MCP client cannot know which
+model consumes the tool, so it always presents a well-formed, non-empty schema.
+
+``normalize_tool_input_schema`` synthesizes a single *optional* no-op field for
+empty-schema tools. The field is a presentation-only placeholder: it is stripped
+from the arguments before the real ``tools/call`` (see
+``IInstance._tool_invoke_dynamic``), so the MCP server never sees it. Schemas
+that already declare real ``properties`` pass through unchanged.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+# Reserved argument name synthesized for zero-argument tools. The ``rr_`` prefix
+# makes a collision with a real MCP argument vanishingly unlikely, and it is only
+# ever added when the tool declares no properties of its own. It deliberately has
+# no leading underscore: pydantic ``create_model`` (used by the LangChain/CrewAI/
+# DeepAgent tool builders) rejects field names that start with ``_``.
+NOOP_ARG_NAME = 'rr_no_args'
+
+
+def normalize_tool_input_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Return a model-safe JSON Schema for a tool's input.
+
+    If ``schema`` already declares a non-empty ``properties`` map it is returned
+    unchanged. Otherwise (missing schema, bare ``{'type': 'object'}``, or explicit
+    ``{'type': 'object', 'properties': {}}``) a single optional ``rr_no_args``
+    string field is synthesized so strict reasoning models keep the tool in their
+    catalog. Any other keys already present on the schema are preserved.
+    """
+    if not isinstance(schema, dict):
+        schema = {'type': 'object'}
+
+    props = schema.get('properties')
+    if isinstance(props, dict) and props:
+        # Real arguments — leave the tool's declared schema untouched.
+        return schema
+
+    return {
+        **schema,
+        'type': 'object',
+        'properties': {
+            NOOP_ARG_NAME: {
+                'type': 'string',
+                'description': 'This tool takes no arguments. Leave empty or omit.',
+            }
+        },
+        'required': [],
+    }
+
+
+def strip_synthesized_args(arguments: Any) -> Any:
+    """
+    Remove the synthesized ``rr_no_args`` placeholder from tool arguments.
+
+    Called on the invoke path before a ``tools/call`` so a model that fills in
+    the presentation-only no-op field never leaks it to the MCP server. Non-dict
+    inputs and dicts without the placeholder are returned unchanged.
+    """
+    if not isinstance(arguments, dict) or NOOP_ARG_NAME not in arguments:
+        return arguments
+    return {k: v for k, v in arguments.items() if k != NOOP_ARG_NAME}

--- a/nodes/src/nodes/tool_mcp_client/mcp_schema.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_schema.py
@@ -33,10 +33,11 @@ models (e.g. ``llama-3.3-70b``) tolerate it. The MCP client cannot know which
 model consumes the tool, so it always presents a well-formed, non-empty schema.
 
 ``normalize_tool_input_schema`` synthesizes a single *optional* no-op field for
-empty-schema tools. The field is a presentation-only placeholder: it is stripped
-from the arguments before the real ``tools/call`` (see
-``IInstance._tool_invoke_dynamic``), so the MCP server never sees it. Schemas
-that already declare real ``properties`` pass through unchanged.
+empty-schema tools. The cached tool definition records when that field was
+synthesized, so it is stripped from the arguments before the real ``tools/call``
+(see ``IInstance._tool_invoke_dynamic``) without removing a real MCP argument
+that happens to share its name. Schemas that already declare real ``properties``
+pass through unchanged.
 """
 
 from __future__ import annotations
@@ -49,6 +50,11 @@ from typing import Any, Dict, Optional
 # no leading underscore: pydantic ``create_model`` (used by the LangChain/CrewAI/
 # DeepAgent tool builders) rejects field names that start with ``_``.
 NOOP_ARG_NAME = 'rr_no_args'
+
+
+def input_schema_needs_noop_placeholder(schema: Any) -> bool:
+    """Return whether normalization will synthesize the no-op placeholder."""
+    return not isinstance(schema, dict) or not isinstance(schema.get('properties'), dict) or not schema['properties']
 
 
 def normalize_tool_input_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -64,8 +70,7 @@ def normalize_tool_input_schema(schema: Optional[Dict[str, Any]]) -> Dict[str, A
     if not isinstance(schema, dict):
         schema = {'type': 'object'}
 
-    props = schema.get('properties')
-    if isinstance(props, dict) and props:
+    if not input_schema_needs_noop_placeholder(schema):
         # Real arguments — leave the tool's declared schema untouched.
         return schema
 

--- a/nodes/src/nodes/tool_mcp_client/mcp_sse_client.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_sse_client.py
@@ -50,6 +50,11 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+try:
+    from .mcp_schema import normalize_tool_input_schema
+except ImportError:  # pragma: no cover - standalone import (e.g. unit tests)
+    from mcp_schema import normalize_tool_input_schema
+
 
 class McpProtocolError(RuntimeError):
     pass
@@ -159,7 +164,8 @@ class McpSseClient:
             if not isinstance(name, str) or not name:
                 continue
             desc = t.get('description') if isinstance(t.get('description'), str) else ''
-            schema = t.get('inputSchema') if isinstance(t.get('inputSchema'), dict) else {'type': 'object'}
+            raw = t.get('inputSchema')
+            schema = normalize_tool_input_schema(raw if isinstance(raw, dict) else None)
             out.append(McpToolDef(name=name, description=desc, inputSchema=schema))
         return out
 

--- a/nodes/src/nodes/tool_mcp_client/mcp_sse_client.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_sse_client.py
@@ -51,9 +51,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 try:
-    from .mcp_schema import normalize_tool_input_schema
+    from .mcp_schema import input_schema_needs_noop_placeholder, normalize_tool_input_schema
 except ImportError:  # pragma: no cover - standalone import (e.g. unit tests)
-    from mcp_schema import normalize_tool_input_schema
+    from mcp_schema import input_schema_needs_noop_placeholder, normalize_tool_input_schema
 
 
 class McpProtocolError(RuntimeError):
@@ -65,6 +65,7 @@ class McpToolDef:
     name: str
     description: str
     inputSchema: Dict[str, Any]
+    has_synthesized_noop_arg: bool = False
 
 
 class McpSseClient:
@@ -165,8 +166,16 @@ class McpSseClient:
                 continue
             desc = t.get('description') if isinstance(t.get('description'), str) else ''
             raw = t.get('inputSchema')
-            schema = normalize_tool_input_schema(raw if isinstance(raw, dict) else None)
-            out.append(McpToolDef(name=name, description=desc, inputSchema=schema))
+            input_schema = raw if isinstance(raw, dict) else None
+            schema = normalize_tool_input_schema(input_schema)
+            out.append(
+                McpToolDef(
+                    name=name,
+                    description=desc,
+                    inputSchema=schema,
+                    has_synthesized_noop_arg=input_schema_needs_noop_placeholder(input_schema),
+                )
+            )
         return out
 
     def call_tool(self, *, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/nodes/src/nodes/tool_mcp_client/mcp_stdio_client.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_stdio_client.py
@@ -43,6 +43,11 @@ import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+try:
+    from .mcp_schema import normalize_tool_input_schema
+except ImportError:  # pragma: no cover - standalone import (e.g. unit tests)
+    from mcp_schema import normalize_tool_input_schema
+
 
 class McpProtocolError(RuntimeError):
     pass
@@ -177,7 +182,8 @@ class McpStdioClient:
             if not isinstance(name, str) or not name:
                 continue
             desc = t.get('description') if isinstance(t.get('description'), str) else ''
-            schema = t.get('inputSchema') if isinstance(t.get('inputSchema'), dict) else {'type': 'object'}
+            raw = t.get('inputSchema')
+            schema = normalize_tool_input_schema(raw if isinstance(raw, dict) else None)
             out.append(McpToolDef(name=name, description=desc, inputSchema=schema))
         return out
 

--- a/nodes/src/nodes/tool_mcp_client/mcp_stdio_client.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_stdio_client.py
@@ -44,9 +44,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 try:
-    from .mcp_schema import normalize_tool_input_schema
+    from .mcp_schema import input_schema_needs_noop_placeholder, normalize_tool_input_schema
 except ImportError:  # pragma: no cover - standalone import (e.g. unit tests)
-    from mcp_schema import normalize_tool_input_schema
+    from mcp_schema import input_schema_needs_noop_placeholder, normalize_tool_input_schema
 
 
 class McpProtocolError(RuntimeError):
@@ -58,6 +58,7 @@ class McpToolDef:
     name: str
     description: str
     inputSchema: Dict[str, Any]
+    has_synthesized_noop_arg: bool = False
 
 
 class McpStdioClient:
@@ -183,8 +184,16 @@ class McpStdioClient:
                 continue
             desc = t.get('description') if isinstance(t.get('description'), str) else ''
             raw = t.get('inputSchema')
-            schema = normalize_tool_input_schema(raw if isinstance(raw, dict) else None)
-            out.append(McpToolDef(name=name, description=desc, inputSchema=schema))
+            input_schema = raw if isinstance(raw, dict) else None
+            schema = normalize_tool_input_schema(input_schema)
+            out.append(
+                McpToolDef(
+                    name=name,
+                    description=desc,
+                    inputSchema=schema,
+                    has_synthesized_noop_arg=input_schema_needs_noop_placeholder(input_schema),
+                )
+            )
         return out
 
     def call_tool(self, *, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/nodes/src/nodes/tool_mcp_client/mcp_streamable_http_client.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_streamable_http_client.py
@@ -53,6 +53,11 @@ import urllib.request
 from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional
 
+try:
+    from .mcp_schema import normalize_tool_input_schema
+except ImportError:  # pragma: no cover - standalone import (e.g. unit tests)
+    from mcp_schema import normalize_tool_input_schema
+
 
 class McpProtocolError(RuntimeError):
     pass
@@ -171,7 +176,8 @@ class McpStreamableHttpClient:
             if not isinstance(name, str) or not name:
                 continue
             desc = t.get('description') if isinstance(t.get('description'), str) else ''
-            schema = t.get('inputSchema') if isinstance(t.get('inputSchema'), dict) else {'type': 'object'}
+            raw = t.get('inputSchema')
+            schema = normalize_tool_input_schema(raw if isinstance(raw, dict) else None)
             out.append(McpToolDef(name=name, description=desc, inputSchema=schema))
         return out
 

--- a/nodes/src/nodes/tool_mcp_client/mcp_streamable_http_client.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_streamable_http_client.py
@@ -54,9 +54,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Optional
 
 try:
-    from .mcp_schema import normalize_tool_input_schema
+    from .mcp_schema import input_schema_needs_noop_placeholder, normalize_tool_input_schema
 except ImportError:  # pragma: no cover - standalone import (e.g. unit tests)
-    from mcp_schema import normalize_tool_input_schema
+    from mcp_schema import input_schema_needs_noop_placeholder, normalize_tool_input_schema
 
 
 class McpProtocolError(RuntimeError):
@@ -77,6 +77,7 @@ class McpToolDef:
     name: str
     description: str
     inputSchema: Dict[str, Any]
+    has_synthesized_noop_arg: bool = False
 
 
 class McpStreamableHttpClient:
@@ -177,8 +178,16 @@ class McpStreamableHttpClient:
                 continue
             desc = t.get('description') if isinstance(t.get('description'), str) else ''
             raw = t.get('inputSchema')
-            schema = normalize_tool_input_schema(raw if isinstance(raw, dict) else None)
-            out.append(McpToolDef(name=name, description=desc, inputSchema=schema))
+            input_schema = raw if isinstance(raw, dict) else None
+            schema = normalize_tool_input_schema(input_schema)
+            out.append(
+                McpToolDef(
+                    name=name,
+                    description=desc,
+                    inputSchema=schema,
+                    has_synthesized_noop_arg=input_schema_needs_noop_placeholder(input_schema),
+                )
+            )
         return out
 
     def call_tool(self, *, name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/nodes/test/tool_mcp_client/stub_mcp_server.py
+++ b/nodes/test/tool_mcp_client/stub_mcp_server.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Minimal stdio MCP server for testing tool_mcp_client.
+
+Speaks line-delimited JSON-RPC over stdin/stdout (the same transport
+``McpStdioClient`` drives). It intentionally exposes zero-argument tools in the
+two degenerate shapes we care about, plus a normal tool as a control:
+
+- ``no_schema_tool``    — tool advertised with NO ``inputSchema`` key at all.
+- ``empty_props_tool``  — tool with an explicit ``{'type':'object','properties':{}}``.
+- ``echo_tool``         — tool with a real required argument.
+
+``tools/call`` echoes back the exact ``arguments`` object the server received
+under ``received_arguments`` so tests can assert that the synthesized no-op
+placeholder (``rr_no_args``) is stripped before the call reaches the server.
+"""
+
+import json
+import sys
+
+TOOLS = [
+    {
+        'name': 'no_schema_tool',
+        'description': 'Zero-argument tool advertised with no inputSchema.',
+        # NOTE: deliberately omit 'inputSchema' entirely.
+    },
+    {
+        'name': 'empty_props_tool',
+        'description': 'Zero-argument tool with an explicit empty properties map.',
+        'inputSchema': {'type': 'object', 'properties': {}},
+    },
+    {
+        'name': 'echo_tool',
+        'description': 'Control tool that takes a real required argument.',
+        'inputSchema': {
+            'type': 'object',
+            'properties': {'msg': {'type': 'string', 'description': 'Message to echo'}},
+            'required': ['msg'],
+        },
+    },
+]
+
+
+def _write(msg):
+    sys.stdout.write(json.dumps(msg, ensure_ascii=False) + '\n')
+    sys.stdout.flush()
+
+
+def _handle(msg):
+    """Return a JSON-RPC response dict, or None for notifications."""
+    if not isinstance(msg, dict):
+        return None
+    method = msg.get('method')
+    msg_id = msg.get('id')
+    params = msg.get('params') or {}
+
+    # Notifications carry no id and expect no response.
+    if msg_id is None:
+        return None
+
+    if method == 'initialize':
+        return {
+            'jsonrpc': '2.0',
+            'id': msg_id,
+            'result': {
+                'protocolVersion': params.get('protocolVersion', '2024-11-05'),
+                'capabilities': {'tools': {}},
+                'serverInfo': {'name': 'stub-mcp', 'version': '0.1.0'},
+            },
+        }
+
+    if method == 'tools/list':
+        return {'jsonrpc': '2.0', 'id': msg_id, 'result': {'tools': TOOLS}}
+
+    if method == 'tools/call':
+        name = params.get('name')
+        arguments = params.get('arguments', {})
+        known = {t['name'] for t in TOOLS}
+        if name not in known:
+            return {
+                'jsonrpc': '2.0',
+                'id': msg_id,
+                'error': {'code': -32602, 'message': f'Tool {name} not found'},
+            }
+        # Echo back exactly what we received so tests can assert on it.
+        return {
+            'jsonrpc': '2.0',
+            'id': msg_id,
+            'result': {
+                'content': [{'type': 'text', 'text': f'called {name}'}],
+                'received_arguments': arguments,
+            },
+        }
+
+    return {
+        'jsonrpc': '2.0',
+        'id': msg_id,
+        'error': {'code': -32601, 'message': f'Method not found: {method}'},
+    }
+
+
+def main():
+    for line in sys.stdin:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            msg = json.loads(line)
+        except Exception:
+            continue
+        response = _handle(msg)
+        if response is not None:
+            _write(response)
+
+
+if __name__ == '__main__':
+    main()

--- a/nodes/test/tool_mcp_client/test_mcp_agent_catalog.py
+++ b/nodes/test/tool_mcp_client/test_mcp_agent_catalog.py
@@ -1,0 +1,86 @@
+"""Agent-catalog assertions for zero-argument MCP tools (issue #1404).
+
+Proves, through the *real* ``agent_rocketride`` on-demand catalog builder
+(``planner._build_all_tool_descriptions`` — the exact path the issue names),
+that after normalization a zero-argument MCP tool appears in the catalog with a
+genuine ``properties`` map, so a strict reasoning model keeps it instead of
+dropping it.
+
+The ``agent_langchain`` path is covered by code (it reads the same ``inputSchema``
+key this PR now emits) plus the transport/normalization tests in
+``test_zero_arg_tools.py``; it is not re-exercised here because constructing its
+pydantic tool models from a dynamically-loaded module is environment-fragile.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+import types
+
+import pytest
+
+_HERE = os.path.dirname(__file__)
+_NODES = os.path.join(_HERE, '..', '..', 'src', 'nodes')
+sys.path.insert(0, os.path.join(_NODES, 'tool_mcp_client'))
+
+from mcp_schema import NOOP_ARG_NAME, normalize_tool_input_schema  # noqa: E402
+
+_PLANNER_PY = os.path.join(_NODES, 'agent_rocketride', 'planner.py')
+
+
+def _load_module(path, modname):
+    """Load a node source file under a unique module name, registered in
+    ``sys.modules`` before exec.
+    """
+    spec = importlib.util.spec_from_file_location(modname, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+try:
+    _planner = _load_module(_PLANNER_PY, '_rr_agent_rocketride_planner_under_test')
+    _IMPORT_ERR = None
+except Exception as exc:  # pragma: no cover - env without engine libs
+    _planner = None
+    _IMPORT_ERR = exc
+
+pytestmark = pytest.mark.skipif(_planner is None, reason=f'agent_rocketride planner not importable: {_IMPORT_ERR}')
+
+# The schema an MCP zero-argument tool now carries after normalization.
+_ZERO_ARG_SCHEMA = normalize_tool_input_schema(None)
+
+
+def _catalog_for(descriptor):
+    ctx = types.SimpleNamespace(tools=types.SimpleNamespace(list=[descriptor]))
+    return _planner._build_all_tool_descriptions(ctx)
+
+
+def test_rocketride_on_demand_catalog_lists_zero_arg_tool_with_real_property():
+    """After normalization a zero-argument MCP tool appears in the on-demand
+    catalog with a non-empty ``properties`` map — the exact path issue #1404
+    reports.
+    """
+    descriptor = {
+        'name': 'stub.no_schema_tool',
+        'description': 'Zero-argument MCP tool',
+        'inputSchema': _ZERO_ARG_SCHEMA,
+    }
+    catalog = _catalog_for(descriptor)
+    assert 'stub.no_schema_tool' in catalog
+
+    line = json.loads(catalog.splitlines()[0])
+    props = line['inputSchema']['properties']
+    assert props and NOOP_ARG_NAME in props
+
+
+def test_rocketride_catalog_bare_schema_has_no_properties_pre_fix():
+    """Documents the pre-fix hazard: a bare ``{'type': 'object'}`` descriptor
+    serializes into the catalog with no ``properties`` — the degenerate shape
+    reasoning models drop. Normalization at the MCP source is what prevents it.
+    """
+    bare = {'name': 'srv.tool', 'description': 'd', 'inputSchema': {'type': 'object'}}
+    line = json.loads(_catalog_for(bare).splitlines()[0])
+    assert not line['inputSchema'].get('properties')

--- a/nodes/test/tool_mcp_client/test_zero_arg_tools.py
+++ b/nodes/test/tool_mcp_client/test_zero_arg_tools.py
@@ -1,0 +1,146 @@
+"""Tests for zero-argument MCP tool handling (issue #1404).
+
+Reasoning-model agents silently drop a tool whose input schema has no
+``properties``. The MCP client now normalizes such schemas to carry a single
+synthesized optional no-op field (``rr_no_args``) so strict models keep the
+tool, and strips that field again before the real ``tools/call``.
+
+Covers:
+- ``normalize_tool_input_schema`` (pure) — every degenerate schema shape.
+- ``strip_synthesized_args`` (pure) — the exact helper the invoke path uses.
+- End-to-end against a stub stdio MCP server: discovery shapes + that the
+  synthesized field never reaches the server.
+"""
+
+import os
+import sys
+
+import pytest
+
+# Import the node modules the same way the sibling test_sse_redirect.py does:
+# add the node source dir to sys.path and import the transport standalone.
+_NODE_SRC = os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'nodes', 'tool_mcp_client')
+sys.path.insert(0, _NODE_SRC)
+
+from mcp_schema import NOOP_ARG_NAME, normalize_tool_input_schema, strip_synthesized_args  # noqa: E402
+from mcp_stdio_client import McpStdioClient  # noqa: E402
+
+STUB_SERVER = os.path.join(os.path.dirname(__file__), 'stub_mcp_server.py')
+
+
+# ---------------------------------------------------------------------------
+# normalize_tool_input_schema — pure unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeSchema:
+    def _assert_synthesized(self, schema):
+        props = schema.get('properties')
+        assert isinstance(props, dict)
+        assert list(props.keys()) == [NOOP_ARG_NAME]
+        assert props[NOOP_ARG_NAME]['type'] == 'string'
+        assert schema['type'] == 'object'
+        assert schema.get('required') == []
+
+    def test_none_is_synthesized(self):
+        self._assert_synthesized(normalize_tool_input_schema(None))
+
+    def test_non_dict_is_synthesized(self):
+        self._assert_synthesized(normalize_tool_input_schema('not-a-schema'))
+        self._assert_synthesized(normalize_tool_input_schema(123))
+
+    def test_bare_object_is_synthesized(self):
+        # The exact shape the transports used to default to.
+        self._assert_synthesized(normalize_tool_input_schema({'type': 'object'}))
+
+    def test_explicit_empty_properties_is_synthesized(self):
+        self._assert_synthesized(normalize_tool_input_schema({'type': 'object', 'properties': {}, 'required': []}))
+
+    def test_non_empty_properties_passes_through_unchanged(self):
+        original = {
+            'type': 'object',
+            'properties': {'msg': {'type': 'string'}},
+            'required': ['msg'],
+        }
+        result = normalize_tool_input_schema(original)
+        assert result is original  # untouched, same object
+        assert NOOP_ARG_NAME not in result['properties']
+
+    def test_preserves_extra_schema_keys(self):
+        result = normalize_tool_input_schema({'type': 'object', 'title': 'Foo', 'description': 'bar'})
+        assert result['title'] == 'Foo'
+        assert result['description'] == 'bar'
+        self._assert_synthesized(result)
+
+
+# ---------------------------------------------------------------------------
+# strip_synthesized_args — pure unit tests (the exact invoke-path helper)
+# ---------------------------------------------------------------------------
+
+
+class TestStripSynthesizedArgs:
+    def test_strips_noop_key(self):
+        assert strip_synthesized_args({NOOP_ARG_NAME: 'whatever', 'a': 1}) == {'a': 1}
+
+    def test_strips_when_only_noop(self):
+        assert strip_synthesized_args({NOOP_ARG_NAME: ''}) == {}
+
+    def test_leaves_real_args_untouched(self):
+        args = {'a': 1, 'b': 2}
+        assert strip_synthesized_args(args) == {'a': 1, 'b': 2}
+
+    def test_empty_dict_unchanged(self):
+        assert strip_synthesized_args({}) == {}
+
+    def test_non_dict_unchanged(self):
+        assert strip_synthesized_args(None) is None
+        assert strip_synthesized_args('x') == 'x'
+
+
+# ---------------------------------------------------------------------------
+# End-to-end against the stub stdio MCP server
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client():
+    c = McpStdioClient(command=sys.executable, args=[STUB_SERVER], timeout_s=10.0)
+    c.start()
+    try:
+        yield c
+    finally:
+        c.stop()
+
+
+class TestStubIntegration:
+    def test_zero_arg_tools_get_nonempty_properties(self, client):
+        tools = {t.name: t for t in client.list_tools()}
+        assert set(tools) == {'no_schema_tool', 'empty_props_tool', 'echo_tool'}
+
+        # Both zero-argument shapes are normalized to a non-empty properties map
+        # carrying the synthesized no-op field.
+        for name in ('no_schema_tool', 'empty_props_tool'):
+            props = tools[name].inputSchema.get('properties')
+            assert isinstance(props, dict) and props, f'{name} still has empty properties'
+            assert NOOP_ARG_NAME in props, f'{name} missing synthesized arg'
+
+    def test_real_arg_tool_schema_untouched(self, client):
+        tools = {t.name: t for t in client.list_tools()}
+        echo = tools['echo_tool'].inputSchema
+        assert set(echo['properties']) == {'msg'}
+        assert NOOP_ARG_NAME not in echo['properties']
+
+    def test_synthesized_arg_never_reaches_server(self, client):
+        # Simulate the invoke path: a model fills in the presentation-only no-op
+        # field; the node strips it before dispatching to the MCP server.
+        model_args = strip_synthesized_args({NOOP_ARG_NAME: 'ignored'})
+        result = client.call_tool(name='no_schema_tool', arguments=model_args)
+        assert result['received_arguments'] == {}
+
+    def test_empty_call_succeeds(self, client):
+        result = client.call_tool(name='empty_props_tool', arguments={})
+        assert result['received_arguments'] == {}
+
+    def test_real_args_pass_through(self, client):
+        result = client.call_tool(name='echo_tool', arguments={'msg': 'hi'})
+        assert result['received_arguments'] == {'msg': 'hi'}

--- a/nodes/test/tool_mcp_client/test_zero_arg_tools.py
+++ b/nodes/test/tool_mcp_client/test_zero_arg_tools.py
@@ -7,9 +7,10 @@ tool, and strips that field again before the real ``tools/call``.
 
 Covers:
 - ``normalize_tool_input_schema`` (pure) — every degenerate schema shape.
-- ``strip_synthesized_args`` (pure) — the exact helper the invoke path uses.
-- End-to-end against a stub stdio MCP server: discovery shapes + that the
-  synthesized field never reaches the server.
+- The production invoke path — synthesized placeholders are removed, while a
+  real MCP argument named ``rr_no_args`` is preserved.
+- End-to-end against a stub stdio MCP server: discovery shapes + transport
+  normalization.
 """
 
 import os
@@ -30,6 +31,8 @@ def _ensure_iglobal_import_stubs():
     rocketlib = sys.modules.get('rocketlib') or types.ModuleType('rocketlib')
     if not hasattr(rocketlib, 'IGlobalBase'):
         rocketlib.IGlobalBase = type('IGlobalBase', (), {})
+    if not hasattr(rocketlib, 'IInstanceBase'):
+        rocketlib.IInstanceBase = type('IInstanceBase', (), {})
     if not hasattr(rocketlib, 'OPEN_MODE'):
         rocketlib.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
     if not hasattr(rocketlib, 'warning'):
@@ -56,10 +59,10 @@ def _ensure_iglobal_import_stubs():
 
 _ensure_iglobal_import_stubs()
 
-from mcp_schema import NOOP_ARG_NAME, normalize_tool_input_schema, strip_synthesized_args  # noqa: E402
-from mcp_stdio_client import McpStdioClient  # noqa: E402
 from tool_mcp_client.IGlobal import IGlobal  # noqa: E402
-from tool_mcp_client.mcp_stdio_client import McpToolDef  # noqa: E402
+from tool_mcp_client.IInstance import IInstance  # noqa: E402
+from tool_mcp_client.mcp_schema import NOOP_ARG_NAME, normalize_tool_input_schema, strip_synthesized_args  # noqa: E402
+from tool_mcp_client.mcp_stdio_client import McpStdioClient, McpToolDef  # noqa: E402
 
 STUB_SERVER = os.path.join(os.path.dirname(__file__), 'stub_mcp_server.py')
 
@@ -110,7 +113,7 @@ class TestNormalizeSchema:
 
 
 # ---------------------------------------------------------------------------
-# strip_synthesized_args — pure unit tests (the exact invoke-path helper)
+# strip_synthesized_args — pure unit tests
 # ---------------------------------------------------------------------------
 
 
@@ -158,6 +161,60 @@ def test_list_namespaced_tools_emits_cached_schema_under_camel_case_key():
     assert 'input_schema' not in descriptor
 
 
+class _RecordingClient:
+    def __init__(self):
+        self.calls = []
+
+    def call_tool(self, *, name, arguments):
+        self.calls.append((name, arguments))
+        return {'received_arguments': arguments}
+
+
+def _instance_with_cached_tool(tool):
+    client = _RecordingClient()
+    iglobal = IGlobal.__new__(IGlobal)
+    iglobal.serverName = 'cached'
+    iglobal._client = client
+    iglobal._cache_tools([tool])
+    instance = IInstance.__new__(IInstance)
+    instance.IGlobal = iglobal
+    return instance, client
+
+
+def test_invoke_strips_synthesized_noop_argument_before_tools_call():
+    instance, client = _instance_with_cached_tool(
+        McpToolDef(
+            name='zero_arg',
+            description='',
+            inputSchema=normalize_tool_input_schema(None),
+            has_synthesized_noop_arg=True,
+        )
+    )
+
+    result = instance._tool_invoke_dynamic(tool_name='cached.zero_arg', input_obj={NOOP_ARG_NAME: 'ignored'})
+
+    assert result['received_arguments'] == {}
+    assert client.calls == [('zero_arg', {})]
+
+
+def test_invoke_preserves_real_rr_no_args_argument_before_tools_call():
+    schema = {
+        'type': 'object',
+        'properties': {NOOP_ARG_NAME: {'type': 'string'}},
+        'required': [NOOP_ARG_NAME],
+    }
+    instance, client = _instance_with_cached_tool(
+        McpToolDef(name='real_rr_no_args', description='', inputSchema=schema)
+    )
+
+    result = instance._tool_invoke_dynamic(
+        tool_name='cached.real_rr_no_args', input_obj={NOOP_ARG_NAME: 'forward this'}
+    )
+
+    assert result['received_arguments'] == {NOOP_ARG_NAME: 'forward this'}
+    assert client.calls == [('real_rr_no_args', {NOOP_ARG_NAME: 'forward this'})]
+
+
 # ---------------------------------------------------------------------------
 # End-to-end against the stub stdio MCP server
 # ---------------------------------------------------------------------------
@@ -184,16 +241,18 @@ class TestStubIntegration:
             props = tools[name].inputSchema.get('properties')
             assert isinstance(props, dict) and props, f'{name} still has empty properties'
             assert NOOP_ARG_NAME in props, f'{name} missing synthesized arg'
+            assert tools[name].has_synthesized_noop_arg
 
     def test_real_arg_tool_schema_untouched(self, client):
         tools = {t.name: t for t in client.list_tools()}
         echo = tools['echo_tool'].inputSchema
         assert set(echo['properties']) == {'msg'}
         assert NOOP_ARG_NAME not in echo['properties']
+        assert not tools['echo_tool'].has_synthesized_noop_arg
 
     def test_synthesized_arg_never_reaches_server(self, client):
-        # Simulate the invoke path: a model fills in the presentation-only no-op
-        # field; the node strips it before dispatching to the MCP server.
+        # Exercise the transport with the exact arguments the production invoke
+        # path sends after it removes the presentation-only no-op field.
         model_args = strip_synthesized_args({NOOP_ARG_NAME: 'ignored'})
         result = client.call_tool(name='no_schema_tool', arguments=model_args)
         assert result['received_arguments'] == {}

--- a/nodes/test/tool_mcp_client/test_zero_arg_tools.py
+++ b/nodes/test/tool_mcp_client/test_zero_arg_tools.py
@@ -14,6 +14,8 @@ Covers:
 
 import os
 import sys
+import types
+from pathlib import Path
 
 import pytest
 
@@ -22,8 +24,42 @@ import pytest
 _NODE_SRC = os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'nodes', 'tool_mcp_client')
 sys.path.insert(0, _NODE_SRC)
 
+
+def _ensure_iglobal_import_stubs():
+    """Provide the minimal engine imports required by the real IGlobal module."""
+    rocketlib = sys.modules.get('rocketlib') or types.ModuleType('rocketlib')
+    if not hasattr(rocketlib, 'IGlobalBase'):
+        rocketlib.IGlobalBase = type('IGlobalBase', (), {})
+    if not hasattr(rocketlib, 'OPEN_MODE'):
+        rocketlib.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
+    if not hasattr(rocketlib, 'warning'):
+        rocketlib.warning = lambda *_args, **_kwargs: None
+    sys.modules['rocketlib'] = rocketlib
+
+    for name in ('ai', 'ai.common', 'ai.common.config'):
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+    if not hasattr(sys.modules['ai.common.config'], 'Config'):
+
+        class _Config:
+            @staticmethod
+            def getNodeConfig(*_args, **_kwargs):
+                return {}
+
+        sys.modules['ai.common.config'].Config = _Config
+
+    if 'tool_mcp_client' not in sys.modules:
+        package = types.ModuleType('tool_mcp_client')
+        package.__path__ = [str(Path(_NODE_SRC).resolve())]
+        sys.modules['tool_mcp_client'] = package
+
+
+_ensure_iglobal_import_stubs()
+
 from mcp_schema import NOOP_ARG_NAME, normalize_tool_input_schema, strip_synthesized_args  # noqa: E402
 from mcp_stdio_client import McpStdioClient  # noqa: E402
+from tool_mcp_client.IGlobal import IGlobal  # noqa: E402
+from tool_mcp_client.mcp_stdio_client import McpToolDef  # noqa: E402
 
 STUB_SERVER = os.path.join(os.path.dirname(__file__), 'stub_mcp_server.py')
 
@@ -95,6 +131,31 @@ class TestStripSynthesizedArgs:
     def test_non_dict_unchanged(self):
         assert strip_synthesized_args(None) is None
         assert strip_synthesized_args('x') == 'x'
+
+
+# ---------------------------------------------------------------------------
+# IGlobal cached-descriptor contract — server-free production path
+# ---------------------------------------------------------------------------
+
+
+def test_list_namespaced_tools_emits_cached_schema_under_camel_case_key():
+    """The production cache accessor exposes the MCP schema as ``inputSchema``."""
+    schema = {
+        'type': 'object',
+        'properties': {'query': {'type': 'string'}},
+        'required': ['query'],
+    }
+    iglobal = IGlobal.__new__(IGlobal)
+    iglobal.serverName = 'cached'
+    iglobal._cache_tools([McpToolDef(name='search', description='Search documents', inputSchema=schema)])
+
+    [descriptor] = iglobal.list_namespaced_tools()
+
+    assert descriptor['name'] == 'cached.search'
+    assert descriptor['description'] == 'Search documents'
+    assert descriptor['inputSchema'] is schema
+    assert descriptor['inputSchema'] == schema
+    assert 'input_schema' not in descriptor
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Normalize empty MCP tool input schemas across STDIO, SSE, and streamable HTTP by adding one optional `rr_no_args` placeholder. Strict reasoning models otherwise drop zero-argument tools from their catalog.
- Record whether each cached tool actually received that synthesized placeholder. `_tool_invoke_dynamic` strips it only for those tools, so a server tool that genuinely declares an argument named `rr_no_args` keeps its value.
- Emit the schema as `inputSchema` (camel case), which is the key consumed by agent implementations, and add transport, invocation, and real `agent_rocketride` catalog regression tests.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] Full `./builder test` suite (covered by CI)

- `./dist/server/engine -m pytest nodes/test/tool_mcp_client -q` -> **31 passed**
- `./builder nodes:test-contracts` -> **286 passed**
- Ruff checks on all changed Python files -> clean

The catalog test executes the real `agent_rocketride` on-demand catalog builder. The `agent_langchain` path reads the same corrected `inputSchema` descriptor key but is not constructed in this test because its dynamically loaded Pydantic models are environment-sensitive.

A live run against the reported Groq reasoning model was not possible without credentials; the tests instead verify the exact schema catalog and MCP call arguments.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (not applicable)
- [x] Breaking changes documented (none; the old `input_schema` key had no working agent consumer)

## Linked Issue

Fixes #1404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Zero-argument MCP tools are now normalized in tool catalogs with a safe placeholder input field, improving agent discovery.

* **Bug Fixes**
  * `inputSchema` handling is now consistent across MCP clients (including correct casing in exposed tool metadata).
  * Placeholder arguments are automatically removed before tool invocation, so servers receive only real arguments (while preserving genuine `rr_no_args`).

* **Documentation**
  * Added guidance describing the placeholder behavior for zero-argument tools.

* **Tests**
  * Added contract and integration tests (with a stub MCP server) covering catalog normalization and end-to-end invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
