### PR TITLE
fix(build): compare content, not mtime, when sync file sizes match (#1477)

### DIFF
--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -274,23 +274,32 @@ async function readChunkFull(fh, buf) {
  */
 async function filesEqual(a, b) {
     const CHUNK_SIZE = 64 * 1024;
-    const [fhA, fhB] = await Promise.all([fsp.open(a, 'r'), fsp.open(b, 'r')]);
+    // Open sequentially with nested try/finally. Opening both under Promise.all
+    // would leak the first handle if the second open rejected (Promise.all
+    // rejects at once, orphaning the resolved handle) — a slow FD leak that can
+    // build to EMFILE across a large sync.
+    const fhA = await fsp.open(a, 'r');
     try {
-        const bufA = Buffer.allocUnsafe(CHUNK_SIZE);
-        const bufB = Buffer.allocUnsafe(CHUNK_SIZE);
-        for (;;) {
-            const [readA, readB] = await Promise.all([
-                readChunkFull(fhA, bufA),
-                readChunkFull(fhB, bufB),
-            ]);
-            // Divergent lengths (or one file hitting EOF first) => not equal.
-            if (readA !== readB) return false;
-            // Both reached EOF with every prior window equal => identical.
-            if (readA === 0) return true;
-            if (!bufA.subarray(0, readA).equals(bufB.subarray(0, readB))) return false;
+        const fhB = await fsp.open(b, 'r');
+        try {
+            const bufA = Buffer.allocUnsafe(CHUNK_SIZE);
+            const bufB = Buffer.allocUnsafe(CHUNK_SIZE);
+            for (;;) {
+                const [readA, readB] = await Promise.all([
+                    readChunkFull(fhA, bufA),
+                    readChunkFull(fhB, bufB),
+                ]);
+                // Divergent lengths (or one file hitting EOF first) => not equal.
+                if (readA !== readB) return false;
+                // Both reached EOF with every prior window equal => identical.
+                if (readA === 0) return true;
+                if (!bufA.subarray(0, readA).equals(bufB.subarray(0, readB))) return false;
+            }
+        } finally {
+            await fhB.close();
         }
     } finally {
-        await Promise.all([fhA.close(), fhB.close()]);
+        await fhA.close();
     }
 }
 

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -234,6 +234,26 @@ async function copyFileEnsure(src, dest) {
 }
 
 /**
+ * Byte-compare the contents of two files.
+ *
+ * Used by the incremental sync to decide whether a file actually changed.
+ * File size is a cheap pre-filter — differently-sized files are never equal,
+ * so callers should skip this call when sizes differ. Same-size files must be
+ * compared by content, because a same-length edit (e.g. a swapped
+ * content-hash string in an index.html) does not change the size and cannot
+ * be detected by size or mtime alone.
+ *
+ * @param {string} a - First file path
+ * @param {string} b - Second file path
+ * @returns {Promise<boolean>} True if both files have identical bytes
+ */
+async function filesEqual(a, b) {
+    // Read as raw Buffers (no encoding) so the compare is byte-exact.
+    const [bufA, bufB] = await Promise.all([fsp.readFile(a), fsp.readFile(b)]);
+    return bufA.equals(bufB);
+}
+
+/**
  * Copy a directory recursively
  * @param {string} src - Source directory path
  * @param {string} dest - Destination directory path
@@ -686,6 +706,9 @@ module.exports = {
     copyFileEnsure,
     copyDir,
     copyDirEnsure,
+
+    // Comparing
+    filesEqual,
     
     // Stats
     stat,

--- a/scripts/lib/fs.js
+++ b/scripts/lib/fs.js
@@ -234,6 +234,27 @@ async function copyFileEnsure(src, dest) {
 }
 
 /**
+ * Fill a buffer from a file handle, looping until it is full or EOF is hit.
+ *
+ * A single read() may return fewer bytes than requested even mid-file, so this
+ * keeps reading into the same buffer until the requested window is complete.
+ * That guarantees two files are compared on aligned byte boundaries.
+ *
+ * @param {import('fs/promises').FileHandle} fh - Open file handle
+ * @param {Buffer} buf - Destination buffer to fill
+ * @returns {Promise<number>} Bytes read into buf (0 once EOF is reached)
+ */
+async function readChunkFull(fh, buf) {
+    let offset = 0;
+    while (offset < buf.length) {
+        const { bytesRead } = await fh.read(buf, offset, buf.length - offset, null);
+        if (bytesRead === 0) break; // EOF
+        offset += bytesRead;
+    }
+    return offset;
+}
+
+/**
  * Byte-compare the contents of two files.
  *
  * Used by the incremental sync to decide whether a file actually changed.
@@ -243,14 +264,34 @@ async function copyFileEnsure(src, dest) {
  * content-hash string in an index.html) does not change the size and cannot
  * be detected by size or mtime alone.
  *
+ * The compare runs in bounded chunks and stops at the first mismatch, so it
+ * never allocates two whole-file buffers — a large same-size asset costs two
+ * fixed windows, not two full copies in memory.
+ *
  * @param {string} a - First file path
  * @param {string} b - Second file path
  * @returns {Promise<boolean>} True if both files have identical bytes
  */
 async function filesEqual(a, b) {
-    // Read as raw Buffers (no encoding) so the compare is byte-exact.
-    const [bufA, bufB] = await Promise.all([fsp.readFile(a), fsp.readFile(b)]);
-    return bufA.equals(bufB);
+    const CHUNK_SIZE = 64 * 1024;
+    const [fhA, fhB] = await Promise.all([fsp.open(a, 'r'), fsp.open(b, 'r')]);
+    try {
+        const bufA = Buffer.allocUnsafe(CHUNK_SIZE);
+        const bufB = Buffer.allocUnsafe(CHUNK_SIZE);
+        for (;;) {
+            const [readA, readB] = await Promise.all([
+                readChunkFull(fhA, bufA),
+                readChunkFull(fhB, bufB),
+            ]);
+            // Divergent lengths (or one file hitting EOF first) => not equal.
+            if (readA !== readB) return false;
+            // Both reached EOF with every prior window equal => identical.
+            if (readA === 0) return true;
+            if (!bufA.subarray(0, readA).equals(bufB.subarray(0, readB))) return false;
+        }
+    } finally {
+        await Promise.all([fhA.close(), fhB.close()]);
+    }
 }
 
 /**

--- a/scripts/lib/sync.js
+++ b/scripts/lib/sync.js
@@ -11,7 +11,7 @@ const SERVER_DIR = path.join(DIST_ROOT, 'server');
 
 /**
  * Incrementally sync source to destination directory (MIRROR or OVERLAY mode)
- * - Only copies files that are new or modified (based on mtime + size)
+ * - Only copies files that are new or modified (based on size + content)
  * - Removes files in dest that don't exist in source in MIRROR mode (default)
  * - Ignores files and directories by specified patterns (default: '\*\*\/\_\_pycache\_\_\/\*\*')
  * 

--- a/scripts/lib/sync.js
+++ b/scripts/lib/sync.js
@@ -4,7 +4,7 @@
  * Provides smart directory synchronization that only copies changed files.
  */
 const path = require('path');
-const { exists, stat, copyFileEnsure, unlink } = require('./fs');
+const { exists, stat, copyFileEnsure, unlink, filesEqual } = require('./fs');
 const { setState, } = require('./state');
 const { DIST_ROOT } = require('./paths');
 const SERVER_DIR = path.join(DIST_ROOT, 'server');
@@ -72,7 +72,12 @@ async function syncDir(src, dest, options = {}, stats = { added: 0, updated: 0, 
             const srcStat = await stat(srcPath);
             const destStat = await stat(destPath);
 
-            if (srcStat.size === destStat.size && srcStat.mtimeMs <= destStat.mtimeMs) {
+            // Skip only when the file is genuinely unchanged. Size is a cheap
+            // pre-filter; when sizes match we must compare content, because a
+            // same-length edit (e.g. a swapped bundle-hash string in index.html)
+            // does not change the size and an mtime-ordering gate misses it — a
+            // stale file then keeps referencing a deleted sibling (#1477).
+            if (srcStat.size === destStat.size && await filesEqual(srcPath, destPath)) {
                 stats.unchanged++;
             } else {
                 if (!dryRun) {
@@ -119,7 +124,7 @@ async function syncDir(src, dest, options = {}, stats = { added: 0, updated: 0, 
 }
 
 /**
- * Incrementally sync a single file (same mtime/size rules as syncDir).
+ * Incrementally sync a single file (same size + content-compare rule as syncDir).
  *
  * @param {string} src - Source file path
  * @param {string} dest - Destination file path
@@ -152,7 +157,10 @@ async function syncFile(src, dest, options = {}, stats = { added: 0, updated: 0,
 
     // Process source file - copy new/modified
     if (destStat) {
-        if (srcStat.size === destStat.size && srcStat.mtimeMs <= destStat.mtimeMs) {
+        // Same content-comparison rule as syncDir: size pre-filter, then a
+        // byte compare on same-size files so same-length edits are not
+        // skipped by an mtime-ordering heuristic (#1477).
+        if (srcStat.size === destStat.size && await filesEqual(src, dest)) {
             stats.unchanged++;
         } else {
             if (!dryRun) {

--- a/scripts/lib/sync.test.js
+++ b/scripts/lib/sync.test.js
@@ -1,0 +1,149 @@
+/**
+ * Regression tests for content-based incremental sync (#1477).
+ *
+ * The bug: syncDir/syncFile skipped a copy when `size === size && srcMtime <=
+ * destMtime`. A rebuilt index.html kept the same byte length but swapped its
+ * bundle-hash string, and its source mtime was older than the already-present
+ * destination — so the changed file was silently skipped and shipped stale.
+ *
+ * These tests pin the fix: a same-size file whose bytes changed is always
+ * copied, regardless of mtime ordering, while a byte-identical file is skipped.
+ *
+ * No test runner is wired into this repo's build scripts yet, so this uses the
+ * zero-dependency built-in runner. Run:
+ *     node --test scripts/lib/sync.test.js
+ */
+const { test } = require('node:test');
+const assert = require('node:assert');
+const os = require('node:os');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const { filesEqual } = require('./fs');
+const { syncFile, syncDir } = require('./sync');
+
+/**
+ * Create a fresh, empty temp directory for a single test case.
+ * @returns {string} Absolute path to the new directory
+ */
+function tmpDir() {
+    return fs.mkdtempSync(path.join(os.tmpdir(), 'rr-sync-test-'));
+}
+
+/**
+ * Write a file and force its mtime to a fixed epoch-second value, so tests can
+ * reproduce the exact "source older than destination" trigger deterministically.
+ * @param {string} file - File path to write
+ * @param {string|Buffer} content - File contents
+ * @param {number} mtimeSec - Modification time, seconds since the epoch
+ */
+function writeWithMtime(file, content, mtimeSec) {
+    fs.writeFileSync(file, content);
+    fs.utimesSync(file, mtimeSec, mtimeSec);
+}
+
+// --- filesEqual ------------------------------------------------------------
+
+test('filesEqual: same length, different bytes -> false', async () => {
+    const dir = tmpDir();
+    const a = path.join(dir, 'a');
+    const b = path.join(dir, 'b');
+    // Same 15-byte length, one differing character (the exact bug shape).
+    fs.writeFileSync(a, 'index.<AAAA>.js');
+    fs.writeFileSync(b, 'index.<BBBB>.js');
+    assert.equal(fs.statSync(a).size, fs.statSync(b).size);
+    assert.equal(await filesEqual(a, b), false);
+});
+
+test('filesEqual: identical bytes -> true', async () => {
+    const dir = tmpDir();
+    const a = path.join(dir, 'a');
+    const b = path.join(dir, 'b');
+    fs.writeFileSync(a, 'index.<AAAA>.js');
+    fs.writeFileSync(b, 'index.<AAAA>.js');
+    assert.equal(await filesEqual(a, b), true);
+});
+
+test('filesEqual: multi-chunk files differing only in the final chunk -> false', async () => {
+    const dir = tmpDir();
+    const a = path.join(dir, 'a');
+    const b = path.join(dir, 'b');
+    // Larger than the 64 KiB read window so the chunk loop runs more than once.
+    const base = Buffer.alloc(200 * 1024, 0x61);
+    const other = Buffer.from(base);
+    other[other.length - 1] = 0x62; // flip the very last byte
+    fs.writeFileSync(a, base);
+    fs.writeFileSync(b, other);
+    assert.equal(base.length, other.length);
+    assert.equal(await filesEqual(a, b), false);
+    // And identical large files still compare equal across chunks.
+    fs.writeFileSync(b, base);
+    assert.equal(await filesEqual(a, b), true);
+});
+
+// --- syncFile --------------------------------------------------------------
+
+test('syncFile: same-size changed bytes with OLDER source mtime -> copied', async () => {
+    const dir = tmpDir();
+    const src = path.join(dir, 'src.html');
+    const dest = path.join(dir, 'dest.html');
+    // Destination is the newer file on disk; source is older but has new bytes.
+    writeWithMtime(dest, 'index.<OLD0>.js', 2_000_000_000);
+    writeWithMtime(src, 'index.<NEW0>.js', 1_000_000_000);
+    assert.equal(fs.statSync(src).size, fs.statSync(dest).size);
+
+    const stats = await syncFile(src, dest);
+
+    assert.equal(stats.updated, 1);
+    assert.equal(stats.unchanged, 0);
+    assert.equal(fs.readFileSync(dest, 'utf8'), 'index.<NEW0>.js');
+});
+
+test('syncFile: byte-identical file -> skipped (no perpetual recopy)', async () => {
+    const dir = tmpDir();
+    const src = path.join(dir, 'src.html');
+    const dest = path.join(dir, 'dest.html');
+    writeWithMtime(dest, 'index.<SAME>.js', 2_000_000_000);
+    writeWithMtime(src, 'index.<SAME>.js', 1_000_000_000);
+
+    const stats = await syncFile(src, dest);
+
+    assert.equal(stats.unchanged, 1);
+    assert.equal(stats.updated, 0);
+});
+
+test('syncFile: differently sized file -> copied', async () => {
+    const dir = tmpDir();
+    const src = path.join(dir, 'src.html');
+    const dest = path.join(dir, 'dest.html');
+    writeWithMtime(dest, 'short', 2_000_000_000);
+    writeWithMtime(src, 'a much longer body', 1_000_000_000);
+
+    const stats = await syncFile(src, dest);
+
+    assert.equal(stats.updated, 1);
+    assert.equal(fs.readFileSync(dest, 'utf8'), 'a much longer body');
+});
+
+// --- syncDir ---------------------------------------------------------------
+
+test('syncDir: same-size changed file with older mtime is updated; identical file is skipped', async () => {
+    const root = tmpDir();
+    const src = path.join(root, 'src');
+    const dest = path.join(root, 'dest');
+    fs.mkdirSync(src);
+    fs.mkdirSync(dest);
+
+    // changed.js: same length, different bytes, source mtime OLDER than dest.
+    writeWithMtime(path.join(dest, 'changed.js'), 'v=<AAAA>', 2_000_000_000);
+    writeWithMtime(path.join(src, 'changed.js'), 'v=<BBBB>', 1_000_000_000);
+    // same.js: byte-identical, source mtime OLDER than dest.
+    writeWithMtime(path.join(dest, 'same.js'), 'unchanged', 2_000_000_000);
+    writeWithMtime(path.join(src, 'same.js'), 'unchanged', 1_000_000_000);
+
+    const stats = await syncDir(src, dest);
+
+    assert.equal(stats.updated, 1);
+    assert.equal(stats.unchanged, 1);
+    assert.equal(fs.readFileSync(path.join(dest, 'changed.js'), 'utf8'), 'v=<BBBB>');
+});


### PR DESCRIPTION
Fixes #1477

## Problem
`syncDir`/`syncFile` in `scripts/lib/sync.js` skip copying a file when the sizes are equal and the source mtime is **not strictly newer** than the destination:

```js
if (srcStat.size === destStat.size && srcStat.mtimeMs <= destStat.mtimeMs) {
    stats.unchanged++;   // SKIP copy
}
```

This can **never** detect a same-length content change when the source mtime isn't strictly newer. Concrete failure: a rebuilt `chat-ui` `index.html` kept the same **706-byte** size but swapped its bundle-hash string, and the freshly built source had an *older* mtime than the already-present dest → `size==size && src.mtime<=dest.mtime` → skipped. The stale `index.html` kept referencing the deleted `index.<hash>.js`; the server's SPA fallback returns `index.html` for the missing `.js`, so the browser parses HTML as JS:

```
Uncaught SyntaxError: Unexpected token '<'
```

→ **Chat webview white screen.**

## Fix
Gate the skip on **content**, not mtime ordering (as proposed in the issue):

- Size stays as a cheap fast-path pre-filter — differently-sized files copy as before.
- Same-size files are **byte-compared** via a new `fs.filesEqual()` helper; a file is copied whenever content differs, regardless of mtime.
- The `srcStat.mtimeMs <= destStat.mtimeMs` correctness gate (the bug) is dropped.
- Factored into **one helper** (`scripts/lib/fs.js`) so `syncDir` (`:75`) and `syncFile` (`:155`) cannot drift.

This also sidesteps the `copyFileEnsure`-mtime concern noted in the issue: correctness no longer depends on mtime at all, so there is no risk of either perpetual recopies or missed updates.

## Verification (run locally with node against the real modules)
```
PASS filesEqual: same-length different content -> false
PASS filesEqual: identical content -> true
PASS syncFile: same-size + older-src content change -> COPIED (was skipped before)
PASS syncFile: identical content -> skipped
```
The harness reproduces the exact bug trigger (same size, source mtime older than dest, swapped same-length hash string): pre-fix that file was skipped; post-fix it is copied. Identical files are still skipped, so there are no perpetual recopies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization accuracy by determining whether files are truly unchanged via byte-for-byte content comparison (not only timestamps).
  * Same-size files are now correctly updated when their contents differ, even if the source modification time is not newer.
* **New Features**
  * Added byte-level file comparison used by incremental sync decisions.
* **Tests**
  * Added regression tests covering identical-content skipping and large-file comparisons, including cases with same size but different bytes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->