### PR TITLE
fix(shared-ui): persist Google OAuth tokens to node config and stop authType flip

### DIFF
--- a/apps/vscode/docs/google-oauth.md
+++ b/apps/vscode/docs/google-oauth.md
@@ -15,7 +15,11 @@ browser and receives the resulting tokens through a deep link.
 1. The webview asks the host to open the hosted OAuth broker URL.
 2. The extension opens the system browser at the broker
    (`https://oauth2.rocketride.ai/google?...`), passing the node's service
-   config and a `baseURL` return address.
+   config, a `baseURL` return address, and an explicit `scope` parameter for
+   the node's selected access tier. The broker's default consent grants only
+   Drive and profile scopes — never Gmail — so the tier's Gmail scopes must
+   always be requested explicitly (see `GMAIL_TIER_SCOPES` in
+   `LoginWithGoogleButton.tsx`, mirroring `google_access.py`).
 3. The user completes Google's consent screen. The broker exchanges the code
    using its own verified Google application; no client secret ever reaches
    the extension or the pipeline config.
@@ -54,12 +58,24 @@ generated form schema names dotted `services.json` field ids (for example
 `google.userToken`) by their last component. The `parameters.*` locations some
 widgets also read are legacy and are never written by this flow.
 
+## Scopes and access tiers
+
+The granted scopes are fixed at consent time. Raising a node's access tier
+after connecting (for example `modify` → `send`) requires disconnecting and
+reconnecting the Google account so the new tier's scopes are consented.
+Lowering the tier does not: the engine's scope check treats
+`https://mail.google.com/` as covering every Gmail scope and `gmail.modify`
+as covering `gmail.readonly` (`missing_scopes` in `core/google_access.py`).
+Tokens without a `scope` field are accepted (fail-open, for older tokens).
+
 ## Limitation
 
 Tokens are applied by the node config panel. If the panel is closed when the
 deep link returns, the tokens stay pending in the editor until the panel is
 reopened for the node that started the login (or until the editor reloads and
-the redelivery expires).
+the redelivery expires). There is also no disconnect affordance yet — the
+login button disables once authenticated; clearing a token currently means
+editing the `.pipe` by hand.
 
 ## Token refresh
 

--- a/apps/vscode/docs/google-oauth.md
+++ b/apps/vscode/docs/google-oauth.md
@@ -22,8 +22,13 @@ browser and receives the resulting tokens through a deep link.
 4. The broker redirects to the bounce page
    (`https://api.rocketride.ai/auth/vscode/google`), which forwards the result
    to the editor deep link `vscode://rocketride.rocketride/auth/google`.
-5. The extension routes the tokens back to the node that started the login and
-   saves them into the node's configuration.
+5. The extension routes the tokens to the **live** editor for the document
+   that started the login (resolved at delivery time — the original webview
+   may have been recycled during the browser round-trip). If no live editor
+   exists, the tokens are held and redelivered after the next editor load;
+   undelivered tokens expire after 5 minutes. After the webview applies the
+   tokens, the host saves the document, so the tokens reach the `.pipe` file
+   without a manual save.
 
 ## Host and webview contract
 
@@ -31,14 +36,30 @@ Messages exchanged between the extension host and the pipeline editor webview:
 
 | Direction | Message | Payload | Purpose |
 | --- | --- | --- | --- |
-| host to webview | `project:load` | `oauthReturnUrl: string` | The `baseURL` the webview passes to the broker. In VS Code this is the bounce page URL carrying the editor's URI scheme (`?scheme=vscode`, `vscode-insiders`, etc.). Sent on every load; a load also clears any pending tokens. |
+| host to webview | `project:load` | `oauthReturnUrl: string` | The `baseURL` the webview passes to the broker. In VS Code this is the bounce page URL carrying the editor's URI scheme (`?scheme=vscode`, `vscode-insiders`, etc.). Sent on every load; a load also clears any webview-held pending tokens — but the host redelivers undelivered broker tokens right after the load, so a reload during the browser trip does not lose them. |
 | webview to host | `project:openExternal` | `url: string` | Ask the host to open the broker URL in the system browser. The host registers a one-shot token waiter keyed by the URL's `node_id` before opening. If the browser fails to open, the waiter is unregistered and an error is shown. |
-| host to webview | `project:oauthTokens` | `tokens: string, state: string` | Raw broker result delivered after the deep link returns. `state` is JSON echoing the originating `node_id`; the config panel applies tokens only to the matching node, then clears them. |
+| host to webview | `project:oauthTokens` | `tokens: string, state: string` | Raw broker result, delivered to the current live webview for the originating document. `state` is JSON echoing the originating `node_id`; the config panel applies tokens only to the matching node, then clears them. The host saves the document after the first `project:contentChanged` that follows a delivery (one-shot), so no manual save is needed. |
 
 The deep link handled by the extension is
 `<uriScheme>://rocketride.rocketride/auth/google` with query parameters
 `tokens`, `state`, and on failure `oauth_error` / `error` /
 `error_description` (see `CloudAuthProvider.handleGoogleOAuth`).
+
+## Saved config shape
+
+Tokens land at the node config **root**: `authType: "user"` and
+`userToken: "<JSON token string>"`. Node configs are flat — the engine reads
+`cfg.get('authType')` / `cfg.get('userToken')` at the top level, and the
+generated form schema names dotted `services.json` field ids (for example
+`google.userToken`) by their last component. The `parameters.*` locations some
+widgets also read are legacy and are never written by this flow.
+
+## Limitation
+
+Tokens are applied by the node config panel. If the panel is closed when the
+deep link returns, the tokens stay pending in the editor until the panel is
+reopened for the node that started the login (or until the editor reloads and
+the redelivery expires).
 
 ## Token refresh
 

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -34,6 +34,11 @@ import { handleMissingEnvVars } from '../shared/util/envVarCheck';
 const PREFS_KEY = 'rocketride.prefs';
 const LAYOUTS_KEY = 'rocketride.layouts';
 
+// How long undelivered OAuth tokens are kept for redelivery after a webview
+// reload. Long enough to cover a slow consent flow, short enough that stale
+// tokens don't linger.
+const OAUTH_REDELIVERY_TTL_MS = 5 * 60 * 1000;
+
 // =============================================================================
 // TYPES
 // =============================================================================
@@ -50,6 +55,8 @@ interface EditorState {
 	isDisposed: boolean;
 	isReady: boolean;
 	cachedStatuses: Record<string, TaskStatus>;
+	/** One-shot: save the document after the next contentChanged, so OAuth tokens reach disk without a manual save. */
+	saveAfterOAuthApply?: boolean;
 }
 
 // =============================================================================
@@ -62,6 +69,10 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 	private connectionManager = ConnectionManager.getInstance();
 	private logger = getLogger();
 	private savesForRun: Set<string> = new Set();
+	// OAuth tokens that arrived while no live webview existed for their
+	// document (e.g. the editor was recycled during the browser round-trip),
+	// keyed by document URI. Redelivered after the next view:ready.
+	private undeliveredOAuthTokens: Map<string, { tokens: string; state: string; expiresAt: number }> = new Map();
 
 	constructor(private readonly context: vscode.ExtensionContext) {
 		this.registerCommands();
@@ -302,6 +313,61 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 	}
 
 	// =========================================================================
+	// OAUTH TOKEN DELIVERY
+	// =========================================================================
+
+	/**
+	 * The live editor state for a document, if any. The custom editor is
+	 * registered with supportsMultipleEditorsPerDocument: false, so at most
+	 * one live webview exists per document.
+	 */
+	private findLiveEditorState(docKey: string): EditorState | undefined {
+		for (const editorState of this.editorStates.values()) {
+			if (!editorState.isDisposed && editorState.isReady && editorState.document.uri.toString() === docKey) {
+				return editorState;
+			}
+		}
+		return undefined;
+	}
+
+	/**
+	 * Deliver broker OAuth tokens to the live webview for the document that
+	 * started the login. The webview instance that armed the waiter may have
+	 * been disposed during the browser round-trip, so the target is resolved
+	 * at delivery time; with no live target the tokens are stashed and
+	 * redelivered after the next view:ready.
+	 */
+	private deliverOAuthTokens(docKey: string, tokens: string, state: string): void {
+		const stash = () => {
+			this.undeliveredOAuthTokens.set(docKey, { tokens, state, expiresAt: Date.now() + OAUTH_REDELIVERY_TTL_MS });
+		};
+
+		const editorState = this.findLiveEditorState(docKey);
+		if (!editorState) {
+			this.logger.info('[ProjectProvider] OAuth tokens arrived with no live editor; holding for redelivery');
+			stash();
+			return;
+		}
+
+		// Arm the one-shot save before posting: the token apply surfaces as the
+		// next project:contentChanged, which must reach disk without Ctrl+S.
+		editorState.saveAfterOAuthApply = true;
+		editorState.webviewPanel.webview.postMessage({ type: 'project:oauthTokens', tokens, state }).then(
+			(posted) => {
+				if (!posted) {
+					editorState.saveAfterOAuthApply = false;
+					stash();
+				}
+			},
+			(err: unknown) => {
+				editorState.saveAfterOAuthApply = false;
+				stash();
+				this.logger.error(`[ProjectProvider] Failed to deliver OAuth tokens: ${err}`);
+			}
+		);
+	}
+
+	// =========================================================================
 	// RESOLVE CUSTOM TEXT EDITOR
 	// =========================================================================
 
@@ -382,6 +448,18 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 					});
 					webview.postMessage({ type: 'project:dirtyState', isDirty: document.isDirty, isNew: document.isUntitled });
 
+					// Redeliver OAuth tokens that arrived while this document had no
+					// live webview. Safe ordering: the webview clears its pending
+					// tokens in the project:load handler above, so this arrives after.
+					const oauthKey = document.uri.toString();
+					const undelivered = this.undeliveredOAuthTokens.get(oauthKey);
+					if (undelivered) {
+						this.undeliveredOAuthTokens.delete(oauthKey);
+						if (undelivered.expiresAt > Date.now()) {
+							this.deliverOAuthTokens(oauthKey, undelivered.tokens, undelivered.state);
+						}
+					}
+
 					// Kick off background services refresh
 					this.connectionManager.refreshServices().catch((err) => {
 						this.logger.error(`Background services refresh failed: ${err}`);
@@ -400,7 +478,15 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 				case 'project:contentChanged': {
 					if (data.project) {
 						const content = typeof data.project === 'string' ? data.project : JSON.stringify(data.project);
-						this.applyDocumentEdit(document, content);
+						const { applied } = await this.applyDocumentEdit(document, content);
+						// One-shot save after an OAuth token apply: tokens must reach
+						// the .pipe on disk without requiring a manual save.
+						if (editorState.saveAfterOAuthApply) {
+							editorState.saveAfterOAuthApply = false;
+							if (applied || document.isDirty) {
+								await document.save();
+							}
+						}
 					}
 					break;
 				}
@@ -502,10 +588,13 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 							break;
 						}
 						// Key the waiter by the node that started the login so the
-						// deep-link return routes to the right editor.
+						// deep-link return routes to the right editor. The callback
+						// resolves the live webview at delivery time — this webview
+						// instance may be disposed during the browser round-trip.
 						const nodeId = parsedUrl.searchParams.get('node_id') || (data.url as string);
+						const docKey = document.uri.toString();
 						const unregister = CloudAuthProvider.getInstance().setPendingGoogleOAuth(nodeId, (tokens, state) => {
-							webview.postMessage({ type: 'project:oauthTokens', tokens, state });
+							this.deliverOAuthTokens(docKey, tokens, state);
 						});
 						// Pass the raw string: Uri.parse re-encodes the query and un-escapes
 						// %3B/%3A, and Zitadel's Go parser rejects raw semicolons in queries

--- a/nodes/src/nodes/core/google_access.py
+++ b/nodes/src/nodes/core/google_access.py
@@ -128,6 +128,36 @@ _G = 'https://www.googleapis.com/auth'
 # permanently delete (messages.delete); gmail.modify only trashes.
 _GMAIL_FULL = 'https://mail.google.com/'
 
+
+def _scope_satisfied(required: str, granted: set[str]) -> bool:
+    """True when a granted scope covers the required one, including supersets."""
+    if required in granted:
+        return True
+    # The full mailbox scope supersets every Gmail scope
+    if required.startswith(f'{_G}/gmail.') and _GMAIL_FULL in granted:
+        return True
+    # gmail.readonly is implied by gmail.modify (read + organize)
+    if required == f'{_G}/gmail.readonly' and f'{_G}/gmail.modify' in granted:
+        return True
+    # A '.readonly' scope is implied by its writable counterpart (drive,
+    # spreadsheets, documents, calendar, presentations, contacts)
+    if required.endswith('.readonly') and required[: -len('.readonly')] in granted:
+        return True
+    return False
+
+
+def missing_scopes(granted: set[str], required: list[str]) -> list[str]:
+    """
+    Required scopes not satisfied by the granted set.
+
+    Fail-open when the grant is unknown (empty set): older tokens may lack a
+    scope field, and the absence of evidence must not block validation.
+    """
+    if not granted:
+        return []
+    return [s for s in required if not _scope_satisfied(s, granted)]
+
+
 GMAIL = AccessSpec(
     scopes={
         'readonly': [f'{_G}/gmail.readonly'],

--- a/nodes/src/nodes/tool_gmail/IGlobal.py
+++ b/nodes/src/nodes/tool_gmail/IGlobal.py
@@ -78,15 +78,18 @@ class IGlobal(IGlobalBase):
                     warning('Gmail: sign in with Google to provide an access token')
                 else:
                     try:
+                        from nodes.core.google_access import missing_scopes
+
                         from .gmail_client import _decode_blob
                         import json as _json
 
                         token_info = _json.loads(_decode_blob(token_str))
                         granted = set((token_info.get('scope') or '').split())
                         resolved = resolve_google_access(cfg, GMAIL)
-                        _full = 'https://mail.google.com/'
-                        missing = [] if _full in granted else [s for s in resolved.scopes if s not in granted]
-                        if missing and granted:
+                        # Superset-aware (full mailbox, modify covers readonly);
+                        # empty scope field is fail-open.
+                        missing = missing_scopes(granted, resolved.scopes)
+                        if missing:
                             warning(
                                 'Gmail: your Google account authorization is missing scopes '
                                 'for the selected access tier. Please disconnect and reconnect '

--- a/nodes/src/nodes/tool_gmail/IInstance.py
+++ b/nodes/src/nodes/tool_gmail/IInstance.py
@@ -187,10 +187,12 @@ class IInstance(IInstanceBase):
         except Exception:
             pass
 
-        if _GMAIL_FULL_SCOPE in granted_scopes:
-            missing: list[str] = []
-        elif scope_available:
-            missing = [s for s in access.scopes if s not in granted_scopes]
+        if scope_available:
+            from nodes.core.google_access import missing_scopes
+
+            # Superset-aware: full mailbox covers everything, gmail.modify
+            # covers gmail.readonly. Empty scope field is fail-open.
+            missing = missing_scopes(granted_scopes, access.scopes)
         else:
             missing = []  # service account — scopes come from key, not token
 

--- a/nodes/src/nodes/tool_gmail/gmail_client.py
+++ b/nodes/src/nodes/tool_gmail/gmail_client.py
@@ -145,15 +145,16 @@ def build_service(auth_type: str, cfg: dict, scopes: list[str]) -> Any:
         if expiry_date_ms:
             expiry = _dt.datetime.utcfromtimestamp(expiry_date_ms / 1000)
 
+        from nodes.core.google_access import missing_scopes
+
         granted_scopes = set((info.get('scope') or '').split())
-        if granted_scopes and _GMAIL_FULL_SCOPE not in granted_scopes:
-            missing = [s for s in scopes if s not in granted_scopes]
-            if missing:
-                raise ValueError(
-                    'Gmail: your Google account authorization is missing required scopes '
-                    'for the selected access tier. Please disconnect and reconnect your '
-                    f'Google account. Missing: {", ".join(missing)}'
-                )
+        missing = missing_scopes(granted_scopes, scopes)
+        if missing:
+            raise ValueError(
+                'Gmail: your Google account authorization is missing required scopes '
+                'for the selected access tier. Please disconnect and reconnect your '
+                f'Google account. Missing: {", ".join(missing)}'
+            )
 
         if client_id and client_secret:
             # Standard Google OAuth2 credentials: the library handles refresh automatically.

--- a/nodes/test/tool_gmail/test_gmail.py
+++ b/nodes/test/tool_gmail/test_gmail.py
@@ -570,6 +570,59 @@ def test_check_connection_ok_with_full_scope(monkeypatch):
     assert result['action'] is None
 
 
+def test_check_connection_readonly_satisfied_by_modify(monkeypatch):
+    """A token granted gmail.modify covers the readonly tier (scope implication)."""
+    mocks = Path(__file__).resolve().parents[1] / 'mocks'
+    monkeypatch.syspath_prepend(str(mocks))
+    inst = _inst_with_token(
+        'readonly', {'access_token': 'tok', 'scope': 'https://www.googleapis.com/auth/gmail.modify'}
+    )
+    _patch_config(monkeypatch, inst)
+    result = inst.check_connection({})
+    assert result['connection_ok']
+    assert result['missing_scopes'] == []
+
+
+# ---------------------------------------------------------------------------
+# missing_scopes helper (google_access)
+# ---------------------------------------------------------------------------
+
+
+_SCOPE_G = 'https://www.googleapis.com/auth'
+
+
+def test_missing_scopes_drive_only_grant_fails_modify():
+    """The broker's default grant (drive + profile) does not cover the modify tier."""
+    granted = {f'{_SCOPE_G}/drive', f'{_SCOPE_G}/userinfo.email', f'{_SCOPE_G}/userinfo.profile', 'openid'}
+    assert ga.missing_scopes(granted, ga.GMAIL.scopes['modify']) == [f'{_SCOPE_G}/gmail.modify']
+
+
+def test_missing_scopes_modify_satisfies_readonly():
+    assert ga.missing_scopes({f'{_SCOPE_G}/gmail.modify'}, ga.GMAIL.scopes['readonly']) == []
+
+
+def test_missing_scopes_full_mailbox_satisfies_all_gmail_tiers():
+    granted = {'https://mail.google.com/'}
+    for tier_scopes in ga.GMAIL.scopes.values():
+        assert ga.missing_scopes(granted, tier_scopes) == []
+
+
+def test_missing_scopes_empty_grant_is_fail_open():
+    """Older tokens without a scope field must not be reported as missing scopes."""
+    assert ga.missing_scopes(set(), ga.GMAIL.scopes['send']) == []
+
+
+def test_missing_scopes_readonly_implied_by_writable_counterpart():
+    """Generic implication: a .readonly requirement is covered by its writable scope."""
+    assert ga.missing_scopes({f'{_SCOPE_G}/drive'}, ga.DRIVE.scopes['readonly']) == []
+
+
+def test_missing_scopes_exact_match_still_required_for_extended():
+    granted = {f'{_SCOPE_G}/gmail.modify'}
+    missing = ga.missing_scopes(granted, ga.GMAIL.scopes['send'])
+    assert missing == [f'{_SCOPE_G}/gmail.send']
+
+
 def test_thread_trash_and_untrash():
     inst = make_inst(results={'trash': {'id': 't1', 'messages': []}, 'untrash': {'id': 't1', 'messages': []}})
     assert inst.thread_trash({'id': 't1'})['id'] == 't1'

--- a/packages/shared-ui/src/components/canvas/components/panels/node-config/NodeConfigPanel.tsx
+++ b/packages/shared-ui/src/components/canvas/components/panels/node-config/NodeConfigPanel.tsx
@@ -286,6 +286,14 @@ export default function NodeConfigPanel({ node, onClose }: INodeConfigPanelProps
 		}
 		if (targetNodeId && targetNodeId !== node.id) return;
 
+		// updateNode silently no-ops on a locked graph — surface it and keep
+		// the tokens pending; unlocking re-runs this effect and applies them.
+		if (isLocked) {
+			setValidationError('The canvas is locked — unlock it to apply the Google sign-in tokens.');
+			return;
+		}
+		setValidationError(null);
+
 		const enrichedConfig = applyGoogleTokens(node.data.config ?? {}, tokens, state);
 		persistTokensFromFormData(enrichedConfig, persistedAuthTokens);
 		setFormValues(enrichedConfig);
@@ -293,7 +301,7 @@ export default function NodeConfigPanel({ node, onClose }: INodeConfigPanelProps
 
 		clearPendingOAuthTokens?.();
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [pendingOAuthTokens, node.id]);
+	}, [pendingOAuthTokens, node.id, isLocked]);
 
 	// --- RJSF change handler ------------------------------------------------
 	const onChange = useCallback(
@@ -338,7 +346,7 @@ export default function NodeConfigPanel({ node, onClose }: INodeConfigPanelProps
 					return error;
 				});
 		},
-		[formValues],
+		[formValues]
 	);
 
 	// --- Save: details only (no schema) ------------------------------------

--- a/packages/shared-ui/src/components/canvas/components/panels/node-config/authTokenHelpers.ts
+++ b/packages/shared-ui/src/components/canvas/components/panels/node-config/authTokenHelpers.ts
@@ -45,15 +45,24 @@
  * Kept separate from RJSF form state to survive field-dropping re-renders.
  */
 export interface IAuthTokensRef {
-	/** Generic user authentication token. */
+	/** Generic user authentication token (parameters scope). */
 	userToken?: string;
-	/** Authentication method identifier (e.g. "oauth2", "apikey"). */
+	/** Authentication method identifier (e.g. "oauth2", "apikey") (parameters scope). */
 	authType?: string;
-	/** Google-specific OAuth tokens and expiry metadata. */
+	/** Google-specific OAuth tokens and expiry metadata (parameters scope). */
 	google?: {
 		userToken?: string;
 		accessToken?: string;
 		tokenExpiry?: number;
+	};
+	/**
+	 * Tokens living at the config ROOT — flat node schemas (e.g. tool_gmail)
+	 * keep authType/userToken at the top level, which is where the engine
+	 * reads them (cfg.get('authType') / cfg.get('userToken')).
+	 */
+	root?: {
+		userToken?: string;
+		authType?: string;
 	};
 }
 
@@ -91,6 +100,15 @@ export type IFormDataWithParameters = Record<string, any> & {
 export function persistTokensFromFormData(formData: IFormDataWithParameters, tokensRef: { current: IAuthTokensRef }): void {
 	const params = formData?.parameters ?? {};
 
+	// Root-scoped tokens (flat node schemas like tool_gmail)
+	if (formData?.userToken || formData?.authType) {
+		tokensRef.current.root = {
+			...(tokensRef.current.root ?? {}),
+			...(formData.userToken && { userToken: formData.userToken as string }),
+			...(formData.authType && { authType: formData.authType as string }),
+		};
+	}
+
 	// Copy each known token field, but only if a value exists
 	if (params.userToken) tokensRef.current.userToken = params.userToken;
 	if (params.authType) tokensRef.current.authType = params.authType;
@@ -126,14 +144,20 @@ export function persistTokensFromFormData(formData: IFormDataWithParameters, tok
  * @returns Form data with tokens restored.
  */
 export function mergeAuthTokensIntoFormData(formData: IFormDataWithParameters, previousFormData: IFormDataWithParameters, tokensRef: { current: IAuthTokensRef }): IFormDataWithParameters {
+	const prevRoot = previousFormData ?? {};
 	const prevParams = previousFormData?.parameters ?? {};
 	const newParams = formData?.parameters ?? {};
 	const persisted = tokensRef.current;
 
-	// Resolve each token: previousParams > persistedRef > newParams
+	// Root-scoped tokens (flat node schemas like tool_gmail). userToken is a
+	// conditional-hidden field RJSF drops while authType === 'service', so it
+	// is restored from the previous data / ref. authType is a visible field —
+	// the new form value must win or the user's selection reverts on change.
+	const rootUserToken = formData?.userToken || prevRoot.userToken || persisted.root?.userToken;
+	const rootAuthType = formData?.authType || prevRoot.authType || persisted.root?.authType;
+
+	// Parameters-scoped tokens: previousParams > persistedRef (> newParams for authType)
 	const userToken = prevParams.userToken || persisted.userToken;
-	// authType is a visible dropdown, not a hidden field RJSF drops — the new
-	// form value must win or the user's selection reverts on every change.
 	const authType = newParams.authType || prevParams.authType || persisted.authType;
 	const googleUserToken = prevParams.google?.userToken || persisted.google?.userToken;
 	const googleAccessToken = prevParams.google?.accessToken || persisted.google?.accessToken;
@@ -142,20 +166,37 @@ export function mergeAuthTokensIntoFormData(formData: IFormDataWithParameters, p
 	// Build merged form data with recovered tokens overlaid
 	const merged: IFormDataWithParameters = {
 		...formData,
-		parameters: {
+		...(rootUserToken && { userToken: rootUserToken }),
+		...(rootAuthType && { authType: rootAuthType }),
+	};
+
+	// Emit `parameters`/`google` only when the form already carries them or a
+	// token resolved into that scope — fabricating empty objects here pollutes
+	// every node's saved config with `"parameters": {"google": {}}`.
+	const google = {
+		...(newParams.google ?? {}),
+		...(googleUserToken && { userToken: googleUserToken }),
+		...(googleAccessToken && { accessToken: googleAccessToken }),
+		...(googleTokenExpiry && { tokenExpiry: googleTokenExpiry }),
+	};
+	const hasGoogle = Object.keys(google).length > 0;
+	if (formData?.parameters || userToken || authType || hasGoogle) {
+		merged.parameters = {
 			...newParams,
 			...(userToken && { userToken }),
 			...(authType && { authType }),
-			google: {
-				...(newParams.google ?? {}),
-				...(googleUserToken && { userToken: googleUserToken }),
-				...(googleAccessToken && { accessToken: googleAccessToken }),
-				...(googleTokenExpiry && { tokenExpiry: googleTokenExpiry }),
-			},
-		},
-	};
+			...(hasGoogle && { google }),
+		};
+	}
 
 	// Sync the ref with the latest resolved tokens
+	if (rootUserToken || rootAuthType) {
+		tokensRef.current.root = {
+			...(tokensRef.current.root ?? {}),
+			...(rootUserToken && { userToken: rootUserToken as string }),
+			...(rootAuthType && { authType: rootAuthType as string }),
+		};
+	}
 	if (userToken) tokensRef.current.userToken = userToken;
 	if (authType) tokensRef.current.authType = authType;
 	if (googleUserToken || googleAccessToken || googleTokenExpiry) {

--- a/packages/shared-ui/src/components/canvas/components/panels/node-config/authTokenHelpers.ts
+++ b/packages/shared-ui/src/components/canvas/components/panels/node-config/authTokenHelpers.ts
@@ -132,7 +132,9 @@ export function mergeAuthTokensIntoFormData(formData: IFormDataWithParameters, p
 
 	// Resolve each token: previousParams > persistedRef > newParams
 	const userToken = prevParams.userToken || persisted.userToken;
-	const authType = prevParams.authType || persisted.authType || newParams.authType;
+	// authType is a visible dropdown, not a hidden field RJSF drops — the new
+	// form value must win or the user's selection reverts on every change.
+	const authType = newParams.authType || prevParams.authType || persisted.authType;
 	const googleUserToken = prevParams.google?.userToken || persisted.google?.userToken;
 	const googleAccessToken = prevParams.google?.accessToken || persisted.google?.accessToken;
 	const googleTokenExpiry = prevParams.google?.tokenExpiry || persisted.google?.tokenExpiry;
@@ -185,8 +187,9 @@ export function mergeAuthTokensIntoFormData(formData: IFormDataWithParameters, p
  * @param onChanged  - Callback to notify the host that content changed.
  */
 export async function persistOAuthTokensAndSave(nodeId: string, formData: IFormDataWithParameters, updateNode: (nodeId: string, data: Record<string, unknown>) => void, onChanged: () => void): Promise<void> {
-	// Apply token-enriched form data to the node
-	updateNode(nodeId, { formData });
+	// Apply token-enriched form data to the node's canonical config field —
+	// serialization reads data.config, so any other key is never saved.
+	updateNode(nodeId, { config: formData });
 
 	// Wait for React to flush: microtask → animation frame → resolved
 	await new Promise<void>((resolve) => {

--- a/packages/shared-ui/src/components/canvas/components/panels/node-config/useOAuthCallbacks.ts
+++ b/packages/shared-ui/src/components/canvas/components/panels/node-config/useOAuthCallbacks.ts
@@ -28,9 +28,14 @@ export function useOAuthCallbacks() {
 	 * `tokens`/`state` strings produced by the OAuth broker — shared by the
 	 * URL-param path (web) and the host-message path (VS Code).
 	 *
+	 * Tokens are written to the form-data ROOT (`authType`, `userToken`): node
+	 * configs are flat — the engine reads cfg.get('authType')/cfg.get('userToken')
+	 * at the top level and the generated RJSF schema names dotted services.json
+	 * field ids by their last component, so root is the only location both see.
+	 *
 	 * @param formData The node's current form data.
 	 * @param tokensParam JSON string of `{access_token, refresh_token, ...}`.
-	 * @param stateParam JSON string of `{service, type, ...}` (may be empty).
+	 * @param stateParam JSON string of `{type, node_id, ...}` (may be empty).
 	 * @return The enriched form data, or the input unchanged when no tokens.
 	 */
 	const applyGoogleTokens = useCallback(
@@ -38,14 +43,12 @@ export function useOAuthCallbacks() {
 			if (!tokensParam) return formData;
 
 			let parsedState: Record<string, unknown> = {};
-			let service: Record<string, unknown> = {};
 			let tokens: Record<string, unknown> = {};
 			let authType = '';
 
 			try {
 				if (stateParam) {
 					parsedState = JSON.parse(stateParam);
-					service = JSON.parse((parsedState?.service as string) ?? '{}');
 					authType = (parsedState?.type as string) || '';
 				}
 				tokens = JSON.parse(tokensParam);
@@ -55,9 +58,6 @@ export function useOAuthCallbacks() {
 				// token object full of undefined fields.
 				return formData;
 			}
-
-			const existingParams = (formData.parameters as Record<string, unknown>) || {};
-			const serviceParams = (service.parameters as Record<string, unknown>) || {};
 
 			const oAuthServerUrl = tokens.oauth_server_url || `${oauth2RootUrl || ''}/refresh`;
 
@@ -71,21 +71,12 @@ export function useOAuthCallbacks() {
 			};
 			const userTokenJson = JSON.stringify(fullTokenObject);
 
+			// A fresh user token with no/malformed state must still switch the
+			// node to user auth — 'service' would make the engine ignore it.
 			return {
 				...formData,
-				parameters: {
-					...existingParams,
-					...serviceParams,
-					userToken: userTokenJson,
-					...(authType && { authType }),
-					google: {
-						...((existingParams.google as Record<string, unknown>) || {}),
-						...((serviceParams.google as Record<string, unknown>) || {}),
-						userToken: userTokenJson,
-						accessToken: tokens.access_token,
-						tokenExpiry: tokens.expiry_date,
-					},
-				},
+				userToken: userTokenJson,
+				authType: authType || 'user',
 			};
 		},
 		[oauth2RootUrl]

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
@@ -76,9 +76,10 @@ export default function LoginWithGoogleButton<T = unknown, S extends StrictRJSFS
 			);
 		}
 
-		// Default to 'user' auth type for personal Google OAuth (as opposed to service account)
-		const authType = formValues.parameters?.authType || 'user';
-		url.searchParams.set('type', authType);
+		// "Login with Google" is personal OAuth by definition; service accounts
+		// use an uploaded key, never this flow. The broker echoes the type back
+		// in `state`, which switches the node's authType to 'user' on success.
+		url.searchParams.set('type', 'user');
 
 		// Tell the broker where to return tokens. Web hosts redirect back to the
 		// current page; hosts that can't receive a web redirect (VS Code) supply

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
@@ -86,20 +86,22 @@ export default function LoginWithGoogleButton<T = unknown, S extends StrictRJSFS
 		// a deep link via oauthReturnUrl that they intercept out-of-band.
 		url.searchParams.set('baseURL', oauthReturnUrl || window.location.href);
 
-		// For Gmail tiers beyond the broker's default (modify), pass the required
-		// scopes explicitly so the broker requests the right Google consent. Keys
-		// mirror google_access.py GMAIL.scopes. readonly/modify are omitted because
-		// the broker handles them by default; non-Gmail services whose access field
+		// Pass the selected tier's Gmail scopes explicitly — the broker's default
+		// consent grants only Drive + profile scopes, never Gmail, so every tier
+		// (including readonly/modify) must request its scopes here. Keys mirror
+		// google_access.py GMAIL.scopes; non-Gmail services whose access field
 		// uses different values (e.g. 'write') won't match any key here.
 		const _G = 'https://www.googleapis.com/auth';
-		const GMAIL_EXTENDED_SCOPES: Record<string, string[]> = {
+		const GMAIL_TIER_SCOPES: Record<string, string[]> = {
+			readonly: [`${_G}/gmail.readonly`],
+			modify: [`${_G}/gmail.modify`],
 			send: [`${_G}/gmail.modify`, `${_G}/gmail.send`],
 			settings: [`${_G}/gmail.modify`, `${_G}/gmail.settings.basic`],
 			settings_sharing: [`${_G}/gmail.modify`, `${_G}/gmail.settings.basic`, `${_G}/gmail.settings.sharing`],
 			full: ['https://mail.google.com/'],
 		};
 		const accessTier = (formValues.access ?? formValues.parameters?.access) as string | undefined;
-		const tierScopes = accessTier ? GMAIL_EXTENDED_SCOPES[accessTier] : undefined;
+		const tierScopes = accessTier ? GMAIL_TIER_SCOPES[accessTier] : undefined;
 		if (tierScopes?.length) {
 			url.searchParams.set('scope', tierScopes.join(' '));
 		}

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
@@ -98,7 +98,7 @@ export default function LoginWithGoogleButton<T = unknown, S extends StrictRJSFS
 			settings_sharing: [`${_G}/gmail.modify`, `${_G}/gmail.settings.basic`, `${_G}/gmail.settings.sharing`],
 			full: ['https://mail.google.com/'],
 		};
-		const accessTier = formValues.parameters?.access as string | undefined;
+		const accessTier = (formValues.access ?? formValues.parameters?.access) as string | undefined;
 		const tierScopes = accessTier ? GMAIL_EXTENDED_SCOPES[accessTier] : undefined;
 		if (tierScopes?.length) {
 			url.searchParams.set('scope', tierScopes.join(' '));
@@ -120,8 +120,9 @@ export default function LoginWithGoogleButton<T = unknown, S extends StrictRJSFS
 		return 'primary';
 	}, [formContext?.formDataErrors]);
 
-	// Check if user is already authenticated by looking for a userToken in either nested or flat location
-	const authenticated = formValues?.parameters?.google?.userToken?.length || formValues?.parameters?.userToken?.length;
+	// Check if user is already authenticated. Flat node schemas (tool_gmail)
+	// keep userToken at the config root; the parameters.* locations are legacy.
+	const authenticated = formValues?.userToken?.length || formValues?.parameters?.google?.userToken?.length || formValues?.parameters?.userToken?.length;
 
 	// i18n is not initialized in every host (e.g. the VS Code webview). When a key
 	// doesn't resolve, t() returns the key itself — fall back to a literal so the
@@ -137,8 +138,8 @@ export default function LoginWithGoogleButton<T = unknown, S extends StrictRJSFS
 	// marker so GoogleDrivePickerWidget can detect when a fresh token is available after OAuth.
 	// This effect does NOT open the picker - it only signals token availability.
 	useEffect(() => {
-		// Look for the user token in both possible locations (nested under google or flat)
-		const savedUserToken = formValues.parameters?.google?.userToken || formValues.parameters?.userToken;
+		// Look for the user token in all possible locations (config root first, then legacy nested)
+		const savedUserToken = formValues.userToken || formValues.parameters?.google?.userToken || formValues.parameters?.userToken;
 		const pickerWindow = window as typeof window & { __googlePickerLastToken?: string };
 
 		if (!savedUserToken) {


### PR DESCRIPTION
## Summary

Three rounds of fixes for the Gmail node's Google OAuth flow in the IDE (and the shared web path).

**Round 1 (06eb43f6):** after the OAuth redirect, the token-enriched config was written to a dead `formData` key (serialization reads only `data.config`), the authType dropdown reverted because the merge helper let the previous value beat the user's selection, and the login button sent the node's current authType (`service`) to the broker.

**Round 2 (57deca64):** retest still failed — two deeper layers:

- **Config shape:** the engine reads flat root keys (`cfg.get('authType')` / `cfg.get('userToken')`, `IGlobal.py:64,77`) and the generated RJSF schema is flat root (dotted `services.json` field ids reduce to their last component — `services.cpp:getFieldName`). `applyGoogleTokens` nested everything under `parameters.*` — invisible to both. Now writes root `authType: 'user'` + root `userToken`. The merge helpers track a root token scope and no longer fabricate `parameters: {"google": {}}` on every node (this was polluting unrelated nodes' saved configs). The button reads root-first.
- **Delivery/persistence:** the host waiter captured the webview instance at login time — tokens posted to a dead webview if the editor recycled during the browser trip. Now the live webview for the originating document is resolved at delivery time, undelivered tokens are stashed and redelivered after the next `view:ready` (5-min TTL), and the host saves the document once after the token-apply `contentChanged` — previously a successful apply only marked the doc dirty and the `.pipe` on disk never changed without Ctrl+S. A locked canvas now surfaces an error instead of silently discarding tokens, and retries on unlock.

**Round 3 (6f745a57):** redirect + persistence now work, but validation warned `Missing: .../gmail.modify`. A live token's granted scopes were `drive userinfo.email userinfo.profile openid` — the hosted broker's default consent grants **no Gmail scopes**, and the button only sent an explicit `scope` param for extended tiers, wrongly assuming the broker covers readonly/modify by default. Fixes:

- Complete `GMAIL_TIER_SCOPES` table — every tier now sends its scopes explicitly to the broker.
- Shared `google_access.missing_scopes()` replaces three copy-pasted checkers, superset-aware (full mailbox ⊇ all Gmail scopes; `gmail.modify` ⊇ `gmail.readonly`; `.readonly` ⊆ writable counterpart; empty grant fail-open for older tokens). Also fixes the latent false warning when downgrading tier below the consented scope.
- Tests for the helper + check_connection implication case.

`apps/vscode/docs/google-oauth.md` updated (delivery semantics, auto-save, saved config shape, explicit tier scopes, panel-open + no-disconnect limitations).

**Migration:** tokens minted before round 3 carry a Drive-only grant — disconnect/reconnect required. No disconnect affordance exists yet (follow-up candidate).

Fixes #1547

## Testing

- `python -m pytest nodes/test/tool_gmail/` — 91 passed.
- `python -m ruff check/format` clean on touched python; `./builder build vscode` passes; `npx tsc --noEmit` clean for the extension host; prettier clean.
- Manual (dev host): login on Gmail node → consent screen shows Gmail permission for the tier → panel shows Authenticated, Authentication Type = User; `.pipe` auto-saves with root `"authType": "user"` + root `"userToken"` whose `scope` contains `gmail.modify`; validate/save shows no missing-scope warning; tier downgrade after connect no longer warns; close/reopen editor mid-consent → tokens still applied via redelivery; locked canvas shows error, applies after unlock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Google OAuth tokens are now stored consistently in node configurations.
  - OAuth callbacks are reliably delivered across VS Code editor reloads and automatically saved.
  - Gmail access tiers now request and validate the appropriate permissions, including read-only access.
  - Authentication remains pending while a canvas is locked and resumes after unlocking.

- **Bug Fixes**
  - Improved handling of OAuth tokens when configuration panels are closed or temporarily unavailable.
  - Added support for recognizing equivalent or broader Gmail permissions.
  - Prevented OAuth tokens from being applied to the wrong node configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->