### PR TITLE
fix(ci): read full marker body in Discord issue/PR notifiers (stop duplicate forum posts)

### DIFF
--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -139,8 +139,12 @@ jobs:
           COMMENTS=$(gh api --paginate "/repos/$REPO/issues/$NUMBER/comments" \
             | jq -s 'add // [] | [.[] | {id: .id, body: .body, author: .user.login}]')
 
-          MARKER_BODY=$(echo "$COMMENTS" | \
-            jq -r --arg re "$DISCORD_MARKER_PATTERN" '.[] | select(.author == "github-actions[bot]" and (.body | test($re))) | .body' | head -1)
+          # First matching marker comment's FULL body. NB: the body is a multi-
+          # line <details> block, so this must NOT be piped through `head -1`
+          # (that keeps only "<details>" and drops the marker line, so the
+          # msg/thread ids never resolve and every event reposts a duplicate).
+          MARKER_BODY=$(printf '%s' "$COMMENTS" | \
+            jq -r --arg re "$DISCORD_MARKER_PATTERN" 'first(.[] | select(.author == "github-actions[bot]" and (.body | test($re))) | .body) // ""')
           DISCORD_MSG_ID=$(printf '%s' "$MARKER_BODY" | extract_discord_marker)
           DISCORD_THREAD_ID=$(printf '%s' "$MARKER_BODY" | extract_discord_thread)
 

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -241,8 +241,12 @@ jobs:
           COMMENTS=$(gh api --paginate "/repos/$REPO/issues/$PR_NUMBER/comments" \
             | jq -s 'add // [] | [.[] | {id: .id, body: .body, author: .user.login}]')
 
-          MARKER_BODY=$(echo "$COMMENTS" | \
-            jq -r --arg re "$DISCORD_MARKER_PATTERN" '.[] | select(.author == "github-actions[bot]" and (.body | test($re))) | .body' | head -1)
+          # First matching marker comment's FULL body. NB: the body is a multi-
+          # line <details> block, so this must NOT be piped through `head -1`
+          # (that keeps only "<details>" and drops the marker line, so the
+          # msg/thread ids never resolve and every event reposts a duplicate).
+          MARKER_BODY=$(printf '%s' "$COMMENTS" | \
+            jq -r --arg re "$DISCORD_MARKER_PATTERN" 'first(.[] | select(.author == "github-actions[bot]" and (.body | test($re))) | .body) // ""')
           DISCORD_MSG_ID=$(printf '%s' "$MARKER_BODY" | extract_discord_marker)
           DISCORD_THREAD_ID=$(printf '%s' "$MARKER_BODY" | extract_discord_thread)
 


### PR DESCRIPTION
## Summary

- The Discord issue/PR forum notifiers were reposting a **new forum thread on every event** (10× duplicates on PR #1521) instead of updating the existing post.
- Cause: the sync-marker lookup piped the comment body through `head -1`, but the marker sits inside a multi-line `<details>` block — so only `<details>` was kept and `extract_discord_marker` / `extract_discord_thread` always returned empty → `DISCORD_MSG_ID` empty → the notifier created a fresh thread each run.
- Fix: read the **first matching comment's full body** via jq `first(...)` in `discord-issues.yml` and `discord-pr.yml`.

## Type

fix (CI)

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

- YAML parses for both workflows.
- Verified live against a real marker (#1526): the fixed lookup extracts msg, thread, whereas the old `head -1` logic returned `msg=[] thread=[]`
- `discord-discussions.yml` was already correct (uses `find_marker` + full-body pipe, no `head -1`) — no change needed.
- The `.id | head -1` lookups in the 404 branch are intentionally untouched (`.id` is single-line).

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included

## Linked Issue

Closes #1529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord notification handling so existing marker messages are found reliably, even when the marker spans multiple lines.
  * Prevented duplicate Discord threads/messages from being posted for later updates by ensuring message and thread references resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->