### PR TITLE
fix(checkout): carry validated promo into preselected-plan checkout (stage)

### DIFF
--- a/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
+++ b/apps/shell-ui/src/components/layout/CheckoutFlow.tsx
@@ -26,7 +26,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { CheckoutModal } from 'shared';
-import type { CheckoutPlan } from 'shared';
+import type { CheckoutPlan, PromoValidation } from 'shared';
 import { ConnectionManager } from '../../connection/connection';
 import type { AppManifestEntry } from '../../workspace/types';
 
@@ -57,6 +57,10 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 	/** Optional plan preselected by the caller (e.g. the web pricing page) to
 	 *  skip the picker and go straight to payment; null = show the picker. */
 	const [presetPlan, setPresetPlan] = useState<CheckoutPlan | null>(null);
+	/** Optional validated discount code passed alongside the preselected plan
+	 *  (e.g. from the web pricing page) so it rides into the auto-advanced
+	 *  checkout; null = no promo. Cleared whenever presetPlan is cleared. */
+	const [presetPromo, setPresetPromo] = useState<PromoValidation | null>(null);
 	/** Pending timer that clears the post-purchase welcome status message. */
 	const statusClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -70,9 +74,10 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 	useEffect(() => {
 		return ConnectionManager.getInstance().on(
 			'shell:subscribe',
-			({ app, plan }: { app: unknown; plan?: CheckoutPlan }) => {
+			({ app, plan, promo }: { app: unknown; plan?: CheckoutPlan; promo?: PromoValidation | null }) => {
 				setCheckoutApp(app as AppManifestEntry);
 				setPresetPlan(plan ?? null);
+				setPresetPromo(promo ?? null);
 			},
 		);
 	}, []);
@@ -101,6 +106,7 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 			appDescription={checkoutApp.description}
 			stripePublishableKey={stripeKey}
 			preselectedPlan={presetPlan ?? undefined}
+			preselectedPromo={presetPromo ?? undefined}
 			onFetchPlans={async () => {
 				const c = cm.getClient();
 				if (!c) throw new Error('Not connected');
@@ -139,6 +145,7 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 				const appName = checkoutApp.name;
 				setCheckoutApp(null);
 				setPresetPlan(null);
+				setPresetPromo(null);
 				cm.emit('shell:switchApp', { appId });
 				cm.emit('shell:statusMessage', { message: `Welcome to ${appName} — your plan is now active.` });
 				// Auto-clear so the confirmation doesn't linger in the status bar.
@@ -146,7 +153,7 @@ export const CheckoutFlow: React.FC<CheckoutFlowProps> = ({ stripeKey, orgId }) 
 				if (statusClearTimer.current) clearTimeout(statusClearTimer.current);
 				statusClearTimer.current = setTimeout(() => cm.emit('shell:statusMessage', { message: null }), 5000);
 			}}
-			onClose={() => { setCheckoutApp(null); setPresetPlan(null); }}
+			onClose={() => { setCheckoutApp(null); setPresetPlan(null); setPresetPromo(null); }}
 		/>
 	);
 };

--- a/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
+++ b/packages/shared-ui/src/modules/checkout/CheckoutModal.tsx
@@ -445,6 +445,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 	appDescription,
 	stripePublishableKey,
 	preselectedPlan,
+	preselectedPromo,
 	onFetchPlans,
 	onCreateCheckout,
 	onConfirmPending,
@@ -473,7 +474,7 @@ export const CheckoutModal: React.FC<CheckoutModalProps> = ({
 	// ── Promo code state ─────────────────────────────────────────────────
 	const promoEnabled = Boolean(onValidatePromoCode);
 	const [promoInput, setPromoInput] = useState('');
-	const [appliedPromo, setAppliedPromo] = useState<PromoValidation | null>(null);
+	const [appliedPromo, setAppliedPromo] = useState<PromoValidation | null>(preselectedPromo ?? null);
 	const [promoBusy, setPromoBusy] = useState(false);
 	const [promoError, setPromoError] = useState<string | null>(null);
 	// Set after a grant/hackathon code redeems — renders the success block

--- a/packages/shared-ui/src/modules/checkout/types.ts
+++ b/packages/shared-ui/src/modules/checkout/types.ts
@@ -206,6 +206,13 @@ export interface CheckoutModalBaseProps {
 	 */
 	preselectedPlan?: CheckoutPlan;
 
+	/**
+	 * Discount code (already validated on the pricing page) to apply to a
+	 * preselected-plan checkout. Seeds the applied promo so the auto-advanced
+	 * payment step shows and charges the discounted amount.
+	 */
+	preselectedPromo?: PromoValidation | null;
+
 	/** Fetches available subscription plans from the server. */
 	onFetchPlans: () => Promise<CheckoutPlan[]>;
 

--- a/packages/shared-ui/src/types/shell.ts
+++ b/packages/shared-ui/src/types/shell.ts
@@ -34,7 +34,7 @@
 
 import type { ConnectResult, DAPMessage } from 'rocketride';
 import type { ConnectionStatus } from './connection';
-import type { CheckoutPlan } from '../modules/checkout/types';
+import type { CheckoutPlan, PromoValidation } from '../modules/checkout/types';
 
 // =============================================================================
 // APP ENTRY — minimal shape for app catalog events
@@ -185,8 +185,10 @@ export interface ShellConnectionEventMap {
 	 * Opens the CheckoutModal. The `app` field is the manifest entry. The
 	 * optional `plan` preselects a tier and skips the picker — going straight
 	 * to payment (used by the web pricing page); omit it to show the picker.
+	 * The optional `promo` carries a discount code already validated on the
+	 * pricing page, so the skipped-picker checkout still applies the discount.
 	 */
-	'shell:subscribe': { app: ShellAppEntry; plan?: CheckoutPlan };
+	'shell:subscribe': { app: ShellAppEntry; plan?: CheckoutPlan; promo?: PromoValidation | null };
 
 	/** Navigate back to the My Apps launcher screen. */
 	'shell:myApps': Record<string, never>;


### PR DESCRIPTION
Backports the checkout-promo change from #1604 (merged to develop) onto `stage`. Threads a validated promo through `shell:subscribe` / `CheckoutModal` `preselectedPromo` so a promo chosen on the web pricing page applies in the skip-to-payment checkout. Same 4-file scope as #1604, adapted to stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)