### PR TITLE
fix(ui): guard sessionStorage access against strict-privacy crash (#1453)

### DIFF
--- a/apps/chat-ui/src/App.tsx
+++ b/apps/chat-ui/src/App.tsx
@@ -28,6 +28,7 @@ import { VSCodeProvider, VSCodeContextType } from './hooks/useVSCode';
 import { ChatContainer } from './components/ChatContainer';
 import { API_CONFIG, setAPIConfig } from './config/apiConfig';
 import { startClient } from './hooks/clientSingleton';
+import { safeSessionStorage } from './utils/safeStorage';
 
 const App: React.FC = () => {
 	const [isVSCode] = useState(() => 'acquireVsCodeApi' in window);
@@ -99,7 +100,7 @@ const App: React.FC = () => {
 			window.history.replaceState({}, '', window.location.pathname);
 		} else if (!isVSCode) {
 			// Fall back to session storage (skip in VSCode webview - shared storage would mix auth across tabs)
-			token = sessionStorage.getItem('auth') || '';
+			token = safeSessionStorage.getItem('auth') || '';
 		}
 		if (!token && API_CONFIG.devMode && API_CONFIG.ROCKETRIDE_APIKEY) {
 			token = API_CONFIG.ROCKETRIDE_APIKEY;
@@ -126,7 +127,7 @@ const App: React.FC = () => {
 
 		// Save the token in session storage (skip in VSCode) and our state
 		if (!isVSCode) {
-			sessionStorage.setItem('auth', token);
+			safeSessionStorage.setItem('auth', token);
 		}
 		setAuthToken(token);
 

--- a/apps/chat-ui/src/utils/safeStorage.ts
+++ b/apps/chat-ui/src/utils/safeStorage.ts
@@ -1,0 +1,71 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Safe `sessionStorage` accessors.
+ *
+ * Bare `sessionStorage` access throws a `SecurityError` in strict privacy
+ * modes (Safari Private Browsing, Chrome Incognito with third-party storage
+ * blocked, or when the UI is embedded in a sandboxed iframe). When that throw
+ * happens at module-eval time or during the initial React render, it aborts
+ * the whole render cycle and the user gets a blank white screen.
+ *
+ * These helpers swallow the exception and fall back to a harmless default so
+ * the app degrades to in-memory/limited functionality instead of crashing.
+ */
+export const safeSessionStorage = {
+	/**
+	 * Read a value from `sessionStorage`, returning `null` if storage is
+	 * unavailable or the key is missing.
+	 */
+	getItem(key: string): string | null {
+		try {
+			return sessionStorage.getItem(key);
+		} catch {
+			return null;
+		}
+	},
+
+	/**
+	 * Write a value to `sessionStorage`. No-ops if storage is unavailable.
+	 */
+	setItem(key: string, value: string): void {
+		try {
+			sessionStorage.setItem(key, value);
+		} catch {
+			/* storage unavailable — degrade gracefully */
+		}
+	},
+
+	/**
+	 * Remove a value from `sessionStorage`. No-ops if storage is unavailable.
+	 */
+	removeItem(key: string): void {
+		try {
+			sessionStorage.removeItem(key);
+		} catch {
+			/* storage unavailable — degrade gracefully */
+		}
+	},
+};

--- a/apps/chat-ui/src/utils/safeStorage.ts
+++ b/apps/chat-ui/src/utils/safeStorage.ts
@@ -33,6 +33,13 @@
  *
  * These helpers swallow the exception and fall back to a harmless default so
  * the app degrades to in-memory/limited functionality instead of crashing.
+ *
+ * NOTE: This helper is intentionally duplicated across the UI apps that do not
+ * share a common workspace package. Keep the copies in sync — apply any bug fix
+ * or new method (e.g. `clear`) to all three:
+ *   - apps/chat-ui/src/utils/safeStorage.ts
+ *   - apps/dropper-ui/src/utils/safeStorage.ts
+ *   - apps/shell-ui/src/util/safeStorage.ts
  */
 export const safeSessionStorage = {
 	/**

--- a/apps/dropper-ui/src/App.tsx
+++ b/apps/dropper-ui/src/App.tsx
@@ -10,6 +10,7 @@ import { VSCodeProvider, VSCodeContextType } from './hooks/useVSCode';
 import { DropperContainer } from './components/DropperContainer';
 import { API_CONFIG, setAPIConfig } from './config/apiConfig';
 import { startClient } from './hooks/clientSingleton';
+import { safeSessionStorage } from './utils/safeStorage';
 
 const App: React.FC = () => {
 	const [isVSCode] = useState(() => 'acquireVsCodeApi' in window);
@@ -71,7 +72,7 @@ const App: React.FC = () => {
 		if (token) {
 			window.history.replaceState({}, '', window.location.pathname);
 		} else if (!isVSCode) {
-			token = sessionStorage.getItem('auth') || '';
+			token = safeSessionStorage.getItem('auth') || '';
 		}
 		if (!token && API_CONFIG.devMode && API_CONFIG.ROCKETRIDE_APIKEY) {
 			token = API_CONFIG.ROCKETRIDE_APIKEY;
@@ -94,7 +95,7 @@ const App: React.FC = () => {
 		});
 
 		if (!isVSCode) {
-			sessionStorage.setItem('auth', token);
+			safeSessionStorage.setItem('auth', token);
 		}
 		setAuthToken(token);
 

--- a/apps/dropper-ui/src/hooks/clientSingleton.ts
+++ b/apps/dropper-ui/src/hooks/clientSingleton.ts
@@ -41,6 +41,7 @@
 
 import { RocketRideClient, RocketRideClientConfig, ConnectionException } from 'rocketride';
 import { API_CONFIG } from '../config/apiConfig';
+import { safeSessionStorage } from '../utils/safeStorage';
 
 // ============================================================================
 // SINGLETON STATE
@@ -120,7 +121,7 @@ let lastConnectionError: { reason: string; hasError: boolean } | null = null;
  */
 async function getAuthToken(): Promise<string | null> {
 	// Check session storage first for cached token
-	let auth = sessionStorage.getItem('auth');
+	let auth = safeSessionStorage.getItem('auth');
 	if (auth) return auth;
 
 	if (API_CONFIG.devMode) {
@@ -150,7 +151,7 @@ async function getAuthToken(): Promise<string | null> {
 	}
 
 	// Cache token in session storage for subsequent requests
-	if (auth) sessionStorage.setItem('auth', auth);
+	if (auth) safeSessionStorage.setItem('auth', auth);
 	return auth;
 }
 

--- a/apps/dropper-ui/src/utils/safeStorage.ts
+++ b/apps/dropper-ui/src/utils/safeStorage.ts
@@ -1,0 +1,71 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Safe `sessionStorage` accessors.
+ *
+ * Bare `sessionStorage` access throws a `SecurityError` in strict privacy
+ * modes (Safari Private Browsing, Chrome Incognito with third-party storage
+ * blocked, or when the UI is embedded in a sandboxed iframe). When that throw
+ * happens at module-eval time or during the initial React render, it aborts
+ * the whole render cycle and the user gets a blank white screen.
+ *
+ * These helpers swallow the exception and fall back to a harmless default so
+ * the app degrades to in-memory/limited functionality instead of crashing.
+ */
+export const safeSessionStorage = {
+	/**
+	 * Read a value from `sessionStorage`, returning `null` if storage is
+	 * unavailable or the key is missing.
+	 */
+	getItem(key: string): string | null {
+		try {
+			return sessionStorage.getItem(key);
+		} catch {
+			return null;
+		}
+	},
+
+	/**
+	 * Write a value to `sessionStorage`. No-ops if storage is unavailable.
+	 */
+	setItem(key: string, value: string): void {
+		try {
+			sessionStorage.setItem(key, value);
+		} catch {
+			/* storage unavailable — degrade gracefully */
+		}
+	},
+
+	/**
+	 * Remove a value from `sessionStorage`. No-ops if storage is unavailable.
+	 */
+	removeItem(key: string): void {
+		try {
+			sessionStorage.removeItem(key);
+		} catch {
+			/* storage unavailable — degrade gracefully */
+		}
+	},
+};

--- a/apps/dropper-ui/src/utils/safeStorage.ts
+++ b/apps/dropper-ui/src/utils/safeStorage.ts
@@ -33,6 +33,13 @@
  *
  * These helpers swallow the exception and fall back to a harmless default so
  * the app degrades to in-memory/limited functionality instead of crashing.
+ *
+ * NOTE: This helper is intentionally duplicated across the UI apps that do not
+ * share a common workspace package. Keep the copies in sync — apply any bug fix
+ * or new method (e.g. `clear`) to all three:
+ *   - apps/chat-ui/src/utils/safeStorage.ts
+ *   - apps/dropper-ui/src/utils/safeStorage.ts
+ *   - apps/shell-ui/src/util/safeStorage.ts
  */
 export const safeSessionStorage = {
 	/**

--- a/apps/shell-ui/src/util/pkce.ts
+++ b/apps/shell-ui/src/util/pkce.ts
@@ -20,6 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { safeSessionStorage } from './safeStorage';
+
 // =============================================================================
 // PKCE — Client-side OAuth PKCE utilities
 // Browser-only (uses crypto.subtle and fetch).
@@ -114,7 +116,7 @@ export async function generatePkce(): Promise<PkceChallenge> {
 
     // Persist the verifier in sessionStorage so it survives the browser
     // redirect to the Zitadel authorization endpoint and back.
-    sessionStorage.setItem(PKCE_VERIFIER_KEY, verifier);
+    safeSessionStorage.setItem(PKCE_VERIFIER_KEY, verifier);
 
     return { verifier, challenge };
 }
@@ -132,7 +134,7 @@ export function getStoredVerifier(): string | null {
     // Read the previously stored verifier from sessionStorage.
     // Returns null if the key does not exist (e.g., the tab was closed
     // between the initial navigation and the redirect callback).
-    return sessionStorage.getItem(PKCE_VERIFIER_KEY);
+    return safeSessionStorage.getItem(PKCE_VERIFIER_KEY);
 }
 
 /**
@@ -143,7 +145,7 @@ export function getStoredVerifier(): string | null {
  */
 export function clearStoredVerifier(): void {
     // Remove the verifier entry from sessionStorage so it cannot be reused.
-    sessionStorage.removeItem(PKCE_VERIFIER_KEY);
+    safeSessionStorage.removeItem(PKCE_VERIFIER_KEY);
 }
 
 // =============================================================================

--- a/apps/shell-ui/src/util/safeStorage.ts
+++ b/apps/shell-ui/src/util/safeStorage.ts
@@ -1,0 +1,71 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Safe `sessionStorage` accessors.
+ *
+ * Bare `sessionStorage` access throws a `SecurityError` in strict privacy
+ * modes (Safari Private Browsing, Chrome Incognito with third-party storage
+ * blocked, or when the UI is embedded in a sandboxed iframe). When that throw
+ * happens at module-eval time or during the initial React render, it aborts
+ * the whole render cycle and the user gets a blank white screen.
+ *
+ * These helpers swallow the exception and fall back to a harmless default so
+ * the app degrades to in-memory/limited functionality instead of crashing.
+ */
+export const safeSessionStorage = {
+	/**
+	 * Read a value from `sessionStorage`, returning `null` if storage is
+	 * unavailable or the key is missing.
+	 */
+	getItem(key: string): string | null {
+		try {
+			return sessionStorage.getItem(key);
+		} catch {
+			return null;
+		}
+	},
+
+	/**
+	 * Write a value to `sessionStorage`. No-ops if storage is unavailable.
+	 */
+	setItem(key: string, value: string): void {
+		try {
+			sessionStorage.setItem(key, value);
+		} catch {
+			/* storage unavailable — degrade gracefully */
+		}
+	},
+
+	/**
+	 * Remove a value from `sessionStorage`. No-ops if storage is unavailable.
+	 */
+	removeItem(key: string): void {
+		try {
+			sessionStorage.removeItem(key);
+		} catch {
+			/* storage unavailable — degrade gracefully */
+		}
+	},
+};

--- a/apps/shell-ui/src/util/safeStorage.ts
+++ b/apps/shell-ui/src/util/safeStorage.ts
@@ -33,6 +33,13 @@
  *
  * These helpers swallow the exception and fall back to a harmless default so
  * the app degrades to in-memory/limited functionality instead of crashing.
+ *
+ * NOTE: This helper is intentionally duplicated across the UI apps that do not
+ * share a common workspace package. Keep the copies in sync — apply any bug fix
+ * or new method (e.g. `clear`) to all three:
+ *   - apps/chat-ui/src/utils/safeStorage.ts
+ *   - apps/dropper-ui/src/utils/safeStorage.ts
+ *   - apps/shell-ui/src/util/safeStorage.ts
  */
 export const safeSessionStorage = {
 	/**


### PR DESCRIPTION
Fixes #1453

## Problem
Bare `sessionStorage` access throws a `SecurityError` in strict privacy modes (Safari Private Browsing, Chrome Incognito with third-party storage blocked, or when the UI is embedded in a sandboxed iframe). Because these calls run at **module-eval time** (`clientSingleton.ts`) and during the **initial React render** (`App.tsx`), the unhandled throw aborts the render cycle and the user gets a blank white screen — a denial of service.

## Fix
Add a small `safeSessionStorage` helper (try/catch wrappers falling back to `null` / no-op) in each affected app and route the previously-unguarded calls through it:

- `apps/chat-ui/src/App.tsx`
- `apps/dropper-ui/src/App.tsx`
- `apps/dropper-ui/src/hooks/clientSingleton.ts`
- `apps/shell-ui/src/util/pkce.ts`

This mirrors the safe pattern already used in `apps/shell-ui/src/connection/connection.ts`.

## Scope note
Audited every `sessionStorage`/`localStorage` access across `chat-ui`, `dropper-ui`, and `shell-ui`. The shell-ui auth providers (`ApiKeyAuthProvider`, `CloudAuthProvider`), `WorkspaceContext`, `connection.ts` and `Shell.tsx` **already** wrap their access in try/catch, so they are intentionally left unchanged. Only the genuinely-unguarded sites are touched.

## Behavior
When storage is unavailable the app now degrades to in-memory/limited functionality instead of crashing — reads return `null`, writes/removes no-op.

## Testing
Static change only (import + identifier swap, signatures identical to native `sessionStorage`). Local type-check not run — monorepo toolchain (pnpm) is not installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability in restrictive browser, privacy, and sandboxed iframe environments by safely handling session storage access.
  * Prevented failures to read or write session-stored auth data from interrupting startup or initial rendering.
  * Ensured PKCE verifier persistence continues to work when session storage is available, while failing gracefully when it is not.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->