### PR TITLE
fix(shell-ui): route all auth entries to the Zitadel login page (register via its built-in link)

### DIFF
--- a/apps/shell-ui/src/auth/CloudAuthProvider.ts
+++ b/apps/shell-ui/src/auth/CloudAuthProvider.ts
@@ -104,7 +104,9 @@ export class CloudAuthProvider implements IAuthProvider {
 	 * authorize endpoint.
 	 *
 	 * @param appId - Optional app ID to activate after sign-in completes.
-	 * @param register - If true, shows Zitadel's signup form instead of login.
+	 * @param register - Retained for compatibility; no longer changes the
+	 *                   destination. All flows land on Zitadel's login page,
+	 *                   which offers a Register link for new users.
 	 */
 	public async signIn(appId?: string, register?: boolean): Promise<void> {
 		if (!this.zitadelUrl || !this.clientId) {

--- a/apps/shell-ui/src/connection/connection.ts
+++ b/apps/shell-ui/src/connection/connection.ts
@@ -359,8 +359,9 @@ export class ConnectionManager implements IConnectionManager {
 	 * Delegates to the auth provider's ``signIn()`` method. Falls back to
 	 * the legacy PKCE flow if no auth provider is configured.
 	 *
-	 * @param register - If true, requests Zitadel's sign-up form (prompt=create)
-	 *                   instead of the default sign-in form.
+	 * @param register - Retained for compatibility; no longer changes the
+	 *                   destination. All flows land on Zitadel's login page
+	 *                   (prompt=login), which offers a Register link.
 	 */
 	public async startOAuth(register?: boolean): Promise<void> {
 		// One-shot: a redirect is coming; never start a second authorize in the

--- a/apps/shell-ui/src/util/pkce.ts
+++ b/apps/shell-ui/src/util/pkce.ts
@@ -161,7 +161,8 @@ export function clearStoredVerifier(): void {
  * @param clientId      - Zitadel application client ID
  * @param redirectUri   - Where Zitadel redirects after auth (typically window.location.origin)
  * @param challenge     - PKCE code_challenge (from generatePkce)
- * @param register      - If true, shows signup form instead of login form
+ * @param _register     - Historical sign-up intent flag; both flows now land on
+ *                        the login page (with its Register link), see below
  * @returns The fully formed authorization URL string ready for browser navigation.
  */
 export function buildAuthUrl(
@@ -169,7 +170,7 @@ export function buildAuthUrl(
     clientId: string,
     redirectUri: string,
     challenge: string,
-    register = false,
+    _register = false,
 ): string {
     // Assemble the standard OAuth 2.0 authorization request parameters.
     // The scope includes openid and profile for basic identity, email and phone
@@ -184,10 +185,13 @@ export function buildAuthUrl(
         code_challenge_method: 'S256',
     });
 
-    // register -> sign-up form; otherwise force the login UI (prompt=login) so
-    // Zitadel never silently reuses its SSO session and blocks switching accounts.
-    if (register) params.set('prompt', 'create');
-    else params.set('prompt', 'login');
+    // Always land on Zitadel's login page (prompt=login): it forces the login UI
+    // so Zitadel never silently reuses its SSO session (account switching stays
+    // possible), and its built-in "Register" link covers new users. prompt=create
+    // dead-ends returning users on the sign-up form with no path to log in
+    // ("could not sign up at this time"), so the register flag no longer maps
+    // to it. The parameter is kept so callers' intent stays visible at call sites.
+    params.set('prompt', 'login');
 
     // Strip any trailing slash from the base URL before appending the path
     // to avoid a double-slash in the resulting URL.


### PR DESCRIPTION
## Returning users who click "Get Started" dead-end at Zitadel's registration form

Every "Get Started" CTA sends `prompt=create`, which drops returning users on Zitadel's create-account form; submitting an existing email dead-ends at "could not sign up at this time" with **no path to log in** (reported in rocketride-ai/rocketride-saas#300, P1).

**Fix:** one file, `apps/shell-ui/src/util/pkce.ts` — stop mapping `register` to `prompt=create`; every auth entry now sends `prompt=login`. The `prompt=login` behavior is kept deliberately (per the existing comment: it prevents Zitadel from silently reusing an SSO session, which would lock users out of account switching). New users use the **"Register new user"** link that Zitadel's Login V2 page shows when the org's login policy allows registration, so both audiences get a working path from every CTA.

The `register` parameter is left in the signature chain (documented as no longer changing the prompt) so the home-ui emit sites need no coordinated change.

⚠️ Deploy dependency: the **prod** Zitadel org login policy must have registration enabled so the hosted login page shows the Register link — one-glance check in the Zitadel console. Verified true by default on a clean v4.15.1 instance.

## Testing

- [x] Tested locally — Playwright on a local Zitadel v4.15.1 + Login V2 stack (same versions as prod): "Get Started" lands on the login-name form **with** "Register new user" visible; an existing user completes login from that entry and lands signed in — no dead-end. `tsc --noEmit` clean.
- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included

## Linked Issue

Fixes rocketride-ai/rocketride-saas#300

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated authentication flows so both sign-in and registration consistently open the login page.
  * Improved consistency when initiating OAuth authentication.  
  * Updated related documentation to clarify that the retained compatibility “register” option no longer changes the redirect destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->