### PR TITLE
ci(os-matrix): fix the container env so the distro matrix actually runs

### DIFF
--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -21,6 +21,9 @@ permissions:
 
 env:
   GH_TOKEN: ${{ github.token }}
+  # Non-interactive apt so tzdata/debconf never block the install in a container
+  # with no tty (harmless on the dnf distros).
+  DEBIAN_FRONTEND: noninteractive
   # Build every vcpkg dependency from source on each distro (no binary cache) —
   # that is the actual cross-OS compile test. A read-only nuget cache can be
   # layered in later to speed up the triplet-matching legs.
@@ -43,21 +46,46 @@ jobs:
           - fedora:latest
           - almalinux:9 # RHEL-compatible; may need EPEL / RHEL-column tuning in compiler-unix.sh — a break here is informative
     steps:
-      # Minimal base images ship without git; actions/checkout needs it for a
-      # real clone (submodules), so bootstrap it (+ curl/ca-certificates) first.
-      - name: Bootstrap git
+      # Minimal base images ship without git, Python, or the Python build
+      # backends. actions/checkout needs git; compiler-unix.sh installs the
+      # C/C++ toolchain but requires — and does not install — python3 plus the
+      # `build`/`wheel` modules (it prints "Missing Python build tools" and
+      # exits). Provide all of it here so the matrix tests the engine, not the
+      # bare base image.
+      - name: Bootstrap base build prerequisites
         shell: bash
         run: |
+          set -eux
           if command -v apt-get >/dev/null 2>&1; then
-            apt-get update && apt-get install -y --no-install-recommends git ca-certificates curl
+            apt-get update
+            apt-get install -y --no-install-recommends \
+              git ca-certificates curl \
+              python3 python3-pip python3-venv
           elif command -v dnf >/dev/null 2>&1; then
-            dnf install -y git ca-certificates curl
+            # --allowerasing: minimal EL/Fedora images ship curl-minimal, which
+            # conflicts with the full curl package and aborts the whole install.
+            dnf install -y --allowerasing \
+              git ca-certificates curl \
+              python3 python3-pip
           fi
+          # Pre-provide the Python build backends compiler-unix.sh refuses to
+          # auto-install. --break-system-packages for PEP-668 (24.04+/Fedora
+          # mark the system env externally-managed); the fallback covers the
+          # older pip on 22.04 that lacks that flag.
+          python3 -m pip install --break-system-packages --upgrade build wheel \
+            || python3 -m pip install --upgrade build wheel
 
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
+
+      # The container runs as root but the checked-out tree is owned by the
+      # runner UID (host bind-mount), so git aborts ./builder's calls with
+      # "detected dubious ownership". Trust the workspace.
+      - name: Trust the workspace
+        shell: bash
+        run: git config --global --add safe.directory '*'
 
       - name: Install build prerequisites (cross-distro)
         shell: bash

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: recursive
-
+          persist-credentials: false
       # The container runs as root but the checked-out tree is owned by the
       # runner UID (host bind-mount), so git aborts ./builder's calls with
       # "detected dubious ownership". Trust the workspace.

--- a/.github/workflows/os-matrix.yml
+++ b/.github/workflows/os-matrix.yml
@@ -69,11 +69,14 @@ jobs:
               python3 python3-pip
           fi
           # Pre-provide the Python build backends compiler-unix.sh refuses to
-          # auto-install. --break-system-packages for PEP-668 (24.04+/Fedora
-          # mark the system env externally-managed); the fallback covers the
-          # older pip on 22.04 that lacks that flag.
-          python3 -m pip install --break-system-packages --upgrade build wheel \
-            || python3 -m pip install --upgrade build wheel
+          # auto-install. No --upgrade: on 24.04+ `wheel` is distro-managed and
+          # pip can't uninstall it (no RECORD) — upgrading aborts the whole
+          # bootstrap; a plain install just skips the already-satisfied wheel.
+          # --break-system-packages for PEP-668 (24.04+/Fedora mark the env
+          # externally-managed); the fallback covers 22.04's older pip that
+          # lacks that flag (and isn't externally-managed anyway).
+          python3 -m pip install --break-system-packages build wheel \
+            || python3 -m pip install build wheel
 
       - name: Check out repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
The **OS Matrix** was red on all five legs — but for **container-environment** reasons, not engine regressions, so it couldn't tell us which distros actually compile. Diagnosed from the 07-15 dispatch (all 5 failed at *different* steps):

| Leg | Failed at | Root cause |
|---|---|---|
| almalinux:9 | Bootstrap | `dnf install curl` conflicts with `curl-minimal` in the base image |
| ubuntu 22/24/26 | compiler-unix.sh | toolchain installs, then "Missing Python build tools" — the minimal image lacks python3 + the `build`/`wheel` backends it requires but won't auto-install (#1465 correctly made this fatal) |
| fedora:latest | `./builder` build | `fatal: detected dubious ownership` — root container vs runner-owned checkout |

### Fix (workflow-only)
- Bootstrap now installs **python3 + pip + venv** and pip-installs **`build`/`wheel`** (`--break-system-packages` for PEP-668, with a fallback for 22.04's older pip).
- `dnf --allowerasing` so `curl` can replace `curl-minimal`.
- `git config --global --add safe.directory '*'` after checkout.
- `DEBIAN_FRONTEND=noninteractive` job-wide.

Now the legs get past setup and the matrix surfaces **real** per-distro compile/test results — its whole purpose. I'm dispatching it on this branch to validate; genuine per-distro breaks that remain (e.g. RHEL-column tuning on almalinux, or a too-new toolchain on fedora) are the matrix doing its job and are separate follow-ups.

cc @asclearuc (you hit this on Fedora this morning) — this unblocks running compilation through the matrix instead of local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved cross-platform CI setup by ensuring required build tools and Python environment components are available before running tests.
  * Prevented interactive dependency prompts during automated package installation.
  * Added a workspace trust configuration to avoid repository “dubious ownership” errors in containerized runs.
  * Pre-installed Python packaging tooling needed to build distributions as part of the test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->