### PR TITLE
fix(ai): raise task error/warning history cap from 50 to a named constant (#1414)

### DIFF
--- a/packages/ai/src/ai/constants.py
+++ b/packages/ai/src/ai/constants.py
@@ -52,6 +52,7 @@ CONST_MAX_READY_TIME = 5 * 60  # seconds to wait for task to become ready
 CONST_READY_POLL_INTERVAL = 0.250  # seconds between readiness checks
 CONST_SUBPROCESS_BUFFER_LIMIT = 16 * 1024 * 1024  # bytes for subprocess stdin/stdout/stderr buffers (16MB)
 CONST_STATUS_UPDATE_CANCEL_TIMEOUT = 2.0  # seconds to wait for status update task cancellation
+CONST_STATUS_HISTORY_LIMIT = 1000  # max error/warning messages retained per task in memory (was 50; see #1414)
 CONST_DEFAULT_TTL = 15 * 60  # default time-to-live for idle tasks in seconds (15 minutes)
 CONST_TTL_CHECK = 60  # check for tasks to kill every 60 seconds
 

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -50,6 +50,7 @@ from ai.constants import (
     CONST_READY_POLL_INTERVAL,
     CONST_SUBPROCESS_BUFFER_LIMIT,
     CONST_STATUS_UPDATE_CANCEL_TIMEOUT,
+    CONST_STATUS_HISTORY_LIMIT,
     CONST_ANALYTICS_SLOWEST_DOCS,
 )
 from ai import CONST_AI_NODE_SCRIPT
@@ -1373,16 +1374,16 @@ class Task(DAPBase):
             error_message = body.get('message', '')
             self._status.errors.append(error_message)
 
-            if len(self._status.errors) > 50:
-                self._status.errors = self._status.errors[-50:]
+            if len(self._status.errors) > CONST_STATUS_HISTORY_LIMIT:
+                self._status.errors = self._status.errors[-CONST_STATUS_HISTORY_LIMIT:]
 
         # Handle warning messages with buffer management
         elif event_type == 'apaevt_status_warning':
             warning_message = body.get('message', '')
             self._status.warnings.append(warning_message)
 
-            if len(self._status.warnings) > 50:
-                self._status.warnings = self._status.warnings[-50:]
+            if len(self._status.warnings) > CONST_STATUS_HISTORY_LIMIT:
+                self._status.warnings = self._status.warnings[-CONST_STATUS_HISTORY_LIMIT:]
 
         # Handle download progress
         elif event_type == 'apaevt_status_download':

--- a/packages/ai/tests/ai/modules/task/test_task_engine.py
+++ b/packages/ai/tests/ai/modules/task/test_task_engine.py
@@ -545,8 +545,8 @@ def test_update_status_errors_buffer_trims_to_limit():
     assert 'err-0' not in t._status.errors  # oldest evicted
 
 
-def test_update_status_warning_event_appends_and_trims():
-    """An ``apaevt_status_warning`` event appends to warnings with the same history cap."""
+def test_update_status_warning_event_appends_to_warnings():
+    """An ``apaevt_status_warning`` event appends to ``status.warnings``."""
     t = _task(status=_make_status_for_update())
     Task._update_status(
         t,
@@ -556,6 +556,22 @@ def test_update_status_warning_event_appends_and_trims():
         },
     )
     assert t._status.warnings == ['memory pressure']
+
+
+def test_update_status_warnings_buffer_trims_to_limit():
+    """Warning buffer keeps only the most recent CONST_STATUS_HISTORY_LIMIT entries."""
+    t = _task(status=_make_status_for_update())
+    t._status.warnings = [f'warn-{i}' for i in range(CONST_STATUS_HISTORY_LIMIT)]
+    Task._update_status(
+        t,
+        {
+            'event': 'apaevt_status_warning',
+            'body': {'message': 'warn-new'},
+        },
+    )
+    assert len(t._status.warnings) == CONST_STATUS_HISTORY_LIMIT
+    assert t._status.warnings[-1] == 'warn-new'
+    assert 'warn-0' not in t._status.warnings  # oldest evicted
 
 
 def test_update_status_download_event_sets_status_string():

--- a/packages/ai/tests/ai/modules/task/test_task_engine.py
+++ b/packages/ai/tests/ai/modules/task/test_task_engine.py
@@ -33,6 +33,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from ai.constants import CONST_STATUS_HISTORY_LIMIT
 from ai.modules.task.task_engine import CONST_TRACE_PAYLOAD_CAP, CONST_TRACE_PREVIEW_BYTES, Task, cap_trace_payload
 
 
@@ -528,10 +529,10 @@ def test_update_status_error_event_appends_to_errors():
     assert t._status.errors == ['disk full']
 
 
-def test_update_status_errors_buffer_trims_to_50():
-    """Error buffer keeps only the most recent 50 entries."""
+def test_update_status_errors_buffer_trims_to_limit():
+    """Error buffer keeps only the most recent CONST_STATUS_HISTORY_LIMIT entries."""
     t = _task(status=_make_status_for_update())
-    t._status.errors = [f'err-{i}' for i in range(50)]
+    t._status.errors = [f'err-{i}' for i in range(CONST_STATUS_HISTORY_LIMIT)]
     Task._update_status(
         t,
         {
@@ -539,13 +540,13 @@ def test_update_status_errors_buffer_trims_to_50():
             'body': {'message': 'err-new'},
         },
     )
-    assert len(t._status.errors) == 50
+    assert len(t._status.errors) == CONST_STATUS_HISTORY_LIMIT
     assert t._status.errors[-1] == 'err-new'
     assert 'err-0' not in t._status.errors  # oldest evicted
 
 
 def test_update_status_warning_event_appends_and_trims():
-    """An ``apaevt_status_warning`` event appends to warnings with the same 50-cap."""
+    """An ``apaevt_status_warning`` event appends to warnings with the same history cap."""
     t = _task(status=_make_status_for_update())
     Task._update_status(
         t,

--- a/packages/client-python/src/rocketride/types/task.py
+++ b/packages/client-python/src/rocketride/types/task.py
@@ -360,10 +360,12 @@ class TASK_STATUS(BaseModel):
 
     # Error and Warning Management with History
     warnings: List[str] = Field(
-        default_factory=list, description='Warning message history (limited to 50 recent entries)'
+        default_factory=list, description='Warning message history (limited to 1000 recent entries)'
     )
 
-    errors: List[str] = Field(default_factory=list, description='Error message history (limited to 50 recent entries)')
+    errors: List[str] = Field(
+        default_factory=list, description='Error message history (limited to 1000 recent entries)'
+    )
 
     # Current Processing Context
     currentObject: str = Field(default='', description='Name/identifier of the item currently being processed')

--- a/packages/client-typescript/docs/guide/methods/get-task-status.md
+++ b/packages/client-typescript/docs/guide/methods/get-task-status.md
@@ -60,8 +60,8 @@ const status = await client.getTaskStatus(token);
 | `completedSize` | `int` | Bytes processed successfully |
 | `rateCount` | `int` | Current processing rate (items/sec) |
 | `rateSize` | `int` | Current processing rate (bytes/sec) |
-| `errors` | `list[str]` | Recent error messages (max 50) |
-| `warnings` | `list[str]` | Recent warning messages (max 50) |
+| `errors` | `list[str]` | Recent error messages (max 1000) |
+| `warnings` | `list[str]` | Recent warning messages (max 1000) |
 | `status` | `str` | Current status message |
 | `currentObject` | `str` | Item currently being processed |
 | `exitCode` | `int` | Process exit code (0 = success) |

--- a/packages/client-typescript/src/client/types/task.ts
+++ b/packages/client-typescript/src/client/types/task.ts
@@ -249,10 +249,10 @@ export interface TASK_STATUS {
 
 	// Error and Warning Management with History
 
-	/** Warning message history (limited to 50 recent entries) */
+	/** Warning message history (limited to 1000 recent entries) */
 	warnings: string[];
 
-	/** Error message history (limited to 50 recent entries) */
+	/** Error message history (limited to 1000 recent entries) */
 	errors: string[];
 
 	// Current Processing Context


### PR DESCRIPTION
Addresses #1414 (the error/warning cap portion — see Scope below).

## Problem
Live task status kept only the **50** most recent error and **50** most recent warning messages. In `packages/ai/src/ai/modules/task/task_engine.py` the buffers were trimmed with a hardcoded magic number:

```python
if len(self._status.errors) > 50:
    self._status.errors = self._status.errors[-50:]
# ...and the same for warnings
```

On a run that emits many diagnostics, the earliest errors are discarded before anyone can read them — the exact symptom reported in #1414 ("error/warning arrays capped at 50").

## Fix
- Replace both magic `50`s with a single named constant **`CONST_STATUS_HISTORY_LIMIT = 1000`**, added next to the other `CONST_*` limits in `ai/constants.py`.
- Update the `TASK_STATUS.errors` / `.warnings` field descriptions in the Python SDK (`packages/client-python/src/rocketride/types/task.py`) to match.

This retains far more history in memory (1000 vs 50) while keeping a bound, so a pathological run can't grow the buffers without limit. Using a named constant means the value lives in one place if it ever needs tuning.

## Scope
This intentionally covers **only the in-memory cap**. The other half of #1414 — durable run-history persistence (JSONL sink, downloadable trace, surviving disconnect) — is a substantially larger change and is left as a separate follow-up. Filing this as a focused, reviewable first step rather than bundling both.

## Verification
- `ruff check` — All checks passed
- `ruff format --check` — clean (all 3 files)
- Trim logic verified: past the limit, the buffer retains the last 1000 entries (drops oldest); under the limit, all entries are kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Task status history now retains up to **1,000** recent warnings and errors, increased from **50**.
  - Older entries are removed as needed to maintain the 1,000-message limit.

- **Documentation**
  - Updated task status references and field descriptions to reflect the 1,000-entry history limit.

- **Tests**
  - Updated coverage to verify the expanded history limit and removal of the oldest entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->