### PR TITLE
fix(nodes): warn that parse/llamaparse are not provenance-preserving (RR-1406)

### DIFF
--- a/nodes/src/nodes/core/parser/README.md
+++ b/nodes/src/nodes/core/parser/README.md
@@ -12,6 +12,8 @@ sidebar_position: 1
 
 Extracts structured content from a wide variety of document types. The Parser automatically identifies embedded content and routes it to the appropriate output lane, making text, tables, images, audio, and video accessible for downstream processing.
 
+> **⚠️ Provenance limitation — not for audit-grade extraction.** Output is flattened to Markdown: page boundaries, bbox/polygon coordinates, and the table-HTML cell grid are dropped, so cell-level provenance and coordinate-based review cannot be reconstructed. Do not use this node where every value must trace back to its exact source cell (e.g. financial-table / regulatory extraction). For structure-preserving parsing that retains table HTML plus page and coordinate data, use the **`datalab_parse`** node instead.
+
 **Lanes:**
 
 | Lane in | Lane out | Description             |

--- a/nodes/src/nodes/core/services.parse.json
+++ b/nodes/src/nodes/core/services.parse.json
@@ -29,7 +29,7 @@
 	// Optional:
 	//		Description to of this driver
 	//
-	"description": ["A document parsing component that extracts rich content from a wide variety ", "of document types. It automatically identifies and processes embedded content, ", "producing structured outputs including plain text, tables, images, audio, and ", "video. This enables comprehensive analysis of complex documents and media files ", "by making their contents accessible for downstream processing in the pipeline."],
+	"description": ["A document parsing component that extracts rich content from a wide variety ", "of document types. It automatically identifies and processes embedded content, ", "producing structured outputs including plain text, tables, images, audio, and ", "video. This enables comprehensive analysis of complex documents and media files ", "by making their contents accessible for downstream processing in the pipeline. ", "Note: output is flattened to Markdown and does not preserve cell-level provenance ", "(page boundaries, bbox coordinates, or the table-HTML cell grid), so it is not suitable ", "for audit-grade or provenance-bearing extraction; use the datalab_parse node for ", "structure-preserving parsing with page and coordinate data."],
 	//
 	// Optional:
 	//	  The icon is the icon to display in the UI for this node

--- a/nodes/src/nodes/llamaparse/IGlobal.py
+++ b/nodes/src/nodes/llamaparse/IGlobal.py
@@ -222,6 +222,17 @@ class IGlobal(IGlobalBase):
         if self._llama_parse:
             bag['llama_parse'] = self._llama_parse
             debug('LlamaParse Global: LlamaParse initialized successfully')
+
+            # Provenance advisory (issue #1406): this node emits flattened Markdown and
+            # does not preserve cell-level provenance. Warn once at init so pipeline
+            # authors building audit-grade extraction see it in the run logs. The
+            # structure-preserving alternative is the datalab_parse node (#1425).
+            warning(
+                'LlamaParse Global: this node flattens documents to Markdown and does not preserve '
+                'cell-level provenance (page boundaries, bbox coordinates, or the table-HTML cell grid). '
+                'It is not suitable for audit-grade or provenance-bearing extraction. For structure-preserving '
+                'parsing (HTML + tables with page/coordinates), use the datalab_parse node.'
+            )
         else:
             error_msg = 'LlamaParse Global: Critical error - failed to initialize LlamaParse instance'
             warning(error_msg)

--- a/nodes/src/nodes/llamaparse/README.md
+++ b/nodes/src/nodes/llamaparse/README.md
@@ -2,6 +2,8 @@
 
 A RocketRide data node that parses documents with the LlamaParse cloud service and emits the extracted text and tables into the pipeline.
 
+> **⚠️ Provenance limitation — not for audit-grade extraction.** This node flattens documents to Markdown: it drops page boundaries, bbox/polygon coordinates, and the table-HTML cell grid, so cell-level provenance and coordinate-based review cannot be reconstructed from its output. Do not use it where every value must trace back to its exact source cell (e.g. financial-table / regulatory extraction). For structure-preserving parsing that retains table HTML plus page and coordinate data, use the **`datalab_parse`** node instead.
+
 ## What it does
 
 Sends incoming documents to the LlamaIndex / LlamaParse cloud API (via the `llama-parse` Python library) and emits the results. Handles PDFs, images, Word documents, Excel spreadsheets, and other formats, with table extraction, layout preservation, and Markdown output. Processing happens in the cloud: a LlamaIndex API key is required, and the run aborts at startup if none is configured.

--- a/nodes/src/nodes/llamaparse/services.json
+++ b/nodes/src/nodes/llamaparse/services.json
@@ -47,7 +47,7 @@
 	// Optional:
 	//		Description to of this driver
 	//
-	"description": ["A document parsing component that uses LlamaParse to extract text and structured data ", "from various document formats including PDFs, images, Word documents, Excel spreadsheets, ", "and other formats. It provides high-quality text extraction with support for tables, ", "layout preservation, and markdown output formatting."],
+	"description": ["A document parsing component that uses LlamaParse to extract text and structured data ", "from various document formats including PDFs, images, Word documents, Excel spreadsheets, ", "and other formats. It provides high-quality text extraction with support for tables, ", "layout preservation, and markdown output formatting. ", "Note: output is flattened to Markdown and does not preserve cell-level provenance ", "(page boundaries, bbox coordinates, or the table-HTML cell grid), so it is not suitable ", "for audit-grade or provenance-bearing extraction; use the datalab_parse node for ", "structure-preserving parsing with page and coordinate data."],
 	//
 	// Optional:
 	//	  The icon is the icon to display in the UI for this node


### PR DESCRIPTION
## Summary

- The native `parse` and the `llamaparse` node both flatten documents to Markdown, dropping page boundaries, bbox/polygon coordinates, and the table-HTML cell grid — so cell-level provenance can't be reconstructed for audit-grade extraction.
- Documents this limitation prominently on both nodes (READMEs + catalog `description`) and emits a one-time runtime `warning()` from the LlamaParse node steering users to the structure-preserving `datalab_parse` node (#1425).
- No parsing/output behavior change. The structural lossless parser is tracked separately by #1425 (`datalab_parse`), which Epic #1432 names as the structural fix for this bug — this PR deliberately does not duplicate it.

## Type

fix / docs

## Testing

- [x] `ruff check nodes/src/nodes/llamaparse/IGlobal.py` — all checks passed
- [x] `py_compile` on `IGlobal.py` — compiles
- [x] JSON5 validity of both edited `services*.json` files
- [x] AST check: exactly one provenance `warning()` wired in `beginGlobal`
- [x] Confirmed the README auto-generated block is unchanged
- [ ] `./builder test` — not runnable in sandbox (C++ engine); CI covers it

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (n/a)
- [x] Breaking changes documented (none — additive docs + one log line)

## Linked Issue

Fixes #1406


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clear warnings that certain parsing outputs are flattened to Markdown and do not preserve page, coordinate, or table-cell provenance.
  * Pointed users to the structure-preserving parsing option when they need audit-grade or cell-level detail.
* **Bug Fixes**
  * Improved in-app guidance so limitations are shown during setup and in node descriptions, reducing confusion about what information is retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->