### PR TITLE
fix(nodes): reclassify FalkorDB as database, not store [stage]

### DIFF
--- a/nodes/src/nodes/tool_falkordb/services.json
+++ b/nodes/src/nodes/tool_falkordb/services.json
@@ -1,7 +1,7 @@
 {
 	"title": "FalkorDB",
 	"protocol": "tool_falkordb://",
-	"classType": ["store", "tool"],
+	"classType": ["database", "tool"],
 	"capabilities": ["invoke", "experimental"],
 	"register": "filter",
 	"node": "python",


### PR DESCRIPTION
Dual-PR (stage) of #1580 per Rod's develop+stage rule, so the release ships FalkorDB classType `[database,tool]` not `store`. Ariel approved merging this interim while he extracts the proper `graph` base-class separately. cc @anandray