### PR TITLE
fix(nodes): reclassify FalkorDB as database, not store

### DIFF
--- a/nodes/src/nodes/tool_falkordb/services.json
+++ b/nodes/src/nodes/tool_falkordb/services.json
@@ -1,7 +1,7 @@
 {
 	"title": "FalkorDB",
 	"protocol": "tool_falkordb://",
-	"classType": ["store", "tool"],
+	"classType": ["database", "tool"],
 	"capabilities": ["invoke", "experimental"],
 	"register": "filter",
 	"node": "python",


### PR DESCRIPTION
Phase 1 of Joe's FalkorDB request (EU/US Dev sync, for **today's release**): FalkorDB is a graph DB, not a vector store, so reclassify its `classType` from `store` to `database` — mirroring `db_neo4j` / `db_hydradb` (`["database","tool"]`). Undoes the classType from #1474.

One-line change; validated JSON.

**Deferred (Joe's optional / Phase 2):** the `tool_falkordb`→`db_falkordb` rename (touches the protocol, module path, and every field key → can break existing pipes, so not a same-day change) and the new dedicated `graph` classType + class.

cc @anandray for review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the FalkorDB tool classification to identify it as a database service while retaining its tool designation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->