### PR TITLE
fix(endpoints): unique stable per-pipe endpoint URLs ({host}/{type}/{project_id}/{source})

### DIFF
--- a/nodes/src/nodes/webhook/IEndpoint.py
+++ b/nodes/src/nodes/webhook/IEndpoint.py
@@ -64,9 +64,9 @@ class IEndpoint(IEndpointBase):
                 # These should NOT be replacable strings!!!
                 info = {
                     'button-text': 'Chat now',
-                    'button-link': '{host}/chat?auth={public_auth}',
+                    'button-link': '{host}/chat/{project_id}/{source}?auth={public_auth}',
                     'url-text': 'Chat interface URL',
-                    'url-link': '{host}/chat',
+                    'url-link': '{host}/chat/{project_id}/{source}',
                     'auth-text': 'Public Authorization Key',
                     'auth-key': '{public_auth}',
                     'token-text': 'Private Token',
@@ -88,9 +88,9 @@ class IEndpoint(IEndpointBase):
                 # These should NOT be replacable strings!!!
                 info = {
                     'button-text': 'Drop now',
-                    'button-link': '{host}/dropper?auth={public_auth}',
+                    'button-link': '{host}/dropper/{project_id}/{source}?auth={public_auth}',
                     'url-text': 'Dropper interface URL',
-                    'url-link': '{host}/dropper',
+                    'url-link': '{host}/dropper/{project_id}/{source}',
                     'auth-text': 'Public Authorization Key',
                     'auth-key': '{public_auth}',
                     'token-text': 'Private Token',
@@ -115,7 +115,7 @@ class IEndpoint(IEndpointBase):
                 }
                 info = {
                     'url-text': url_text_map[self.endpoint.logicalType],
-                    'url-link': '{host}/webhook',
+                    'url-link': '{host}/webhook/{project_id}/{source}',
                     'auth-text': 'Public Authorization Key',
                     'auth-key': '{public_auth}',
                     'token-text': 'Private Token',

--- a/nodes/src/nodes/webhook/README.md
+++ b/nodes/src/nodes/webhook/README.md
@@ -12,7 +12,7 @@ Stands up its own HTTP endpoint and forwards incoming data into the attached pip
 
 The server is a **FastAPI / Uvicorn** wrapper (`ai.web.WebServer`). The engine passes the bind address on the command line (`--data_host`, `--data_port`, defaulting to `localhost:5567`); the node loads the `data` module, which registers a `/task/data` websocket as the data plane between the public endpoint and the pipeline. The node keeps running until the pipeline is stopped, the source task completes only when the server exits.
 
-After the pipeline starts, the Project Log displays the interface URL, the public authorization key, and the private token, so callers know how to reach the endpoint (the chat link form is `{host}/chat?auth={public_auth}`).
+After the pipeline starts, the Project Log displays a stable, pipe-specific interface URL, the public authorization key, and the private token, so callers know how to reach the endpoint. The URL forms are `{host}/chat/{project_id}/{source}?auth={public_auth}`, `{host}/dropper/{project_id}/{source}?auth={public_auth}`, and `{host}/webhook/{project_id}/{source}`. The legacy `/chat`, `/dropper`, `/webhook`, and `/task/data` URLs continue to work for existing integrations.
 
 ---
 

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -979,6 +979,10 @@ class Task(DAPBase):
                         # Handle string notes - simple replacement
                         note = note.replace('{token}', self.token)
                         note = note.replace('{public_auth}', self.public_auth)
+                        if self.project_id is not None:
+                            note = note.replace('{project_id}', str(self.project_id))
+                        if self.source is not None:
+                            note = note.replace('{source}', str(self.source))
                         self._status.notes.append(note)
                     elif isinstance(note, dict):
                         # Handle dict notes - walk through and replace in all string values
@@ -988,6 +992,10 @@ class Task(DAPBase):
                                 # Replace tokens in string values
                                 value = value.replace('{token}', self.token)
                                 value = value.replace('{public_auth}', self.public_auth)
+                                if self.project_id is not None:
+                                    value = value.replace('{project_id}', str(self.project_id))
+                                if self.source is not None:
+                                    value = value.replace('{source}', str(self.source))
                             processed_note[key] = value
                         self._status.notes.append(processed_note)
                     else:

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -979,10 +979,14 @@ class Task(DAPBase):
                         # Handle string notes - simple replacement
                         note = note.replace('{token}', self.token)
                         note = note.replace('{public_auth}', self.public_auth)
-                        if self.project_id is not None:
-                            note = note.replace('{project_id}', str(self.project_id))
-                        if self.source is not None:
-                            note = note.replace('{source}', str(self.source))
+                        # getattr: partially-initialized tasks (and test stubs)
+                        # may not carry the identity attributes at all.
+                        project_id = getattr(self, 'project_id', None)
+                        source = getattr(self, 'source', None)
+                        if project_id is not None:
+                            note = note.replace('{project_id}', str(project_id))
+                        if source is not None:
+                            note = note.replace('{source}', str(source))
                         self._status.notes.append(note)
                     elif isinstance(note, dict):
                         # Handle dict notes - walk through and replace in all string values
@@ -992,10 +996,12 @@ class Task(DAPBase):
                                 # Replace tokens in string values
                                 value = value.replace('{token}', self.token)
                                 value = value.replace('{public_auth}', self.public_auth)
-                                if self.project_id is not None:
-                                    value = value.replace('{project_id}', str(self.project_id))
-                                if self.source is not None:
-                                    value = value.replace('{source}', str(self.source))
+                                project_id = getattr(self, 'project_id', None)
+                                source = getattr(self, 'source', None)
+                                if project_id is not None:
+                                    value = value.replace('{project_id}', str(project_id))
+                                if source is not None:
+                                    value = value.replace('{source}', str(source))
                             processed_note[key] = value
                         self._status.notes.append(processed_note)
                     else:

--- a/packages/ai/src/ai/modules/task_http/__init__.py
+++ b/packages/ai/src/ai/modules/task_http/__init__.py
@@ -23,11 +23,13 @@ def initModule(server: WebServer, config: Dict[str, Any]):
     # Preferred routes (POST)
     server.add_route('/task', task_Execute, methods=['POST'])
     server.add_route('/task/data', task_Data, methods=['POST'])
+    server.add_route('/task/data/{project_id}/{source}', task_Data, methods=['POST'])
     server.add_route('/task', task_Status, methods=['GET'])
     server.add_route('/task', task_Cancel, methods=['DELETE'])
 
     # Alias to /task/data
     server.add_route('/webhook', task_Data, methods=['POST'])
+    server.add_route('/webhook/{project_id}/{source}', task_Data, methods=['POST'])
 
     # Deprecated routes (PUT) - kept for backward compatibility
     server.add_route('/task', task_Execute, methods=['PUT'], deprecated=True)

--- a/packages/ai/src/ai/modules/task_http/task_data.py
+++ b/packages/ai/src/ai/modules/task_http/task_data.py
@@ -469,6 +469,16 @@ async def task_Data(
     client = None
 
     try:
+        if token is None:
+            project_id = request.path_params.get('project_id')
+            source = request.path_params.get('source')
+            if project_id is not None and source is not None:
+                try:
+                    control = request.app.state.task.get_task_control_by_project(project_id, source)
+                    token = control.token
+                except Exception:
+                    pass
+
         # Get the WebServer instance from application state
         server: WebServer = request.app.state.server
         port = server.get_port()

--- a/packages/ai/src/ai/modules/task_http/task_data.py
+++ b/packages/ai/src/ai/modules/task_http/task_data.py
@@ -476,7 +476,10 @@ async def task_Data(
                 try:
                     control = request.app.state.task.get_task_control_by_project(project_id, source)
                     token = control.token
-                except Exception:
+                except RuntimeError:
+                    # Documented missing-task case ('Your pipeline is not
+                    # running') — fall back to token=None so the request takes
+                    # the normal auth/404 path. Anything else propagates.
                     pass
 
         # Get the WebServer instance from application state

--- a/packages/docs/content-static/examples/webhook-pipeline.md
+++ b/packages/docs/content-static/examples/webhook-pipeline.md
@@ -15,6 +15,7 @@ Save this as `chat.pipe`:
 
 ```json
 {
+  "project_id": "webhook-example",
   "nodes": [
     {
       "id": "source_1",
@@ -57,7 +58,7 @@ Output:
 
 ```text
 Webhook ready - system is ready to accept requests
-  URL:  http://localhost:5567/task/data
+  URL:  http://localhost:5567/webhook/webhook-example/source_1
   Auth: <public-auth-key>
   Token: <private-token>
 ```
@@ -67,7 +68,7 @@ Keep the terminal open — the pipeline runs until you stop it.
 ## Send a question
 
 ```bash
-curl -X POST http://localhost:5567/task/data \
+curl -X POST "http://localhost:5567/webhook/webhook-example/source_1" \
   -H "Authorization: Bearer <public-auth-key>" \
   -H "Content-Type: text/plain" \
   -d "What is the capital of France?"
@@ -92,13 +93,17 @@ Restart the pipeline. The engine prints a chat URL:
 
 ```text
 Chat ready - system is ready to accept questions
-  URL: http://localhost:5567/chat?auth=<public-auth-key>
+  URL: http://localhost:5567/chat/webhook-example/source_1?auth=<public-auth-key>
 ```
 
 Open that URL in a browser and start typing. The `?auth=` query parameter is a
-convenience for the browser; the endpoint also accepts the key in an
-`Authorization: Bearer <public-auth-key>` header, the same scheme the webhook
-endpoint uses.
+convenience for supplying the credential to the browser; the Chat UI stores it
+in session storage for subsequent page loads. Webhook requests use the same key
+in an `Authorization: Bearer <public-auth-key>` header.
+
+Each displayed URL includes the project and source identifiers, so it remains
+specific to this pipeline. The legacy `/webhook`, `/task/data`, `/chat`, and
+`/dropper` URLs continue to work for existing integrations.
 
 ## Add a system prompt
 


### PR DESCRIPTION
## Two pipes with same-typed source nodes advertise the same endpoint URL

Endpoint URLs are derived only from the source node type (`{host}/chat`, `{host}/dropper`, `{host}/webhook` in `webhook/IEndpoint.py`), so any two pipes with same-typed sources show identical URLs — users can't tell endpoints apart and rely on the opaque `?auth=` token for disambiguation (reported in rocketride-ai/rocketride-saas#262).

**Fix — additive, no breaking changes:**

- Advertised URLs now embed the canonical task identity: `{host}/{type}/{project_id}/{source}` (e.g. `/chat/<project-uuid>/chat_1`). `project_id` + `source` is exactly the engine's task identity and the same input that already deterministically derives the `pk_`/`tk_` tokens — stable across restarts, no secret in the path.
- `task_engine` substitutes the new `{project_id}`/`{source}` placeholders alongside the existing `{public_auth}`.
- New POST routes `/webhook/{project_id}/{source}` and `/task/data/{project_id}/{source}` → `task_Data`, which resolves the task from the path when no explicit token param is supplied. Existing auth precedence unchanged.
- Legacy routes and `?auth=` resolution untouched — every currently-deployed URL keeps working.
- No SPA or UI changes needed (verified: chat/dropper static routes already index-fallback on deep paths, `assetPrefix` is absolute, and the SPAs identify their task from `?auth=`, not the path). Docs updated (webhook-pipeline example + webhook README).

## Testing

- [x] Tested locally — E2E on a patched engine: two pipes with identically-named webhook sources → distinct URLs (`/webhook/proj-a-262/webhook_1` vs `/webhook/proj-b-262/webhook_1`); POST to each pretty path → 200 into the correct pipe; POST to legacy `/webhook` with Bearer token → 200; relaunch → byte-identical URLs and tokens (deterministic identity confirmed).
- [x] Tests added or updated — n/a (behavior covered by the E2E script; no existing suite for this surface)
- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included

## Linked Issue

Fixes rocketride-ai/rocketride-saas#262

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added project- and source-aware URL patterns for Chat, Dropper, Webhook, and task data endpoints, including `POST /task/data/{project_id}/{source}` and `/webhook/{project_id}/{source}` aliasing.
  * Task note templating now supports `{project_id}` and `{source}` placeholders.
* **Bug Fixes**
  * Improved project-specific task data handling by auto-resolving missing tokens from the request context when possible.
  * Preserved compatibility with legacy endpoint URL paths.
* **Documentation**
  * Updated webhook and pipeline examples to use project-aware URLs and clarified `?auth=` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->