### PR TITLE
fix(nodes): accept documents input lane in extract_data

### DIFF
--- a/nodes/src/nodes/extract_data/IInstance.py
+++ b/nodes/src/nodes/extract_data/IInstance.py
@@ -22,7 +22,7 @@
 # =============================================================================
 
 import json
-from typing import List
+from typing import List, Union
 from rocketlib import IInstanceBase, Entry
 from ai.common.schema import Doc, DocMetadata, Question, QuestionType, Answer
 from ai.common.util import normalize
@@ -38,13 +38,13 @@ class IInstance(IInstanceBase):
     chunkId: int = 0
     table: List = []
 
-    def _extractData(self, text: str) -> List[Doc]:
+    def _extractData(self, text: Union[str, List[Doc]]) -> List[Doc]:
         """
-        Extract data from the given text/tables.
+        Extract data from the given text/tables/documents.
 
         Args:
             metadata (Dict[str, Any]): Metadata associated with the document.
-            text (str): Text content of the document.
+            text (Union[str, List[Doc]]): Text content, or documents, to extract from.
 
         Returns:
             List[Doc]: A list of documents with extracted definitions.
@@ -153,6 +153,15 @@ class IInstance(IInstanceBase):
             text (str): The input text to process.
         """
         self._extractData(text)
+
+    def writeDocuments(self, documents: List[Doc]):
+        """
+        Process and write document data. Extracts definitions from the documents' content, so an upstream ``documents`` lane (e.g. a preprocessor or embeddings node) can feed extraction directly.
+
+        Args:
+            documents (List[Doc]): The input documents to process.
+        """
+        self._extractData(documents)
 
     def writeAnswers(self, answer: Answer):
         # Save the new table

--- a/nodes/src/nodes/extract_data/IInstance.py
+++ b/nodes/src/nodes/extract_data/IInstance.py
@@ -38,16 +38,15 @@ class IInstance(IInstanceBase):
     chunkId: int = 0
     table: List = []
 
-    def _extractData(self, text: Union[str, List[Doc]]) -> List[Doc]:
+    def _extractData(self, text: Union[str, List[Doc]]) -> None:
         """
         Extract data from the given text/tables/documents.
 
         Args:
-            metadata (Dict[str, Any]): Metadata associated with the document.
             text (Union[str, List[Doc]]): Text content, or documents, to extract from.
 
         Returns:
-            List[Doc]: A list of documents with extracted definitions.
+            None: The LLM result is forwarded to ``writeAnswers``.
         """
         question: Question = Question(
             type=QuestionType.QUESTION, expectJson=True, role='You are a master at extracting data from text documents.'

--- a/nodes/src/nodes/extract_data/README.md
+++ b/nodes/src/nodes/extract_data/README.md
@@ -24,12 +24,16 @@ No third-party Python dependencies (requirements.txt is empty).
 
 ### Lanes
 
-| Lane in | Lane out    | Description                                                      |
-| ------- | ----------- | ---------------------------------------------------------------- |
-| `text`  | `answers`   | Extract fields from text, emit as JSON                           |
-| `text`  | `documents` | Extract fields from text, emit one document per row              |
-| `table` | `answers`   | Extract/transform fields from a table, emit as JSON              |
-| `table` | `documents` | Extract/transform fields from a table, emit one document per row |
+| Lane in     | Lane out    | Description                                                          |
+| ----------- | ----------- | ------------------------------------------------------------------- |
+| `text`      | `answers`   | Extract fields from text, emit as JSON                              |
+| `text`      | `documents` | Extract fields from text, emit one document per row                 |
+| `table`     | `answers`   | Extract/transform fields from a table, emit as JSON                 |
+| `table`     | `documents` | Extract/transform fields from a table, emit one document per row    |
+| `documents` | `answers`   | Extract fields from a document's content, emit as JSON              |
+| `documents` | `documents` | Extract fields from a document's content, emit one document per row |
+
+The `documents` input lane lets a `documents`-producing node (e.g. a preprocessor or an embeddings node) feed extraction directly, without an intermediate conversion to text.
 
 On close, the `answers` lane (if connected) receives one JSON answer containing the full table. The `documents` lane (if connected) receives one document per extracted row, with the row serialized as JSON in the document content.
 

--- a/nodes/src/nodes/extract_data/services.json
+++ b/nodes/src/nodes/extract_data/services.json
@@ -68,7 +68,8 @@
 	},
 	"lanes": {
 		"table": ["answers", "documents"],
-		"text": ["answers", "documents"]
+		"text": ["answers", "documents"],
+		"documents": ["answers", "documents"]
 	},
 	//
 	//	Optional:

--- a/nodes/test/test_extract_data.py
+++ b/nodes/test/test_extract_data.py
@@ -1,0 +1,156 @@
+"""Regression tests for the extract_data node (IInstance.py).
+
+Covers the `documents` input lane added for issue #1408:
+  - writeDocuments forwards the received documents to _extractData unchanged
+  - _extractData feeds those documents into the LLM question via addDocuments
+
+Server-free: the engine/AI modules the node imports are stubbed (only for the
+attributes it needs, and only when missing) so the node's Python can be imported
+and driven with plain pytest, no running server. When the real modules are
+present (CI) they are left untouched and this becomes a light integration test.
+"""
+
+import importlib
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+class _StubBase:
+    """Stand-in for rocketlib IInstanceBase / IGlobalBase."""
+
+    def preventDefault(self) -> None:
+        pass
+
+
+class _StubDoc:
+    """Minimal stand-in for ai.common.schema.Doc (real Doc has page_content)."""
+
+    def __init__(self, page_content=None, **kwargs):
+        self.page_content = page_content
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _module(name):
+    """Return sys.modules[name], creating an empty module if absent."""
+    mod = sys.modules.get(name)
+    if mod is None:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    return mod
+
+
+def _ensure_attrs(mod, **attrs):
+    """Add attributes only when the module doesn't already define them."""
+    for name, value in attrs.items():
+        if not hasattr(mod, name):
+            setattr(mod, name, value)
+
+
+# Augment (never replace) the modules the node imports, so this coexists with
+# both the real packages and the partial stubs other node tests install.
+_ensure_attrs(
+    _module('rocketlib'),
+    IInstanceBase=_StubBase,
+    IGlobalBase=_StubBase,
+    Entry=object,
+    warning=lambda *a, **kw: None,
+    debug=lambda *a, **kw: None,
+)
+_ensure_attrs(_module('rocketlib.types'), IInvokeLLM=MagicMock())
+_module('ai')
+_module('ai.common')
+_ensure_attrs(
+    _module('ai.common.schema'),
+    Doc=_StubDoc,
+    DocMetadata=MagicMock(),
+    Question=MagicMock(),
+    QuestionType=types.SimpleNamespace(QUESTION='question'),
+    Answer=MagicMock(),
+)
+_ensure_attrs(_module('ai.common.util'), normalize=lambda text: text)
+_ensure_attrs(_module('ai.common.config'), Config=MagicMock())
+
+# Import the node package (its parent dir goes on the path, like test_contracts).
+# importlib is used so we get the *module* (the package __init__ rebinds the name
+# `IInstance` to the class, which shadows the submodule for `import ... as`).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes'))
+node_module = importlib.import_module('extract_data.IInstance')
+
+IInstance = node_module.IInstance
+Doc = node_module.Doc  # exactly the Doc the node imported (stub or real)
+
+
+def _make_instance():
+    """Build an IInstance with the framework-provided attrs faked out.
+
+    Uses __new__ to skip the base __init__ (whose signature differs between the
+    real engine base and the stub); the handlers only touch the attrs set here.
+    """
+    inst = IInstance.__new__(IInstance)
+    inst.IGlobal = types.SimpleNamespace(fields=[])
+    inst.instance = MagicMock()
+    inst.table = []
+    inst.chunkId = 0
+    return inst
+
+
+class TestWriteDocumentsRouting:
+    """writeDocuments must hand the documents straight to _extractData."""
+
+    def test_forwards_documents_to_extract(self):
+        inst = _make_instance()
+        received = []
+        inst._extractData = lambda arg: received.append(arg)
+
+        docs = [Doc(page_content='Alice, 30'), Doc(page_content='Bob, 40')]
+        inst.writeDocuments(docs)
+
+        assert received == [docs], f'writeDocuments should forward the doc list unchanged, got {received}'
+
+    def test_empty_document_list_still_extracts(self):
+        inst = _make_instance()
+        received = []
+        inst._extractData = lambda arg: received.append(arg)
+
+        inst.writeDocuments([])
+
+        assert received == [[]], 'writeDocuments([]) should still invoke extraction with an empty list'
+
+
+class TestDocumentsReachQuestion:
+    """_extractData must feed the documents into the LLM question."""
+
+    def test_page_content_reaches_question(self, monkeypatch):
+        # Record the question the node builds, and neutralise the LLM round-trip.
+        class RecordingQuestion:
+            last = None
+
+            def __init__(self, *a, **kw):
+                self.documents = []
+                RecordingQuestion.last = self
+
+            def addInstruction(self, *a, **kw):
+                pass
+
+            def addContext(self, *a, **kw):
+                pass
+
+            def addDocuments(self, documents):
+                self.documents.append(documents)
+
+        monkeypatch.setattr(node_module, 'Question', RecordingQuestion)
+        monkeypatch.setattr(node_module, 'IInvokeLLM', types.SimpleNamespace(Ask=lambda **kw: kw))
+
+        inst = _make_instance()
+        inst.writeAnswers = lambda result: None  # skip answer handling for this test
+
+        docs = [Doc(page_content='Alice, 30'), Doc(page_content='Bob, 40')]
+        inst.writeDocuments(docs)
+
+        question = RecordingQuestion.last
+        assert question is not None, '_extractData should have built a Question'
+        assert question.documents == [docs], f'documents should be passed to addDocuments, got {question.documents}'
+        assert inst.instance.invoke.called, 'the LLM should be invoked with the built question'

--- a/nodes/test/test_extract_data.py
+++ b/nodes/test/test_extract_data.py
@@ -14,7 +14,26 @@ import importlib
 import os
 import sys
 import types
+from pathlib import Path
 from unittest.mock import MagicMock
+
+
+_TEST_ROOT = Path(__file__).resolve().parent
+if str(_TEST_ROOT) not in sys.path:
+    sys.path.insert(0, str(_TEST_ROOT))
+
+from framework.discovery import _parse_service_json
+
+
+_SERVICES_PATH = _TEST_ROOT.parent / 'src' / 'nodes' / 'extract_data' / 'services.json'
+
+
+def test_services_documents_lane_maps_to_answers_and_documents():
+    """The services contract exposes the documents input lane."""
+    services = _parse_service_json(str(_SERVICES_PATH))
+
+    assert services is not None
+    assert services['lanes']['documents'] == ['answers', 'documents']
 
 
 class _StubBase:

--- a/nodes/test/test_extract_data.py
+++ b/nodes/test/test_extract_data.py
@@ -11,21 +11,29 @@ present (CI) they are left untouched and this becomes a light integration test.
 """
 
 import importlib
-import os
 import sys
 import types
 from pathlib import Path
 from unittest.mock import MagicMock
 
+import pytest
+
+from test.framework.discovery import _parse_service_json
+
 
 _TEST_ROOT = Path(__file__).resolve().parent
-if str(_TEST_ROOT) not in sys.path:
-    sys.path.insert(0, str(_TEST_ROOT))
-
-from framework.discovery import _parse_service_json
-
-
 _SERVICES_PATH = _TEST_ROOT.parent / 'src' / 'nodes' / 'extract_data' / 'services.json'
+_NODE_ROOT = _TEST_ROOT.parent / 'src' / 'nodes'
+_STUB_MODULE_NAMES = (
+    'rocketlib',
+    'rocketlib.types',
+    'ai',
+    'ai.common',
+    'ai.common.schema',
+    'ai.common.util',
+    'ai.common.config',
+)
+_MISSING = object()
 
 
 def test_services_documents_lane_maps_to_answers_and_documents():
@@ -52,63 +60,99 @@ class _StubDoc:
             setattr(self, key, value)
 
 
-def _module(name):
-    """Return sys.modules[name], creating an empty module if absent."""
+def _stub_module(monkeypatch, name):
+    """Return a temporary module, creating it only for this test's import."""
     mod = sys.modules.get(name)
     if mod is None:
         mod = types.ModuleType(name)
-        sys.modules[name] = mod
+        monkeypatch.setitem(sys.modules, name, mod)
+
+        parent_name, _, child_name = name.rpartition('.')
+        if parent_name:
+            parent = _stub_module(monkeypatch, parent_name)
+            monkeypatch.setattr(parent, child_name, mod, raising=False)
+
     return mod
 
 
-def _ensure_attrs(mod, **attrs):
-    """Add attributes only when the module doesn't already define them."""
+def _ensure_attrs(monkeypatch, mod, **attrs):
+    """Temporarily add attributes only when the module lacks them."""
     for name, value in attrs.items():
         if not hasattr(mod, name):
-            setattr(mod, name, value)
+            monkeypatch.setattr(mod, name, value, raising=False)
 
 
-# Augment (never replace) the modules the node imports, so this coexists with
-# both the real packages and the partial stubs other node tests install.
-_ensure_attrs(
-    _module('rocketlib'),
-    IInstanceBase=_StubBase,
-    IGlobalBase=_StubBase,
-    Entry=object,
-    warning=lambda *a, **kw: None,
-    debug=lambda *a, **kw: None,
-)
-_ensure_attrs(_module('rocketlib.types'), IInvokeLLM=MagicMock())
-_module('ai')
-_module('ai.common')
-_ensure_attrs(
-    _module('ai.common.schema'),
-    Doc=_StubDoc,
-    DocMetadata=MagicMock(),
-    Question=MagicMock(),
-    QuestionType=types.SimpleNamespace(QUESTION='question'),
-    Answer=MagicMock(),
-)
-_ensure_attrs(_module('ai.common.util'), normalize=lambda text: text)
-_ensure_attrs(_module('ai.common.config'), Config=MagicMock())
+@pytest.fixture
+def extract_data_module(monkeypatch, request):
+    """Import the node with temporary dependencies and restore interpreter state."""
+    original_path = list(sys.path)
+    original_stubs = {name: sys.modules.get(name, _MISSING) for name in _STUB_MODULE_NAMES}
+    original_node_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == 'extract_data' or name.startswith('extract_data.')
+    }
 
-# Import the node package (its parent dir goes on the path, like test_contracts).
-# importlib is used so we get the *module* (the package __init__ rebinds the name
-# `IInstance` to the class, which shadows the submodule for `import ... as`).
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes'))
-node_module = importlib.import_module('extract_data.IInstance')
+    def assert_import_state_restored():
+        """Restore the node import and verify that temporary state did not leak."""
+        for name in tuple(sys.modules):
+            if (name == 'extract_data' or name.startswith('extract_data.')) and name not in original_node_modules:
+                del sys.modules[name]
+        sys.modules.update(original_node_modules)
 
-IInstance = node_module.IInstance
-Doc = node_module.Doc  # exactly the Doc the node imported (stub or real)
+        assert sys.path == original_path
+        for name, original_module in original_stubs.items():
+            if original_module is _MISSING:
+                assert name not in sys.modules
+            else:
+                assert sys.modules[name] is original_module
+        for name, original_module in original_node_modules.items():
+            assert sys.modules[name] is original_module
+
+    request.addfinalizer(assert_import_state_restored)
+
+    with monkeypatch.context() as patch:
+        # Augment (never replace) real modules, while keeping partial stubs local
+        # to this fixture so they cannot affect other tests.
+        _ensure_attrs(
+            patch,
+            _stub_module(patch, 'rocketlib'),
+            IInstanceBase=_StubBase,
+            IGlobalBase=_StubBase,
+            Entry=object,
+            warning=lambda *a, **kw: None,
+            debug=lambda *a, **kw: None,
+        )
+        _ensure_attrs(patch, _stub_module(patch, 'rocketlib.types'), IInvokeLLM=MagicMock())
+        _stub_module(patch, 'ai')
+        _stub_module(patch, 'ai.common')
+        _ensure_attrs(
+            patch,
+            _stub_module(patch, 'ai.common.schema'),
+            Doc=_StubDoc,
+            DocMetadata=MagicMock(),
+            Question=MagicMock(),
+            QuestionType=types.SimpleNamespace(QUESTION='question'),
+            Answer=MagicMock(),
+        )
+        _ensure_attrs(patch, _stub_module(patch, 'ai.common.util'), normalize=lambda text: text)
+        _ensure_attrs(patch, _stub_module(patch, 'ai.common.config'), Config=MagicMock())
+
+        # Import the node package (its parent dir goes on the path, like test_contracts).
+        # importlib is used so we get the *module* (the package __init__ rebinds
+        # `IInstance` to the class, which shadows the submodule for `import ... as`).
+        patch.syspath_prepend(str(_NODE_ROOT))
+        yield importlib.import_module('extract_data.IInstance')
 
 
-def _make_instance():
+def _make_instance(node_module):
     """Build an IInstance with the framework-provided attrs faked out.
 
     Uses __new__ to skip the base __init__ (whose signature differs between the
     real engine base and the stub); the handlers only touch the attrs set here.
     """
-    inst = IInstance.__new__(IInstance)
+    instance_class = node_module.IInstance
+    inst = instance_class.__new__(instance_class)
     inst.IGlobal = types.SimpleNamespace(fields=[])
     inst.instance = MagicMock()
     inst.table = []
@@ -119,18 +163,19 @@ def _make_instance():
 class TestWriteDocumentsRouting:
     """writeDocuments must hand the documents straight to _extractData."""
 
-    def test_forwards_documents_to_extract(self):
-        inst = _make_instance()
+    def test_forwards_documents_to_extract(self, extract_data_module):
+        inst = _make_instance(extract_data_module)
         received = []
         inst._extractData = lambda arg: received.append(arg)
 
+        Doc = extract_data_module.Doc
         docs = [Doc(page_content='Alice, 30'), Doc(page_content='Bob, 40')]
         inst.writeDocuments(docs)
 
         assert received == [docs], f'writeDocuments should forward the doc list unchanged, got {received}'
 
-    def test_empty_document_list_still_extracts(self):
-        inst = _make_instance()
+    def test_empty_document_list_still_extracts(self, extract_data_module):
+        inst = _make_instance(extract_data_module)
         received = []
         inst._extractData = lambda arg: received.append(arg)
 
@@ -142,7 +187,7 @@ class TestWriteDocumentsRouting:
 class TestDocumentsReachQuestion:
     """_extractData must feed the documents into the LLM question."""
 
-    def test_page_content_reaches_question(self, monkeypatch):
+    def test_page_content_reaches_question(self, monkeypatch, extract_data_module):
         # Record the question the node builds, and neutralise the LLM round-trip.
         class RecordingQuestion:
             last = None
@@ -160,12 +205,13 @@ class TestDocumentsReachQuestion:
             def addDocuments(self, documents):
                 self.documents.append(documents)
 
-        monkeypatch.setattr(node_module, 'Question', RecordingQuestion)
-        monkeypatch.setattr(node_module, 'IInvokeLLM', types.SimpleNamespace(Ask=lambda **kw: kw))
+        monkeypatch.setattr(extract_data_module, 'Question', RecordingQuestion)
+        monkeypatch.setattr(extract_data_module, 'IInvokeLLM', types.SimpleNamespace(Ask=lambda **kw: kw))
 
-        inst = _make_instance()
+        inst = _make_instance(extract_data_module)
         inst.writeAnswers = lambda result: None  # skip answer handling for this test
 
+        Doc = extract_data_module.Doc
         docs = [Doc(page_content='Alice, 30'), Doc(page_content='Bob, 40')]
         inst.writeDocuments(docs)
 


### PR DESCRIPTION
## Summary

- Add a `documents` input lane to the `extract_data` (Data Extractor) node so a documents-producing node can feed extraction directly. Previously the engine rejected that wiring with `input lane documents not found`, blocking the intuitive `parse -> preprocessor -> extract_data` pipeline shape.
- Add a `writeDocuments` handler that runs document content through the existing `_extractData` path. `Question.addDocuments` already accepts `List[Doc]`, so this mirrors the established `prompt` and `ner` node pattern without changing existing lanes.
- Update the README and add server-free regression tests for both the `services.json` lane contract and handler wiring. The test-only dependency stubs are fixture-scoped and restored after each test.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] Full `./builder test` suite (covered by CI)

- `./dist/server/engine -m pytest nodes/test/test_extract_data.py -q` -> **4 passed**
- `./builder nodes:test-contracts` -> **286 passed**
- `ruff check nodes/test/test_extract_data.py nodes/src/nodes/extract_data/IInstance.py` -> clean

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (not applicable)
- [x] Breaking changes documented (none; this is additive)

## Linked Issue

Closes #1408

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct extract-data support for preprocessed documents via a new documents input/output lane.
  * Enables extraction to preserve documents end-to-end (including per-row document results), with document lists routed through the extraction flow.
* **Documentation**
  * Updated extract-data lane documentation and lane configuration to describe the new documents behavior.
* **Tests**
  * Added server-free regression tests validating the documents lane mapping, routing, and empty-list handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
