### PR TITLE
fix(auth): register /auth/vscode/google outside the standardEndpoints gate (cloud Gmail OAuth)

### DIFF
--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -313,11 +313,13 @@ class WebServer:
             self.add_route('/use', use, ['POST'])
             self.add_route('/shutdown', shutdown, ['POST'])
             self.add_route('/auth/callback', auth_callback, ['GET'], public=True)
-            self.add_route('/auth/vscode/google', vscode_oauth_bounce, ['GET'], public=True)
 
         # These are always there - no way to turn them off
         self.add_route('/status', status, ['GET'])
         self.add_route('/version', version, ['GET'], public=True)
+        # OAuth bounce endpoints must stay registered even when standardEndpoints
+        # is off (cloud/eaas), else the Gmail-tool Google OAuth deep-link 401s.
+        self.add_route('/auth/vscode/google', vscode_oauth_bounce, ['GET'], public=True)
 
         # Configure the Uvicorn server immediately upon initialization
         self.server = self._configure_server()


### PR DESCRIPTION
## The Gmail-tool Google OAuth bounce 401s in cloud

`/auth/vscode/google` (and its handler + import) already ship, but the route is registered **only** inside `if register_standard_endpoints:`. The cloud entrypoint `eaas.py` starts the server with `standardEndpoints=False`, so in cloud the route is never registered and `AuthMiddleware` returns `401 Access denied` — the Gmail node's "Login with Google" deep-link never fires. (Verified against the running prod pod: route present in source, `add_route` skipped, endpoint 401.)

**Fix:** move the `/auth/vscode/google` registration to the always-on section (next to `/version`) so the public OAuth bounce works regardless of `standardEndpoints`.

Note: `/auth/callback` (and `/ping`) are gated the same way and are also dark in cloud — left as-is here since only the Gmail bounce was reported; happy to move `/auth/callback` too if cloud needs the PKCE safety-net.

Prod was hotfixed immediately via a saas ALB overlay (rocketride-saas) that re-registers the route; this PR is the durable engine fix so that overlay can be dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured VS Code Google sign-in continues to work even when standard server endpoints are disabled.
  * Preserved availability of OAuth authentication routes alongside status and version endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->