### PR TITLE
docs: agent/crawler readiness — robots.txt, sitemap lastmod, ship the LLM surface

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,6 +32,10 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
+          # docs:gather stamps each page with its source file's last commit
+          # date, which feeds the sitemap's <lastmod>. A shallow clone has a
+          # single commit, so every page would date to the clone day.
+          fetch-depth: 0
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:

--- a/packages/docs/.gitignore
+++ b/packages/docs/.gitignore
@@ -6,10 +6,11 @@
 /content
 
 # Generated static artifacts (.md siblings, llms.txt, llms-full.txt).
-# Keep committed assets (img/) and the placeholder.
+# Keep committed assets (img/, robots.txt) and the placeholder.
 /static/*
 !/static/.gitkeep
 !/static/img/
+!/static/robots.txt
 
 node_modules
 *.log

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -61,8 +61,14 @@ const config: Config = {
 					path: contentPath,
 					routeBasePath: '/',
 					sidebarPath: './sidebars.ts',
+					showLastUpdateTime: true,
 				},
 				blog: false,
+				sitemap: {
+					lastmod: 'date',
+					changefreq: null,
+					priority: null,
+				},
 				theme: {
 					customCss: './src/css/custom.css',
 				},

--- a/packages/docs/scripts/lib/gather.js
+++ b/packages/docs/scripts/lib/gather.js
@@ -261,13 +261,62 @@ function discoverContributors() {
 	return contributors;
 }
 
-/** Remove generated artifacts from static/ (keep .gitkeep and img/). */
+/** Remove generated artifacts from static/ (keep .gitkeep, img/, and committed files). */
 async function clearGeneratedStatic(staticDir) {
 	if (!(await exists(staticDir))) return;
+	const KEEP = new Set(['.gitkeep', 'img', 'robots.txt']);
 	for (const name of await readDir(staticDir)) {
-		if (name === '.gitkeep' || name === 'img') continue;
+		if (KEEP.has(name)) continue;
 		await rm(path.join(staticDir, name));
 	}
+}
+
+// --- last_update stamping ----------------------------------------------------
+// The assembled content tree under BUILD_ROOT is not git-tracked, so Docusaurus
+// cannot infer page dates there (`showLastUpdateTime` finds nothing and the
+// sitemap emits no <lastmod>). Stamp each staged page's front matter with the
+// SOURCE file's last git commit date instead — Docusaurus prefers a
+// `last_update` front-matter entry over git when present.
+const { execFileSync } = require('node:child_process');
+const _gitDateCache = new Map();
+
+/**
+ * Last commit date (YYYY-MM-DD) of a source file, or null outside a git
+ * checkout / for untracked files. Cached per path. Requires git history at
+ * build time — a shallow CI clone collapses every date to the clone day, so
+ * the docs job should use fetch-depth: 0.
+ * @param {string} srcAbs - absolute path of the git-tracked source file.
+ * @return {string|null}
+ */
+function gitLastUpdate(srcAbs) {
+	if (_gitDateCache.has(srcAbs)) return _gitDateCache.get(srcAbs);
+	let date = null;
+	try {
+		date = execFileSync('git', ['log', '-1', '--format=%cs', '--', srcAbs], {
+			cwd: path.dirname(srcAbs), encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'],
+		}).trim() || null;
+	} catch {
+		/* not a git checkout — leave null; the page simply carries no date */
+	}
+	_gitDateCache.set(srcAbs, date);
+	return date;
+}
+
+/**
+ * Merge `last_update: {date}` into a page's front matter (creating the block
+ * when absent). No-op when date is null or the page already declares one.
+ * @param {string} content - staged page content (md/mdx).
+ * @param {string|null} date - YYYY-MM-DD from gitLastUpdate().
+ * @return {string}
+ */
+function stampLastUpdate(content, date) {
+	if (!date || /(^|\n)last_update\s*:/.test(content)) return content;
+	if (content.startsWith('---\n')) {
+		const end = content.indexOf('\n---', 4);
+		if (end !== -1) return `${content.slice(0, end)}\nlast_update:\n  date: ${date}${content.slice(end)}`;
+		return content;
+	}
+	return `---\nlast_update:\n  date: ${date}\n---\n\n${content}`;
 }
 
 /**
@@ -291,7 +340,9 @@ async function stageFile({ srcAbs, destAbs, siblingAbs, content, mode }) {
 			await copyFile(srcAbs, destAbs); // Windows symlink may need privilege
 		}
 	} else {
-		await copyFile(srcAbs, destAbs);
+		// Real write instead of a byte copy so the staged page carries the source
+		// file's git date (the assembled content tree itself is not git-tracked).
+		await writeFileEnsure(destAbs, stampLastUpdate(content, gitLastUpdate(srcAbs)));
 	}
 	// Raw pre-MDX sibling for the LLM surface.
 	await writeFileEnsure(siblingAbs, content);
@@ -393,7 +444,7 @@ async function gather({ projectRoot, contentStaticDir, contentDir, staticDir, mo
 			// index so the parent label is clickable.
 			const folderRel = toPosix(path.join(NODES_DIR, cat.slug, name));
 			await writeFileEnsure(path.join(contentDir, folderRel, '_category_.json'), JSON.stringify({ label, collapsed: true, link: { type: 'doc', id: `${folderRel}/index` } }, null, 2));
-			await writeFileEnsure(path.join(contentDir, folderRel, 'index.md'), stageNodeMarkdown(content, { slug: `/${route}`, title: existingTitle ? null : label }));
+			await writeFileEnsure(path.join(contentDir, folderRel, 'index.md'), stampLastUpdate(stageNodeMarkdown(content, { slug: `/${route}`, title: existingTitle ? null : label }), gitLastUpdate(srcAbs)));
 			await writeFileEnsure(path.join(staticDir, `${route}.md`), content);
 			manifest.push({ id: route, route: `/${route}`, title: label, mdSibling: `/${route}.md`, source: srcAbs, node: name, category: cat.label, categoryOrder: cat.position, description });
 			const serviceDescriptions = await readServiceDescriptions(nodeDir);
@@ -406,7 +457,7 @@ async function gather({ projectRoot, contentStaticDir, contentDir, staticDir, mo
 				const vExistingTitle = frontMatterTitle(vcontent);
 				const vlabel = vExistingTitle || nodeLabel(variant, '');
 				const vdescription = variantDescription(variant, serviceDescriptions);
-				await writeFileEnsure(path.join(contentDir, folderRel, `${variant}.md`), stageNodeMarkdown(vcontent, { slug: `/${vroute}`, title: vExistingTitle ? null : vlabel }));
+				await writeFileEnsure(path.join(contentDir, folderRel, `${variant}.md`), stampLastUpdate(stageNodeMarkdown(vcontent, { slug: `/${vroute}`, title: vExistingTitle ? null : vlabel }), gitLastUpdate(vsrcAbs)));
 				await writeFileEnsure(path.join(staticDir, `${vroute}.md`), vcontent);
 				manifest.push({ id: vroute, route: `/${vroute}`, title: vlabel, mdSibling: `/${vroute}.md`, source: vsrcAbs, node: name, variant, category: cat.label, categoryOrder: cat.position, description: vdescription });
 			}
@@ -416,7 +467,7 @@ async function gather({ projectRoot, contentStaticDir, contentDir, staticDir, mo
 		// fills in when missing, and the body H1 is dropped to avoid a duplicate
 		// heading. Always a real write — a symlink can't carry the edits.
 		const destAbs = path.join(contentDir, NODES_DIR, cat.slug, `${name}.md`);
-		await writeFileEnsure(destAbs, stageNodeMarkdown(content, { slug: `/${route}`, title: existingTitle ? null : label }));
+		await writeFileEnsure(destAbs, stampLastUpdate(stageNodeMarkdown(content, { slug: `/${route}`, title: existingTitle ? null : label }), gitLastUpdate(srcAbs)));
 		await writeFileEnsure(path.join(staticDir, `${route}.md`), content);
 		manifest.push({ id: route, route: `/${route}`, title: label, mdSibling: `/${route}.md`, source: srcAbs, node: name, category: cat.label, categoryOrder: cat.position, description });
 	}

--- a/packages/docs/scripts/lib/gather.js
+++ b/packages/docs/scripts/lib/gather.js
@@ -91,12 +91,17 @@ async function readNodeMeta(nodeDir) {
 	return { classType, title, description: extractDescription(text) };
 }
 
-/** Extract a first-sentence description from a raw services*.json text string. */
+/**
+ * Extract a first-sentence description from a raw services*.json text string.
+ * The JSON `description` is an array of complete lines, so they join with a
+ * space — joining bare runs them together ("a node.Can be invoked"), which also
+ * defeats the '. ' sentence split below and returns the whole blob.
+ */
 function extractDescription(text) {
 	const m = /"description"\s*:\s*\[([^\]]*)\]/.exec(text);
 	if (!m) return '';
 	const parts = m[1].match(/"((?:[^"\\]|\\.)*)"/g) || [];
-	const full = parts.map((s) => s.slice(1, -1)).join('').trim();
+	const full = parts.map((s) => s.slice(1, -1)).join(' ').replace(/\s+/g, ' ').trim();
 	const dot = full.indexOf('. ');
 	return dot >= 0 ? full.slice(0, dot + 1) : full;
 }
@@ -211,6 +216,48 @@ function frontMatterTitle(content) {
 	if (!m) return null;
 	const t = /(^|\n)title:\s*(.+?)\s*(\n|$)/.exec(m[1]);
 	return t ? t[2].replace(/^['"]|['"]$/g, '') : null;
+}
+
+/**
+ * First-sentence description for a markdown/MDX page, mirroring what Docusaurus
+ * derives for its meta description. A front-matter `description:` wins when the
+ * page declares one; otherwise the first prose paragraph is used, skipping MDX
+ * imports, JSX, headings, code fences, tables and admonitions. Node pages get
+ * their description from services*.json instead (see extractDescription).
+ * @param {string} content - raw page content (md/mdx).
+ * @return {string} description, or '' when the page has no leading prose.
+ */
+function pageDescription(content) {
+	const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+	if (fm) {
+		const d = /(^|\n)description:\s*(.+?)\s*(\n|$)/.exec(fm[1]);
+		if (d) return d[2].replace(/^['"]|['"]$/g, '');
+	}
+	const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '');
+	const para = [];
+	let inFence = false;
+	for (const line of body.split(/\r?\n/)) {
+		const t = line.trim();
+		// Skip fenced blocks wholesale — the fence delimiters AND their contents.
+		if (/^(```|~~~)/.test(t)) {
+			if (para.length) break;
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
+		if (!t) {
+			if (para.length) break;
+			continue;
+		}
+		if (/^(#{1,6}\s|:::|<!--|\||[<{]|import\s|export\s|-{3,})/.test(t)) {
+			if (para.length) break;
+			continue;
+		}
+		para.push(t);
+	}
+	const prose = para.join(' ').replace(/\[([^\]]+)\]\([^)]*\)/g, '$1').replace(/[*`_]/g, '').trim();
+	const m = /^(.+?[.!?])(\s|$)/.exec(prose);
+	return (m ? m[1] : prose).slice(0, 200).trim();
 }
 
 /** First markdown heading, as a title fallback. */
@@ -385,7 +432,7 @@ async function gather({ projectRoot, contentStaticDir, contentDir, staticDir, mo
 			const destAbs = path.join(contentDir, `${docId || 'index'}${ext}`);
 			const siblingAbs = path.join(staticDir, `${docId || 'index'}.md`);
 			await stageFile({ srcAbs, destAbs, siblingAbs, content, mode });
-			manifest.push({ id: docId || 'index', route: docId ? `/${docId}` : '/', title: frontMatterTitle(content) || headingTitle(content) || docId || 'Home', mdSibling: `/${docId || 'index'}.md`, source: srcAbs });
+			manifest.push({ id: docId || 'index', route: docId ? `/${docId}` : '/', title: frontMatterTitle(content) || headingTitle(content) || docId || 'Home', mdSibling: `/${docId || 'index'}.md`, source: srcAbs, description: pageDescription(content) });
 		}
 	}
 
@@ -489,7 +536,7 @@ async function gather({ projectRoot, contentStaticDir, contentDir, staticDir, mo
 		const destAbs = path.join(contentDir, `${docId}${ext}`);
 		const siblingAbs = path.join(staticDir, `${docId}.md`);
 		await stageFile({ srcAbs: abs, destAbs, siblingAbs, content, mode });
-		manifest.push({ id: docId, route: `/${docId}`, title: frontMatterTitle(content) || headingTitle(content) || docId, mdSibling: `/${docId}.md`, source: abs, module: owner.module });
+		manifest.push({ id: docId, route: `/${docId}`, title: frontMatterTitle(content) || headingTitle(content) || docId, mdSibling: `/${docId}.md`, source: abs, module: owner.module, description: pageDescription(content) });
 	}
 
 	// 4. Placeholders for spine slots still lacking content (keeps the build green).
@@ -553,4 +600,4 @@ async function ensurePlaceholders({ contentDir, staticDir, routes, manifest }) {
 	}
 }
 
-module.exports = { gather, docIdFor };
+module.exports = { gather, docIdFor, pageDescription, stampLastUpdate };

--- a/packages/docs/scripts/lib/gather.js
+++ b/packages/docs/scripts/lib/gather.js
@@ -230,8 +230,22 @@ function frontMatterTitle(content) {
 function pageDescription(content) {
 	const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
 	if (fm) {
-		const d = /(^|\n)description:\s*(.+?)\s*(\n|$)/.exec(fm[1]);
-		if (d) return d[2].replace(/^['"]|['"]$/g, '');
+		const d = /(^|\n)description:[ \t]*(.*)/.exec(fm[1]);
+		if (d) {
+			const inline = d[2].trim();
+			if (/^[>|][-+\d]*$/.test(inline)) {
+				// YAML block scalar (`description: >`, `|`, `>-`, …). The text is the
+				// indented run that follows; the indicator itself is not the value.
+				const block = [];
+				for (const line of fm[1].slice(d.index + d[0].length).split(/\r?\n/).slice(1)) {
+					if (!/^[ \t]+\S/.test(line)) break;
+					block.push(line.trim());
+				}
+				if (block.length) return block.join(' ');
+			} else if (inline) {
+				return inline.replace(/^['"]|['"]$/g, '');
+			}
+		}
 	}
 	const body = content.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n/, '');
 	const para = [];
@@ -357,7 +371,11 @@ function gitLastUpdate(srcAbs) {
  * @return {string}
  */
 function stampLastUpdate(content, date) {
-	if (!date || /(^|\n)last_update\s*:/.test(content)) return content;
+	if (!date) return content;
+	// Scope the check to the front matter — a `last_update:` line in the body
+	// (a YAML sample, say) must not silently cost the page its sitemap date.
+	const declared = /^---\r?\n([\s\S]*?)\r?\n---/.exec(content);
+	if (declared && /(^|\n)last_update\s*:/.test(declared[1])) return content;
 	if (/^---\r?\n/.test(content)) {
 		const end = content.indexOf('\n---', 4);
 		if (end !== -1) return `${content.slice(0, end)}\nlast_update:\n  date: ${date}${content.slice(end)}`;

--- a/packages/docs/scripts/lib/gather.js
+++ b/packages/docs/scripts/lib/gather.js
@@ -311,7 +311,7 @@ function gitLastUpdate(srcAbs) {
  */
 function stampLastUpdate(content, date) {
 	if (!date || /(^|\n)last_update\s*:/.test(content)) return content;
-	if (content.startsWith('---\n')) {
+	if (/^---\r?\n/.test(content)) {
 		const end = content.indexOf('\n---', 4);
 		if (end !== -1) return `${content.slice(0, end)}\nlast_update:\n  date: ${date}${content.slice(end)}`;
 		return content;

--- a/packages/docs/scripts/lib/llms.js
+++ b/packages/docs/scripts/lib/llms.js
@@ -14,6 +14,10 @@ const { sections, sectionFor } = require('./spine');
 
 const SITE_TITLE = 'RocketRide Documentation';
 const SITE_DESC = 'Build, run, and ship data + AI pipelines with the RocketRide toolchain.';
+// Absolute base for llms.txt links. The llms.txt format specifies URLs, and an
+// agent that fetched the file on its own has no base to resolve against.
+// Mirrors `url` in docusaurus.config.ts.
+const SITE_URL = 'https://docs.rocketride.org';
 
 // One-line description per node type (category label from gather.js
 // NODE_CATEGORIES). Used to annotate each heading in the catalog. A label with
@@ -190,7 +194,7 @@ function llmsIndex(manifest) {
 		if (!entries || !entries.length) continue;
 		lines.push(`## ${label}`, '');
 		for (const e of entries.sort((a, b) => a.route.localeCompare(b.route))) {
-			lines.push(`- [${e.title}](${e.mdSibling})`);
+			lines.push(`- [${e.title}](${SITE_URL}${e.mdSibling})${e.description ? `: ${e.description}` : ''}`);
 		}
 		lines.push('');
 	}

--- a/packages/docs/src/lib/gather.test.mjs
+++ b/packages/docs/src/lib/gather.test.mjs
@@ -1,0 +1,71 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { pageDescription, stampLastUpdate } = require('../../scripts/lib/gather.js');
+
+describe('pageDescription', () => {
+	it('prefers a front-matter description when the page declares one', () => {
+		const md = '---\ntitle: Hi\ndescription: Declared up front.\n---\n\n# Hi\n\nProse instead.\n';
+		assert.equal(pageDescription(md), 'Declared up front.');
+	});
+
+	it('falls back to the first prose sentence, skipping the heading', () => {
+		const md = '---\ntitle: Hi\n---\n\n# Hi\n\nA pipeline is a graph. More after the stop.\n';
+		assert.equal(pageDescription(md), 'A pipeline is a graph.');
+	});
+
+	it('skips MDX imports and JSX to reach the prose', () => {
+		const md = "---\ntitle: Q\n---\n\nimport { Foo } from 'react-icons';\n\n<Foo />\n\n# Q\n\nPick the path that suits you.\n";
+		assert.equal(pageDescription(md), 'Pick the path that suits you.');
+	});
+
+	it('strips inline links and emphasis from the extracted sentence', () => {
+		const md = '# T\n\nSee the [engine](/concepts/engine) and **run** it.\n';
+		assert.equal(pageDescription(md), 'See the engine and run it.');
+	});
+
+	it('returns an empty string when the page has no leading prose', () => {
+		assert.equal(pageDescription('---\ntitle: T\n---\n\n# T\n\n```js\ncode();\n```\n'), '');
+	});
+});
+
+describe('stampLastUpdate', () => {
+	const D = '2026-07-16';
+
+	it('merges into an existing front-matter block', () => {
+		const out = stampLastUpdate('---\ntitle: Hi\n---\n\n# Body\n', D);
+		assert.match(out, /^---\ntitle: Hi\nlast_update:\n {2}date: 2026-07-16\n---\n/);
+	});
+
+	it('creates a front-matter block when the page has none', () => {
+		const out = stampLastUpdate('# Body\n', D);
+		assert.match(out, /^---\nlast_update:\n {2}date: 2026-07-16\n---\n\n# Body\n$/);
+	});
+
+	// Regression: startsWith('---\n') was false on a CRLF checkout, so a SECOND
+	// front-matter block was prepended and `title` fell out into the body.
+	it('merges into CRLF front matter rather than prepending a second block', () => {
+		const out = stampLastUpdate('---\r\ntitle: Hi\r\n---\r\n\r\n# Body\r\n', D);
+		assert.equal((out.match(/^---\r?$/gm) || []).length, 2, 'exactly one front-matter block');
+		assert.match(out, /title: Hi/);
+		assert.match(out, /date: 2026-07-16/);
+		// title must still be inside the front matter, not stranded in the body.
+		const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)[1];
+		assert.match(fm, /title: Hi/);
+	});
+
+	it('is a no-op when the date is null or a date is already declared', () => {
+		assert.equal(stampLastUpdate('# B\n', null), '# B\n');
+		const already = '---\nlast_update:\n  date: 2020-01-01\n---\n\n# B\n';
+		assert.equal(stampLastUpdate(already, D), already);
+	});
+
+	it('does not treat a body horizontal rule as the front-matter close', () => {
+		const out = stampLastUpdate('---\ntitle: Hi\n---\n\n# Body\n\n---\n\nmore\n', D);
+		const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)[1];
+		assert.match(fm, /last_update/);
+		assert.match(fm, /title: Hi/);
+	});
+});

--- a/packages/docs/src/lib/gather.test.mjs
+++ b/packages/docs/src/lib/gather.test.mjs
@@ -11,6 +11,27 @@ describe('pageDescription', () => {
 		assert.equal(pageDescription(md), 'Declared up front.');
 	});
 
+	// A block scalar's value is the indented run beneath it; the bare '>' or '|'
+	// indicator must never become the description.
+	it('reads a folded block-scalar description', () => {
+		const md = '---\ntitle: T\ndescription: >\n  Folded across\n  two lines.\n---\n\n# T\n\nProse.\n';
+		assert.equal(pageDescription(md), 'Folded across two lines.');
+	});
+
+	it('reads a literal block-scalar description', () => {
+		const md = '---\ntitle: T\ndescription: |\n  Literal block.\n---\n\n# T\n\nProse.\n';
+		assert.equal(pageDescription(md), 'Literal block.');
+	});
+
+	it('reads a chomped block-scalar description', () => {
+		const md = '---\ntitle: T\ndescription: >-\n  Stripped fold.\n---\n\n# T\n\nProse.\n';
+		assert.equal(pageDescription(md), 'Stripped fold.');
+	});
+
+	it('strips surrounding quotes from an inline description', () => {
+		assert.equal(pageDescription('---\ntitle: T\ndescription: "Quoted."\n---\n\n# T\n\nProse.\n'), 'Quoted.');
+	});
+
 	it('falls back to the first prose sentence, skipping the heading', () => {
 		const md = '---\ntitle: Hi\n---\n\n# Hi\n\nA pipeline is a graph. More after the stop.\n';
 		assert.equal(pageDescription(md), 'A pipeline is a graph.');
@@ -54,6 +75,13 @@ describe('stampLastUpdate', () => {
 		// title must still be inside the front matter, not stranded in the body.
 		const fm = /^---\r?\n([\s\S]*?)\r?\n---/.exec(out)[1];
 		assert.match(fm, /title: Hi/);
+	});
+
+	// The guard reads the front matter only: a `last_update:` line in the body
+	// (a YAML code sample) must not cost the page its sitemap date.
+	it('stamps a page whose body merely mentions last_update', () => {
+		const md = '---\ntitle: T\n---\n\n# T\n\n```yaml\nlast_update:\n  date: 2020-01-01\n```\n';
+		assert.match(stampLastUpdate(md, D), /date: 2026-07-16/);
 	});
 
 	it('is a no-op when the date is null or a date is already declared', () => {

--- a/packages/docs/src/lib/llms.test.mjs
+++ b/packages/docs/src/lib/llms.test.mjs
@@ -20,7 +20,7 @@ describe('buildIndex', () => {
 
 		const manifest = [
 			{ id: 'quickstart', route: '/quickstart', title: 'Quickstart', mdSibling: '/quickstart.md' },
-			{ id: 'concepts/pipelines', route: '/concepts/pipelines', title: 'Pipelines', mdSibling: '/concepts/pipelines.md' },
+			{ id: 'concepts/pipelines', route: '/concepts/pipelines', title: 'Pipelines', mdSibling: '/concepts/pipelines.md', description: 'A pipeline is a directed graph of nodes.' },
 			{ id: 'nodes/webhook', route: '/nodes/webhook', title: 'webhook', mdSibling: '/nodes/webhook.md', node: 'webhook' },
 		];
 		await writeFile(path.join(contentDir, '.manifest.json'), JSON.stringify(manifest));
@@ -43,7 +43,11 @@ describe('buildIndex', () => {
 		assert.match(index, /^# RocketRide Documentation/m);
 		assert.match(index, /## Quickstart/);
 		assert.match(index, /## Concepts/);
-		assert.match(index, /\[Pipelines\]\(\/concepts\/pipelines\.md\)/);
+		// Links are absolute (the llms.txt format specifies URLs) and carry the
+		// manifest description when the page has one.
+		assert.match(index, /\[Pipelines\]\(https:\/\/docs\.rocketride\.org\/concepts\/pipelines\.md\): A pipeline is a directed graph of nodes\./);
+		// An entry without a description degrades to a bare link, no trailing colon.
+		assert.match(index, /\[Quickstart\]\(https:\/\/docs\.rocketride\.org\/quickstart\.md\)\n/);
 		// Quickstart section precedes Concepts (spine order)
 		assert.ok(index.indexOf('## Quickstart') < index.indexOf('## Concepts'));
 	});

--- a/packages/docs/static/robots.txt
+++ b/packages/docs/static/robots.txt
@@ -1,5 +1,18 @@
 # robots.txt for docs.rocketride.org
 # Explicitly welcomes AI crawlers + declares sitemap.
+#
+# WARNING, if you are about to add a rule here:
+#   Per RFC 9309 a crawler obeys only the ONE most specific User-agent group
+#   that matches it, and ignores every other group -- including `*`. Each bot
+#   named below therefore reads its own two lines and never sees the `*` group
+#   at all. A `Disallow:` added to `*` alone would bind Googlebot but NOT
+#   GPTBot, ClaudeBot, PerplexityBot, or anything else named here. That failure
+#   is silent: robots.txt has no linting and no CI check. Any rule intended for
+#   everyone must be repeated in every group below.
+#
+# The named groups are kept because they state the intent -- we welcome AI
+# crawlers -- in a form a human can read. Behaviourally they are identical
+# today to the `*` group on its own, which already allows everything.
 
 User-agent: GPTBot
 Allow: /

--- a/packages/docs/static/robots.txt
+++ b/packages/docs/static/robots.txt
@@ -1,0 +1,37 @@
+# robots.txt for docs.rocketride.org
+# Explicitly welcomes AI crawlers + declares sitemap.
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Bingbot
+Allow: /
+
+User-agent: *
+Allow: /
+
+Sitemap: https://docs.rocketride.org/sitemap.xml


### PR DESCRIPTION
## Summary

Three changes that make `docs.rocketride.org` readable by AI assistants and crawlers.

**1. Add `packages/docs/static/robots.txt`** — a single `User-agent: *` / `Allow: /` group plus the sitemap declaration. Needs a `.gitignore` exception and a `KEEP` set in `clearGeneratedStatic()`, which otherwise wipes everything in `static/` except `.gitkeep`/`img/` on every gather.

**2. Emit `<lastmod>` in the sitemap** — `showLastUpdateTime: true` + `sitemap` options in `docusaurus.config.ts`, and `gather.js` stamps each staged page's front matter with the SOURCE file's last git commit date. The assembled content tree is not git-tracked, so Docusaurus cannot date pages without this (0/162 URLs dated without, 159/162 with — the 3 undated are generated pages with no git source). The live sitemap today has no `<lastmod>` at all and carries `changefreq`/`priority`, which Docusaurus' own source comments call "useless".

**3. Make llms.txt actually useful** — it listed every page as a bare relative link, so an agent had to fetch all 161 pages to learn what any of them covered. Now each entry is `- [title](absolute-url): description`. The manifest already carried descriptions for node pages (they fed the `/nodes` catalog table but never llms.txt); doc pages had none, so `pageDescription()` derives one — front-matter `description:` when declared, else the first prose sentence, skipping MDX imports, JSX, headings, tables and fenced blocks, mirroring what Docusaurus derives for its meta description. URLs are absolute because the llms.txt format specifies URLs and an agent that fetched the file standalone has no base to resolve against.

**Correction to an earlier version of this description:** it claimed production 404s on the LLM surface. That is wrong — `/llms.txt`, `/llms-full.txt` and the per-page `.md` siblings are all already live and serving `text/plain`. **Only `/robots.txt` 404s.** Item 3 above is therefore about the *quality* of a file that already ships, not about shipping it.

### On the robots.txt shape

The per-crawler groups are exactly as the issue specifies them. Kept, but with a warning recorded inline (a097b689), because they carry a trap worth knowing about before anyone edits this file:

Per **RFC 9309** a crawler obeys only the single most specific matching `User-agent` group and ignores all others, **including `*`**. Every bot named here therefore reads its own two lines and never sees the `*` group. Today that is harmless — the groups are behaviourally identical to `*` alone, which already allows everything. But a `Disallow:` added later to `*` alone would bind Googlebot and *not* the named AI bots, silently, since robots.txt has no linting. Demonstrated with `urllib.robotparser`, adding `Disallow: /internal` to the `*` group:

| Bot | Result |
| --- | --- |
| GPTBot | **still fetches `/internal`** |
| ClaudeBot | **still fetches `/internal`** |
| Googlebot | blocked |

Collapsing to a single wildcard group would remove the trap, but the groups also state the intent — *we welcome AI crawlers* — in a form a human reads, which is what the issue asked for. So they stay and the trap is documented next to them; any rule meant for everyone must be repeated in every group.

**Worth a conscious ✅ from reviewers:** allow-all includes `Google-Extended` and `CCBot`, which are not ordinary crawlers — they are training-data controls (Gemini/Vertex, and Common Crawl, which feeds many corpora). This PR opts the docs into AI training. For public docs that is normally the goal, but it is a product decision, not a technicality.

### Two defects found while reviewing this branch, fixed here

- **`fetch-depth: 0` for the docs build** (d84f264) — originally written up as a note asking a maintainer to configure it, but `.github/workflows/docs.yml` is in this repo and had no `fetch-depth`, so `actions/checkout` defaulted to `1`. The headline feature would have shipped broken: with a single-commit history all 162 pages date to the clone day, so the sitemap would claim the whole site changed on every deploy. Google ignores `lastmod` it does not trust, making that strictly worse than emitting none. **This pulls `.github/workflows/**` into the diff, so the CI `changes` filter now classifies this PR as code and runs the full build matrix instead of skipping it.**
- **CRLF front matter** (46887a75) — `stampLastUpdate()` detected front matter with `startsWith('---\n')`, false on a CRLF checkout. It then prepended a *second* front-matter block instead of merging, dropping `title` out of the front matter and into the body as literal text. `.gitattributes` sets `* text=auto` and pins `eol=lf` only for `.patch`/`.sh`/`.py`, so `.md` is CRLF in a Windows working tree. CI builds on ubuntu, so deploys were unaffected — this corrupted local Windows builds. One-line fix (`/^---\r?\n/`), which also brings it in line with `frontMatterTitle()` right above it, already CRLF-tolerant.

Also fixed in passing: `extractDescription()` joined the `services*.json` description array bare, producing `a node.Can be invoked` and defeating its own `'. '` sentence split, so node blurbs ran on untruncated. Joining with a space fixes both. Invisible before, visible now that these strings are llms.txt descriptions.

### Heads-up: the docs deploy is red on develop, unrelated to this PR

Noticed while verifying this branch — **flagging only, deliberately not fixed here** since it is outside this PR's scope and deserves its own issue.

`builder docs:build` fails on develop right now, so nothing has shipped to docs.rocketride.org since the graph migration (457d137c) landed. The migration renamed `db_neo4j` → `graph_neo4j` and correctly added a `/nodes/db_neo4j` → `/nodes/graph_neo4j` redirect in `redirects.ts`, but `content-static/integrations/neo4j.md` still links the old path. Node page routes come from the node's directory name (`gather.js`), so `/nodes/db_neo4j` no longer exists as a route, and `onBrokenLinks: 'throw'` fails the build. Docusaurus' broken-link check does not consider client redirects, so the redirect does not save it:

```
- Broken link on source page path = /integrations/neo4j:
   -> linking to /nodes/db_neo4j
```

Same error in the failing develop run (29535879279). Note this never affects PR CI — `docs.yml` only triggers on push to develop. It does mean **this PR's output will not appear on the site until that is fixed**, whoever picks it up.

## Type

docs

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`pageDescription()` and `stampLastUpdate()` are pure and now unit-covered (`packages/docs/src/lib/gather.test.mjs`), alongside the updated `llms.test.mjs`. **35/35 pass.** Several cases exist because they caught real defects rather than confirming intent: the fenced-block case (the first draft returned `code();` as a page description), and the two CodeRabbit found — a YAML block scalar (`description: >`) yielding the bare indicator, and a body mention of `last_update:` silently costing a page its `<lastmod>`. Both were reproduced failing before being fixed in b509130a.

Verified end to end with a real `registry discover` → `gather` → `index` → **`docusaurus build`** (3.8.1) — build green, and the built site checked directly:

| Check | Result |
| --- | --- |
| `robots.txt` shipped | yes, and **verified it survives `clearGeneratedStatic()`** — seeded `static/` with a stale `llms.txt`/`quickstart.md` alongside it; the stale files were cleared, `robots.txt`/`img/`/`.gitkeep` kept |
| sitemap | 162 URLs, **159 with `<lastmod>`** |
| dates are real | **16 distinct dates** (2026-04-11 … 2026-07-01) — this is what `fetch-depth: 0` buys; without it all 16 collapse to one |
| `changefreq` / `priority` | 0 / 0 — gone |
| llms.txt | 161 links, **161 absolute, 158 described** (the 3 without are generated or source-less pages) |

Also: `pageDescription` spot-checked across all 31 spine pages (31 clean, 0 empty, 0 malformed); `robots.txt` validated with Python's `urllib.robotparser`; the three `sitemap` options checked against the installed `@docusaurus/plugin-sitemap` Joi schema, which explicitly permits `null` for each; `prettier --check` clean.

`./builder test` not run — happy to if required.

`docs:gather-dev` (symlink mode) does not stamp dates, so the dev preview shows none; the production build uses copy mode and does. Intentional — a symlink cannot carry the front-matter edit.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable) — none; every piece is independently revertible, robots.txt is allow-only

## Linked Issue

Fixes #1615


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved sitemap metadata with accurate page update dates.
  * Added richer page descriptions and corrected descriptions with merged words.
  * Updated generated documentation links to use absolute URLs.
  * Added crawler access rules and a sitemap reference for documentation.

* **Bug Fixes**
  * Preserved required static documentation assets during builds.
  * Improved handling of page metadata and generated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->