### PR TITLE
fix(chroma): validate server version and surface silent index failures

### DIFF
--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -139,12 +139,7 @@ class Store(DocumentStoreBase):
                 f'>= {floor}). Original error: {e}'
             ) from e
 
-        # Best-effort server-version floor check. get_version() is not present on every
-        # chromadb client build, so treat its absence/failure as "unknown" rather than a
-        # connection error — the wrapper above and the index-path guards cover hard incompat.
-        server_version = self._getServerVersion()
-        if server_version:
-            _check_server_version(server_version)
+        self._enforceServerVersion()
         return
 
     def __del__(self):
@@ -200,9 +195,9 @@ class Store(DocumentStoreBase):
         """
         Return the Chroma server version string, or None if it can't be determined.
 
-        Defensive: get_version() is not present on every chromadb client build (the thin
-        `chromadb-client` has shipped client shapes without it), so its absence, failure,
-        or non-string result must not be mistaken for a connection error.
+        Defensive: the pinned `chromadb-client` (1.5.9) does expose get_version(), but a
+        probe that is absent, fails, or returns a non-string must not be mistaken for a
+        connection error — the connect wrapper and index-path guards cover hard incompat.
         """
         getter = getattr(self.client, 'get_version', None)
         if not callable(getter):
@@ -212,6 +207,24 @@ class Store(DocumentStoreBase):
             return version if isinstance(version, str) else None
         except Exception:
             return None
+
+    def _enforceServerVersion(self) -> None:
+        """
+        Reject a server below the supported floor, dropping the client handle with it.
+
+        An unknown version is not a rejection (see _getServerVersion). When the floor does
+        reject, the handle is cleared first so a caller that survives the raise cannot keep
+        issuing calls against a server we just declared incompatible — matching the
+        connect-failure path above.
+        """
+        server_version = self._getServerVersion()
+        if not server_version:
+            return
+        try:
+            _check_server_version(server_version)
+        except Exception:
+            self.client = None
+            raise
 
     def _doesCollectionExist(self) -> bool:
         """

--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -133,9 +133,10 @@ class Store(DocumentStoreBase):
             self.client = None
             floor = f'{_MIN_CHROMA_VERSION[0]}.{_MIN_CHROMA_VERSION[1]}'
             raise Exception(
-                f'Failed to connect to Chroma at {self.host}:{self.port}. This often means '
-                f'the Chroma server is too old or incompatible with the client (RocketRide '
-                f'requires Chroma server >= {floor}). Original error: {e}'
+                f'Failed to connect to Chroma at {self.host}:{self.port}. This may be due to '
+                f'network/connectivity issues, invalid host/port/credentials, or an '
+                f'incompatible/too-old Chroma server (RocketRide requires Chroma server '
+                f'>= {floor}). Original error: {e}'
             ) from e
 
         # Best-effort server-version floor check. get_version() is not present on every

--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -200,14 +200,15 @@ class Store(DocumentStoreBase):
         Return the Chroma server version string, or None if it can't be determined.
 
         Defensive: get_version() is not present on every chromadb client build (the thin
-        `chromadb-client` has shipped client shapes without it), so its absence or failure
-        must not be mistaken for a connection error.
+        `chromadb-client` has shipped client shapes without it), so its absence, failure,
+        or non-string result must not be mistaken for a connection error.
         """
         getter = getattr(self.client, 'get_version', None)
         if not callable(getter):
             return None
         try:
-            return getter()
+            version = getter()
+            return version if isinstance(version, str) else None
         except Exception:
             return None
 

--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -33,12 +33,31 @@ from chromadb.config import Settings
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase
 from ai.common.config import Config
-from rocketlib import debug
 import uuid
 import numpy as np
 import json
 import sys
 import re
+
+
+# Minimum Chroma *server* major version this client supports. Older servers speak an
+# incompatible API and fail cryptically (e.g. KeyError('_type')) instead of indexing.
+_MIN_CHROMA_MAJOR = 1
+
+
+def _check_server_version(version: str) -> None:
+    """
+    Raise a clear error if the connected Chroma server is too old.
+
+    Lenient by design: if the version string can't be parsed we do not block the
+    connection (the connect-time wrapper still surfaces any hard incompatibility).
+    """
+    match = re.match(r'\s*v?(\d+)', version or '')
+    if match and int(match.group(1)) < _MIN_CHROMA_MAJOR:
+        raise Exception(
+            f'Chroma server version {version} is too old; RocketRide requires '
+            f'Chroma >= {_MIN_CHROMA_MAJOR}.0. Please upgrade your Chroma server.'
+        )
 
 
 class Store(DocumentStoreBase):
@@ -89,17 +108,33 @@ class Store(DocumentStoreBase):
         else:
             raise Exception('The metric you provided in the config.json does not match required chroma configurations')
 
-        if profile == 'local':
-            self.client = chromadb.HttpClient(host=self.host, port=self.port)
-        else:
-            self.client = chromadb.HttpClient(
-                host=self.host,
-                port=self.port,
-                settings=Settings(
-                    chroma_client_auth_provider='chromadb.auth.token_authn.TokenAuthClientProvider',
-                    chroma_client_auth_credentials=self.apikey,
-                ),
-            )
+        # Construct the client and probe the server version in one place. The Chroma
+        # client connects eagerly (identity/tenant validation on construction), so an
+        # incompatible/old server surfaces here as a cryptic error (e.g. KeyError('_type')).
+        # Wrap it so the user gets an actionable message instead of a silent failure.
+        try:
+            if profile == 'local':
+                self.client = chromadb.HttpClient(host=self.host, port=self.port)
+            else:
+                self.client = chromadb.HttpClient(
+                    host=self.host,
+                    port=self.port,
+                    settings=Settings(
+                        chroma_client_auth_provider='chromadb.auth.token_authn.TokenAuthClientProvider',
+                        chroma_client_auth_credentials=self.apikey,
+                    ),
+                )
+            server_version = self.client.get_version()
+        except Exception as e:
+            self.client = None
+            raise Exception(
+                f'Failed to connect to Chroma at {self.host}:{self.port}. This often means '
+                f'the Chroma server is too old or incompatible with the client (RocketRide '
+                f'requires Chroma server >= {_MIN_CHROMA_MAJOR}.0). Original error: {e}'
+            ) from e
+
+        # Server reachable: enforce the supported version floor with a precise message.
+        _check_server_version(server_version)
         return
 
     def __del__(self):
@@ -157,8 +192,11 @@ class Store(DocumentStoreBase):
         """
         if self.client is None:
             return False
+        # Normalize across client versions: list_collections() returns collection *names*
+        # (strings) on some versions and Collection *objects* (with a .name) on others.
         collections = self.client.list_collections()
-        if self.collection in collections:
+        names = [c if isinstance(c, str) else getattr(c, 'name', c) for c in collections]
+        if self.collection in names:
             if self.collectionObj is None:
                 self.collectionObj = self.client.get_collection(name=self.collection)
             return True
@@ -183,8 +221,11 @@ class Store(DocumentStoreBase):
             return True
 
         except Exception as e:
-            debug(f'Error creating collection: {e}')
-            return False
+            # Surface the real cause instead of swallowing it into a transient trace.
+            # The only caller (base createCollection) ignores the return value, so a
+            # bare `return False` here left collectionObj as None and produced a cryptic
+            # "'NoneType' object has no attribute 'delete'" crash downstream in flush().
+            raise Exception(f'Error creating Chroma collection: {e}') from e
 
     def _convertFilter(self, docFilter: DocFilter) -> Dict[str, Any]:
         filters = []
@@ -415,6 +456,14 @@ class Store(DocumentStoreBase):
 
         def flush():
             nonlocal ids, embeddings, metadatas, documents
+            # Defense in depth: never index against a missing collection. Surface a clear,
+            # actionable error instead of a cryptic "'NoneType' object has no attribute
+            # 'delete'" if the collection was not created (e.g. a failed/incompatible server).
+            if self.collectionObj is None:
+                raise Exception(
+                    'Chroma collection is not available (creation may have failed); cannot '
+                    'index documents. Check the Chroma server connection and version.'
+                )
             if object_ids_to_delete:
                 if len(object_ids_to_delete) > 1:
                     filter_condition = {'$or': [{'objectId': object_id} for object_id in object_ids_to_delete]}

--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -33,6 +33,7 @@ from chromadb.config import Settings
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase
 from ai.common.config import Config
+from rocketlib import debug
 import uuid
 import numpy as np
 import json
@@ -40,23 +41,27 @@ import sys
 import re
 
 
-# Minimum Chroma *server* major version this client supports. Older servers speak an
-# incompatible API and fail cryptically (e.g. KeyError('_type')) instead of indexing.
-_MIN_CHROMA_MAJOR = 1
+# Minimum Chroma *server* version this client supports, as (major, minor). The v2
+# tenant/database API the modern client requires landed in Chroma 0.6.0; older servers
+# (e.g. 0.5.18) fail cryptically (KeyError('_type')) instead of indexing. The project's
+# own test infra runs chromadb/chroma:0.6.3, which works.
+_MIN_CHROMA_VERSION = (0, 6)
 
 
 def _check_server_version(version: str) -> None:
     """
     Raise a clear error if the connected Chroma server is too old.
 
-    Lenient by design: if the version string can't be parsed we do not block the
-    connection (the connect-time wrapper still surfaces any hard incompatibility).
+    Lenient by design: if the version string can't be parsed (or has no minor component)
+    we do not block the connection (the connect-time wrapper still surfaces any hard
+    incompatibility).
     """
-    match = re.match(r'\s*v?(\d+)', version or '')
-    if match and int(match.group(1)) < _MIN_CHROMA_MAJOR:
+    match = re.match(r'\s*v?(\d+)\.(\d+)', version or '')
+    if match and (int(match.group(1)), int(match.group(2))) < _MIN_CHROMA_VERSION:
+        floor = f'{_MIN_CHROMA_VERSION[0]}.{_MIN_CHROMA_VERSION[1]}'
         raise Exception(
             f'Chroma server version {version} is too old; RocketRide requires '
-            f'Chroma >= {_MIN_CHROMA_MAJOR}.0. Please upgrade your Chroma server.'
+            f'Chroma >= {floor}. Please upgrade your Chroma server.'
         )
 
 
@@ -108,10 +113,10 @@ class Store(DocumentStoreBase):
         else:
             raise Exception('The metric you provided in the config.json does not match required chroma configurations')
 
-        # Construct the client and probe the server version in one place. The Chroma
-        # client connects eagerly (identity/tenant validation on construction), so an
-        # incompatible/old server surfaces here as a cryptic error (e.g. KeyError('_type')).
-        # Wrap it so the user gets an actionable message instead of a silent failure.
+        # The Chroma client connects eagerly (identity/tenant validation on construction),
+        # so an incompatible/old server surfaces here as a cryptic error (e.g.
+        # KeyError('_type')). Wrap it so the user gets an actionable message instead of a
+        # silent failure.
         try:
             if profile == 'local':
                 self.client = chromadb.HttpClient(host=self.host, port=self.port)
@@ -124,17 +129,21 @@ class Store(DocumentStoreBase):
                         chroma_client_auth_credentials=self.apikey,
                     ),
                 )
-            server_version = self.client.get_version()
         except Exception as e:
             self.client = None
+            floor = f'{_MIN_CHROMA_VERSION[0]}.{_MIN_CHROMA_VERSION[1]}'
             raise Exception(
                 f'Failed to connect to Chroma at {self.host}:{self.port}. This often means '
                 f'the Chroma server is too old or incompatible with the client (RocketRide '
-                f'requires Chroma server >= {_MIN_CHROMA_MAJOR}.0). Original error: {e}'
+                f'requires Chroma server >= {floor}). Original error: {e}'
             ) from e
 
-        # Server reachable: enforce the supported version floor with a precise message.
-        _check_server_version(server_version)
+        # Best-effort server-version floor check. get_version() is not present on every
+        # chromadb client build, so treat its absence/failure as "unknown" rather than a
+        # connection error — the wrapper above and the index-path guards cover hard incompat.
+        server_version = self._getServerVersion()
+        if server_version:
+            _check_server_version(server_version)
         return
 
     def __del__(self):
@@ -185,6 +194,22 @@ class Store(DocumentStoreBase):
             debug(f'chroma: port {parsed} is out of range 1-65535; using default {default}')
             return default
         return parsed
+
+    def _getServerVersion(self) -> str | None:
+        """
+        Return the Chroma server version string, or None if it can't be determined.
+
+        Defensive: get_version() is not present on every chromadb client build (the thin
+        `chromadb-client` has shipped client shapes without it), so its absence or failure
+        must not be mistaken for a connection error.
+        """
+        getter = getattr(self.client, 'get_version', None)
+        if not callable(getter):
+            return None
+        try:
+            return getter()
+        except Exception:
+            return None
 
     def _doesCollectionExist(self) -> bool:
         """

--- a/nodes/src/nodes/store_chroma/requirements.txt
+++ b/nodes/src/nodes/store_chroma/requirements.txt
@@ -1,4 +1,2 @@
-# ChromaDB HTTP client only (not the full embedded database).
-# Pin to >=1.0 so the client matches the supported Chroma server floor that chroma.py
-# validates at connect time (see _check_server_version / _MIN_CHROMA_MAJOR).
-chromadb-client>=1.0.0
+# ChromaDB HTTP client only (not the full embedded database)
+chromadb-client

--- a/nodes/src/nodes/store_chroma/requirements.txt
+++ b/nodes/src/nodes/store_chroma/requirements.txt
@@ -1,2 +1,4 @@
-# ChromaDB HTTP client only (not the full embedded database)
-chromadb-client
+# ChromaDB HTTP client only (not the full embedded database).
+# Pin to >=1.0 so the client matches the supported Chroma server floor that chroma.py
+# validates at connect time (see _check_server_version / _MIN_CHROMA_MAJOR).
+chromadb-client>=1.0.0

--- a/nodes/test/store_chroma/test_version_compat.py
+++ b/nodes/test/store_chroma/test_version_compat.py
@@ -83,9 +83,9 @@ def _load_module() -> ModuleType:
 # --- _check_server_version ---------------------------------------------------
 
 
-@pytest.mark.parametrize('version', ['0.5.18', '0.6.0', '0.4.24'])
+@pytest.mark.parametrize('version', ['0.5.18', '0.5.99', '0.4.24'])
 def test_check_server_version_rejects_old_servers(version: str) -> None:
-    """Servers older than the supported major floor must raise a clear, actionable error."""
+    """Servers below the supported floor (< 0.6) must raise a clear, actionable error."""
     module = _load_module()
     with pytest.raises(Exception) as exc:
         module._check_server_version(version)
@@ -93,18 +93,49 @@ def test_check_server_version_rejects_old_servers(version: str) -> None:
     assert version in str(exc.value)
 
 
-@pytest.mark.parametrize('version', ['1.0.0', '1.5.9', 'v2.0.1', '3.2.2'])
+@pytest.mark.parametrize('version', ['0.6.0', '0.6.3', '1.0.0', '1.5.9', 'v2.0.1', '3.2.2'])
 def test_check_server_version_accepts_supported_servers(version: str) -> None:
-    """Servers at or above the supported major floor must pass without raising."""
+    """Servers at or above the floor pass — including 0.6.x (the project's own test infra)."""
     module = _load_module()
     module._check_server_version(version)  # must not raise
 
 
-@pytest.mark.parametrize('version', ['', 'garbage', None])
+@pytest.mark.parametrize('version', ['', 'garbage', '1', None])
 def test_check_server_version_is_lenient_on_unparseable(version: object) -> None:
-    """Unparseable version strings must not block the connection (connect wrapper covers it)."""
+    """Unparseable/partial version strings must not block the connection (wrapper covers it)."""
     module = _load_module()
     module._check_server_version(version)  # must not raise
+
+
+# --- _getServerVersion is defensive (thin clients may lack get_version) -------
+
+
+def test_get_server_version_returns_none_when_method_absent() -> None:
+    """A client without get_version must yield None, not raise (the bug that broke CI)."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    store.client = SimpleNamespace()  # no get_version attribute
+    assert store._getServerVersion() is None
+
+
+def test_get_server_version_returns_value_when_available() -> None:
+    """When get_version exists, its return value is used."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    store.client = SimpleNamespace(get_version=lambda: '0.6.3')
+    assert store._getServerVersion() == '0.6.3'
+
+
+def test_get_server_version_returns_none_when_probe_raises() -> None:
+    """A failing get_version must be swallowed to None, not surface as a connection error."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+
+    def _boom() -> str:
+        raise RuntimeError("KeyError('_type')")
+
+    store.client = SimpleNamespace(get_version=_boom)
+    assert store._getServerVersion() is None
 
 
 # --- _doesCollectionExist normalization --------------------------------------

--- a/nodes/test/store_chroma/test_version_compat.py
+++ b/nodes/test/store_chroma/test_version_compat.py
@@ -138,6 +138,18 @@ def test_get_server_version_returns_none_when_probe_raises() -> None:
     assert store._getServerVersion() is None
 
 
+@pytest.mark.parametrize('result', [6, object(), None], ids=['integer', 'object', 'none'])
+def test_get_server_version_treats_non_string_probe_results_as_unknown(result: object) -> None:
+    """Unexpected probe result types must not fail the open()-style version check."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    store.client = SimpleNamespace(get_version=lambda: result)
+
+    server_version = store._getServerVersion()
+    assert server_version is None
+    module._check_server_version(server_version)
+
+
 # --- _doesCollectionExist normalization --------------------------------------
 
 

--- a/nodes/test/store_chroma/test_version_compat.py
+++ b/nodes/test/store_chroma/test_version_compat.py
@@ -150,6 +150,46 @@ def test_get_server_version_treats_non_string_probe_results_as_unknown(result: o
     module._check_server_version(server_version)
 
 
+# --- _enforceServerVersion drops the handle it rejects -----------------------
+
+
+def test_enforce_server_version_clears_client_when_server_too_old() -> None:
+    """A rejected server must not leave a usable client handle behind."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    store.client = SimpleNamespace(get_version=lambda: '0.5.18')
+
+    with pytest.raises(Exception) as exc:
+        store._enforceServerVersion()
+
+    assert 'too old' in str(exc.value)
+    assert store.client is None
+
+
+def test_enforce_server_version_keeps_client_on_supported_server() -> None:
+    """A supported server passes the floor and keeps its handle."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    client = SimpleNamespace(get_version=lambda: '0.6.3')
+    store.client = client
+
+    store._enforceServerVersion()
+
+    assert store.client is client
+
+
+def test_enforce_server_version_keeps_client_when_version_unknown() -> None:
+    """An undeterminable version is not a rejection, so the handle survives."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    client = SimpleNamespace()  # no get_version
+    store.client = client
+
+    store._enforceServerVersion()
+
+    assert store.client is client
+
+
 # --- _doesCollectionExist normalization --------------------------------------
 
 

--- a/nodes/test/store_chroma/test_version_compat.py
+++ b/nodes/test/store_chroma/test_version_compat.py
@@ -1,0 +1,187 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression tests for Chroma issue #1405: server-version validation, list_collections
+shape normalization, and non-silent index failure (no swallowed error / no NoneType crash).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+_STUB_MODULE_NAMES = (
+    'chromadb',
+    'chromadb.config',
+    'numpy',
+    'chroma_store_under_test',
+)
+
+
+def _install_min_stubs() -> None:
+    """Minimal stubs so `chroma.py` can be imported without the real chromadb/numpy."""
+    chromadb = types.ModuleType('chromadb')
+
+    class _HttpClient:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+    chromadb.HttpClient = _HttpClient
+    chromadb.Collection = object
+    sys.modules['chromadb'] = chromadb
+
+    chromadb_config = types.ModuleType('chromadb.config')
+
+    class Settings:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+    chromadb_config.Settings = Settings
+    sys.modules['chromadb.config'] = chromadb_config
+
+    numpy_mod = types.ModuleType('numpy')
+    numpy_mod.exp = math.exp
+    numpy_mod.int64 = int
+    sys.modules['numpy'] = numpy_mod
+
+
+@contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    original = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    _install_min_stubs()
+    try:
+        yield
+    finally:
+        for name in _STUB_MODULE_NAMES:
+            if original.get(name) is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original[name]
+
+
+def _load_module() -> ModuleType:
+    nodes_root = Path(__file__).resolve().parent.parent.parent
+    chroma_py = nodes_root / 'src' / 'nodes' / 'store_chroma' / 'chroma.py'
+    with _scoped_stubs():
+        spec = importlib.util.spec_from_file_location('chroma_store_under_test', chroma_py)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+# --- _check_server_version ---------------------------------------------------
+
+
+@pytest.mark.parametrize('version', ['0.5.18', '0.6.0', '0.4.24'])
+def test_check_server_version_rejects_old_servers(version: str) -> None:
+    """Servers older than the supported major floor must raise a clear, actionable error."""
+    module = _load_module()
+    with pytest.raises(Exception) as exc:
+        module._check_server_version(version)
+    assert 'too old' in str(exc.value)
+    assert version in str(exc.value)
+
+
+@pytest.mark.parametrize('version', ['1.0.0', '1.5.9', 'v2.0.1', '3.2.2'])
+def test_check_server_version_accepts_supported_servers(version: str) -> None:
+    """Servers at or above the supported major floor must pass without raising."""
+    module = _load_module()
+    module._check_server_version(version)  # must not raise
+
+
+@pytest.mark.parametrize('version', ['', 'garbage', None])
+def test_check_server_version_is_lenient_on_unparseable(version: object) -> None:
+    """Unparseable version strings must not block the connection (connect wrapper covers it)."""
+    module = _load_module()
+    module._check_server_version(version)  # must not raise
+
+
+# --- _doesCollectionExist normalization --------------------------------------
+
+
+def _store_with_client(collections: list) -> object:
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    store.collection = 'mycoll'
+    store.collectionObj = None
+    store.client = SimpleNamespace(
+        list_collections=lambda: collections,
+        get_collection=lambda name: SimpleNamespace(name=name, _sentinel=True),
+    )
+    return store
+
+
+def test_does_collection_exist_with_name_strings() -> None:
+    """Older clients return collection *names* (strings)."""
+    store = _store_with_client(['other', 'mycoll'])
+    assert store._doesCollectionExist() is True
+    assert getattr(store.collectionObj, '_sentinel', False) is True
+
+
+def test_does_collection_exist_with_collection_objects() -> None:
+    """Newer clients return Collection *objects* with a .name attribute."""
+    objects = [SimpleNamespace(name='other'), SimpleNamespace(name='mycoll')]
+    store = _store_with_client(objects)
+    assert store._doesCollectionExist() is True
+    assert getattr(store.collectionObj, '_sentinel', False) is True
+
+
+def test_does_collection_exist_false_when_absent() -> None:
+    """Absent collection returns False for both shapes."""
+    assert _store_with_client(['a', 'b'])._doesCollectionExist() is False
+    assert _store_with_client([SimpleNamespace(name='a')])._doesCollectionExist() is False
+
+
+# --- _createCollection no longer swallows the real error ---------------------
+
+
+def test_create_collection_reraises_and_leaves_collection_none() -> None:
+    """A failed create must raise (not return False and leave collectionObj None silently)."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    store.collection = 'mycoll'
+    store.similarity = 'cosine'
+    store.collectionObj = None
+
+    def _boom(*_a: object, **_k: object) -> object:
+        raise RuntimeError("KeyError('_type')")
+
+    store.client = SimpleNamespace(get_or_create_collection=_boom)
+
+    with pytest.raises(Exception) as exc:
+        store._createCollection(5)
+    assert 'Error creating Chroma collection' in str(exc.value)
+    assert store.collectionObj is None
+
+
+# --- flush guard: no cryptic NoneType crash ----------------------------------
+
+
+def _fake_chunk() -> SimpleNamespace:
+    metadata = SimpleNamespace(chunkId=0, objectId='o1', toDict=lambda: {'objectId': 'o1', 'chunkId': 0})
+    return SimpleNamespace(metadata=metadata, embedding=[0.1, 0.2, 0.3], page_content='hello')
+
+
+def test_add_chunks_raises_clear_error_when_collection_missing() -> None:
+    """With collectionObj None, indexing must raise a clear message, not AttributeError."""
+    module = _load_module()
+    store = module.Store.__new__(module.Store)
+    store.collectionObj = None  # collection was never created
+    store.payload_limit = 32 * 1024 * 1024
+
+    with pytest.raises(Exception) as exc:
+        store.addChunks([_fake_chunk()], checkCollection=False)
+    message = str(exc.value)
+    assert 'collection' in message.lower()
+    assert 'NoneType' not in message  # not the cryptic attribute-error text


### PR DESCRIPTION
## Summary

- Chroma silently indexed nothing against incompatible/old servers: the real error (`KeyError('_type')`) was swallowed into a transient trace, and the user only saw a cryptic `'NoneType' object has no attribute 'delete'` crash + "0 done · 1 error" while downstream chat hallucinated.
- **Validate the Chroma server version on connect** (floor **0.6.0** — the v2 tenant/database API boundary; 0.5.18 fails, and the project's own test infra runs `chromadb/chroma:0.6.3`). The client construction is wrapped so an incompatible/old server yields an actionable message instead of a cryptic one. The precise version probe (`get_version`) is **best-effort** — it's absent on some thin `chromadb-client` builds, so its absence/failure is treated as "unknown", never a false connection error.
- Stop the silent/cryptic failure in the index path: `_createCollection` now re-raises the real cause instead of swallowing it, and `flush()` guards a missing collection with a clear message (defense in depth).
- Harden `_doesCollectionExist` to accept both `list_collections()` shapes (names *and* Collection objects), fixing a latent always-empty-search bug on newer clients.

## Type

fix

## Testing

- [x] Tests added or updated — `nodes/test/chroma/test_version_compat.py` (21 cases: version floor incl. 0.6.x accept, defensive `get_version` probe, list_collections normalization, `_createCollection` re-raise, flush guard)
- [x] Tested locally — new + existing chroma tests pass (28 passed); `ruff check`/`format` clean; `py_compile` OK
- [ ] `./builder test` passes — verified via CI (the `chroma:services:local` node test runs the real thin client against `chromadb/chroma:0.6.3`); docker was unavailable locally to reproduce it

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a
- [ ] Breaking changes documented (if applicable) — n/a (error surfacing only; no config/API change)

## Linked Issue

Fixes #1405

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a minimum supported Chroma server version with clear, “too-old” error messaging.
  * Improved robustness when detecting server version and listing collections across differing client behaviors.
  * Updated collection creation and chunk-adding flows to fail fast with more actionable errors when the collection is unavailable.
* **Tests**
  * Added regression coverage for server-version validation, defensive version detection, collection existence normalization, and improved error propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->