### PR TITLE
feat(nodes): add tool_drive — Google Drive tool node

### DIFF
--- a/nodes/src/nodes/tool_google_workspace/drive.svg
+++ b/nodes/src/nodes/tool_google_workspace/drive.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+  <path fill="#0066DA" d="M4.5 20l3-5.2h13l-3 5.2z"/>
+  <path fill="#00AC47" d="M8 3.5l6.5 11.3H8L4.5 8.7z"/>
+  <path fill="#FFBA00" d="M14.5 14.8L8 3.5h6.5L21 14.8z"/>
+</svg>

--- a/nodes/src/nodes/tool_google_workspace/drive/IGlobal.py
+++ b/nodes/src/nodes/tool_google_workspace/drive/IGlobal.py
@@ -1,0 +1,45 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Google Drive global state backed by the shared Workspace lifecycle."""
+
+from ..IGlobal import GoogleToolGlobalBase
+from .client import SERVICE, resolve_account_domain
+
+
+class IGlobal(GoogleToolGlobalBase):
+    """Global state for Drive: resolved access, Drive v3 service, and account domain."""
+
+    SERVICE = SERVICE
+    SPEC_NAME = 'DRIVE'
+    account_domain = None
+
+    def _after_begin(self, cfg: dict) -> None:
+        auth_type = (cfg.get('authType') or 'service').strip()
+        self.account_domain = resolve_account_domain(auth_type, cfg)
+
+    def endGlobal(self) -> None:
+        super().endGlobal()
+        self.account_domain = None

--- a/nodes/src/nodes/tool_google_workspace/drive/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/drive/IInstance.py
@@ -1,0 +1,904 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""
+Google Drive tool node instance.
+
+Exposes the Drive v3 surface as agent tools: list/search files, read metadata,
+download binary files and export native Docs/Sheets/Slides, create/update/copy/
+move files and folders, manage permissions (sharing), trash/untrash, track
+changes, and permanently delete. Every file operation targets My Drive and
+shared drives (supportsAllDrives).
+
+Write operations require the ``write`` tier. Two destructive capabilities are
+additionally gated behind explicit config flags: public/external sharing
+(``allowPublicSharing``) and permanent delete (``allowHardDelete``).
+
+Operational targets (fileId, folderId, permissionId) are always invoke-time
+parameters — never node config.
+"""
+
+from __future__ import annotations
+
+import base64
+
+from rocketlib import tool_function
+
+from ai.common.utils import normalize_tool_input, optional_str, require_str
+
+from .client import (
+    SERVICE,
+    _FILE_FIELDS,
+    clean_binary,
+    clean_change,
+    clean_drive,
+    clean_file,
+    clean_file_list,
+    clean_permission,
+    execute,
+    execute_media,
+)
+from ..IInstance import GoogleToolInstanceBase
+from .IGlobal import IGlobal
+
+# Google-native docs (Docs/Sheets/Slides/etc.) have no binary blob; they must be
+# exported (file_export), not downloaded (file_download).
+_GOOGLE_NATIVE_PREFIX = 'application/vnd.google-apps.'
+_FOLDER_MIME = 'application/vnd.google-apps.folder'
+
+# Download cap: get_media buffers the whole body in memory and returns base64.
+_MAX_DOWNLOAD = 10 * 1024 * 1024  # 10 MiB
+
+_PERM_TYPES = ('user', 'group', 'domain', 'anyone')
+_PERM_ROLES = ('reader', 'commenter', 'writer', 'fileOrganizer', 'organizer', 'owner')
+
+# Fields returned for a permission resource.
+_PERM_FIELDS = 'id,type,role,emailAddress,domain,allowFileDiscovery'
+
+
+class IInstance(GoogleToolInstanceBase):
+    IGlobal: IGlobal
+    SERVICE = SERVICE
+
+    # -----------------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------------
+
+    def _account_domain(self) -> str | None:
+        """Return the resolved account domain (or None/UNKNOWN)."""
+        return getattr(self.IGlobal, 'account_domain', None)
+
+    @staticmethod
+    def _int_arg(args: dict, key: str, default: int, lo: int, hi: int) -> int:
+        """Read an integer arg, defaulting only on None and clamping to [lo, hi].
+
+        ``args.get(key) or default`` silently turns an explicit 0 into the
+        default, bypassing the clamp; a bool must never be coerced to an int.
+        """
+        value = args.get(key)
+        if value is None:
+            value = default
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise ValueError(f'{key} must be an integer')
+        return max(lo, min(value, hi))
+
+    @staticmethod
+    def _opt_str_list(args: dict, key: str, op: str) -> list[str] | None:
+        """Validate an optional non-empty list of id strings (e.g. parents)."""
+        value = args.get(key)
+        if value is None:
+            return None
+        if not isinstance(value, list) or not value or not all(isinstance(i, str) and i.strip() for i in value):
+            raise ValueError(f'{op}: "{key}" must be a non-empty list of id strings')
+        return value
+
+    @staticmethod
+    def _decode_content(args: dict, key: str, op: str) -> bytes | None:
+        """Decode an optional base64 content arg into bytes (padding-tolerant)."""
+        raw = args.get(key)
+        if raw is None:
+            return None
+        if not isinstance(raw, str):
+            raise ValueError(f'{op}: "{key}" must be a base64-encoded string')
+        s = raw.strip()
+        try:
+            return base64.b64decode(s + '=' * ((-len(s)) % 4))
+        except Exception as exc:
+            raise ValueError(f'{op}: "{key}" is not valid base64: {exc}') from exc
+
+    def _require_sharing_allowed(self, args: dict) -> None:
+        """Gate permission_create per the account-domain sharing rule.
+
+        - type ``anyone``  -> always require ``allowPublicSharing``.
+        - type ``domain``  -> require the flag UNLESS the target domain equals
+          the account's own domain.
+        - type ``user``/``group`` -> require the flag ONLY when the account
+          domain is known AND the grantee's email domain differs.
+        - When the account domain is UNKNOWN: anyone/domain are gated; user/group
+          grants are allowed (treated as internal).
+
+        Both public-link and external-party grants are gated by the single
+        ``allowPublicSharing`` flag.
+        """
+        ptype = args.get('type')
+        domain = self._account_domain()
+
+        if ptype == 'anyone':
+            self._access().require_flag('allowPublicSharing', 'permission_create (type=anyone, public link)')
+            return
+
+        if ptype == 'domain':
+            target = str(args.get('domain') or '').strip().lower()
+            if domain and target and target == domain:
+                return  # sharing within the account's own domain
+            self._access().require_flag('allowPublicSharing', 'permission_create (external / other-domain grant)')
+            return
+
+        if ptype in ('user', 'group'):
+            if domain:  # account domain known: gate cross-domain grants
+                email = str(args.get('emailAddress') or '').strip().lower()
+                grantee_domain = email.rsplit('@', 1)[-1] if '@' in email else ''
+                if grantee_domain and grantee_domain != domain:
+                    self._access().require_flag(
+                        'allowPublicSharing', 'permission_create (external grantee, different domain)'
+                    )
+            # Unknown account domain: user/group grants are allowed (treated internal).
+            return
+
+    def _files(self):
+        return self._svc().files()
+
+    # =======================================================================
+    # DIAGNOSTICS
+    # =======================================================================
+
+    @tool_function(
+        description=(
+            'Check the Google Drive connection and verify that the granted OAuth scopes cover the '
+            "node's configured access tier. Call this when a Drive operation fails with a scope or "
+            'permission error. Returns connection_ok: true when the required scopes are present.'
+        ),
+        input_schema={'type': 'object', 'properties': {}, 'required': []},
+    )
+    def check_connection(self, args: dict) -> dict:
+        """Check Drive connection status and whether granted OAuth scopes cover the access tier. Read-only."""
+        return self._check_connection_impl()
+
+    # =======================================================================
+    # FILES — read
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'q': {
+                    'type': 'string',
+                    'description': (
+                        'Optional Drive query string. Examples: '
+                        '"name contains \'report\'" ; '
+                        '"\'FOLDER_ID\' in parents and trashed = false" ; '
+                        '"mimeType = \'application/pdf\'".'
+                    ),
+                },
+                'pageSize': {'type': 'integer', 'description': 'Max files to return (1-100, default 25)'},
+                'pageToken': {'type': 'string', 'description': 'Page token from a previous call'},
+                'orderBy': {'type': 'string', 'description': 'Sort key, e.g. "modifiedTime desc" or "name"'},
+                'driveId': {'type': 'string', 'description': 'Restrict to a specific shared drive id'},
+                'corpora': {
+                    'type': 'string',
+                    'description': 'Search scope: "user", "drive" (requires driveId), "allDrives", or "domain"',
+                },
+            },
+        },
+        description=(
+            'List Drive files, optionally filtered by a query "q". Searches My Drive and shared drives. '
+            'Returns {files:[{id,name,description,mimeType,parents,webViewLink,modifiedTime,size,trashed,driveId}], '
+            'nextPageToken}. For a required-query search use file_search.'
+        ),
+    )
+    def file_list(self, args: dict) -> dict:
+        """List Drive files (optionally filtered by a query). Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        params: dict = {
+            'pageSize': self._int_arg(args, 'pageSize', 25, 1, 100),
+            'supportsAllDrives': True,
+            'includeItemsFromAllDrives': True,
+            'fields': f'nextPageToken, files({_FILE_FIELDS})',
+        }
+        q = optional_str(args, 'q', tool_name='file_list')
+        if q and q.strip():
+            params['q'] = q
+        page_token = optional_str(args, 'pageToken', tool_name='file_list')
+        if page_token and page_token.strip():
+            params['pageToken'] = page_token
+        order_by = optional_str(args, 'orderBy', tool_name='file_list')
+        if order_by and order_by.strip():
+            params['orderBy'] = order_by
+        drive_id = optional_str(args, 'driveId', tool_name='file_list')
+        corpora = optional_str(args, 'corpora', tool_name='file_list')
+        if drive_id and drive_id.strip():
+            params['driveId'] = drive_id
+            params['corpora'] = corpora.strip() if (corpora and corpora.strip()) else 'drive'
+        elif corpora and corpora.strip():
+            params['corpora'] = corpora.strip()
+        data = execute(self._files().list(**params))
+        return clean_file_list(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['q'],
+            'properties': {
+                'q': {
+                    'type': 'string',
+                    'description': (
+                        'Required Drive query string (Drive search syntax). Examples: '
+                        '"name = \'Budget 2026\'" ; '
+                        '"fullText contains \'quarterly revenue\'" ; '
+                        '"mimeType = \'application/vnd.google-apps.folder\' and trashed = false".'
+                    ),
+                },
+                'pageSize': {'type': 'integer', 'description': 'Max files to return (1-100, default 25)'},
+                'pageToken': {'type': 'string', 'description': 'Page token from a previous call'},
+                'orderBy': {'type': 'string', 'description': 'Sort key, e.g. "modifiedTime desc"'},
+                'driveId': {'type': 'string', 'description': 'Restrict to a specific shared drive id'},
+                'corpora': {'type': 'string', 'description': 'Search scope (see file_list)'},
+            },
+        },
+        description=(
+            'Search Drive files with a required query "q" (Drive query syntax). A thin wrapper over '
+            'file_list that enforces a query. Use operators like contains, =, and "in parents", e.g. '
+            '"name contains \'invoice\'", "\'FOLDER_ID\' in parents", "fullText contains \'contract\'".'
+        ),
+    )
+    def file_search(self, args: dict) -> dict:
+        """Search Drive files with a required query. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        require_str(args, 'q', tool_name='file_search')
+        return self.file_list(args)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {'fileId': {'type': 'string', 'description': 'The file id'}},
+        },
+        description=(
+            "Get a single file's metadata: id, name, description, mimeType, parents, webViewLink, "
+            'modifiedTime, size, trashed, driveId. Works for files in My Drive and shared drives.'
+        ),
+    )
+    def file_get(self, args: dict) -> dict:
+        """Get one file's cleaned metadata. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        fid = require_str(args, 'fileId', tool_name='file_get')
+        data = execute(self._files().get(fileId=fid, supportsAllDrives=True, fields=_FILE_FIELDS))
+        return clean_file(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {'fileId': {'type': 'string', 'description': 'The file id to download'}},
+        },
+        description=(
+            'Download a NON-native binary file (PDF, image, .docx, .csv, etc.) and return its bytes as '
+            'base64 in {fileId, mimeType, size, data_base64}. Refuses Google-native files '
+            '(Docs/Sheets/Slides, mimeType application/vnd.google-apps.*) — use file_export for those. '
+            'Capped at 10 MiB; larger files raise with their size.'
+        ),
+    )
+    def file_download(self, args: dict) -> dict:
+        """Download a non-native file as base64 (10 MiB cap; native files raise). Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        fid = require_str(args, 'fileId', tool_name='file_download')
+        meta = execute(self._files().get(fileId=fid, supportsAllDrives=True, fields='id,name,mimeType,size'))
+        mime = meta.get('mimeType')
+        if isinstance(mime, str) and mime.startswith(_GOOGLE_NATIVE_PREFIX):
+            raise ValueError(
+                f'file_download cannot download the Google-native file {fid!r} (mimeType {mime}). '
+                'Native Docs/Sheets/Slides have no binary blob — use file_export with a target '
+                'mimeType (e.g. application/pdf) instead.'
+            )
+        size_str = meta.get('size')
+        if size_str is not None:
+            try:
+                size_int = int(size_str)
+            except (TypeError, ValueError):
+                size_int = None
+            if size_int is not None and size_int > _MAX_DOWNLOAD:
+                raise ValueError(
+                    f'file_download: {fid!r} is {size_int} bytes, over the {_MAX_DOWNLOAD}-byte (10 MiB) cap. '
+                    'Fetch a smaller file, or retrieve this file out of band.'
+                )
+        raw = execute_media(self._files().get_media(fileId=fid, supportsAllDrives=True))
+        raw = bytes(raw or b'')
+        if len(raw) > _MAX_DOWNLOAD:
+            raise ValueError(
+                f'file_download: {fid!r} is {len(raw)} bytes, over the {_MAX_DOWNLOAD}-byte (10 MiB) cap. '
+                'Fetch a smaller file, or retrieve this file out of band.'
+            )
+        return clean_binary(fid, mime, len(raw), base64.b64encode(raw).decode('ascii'))
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId', 'mimeType'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The Google-native file id to export'},
+                'mimeType': {
+                    'type': 'string',
+                    'description': (
+                        'Export target mimeType, e.g. application/pdf, text/plain, '
+                        'application/vnd.openxmlformats-officedocument.wordprocessingml.document (.docx), '
+                        'text/csv (Sheets).'
+                    ),
+                },
+            },
+        },
+        description=(
+            'Export a Google-native file (Docs/Sheets/Slides) to a chosen format and return the bytes as '
+            'base64 in {fileId, mimeType, size, data_base64}. Native files must be EXPORTED, not '
+            'downloaded (use file_download for non-native binaries). The export API caps output at ~10 MiB.'
+        ),
+    )
+    def file_export(self, args: dict) -> dict:
+        """Export a Google-native file to a target format as base64. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        fid = require_str(args, 'fileId', tool_name='file_export')
+        mime = require_str(args, 'mimeType', tool_name='file_export')
+        raw = execute_media(self._files().export_media(fileId=fid, mimeType=mime))
+        raw = bytes(raw or b'')
+        return clean_binary(fid, mime, len(raw), base64.b64encode(raw).decode('ascii'))
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'pageSize': {'type': 'integer', 'description': 'Max shared drives to return (1-100, default 25)'},
+                'pageToken': {'type': 'string', 'description': 'Page token from a previous call'},
+            },
+        },
+        description='List the shared drives the account can access. Returns {drives:[{id,name}], nextPageToken}.',
+    )
+    def drives_list(self, args: dict) -> dict:
+        """List accessible shared drives. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        params: dict = {
+            'pageSize': self._int_arg(args, 'pageSize', 25, 1, 100),
+            'fields': 'nextPageToken, drives(id,name)',
+        }
+        page_token = optional_str(args, 'pageToken', tool_name='drives_list')
+        if page_token and page_token.strip():
+            params['pageToken'] = page_token
+        data = execute(self._svc().drives().list(**params))
+        out: dict = {'drives': [clean_drive(d) for d in data.get('drives') or []]}
+        if data.get('nextPageToken'):
+            out['nextPageToken'] = data['nextPageToken']
+        return out
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'pageToken': {
+                    'type': 'string',
+                    'description': (
+                        'The change page token. If omitted, this returns a startPageToken to call again with — '
+                        'changes are only tracked from that token forward.'
+                    ),
+                },
+                'driveId': {'type': 'string', 'description': 'Track changes on a specific shared drive'},
+            },
+        },
+        description=(
+            'Track file changes. Call with no pageToken first to get {startPageToken}; then call again '
+            'passing it as pageToken to receive changes since then. Returns {changes:[{fileId,removed,time,'
+            'file}], newStartPageToken, nextPageToken}. Save newStartPageToken for the next poll.'
+        ),
+    )
+    def changes_list(self, args: dict) -> dict:
+        """List Drive changes since a page token (bootstrapping a token when none is given). Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        page_token = args.get('pageToken')
+        drive_id = optional_str(args, 'driveId', tool_name='changes_list')
+        if page_token is None or (isinstance(page_token, str) and not page_token.strip()):
+            # Start tokens are per corpus: without driveId a shared-drive caller
+            # would get a My-Drive token that the next (driveId) call rejects.
+            boot_params: dict = {'supportsAllDrives': True}
+            if drive_id and drive_id.strip():
+                boot_params['driveId'] = drive_id
+            data = execute(self._svc().changes().getStartPageToken(**boot_params))
+            return {
+                'startPageToken': data.get('startPageToken'),
+                'message': (
+                    'No pageToken was supplied. Call changes_list again with this startPageToken as '
+                    '"pageToken" to fetch changes made from now on.'
+                ),
+            }
+        if not isinstance(page_token, str):
+            raise ValueError('changes_list: "pageToken" must be a string')
+        params: dict = {
+            'pageToken': page_token,
+            'supportsAllDrives': True,
+            'includeItemsFromAllDrives': True,
+            'fields': f'newStartPageToken, nextPageToken, changes(fileId,removed,time,file({_FILE_FIELDS}))',
+        }
+        if drive_id and drive_id.strip():
+            params['driveId'] = drive_id
+        data = execute(self._svc().changes().list(**params))
+        out: dict = {'changes': [clean_change(c) for c in data.get('changes') or []]}
+        if data.get('newStartPageToken'):
+            out['newStartPageToken'] = data['newStartPageToken']
+        if data.get('nextPageToken'):
+            out['nextPageToken'] = data['nextPageToken']
+        return out
+
+    # =======================================================================
+    # FILES — write
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['name'],
+            'properties': {
+                'name': {'type': 'string', 'description': 'Name for the new file'},
+                'parents': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': 'Optional parent folder id(s) to create the file in',
+                },
+                'mimeType': {'type': 'string', 'description': 'Optional mimeType for the new file'},
+                'description': {'type': 'string', 'description': 'Optional description for the new file'},
+                'content_base64': {
+                    'type': 'string',
+                    'description': 'Optional base64 file content (uploaded as the file body)',
+                },
+            },
+        },
+        description=(
+            'Create a new Drive file. Optionally place it in parent folder(s), set its mimeType and '
+            'description, and upload base64 content as the body. Returns the cleaned file. Requires '
+            'the write tier. For a folder use folder_create.'
+        ),
+    )
+    def file_create(self, args: dict) -> dict:
+        """Create a Drive file (optionally with content). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('file_create')
+        name = require_str(args, 'name', tool_name='file_create')
+        body: dict = {'name': name}
+        parents = self._opt_str_list(args, 'parents', 'file_create')
+        if parents:
+            body['parents'] = parents
+        mime = optional_str(args, 'mimeType', tool_name='file_create')
+        if mime and mime.strip():
+            body['mimeType'] = mime
+        description = optional_str(args, 'description', tool_name='file_create')
+        if description and description.strip():
+            body['description'] = description
+        content = self._decode_content(args, 'content_base64', 'file_create')
+        params: dict = {'body': body, 'supportsAllDrives': True, 'fields': _FILE_FIELDS}
+        if content is not None:
+            from googleapiclient.http import MediaInMemoryUpload
+
+            params['media_body'] = MediaInMemoryUpload(content, mimetype=(mime or 'application/octet-stream'))
+        data = execute(self._files().create(**params))
+        return clean_file(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The file id to update'},
+                'name': {'type': 'string', 'description': 'Optional new name'},
+                'description': {'type': 'string', 'description': 'Optional new description'},
+                'content_base64': {
+                    'type': 'string',
+                    'description': 'Optional base64 content that REPLACES the file body',
+                },
+            },
+        },
+        description=(
+            'Update a file: rename, set its description, and/or replace its content with new base64 bytes. '
+            'Returns the cleaned file. Requires the write tier.'
+        ),
+    )
+    def file_update(self, args: dict) -> dict:
+        """Update a file's name/description and optionally replace its content. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('file_update')
+        fid = require_str(args, 'fileId', tool_name='file_update')
+        body: dict = {}
+        name = optional_str(args, 'name', tool_name='file_update')
+        if name and name.strip():
+            body['name'] = name
+        desc = optional_str(args, 'description', tool_name='file_update')
+        if desc is not None:
+            body['description'] = desc
+        content = self._decode_content(args, 'content_base64', 'file_update')
+        if not body and content is None:
+            raise ValueError('file_update: provide at least one field to change')
+        params: dict = {'fileId': fid, 'body': body, 'supportsAllDrives': True, 'fields': _FILE_FIELDS}
+        if content is not None:
+            from googleapiclient.http import MediaInMemoryUpload
+
+            params['media_body'] = MediaInMemoryUpload(content, mimetype='application/octet-stream')
+        data = execute(self._files().update(**params))
+        return clean_file(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The file id to copy'},
+                'name': {'type': 'string', 'description': 'Optional name for the copy'},
+                'description': {'type': 'string', 'description': 'Optional description for the copy'},
+                'parents': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': 'Optional parent folder id(s) for the copy',
+                },
+            },
+        },
+        description=(
+            'Copy a file. Optionally rename the copy, set its description, and place it in specific '
+            'folder(s). Requires the write tier.'
+        ),
+    )
+    def file_copy(self, args: dict) -> dict:
+        """Copy a file. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('file_copy')
+        fid = require_str(args, 'fileId', tool_name='file_copy')
+        body: dict = {}
+        name = optional_str(args, 'name', tool_name='file_copy')
+        if name and name.strip():
+            body['name'] = name
+        description = optional_str(args, 'description', tool_name='file_copy')
+        if description and description.strip():
+            body['description'] = description
+        parents = self._opt_str_list(args, 'parents', 'file_copy')
+        if parents:
+            body['parents'] = parents
+        data = execute(self._files().copy(fileId=fid, body=body, supportsAllDrives=True, fields=_FILE_FIELDS))
+        return clean_file(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId', 'addParents'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The file id to move'},
+                'addParents': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': 'Destination parent folder id(s) to add',
+                },
+                'removeParents': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': "Parent id(s) to remove; defaults to the file's current parents",
+                },
+            },
+        },
+        description=(
+            'Move a file to different folder(s) by adding new parents and removing old ones. If '
+            "removeParents is omitted, the file's current parents are removed (a plain move). "
+            'Requires the write tier.'
+        ),
+    )
+    def file_move(self, args: dict) -> dict:
+        """Move a file between folders (add/remove parents). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('file_move')
+        fid = require_str(args, 'fileId', tool_name='file_move')
+        add_parents = self._opt_str_list(args, 'addParents', 'file_move')
+        if not add_parents:
+            raise ValueError('file_move: "addParents" must be a non-empty list of destination folder id(s)')
+        remove_parents = self._opt_str_list(args, 'removeParents', 'file_move')
+        if remove_parents is None:
+            current = execute(self._files().get(fileId=fid, supportsAllDrives=True, fields='parents'))
+            remove_parents = current.get('parents') or []
+        data = execute(
+            self._files().update(
+                fileId=fid,
+                addParents=','.join(add_parents),
+                removeParents=','.join(remove_parents),
+                body={},
+                supportsAllDrives=True,
+                fields=_FILE_FIELDS,
+            )
+        )
+        return clean_file(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {'fileId': {'type': 'string', 'description': 'The file id to move to Trash'}},
+        },
+        description=(
+            'Move a file to Trash (recoverable). This is the safe, reversible alternative to file_delete. '
+            'Requires the write tier.'
+        ),
+    )
+    def file_trash(self, args: dict) -> dict:
+        """Move a file to Trash (recoverable). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('file_trash')
+        fid = require_str(args, 'fileId', tool_name='file_trash')
+        data = execute(
+            self._files().update(fileId=fid, body={'trashed': True}, supportsAllDrives=True, fields=_FILE_FIELDS)
+        )
+        return clean_file(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {'fileId': {'type': 'string', 'description': 'The file id to restore from Trash'}},
+        },
+        description='Restore a file from Trash. Requires the write tier.',
+    )
+    def file_untrash(self, args: dict) -> dict:
+        """Restore a file from Trash. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('file_untrash')
+        fid = require_str(args, 'fileId', tool_name='file_untrash')
+        data = execute(
+            self._files().update(fileId=fid, body={'trashed': False}, supportsAllDrives=True, fields=_FILE_FIELDS)
+        )
+        return clean_file(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['name'],
+            'properties': {
+                'name': {'type': 'string', 'description': 'Name for the new folder'},
+                'description': {'type': 'string', 'description': 'Optional description for the new folder'},
+                'parents': {
+                    'type': 'array',
+                    'items': {'type': 'string'},
+                    'description': 'Optional parent folder id(s) to create the folder in',
+                },
+            },
+        },
+        description=(
+            'Create a new folder. Optionally set its description and nest it under parent folder(s). '
+            'Requires the write tier.'
+        ),
+    )
+    def folder_create(self, args: dict) -> dict:
+        """Create a folder. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('folder_create')
+        name = require_str(args, 'name', tool_name='folder_create')
+        body: dict = {'name': name, 'mimeType': _FOLDER_MIME}
+        description = optional_str(args, 'description', tool_name='folder_create')
+        if description and description.strip():
+            body['description'] = description
+        parents = self._opt_str_list(args, 'parents', 'folder_create')
+        if parents:
+            body['parents'] = parents
+        data = execute(self._files().create(body=body, supportsAllDrives=True, fields=_FILE_FIELDS))
+        return clean_file(data)
+
+    # =======================================================================
+    # PERMISSIONS (sharing) — write
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The file id'},
+                'pageToken': {'type': 'string', 'description': 'Page token from a previous call'},
+            },
+        },
+        description=(
+            'List the permissions (sharing entries) on a file: id, type, role, emailAddress, domain, '
+            'allowFileDiscovery. Available at the read-only tier.'
+        ),
+    )
+    def permission_list(self, args: dict) -> dict:
+        """List a file's permissions. Read-only."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        fid = require_str(args, 'fileId', tool_name='permission_list')
+        params: dict = {
+            'fileId': fid,
+            'supportsAllDrives': True,
+            'fields': f'nextPageToken, permissions({_PERM_FIELDS})',
+        }
+        page_token = optional_str(args, 'pageToken', tool_name='permission_list')
+        if page_token and page_token.strip():
+            params['pageToken'] = page_token
+        data = execute(self._svc().permissions().list(**params))
+        out: dict = {'permissions': [clean_permission(p) for p in data.get('permissions') or []]}
+        if data.get('nextPageToken'):
+            out['nextPageToken'] = data['nextPageToken']
+        return out
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId', 'permissionId', 'role'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The file id'},
+                'permissionId': {'type': 'string', 'description': 'The permission id (from permission_list)'},
+                'role': {
+                    'type': 'string',
+                    'enum': list(_PERM_ROLES),
+                    'description': 'New role: reader, commenter, writer, fileOrganizer, organizer, or owner',
+                },
+            },
+        },
+        description='Change the role of an existing permission. Requires the write tier.',
+    )
+    def permission_update(self, args: dict) -> dict:
+        """Update an existing permission's role. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('permission_update')
+        fid = require_str(args, 'fileId', tool_name='permission_update')
+        pid = require_str(args, 'permissionId', tool_name='permission_update')
+        role = self._enum_arg(args, 'role', _PERM_ROLES, None)
+        if role is None:
+            raise ValueError(f'permission_update: "role" is required, one of {list(_PERM_ROLES)}')
+        # Deliberate asymmetry: updates re-run the sharing gate even when narrowing;
+        # delete/revoke stays ungated so permission removal remains fail-closed.
+        # Broadening an existing grant is sharing too: an ungated update could
+        # widen a public/external permission the create-gate would have refused,
+        # so run the same gate against the existing grantee before changing it.
+        current = execute(
+            self._svc().permissions().get(fileId=fid, permissionId=pid, supportsAllDrives=True, fields=_PERM_FIELDS)
+        )
+        self._require_sharing_allowed(
+            {
+                'type': current.get('type'),
+                'domain': current.get('domain'),
+                'emailAddress': current.get('emailAddress'),
+            }
+        )
+        data = execute(
+            self._svc()
+            .permissions()
+            .update(fileId=fid, permissionId=pid, body={'role': role}, supportsAllDrives=True, fields=_PERM_FIELDS)
+        )
+        return clean_permission(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId', 'permissionId'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The file id'},
+                'permissionId': {'type': 'string', 'description': 'The permission id to revoke'},
+            },
+        },
+        description='Revoke (delete) a permission, removing that access. Requires the write tier.',
+    )
+    def permission_delete(self, args: dict) -> dict:
+        """Revoke a permission. Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('permission_delete')
+        fid = require_str(args, 'fileId', tool_name='permission_delete')
+        pid = require_str(args, 'permissionId', tool_name='permission_delete')
+        execute(self._svc().permissions().delete(fileId=fid, permissionId=pid, supportsAllDrives=True))
+        return {'deleted': True, 'fileId': fid, 'permissionId': pid}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId', 'type', 'role'],
+            'properties': {
+                'fileId': {'type': 'string', 'description': 'The file id to share'},
+                'type': {
+                    'type': 'string',
+                    'enum': list(_PERM_TYPES),
+                    'description': 'Grantee type: user, group, domain, or anyone',
+                },
+                'role': {
+                    'type': 'string',
+                    'enum': list(_PERM_ROLES),
+                    'description': 'reader, commenter, writer, fileOrganizer, organizer, or owner',
+                },
+                'emailAddress': {'type': 'string', 'description': 'Required for type user/group'},
+                'domain': {'type': 'string', 'description': 'Required for type domain'},
+                'sendNotificationEmail': {
+                    'type': 'boolean',
+                    'description': 'For user/group grants: email the grantee (default true; always sent)',
+                },
+            },
+        },
+        description=(
+            'Grant access to a file. GATED sharing: a grant to type "anyone" (public link) or to a domain '
+            "or user OUTSIDE the account's own domain requires the node's allowPublicSharing flag to be on; "
+            'same-domain and internal user/group grants are always allowed. When the account domain is '
+            'unknown, anyone/domain grants are gated and user/group grants are treated as internal. '
+            'user/group grants always send a notification email by default. Requires the write tier.'
+        ),
+    )
+    def permission_create(self, args: dict) -> dict:
+        """Grant access to a file (gated for public / external sharing). Requires the write tier."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        # require_write FIRST, then the sharing gate.
+        self._access().require_write('permission_create')
+        fid = require_str(args, 'fileId', tool_name='permission_create')
+        ptype = self._enum_arg(args, 'type', _PERM_TYPES, None)
+        if ptype is None:
+            raise ValueError(f'permission_create: "type" is required, one of {list(_PERM_TYPES)}')
+        role = self._enum_arg(args, 'role', _PERM_ROLES, None)
+        if role is None:
+            raise ValueError(f'permission_create: "role" is required, one of {list(_PERM_ROLES)}')
+        body: dict = {'type': ptype, 'role': role}
+        if ptype in ('user', 'group'):
+            body['emailAddress'] = require_str(args, 'emailAddress', tool_name='permission_create')
+        elif ptype == 'domain':
+            body['domain'] = require_str(args, 'domain', tool_name='permission_create')
+
+        # Sharing gate: reads the (validated) type/domain/emailAddress.
+        self._require_sharing_allowed(args)
+
+        params: dict = {'fileId': fid, 'body': body, 'supportsAllDrives': True, 'fields': _PERM_FIELDS}
+        if ptype in ('user', 'group'):
+            # Documented default true, always sent explicitly.
+            send = args.get('sendNotificationEmail')
+            params['sendNotificationEmail'] = send if isinstance(send, bool) else True
+        else:
+            # Google requires no notification for anyone/domain grants.
+            params['sendNotificationEmail'] = False
+        data = execute(self._svc().permissions().create(**params))
+        return clean_permission(data)
+
+    # =======================================================================
+    # GATED — permanent delete
+    # =======================================================================
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['fileId'],
+            'properties': {'fileId': {'type': 'string', 'description': 'The file id to permanently delete'}},
+        },
+        description=(
+            'PERMANENTLY delete a file, bypassing Trash. This is IRREVERSIBLE. Requires the write tier AND '
+            "the node's allowHardDelete flag. Prefer file_trash (recoverable) unless permanent deletion is "
+            'explicitly required.'
+        ),
+    )
+    def file_delete(self, args: dict) -> dict:
+        """Permanently delete a file, bypassing Trash (irreversible). Requires write + allowHardDelete."""
+        args = normalize_tool_input(args, tool_name='tool_drive')
+        self._access().require_write('file_delete')
+        self._access().require_flag('allowHardDelete', 'file_delete')
+        fid = require_str(args, 'fileId', tool_name='file_delete')
+        execute(self._files().delete(fileId=fid, supportsAllDrives=True))
+        return {'deleted': True, 'fileId': fid, 'permanent': True}

--- a/nodes/src/nodes/tool_google_workspace/drive/README.md
+++ b/nodes/src/nodes/tool_google_workspace/drive/README.md
@@ -1,0 +1,143 @@
+# Google Drive tool node (`tool_drive`)
+
+Exposes the Google Drive API v3 as agent tools: list and search files, read
+metadata, download binary files and export native Docs/Sheets/Slides,
+create/update/copy/move files and folders, manage sharing (permissions),
+trash/untrash, track changes, and permanently delete. Works across My Drive and
+shared drives.
+
+## What it does
+
+An agent-invocable tool node — no data flows through lanes. Each operation is a
+`@tool_function` an agent calls on demand. Operational targets (`fileId`,
+`folderId`, `permissionId`) are always tool-call parameters, never node config.
+Outputs are cleaned shapes (`id`, `name`, `mimeType`, `parents`, `webViewLink`,
+`modifiedTime`, `size`, `trashed`, `driveId`), not raw API JSON. Every file
+operation sets `supportsAllDrives` so shared-drive items work transparently.
+
+## Configuration
+
+| Field | Notes |
+|-------|-------|
+| `google.authType` | `service` (service account) or `user` (OAuth). |
+| `google.serviceKey` / `google.adminEmail` | Service account JSON key; `adminEmail` enables domain-wide delegation (impersonate that user) and sets the account's own domain for the sharing gate. |
+| `google.oAuthButton` / `google.userToken` | User OAuth: sign in to populate the access token. |
+| `drive.access` | `readonly` or `write` (default). Resolved by the shared `DRIVE` spec in `core/google_access.py`; scopes are never hand-entered. |
+| `drive.allowPublicSharing` | Off by default. Gate for anyone-with-link and external-domain grants (see Sharing gate). |
+| `drive.allowHardDelete` | Off by default. Gate for `file_delete` (permanent delete, bypasses Trash, irreversible). |
+
+### Access tiers → scopes
+
+| Tier | Scope | Capability |
+|------|-------|------------|
+| `readonly` | `drive.readonly` | list/search, read metadata and permissions, download, export |
+| `write` | `drive` | full read/write (default) |
+
+## Tools
+
+- **Read:** `file_list` (optional query `q`), `file_search` (query required),
+  `file_get` (metadata), `file_download` (non-native binary → base64),
+  `file_export` (native Docs/Sheets/Slides → base64 in a chosen format),
+  `drives_list` (shared drives), `changes_list` (change tracking),
+  `permission_list` (sharing entries).
+- **Write:** `file_create`, `file_update`, `file_copy`, `file_move`,
+  `file_trash`, `file_untrash`, `folder_create`, `permission_update`,
+  `permission_delete`, `permission_create`.
+- **Gated:** `file_delete` (permanent delete).
+- **Diagnostics:** `check_connection` verifies granted scopes cover the tier.
+
+### Download vs. export (native files)
+
+Google-native files (Docs, Sheets, Slides — `mimeType`
+`application/vnd.google-apps.*`) have **no binary blob**. `file_download`
+**refuses** them with a pointer to `file_export`. Use `file_export` with a
+target `mimeType` (e.g. `application/pdf`,
+`application/vnd.openxmlformats-officedocument.wordprocessingml.document` for
+`.docx`, `text/csv` for Sheets) to render native files into a real format. Both
+return `{fileId, mimeType, size, data_base64}`. `file_download` caps at 10 MiB
+(checked via metadata first); `file_export` is capped at ~10 MiB by Google.
+`file_export`'s PDF/`.docx` output is what feeds the `tool_docs` / #1058 export
+workflow.
+
+### Sharing gate (`permission_create` + `allowPublicSharing`)
+
+Granting access is gated so an agent cannot silently make files public or share
+them externally. The account's **own domain** is resolved from `adminEmail`
+(service auth) or from the user token's `hd`/`email` claim (user auth); when it
+can't be determined it is **unknown**.
+
+| Grant `type` | Requires `allowPublicSharing`? |
+|--------------|--------------------------------|
+| `anyone` (public link) | Always. |
+| `domain` == account's own domain | No. |
+| `domain` != own domain (or unknown) | Yes. |
+| `user` / `group`, same domain as account | No. |
+| `user` / `group`, different domain (account domain known) | Yes. |
+| `user` / `group`, account domain **unknown** | No — treated as internal. |
+
+Both the public-link and external-party cases are gated by the single
+`allowPublicSharing` flag. When it is off, a gated grant raises
+`GoogleAccessError` naming the flag. `user`/`group` grants always send a
+notification email by default (`sendNotificationEmail`, default `true`).
+
+Moving or copying a file into an already-public folder inherits that folder's
+ACL, which is a sharing path this gate cannot see.
+
+### Hard-delete gate (`file_delete` + `allowHardDelete`)
+
+`file_delete` **permanently** removes a file, bypassing Trash — **irreversible**.
+It requires the `write` tier **and** the `allowHardDelete` flag. `file_trash`
+(recoverable) is the safe alternative and needs only `write`.
+
+### Shared drives
+
+Every file operation passes `supportsAllDrives=True` (and reads pass
+`includeItemsFromAllDrives=True`), so files on shared drives are visible and
+mutable. `file_list`/`file_search` accept `driveId` + `corpora` to scope a
+search to one shared drive; `drives_list` enumerates accessible shared drives;
+`changes_list` accepts a `driveId` to track a specific shared drive.
+
+## Setup
+
+Authenticate with either a Google **service account** (`google.serviceKey` JSON,
+optionally `google.adminEmail` for domain-wide delegation) or **user OAuth**
+(click sign-in to populate `google.userToken`). The Drive API must be enabled on
+the Google Cloud project backing the credential.
+
+## Limits
+
+- `file_download` caps at 10 MiB (checked from metadata before fetching);
+  `file_export` at Google's ~10 MiB export limit.
+- List calls page with `pageToken`; `pageSize` clamps to 1–100 (default 25).
+- Rate limits are per Google project; the node retries `429`/`5xx` with
+  exponential backoff.
+
+## Examples
+
+```text
+file_search   { "q": "name contains 'invoice' and trashed = false" }
+file_get      { "fileId": "1AbC..." }
+file_export   { "fileId": "1Doc...", "mimeType": "application/pdf" }
+file_trash    { "fileId": "1AbC..." }
+```
+
+## Upstream docs
+
+- Google Drive API v3: https://developers.google.com/drive/api/reference/rest/v3
+- Search query syntax: https://developers.google.com/drive/api/guides/search-files
+- Exporting native files: https://developers.google.com/drive/api/guides/manage-downloads
+
+## Troubleshooting
+
+- **Scope / 403 errors:** call `check_connection`; if scopes are missing,
+  disconnect and reconnect the Google account at the required access tier.
+- **`access` is read-only:** write operations raise `GoogleAccessError`; raise
+  `drive.access` to `write`.
+- **Sharing refused:** the grant is public/external and `allowPublicSharing` is
+  off — enable it, or grant to an internal user/domain.
+- **Delete refused:** `file_delete` needs `allowHardDelete`; use `file_trash`
+  for a recoverable delete.
+- **`file_download` refused:** the file is Google-native — use `file_export`.
+
+<!-- ROCKETRIDE:GENERATED:PARAMS START -->
+<!-- ROCKETRIDE:GENERATED:PARAMS END -->

--- a/nodes/src/nodes/tool_google_workspace/drive/__init__.py
+++ b/nodes/src/nodes/tool_google_workspace/drive/__init__.py
@@ -1,0 +1,29 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/tool_google_workspace/drive/client.py
+++ b/nodes/src/nodes/tool_google_workspace/drive/client.py
@@ -1,0 +1,183 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Google Drive-specific service bindings, domain helpers, and response cleaners."""
+
+from __future__ import annotations
+
+import functools
+import json
+from typing import Any
+
+from .. import google_client
+
+_G = 'https://www.googleapis.com/auth'
+
+SERVICE = google_client.GoogleService(
+    product='Google Drive',
+    api='drive',
+    version='v3',
+    superset_scopes=frozenset({f'{_G}/drive'}),
+)
+
+resolve_refresh_url = functools.partial(google_client.resolve_refresh_url, SERVICE)
+resolve_token_uri = functools.partial(google_client.resolve_token_uri, SERVICE)
+token_scope_report = functools.partial(google_client.token_scope_report, SERVICE)
+build_service = functools.partial(google_client.build_service, SERVICE)
+execute = functools.partial(google_client.execute, SERVICE)
+_decode_blob = google_client._decode_blob
+
+# The compact file field set requested on every metadata read/write.
+_FILE_FIELDS = 'id,name,description,mimeType,parents,webViewLink,modifiedTime,size,trashed,driveId'
+
+
+def execute_media(request: Any) -> bytes:
+    """Run a Drive get_media/export_media request returning raw bytes."""
+    return google_client.execute(SERVICE, request, binary=True)
+
+
+# Consumer domains prove nothing about organisational membership: for a personal
+# account the email-derived "own domain" would be gmail.com, and the sharing gate
+# would then wave through a grant to ANY @gmail.com address as "same domain".
+_CONSUMER_DOMAINS = frozenset({'gmail.com', 'googlemail.com'})
+
+
+def _domain_or_unknown(raw_email: str) -> str | None:
+    """Extract the domain of an email, mapping consumer domains to None (UNKNOWN)."""
+    domain = raw_email.rsplit('@', 1)[-1].strip().lower() or None
+    return None if domain in _CONSUMER_DOMAINS else domain
+
+
+def resolve_account_domain(auth_type: str, cfg: dict) -> str | None:
+    """Resolve the account's own domain for the sharing gate.
+
+    Service auth: the domain of ``adminEmail`` (the impersonated user). User
+    auth: the token's ``hd`` (hosted-domain) claim, else the domain of its
+    ``email`` claim. Consumer domains (gmail.com/googlemail.com) resolve to
+    UNKNOWN — a personal account is not an organisation, so "same domain" must
+    never match another random consumer address. Returns None (UNKNOWN) when the
+    domain can't be determined; callers treat UNKNOWN by gating anyone/domain
+    grants and allowing user/group.
+    """
+    if auth_type == 'user':
+        token = str(cfg.get('userToken') or '').strip()
+        if not token:
+            return None
+        try:
+            info = json.loads(_decode_blob(token))
+        except Exception:
+            return None
+        hd = info.get('hd')
+        if isinstance(hd, str) and hd.strip():
+            return hd.strip().lower()
+        email = info.get('email')
+        if isinstance(email, str) and '@' in email:
+            return _domain_or_unknown(email)
+        return None
+    admin = str(cfg.get('adminEmail') or '').strip()
+    if admin and '@' in admin:
+        return _domain_or_unknown(admin)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Response cleaners
+# ---------------------------------------------------------------------------
+
+
+def clean_file(f: dict | None) -> dict:
+    """Compact a Drive file resource to the agent-facing field set."""
+    if not isinstance(f, dict):
+        return {}
+    out = {
+        'id': f.get('id'),
+        'name': f.get('name'),
+        'description': f.get('description'),
+        'mimeType': f.get('mimeType'),
+        'parents': f.get('parents'),
+        'webViewLink': f.get('webViewLink'),
+        'modifiedTime': f.get('modifiedTime'),
+        'size': f.get('size'),
+        'trashed': f.get('trashed'),
+        'driveId': f.get('driveId'),
+    }
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def clean_file_list(data: dict | None) -> dict:
+    """Compact a files.list response: cleaned files + nextPageToken."""
+    if not isinstance(data, dict):
+        return {'files': []}
+    out: dict = {'files': [clean_file(f) for f in data.get('files') or []]}
+    if data.get('nextPageToken'):
+        out['nextPageToken'] = data['nextPageToken']
+    return out
+
+
+def clean_permission(p: dict | None) -> dict:
+    """Compact a permission resource: id, type, role, grantee, discoverability."""
+    if not isinstance(p, dict):
+        return {}
+    out = {
+        'id': p.get('id'),
+        'type': p.get('type'),
+        'role': p.get('role'),
+        'emailAddress': p.get('emailAddress'),
+        'domain': p.get('domain'),
+        'allowFileDiscovery': p.get('allowFileDiscovery'),
+    }
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def clean_drive(d: dict | None) -> dict:
+    """Compact a shared-drive resource: id + name."""
+    if not isinstance(d, dict):
+        return {}
+    out = {'id': d.get('id'), 'name': d.get('name')}
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def clean_change(c: dict | None) -> dict:
+    """Compact a change record: fileId, removed, time, and the cleaned file."""
+    if not isinstance(c, dict):
+        return {}
+    out: dict = {
+        'fileId': c.get('fileId'),
+        'removed': c.get('removed'),
+        'time': c.get('time'),
+    }
+    if isinstance(c.get('file'), dict):
+        out['file'] = clean_file(c['file'])
+    return {k: v for k, v in out.items() if v is not None}
+
+
+def clean_binary(file_id: str, mime_type: str | None, size: int, data_base64: str) -> dict:
+    """Shape a downloaded/exported blob for return: id, mimeType, byte size, base64."""
+    return {
+        'fileId': file_id,
+        'mimeType': mime_type,
+        'size': size,
+        'data_base64': data_base64,
+    }

--- a/nodes/src/nodes/tool_google_workspace/services.drive.json
+++ b/nodes/src/nodes/tool_google_workspace/services.drive.json
@@ -1,0 +1,59 @@
+{
+	"title": "Google Drive",
+	"protocol": "tool_drive://",
+	"classType": ["tool"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.tool_google_workspace.drive",
+	"prefix": "drive",
+	"icon": "drive.svg",
+	"documentation": "https://docs.rocketride.org",
+	"description": ["Exposes Google Drive operations as agent tools.", "List and search files, read metadata, download binary files and export native Docs/Sheets/Slides, create/update/copy/move files and folders, manage permissions (sharing), trash and untrash, and track changes. Supports My Drive and shared drives.", "Public and external-domain sharing, and permanent delete, are gated behind explicit config flags. Authenticates via a Google service account or user OAuth."],
+	"tile": ["Google Drive (${parameters.drive.access})"],
+	"lanes": {},
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"title": "Google Drive",
+				"authType": "service",
+				"serviceKey": "",
+				"adminEmail": "",
+				"userToken": "",
+				"access": "write"
+			}
+		}
+	},
+	"fields": {
+		"drive.access": {
+			"type": "string",
+			"title": "Access level",
+			"description": "Drive scopes to request. readonly: list, read metadata, download, and export only. write: full read/write (create, update, copy, move, trash, folders, and sharing).",
+			"default": "write",
+			"enum": [
+				["readonly", "Read-only"],
+				["write", "Read/write"]
+			]
+		},
+		"drive.allowPublicSharing": {
+			"type": "boolean",
+			"title": "Allow public / external sharing",
+			"description": "Off by default. When off, permission_create refuses anyone-with-link grants and grants to a domain or user outside the account's own domain. Turn on to allow sharing files publicly or with external parties.",
+			"default": false
+		},
+		"drive.allowHardDelete": {
+			"type": "boolean",
+			"title": "Allow permanent delete",
+			"description": "Off by default. When off, file_delete (which permanently deletes a file, bypassing Trash and irreversibly) is refused. Turn on to allow permanent deletion; file_trash is the recoverable alternative.",
+			"default": false
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Google Drive",
+			"properties": ["type", "google.authType", "drive.access"]
+		}
+	]
+}

--- a/nodes/test/tool_drive/test_drive.py
+++ b/nodes/test/tool_drive/test_drive.py
@@ -1,0 +1,825 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Unit tests for the tool_drive node (no network, no engine runtime).
+
+Bootstrap mirrors test_sheets.py / test_gmail.py: inject lightweight stubs for
+the engine runtime modules ONLY if absent, import the module under test, then
+drop the stubs so they never leak into a shared pytest session. The Google SDK
+is never imported — IInstance receives a FakeDrive service and a real
+GoogleAccess.
+"""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+_NODES_SRC = Path(__file__).resolve().parents[2] / 'src'
+if str(_NODES_SRC) not in sys.path:
+    sys.path.insert(0, str(_NODES_SRC))
+
+_SERVICES_JSON = _NODES_SRC / 'nodes' / 'tool_google_workspace' / 'services.drive.json'
+
+
+def _require_str(args, key, *, tool_name=''):
+    value = args.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f'{tool_name or key}: "{key}" is required')
+    return value.strip()
+
+
+def _build_import_stubs():
+    rocketlib = MagicMock()
+    rocketlib.IInstanceBase = object
+    rocketlib.IGlobalBase = object
+    rocketlib.tool_function = lambda **kwargs: lambda f: f
+    rocketlib.OPEN_MODE = MagicMock()
+    rocketlib.warning = lambda *a, **kw: None
+
+    depends = MagicMock()
+    depends.depends = lambda *a, **kw: None
+
+    ai_common_utils = MagicMock()
+    ai_common_utils.normalize_tool_input = lambda args, **kw: args if isinstance(args, dict) else {}
+    ai_common_utils.require_str = _require_str
+
+    def _stub_require_int(args, key, *, lo=None, hi=None, tool_name=''):
+        prefix = f'{tool_name}: ' if tool_name else ''
+        val = args.get(key)
+        if val is None:
+            raise ValueError(f'{prefix}"{key}" is required')
+        if isinstance(val, (bool, float)) or not isinstance(val, (int, str)):
+            raise ValueError(f'{prefix}"{key}" must be an integer')
+        try:
+            out = int(val)
+        except (TypeError, ValueError, OverflowError):
+            raise ValueError(f'{prefix}"{key}" must be an integer')
+        if (lo is not None and out < lo) or (hi is not None and out > hi):
+            raise ValueError(f'{prefix}"{key}" must be an integer')
+        return out
+
+    def _stub_optional_int(args, key, *, default=None, lo=None, hi=None, tool_name=''):
+        if key not in args or args[key] is None:
+            return default
+        return _stub_require_int(args, key, lo=lo, hi=hi, tool_name=tool_name)
+
+    def _stub_optional_str(args, key, *, default=None, tool_name=''):
+        if key not in args or args[key] is None:
+            return default
+        val = args[key]
+        if not isinstance(val, str):
+            prefix = f'{tool_name}: ' if tool_name else ''
+            raise ValueError(f'{prefix}"{key}" must be a string')
+        return val
+
+    ai_common_utils.require_int = _stub_require_int
+    ai_common_utils.optional_int = _stub_optional_int
+    ai_common_utils.optional_str = _stub_optional_str
+
+    return {
+        'rocketlib': rocketlib,
+        'depends': depends,
+        'ai': MagicMock(),
+        'ai.common': MagicMock(),
+        'ai.common.utils': ai_common_utils,
+        'ai.common.config': MagicMock(),
+    }
+
+
+_added = []
+for _name, _stub in _build_import_stubs().items():
+    if _name not in sys.modules:
+        sys.modules[_name] = _stub
+        _added.append(_name)
+
+drive_iinstance = importlib.import_module('nodes.tool_google_workspace.drive.IInstance')
+drive_client = importlib.import_module('nodes.tool_google_workspace.drive.client')
+ga = importlib.import_module('nodes.core.google_access')
+
+for _name in _added:
+    sys.modules.pop(_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Fake Drive service: records terminal calls, returns canned results.
+# ---------------------------------------------------------------------------
+
+
+class _Req:
+    def __init__(self, result):
+        self.result = result
+
+    def execute(self):
+        if isinstance(self.result, Exception):
+            raise self.result
+        return self.result
+
+
+class _Node:
+    def __init__(self, sv, path):
+        self._sv = sv
+        self._path = path
+
+    def __getattr__(self, name):
+        def method(**kwargs):
+            self._sv.calls.append((name, kwargs))
+            return _Req(self._sv.results.get(name, {}))
+
+        return method
+
+
+class FakeDrive:
+    def __init__(self, results=None):
+        self.calls = []
+        self.results = results or {}
+
+    def files(self):
+        return _Node(self, 'files')
+
+    def permissions(self):
+        return _Node(self, 'permissions')
+
+    def drives(self):
+        return _Node(self, 'drives')
+
+    def changes(self):
+        return _Node(self, 'changes')
+
+    def call_for(self, op):
+        """Return the kwargs of the FIRST recorded call to terminal method ``op``."""
+        return next((kw for n, kw in self.calls if n == op), None)
+
+    def calls_for(self, op):
+        return [kw for n, kw in self.calls if n == op]
+
+
+def _make(cfg=None, results=None, account_domain=None):
+    """Build an IInstance wired to a FakeDrive and a real resolved GoogleAccess."""
+    inst = drive_iinstance.IInstance()
+    access = ga.resolve_google_access(cfg or {'access': 'write'}, ga.DRIVE)
+    inst.IGlobal = types.SimpleNamespace(service=FakeDrive(results or {}), access=access, account_domain=account_domain)
+    return inst
+
+
+_WRITE_FLAGS = {'access': 'write', 'allowPublicSharing': True, 'allowHardDelete': True}
+
+
+# ---------------------------------------------------------------------------
+# Access spec / defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_tier_is_write():
+    access = ga.resolve_google_access({}, ga.DRIVE)
+    assert access.tier == 'write'
+    assert access.can_write is True
+    assert access.flags == {'allowPublicSharing': False, 'allowHardDelete': False}
+
+
+def test_readonly_tier_no_write():
+    access = ga.resolve_google_access({'access': 'readonly'}, ga.DRIVE)
+    assert access.can_write is False
+
+
+def test_flag_misconfig_string_raises():
+    with pytest.raises(ga.GoogleAccessError):
+        ga.resolve_google_access({'access': 'write', 'allowPublicSharing': 'true'}, ga.DRIVE)
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+
+
+def test_file_list_defaults_and_all_drives():
+    inst = _make(results={'list': {'files': [{'id': 'f1', 'name': 'A', 'mimeType': 'text/plain'}]}})
+    out = inst.file_list({})
+    assert out['files'][0] == {'id': 'f1', 'name': 'A', 'mimeType': 'text/plain'}
+    kw = inst.IGlobal.service.call_for('list')
+    assert kw['supportsAllDrives'] is True
+    assert kw['includeItemsFromAllDrives'] is True
+    assert kw['pageSize'] == 25
+    assert 'q' not in kw
+
+
+def test_file_list_pagesize_clamped_and_explicit_zero_survives():
+    inst = _make(results={'list': {'files': []}})
+    inst.file_list({'pageSize': 500})
+    assert inst.IGlobal.service.call_for('list')['pageSize'] == 100
+    inst2 = _make(results={'list': {'files': []}})
+    inst2.file_list({'pageSize': 0})  # explicit 0 clamps up to 1, not defaulted to 25
+    assert inst2.IGlobal.service.call_for('list')['pageSize'] == 1
+
+
+def test_file_list_pagesize_rejects_bool():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.file_list({'pageSize': True})
+
+
+def test_file_list_driveid_sets_corpora():
+    inst = _make(results={'list': {'files': []}})
+    inst.file_list({'driveId': 'D1'})
+    kw = inst.IGlobal.service.call_for('list')
+    assert kw['driveId'] == 'D1'
+    assert kw['corpora'] == 'drive'
+
+
+def test_file_search_requires_q():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.file_search({})
+
+
+def test_file_search_delegates_with_query():
+    inst = _make(results={'list': {'files': [{'id': 'f9', 'name': 'inv'}]}})
+    out = inst.file_search({'q': "name contains 'inv'"})
+    assert out['files'][0]['id'] == 'f9'
+    assert inst.IGlobal.service.call_for('list')['q'] == "name contains 'inv'"
+
+
+def test_file_get_cleans_and_all_drives():
+    raw = {
+        'id': 'f1',
+        'name': 'Doc',
+        'description': 'Canvas validation code: DRIVE-CONTRACT-83',
+        'mimeType': 'application/pdf',
+        'parents': ['p1'],
+        'webViewLink': 'http://x',
+        'modifiedTime': '2026-01-01T00:00:00Z',
+        'size': '1234',
+        'trashed': False,
+        'driveId': 'D1',
+    }
+    inst = _make(results={'get': raw})
+    out = inst.file_get({'fileId': 'f1'})
+    assert out['id'] == 'f1' and out['size'] == '1234' and out['driveId'] == 'D1'
+    assert out['description'] == 'Canvas validation code: DRIVE-CONTRACT-83'
+    assert 'description' in inst.IGlobal.service.call_for('get')['fields'].split(',')
+    assert inst.IGlobal.service.call_for('get')['supportsAllDrives'] is True
+
+
+def test_file_get_requires_fileid():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.file_get({})
+
+
+def test_file_download_returns_base64():
+    inst = _make(results={'get': {'mimeType': 'text/plain', 'size': '5'}, 'get_media': b'hello'})
+    out = inst.file_download({'fileId': 'f1'})
+    assert out == {
+        'fileId': 'f1',
+        'mimeType': 'text/plain',
+        'size': 5,
+        'data_base64': base64.b64encode(b'hello').decode('ascii'),
+    }
+    assert inst.IGlobal.service.call_for('get_media')['supportsAllDrives'] is True
+
+
+def test_file_download_refuses_native_pointing_to_export():
+    inst = _make(results={'get': {'mimeType': 'application/vnd.google-apps.document'}})
+    with pytest.raises(ValueError) as exc:
+        inst.file_download({'fileId': 'f1'})
+    assert 'file_export' in str(exc.value)
+
+
+def test_file_download_size_cap_raises():
+    inst = _make(results={'get': {'mimeType': 'application/pdf', 'size': str(11 * 1024 * 1024)}})
+    with pytest.raises(ValueError) as exc:
+        inst.file_download({'fileId': 'f1'})
+    assert 'cap' in str(exc.value).lower()
+
+
+def test_file_download_size_cap_raises_when_metadata_omits_size():
+    raw = b'x' * (drive_iinstance._MAX_DOWNLOAD + 1)
+    inst = _make(results={'get': {'mimeType': 'application/pdf'}, 'get_media': raw})
+    with pytest.raises(ValueError) as exc:
+        inst.file_download({'fileId': 'f1'})
+    assert 'cap' in str(exc.value).lower()
+
+
+def test_file_export_returns_base64():
+    inst = _make(results={'export_media': b'%PDF-1.4'})
+    out = inst.file_export({'fileId': 'doc1', 'mimeType': 'application/pdf'})
+    assert out['fileId'] == 'doc1'
+    assert out['mimeType'] == 'application/pdf'
+    assert out['data_base64'] == base64.b64encode(b'%PDF-1.4').decode('ascii')
+    assert inst.IGlobal.service.call_for('export_media')['mimeType'] == 'application/pdf'
+
+
+def test_file_export_requires_mimetype():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.file_export({'fileId': 'doc1'})
+
+
+def test_drives_list():
+    inst = _make(results={'list': {'drives': [{'id': 'D1', 'name': 'Team'}], 'nextPageToken': 'nt'}})
+    out = inst.drives_list({})
+    assert out['drives'] == [{'id': 'D1', 'name': 'Team'}]
+    assert out['nextPageToken'] == 'nt'
+
+
+def test_changes_list_bootstrap_forwards_drive_id():
+    # Start tokens are per corpus: the shared-drive bootstrap must carry driveId.
+    inst = _make(results={'getStartPageToken': {'startPageToken': '77'}})
+    out = inst.changes_list({'driveId': 'D1'})
+    assert out['startPageToken'] == '77'
+    kw = inst.IGlobal.service.call_for('getStartPageToken')
+    assert kw['driveId'] == 'D1' and kw['supportsAllDrives'] is True
+
+
+def test_changes_list_bootstraps_start_token():
+    inst = _make(results={'getStartPageToken': {'startPageToken': '900'}})
+    out = inst.changes_list({})
+    assert out['startPageToken'] == '900'
+    assert 'message' in out
+    assert inst.IGlobal.service.call_for('getStartPageToken')['supportsAllDrives'] is True
+
+
+def test_changes_list_with_token():
+    inst = _make(
+        results={
+            'list': {
+                'newStartPageToken': '950',
+                'changes': [
+                    {
+                        'fileId': 'f1',
+                        'removed': False,
+                        'time': 't',
+                        'file': {
+                            'id': 'f1',
+                            'name': 'A',
+                            'description': 'Canvas validation code: DRIVE-CONTRACT-83',
+                        },
+                    }
+                ],
+            }
+        }
+    )
+    out = inst.changes_list({'pageToken': '900'})
+    assert out['newStartPageToken'] == '950'
+    assert out['changes'][0] == {
+        'fileId': 'f1',
+        'removed': False,
+        'time': 't',
+        'file': {'id': 'f1', 'name': 'A', 'description': 'Canvas validation code: DRIVE-CONTRACT-83'},
+    }
+    assert out['changes'][0]['file']['description'] == 'Canvas validation code: DRIVE-CONTRACT-83'
+    kw = inst.IGlobal.service.call_for('list')
+    assert kw['pageToken'] == '900' and kw['supportsAllDrives'] is True
+
+
+# ---------------------------------------------------------------------------
+# Writes — files
+# ---------------------------------------------------------------------------
+
+
+def test_file_create_metadata_only():
+    inst = _make(results={'create': {'id': 'n1', 'name': 'New'}})
+    out = inst.file_create({'name': 'New', 'parents': ['folder1']})
+    assert out == {'id': 'n1', 'name': 'New'}
+    kw = inst.IGlobal.service.call_for('create')
+    assert kw['body'] == {'name': 'New', 'parents': ['folder1']}
+    assert kw['supportsAllDrives'] is True
+    assert 'media_body' not in kw
+
+
+def test_folder_create_sets_folder_mime():
+    inst = _make(results={'create': {'id': 'd1', 'name': 'Folder'}})
+    inst.folder_create({'name': 'Folder'})
+    body = inst.IGlobal.service.call_for('create')['body']
+    assert body['mimeType'] == 'application/vnd.google-apps.folder'
+
+
+def test_file_copy():
+    inst = _make(results={'copy': {'id': 'c1', 'name': 'Copy'}})
+    out = inst.file_copy({'fileId': 'f1', 'name': 'Copy'})
+    assert out['id'] == 'c1'
+    kw = inst.IGlobal.service.call_for('copy')
+    assert kw['fileId'] == 'f1' and kw['body'] == {'name': 'Copy'} and kw['supportsAllDrives'] is True
+
+
+def test_file_move_add_and_remove_parents_recorded():
+    inst = _make(results={'get': {'parents': ['old1', 'old2']}, 'update': {'id': 'f1', 'parents': ['new1']}})
+    inst.file_move({'fileId': 'f1', 'addParents': ['new1']})
+    kw = inst.IGlobal.service.call_for('update')
+    assert kw['addParents'] == 'new1'
+    assert kw['removeParents'] == 'old1,old2'  # defaulted from current parents
+    assert kw['supportsAllDrives'] is True
+    # current parents were fetched via files().get(fields='parents')
+    assert inst.IGlobal.service.call_for('get')['fields'] == 'parents'
+
+
+def test_file_move_explicit_remove_parents():
+    inst = _make(results={'update': {'id': 'f1'}})
+    inst.file_move({'fileId': 'f1', 'addParents': ['new1'], 'removeParents': ['keep_out']})
+    kw = inst.IGlobal.service.call_for('update')
+    assert kw['removeParents'] == 'keep_out'
+    # no metadata fetch when removeParents supplied
+    assert inst.IGlobal.service.call_for('get') is None
+
+
+def test_file_move_requires_add_parents():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.file_move({'fileId': 'f1'})
+
+
+def test_file_trash_sets_flag():
+    inst = _make(results={'update': {'id': 'f1', 'trashed': True}})
+    out = inst.file_trash({'fileId': 'f1'})
+    assert out['trashed'] is True
+    kw = inst.IGlobal.service.call_for('update')
+    assert kw['body'] == {'trashed': True} and kw['supportsAllDrives'] is True
+
+
+def test_file_untrash_sets_flag():
+    inst = _make(results={'update': {'id': 'f1', 'trashed': False}})
+    inst.file_untrash({'fileId': 'f1'})
+    assert inst.IGlobal.service.call_for('update')['body'] == {'trashed': False}
+
+
+def test_file_update_rename():
+    inst = _make(results={'update': {'id': 'f1', 'name': 'Renamed'}})
+    inst.file_update({'fileId': 'f1', 'name': 'Renamed', 'description': 'd'})
+    body = inst.IGlobal.service.call_for('update')['body']
+    assert body == {'name': 'Renamed', 'description': 'd'}
+
+
+def test_file_update_requires_a_field_to_change():
+    inst = _make()
+    with pytest.raises(ValueError, match='^file_update: provide at least one field to change$'):
+        inst.file_update({'fileId': 'f1'})
+    assert inst.IGlobal.service.call_for('update') is None
+
+
+# ---------------------------------------------------------------------------
+# Permissions
+# ---------------------------------------------------------------------------
+
+
+def test_permission_list():
+    inst = _make(
+        cfg={'access': 'readonly'},
+        results={'list': {'permissions': [{'id': 'p1', 'type': 'user', 'role': 'writer'}]}},
+    )
+    out = inst.permission_list({'fileId': 'f1'})
+    assert out['permissions'][0] == {'id': 'p1', 'type': 'user', 'role': 'writer'}
+    assert inst.IGlobal.service.call_for('list')['supportsAllDrives'] is True
+
+
+def test_permission_update():
+    inst = _make(
+        results={
+            'get': {'id': 'p1', 'type': 'user', 'emailAddress': 'sam@x.com'},
+            'update': {'id': 'p1', 'type': 'user', 'role': 'reader'},
+        }
+    )
+    inst.permission_update({'fileId': 'f1', 'permissionId': 'p1', 'role': 'reader'})
+    kw = inst.IGlobal.service.call_for('update')
+    assert kw['permissionId'] == 'p1' and kw['body'] == {'role': 'reader'}
+
+
+def test_permission_update_gates_existing_public_grant():
+    # Broadening an existing anyone-permission is sharing: same gate as create.
+    inst = _make(results={'get': {'id': 'p1', 'type': 'anyone', 'role': 'reader'}})
+    with pytest.raises(ga.GoogleAccessError) as exc:
+        inst.permission_update({'fileId': 'f1', 'permissionId': 'p1', 'role': 'writer'})
+    assert 'allowPublicSharing' in str(exc.value)
+    assert inst.IGlobal.service.call_for('update') is None  # role never changed
+
+
+def test_permission_update_public_grant_allowed_with_flag():
+    inst = _make(
+        cfg=dict(_WRITE_FLAGS),
+        results={
+            'get': {'id': 'p1', 'type': 'anyone', 'role': 'reader'},
+            'update': {'id': 'p1', 'type': 'anyone', 'role': 'writer'},
+        },
+    )
+    out = inst.permission_update({'fileId': 'f1', 'permissionId': 'p1', 'role': 'writer'})
+    assert out['role'] == 'writer'
+
+
+def test_permission_update_rejects_bad_role():
+    inst = _make()
+    with pytest.raises(ValueError):
+        inst.permission_update({'fileId': 'f1', 'permissionId': 'p1', 'role': 'god'})
+
+
+def test_permission_delete():
+    inst = _make(results={'delete': {}})
+    out = inst.permission_delete({'fileId': 'f1', 'permissionId': 'p1'})
+    assert out == {'deleted': True, 'fileId': 'f1', 'permissionId': 'p1'}
+
+
+# ---------------------------------------------------------------------------
+# Gating matrix — readonly
+# ---------------------------------------------------------------------------
+
+_WRITE_METHODS = [
+    ('file_create', {'name': 'x'}),
+    ('file_update', {'fileId': 'f1', 'name': 'x'}),
+    ('file_copy', {'fileId': 'f1'}),
+    ('file_move', {'fileId': 'f1', 'addParents': ['n']}),
+    ('file_trash', {'fileId': 'f1'}),
+    ('file_untrash', {'fileId': 'f1'}),
+    ('folder_create', {'name': 'x'}),
+    ('permission_update', {'fileId': 'f1', 'permissionId': 'p1', 'role': 'reader'}),
+    ('permission_delete', {'fileId': 'f1', 'permissionId': 'p1'}),
+    ('permission_create', {'fileId': 'f1', 'type': 'user', 'role': 'reader', 'emailAddress': 'a@x.com'}),
+    ('file_delete', {'fileId': 'f1'}),
+]
+
+
+@pytest.mark.parametrize('method,args', _WRITE_METHODS)
+def test_readonly_denies_all_writes(method, args):
+    inst = _make(cfg={'access': 'readonly'})
+    with pytest.raises(ga.GoogleAccessError):
+        getattr(inst, method)(dict(args))
+
+
+# ---------------------------------------------------------------------------
+# Gating matrix — sharing gate (allowPublicSharing)
+# ---------------------------------------------------------------------------
+
+
+def _perm_inst(cfg, account_domain):
+    return _make(
+        cfg=cfg, results={'create': {'id': 'p1', 'type': 'user', 'role': 'reader'}}, account_domain=account_domain
+    )
+
+
+def test_share_anyone_gated_when_flag_off():
+    inst = _perm_inst({'access': 'write'}, 'acme.com')
+    with pytest.raises(ga.GoogleAccessError) as exc:
+        inst.permission_create({'fileId': 'f1', 'type': 'anyone', 'role': 'reader'})
+    assert 'allowPublicSharing' in str(exc.value)
+
+
+def test_share_internal_user_passes_flag_off():
+    inst = _perm_inst({'access': 'write'}, 'acme.com')
+    inst.permission_create({'fileId': 'f1', 'type': 'user', 'role': 'reader', 'emailAddress': 'bob@acme.com'})
+    assert inst.IGlobal.service.call_for('create') is not None
+
+
+def test_share_external_user_gated_flag_off():
+    inst = _perm_inst({'access': 'write'}, 'acme.com')
+    with pytest.raises(ga.GoogleAccessError) as exc:
+        inst.permission_create({'fileId': 'f1', 'type': 'user', 'role': 'reader', 'emailAddress': 'eve@evil.com'})
+    assert 'allowPublicSharing' in str(exc.value)
+
+
+def test_share_domain_same_passes_flag_off():
+    inst = _perm_inst({'access': 'write'}, 'acme.com')
+    inst.permission_create({'fileId': 'f1', 'type': 'domain', 'role': 'reader', 'domain': 'acme.com'})
+    assert inst.IGlobal.service.call_for('create') is not None
+
+
+def test_share_domain_other_gated_flag_off():
+    inst = _perm_inst({'access': 'write'}, 'acme.com')
+    with pytest.raises(ga.GoogleAccessError):
+        inst.permission_create({'fileId': 'f1', 'type': 'domain', 'role': 'reader', 'domain': 'other.com'})
+
+
+def test_share_unknown_domain_anyone_and_domain_gated_user_passes():
+    inst = _perm_inst({'access': 'write'}, None)  # UNKNOWN account domain
+    with pytest.raises(ga.GoogleAccessError):
+        inst.permission_create({'fileId': 'f1', 'type': 'anyone', 'role': 'reader'})
+    inst2 = _perm_inst({'access': 'write'}, None)
+    with pytest.raises(ga.GoogleAccessError):
+        inst2.permission_create({'fileId': 'f1', 'type': 'domain', 'role': 'reader', 'domain': 'anything.com'})
+    inst3 = _perm_inst({'access': 'write'}, None)
+    inst3.permission_create({'fileId': 'f1', 'type': 'user', 'role': 'reader', 'emailAddress': 'x@whoever.com'})
+    assert inst3.IGlobal.service.call_for('create') is not None
+
+
+def test_share_gated_ops_pass_with_flag_on():
+    inst = _perm_inst(_WRITE_FLAGS, 'acme.com')
+    inst.permission_create({'fileId': 'f1', 'type': 'anyone', 'role': 'reader'})
+    kw = inst.IGlobal.service.call_for('create')
+    assert kw['body'] == {'type': 'anyone', 'role': 'reader'}
+    assert kw['sendNotificationEmail'] is False  # anyone: no notification
+
+
+def test_share_user_grant_always_sends_notification():
+    inst = _perm_inst(_WRITE_FLAGS, 'acme.com')
+    inst.permission_create({'fileId': 'f1', 'type': 'user', 'role': 'writer', 'emailAddress': 'eve@evil.com'})
+    assert inst.IGlobal.service.call_for('create')['sendNotificationEmail'] is True
+
+
+def test_share_user_requires_email():
+    inst = _perm_inst(_WRITE_FLAGS, 'acme.com')
+    with pytest.raises(ValueError):
+        inst.permission_create({'fileId': 'f1', 'type': 'user', 'role': 'reader'})
+
+
+# ---------------------------------------------------------------------------
+# Gating matrix — hard delete (allowHardDelete)
+# ---------------------------------------------------------------------------
+
+
+def test_file_delete_gated_when_flag_off():
+    inst = _make(cfg={'access': 'write'})
+    with pytest.raises(ga.GoogleAccessError) as exc:
+        inst.file_delete({'fileId': 'f1'})
+    assert 'allowHardDelete' in str(exc.value)
+
+
+def test_file_delete_passes_with_flag_on():
+    inst = _make(cfg=_WRITE_FLAGS, results={'delete': {}})
+    out = inst.file_delete({'fileId': 'f1'})
+    assert out == {'deleted': True, 'fileId': 'f1', 'permanent': True}
+    assert inst.IGlobal.service.call_for('delete')['supportsAllDrives'] is True
+
+
+def test_file_trash_passes_at_write_without_flag():
+    inst = _make(cfg={'access': 'write'}, results={'update': {'id': 'f1', 'trashed': True}})
+    out = inst.file_trash({'fileId': 'f1'})
+    assert out['trashed'] is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_account_domain helper
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_account_domain_service_admin_email():
+    assert drive_client.resolve_account_domain('service', {'adminEmail': 'admin@Acme.com'}) == 'acme.com'
+
+
+def test_resolve_account_domain_service_no_admin_is_none():
+    assert drive_client.resolve_account_domain('service', {}) is None
+
+
+def test_resolve_account_domain_treats_consumer_domains_as_unknown():
+    # A personal account is not an organisation: gmail.com must never become
+    # the "own domain" that waves through grants to other consumer addresses.
+    token = json.dumps({'email': 'someone@gmail.com'})
+    assert drive_client.resolve_account_domain('user', {'userToken': token}) is None
+    assert drive_client.resolve_account_domain('service', {'adminEmail': 'x@googlemail.com'}) is None
+
+
+def test_resolve_account_domain_user_hd_claim():
+    token = json.dumps({'scope': 'x', 'hd': 'Corp.com'})
+    assert drive_client.resolve_account_domain('user', {'userToken': token}) == 'corp.com'
+
+
+def test_resolve_account_domain_user_email_claim():
+    token = json.dumps({'email': 'me@team.io'})
+    assert drive_client.resolve_account_domain('user', {'userToken': token}) == 'team.io'
+
+
+def test_resolve_account_domain_user_no_claim_is_none():
+    token = json.dumps({'access_token': 'abc'})
+    assert drive_client.resolve_account_domain('user', {'userToken': token}) is None
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics
+# ---------------------------------------------------------------------------
+
+
+def test_check_connection_reports_ok():
+    inst = _make()
+    out = inst.check_connection({})
+    assert out['connection_ok'] is True
+    assert out['access'] == 'write'
+    assert any('drive' in s for s in out['requiredScopes'])
+
+
+# ---------------------------------------------------------------------------
+# Error mapping
+# ---------------------------------------------------------------------------
+
+
+class _HttpErr(Exception):
+    def __init__(self, status, reason, content=b''):
+        super().__init__(reason)
+        self.resp = types.SimpleNamespace(status=status)
+        self.reason = reason
+        self.content = content
+
+
+def test_execute_maps_403_to_actionable_valueerror():
+    inst = _make(results={'get': _HttpErr(403, 'insufficientPermissions')})
+    with pytest.raises(ValueError) as exc:
+        inst.file_get({'fileId': 'f1'})
+    assert '403' in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# services.json contract
+# ---------------------------------------------------------------------------
+
+
+def test_services_json_shape():
+    data = json.loads(_SERVICES_JSON.read_text(encoding='utf-8'))
+    assert data['title'] == 'Google Drive'
+    assert data['protocol'] == 'tool_drive://'
+    assert data['classType'] == ['tool']
+    assert data['capabilities'] == ['invoke']
+    assert data['lanes'] == {}
+    assert data['prefix'] == 'drive'
+    assert data['path'] == 'nodes.tool_google_workspace.drive'
+    assert data['icon'] == 'drive.svg'
+    assert 'drive.access' in data['fields']
+    assert data['fields']['drive.access']['default'] == 'write'
+    assert [row[0] for row in data['fields']['drive.access']['enum']] == ['readonly', 'write']
+    # Both destructive gate fields present (issue AC).
+    assert 'drive.allowPublicSharing' in data['fields']
+    assert 'drive.allowHardDelete' in data['fields']
+    assert data['fields']['drive.allowPublicSharing']['default'] is False
+    assert data['fields']['drive.allowHardDelete']['default'] is False
+    assert data['shape'][0]['properties'] == ['type', 'google.authType', 'drive.access']
+    # OAuth node: no dynamic test block.
+    assert 'test' not in data
+
+
+def test_services_json_no_secret_defaults():
+    data = json.loads(_SERVICES_JSON.read_text(encoding='utf-8'))
+    prof = data['preconfig']['profiles']['default']
+    assert prof.get('serviceKey', '') == ''
+    assert prof.get('userToken', '') == ''
+    # Gate flags are NOT in the profile (absent => False, gmail precedent).
+    assert 'allowPublicSharing' not in prof
+    assert 'allowHardDelete' not in prof
+
+
+# ---------------------------------------------------------------------------
+# Completeness
+# ---------------------------------------------------------------------------
+
+
+def test_all_tools_present():
+    expected = {
+        'check_connection',
+        'file_list',
+        'file_search',
+        'file_get',
+        'file_download',
+        'file_export',
+        'drives_list',
+        'changes_list',
+        'file_create',
+        'file_update',
+        'file_copy',
+        'file_move',
+        'file_trash',
+        'file_untrash',
+        'folder_create',
+        'permission_list',
+        'permission_update',
+        'permission_delete',
+        'permission_create',
+        'file_delete',
+    }
+    for name in expected:
+        assert callable(getattr(drive_iinstance.IInstance, name)), f'missing tool: {name}'
+
+
+def test_file_create_passes_description():
+    inst = _make(results={'create': {'id': 'n2', 'name': 'New', 'description': 'Canvas code'}})
+    out = inst.file_create({'name': 'New', 'description': 'Canvas code'})
+    assert inst.IGlobal.service.call_for('create')['body']['description'] == 'Canvas code'
+    assert out['description'] == 'Canvas code'
+
+
+def test_folder_create_passes_description():
+    inst = _make(results={'create': {'id': 'd2', 'name': 'Folder', 'description': 'Canvas code'}})
+    inst.folder_create({'name': 'Folder', 'description': 'Canvas code'})
+    assert inst.IGlobal.service.call_for('create')['body']['description'] == 'Canvas code'
+
+
+def test_file_copy_passes_description():
+    inst = _make(results={'copy': {'id': 'c2', 'name': 'Copy', 'description': 'Canvas code'}})
+    inst.file_copy({'fileId': 'f1', 'name': 'Copy', 'description': 'Canvas code'})
+    assert inst.IGlobal.service.call_for('copy')['body']['description'] == 'Canvas code'
+
+
+def test_token_scope_report_covered_missing_absent_and_malformed():
+    required = ['https://www.googleapis.com/auth/drive']
+    assert drive_client.token_scope_report({}, required) == (set(), True, [])
+    covered_cfg = {'userToken': '{"scope": "https://www.googleapis.com/auth/drive"}'}
+    granted, covered, missing = drive_client.token_scope_report(covered_cfg, required)
+    assert covered is True and missing == []
+    other_cfg = {'userToken': '{"scope": "https://www.googleapis.com/auth/unrelated"}'}
+    granted, covered, missing = drive_client.token_scope_report(other_cfg, required)
+    assert covered is False and missing == required
+    with pytest.raises(ValueError):
+        drive_client.token_scope_report({'userToken': '{bad'}, required)


### PR DESCRIPTION
## Summary

- Add `tool_drive` — an agent-invocable Google Drive tool node (mirrors the shipped `tool_gmail`: shared `core/google_access.py` auth, user-OAuth + service-account).
- 20 operations across files (`file_list`/`file_search`/`file_get`/`file_download`/`file_export`/`file_create`/`file_update`/`file_copy`/`file_move`/`file_trash`/`file_untrash`/`file_delete`), `folder_create`, permissions (`permission_list`/`permission_create`/`permission_update`/`permission_delete`), `drives_list`, `changes_list`, and `check_connection`.
- Two safety gates: `allowPublicSharing` (anyone-grants and external/other-domain grants) and `allowHardDelete` (`file_delete`; trashing stays ungated).
- Includes two contract fixes: commit `4f31b6c5` requests and preserves `description` in every cleaned file response (previously `_FILE_FIELDS` never asked for it and `clean_file()` dropped it), and commit `18d81f20` lets `file_create`/`folder_create`/`file_copy` accept `description` (previously only `file_update` did, so agents couldn't set it at creation time).

## Type

feature (new agent-tool node) + tests

## Testing

- [x] Tests added or updated — 69 unit + service/contract tests (`nodes/test/tool_drive/`), incl. description regressions on create/copy/folder and metadata-response paths
- [x] Tested locally — Python 3.12: 69 unit pass, 294 contract tests pass, `ruff check`/`format` clean
- [ ] `./builder test` passes — not run locally (full C++ engine recompile); node contract/dynamic tests run in CI

Live end-to-end as a real user (user-OAuth token, personal GCP project): all 20 operations against the real Drive API — byte-exact SHA-256 download, native `file_export` to PDF, change-token flow, copy/move/trash/untrash, the full `anyone` permission lifecycle (deny → create → verify → update to commenter → delete → verify absent), and hard-delete verified as a 404. Both gates exercised in both directions. Agent-in-canvas run covered every operation; the `file_create` description gap above was caught by that run and fixed. All test fixtures cleaned up and verified; no resources left publicly shared.

## Notes for reviewers

- `permission_list` is placed under the write tier to match issue #1056's grouping of it with the other permission operations. Flagging in case you'd prefer it in the read tier.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a; node README with generated marker block included
- [x] Breaking changes documented (if applicable) — none (purely additive node)

## Linked Issue

Closes #1056


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Google Drive agent tool with listing/search, metadata reads, downloads/exports, create/update/copy/move, trash/untrash, folder creation, change tracking, and permission management.
  * Includes connection diagnostics, access tiers (read-only/write), shared-drive compatibility, and public-sharing and hard-delete gating.
* **Documentation**
  * Added a complete tool README covering setup/auth, parameters, cleaned outputs, limits, and troubleshooting.
* **Bug Fixes**
  * Strengthened OAuth/token validation, scope/tier coverage checks, native Google download refusal, and clearer authorization vs sharing errors with retry handling.
* **Tests**
  * Added extensive offline unit tests for request/response shaping, pagination/change tokens, gating rules, and client robustness.
* **Chores**
  * Added the tool service configuration and explicit Google Drive/OAuth dependencies with version constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->