### PR TITLE
ci(lockfile): use RELEASE_BOT_* App secrets (rocketride-server naming)

### DIFF
--- a/.github/workflows/lock-node-deps.yml
+++ b/.github/workflows/lock-node-deps.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload lockfile artifact
         if: ${{ steps.compile.outcome == 'success' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: node-constraints-lock
           path: ${{ env.LOCKFILE }}

--- a/.github/workflows/lock-node-deps.yml
+++ b/.github/workflows/lock-node-deps.yml
@@ -67,8 +67,8 @@ jobs:
         if: ${{ github.event_name != 'pull_request' }}
         uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
         with:
-          app-id: ${{ secrets.GH_APP_ID }}
-          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_PRIVATE_KEY }}
           permission-contents: write
 
       - name: Checkout


### PR DESCRIPTION
## What
The just-merged `lock-node-deps.yml` referenced `secrets.GH_APP_ID` / `GH_APP_PRIVATE_KEY` — that's the **saas/terraform** App naming. rocketride-server's App-token secrets are **`RELEASE_BOT_APP_ID` / `RELEASE_BOT_PRIVATE_KEY`** (same App used by `_release.yaml`). The first real dispatch failed at the app-token step (`Input required and not supplied: app-id`) **before reaching the compile**, so the `--no-build-isolation` solve is still unvalidated.

## Fix
Point the two secret refs at `RELEASE_BOT_*`. After this merges I'll re-dispatch to actually validate the universal solve.

## Follow-up caveat (not this PR)
The auto-commit path does `git push origin HEAD:develop`. develop is protected (PR + CI + conversation-resolution), so the bot push only works if the RELEASE_BOT App is a **bypass actor** on develop — needs verifying. On `pull_request` the token step is skipped entirely (solve-only), so the **lint-gate use case is unaffected** either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)