### PR TITLE
fix(shared-ui): key OAuth tier scopes by node provider (#1547)

### DIFF
--- a/apps/vscode/docs/google-oauth.md
+++ b/apps/vscode/docs/google-oauth.md
@@ -16,10 +16,15 @@ browser and receives the resulting tokens through a deep link.
 2. The extension opens the system browser at the broker
    (`https://oauth2.rocketride.ai/google?...`), passing the node's service
    config, a `baseURL` return address, and an explicit `scope` parameter for
-   the node's selected access tier. The broker's default consent grants only
-   Drive and profile scopes — never Gmail — so the tier's Gmail scopes must
-   always be requested explicitly (see `GMAIL_TIER_SCOPES` in
-   `LoginWithGoogleButton.tsx`, mirroring `google_access.py`).
+   the node's selected access tier. Scopes are keyed by the node's provider
+   (see `SERVICE_TIER_SCOPES` in `LoginWithGoogleButton.tsx`, mirroring the
+   per-service `AccessSpec`s in `google_access.py`); an unknown provider or
+   tier sends no `scope` parameter. The broker grants identity
+   (`openid email profile`) plus exactly the requested scopes — least
+   privilege — validated against an allowlist (unknown scopes are rejected
+   with `400 invalid_scope`). Requests without a `scope` parameter fall back
+   to the broker's legacy default consent (identity + Drive), which never
+   includes Gmail.
 3. The user completes Google's consent screen. The broker exchanges the code
    using its own verified Google application; no client secret ever reaches
    the extension or the pipeline config.

--- a/packages/shared-ui/src/components/canvas/components/panels/node-config/NodeConfigPanel.tsx
+++ b/packages/shared-ui/src/components/canvas/components/panels/node-config/NodeConfigPanel.tsx
@@ -589,6 +589,7 @@ export default function NodeConfigPanel({ node, onClose }: INodeConfigPanelProps
 										googlePickerDeveloperKey,
 										googlePickerClientId,
 										nodeId: node.id,
+										provider: node.data.provider,
 										formDataErrors: node.data.formDataErrors,
 										envKeys,
 									}}

--- a/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
+++ b/packages/shared-ui/src/components/canvas/components/rjsf-widgets/social-buttons/LoginWithGoogleButton.tsx
@@ -86,22 +86,26 @@ export default function LoginWithGoogleButton<T = unknown, S extends StrictRJSFS
 		// a deep link via oauthReturnUrl that they intercept out-of-band.
 		url.searchParams.set('baseURL', oauthReturnUrl || window.location.href);
 
-		// Pass the selected tier's Gmail scopes explicitly — the broker's default
-		// consent grants only Drive + profile scopes, never Gmail, so every tier
-		// (including readonly/modify) must request its scopes here. Keys mirror
-		// google_access.py GMAIL.scopes; non-Gmail services whose access field
-		// uses different values (e.g. 'write') won't match any key here.
+		// Pass the selected tier's scopes explicitly, keyed by the node's
+		// provider — the broker grants identity plus exactly the requested
+		// scopes (least privilege), or its legacy default consent when no
+		// scope param is sent. Maps mirror the per-service AccessSpecs in
+		// core/google_access.py. An unknown provider or tier sends no scope
+		// param rather than guessing another service's scopes.
 		const _G = 'https://www.googleapis.com/auth';
-		const GMAIL_TIER_SCOPES: Record<string, string[]> = {
-			readonly: [`${_G}/gmail.readonly`],
-			modify: [`${_G}/gmail.modify`],
-			send: [`${_G}/gmail.modify`, `${_G}/gmail.send`],
-			settings: [`${_G}/gmail.modify`, `${_G}/gmail.settings.basic`],
-			settings_sharing: [`${_G}/gmail.modify`, `${_G}/gmail.settings.basic`, `${_G}/gmail.settings.sharing`],
-			full: ['https://mail.google.com/'],
+		const SERVICE_TIER_SCOPES: Record<string, Record<string, string[]>> = {
+			tool_gmail: {
+				readonly: [`${_G}/gmail.readonly`],
+				modify: [`${_G}/gmail.modify`],
+				send: [`${_G}/gmail.modify`, `${_G}/gmail.send`],
+				settings: [`${_G}/gmail.modify`, `${_G}/gmail.settings.basic`],
+				settings_sharing: [`${_G}/gmail.modify`, `${_G}/gmail.settings.basic`, `${_G}/gmail.settings.sharing`],
+				full: ['https://mail.google.com/'],
+			},
 		};
+		const provider = formContext?.provider as string | undefined;
 		const accessTier = (formValues.access ?? formValues.parameters?.access) as string | undefined;
-		const tierScopes = accessTier ? GMAIL_TIER_SCOPES[accessTier] : undefined;
+		const tierScopes = provider && accessTier ? SERVICE_TIER_SCOPES[provider]?.[accessTier] : undefined;
 		if (tierScopes?.length) {
 			url.searchParams.set('scope', tierScopes.join(' '));
 		}


### PR DESCRIPTION
## Summary

- Pass `node.data.provider` into the RJSF `formContext` so the Google login widget knows which service it is configuring
- Key the OAuth scope map by provider (`SERVICE_TIER_SCOPES[provider][tier]`) instead of tier name alone; unknown provider/tier sends no `scope` param rather than guessing another service's scopes (previously a future non-Gmail node with `access='readonly'` would have requested `gmail.readonly`)
- Pairs with the broker least-privilege change (rocketride-ai/terraform `fix/oauth2-google-scope-passthrough`): broker grants identity + exactly the requested scopes, so a Gmail-tier login no longer also receives full Drive access

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Related Issues

Refs #1547 — full fix also requires the broker Lambda deploy in rocketride-ai/terraform (branch `fix/oauth2-google-scope-passthrough`, pending push by repo owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google sign-in scope handling across providers and access tiers.
  * Requests only approved scopes and returns a clear error for unsupported scopes.
  * Preserves legacy sign-in behavior when no scope is specified.
* **Documentation**
  * Clarified Google OAuth scope selection, validation, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->