### PR TITLE
fix(nodes): retry Gmail rate-limit 403s instead of failing fast (#1560)

### DIFF
--- a/nodes/src/nodes/tool_gmail/gmail_client.py
+++ b/nodes/src/nodes/tool_gmail/gmail_client.py
@@ -90,6 +90,40 @@ def resolve_refresh_url(token_url: object) -> str | None:
 # HTTP status codes worth retrying (rate-limit + transient server errors).
 _RETRY_STATUSES = {429, 500, 502, 503, 504}
 
+# Structured error reasons that make a 403 a retryable rate-limit/quota error
+# rather than a hard auth/scope failure.
+_RATE_LIMIT_403_REASONS = frozenset({'userRateLimitExceeded', 'rateLimitExceeded', 'quotaExceeded'})
+
+
+def _is_rate_limit_403(exc: object) -> bool:
+    """True when a 403 is a retryable rate-limit/quota error, not an auth/scope 403.
+
+    Gmail reports the specific cause in the structured error body
+    (``error.status`` or ``error.errors[].reason``). Only rate-limit/quota
+    reasons are transient and worth retrying; scope/permission 403s must fail
+    fast. Any parse failure conservatively returns False (treat as non-retryable).
+    """
+    content = getattr(exc, 'content', None)
+    if not content:
+        return False
+    try:
+        if isinstance(content, (bytes, bytearray)):
+            content = content.decode('utf-8', 'replace')
+        body = json.loads(content)
+    except (ValueError, TypeError):
+        return False
+
+    error = body.get('error') if isinstance(body, dict) else None
+    if not isinstance(error, dict):
+        return False
+    if error.get('status') in _RATE_LIMIT_403_REASONS:
+        return True
+    for item in error.get('errors') or []:
+        if isinstance(item, dict) and item.get('reason') in _RATE_LIMIT_403_REASONS:
+            return True
+    return False
+
+
 # Google's full-access Gmail scope — a superset of all granular Gmail scopes.
 _GMAIL_FULL_SCOPE = 'https://mail.google.com/'
 
@@ -242,7 +276,11 @@ def execute(request: Any) -> dict:
             return request.execute() or {}
         except Exception as exc:  # googleapiclient.errors.HttpError and transport errors
             status = getattr(getattr(exc, 'resp', None), 'status', None)
-            if status and int(status) in _RETRY_STATUSES and attempt < 3:
+            istatus = int(status) if status else None
+            # Retry transient statuses, plus 403s that the structured error body
+            # identifies as rate-limit/quota (not scope/permission) failures.
+            retryable = istatus in _RETRY_STATUSES or (istatus == 403 and _is_rate_limit_403(exc))
+            if retryable and attempt < 3:
                 _time.sleep(min(base_delay * (2**attempt), 60.0))
                 continue
             detail = getattr(exc, 'reason', None) or str(exc)

--- a/nodes/test/tool_gmail/test_gmail.py
+++ b/nodes/test/tool_gmail/test_gmail.py
@@ -242,6 +242,65 @@ def test_error_path_wraps_http_error():
 
 
 # ---------------------------------------------------------------------------
+# execute() retry: rate-limit 403s are retryable, scope 403s are not (#1560)
+# ---------------------------------------------------------------------------
+
+
+class _FakeHttpError(Exception):
+    """Stand-in for googleapiclient.errors.HttpError with a status + JSON body."""
+
+    def __init__(self, status, content=b''):
+        super().__init__(f'HTTP {status}')
+        self.resp = types.SimpleNamespace(status=status)
+        self.content = content
+        self.reason = 'Forbidden'
+
+
+def _rate_limit_body(reason):
+    return json.dumps({'error': {'errors': [{'reason': reason}], 'status': 'PERMISSION_DENIED'}}).encode()
+
+
+@pytest.mark.parametrize('reason', ['userRateLimitExceeded', 'rateLimitExceeded', 'quotaExceeded'])
+def test_is_rate_limit_403_detects_reasons(reason):
+    assert gmail_client._is_rate_limit_403(_FakeHttpError(403, _rate_limit_body(reason)))
+
+
+def test_is_rate_limit_403_ignores_scope_and_garbage():
+    assert not gmail_client._is_rate_limit_403(_FakeHttpError(403, _rate_limit_body('insufficientPermissions')))
+    assert not gmail_client._is_rate_limit_403(_FakeHttpError(403, b'<html>not json'))
+    assert not gmail_client._is_rate_limit_403(_FakeHttpError(403, b''))
+
+
+def test_execute_retries_rate_limit_403_then_succeeds(monkeypatch):
+    monkeypatch.setattr(gmail_client._time, 'sleep', lambda *a, **kw: None)
+    calls = {'n': 0}
+
+    class _R:
+        def execute(self):
+            calls['n'] += 1
+            if calls['n'] < 3:
+                raise _FakeHttpError(403, _rate_limit_body('rateLimitExceeded'))
+            return {'ok': True}
+
+    assert gmail_client.execute(_R()) == {'ok': True}
+    assert calls['n'] == 3
+
+
+def test_execute_does_not_retry_scope_403(monkeypatch):
+    monkeypatch.setattr(gmail_client._time, 'sleep', lambda *a, **kw: None)
+    calls = {'n': 0}
+
+    class _R:
+        def execute(self):
+            calls['n'] += 1
+            raise _FakeHttpError(403, _rate_limit_body('insufficientPermissions'))
+
+    with pytest.raises(ValueError, match='403'):
+        gmail_client.execute(_R())
+    assert calls['n'] == 1  # failed fast, no retry
+
+
+# ---------------------------------------------------------------------------
 # Write gating
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Addresses #1560 (the 403 rate-limit retry item — see Scope).

## Problem
`gmail_client.execute()` retries transient `429`/`5xx` statuses but **fails fast on every `403`**. Gmail returns rate-limit/quota conditions as `403` with a structured reason (`userRateLimitExceeded`, `rateLimitExceeded`, `quotaExceeded`) — those are transient and retryable, but currently surface as a hard error mid-run.

## Fix
- Add `_is_rate_limit_403(exc)` which parses the structured error body (`error.status` / `error.errors[].reason`) and returns True only for rate-limit/quota reasons. Any parse failure conservatively returns False (non-retryable).
- Include such 403s in the `execute()` retry path alongside the existing transient statuses. **Scope/permission 403s still fail fast** with the reconnect message.

## Tests
- `_is_rate_limit_403`: detects all three rate-limit reasons; rejects a scope reason, non-JSON, and empty body.
- `execute()`: a rate-limit 403 is retried and then succeeds; a scope 403 fails immediately with no retry.
- `_time.sleep` is patched so the backoff doesn't slow the suite.

## Verification (run locally)
```
python -m pytest nodes/test/tool_gmail/test_gmail.py  →  90 passed
ruff check   →  All checks passed
ruff format  →  already formatted
```

## Scope
This is the **403 rate-limit retry** item of #1560. The credential-hardening items (token_uri validation, broker-refresh reliability, schemeless broker URL) are handled in #1569; the protobuf floor bump and the `nodes/core/` client hoist remain as separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gmail request handling for temporary rate limits and quota-related errors.
  * Retryable 403 responses are now retried automatically, while authorization and permission errors fail immediately with a clear message.
  * Added coverage for retry behavior, error classification, and malformed responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->