### PR TITLE
fix(build): make Breakpad symbol generation non-fatal (#1595)

### DIFF
--- a/packages/server/CMakeLists.txt
+++ b/packages/server/CMakeLists.txt
@@ -137,6 +137,10 @@ option(BUILD_TESTS "Build test suites" ON)
 option(BUILD_DOCS "Build documentation" OFF)
 option(ENABLE_PYTHON "Enable Python node support" ON)
 
+# Breakpad symbols are only needed to symbolicate crash dumps, so a dump_syms
+# failure warns instead of failing the build. Release/CI can force it on.
+option(ROCKETRIDE_REQUIRE_BREAKPAD_SYMBOLS "Fail the build if Breakpad symbol generation fails" OFF)
+
 message(STATUS "Build tests : ${BUILD_TESTS}")
 message(STATUS "Build docs  : ${BUILD_DOCS}")
 message(STATUS "Python support: ${ENABLE_PYTHON}")

--- a/packages/server/cmake/rocketride.cmake
+++ b/packages/server/cmake/rocketride.cmake
@@ -78,15 +78,25 @@ function(rocketride_set_common_target_options target)
             if(ROCKETRIDE_PLAT_LIN AND "${CMAKE_BUILD_TYPE}" MATCHES "Release")
                 set(breakpad_bin_dump_syms "${VCPKG_INSTALLED_TRIPLET_DIR}/bin/dump_syms")
                 if(NOT EXISTS ${breakpad_bin_dump_syms})
-                    message(FATAL_ERROR "Breakpad's dump_syms tool not found at expected path: ${breakpad_bin_dump_syms}")
-                endif()
+                    if(ROCKETRIDE_REQUIRE_BREAKPAD_SYMBOLS)
+                        message(FATAL_ERROR "Breakpad's dump_syms tool not found at expected path: ${breakpad_bin_dump_syms}")
+                    endif()
+                    message(WARNING "Breakpad's dump_syms tool not found at ${breakpad_bin_dump_syms}; building ${TARGET_NAME} without Breakpad symbols")
+                else()
+                    rocketride_msg("Breakpad's dump_syms tool found at ${breakpad_bin_dump_syms}")
 
-                rocketride_msg("Breakpad's dump_syms tool found at ${breakpad_bin_dump_syms}")
-                add_custom_command(TARGET ${target} POST_BUILD
-                    COMMAND ${CMAKE_COMMAND} -E env bash -c "${breakpad_bin_dump_syms} ${TARGET_DEBUG_FILE} > ${TARGET_DEBUG_SYMS_FILE}"
-                    COMMENT "Dumping Breakpad symbols from ${TARGET_NAME}(${TARGET_DEBUG_SYMS_FILE})"
-                    VERBATIM
-                )
+                    set(dump_syms_cmd "${breakpad_bin_dump_syms} ${TARGET_DEBUG_FILE} > ${TARGET_DEBUG_SYMS_FILE}")
+                    if(NOT ROCKETRIDE_REQUIRE_BREAKPAD_SYMBOLS)
+                        # Discard the truncated output so nothing downstream mistakes it for real symbols.
+                        string(APPEND dump_syms_cmd " || { rm -f ${TARGET_DEBUG_SYMS_FILE}; echo 'WARNING: dump_syms failed for ${TARGET_NAME}; continuing without Breakpad symbols' >&2; }")
+                    endif()
+
+                    add_custom_command(TARGET ${target} POST_BUILD
+                        COMMAND ${CMAKE_COMMAND} -E env bash -c "${dump_syms_cmd}"
+                        COMMENT "Dumping Breakpad symbols from ${TARGET_NAME}(${TARGET_DEBUG_SYMS_FILE})"
+                        VERBATIM
+                    )
+                endif()
             endif()
         endif()
     endif()


### PR DESCRIPTION
## Summary

A dump_syms failure aborted the entire engine build, even though the symbols are only used to symbolicate crash dumps — nothing on Linux consumes engine.symbols downstream (tasks.js packages it on Windows only).

Guard both failure paths behind ROCKETRIDE_REQUIRE_BREAKPAD_SYMBOLS (default OFF): a missing dump_syms tool and a failing dump now warn and continue instead of failing. On failure the truncated output is removed so nothing mistakes an empty engine.symbols for real symbols — the shell redirect creates the file before dump_syms runs.

Build with -DROCKETRIDE_REQUIRE_BREAKPAD_SYMBOLS=ON to restore the previous fail-hard behaviour for release/CI.

## Type

fix

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a build option to control whether Breakpad crash-symbol generation is required.

* **Bug Fixes**
  * Builds can now continue with a warning when Breakpad tools are unavailable or symbol generation fails, unless strict enforcement is enabled.
  * Prevented incomplete crash-symbol files from being used after generation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->