### PR TITLE
fix(nodes): render Prompt node instructions as multi-line textarea (#1516)

### DIFF
--- a/nodes/src/nodes/prompt/services.json
+++ b/nodes/src/nodes/prompt/services.json
@@ -132,7 +132,8 @@
 			"title": "Instructions",
 			"description": "Multiple instructions to add to questions before sending to LLM",
 			"items": {
-				"type": "string"
+				"type": "string",
+				"format": "textarea"
 			}
 		}
 	},


### PR DESCRIPTION
Fixes #1516

## Problem
In the visual editor's node config panel, the **Prompt** node's **Instructions** rows render as single-line inputs. Long system prompts get clipped mid-word with no wrap, resize, or multi-line editing — painful to author or review.

## Fix
Add `"format": "textarea"` to the `instructions` array **items** in the Prompt node schema:

```json
"items": {
    "type": "string",
    "format": "textarea"
}
```

RJSF maps the `textarea` format to the already-registered `TextareaWidget` (an auto-growing, word-wrapping MUI multiline field, `minRows=1` / `maxRows=5`). Each instruction row now grows with its content instead of truncating — no new component or widget needed.

## Why this approach
This mirrors the **exact pattern already used by the `agent_langchain` node**, which exposes the same `instructions` array and already renders it as a textarea. Following the established convention keeps the node schemas consistent.

## Scope / safety
- **UI-only.** No `.pipe` schema change — the field is still an array of strings.
- **No generated-doc change.** The item-level `format` is a render hint and does not appear in the `ROCKETRIDE:GENERATED:PARAMS` table (verified against `agent_langchain`, whose generated table shows `instructions | array | …` with no format), so `nodes:docs-generate` output is unchanged.
- JSON validated.

## Testing
Static schema change routed through an existing, in-use widget. Local visual verification not run — the monorepo toolchain (pnpm) is not installed in this environment; maintainer CI + the identical `agent_langchain` precedent cover the behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instruction fields now use a larger, multiline text area for easier editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->