### PR TITLE
fix(store): honor _createCollection() return value before indexing

### DIFF
--- a/nodes/src/nodes/store_milvus/milvus.py
+++ b/nodes/src/nodes/store_milvus/milvus.py
@@ -143,7 +143,7 @@ class Store(DocumentStoreBase):
 
     def _createCollection(self, vectorSize: int) -> bool:
         """
-        Create a collection, doesn't return anything.
+        Create a collection, returning True on success and raising on failure.
         """
         # no collection present so far -> Let's build by starting with the parameters for the schema
 
@@ -186,11 +186,8 @@ class Store(DocumentStoreBase):
         # this method is called from the base class createCollection() which already
         # holds collectionLock. Using doesCollectionExist() would cause a deadlock.
         if not self._doesCollectionExist():
-            try:
-                self.client.create_collection(collection_name=self.collection, schema=schema, index_params=index_params)
-            except Exception:
-                return True
-        return False
+            self.client.create_collection(collection_name=self.collection, schema=schema, index_params=index_params)
+        return True
 
     def _convertFilter(self, docFilter: DocFilter) -> str:
         """

--- a/packages/ai/src/ai/common/store/document_store.py
+++ b/packages/ai/src/ai/common/store/document_store.py
@@ -39,7 +39,10 @@ class DocumentStoreBase(ABC):
         """
         Create the collection.
 
-        This the abstract method that the driver must implement
+        This the abstract method that the driver must implement. Implementations
+        must either raise on failure or explicitly return False; the caller
+        (createCollection) treats a return value of exactly False as failure and
+        aborts before indexing any documents.
         """
 
     @abstractmethod
@@ -515,7 +518,14 @@ class DocumentStoreBase(ABC):
             doc.embedding = [0] * vectorSize  # List of zeros for validation purposes
 
             # Create the actual collection with the specified vector size
-            self._createCollection(vectorSize)
+            created = self._createCollection(vectorSize)
+
+            # Some drivers signal failure by returning False instead of raising;
+            # honor that instead of silently indexing into a collection that was
+            # never created (do not treat None as failure - a few drivers return
+            # nothing on success).
+            if created is False:
+                raise Exception(f'{type(self).__name__} failed to create the vector collection')
 
             # Add the "bogus" document to the collection
             self.addChunks([doc], checkCollection=False)

--- a/packages/ai/src/ai/common/store/document_store.py
+++ b/packages/ai/src/ai/common/store/document_store.py
@@ -35,7 +35,7 @@ class DocumentStoreBase(ABC):
         """
 
     @abstractmethod
-    def _createCollection() -> bool:
+    def _createCollection() -> bool | None:
         """
         Create the collection.
 
@@ -43,6 +43,10 @@ class DocumentStoreBase(ABC):
         must either raise on failure or explicitly return False; the caller
         (createCollection) treats a return value of exactly False as failure and
         aborts before indexing any documents.
+
+        The return is annotated bool | None because None is a legitimate success
+        value here: store_weaviate, store_postgres and rocketride_vector create
+        the collection and return nothing. Only an explicit False means failure.
         """
 
     @abstractmethod

--- a/packages/ai/tests/ai/common/store/test_document_store.py
+++ b/packages/ai/tests/ai/common/store/test_document_store.py
@@ -1,0 +1,97 @@
+"""
+Unit tests for ai.common.store.document_store.DocumentStoreBase.createCollection.
+
+Regression coverage for issue #1495: createCollection() must not silently proceed
+to index documents when the driver's _createCollection() reports failure via a
+bare `return False` (as opposed to raising).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.common.schema import Doc, DocMetadata
+from ai.common.store import DocumentStoreBase
+
+
+class _FakeStore(DocumentStoreBase):
+    """Minimal concrete DocumentStoreBase for exercising createCollection() in isolation."""
+
+    def __init__(self, create_result):
+        super().__init__('fake', {}, {})
+        self._create_result = create_result
+        # Shadow the concrete addChunks below with a mock so tests can assert on
+        # the calls. The class-level definition is what satisfies the ABC.
+        self.addChunks = MagicMock()
+
+    def _doesCollectionExist(self):
+        return False
+
+    def _createCollection(self, vectorSize):
+        if isinstance(self._create_result, Exception):
+            raise self._create_result
+        return self._create_result
+
+    def addChunks(self, chunks, checkCollection=True):
+        # Concrete implementation so the ABC is instantiable; each instance
+        # replaces this with a MagicMock in __init__.
+        return None
+
+    def count_documents(self):
+        return 0
+
+    def searchKeyword(self, query, docFilter):
+        return []
+
+    def searchSemantic(self, query, docFilter):
+        return []
+
+    def get(self, docFilter, checkCollection=True):
+        return []
+
+    def getPaths(self, parent=None, offset=0, limit=1000):
+        return {}
+
+    def remove(self, objectIds):
+        return None
+
+    def markDeleted(self, objectIds):
+        return None
+
+    def markActive(self, objectIds):
+        return None
+
+    def render(self, objectId, callback):
+        return None
+
+
+def _make_docs():
+    metadata = DocMetadata(objectId='obj', chunkId=0)
+    doc = Doc(page_content='hello', metadata=metadata, embedding=[0.1, 0.2, 0.3], score=0.0)
+    doc.embedding_model = 'test-model'
+    return [doc]
+
+
+def test_create_collection_raises_when_driver_returns_false():
+    store = _FakeStore(create_result=False)
+
+    with pytest.raises(Exception):
+        store.createCollection(_make_docs())
+
+    store.addChunks.assert_not_called()
+
+
+def test_create_collection_succeeds_when_driver_returns_true():
+    store = _FakeStore(create_result=True)
+
+    assert store.createCollection(_make_docs()) is True
+    store.addChunks.assert_called_once()
+
+
+def test_create_collection_propagates_driver_exception():
+    store = _FakeStore(create_result=RuntimeError('boom'))
+
+    with pytest.raises(RuntimeError, match='boom'):
+        store.createCollection(_make_docs())
+
+    store.addChunks.assert_not_called()

--- a/packages/ai/tests/ai/common/store/test_document_store.py
+++ b/packages/ai/tests/ai/common/store/test_document_store.py
@@ -75,7 +75,12 @@ def _make_docs():
 def test_create_collection_raises_when_driver_returns_false():
     store = _FakeStore(create_result=False)
 
-    with pytest.raises(Exception):
+    # The whole point of #1495 is that the failure is *named*: the old behaviour
+    # surfaced as a cryptic AttributeError from deep inside addChunks (e.g.
+    # Chroma's "'NoneType' object has no attribute 'delete'"), far from the
+    # driver that actually failed. Assert the message identifies the store, not
+    # merely that something was raised.
+    with pytest.raises(Exception, match='_FakeStore failed to create the vector collection'):
         store.createCollection(_make_docs())
 
     store.addChunks.assert_not_called()
@@ -88,10 +93,50 @@ def test_create_collection_succeeds_when_driver_returns_true():
     store.addChunks.assert_called_once()
 
 
+def test_create_collection_treats_none_as_success():
+    # The check is deliberately `is False`, not falsy: store_weaviate,
+    # store_postgres and rocketride_vector return nothing on success, and
+    # treating their None as failure would break every one of them.
+    store = _FakeStore(create_result=None)
+
+    assert store.createCollection(_make_docs()) is True
+    store.addChunks.assert_called_once()
+
+
 def test_create_collection_propagates_driver_exception():
     store = _FakeStore(create_result=RuntimeError('boom'))
 
     with pytest.raises(RuntimeError, match='boom'):
+        store.createCollection(_make_docs())
+
+    store.addChunks.assert_not_called()
+
+
+class _SwallowingStore(_FakeStore):
+    """
+    A driver shaped like store_astra: it catches every exception from the
+    provider client, warns, and reports failure by returning False.
+
+    nodes/src/nodes/store_astra/astra_db.py does exactly this, so the real
+    provider error never reaches the base at all -- `is False` is the only
+    signal left that anything went wrong.
+    """
+
+    def __init__(self):
+        super().__init__(create_result=None)
+
+    def _createCollection(self, vectorSize):
+        try:
+            raise RuntimeError('provider rejected the collection definition')
+        except Exception:
+            # Swallowed and downgraded to a bool, exactly as the driver does.
+            return False
+
+
+def test_create_collection_catches_a_driver_that_swallows_its_own_error():
+    store = _SwallowingStore()
+
+    with pytest.raises(Exception, match='_SwallowingStore failed to create the vector collection'):
         store.createCollection(_make_docs())
 
     store.addChunks.assert_not_called()


### PR DESCRIPTION
`DocumentStoreBase.createCollection()` discarded the bool returned by the
provider-specific `_createCollection()`, so a driver that reported failure by
returning `False` was ignored: the base proceeded to `addChunks()` against a
collection that was never created, crashing cryptically (e.g. Chroma's
`'NoneType' object has no attribute 'delete'`) far from the real cause.

## Summary

- **Base fix:** `DocumentStoreBase.createCollection()` (now in `packages/ai/src/ai/common/store/document_store.py`) captures `_createCollection()`'s return value and raises a clear error when it is exactly `False`, *before* calling `addChunks()`. `is False` is deliberate — drivers that return `None` on success (`store_weaviate`, `store_postgres`, `rocketride_vector`) are unaffected, and drivers that raise on failure (`store_qdrant`, `store_pinecone`) propagate their own error before the check is reached. `store_elasticsearch`, which already returns `True`/`False` correctly, gains the intended behaviour for free.
- **Milvus prerequisite:** `store_milvus._createCollection` had inverted semantics (returned `False` on success, `True` on failure), which honoring the return value would otherwise break. Corrected to the documented contract: return `True` on success and let real failures raise (removing a `try/except` that swallowed the real error).
- **Contract:** the abstract `_createCollection` is annotated `bool | None`. Implementations may return `True`, return `None`, or raise; only an explicit `False` means failure, and the signature previously said `bool`.
- **Test:** added `packages/ai/tests/ai/common/store/test_document_store.py` covering raise-on-`False`, `True`-success, `None`-success, exception propagation, and a driver that swallows its own error and reports `False` (the `store_astra` shape). The `False` case asserts the message names the store — #1495 is about the failure being *named*, not merely raised.

`store_astra` is the clearest beneficiary: [`astra_db.py:143-145`](https://github.com/rocketride-org/rocketride-server/blob/develop/nodes/src/nodes/store_astra/astra_db.py#L143-L145) catches every exception from `create_collection`, warns, and returns `False`, so the real provider error never reaches the base at all — `is False` is the only signal left that anything went wrong. That driver shape now has its own regression test (thanks @nihalnihalani for spotting it was missing from this list).

Scope is intentionally limited to #1495. `store_atlas`'s always-`True` swallow (it logs and `return True` even when the vector index fails, so the base never sees a failure to honour) and `store_weaviate`/`store_postgres`'s `None`-return are separate defects that do not interact with this fix (the `is False` check leaves them working) and are left for follow-up issues.

> **Rebased onto current `develop`.** No conflicts. The fix itself is unchanged from the original review; it sits at the post-refactor paths (`ai/common/store.py` → `ai/common/store/document_store.py`, `nodes/milvus/` → `nodes/store_milvus/`).

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

On the rebased tree: the 5 `createCollection` cases in `test_document_store.py` pass, and `nodes/test/store_milvus` passes (20 passed, 2 skipped), both run against the engine. `ruff check` / `ruff format --check` are clean on the changed files. The full `./builder test` was not run locally (unrelated local environment limits); CI covers it.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1495


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Collection creation failures are now correctly reported instead of being treated as successful.
  * Document indexing no longer proceeds when collection creation fails.
  * Errors from the collection provider now propagate to callers for clearer handling.
  * Successful collection creation continues to support providers that return either success confirmation or no explicit result.

* **Tests**
  * Added coverage for successful creation, explicit failures, provider errors, and prevention of indexing after failed creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
