### PR TITLE
fix(vscode): auto-populate .env with resolved engine URI/key on connect

### DIFF
--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -65,6 +65,14 @@ The settings (cog) button in the canvas toolbar opens the **Pipeline Settings** 
 
 Internally, the editor webview passes the timeout to the extension host as an optional `ttl` field (in seconds; `0` = no timeout, omitted = server default) on the `status:pipelineAction` message when the action is `run` or `restart`.
 
+## `.env` Auto-Sync
+
+After a successful engine connection, the extension syncs the workspace `.env` only for the **development** connection group using a self-hosted mode (local, Docker, service, or direct/on-prem connection). It writes the resolved `ROCKETRIDE_URI` (including a dynamic local port when applicable) and `ROCKETRIDE_APIKEY`, preserves existing comments and variables, and does not rewrite the file when its contents are already current.
+
+Cloud connections are not synced because their OAuth token is not an SDK API key. Deployment connections, workspaces with no folder open, and unreadable `.env` files are also skipped; a sync failure never affects the connection itself. Keep `.env` gitignored.
+
+The extension never automatically removes these keys: disconnecting, engine exit, or switching to cloud leaves the last-synced values in place. Remove them by hand if you no longer want them. Each self-hosted connection syncs again, so a hand-edited `ROCKETRIDE_APIKEY` is overwritten on the next successful connection.
+
 ## Monitoring Execution
 
 The **Status** page shows:

--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -71,7 +71,7 @@ After a successful engine connection, the extension syncs the workspace `.env` o
 
 Cloud connections are not synced because their OAuth token is not an SDK API key. Deployment connections, workspaces with no folder open, and unreadable `.env` files are also skipped; a sync failure never affects the connection itself. Keep `.env` gitignored.
 
-The extension never automatically removes these keys: disconnecting, engine exit, or switching to cloud leaves the last-synced values in place. Remove them by hand if you no longer want them. Each self-hosted connection syncs again, so a hand-edited `ROCKETRIDE_APIKEY` is overwritten on the next successful connection.
+The extension never automatically removes these keys: disconnecting, engine exit, or switching to cloud leaves the last-synced values in place. Remove them by hand if you no longer want them. Each development-group self-hosted connection syncs again, so a hand-edited `ROCKETRIDE_APIKEY` is overwritten on the next successful connection.
 
 ## Monitoring Execution
 

--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -67,7 +67,7 @@ Internally, the editor webview passes the timeout to the extension host as an op
 
 ## `.env` Auto-Sync
 
-After a successful engine connection, the extension syncs the workspace `.env` only for the **development** connection group using a self-hosted mode (local, Docker, service, or direct/on-prem connection). It writes the resolved `ROCKETRIDE_URI` (including a dynamic local port when applicable) and `ROCKETRIDE_APIKEY`, preserves existing comments and variables, and does not rewrite the file when its contents are already current.
+After a successful engine connection, the extension syncs the workspace `.env` only for the **development** connection group using a self-hosted mode (local, Docker, service, or direct/on-prem connection). It writes the resolved `ROCKETRIDE_URI` (including a dynamic local port when applicable) and `ROCKETRIDE_APIKEY`, preserves existing comments and variables, and does not rewrite the file when its contents are already current. The RocketRide **Python SDK** reads the workspace `.env` automatically from its process working directory; the TypeScript SDK and CLIs read only process environment variables, so export the values first (for example, `set -a; source .env`).
 
 Cloud connections are not synced because their OAuth token is not an SDK API key. Deployment connections, workspaces with no folder open, and unreadable `.env` files are also skipped; a sync failure never affects the connection itself. Keep `.env` gitignored.
 

--- a/apps/vscode/src/connection/connection.ts
+++ b/apps/vscode/src/connection/connection.ts
@@ -53,6 +53,7 @@ import { getLogger, safeJSONStringify } from '../shared/util/output';
 import { icons } from '../shared/util/icons';
 import { ConnectionStatus, ConnectionState } from '../shared/types';
 import { connectionModeRequiresApiKey, connectionModeUsesOAuth } from '../shared/util/connectionModeAuth';
+import { mergeEnvText, resolveConnectionEnv } from '../shared/util/envFile';
 import { getIdeName } from '../shared/util/ide';
 import { CloudAuthProvider } from '../auth/CloudAuthProvider';
 
@@ -257,6 +258,55 @@ export class ConnectionManager extends EventEmitter {
 
 		await this.client.connect(auth, { uri });
 		// onConnected callback in createClient() handles state update
+
+		// Persist the resolved engine URI + key to the workspace .env so the
+		// RocketRide SDK/CLI can drive the same (self-hosted) engine. Best-effort:
+		// a failure here must never break an otherwise-successful connection.
+		await this.syncEnvFile(mode, auth);
+	}
+
+	/**
+	 * Writes ROCKETRIDE_URI / ROCKETRIDE_APIKEY into the workspace `.env` for
+	 * self-hosted engine connections (local/docker/service/onprem) on the
+	 * development group, preserving any existing comments and user variables.
+	 *
+	 * Uses the resolved engine URI (getHttpUrl() — the real, possibly dynamic
+	 * local port) rather than a hardcoded default. No-op for cloud (OAuth token
+	 * is not a usable SDK key), for the deployment group, or when no workspace
+	 * is open. Skips the write when the file already matches, so reconnects
+	 * don't churn `.env`.
+	 */
+	private async syncEnvFile(mode: ConnectionMode, apiKey: string): Promise<void> {
+		try {
+			const updates = resolveConnectionEnv({
+				group: this.group,
+				mode,
+				httpUrl: this.getHttpUrl(),
+				apiKey,
+			});
+			const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri;
+			if (!updates || !workspaceRoot) {
+				return;
+			}
+
+			const envUri = vscode.Uri.joinPath(workspaceRoot, '.env');
+			let existing = '';
+			try {
+				existing = Buffer.from(await vscode.workspace.fs.readFile(envUri)).toString('utf8');
+			} catch {
+				// .env doesn't exist yet — it will be created.
+			}
+
+			const merged = mergeEnvText(existing, updates);
+			if (merged === existing) {
+				return;
+			}
+
+			await vscode.workspace.fs.writeFile(envUri, Buffer.from(merged, 'utf8'));
+			this.logger.output(`${icons.success} Synced ROCKETRIDE_URI/ROCKETRIDE_APIKEY to .env`);
+		} catch (err) {
+			this.logger.error(`Failed to sync .env: ${err}`);
+		}
 	}
 
 	// =========================================================================

--- a/apps/vscode/src/connection/connection.ts
+++ b/apps/vscode/src/connection/connection.ts
@@ -293,7 +293,10 @@ export class ConnectionManager extends EventEmitter {
 			let existing = '';
 			try {
 				existing = Buffer.from(await vscode.workspace.fs.readFile(envUri)).toString('utf8');
-			} catch {
+			} catch (err) {
+				if (!(err instanceof vscode.FileSystemError && err.code === 'FileNotFound')) {
+					throw err;
+				}
 				// .env doesn't exist yet — it will be created.
 			}
 

--- a/apps/vscode/src/shared/util/envFile.ts
+++ b/apps/vscode/src/shared/util/envFile.ts
@@ -1,0 +1,164 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+/**
+ * Pure helpers for maintaining the workspace `.env` file that the RocketRide
+ * SDK/CLI read (`ROCKETRIDE_URI` / `ROCKETRIDE_APIKEY`).
+ *
+ * These functions are deliberately free of any `vscode` import so they can be
+ * unit-tested standalone with `node:test` (see envFile.test.ts). The actual
+ * filesystem read/write lives in the ConnectionManager, which already depends
+ * on `vscode`.
+ */
+
+import { connectionModeUsesOAuth } from './connectionModeAuth';
+
+/** The two keys the RocketRide SDK/CLI look up to reach the engine. */
+export const ROCKETRIDE_URI_KEY = 'ROCKETRIDE_URI';
+export const ROCKETRIDE_APIKEY_KEY = 'ROCKETRIDE_APIKEY';
+
+/** Quote a value only when it contains characters that would break parsing. */
+function quoteIfNeeded(value: string): string {
+	return /[\s#=]/.test(value) ? `"${value}"` : value;
+}
+
+/**
+ * Patches `.env` text by updating, adding, or removing keys while preserving
+ * comments, blank lines, ordering, and unrelated user variables.
+ *
+ * - Existing keys present in `updates` are rewritten in place.
+ * - Keys in `updates` not already present are appended (after a blank
+ *   separator line when the file has trailing content).
+ * - Keys in `keysToRemove` are dropped.
+ * - When `existingText` is empty/whitespace, the file is generated from the
+ *   `updates` alone (one `KEY=VALUE` line each, trailing newline).
+ *
+ * Idempotent: `mergeEnvText(mergeEnvText(t, u), u) === mergeEnvText(t, u)`.
+ */
+export function mergeEnvText(
+	existingText: string,
+	updates: Record<string, string>,
+	keysToRemove?: Set<string>,
+): string {
+	// New/empty file — generate from scratch in insertion order.
+	if (!existingText.trim()) {
+		const keys = Object.keys(updates);
+		if (keys.length === 0) {
+			return existingText;
+		}
+		return keys.map((key) => `${key}=${quoteIfNeeded(updates[key])}`).join('\n') + '\n';
+	}
+
+	const lines = existingText.split('\n');
+	const consumedKeys = new Set<string>();
+	const resultLines: string[] = [];
+
+	for (const line of lines) {
+		const trimmed = line.trim();
+
+		// Preserve blank lines and comments verbatim.
+		if (!trimmed || trimmed.startsWith('#')) {
+			resultLines.push(line);
+			continue;
+		}
+
+		// Preserve anything that isn't a KEY=VALUE assignment verbatim.
+		const match = trimmed.match(/^([^=]+)=(.*)$/);
+		if (!match) {
+			resultLines.push(line);
+			continue;
+		}
+
+		const key = match[1].trim();
+
+		if (keysToRemove && keysToRemove.has(key)) {
+			continue;
+		}
+
+		if (key in updates) {
+			resultLines.push(`${key}=${quoteIfNeeded(updates[key])}`);
+			consumedKeys.add(key);
+		} else {
+			resultLines.push(line);
+		}
+	}
+
+	// Append keys that weren't already present.
+	const newKeys = Object.keys(updates).filter((k) => !consumedKeys.has(k));
+	if (newKeys.length > 0) {
+		const lastLine = resultLines[resultLines.length - 1];
+		if (lastLine !== undefined && lastLine.trim() !== '') {
+			resultLines.push('');
+		}
+		for (const key of newKeys) {
+			resultLines.push(`${key}=${quoteIfNeeded(updates[key])}`);
+		}
+	}
+
+	return resultLines.join('\n');
+}
+
+/** Inputs for {@link resolveConnectionEnv}. */
+export interface ConnectionEnvArgs {
+	/** Connection group — only the `development` group owns the project `.env`. */
+	group: string;
+	/** Resolved connection mode (local/docker/service/onprem/cloud). */
+	mode: string;
+	/** HTTP(S) base URL of the engine (e.g. `http://localhost:54321`). */
+	httpUrl: string;
+	/** The API key used to authenticate this connection. */
+	apiKey: string;
+}
+
+/**
+ * Decides which `ROCKETRIDE_*` vars the extension should persist to the
+ * workspace `.env` for a given connection, or `null` when it should not touch
+ * `.env` at all.
+ *
+ * Rules:
+ * - Only the `development` connection writes `.env` (the SDK/CLI dev workflow);
+ *   the `deployment` group must never fight over the same file.
+ * - Cloud is skipped: it authenticates with a short-lived OAuth token, which is
+ *   not usable as an SDK API key. Self-hosted modes (local/docker/service/
+ *   onprem) get a real, reusable URI + key.
+ * - A missing/empty `httpUrl` yields `null` (nothing useful to write).
+ */
+export function resolveConnectionEnv(args: ConnectionEnvArgs): Record<string, string> | null {
+	const { group, mode, httpUrl, apiKey } = args;
+
+	if (group !== 'development') {
+		return null;
+	}
+	if (connectionModeUsesOAuth(mode)) {
+		return null;
+	}
+	if (!httpUrl) {
+		return null;
+	}
+
+	const updates: Record<string, string> = { [ROCKETRIDE_URI_KEY]: httpUrl };
+	if (apiKey) {
+		updates[ROCKETRIDE_APIKEY_KEY] = apiKey;
+	}
+	return updates;
+}

--- a/apps/vscode/src/shared/util/envFile.ts
+++ b/apps/vscode/src/shared/util/envFile.ts
@@ -40,10 +40,18 @@ export const ROCKETRIDE_APIKEY_KEY = 'ROCKETRIDE_APIKEY';
 
 /** Quote a value only when it contains characters that would break parsing. */
 function quoteIfNeeded(value: string): string {
-	if (!/[\s#="]/.test(value)) {
+	const isWrappedInMatchingQuotes =
+		(value.startsWith('"') && value.endsWith('"')) ||
+		(value.startsWith("'") && value.endsWith("'"));
+	if (!/[\s#=]/.test(value) && !isWrappedInMatchingQuotes) {
 		return value;
 	}
-	return `"${value.replace(/(["\\])/g, '\\$1')}"`;
+
+	// Written so client.py's parser reads back exactly the original value.
+	if (value.endsWith('"') && !value.includes("'")) {
+		return `'${value}'`;
+	}
+	return `"${value}"`;
 }
 
 /**
@@ -64,13 +72,15 @@ export function mergeEnvText(
 	updates: Record<string, string>,
 	keysToRemove?: Set<string>,
 ): string {
+	const updateEntries = Object.entries(updates);
+
 	// New/empty file — generate from scratch in insertion order.
 	if (!existingText.trim()) {
-		const keys = Object.keys(updates);
-		if (keys.length === 0) {
+		if (updateEntries.length === 0) {
 			return existingText;
 		}
-		return keys.map((key) => `${key}=${quoteIfNeeded(updates[key])}`).join('\n') + '\n';
+		const eol = existingText.includes('\r\n') ? '\r\n' : '\n';
+		return updateEntries.map(([key, value]) => `${key}=${quoteIfNeeded(value)}`).join(eol) + eol;
 	}
 
 	// Match the file's existing line-ending convention so rewritten or appended
@@ -102,7 +112,7 @@ export function mergeEnvText(
 			continue;
 		}
 
-		if (key in updates) {
+		if (Object.hasOwn(updates, key)) {
 			resultLines.push(`${key}=${quoteIfNeeded(updates[key])}`);
 			consumedKeys.add(key);
 		} else {
@@ -111,14 +121,14 @@ export function mergeEnvText(
 	}
 
 	// Append keys that weren't already present.
-	const newKeys = Object.keys(updates).filter((k) => !consumedKeys.has(k));
-	if (newKeys.length > 0) {
+	const newEntries = updateEntries.filter(([key]) => !consumedKeys.has(key));
+	if (newEntries.length > 0) {
 		const lastLine = resultLines[resultLines.length - 1];
 		if (lastLine !== undefined && lastLine.trim() !== '') {
 			resultLines.push('');
 		}
-		for (const key of newKeys) {
-			resultLines.push(`${key}=${quoteIfNeeded(updates[key])}`);
+		for (const [key, value] of newEntries) {
+			resultLines.push(`${key}=${quoteIfNeeded(value)}`);
 		}
 	}
 
@@ -159,7 +169,7 @@ export function resolveConnectionEnv(args: ConnectionEnvArgs): Record<string, st
 	if (connectionModeUsesOAuth(mode)) {
 		return null;
 	}
-	if (!httpUrl) {
+	if (!httpUrl || /[\r\n]/.test(httpUrl) || /[\r\n]/.test(apiKey)) {
 		return null;
 	}
 

--- a/apps/vscode/src/shared/util/envFile.ts
+++ b/apps/vscode/src/shared/util/envFile.ts
@@ -40,7 +40,10 @@ export const ROCKETRIDE_APIKEY_KEY = 'ROCKETRIDE_APIKEY';
 
 /** Quote a value only when it contains characters that would break parsing. */
 function quoteIfNeeded(value: string): string {
-	return /[\s#=]/.test(value) ? `"${value}"` : value;
+	if (!/[\s#="]/.test(value)) {
+		return value;
+	}
+	return `"${value.replace(/(["\\])/g, '\\$1')}"`;
 }
 
 /**
@@ -70,7 +73,10 @@ export function mergeEnvText(
 		return keys.map((key) => `${key}=${quoteIfNeeded(updates[key])}`).join('\n') + '\n';
 	}
 
-	const lines = existingText.split('\n');
+	// Match the file's existing line-ending convention so rewritten or appended
+	// lines don't produce a mixed CRLF/LF file.
+	const eol = existingText.includes('\r\n') ? '\r\n' : '\n';
+	const lines = existingText.split(/\r?\n/);
 	const consumedKeys = new Set<string>();
 	const resultLines: string[] = [];
 
@@ -116,7 +122,7 @@ export function mergeEnvText(
 		}
 	}
 
-	return resultLines.join('\n');
+	return resultLines.join(eol);
 }
 
 /** Inputs for {@link resolveConnectionEnv}. */

--- a/apps/vscode/src/shared/util/envFile.ts
+++ b/apps/vscode/src/shared/util/envFile.ts
@@ -31,6 +31,7 @@
  * on `vscode`.
  */
 
+import type { ConnectionGroup, ConnectionMode } from '../../config';
 import { connectionModeUsesOAuth } from './connectionModeAuth';
 
 /** The two keys the RocketRide SDK/CLI look up to reach the engine. */
@@ -121,9 +122,9 @@ export function mergeEnvText(
 /** Inputs for {@link resolveConnectionEnv}. */
 export interface ConnectionEnvArgs {
 	/** Connection group — only the `development` group owns the project `.env`. */
-	group: string;
+	group: ConnectionGroup;
 	/** Resolved connection mode (local/docker/service/onprem/cloud). */
-	mode: string;
+	mode: ConnectionMode;
 	/** HTTP(S) base URL of the engine (e.g. `http://localhost:54321`). */
 	httpUrl: string;
 	/** The API key used to authenticate this connection. */

--- a/apps/vscode/src/test/envFile.test.ts
+++ b/apps/vscode/src/test/envFile.test.ts
@@ -1,0 +1,130 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mergeEnvText, resolveConnectionEnv } from '../shared/util/envFile';
+
+const URI = 'http://localhost:54321';
+const KEY = 'MYAPIKEY';
+const updates = { ROCKETRIDE_URI: URI, ROCKETRIDE_APIKEY: KEY };
+
+// --- mergeEnvText ------------------------------------------------------------
+
+test('creates a new file from scratch when none exists', () => {
+	assert.equal(
+		mergeEnvText('', updates),
+		`ROCKETRIDE_URI=${URI}\nROCKETRIDE_APIKEY=${KEY}\n`,
+	);
+});
+
+test('returns text unchanged when there is nothing to write', () => {
+	assert.equal(mergeEnvText('', {}), '');
+	assert.equal(mergeEnvText('# just a comment\n', {}), '# just a comment\n');
+});
+
+test('updates an existing key in place, keeping its position', () => {
+	const existing = 'ROCKETRIDE_URI=http://localhost:5565\nFOO=bar';
+	assert.equal(
+		mergeEnvText(existing, { ROCKETRIDE_URI: URI }),
+		`ROCKETRIDE_URI=${URI}\nFOO=bar`,
+	);
+});
+
+test('preserves comments, blank lines, and unrelated user variables', () => {
+	const existing = '# my env\n\nFOO=bar\n# trailing note';
+	const result = mergeEnvText(existing, updates);
+	assert.ok(result.includes('# my env'));
+	assert.ok(result.includes('FOO=bar'));
+	assert.ok(result.includes('# trailing note'));
+	assert.ok(result.includes(`ROCKETRIDE_URI=${URI}`));
+	assert.ok(result.includes(`ROCKETRIDE_APIKEY=${KEY}`));
+});
+
+test('appends new keys after a blank separator when file has content', () => {
+	const existing = 'FOO=bar';
+	assert.equal(
+		mergeEnvText(existing, updates),
+		`FOO=bar\n\nROCKETRIDE_URI=${URI}\nROCKETRIDE_APIKEY=${KEY}`,
+	);
+});
+
+test('quotes values containing whitespace, # or =', () => {
+	assert.equal(mergeEnvText('', { A: 'has space' }), 'A="has space"\n');
+	assert.equal(mergeEnvText('', { A: 'a#b' }), 'A="a#b"\n');
+	assert.equal(mergeEnvText('', { A: 'a=b' }), 'A="a=b"\n');
+	assert.equal(mergeEnvText('', { A: 'plain' }), 'A=plain\n');
+});
+
+test('is idempotent — merging the same updates twice is a no-op', () => {
+	const once = mergeEnvText('# header\nFOO=bar\n', updates);
+	const twice = mergeEnvText(once, updates);
+	assert.equal(twice, once);
+});
+
+test('removes keys listed in keysToRemove', () => {
+	const existing = 'FOO=bar\nOLD=gone\nROCKETRIDE_URI=old';
+	assert.equal(
+		mergeEnvText(existing, { ROCKETRIDE_URI: URI }, new Set(['OLD'])),
+		`FOO=bar\nROCKETRIDE_URI=${URI}`,
+	);
+});
+
+// --- resolveConnectionEnv ----------------------------------------------------
+
+for (const mode of ['local', 'docker', 'service', 'onprem']) {
+	test(`writes both vars for self-hosted mode: ${mode}`, () => {
+		assert.deepEqual(
+			resolveConnectionEnv({ group: 'development', mode, httpUrl: URI, apiKey: KEY }),
+			{ ROCKETRIDE_URI: URI, ROCKETRIDE_APIKEY: KEY },
+		);
+	});
+}
+
+test('skips cloud mode (OAuth token is not an SDK key)', () => {
+	assert.equal(
+		resolveConnectionEnv({ group: 'development', mode: 'cloud', httpUrl: 'https://api.rocketride.ai', apiKey: 'oauth-token' }),
+		null,
+	);
+});
+
+test('skips the deployment group so it never fights over .env', () => {
+	assert.equal(
+		resolveConnectionEnv({ group: 'deployment', mode: 'local', httpUrl: URI, apiKey: KEY }),
+		null,
+	);
+});
+
+test('returns null when there is no resolvable URI', () => {
+	assert.equal(
+		resolveConnectionEnv({ group: 'development', mode: 'local', httpUrl: '', apiKey: KEY }),
+		null,
+	);
+});
+
+test('writes only the URI when no API key is available', () => {
+	assert.deepEqual(
+		resolveConnectionEnv({ group: 'development', mode: 'local', httpUrl: URI, apiKey: '' }),
+		{ ROCKETRIDE_URI: URI },
+	);
+});

--- a/apps/vscode/src/test/envFile.test.ts
+++ b/apps/vscode/src/test/envFile.test.ts
@@ -92,7 +92,7 @@ test('removes keys listed in keysToRemove', () => {
 
 // --- resolveConnectionEnv ----------------------------------------------------
 
-for (const mode of ['local', 'docker', 'service', 'onprem']) {
+for (const mode of ['local', 'docker', 'service', 'onprem'] as const) {
 	test(`writes both vars for self-hosted mode: ${mode}`, () => {
 		assert.deepEqual(
 			resolveConnectionEnv({ group: 'development', mode, httpUrl: URI, apiKey: KEY }),

--- a/apps/vscode/src/test/envFile.test.ts
+++ b/apps/vscode/src/test/envFile.test.ts
@@ -29,6 +29,29 @@ const URI = 'http://localhost:54321';
 const KEY = 'MYAPIKEY';
 const updates = { ROCKETRIDE_URI: URI, ROCKETRIDE_APIKEY: KEY };
 
+/** Mimics the workspace .env parsing in packages/client-python/src/rocketride/client.py. */
+function parseClientPythonEnv(text: string): Record<string, string> {
+	const env: Record<string, string> = {};
+	for (const line of text.split(/\r?\n/)) {
+		const trimmedLine = line.trim();
+		if (!trimmedLine || trimmedLine.startsWith('#') || !trimmedLine.includes('=')) {
+			continue;
+		}
+
+		const separator = trimmedLine.indexOf('=');
+		const key = trimmedLine.slice(0, separator).trim();
+		let value = trimmedLine.slice(separator + 1).trim();
+		if (
+			(value.startsWith('"') && value.endsWith('"')) ||
+			(value.startsWith("'") && value.endsWith("'"))
+		) {
+			value = value.slice(1, -1);
+		}
+		env[key] = value;
+	}
+	return env;
+}
+
 // --- mergeEnvText ------------------------------------------------------------
 
 test('creates a new file from scratch when none exists', () => {
@@ -90,10 +113,25 @@ test('removes keys listed in keysToRemove', () => {
 	);
 });
 
-test('escapes internal quotes and backslashes when a value needs quoting', () => {
+test('writes raw internal quotes and backslashes when a value needs quoting', () => {
 	assert.equal(
 		mergeEnvText('', { ROCKETRIDE_APIKEY: 'has "quote" and \\slash' }),
-		'ROCKETRIDE_APIKEY="has \\"quote\\" and \\\\slash"\n',
+		'ROCKETRIDE_APIKEY="has "quote" and \\slash"\n',
+	);
+});
+
+test('round-trips values through the client.py parser', () => {
+	for (const value of ['plain', 'has spaces', 'has an "inner quote"', '"fully wrapped"', "'fully wrapped'", 'ends with "']) {
+		assert.equal(parseClientPythonEnv(mergeEnvText('', { VALUE: value })).VALUE, value);
+	}
+});
+
+test('does not treat inherited property names as sync updates', () => {
+	const existing = 'toString=x\n__proto__=y\nFOO=bar';
+	assert.doesNotThrow(() => mergeEnvText(existing, { ROCKETRIDE_URI: URI }));
+	assert.equal(
+		mergeEnvText(existing, { ROCKETRIDE_URI: URI }),
+		`toString=x\n__proto__=y\nFOO=bar\n\nROCKETRIDE_URI=${URI}`,
 	);
 });
 
@@ -105,6 +143,13 @@ test('preserves CRLF line endings without mixing in LF-only lines', () => {
 		`# my env\r\nFOO=bar\r\nROCKETRIDE_URI=${URI}\r\n\r\nROCKETRIDE_APIKEY=${KEY}`,
 	);
 	assert.ok(!/[^\r]\n/.test(result), 'no bare LF line endings');
+});
+
+test('uses CRLF when generating from a whitespace-only CRLF file', () => {
+	assert.equal(
+		mergeEnvText(' \r\n\t\r\n', { ROCKETRIDE_URI: URI }),
+		`ROCKETRIDE_URI=${URI}\r\n`,
+	);
 });
 
 // --- resolveConnectionEnv ----------------------------------------------------
@@ -135,6 +180,17 @@ test('skips the deployment group so it never fights over .env', () => {
 test('returns null when there is no resolvable URI', () => {
 	assert.equal(
 		resolveConnectionEnv({ group: 'development', mode: 'local', httpUrl: '', apiKey: KEY }),
+		null,
+	);
+});
+
+test('returns null when URI or API key contains a newline', () => {
+	assert.equal(
+		resolveConnectionEnv({ group: 'development', mode: 'local', httpUrl: `${URI}\nnext`, apiKey: KEY }),
+		null,
+	);
+	assert.equal(
+		resolveConnectionEnv({ group: 'development', mode: 'local', httpUrl: URI, apiKey: `${KEY}\rnext` }),
 		null,
 	);
 });

--- a/apps/vscode/src/test/envFile.test.ts
+++ b/apps/vscode/src/test/envFile.test.ts
@@ -90,6 +90,23 @@ test('removes keys listed in keysToRemove', () => {
 	);
 });
 
+test('escapes internal quotes and backslashes when a value needs quoting', () => {
+	assert.equal(
+		mergeEnvText('', { ROCKETRIDE_APIKEY: 'has "quote" and \\slash' }),
+		'ROCKETRIDE_APIKEY="has \\"quote\\" and \\\\slash"\n',
+	);
+});
+
+test('preserves CRLF line endings without mixing in LF-only lines', () => {
+	const existing = '# my env\r\nFOO=bar\r\nROCKETRIDE_URI=http://localhost:5565\r\n';
+	const result = mergeEnvText(existing, updates);
+	assert.equal(
+		result,
+		`# my env\r\nFOO=bar\r\nROCKETRIDE_URI=${URI}\r\n\r\nROCKETRIDE_APIKEY=${KEY}`,
+	);
+	assert.ok(!/[^\r]\n/.test(result), 'no bare LF line endings');
+});
+
 // --- resolveConnectionEnv ----------------------------------------------------
 
 for (const mode of ['local', 'docker', 'service', 'onprem'] as const) {

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -2,21 +2,21 @@
 
 ## Python: Complete Working Project
 
-### Step 1: Check `.env` File (Auto-Created)
+### Step 1: Set Up the `.env` File
 
-The RocketRide extension automatically creates/updates `.env` with your configured settings:
+When you connect the extension to a **self-hosted engine** (local, docker, service, or on-prem), it auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
 
 ```env
-# Auto-populated from extension settings (rocketride.hostUrl and API key)
-ROCKETRIDE_URI=https://api.rocketride.ai  # Your configured server
-ROCKETRIDE_APIKEY=your-api-key-here     # From extension settings
+# Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
+ROCKETRIDE_URI=http://localhost:54123   # live engine address (auto-filled)
+ROCKETRIDE_APIKEY=MYAPIKEY              # self-hosted default; set your own for cloud
 
 # Add your custom variables:
 ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are automatically synced from your extension settings. You can add additional custom variables as needed.
+> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed.
 
 ### Step 2: Install Client
 
@@ -106,21 +106,21 @@ python main.py
 
 ## TypeScript: Complete Working Project
 
-### Step 1: Check `.env` File (Auto-Created)
+### Step 1: Set Up the `.env` File
 
-The RocketRide extension automatically creates/updates `.env` with your configured settings:
+When you connect the extension to a **self-hosted engine** (local, docker, service, or on-prem), it auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
 
 ```env
-# Auto-populated from extension settings (rocketride.hostUrl and API key)
-ROCKETRIDE_URI=https://api.rocketride.ai  # Your configured server
-ROCKETRIDE_APIKEY=your-api-key-here     # From extension settings
+# Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
+ROCKETRIDE_URI=http://localhost:54123   # live engine address (auto-filled)
+ROCKETRIDE_APIKEY=MYAPIKEY              # self-hosted default; set your own for cloud
 
 # Add your custom variables:
 ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` are automatically synced from your extension settings. You can add additional custom variables as needed.
+> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed.
 
 ### Step 2: Install Client
 
@@ -275,7 +275,7 @@ await client.disconnect();
 ### Always Do This:
 
 1. Configure server URL in extension settings (`rocketride.hostUrl` and API key)
-2. Extension auto-creates/updates `.env` with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`
+2. On connect to a self-hosted engine the extension auto-populates `.env` with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (for cloud, set `ROCKETRIDE_APIKEY` manually)
 3. Use empty constructor: `RocketRideClient()` or `new RocketRideClient()`
 4. Use literal GUID for `project_id` - generate a new one per pipeline
 5. Use `${ROCKETRIDE_*}` variables in component `config` fields
@@ -286,7 +286,7 @@ await client.disconnect();
 
 1. Hardcode `uri` or `auth` in constructor (use `.env` instead)
 2. Use variables in `project_id` field (must be literal GUID)
-3. Manually edit `ROCKETRIDE_URI` or `ROCKETRIDE_APIKEY` in `.env` (use extension settings)
+3. Hand-edit `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` for a self-hosted engine — the extension re-syncs them on connect (change them via extension settings; for cloud, set `ROCKETRIDE_APIKEY` manually)
 4. Skip `connect()` or `disconnect()`
 5. Use non-ROCKETRIDE\_\* variables in pipelines
 6. Use `.json` extension for pipeline files (use `.pipe`)

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -7,7 +7,7 @@
 When you connect to a **self-hosted engine** (local, docker, service, or on-prem) using the extension's **development connection group**, the extension auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
 
 ```env
-# Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
+# Development-group self-hosted engines: auto-filled on connect (local uses the real dynamic port).
 # live engine address (auto-filled)
 ROCKETRIDE_URI=http://localhost:54123
 # self-hosted default; set your own for cloud
@@ -113,7 +113,7 @@ python main.py
 When you connect to a **self-hosted engine** (local, docker, service, or on-prem) using the extension's **development connection group**, the extension auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
 
 ```env
-# Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
+# Development-group self-hosted engines: auto-filled on connect (local uses the real dynamic port).
 # live engine address (auto-filled)
 ROCKETRIDE_URI=http://localhost:54123
 # self-hosted default; set your own for cloud
@@ -288,7 +288,7 @@ await client.disconnect();
 
 ### Never Do This:
 
-1. Hardcode `uri` or `auth` in constructor (use `.env` instead)
+1. Hardcode `uri` or `auth` in the constructor (load `ROCKETRIDE_*` values into the process environment instead)
 2. Use variables in `project_id` field (must be literal GUID)
 3. Hand-edit `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` for a self-hosted engine in the development connection group — the extension re-syncs them on connect (change them via extension settings; for cloud, set `ROCKETRIDE_APIKEY` manually)
 4. Skip `connect()` or `disconnect()`

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -124,7 +124,7 @@ ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed.
+> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. The TypeScript client reads `process.env`; it does not load `.env` itself, so load the file when starting the process as shown below.
 
 ### Step 2: Install Client
 
@@ -175,7 +175,7 @@ Pipeline files **must** use the `.pipe` extension.
 import { RocketRideClient } from 'rocketride';
 
 async function main() {
-	// Client reads configuration from .env automatically
+	// Client reads ROCKETRIDE_* values from process.env
 	const client = new RocketRideClient();
 
 	try {
@@ -208,7 +208,7 @@ main().catch(console.error);
 ### Step 5: Run
 
 ```bash
-npx tsx main.ts
+npx tsx --env-file=.env main.ts
 ```
 
 ---

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -8,8 +8,10 @@ When you connect the extension to a **self-hosted engine** (local, docker, servi
 
 ```env
 # Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
-ROCKETRIDE_URI=http://localhost:54123   # live engine address (auto-filled)
-ROCKETRIDE_APIKEY=MYAPIKEY              # self-hosted default; set your own for cloud
+# live engine address (auto-filled)
+ROCKETRIDE_URI=http://localhost:54123
+# self-hosted default; set your own for cloud
+ROCKETRIDE_APIKEY=MYAPIKEY
 
 # Add your custom variables:
 ROCKETRIDE_INPUT_PATH=/data/input
@@ -112,8 +114,10 @@ When you connect the extension to a **self-hosted engine** (local, docker, servi
 
 ```env
 # Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
-ROCKETRIDE_URI=http://localhost:54123   # live engine address (auto-filled)
-ROCKETRIDE_APIKEY=MYAPIKEY              # self-hosted default; set your own for cloud
+# live engine address (auto-filled)
+ROCKETRIDE_URI=http://localhost:54123
+# self-hosted default; set your own for cloud
+ROCKETRIDE_APIKEY=MYAPIKEY
 
 # Add your custom variables:
 ROCKETRIDE_INPUT_PATH=/data/input

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -18,7 +18,7 @@ ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
+> **Note:** For self-hosted engines in the development connection group, the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
 
 ### Step 2: Install Client
 
@@ -124,7 +124,7 @@ ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. The TypeScript client reads `process.env`; it does not load `.env` itself, so load the file when starting the process as shown below. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
+> **Note:** For self-hosted engines in the development connection group, the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. The TypeScript client reads `process.env`; it does not load `.env` itself, so load the file when starting the process as shown below. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
 
 ### Step 2: Install Client
 

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -18,7 +18,7 @@ ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed.
+> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
 
 ### Step 2: Install Client
 
@@ -124,7 +124,7 @@ ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. The TypeScript client reads `process.env`; it does not load `.env` itself, so load the file when starting the process as shown below.
+> **Note:** For self-hosted engines the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. The TypeScript client reads `process.env`; it does not load `.env` itself, so load the file when starting the process as shown below. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
 
 ### Step 2: Install Client
 

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ### Step 1: Set Up the `.env` File
 
-When you connect the extension to a **self-hosted engine** (local, docker, service, or on-prem), it auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
+When you connect to a **self-hosted engine** (local, docker, service, or on-prem) using the extension's **development connection group**, the extension auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
 
 ```env
 # Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
@@ -110,7 +110,7 @@ python main.py
 
 ### Step 1: Set Up the `.env` File
 
-When you connect the extension to a **self-hosted engine** (local, docker, service, or on-prem), it auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
+When you connect to a **self-hosted engine** (local, docker, service, or on-prem) using the extension's **development connection group**, the extension auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
 
 ```env
 # Self-hosted engines: auto-filled on connect (local uses the real dynamic port).
@@ -279,7 +279,7 @@ await client.disconnect();
 ### Always Do This:
 
 1. Configure server URL in extension settings (`rocketride.hostUrl` and API key)
-2. On connect to a self-hosted engine the extension auto-populates `.env` with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (for cloud, set `ROCKETRIDE_APIKEY` manually)
+2. When the extension's development connection group connects to a self-hosted engine, it auto-populates `.env` with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (for cloud, set `ROCKETRIDE_APIKEY` manually)
 3. Use empty constructor: `RocketRideClient()` or `new RocketRideClient()`
 4. Use literal GUID for `project_id` - generate a new one per pipeline
 5. Use `${ROCKETRIDE_*}` variables in component `config` fields
@@ -290,7 +290,7 @@ await client.disconnect();
 
 1. Hardcode `uri` or `auth` in constructor (use `.env` instead)
 2. Use variables in `project_id` field (must be literal GUID)
-3. Hand-edit `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` for a self-hosted engine — the extension re-syncs them on connect (change them via extension settings; for cloud, set `ROCKETRIDE_APIKEY` manually)
+3. Hand-edit `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` for a self-hosted engine in the development connection group — the extension re-syncs them on connect (change them via extension settings; for cloud, set `ROCKETRIDE_APIKEY` manually)
 4. Skip `connect()` or `disconnect()`
 5. Use non-ROCKETRIDE\_\* variables in pipelines
 6. Use `.json` extension for pipeline files (use `.pipe`)

--- a/docs/agents/ROCKETRIDE_README.md
+++ b/docs/agents/ROCKETRIDE_README.md
@@ -43,7 +43,7 @@ Before writing ANY RocketRide code, you MUST:
 - [ ] Read ROCKETRIDE_PIPELINE_RULES.md, ROCKETRIDE_COMPONENT_REFERENCE.md and ROCKETRIDE_COMMON_MISTAKES.md
 - [ ] If you are creating a python project, create a virtual environment
 - [ ] Create the pipeline file(s) using `.pipe` extension (e.g., `chat.pipe`, `ingestion.pipe`)
-- [ ] The extension automatically creates/updates `.env` with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` from settings
+- [ ] On connect to a self-hosted engine (local/docker/service/onprem), the extension auto-populates `.env` with the live `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`; for cloud, set `ROCKETRIDE_APIKEY` manually
 - [ ] Create an `env.example` file documenting any custom variables used in your pipeline files
 - [ ] Open the `.env` file in the workspace editor (as a tab) so the user can verify settings and add custom variables (e.g., `ROCKETRIDE_INPUT_PATH`, `ROCKETRIDE_OUTPUT_PATH`, etc.)
 - [ ] Always install the appropriate RocketRide client:

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -374,7 +374,7 @@ export class RocketRideClient extends DAPClient {
 	 * Configuration priority (highest to lowest):
 	 * 1. Values passed in config parameter (auth, uri)
 	 * 2. Values from env parameter (if provided)
-	 * 3. Values from .env file (Node.js only)
+	 * 3. Values from the process environment (Node.js only)
 	 * 4. Default values
 	 *
 	 * @param config - Configuration options for the client
@@ -389,7 +389,7 @@ export class RocketRideClient extends DAPClient {
 	 * @param config.maxRetryTime - Max total time in ms to keep retrying connections
 	 * @param config.module - Optional module name for client identification
 	 *
-	 * @throws Error if auth is not provided via config, env, or .env file
+	 * @throws Error if auth is not provided via config, env, or the process environment
 	 *
 	 * @example
 	 * ```typescript
@@ -1019,7 +1019,7 @@ export class RocketRideClient extends DAPClient {
 	 *
 	 * This method loads and executes a pipeline configuration. It automatically performs
 	 * environment variable substitution on the pipeline config, replacing ${ROCKETRIDE_*}
-	 * placeholders with values from the .env file or the `env` dictionary passed to the constructor.
+	 * placeholders with values from the process environment or the `env` dictionary passed to the constructor.
 	 *
 	 * When loading from a file via `filepath`, the client automatically unwraps `.pipe` files
 	 * that use the `{ "pipeline": { ... } }` wrapper format. If the file contains a top-level
@@ -1135,7 +1135,7 @@ export class RocketRideClient extends DAPClient {
 		if (pipelineTraceLevel !== undefined) {
 			arguments_.pipelineTraceLevel = pipelineTraceLevel;
 		}
-		// Build ROCKETRIDE_* env from client's .env + caller overrides
+		// Build ROCKETRIDE_* env from the client's process environment + caller overrides
 		const rocketEnv: Record<string, string> = {};
 		for (const [k, v] of Object.entries(this._env)) {
 			if (k.startsWith('ROCKETRIDE_')) rocketEnv[k] = v;

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -371,18 +371,19 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Creates a new RocketRideClient instance.
 	 *
-	 * Configuration priority (highest to lowest):
-	 * 1. Values passed in config parameter (auth, uri)
-	 * 2. Values from env parameter (if provided)
-	 * 3. Values from the process environment (Node.js only)
-	 * 4. Default values
+	 * `config.env` is copied as the configured environment map when provided;
+	 * otherwise Node.js values are copied from `process.env`. The two maps are not merged.
+	 * `config.uri` overrides `ROCKETRIDE_URI`; `config.auth` supplies the fallback
+	 * credential used when `login()` receives no credential and the configured environment
+	 * has no `ROCKETRIDE_APIKEY`.
 	 *
 	 * The client does not load `.env` files; load them into `process.env` before construction
 	 * (for example, start Node with `--env-file=.env`).
 	 *
 	 * @param config - Configuration options for the client
-	 * @param config.auth - API key for authentication (required)
-	 * @param config.uri - Server URI (default: CONST_DEFAULT_SERVICE)
+	 * @param config.auth - Optional initial API key; `login()` can also use
+	 *   `ROCKETRIDE_APIKEY` from the configured environment
+	 * @param config.uri - Server URI (default: CONST_DEFAULT_WEB_CLOUD)
 	 * @param config.env - Environment variables dictionary for configuration and substitution
 	 * @param config.onEvent - Callback for server events
 	 * @param config.onConnected - Callback when connection is established
@@ -391,8 +392,6 @@ export class RocketRideClient extends DAPClient {
 	 * @param config.requestTimeout - Default timeout in ms for individual requests
 	 * @param config.maxRetryTime - Max total time in ms to keep retrying connections
 	 * @param config.module - Optional module name for client identification
-	 *
-	 * @throws Error if auth is not provided via config, env, or the process environment
 	 *
 	 * @example
 	 * ```typescript
@@ -418,8 +417,7 @@ export class RocketRideClient extends DAPClient {
 		// Check if we're in Node.js or browser environment
 		const isBrowser = typeof window !== 'undefined';
 
-		// Build environment variables dictionary
-		// Priority: provided env > process.env (Node.js only)
+		// Use config.env exclusively when supplied; otherwise copy process.env in Node.js.
 		let clientEnv: Record<string, string> = {};
 
 		if (config.env) {
@@ -776,7 +774,8 @@ export class RocketRideClient extends DAPClient {
 	 * @param credential - API key, rr_ token, or PKCE code object.
 	 * @param options - Optional URI override and/or timeout.
 	 * @returns ConnectResult with user identity on success.
-	 * @throws AuthenticationException on auth failure (transport stays attached).
+	 * @throws AuthenticationException on auth failure, including when no credential is
+	 * available from the argument or configured environment (transport stays attached).
 	 */
 	async login(
 		credential?: string | { code: string; verifier: string; redirectUri: string },
@@ -860,6 +859,8 @@ export class RocketRideClient extends DAPClient {
 	 *
 	 * @param credential - API key / Zitadel access_token / rr_ user token / PKCE code object.
 	 * @param options - Optional overrides: uri and/or timeout.
+	 * @throws AuthenticationException on auth failure, including when no credential is
+	 * available from the argument or configured environment.
 	 */
 	async connect(credential?: string | { code: string; verifier: string; redirectUri: string }, options?: { uri?: string; timeout?: number }): Promise<ConnectResult> {
 		this._currentReconnectDelay = 250;
@@ -895,11 +896,10 @@ export class RocketRideClient extends DAPClient {
 	 * Update the environment variables used for pipeline substitution.
 	 *
 	 * Replaces the client's env dictionary (seeded from `config.env` or, in
-	 * Node, from `process.env`) with a copy of the given map. {@link use} and
-	 * {@link validate} read it to build the `ROCKETRIDE_*` substitution env
-	 * sent with the pipeline; `attach()` also consults `ROCKETRIDE_APIKEY`
-	 * from it when no explicit credential is supplied. Mirrors the Python
-	 * SDK's `set_env`.
+	 * Node, from `process.env`) with a copy of the given map. {@link use} reads
+	 * it to build the `ROCKETRIDE_*` substitution env sent with the pipeline.
+	 * `login()` also consults `ROCKETRIDE_APIKEY` from it when no explicit
+	 * credential is supplied. Mirrors the Python SDK's `set_env`.
 	 *
 	 * @param env - The new environment map; copied, so later caller-side
 	 *   mutations have no effect.
@@ -1020,9 +1020,8 @@ export class RocketRideClient extends DAPClient {
 	/**
 	 * Start an RocketRide pipeline for processing data.
 	 *
-	 * This method loads and executes a pipeline configuration. It automatically performs
-	 * environment variable substitution on the pipeline config, replacing ${ROCKETRIDE_*}
-	 * placeholders with values from the process environment or the `env` dictionary passed to the constructor.
+	 * This method loads a pipeline configuration and sends the client's configured
+	 * `ROCKETRIDE_*` values plus any per-use overrides to the server for substitution.
 	 *
 	 * When loading from a file via `filepath`, the client automatically unwraps `.pipe` files
 	 * that use the `{ "pipeline": { ... } }` wrapper format. If the file contains a top-level
@@ -1074,7 +1073,7 @@ export class RocketRideClient extends DAPClient {
 			pipelineTraceLevel?: 'none' | 'metadata' | 'summary' | 'full';
 			/** Optional display name for the task (e.g. shown in dashboard). */
 			name?: string;
-			/** ROCKETRIDE_* environment overrides merged on top of server-side env. */
+			/** Unfiltered per-use values merged over the filtered `ROCKETRIDE_*` client environment. */
 			env?: Record<string, string>;
 			/** Team ID to run the task under. Defaults to the user's default team. */
 			teamId?: string;
@@ -1109,7 +1108,7 @@ export class RocketRideClient extends DAPClient {
 		// Create a deep copy of the pipeline config to avoid modifying the original
 		const processedConfig = JSON.parse(JSON.stringify(pipelineConfig));
 
-		// Override source if specified (after substitution)
+		// Override source if specified before sending the execution request.
 		if (source !== undefined) {
 			processedConfig.source = source;
 		}
@@ -1138,7 +1137,7 @@ export class RocketRideClient extends DAPClient {
 		if (pipelineTraceLevel !== undefined) {
 			arguments_.pipelineTraceLevel = pipelineTraceLevel;
 		}
-		// Build ROCKETRIDE_* env from the client's process environment + caller overrides
+		// Filter _env (seeded by config.env/process.env or replaced by setEnv), then apply per-use overrides.
 		const rocketEnv: Record<string, string> = {};
 		for (const [k, v] of Object.entries(this._env)) {
 			if (k.startsWith('ROCKETRIDE_')) rocketEnv[k] = v;

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -774,8 +774,9 @@ export class RocketRideClient extends DAPClient {
 	 * @param credential - API key, rr_ token, or PKCE code object.
 	 * @param options - Optional URI override and/or timeout.
 	 * @returns ConnectResult with user identity on success.
-	 * @throws AuthenticationException on auth failure, including when no credential is
-	 * available from the argument or configured environment (transport stays attached).
+	 * @throws AuthenticationException when the server rejects authentication. Credential
+	 * resolution checks the argument, configured environment, and stored client state
+	 * (initialized by `config.auth` and updated after authentication). The transport stays attached.
 	 */
 	async login(
 		credential?: string | { code: string; verifier: string; redirectUri: string },
@@ -859,8 +860,9 @@ export class RocketRideClient extends DAPClient {
 	 *
 	 * @param credential - API key / Zitadel access_token / rr_ user token / PKCE code object.
 	 * @param options - Optional overrides: uri and/or timeout.
-	 * @throws AuthenticationException on auth failure, including when no credential is
-	 * available from the argument or configured environment.
+	 * @throws AuthenticationException when the server rejects authentication. Credential
+	 * resolution checks the argument, configured environment, and stored client state
+	 * (initialized by `config.auth` and updated after authentication).
 	 */
 	async connect(credential?: string | { code: string; verifier: string; redirectUri: string }, options?: { uri?: string; timeout?: number }): Promise<ConnectResult> {
 		this._currentReconnectDelay = 250;

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -377,6 +377,9 @@ export class RocketRideClient extends DAPClient {
 	 * 3. Values from the process environment (Node.js only)
 	 * 4. Default values
 	 *
+	 * The client does not load `.env` files; load them into `process.env` before construction
+	 * (for example, start Node with `--env-file=.env`).
+	 *
 	 * @param config - Configuration options for the client
 	 * @param config.auth - API key for authentication (required)
 	 * @param config.uri - Server URI (default: CONST_DEFAULT_SERVICE)


### PR DESCRIPTION
## Summary

- Local engine mode spawns the engine on a **dynamic** port (`--port=0`) and kept the
  URL in memory only, so the workspace `.env` was never written. The SDK/CLI read
  `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` from `.env`, fell back to the default
  `http://localhost:5565`, and could not reach the engine — blocking all programmatic
  ingest/validation in local mode.
- **Root cause:** the comment-preserving `.env` writer that used to do this
  (`ensureEnvFileSync`/`updateEnvRawText`/`saveEnvFile` in `apps/vscode/src/config.ts`)
  was dropped in the shell-ui/client-SDK refactor (#803). The docs still claimed it worked.
- **Fix:** reinstate it as a small pure util `shared/util/envFile.ts` (`mergeEnvText` +
  `resolveConnectionEnv`) and call it from `ConnectionManager.connectToEngine` after a
  successful connect. On the `development` group + a self-hosted engine
  (local/docker/service/onprem) it syncs the **resolved** `ROCKETRIDE_URI`
  (`getHttpUrl()` — the real dynamic local port, not `:5565`) and the connection key into
  `.env`, preserving existing comments/variables and skipping unchanged writes. Cloud is
  excluded (its OAuth token isn't a usable SDK key). Docs corrected to match.

## Type

fix (vscode)

## Testing

- [x] Tests added or updated — `apps/vscode/src/test/envFile.test.ts` (16 `node:test` cases:
      merge create/update/preserve-comments/append/quote/idempotency/remove +
      `resolveConnectionEnv` mode & group gating)
- [x] Tested locally — 16/16 unit tests pass; an end-to-end filesystem simulation of
      `syncEnvFile` passes every case (create with real dynamic port, idempotent-reconnect
      skip, in-place port update, comment/user-var preservation, cloud + deployment exclusion)
- [ ] `./builder test` passes

> Full `tsc`/bundle needs the `rocketride` workspace SDK's `dist/` (built by CI) — my files
> add zero new type errors. A live local-engine SDK connect wasn't run (engine binary/native
> lib unavailable headless); the `.env` output is standard `KEY=value` the SDK already parses.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a
- [ ] Breaking changes documented (if applicable) — none

## Linked Issue

Fixes #1413


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added best-effort workspace `.env` auto-sync for self-hosted **development** (non-OAuth) engine connections, persisting `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (when available) while preserving existing comments/variables and avoiding unnecessary rewrites; sync failures won’t block connection.
* **Documentation**
  * Updated quickstart/readme/usage with `.env` Auto-Sync behavior, re-sync-on-connect, RocketRide Python vs TypeScript environment loading, and skip/failure rules (cloud/deployment, no open folder, unreadable/missing `.env`).
* **Tests**
  * Added coverage for `.env` merging/quoting/idempotency (including CRLF) and connection env-resolution rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->