### PR TITLE
fix(docs): use docs.rocketride.org in issue template (#1534)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://docs.rocketride.ai
+    url: https://docs.rocketride.org
     about: Check the docs for guides, API references, and examples.
   - name: Wiki
     url: https://github.com/rocketride-org/rocketride-server/wiki


### PR DESCRIPTION
## Summary

Replace the remaining `docs.rocketride.ai` reference in `.github/ISSUE_TEMPLATE/config.yml` with `docs.rocketride.org` for consistency.

## Type

- [x] fix (docs)

## Testing

- [ ] Tests added or updated (not needed)
- [x] Tested locally
- [x] Verified the URL change.
- [ ] `./builder test` passes (not needed)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1534 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation contact link to point to the new website address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->