### PR TITLE
fix(ai): retry without stop param on 400 unsupported_parameter

### DIFF
--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -9,6 +9,7 @@ ChatBase consumes Adapters and never touches provider-native content shapes.
 Design: repo discussion #1679 (RFC — virtualized provider Adapter).
 """
 
+import re
 import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -227,6 +228,73 @@ def flatten_content(content: Any) -> str:
     return flatten_content_parts(content)[0]
 
 
+# Word-boundary match so "stopped" / "nonstop" / "stop_reason" do not trip the heuristic.
+# Anthropic names the parameter stop_sequences; `_` is a word char so `\bstop\b` misses it.
+_STOP_WORD_RE = re.compile(r'\bstop(?:_sequences)?\b', re.IGNORECASE)
+
+
+def is_stop_rejection(e: Exception, stop_sent: bool) -> bool:
+    """Return True when ``e`` indicates the provider rejected a ``stop`` parameter.
+
+    Prefers structured API error fields (``status_code`` / ``code`` / ``param``),
+    including OpenAI's nested ``body['error']`` shape. Falls back to a
+    word-boundary string match of ``stop`` / ``stop_sequences`` only when those
+    structured fields are absent. If structured fields are present and clearly
+    point at something else, the string heuristic is not consulted.
+
+    A match of ``stop_sequences`` is enough on its own (Anthropic extra-field
+    400s look like ``stop_sequences: Extra inputs are not permitted``). A match
+    of ``stop`` still requires ``unsupported`` or ``invalid`` in the message.
+
+    Callers that retry without ``stop`` accept that the model may emit past the
+    stop sequence; agent-level truncation (``truncate_at_stop_words``) is the
+    backstop.
+    """
+    if not stop_sent:
+        return False
+
+    status = getattr(e, 'status_code', None)
+    code = getattr(e, 'code', None)
+    param = getattr(e, 'param', None)
+    nested_message = None
+
+    body = getattr(e, 'body', None)
+    if isinstance(body, dict):
+        # OpenAI: {"error": {"message":…, "type":…, "param":…, "code":…}}
+        # Anthropic: {"type": "error", "error": {"type":…, "message":…}} (often no code/param)
+        nested = body.get('error')
+        err = nested if isinstance(nested, dict) else body
+        code = code or err.get('code')
+        param = param or err.get('param')
+        msg = err.get('message')
+        if isinstance(msg, str):
+            nested_message = msg
+
+    if status == 400 and (code == 'unsupported_parameter' or param in ('stop', 'stop_sequences')):
+        return True
+
+    # Structured fields present and non-matching: do not fall through to substrings.
+    if param is not None and param not in ('stop', 'stop_sequences'):
+        return False
+    if status is not None and status != 400:
+        return False
+    if code is not None and code != 'unsupported_parameter':
+        return False
+
+    haystack = str(e)
+    if nested_message:
+        haystack = f'{haystack} {nested_message}'
+    err_str = haystack.lower()
+    matched = _STOP_WORD_RE.search(err_str)
+    if not matched:
+        return False
+    # Anthropic extra-field 400s are "stop_sequences: Extra inputs are not permitted"
+    # with neither "unsupported" nor "invalid" in the message.
+    if matched.group(0).lower() == 'stop_sequences':
+        return True
+    return 'unsupported' in err_str or 'invalid' in err_str
+
+
 def is_usage_flag_rejection(e: Exception) -> bool:
     """True when an endpoint refused the request itself, so one retry without the flag pays off.
 
@@ -374,6 +442,12 @@ class LangChainAdapter:
         self.reasoning: str = ''
 
     def stream(self, user_text: str) -> Iterator[Event]:
+        """Stream Events; retry once without ``stop`` if the provider rejects it at create time.
+
+        Fallback applies only to stream creation / first chunk — never after output has
+        already been yielded. On retry the model may emit past the stop sequence;
+        agent-level truncation is the backstop.
+        """
         self.history.append({'role': 'user', 'content': user_text})
         parse = _make_stream_content_parser(True)
         parts: list[str] = []
@@ -405,25 +479,36 @@ class LangChainAdapter:
         except StopIteration:
             gen, piece = None, None
         except Exception as e:
-            # Retry without the usage flag ONLY for the failure it causes: a client error
-            # rejecting stream_options.include_usage (an old vLLM/strict proxy — 400 from the
-            # openai SDK, 422 from a FastAPI-based server). Re-raise everything else — a
-            # 401/429 surfaces without a second round trip, and a transient connection/timeout
-            # (no status_code) is not mistaken for a flag rejection and silently retried
-            # unmetered.
-            if not ask_usage or not is_usage_flag_rejection(e):
-                raise
-            from rocketlib import warning
+            # Retry without stop and/or stream_usage, at most once each, and only before
+            # any chunk has been yielded. Same first-chunk gate as include_usage.
+            dropped_stop = dropped_usage = False
+            while True:
+                if not dropped_stop and is_stop_rejection(e, 'stop' in skw):
+                    # Local import avoids a rocketlib <-> ai.common cycle at module load.
+                    from rocketlib import warning
 
-            warning(
-                f'LangChain stream rejected stream_usage ({type(e).__name__}); '
-                'retrying without include_usage (this call is unmetered).'
-            )
-            skw.pop('stream_usage', None)
-            try:
-                gen, piece = _open(skw)
-            except StopIteration:
-                gen, piece = None, None
+                    warning(f"LLM rejected 'stop' parameter: {e}. Retrying stream without stop.")
+                    skw.pop('stop', None)
+                    dropped_stop = True
+                elif not dropped_usage and ask_usage and skw.get('stream_usage') and is_usage_flag_rejection(e):
+                    from rocketlib import warning
+
+                    warning(
+                        f'LangChain stream rejected stream_usage ({type(e).__name__}); '
+                        'retrying without include_usage (this call is unmetered).'
+                    )
+                    skw.pop('stream_usage', None)
+                    dropped_usage = True
+                else:
+                    raise
+                try:
+                    gen, piece = _open(skw)
+                    break
+                except StopIteration:
+                    gen, piece = None, None
+                    break
+                except Exception as retry_err:
+                    e = retry_err
 
         # try/finally so a mid-stream raise still records the usage the chunks already
         # carried, matching the two native adapters.
@@ -475,13 +560,28 @@ class LangChainAdapter:
     def collect(self, user_text: str) -> tuple[str, list[Any]]:
         """Non-streaming drain: invoke() + shared normalization. A genuinely different
         mechanism from stream(), so it can still recover when streaming fails.
+
+        Retries once without ``stop`` if the provider rejects it. On retry the model may
+        emit past the stop sequence; agent-level truncation is the backstop.
         """
         had_history = bool(self.history)
         self.history.append({'role': 'user', 'content': user_text})
         # Single-turn callers keep the historical contract: the backend is handed the
         # prompt string it was given, not a one-element message list.
         payload = self.history if had_history else user_text
-        result = self.llm.invoke(payload, **self.stream_kwargs)
+        kwargs = dict(self.stream_kwargs)
+        try:
+            result = self.llm.invoke(payload, **kwargs)
+        except Exception as e:
+            if is_stop_rejection(e, 'stop' in kwargs):
+                # Local import avoids a rocketlib <-> ai.common cycle at module load.
+                from rocketlib import warning
+
+                warning(f"LLM rejected 'stop' parameter: {e}. Retrying without stop.")
+                kwargs.pop('stop', None)
+                result = self.llm.invoke(payload, **kwargs)
+            else:
+                raise
         report_usage_metadata(getattr(result, 'usage_metadata', None), self.llm)
         text, self.reasoning = flatten_content_parts(getattr(result, 'content', ''))
         assistant = {'role': 'assistant', 'content': text}

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from rocketlib import debug, warning
 
-from ai.common.llm_adapter import Event, drive_adapter, is_usage_flag_rejection, report_llm_tokens
+from ai.common.llm_adapter import Event, drive_adapter, is_stop_rejection, is_usage_flag_rejection, report_llm_tokens
 
 # Per-call carrier for API-level stop sequences (e.g. CrewAI's ReAct "\nObservation:").
 # Set on the ask path in llm_base._question and read at every model sink so the stop
@@ -185,9 +185,8 @@ class NativeAnthropicAdapter:
         # INVARIANT: consume synchronously within ask() while STOP_SEQUENCES_VAR is still set.
         self.history.append({'role': 'user', 'content': user_text})
         llm = self.chat._llm
-        payload: dict[str, Any] = dict(
-            llm._get_request_payload(user_text, stop=STOP_SEQUENCES_VAR.get() or None, stream=True)
-        )
+        stop = STOP_SEQUENCES_VAR.get() or None
+        payload: dict[str, Any] = dict(llm._get_request_payload(user_text, stop=stop, stream=True))
         # Thinking is added per call (not baked into the client) so it rides only this native
         # streaming path — the agent / expectJson path never gets it.
         payload.update(getattr(self.chat, '_thinking_mode_kwargs', None) or {})
@@ -198,7 +197,17 @@ class NativeAnthropicAdapter:
 
         parts: list[str] = []
         input_tokens = output_tokens = cache_read = cache_creation = 0
-        raw_stream = _open_raw_message_stream(client, payload)
+        try:
+            raw_stream = _open_raw_message_stream(client, payload)
+        except Exception as e:
+            # Retry only before any chunks reach the UI (create-time 400).
+            if stop and is_stop_rejection(e, True):
+                warning(f"LLM rejected 'stop' parameter: {e}. Retrying native stream without stop.")
+                payload = dict(llm._get_request_payload(user_text, stop=None, stream=True))
+                payload.update(getattr(self.chat, '_thinking_mode_kwargs', None) or {})
+                raw_stream = _open_raw_message_stream(client, payload)
+            else:
+                raise
         try:
             for event in raw_stream:
                 et = _event_type_name(event)
@@ -309,6 +318,9 @@ def try_openai_compat_reasoning_stream(
         'max_tokens': chat._modelOutputTokens,
     }
     kwargs.update(getattr(chat, '_reasoning_kwargs', {}))
+    stop = STOP_SEQUENCES_VAR.get() or None
+    if stop:
+        kwargs['stop'] = stop
 
     parts: list[str] = []
     finish_reason: Optional[str] = None
@@ -340,34 +352,46 @@ def try_openai_compat_reasoning_stream(
     try:
         _drain(kwargs)
     except Exception as e:
-        # This handler is wired ONLY for custom base URLs (ChatBase returns early unless
-        # openai_api_base is set), which is exactly where include_usage can be rejected. Retry
-        # once without it ONLY on a flag rejection (a 400/422 client error) before any chunk:
-        # nothing has reached on_chunk yet, so the retry cannot duplicate visible output — we
-        # just forgo the usage chunk (that endpoint goes unmetered) and keep reasoning
-        # streaming alive. A 401/429 or a mid-stream failure is not retried here — it falls
-        # straight through to the non-streaming path (which meters itself), so a rate limit
-        # stays at two round trips.
-        if emitted == 0 and 'stream_options' in kwargs and is_usage_flag_rejection(e):
-            warning(
-                f'llm_native_stream openai_compat_reasoning: endpoint rejected stream_options '
-                f'({type(e).__name__}); retrying without include_usage (this call is unmetered).'
-            )
-            kwargs.pop('stream_options', None)
+        # Retry stop and/or include_usage only before any chunk has reached the UI.
+        pending = e
+        if emitted == 0 and stop and is_stop_rejection(e, True):
+            warning(f"LLM rejected 'stop' parameter: {e}. Retrying openai_compat stream without stop.")
+            kwargs.pop('stop', None)
             try:
                 _drain(kwargs)
-            except Exception as e2:
+            except Exception as retry_err:
+                pending = retry_err
+            else:
+                pending = None
+        if pending is not None:
+            # This handler is wired ONLY for custom base URLs (ChatBase returns early unless
+            # openai_api_base is set), which is exactly where include_usage can be rejected. Retry
+            # once without it ONLY on a flag rejection (a 400/422 client error) before any chunk:
+            # nothing has reached on_chunk yet, so the retry cannot duplicate visible output — we
+            # just forgo the usage chunk (that endpoint goes unmetered) and keep reasoning
+            # streaming alive. A 401/429 or a mid-stream failure is not retried here — it falls
+            # straight through to the non-streaming path (which meters itself), so a rate limit
+            # stays at two round trips.
+            if emitted == 0 and 'stream_options' in kwargs and is_usage_flag_rejection(pending):
                 warning(
-                    f'llm_native_stream openai_compat_reasoning: stream failed ({type(e2).__name__}): {e2} '
+                    f'llm_native_stream openai_compat_reasoning: endpoint rejected stream_options '
+                    f'({type(pending).__name__}); retrying without include_usage (this call is unmetered).'
+                )
+                kwargs.pop('stream_options', None)
+                try:
+                    _drain(kwargs)
+                except Exception as e2:
+                    warning(
+                        f'llm_native_stream openai_compat_reasoning: stream failed ({type(e2).__name__}): {e2} '
+                        '(falling back to non-streaming chat).'
+                    )
+                    return None
+            else:
+                warning(
+                    f'llm_native_stream openai_compat_reasoning: stream failed ({type(pending).__name__}): {pending} '
                     '(falling back to non-streaming chat).'
                 )
                 return None
-        else:
-            warning(
-                f'llm_native_stream openai_compat_reasoning: stream failed ({type(e).__name__}): {e} '
-                '(falling back to non-streaming chat).'
-            )
-            return None
 
     # The stream drained to completion (no exception escaped above). Report the usage it
     # carried, once, on this success path — a mid-stream failure returned None in the except

--- a/packages/ai/tests/ai/common/test_chat_fallback.py
+++ b/packages/ai/tests/ai/common/test_chat_fallback.py
@@ -1,0 +1,489 @@
+import pytest
+
+from ai.common.llm_adapter import Event, LangChainAdapter, is_stop_rejection
+from ai.common.llm_native_stream import (
+    STOP_SEQUENCES_VAR,
+    NativeAnthropicAdapter,
+    try_openai_compat_reasoning_stream,
+)
+
+
+class _Piece:
+    def __init__(self, content, response_metadata=None):
+        self.content = content
+        self.response_metadata = response_metadata
+
+
+class _FakeApiError(Exception):
+    """Minimal stand-in for openai.BadRequestError-shaped exceptions."""
+
+    def __init__(self, message, *, status_code=None, code=None, param=None, body=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.param = param
+        self.body = body
+
+
+class MockInvokeLLM:
+    def __init__(self, should_fail_on_stop=True):
+        self.should_fail_on_stop = should_fail_on_stop
+        self.invoked_kwargs = []
+
+    def invoke(self, prompt, **kwargs):
+        self.invoked_kwargs.append(kwargs)
+        if self.should_fail_on_stop and 'stop' in kwargs:
+            raise ValueError("unsupported_parameter: 'stop'")
+        return _Piece('success')
+
+    def stream(self, messages, **kwargs):
+        raise AssertionError('stream should not be used in collect tests')
+
+
+class MockStreamLLM:
+    def __init__(self, should_fail_on_stop=True):
+        self.should_fail_on_stop = should_fail_on_stop
+        self.streamed_kwargs = []
+
+    def stream(self, messages, **kwargs):
+        self.streamed_kwargs.append(kwargs)
+        if self.should_fail_on_stop and 'stop' in kwargs:
+
+            def failing_generator():
+                raise ValueError("unsupported_parameter: 'stop' is invalid")
+                yield _Piece('never')
+
+            return failing_generator()
+
+        def success_generator():
+            yield _Piece('chunk1')
+            yield _Piece('chunk2')
+
+        return success_generator()
+
+
+def test_is_stop_rejection_structured_nested_openai_body():
+    """OpenAI nests code/param under body['error']; top-level .get misses them."""
+    err = _FakeApiError(
+        'ignored string',
+        status_code=400,
+        body={
+            'error': {
+                'message': "Unsupported parameter: 'stop' is not supported with this model.",
+                'type': 'invalid_request_error',
+                'param': 'stop',
+                'code': 'unsupported_parameter',
+            }
+        },
+    )
+    assert is_stop_rejection(err, True) is True
+
+
+def test_is_stop_rejection_structured_top_level_fields():
+    err = _FakeApiError(
+        'ignored',
+        status_code=400,
+        code='unsupported_parameter',
+        param='stop',
+    )
+    assert is_stop_rejection(err, True) is True
+
+
+def test_is_stop_rejection_string_heuristic_word_boundary():
+    assert is_stop_rejection(ValueError("unsupported_parameter: 'stop'"), True) is True
+    assert is_stop_rejection(ValueError('stop_sequences: Extra inputs are not permitted'), True) is True
+    assert is_stop_rejection(ValueError('Invalid API key'), True) is False
+    assert is_stop_rejection(ValueError('Request stopped by client'), True) is False
+    assert is_stop_rejection(ValueError('invalid_request_error: unsupported model'), True) is False
+    assert is_stop_rejection(ValueError('nonstop generation failed'), True) is False
+
+
+def test_is_stop_rejection_anthropic_message_only_body():
+    """Anthropic 400s often have no code/param — only a stop_sequences message."""
+    err = _FakeApiError(
+        'stop_sequences: Extra inputs are not permitted',
+        status_code=400,
+        body={
+            'type': 'error',
+            'error': {
+                'type': 'invalid_request_error',
+                'message': 'stop_sequences: Extra inputs are not permitted',
+            },
+        },
+    )
+    assert is_stop_rejection(err, True) is True
+
+
+def test_is_stop_rejection_structured_nonmatch_skips_string_heuristic():
+    """Present structured fields that are not a stop rejection must not retry."""
+    rate_limited = _FakeApiError(
+        'invalid stop: unsupported',
+        status_code=429,
+        body={'error': {'code': 'rate_limit_exceeded'}},
+    )
+    assert is_stop_rejection(rate_limited, True) is False
+
+    wrong_param = _FakeApiError(
+        "unsupported_parameter: 'stop'",
+        status_code=400,
+        param='messages',
+    )
+    assert is_stop_rejection(wrong_param, True) is False
+
+
+def test_is_stop_rejection_requires_stop_sent():
+    assert is_stop_rejection(ValueError("unsupported_parameter: 'stop'"), False) is False
+
+
+def test_langchain_collect_retries_without_stop():
+    llm = MockInvokeLLM(should_fail_on_stop=True)
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:']})
+
+    text, _items = adapter.collect('Hello')
+
+    assert text == 'success'
+    assert len(llm.invoked_kwargs) == 2
+    assert 'stop' in llm.invoked_kwargs[0]
+    assert 'stop' not in llm.invoked_kwargs[1]
+
+
+def test_langchain_collect_retry_preserves_non_stop_kwargs():
+    llm = MockInvokeLLM(should_fail_on_stop=True)
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:'], 'temperature': 0.2})
+
+    adapter.collect('Hello')
+
+    assert llm.invoked_kwargs[0]['stop'] == ['\nObservation:']
+    assert llm.invoked_kwargs[0]['temperature'] == 0.2
+    assert 'stop' not in llm.invoked_kwargs[1]
+    assert llm.invoked_kwargs[1] == {'temperature': 0.2}
+
+
+def test_langchain_collect_success_with_stop():
+    llm = MockInvokeLLM(should_fail_on_stop=False)
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:']})
+
+    text, _items = adapter.collect('Hello')
+
+    assert text == 'success'
+    assert len(llm.invoked_kwargs) == 1
+    assert 'stop' in llm.invoked_kwargs[0]
+
+
+def test_langchain_stream_retries_without_stop():
+    llm = MockStreamLLM(should_fail_on_stop=True)
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:']})
+
+    text = ''.join(e.text for e in adapter.stream('Hello') if e.type == 'text')
+
+    assert text == 'chunk1chunk2'
+    assert len(llm.streamed_kwargs) == 2
+    assert 'stop' in llm.streamed_kwargs[0]
+    assert 'stop' not in llm.streamed_kwargs[1]
+
+
+def test_langchain_stream_success_with_stop():
+    llm = MockStreamLLM(should_fail_on_stop=False)
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:']})
+
+    events = list(adapter.stream('Hello'))
+
+    assert Event('text', 'chunk1') in events
+    assert Event('text', 'chunk2') in events
+    assert len(llm.streamed_kwargs) == 1
+    assert 'stop' in llm.streamed_kwargs[0]
+
+
+def test_langchain_collect_empty_stop_does_not_retry():
+    llm = MockInvokeLLM()
+
+    def failing_invoke(prompt, **kwargs):
+        llm.invoked_kwargs.append(kwargs)
+        raise ValueError("unsupported_parameter: 'stop'")
+
+    llm.invoke = failing_invoke
+    adapter = LangChainAdapter(llm, stream_kwargs={})
+
+    with pytest.raises(ValueError, match="unsupported_parameter: 'stop'"):
+        adapter.collect('Hello')
+
+    assert len(llm.invoked_kwargs) == 1
+
+
+def test_langchain_collect_unrelated_error_does_not_retry():
+    llm = MockInvokeLLM()
+
+    def failing_invoke(prompt, **kwargs):
+        llm.invoked_kwargs.append(kwargs)
+        raise ValueError('Rate limit exceeded')
+
+    llm.invoke = failing_invoke
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:']})
+
+    with pytest.raises(ValueError, match='Rate limit exceeded'):
+        adapter.collect('Hello')
+
+    assert len(llm.invoked_kwargs) == 1
+
+
+def test_langchain_stream_empty_stop_does_not_retry():
+    llm = MockStreamLLM()
+
+    def failing_stream(messages, **kwargs):
+        llm.streamed_kwargs.append(kwargs)
+
+        def gen():
+            raise ValueError("unsupported_parameter: 'stop'")
+            yield _Piece('never')
+
+        return gen()
+
+    llm.stream = failing_stream
+    adapter = LangChainAdapter(llm, stream_kwargs={})
+
+    with pytest.raises(ValueError, match="unsupported_parameter: 'stop'"):
+        list(adapter.stream('Hello'))
+
+    assert len(llm.streamed_kwargs) == 1
+
+
+def test_langchain_stream_unrelated_error_does_not_retry():
+    llm = MockStreamLLM()
+
+    def failing_stream(messages, **kwargs):
+        llm.streamed_kwargs.append(kwargs)
+
+        def gen():
+            raise ValueError('Rate limit exceeded')
+            yield _Piece('never')
+
+        return gen()
+
+    llm.stream = failing_stream
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:']})
+
+    with pytest.raises(ValueError, match='Rate limit exceeded'):
+        list(adapter.stream('Hello'))
+
+    assert len(llm.streamed_kwargs) == 1
+
+
+def test_langchain_stream_mid_stream_error_does_not_retry():
+    """Error after the first chunk must not restart the stream (no duplicate emit)."""
+    llm = MockStreamLLM()
+
+    def failing_stream(messages, **kwargs):
+        llm.streamed_kwargs.append(kwargs)
+
+        def gen():
+            yield _Piece('chunk1')
+            raise ValueError("unsupported_parameter: 'stop'")
+
+        return gen()
+
+    llm.stream = failing_stream
+    adapter = LangChainAdapter(llm, stream_kwargs={'stop': ['\nObservation:']})
+
+    with pytest.raises(ValueError, match="unsupported_parameter: 'stop'"):
+        list(adapter.stream('Hello'))
+
+    assert len(llm.streamed_kwargs) == 1
+
+
+class _FakeCompletions:
+    def __init__(self, create_fn):
+        self.create = create_fn
+
+
+class _FakeChat:
+    def __init__(self, create_fn):
+        self.completions = _FakeCompletions(create_fn)
+
+
+class _FakeOpenAIClient:
+    def __init__(self, create_fn):
+        self.chat = _FakeChat(create_fn)
+
+
+class _FakeDelta:
+    def __init__(self, content=None, reasoning_content=None):
+        self.content = content
+        self.reasoning_content = reasoning_content
+
+
+class _FakeChoice:
+    def __init__(self, content, finish_reason=None):
+        self.delta = _FakeDelta(content=content)
+        self.finish_reason = finish_reason
+
+
+class _FakeChunk:
+    def __init__(self, content, finish_reason=None):
+        self.choices = [_FakeChoice(content, finish_reason)]
+
+
+def test_openai_compat_native_stream_retries_without_stop():
+    calls = []
+
+    def create(**kwargs):
+        calls.append(dict(kwargs))
+        if 'stop' in kwargs:
+            raise _FakeApiError(
+                "Unsupported parameter: 'stop'",
+                status_code=400,
+                body={'error': {'code': 'unsupported_parameter', 'param': 'stop'}},
+            )
+        return iter([_FakeChunk('hello', finish_reason='stop')])
+
+    chat = type(
+        'Chat',
+        (),
+        {
+            '_raw_openai_client': _FakeOpenAIClient(create),
+            '_model': 'deepseek-reasoner',
+            '_modelOutputTokens': 128,
+            '_reasoning_kwargs': {},
+        },
+    )()
+
+    token = STOP_SEQUENCES_VAR.set(['\nObservation:'])
+    try:
+        chunks = []
+        text = try_openai_compat_reasoning_stream(chat, 'prompt', chunks.append, None, None)
+    finally:
+        STOP_SEQUENCES_VAR.reset(token)
+
+    assert text == 'hello'
+    assert chunks == ['hello']
+    assert len(calls) == 2
+    assert calls[0].get('stop') == ['\nObservation:']
+    assert 'stop' not in calls[1]
+
+
+def test_openai_compat_native_stream_retries_on_message_only_body():
+    """Third-party openai_compat 400s are often message-only, with no code/param."""
+    calls = []
+
+    def create(**kwargs):
+        calls.append(dict(kwargs))
+        if 'stop' in kwargs:
+            raise _FakeApiError(
+                "Unsupported parameter: 'stop' is not supported with this model.",
+                status_code=400,
+                body={'error': {'message': "Unsupported parameter: 'stop' is not supported with this model."}},
+            )
+        return iter([_FakeChunk('hello', finish_reason='stop')])
+
+    chat = type(
+        'Chat',
+        (),
+        {
+            '_raw_openai_client': _FakeOpenAIClient(create),
+            '_model': 'deepseek-reasoner',
+            '_modelOutputTokens': 128,
+            '_reasoning_kwargs': {},
+        },
+    )()
+
+    token = STOP_SEQUENCES_VAR.set(['\nObservation:'])
+    try:
+        text = try_openai_compat_reasoning_stream(chat, 'prompt', lambda _: None, None, None)
+    finally:
+        STOP_SEQUENCES_VAR.reset(token)
+
+    assert text == 'hello'
+    assert len(calls) == 2
+    assert 'stop' in calls[0]
+    assert 'stop' not in calls[1]
+
+
+def test_openai_compat_native_stream_unrelated_error_does_not_retry():
+    calls = []
+
+    def create(**kwargs):
+        calls.append(dict(kwargs))
+        raise ValueError('authentication failed')
+
+    chat = type(
+        'Chat',
+        (),
+        {
+            '_raw_openai_client': _FakeOpenAIClient(create),
+            '_model': 'deepseek-reasoner',
+            '_modelOutputTokens': 128,
+            '_reasoning_kwargs': {},
+        },
+    )()
+
+    token = STOP_SEQUENCES_VAR.set(['\nObservation:'])
+    try:
+        text = try_openai_compat_reasoning_stream(chat, 'prompt', lambda _: None, None, None)
+    finally:
+        STOP_SEQUENCES_VAR.reset(token)
+
+    assert text is None
+    assert len(calls) == 1
+
+
+def test_anthropic_native_stream_retries_without_stop(monkeypatch):
+    """Retry native Anthropic create without stop_sequences on a real Anthropic 400.
+
+    Production rejections are message-only (``stop_sequences: Extra inputs are
+    not permitted``) with no ``code``/``param``. Fabricating OpenAI's structured
+    fields would let this pass without exercising the string branch.
+    """
+    from ai.common import llm_native_stream as ns
+
+    payloads = []
+    open_calls = []
+
+    class _FakeLLM:
+        def _get_request_payload(self, prompt, stop=None, stream=False):
+            payloads.append({'stop': stop, 'stream': stream})
+            out = {'model': 'claude', 'messages': [], 'max_tokens': 16, 'stream': True}
+            if stop:
+                out['stop_sequences'] = stop
+            return out
+
+        def _client(self):
+            return object()
+
+    class _Evt:
+        type = 'content_block_delta'
+
+        class delta:
+            type = 'text_delta'
+            text = 'ok'
+
+    def fake_open(client, payload):
+        open_calls.append(dict(payload))
+        if payload.get('stop_sequences'):
+            raise _FakeApiError(
+                'stop_sequences: Extra inputs are not permitted',
+                status_code=400,
+                body={
+                    'type': 'error',
+                    'error': {
+                        'type': 'invalid_request_error',
+                        'message': 'stop_sequences: Extra inputs are not permitted',
+                    },
+                },
+            )
+        return [_Evt()]
+
+    monkeypatch.setattr(ns, '_open_raw_message_stream', fake_open)
+
+    chat = type('Chat', (), {'_llm': _FakeLLM(), '_thinking_mode_kwargs': {}})()
+    token = STOP_SEQUENCES_VAR.set(['\nObservation:'])
+    try:
+        events = list(NativeAnthropicAdapter(chat).stream('prompt'))
+    finally:
+        STOP_SEQUENCES_VAR.reset(token)
+
+    assert Event('text', 'ok') in events
+    assert len(payloads) == 2
+    assert payloads[0]['stop'] == ['\nObservation:']
+    assert payloads[1]['stop'] is None
+    assert len(open_calls) == 2
+    assert open_calls[0].get('stop_sequences') == ['\nObservation:']
+    assert 'stop_sequences' not in open_calls[1]


### PR DESCRIPTION
Fixes #1538.  Prevents pipeline crashes when a provider rejects the ReAct `stop` / `stop_sequences` parameter (OpenAI reasoning models, Anthropic, openai-compat).

## Summary

<!-- Describe your changes in 1-3 bullet points -->

* **Adapter fallback:** `LangChainAdapter.stream` / `.collect` catch a provider 400 that rejects `stop` and retry once without that parameter, before any chunks have been emitted. Relies on the existing `truncate_at_stop_words` backstop on the agent path.
* **Native stream fallback:** The Anthropic Messages create path (`stop_sequences`) and the `openai_compat_reasoning` Chat Completions create path (`stop`) retry once without stop on the same class of 400.
* **Behaviour change:** `openai_compat_reasoning` now **sends** `STOP_SEQUENCES_VAR` as `stop` (it previously ignored it). DeepSeek-reasoner-class models get API-level ReAct truncation on the first successful attempt; if the provider rejects `stop`, we retry without it.
* **Matcher:** `is_stop_rejection` prefers nested structured fields (`body['error'].code` / `.param`, including `stop_sequences`) and falls back to a word-boundary match of `stop` / `stop_sequences`. A `stop_sequences` hit is enough on its own so Anthropic extra-field 400s retry.
* **Tests:** `test_chat_fallback.py` covers invoke and stream retry, negative cases, mid-stream no-duplicate-emit, Anthropic-shaped message-only 400s, and openai_compat native create.


## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->
fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #1538 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chat now gracefully falls back when the language model backend doesn’t support per-call stop parameters, for both standard responses and streaming.
  * Per-call stop sequences still override defaults when provided.
  * When stop parameters are unsupported or invalid, retries no longer fail the request and continue generating content.
  * Response truncation tied to stop sequences remains more consistent.

* **Tests**
  * Added coverage for invoke and streaming fallback behavior, including cases where fallback should not occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->