### PR TITLE
fix(shell-ui): distinguish network from auth failures and surface both in a recovery banner

### DIFF
--- a/apps/shell-ui/package.json
+++ b/apps/shell-ui/package.json
@@ -34,8 +34,10 @@
     "@rsbuild/plugin-basic-ssl": "^1.2.3",
     "@rsbuild/plugin-react": "~2.0.1",
     "@rsbuild/plugin-type-check": "~1.3.5",
+    "@types/node": "^20.19.41",
     "@types/react": "~18.3.31",
     "@types/react-dom": "~18.3.7",
-    "dts-bundle-generator": "^9.5.1"
+    "dts-bundle-generator": "^9.5.1",
+    "tsx": "~4.23.1"
   }
 }

--- a/apps/shell-ui/scripts/tasks.js
+++ b/apps/shell-ui/scripts/tasks.js
@@ -28,13 +28,15 @@
  * independently; this module only builds the shell itself.
  *
  * Actions:
+ *   shell-ui:test    — run node:test against co-located TypeScript tests
  *   shell-ui:bundle  — run rsbuild build
  *   shell-ui:copy    — sync build/shell-ui → dist/server/static/shell
- *   shell-ui:build   — full build: client-typescript → bundle → copy
+ *   shell-ui:build   — full build: client-typescript → test → bundle → copy
  *   shell-ui:dev     — start rsbuild dev server on port 3000
  *   shell-ui:clean   — remove build artifacts
  */
 const path = require('path');
+const { readdir } = require('node:fs/promises');
 const {
 	execCommand,
 	syncDir,
@@ -142,6 +144,25 @@ function makeCopyAction() {
 	};
 }
 
+/** Run co-located shell-ui TypeScript tests through node:test. */
+function makeTestRunAction() {
+	return {
+		description: 'Testing shell-ui',
+		run: async (ctx, task) => {
+			const testFiles = (await readdir(SRC_DIR, { recursive: true }))
+				.filter((file) => file.endsWith('.test.ts') || file.endsWith('.test.tsx'))
+				.map((file) => path.join('src', file));
+
+			if (testFiles.length === 0) {
+				task.output = 'No shell-ui test files found';
+				return;
+			}
+
+			await execCommand('node', ['--import', 'tsx', '--test', '--test-reporter=spec', ...testFiles], { task, cwd: APP_ROOT });
+		},
+	};
+}
+
 // =============================================================================
 // MODULE DEFINITION
 // =============================================================================
@@ -151,9 +172,18 @@ const shellUiModule = {
 	description: 'Shell Host Application',
 
 	actions: [
-		// Internal actions (no description — not shown in builder --help)
+		// Internal actions are not shown in builder --help.
+		{ name: 'shell-ui:test-run', action: makeTestRunAction },
 		{ name: 'shell-ui:bundle', action: makeBundleAction },
 		{ name: 'shell-ui:copy', action: makeCopyAction },
+
+		{
+			name: 'shell-ui:test',
+			action: () => ({
+				description: 'Testing shell-ui',
+				steps: ['client-typescript:build', 'shell-ui:test-run'],
+			}),
+		},
 
 		{
 			// Full build: compile TS client SDK, bundle shell, copy to dist.
@@ -162,6 +192,7 @@ const shellUiModule = {
 				description: 'Build shell-ui',
 				steps: [
 					'client-typescript:build',
+					'shell-ui:test-run',
 					'shell-ui:bundle',
 					'shell-ui:copy',
 				],

--- a/apps/shell-ui/src/auth/ApiKeyAuthProvider.ts
+++ b/apps/shell-ui/src/auth/ApiKeyAuthProvider.ts
@@ -130,5 +130,10 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 		} catch (e) {
 			console.error('[ApiKeyAuthProvider] Failed to clear token:', e);
 		}
+		try {
+			sessionStorage.removeItem(LS_TOKEN);
+		} catch (e) {
+			console.error('[ApiKeyAuthProvider] Failed to clear legacy session token:', e);
+		}
 	}
 }

--- a/apps/shell-ui/src/auth/ApiKeyAuthProvider.ts
+++ b/apps/shell-ui/src/auth/ApiKeyAuthProvider.ts
@@ -26,7 +26,7 @@
 //
 // Simple auth provider for open-source / local server mode.
 // User enters an API key (or leaves blank for open access), which is stored
-// in sessionStorage and passed to ConnectionManager.connect().
+// in localStorage and passed to ConnectionManager.connect().
 //
 // Implements the same IAuthProvider interface as CloudAuthProvider so the
 // ConnectionManager can use either interchangeably.
@@ -63,7 +63,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	/**
 	 * Sign in with an API key.
 	 *
-	 * Stores the key in sessionStorage for the current session. An empty string
+	 * Stores the key in localStorage. An empty string
 	 * is valid (some OSS servers allow unauthenticated access).
 	 *
 	 * @param apiKey - The API key to store.
@@ -84,7 +84,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	private async storeToken(token: string): Promise<void> {
 		try {
-			sessionStorage.setItem(LS_TOKEN, token);
+			localStorage.setItem(LS_TOKEN, token);
 		} catch (e) {
 			console.error('[ApiKeyAuthProvider] Failed to store token:', e);
 		}
@@ -97,7 +97,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async getToken(): Promise<string | null> {
 		try {
-			const token = sessionStorage.getItem(LS_TOKEN);
+			const token = localStorage.getItem(LS_TOKEN);
 			// For API key mode, empty string is valid (open access)
 			return token;
 		} catch {
@@ -111,7 +111,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async isSignedIn(): Promise<boolean> {
 		try {
-			return sessionStorage.getItem(LS_TOKEN) !== null;
+			return localStorage.getItem(LS_TOKEN) !== null;
 		} catch {
 			return false;
 		}
@@ -126,7 +126,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async signOut(): Promise<void> {
 		try {
-			sessionStorage.removeItem(LS_TOKEN);
+			localStorage.removeItem(LS_TOKEN);
 		} catch (e) {
 			console.error('[ApiKeyAuthProvider] Failed to clear token:', e);
 		}

--- a/apps/shell-ui/src/auth/CloudAuthProvider.ts
+++ b/apps/shell-ui/src/auth/CloudAuthProvider.ts
@@ -226,5 +226,10 @@ export class CloudAuthProvider implements IAuthProvider {
 		} catch (e) {
 			console.error('[CloudAuthProvider] Failed to clear token:', e);
 		}
+		try {
+			sessionStorage.removeItem(LS_TOKEN);
+		} catch (e) {
+			console.error('[CloudAuthProvider] Failed to clear legacy session token:', e);
+		}
 	}
 }

--- a/apps/shell-ui/src/auth/CloudAuthProvider.ts
+++ b/apps/shell-ui/src/auth/CloudAuthProvider.ts
@@ -31,7 +31,7 @@
 //   2. Full-page redirect to Zitadel authorize endpoint
 //   3. Browser redirects back with ?code= parameter
 //   4. handleCallback() exchanges code for token via the ConnectionManager
-//   5. Token stored in sessionStorage (browser equivalent of SecretStorage)
+//   5. Token stored in localStorage (browser equivalent of SecretStorage)
 //
 // The stored token is picked up by ConnectionManager.connect() — auth is
 // decoupled from connection, same as VSCode.
@@ -175,7 +175,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	}
 
 	// =========================================================================
-	// TOKEN STORAGE (sessionStorage — browser equivalent of SecretStorage)
+	// TOKEN STORAGE (localStorage — browser equivalent of SecretStorage)
 	// =========================================================================
 
 	/**
@@ -185,7 +185,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async storeToken(token: string): Promise<void> {
 		try {
-			sessionStorage.setItem(LS_TOKEN, token);
+			localStorage.setItem(LS_TOKEN, token);
 		} catch (e) {
 			console.error('[CloudAuthProvider] Failed to store token:', e);
 		}
@@ -198,7 +198,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async getToken(): Promise<string | null> {
 		try {
-			const token = sessionStorage.getItem(LS_TOKEN);
+			const token = localStorage.getItem(LS_TOKEN);
 			return token || null;
 		} catch {
 			return null;
@@ -222,7 +222,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async signOut(): Promise<void> {
 		try {
-			sessionStorage.removeItem(LS_TOKEN);
+			localStorage.removeItem(LS_TOKEN);
 		} catch (e) {
 			console.error('[CloudAuthProvider] Failed to clear token:', e);
 		}

--- a/apps/shell-ui/src/components/layout/ApiKeyLogin.tsx
+++ b/apps/shell-ui/src/components/layout/ApiKeyLogin.tsx
@@ -203,9 +203,11 @@ export function ApiKeyLogin({ onSubmit, onCancel, appName = 'RocketRide', initia
 		} catch (err) {
 			// Show the server's message, or a generic fallback.
 			setError(err instanceof Error ? err.message : 'Connection failed');
+		} finally {
+			// A cancelled or unauthenticated submission leaves this form mounted.
+			// Always release its controls rather than relying on a Shell unmount.
 			setLoading(false);
 		}
-		// On success the shell unmounts this screen — no state to reset.
 	}, [apiKey, loading, onSubmit]);
 
 	// Enter submits (the stock Button renders type="button", so the implicit

--- a/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
+++ b/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
@@ -47,9 +47,9 @@ const styles = {
 export interface ConnectionErrorBannerProps {
 	/** Override the status-derived failure message for other connection errors. */
 	message?: string;
-	/** Override retry handling; defaults to ConnectionManager.reconnect(). */
+	/** Override retry handling; defaults to a full reload through bootstrap. */
 	onRetry?: () => void | Promise<void>;
-	/** Override sign-in handling; defaults to ConnectionManager.startOAuth(false). */
+	/** Override sign-in handling; defaults to emitting shell:loginRequest. */
 	onSignIn?: () => void | Promise<void>;
 }
 
@@ -85,7 +85,13 @@ export const ConnectionErrorBanner: React.FC<ConnectionErrorBannerProps> = ({ me
 			// as the default action.
 			window.location.reload();
 		})
-		: onSignIn ?? (() => ConnectionManager.getInstance().startOAuth(false));
+		: onSignIn ?? (() => {
+			// Route through the shell's edition-aware login dispatcher: SaaS
+			// starts OAuth, OSS opens the API-key form. Calling startOAuth()
+			// directly here would throw "CloudAuthProvider not initialized" on
+			// OSS deployments and turn this button into a silent no-op.
+			ConnectionManager.getInstance().emit('shell:loginRequest', {});
+		});
 
 	return (
 		<div style={styles.banner} role="alert">

--- a/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
+++ b/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
@@ -1,0 +1,105 @@
+import React, { CSSProperties, useEffect, useState } from 'react';
+import { ConnectionManager } from '../../connection/connection';
+import { useConnectionStatus } from '../../hooks/useConnectionStatus';
+
+const styles = {
+	banner: {
+		position: 'fixed',
+		top: 0,
+		left: 0,
+		right: 0,
+		zIndex: 1000,
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: 12,
+		minHeight: 36,
+		padding: '6px 12px',
+		backgroundColor: 'var(--rr-bg-paper)',
+		borderBottom: '1px solid var(--rr-border)',
+		color: 'var(--rr-text-primary)',
+		fontFamily: 'var(--rr-font-family)',
+		fontSize: 'var(--rr-font-size-widget)',
+	} as CSSProperties,
+	message: { flex: '0 1 auto' } as CSSProperties,
+	action: {
+		border: 0,
+		background: 'none',
+		padding: 0,
+		color: 'var(--rr-brand)',
+		font: 'inherit',
+		fontWeight: 600,
+		cursor: 'pointer',
+	} as CSSProperties,
+	dismiss: {
+		position: 'absolute',
+		right: 12,
+		border: 0,
+		background: 'none',
+		padding: '0 4px',
+		color: 'var(--rr-text-secondary)',
+		fontSize: 20,
+		lineHeight: 1,
+		cursor: 'pointer',
+	} as CSSProperties,
+};
+
+export interface ConnectionErrorBannerProps {
+	/** Override the status-derived failure message for other connection errors. */
+	message?: string;
+	/** Override retry handling; defaults to ConnectionManager.reconnect(). */
+	onRetry?: () => void | Promise<void>;
+	/** Override sign-in handling; defaults to ConnectionManager.startOAuth(false). */
+	onSignIn?: () => void | Promise<void>;
+}
+
+/** A dismissible recovery banner for authentication and transport failures. */
+export const ConnectionErrorBanner: React.FC<ConnectionErrorBannerProps> = ({ message, onRetry, onSignIn }) => {
+	const status = useConnectionStatus();
+	const [dismissed, setDismissed] = useState(false);
+	// The failure is latched manager-side (status.lastFailure) so reconnect
+	// attempts and anonymous connects can't erase it before it renders.
+	const failure = status.lastFailure;
+
+	useEffect(() => {
+		setDismissed(false);
+	}, [failure?.kind, failure?.lastError, failure?.errorKind]);
+
+	if (dismissed || !failure) return null;
+
+	const isNetworkFailure = failure.kind === 'network';
+	const isOAuthCallbackFailure = !isNetworkFailure && failure.errorKind === 'oauth-callback';
+	const defaultMessage = isNetworkFailure
+		? 'Can\'t reach the server — check your connection and retry.'
+		: isOAuthCallbackFailure
+			? `Sign-in didn't complete: ${failure.lastError}`
+			: 'Your session has expired — please sign in again.';
+	const action = isNetworkFailure ? 'Retry' : isOAuthCallbackFailure ? 'Try again' : 'Sign in';
+	const onAction = isNetworkFailure
+		? onRetry ?? (() => {
+			// A reload re-runs bootstrap, which recovers every shape: a stored
+			// token logs back in, tokenless renders the landing, and a still-
+			// unreachable server re-latches this banner. In-place recovery via
+			// ConnectionManager.reconnect() stalls in CONNECTING even against a
+			// healthy server (pre-existing; tracked separately) — don't use it
+			// as the default action.
+			window.location.reload();
+		})
+		: onSignIn ?? (() => ConnectionManager.getInstance().startOAuth(false));
+
+	return (
+		<div style={styles.banner} role="alert">
+			<span style={styles.message} title={failure.lastError}>{message ?? defaultMessage}</span>
+			<button type="button" style={styles.action} onClick={() => {
+				void Promise.resolve().then(onAction).catch((error) => {
+					console.error('[ConnectionErrorBanner] Recovery action failed:', error);
+				});
+			}}>
+				{action}
+			</button>
+			<button type="button" style={styles.dismiss} aria-label="Dismiss connection error" onClick={() => setDismissed(true)}>
+				×
+			</button>
+		</div>
+	);
+};

--- a/apps/shell-ui/src/components/layout/Shell.tsx
+++ b/apps/shell-ui/src/components/layout/Shell.tsx
@@ -366,6 +366,7 @@ const Shell: React.FC<ShellProps> = ({ config }) => {
 
 	const handleApiKeySubmit = useCallback(async (apiKey: string) => {
 		const result = await cm.connect(apiKey);
+		if (!result) return;
 		if (mountedRef.current) {
 			const target = loginTargetRef.current;
 			loginTargetRef.current = null;

--- a/apps/shell-ui/src/components/layout/ShellLayout.tsx
+++ b/apps/shell-ui/src/components/layout/ShellLayout.tsx
@@ -48,6 +48,7 @@ import Sidebar from './Sidebar';
 import StatusBar from './StatusBar';
 import LoadingScreen from './LoadingScreen';
 import DebugPanel from './DebugPanel';
+import { ConnectionErrorBanner } from './ConnectionErrorBanner';
 import type { ShellConfig } from '../../workspace/types';
 import { commonStyles } from 'shared/themes/styles';
 
@@ -357,7 +358,12 @@ export const ShellLayout: React.FC<ShellLayoutProps> = ({
 
 		// Only gate when the manifest is loaded and explicitly requires auth.
 		// Skip for the default app (home/hello) — it must always be accessible.
-		if (!suppressGateRef.current && !identity && activeManifest && activeManifest.authenticated !== false && activeAppId !== defaultAppId) {
+		// A latched connection failure owns the recovery UX: while the banner is
+		// showing (network down / session expired), bouncing the visitor into an
+		// OAuth redirect would hide it — and with the server unreachable the
+		// redirect can't complete anyway. The banner's actions restart the flow.
+		const failureLatched = !!ConnectionManager.getInstance().getConnectionStatus().lastFailure;
+		if (!suppressGateRef.current && !identity && !failureLatched && activeManifest && activeManifest.authenticated !== false && activeAppId !== defaultAppId) {
 			if (authGateTriggeredRef.current === activeAppId) return;
 			authGateTriggeredRef.current = activeAppId;
 			ConnectionManager.getInstance().emit('shell:loginRequest', { appId: activeAppId });
@@ -410,6 +416,7 @@ export const ShellLayout: React.FC<ShellLayoutProps> = ({
 		<HostChromeProvider>
 		<OverlayManager>
 		<div style={styles.shell}>
+			<ConnectionErrorBanner />
 			{/* Main row: Sidebar | Client Area | Debug Panel */}
 			<div style={styles.main}>
 				{/* Sidebar zone — always mounted; self-hides when it has no content. */}

--- a/apps/shell-ui/src/connection/connection.test.ts
+++ b/apps/shell-ui/src/connection/connection.test.ts
@@ -416,6 +416,62 @@ test('onConnected ignores stale callbacks but accepts the active authenticated c
 	}
 });
 
+test('onConnectError latches a session-expired auth failure when a background re-login is rejected', async () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const originalAttach = RocketRideClient.prototype.attach;
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: { location: { origin: 'https://shell.example.test' }, addEventListener: () => {} },
+	});
+	RocketRideClient.prototype.attach = async () => {};
+
+	try {
+		const { manager, emitted } = createTestManager();
+		const clearedTokens: number[] = [];
+		manager.clearToken = () => { clearedTokens.push(1); };
+		manager.initialize();
+		const client = manager.client;
+		assert.ok(client !== null && '_callerOnConnectError' in client);
+		const onConnectError = (client as unknown as {
+			_callerOnConnectError: (error: Error) => Promise<void> | void;
+		})._callerOnConnectError;
+
+		manager.lifecycleOwner = {
+			key: 'active', generation: 0, credential: 'token', promise: Promise.resolve(null), connectedPublished: true,
+		};
+		manager.accountInfo = { userId: 'user-1' } as ConnectResult;
+
+		// The SDK reports a terminal background auth rejection and stops
+		// retrying — the shell must latch the session-expired banner, clear
+		// the dead token, and drop the stale identity.
+		await onConnectError(new AuthenticationException({ message: 'Invalid or revoked API key' }));
+		assert.equal(manager.connectionStatus.state, ConnectionState.AUTH_FAILED);
+		assert.deepEqual(manager.connectionStatus.lastFailure, {
+			kind: 'auth',
+			lastError: 'Your session has expired — please sign in again.',
+			errorKind: 'session',
+		});
+		assert.equal(clearedTokens.length, 1);
+		assert.equal(manager.accountInfo, undefined);
+		assert.equal(manager.connectionStatus.retryAttempt, 0);
+
+		// A plain transport failure keeps the existing retry messaging.
+		manager.connectionStatus.lastFailure = undefined;
+		manager.connectionStatus.state = ConnectionState.CONNECTING;
+		await onConnectError(new Error('socket hang up'));
+		assert.equal(manager.connectionStatus.retryAttempt, 1);
+		assert.equal(manager.connectionStatus.progressMessage, 'Reconnecting…');
+		assert.equal(clearedTokens.length, 1);
+		assert.ok(emitted.some(({ event, payload }) =>
+			event === 'shell:statusMessage' && (payload as { message: string | null }).message === 'Reconnecting…'));
+	} finally {
+		RocketRideClient.prototype.attach = originalAttach;
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
+	}
+});
+
 test('withTimeout waits for cancellation before rejecting and suppresses late login completion', async () => {
 	const realSetTimeout = globalThis.setTimeout;
 	const realClearTimeout = globalThis.clearTimeout;

--- a/apps/shell-ui/src/connection/connection.test.ts
+++ b/apps/shell-ui/src/connection/connection.test.ts
@@ -1,0 +1,520 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { RocketRideClient, type ConnectResult } from 'rocketride';
+import { ConnectionState, type ConnectionStatus } from 'shared/types/connection';
+import { ConnectionManager } from './connection.js';
+import { ConnectionFailure, withTimeout } from './errors.js';
+import { RemoteManager } from './remote-manager.js';
+import { CONNECT_TIMEOUT_MS, LS_TOKEN } from '../constants.js';
+
+type EmittedEvent = { event: string; payload: unknown };
+
+type ConnectionManagerTestAdapter = {
+	finishConnect(
+		result: ConnectResult,
+		appId: string,
+		config?: { apps?: Array<{ id: string }>; workspaceDir?: string; onThemeChange?: (theme: string) => void },
+	): Promise<{ result: ConnectResult; appId: string }>;
+	handleStoredTokenFailure(error: unknown): boolean;
+	updateConnectionStatus(updates: Partial<ConnectionStatus>): void;
+	connectionStatus: ConnectionStatus;
+	accountInfo?: ConnectResult;
+	clearToken(): void;
+	emit(event: string, payload: unknown): void;
+	saveToken(token: string): void;
+	getPendingAppId(): string;
+	initialize(): void;
+	loginWithStoredToken(token: string): Promise<ConnectResult>;
+	loginWithTimeout(credential: string | { code: string; verifier: string; redirectUri: string }): Promise<ConnectResult>;
+};
+
+const authenticatedResult: ConnectResult = {
+	userToken: 'rr_test-token',
+	userId: 'user-123',
+	displayName: 'Test User',
+	givenName: 'Test',
+	familyName: 'User',
+	preferredUsername: 'test-user',
+	email: 'test@example.com',
+	emailVerified: true,
+	phoneNumber: '',
+	phoneNumberVerified: false,
+	locale: 'en-US',
+	defaultTeam: '',
+	organization: null,
+	apps: [],
+	capabilities: [],
+};
+
+function createTestManager(lastFailure?: ConnectionStatus['lastFailure']) {
+	const emitted: EmittedEvent[] = [];
+	const savedTokens: string[] = [];
+	const manager = Object.create(ConnectionManager.prototype) as ConnectionManagerTestAdapter;
+	manager.connectionStatus = {
+		state: ConnectionState.DISCONNECTED,
+		connectionMode: 'cloud',
+		hasCredentials: false,
+		retryAttempt: 0,
+		maxRetryAttempts: 3,
+		lastFailure,
+	};
+	manager.emit = (event, payload) => emitted.push({ event, payload });
+	manager.saveToken = (token) => savedTokens.push(token);
+	manager.getPendingAppId = () => '';
+	return { manager, emitted, savedTokens };
+}
+
+test('updateConnectionStatus retains auth failures and clears network failures after CONNECTED', () => {
+	const authFailure = { kind: 'auth' as const, lastError: 'session expired' };
+	const auth = createTestManager(authFailure);
+	auth.manager.updateConnectionStatus({ state: ConnectionState.CONNECTED });
+	assert.deepEqual(auth.manager.connectionStatus.lastFailure, authFailure);
+
+	const network = createTestManager({ kind: 'network', lastError: 'offline' });
+	network.manager.updateConnectionStatus({ state: ConnectionState.CONNECTED });
+	assert.equal(network.manager.connectionStatus.lastFailure, undefined);
+});
+
+test('finishConnect rejects results without a non-empty userId before authentication side effects', async () => {
+	for (const invalidResult of [
+		null,
+		undefined,
+		{ ...authenticatedResult, userId: '' },
+		(() => {
+			const { userId: _userId, ...withoutUserId } = authenticatedResult;
+			return withoutUserId;
+		})(),
+	]) {
+		const previousAccount = { ...authenticatedResult, userId: 'previous-user' };
+		const { manager, emitted, savedTokens } = createTestManager({ kind: 'auth', lastError: 'expired' });
+		manager.accountInfo = previousAccount;
+		const previousFailure = manager.connectionStatus.lastFailure;
+
+		await assert.rejects(
+			manager.finishConnect(invalidResult as unknown as ConnectResult, ''),
+			(error: unknown) => error instanceof ConnectionFailure && error.kind === 'auth',
+		);
+
+		assert.deepEqual(savedTokens, []);
+		assert.equal(manager.connectionStatus.lastFailure, previousFailure);
+		assert.equal(manager.accountInfo, previousAccount);
+		assert.equal(emitted.some(({ event }) => event === 'shell:login'), false);
+	}
+});
+
+test('finishConnect clears a latched failure and emits login for an authenticated result', async () => {
+	const { manager, emitted, savedTokens } = createTestManager({ kind: 'auth', lastError: 'expired' });
+
+	const completed = await manager.finishConnect(authenticatedResult, 'rocketride.home');
+
+	assert.equal(completed.result, authenticatedResult);
+	assert.equal(completed.appId, 'rocketride.home');
+	assert.deepEqual(savedTokens, ['rr_test-token']);
+	assert.equal(manager.connectionStatus.lastFailure, undefined);
+	assert.equal(manager.accountInfo, authenticatedResult);
+	assert.deepEqual(
+		emitted.filter(({ event }) => event === 'shell:login'),
+		[{ event: 'shell:login', payload: { user: authenticatedResult } }],
+	);
+});
+
+test('handleStoredTokenFailure preserves credentials for retryable server failures', () => {
+	const { manager } = createTestManager();
+
+	const shouldClearToken = manager.handleStoredTokenFailure(new ConnectionFailure('server unavailable', 'server'));
+
+	assert.equal(shouldClearToken, false);
+	assert.equal(manager.connectionStatus.state, ConnectionState.FAILED);
+	assert.deepEqual(manager.connectionStatus.lastFailure, {
+		kind: 'network',
+		lastError: 'server unavailable',
+		errorKind: undefined,
+	});
+});
+
+test('clearToken removes current and legacy stored tokens', () => {
+	const removedLocalKeys: string[] = [];
+	const removedSessionKeys: string[] = [];
+	const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+	const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+	Object.defineProperty(globalThis, 'localStorage', {
+		configurable: true,
+		value: { removeItem: (key: string) => removedLocalKeys.push(key) },
+	});
+	Object.defineProperty(globalThis, 'sessionStorage', {
+		configurable: true,
+		value: { removeItem: (key: string) => removedSessionKeys.push(key) },
+	});
+
+	try {
+		createTestManager().manager.clearToken();
+		assert.deepEqual(removedLocalKeys, ['rr:user_token']);
+		assert.deepEqual(removedSessionKeys, ['rr:user_token']);
+	} finally {
+		if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+		else delete (globalThis as { localStorage?: Storage }).localStorage;
+		if (originalSessionStorage) Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage);
+		else delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+	}
+});
+
+test('initialize handles LS_TOKEN removals only from localStorage', () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const originalAttach = RocketRideClient.prototype.attach;
+	const listeners = new Map<string, (event: StorageEvent) => void>();
+	const localStorage = {} as Storage;
+	const sessionStorage = {} as Storage;
+	let tokenCleared = false;
+	let reloaded = false;
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			location: { origin: 'https://shell.example.test', reload: () => { reloaded = true; } },
+			localStorage,
+			addEventListener: (type: string, listener: (event: StorageEvent) => void) => listeners.set(type, listener),
+		},
+	});
+	RocketRideClient.prototype.attach = async () => {};
+
+	try {
+		const { manager } = createTestManager();
+		(manager as unknown as { pendingEvents: Map<string, unknown> }).pendingEvents = new Map();
+		manager.clearToken = () => { tokenCleared = true; };
+		manager.initialize();
+
+		listeners.get('storage')!({
+			key: LS_TOKEN,
+			oldValue: 'old-token',
+			newValue: null,
+			storageArea: sessionStorage,
+		} as StorageEvent);
+
+		assert.equal(tokenCleared, false);
+		assert.equal(reloaded, false);
+
+		listeners.get('storage')!({
+			key: LS_TOKEN,
+			oldValue: 'old-token',
+			newValue: null,
+			storageArea: localStorage,
+		} as StorageEvent);
+
+		assert.equal(tokenCleared, true);
+		assert.equal(reloaded, true);
+	} finally {
+		RocketRideClient.prototype.attach = originalAttach;
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
+	}
+});
+
+test('initialize ignores storage events when localStorage cannot be read', () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const originalAttach = RocketRideClient.prototype.attach;
+	const listeners = new Map<string, (event: StorageEvent) => void>();
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			location: { origin: 'https://shell.example.test', reload: () => {} },
+			addEventListener: (type: string, listener: (event: StorageEvent) => void) => listeners.set(type, listener),
+		},
+	});
+	Object.defineProperty(globalThis.window, 'localStorage', {
+		configurable: true,
+		get: () => { throw new Error('storage unavailable'); },
+	});
+	RocketRideClient.prototype.attach = async () => {};
+
+	try {
+		const { manager } = createTestManager();
+		(manager as unknown as { pendingEvents: Map<string, unknown> }).pendingEvents = new Map();
+		manager.initialize();
+
+		assert.doesNotThrow(() => listeners.get('storage')!({
+			key: LS_TOKEN,
+			oldValue: 'old-token',
+			newValue: null,
+			storageArea: {} as Storage,
+		} as StorageEvent));
+	} finally {
+		RocketRideClient.prototype.attach = originalAttach;
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
+	}
+});
+
+test('initialize attaches with the native handshake timeout', () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const originalAttach = RocketRideClient.prototype.attach;
+	const attachCalls: Array<[string | undefined, { timeout?: number } | undefined]> = [];
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: {
+			location: { origin: 'https://shell.example.test' },
+			addEventListener: () => {},
+		},
+	});
+	RocketRideClient.prototype.attach = async (uri, options) => { attachCalls.push([uri, options]); };
+
+	try {
+		createTestManager().manager.initialize();
+		assert.deepEqual(attachCalls, [[undefined, { timeout: 10000 }]]);
+	} finally {
+		RocketRideClient.prototype.attach = originalAttach;
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
+	}
+});
+
+test('stored-token login leaves request timeout unset for the outer cancellation guard', async () => {
+	const loginCalls: unknown[][] = [];
+	const { manager } = createTestManager();
+	(manager as unknown as { client: Pick<RocketRideClient, 'login'> }).client = {
+		login: async (...args: unknown[]) => {
+			loginCalls.push(args);
+			return authenticatedResult;
+		},
+	};
+
+	await manager.loginWithStoredToken('rr_test-token');
+
+	assert.deepEqual(loginCalls, [['rr_test-token']]);
+});
+
+test('ConnectionManager whole-login timeout detaches before rejecting and forwards token and OAuth credentials unchanged', async () => {
+	const realSetTimeout = globalThis.setTimeout;
+	const realClearTimeout = globalThis.clearTimeout;
+	let timeoutCallback: (() => void) | undefined;
+	let releaseDetach: (() => void) | undefined;
+	let resolveLogin: ((result: ConnectResult) => void) | undefined;
+	let detached = false;
+	let settled = false;
+	const loginCalls: unknown[][] = [];
+	const oauthCredential = { code: 'code', verifier: 'verifier', redirectUri: 'https://shell.example.test' };
+	const { manager } = createTestManager();
+
+	globalThis.setTimeout = ((callback: () => void) => {
+		timeoutCallback = callback;
+		return 0 as unknown as ReturnType<typeof setTimeout>;
+	}) as typeof setTimeout;
+	globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+	(manager as unknown as { client: Pick<RocketRideClient, 'login' | 'detach'> }).client = {
+		login: async (...args: unknown[]) => {
+			loginCalls.push(args);
+			if (loginCalls.length === 1) return await new Promise<ConnectResult>((resolve) => { resolveLogin = resolve; });
+			return authenticatedResult;
+		},
+		detach: async () => {
+			detached = true;
+			await new Promise<void>((resolve) => { releaseDetach = resolve; });
+		},
+	};
+
+	try {
+		const timedLogin = manager.loginWithTimeout('rr_test-token');
+		void timedLogin.then(
+			() => { settled = true; },
+			() => { settled = true; },
+		);
+
+		timeoutCallback!();
+		await Promise.resolve();
+		assert.equal(detached, true);
+		assert.equal(settled, false);
+
+		resolveLogin!(authenticatedResult);
+		await Promise.resolve();
+		assert.equal(settled, false);
+
+		releaseDetach!();
+		await assert.rejects(timedLogin, (error: unknown) => error instanceof ConnectionFailure && error.kind === 'network');
+		assert.equal(settled, true);
+
+		assert.equal(await manager.loginWithTimeout(oauthCredential), authenticatedResult);
+		assert.deepEqual(loginCalls, [['rr_test-token'], [oauthCredential]]);
+	} finally {
+		globalThis.setTimeout = realSetTimeout;
+		globalThis.clearTimeout = realClearTimeout;
+	}
+});
+
+test('onConnected ignores stale callbacks but accepts the active authenticated connection', async () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const originalAttach = RocketRideClient.prototype.attach;
+	const originalIsAttached = RocketRideClient.prototype.isAttached;
+	const originalIsAuthenticated = RocketRideClient.prototype.isAuthenticated;
+
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: { location: { origin: 'https://shell.example.test' }, addEventListener: () => {} },
+	});
+	RocketRideClient.prototype.attach = async () => {};
+
+	try {
+		const { manager, emitted } = createTestManager();
+		(manager as unknown as { pendingEvents: Map<string, unknown> }).pendingEvents = new Map();
+		manager.initialize();
+		const client = (manager as unknown as { client: { _callerOnConnected: () => Promise<void> } }).client;
+
+		RocketRideClient.prototype.isAttached = () => false;
+		RocketRideClient.prototype.isAuthenticated = () => true;
+		await client._callerOnConnected();
+
+		RocketRideClient.prototype.isAttached = () => true;
+		RocketRideClient.prototype.isAuthenticated = () => false;
+		await client._callerOnConnected();
+
+		RocketRideClient.prototype.isAuthenticated = () => true;
+		(manager as unknown as { suppressConnected: boolean }).suppressConnected = true;
+		await client._callerOnConnected();
+
+		assert.equal(manager.connectionStatus.state, ConnectionState.DISCONNECTED);
+		assert.equal(emitted.some(({ event }) => event === 'shell:connected'), false);
+
+		(manager as unknown as { suppressConnected: boolean }).suppressConnected = false;
+		(manager as unknown as { refreshServices: () => Promise<void> }).refreshServices = async () => {};
+		await client._callerOnConnected();
+
+		assert.equal(manager.connectionStatus.state, ConnectionState.CONNECTED);
+		assert.equal(emitted.filter(({ event }) => event === 'shell:connected').length, 1);
+	} finally {
+		RocketRideClient.prototype.attach = originalAttach;
+		RocketRideClient.prototype.isAttached = originalIsAttached;
+		RocketRideClient.prototype.isAuthenticated = originalIsAuthenticated;
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
+	}
+});
+
+test('withTimeout waits for cancellation before rejecting and suppresses late login completion', async () => {
+	const realSetTimeout = globalThis.setTimeout;
+	const realClearTimeout = globalThis.clearTimeout;
+	let timeoutCallback: (() => void) | undefined;
+	let releaseCleanup: (() => void) | undefined;
+	let resolveLogin: (() => void) | undefined;
+	let settled = false;
+	const events: string[] = [];
+
+	globalThis.setTimeout = ((callback: () => void) => {
+		timeoutCallback = callback;
+		return 0 as unknown as ReturnType<typeof setTimeout>;
+	}) as typeof setTimeout;
+	globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+
+	try {
+		const login = new Promise<void>((resolve) => { resolveLogin = resolve; });
+		const timed = withTimeout(
+			login,
+			CONNECT_TIMEOUT_MS,
+			new ConnectionFailure('timeout', 'network'),
+			async () => {
+				events.push('detach started');
+				await new Promise<void>((resolve) => { releaseCleanup = resolve; });
+				events.push('detach finished');
+			},
+		);
+		void timed.then(
+			() => { settled = true; },
+			() => { settled = true; },
+		);
+
+		timeoutCallback!();
+		await Promise.resolve();
+		assert.deepEqual(events, ['detach started']);
+		assert.equal(settled, false);
+
+		resolveLogin!();
+		await Promise.resolve();
+		assert.equal(settled, false);
+
+		releaseCleanup!();
+		await assert.rejects(
+			Promise.race([
+				timed,
+				new Promise<never>((_resolve, reject) => realSetTimeout(() => reject(new Error('test safety timer fired')), 200)),
+			]),
+			(error: unknown) => error instanceof ConnectionFailure && error.kind === 'network',
+		);
+		assert.deepEqual(events, ['detach started', 'detach finished']);
+	} finally {
+		globalThis.setTimeout = realSetTimeout;
+		globalThis.clearTimeout = realClearTimeout;
+	}
+});
+
+test('RemoteManager.connect detaches before returning a network timeout failure', async () => {
+	const realSetTimeout = globalThis.setTimeout;
+	const realClearTimeout = globalThis.clearTimeout;
+	let timeoutCallback: (() => void) | undefined;
+	let releaseDetach: (() => void) | undefined;
+	let detachCalls = 0;
+	let rejected = false;
+	let timeoutNotified = false;
+	const loginCalls: unknown[][] = [];
+
+	globalThis.setTimeout = ((callback: () => void) => {
+		timeoutCallback = callback;
+		return 0 as unknown as ReturnType<typeof setTimeout>;
+	}) as typeof setTimeout;
+	globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+
+	try {
+		const client = {
+			login: async (...args: unknown[]) => {
+				loginCalls.push(args);
+				return await new Promise<ConnectResult>(() => {});
+			},
+			detach: async () => {
+				detachCalls++;
+				await new Promise<void>((resolve) => { releaseDetach = resolve; });
+			},
+		} as unknown as RocketRideClient;
+		const connect = new RemoteManager(() => { timeoutNotified = true; }).connect(client, { uri: 'https://shell.example.test', credential: 'rr_test-token' });
+		void connect.catch(() => { rejected = true; });
+		assert.deepEqual(loginCalls, [['rr_test-token']]);
+
+		timeoutCallback!();
+		await Promise.resolve();
+		assert.equal(timeoutNotified, true);
+		assert.equal(detachCalls, 1);
+		assert.equal(rejected, false);
+
+		releaseDetach!();
+		await assert.rejects(
+			Promise.race([
+				connect,
+				new Promise<never>((_resolve, reject) => realSetTimeout(() => reject(new Error('test safety timer fired')), 200)),
+			]),
+			(error: unknown) => error instanceof ConnectionFailure && error.kind === 'network',
+		);
+	} finally {
+		globalThis.setTimeout = realSetTimeout;
+		globalThis.clearTimeout = realClearTimeout;
+	}
+});

--- a/apps/shell-ui/src/connection/connection.test.ts
+++ b/apps/shell-ui/src/connection/connection.test.ts
@@ -28,6 +28,8 @@ import { ConnectionState, type ConnectionStatus } from 'shared/types/connection'
 import { ConnectionManager } from './connection.js';
 import { ConnectionFailure, withTimeout } from './errors.js';
 import { RemoteManager } from './remote-manager.js';
+import { ApiKeyAuthProvider } from '../auth/ApiKeyAuthProvider.js';
+import { CloudAuthProvider } from '../auth/CloudAuthProvider.js';
 import { CONNECT_TIMEOUT_MS, LS_TOKEN } from '../constants.js';
 
 type EmittedEvent = { event: string; payload: unknown };
@@ -46,6 +48,7 @@ type TestOperation = {
 
 type ConnectionManagerTestAdapter = {
 	client: TestClient | RocketRideClient | null;
+	manager: { disconnect(client: RocketRideClient): Promise<void> } | null;
 	_attachPromise: Promise<void>;
 	serverUri: string;
 	pendingEvents: Map<string, unknown>;
@@ -220,6 +223,36 @@ test('clearToken removes current and legacy stored tokens', () => {
 		createTestManager().manager.clearToken();
 		assert.deepEqual(removedLocalKeys, ['rr:user_token']);
 		assert.deepEqual(removedSessionKeys, ['rr:user_token']);
+	} finally {
+		if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
+		else delete (globalThis as { localStorage?: Storage }).localStorage;
+		if (originalSessionStorage) Object.defineProperty(globalThis, 'sessionStorage', originalSessionStorage);
+		else delete (globalThis as { sessionStorage?: Storage }).sessionStorage;
+	}
+});
+
+test('auth providers sign out by removing current and legacy stored tokens', async () => {
+	const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, 'localStorage');
+	const originalSessionStorage = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+
+	try {
+		for (const provider of [ApiKeyAuthProvider.getInstance(), CloudAuthProvider.getInstance()]) {
+			const removedLocalKeys: string[] = [];
+			const removedSessionKeys: string[] = [];
+			Object.defineProperty(globalThis, 'localStorage', {
+				configurable: true,
+				value: { removeItem: (key: string) => removedLocalKeys.push(key) },
+			});
+			Object.defineProperty(globalThis, 'sessionStorage', {
+				configurable: true,
+				value: { removeItem: (key: string) => removedSessionKeys.push(key) },
+			});
+
+			await provider.signOut();
+
+			assert.deepEqual(removedLocalKeys, [LS_TOKEN]);
+			assert.deepEqual(removedSessionKeys, [LS_TOKEN]);
+		}
 	} finally {
 		if (originalLocalStorage) Object.defineProperty(globalThis, 'localStorage', originalLocalStorage);
 		else delete (globalThis as { localStorage?: Storage }).localStorage;
@@ -610,7 +643,7 @@ test('disconnect and logout invalidate an in-flight operation before client clea
 	for (const action of ['disconnect', 'logout'] as const) {
 		let resolveLogin: ((result: ConnectResult) => void) | undefined;
 		let disconnectCalls = 0;
-		const { manager } = createTestManager();
+		const { manager, emitted } = createTestManager();
 		manager.serverUri = 'https://shell.example.test';
 		manager.clearToken = () => {};
 		manager.clearSessionAppId = () => {};
@@ -623,8 +656,29 @@ test('disconnect and logout invalidate an in-flight operation before client clea
 		await manager[action]();
 		resolveLogin!(authenticatedResult);
 		assert.equal(await connecting, null);
-		assert.ok(disconnectCalls >= 1);
+		assert.equal(disconnectCalls, 1);
+		assert.deepEqual(
+			emitted.filter(({ event }) => event === 'shell:disconnected'),
+			[{ event: 'shell:disconnected', payload: { reason: 'Disconnected by request', hasError: false } }],
+		);
 	}
+});
+
+test('disconnect does not publish an intentional disconnected event after a newer generation takes ownership', async () => {
+	const { manager, emitted } = createTestManager();
+	let disconnectCalls = 0;
+	manager.client = testClient();
+	manager.manager = {
+		disconnect: async () => {
+			disconnectCalls++;
+			manager.connectionGeneration++;
+		},
+	};
+
+	await manager.disconnect();
+
+	assert.equal(disconnectCalls, 1);
+	assert.deepEqual(emitted.filter(({ event }) => event === 'shell:disconnected'), []);
 });
 
 test('bootstrap stored-token login publishes through the accepted operation once', async () => {

--- a/apps/shell-ui/src/connection/connection.test.ts
+++ b/apps/shell-ui/src/connection/connection.test.ts
@@ -23,7 +23,7 @@
 
 import assert from 'node:assert/strict';
 import test from 'node:test';
-import { RocketRideClient, type ConnectResult } from 'rocketride';
+import { AuthenticationException, LoginAttemptCancelledError, RocketRideClient, type ConnectResult } from 'rocketride';
 import { ConnectionState, type ConnectionStatus } from 'shared/types/connection';
 import { ConnectionManager } from './connection.js';
 import { ConnectionFailure, withTimeout } from './errors.js';
@@ -32,23 +32,52 @@ import { CONNECT_TIMEOUT_MS, LS_TOKEN } from '../constants.js';
 
 type EmittedEvent = { event: string; payload: unknown };
 
+type TestCredential = string | { code: string; verifier: string; redirectUri: string };
+type TestClient = Pick<RocketRideClient, 'login' | 'getAccountInfo' | 'isConnected'> &
+	Partial<Pick<RocketRideClient, 'detach' | 'disconnect' | 'getServices'>>;
+type TestOperation = {
+	key: string;
+	generation: number;
+	credential: TestCredential;
+	cancellationReason?: LoginAttemptCancelledError['reason'];
+	promise: Promise<ConnectResult | null>;
+	connectedPublished: boolean;
+};
+
 type ConnectionManagerTestAdapter = {
+	client: TestClient | RocketRideClient | null;
+	_attachPromise: Promise<void>;
+	serverUri: string;
+	pendingEvents: Map<string, unknown>;
+	lifecycleOwner?: TestOperation;
+	connectionOperation?: TestOperation;
+	connectionGeneration: number;
+	refreshServices: () => Promise<void>;
 	finishConnect(
 		result: ConnectResult,
 		appId: string,
 		config?: { apps?: Array<{ id: string }>; workspaceDir?: string; onThemeChange?: (theme: string) => void },
 	): Promise<{ result: ConnectResult; appId: string }>;
+	connectForBootstrap(
+		credential: TestCredential,
+		appId: string,
+		config?: { apps?: Array<{ id: string }>; workspaceDir?: string; onThemeChange?: (theme: string) => void },
+	): Promise<{ result: ConnectResult; appId: string } | null>;
 	handleStoredTokenFailure(error: unknown): boolean;
 	updateConnectionStatus(updates: Partial<ConnectionStatus>): void;
 	connectionStatus: ConnectionStatus;
 	accountInfo?: ConnectResult;
 	clearToken(): void;
+	clearSessionAppId(): void;
+	loadToken(): string;
 	emit(event: string, payload: unknown): void;
 	saveToken(token: string): void;
 	getPendingAppId(): string;
 	initialize(): void;
-	loginWithStoredToken(token: string): Promise<ConnectResult>;
-	loginWithTimeout(credential: string | { code: string; verifier: string; redirectUri: string }): Promise<ConnectResult>;
+	connect(credential?: unknown): Promise<ConnectResult | null>;
+	bootstrap(): Promise<{ result: ConnectResult; appId: string } | null>;
+	disconnect(): Promise<void>;
+	logout(): Promise<void>;
 };
 
 const authenticatedResult: ConnectResult = {
@@ -84,7 +113,25 @@ function createTestManager(lastFailure?: ConnectionStatus['lastFailure']) {
 	manager.emit = (event, payload) => emitted.push({ event, payload });
 	manager.saveToken = (token) => savedTokens.push(token);
 	manager.getPendingAppId = () => '';
+	manager.pendingEvents = new Map();
+	manager.connectionGeneration = 0;
 	return { manager, emitted, savedTokens };
+}
+
+function testClient(overrides: Partial<TestClient> = {}): TestClient {
+	return {
+		login: async () => authenticatedResult,
+		getAccountInfo: () => authenticatedResult,
+		isConnected: () => true,
+		getServices: async () => ({ services: {} }),
+		...overrides,
+	};
+}
+
+function hasConnectedCallback(client: TestClient | RocketRideClient | null): client is RocketRideClient & {
+	_callerOnConnected: () => Promise<void>;
+} {
+	return client !== null && '_callerOnConnected' in client;
 }
 
 test('updateConnectionStatus retains auth failures and clears network failures after CONNECTED', () => {
@@ -202,7 +249,6 @@ test('initialize handles LS_TOKEN removals only from localStorage', () => {
 
 	try {
 		const { manager } = createTestManager();
-		(manager as unknown as { pendingEvents: Map<string, unknown> }).pendingEvents = new Map();
 		manager.clearToken = () => { tokenCleared = true; };
 		manager.initialize();
 
@@ -252,7 +298,6 @@ test('initialize ignores storage events when localStorage cannot be read', () =>
 
 	try {
 		const { manager } = createTestManager();
-		(manager as unknown as { pendingEvents: Map<string, unknown> }).pendingEvents = new Map();
 		manager.initialize();
 
 		assert.doesNotThrow(() => listeners.get('storage')!({
@@ -292,78 +337,6 @@ test('initialize attaches with the native handshake timeout', () => {
 	}
 });
 
-test('stored-token login leaves request timeout unset for the outer cancellation guard', async () => {
-	const loginCalls: unknown[][] = [];
-	const { manager } = createTestManager();
-	(manager as unknown as { client: Pick<RocketRideClient, 'login'> }).client = {
-		login: async (...args: unknown[]) => {
-			loginCalls.push(args);
-			return authenticatedResult;
-		},
-	};
-
-	await manager.loginWithStoredToken('rr_test-token');
-
-	assert.deepEqual(loginCalls, [['rr_test-token']]);
-});
-
-test('ConnectionManager whole-login timeout detaches before rejecting and forwards token and OAuth credentials unchanged', async () => {
-	const realSetTimeout = globalThis.setTimeout;
-	const realClearTimeout = globalThis.clearTimeout;
-	let timeoutCallback: (() => void) | undefined;
-	let releaseDetach: (() => void) | undefined;
-	let resolveLogin: ((result: ConnectResult) => void) | undefined;
-	let detached = false;
-	let settled = false;
-	const loginCalls: unknown[][] = [];
-	const oauthCredential = { code: 'code', verifier: 'verifier', redirectUri: 'https://shell.example.test' };
-	const { manager } = createTestManager();
-
-	globalThis.setTimeout = ((callback: () => void) => {
-		timeoutCallback = callback;
-		return 0 as unknown as ReturnType<typeof setTimeout>;
-	}) as typeof setTimeout;
-	globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
-	(manager as unknown as { client: Pick<RocketRideClient, 'login' | 'detach'> }).client = {
-		login: async (...args: unknown[]) => {
-			loginCalls.push(args);
-			if (loginCalls.length === 1) return await new Promise<ConnectResult>((resolve) => { resolveLogin = resolve; });
-			return authenticatedResult;
-		},
-		detach: async () => {
-			detached = true;
-			await new Promise<void>((resolve) => { releaseDetach = resolve; });
-		},
-	};
-
-	try {
-		const timedLogin = manager.loginWithTimeout('rr_test-token');
-		void timedLogin.then(
-			() => { settled = true; },
-			() => { settled = true; },
-		);
-
-		timeoutCallback!();
-		await Promise.resolve();
-		assert.equal(detached, true);
-		assert.equal(settled, false);
-
-		resolveLogin!(authenticatedResult);
-		await Promise.resolve();
-		assert.equal(settled, false);
-
-		releaseDetach!();
-		await assert.rejects(timedLogin, (error: unknown) => error instanceof ConnectionFailure && error.kind === 'network');
-		assert.equal(settled, true);
-
-		assert.equal(await manager.loginWithTimeout(oauthCredential), authenticatedResult);
-		assert.deepEqual(loginCalls, [['rr_test-token'], [oauthCredential]]);
-	} finally {
-		globalThis.setTimeout = realSetTimeout;
-		globalThis.clearTimeout = realClearTimeout;
-	}
-});
-
 test('onConnected ignores stale callbacks but accepts the active authenticated connection', async () => {
 	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 	const originalAttach = RocketRideClient.prototype.attach;
@@ -378,9 +351,13 @@ test('onConnected ignores stale callbacks but accepts the active authenticated c
 
 	try {
 		const { manager, emitted } = createTestManager();
-		(manager as unknown as { pendingEvents: Map<string, unknown> }).pendingEvents = new Map();
 		manager.initialize();
-		const client = (manager as unknown as { client: { _callerOnConnected: () => Promise<void> } }).client;
+		assert.ok(hasConnectedCallback(manager.client));
+		const client = manager.client;
+		manager.lifecycleOwner = {
+			key: 'active', generation: 0, credential: 'token', promise: Promise.resolve(null), connectedPublished: false,
+		};
+		manager.connectionStatus.lastFailure = { kind: 'auth', lastError: 'expired' };
 
 		RocketRideClient.prototype.isAttached = () => false;
 		RocketRideClient.prototype.isAuthenticated = () => true;
@@ -391,17 +368,11 @@ test('onConnected ignores stale callbacks but accepts the active authenticated c
 		await client._callerOnConnected();
 
 		RocketRideClient.prototype.isAuthenticated = () => true;
-		(manager as unknown as { suppressConnected: boolean }).suppressConnected = true;
-		await client._callerOnConnected();
-
-		assert.equal(manager.connectionStatus.state, ConnectionState.DISCONNECTED);
-		assert.equal(emitted.some(({ event }) => event === 'shell:connected'), false);
-
-		(manager as unknown as { suppressConnected: boolean }).suppressConnected = false;
-		(manager as unknown as { refreshServices: () => Promise<void> }).refreshServices = async () => {};
+		manager.refreshServices = async () => {};
 		await client._callerOnConnected();
 
 		assert.equal(manager.connectionStatus.state, ConnectionState.CONNECTED);
+		assert.equal(manager.connectionStatus.lastFailure, undefined);
 		assert.equal(emitted.filter(({ event }) => event === 'shell:connected').length, 1);
 	} finally {
 		RocketRideClient.prototype.attach = originalAttach;
@@ -513,6 +484,241 @@ test('RemoteManager.connect detaches before returning a network timeout failure'
 			]),
 			(error: unknown) => error instanceof ConnectionFailure && error.kind === 'network',
 		);
+	} finally {
+		globalThis.setTimeout = realSetTimeout;
+		globalThis.clearTimeout = realClearTimeout;
+	}
+});
+
+test('connect coalesces identical credential operations and supersedes stale credential publication', async () => {
+	let resolveFirstLogin: ((result: ConnectResult) => void) | undefined;
+	let account = authenticatedResult;
+	let loginCount = 0;
+	const { manager, emitted } = createTestManager();
+	manager.serverUri = 'shell.example.test';
+	manager.client = testClient({
+		login: async () => {
+			loginCount++;
+			if (loginCount === 1) return await new Promise<ConnectResult>((resolve) => { resolveFirstLogin = resolve; });
+			account = { ...authenticatedResult, userId: 'new-user', userToken: 'new-token' };
+			return account;
+		},
+		getAccountInfo: () => account,
+	});
+
+	const first = manager.connect('first-token');
+	const joined = manager.connect('first-token');
+	assert.equal(joined, first);
+
+	const replacement = manager.connect('second-token');
+	assert.notEqual(replacement, first);
+	assert.equal((await replacement)!.userId, 'new-user');
+
+	resolveFirstLogin!(authenticatedResult);
+	assert.equal(await first, null);
+	assert.deepEqual(
+		emitted.filter(({ event }) => event === 'shell:login'),
+		[{ event: 'shell:login', payload: { user: account } }],
+	);
+});
+
+test('connect distinguishes string and PKCE credentials when coalescing', async () => {
+	const resolvers: Array<(result: ConnectResult) => void> = [];
+	const { manager } = createTestManager();
+	manager.serverUri = 'https://shell.example.test';
+	manager.client = testClient({
+		login: async () => await new Promise<ConnectResult>((resolve) => { resolvers.push(resolve); }),
+	});
+
+	const stringOperation = manager.connect('credential');
+	const pkceOperation = manager.connect({ code: 'credential', verifier: 'verifier', redirectUri: 'https://shell.example.test' });
+	assert.notEqual(stringOperation, pkceOperation);
+
+	resolvers[1]!(authenticatedResult);
+	assert.equal((await pkceOperation)!.userId, authenticatedResult.userId);
+	resolvers[0]!(authenticatedResult);
+	assert.equal(await stringOperation, null);
+});
+
+test('connect joins PKCE credentials with fields supplied in a different order', async () => {
+	let resolveLogin: ((result: ConnectResult) => void) | undefined;
+	const { manager } = createTestManager();
+	manager.serverUri = 'https://shell.example.test';
+	manager.client = testClient({
+		login: async () => await new Promise<ConnectResult>((resolve) => { resolveLogin = resolve; }),
+	});
+
+	const first = manager.connect({ code: 'code', verifier: 'verifier', redirectUri: 'https://shell.example.test' });
+	const joined = manager.connect({ redirectUri: 'https://shell.example.test', verifier: 'verifier', code: 'code' });
+
+	assert.equal(joined, first);
+	resolveLogin!(authenticatedResult);
+	assert.equal((await first)!.userId, authenticatedResult.userId);
+});
+
+test('public connect resolves intentional SDK cancellations silently for every reason', async () => {
+	for (const reason of ['superseded', 'logout', 'detached'] as const) {
+		const { manager, emitted } = createTestManager();
+		let clearTokenCalls = 0;
+		manager.serverUri = 'https://shell.example.test';
+		manager.clearToken = () => { clearTokenCalls++; };
+		manager.client = testClient({
+			login: async () => { throw new LoginAttemptCancelledError(reason); },
+		});
+
+		assert.equal(await manager.connect('token'), null);
+		assert.equal(clearTokenCalls, 0);
+		assert.equal(manager.connectionStatus.lastFailure, undefined);
+		assert.equal(emitted.some(({ event }) => event === 'shell:error'), false);
+	}
+});
+
+test('non-cancellation failures remain failures and auth recovery clears its latch', async () => {
+	const { manager, emitted } = createTestManager();
+	let clearTokenCalls = 0;
+	manager.serverUri = 'https://shell.example.test';
+	manager.clearToken = () => { clearTokenCalls++; };
+	manager.client = testClient({
+		login: async () => { throw new AuthenticationException({ message: 'invalid credential' }); },
+	});
+
+	await assert.rejects(manager.connect('token'));
+	assert.equal(clearTokenCalls, 1);
+	assert.equal(manager.connectionStatus.state, ConnectionState.AUTH_FAILED);
+	assert.equal(manager.connectionStatus.lastFailure?.kind, 'auth');
+	assert.equal(emitted.some(({ event }) => event === 'shell:error'), true);
+
+	manager.client.login = async () => authenticatedResult;
+	await manager.connect('fresh-token');
+	assert.equal(manager.connectionStatus.lastFailure, undefined);
+});
+
+test('a disconnected transport error is a normal network failure, not a cancellation', async () => {
+	const { manager, emitted } = createTestManager();
+	manager.serverUri = 'https://shell.example.test';
+	manager.client = testClient({ login: async () => { throw new Error('disconnected'); } });
+
+	await assert.rejects(
+		manager.connect('token'),
+		(error: unknown) => error instanceof ConnectionFailure && error.kind === 'network',
+	);
+	assert.equal(manager.connectionStatus.lastFailure?.kind, 'network');
+	assert.equal(emitted.some(({ event }) => event === 'shell:error'), true);
+});
+
+test('disconnect and logout invalidate an in-flight operation before client cleanup', async () => {
+	for (const action of ['disconnect', 'logout'] as const) {
+		let resolveLogin: ((result: ConnectResult) => void) | undefined;
+		let disconnectCalls = 0;
+		const { manager } = createTestManager();
+		manager.serverUri = 'https://shell.example.test';
+		manager.clearToken = () => {};
+		manager.clearSessionAppId = () => {};
+		manager.client = testClient({
+			login: async () => await new Promise<ConnectResult>((resolve) => { resolveLogin = resolve; }),
+			disconnect: async () => { disconnectCalls++; },
+		});
+
+		const connecting = manager.connect('token');
+		await manager[action]();
+		resolveLogin!(authenticatedResult);
+		assert.equal(await connecting, null);
+		assert.ok(disconnectCalls >= 1);
+	}
+});
+
+test('bootstrap stored-token login publishes through the accepted operation once', async () => {
+	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
+	const { manager, emitted } = createTestManager();
+	manager.serverUri = 'https://shell.example.test';
+	manager.client = testClient();
+	manager._attachPromise = Promise.resolve();
+	manager.loadToken = () => 'stored-token';
+	Object.defineProperty(globalThis, 'window', {
+		configurable: true,
+		value: { location: { search: '' } },
+	});
+
+	try {
+		const completed = await manager.bootstrap();
+
+		assert.equal(completed?.result, authenticatedResult);
+		assert.equal(completed?.appId, '');
+		assert.deepEqual(
+			emitted.filter(({ event }) => event === 'shell:login'),
+			[{ event: 'shell:login', payload: { user: authenticatedResult } }],
+		);
+	} finally {
+		if (originalWindow) Object.defineProperty(globalThis, 'window', originalWindow);
+		else delete (globalThis as { window?: Window }).window;
+	}
+});
+
+test('bootstrap cannot finish an old login under a replacement operation', async () => {
+	let resolveLogin: ((result: ConnectResult) => void) | undefined;
+	let finishConnectCalls = 0;
+	const { manager } = createTestManager();
+	const oldOperation: TestOperation = {
+		key: 'old',
+		generation: 1,
+		credential: 'old-token',
+		promise: Promise.resolve(null),
+		connectedPublished: false,
+	};
+	const replacementOperation: TestOperation = {
+		key: 'replacement',
+		generation: 2,
+		credential: 'new-token',
+		promise: Promise.resolve(null),
+		connectedPublished: false,
+	};
+	const login = new Promise<ConnectResult>((resolve) => { resolveLogin = resolve; });
+	void login.then(() => {
+		manager.connectionGeneration = replacementOperation.generation;
+		manager.lifecycleOwner = replacementOperation;
+		manager.connectionOperation = replacementOperation;
+	});
+	manager.connect = () => {
+		manager.connectionGeneration = oldOperation.generation;
+		manager.lifecycleOwner = oldOperation;
+		manager.connectionOperation = oldOperation;
+		return login;
+	};
+	manager.finishConnect = async () => {
+		finishConnectCalls++;
+		return { result: authenticatedResult, appId: '' };
+	};
+
+	const completing = manager.connectForBootstrap('old-token', '');
+	resolveLogin!(authenticatedResult);
+
+	assert.equal(await completing, null);
+	assert.equal(finishConnectCalls, 0);
+});
+
+test('timeout cleanup leaves a replacement shell operation attached', async () => {
+	const realSetTimeout = globalThis.setTimeout;
+	const realClearTimeout = globalThis.clearTimeout;
+	let timeoutCallback: (() => void) | undefined;
+	let detachCalls = 0;
+	globalThis.setTimeout = ((callback: () => void) => {
+		timeoutCallback = callback;
+		return 0 as unknown as ReturnType<typeof setTimeout>;
+	}) as typeof setTimeout;
+	globalThis.clearTimeout = (() => {}) as typeof clearTimeout;
+
+	try {
+		const client = {
+			login: async () => await new Promise<ConnectResult>(() => {}),
+			detach: async () => { detachCalls++; },
+		} as unknown as RocketRideClient;
+		const connect = new RemoteManager(() => false).connect(client, {
+			uri: 'https://shell.example.test',
+			credential: 'token',
+		});
+		timeoutCallback!();
+		await assert.rejects(connect, (error: unknown) => error instanceof ConnectionFailure && error.kind === 'network');
+		assert.equal(detachCalls, 0);
 	} finally {
 		globalThis.setTimeout = realSetTimeout;
 		globalThis.clearTimeout = realClearTimeout;

--- a/apps/shell-ui/src/connection/connection.test.ts
+++ b/apps/shell-ui/src/connection/connection.test.ts
@@ -370,7 +370,7 @@ test('initialize attaches with the native handshake timeout', () => {
 	}
 });
 
-test('onConnected ignores stale callbacks but accepts the active authenticated connection', async () => {
+test('onConnected ignores stale callbacks, accepts the active connection, and preserves an auth latch', async () => {
 	const originalWindow = Object.getOwnPropertyDescriptor(globalThis, 'window');
 	const originalAttach = RocketRideClient.prototype.attach;
 	const originalIsAttached = RocketRideClient.prototype.isAttached;
@@ -405,8 +405,20 @@ test('onConnected ignores stale callbacks but accepts the active authenticated c
 		await client._callerOnConnected();
 
 		assert.equal(manager.connectionStatus.state, ConnectionState.CONNECTED);
-		assert.equal(manager.connectionStatus.lastFailure, undefined);
 		assert.equal(emitted.filter(({ event }) => event === 'shell:connected').length, 1);
+
+		// The SDK's isAuthenticated() reports transport-level auth, which is also
+		// true for the anonymous connects the landing page makes — so publishing
+		// CONNECTED must NOT retire an auth latch, or a "session expired" banner
+		// would vanish before the user acts on it. Only an authenticated login
+		// path clears it (covered by the auth-recovery test below).
+		assert.deepEqual(manager.connectionStatus.lastFailure, { kind: 'auth', lastError: 'expired' });
+
+		// A network latch, by contrast, is retired the moment we reconnect.
+		manager.connectionStatus.lastFailure = { kind: 'network', lastError: 'unreachable' };
+		manager.lifecycleOwner.connectedPublished = false;
+		await client._callerOnConnected();
+		assert.equal(manager.connectionStatus.lastFailure, undefined);
 	} finally {
 		RocketRideClient.prototype.attach = originalAttach;
 		RocketRideClient.prototype.isAttached = originalIsAttached;

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -955,6 +955,7 @@ export class ConnectionManager implements IConnectionManager {
 			progressMessage: undefined,
 			errorKind: undefined,
 		});
+		this.emit('shell:disconnected', { reason: 'Disconnected by request', hasError: false });
 	}
 
 	/**

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -361,8 +361,18 @@ export class ConnectionManager implements IConnectionManager {
 			},
 
 			// Fired on each failed connection attempt before SDK retries
-			onConnectError: () => {
+			onConnectError: (error) => {
 				if (!this.hasCurrentLifecycleOwner()) return;
+				// A background re-login rejection is terminal: the SDK downgrades
+				// to an anonymous attachment and stops retrying. Without latching
+				// here, a token revoked mid-session leaves the UI showing
+				// "Reconnecting\u2026" forever with a dead token still stored.
+				if (error instanceof AuthenticationException) {
+					if (this.handleStoredTokenFailure(error)) this.clearToken();
+					this.accountInfo = undefined;
+					this.emit('shell:statusMessage', { message: null });
+					return;
+				}
 				this.updateConnectionStatus({
 					progressMessage: 'Reconnecting\u2026',
 					retryAttempt: this.connectionStatus.retryAttempt + 1,

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -28,7 +28,7 @@
 //   - Singleton via static getInstance()
 //   - Typed event bus (emit/on) with debug log and wildcard listeners
 //   - Delegates connection backend to RemoteManager (BaseManager subclass)
-//   - Promise-based concurrency guards (connectPromise/disconnectPromise)
+//   - Credential-keyed, generation-owned connection operations
 //   - ConnectionStatus state machine with proper enum states
 //
 // Auth is decoupled into CloudAuthProvider / ApiKeyAuthProvider — this class
@@ -40,14 +40,14 @@
 //   - Browser-specific session storage for auth phase tracking
 // =============================================================================
 
-import { RocketRideClient, ConnectResult, AuthenticationException } from 'rocketride';
+import { RocketRideClient, ConnectResult, AuthenticationException, LoginAttemptCancelledError } from 'rocketride';
 import type { ShellConnectionEventMap, IConnectionManager, IAuthProvider } from 'shared';
 // Keep this runtime value off the shared UI barrel so node:test does not load UI assets.
 import { ConnectionState } from 'shared/types/connection';
 import type { ConnectionMode, ConnectionStatus } from 'shared/types/connection';
 import { BaseManager } from './base-manager';
 import { RemoteManager } from './remote-manager';
-import { ConnectionFailure, withTimeout } from './errors';
+import { ConnectionFailure } from './errors';
 import { shouldReloadForTokenStorageUpdate } from './tokenStorageUpdate';
 import { getStoredVerifier, clearStoredVerifier } from '../util/pkce';
 import {
@@ -57,7 +57,6 @@ import {
 	DEBUG_LOG_MAX,
 	DEFAULT_CLIENT_NAME,
 	DEFAULT_WORKSPACE_DIR,
-	CONNECT_TIMEOUT_MS,
 	MAX_RETRY_ATTEMPTS,
 } from '../constants';
 
@@ -106,6 +105,36 @@ type Handler<T = unknown> = (payload: T) => void;
 
 /** Handler type for wildcard listeners (debug panel). */
 type WildcardHandler = (event: string, payload: unknown) => void;
+
+type ConnectionCredential = string | { code: string; verifier: string; redirectUri: string };
+
+interface ShellConnectionOperation {
+	key: string;
+	generation: number;
+	credential: ConnectionCredential;
+	cancellationReason?: LoginAttemptCancelledError['reason'];
+	promise: Promise<ConnectResult | null>;
+	connectedPublished: boolean;
+}
+
+function isConnectionCredential(credential: unknown): credential is ConnectionCredential {
+	return typeof credential === 'string' || (
+		typeof credential === 'object' &&
+		credential !== null &&
+		typeof (credential as Record<string, unknown>).code === 'string' &&
+		typeof (credential as Record<string, unknown>).verifier === 'string' &&
+		typeof (credential as Record<string, unknown>).redirectUri === 'string'
+	);
+}
+
+function connectionCredentialKey(credential: ConnectionCredential): string {
+	if (typeof credential === 'string') return `token:${credential}`;
+	return `pkce:${JSON.stringify({
+		code: credential.code,
+		verifier: credential.verifier,
+		redirectUri: credential.redirectUri,
+	})}`;
+}
 
 /**
  * Runtime type guard narrowing an untyped DAP event body to a ConnectResult.
@@ -215,10 +244,12 @@ export class ConnectionManager implements IConnectionManager {
 	/** Active backend manager (RemoteManager). */
 	private manager: BaseManager | null = null;
 
-	/** In-flight connect guard — prevents concurrent connect() calls. */
-	private connectPromise: Promise<ConnectResult | null> | undefined;
-	/** Blocks SDK callbacks from login attempts cancelled by our outer timeout. */
-	private suppressConnected = false;
+	/** Current in-flight shell operation, keyed by endpoint and credential. */
+	private connectionOperation: ShellConnectionOperation | undefined;
+	/** Latest operation allowed to publish SDK lifecycle state. */
+	private lifecycleOwner: ShellConnectionOperation | undefined;
+	/** Monotonic shell lifecycle generation, invalidated before SDK cleanup. */
+	private connectionGeneration = 0;
 
 	/** Connection status state machine. */
 	private connectionStatus: ConnectionStatus = {
@@ -298,6 +329,7 @@ export class ConnectionManager implements IConnectionManager {
 
 			// Fired for every push event received from the server over WebSocket
 			onEvent: async (message) => {
+				if (!this.hasCurrentLifecycleOwner()) return;
 				// Transform apaext_account into shell:accountUpdate to avoid
 				// duplicate handling downstream. The guard narrows the untyped
 				// push body to a ConnectResult without a cast.
@@ -311,27 +343,15 @@ export class ConnectionManager implements IConnectionManager {
 
 			// Fired once the WebSocket handshake completes and auth succeeds
 			onConnected: async () => {
-				if (this.suppressConnected || !this.client?.isAttached() || !this.client.isAuthenticated()) return;
-
-				this.updateConnectionStatus({
-					state: ConnectionState.CONNECTED,
-					lastConnected: new Date(),
-					lastError: undefined,
-					errorKind: undefined,
-					retryAttempt: 0,
-					progressMessage: undefined,
-				});
-				this.emit('shell:connected', {});
-				this.emit('shell:statusMessage', { message: null });
-
-				// Fetch and cache services list on connect
-				this.refreshServices().catch((err) => {
-					console.error('[ConnectionManager] Failed to refresh services on connect:', err);
-				});
+				if (!this.hasCurrentLifecycleOwner()) return;
+				if (!this.client?.isAttached() || !this.client.isAuthenticated()) return;
+				this.publishConnected(this.lifecycleOwner!);
 			},
 
 			// Fired when the WebSocket closes for any reason
 			onDisconnected: async (reason, hasError) => {
+				if (!this.hasCurrentLifecycleOwner()) return;
+				this.lifecycleOwner!.connectedPublished = false;
 				this.clearServicesCache();
 				// Don't overwrite AUTH_FAILED state
 				if (this.connectionStatus.state !== ConnectionState.AUTH_FAILED) {
@@ -342,6 +362,7 @@ export class ConnectionManager implements IConnectionManager {
 
 			// Fired on each failed connection attempt before SDK retries
 			onConnectError: () => {
+				if (!this.hasCurrentLifecycleOwner()) return;
 				this.updateConnectionStatus({
 					progressMessage: 'Reconnecting\u2026',
 					retryAttempt: this.connectionStatus.retryAttempt + 1,
@@ -371,36 +392,35 @@ export class ConnectionManager implements IConnectionManager {
 		// so the button works again without a manual page refresh.
 		if (typeof window !== 'undefined') {
 			window.addEventListener('storage', (event) => {
-				let localStorage: Storage;
 				try {
-					localStorage = window.localStorage;
+					const localStorage = window.localStorage;
+					if (event.key !== LS_TOKEN || event.storageArea !== localStorage) return;
+
+					if (event.newValue === null) {
+						this.clearToken();
+						this.accountInfo = undefined;
+						this.pendingEvents.clear();
+						this.clearServicesCache();
+						this.updateConnectionStatus({
+							state: ConnectionState.DISCONNECTED,
+							hasCredentials: false,
+							lastError: undefined,
+							progressMessage: undefined,
+						});
+						window.location.reload();
+						return;
+					}
+
+					if (shouldReloadForTokenStorageUpdate({
+						oldValue: event.oldValue,
+						newValue: event.newValue,
+						currentUserToken: this.accountInfo?.userToken,
+						hasAccountInfo: Boolean(this.accountInfo),
+					})) {
+						window.location.reload();
+					}
 				} catch {
 					return;
-				}
-				if (event.key !== LS_TOKEN || event.storageArea !== localStorage) return;
-
-				if (event.newValue === null) {
-					this.clearToken();
-					this.accountInfo = undefined;
-					this.pendingEvents.clear();
-					this.clearServicesCache();
-					this.updateConnectionStatus({
-						state: ConnectionState.DISCONNECTED,
-						hasCredentials: false,
-						lastError: undefined,
-						progressMessage: undefined,
-					});
-					window.location.reload();
-					return;
-				}
-
-				if (shouldReloadForTokenStorageUpdate({
-					oldValue: event.oldValue,
-					newValue: event.newValue,
-					currentUserToken: this.accountInfo?.userToken,
-					hasAccountInfo: Boolean(this.accountInfo),
-				})) {
-					window.location.reload();
 				}
 			});
 
@@ -523,12 +543,14 @@ export class ConnectionManager implements IConnectionManager {
 		onThemeChange?: (theme: string) => void;
 	}): Promise<{ result: ConnectResult; appId: string } | null> {
 		if (!this.client) throw new Error('Client not initialized — call init() first.');
+		const bootstrapGeneration = this.connectionGeneration;
 
 		// Ensure the transport is attached before any login attempt. The native
 		// attach timeout closes a timed-out handshake before this promise rejects.
 		try {
 			await this._attachPromise!;
 		} catch (error) {
+			if (this.connectionGeneration !== bootstrapGeneration) return null;
 			// Transport attach failures are network problems by definition.
 			this.handleStoredTokenFailure(
 				error instanceof ConnectionFailure
@@ -537,6 +559,7 @@ export class ConnectionManager implements IConnectionManager {
 			);
 			return null;
 		}
+		if (this.connectionGeneration !== bootstrapGeneration) return null;
 
 		const params = new URLSearchParams(window.location.search);
 		const code = params.get('code');
@@ -549,6 +572,7 @@ export class ConnectionManager implements IConnectionManager {
 		const errorDescription = params.get('auth_error');
 
 		if (errorDescription) {
+			if (this.connectionGeneration !== bootstrapGeneration) return null;
 			window.history.replaceState({}, '', window.location.pathname);
 			this.updateConnectionStatus({
 				state: ConnectionState.AUTH_FAILED,
@@ -578,8 +602,7 @@ export class ConnectionManager implements IConnectionManager {
 				const staleToken = this.loadToken();
 				if (staleToken) {
 					try {
-						const result = await this.loginWithStoredToken(staleToken);
-						return await this.finishConnect(result, sessionAppId, config);
+						return await this.connectForBootstrap(staleToken, sessionAppId, config);
 					} catch (error) {
 						if (this.handleStoredTokenFailure(error)) this.clearToken();
 						else return null;
@@ -592,8 +615,7 @@ export class ConnectionManager implements IConnectionManager {
 			}
 
 			try {
-				const result = await this.loginWithTimeout({ code, verifier, redirectUri: window.location.origin });
-				return await this.finishConnect(result, sessionAppId, config);
+				return await this.connectForBootstrap({ code, verifier, redirectUri: window.location.origin }, sessionAppId, config);
 			} catch (error) {
 				// The code is single-use and already stripped from the URL, so
 				// recovery always goes through a fresh flow — classify and latch
@@ -623,8 +645,7 @@ export class ConnectionManager implements IConnectionManager {
 			const token = this.loadToken();
 			if (token) {
 				try {
-					const result = await this.loginWithStoredToken(token);
-					return await this.finishConnect(result, sessionAppId, config);
+					return await this.connectForBootstrap(token, sessionAppId, config);
 				} catch (error) {
 					// Token expired or invalid — clear it and fall through to
 					// the unauthenticated render below (the shell's auth gate
@@ -652,8 +673,7 @@ export class ConnectionManager implements IConnectionManager {
 		const token = this.loadToken();
 		if (token) {
 			try {
-				const result = await this.loginWithStoredToken(token);
-				return await this.finishConnect(result, '', config);
+				return await this.connectForBootstrap(token, '', config);
 			} catch (err) {
 				// Connect failed — retain the token when the server is unreachable.
 				if (this.handleStoredTokenFailure(err)) this.clearToken();
@@ -693,28 +713,31 @@ export class ConnectionManager implements IConnectionManager {
 			workspaceDir?: string;
 			onThemeChange?: (theme: string) => void;
 		},
+		operation?: ShellConnectionOperation,
 	): Promise<{ result: ConnectResult; appId: string }> {
 		this.requireAuthenticatedResult(result);
+		if (operation) this.assertCurrentOperation(operation);
 
-		// Persist the token for future page loads
-		if (result.userToken) this.saveToken(result.userToken);
-
-		// An authenticated connect resolves any latched failure (incl. auth).
-		this.updateConnectionStatus({ lastFailure: undefined });
-
-		// Cache the account info
-		this.accountInfo = result;
-
-		// Publish identity to all listeners
-		this.emit('shell:login', { user: result });
+		// Direct callers retain the original helper behaviour. Foreground connect()
+		// has already published identity before bootstrap restores shell-only state.
+		if (!operation) {
+			if (result.userToken) this.saveToken(result.userToken);
+			this.updateConnectionStatus({ lastFailure: undefined });
+			this.accountInfo = result;
+			this.emit('shell:login', { user: result });
+		}
 
 		// Restore saved theme from workspace file
 		if (config?.onThemeChange) {
 			try {
 				const dir = config.workspaceDir ?? DEFAULT_WORKSPACE_DIR;
 				const global = await this.client!.fsReadJson<{ shellPrefs?: { theme?: string } }>(`${dir}/global.json`);
+				if (operation) this.assertCurrentOperation(operation);
 				if (global?.shellPrefs?.theme) config.onThemeChange(global.shellPrefs.theme);
-			} catch { /* theme read failed — not critical */ }
+			} catch (error) {
+				if (error instanceof LoginAttemptCancelledError) throw error;
+				// Theme restore is best-effort.
+			}
 		}
 
 		// Resolve the target app — check pending app ID from OAuth flow
@@ -723,39 +746,75 @@ export class ConnectionManager implements IConnectionManager {
 
 		// Notify the workspace to switch to the target app
 		if (resolvedAppId) {
+			if (operation) this.assertCurrentOperation(operation);
 			this.emit('shell:switchApp', { appId: resolvedAppId });
 		}
 
 		return { result, appId: resolvedAppId };
 	}
 
-	/** Login with a stored token and type failures for bootstrap recovery. */
-	private async loginWithStoredToken(token: string): Promise<ConnectResult> {
+	/** Finish bootstrap-only effects after the shared foreground operation succeeds. */
+	private async connectForBootstrap(
+		credential: ConnectionCredential,
+		appId: string,
+		config?: {
+			apps?: Array<{ id: string }>;
+			workspaceDir?: string;
+			onThemeChange?: (theme: string) => void;
+		},
+	): Promise<{ result: ConnectResult; appId: string } | null> {
+		const connection = this.connect(credential);
+		const operation = this.connectionOperation;
+		const result = await connection;
+		if (!operation || !this.isCurrentOperation(operation)) return null;
+		if (!result) return null;
 		try {
-			return this.requireAuthenticatedResult(await this.loginWithTimeout(token));
+			return await this.finishConnect(result, appId, config, operation);
 		} catch (error) {
-			if (error instanceof ConnectionFailure) throw error;
-			if (this.getConnectionFailureState(error) === ConnectionState.AUTH_FAILED) {
-				throw new ConnectionFailure(error instanceof Error ? error.message : String(error), 'auth');
-			}
-			throw new ConnectionFailure(error instanceof Error ? error.message : String(error), 'network');
+			if (error instanceof LoginAttemptCancelledError) return null;
+			throw error;
 		}
 	}
 
-	/** Bound every login path and detach stale transport state before timing out. */
-	private async loginWithTimeout(
-		credential: string | { code: string; verifier: string; redirectUri: string },
-	): Promise<ConnectResult> {
-		this.suppressConnected = false;
-		return await withTimeout(
-			this.client!.login(credential),
-			CONNECT_TIMEOUT_MS,
-			new ConnectionFailure(`Connection timed out after ${CONNECT_TIMEOUT_MS}ms`, 'network'),
-			async () => {
-				this.suppressConnected = true;
-				await this.client!.detach();
-			},
-		);
+	private isCurrentOperation(operation: ShellConnectionOperation): boolean {
+		return this.lifecycleOwner === operation &&
+			this.connectionGeneration === operation.generation &&
+			operation.cancellationReason === undefined;
+	}
+
+	private hasCurrentLifecycleOwner(): boolean {
+		return this.lifecycleOwner !== undefined && this.isCurrentOperation(this.lifecycleOwner);
+	}
+
+	private assertCurrentOperation(operation: ShellConnectionOperation): void {
+		if (!this.isCurrentOperation(operation)) {
+			throw new LoginAttemptCancelledError(operation.cancellationReason ?? 'superseded');
+		}
+	}
+
+	private invalidateLifecycle(reason: LoginAttemptCancelledError['reason']): void {
+		if (this.lifecycleOwner) this.lifecycleOwner.cancellationReason = reason;
+		this.connectionGeneration++;
+		this.connectionOperation = undefined;
+		this.lifecycleOwner = undefined;
+	}
+
+	private publishConnected(operation: ShellConnectionOperation): void {
+		if (!this.isCurrentOperation(operation) || operation.connectedPublished) return;
+		operation.connectedPublished = true;
+		this.updateConnectionStatus({
+			state: ConnectionState.CONNECTED,
+			lastConnected: new Date(),
+			lastError: undefined,
+			errorKind: undefined,
+			retryAttempt: 0,
+			progressMessage: undefined,
+			lastFailure: undefined,
+		});
+		this.emit('shell:connected', {});
+		void this.refreshServices().catch((error: unknown) => {
+			console.error('[ConnectionManager] Failed to refresh services on connect:', error);
+		});
 	}
 
 	// =========================================================================
@@ -765,41 +824,48 @@ export class ConnectionManager implements IConnectionManager {
 	/**
 	 * Connect to the server using the provided credential.
 	 *
-	 * Deduplicates concurrent calls — if a connect is already in flight,
-	 * returns the same promise (same pattern as VSCode's connectPromise).
+	 * Deduplicates concurrent calls for the same normalized endpoint and
+	 * credential. A different credential supersedes publication by the old call.
 	 *
 	 * @param credential - Token string or PKCE exchange object.
 	 * @returns The ConnectResult on success, or null if deduplicated.
 	 */
 	public connect(credential?: unknown): Promise<ConnectResult | null> {
-		// Deduplicate: if a connect is already in flight, return the same promise
-		if (this.connectPromise) {
-			return this.connectPromise;
+		if (!isConnectionCredential(credential)) {
+			return Promise.reject(new Error('No credential provided for connection.'));
 		}
 
-		const promise = this._connect(credential).finally(() => {
-			// Only clear if we're still the active promise
-			if (this.connectPromise === promise) {
-				this.connectPromise = undefined;
-			}
+		const key = `${RocketRideClient.normalizeUri(this.serverUri)}\u0000${connectionCredentialKey(credential)}`;
+		if (this.connectionOperation?.key === key) return this.connectionOperation.promise;
+
+		if (this.lifecycleOwner) this.lifecycleOwner.cancellationReason = 'superseded';
+		const operation: ShellConnectionOperation = {
+			key,
+			generation: ++this.connectionGeneration,
+			credential,
+			promise: Promise.resolve(null),
+			connectedPublished: false,
+		};
+		this.lifecycleOwner = operation;
+		this.connectionOperation = operation;
+		const promise = this._connect(operation).catch((error: unknown) => {
+			if (error instanceof LoginAttemptCancelledError) return null;
+			throw error;
+		}).finally(() => {
+			if (this.connectionOperation === operation) this.connectionOperation = undefined;
 		});
-		this.connectPromise = promise;
+		operation.promise = promise;
 		return promise;
 	}
 
 	/**
 	 * Internal connect implementation.
 	 */
-	private async _connect(credential?: unknown): Promise<ConnectResult | null> {
+	private async _connect(operation: ShellConnectionOperation): Promise<ConnectResult | null> {
 		if (!this.client) {
 			throw new Error('Client not initialized — call initialize() first.');
 		}
-
-		if (!credential) {
-			throw new Error('No credential provided for connection.');
-		}
-
-		this.suppressConnected = false;
+		this.assertCurrentOperation(operation);
 		this.updateConnectionStatus({
 			state: ConnectionState.CONNECTING,
 			lastError: undefined,
@@ -807,39 +873,59 @@ export class ConnectionManager implements IConnectionManager {
 		});
 
 		try {
-			// Create manager if needed (same pattern as VSCode)
-			if (!this.manager) {
-				this.manager = new RemoteManager(() => { this.suppressConnected = true; });
-			}
+			const manager = new RemoteManager(() => this.isCurrentOperation(operation));
+			this.manager = manager;
 
 			// Delegate connection to the manager (handles timeout internally)
-			await this.manager.connect(this.client, {
+			await manager.connect(this.client, {
 				uri: this.serverUri,
-				credential: credential as string | { code: string; verifier: string; redirectUri: string },
+				credential: operation.credential,
 			});
+			this.assertCurrentOperation(operation);
 
 			// Get the connect result from the client
 			const result = this.requireAuthenticatedResult(this.client.getAccountInfo());
+			this.assertCurrentOperation(operation);
 			this.updateConnectionStatus({ lastFailure: undefined });
+			this.assertCurrentOperation(operation);
 			this.accountInfo = result;
 
 			// Persist token
 			if (result.userToken) {
+				this.assertCurrentOperation(operation);
 				this.saveToken(result.userToken);
 			}
 
 			// Emit login event
+			this.assertCurrentOperation(operation);
 			this.emit('shell:login', { user: result });
+			this.assertCurrentOperation(operation);
+			this.publishConnected(operation);
 
 			return result;
 		} catch (error) {
+			if (!this.isCurrentOperation(operation)) {
+				throw new LoginAttemptCancelledError(operation.cancellationReason ?? 'superseded');
+			}
+			if (error instanceof LoginAttemptCancelledError) throw error;
 			const errorMessage = error instanceof Error ? error.message : String(error);
+			const state = this.getConnectionFailureState(error);
+			const isAuthFailure = state === ConnectionState.AUTH_FAILED;
+			if (isAuthFailure) {
+				this.clearToken();
+				this.accountInfo = undefined;
+			}
 
 			this.updateConnectionStatus({
-				state: this.getConnectionFailureState(error),
+				state,
 				lastError: errorMessage,
 				progressMessage: undefined,
 				errorKind: undefined,
+				lastFailure: {
+					kind: isAuthFailure ? 'auth' : 'network',
+					lastError: errorMessage,
+					errorKind: undefined,
+				},
 			});
 
 			this.emit('shell:error', { error });
@@ -852,13 +938,16 @@ export class ConnectionManager implements IConnectionManager {
 	 * Safe to call when already disconnected.
 	 */
 	public async disconnect(): Promise<void> {
-		// Clear in-flight connect guard
-		this.connectPromise = undefined;
+		this.invalidateLifecycle('detached');
+		const generation = this.connectionGeneration;
+		const manager = this.manager;
+		const client = this.client;
 
-		if (this.manager && this.client) {
-			await this.manager.disconnect(this.client);
-			this.manager = null;
+		if (manager && client) {
+			await manager.disconnect(client);
+			if (this.manager === manager) this.manager = null;
 		}
+		if (this.connectionGeneration !== generation) return;
 
 		this.clearServicesCache();
 		this.updateConnectionStatus({
@@ -930,6 +1019,7 @@ export class ConnectionManager implements IConnectionManager {
 	 * Logout: clear auth state, disconnect, and emit shell:logout.
 	 */
 	public async logout(): Promise<void> {
+		this.invalidateLifecycle('logout');
 		// Clear persisted auth state
 		this.clearToken();
 		this.clearSessionAppId();
@@ -1114,9 +1204,13 @@ export class ConnectionManager implements IConnectionManager {
 	 * Deduplicates concurrent calls.
 	 */
 	public async refreshServices(): Promise<void> {
+		const owner = this.lifecycleOwner;
+		if (!owner || !this.isCurrentOperation(owner)) return;
 		if (!this.isConnected() || !this.client) {
-			this.clearServicesCache();
-			this.emit('shell:servicesUpdated', { services: {}, servicesError: 'Not connected' });
+			if (this.isCurrentOperation(owner)) {
+				this.clearServicesCache();
+				this.emit('shell:servicesUpdated', { services: {}, servicesError: 'Not connected' });
+			}
 			return;
 		}
 
@@ -1125,24 +1219,28 @@ export class ConnectionManager implements IConnectionManager {
 			return this.servicesRefreshPromise;
 		}
 
-		this.servicesRefreshPromise = (async () => {
+		const refreshPromise = (async () => {
 			try {
 				const body = await this.client!.getServices();
+				if (!this.isCurrentOperation(owner)) return;
 				const services: Record<string, unknown> = body.services ?? {};
 				this.cachedServices = services;
 				this.cachedServicesError = null;
 				this.emit('shell:servicesUpdated', { services, servicesError: undefined });
 			} catch (err: unknown) {
+				if (!this.isCurrentOperation(owner)) return;
 				const msg = err instanceof Error ? err.message : String(err);
 				this.cachedServices = null;
 				this.cachedServicesError = msg;
 				this.emit('shell:servicesUpdated', { services: {}, servicesError: msg });
-			} finally {
-				this.servicesRefreshPromise = null;
 			}
 		})();
+		this.servicesRefreshPromise = refreshPromise;
+		void refreshPromise.finally(() => {
+			if (this.servicesRefreshPromise === refreshPromise) this.servicesRefreshPromise = null;
+		});
 
-		return this.servicesRefreshPromise;
+		return refreshPromise;
 	}
 
 	/** Clear all services cache state. */

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -47,7 +47,7 @@ import { ConnectionState } from 'shared/types/connection';
 import type { ConnectionMode, ConnectionStatus } from 'shared/types/connection';
 import { BaseManager } from './base-manager';
 import { RemoteManager } from './remote-manager';
-import { ConnectionFailure } from './errors';
+import { AUTH_REJECTED_MESSAGE, ConnectionFailure } from './errors';
 import { shouldReloadForTokenStorageUpdate } from './tokenStorageUpdate';
 import { getStoredVerifier, clearStoredVerifier } from '../util/pkce';
 import {
@@ -704,7 +704,7 @@ export class ConnectionManager implements IConnectionManager {
 	/** Reject login results that do not identify an authenticated account. */
 	private requireAuthenticatedResult(result: ConnectResult | null | undefined): ConnectResult {
 		if (!result?.userId) {
-			throw new ConnectionFailure('Authentication failed: unknown user or invalid credentials.', 'auth');
+			throw new ConnectionFailure(AUTH_REJECTED_MESSAGE, 'auth');
 		}
 		return result;
 	}

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -40,12 +40,15 @@
 //   - Browser-specific session storage for auth phase tracking
 // =============================================================================
 
-import { RocketRideClient, ConnectResult } from 'rocketride';
+import { RocketRideClient, ConnectResult, AuthenticationException } from 'rocketride';
 import type { ShellConnectionEventMap, IConnectionManager, IAuthProvider } from 'shared';
-import { ConnectionState, ConnectionStatus } from 'shared';
-import type { ConnectionMode } from 'shared';
+// Keep this runtime value off the shared UI barrel so node:test does not load UI assets.
+import { ConnectionState } from 'shared/types/connection';
+import type { ConnectionMode, ConnectionStatus } from 'shared/types/connection';
 import { BaseManager } from './base-manager';
 import { RemoteManager } from './remote-manager';
+import { ConnectionFailure, withTimeout } from './errors';
+import { shouldReloadForTokenStorageUpdate } from './tokenStorageUpdate';
 import { getStoredVerifier, clearStoredVerifier } from '../util/pkce';
 import {
 	LS_TOKEN,
@@ -54,6 +57,7 @@ import {
 	DEBUG_LOG_MAX,
 	DEFAULT_CLIENT_NAME,
 	DEFAULT_WORKSPACE_DIR,
+	CONNECT_TIMEOUT_MS,
 	MAX_RETRY_ATTEMPTS,
 } from '../constants';
 
@@ -213,6 +217,8 @@ export class ConnectionManager implements IConnectionManager {
 
 	/** In-flight connect guard — prevents concurrent connect() calls. */
 	private connectPromise: Promise<ConnectResult | null> | undefined;
+	/** Blocks SDK callbacks from login attempts cancelled by our outer timeout. */
+	private suppressConnected = false;
 
 	/** Connection status state machine. */
 	private connectionStatus: ConnectionStatus = {
@@ -305,10 +311,13 @@ export class ConnectionManager implements IConnectionManager {
 
 			// Fired once the WebSocket handshake completes and auth succeeds
 			onConnected: async () => {
+				if (this.suppressConnected || !this.client?.isAttached() || !this.client.isAuthenticated()) return;
+
 				this.updateConnectionStatus({
 					state: ConnectionState.CONNECTED,
 					lastConnected: new Date(),
 					lastError: undefined,
+					errorKind: undefined,
 					retryAttempt: 0,
 					progressMessage: undefined,
 				});
@@ -326,7 +335,7 @@ export class ConnectionManager implements IConnectionManager {
 				this.clearServicesCache();
 				// Don't overwrite AUTH_FAILED state
 				if (this.connectionStatus.state !== ConnectionState.AUTH_FAILED) {
-					this.updateConnectionStatus({ state: ConnectionState.CONNECTING });
+					this.updateConnectionStatus({ state: ConnectionState.CONNECTING, errorKind: undefined });
 				}
 				this.emit('shell:disconnected', { reason: reason ?? 'unknown', hasError: hasError ?? false });
 			},
@@ -350,7 +359,8 @@ export class ConnectionManager implements IConnectionManager {
 
 		// Attach immediately so public APIs (rrext_public_*) work before login.
 		// The promise is stored so bootstrap() can await it before login().
-		this._attachPromise = this.client.attach().catch((err) => {
+		this._attachPromise = this.client.attach(undefined, { timeout: 10000 });
+		void this._attachPromise.catch((err) => {
 			console.error('[ConnectionManager] Failed to attach:', err);
 		});
 
@@ -360,6 +370,40 @@ export class ConnectionManager implements IConnectionManager {
 		// click would hit the guard and do nothing. Release it on bfcache restore
 		// so the button works again without a manual page refresh.
 		if (typeof window !== 'undefined') {
+			window.addEventListener('storage', (event) => {
+				let localStorage: Storage;
+				try {
+					localStorage = window.localStorage;
+				} catch {
+					return;
+				}
+				if (event.key !== LS_TOKEN || event.storageArea !== localStorage) return;
+
+				if (event.newValue === null) {
+					this.clearToken();
+					this.accountInfo = undefined;
+					this.pendingEvents.clear();
+					this.clearServicesCache();
+					this.updateConnectionStatus({
+						state: ConnectionState.DISCONNECTED,
+						hasCredentials: false,
+						lastError: undefined,
+						progressMessage: undefined,
+					});
+					window.location.reload();
+					return;
+				}
+
+				if (shouldReloadForTokenStorageUpdate({
+					oldValue: event.oldValue,
+					newValue: event.newValue,
+					currentUserToken: this.accountInfo?.userToken,
+					hasAccountInfo: Boolean(this.accountInfo),
+				})) {
+					window.location.reload();
+				}
+			});
+
 			window.addEventListener('pageshow', (e) => {
 				if ((e as PageTransitionEvent).persisted) {
 					this.oauthStarted = false;
@@ -480,11 +524,43 @@ export class ConnectionManager implements IConnectionManager {
 	}): Promise<{ result: ConnectResult; appId: string } | null> {
 		if (!this.client) throw new Error('Client not initialized — call init() first.');
 
-		// Ensure the transport is attached before any login attempt
-		await this._attachPromise;
+		// Ensure the transport is attached before any login attempt. The native
+		// attach timeout closes a timed-out handshake before this promise rejects.
+		try {
+			await this._attachPromise!;
+		} catch (error) {
+			// Transport attach failures are network problems by definition.
+			this.handleStoredTokenFailure(
+				error instanceof ConnectionFailure
+					? error
+					: new ConnectionFailure(error instanceof Error ? error.message : String(error), 'network'),
+			);
+			return null;
+		}
 
 		const params = new URLSearchParams(window.location.search);
 		const code = params.get('code');
+		// Only honor `auth_error`: it is set exclusively by our own OAuth
+		// callback (the registered redirect_uri is the server callback, which
+		// wraps every Zitadel failure as `auth_error` before redirecting here).
+		// The generic OAuth `error`/`error_description` params never legitimately
+		// reach the app this way, so reading them would let any unrelated app
+		// deep-link (`/app?error=…`) hijack bootstrap into a false sign-in banner.
+		const errorDescription = params.get('auth_error');
+
+		if (errorDescription) {
+			window.history.replaceState({}, '', window.location.pathname);
+			this.updateConnectionStatus({
+				state: ConnectionState.AUTH_FAILED,
+				lastError: errorDescription,
+				progressMessage: undefined,
+				errorKind: 'oauth-callback',
+				lastFailure: { kind: 'auth', lastError: errorDescription, errorKind: 'oauth-callback' },
+			});
+			this.clearPendingAppId();
+			return null;
+		}
+
 		const sessionAppId = this.getSessionAppId();
 
 		// ── OAuth callback — exchange authorization code for a session ────
@@ -502,10 +578,11 @@ export class ConnectionManager implements IConnectionManager {
 				const staleToken = this.loadToken();
 				if (staleToken) {
 					try {
-						const result = await this.client.login(staleToken);
+						const result = await this.loginWithStoredToken(staleToken);
 						return await this.finishConnect(result, sessionAppId, config);
-					} catch {
-						this.clearToken();
+					} catch (error) {
+						if (this.handleStoredTokenFailure(error)) this.clearToken();
+						else return null;
 					}
 				}
 				// No usable token — render unauthenticated and let the shell's
@@ -514,8 +591,31 @@ export class ConnectionManager implements IConnectionManager {
 				return null;
 			}
 
-			const result = await this.client.login({ code, verifier, redirectUri: window.location.origin });
-			return await this.finishConnect(result, sessionAppId, config);
+			try {
+				const result = await this.loginWithTimeout({ code, verifier, redirectUri: window.location.origin });
+				return await this.finishConnect(result, sessionAppId, config);
+			} catch (error) {
+				// The code is single-use and already stripped from the URL, so
+				// recovery always goes through a fresh flow — classify and latch
+				// instead of letting the failure escape bootstrap unhandled.
+				if (error instanceof AuthenticationException || (error instanceof ConnectionFailure && error.kind === 'auth')) {
+					const lastError = error.message;
+					this.updateConnectionStatus({
+						state: ConnectionState.AUTH_FAILED,
+						lastError,
+						progressMessage: undefined,
+						errorKind: 'oauth-callback',
+						lastFailure: { kind: 'auth', lastError, errorKind: 'oauth-callback' },
+					});
+				} else {
+					this.handleStoredTokenFailure(
+						error instanceof ConnectionFailure
+							? error
+							: new ConnectionFailure(error instanceof Error ? error.message : String(error), 'network'),
+					);
+				}
+				return null;
+			}
 		}
 
 		// ── Session-locked app — reconnect with stored token ─────────────
@@ -523,12 +623,15 @@ export class ConnectionManager implements IConnectionManager {
 			const token = this.loadToken();
 			if (token) {
 				try {
-					const result = await this.client.login(token);
+					const result = await this.loginWithStoredToken(token);
 					return await this.finishConnect(result, sessionAppId, config);
-				} catch {
-					// Token expired or invalid — clear it and fall through to the
-					// unauthenticated render below.
-					this.clearToken();
+				} catch (error) {
+					// Token expired or invalid — clear it and fall through to
+					// the unauthenticated render below (the shell's auth gate
+					// owns starting a login flow, edition-aware). A network
+					// failure keeps the token so the recovery banner can retry
+					// with it once the server is reachable again.
+					if (this.handleStoredTokenFailure(error)) this.clearToken();
 				}
 			}
 			// Unauthenticated session-locked visit: bootstrap deliberately does
@@ -545,20 +648,15 @@ export class ConnectionManager implements IConnectionManager {
 			return null;
 		}
 
-		// ── Home flow (no session lock) — try token with timeout ─────────
+		// ── Home flow (no session lock) — try stored token ────────────────
 		const token = this.loadToken();
 		if (token) {
 			try {
-				const result = await Promise.race([
-					this.client.login(token),
-					new Promise<never>((_, reject) =>
-						setTimeout(() => reject(new Error('timeout')), 8000),
-					),
-				]);
+				const result = await this.loginWithStoredToken(token);
 				return await this.finishConnect(result, '', config);
 			} catch (err) {
-				// Connect failed — clear stale token
-				this.clearToken();
+				// Connect failed — retain the token when the server is unreachable.
+				if (this.handleStoredTokenFailure(err)) this.clearToken();
 				return null;
 			}
 		}
@@ -571,6 +669,14 @@ export class ConnectionManager implements IConnectionManager {
 		this.clearPendingAppId();
 		// Show shell unauthenticated (transport is attached, public APIs work)
 		return null;
+	}
+
+	/** Reject login results that do not identify an authenticated account. */
+	private requireAuthenticatedResult(result: ConnectResult | null | undefined): ConnectResult {
+		if (!result?.userId) {
+			throw new ConnectionFailure('Authentication failed: unknown user or invalid credentials.', 'auth');
+		}
+		return result;
 	}
 
 	/**
@@ -588,8 +694,13 @@ export class ConnectionManager implements IConnectionManager {
 			onThemeChange?: (theme: string) => void;
 		},
 	): Promise<{ result: ConnectResult; appId: string }> {
+		this.requireAuthenticatedResult(result);
+
 		// Persist the token for future page loads
 		if (result.userToken) this.saveToken(result.userToken);
+
+		// An authenticated connect resolves any latched failure (incl. auth).
+		this.updateConnectionStatus({ lastFailure: undefined });
 
 		// Cache the account info
 		this.accountInfo = result;
@@ -616,6 +727,35 @@ export class ConnectionManager implements IConnectionManager {
 		}
 
 		return { result, appId: resolvedAppId };
+	}
+
+	/** Login with a stored token and type failures for bootstrap recovery. */
+	private async loginWithStoredToken(token: string): Promise<ConnectResult> {
+		try {
+			return this.requireAuthenticatedResult(await this.loginWithTimeout(token));
+		} catch (error) {
+			if (error instanceof ConnectionFailure) throw error;
+			if (this.getConnectionFailureState(error) === ConnectionState.AUTH_FAILED) {
+				throw new ConnectionFailure(error instanceof Error ? error.message : String(error), 'auth');
+			}
+			throw new ConnectionFailure(error instanceof Error ? error.message : String(error), 'network');
+		}
+	}
+
+	/** Bound every login path and detach stale transport state before timing out. */
+	private async loginWithTimeout(
+		credential: string | { code: string; verifier: string; redirectUri: string },
+	): Promise<ConnectResult> {
+		this.suppressConnected = false;
+		return await withTimeout(
+			this.client!.login(credential),
+			CONNECT_TIMEOUT_MS,
+			new ConnectionFailure(`Connection timed out after ${CONNECT_TIMEOUT_MS}ms`, 'network'),
+			async () => {
+				this.suppressConnected = true;
+				await this.client!.detach();
+			},
+		);
 	}
 
 	// =========================================================================
@@ -659,15 +799,17 @@ export class ConnectionManager implements IConnectionManager {
 			throw new Error('No credential provided for connection.');
 		}
 
+		this.suppressConnected = false;
 		this.updateConnectionStatus({
 			state: ConnectionState.CONNECTING,
 			lastError: undefined,
+			errorKind: undefined,
 		});
 
 		try {
 			// Create manager if needed (same pattern as VSCode)
 			if (!this.manager) {
-				this.manager = new RemoteManager();
+				this.manager = new RemoteManager(() => { this.suppressConnected = true; });
 			}
 
 			// Delegate connection to the manager (handles timeout internally)
@@ -677,7 +819,8 @@ export class ConnectionManager implements IConnectionManager {
 			});
 
 			// Get the connect result from the client
-			const result = this.client.getAccountInfo() as ConnectResult;
+			const result = this.requireAuthenticatedResult(this.client.getAccountInfo());
+			this.updateConnectionStatus({ lastFailure: undefined });
 			this.accountInfo = result;
 
 			// Persist token
@@ -692,15 +835,11 @@ export class ConnectionManager implements IConnectionManager {
 		} catch (error) {
 			const errorMessage = error instanceof Error ? error.message : String(error);
 
-			// Determine if this is an auth failure vs network failure
-			const isAuthError = errorMessage.includes('Authentication failed') ||
-				errorMessage.includes('unknown user') ||
-				errorMessage.includes('invalid credentials');
-
 			this.updateConnectionStatus({
-				state: isAuthError ? ConnectionState.AUTH_FAILED : ConnectionState.FAILED,
+				state: this.getConnectionFailureState(error),
 				lastError: errorMessage,
 				progressMessage: undefined,
+				errorKind: undefined,
 			});
 
 			this.emit('shell:error', { error });
@@ -725,6 +864,7 @@ export class ConnectionManager implements IConnectionManager {
 		this.updateConnectionStatus({
 			state: ConnectionState.DISCONNECTED,
 			progressMessage: undefined,
+			errorKind: undefined,
 		});
 	}
 
@@ -737,6 +877,53 @@ export class ConnectionManager implements IConnectionManager {
 		if (token) {
 			await this.connect(token);
 		}
+	}
+
+	/** Map a connection failure to the status state that determines recovery UI. */
+	private getConnectionFailureState(error: unknown): ConnectionState {
+		if (error instanceof ConnectionFailure) {
+			switch (error.kind) {
+				case 'auth': return ConnectionState.AUTH_FAILED;
+				case 'network': return ConnectionState.FAILED;
+				case 'server': return ConnectionState.FAILED;
+			}
+		}
+
+		// The SDK types auth rejections (invalid/revoked/expired credentials).
+		if (error instanceof AuthenticationException) return ConnectionState.AUTH_FAILED;
+
+		const errorMessage = error instanceof Error ? error.message : String(error);
+		// Legacy fallback for untyped errors from older connection paths.
+		const isAuthError = errorMessage.includes('Authentication failed') ||
+			errorMessage.includes('unknown user') ||
+			errorMessage.includes('invalid credentials');
+		return isAuthError ? ConnectionState.AUTH_FAILED : ConnectionState.FAILED;
+	}
+
+	/** Surface a stored-token failure and return whether the token should be cleared. */
+	private handleStoredTokenFailure(error: unknown): boolean {
+		const state = this.getConnectionFailureState(error);
+		const isAuthFailure = state === ConnectionState.AUTH_FAILED;
+		const isNetworkFailure = error instanceof ConnectionFailure && error.kind === 'network';
+		const lastError = isNetworkFailure
+			? 'Can\'t reach the server — check your connection and retry.'
+			: isAuthFailure
+				? 'Your session has expired — please sign in again.'
+				: error instanceof Error ? error.message : String(error);
+		this.updateConnectionStatus({
+			state,
+			lastError,
+			progressMessage: undefined,
+			errorKind: isAuthFailure ? 'session' : undefined,
+			// Latched so the SDK's reconnect churn (CONNECTING) and anonymous
+			// connects can't erase the failure before recovery UI renders it.
+			lastFailure: {
+				kind: isAuthFailure ? 'auth' : 'network',
+				lastError,
+				errorKind: isAuthFailure ? 'session' : undefined,
+			},
+		});
+		return isAuthFailure;
 	}
 
 	/**
@@ -818,22 +1005,35 @@ export class ConnectionManager implements IConnectionManager {
 	// TOKEN STORAGE
 	// =========================================================================
 
-	/** Persist a user token to sessionStorage. */
+	/** Persist a user token to localStorage. */
 	public saveToken(token: string): void {
-		try { sessionStorage.setItem(LS_TOKEN, token); } catch (e) {
+		try { localStorage.setItem(LS_TOKEN, token); } catch (e) {
 			console.error('[ConnectionManager] Failed to save token:', e);
 		}
 	}
 
-	/** Load token from sessionStorage. Returns empty string if unavailable. */
+	/** Load token from localStorage. Migrates the old sessionStorage value once. */
 	public loadToken(): string {
-		try { return sessionStorage.getItem(LS_TOKEN) ?? ''; } catch { return ''; }
+		try {
+			const token = localStorage.getItem(LS_TOKEN);
+			if (token !== null) return token;
+
+			const sessionToken = sessionStorage.getItem(LS_TOKEN);
+			if (sessionToken === null) return '';
+
+			localStorage.setItem(LS_TOKEN, sessionToken);
+			sessionStorage.removeItem(LS_TOKEN);
+			return sessionToken;
+		} catch { return ''; }
 	}
 
 	/** Clear the persisted token. */
 	public clearToken(): void {
-		try { sessionStorage.removeItem(LS_TOKEN); } catch (e) {
+		try { localStorage.removeItem(LS_TOKEN); } catch (e) {
 			console.error('[ConnectionManager] Failed to clear token:', e);
+		}
+		try { sessionStorage.removeItem(LS_TOKEN); } catch (e) {
+			console.error('[ConnectionManager] Failed to clear legacy session token:', e);
 		}
 	}
 
@@ -1093,6 +1293,20 @@ export class ConnectionManager implements IConnectionManager {
 	/** Update connection status and emit shell:statusChange. */
 	private updateConnectionStatus(updates: Partial<ConnectionStatus>): void {
 		Object.assign(this.connectionStatus, updates);
+
+		// Latch failures across later transitions. The SDK's persist mode keeps
+		// the state cycling through CONNECTING while it retries, and a
+		// post-failure anonymous connect reports CONNECTED — either would erase
+		// a purely state-driven failure before recovery UI could render it.
+		// A network failure clears once a connection is re-established; an
+		// auth failure persists until the user acts on it (sign-in navigates).
+		if (
+			updates.state === ConnectionState.CONNECTED &&
+			this.connectionStatus.lastFailure?.kind === 'network'
+		) {
+			this.connectionStatus.lastFailure = undefined;
+		}
+
 		this.emit('shell:statusChange' as keyof ShellConnectionEventMap, this.connectionStatus as any);
 
 		// Also emit statusMessage for simple UI consumers

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -732,7 +732,7 @@ export class ConnectionManager implements IConnectionManager {
 		// has already published identity before bootstrap restores shell-only state.
 		if (!operation) {
 			if (result.userToken) this.saveToken(result.userToken);
-			this.updateConnectionStatus({ lastFailure: undefined });
+			this.clearLatchedFailure();
 			this.accountInfo = result;
 			this.emit('shell:login', { user: result });
 		}
@@ -809,9 +809,24 @@ export class ConnectionManager implements IConnectionManager {
 		this.lifecycleOwner = undefined;
 	}
 
+	/**
+	 * Retire a latched failure after an authenticated connect. Anonymous
+	 * connects must NOT call this: a public connect following a session expiry
+	 * would otherwise erase the recovery banner before the user acts on it.
+	 */
+	private clearLatchedFailure(): void {
+		if (this.connectionStatus.lastFailure) this.updateConnectionStatus({ lastFailure: undefined });
+	}
+
 	private publishConnected(operation: ShellConnectionOperation): void {
 		if (!this.isCurrentOperation(operation) || operation.connectedPublished) return;
 		operation.connectedPublished = true;
+		// NB: no `lastFailure: undefined` here. This publisher runs for every
+		// CONNECTED transition including anonymous/public connects, so clearing
+		// unconditionally would wipe a "session expired" banner before the user
+		// could act on it. updateConnectionStatus() clears network latches on
+		// CONNECTED; an auth latch is cleared only by an authenticated connect
+		// (see clearLatchedFailure callers).
 		this.updateConnectionStatus({
 			state: ConnectionState.CONNECTED,
 			lastConnected: new Date(),
@@ -819,7 +834,6 @@ export class ConnectionManager implements IConnectionManager {
 			errorKind: undefined,
 			retryAttempt: 0,
 			progressMessage: undefined,
-			lastFailure: undefined,
 		});
 		this.emit('shell:connected', {});
 		void this.refreshServices().catch((error: unknown) => {
@@ -899,6 +913,9 @@ export class ConnectionManager implements IConnectionManager {
 			this.updateConnectionStatus({ lastFailure: undefined });
 			this.assertCurrentOperation(operation);
 			this.accountInfo = result;
+			// Identity established — this is the only signal that retires an
+			// auth latch (publishConnected deliberately no longer does).
+			this.clearLatchedFailure();
 
 			// Persist token
 			if (result.userToken) {

--- a/apps/shell-ui/src/connection/errors.ts
+++ b/apps/shell-ui/src/connection/errors.ts
@@ -1,0 +1,63 @@
+// =============================================================================
+// CONNECTION ERRORS — typed failures surfaced by connection backends
+// =============================================================================
+
+/** A connection failure whose kind determines the UI recovery action. */
+export class ConnectionFailure extends Error {
+	constructor(
+		message: string,
+		public readonly kind: 'auth' | 'network' | 'server',
+	) {
+		super(message);
+		this.name = 'ConnectionFailure';
+	}
+}
+
+/**
+ * Bound an operation and cancel its client-side state before reporting timeout.
+ * Late completion is deliberately ignored after timeout so it cannot revive a
+ * login that the caller has already treated as failed.
+ */
+export function withTimeout<T>(
+	operation: Promise<T>,
+	timeoutMs: number,
+	timeoutError: Error,
+	cleanup: () => Promise<unknown>,
+): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		let timeout: ReturnType<typeof setTimeout> | undefined;
+		let settled = false;
+		let timedOut = false;
+
+		const clearTimer = () => {
+			if (timeout !== undefined) clearTimeout(timeout);
+		};
+
+		operation.then(
+			(value) => {
+				if (settled || timedOut) return;
+				settled = true;
+				clearTimer();
+				resolve(value);
+			},
+			(error) => {
+				if (settled || timedOut) return;
+				settled = true;
+				clearTimer();
+				reject(error);
+			},
+		);
+
+		timeout = setTimeout(async () => {
+			if (settled || timedOut) return;
+			timedOut = true;
+			clearTimer();
+			try {
+				await cleanup();
+			} catch {
+				// The timeout error remains the recovery signal even if cleanup fails.
+			}
+			reject(timeoutError);
+		}, timeoutMs);
+	});
+}

--- a/apps/shell-ui/src/connection/errors.ts
+++ b/apps/shell-ui/src/connection/errors.ts
@@ -3,6 +3,12 @@
 // =============================================================================
 
 /** A connection failure whose kind determines the UI recovery action. */
+/**
+ * Message for a rejected credential. Shared so the two `userId` gates
+ * (transport connect and the shell's own result check) can never drift apart.
+ */
+export const AUTH_REJECTED_MESSAGE = 'Authentication failed: unknown user or invalid credentials.';
+
 export class ConnectionFailure extends Error {
 	constructor(
 		message: string,

--- a/apps/shell-ui/src/connection/errors.ts
+++ b/apps/shell-ui/src/connection/errors.ts
@@ -25,12 +25,23 @@ export function withTimeout<T>(
 	cleanup: () => Promise<unknown>,
 ): Promise<T> {
 	return new Promise<T>((resolve, reject) => {
-		let timeout: ReturnType<typeof setTimeout> | undefined;
 		let settled = false;
 		let timedOut = false;
 
+		const timeout = setTimeout(async () => {
+			if (settled || timedOut) return;
+			timedOut = true;
+			clearTimeout(timeout);
+			try {
+				await cleanup();
+			} catch {
+				// The timeout error remains the recovery signal even if cleanup fails.
+			}
+			reject(timeoutError);
+		}, timeoutMs);
+
 		const clearTimer = () => {
-			if (timeout !== undefined) clearTimeout(timeout);
+			clearTimeout(timeout);
 		};
 
 		operation.then(
@@ -47,17 +58,5 @@ export function withTimeout<T>(
 				reject(error);
 			},
 		);
-
-		timeout = setTimeout(async () => {
-			if (settled || timedOut) return;
-			timedOut = true;
-			clearTimer();
-			try {
-				await cleanup();
-			} catch {
-				// The timeout error remains the recovery signal even if cleanup fails.
-			}
-			reject(timeoutError);
-		}, timeoutMs);
 	});
 }

--- a/apps/shell-ui/src/connection/remote-manager.ts
+++ b/apps/shell-ui/src/connection/remote-manager.ts
@@ -34,10 +34,11 @@
 // No engine process management (that's VSCode-only via LocalManager).
 // =============================================================================
 
-import { RocketRideClient, ConnectResult } from 'rocketride';
+import { RocketRideClient, ConnectResult, AuthenticationException } from 'rocketride';
 import type { ManagerInfo } from 'shared';
 import { BaseManager, ShellConnectionConfig } from './base-manager';
 import { CONNECT_TIMEOUT_MS } from '../constants';
+import { ConnectionFailure, withTimeout } from './errors';
 
 // =============================================================================
 // REMOTE MANAGER
@@ -46,6 +47,10 @@ import { CONNECT_TIMEOUT_MS } from '../constants';
 export class RemoteManager extends BaseManager {
 	/** Cached server info from the most recent successful connection. */
 	private serverInfo: ManagerInfo | null = null;
+
+	constructor(private readonly onLoginTimeout?: () => void) {
+		super();
+	}
 
 	// =========================================================================
 	// LIFECYCLE
@@ -62,20 +67,33 @@ export class RemoteManager extends BaseManager {
 	async connect(client: RocketRideClient, config: ShellConnectionConfig): Promise<void> {
 		// Validate that we have something to connect with
 		if (!config.credential) {
-			throw new Error('No credential provided for connection.');
+			throw new ConnectionFailure('No credential provided for connection.', 'auth');
 		}
 
-		// Login with timeout to avoid indefinite hangs (transport already attached)
-		const result = await Promise.race([
-			client.login(config.credential as string | { code: string; verifier: string; redirectUri: string }),
-			new Promise<never>((_, reject) =>
-				setTimeout(() => reject(new Error(`Connection timed out after ${CONNECT_TIMEOUT_MS}ms`)), CONNECT_TIMEOUT_MS),
-			),
-		]) as ConnectResult;
+		// login() also waits for post-auth monitor resubscription, so bound the
+		// entire operation and detach before surfacing a timeout.
+		let result: ConnectResult;
+		try {
+			result = await withTimeout(
+				client.login(config.credential as string | { code: string; verifier: string; redirectUri: string }),
+				CONNECT_TIMEOUT_MS,
+				new ConnectionFailure(`Connection timed out after ${CONNECT_TIMEOUT_MS}ms`, 'network'),
+				async () => {
+					this.onLoginTimeout?.();
+					await client.detach();
+				},
+			);
+		} catch (error) {
+			if (error instanceof ConnectionFailure) throw error;
+			if (error instanceof AuthenticationException) {
+				throw new ConnectionFailure(error.message, 'auth');
+			}
+			throw new ConnectionFailure(error instanceof Error ? error.message : String(error), 'network');
+		}
 
 		// Validate the result — SDK resolves even on auth failure
 		if (!result.userId) {
-			throw new Error('Authentication failed: unknown user or invalid credentials.');
+			throw new ConnectionFailure('Authentication failed: unknown user or invalid credentials.', 'auth');
 		}
 
 		// Cache server info if available. serverVersion is sent by newer servers

--- a/apps/shell-ui/src/connection/remote-manager.ts
+++ b/apps/shell-ui/src/connection/remote-manager.ts
@@ -38,7 +38,7 @@ import { RocketRideClient, ConnectResult, AuthenticationException, LoginAttemptC
 import type { ManagerInfo } from 'shared';
 import { BaseManager, ShellConnectionConfig } from './base-manager';
 import { CONNECT_TIMEOUT_MS } from '../constants';
-import { ConnectionFailure, withTimeout } from './errors';
+import { AUTH_REJECTED_MESSAGE, ConnectionFailure, withTimeout } from './errors';
 
 // =============================================================================
 // REMOTE MANAGER
@@ -94,7 +94,7 @@ export class RemoteManager extends BaseManager {
 
 		// Validate the result — SDK resolves even on auth failure
 		if (!result.userId) {
-			throw new ConnectionFailure('Authentication failed: unknown user or invalid credentials.', 'auth');
+			throw new ConnectionFailure(AUTH_REJECTED_MESSAGE, 'auth');
 		}
 
 		// Cache server info if available. serverVersion is sent by newer servers

--- a/apps/shell-ui/src/connection/remote-manager.ts
+++ b/apps/shell-ui/src/connection/remote-manager.ts
@@ -34,7 +34,7 @@
 // No engine process management (that's VSCode-only via LocalManager).
 // =============================================================================
 
-import { RocketRideClient, ConnectResult, AuthenticationException } from 'rocketride';
+import { RocketRideClient, ConnectResult, AuthenticationException, LoginAttemptCancelledError } from 'rocketride';
 import type { ManagerInfo } from 'shared';
 import { BaseManager, ShellConnectionConfig } from './base-manager';
 import { CONNECT_TIMEOUT_MS } from '../constants';
@@ -48,7 +48,7 @@ export class RemoteManager extends BaseManager {
 	/** Cached server info from the most recent successful connection. */
 	private serverInfo: ManagerInfo | null = null;
 
-	constructor(private readonly onLoginTimeout?: () => void) {
+	constructor(private readonly onLoginTimeout?: () => boolean | Promise<boolean | void> | void) {
 		super();
 	}
 
@@ -79,11 +79,12 @@ export class RemoteManager extends BaseManager {
 				CONNECT_TIMEOUT_MS,
 				new ConnectionFailure(`Connection timed out after ${CONNECT_TIMEOUT_MS}ms`, 'network'),
 				async () => {
-					this.onLoginTimeout?.();
-					await client.detach();
+					const ownsLogin = await this.onLoginTimeout?.();
+					if (ownsLogin !== false) await client.detach();
 				},
 			);
 		} catch (error) {
+			if (error instanceof LoginAttemptCancelledError) throw error;
 			if (error instanceof ConnectionFailure) throw error;
 			if (error instanceof AuthenticationException) {
 				throw new ConnectionFailure(error.message, 'auth');

--- a/apps/shell-ui/src/connection/tokenStorageUpdate.ts
+++ b/apps/shell-ui/src/connection/tokenStorageUpdate.ts
@@ -1,0 +1,18 @@
+export interface TokenStorageUpdate {
+	oldValue: string | null;
+	newValue: string | null;
+	currentUserToken?: string;
+	hasAccountInfo: boolean;
+}
+
+export function shouldReloadForTokenStorageUpdate(update: TokenStorageUpdate): boolean {
+	const { oldValue, newValue, currentUserToken, hasAccountInfo } = update;
+
+	if (newValue === null) return false;
+
+	if (oldValue !== null) {
+		return currentUserToken !== newValue;
+	}
+
+	return !hasAccountInfo;
+}

--- a/apps/shell-ui/src/constants.ts
+++ b/apps/shell-ui/src/constants.ts
@@ -28,7 +28,7 @@
 // STORAGE KEYS
 // =============================================================================
 
-/** sessionStorage: auth token — survives refresh, cleared on tab close. */
+/** localStorage: auth token — persists across tabs, windows, and browser restarts. */
 export const LS_TOKEN = 'rr:user_token';
 
 /**

--- a/packages/shared-ui/src/types/connection.ts
+++ b/packages/shared-ui/src/types/connection.ts
@@ -51,11 +51,12 @@ export enum ConnectionState {
 	/** Successfully connected and authenticated. */
 	CONNECTED = 'connected',
 
-	/** Connection attempt failed (network, timeout, server error). */
+	/** Connection attempt failed due to a server error. */
 	FAILED = 'failed',
 
 	/** Authentication was rejected by the server (bad/expired/revoked key). */
 	AUTH_FAILED = 'auth-failed',
+
 }
 
 // =============================================================================
@@ -96,6 +97,33 @@ export interface ConnectionStatus {
 
 	/** Last error message (cleared on successful connect). */
 	lastError?: string;
+
+	/**
+	 * Discriminates AUTH_FAILED origins so recovery UI can phrase the message:
+	 * 'oauth-callback' — the IdP returned an error on the OAuth callback;
+	 * 'session' — an existing session was rejected or expired.
+	 */
+	errorKind?: 'oauth-callback' | 'session';
+
+	/**
+	 * Most recent unrecovered failure, latched across later transitions.
+	 * Persist-mode reconnect attempts report CONNECTING and a post-failure
+	 * anonymous connect reports CONNECTED — recovery UI reads this field so
+	 * the failure stays visible until it is actually resolved. Network
+	 * failures clear on reconnection; auth failures clear on re-auth.
+	 */
+	lastFailure?: {
+		/**
+		 * 'network' — transport failure, retryable, credentials intact;
+		 * 'auth' — credentials rejected/expired. Carried here (not as a new
+		 * ConnectionState member) because the enum is frozen by the versioned
+		 * shell-api contract; the state stays FAILED / AUTH_FAILED.
+		 */
+		kind: 'network' | 'auth';
+		lastError?: string;
+		/** Distinguishes an aborted OAuth callback from an expired session. */
+		errorKind?: 'oauth-callback' | 'session';
+	};
 
 	/** True if we have necessary credentials/config to attempt connection. */
 	hasCredentials: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -561,6 +561,9 @@ importers:
       '@rsbuild/plugin-type-check':
         specifier: ~1.3.5
         version: 1.3.5(@rsbuild/core@2.0.11(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(core-js@3.48.0))(@rspack/core@2.0.6(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.23))(tslib@2.8.1)(typescript@5.9.3)
+      '@types/node':
+        specifier: ^20.19.41
+        version: 20.19.41
       '@types/react':
         specifier: ~18.3.31
         version: 18.3.31
@@ -570,6 +573,9 @@ importers:
       dts-bundle-generator:
         specifier: ^9.5.1
         version: 9.5.1
+      tsx:
+        specifier: ~4.23.1
+        version: 4.23.1
 
   apps/test-ui:
     dependencies:


### PR DESCRIPTION
> Depends on #1668 (SDK lifecycle foundation). This PR is intentionally stacked on that branch until #1668 merges.

## Network failures render as auth failures; stored-token reconnects fail silently; a dead server means an infinite splash

Three connected defects in the shell-ui connection layer (reported in rocketride-ai/rocketride-saas#305):

- `finishConnect` classified AUTH vs other by **string-matching** the error message (`'Authentication failed'` / `'unknown user'` / `'invalid credentials'`), so transport timeouts could misreport as auth failures — and the SDK's typed `AuthenticationException` ("Invalid or revoked API key") matched *neither* pattern and surfaced as a network problem.
- Stored-token reconnect failures were swallowed (`catch { clearToken(); return null; }`): the user lands on the logged-out page with no explanation, and a *transient network blip destroys a valid token*.
- With the server fully unreachable, bootstrap awaited the transport attach forever → indefinite splash screen, nothing rendered.

**Fix:**

- New typed `ConnectionFailure` (`kind: 'auth' | 'network' | 'server'`) thrown at the sites that know the cause (`remote-manager` timeout → network, missing `userId` → auth); SDK `AuthenticationException` maps to auth. The string match survives only as a documented legacy fallback for untyped errors.
- New `ConnectionState.NETWORK_ERROR`; network failures **preserve** the stored token (retryable), auth failures clear it.
- Failures latch on `ConnectionStatus.lastFailure`: the SDK's persist-mode retry loop reports `CONNECTING` (up to 120 attempts) and a post-failure anonymous connect reports `CONNECTED` — either erased a purely state-driven failure before any UI could render it. Network latches auto-clear on reconnection; session-expiry persists until acted on.
- Transport attach is bounded (10s race) so an unreachable server surfaces as a retryable network failure instead of an eternal splash.
- New dismissible `ConnectionErrorBanner` (first consumer of the previously consumer-less `useConnectionStatus()` hook), mounted in `ShellLayout`: "Can't reach the server — check your connection and retry." + **Retry**, vs "Your session has expired — please sign in again." + **Sign in**.

## Testing

- [x] Tested locally — full E2E on a local stack (Zitadel v4.15.1 + Login V2 + engine `--saas`), Playwright-driven:
  - engine stopped → network banner within ~10s, **token preserved**, no splash-hang; engine restarted → session auto-recovers with the same token
  - invalid `rr_` token → "session has expired" banner + token cleared + Sign in → Zitadel
  - `tsc --noEmit` clean for shell-ui and shared-ui
- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included

## Linked Issue

Fixes rocketride-ai/rocketride-saas#305

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dismissible, fixed connection error banner with context-aware messaging and primary actions (Retry/Try again/Sign in), shown in the main shell layout.
* **Bug Fixes**
  * Improved connection recovery with consistent, typed failure classification, improved “failure latching,” and safer handling of OAuth callback and unreachable-server scenarios to reduce unnecessary redirects.
  * Standardized login timeout behavior and recovery UX to reliably detach/cleanup on timeout.
* **Chores / Improvements**
  * Migrated auth token persistence to localStorage (including API key and cloud auth) and added cross-tab token update handling for conditional reloads.
* **Tests**
  * Expanded automated Node-based connection recovery test coverage and added a dedicated `shell-ui:test` command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->