### PR TITLE
fix(events-ui): remove client-side token filter that emptied the event stream

### DIFF
--- a/apps/events-ui/src/EventsApp.tsx
+++ b/apps/events-ui/src/EventsApp.tsx
@@ -63,8 +63,9 @@ const EventsApp: React.FC<ShellAppProps> = (_props) => {
 		// Only capture DAP events
 		if (event.type !== 'event') return;
 
-		// Token filter: if config.token is not '*', check it matches
-		if (config.token !== '*' && event.token !== config.token) return;
+		// No client-side token filter: DAP events carry no top-level `token`, and
+		// the server-side subscription below (addMonitor) already scopes the stream
+		// to the selected token. Re-adding an `event.token` check drops every event.
 
 		const captured: CapturedEvent = {
 			id: nextIdRef.current++,


### PR DESCRIPTION
## Summary

- Remove the Event Monitor's client-side token filter, which dropped 100% of
  events whenever a concrete task token was entered (only `*` worked).
- It compared `event.token`, but DAP event envelopes carry no top-level `token`
  field, so the check was always true. The server-side subscription
  (`addMonitor({ token }, types)`) already scopes the stream to the token, so
  the client-side check was redundant and incorrect.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none (`*` behavior unchanged)

## Linked Issue

Fixes #1629


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event handling so incoming `shell:event` updates are no longer silently discarded due to client-side token filtering.
  * Event-to-task correlation continues to be handled reliably by the server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->