### PR TITLE
fix(shell): OSS engine shell-UI talks same-origin, not cloud (local/docker/service)

### DIFF
--- a/apps/shell-ui/src/bootstrap.tsx
+++ b/apps/shell-ui/src/bootstrap.tsx
@@ -40,8 +40,23 @@ import { registerAndMapApps } from './lib/appLoader';
  * 5. Renders the Shell React tree.
  */
 async function main() {
-	// Read the server URI from the build-time env define
-	const serverUri = process.env.ROCKETRIDE_URI || 'localhost:5565';
+	// Resolve the server URI with three-tier precedence:
+	//   1. Runtime injection (window.__ROCKETRIDE_URI__) — set by shell.py at
+	//      serve time to the request's OWN origin. This is what makes local /
+	//      docker / self-hosted "same-origin": the engine that served this HTML
+	//      tells the SPA to talk back to the exact host:port the browser used,
+	//      overriding whatever ROCKETRIDE_URI was baked at build time.
+	//   2. Build-time define (process.env.ROCKETRIDE_URI) — used by the standalone
+	//      rsbuild dev server (UI :3000, engine :5565 → NOT same-origin) and by the
+	//      cloud S3 build (UI cloud.rocketride.ai, API api.rocketride.ai).
+	//   3. window.location.origin — last-resort fallback.
+	// getServerInfo()/normalizeUri() accepts a bare host, http(s):// or ws(s)://.
+	const injected = (window as unknown as { __ROCKETRIDE_URI__?: string }).__ROCKETRIDE_URI__;
+	const serverUri =
+		(injected && injected !== '__ROCKETRIDE_URI__' ? injected : '') ||
+		process.env.ROCKETRIDE_URI ||
+		(typeof window !== 'undefined' ? window.location.origin : '') ||
+		'localhost:5565';
 
 	// Probe the server for capabilities and public apps (no auth required)
 	let capabilities: string[] = [];

--- a/packages/ai/src/ai/modules/shell/shell.py
+++ b/packages/ai/src/ai/modules/shell/shell.py
@@ -42,10 +42,11 @@ Routes:
 
 import os
 import sys
+import json
 from pathlib import Path
 
 from fastapi import HTTPException
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, HTMLResponse
 
 from ai.web import Request
 
@@ -85,6 +86,43 @@ def _resolve_safe(base_dir: str, requested_path: str) -> Path:
         return Path(base_dir) / 'index.html'
 
 
+def _client_origin(request: Request) -> str:
+    """
+    Reconstruct the origin (scheme://host[:port]) the browser used to reach us,
+    honouring a TLS-terminating / port-mapping reverse proxy in front of the
+    engine (docker port map, self-hosted service behind nginx/traefik).
+
+    Order: X-Forwarded-Proto/Host (proxy) → Host header → request.url.
+    """
+    host = request.headers.get('x-forwarded-host') or request.headers.get('host') or request.url.netloc
+    proto = request.headers.get('x-forwarded-proto') or request.url.scheme or 'http'
+    # X-Forwarded-* may be comma-joined hop lists; take the first (client-facing) hop.
+    host = host.split(',')[0].strip()
+    proto = proto.split(',')[0].strip()
+    return f'{proto}://{host}'
+
+
+def _serve_index(request: Request, index_path: Path) -> HTMLResponse:
+    """
+    Serve the shell SPA entry with the engine's OWN origin injected as
+    window.__ROCKETRIDE_URI__, so the bundled shell-UI always talks back to the
+    host that served it (same-origin), regardless of the build-time define.
+
+    Runs ONLY on the engine-served path (local / docker / self-hosted). The cloud
+    UI is served from S3/CloudFront and never reaches this handler, so it keeps
+    its explicit build-time ROCKETRIDE_URI (api.rocketride.ai).
+    """
+    html = index_path.read_text(encoding='utf-8')
+    snippet = f'<script>window.__ROCKETRIDE_URI__={json.dumps(_client_origin(request))};</script>'
+    # Inject as the first child of <head> so it runs before the MF bundle loads.
+    if '<head>' in html:
+        html = html.replace('<head>', '<head>\n    ' + snippet, 1)
+    else:
+        html = snippet + html
+    # index.html carries a request-specific origin — never cache it.
+    return HTMLResponse(html, headers={'Cache-Control': 'no-store'})
+
+
 async def shell_static(request: Request):
     """
     Serve static files for the shell SPA with client-side routing fallback.
@@ -117,16 +155,16 @@ async def shell_static(request: Request):
 
     # Resolve safely within the shell root
     file_path = _resolve_safe(_shell_root, raw_path)
+    index_path = (Path(_shell_root) / 'index.html').resolve()
 
-    # Serve the file if it exists
-    if file_path.exists() and file_path.is_file():
+    # Real asset files (JS/CSS/themes/favicon) — serve unchanged.
+    if file_path.exists() and file_path.is_file() and file_path != index_path:
         return FileResponse(file_path)
 
-    # SPA fallback: serve index.html for any unmatched route so that
-    # client-side routing (React Router, etc.) can handle it.
-    index_path = Path(_shell_root) / 'index.html'
+    # index.html — bare "/", explicit /shell/index.html, or SPA fallback.
+    # Inject the engine's own origin so the bundled shell-UI is same-origin.
     if index_path.exists() and index_path.is_file():
-        return FileResponse(index_path)
+        return _serve_index(request, index_path)
 
     # Shell hasn't been built yet
     raise HTTPException(


### PR DESCRIPTION
**Draft for the Dmitrii↔Rod session — do not merge until Rod signs off on the approach.**

Fixes the standup bug: a locally-run OSS engine's bundled shell-UI hits `api.rocketride.ai` (cloud) instead of the local engine. Root cause: the release CI bakes `ROCKETRIDE_URI=wss://api.rocketride.ai` into the shell-UI (so published clients default to cloud), and `bootstrap.tsx` only falls back to localhost when the baked value is empty; `shell.py` serves the SPA static with no runtime URI.

**Approach (hybrid, server-side origin injection):**
- `shell.py` injects `window.__ROCKETRIDE_URI__ = <request origin>` (from `X-Forwarded-*`/`Host`) into `index.html` at serve time. Runs ONLY on the engine-served path.
- `bootstrap.tsx` resolves the URI with 3-tier precedence: injection > baked `process.env.ROCKETRIDE_URI` > `window.location.origin`.
- **No CI change, no VS Code change, no cloud change.** The cloud UI is served from S3/CloudFront (never hits `shell.py`) so it keeps its baked `api.rocketride.ai`.

**Mode matrix (Rod's constraint — don't break local/docker/service):**

| Mode | Before | After |
|---|---|---|
| rsbuild dev (UI :3000) | localhost:5565 ✓ | unchanged (no injection) ✓ |
| local `rocketride serve` | ❌ cloud | inject localhost:5565 ✓ |
| docker (host:8080) | ❌ cloud | inject host:8080 ✓ |
| service/self-hosted | ❌ cloud | inject real host (X-Forwarded-*) ✓ |
| cloud (S3) | api.rocketride.ai ✓ | unchanged (no shell.py) ✓ |

3 modes fixed, 2 provably unchanged, 0 regressions. Ships via a normal engine build+release (Path A). Full design + test plan in the office prep pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)