### PR TITLE
fix(vscode): group Deep Agent Subagent under AGENT in node picker (#1505)

### DIFF
--- a/packages/shared-ui/src/components/canvas/util/helpers.tsx
+++ b/packages/shared-ui/src/components/canvas/util/helpers.tsx
@@ -153,6 +153,21 @@ export const resolveDefaultFormData = (_id: string, schema: Record<string, unkno
 };
 
 /**
+ * Display-only aliases for inventory category keys. Some `classType` tags are
+ * invoke-channel connection contracts rather than standalone node categories, so
+ * the Add Node picker should not give them their own section. `deepagent` is the
+ * classType a `Deep Agent Subagent` carries so it can be wired into a Deep Agent
+ * orchestrator's `deepagent` invoke channel (the picker's invoke matching gates on
+ * `classType.includes(channelKey)`), so the tag must stay on the node. Aliasing it
+ * onto the `agent` display bucket lists the subagent under AGENT alongside Deep
+ * Agent instead of rendering an orphan single-item DEEPAGENT category, without
+ * touching the node's real `classType` (so invoke wiring is unaffected).
+ */
+const CATEGORY_DISPLAY_ALIASES: Record<string, string> = {
+	deepagent: 'agent',
+};
+
+/**
  * Builds the node inventory from the service catalog. Groups services
  * by their `classType` (e.g., source, llm, database) into categorized buckets,
  * resolves icon paths, applies capability filters (excluding NoSaas services),
@@ -194,7 +209,11 @@ export const buildInventory = (forms: Record<string, IService> = {}) => {
 		const classTypes = Array.isArray(value.classType) ? value.classType : [value.classType];
 
 		for (const classType of classTypes) {
-			const services = classType in _inventory ? _inventory[classType] : {};
+			// Group under the display alias when one exists (e.g. deepagent -> agent),
+			// otherwise under the classType itself. Keeps invoke-only classTypes from
+			// spawning their own orphan category in the picker.
+			const displayType = CATEGORY_DISPLAY_ALIASES[classType] ?? classType;
+			const services = displayType in _inventory ? _inventory[displayType] : {};
 
 			// `value.icon` is the raw icon identifier from the service JSON
 			// (e.g. "openai.svg"). It is passed straight to the <Icon> component
@@ -205,7 +224,7 @@ export const buildInventory = (forms: Record<string, IService> = {}) => {
 			};
 
 			services[key] = _value;
-			_inventory[classType] = services;
+			_inventory[displayType] = services;
 		}
 	}
 


### PR DESCRIPTION
## What

In the **Add Node** picker, `Deep Agent Subagent` rendered as the sole member of an orphan **DEEPAGENT** category instead of sitting under **AGENT** with `Deep Agent`. This groups it under **AGENT** and removes the standalone category.

Closes #1505.

## Root cause

`buildInventory` (`packages/shared-ui/src/components/canvas/util/helpers.tsx`) creates one inventory bucket **per `classType` string**, and `CATEGORY_TITLES` has no `deepagent` entry, so the panel rendered the raw key as **DEEPAGENT**. The two nodes are tagged:

| Node | `classType` | Picker bucket (before) |
| --- | --- | --- |
| Deep Agent | `["agent", "tool"]` | AGENT (+ `Tool` tag) |
| Deep Agent Subagent | `["deepagent"]` | **DEEPAGENT** (orphan) |

## Why not just retag the node

The obvious one-liner, changing the subagent's `classType` to `["agent"]`, **would ship a regression.** The Deep Agent orchestrator declares an invoke channel literally named `deepagent`, and the canvas gates which nodes may connect to an invoke channel on the node's classType:

```ts
// canvas/components/panels/quick-add/QuickAddPopup.tsx (~L216-218)
if (isInvocable && Array.isArray(service.classType) && service.classType.includes(invokeKey)) { ... }
```

So dragging from a Deep Agent's `deepagent` invoke handle only offers nodes whose `classType.includes("deepagent")`. Retagging the subagent to `["agent"]` would remove it from that candidate set, breaking the ability to wire a subagent into a Deep Agent. `["deepagent"]` is the connection contract, not just a picker tag, so it must stay on the node.

## The fix (display-layer, non-breaking)

Add a small `CATEGORY_DISPLAY_ALIASES` map in `buildInventory` that folds the `deepagent` bucket into `agent` **for display only**:

```ts
const CATEGORY_DISPLAY_ALIASES: Record<string, string> = { deepagent: 'agent' };
// ...
const displayType = CATEGORY_DISPLAY_ALIASES[classType] ?? classType;
```

The node's real `classType` is untouched, so invoke wiring is unaffected. This lives in `shared-ui`, so it applies to **both** the VS Code extension and the cloud SaaS canvas. 1 file, +21/-2.

## Verification

- **Type-check:** `tsc --noEmit` on `shared-ui` yields the exact same error set with and without this change (86 vs 86, `diff` identical); the changed file itself contributes **0** errors. (The 86 are pre-existing workspace build-ordering errors, e.g. the unbuilt `rocketride` package and a generated `light.json`, unrelated to this PR.)
- **Grouping logic:** a standalone repro of `buildInventory`'s category assignment against a realistic catalog fixture confirms the subagent lands in the `agent` bucket, **no `deepagent` bucket is created**, and every other bucket is unchanged (Deep Agent still tool-tagged; llm/tool/source untouched).
- **Wiring safety:** no change under `nodes/src/nodes/agent_deepagent/**`; the invoke-matching code path (`QuickAddPopup`) is untouched, so subagent↔orchestrator wiring and `getControllerNodeIds('deepagent')` discovery are unaffected.

Note: `shared-ui`'s standalone `rslib build` currently fails on a pre-existing missing entry (`./src/modules/canvas/index.tsx`) at config-compose time, before any source is read, so it is independent of this change; the real bundle is exercised by the extension build in CI.

## Screenshot

<img width="278" height="479" alt="deepagent-picker-1505" src="https://github.com/user-attachments/assets/85916603-5198-4316-bad3-c611bf25b704" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**


  * Improved how services are grouped in the inventory picker so `deepagent` now appears under the existing `agent` category instead of showing up as a separate option.
  * Kept the original service type intact behind the scenes while updating the displayed category, preserving expected behavior elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->