### PR TITLE
fix(server): make the crashpad port build and symbolicate on macOS

### DIFF
--- a/packages/server/cmake/ports/crashpad/portfile.cmake
+++ b/packages/server/cmake/ports/crashpad/portfile.cmake
@@ -133,6 +133,10 @@ elseif(VCPKG_TARGET_IS_LINUX)
 elseif(VCPKG_TARGET_IS_OSX)
     string(APPEND OPTIONS " target_os=\"mac\"")
 
+    # mini_chromium's gn alink shells out to bare `libtool -static` (no gn arg for it),
+    # which picks up Homebrew's GNU libtool if present. Keep Apple's toolchain first.
+    set(ENV{PATH} "/usr/bin:$ENV{PATH}")
+
 elseif(VCPKG_TARGET_IS_WINDOWS AND NOT VCPKG_TARGET_IS_MINGW)
     string(APPEND OPTIONS " target_os=\"win\"")
 

--- a/packages/server/cmake/rocketride.cmake
+++ b/packages/server/cmake/rocketride.cmake
@@ -81,11 +81,18 @@ function(rocketride_set_common_target_options target)
                 find_program(ROCKETRIDE_DUMP_SYMS dump_syms)
                 if(ROCKETRIDE_DUMP_SYMS)
                     set(TARGET_SYMBOLS_DIR ${TARGET_FILE_DIR}/symbols)
-                    # Binary only: dump_syms follows .gnu_debuglink for one .sym with the
-                    # real debug-id (adding the .debug arg emits a spurious zero-id module).
+                    if(ROCKETRIDE_PLAT_MAC)
+                        # No .gnu_debuglink on mac: feed dump_syms the DWARF inside the
+                        # dSYM bundle, or the .sym carries public symbols and no lines.
+                        set(DUMP_SYMS_INPUT ${TARGET_DEBUG_FILE}/Contents/Resources/DWARF/${TARGET_NAME})
+                    else()
+                        # Binary only: dump_syms follows .gnu_debuglink for one .sym with the
+                        # real debug-id (adding the .debug arg emits a spurious zero-id module).
+                        set(DUMP_SYMS_INPUT ${TARGET_FILE})
+                    endif()
                     add_custom_command(TARGET ${target} POST_BUILD
                         COMMAND ${CMAKE_COMMAND} -E make_directory ${TARGET_SYMBOLS_DIR}
-                        COMMAND sh -c "\"$0\" \"$1\" --store \"$2\" >/dev/null" ${ROCKETRIDE_DUMP_SYMS} ${TARGET_FILE} ${TARGET_SYMBOLS_DIR}
+                        COMMAND sh -c "\"$0\" --inlines \"$1\" --store \"$2\" >/dev/null" ${ROCKETRIDE_DUMP_SYMS} ${DUMP_SYMS_INPUT} ${TARGET_SYMBOLS_DIR}
                         COMMENT "Dumping symbols from ${TARGET_NAME} to ${TARGET_SYMBOLS_DIR}"
                         VERBATIM
                     )

--- a/scripts/compiler-unix.sh
+++ b/scripts/compiler-unix.sh
@@ -69,6 +69,7 @@ LLVM_APT_VERSION=""         # apt.llvm.org clang major to add when the distro ar
 LLVM_TARBALL_PREFIX="$REAL_HOME/toolchains/llvm"  # user-local install root (no root needed to unpack)
 LLVM_TARBALL_FALLBACK="18.1.8"  # used only if the latest 18.x can't be discovered online
 DUMP_SYMS_DIR="$REAL_HOME/toolchains/bin"  # user-local bin for build tools (dump_syms); on the build PATH via tasks.js
+DUMP_SYMS_VERSION="v2.3.7"  # pinned: the releases/latest API is unauthenticated and rate-limited on CI
 
 # Supported clang range on Linux: 16 (Crashpad needs C++20 <ranges>) .. 18
 # (engine doesn't build with clang >= 19). Install target is clang-18.
@@ -598,16 +599,15 @@ install_dump_syms() {
     local os arch asset
     os=$(uname -s); arch=$(uname -m)
     case "$os/$arch" in
-        Linux/x86_64)  asset='dump_syms-x86_64-unknown-linux-gnu\.tar\.xz' ;;
-        Darwin/arm64)  asset='dump_syms-aarch64-apple-darwin\.tar\.xz' ;;
-        Darwin/x86_64) asset='dump_syms-x86_64-apple-darwin\.tar\.xz' ;;
+        Linux/x86_64)  asset='dump_syms-x86_64-unknown-linux-gnu.tar.xz' ;;
+        Darwin/arm64)  asset='dump_syms-aarch64-apple-darwin.tar.xz' ;;
+        Darwin/x86_64) asset='dump_syms-x86_64-apple-darwin.tar.xz' ;;
         *) echo "⚠ no prebuilt dump_syms for $os/$arch — install it manually (cargo install dump_syms) for crash symbols"; return 0 ;;
     esac
 
-    local url
-    url=$(curl -fsSL "https://api.github.com/repos/mozilla/dump_syms/releases/latest" 2>/dev/null \
-          | grep -oE '"browser_download_url": *"[^"]+"' | cut -d'"' -f4 | grep -E "$asset" | head -1)
-    [ -z "$url" ] && { echo "⚠ no prebuilt dump_syms release found for $os/$arch — skipping"; return 0; }
+    # Build the release URL from the pinned tag: querying releases/latest needs no auth
+    # but is IP-rate-limited, and a throttled reply silently skipped the install.
+    local url="https://github.com/mozilla/dump_syms/releases/download/$DUMP_SYMS_VERSION/$asset"
 
     echo "→ downloading dump_syms ($arch)..."
     local tmp; tmp=$(as_user mktemp -d)


### PR DESCRIPTION
## Summary

The two macOS issues from my review of #1524, fixed and verified on this Mac (macOS 26.5 / Apple Silicon). Targets `feat/crashpad` so they land inside your PR — merge or cherry-pick, whatever suits you.

Three atomic commits, one per root cause:

1. **`libtool`** — the port doesn't build on a typical dev Mac. mini_chromium's gn `alink` shells out to bare `libtool -static`, and Homebrew's GNU libtool wins if it's on PATH. There's no gn arg for libtool (mac uses it instead of `ar`, so `clang_path` doesn't reach it), so the port now puts Apple's toolchain first on its own PATH.
2. **`dump_syms` never installed on mac** — `install_dump_syms` resolved the asset via the unauthenticated `releases/latest` API, which is IP-rate-limited; the empty reply was swallowed and mac shipped with no symbol store. Now the URL is built from a pinned tag: no API call, no rate limit, no token, same version everywhere.
3. **`dump_syms` invocation was Linux-only** — `dump_syms <binary>` follows `.gnu_debuglink`, which macOS doesn't have, so the dSYM `dsymutil` had just produced was ignored. Now mac gets the DWARF inside the bundle, plus `--inlines`. Linux is unchanged.

## Testing

**1 — libtool (A/B, real port build, Homebrew libtool on PATH):**

| portfile | result |
|---|---|
| `feat/crashpad` as-is | ❌ `libtool: error: unrecognised option: '-static'` → `ninja: build stopped` at `obj/util/libmig_output.a` |
| with this fix | ✅ 196 objects, static libs archived, `crashpad_handler` is a valid arm64 Mach-O and runs |

**2 — dump_syms install:** ran the real function on Darwin/arm64 where CI logged `no prebuilt dump_syms release found — skipping`; the pinned URL installs `dump_syms 2.3.7`. All three assets (linux-gnu, aarch64-darwin, x86_64-darwin) verified present at the pinned tag, which is also currently `latest`.

**3 — symbols:** built a Release target through the same `POST_BUILD` sequence as `rocketride.cmake` (dsymutil → dump_syms), with a `static` function and a forced-inline frame:

| dump_syms input | symbols |
|---|---|
| `<binary>` (current) | FUNC=0 FILE=0 INLINE=0 — public only |
| `<dSYM>/Contents/Resources/DWARF/<bin>` + `--inlines` | FUNC=1 FILE=1 INLINE=3 |

Debug-id in the generated `.sym` matches the linked image's UUID in both cases, so `minidump-stackwalk` finds it — the difference is purely what's inside. That's `func + 0x4` versus `file:line`.

Not run: `./builder test` end-to-end (these touch the port build and symbol generation, so CI on the three runners is the real check). Windows is untouched.

## Notes

- The `set(ENV{PATH})` in the portfile is scoped to the port build. On an `appleclang` triplet, preferring `/usr/bin` also keeps gn's bare `clang` consistent with the compiler the rest of the engine uses, which is the intent anyway.
- `--inlines` applies on Linux too — same command line. It only adds INLINE records.
- The minor points from my review (old crashpad REF vs macOS 26, `crashpad_handler` duplicated under `tools/` and `tools/crashpad/`, dump DB in `TMPDIR`, signing the extra binary for Gatekeeper) are **not** in here — happy to take any of them separately if you want.
