### PR TITLE
docs: fix nonexistent 'rrext_store get_all_projects' CLI example

### DIFF
--- a/docs/README-python-client.md
+++ b/docs/README-python-client.md
@@ -570,7 +570,7 @@ rocketride status --token <token>            # Monitor task progress
 rocketride stop --token <token>              # Terminate a running task
 rocketride list                              # List all active tasks
 rocketride events ALL --token <token>        # Stream task events
-rocketride rrext_store get_all_projects      # List stored projects
+rocketride store dir /                       # List the root of the file store
 ```
 
 All commands accept `--uri` and `--apikey` flags, or read from environment variables.

--- a/docs/README-python-client.md
+++ b/docs/README-python-client.md
@@ -573,6 +573,8 @@ rocketride events ALL --token <token>        # Stream task events
 rocketride store dir /                       # List the root of the file store
 ```
 
+The `store` command's sub-commands are `dir`, `type`, `write`, `rm`, `mkdir`, and `stat` — run `rocketride store --help` for details.
+
 All commands accept `--uri` and `--apikey` flags, or read from environment variables.
 
 ## Configuration

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -728,6 +728,8 @@ rocketride events ALL --token <token>        # Stream task events
 rocketride store dir /                       # List the root of the file store
 ```
 
+The `store` command's sub-commands are `dir`, `type`, `write`, `rm`, `mkdir`, and `stat` — run `rocketride store --help` for details.
+
 All commands accept `--uri` and `--apikey` flags, or read from environment variables.
 
 ## Configuration

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -725,7 +725,7 @@ rocketride status --token <token>            # Monitor task progress
 rocketride stop --token <token>              # Terminate a running task
 rocketride list                              # List all active tasks
 rocketride events ALL --token <token>        # Stream task events
-rocketride rrext_store get_all_projects      # List stored projects
+rocketride store dir /                       # List the root of the file store
 ```
 
 All commands accept `--uri` and `--apikey` flags, or read from environment variables.


### PR DESCRIPTION
## Summary


- The CLI examples block in `docs/README-python-client.md` and `packages/client-python/docs/index.md` ends with `rocketride rrext_store get_all_projects`, which is not a real command: the CLI registers the file store as `store` (`packages/client-python/src/rocketride/cli/main.py:470`) — `rrext_store` is only the wire name — and the `store` sub-commands are `dir`, `type`, `write`, `rm`, `mkdir`, `stat` (`cli/commands/store.py:51-58`); there is no `get_all_projects`.
- Replaces that line in both files with `rocketride store dir /`, the invocation already documented for the same command in `packages/docs/content-static/cli.mdx:277` (`store dir` takes an optional positional path, `cli/main.py:484`).
- Adds one sentence under the block listing the six real sub-commands and pointing at `rocketride store --help`, so the example set does not silently drift again.

`docs/README-python-client.md` is the canonical PyPI long description (`packages/client-python/scripts/tasks.js:50-63` copies it into the wheel build dir), so the bad example is currently on the public package page.

## Type

docs (fix)

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes — CI run [33848506282](https://github.com/rocketride-org/rocketride-server/actions/runs/33848506282) on `9b349c09` ran `./builder test --verbose --sequential` in all three Build jobs (Ubuntu 22.04, Windows Server 2022, macOS ARM64), all green; `CI OK` success at 2026-09-04T07:49Z.

Docs-only change; no test file applies. What was verified locally against this branch:

- Built the real argparse parser from `RocketRideCLI.setup_parser()` and confirmed the documented invocation parses: top-level commands are `['events', 'list', 'start', 'status', 'stop', 'store', 'upload']` (no `rrext_store`); `store` sub-commands are exactly `['dir', 'type', 'write', 'rm', 'mkdir', 'stat']`; `parse_args(['store', 'dir', '/'])` yields `command='store'`, `store_subcommand='dir'`, `path='/'`; both `['store', 'get_all_projects']` and `['rrext_store', 'get_all_projects']` exit 2.
- `git grep -n 'rrext_store' -- '*.md' '*.mdx'` and `git grep -n 'get_all_projects' -- '*.md' '*.mdx'` return zero hits after the change (they returned exactly these two lines before). `rrext_store` itself still appears in Python source, as intended — it is the wire name of the command, not a CLI verb.
- `git grep -n 'store dir /'` now hits `docs/README-python-client.md`, `packages/client-python/docs/index.md` and `packages/docs/content-static/cli.mdx:277,280` — the three copies agree.
- The `#` comment column in the bash block is unchanged (column 46, same as the surrounding example lines).
- `ruff check .` -> All checks passed; `ruff format --check .` -> 1473 files already formatted (ruff 0.15.0, on a clean `git archive` of `9b349c09`); `gitleaks git --log-opts=upstream/develop..HEAD` -> no leaks found. (No Python or config is touched by this PR; run for completeness.)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none; docs-only

## Sync with develop (2026-09-04)

- Rebased onto `upstream/develop` @ `65a2e133a10ed762640ce71a63ef13e8abf6dfc0`. Clean rebase, **no conflicts**, nothing dropped or ported. The branch is still exactly two commits:

  | Commit | Subject |
  |---|---|
  | `a6464d63` | docs: fix nonexistent 'rrext_store get_all_projects' CLI example |
  | `9b349c09` | docs: list store sub-commands under the CLI examples (review follow-up) |

- Diff against develop is still exactly the two doc files, **+6 / -2**.
- Since the rebase, develop has moved 6 commits further (`52151540`..`0788b9c4`, latest 2026-09-04T05:02Z). None of them touch either doc file, and `git merge-tree --write-tree upstream/develop <head>` is clean (no conflict entries), so GitHub reports the PR as MERGEABLE; I have not re-pushed for a cosmetic rebase. On `0788b9c4` the bogus line is still present at `docs/README-python-client.md:573` and `packages/client-python/docs/index.md:728`, and the `store` sub-parser still registers exactly `dir`/`type`/`write`/`rm`/`mkdir`/`stat` (`cli/main.py:483-507`).
- CI had last run on 2026-07-17 against a base 162 commits behind. It has now run on `9b349c09`: run [33848506282](https://github.com/rocketride-org/rocketride-server/actions/runs/33848506282) is green end to end — Ruff, gitleaks, Shell API contract (including the credentials-catalog `--check` and regen-derived guards added in August), Build on Ubuntu/Windows/macOS with the Postgres/pgvector + AGE containers, check-externals (PR), and `CI OK`. CodeRabbit's full re-review of `9b349c09` produced no actionable comments and its 5 pre-merge checks all pass.

## Related / overlap

- #1736 replaces the same README line (with `rocketride store dir` and a different comment) but is currently CONFLICTING against develop and does not touch `packages/client-python/docs/index.md`; #2139 deletes both files but is also CONFLICTING. Neither is mergeable today. Happy to align wording to whichever lands first — this PR is a two-line fix that can go in independently and is the only change that fixes both files.

## Linked Issue


Refs #1735 (registry package pages out of date). There is no scoped issue for this specific example yet: I was not able to open one from my account. If a maintainer would rather have a dedicated issue, please file it (or say that `Refs #1735` is enough) and I will add the `Fixes #<n>` line here and rename the branch to `docs/RR-<n>-fix-readme-store-cli-example` per CONTRIBUTING.md. Until then the branch name does not follow the `<type>/RR-<issue>-<desc>` convention for that reason alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Python client CLI examples to replace the outdated project-listing command with `rocketride store dir /` for listing the root of the server file store.
  * Expanded the `store` command documentation to include its available subcommands: `dir`, `type`, `write`, `rm`, `mkdir`, and `stat`.
  * Added guidance to use `rocketride store --help` for additional command details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
