### PR TITLE
fix(shell-ui): surface OAuth callback errors from ?auth_error

### DIFF
--- a/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
+++ b/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
@@ -69,10 +69,13 @@ export const ConnectionErrorBanner: React.FC<ConnectionErrorBannerProps> = ({ me
 	if (dismissed || !failure) return null;
 
 	const isNetworkFailure = failure.state === ConnectionState.NETWORK_ERROR;
+	const isOAuthCallbackFailure = !isNetworkFailure && failure.errorKind === 'oauth-callback';
 	const defaultMessage = isNetworkFailure
 		? 'Can\'t reach the server — check your connection and retry.'
-		: 'Your session has expired — please sign in again.';
-	const action = isNetworkFailure ? 'Retry' : 'Sign in';
+		: isOAuthCallbackFailure
+			? `Sign-in didn't complete: ${failure.lastError}`
+			: 'Your session has expired — please sign in again.';
+	const action = isNetworkFailure ? 'Retry' : isOAuthCallbackFailure ? 'Try again' : 'Sign in';
 	const onAction = isNetworkFailure
 		? onRetry ?? (() => ConnectionManager.getInstance().reconnect())
 		: onSignIn ?? (() => ConnectionManager.getInstance().startOAuth(false));

--- a/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
+++ b/apps/shell-ui/src/components/layout/ConnectionErrorBanner.tsx
@@ -64,7 +64,7 @@ export const ConnectionErrorBanner: React.FC<ConnectionErrorBannerProps> = ({ me
 
 	useEffect(() => {
 		setDismissed(false);
-	}, [failure?.state, failure?.lastError]);
+	}, [failure?.state, failure?.lastError, failure?.errorKind]);
 
 	if (dismissed || !failure) return null;
 

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -454,7 +454,7 @@ export class ConnectionManager implements IConnectionManager {
 
 		const params = new URLSearchParams(window.location.search);
 		const code = params.get('code');
-		const errorDescription = params.get('auth_error') ?? params.get('error_description') ?? params.get('error');
+		const errorDescription = params.get('auth_error') || params.get('error_description') || params.get('error');
 
 		if (errorDescription) {
 			window.history.replaceState({}, '', window.location.pathname);

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -454,7 +454,13 @@ export class ConnectionManager implements IConnectionManager {
 
 		const params = new URLSearchParams(window.location.search);
 		const code = params.get('code');
-		const errorDescription = params.get('auth_error') || params.get('error_description') || params.get('error');
+		// Only honor `auth_error`: it is set exclusively by our own OAuth
+		// callback (the registered redirect_uri is the server callback, which
+		// wraps every Zitadel failure as `auth_error` before redirecting here).
+		// The generic OAuth `error`/`error_description` params never legitimately
+		// reach the app this way, so reading them would let any unrelated app
+		// deep-link (`/app?error=…`) hijack bootstrap into a false sign-in banner.
+		const errorDescription = params.get('auth_error');
 
 		if (errorDescription) {
 			window.history.replaceState({}, '', window.location.pathname);

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -260,6 +260,7 @@ export class ConnectionManager implements IConnectionManager {
 					state: ConnectionState.CONNECTED,
 					lastConnected: new Date(),
 					lastError: undefined,
+					errorKind: undefined,
 					retryAttempt: 0,
 					progressMessage: undefined,
 				});
@@ -277,7 +278,7 @@ export class ConnectionManager implements IConnectionManager {
 				this.clearServicesCache();
 				// Don't overwrite AUTH_FAILED state
 				if (this.connectionStatus.state !== ConnectionState.AUTH_FAILED) {
-					this.updateConnectionStatus({ state: ConnectionState.CONNECTING });
+					this.updateConnectionStatus({ state: ConnectionState.CONNECTING, errorKind: undefined });
 				}
 				this.emit('shell:disconnected', { reason: reason ?? 'unknown', hasError: hasError ?? false });
 			},
@@ -453,6 +454,20 @@ export class ConnectionManager implements IConnectionManager {
 
 		const params = new URLSearchParams(window.location.search);
 		const code = params.get('code');
+		const errorDescription = params.get('auth_error') ?? params.get('error_description') ?? params.get('error');
+
+		if (errorDescription) {
+			window.history.replaceState({}, '', window.location.pathname);
+			this.updateConnectionStatus({
+				state: ConnectionState.AUTH_FAILED,
+				lastError: errorDescription,
+				progressMessage: undefined,
+				errorKind: 'oauth-callback',
+			});
+			this.clearPendingAppId();
+			return null;
+		}
+
 		const sessionAppId = this.getSessionAppId();
 
 		// ── OAuth callback — exchange authorization code for a session ────
@@ -644,6 +659,7 @@ export class ConnectionManager implements IConnectionManager {
 		this.updateConnectionStatus({
 			state: ConnectionState.CONNECTING,
 			lastError: undefined,
+			errorKind: undefined,
 		});
 
 		try {
@@ -678,6 +694,7 @@ export class ConnectionManager implements IConnectionManager {
 				state: this.getConnectionFailureState(error),
 				lastError: errorMessage,
 				progressMessage: undefined,
+				errorKind: undefined,
 			});
 
 			this.emit('shell:error', { error });
@@ -702,6 +719,7 @@ export class ConnectionManager implements IConnectionManager {
 		this.updateConnectionStatus({
 			state: ConnectionState.DISCONNECTED,
 			progressMessage: undefined,
+			errorKind: undefined,
 		});
 	}
 
@@ -749,6 +767,7 @@ export class ConnectionManager implements IConnectionManager {
 					? 'Your session has expired — please sign in again.'
 					: error instanceof Error ? error.message : String(error),
 			progressMessage: undefined,
+			errorKind: state === ConnectionState.AUTH_FAILED ? 'session' : undefined,
 		});
 		return !isNetworkFailure;
 	}
@@ -1118,6 +1137,7 @@ export class ConnectionManager implements IConnectionManager {
 			this.connectionStatus.lastFailure = {
 				state: updates.state,
 				lastError: updates.lastError ?? this.connectionStatus.lastError,
+				errorKind: updates.errorKind ?? this.connectionStatus.errorKind,
 			};
 		} else if (
 			updates.state === ConnectionState.CONNECTED &&

--- a/packages/shared-ui/src/types/connection.ts
+++ b/packages/shared-ui/src/types/connection.ts
@@ -101,6 +101,13 @@ export interface ConnectionStatus {
 	lastError?: string;
 
 	/**
+	 * Discriminates AUTH_FAILED origins so recovery UI can phrase the message:
+	 * 'oauth-callback' — the IdP returned an error on the OAuth callback;
+	 * 'session' — an existing session was rejected or expired.
+	 */
+	errorKind?: 'oauth-callback' | 'session';
+
+	/**
 	 * Most recent unrecovered failure, latched across later transitions.
 	 * Persist-mode reconnect attempts report CONNECTING and a post-failure
 	 * anonymous connect reports CONNECTED — recovery UI reads this field so
@@ -110,6 +117,7 @@ export interface ConnectionStatus {
 	lastFailure?: {
 		state: ConnectionState.NETWORK_ERROR | ConnectionState.AUTH_FAILED;
 		lastError?: string;
+		errorKind?: 'oauth-callback' | 'session';
 	};
 
 	/** True if we have necessary credentials/config to attempt connection. */


### PR DESCRIPTION
## Zitadel failures never reach the user: `?auth_error` is set by the callback and read by nobody

`packages/ai/src/ai/web/endpoints/auth_callback.py` redirects OAuth failures back to the app as `?auth_error=<description>` — but no web client ever reads the parameter (reported in rocketride-ai/rocketride-saas#301). Users who cancel at Zitadel, or hit any IdP-side failure, land back on the logged-out page with zero feedback, and the error param sticks around in the URL.

**Fix:** `_bootstrap()` now reads `auth_error` (plus standard `error`/`error_description`) right where it already parses `?code`, strips it from the URL via the existing `history.replaceState` cleanup, and surfaces it through the #1553 recovery banner with a new `errorKind: 'oauth-callback' | 'session'` discriminator on `ConnectionStatus`: **"Sign-in didn't complete: \<IdP description\>"** with a **Try again** action that restarts the OAuth flow.

Stacked on #1553 (base is `fix/305-network-vs-auth-errors`; GitHub will retarget to `develop` when it merges — the diff here is one commit).

## Testing

- [x] Tested locally — Playwright on the local Zitadel stack: `/?auth_error=User%20cancelled%20the%20request` → banner "Sign-in didn't complete: User cancelled the request", URL cleaned to `/`, logged-out landing intact, **Try again** navigates to the Zitadel login page. `tsc --noEmit` clean.
- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included

## Linked Issue

Fixes rocketride-ai/rocketride-saas#301

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in error messaging for OAuth callback failures.
  * Added a clear “Try again” action when sign-in doesn’t complete.
  * Preserved existing network retry and session-expired recovery messages.
  * Connection errors now retain their category across recovery attempts for more accurate guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->