### PR TITLE
fix(shell-ui): persist login session in localStorage across tabs and restarts

### DIFF
--- a/apps/shell-ui/src/auth/ApiKeyAuthProvider.ts
+++ b/apps/shell-ui/src/auth/ApiKeyAuthProvider.ts
@@ -26,7 +26,7 @@
 //
 // Simple auth provider for open-source / local server mode.
 // User enters an API key (or leaves blank for open access), which is stored
-// in sessionStorage and passed to ConnectionManager.connect().
+// in localStorage and passed to ConnectionManager.connect().
 //
 // Implements the same IAuthProvider interface as CloudAuthProvider so the
 // ConnectionManager can use either interchangeably.
@@ -63,7 +63,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	/**
 	 * Sign in with an API key.
 	 *
-	 * Stores the key in sessionStorage for the current session. An empty string
+	 * Stores the key in localStorage. An empty string
 	 * is valid (some OSS servers allow unauthenticated access).
 	 *
 	 * @param apiKey - The API key to store.
@@ -84,7 +84,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	private async storeToken(token: string): Promise<void> {
 		try {
-			sessionStorage.setItem(LS_TOKEN, token);
+			localStorage.setItem(LS_TOKEN, token);
 		} catch (e) {
 			console.error('[ApiKeyAuthProvider] Failed to store token:', e);
 		}
@@ -97,7 +97,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async getToken(): Promise<string | null> {
 		try {
-			const token = sessionStorage.getItem(LS_TOKEN);
+			const token = localStorage.getItem(LS_TOKEN);
 			// For API key mode, empty string is valid (open access)
 			return token;
 		} catch {
@@ -111,7 +111,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async isSignedIn(): Promise<boolean> {
 		try {
-			return sessionStorage.getItem(LS_TOKEN) !== null;
+			return localStorage.getItem(LS_TOKEN) !== null;
 		} catch {
 			return false;
 		}
@@ -126,7 +126,7 @@ export class ApiKeyAuthProvider implements IAuthProvider {
 	 */
 	public async signOut(): Promise<void> {
 		try {
-			sessionStorage.removeItem(LS_TOKEN);
+			localStorage.removeItem(LS_TOKEN);
 		} catch (e) {
 			console.error('[ApiKeyAuthProvider] Failed to clear token:', e);
 		}

--- a/apps/shell-ui/src/auth/CloudAuthProvider.ts
+++ b/apps/shell-ui/src/auth/CloudAuthProvider.ts
@@ -31,7 +31,7 @@
 //   2. Full-page redirect to Zitadel authorize endpoint
 //   3. Browser redirects back with ?code= parameter
 //   4. handleCallback() exchanges code for token via the ConnectionManager
-//   5. Token stored in sessionStorage (browser equivalent of SecretStorage)
+//   5. Token stored in localStorage (browser equivalent of SecretStorage)
 //
 // The stored token is picked up by ConnectionManager.connect() — auth is
 // decoupled from connection, same as VSCode.
@@ -173,7 +173,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	}
 
 	// =========================================================================
-	// TOKEN STORAGE (sessionStorage — browser equivalent of SecretStorage)
+	// TOKEN STORAGE (localStorage — browser equivalent of SecretStorage)
 	// =========================================================================
 
 	/**
@@ -183,7 +183,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async storeToken(token: string): Promise<void> {
 		try {
-			sessionStorage.setItem(LS_TOKEN, token);
+			localStorage.setItem(LS_TOKEN, token);
 		} catch (e) {
 			console.error('[CloudAuthProvider] Failed to store token:', e);
 		}
@@ -196,7 +196,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async getToken(): Promise<string | null> {
 		try {
-			const token = sessionStorage.getItem(LS_TOKEN);
+			const token = localStorage.getItem(LS_TOKEN);
 			return token || null;
 		} catch {
 			return null;
@@ -220,7 +220,7 @@ export class CloudAuthProvider implements IAuthProvider {
 	 */
 	public async signOut(): Promise<void> {
 		try {
-			sessionStorage.removeItem(LS_TOKEN);
+			localStorage.removeItem(LS_TOKEN);
 		} catch (e) {
 			console.error('[CloudAuthProvider] Failed to clear token:', e);
 		}

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -47,6 +47,7 @@ import type { ConnectionMode } from 'shared';
 import { BaseManager } from './base-manager';
 import { RemoteManager } from './remote-manager';
 import { ConnectionFailure } from './errors';
+import { shouldReloadForTokenStorageUpdate } from './tokenStorageUpdate';
 import { getStoredVerifier, clearStoredVerifier } from '../util/pkce';
 import {
 	LS_TOKEN,
@@ -328,17 +329,12 @@ export class ConnectionManager implements IConnectionManager {
 					return;
 				}
 
-				if (
-					event.oldValue !== null &&
-					event.newValue !== null &&
-					this.isConnected() &&
-					this.accountInfo?.userToken === event.oldValue
-				) {
-					window.location.reload();
-					return;
-				}
-
-				if (event.oldValue === null && !this.accountInfo) {
+				if (shouldReloadForTokenStorageUpdate({
+					oldValue: event.oldValue,
+					newValue: event.newValue,
+					currentUserToken: this.accountInfo?.userToken,
+					hasAccountInfo: Boolean(this.accountInfo),
+				})) {
 					window.location.reload();
 				}
 			});

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -328,6 +328,16 @@ export class ConnectionManager implements IConnectionManager {
 					return;
 				}
 
+				if (
+					event.oldValue !== null &&
+					event.newValue !== null &&
+					this.isConnected() &&
+					this.accountInfo?.userToken === event.oldValue
+				) {
+					window.location.reload();
+					return;
+				}
+
 				if (event.oldValue === null && !this.accountInfo) {
 					window.location.reload();
 				}

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -311,6 +311,28 @@ export class ConnectionManager implements IConnectionManager {
 		// click would hit the guard and do nothing. Release it on bfcache restore
 		// so the button works again without a manual page refresh.
 		if (typeof window !== 'undefined') {
+			window.addEventListener('storage', (event) => {
+				if (event.key !== LS_TOKEN) return;
+
+				if (event.newValue === null) {
+					this.accountInfo = undefined;
+					this.pendingEvents.clear();
+					this.clearServicesCache();
+					this.updateConnectionStatus({
+						state: ConnectionState.DISCONNECTED,
+						hasCredentials: false,
+						lastError: undefined,
+						progressMessage: undefined,
+					});
+					window.location.reload();
+					return;
+				}
+
+				if (event.oldValue === null && !this.accountInfo) {
+					window.location.reload();
+				}
+			});
+
 			window.addEventListener('pageshow', (e) => {
 				if ((e as PageTransitionEvent).persisted) {
 					this.oauthStarted = false;
@@ -832,21 +854,31 @@ export class ConnectionManager implements IConnectionManager {
 	// TOKEN STORAGE
 	// =========================================================================
 
-	/** Persist a user token to sessionStorage. */
+	/** Persist a user token to localStorage. */
 	public saveToken(token: string): void {
-		try { sessionStorage.setItem(LS_TOKEN, token); } catch (e) {
+		try { localStorage.setItem(LS_TOKEN, token); } catch (e) {
 			console.error('[ConnectionManager] Failed to save token:', e);
 		}
 	}
 
-	/** Load token from sessionStorage. Returns empty string if unavailable. */
+	/** Load token from localStorage. Migrates the old sessionStorage value once. */
 	public loadToken(): string {
-		try { return sessionStorage.getItem(LS_TOKEN) ?? ''; } catch { return ''; }
+		try {
+			const token = localStorage.getItem(LS_TOKEN);
+			if (token !== null) return token;
+
+			const sessionToken = sessionStorage.getItem(LS_TOKEN);
+			if (sessionToken === null) return '';
+
+			localStorage.setItem(LS_TOKEN, sessionToken);
+			sessionStorage.removeItem(LS_TOKEN);
+			return sessionToken;
+		} catch { return ''; }
 	}
 
 	/** Clear the persisted token. */
 	public clearToken(): void {
-		try { sessionStorage.removeItem(LS_TOKEN); } catch (e) {
+		try { localStorage.removeItem(LS_TOKEN); } catch (e) {
 			console.error('[ConnectionManager] Failed to clear token:', e);
 		}
 	}

--- a/apps/shell-ui/src/connection/tokenStorageUpdate.ts
+++ b/apps/shell-ui/src/connection/tokenStorageUpdate.ts
@@ -1,0 +1,18 @@
+export interface TokenStorageUpdate {
+	oldValue: string | null;
+	newValue: string | null;
+	currentUserToken?: string;
+	hasAccountInfo: boolean;
+}
+
+export function shouldReloadForTokenStorageUpdate(update: TokenStorageUpdate): boolean {
+	const { oldValue, newValue, currentUserToken, hasAccountInfo } = update;
+
+	if (newValue === null) return false;
+
+	if (oldValue !== null) {
+		return currentUserToken !== newValue;
+	}
+
+	return !hasAccountInfo;
+}

--- a/apps/shell-ui/src/constants.ts
+++ b/apps/shell-ui/src/constants.ts
@@ -28,7 +28,7 @@
 // STORAGE KEYS
 // =============================================================================
 
-/** sessionStorage: auth token — survives refresh, cleared on tab close. */
+/** localStorage: auth token — persists across tabs, windows, and browser restarts. */
 export const LS_TOKEN = 'rr:user_token';
 
 /**


### PR DESCRIPTION
## Login session dies with the tab: token lives in sessionStorage

`rr:user_token` was stored in `sessionStorage`, so every new tab, window, or browser restart forced a full OAuth round-trip (reported in rocketride-ai/rocketride-saas#303).

**Why not refresh tokens:** tracing the token lifecycle showed the `rr_` userToken is a **90-day sliding server-side session key** (`ensure_session_key` re-extends it on every login) — not a short-lived access token. Zitadel refresh tokens are received and discarded server-side and add nothing for session persistence. The entire bug is the storage location.

**Fix:**

- Token persistence moves to `localStorage` (with a one-time `sessionStorage` → `localStorage` migration so live sessions survive the deploy), in `CloudAuthProvider`, the `ConnectionManager` helpers, and `ApiKeyAuthProvider` for consistency.
- Cross-tab sync via the `storage` event: signing out in one tab logs out the others; a sign-in is picked up by unauthenticated tabs.

Security note for review: the `rr_` token is DB-backed and individually revocable (`api_keys` table), which bounds the localStorage XSS-theft delta; the 90-day sliding session semantics are unchanged, only where the client keeps the key.

Stacked on #1553 (base is `fix/305-network-vs-auth-errors`; GitHub will retarget to `develop` when it merges — the diff here is one commit).

## Testing

- [x] Tested locally — Playwright on the local Zitadel stack: token present in `localStorage` with `sessionStorage` empty after login; second tab signed in without a redirect; fresh browser context restored from storage state ("restart") signed in; removing the token in tab A logs out tab B. `tsc --noEmit` clean.
- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included

## Linked Issue

Fixes rocketride-ai/rocketride-saas#303

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication sessions now persist across browser tabs, windows, refreshes, and restarts.
  * Sign-in state synchronizes automatically across open tabs.
  * Existing session data is migrated automatically to the new persistence behavior.

* **Bug Fixes**
  * Signing out in one tab now reliably clears the session and disconnects other tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->