### PR TITLE
feat(nodes): add tool_calendar — Google Calendar tool node

### DIFF
--- a/nodes/src/nodes/core/google_access.py
+++ b/nodes/src/nodes/core/google_access.py
@@ -158,7 +158,9 @@ DOCS = AccessSpec(
 CALENDAR = AccessSpec(
     scopes={'readonly': [f'{_G}/calendar.readonly'], 'write': [f'{_G}/calendar']},
     default='write',
-    flags=('allowDelete',),
+    # allowPublicSharing gates default/domain ACL grants (calendar exposure),
+    # mirroring the Drive sharing gate; allowDelete gates event/calendar deletion.
+    flags=('allowDelete', 'allowPublicSharing'),
 )
 SLIDES = AccessSpec(
     scopes={'readonly': [f'{_G}/presentations.readonly'], 'write': [f'{_G}/presentations']},

--- a/nodes/src/nodes/tool_google_workspace/calendar.svg
+++ b/nodes/src/nodes/tool_google_workspace/calendar.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="#4285F4" d="M18 3h-1V1h-2v2H9V1H7v2H6a3 3 0 0 0-3 3v13a3 3 0 0 0 3 3h12a3 3 0 0 0 3-3V6a3 3 0 0 0-3-3zm1 16a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V9h14v10z"/>
+  <path fill="#4285F4" d="M8 12h3v3H8zm0 0"/>
+</svg>

--- a/nodes/src/nodes/tool_google_workspace/calendar/IGlobal.py
+++ b/nodes/src/nodes/tool_google_workspace/calendar/IGlobal.py
@@ -1,0 +1,36 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Google Calendar tool node global state backed by the shared Workspace lifecycle."""
+
+from ..IGlobal import GoogleToolGlobalBase
+from .client import SERVICE
+
+
+class IGlobal(GoogleToolGlobalBase):
+    """Global state for Google Calendar: resolved access plus a Calendar v3 service."""
+
+    SERVICE = SERVICE
+    SPEC_NAME = 'CALENDAR'

--- a/nodes/src/nodes/tool_google_workspace/calendar/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/calendar/IInstance.py
@@ -1,0 +1,834 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Google Calendar tool node instance.
+
+Exposes the Calendar v3 surface as agent tools: list/get/create/update/move/
+delete events (including recurring-series instances and natural-language
+quick-add), query free/busy, and manage calendars and access-control (ACL)
+rules. Write operations require the ``write`` tier; deleting events or calendars
+additionally requires the ``allowDelete`` flag, and ACL rules that expose the
+calendar beyond individual grantees (scopeType ``default``/``domain``) require
+the ``allowPublicSharing`` flag.
+
+Operational targets (calendarId, eventId, ruleId) are always invoke-time
+parameters — never node config. calendarId defaults to ``'primary'``.
+"""
+
+from __future__ import annotations
+
+from rocketlib import tool_function
+
+from ai.common.utils import normalize_tool_input, require_str
+
+from ..IInstance import GoogleToolInstanceBase
+from .client import (
+    SERVICE,
+    clean_acl_list,
+    clean_acl_rule,
+    clean_calendar,
+    clean_calendar_list,
+    clean_event,
+    clean_event_list,
+    clean_freebusy,
+    execute,
+)
+from .IGlobal import IGlobal
+
+# sendUpdates controls whether attendee invitations / notifications go out.
+# We ALWAYS send it explicitly: Google's implicit default is 'none', which would
+# silently NOT notify attendees; the documented node default is 'all'.
+_SEND_UPDATES = ('all', 'externalOnly', 'none')
+_DEFAULT_SEND_UPDATES = 'all'
+
+# ACL roles accepted by acl_insert.
+_ACL_ROLES = ('reader', 'writer', 'owner', 'freeBusyReader')
+_ACL_SCOPE_TYPES = ('user', 'group', 'domain', 'default')
+
+_DEFAULT_MAX_RESULTS = 50
+_MAX_RESULTS_CAP = 250
+
+
+class IInstance(GoogleToolInstanceBase):
+    IGlobal: IGlobal
+    SERVICE = SERVICE
+
+    # -----------------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------------
+
+    def _require_delete(self, op: str) -> None:
+        """Gate deletion behind the ``allowDelete`` flag (checked after the write tier).
+
+        event_delete / calendar_delete permanently remove data; the write tier
+        alone is not consent, so the destructive gate must also be enabled
+        explicitly in the node config.
+        """
+        self._access().require_flag('allowDelete', op)
+
+    @staticmethod
+    def _calendar_id(args: dict) -> str:
+        """Read the target calendarId, defaulting to 'primary' when omitted."""
+        value = args.get('calendarId')
+        if value is None or value == '':
+            return 'primary'
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError('"calendarId" must be a non-empty string')
+        return value.strip()
+
+    @staticmethod
+    def _clamp_results(args: dict) -> int:
+        """Read maxResults, defaulting only on None and clamping to [1, 250]; reject bools.
+
+        `args.get(key) or default` would silently turn an explicit 0 into the
+        default, bypassing the clamp; a bool must never be coerced to 1.
+        """
+        value = args.get('maxResults')
+        if value is None:
+            value = _DEFAULT_MAX_RESULTS
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError('"maxResults" must be an integer')
+        return max(1, min(value, _MAX_RESULTS_CAP))
+
+    @staticmethod
+    def _opt_str(args: dict, key: str, op: str) -> str | None:
+        """Read an optional non-empty string arg; reject present non-strings."""
+        value = args.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f'{op}: "{key}" must be a non-empty string')
+        return value
+
+    @staticmethod
+    def _opt_clearable_str(args: dict, key: str, op: str) -> str | None:
+        """Read an optional string that may be empty to clear an existing field."""
+        value = args.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError(f'{op}: "{key}" must be a string')
+        return value
+
+    @staticmethod
+    def _require_obj(args: dict, key: str, op: str) -> dict:
+        """Validate a required non-empty object (e.g. an event start/end)."""
+        value = args.get(key)
+        if not isinstance(value, dict) or not value:
+            raise ValueError(f'{op}: "{key}" must be a non-empty object')
+        return value
+
+    @staticmethod
+    def _opt_obj(args: dict, key: str, op: str) -> dict | None:
+        """Validate an optional non-empty object when present."""
+        value = args.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, dict) or not value:
+            raise ValueError(f'{op}: "{key}" must be a non-empty object')
+        return value
+
+    @staticmethod
+    def _opt_attendees(args: dict, op: str) -> list | None:
+        """Validate an optional attendees list of objects (each carrying at least an email)."""
+        value = args.get('attendees')
+        if value is None:
+            return None
+        if not isinstance(value, list) or not all(isinstance(a, dict) for a in value):
+            raise ValueError(f'{op}: "attendees" must be a list of attendee objects, e.g. [{{"email": "a@b.com"}}]')
+        return value
+
+    @staticmethod
+    def _opt_str_list(args: dict, key: str, op: str) -> list[str] | None:
+        """Validate an optional non-empty list of non-empty strings (e.g. RRULE recurrence lines)."""
+        value = args.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, list) or not value:
+            raise ValueError(f'{op}: "{key}" must be a non-empty list')
+        if not all(isinstance(i, str) and i.strip() for i in value):
+            raise ValueError(f'{op}: "{key}" must contain only non-empty strings')
+        return value
+
+    @staticmethod
+    def _str_list(args: dict, key: str, op: str) -> list[str]:
+        """Validate a required non-empty list of non-empty strings (e.g. calendar ids)."""
+        value = args.get(key)
+        if not isinstance(value, list) or not value:
+            raise ValueError(f'{op}: "{key}" must be a non-empty list')
+        if not all(isinstance(i, str) and i.strip() for i in value):
+            raise ValueError(f'{op}: "{key}" must contain only non-empty strings')
+        return value
+
+    # =======================================================================
+    # DIAGNOSTICS
+    # =======================================================================
+
+    @tool_function(
+        description=(
+            'Check the Google Calendar connection and verify that the granted OAuth scopes cover the '
+            "node's configured access tier. Call this when a Calendar operation fails with a scope or "
+            'permission error. Returns connection_ok: true when the required scopes are present.'
+        ),
+        input_schema={'type': 'object', 'properties': {}, 'required': []},
+    )
+    def check_connection(self, args: dict) -> dict:
+        """Check Calendar connection status and whether granted OAuth scopes cover the access tier. Read-only."""
+        return self._check_connection_impl(probe=lambda s: execute(s.calendarList().list(maxResults=1)))
+
+    # =======================================================================
+    # EVENTS — read
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': [],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'timeMin': {'type': 'string', 'description': 'RFC3339 lower bound (exclusive) for event end times'},
+                'timeMax': {'type': 'string', 'description': 'RFC3339 upper bound (exclusive) for event start times'},
+                'q': {'type': 'string', 'description': 'Free-text search over event fields'},
+                'maxResults': {
+                    'type': 'integer',
+                    'description': 'Max events per page, clamped to 1..250 (default 50)',
+                },
+                'singleEvents': {
+                    'type': 'boolean',
+                    'description': 'Expand recurring events into single instances (needed for reliable ordering)',
+                },
+                'pageToken': {
+                    'type': 'string',
+                    'description': 'nextPageToken from a prior page to fetch the next page',
+                },
+                'syncToken': {
+                    'type': 'string',
+                    'description': (
+                        'nextSyncToken from a prior full sync. Returns only events changed since then '
+                        '(incremental sync). Do not combine with timeMin/timeMax/q.'
+                    ),
+                },
+            },
+        },
+        description=(
+            'List events on a calendar. Returns {events, nextPageToken, nextSyncToken}. '
+            'For incremental sync, run once (optionally with a time window), store the returned '
+            'nextSyncToken, and pass it back as syncToken next time to receive only changes since. '
+            'nextSyncToken is present only on the last page of a fully-consumed listing. '
+            'Cleaned events include id, status, summary, description, location, htmlLink, start, end, '
+            'organizer, recurrence, attendees, created, and updated when present. Read-only.'
+        ),
+    )
+    def event_list(self, args: dict) -> dict:
+        """List events on a calendar, with optional incremental sync via syncToken. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        params: dict = {'calendarId': self._calendar_id(args), 'maxResults': self._clamp_results(args)}
+        for key in ('timeMin', 'timeMax', 'q', 'pageToken', 'syncToken'):
+            val = self._opt_str(args, key, 'event_list')
+            if val is not None:
+                params[key] = val
+        if 'syncToken' in params and any(key in params for key in ('timeMin', 'timeMax', 'q')):
+            raise ValueError('event_list: "syncToken" cannot be combined with "timeMin", "timeMax", or "q"')
+        single = args.get('singleEvents')
+        if single is not None:
+            if not isinstance(single, bool):
+                raise ValueError('event_list: "singleEvents" must be a boolean')
+            params['singleEvents'] = single
+        data = execute(self._svc().events().list(**params))
+        return clean_event_list(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['eventId'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'eventId': {'type': 'string', 'description': 'The event id to fetch'},
+            },
+        },
+        description=(
+            'Get a single event by id. Returns the cleaned event. '
+            'Cleaned events include id, status, summary, description, location, htmlLink, start, end, '
+            'organizer, recurrence, attendees, created, and updated when present. Read-only.'
+        ),
+    )
+    def event_get(self, args: dict) -> dict:
+        """Get a single event by id. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        cal_id = self._calendar_id(args)
+        event_id = require_str(args, 'eventId', tool_name='event_get')
+        data = execute(self._svc().events().get(calendarId=cal_id, eventId=event_id))
+        return clean_event(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['eventId'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'eventId': {'type': 'string', 'description': 'The recurring-series event id to expand'},
+                'maxResults': {
+                    'type': 'integer',
+                    'description': 'Max instances per page, clamped to 1..250 (default 50)',
+                },
+                'pageToken': {'type': 'string', 'description': 'nextPageToken from a prior page'},
+            },
+        },
+        description=(
+            'Expand a recurring event into its individual instances (occurrences). '
+            'Returns {events, nextPageToken}. '
+            'Cleaned events include id, status, summary, description, location, htmlLink, start, end, '
+            'organizer, recurrence, attendees, created, and updated when present. Read-only.'
+        ),
+    )
+    def event_instances(self, args: dict) -> dict:
+        """Expand a recurring event into its individual instances. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        cal_id = self._calendar_id(args)
+        event_id = require_str(args, 'eventId', tool_name='event_instances')
+        params: dict = {'calendarId': cal_id, 'eventId': event_id, 'maxResults': self._clamp_results(args)}
+        page_token = self._opt_str(args, 'pageToken', 'event_instances')
+        if page_token is not None:
+            params['pageToken'] = page_token
+        data = execute(self._svc().events().instances(**params))
+        return clean_event_list(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['timeMin', 'timeMax', 'calendarIds'],
+            'properties': {
+                'timeMin': {'type': 'string', 'description': 'RFC3339 start of the query window'},
+                'timeMax': {'type': 'string', 'description': 'RFC3339 end of the query window'},
+                'calendarIds': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': 'Calendar ids to query free/busy for (e.g. ["primary", "team@x.com"])',
+                },
+            },
+        },
+        description=(
+            'Query free/busy information across one or more calendars in a time window. '
+            'Returns {timeMin, timeMax, calendars} where each calendar has its busy ranges and any errors. Read-only.'
+        ),
+    )
+    def freebusy_query(self, args: dict) -> dict:
+        """Query free/busy ranges across calendars in a time window. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        time_min = require_str(args, 'timeMin', tool_name='freebusy_query')
+        time_max = require_str(args, 'timeMax', tool_name='freebusy_query')
+        ids = self._str_list(args, 'calendarIds', 'freebusy_query')
+        body = {'timeMin': time_min, 'timeMax': time_max, 'items': [{'id': c} for c in ids]}
+        data = execute(self._svc().freebusy().query(body=body))
+        return clean_freebusy(data)
+
+    # =======================================================================
+    # CALENDARS / ACL — read
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': [],
+            'properties': {
+                'maxResults': {
+                    'type': 'integer',
+                    'description': 'Max calendars per page, clamped to 1..250 (default 50)',
+                },
+                'pageToken': {'type': 'string', 'description': 'nextPageToken from a prior page'},
+                'syncToken': {'type': 'string', 'description': 'nextSyncToken for incremental calendar-list sync'},
+            },
+        },
+        description=(
+            "List the calendars on the user's calendar list. Returns {calendars, nextPageToken, nextSyncToken}. "
+            'Read-only.'
+        ),
+    )
+    def calendar_list(self, args: dict) -> dict:
+        """List the calendars on the user's calendar list. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        params: dict = {'maxResults': self._clamp_results(args)}
+        for key in ('pageToken', 'syncToken'):
+            val = self._opt_str(args, key, 'calendar_list')
+            if val is not None:
+                params[key] = val
+        data = execute(self._svc().calendarList().list(**params))
+        return clean_calendar_list(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': [],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+            },
+        },
+        description='Get a calendar resource (metadata: id, summary, timeZone, description). Read-only.',
+    )
+    def calendar_get(self, args: dict) -> dict:
+        """Get a calendar resource by id. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        cal_id = self._calendar_id(args)
+        data = execute(self._svc().calendars().get(calendarId=cal_id))
+        return clean_calendar(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': [],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'pageToken': {'type': 'string', 'description': 'nextPageToken from a prior page'},
+            },
+        },
+        description=(
+            "List a calendar's access-control (ACL) rules (who can see/edit it and at what role). "
+            'Returns {rules, nextPageToken}. Read-only.'
+        ),
+    )
+    def acl_list(self, args: dict) -> dict:
+        """List a calendar's ACL rules. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        params: dict = {'calendarId': self._calendar_id(args)}
+        page_token = self._opt_str(args, 'pageToken', 'acl_list')
+        if page_token is not None:
+            params['pageToken'] = page_token
+        data = execute(self._svc().acl().list(**params))
+        return clean_acl_list(data)
+
+    # =======================================================================
+    # EVENTS — write
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['summary', 'start', 'end'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'summary': {'type': 'string', 'description': 'Event title'},
+                'start': {
+                    'type': 'object',
+                    'description': 'Event start, e.g. {"dateTime": "2026-07-11T09:00:00-07:00"} or {"date": "2026-07-11"}',
+                },
+                'end': {'type': 'object', 'description': 'Event end, same shape as start'},
+                'description': {'type': 'string', 'description': 'Event description (optional)'},
+                'location': {'type': 'string', 'description': 'Event location (optional)'},
+                'attendees': {
+                    'type': 'array',
+                    'items': {'type': 'object'},
+                    'description': 'Attendee objects, e.g. [{"email": "a@b.com"}] (optional)',
+                },
+                'recurrence': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': 'RRULE/RDATE/EXDATE lines, e.g. ["RRULE:FREQ=WEEKLY;COUNT=5"] (optional)',
+                },
+                'sendUpdates': {
+                    'type': 'string',
+                    'enum': list(_SEND_UPDATES),
+                    'description': "Who to notify: 'all' (default), 'externalOnly', or 'none'",
+                },
+            },
+        },
+        description=(
+            'Create an event. Pass start/end objects through as given. attendees receive invitations at '
+            "write tier per sendUpdates (default 'all' — invites are expected to go out, this is not "
+            'gated). Cleaned events include id, status, summary, description, location, htmlLink, start, end, '
+            'organizer, recurrence, attendees, created, and updated when present. Requires the write tier.'
+        ),
+    )
+    def event_create(self, args: dict) -> dict:
+        """Create an event; sends attendee invitations per sendUpdates (default all). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('event_create')
+        cal_id = self._calendar_id(args)
+        summary = require_str(args, 'summary', tool_name='event_create')
+        body: dict = {
+            'summary': summary,
+            'start': self._require_obj(args, 'start', 'event_create'),
+            'end': self._require_obj(args, 'end', 'event_create'),
+        }
+        self._apply_optional_event_fields(args, body, 'event_create')
+        send_updates = self._enum_arg(args, 'sendUpdates', _SEND_UPDATES, _DEFAULT_SEND_UPDATES)
+        data = execute(self._svc().events().insert(calendarId=cal_id, body=body, sendUpdates=send_updates))
+        return clean_event(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['eventId'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'eventId': {'type': 'string', 'description': 'The event id to update'},
+                'summary': {'type': 'string', 'description': 'New title (optional)'},
+                'start': {'type': 'object', 'description': 'New start object (optional)'},
+                'end': {'type': 'object', 'description': 'New end object (optional)'},
+                'description': {'type': 'string', 'description': 'New description (optional)'},
+                'location': {'type': 'string', 'description': 'New location (optional)'},
+                'attendees': {
+                    'type': 'array',
+                    'items': {'type': 'object'},
+                    'description': 'New attendee list (optional)',
+                },
+                'recurrence': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': 'New recurrence lines (optional)',
+                },
+                'sendUpdates': {
+                    'type': 'string',
+                    'enum': list(_SEND_UPDATES),
+                    'description': "Who to notify: 'all' (default), 'externalOnly', or 'none'",
+                },
+            },
+        },
+        description=(
+            'Partially update an event (events.patch semantics): only the fields you pass are changed, '
+            "others are left as-is. Notifies attendees per sendUpdates (default 'all'). "
+            'Cleaned events include id, status, summary, description, location, htmlLink, start, end, '
+            'organizer, recurrence, attendees, created, and updated when present. Requires the write tier.'
+        ),
+    )
+    def event_update(self, args: dict) -> dict:
+        """Partially update an event (patch semantics). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('event_update')
+        cal_id = self._calendar_id(args)
+        event_id = require_str(args, 'eventId', tool_name='event_update')
+        body: dict = {}
+        summary = self._opt_str(args, 'summary', 'event_update')
+        if summary is not None:
+            body['summary'] = summary
+        start = self._opt_obj(args, 'start', 'event_update')
+        if start is not None:
+            body['start'] = start
+        end = self._opt_obj(args, 'end', 'event_update')
+        if end is not None:
+            body['end'] = end
+        self._apply_optional_event_fields(args, body, 'event_update')
+        if not body:
+            raise ValueError('event_update: provide at least one field to change')
+        send_updates = self._enum_arg(args, 'sendUpdates', _SEND_UPDATES, _DEFAULT_SEND_UPDATES)
+        data = execute(
+            self._svc().events().patch(calendarId=cal_id, eventId=event_id, body=body, sendUpdates=send_updates)
+        )
+        return clean_event(data)
+
+    def _apply_optional_event_fields(self, args: dict, body: dict, op: str) -> None:
+        """Attach the shared optional event fields (description/location/attendees/recurrence) to a body."""
+        string_reader = self._opt_clearable_str if op == 'event_update' else self._opt_str
+        description = string_reader(args, 'description', op)
+        if description is not None:
+            body['description'] = description
+        location = string_reader(args, 'location', op)
+        if location is not None:
+            body['location'] = location
+        attendees = self._opt_attendees(args, op)
+        if attendees is not None:
+            body['attendees'] = attendees
+        recurrence = self._opt_str_list(args, 'recurrence', op)
+        if recurrence is not None:
+            body['recurrence'] = recurrence
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['eventId', 'destination'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Source calendar id (default 'primary')"},
+                'eventId': {'type': 'string', 'description': 'The event id to move'},
+                'destination': {'type': 'string', 'description': 'Destination calendar id to move the event into'},
+                'sendUpdates': {
+                    'type': 'string',
+                    'enum': list(_SEND_UPDATES),
+                    'description': "Who to notify: 'all' (default), 'externalOnly', or 'none'",
+                },
+            },
+        },
+        description=(
+            'Move an event from one calendar to another. Notifies attendees per sendUpdates '
+            "(default 'all'). Cleaned events include id, status, summary, description, location, htmlLink, "
+            'start, end, organizer, recurrence, attendees, created, and updated when present. '
+            'Requires the write tier.'
+        ),
+    )
+    def event_move(self, args: dict) -> dict:
+        """Move an event to another calendar. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('event_move')
+        cal_id = self._calendar_id(args)
+        event_id = require_str(args, 'eventId', tool_name='event_move')
+        destination = require_str(args, 'destination', tool_name='event_move')
+        send_updates = self._enum_arg(args, 'sendUpdates', _SEND_UPDATES, _DEFAULT_SEND_UPDATES)
+        data = execute(
+            self._svc()
+            .events()
+            .move(calendarId=cal_id, eventId=event_id, destination=destination, sendUpdates=send_updates)
+        )
+        return clean_event(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['text'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'text': {
+                    'type': 'string',
+                    'description': 'Natural-language event text, e.g. "Lunch with Sam tomorrow at noon"',
+                },
+                'sendUpdates': {
+                    'type': 'string',
+                    'enum': list(_SEND_UPDATES),
+                    'description': "Who to notify: 'all' (default), 'externalOnly', or 'none'",
+                },
+            },
+        },
+        description=(
+            'Create an event from a natural-language phrase (Google parses date/time/title). '
+            "Notifies attendees per sendUpdates (default 'all'). "
+            'Returns the created event. Cleaned events include id, status, summary, description, location, '
+            'htmlLink, start, end, organizer, recurrence, attendees, created, and updated when present. '
+            'Requires the write tier.'
+        ),
+    )
+    def event_quick_add(self, args: dict) -> dict:
+        """Create an event from a natural-language phrase (quickAdd). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('event_quick_add')
+        cal_id = self._calendar_id(args)
+        text = require_str(args, 'text', tool_name='event_quick_add')
+        send_updates = self._enum_arg(args, 'sendUpdates', _SEND_UPDATES, _DEFAULT_SEND_UPDATES)
+        data = execute(self._svc().events().quickAdd(calendarId=cal_id, text=text, sendUpdates=send_updates))
+        return clean_event(data)
+
+    # =======================================================================
+    # CALENDARS / ACL — write
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['summary'],
+            'properties': {
+                'summary': {'type': 'string', 'description': 'Title for the new calendar'},
+                'timeZone': {'type': 'string', 'description': 'IANA time zone, e.g. "America/Los_Angeles" (optional)'},
+                'description': {'type': 'string', 'description': 'Calendar description (optional)'},
+            },
+        },
+        description='Create a new secondary calendar. Returns its id and metadata. Requires the write tier.',
+    )
+    def calendar_create(self, args: dict) -> dict:
+        """Create a new secondary calendar. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('calendar_create')
+        summary = require_str(args, 'summary', tool_name='calendar_create')
+        body: dict = {'summary': summary}
+        time_zone = self._opt_str(args, 'timeZone', 'calendar_create')
+        if time_zone is not None:
+            body['timeZone'] = time_zone
+        description = self._opt_str(args, 'description', 'calendar_create')
+        if description is not None:
+            body['description'] = description
+        data = execute(self._svc().calendars().insert(body=body))
+        return clean_calendar(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': [],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'summary': {'type': 'string', 'description': 'New title (optional)'},
+                'timeZone': {'type': 'string', 'description': 'New IANA time zone (optional)'},
+                'description': {'type': 'string', 'description': 'New description (optional)'},
+            },
+        },
+        description=(
+            'Partially update a calendar (calendars.patch semantics): only the fields you pass are '
+            'changed. Requires the write tier.'
+        ),
+    )
+    def calendar_update(self, args: dict) -> dict:
+        """Partially update a calendar (patch semantics). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('calendar_update')
+        cal_id = self._calendar_id(args)
+        body: dict = {}
+        for key in ('summary', 'timeZone'):
+            val = self._opt_str(args, key, 'calendar_update')
+            if val is not None:
+                body[key] = val
+        # description may be an empty string to clear the existing value.
+        description = self._opt_clearable_str(args, 'description', 'calendar_update')
+        if description is not None:
+            body['description'] = description
+        if not body:
+            raise ValueError('calendar_update: provide at least one field to change')
+        data = execute(self._svc().calendars().patch(calendarId=cal_id, body=body))
+        return clean_calendar(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['role', 'scopeType'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'role': {
+                    'type': 'string',
+                    'enum': list(_ACL_ROLES),
+                    'description': 'Access role to grant: reader, writer, owner, or freeBusyReader',
+                },
+                'scopeType': {
+                    'type': 'string',
+                    'enum': list(_ACL_SCOPE_TYPES),
+                    'description': (
+                        'Grantee scope type: "user", "group", "domain", or "default" (public). '
+                        '"default" and "domain" expose the calendar broadly and require the '
+                        'allowPublicSharing flag.'
+                    ),
+                },
+                'scopeValue': {
+                    'type': 'string',
+                    'description': 'The email/domain the scope refers to (omit for scopeType "default")',
+                },
+            },
+        },
+        description=(
+            'Grant a calendar access-control rule (share the calendar) at the given role and scope. '
+            "Rules with scopeType 'default' (anyone on the internet) or 'domain' (a whole domain) "
+            'additionally require the allowPublicSharing flag. '
+            'This is a sharing change (write tier), not a deletion. Requires the write tier.'
+        ),
+    )
+    def acl_insert(self, args: dict) -> dict:
+        """Grant a calendar ACL rule (share the calendar). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('acl_insert')
+        cal_id = self._calendar_id(args)
+        role = self._enum_arg(args, 'role', _ACL_ROLES, None)
+        if role is None:
+            raise ValueError(f'acl_insert: "role" is required and must be one of {list(_ACL_ROLES)}')
+        scope_type = self._enum_arg(args, 'scopeType', _ACL_SCOPE_TYPES, None)
+        if scope_type is None:
+            raise ValueError(f'acl_insert: "scopeType" is required and must be one of {list(_ACL_SCOPE_TYPES)}')
+        if scope_type in ('default', 'domain'):
+            # Exposure gate: 'default' shares with anyone on the internet and
+            # 'domain' with a whole domain. Like tool_drive's sharing gate, the
+            # write tier alone is not consent for that blast radius.
+            self._access().require_flag(
+                'allowPublicSharing',
+                f'acl_insert (scopeType={scope_type!r} exposes the calendar beyond individual grantees)',
+            )
+        scope: dict = {'type': scope_type}
+        scope_value = self._opt_str(args, 'scopeValue', 'acl_insert')
+        if scope_type != 'default' and scope_value is None:
+            raise ValueError(f'acl_insert: "scopeValue" is required for scopeType {scope_type!r}')
+        if scope_value is not None:
+            scope['value'] = scope_value
+        body = {'role': role, 'scope': scope}
+        data = execute(self._svc().acl().insert(calendarId=cal_id, body=body))
+        return clean_acl_rule(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['ruleId'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'ruleId': {'type': 'string', 'description': 'The ACL rule id to remove (from acl_list)'},
+            },
+        },
+        description=(
+            'Remove a calendar access-control rule (revoke sharing). This is a sharing change at the '
+            'write tier — it is NOT gated by allowDelete (that flag guards event/calendar deletion). '
+            'Requires the write tier.'
+        ),
+    )
+    def acl_delete(self, args: dict) -> dict:
+        """Remove a calendar ACL rule (revoke sharing). Write tier; not allowDelete-gated."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('acl_delete')
+        cal_id = self._calendar_id(args)
+        rule_id = require_str(args, 'ruleId', tool_name='acl_delete')
+        execute(self._svc().acl().delete(calendarId=cal_id, ruleId=rule_id))
+        return {'deletedRuleId': rule_id}
+
+    # =======================================================================
+    # EVENTS / CALENDARS — delete (write tier + allowDelete flag)
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['eventId'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': "Calendar id (default 'primary')"},
+                'eventId': {'type': 'string', 'description': 'The event id to delete'},
+                'sendUpdates': {
+                    'type': 'string',
+                    'enum': list(_SEND_UPDATES),
+                    'description': "Who to notify of the cancellation: 'all' (default), 'externalOnly', or 'none'",
+                },
+            },
+        },
+        description=(
+            'Permanently delete an event (irreversible). Notifies attendees per sendUpdates '
+            "(default 'all'). Requires the write tier AND the allowDelete flag."
+        ),
+    )
+    def event_delete(self, args: dict) -> dict:
+        """Permanently delete an event. Requires the write tier AND allowDelete."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('event_delete')
+        self._require_delete('event_delete')
+        cal_id = self._calendar_id(args)
+        event_id = require_str(args, 'eventId', tool_name='event_delete')
+        send_updates = self._enum_arg(args, 'sendUpdates', _SEND_UPDATES, _DEFAULT_SEND_UPDATES)
+        execute(self._svc().events().delete(calendarId=cal_id, eventId=event_id, sendUpdates=send_updates))
+        return {'deletedEventId': event_id}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['calendarId'],
+            'properties': {
+                'calendarId': {'type': 'string', 'description': 'The calendar id to delete (secondary calendars only)'},
+            },
+        },
+        description=(
+            'Permanently delete a secondary calendar (irreversible). Requires the write tier AND the allowDelete flag.'
+        ),
+    )
+    def calendar_delete(self, args: dict) -> dict:
+        """Permanently delete a secondary calendar. Requires the write tier AND allowDelete."""
+        args = normalize_tool_input(args, tool_name='tool_calendar')
+        self._access().require_write('calendar_delete')
+        self._require_delete('calendar_delete')
+        cal_id = require_str(args, 'calendarId', tool_name='calendar_delete')
+        execute(self._svc().calendars().delete(calendarId=cal_id))
+        return {'deletedCalendarId': cal_id}

--- a/nodes/src/nodes/tool_google_workspace/calendar/README.md
+++ b/nodes/src/nodes/tool_google_workspace/calendar/README.md
@@ -1,0 +1,124 @@
+# Google Calendar tool node (`tool_calendar`)
+
+Exposes the Google Calendar API v3 as agent tools: list, get, create, update,
+move, quick-add, and delete events (including expanding recurring series into
+instances); query free/busy; manage calendars; and read/insert/delete
+access-control (ACL) rules.
+
+## What it does
+
+An agent-invocable tool node — no data flows through lanes. Each operation is a
+`@tool_function` an agent calls on demand. Operational targets (`calendarId`,
+`eventId`, `ruleId`) are always tool-call parameters, never node config;
+`calendarId` defaults to `primary`. Outputs are cleaned shapes (event
+`id`/`status`/`start`/`end`/`attendees`, calendar metadata, ACL rules, free/busy
+ranges), not raw API JSON.
+
+## Configuration
+
+| Field | Notes |
+|-------|-------|
+| `google.authType` | `service` (service account) or `user` (OAuth). |
+| `google.serviceKey` / `google.adminEmail` | Service account JSON key; `adminEmail` enables domain-wide delegation (impersonate that user). |
+| `google.oAuthButton` / `google.userToken` | User OAuth: sign in to populate the access token. |
+| `calendar.access` | `readonly` or `write` (default). Resolved by the shared `CALENDAR` spec in `core/google_access.py`; scopes are never hand-entered. |
+| `calendar.allowDelete` | Boolean, default **false**. When off, `event_delete` and `calendar_delete` are refused even at the write tier. Enable only to permit permanent, irreversible deletion. |
+| `calendar.allowPublicSharing` | Boolean, default **false**. When off, `acl_insert` refuses rules that expose the calendar beyond individual grantees (scopeType `default` = anyone on the internet, `domain` = everyone in a domain). Grants to individual users/groups are not gated. |
+
+### Access tiers → scopes
+
+| Tier | Scope | Capability |
+|------|-------|------------|
+| `readonly` | `calendar.readonly` | read events, calendars, ACLs, free/busy |
+| `write` | `calendar` | full read/write (default) |
+
+Deletion (`event_delete`, `calendar_delete`) requires the `write` tier **and**
+`calendar.allowDelete` = true. The flag is off by default and, like gmail's
+`allowHardDelete`, is absent from the default profile (absent means false).
+Removing a sharing rule (`acl_delete`) is a write-tier operation and is **not**
+gated by `allowDelete`.
+
+## Tools
+
+- **Read events:** `event_list` (with incremental sync — see below),
+  `event_get`, `event_instances` (expand a recurring series), `freebusy_query`.
+- **Read calendars/ACL:** `calendar_list`, `calendar_get`, `acl_list`.
+- **Write events:** `event_create`, `event_update` (partial / patch semantics),
+  `event_move`, `event_quick_add` (natural-language).
+- **Write calendars/ACL:** `calendar_create`, `calendar_update` (patch),
+  `acl_insert` (share; scopeType `default`/`domain` additionally requires
+  `allowPublicSharing`), `acl_delete` (unshare).
+- **Delete (write + `allowDelete`):** `event_delete`, `calendar_delete`.
+- **Diagnostics:** `check_connection` verifies that granted OAuth scopes cover
+  the configured access tier and probes the Calendar API.
+
+### Incremental sync (`syncToken`)
+
+`event_list` and `calendar_list` return a `nextSyncToken` on the last page of a
+fully-consumed listing. Store it, then pass it back as `syncToken` on the next
+call to receive **only** the events/calendars that changed since — the efficient
+way to keep a local view in sync. Do not combine `syncToken` with `timeMin` /
+`timeMax` / `q`. Paginate with `nextPageToken` until it is absent; the
+`nextSyncToken` appears on that final page.
+
+### Attendee invitations (`sendUpdates`)
+
+Event writes (`event_create`, `event_update`, `event_move`, `event_quick_add`,
+`event_delete`) take a `sendUpdates` parameter — `all` (default), `externalOnly`,
+or `none`. The node **always sends it explicitly**: Google's implicit default is
+`none`, which would silently skip notifying attendees. Sending invitations is
+normal write-tier behavior and is **not** gated separately — an agent with write
+access can invite attendees, so scope the node accordingly.
+
+`event_update` accepts an empty `description` or `location` to clear that field.
+For `acl_insert`, `scopeType` must be `user`, `group`, `domain`, or `default`; `default` and `domain` rules require `calendar.allowPublicSharing` = true;
+the first three require `scopeValue`.
+
+## Setup
+
+Authenticate with either a Google **service account** (`google.serviceKey` JSON,
+optionally `google.adminEmail` for domain-wide delegation) or **user OAuth**
+(click sign-in to populate `google.userToken`). The Google Calendar API must be
+enabled on the Google Cloud project backing the credential.
+
+## Limits
+
+- `maxResults` on listings is clamped to `1..250` (default 50); page with
+  `nextPageToken`.
+- Free/busy queries return busy ranges per calendar plus any per-calendar errors
+  (e.g. a calendar the credential cannot see).
+- Rate limits are per Google project; the node retries `429`, rate-limit/quota
+  `403`, and `5xx` responses with exponential backoff.
+
+## Examples
+
+An agent finds a free slot, then books it and invites a guest:
+
+```
+freebusy_query  { "timeMin": "2026-07-11T09:00:00Z", "timeMax": "2026-07-11T17:00:00Z",
+                  "calendarIds": ["primary"] }
+event_create    { "summary": "Design sync", "start": {"dateTime": "2026-07-11T14:00:00Z"},
+                  "end": {"dateTime": "2026-07-11T15:00:00Z"},
+                  "attendees": [{"email": "sam@example.com"}] }
+```
+
+## Upstream docs
+
+- Google Calendar API v3: https://developers.google.com/calendar/api/v3/reference
+- Events: https://developers.google.com/calendar/api/v3/reference/events
+- Sync (syncToken): https://developers.google.com/calendar/api/guides/sync
+- FreeBusy: https://developers.google.com/calendar/api/v3/reference/freebusy/query
+
+## Troubleshooting
+
+- **Scope / 403 errors:** call `check_connection`; if scopes are missing,
+  disconnect and reconnect the Google account at the required access tier.
+- **`access` is read-only:** write operations raise `GoogleAccessError`; raise
+  `calendar.access` to `write`.
+- **Delete refused at write tier:** `event_delete` / `calendar_delete` also need
+  `calendar.allowDelete` = true; it is off by default.
+- **Attendees not notified:** pass `sendUpdates: "all"` (the node's default) —
+  `none` suppresses invitations.
+
+<!-- ROCKETRIDE:GENERATED:PARAMS START -->
+<!-- ROCKETRIDE:GENERATED:PARAMS END -->

--- a/nodes/src/nodes/tool_google_workspace/calendar/__init__.py
+++ b/nodes/src/nodes/tool_google_workspace/calendar/__init__.py
@@ -1,0 +1,29 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/tool_google_workspace/calendar/client.py
+++ b/nodes/src/nodes/tool_google_workspace/calendar/client.py
@@ -1,0 +1,153 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Google Calendar-specific service bindings and response cleaners."""
+
+from __future__ import annotations
+
+import functools
+
+from .. import google_client
+
+SERVICE = google_client.GoogleService(
+    product='Google Calendar',
+    api='calendar',
+    version='v3',
+    superset_scopes=frozenset({'https://www.googleapis.com/auth/calendar'}),
+)
+
+execute = functools.partial(google_client.execute, SERVICE)
+
+
+# ---------------------------------------------------------------------------
+# Response cleaners
+# ---------------------------------------------------------------------------
+
+
+def _clean_attendee(att: dict | None) -> dict:
+    """Compact a single attendee: email + responseStatus."""
+    if not isinstance(att, dict):
+        return {}
+    return {k: att[k] for k in ('email', 'responseStatus') if k in att}
+
+
+def clean_event(ev: dict | None) -> dict:
+    """Compact a Calendar event into an agent-friendly shape."""
+    if not isinstance(ev, dict):
+        return {}
+    out: dict = {
+        'id': ev.get('id'),
+        'status': ev.get('status'),
+        'summary': ev.get('summary'),
+        'description': ev.get('description'),
+        'location': ev.get('location'),
+        'htmlLink': ev.get('htmlLink'),
+        'start': ev.get('start'),
+        'end': ev.get('end'),
+        'organizer': ev.get('organizer'),
+        'recurrence': ev.get('recurrence'),
+        'created': ev.get('created'),
+        'updated': ev.get('updated'),
+    }
+    if ev.get('attendees') is not None:
+        out['attendees'] = [_clean_attendee(a) for a in ev.get('attendees') or []]
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def clean_event_list(resp: dict | None) -> dict:
+    """Compact an events list/instances response: events + sync/page tokens.
+
+    ``nextSyncToken`` is only present on a fully-consumed (last-page) result and
+    is what an agent passes back as ``syncToken`` for the next incremental sync.
+    """
+    if not isinstance(resp, dict):
+        return {}
+    out: dict = {'events': [clean_event(e) for e in resp.get('items') or []]}
+    if resp.get('nextPageToken') is not None:
+        out['nextPageToken'] = resp.get('nextPageToken')
+    if resp.get('nextSyncToken') is not None:
+        out['nextSyncToken'] = resp.get('nextSyncToken')
+    return out
+
+
+def clean_calendar(cal: dict | None) -> dict:
+    """Compact a calendar resource (from calendars() or a calendarList entry)."""
+    if not isinstance(cal, dict):
+        return {}
+    out: dict = {
+        'id': cal.get('id'),
+        'summary': cal.get('summary'),
+        'timeZone': cal.get('timeZone'),
+        'description': cal.get('description'),
+        'primary': cal.get('primary'),
+    }
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def clean_calendar_list(resp: dict | None) -> dict:
+    """Compact a calendarList().list response: calendars + sync/page tokens."""
+    if not isinstance(resp, dict):
+        return {}
+    out: dict = {'calendars': [clean_calendar(c) for c in resp.get('items') or []]}
+    if resp.get('nextPageToken') is not None:
+        out['nextPageToken'] = resp.get('nextPageToken')
+    if resp.get('nextSyncToken') is not None:
+        out['nextSyncToken'] = resp.get('nextSyncToken')
+    return out
+
+
+def clean_acl_rule(rule: dict | None) -> dict:
+    """Compact an ACL rule: id, role, and scope (type + value)."""
+    if not isinstance(rule, dict):
+        return {}
+    out: dict = {k: rule[k] for k in ('id', 'role', 'scope') if k in rule}
+    return out
+
+
+def clean_acl_list(resp: dict | None) -> dict:
+    """Compact an acl().list response: the ACL rules + optional page token."""
+    if not isinstance(resp, dict):
+        return {}
+    out: dict = {'rules': [clean_acl_rule(r) for r in resp.get('items') or []]}
+    if resp.get('nextPageToken') is not None:
+        out['nextPageToken'] = resp.get('nextPageToken')
+    return out
+
+
+def clean_freebusy(resp: dict | None) -> dict:
+    """Compact a freebusy().query response: per-calendar busy ranges + errors."""
+    if not isinstance(resp, dict):
+        return {}
+    calendars: dict = {}
+    for cal_id, cal in (resp.get('calendars') or {}).items():
+        entry: dict = {'busy': (cal or {}).get('busy') or []}
+        if (cal or {}).get('errors'):
+            entry['errors'] = cal['errors']
+        calendars[cal_id] = entry
+    return {
+        'timeMin': resp.get('timeMin'),
+        'timeMax': resp.get('timeMax'),
+        'calendars': calendars,
+    }

--- a/nodes/src/nodes/tool_google_workspace/services.calendar.json
+++ b/nodes/src/nodes/tool_google_workspace/services.calendar.json
@@ -1,0 +1,79 @@
+{
+	"title": "Google Calendar",
+	"protocol": "tool_calendar://",
+	"classType": [
+		"tool"
+	],
+	"capabilities": [
+		"invoke"
+	],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.tool_google_workspace.calendar",
+	"prefix": "calendar",
+	"icon": "calendar.svg",
+	"documentation": "https://docs.rocketride.org",
+	"description": [
+		"Exposes Google Calendar operations as agent tools.",
+		"List, get, create, update, move, and delete events (including recurring-series instances and natural-language quick-add); query free/busy; manage calendars and access-control (ACL) rules.",
+		"Supports incremental sync via syncToken and sends attendee invites at the write tier. Authenticates via a Google service account or user OAuth."
+	],
+	"tile": [
+		"Google Calendar (${parameters.calendar.access})"
+	],
+	"lanes": {},
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"title": "Google Calendar",
+				"authType": "service",
+				"serviceKey": "",
+				"adminEmail": "",
+				"userToken": "",
+				"access": "write"
+			}
+		}
+	},
+	"fields": {
+		"calendar.access": {
+			"type": "string",
+			"title": "Access level",
+			"description": "Calendar scopes to request. readonly: read events, calendars, ACLs, and free/busy only. write: full read/write (create, update, move, quick-add events; manage calendars and ACLs). Deletion additionally requires the allowDelete flag; public/domain-wide ACL sharing requires allowPublicSharing.",
+			"default": "write",
+			"enum": [
+				[
+					"readonly",
+					"Read-only"
+				],
+				[
+					"write",
+					"Read/write"
+				]
+			]
+		},
+		"calendar.allowDelete": {
+			"type": "boolean",
+			"title": "Allow event / calendar deletion",
+			"description": "When off (the default), event_delete and calendar_delete are refused even at the write tier. Enable only if the agent should be able to permanently delete events and calendars — this is irreversible.",
+			"default": false
+		},
+		"calendar.allowPublicSharing": {
+			"type": "boolean",
+			"title": "Allow public / domain-wide calendar sharing",
+			"description": "Off by default. When off, acl_insert refuses rules that expose the calendar beyond individual grantees (scopeType 'default' = anyone on the internet, and 'domain' = everyone in a domain). Turn on to allow public or domain-wide sharing. Grants to individual users/groups are not gated.",
+			"default": false
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Google Calendar",
+			"properties": [
+				"type",
+				"google.authType",
+				"calendar.access"
+			]
+		}
+	]
+}

--- a/nodes/test/tool_calendar/test_calendar.py
+++ b/nodes/test/tool_calendar/test_calendar.py
@@ -1,0 +1,741 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Unit tests for the tool_calendar node (no network, no engine runtime).
+
+Bootstrap mirrors test_sheets.py / test_gmail.py: inject lightweight stubs for
+the engine runtime modules ONLY if absent, import the module under test, then
+drop the stubs so they never leak into a shared pytest session. The Google SDK
+is never imported — IInstance receives a FakeCalendar service and a real
+GoogleAccess.
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_NODES_SRC = Path(__file__).resolve().parents[2] / 'src'
+if str(_NODES_SRC) not in sys.path:
+    sys.path.insert(0, str(_NODES_SRC))
+
+_SERVICES_JSON = _NODES_SRC / 'nodes' / 'tool_google_workspace' / 'services.calendar.json'
+
+
+def _require_str(args, key, *, tool_name=''):
+    value = args.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f'{tool_name or key}: "{key}" is required')
+    return value.strip()
+
+
+def _build_import_stubs():
+    rocketlib = MagicMock()
+    rocketlib.IInstanceBase = object
+    rocketlib.IGlobalBase = object
+
+    def tool_function(**metadata):
+        def decorate(func):
+            func.__tool_meta__ = metadata
+            return func
+
+        return decorate
+
+    rocketlib.tool_function = tool_function
+    rocketlib.OPEN_MODE = MagicMock()
+    rocketlib.warning = lambda *a, **kw: None
+
+    depends = MagicMock()
+    depends.depends = lambda *a, **kw: None
+
+    ai_common_utils = MagicMock()
+    ai_common_utils.normalize_tool_input = lambda args, **kw: args if isinstance(args, dict) else {}
+    ai_common_utils.require_str = _require_str
+
+    return {
+        'rocketlib': rocketlib,
+        'depends': depends,
+        'ai': MagicMock(),
+        'ai.common': MagicMock(),
+        'ai.common.utils': ai_common_utils,
+        'ai.common.config': MagicMock(),
+    }
+
+
+_added = []
+for _name, _stub in _build_import_stubs().items():
+    if _name not in sys.modules:
+        sys.modules[_name] = _stub
+        _added.append(_name)
+
+_imported_names = (
+    'nodes',
+    'nodes.core',
+    'nodes.tool_google_workspace',
+    'nodes.tool_google_workspace.IInstance',
+    'nodes.tool_google_workspace.IGlobal',
+    'nodes.tool_google_workspace.google_client',
+    'nodes.tool_google_workspace.calendar',
+    'nodes.tool_google_workspace.calendar.IInstance',
+    'nodes.tool_google_workspace.calendar.IGlobal',
+    'nodes.tool_google_workspace.calendar.client',
+    'nodes.core.google_access',
+)
+_preexisting_imports = {name for name in _imported_names if name in sys.modules}
+
+cal_iinstance = importlib.import_module('nodes.tool_google_workspace.calendar.IInstance')
+cal_iglobal = importlib.import_module('nodes.tool_google_workspace.calendar.IGlobal')
+cal_client = importlib.import_module('nodes.tool_google_workspace.calendar.client')
+google_workspace_instance = importlib.import_module('nodes.tool_google_workspace.IInstance')
+google_workspace_global = importlib.import_module('nodes.tool_google_workspace.IGlobal')
+ga = importlib.import_module('nodes.core.google_access')
+_imported_modules = {name: sys.modules[name] for name in _imported_names if name in sys.modules}
+
+for _name in _added:
+    sys.modules.pop(_name, None)
+for _name in _imported_names:
+    if _name not in _preexisting_imports:
+        sys.modules.pop(_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Fake Calendar service: records terminal calls, returns canned results.
+# ---------------------------------------------------------------------------
+
+
+class _Req:
+    def __init__(self, result):
+        self.result = result
+
+    def execute(self):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class _Node:
+    def __init__(self, sv, path):
+        self._sv = sv
+        self._path = path
+
+    def __getattr__(self, name):
+        def method(**kwargs):
+            self._sv.calls.append((name, kwargs))
+            return _Req(self._sv.results.get(name, {}))
+
+        return method
+
+
+class FakeCalendar:
+    def __init__(self, results=None):
+        self.calls = []
+        self.results = results or {}
+
+    def events(self):
+        return _Node(self, 'events')
+
+    def calendarList(self):
+        return _Node(self, 'calendarList')
+
+    def calendars(self):
+        return _Node(self, 'calendars')
+
+    def acl(self):
+        return _Node(self, 'acl')
+
+    def freebusy(self):
+        return _Node(self, 'freebusy')
+
+    def call_for(self, op):
+        """Return the kwargs of the first recorded call to terminal method ``op``."""
+        return next((kw for n, kw in self.calls if n == op), None)
+
+
+def _make(tier='write', results=None, flags=None):
+    """Build an IInstance wired to a FakeCalendar and a real resolved GoogleAccess."""
+    inst = cal_iinstance.IInstance()
+    cfg = {'access': tier}
+    if flags:
+        cfg.update(flags)
+    access = ga.resolve_google_access(cfg, ga.CALENDAR)
+    inst.IGlobal = types.SimpleNamespace(service=FakeCalendar(results or {}), access=access)
+    return inst
+
+
+_EVENT = {
+    'id': 'ev1',
+    'status': 'confirmed',
+    'summary': 'Sync',
+    'description': 'Canvas validation code: CAL-CONTRACT-61',
+    'location': 'RocketRide test room',
+    'htmlLink': 'https://calendar.google.com/ev1',
+    'start': {'dateTime': '2026-07-11T14:00:00Z'},
+    'end': {'dateTime': '2026-07-11T15:00:00Z'},
+    'organizer': {'email': 'me@x.com'},
+    'created': '2026-07-01T00:00:00Z',
+    'updated': '2026-07-02T00:00:00Z',
+    'attendees': [{'email': 'sam@x.com', 'responseStatus': 'accepted', 'displayName': 'drop me'}],
+    'iCalUID': 'drop-me',
+}
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+def test_event_list_cleans_and_returns_sync_token():
+    inst = _make(results={'list': {'items': [_EVENT], 'nextPageToken': 'p2', 'nextSyncToken': 'sync-1'}})
+    out = inst.event_list({'calendarId': 'primary'})
+    assert out['nextSyncToken'] == 'sync-1'
+    assert out['nextPageToken'] == 'p2'
+    ev = out['events'][0]
+    assert ev['id'] == 'ev1' and ev['status'] == 'confirmed'
+    assert ev['attendees'] == [{'email': 'sam@x.com', 'responseStatus': 'accepted'}]  # trimmed
+    assert 'iCalUID' not in ev
+    kw = inst.IGlobal.service.call_for('list')
+    assert kw['calendarId'] == 'primary'
+    assert kw['maxResults'] == 50  # documented default sent explicitly
+
+
+def test_event_list_passes_sync_token_through():
+    inst = _make(results={'list': {'items': []}})
+    inst.event_list({'syncToken': 'ST-9'})
+    kw = inst.IGlobal.service.call_for('list')
+    assert kw['syncToken'] == 'ST-9'
+    assert kw['calendarId'] == 'primary'  # defaults to primary
+
+
+@pytest.mark.parametrize('conflicting_key', ['timeMin', 'timeMax', 'q'])
+def test_event_list_rejects_sync_token_with_filter(conflicting_key):
+    inst = _make()
+    with pytest.raises(ValueError, match='syncToken'):
+        inst.event_list({'syncToken': 'ST-9', conflicting_key: 'value'})
+
+
+def test_event_list_clamps_max_results():
+    inst = _make(results={'list': {'items': []}})
+    inst.event_list({'maxResults': 9999})
+    assert inst.IGlobal.service.call_for('list')['maxResults'] == 250
+
+
+def test_event_list_rejects_bool_max_results():
+    # JSON true must never be coerced to 1.
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.event_list({'maxResults': True})
+
+
+def test_event_get():
+    inst = _make(results={'get': _EVENT})
+    out = inst.event_get({'eventId': 'ev1'})
+    assert out['id'] == 'ev1'
+    assert inst.IGlobal.service.call_for('get')['eventId'] == 'ev1'
+
+
+def test_event_get_preserves_writable_metadata():
+    inst = _make(results={'get': _EVENT})
+    out = inst.event_get({'eventId': 'ev1'})
+    assert out['description'] == 'Canvas validation code: CAL-CONTRACT-61'
+    assert out['location'] == 'RocketRide test room'
+
+
+def test_event_get_requires_event_id():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.event_get({'calendarId': 'primary'})
+
+
+def test_event_get_maps_api_error():
+    inst = _make(results={'get': RuntimeError('boom')})
+    with pytest.raises(ValueError):
+        inst.event_get({'eventId': 'ev1'})
+
+
+def test_event_instances():
+    inst = _make(results={'instances': {'items': [_EVENT], 'nextPageToken': 'p'}})
+    out = inst.event_instances({'eventId': 'ev1', 'maxResults': 10})
+    assert out['events'][0]['id'] == 'ev1'
+    assert out['nextPageToken'] == 'p'
+    kw = inst.IGlobal.service.call_for('instances')
+    assert kw['eventId'] == 'ev1' and kw['maxResults'] == 10
+
+
+def test_freebusy_query():
+    inst = _make(
+        results={
+            'query': {
+                'timeMin': 'a',
+                'timeMax': 'b',
+                'calendars': {'primary': {'busy': [{'start': 's', 'end': 'e'}]}},
+            }
+        }
+    )
+    out = inst.freebusy_query({'timeMin': 'a', 'timeMax': 'b', 'calendarIds': ['primary', 'team@x.com']})
+    assert out['calendars']['primary']['busy'] == [{'start': 's', 'end': 'e'}]
+    body = inst.IGlobal.service.call_for('query')['body']
+    assert body['items'] == [{'id': 'primary'}, {'id': 'team@x.com'}]
+
+
+def test_freebusy_query_requires_calendar_ids():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.freebusy_query({'timeMin': 'a', 'timeMax': 'b', 'calendarIds': []})
+
+
+def test_calendar_list():
+    inst = _make(
+        results={'list': {'items': [{'id': 'c1', 'summary': 'Work', 'timeZone': 'UTC'}], 'nextSyncToken': 'cs'}}
+    )
+    out = inst.calendar_list({})
+    assert out['calendars'][0] == {'id': 'c1', 'summary': 'Work', 'timeZone': 'UTC'}
+    assert out['nextSyncToken'] == 'cs'
+
+
+def test_calendar_get():
+    inst = _make(results={'get': {'id': 'primary', 'summary': 'Me', 'timeZone': 'UTC', 'primary': True}})
+    out = inst.calendar_get({'calendarId': 'primary'})
+    assert out == {'id': 'primary', 'summary': 'Me', 'timeZone': 'UTC', 'primary': True}
+
+
+def test_acl_list():
+    inst = _make(
+        results={
+            'list': {'items': [{'id': 'user:sam', 'role': 'reader', 'scope': {'type': 'user', 'value': 'sam@x.com'}}]}
+        }
+    )
+    out = inst.acl_list({'calendarId': 'primary'})
+    assert out['rules'][0] == {'id': 'user:sam', 'role': 'reader', 'scope': {'type': 'user', 'value': 'sam@x.com'}}
+
+
+# ---------------------------------------------------------------------------
+# Writes — events
+# ---------------------------------------------------------------------------
+
+
+def test_event_create_always_sends_send_updates_all_when_omitted():
+    # The always-send-defaults regression: Google's implicit default is 'none',
+    # which would silently skip attendee invitations. The node must send 'all'.
+    inst = _make(results={'insert': _EVENT})
+    out = inst.event_create(
+        {
+            'summary': 'Sync',
+            'start': {'dateTime': '2026-07-11T14:00:00Z'},
+            'end': {'dateTime': '2026-07-11T15:00:00Z'},
+            'attendees': [{'email': 'sam@x.com'}],
+        }
+    )
+    assert out['id'] == 'ev1'
+    kw = inst.IGlobal.service.call_for('insert')
+    assert kw['sendUpdates'] == 'all'  # documented default, sent explicitly
+    assert kw['body']['summary'] == 'Sync'
+    assert kw['body']['attendees'] == [{'email': 'sam@x.com'}]
+
+
+def test_event_create_honors_explicit_send_updates():
+    inst = _make(results={'insert': _EVENT})
+    inst.event_create(
+        {
+            'summary': 'S',
+            'start': {'date': '2026-07-11'},
+            'end': {'date': '2026-07-12'},
+            'sendUpdates': 'none',
+        }
+    )
+    assert inst.IGlobal.service.call_for('insert')['sendUpdates'] == 'none'
+
+
+def test_event_create_requires_start():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.event_create({'summary': 'S', 'end': {'date': '2026-07-12'}})
+
+
+def test_event_create_rejects_bad_send_updates():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.event_create(
+            {'summary': 'S', 'start': {'date': '2026-07-11'}, 'end': {'date': '2026-07-12'}, 'sendUpdates': 'maybe'}
+        )
+
+
+def test_event_update_partial_and_send_updates():
+    inst = _make(results={'patch': _EVENT})
+    inst.event_update({'eventId': 'ev1', 'summary': 'Renamed'})
+    kw = inst.IGlobal.service.call_for('patch')
+    assert kw['eventId'] == 'ev1'
+    assert kw['body'] == {'summary': 'Renamed'}  # only the changed field
+    assert kw['sendUpdates'] == 'all'
+
+
+def test_event_update_requires_a_field():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.event_update({'eventId': 'ev1'})
+
+
+def test_event_update_allows_empty_description_to_clear_field():
+    inst = _make(results={'patch': _EVENT})
+    inst.event_update({'eventId': 'ev1', 'description': ''})
+    assert inst.IGlobal.service.call_for('patch')['body'] == {'description': ''}
+
+
+def test_event_move():
+    inst = _make(results={'move': _EVENT})
+    inst.event_move({'eventId': 'ev1', 'destination': 'cal2'})
+    kw = inst.IGlobal.service.call_for('move')
+    assert kw['eventId'] == 'ev1' and kw['destination'] == 'cal2'
+    assert kw['sendUpdates'] == 'all'
+
+
+def test_event_move_requires_destination():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.event_move({'eventId': 'ev1'})
+
+
+def test_event_quick_add():
+    inst = _make(results={'quickAdd': _EVENT})
+    out = inst.event_quick_add({'text': 'Lunch tomorrow at noon'})
+    assert out['id'] == 'ev1'
+    kw = inst.IGlobal.service.call_for('quickAdd')
+    assert kw['text'] == 'Lunch tomorrow at noon' and kw['calendarId'] == 'primary'
+    assert kw['sendUpdates'] == 'all'
+
+
+# ---------------------------------------------------------------------------
+# Writes — calendars / ACL
+# ---------------------------------------------------------------------------
+
+
+def test_calendar_create():
+    inst = _make(results={'insert': {'id': 'newcal', 'summary': 'Team'}})
+    out = inst.calendar_create({'summary': 'Team', 'timeZone': 'UTC'})
+    assert out['id'] == 'newcal'
+    assert inst.IGlobal.service.call_for('insert')['body'] == {'summary': 'Team', 'timeZone': 'UTC'}
+
+
+def test_calendar_update():
+    inst = _make(results={'patch': {'id': 'c1', 'summary': 'New'}})
+    inst.calendar_update({'calendarId': 'c1', 'summary': 'New'})
+    assert inst.IGlobal.service.call_for('patch')['body'] == {'summary': 'New'}
+
+
+def test_calendar_update_empty_description_clears_field():
+    inst = _make(results={'patch': {'id': 'c1', 'summary': 'Team'}})
+    inst.calendar_update({'calendarId': 'c1', 'description': ''})
+    assert inst.IGlobal.service.call_for('patch')['body'] == {'description': ''}
+
+
+def test_acl_insert():
+    inst = _make(
+        results={'insert': {'id': 'user:sam', 'role': 'writer', 'scope': {'type': 'user', 'value': 'sam@x.com'}}}
+    )
+    out = inst.acl_insert({'role': 'writer', 'scopeType': 'user', 'scopeValue': 'sam@x.com'})
+    assert out['role'] == 'writer'
+    body = inst.IGlobal.service.call_for('insert')['body']
+    assert body == {'role': 'writer', 'scope': {'type': 'user', 'value': 'sam@x.com'}}
+
+
+def test_acl_insert_rejects_bad_role():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.acl_insert({'role': 'admin', 'scopeType': 'user', 'scopeValue': 'x@y.com'})
+
+
+def test_acl_insert_rejects_invalid_scope_type():
+    inst = _make()
+    with pytest.raises(ValueError, match='scopeType'):
+        inst.acl_insert({'role': 'reader', 'scopeType': 'team', 'scopeValue': 'x@y.com'})
+
+
+@pytest.mark.parametrize('scope_type', ['user', 'group'])
+def test_acl_insert_requires_value_for_named_scope(scope_type):
+    inst = _make()
+    with pytest.raises(ValueError, match='scopeValue'):
+        inst.acl_insert({'role': 'reader', 'scopeType': scope_type})
+
+
+def test_acl_insert_domain_requires_value_once_gate_is_open():
+    inst = _make(flags={'allowPublicSharing': True})
+    with pytest.raises(ValueError, match='scopeValue'):
+        inst.acl_insert({'role': 'reader', 'scopeType': 'domain'})
+
+
+# ---------------------------------------------------------------------------
+# allowPublicSharing gate (calendar exposure)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('scope_type', ['default', 'domain'])
+def test_acl_insert_public_scopes_denied_without_flag(scope_type):
+    inst = _make(tier='write')  # allowPublicSharing absent -> False
+    args = {'role': 'reader', 'scopeType': scope_type}
+    if scope_type == 'domain':
+        args['scopeValue'] = 'example.com'
+    with pytest.raises(ga.GoogleAccessError) as exc:
+        inst.acl_insert(args)
+    assert 'allowPublicSharing' in str(exc.value)
+    assert inst.IGlobal.service.call_for('insert') is None  # nothing reached Google
+
+
+def test_acl_insert_default_allowed_with_flag():
+    inst = _make(
+        flags={'allowPublicSharing': True},
+        results={'insert': {'id': 'default', 'role': 'freeBusyReader', 'scope': {'type': 'default'}}},
+    )
+    out = inst.acl_insert({'role': 'freeBusyReader', 'scopeType': 'default'})
+    assert out['id'] == 'default'
+    body = inst.IGlobal.service.call_for('insert')['body']
+    assert body == {'role': 'freeBusyReader', 'scope': {'type': 'default'}}
+
+
+def test_acl_insert_user_grant_not_gated():
+    # Individual grants stay write-tier: the gate covers broad exposure only.
+    inst = _make(
+        tier='write',  # allowPublicSharing absent -> False
+        results={'insert': {'id': 'user:sam', 'role': 'reader', 'scope': {'type': 'user', 'value': 'sam@x.com'}}},
+    )
+    out = inst.acl_insert({'role': 'reader', 'scopeType': 'user', 'scopeValue': 'sam@x.com'})
+    assert out['id'] == 'user:sam'
+
+
+def test_acl_delete_is_write_tier_not_delete_gated():
+    # acl_delete removes a SHARING rule: write tier, NOT gated by allowDelete.
+    inst = _make(tier='write', results={'delete': {}})  # allowDelete absent -> False
+    out = inst.acl_delete({'calendarId': 'primary', 'ruleId': 'user:sam'})
+    assert out == {'deletedRuleId': 'user:sam'}
+    assert inst.IGlobal.service.call_for('delete')['ruleId'] == 'user:sam'
+
+
+# ---------------------------------------------------------------------------
+# Access tiers
+# ---------------------------------------------------------------------------
+
+
+def test_default_tier_is_write():
+    access = ga.resolve_google_access({}, ga.CALENDAR)
+    assert access.tier == 'write'
+    assert access.can_write is True
+
+
+def test_readonly_tier_allows_reads():
+    inst = _make(tier='readonly', results={'get': _EVENT})
+    assert inst.event_get({'eventId': 'ev1'})['id'] == 'ev1'
+    assert inst.IGlobal.access.can_write is False
+
+
+_WRITE_OPS = [
+    'event_create',
+    'event_update',
+    'event_move',
+    'event_quick_add',
+    'calendar_create',
+    'calendar_update',
+    'acl_insert',
+    'acl_delete',
+    'event_delete',
+    'calendar_delete',
+]
+
+
+@pytest.mark.parametrize('op', _WRITE_OPS)
+def test_readonly_denies_every_write(op):
+    inst = _make(tier='readonly')
+    with pytest.raises(ga.GoogleAccessError):
+        getattr(inst, op)({})
+
+
+# ---------------------------------------------------------------------------
+# allowDelete gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('op,args', [('event_delete', {'eventId': 'ev1'}), ('calendar_delete', {'calendarId': 'c1'})])
+def test_delete_gated_off_by_default_even_at_write_tier(op, args):
+    inst = _make(tier='write')  # allowDelete absent -> False
+    with pytest.raises(ga.GoogleAccessError) as exc:
+        getattr(inst, op)(args)
+    assert 'allowDelete' in str(exc.value)  # the flag is named in the error
+
+
+def test_event_delete_goes_through_when_allowed():
+    inst = _make(tier='write', flags={'allowDelete': True}, results={'delete': {}})
+    out = inst.event_delete({'eventId': 'ev1'})
+    assert out == {'deletedEventId': 'ev1'}
+    kw = inst.IGlobal.service.call_for('delete')
+    assert kw['eventId'] == 'ev1' and kw['sendUpdates'] == 'all'
+
+
+def test_calendar_delete_goes_through_when_allowed():
+    inst = _make(tier='write', flags={'allowDelete': True}, results={'delete': {}})
+    out = inst.calendar_delete({'calendarId': 'c1'})
+    assert out == {'deletedCalendarId': 'c1'}
+    assert inst.IGlobal.service.call_for('delete')['calendarId'] == 'c1'
+
+
+def test_allow_delete_string_true_is_a_misconfig_error():
+    # Strict resolver: a present non-bool ('true') must fail loud, not coerce.
+    with pytest.raises(ga.GoogleAccessError):
+        ga.resolve_google_access({'access': 'write', 'allowDelete': 'true'}, ga.CALENDAR)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_check_connection_reports_ok():
+    inst = _make()
+    out = inst.check_connection({})
+    assert out['connection_ok'] is True
+    assert out['access'] == 'write'
+    assert any('calendar' in s for s in out['requiredScopes'])
+    assert inst.IGlobal.service.call_for('list')['maxResults'] == 1
+
+
+def test_check_connection_reports_probe_failure():
+    inst = _make(results={'list': RuntimeError('probe failed')})
+    out = inst.check_connection({})
+    assert out['connection_ok'] is False
+    assert 'probe failed' in out['error']
+
+
+def test_validate_config_warns_for_malformed_user_token(monkeypatch):
+    warnings = []
+    for name, module in _imported_modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    # setattr (not .return_value) so this holds whether Config is the real class or a stub.
+    monkeypatch.setattr(
+        google_workspace_global.Config,
+        'getNodeConfig',
+        lambda *a, **k: {'authType': 'user', 'userToken': '{bad json'},
+    )
+    monkeypatch.setattr(google_workspace_global, 'warning', warnings.append)
+    glb = cal_iglobal.IGlobal()
+    glb.glb = types.SimpleNamespace(logicalType='calendar', connConfig={})
+    glb.validateConfig()
+    assert any('invalid' in message.lower() for message in warnings)
+
+
+# ---------------------------------------------------------------------------
+# services.json contract
+# ---------------------------------------------------------------------------
+
+
+def test_services_json_shape():
+    data = json.loads(_SERVICES_JSON.read_text(encoding='utf-8'))
+    assert data['classType'] == ['tool']
+    assert data['capabilities'] == ['invoke']
+    assert data['lanes'] == {}  # tool node: no data lanes
+    assert data['prefix'] == 'calendar'
+    assert data['path'] == 'nodes.tool_google_workspace.calendar'
+    assert 'test' not in data  # OAuth node: no dynamic test block
+
+
+def test_calendar_service_uses_shared_workspace_bases():
+    assert cal_client.SERVICE.product == 'Google Calendar'
+    assert cal_client.SERVICE.api == 'calendar'
+    assert cal_client.SERVICE.version == 'v3'
+    assert issubclass(cal_iinstance.IInstance, google_workspace_instance.GoogleToolInstanceBase)
+    assert issubclass(cal_iglobal.IGlobal, google_workspace_global.GoogleToolGlobalBase)
+
+
+def test_services_json_has_access_and_allow_delete_fields():
+    # Issue AC: both calendar.access and calendar.allowDelete must be present.
+    data = json.loads(_SERVICES_JSON.read_text(encoding='utf-8'))
+    assert 'calendar.access' in data['fields']
+    assert 'calendar.allowDelete' in data['fields']
+    assert data['fields']['calendar.access']['default'] == 'write'
+    assert [row[0] for row in data['fields']['calendar.access']['enum']] == ['readonly', 'write']
+    assert data['fields']['calendar.allowDelete']['type'] == 'boolean'
+    assert data['fields']['calendar.allowDelete']['default'] is False
+
+
+def test_services_json_has_allow_public_sharing_field():
+    data = json.loads(_SERVICES_JSON.read_text(encoding='utf-8'))
+    assert data['fields']['calendar.allowPublicSharing']['type'] == 'boolean'
+    assert data['fields']['calendar.allowPublicSharing']['default'] is False
+    # allowDelete must NOT be in the default profile (absent -> False).
+    assert 'allowDelete' not in data['preconfig']['profiles']['default']
+
+
+def test_services_json_no_secret_defaults():
+    """Secrets must never carry a real default (gitleaks scans services*.json)."""
+    data = json.loads(_SERVICES_JSON.read_text(encoding='utf-8'))
+    for prof in data['preconfig']['profiles'].values():
+        assert prof.get('serviceKey', '') == ''
+        assert prof.get('userToken', '') == ''
+
+
+# ---------------------------------------------------------------------------
+# Completeness
+# ---------------------------------------------------------------------------
+
+
+def test_all_seventeen_tools_plus_diagnostic_present():
+    expected = {
+        'check_connection',
+        # reads
+        'event_list',
+        'event_get',
+        'event_instances',
+        'freebusy_query',
+        'calendar_list',
+        'calendar_get',
+        'acl_list',
+        # writes
+        'event_create',
+        'event_update',
+        'event_move',
+        'event_quick_add',
+        'calendar_create',
+        'calendar_update',
+        'acl_insert',
+        'acl_delete',
+        # deletes (gated)
+        'event_delete',
+        'calendar_delete',
+    }
+    for name in expected:
+        method = getattr(cal_iinstance.IInstance, name)
+        assert callable(method), f'missing tool: {name}'
+        metadata = method.__tool_meta__
+        assert metadata['input_schema']['type'] == 'object'
+        assert metadata['description']
+
+
+@pytest.mark.parametrize(
+    'op,args,result_key,result',
+    [
+        ('event_get', {'eventId': 'ev1'}, 'get', _EVENT),
+        ('event_list', {}, 'list', {'items': [_EVENT]}),
+        ('event_instances', {'eventId': 'ev1'}, 'instances', {'items': [_EVENT]}),
+        (
+            'event_create',
+            {'summary': 'Sync', 'start': {'date': '2026-07-11'}, 'end': {'date': '2026-07-12'}},
+            'insert',
+            _EVENT,
+        ),
+        ('event_update', {'eventId': 'ev1', 'summary': 'Sync'}, 'patch', _EVENT),
+        ('event_move', {'eventId': 'ev1', 'destination': 'other'}, 'move', _EVENT),
+        ('event_quick_add', {'text': 'Sync tomorrow at noon'}, 'quickAdd', _EVENT),
+    ],
+)
+def test_all_event_returning_ops_preserve_cleaned_description_and_location(op, args, result_key, result):
+    inst = _make(results={result_key: result})
+    out = getattr(inst, op)(args)
+    event = out['events'][0] if 'events' in out else out
+    assert event['description'] == _EVENT['description']
+    assert event['location'] == _EVENT['location']


### PR DESCRIPTION
## Summary

- Add `tool_calendar` — an agent-invocable Google Calendar tool node (mirrors the shipped `tool_gmail`: shared `core/google_access.py` auth, user-OAuth + service-account).
- 18 operations across events (`event_list`/`event_get`/`event_instances`/`event_create`/`event_update`/`event_move`/`event_quick_add`/`event_delete`), calendars (`calendar_list`/`calendar_get`/`calendar_create`/`calendar_update`/`calendar_delete`), ACLs (`acl_list`/`acl_insert`/`acl_delete`), `freebusy_query`, and `check_connection`.
- Safety gate: `event_delete` and `calendar_delete` require the `allowDelete` flag (`acl_delete` is deliberately write-tier only). `sendUpdates` defaults to `'all'` and is always sent explicitly so attendee notifications aren't silently suppressed.
- Includes a contract fix (commit `c1b5996f`): the event cleaner now preserves `description` and `location` on every event-returning operation (previously dropped), and the returned-field contract is stated in the event tool descriptions so agents know the metadata is available.

## Type

feature (new agent-tool node) + tests

## Testing

- [x] Tests added or updated — 50 unit + service/contract tests (`nodes/test/tool_calendar/`), incl. the writable-metadata regression
- [x] Tested locally — Python 3.12: 50 unit pass, 294 contract tests pass, `ruff check`/`format` clean
- [ ] `./builder test` passes — not run locally (full C++ engine recompile); node contract/dynamic tests run in CI

Live end-to-end as a real user (user-OAuth token, personal GCP project): all 18 operations against the real Calendar API, plus both gate directions (`event_delete`/`calendar_delete` denied without `allowDelete`, succeed with it) and the ACL insert→revoke lifecycle. `description`/`location` round-trip verified live and through an `agent_rocketride` canvas run.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a; node README with generated marker block included
- [x] Breaking changes documented (if applicable) — none (purely additive node)

## Linked Issue

Closes #1059


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Google Calendar tool support (events, calendars, ACL rules, free/busy, recurring expansion) with connection diagnostics.
  * Introduced shared global setup for authenticated access, supporting service accounts and user OAuth with scope-aware authorization.
  * Added configurable deletion controls via `calendar.allowDelete`, with clearable update fields.
* **Documentation**
  * Added detailed tool documentation covering auth modes, parameters, limits, and troubleshooting.
* **Bug Fixes / Improvements**
  * Improved request robustness with retries and normalized agent-friendly outputs.
* **Tests**
  * Expanded unit tests for validation, output shaping, deletion gating, token/scope checks, and retry/rate-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->