### PR TITLE
feat(deps): per-environment Python dependency scoping (Phase 2A)

### DIFF
--- a/nodes/src/nodes/anonymize/glinerRecognizer.py
+++ b/nodes/src/nodes/anonymize/glinerRecognizer.py
@@ -27,7 +27,7 @@ from typing import Any, Dict
 
 from rocketlib import debug, expand
 from ai.common.config import Config
-from ai.common.models import GLiNER
+from ai.common.models.gliner import GLiNER
 from .Ruleparser import RuleParser
 from .anonymize import (
     anonymize as _anonymize,

--- a/nodes/src/nodes/audio_transcribe/IGlobal.py
+++ b/nodes/src/nodes/audio_transcribe/IGlobal.py
@@ -28,7 +28,7 @@ from typing import Any, List
 import numpy as np
 from rocketlib import IGlobalBase, debug
 from ai.common.config import Config
-from ai.common.models import Whisper
+from ai.common.models.audio import Whisper
 
 
 class IGlobal(IGlobalBase):

--- a/nodes/src/nodes/embedding_transformer/sentenceTransformer.py
+++ b/nodes/src/nodes/embedding_transformer/sentenceTransformer.py
@@ -42,7 +42,7 @@ monitorStatus('Loading transformers')
 
 # Load all the heavy weight stuff
 from numpy import ndarray
-from ai.common.models import SentenceTransformer
+from ai.common.models.transformers import SentenceTransformer
 from ai.common.config import Config
 from ai.common.embedding import EmbeddingBase
 from ai.common.schema import Doc, Question

--- a/nodes/src/nodes/ocr/IGlobal.py
+++ b/nodes/src/nodes/ocr/IGlobal.py
@@ -81,15 +81,15 @@ class ModelServerOCR(OCRInstance):
         """Lazy-load the OCR engine from model server (or local fallback)."""
         if self._ocr is None:
             if self.engine == 'doctr':
-                from ai.common.models import DocTR
+                from ai.common.models.ocr import DocTR
 
                 self._ocr = DocTR()
             elif self.engine == 'easyocr':
-                from ai.common.models import EasyOCR
+                from ai.common.models.ocr import EasyOCR
 
                 self._ocr = EasyOCR(languages=self.languages)
             elif self.engine == 'surya':
-                from ai.common.models import Surya
+                from ai.common.models.ocr import Surya
 
                 self._ocr = Surya()
             else:

--- a/nodes/src/nodes/ocr/ocr.py
+++ b/nodes/src/nodes/ocr/ocr.py
@@ -36,7 +36,7 @@ from PIL import Image
 
 from ai.common.reader import ReaderBase
 from ai.common.config import Config
-from ai.common.models import EasyOCR, DocTR, Surya, TrOCR
+from ai.common.models.ocr import EasyOCR, DocTR, Surya, TrOCR
 from rocketlib import debug
 
 

--- a/nodes/test/fixtures/nodes/vtest_alpha/IInstance.py
+++ b/nodes/test/fixtures/nodes/vtest_alpha/IInstance.py
@@ -1,0 +1,19 @@
+"""VTest Alpha instance — text-lane filter importing ``tabulate`` (pinned 0.8.10).
+
+Implements the real filter contract: the engine dispatches inbound lane data to the
+matching ``writeX`` handler (here ``writeText``); output is emitted via
+``self.instance.writeX(...)``. Imports nothing from ``ai.*``.
+"""
+
+import tabulate
+
+from rocketlib import IInstanceBase
+
+
+class IInstance(IInstanceBase):
+    """Passes text through unchanged, touching tabulate so the pinned wheel loads."""
+
+    def writeText(self, text: str):
+        """Handle inbound text: exercise the pinned tabulate, then forward unchanged."""
+        tabulate.tabulate([[text]], tablefmt='plain')
+        self.instance.writeText(text)

--- a/nodes/test/fixtures/nodes/vtest_alpha/__init__.py
+++ b/nodes/test/fixtures/nodes/vtest_alpha/__init__.py
@@ -1,0 +1,10 @@
+"""Test-only dependency-conflict fixture node (see services.json). Never shipped.
+
+Pins ``tabulate==0.8.10`` and imports nothing from ``ai.*`` so a pipeline that
+uses both ``vtest_alpha`` and ``vtest_beta`` produces a deterministic constraints
+conflict isolated to the venv-scoping mechanism.
+"""
+
+from .IInstance import IInstance
+
+__all__ = ['IInstance']

--- a/nodes/test/fixtures/nodes/vtest_alpha/requirements.txt
+++ b/nodes/test/fixtures/nodes/vtest_alpha/requirements.txt
@@ -1,0 +1,4 @@
+# Test-only. Deterministic dependency conflict with vtest_beta (tabulate==0.9.0).
+# tabulate is a tiny pure-Python leaf NOT used by the SDK or engine runtime, so the
+# pin cannot collide with runtime deps — the conflict is isolated to venv scoping.
+tabulate==0.8.10

--- a/nodes/test/fixtures/nodes/vtest_alpha/services.json
+++ b/nodes/test/fixtures/nodes/vtest_alpha/services.json
@@ -1,0 +1,21 @@
+{
+	"title": "VTest Alpha (dependency-conflict fixture)",
+	"protocol": "vtest_alpha://",
+	"classType": ["filter"],
+	"capabilities": [],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.vtest_alpha",
+	"prefix": "VTestAlpha",
+	"description": ["Test-only node. Pins tabulate==0.8.10 to create a deterministic, ai-independent dependency conflict with vtest_beta. Never shipped."],
+	"lanes": {
+		"text": ["text"]
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "VTest Alpha",
+			"properties": []
+		}
+	]
+}

--- a/nodes/test/fixtures/nodes/vtest_beta/IInstance.py
+++ b/nodes/test/fixtures/nodes/vtest_beta/IInstance.py
@@ -1,0 +1,19 @@
+"""VTest Beta instance — text-lane filter importing ``tabulate`` (pinned 0.9.0).
+
+Implements the real filter contract: the engine dispatches inbound lane data to the
+matching ``writeX`` handler (here ``writeText``); output is emitted via
+``self.instance.writeX(...)``. Imports nothing from ``ai.*``.
+"""
+
+import tabulate
+
+from rocketlib import IInstanceBase
+
+
+class IInstance(IInstanceBase):
+    """Passes text through unchanged, touching tabulate so the pinned wheel loads."""
+
+    def writeText(self, text: str):
+        """Handle inbound text: exercise the pinned tabulate, then forward unchanged."""
+        tabulate.tabulate([[text]], tablefmt='github')
+        self.instance.writeText(text)

--- a/nodes/test/fixtures/nodes/vtest_beta/__init__.py
+++ b/nodes/test/fixtures/nodes/vtest_beta/__init__.py
@@ -1,0 +1,9 @@
+"""Test-only dependency-conflict fixture node (see services.json). Never shipped.
+
+Pins ``tabulate==0.9.0`` and imports nothing from ``ai.*`` — the conflicting twin
+of ``vtest_alpha``.
+"""
+
+from .IInstance import IInstance
+
+__all__ = ['IInstance']

--- a/nodes/test/fixtures/nodes/vtest_beta/requirements.txt
+++ b/nodes/test/fixtures/nodes/vtest_beta/requirements.txt
@@ -1,0 +1,4 @@
+# Test-only. Deterministic dependency conflict with vtest_alpha (tabulate==0.8.10).
+# tabulate is a tiny pure-Python leaf NOT used by the SDK or engine runtime, so the
+# pin cannot collide with runtime deps — the conflict is isolated to venv scoping.
+tabulate==0.9.0

--- a/nodes/test/fixtures/nodes/vtest_beta/services.json
+++ b/nodes/test/fixtures/nodes/vtest_beta/services.json
@@ -1,0 +1,21 @@
+{
+	"title": "VTest Beta (dependency-conflict fixture)",
+	"protocol": "vtest_beta://",
+	"classType": ["filter"],
+	"capabilities": [],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.vtest_beta",
+	"prefix": "VTestBeta",
+	"description": ["Test-only node. Pins tabulate==0.9.0 to create a deterministic, ai-independent dependency conflict with vtest_alpha. Never shipped."],
+	"lanes": {
+		"text": ["text"]
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "VTest Beta",
+			"properties": []
+		}
+	]
+}

--- a/packages/server/design/virtual-environments.md
+++ b/packages/server/design/virtual-environments.md
@@ -429,8 +429,15 @@ imports live **exclusively in the local (no-model-server) branch**. Implications
 **Constraints strategy: per-env, compiled independently of the global (VERIFIED live).** The single
 biggest lever venvs pull is *not sharing one constraint resolution*.
 
-- `<exe>/cache/constraints.txt` (**global**) is compiled from the `nodes/**`+`ai/**` globs and governs
-  **only** the base runtime and the legacy path (`ROCKETRIDE_SERVER_USE_VENV=0` / auto-without-venv).
+- `<exe>/cache/constraints.txt` (**global**) governs **only** the base runtime and the legacy path
+  (`ROCKETRIDE_SERVER_USE_VENV=0` / auto-without-venv). Under `=1` the **`nodes/**` glob is dropped from
+  this startup compile** (`_SCOPED_EXCLUDED_GLOBS`) and it is compiled from `ai/**` + the root
+  requirements alone; node dependencies then arrive exclusively through per-env scoped installs.
+  **This gating is load-bearing, not an optimization (VERIFIED live).** While `nodes/**` stayed in the
+  glob, every node in the installation had to be mutually satisfiable: two nodes pinning incompatible
+  versions made `ensure_constraints()` fail at import of `ai/__init__.py`, so **the engine could not
+  start at all** — before any pipeline, endpoint, or per-env logic ran. Per-env scoping cannot deliver
+  its headline benefit while the startup compile still unions the whole node universe.
 - `venvs/<project_id>/<env_id>/constraints.txt` (**per-env**) is compiled from **that env's
   `combined.txt` alone — no global base** — so it resolves versions solely from the requirement files its
   nodes reach. The scoped install **and** the runtime `depends()` calls active in that env both resolve
@@ -556,9 +563,22 @@ overlay no-ops → use base; `depends.py` tolerates a missing `project_id`/`env_
   partitioner. **Must land before the first incompatible node ships**, else the suite breaks.
 
 ### 4.15 Compatibility & the venv master switch (`ROCKETRIDE_SERVER_USE_VENV`)
-The whole feature (venv runtime **and** per-environment scoping) is gated by one env var, so
-downstream/open-source consumers can pin today's behavior. **This is a permanent supported mode, not a
-migration flag.**
+The whole feature (venv runtime **and** per-environment scoping) is gated by one environment variable,
+so downstream/open-source consumers can pin today's behavior. **This is a permanent supported mode, not
+a migration flag.**
+
+The variable is read by `venv_env.use_venv_mode()` at the moment dependencies are resolved. It is set
+on the **server** process (launch config, systemd unit, container env); the task subprocess inherits it,
+and the whole execution path — startup compile, endpoint hook, per-env install — is therefore
+self-consistent. Clients need nothing: an SDK client does not import `rocketlib` (the import in
+`client-python`'s `dap_base` is guarded by `except ImportError`) and so never enters dependency
+resolution at all.
+
+**Known gap.** `<exe>/.env` is loaded by `ai/web/server.py` inside `WebServer.__init__`, but
+`ai/__init__.py` calls `depends()` at import — so a value placed in `.env` is read **after** the
+resolution it would govern and silently has no effect. Putting the switch there therefore does not work
+today. Closing this properly means moving the engine's `load_dotenv` ahead of dependency resolution, not
+teaching `venv_env` to parse the file.
 
 - **Unset (default) = auto.** The partitioner inspects the *resolved* pipeline: an `isolated` group
   present → venv runtime + per-env scoping; none present → today's single-process / global-glob
@@ -568,7 +588,19 @@ migration flag.**
   `constraints.txt` path**. Byte-for-byte today's behavior; **never an error**, even if the document
   contains isolated groups. This is the escape hatch for downstream consumers.
 - **`=1` = force on.** Enables the venv machinery and per-env scoping (still a no-op partition if the
-  pipeline genuinely has no isolated groups, but per-env `main` scoping applies).
+  pipeline genuinely has no isolated groups, but per-env `main` scoping applies). It **also drops
+  `nodes/**` from the global startup compile** (§4.9), which is what actually lets nodes with
+  conflicting pins coexist in one installation.
+
+**Known limit of `auto` (honest).** The startup compile happens at process init, before any pipeline is
+known, so `auto` cannot decide the node-glob question per pipeline: it keeps the legacy union and
+therefore keeps the conflicting-nodes failure. In Phase 2A **only `=1` delivers conflict isolation**.
+Removing the limit means taking node dependencies out of the startup path entirely (resolving them
+per-env on first use) — the same work as the base-runtime-only residual in §4.9.
+
+A second consequence of `=1`: nodes whose imports the AST walk cannot resolve statically (flagged
+`dynamic_imports`) no longer get their dependencies from the startup glob and fall back to the runtime
+`depends()` backstop, which installs into the active overlay (§4.8).
 
 Open-source/default posture: with the var unset, a consumer who never creates an isolated group gets
 exactly today's engine; `=0` additionally guarantees legacy behavior even for documents authored
@@ -753,21 +785,36 @@ and the conflict is isolated to the venv-scoping mechanism — fast, determinist
 **replace `torch 2.0/2.1`** as the conflict fixture. [created 2A; used by 8.3]
 
 ### 8.3 Integration / acceptance
-- **Conflict → no venv → must NOT start (the core proof).** A pipeline with **both** `vtest_alpha` +
-  `vtest_beta` and **no** venv → the union constraints compile is **unsatisfiable** → the pipeline
-  **fails to start** with a clear error naming the conflicting `requests` pins ("Failed to compile
-  constraints"). [2A — the scoping/compile path alone surfaces this]
+
+- **Conflict → isolated to its environment (the core proof) — VERIFIED live.** A pipeline with **both**
+  `vtest_alpha` + `vtest_beta` under `=1`: the engine **starts normally**, the client connects, and the
+  conflict surfaces only in that environment's compile — `venvs/<proj>/main/combined.txt` is written with
+  both pins and `uv pip compile` reports them unsatisfiable. The run aborts with the pin names in the
+  message; **the server stays up** and cleans the task up. Two properties asserted from artifacts: the
+  env's combined file held **9 sources** (the AST-reachable set — the two fixtures, `nodes/webhook` via
+  the `dropper` alias, and the `ai/**` modules reached) rather than the 101 node requirement files in the
+  installation; and the **global** `cache/combined.txt` contained **no** `tabulate` at all, so the base
+  runtime was never touched. [2A]
+- **The same pipeline before the `nodes/**` gating (§4.9) — the counter-proof.** With node requirements
+  still in the startup glob, the identical setup killed `ai/__init__`'s `depends()` at import: the engine
+  **could not start at all**, in every process including the CLI client. This is what motivated the
+  gating.
 - **Conflict → split across venvs → all good.** The same two nodes in **two separate venvs** → each env
   compiles/install its single pin → the pipeline runs **end-to-end**, both `requests` versions
-  coexisting. Assert each overlay's `site-packages` holds the expected version (alpha-env→2.28.2,
-  beta-env→2.31.0) and the other is **absent**. [2B]
+  coexisting. Assert each overlay's `site-packages` holds the expected version (alpha-env→`0.8.10`,
+  beta-env→`0.9.0`) and the other is **absent**. [2B]
 - **Only-needed-installed (scoping).** (a) A pipeline using `vtest_alpha` only → its env has
-  `requests==2.28.2`, **not** the other pin and **not** `whisper`/`faster-whisper`/`torch`. (b) A
+  `tabulate==0.8.10`, **not** the other pin and **not** `whisper`/`faster-whisper`/`torch`. (b) A
   **no-audio** pipeline → `whisper`/`faster-whisper` **absent** from every env's install set; an audio
   pipeline → **present** (the "if whisper isn't needed it isn't installed" check). (c) Assert the
   **requirement-file set processed equals exactly the AST-reachable set**, not the global glob. [2A]
-- **Compatibility (`=0`).** A pipeline that **does** contain an isolated group still runs single-process
-  via the global-glob path (legacy mode), no error — the permanent opt-out (§4.15). [2B]
+- **Compatibility (`=0` and auto) — VERIFIED live.** Both modes ran a real pipeline end-to-end
+  (`venv-detect`, objectId returned) with **no `venvs/` directory created**, every install carrying
+  `-c cache/constraints.txt` and **no `--target`**. The switch is fully reversible, measured on the
+  startup compile: `=1` → 29 sources, **0** of them node paths; `=0` and auto → **130** sources, **101**
+  of them node paths, i.e. exactly the pre-change set. Auto matches legacy because the pipeline has no
+  isolated group. Still owed for 2B: a pipeline that **does** contain an isolated group must run
+  single-process under `=0`, no error — the permanent opt-out (§4.15).
 - **Lifecycle.** Purge, delete-with-nodes, and pipeline-delete reclaim the right `venvs/...` dirs and are
   **blocked while a run is active**. Image lanes cross a venv boundary (all-lane bridge). [2B]
 - **Embedding invariant.** `server:run-engtest` (`python::config` + `webhook`) and `builder nodes:test`

--- a/packages/server/design/virtual-environments.md
+++ b/packages/server/design/virtual-environments.md
@@ -211,12 +211,15 @@ env/handle, never argv.
   (`remote/base/IInstance.py`); large image/video relies on chunking. **Measure a representative
   image/video crossing against a target throughput ceiling as a v1 acceptance criterion**; raise the
   chunk ceiling for AV if it misses.
-- **Target architecture removes this for AV.** In the planned model, AV bytes are written to **cloud
-  storage** (`ai..account.store`) and **only AV metadata / a URL pointer crosses node boundaries** — so
-  the venv bridge carries **tiny metadata, not multi-MB buffers**, and a venv vision node fetches bytes
-  **directly from the store**, not across the bridge. The throughput ceiling above then applies **only
-  to any interim** where AV still crosses in-process/over the bridge. (The child's store fetch needs
-  account/store context — ties into secrets/`ROCKETRIDE_CLIENT_ID` propagation, §6.)
+- **Cloud-store direction shrinks the *payload*, not the *lane set*.** In the planned model AV bytes
+  live in **cloud storage** (`ai..account.store`); the bulk bytes are fetched from the store, not
+  streamed node-to-node. **But AV metadata still travels on the `writeVideo`/`writeAudio`/`writeImage`
+  lanes** — so the bridge must **still implement every AV lane** (§4.4 "all data lanes" is *not*
+  reducible), and those lanes still cross the venv boundary. What changes is the **payload size**: a
+  small metadata/URL frame instead of multi-MB buffers, which is what drops the throughput risk (the
+  ~1 MB chunking is a non-issue for small frames). The interim caveat still holds — before the store
+  migration, raw AV crosses these lanes and the throughput gate above applies. (The child's store fetch
+  needs account/store context — ties into secrets/`ROCKETRIDE_CLIENT_ID` propagation, §6.)
 - **Hardening (deferred to 2C):** OS-access-controlled local IPC so the kernel rejects other-user
   processes *before* any token check — **named pipe + user-SID ACL** (Windows), **Unix domain socket**
   `0700` + `SO_PEERCRED`/`LOCAL_PEERCRED` (Linux/macOS). Matters for **multi-tenant** hosts (Linux
@@ -345,10 +348,13 @@ variant — so the backstop is a narrow safety net, not the primary mechanism.
   transitively reaches the **entire model universe** and over-includes `rfdetr`, `rtmlib`, `gliner`, all
   OCR, `transformers` for an *audio* node. That reintroduces the very torch-conflict + bloat venvs exist
   to remove.
-- **Prerequisite for precise scoping (a repo change, not a walker change):** either nodes import `ai`
-  model submodules **by full path** (as `detect` already does), or the `ai.common.models` barrel
-  `__init__` is made **lazy (PEP 562 `__getattr__`)** so the walk follows only the used name. Until one
-  of these lands, per-env scoping over-includes for every barrel-importing node.
+- **Prerequisite for precise scoping — DONE (Option A applied).** Either nodes import `ai` model
+  submodules **by full path** (as `detect` already does), or the `ai.common.models` barrel `__init__` is
+  made **lazy (PEP 562)**. **Chose Option A** (the 4 barrel importers now use full-path imports —
+  `.gliner`/`.audio`/`.transformers`/`.ocr`); Option B was rejected because it does **not** help the AST
+  walk without a matching walker change (`ast.walk` still traverses the `TYPE_CHECKING` re-export block,
+  or under-includes if that block is removed). Measured effect: `audio_transcribe` **24 → 7** files,
+  `anonymize` **23 → 5**, zero cross-family leaks.
 - **Blast radius + generalization (whole node-tree sweeps, VERIFIED).** The barrel fix is **small and
   bounded: exactly 4 nodes** import via the barrel — `anonymize`, `audio_transcribe`,
   `embedding_transformer`, `ocr` — vs **9 already on full path** (`detect`, `ner`, `pose_estimation`,
@@ -584,17 +590,14 @@ elsewhere that carry `environment`.
 - 🟠 **Phase 2A blast radius = only pipelines where the scoped path is enabled** (`=1`, or auto with
   isolated groups). Under the default (unset, no venvs) **nothing changes** — §4.15 semantics. The
   radius becomes "every pipeline" only if/when a later release flips auto to scoped-by-default.
-- 🟠 **AST correctness is PROVEN; the residual is precision (2A prerequisite, §4.8 Prototype result).**
-  A throwaway static-AST walk over the three hardest nodes (`detect`/`audio_transcribe`/`anonymize`)
-  reached **every** ground-truth requirement file with **zero under-includes and zero dynamic imports**
-  — so a transitive walk (nested imports + correct relative-import resolution) is sound. The remaining
-  risk is **over-inclusion via the `ai.common.models` barrel `__init__`** (it statically re-exports every
-  submodule, so a barrel-importing node pulls the whole ML stack — reintroducing the torch conflict).
-  **2A prerequisite:** make the barrel lazy (PEP 562) or have nodes import submodules by full path (as
-  `detect` already does) — **sized: exactly 4 nodes** (`anonymize`, `audio_transcribe`,
-  `embedding_transformer`, `ocr`); 9 already safe. A whole-tree sweep (481 files) found only **1**
-  dynamic import (`preprocessor_code`, enumerable). Downgraded from 🔴 to 🟠 by the prototype; the
-  earlier "node-file-only AST under-includes" concern is subsumed by the transitive-walk requirement.
+- 🟢 **AST correctness PROVEN and precision prerequisite DONE (§4.8 Prototype result).**
+  `ast_deps.py` (implemented, 13 tests) resolves providers and does the transitive walk; over the three
+  hardest nodes it reached **every** ground-truth requirement file with **zero under-includes and zero
+  dynamic imports**. The over-inclusion residual (the `ai.common.models` barrel `__init__`) is **fixed
+  via Option A** — the 4 barrel importers (`anonymize`, `audio_transcribe`, `embedding_transformer`,
+  `ocr`) now import by full path; measured `audio_transcribe` **24→7** files, `anonymize` **23→5**, no
+  cross-family leaks. A whole-tree sweep (481 files) found only **1** dynamic import (`preprocessor_code`,
+  enumerable). Was 🔴 → 🟠 (prototype) → 🟢 (barrel fix applied).
 - **Scoping should be model-server-aware (footprint optimization, §4.8).** Under `--modelserver` a
   proxied node needs no `ai/**` heavy deps (facades take the `ModelClient` branch; `gpu_guard` blocks
   `import torch`); pruning them shrinks venvs and removes most conflicts. Prerequisite: node
@@ -602,14 +605,15 @@ elsewhere that carry `environment`.
   mode does **not** remove the *compile-time* conflict (that glob union is flag-independent), so venvs
   stay necessary.
 - 🟠 **Concurrent install race** — per-env lock (§4.10).
-- 🟠 **Large image/video crossings — being designed out by the cloud-store direction.** In the target
-  architecture AV bytes live in **cloud storage** (`ai..account.store`) and **only metadata / a URL
-  crosses node boundaries** → the venv bridge carries tiny pointers, not multi-MB buffers, and a venv
-  vision node **fetches from the store directly** (§4.5). So the throughput concern applies **only to any
-  interim** where AV still crosses over the bridge; there, a representative AV crossing must meet a
-  throughput target on the loopback WS bridge (2-hop hub multiplies buffer copies), with UI warning on a
-  heavy-lane boundary and shared-memory zero-copy as the v2 fallback. Store-fetch in the child needs
-  account context (secrets/`ROCKETRIDE_CLIENT_ID` propagation).
+- 🟠 **Large image/video crossings — payload shrinks with cloud store, but the AV lanes stay.** In the
+  target architecture AV bytes live in **cloud storage** (`ai..account.store`); bulk bytes are fetched
+  from the store rather than streamed node-to-node. **AV metadata still crosses on the
+  `writeVideo`/`writeAudio`/`writeImage` lanes**, so the bridge must still implement every AV lane
+  (§4.4 is *not* reducible) — what drops is the per-frame **payload size** (small metadata vs multi-MB
+  buffers), which is what removes the ~1 MB-chunk throughput risk. **Interim** (pre-store): raw AV
+  crosses these lanes and must meet a throughput target on the loopback WS bridge (2-hop hub multiplies
+  buffer copies), with UI warning on a heavy-lane boundary and shared-memory zero-copy as the v2
+  fallback. Store-fetch in the child needs account context (secrets/`ROCKETRIDE_CLIENT_ID` propagation).
 - **Cross-env cyclic deadlock** — v1: detect env-cycles at partition and reject.
 - **Secrets scoping (a win):** partition runs on the *resolved* pipeline, so each child sub-document
   carries only the secrets its own nodes reference (the `ocr` venv never sees the LLM key). Document how

--- a/packages/server/design/virtual-environments.md
+++ b/packages/server/design/virtual-environments.md
@@ -1,0 +1,769 @@
+# Design: Virtual Environments for RocketRide Pipelines
+
+**Status:** Draft (design round — no implementation yet)
+**Scope:** Engine (C++ + embedded Python), `depends.py`, the `remote` sub-pipeline mechanism,
+the pipeline canvas (shared-ui / VS Code), and the test/CLI harnesses.
+**Audience:** Engine + tooling engineers. This is an *internal* design document, not user-facing
+documentation — it deliberately lives in `packages/server/design/`, **not** `packages/server/docs/`
+(which `docs:gather` publishes to the public site under *Protocols › WebSocket*).
+
+---
+
+## 1. Problem
+
+When a pipeline runs, **all** of its nodes execute inside **one** `engine.exe` process (an embedded
+CPython interpreter). Every node module is imported into that single interpreter, sharing **one**
+`lib/site-packages` pinned by **one** `cache/constraints.txt`.
+
+That constraints file is built by globbing **all** node and `ai/` requirements
+(`REQUIREMENTS_GLOBS = ['requirement*.txt', 'nodes/**/requirement*.txt', 'ai/**/requirement*.txt']`,
+`depends.py:58`), concatenating them (`_combine_requirements`), and running **`uv pip compile` over
+the union** (`ensure_constraints`). So if two nodes need incompatible versions (e.g. `torch==2.0` vs
+`torch==2.1`), the unified compile **fails at engine startup** (`_compile_constraints` →
+*"Failed to compile constraints"*), before any pipeline runs.
+
+**Corollary:** today *all shipped nodes must be mutually dependency-compatible*, and a pipeline that
+uses nothing audio-related still drags in `whisper`; nothing NER-related still drags in `gliner`.
+
+**Goal:** let a user partition a pipeline into named **virtual environments** — groups of nodes that
+run in their own OS process with their own isolated `site-packages` — so conflicting dependencies no
+longer collide. Nodes in different environments exchange lane data over secured local IPC.
+
+### Goals
+- Allow nodes with mutually-incompatible Python dependencies to coexist in one pipeline.
+- Scope dependency installation to **only the nodes a pipeline actually uses** (per environment) —
+  faster, smaller, and conflict-surfacing at *compile* time rather than at *runtime*.
+- Reuse existing engine machinery (the `remote` sub-pipeline, `depends.py`, the canvas group node)
+  rather than inventing parallel stacks; **no/minimal C++ engine changes**.
+
+### Non-goals
+- **Not a security sandbox.** Virtual environments isolate *dependencies*, not untrusted code — a
+  node in a venv can still touch the filesystem and network. This is not tenant isolation.
+- Not a general distributed-execution feature. Inter-venv transport is local (loopback) in v1.
+
+---
+
+## 2. Background (verified)
+
+### 2.1 Canvas groups are inert in the engine
+The canvas (`packages/shared-ui/src/components/canvas`, ReactFlow/xyflow) already has a **group node**
+(`INodeType.Group`). Nodes dropped into a group get `parentId`; on save,
+`graph.ts:getProjectComponents()` **nests the group's children into `config.pipeline.components`**.
+
+But a group has **no engine-side meaning today**: there is no `group` provider, nothing flattens or
+recurses into `config.pipeline.components`, and `stack.cpp` (`generatePipelineStack`/`buildConnections`)
+iterates only top-level `components[]`. So a group is purely a UI container; the nested blob in the
+saved document is inert. **The new partitioner is where group structure gets runtime meaning.**
+
+### 2.2 The `remote` sub-pipeline mechanism (the reuse foundation)
+The repo has a **live** remote-sub-pipeline feature under `nodes/src/nodes/remote/`:
+`remote` / `remote_server` nodes + `prepare_pipeline.py` + a WebSocket lane bridge + HTTP endpoints in
+`packages/ai/src/ai/modules/remote/`. It already:
+
+- takes a nested `config.pipeline` (the **same shape** as canvas groups);
+- **rewrites the graph** two ways — `prepareLocalPipeline` *inlines* a sub-pipeline (= "flatten");
+  `prepareRemotePipeline` *inserts bridge/stub nodes + reroutes lanes* (= cut a boundary);
+- bridges lane data over a **token-authed WebSocket** (Bearer token, `~1 MB` chunking);
+- gates members by a **`REMOTING`** capability (on by default; cleared by `noremote`, `services.cpp:1737`).
+
+Two facts that shape the design (both **verified** against the code):
+
+- **Lane coverage is 3, not 5.** Server-side `callLocal` (`remote/base/IInstance.py`) handles only
+  `writeTag`/`writeText`/`writeDocuments` (+ `open`/`closing`/`close`) → **text/tags/documents**;
+  everything else `raise TypeError`. `image`/`video`/`audio`/questions/answers/classifications are
+  missing. (The client also *sends* `words` but the server has **no `writeWords` handler** — a latent
+  network-remote bug to fix separately.)
+- **The transport is not cleanly separable.** WebSocket `_send`/`_recv`/`connect`/`disconnect` are
+  embedded **directly** in `remote/base/IInstance.py`, not behind a transport seam.
+- `remote_source_stub` is **not** a real node — it is *synthesized at runtime* by `prepare_pipeline.py`.
+- `REMOTING`/`noremote` is a **network**-remoting gate; the `noremote` set is local-resource nodes
+  (local filesystem `core` source, DB nodes, `text_output`). Venvs are *same-host*, so this gate may
+  be too restrictive — see §7.
+
+### 2.3 Embedded Python & dependency machinery
+- `init.cpp` initializes CPython with an **isolated `PyConfig`** (`Py_InitializeFromConfig`), home set
+  to the executable dir. **`PYTHONPATH` is ignored** — `sys.path` is mutated at runtime instead
+  (`init.cpp:setPaths`, and `depends.py:_ensure_site_packages` does `sys.path.append(...)`).
+- Linux/macOS statically link CPython into `engine.exe`; Windows ships `python3XX.dll` + the MSVC
+  `vcruntime` next to it, loaded at C++ init **before** `sys.path` is touched.
+- `depends.py` resolves all paths relative to `dirname(sys.executable)`: `engine_cache_dir()` =
+  `<exe>/cache`, `model_cache_dir(name)` = `<exe>/cache/models/<name>`, base site-packages =
+  `<exe>/lib/site-packages`. It already has a `FileLock`/`install.lock` + progress sidecar for
+  concurrent installs.
+- The dev-mode debug shim copies `engine.exe → python.exe` **in the same directory** (so
+  `dirname(sys.executable)` is unchanged). `engtest` (the engine-lib Catch2 binary) asserts
+  `sys.prefix == sys.executable dir == rootDir` — an invariant this design preserves.
+
+### 2.4 `project_id` and multi-source pipelines
+- A pipeline's stable id lives at **`config.pipeline.project_id`** (a GUID; the top-level
+  `project_id` is null). `task_server.py` reuses it and only generates one if absent; it survives
+  edit/save/rename. Unsaved ad-hoc editor runs may get a fresh UUID each run.
+- A pipeline may have **multiple source nodes** (e.g. `dropper_1`, `dropper_2`) = multiple execution
+  lanes. The engine runs **one source per task** (separate `task-*.json` + `taskId` per source), but
+  **every per-source task file carries the FULL `components[]` and the same `project_id`** (verified
+  on `examples/task-0d4f3caa.dropper_1…json` / `task-575adb74.dropper_2…json`).
+
+---
+
+## 3. Design overview
+
+**A virtual environment = a "local remote".** Each isolated group becomes a flat sub-pipeline run by
+a child `engine.exe` process (TARGET mode, as the engine runs any pipeline today), with its own
+isolated `site-packages` overlay. Boundary edges are bridged over a token-authed WebSocket on
+loopback; the main process's orchestrator routes inter-venv frames. The C++ engine is unchanged.
+
+Three pillars:
+
+1. **Per-environment requirement scoping** (the actual conflict fix). Stop globbing all node/`ai`
+   requirements into one resolution; instead each environment compiles + installs **only the nodes it
+   uses**, into its own overlay. This even helps no-venv pipelines (scoped installs). *Foundation —
+   shippable on its own.*
+2. **The venv runtime.** A new first-class canvas **Virtual Environment** container; a Python
+   **partitioner** that turns isolated groups into venv sub-pipelines + bridge nodes; a **`venv`
+   bridge node** (sharing a base with `remote`) carrying all lanes; **local spawn + hub routing**;
+   orchestration (lifecycle, merge-back, observability).
+3. **Polish & scale.** Cross-cut debug/observability, pre-warm, and v2 optimizations (direct
+   venv↔venv mesh, shared-memory for large buffers, the local-IPC transport seam).
+
+---
+
+## 4. Detailed design
+
+### 4.1 The Virtual Environment container (UI)
+The **only new visible/placeable** canvas element is a first-class **Virtual Environment** container
+(its own palette/creation entry). It reuses group *mechanics* (`parentId` nesting, children →
+`config.pipeline.components`, `onNodeDragStop` drop-into) but is distinct from a plain organizational
+group: it carries `config.environment = { name, isolated: true }` and an "isolated" visual treatment
+(badge/border). A **cog** exposes a **Purge environment** action (§4.10).
+
+The **bridge/`remote`/`venv` nodes stay internal** — synthesized/inserted by the partitioner, **never
+in the node palette**, never user-placed. (Like the `remote` nodes today, which are not canvas-exposed.)
+
+VS Code host wiring (`apps/vscode/.../ProjectWebview.tsx`) follows the extension rules
+(`Callout.call`, `AppError`, `logger.*`). The schema field is added to
+`packages/client-typescript/src/client/types/pipeline.ts`.
+
+### 4.2 Pipeline document format — two formats
+
+**Authoring format** (what the canvas saves into `.pipe`): a venv is the existing group node with the
+**only additive change** `config.environment = { name, isolated: true }`. Member nodes keep their
+`input`/`control`; a member's `input.from` may reference a node *outside* the group (lane edges cross
+groups today) — those are the boundary edges.
+
+**Runtime format** (what each `engine.exe` receives): the engine reads only **top-level**
+`components[]` and ignores `config.pipeline`. The **partitioner** (Python, pre-launch, modeled on
+`prepare_pipeline.py`) expands the authoring doc into N **flat** sub-documents — `main` + one per venv
+— inserting bridge nodes at each boundary edge and rewriting the downstream `input.from`.
+
+```jsonc
+// authoring: a "vision" venv with one member (detect), fed by parse(main), feeding response(main)
+{ "id": "venv_vision", "config": {
+    "environment": { "name": "vision", "isolated": true },
+    "pipeline": { "components": [
+      { "id": "detect_1", "provider": "detect", "ui": { "parentId": "venv_vision" },
+        "input": [ { "lane": "image", "from": "parse_1" } ] }   // crosses INTO the venv
+    ] } },
+  "ui": { "nodeType": "group" } }
+```
+
+### 4.3 Partitioner
+A Python transform pass in the task-start path (`task_engine.py`, after `_check_pipeline`, before
+`_build_task`), run **automatically whenever any group is `isolated`** (no isolated groups → no-op).
+Modeled on / generalizing `prepare_pipeline.py`:
+
+- **Non-isolated** groups → **flattened** (children lifted to top level, like `prepareLocalPipeline`).
+- **Isolated** groups → a separate flat sub-pipeline per venv; each boundary **data-lane** edge gets a
+  bridge-node pair + a `channelId` recorded in a routing table.
+- Builds the **env-quotient graph** to detect cross-env cycles.
+- Reads the **full `components[]`**, not the executing source's reachable subgraph (see §4.13).
+
+Covered cases: lane fan-out across envs, multiple lanes per env-pair, A→B→main chains, source/sink
+placement (§4.11). **Invoke/control edges never cross a boundary** (the editor's `isValidConnection`
+requires equal `parentId` for invoke handles; data lanes cross freely) — so cross-env tool-call RPC is
+out of v1 *by construction*. **This is editor-only — C++ does not check `parentId` on invoke edges
+(verified)** — so **the partitioner must enforce it as a hard validation** (reject cross-boundary
+invoke/control edges), not assume the document is well-formed.
+
+### 4.4 Bridge nodes — shared base + a new `venv` node
+The transport is *not* cleanly separable (§2.2), so rather than editing `remote` in place or rebuilding
+a parallel stack:
+
+- **Extract the common bridge base** (lane dispatch/serialization in `callLocal` + the transform) into
+  shared code.
+- Add a **new `venv` / `venv_server`** node pair inheriting it, alongside `remote` / `remote_server`.
+- The `venv` node implements **all data lanes** — the 15 `Binder::MethodNames` minus the
+  `open`/`closing`/`close` framing: `tags, text, table, words, audio, video, questions, answers,
+  image, classifications, classificationContext, documents` (today's `callLocal` covers only 3 data
+  lanes — text/tags/documents), critically `image`/`video`/`audio` (vision is image-heavy). Derive lane
+  handlers from **one table** so a new engine lane forces a wire-format bump, never a silent gap. Reuse
+  the serialization vocabulary in `data_conn.py` (`_determine_lane`, `_begin`/`_write`/`_end`).
+
+This **reuses the fiddly logic** (shared base) while **decoupling** venv work from the live `remote`
+feature — no regression risk to network-remote, and its `words` gap stays its own problem. It is *not*
+the rejected `venvEgress`/`venvIngress` reinvention; it is a sibling of `remote` over one base.
+
+### 4.5 IPC transport & security
+**v1 reuses the existing WebSocket lane bridge bound to loopback, unchanged** — it already carries a
+Bearer token. Bind to `127.0.0.1`; reject unauthenticated connections; deliver the token via inherited
+env/handle, never argv.
+
+- **Known limit (v1 acceptance gate, not a v2 "confirm"):** WS frames chunk at `~1 MB`
+  (`remote/base/IInstance.py`); large image/video relies on chunking. **Measure a representative
+  image/video crossing against a target throughput ceiling as a v1 acceptance criterion**; raise the
+  chunk ceiling for AV if it misses.
+- **Target architecture removes this for AV.** In the planned model, AV bytes are written to **cloud
+  storage** (`ai..account.store`) and **only AV metadata / a URL pointer crosses node boundaries** — so
+  the venv bridge carries **tiny metadata, not multi-MB buffers**, and a venv vision node fetches bytes
+  **directly from the store**, not across the bridge. The throughput ceiling above then applies **only
+  to any interim** where AV still crosses in-process/over the bridge. (The child's store fetch needs
+  account/store context — ties into secrets/`ROCKETRIDE_CLIENT_ID` propagation, §6.)
+- **Hardening (deferred to 2C):** OS-access-controlled local IPC so the kernel rejects other-user
+  processes *before* any token check — **named pipe + user-SID ACL** (Windows), **Unix domain socket**
+  `0700` + `SO_PEERCRED`/`LOCAL_PEERCRED` (Linux/macOS). Matters for **multi-tenant** hosts (Linux
+  cloud especially); single-tenant is fine on loopback + token (same-user child). This is **not
+  Windows-specific** — but it requires the same `IInstance.py` transport refactor that makes the
+  transport not-separable, so it is deferred, not a v1 item.
+
+### 4.6 Inter-venv routing — hub via main
+All venv children connect **only to main**. Main's **orchestrator** (the Python process that spawned
+them, *not* main's node pipeline) owns a socket per child and acts as a **byte router** at the
+transport layer: it reads a frame off one child's socket and forwards it to another's via the routing
+table.
+
+```
+dropper(main) → parse(venv1) → detect(venv2) → return_image(main)
+connections: main↔venv1, main↔venv2   (no venv1↔venv2 link)
+parse(venv1) ──▶ main ──(route by channelId)──▶ detect(venv2)
+```
+
+**The data never enters main's engine/node graph nor main's `site-packages`** — main forwards **opaque
+frames**, so it needs **no codecs/deps** for the data crossing it (a venv-`torch` image passes through
+main without main having `torch`). Routing through main's *nodes* would force main's env to understand
+every crossing lane — explicitly avoided.
+
+Rationale for hub over mesh: N connections (not N²), central lifecycle/token/routing/observability, each
+child authenticates with **only main**. Cost: a venv→venv edge is 2 transfers. **v2 optimization:**
+direct venv↔venv peering for hot large-buffer edges (+ shared-memory for AV).
+
+### 4.7 Per-environment requirement scoping (the conflict fix)
+Today `_find_requirement_files()` globs **all** `nodes/**` + `ai/**` requirements (pipeline-blind);
+the unified `uv pip compile` fails the moment two nodes conflict. Instead:
+
+**Uniform per-environment scoping (main included; one code path).** Each environment compiles +
+installs **only the nodes it uses**, into its own node-set-keyed overlay. The partitioner already knows
+each env's node set, so:
+
+- map the env's components → `provider` → `nodes/src/nodes/<provider>/requirements*.txt`;
+- **AST-discover** the `ai/**` submodules each node imports (§4.8) → include only those
+  `requirements*.txt`;
+- `ensure_constraints()` takes an **explicit requirement-file set + env dir** (not the global glob).
+
+**Node set = the WHOLE document (all sources/lanes), not the executing source's subgraph** — because
+the on-disk env is keyed by `project_id` and shared across all per-source runs. Compiling per-lane would
+each succeed but **conflict at runtime** (dropper_1 lane `torch 2.0` + dropper_2 lane `torch 2.1`);
+full-set compilation surfaces it at **compile time**, and both lanes reuse the **same** venv.
+
+**Consequence / blast radius (must gate).** The base `lib/site-packages` becomes **engine-runtime-only**;
+**all** node deps move into per-environment overlays — even main's, **even for pipelines with no venvs**.
+When enabled, this changes dependency resolution for the *whole* pipeline (main included), so it is
+gated by the **`ROCKETRIDE_SERVER_USE_VENV` master switch (§4.15)** with a **permanent** fallback to
+today's global-glob path (`=0`). The default (auto) only scopes per-env when the pipeline opts in via an
+isolated group — a no-venv pipeline under the default keeps today's global-glob behavior unchanged; the
+legacy path is a supported mode, not a transitional flag.
+
+**Upside:** eliminates "all shipped nodes must be compatible" entirely (conflicts only *within* an env →
+resolved by the venv split); shrinks the overlay-can't-hide-a-base-package limit to only packages the
+**engine runtime itself** needs.
+
+### 4.8 AST discovery of `ai/**` requirements
+Run **once per pipeline init**, cached by node-set hash.
+
+**Input contract.** The partitioner (the only component that reads the `.pipe`) resolves each env's
+components → `provider` → the node's **entry-module path** (resolution rule below) and hands
+`depends.py` an explicit **per-env node-set descriptor**: a list of
+`(provider, entry_module_path)` + the node-set hash + the env dir. **`depends.py` never parses the
+`.pipe`** — a single AST-discovery entry point there walks each entry-module path, follows imports
+into `ai.*` to find the `ai/common/models/<x>` submodules reached, and returns those submodules'
+`requirements*.txt` to fold into the env's requirement-file set. So a pipeline with no audio never
+pulls in `whisper`. This reconciles §4.7 (partitioner resolves the node set) with §9 (the AST walk
+lives in `depends.py`): **the partitioner passes paths; `depends.py` parses them.**
+
+**Resolution rule (verified — NOT `nodes.<provider>`).** The entry module is **not**
+`nodes/src/nodes/<provider>/` by string; that naive rule holds for ~91 of ~133 providers and **breaks
+for ~42**. The authoritative mapping is: `provider` = the `logicalType` (protocol scheme with `://`
+stripped, e.g. `detect://` → `detect`) → its matched `services*.json` → that file's **`path`
+(`nodePath`) field** → dots-to-slashes under `nodes/src/` → a **package dir with `__init__.py`** that
+re-exports `IInstance`/`IGlobal` (and `IEndpoint` for endpoint nodes); the node logic to AST-parse is
+`IInstance.py`/`IGlobal.py` there. Traps the partitioner must handle: **aliases** (many providers →
+one dir: `chat`,`dropper` → `webhook`; all `response_*` → `response`), **sub-package paths** (`remote`
+→ `nodes/remote/client`, whose own `__init__.py` re-exports nothing — you *must* follow `path`),
+**name ≠ dir** (`text-output` → `text_output`, `db_supabase` → `db_postgres`), and **native providers
+with no `path`** (`parse`, `filesys`, `hash`, …) which have **no Python module and are skipped**. The
+engine loader itself does exactly this (`python-global.cpp` uses `serviceDef.nodePath`, not the
+provider string), so the partitioner must read `path` from `services*.json`, never synthesize it.
+
+**Known risk — the AST premise is weaker than it looks (VERIFIED against `detect`, `pose_estimation`,
+`audio_transcribe`, `ner`, `anonymize`).** The heavy pip packages are **not** declared per node and are
+**not** chosen by per-variant `depends()` calls: no `requirements_pose`/`requirements_detection` files
+exist, and `detect`/`pose_estimation` have **no `requirements.txt` and call `depends()` zero times**.
+Instead —
+- a node's `IGlobal.py` typically **defers** the `ai.common.models.*` import into `beginGlobal`
+  (config-gated), and the actual package is a **lazy, config-selected import inside `ai`** — e.g.
+  `from rfdetr import RFDETRBase` inside `ai/common/models/vision/detection.py::_build_backend`, picked
+  by the `engine` config, **two hops from the node file**;
+- config (`profile`/`engine`/`model`) selects a **runtime model backend, never a requirements file**.
+
+Consequences a static node-file AST walk must confront:
+- it **systematically under-includes** — the true deps sit behind deferred/config-driven imports inside
+  `ai`, invisible to a walk of `IGlobal.py`/`IInstance.py`;
+- the `depends()` **backstop does not rescue these nodes** — `detect`/`pose` never call `depends()`, so
+  nothing installs mid-run; today their deps come from the **pre-populated shared `ai`/model-server
+  environment**.
+
+So per-env `ai/**` inclusion **cannot rely on node-file AST alone.** The walk must be **transitive
+through the `ai` package** (follow deferred + config-branch imports inside `ai.common.models.*`, not
+just the node's top-level imports); where a config branch selects among mutually-exclusive backends,
+**include all reachable backends' `requirements*.txt`** (then verify they don't mutually conflict)
+rather than trusting a runtime `depends()` that never fires. Nodes that *do* call `depends()` /
+`load_depends()` (e.g. `detect_segment`, some TTS) install a **single fixed** `requirements.txt`, not a
+variant — so the backstop is a narrow safety net, not the primary mechanism.
+
+**Prototype result (VERIFIED — throwaway static-AST walk run against `detect`, `audio_transcribe`,
+`anonymize`, the three hardest nodes).**
+- **Correctness holds — static AST is feasible.** With two walker requirements — (1) collect
+  **nested/in-function imports** (not just module-level), (2) resolve **relative imports** correctly
+  (`__init__.py` package vs regular-module package) — the walk reached **every** ground-truth
+  requirement file (`requirements_detection.txt`+`requirements_vision.txt`+`torch` for `detect`;
+  `requirements_whisper.txt`+`torch`; `requirements_gliner.txt`+`torch`) with **zero under-includes and
+  zero dynamic `importlib` calls**. The earlier worry that config-selected backends hide from AST was
+  **wrong**: `from rfdetr import RFDETRBase` inside `_build_backend` is a *literal nested* import the
+  walk sees.
+- **The residual problem is PRECISION, not correctness — the `ai.common.models` barrel `__init__`.**
+  `detect` imports by **full submodule path** (`from ai.common.models.vision.detection import …`) → the
+  walk stays tight (only detection+vision+torch). But `audio_transcribe`/`anonymize` import via the
+  **`ai.common.models` package `__init__`, which statically re-exports EVERY submodule** — so the walk
+  transitively reaches the **entire model universe** and over-includes `rfdetr`, `rtmlib`, `gliner`, all
+  OCR, `transformers` for an *audio* node. That reintroduces the very torch-conflict + bloat venvs exist
+  to remove.
+- **Prerequisite for precise scoping (a repo change, not a walker change):** either nodes import `ai`
+  model submodules **by full path** (as `detect` already does), or the `ai.common.models` barrel
+  `__init__` is made **lazy (PEP 562 `__getattr__`)** so the walk follows only the used name. Until one
+  of these lands, per-env scoping over-includes for every barrel-importing node.
+- **Blast radius + generalization (whole node-tree sweeps, VERIFIED).** The barrel fix is **small and
+  bounded: exactly 4 nodes** import via the barrel — `anonymize`, `audio_transcribe`,
+  `embedding_transformer`, `ocr` — vs **9 already on full path** (`detect`, `ner`, `pose_estimation`,
+  `caption`, `depth_estimate`, `audio_tts`, `background_removal`, `detect_segment`, `embedding_image`).
+  So the prerequisite is a **4-node change** (or one lazy-barrel change), not a refactor. And the
+  "no dynamic imports" result **generalizes**: a sweep of **all 481** node+ai-model files found **exactly
+  one** dynamic import — `preprocessor_code/code.py`'s `importlib.import_module(modmap[lang_key])`, a
+  **static lang→module dict** whose targets the walk can enumerate (or the runtime `depends()` backstop
+  covers). Static AST is sound across the tree, modulo that one enumerable case.
+
+**The backstop is not free** — an under-include means a possibly multi-GB `depends()` install happens
+*mid-run* inside the venv child. Specify timing/failure: prefer resolving all reachable variants
+**before readiness**; if a late install is unavoidable, block that lane (surfacing progress via the
+heartbeat) and **fail cleanly** (do not hang) if it errors. AST is the pre-resolution + early-conflict
+layer; runtime `depends()` is the safety net.
+
+**Backstop contract.** (a) Prefer resolving every statically-reachable variant **before readiness**.
+(b) When a dynamic `depends()` fires mid-run, block **only that lane**, surface install progress via
+the existing heartbeat/sidecar (`updateProgress`), and on install failure **fail the lane with a clear
+error** rather than hanging. (c) Bound the mid-run install with a timeout. Canonical cases: the
+config-selected `rfdetr` import inside `ai` for the under-include path (backstop can't fire — `detect`
+calls no `depends()`); `detect_segment`'s `load_depends(__file__)` for the single-fixed-file
+`depends()` path.
+
+**Model-server dimension (`--modelserver`) — a second axis the requirement set depends on (VERIFIED).**
+Every `ai.common.models.*` facade branches on `get_model_server_address()` (`base.py`): with a model
+server set it constructs a thin `ModelClient` (WebSocket RPC) and **never imports torch/rfdetr/whisper**
+(`gpu_guard.py` installs a `sys.meta_path` blocker that makes `import torch` *raise* in this mode);
+without one, `*Loader._ensure_dependencies` (`base.py`) installs + imports the heavy stack. The heavy
+imports live **exclusively in the local (no-model-server) branch**. Implications for scoping:
+- **Sound baseline (flag-agnostic):** both branches are statically present in the same file, so the
+  transitive `ai` walk **over-approximates** — include the heavy `ai/**` requirements regardless of the
+  flag. Always correct, but fat.
+- **Pruning = the payoff:** make scoping **model-server-aware** — a proxied node contributes only
+  wrapper/networking deps, not the `ai/**` heavy files. This shrinks venvs sharply and dissolves most
+  cross-node torch-version conflicts. **Prerequisite:** node `requirements.txt` are **model-server-blind
+  today** — `audio_transcribe` (faster-whisper) and `anonymize` (gliner) install heavy deps even when
+  proxied, whereas `ner` (empty) / `detect_segment` (client-side only) already gate correctly. Pruning
+  requires fixing the blind ones (or the scoper overriding them).
+- **Does NOT sidestep the compile-time conflict.** The torch-2.0-vs-2.1 failure is at **constraints
+  *compile* time** — a union over the `nodes/**` + `ai/**` globs taken **irrespective of `--modelserver`**
+  (the flag changes only runtime install/import). So per-env scoping stays necessary in model-server
+  mode; the flag is a **footprint optimization, not a conflict fix**.
+
+### 4.9 Directory layout, identity & keying
+- `<exe>/lib/site-packages` — **base = engine runtime only** (engLib + bundled deps); **no node deps**.
+- `<exe>/venvs/<project_id>/<env_id>/` — **per-environment overlay** for EVERY env, a **top-level
+  `venvs/` dir** (sibling of `lib/`, `cache/` — **not** under `cache/`). `env_id ∈ { main, <group_id> }`
+  → main lives at `venvs/<project_id>/main`. Each holds `site-packages/` + its own scoped `combined.txt`,
+  `constraints.txt`, `requirements.hash`, lock. The path helpers
+  `_get_combined_path`/`_get_constraints_path`/hash are parameterized by the env dir. **The refactor
+  surface is wider than the path helpers:** `depends.py`'s single-environment module state — the
+  `_processed` set, the `install.lock`, `_progress_path`, and the single-holder heartbeat — must
+  become **env-keyed** too, or concurrent envs collide.
+- `<exe>/cache/models/<name>` — **shared** model weights via `model_cache_dir`, resolved relative to
+  `sys.executable`. The venv child runs the **same `engine.exe`, unmoved**, so it resolves the same
+  `cache/models` automatically. Models are weights, not packages → not isolated per venv.
+
+**Key by stable IDs; name is metadata.**
+
+- `<project_id>` (the pipe-id) is a stable GUID at `config.pipeline.project_id`. Shared across all
+  per-source task runs of the same pipeline.
+- `<group_id>` (the venv-id) = the group node's `id` (e.g. `group_1`) — stable, generated once, **never
+  changes when the venv is renamed** (the display name lives in `config.environment.name`).
+- **Consequence: NO rename logic needed** — renaming a venv changes only metadata, not the path.
+- **Requirements drift** detected by a `requirements.hash` inside the env dir (reusing
+  `depends.py`'s `_compute_hash`/`_load_stored_hash`/`_save_hash`); mismatch → update install in place.
+- **MAX_PATH (decision, not a note):** a 36-char GUID nested above `site-packages` + deep torch/nvidia
+  paths **will** exceed Windows 260, and long-path support is host-opt-in/unreliable → **default to a
+  shortened id segment** (e.g. first 8 hex of the `project_id` GUID; likewise `group_id`). Point all
+  venv installs at **one shared `uv` download cache** so common wheels aren't re-downloaded.
+
+### 4.10 Lifecycle: per-run process, install lock, purge/GC
+- **Venv process = the pipeline run.** A venv child is spawned when the run starts and exits when it
+  ends — a **sibling** of the main `engine.exe`, mirroring today's process-per-run model. It handles all
+  objects in that run but is **never reused across runs**. No warm pool. Two runs (same or different
+  pipeline) → separate processes → no interference.
+- **On-disk env reused across runs** (only the process is per-run): installed once, keyed by stable IDs,
+  drift detected by `requirements.hash`.
+- **Install timing:** lazy on first run + opt-in deploy-time pre-warm; reuse `depends.py`'s existing
+  install-progress reporting verbatim (`updateProgress` / heartbeat / sidecar), tagged per env.
+- **Concurrent-install lock (race fix):** process-per-run + a shared cached env dir + install-on-drift
+  could let two concurrent runs both `uv install --target` into the same `site-packages` → corruption.
+  `depends.py` **already** has the `FileLock`/`install.lock` mechanism — **scope it per env dir** (one
+  lock per `venvs/<proj>/<env>/`, not the single global lock) and define the **second-run
+  wait-on-readiness** vs. fail behavior.
+- **Purge & delete (canvas-driven).** *Purge* = remove all installed packages, keeping standard Python
+  (delete the contents of the venv's `site-packages`; the base/stdlib survives because it's shared).
+  - **Operation A — Purge (cog):** wipes packages, keeps the container + nodes. Allowed only when no run
+    uses that env (active-task registry, `task_server.py`); deleting files a live process holds fails on
+    Windows, so the gate is mandatory. Exposed as an engine command over the protocol (local + cloud).
+  - **Operation B — Delete the container:** asks (1) delete member nodes + connections? (no = ungroup,
+    keep them); (2) also remove the venv? (yes = delete the entire `venvs/<project_id>/<group_id>/`).
+  - **Operation C — Pipeline deleted:** delete the whole `venvs/<project_id>/` subtree.
+  - **Lifecycle coupling:** the dir lives as long as its canvas entity; **orphan-GC reconciliation** is
+    the safety net (pipelines/groups can be deleted out-of-band — e.g. the `.pipe` removed directly).
+    LRU eviction under disk pressure is a separate, secondary mechanism for still-valid-but-stale envs.
+
+### 4.11 Overlay mechanism (sys.path; never move the binary)
+The venv child runs the **original `engine.exe`, unmoved**; the bootstrap reads `ROCKETRIDE_VENV_SITE`
+and does **`sys.path.insert(0, venv_site)`** — the exact mirror of the existing
+`_ensure_site_packages` `append`, but `insert`-ahead-of-base for **overlay precedence** (venv `torch`
+wins; append would let base shadow it). **`PYTHONPATH` won't work** (isolated `PyConfig`); use the
+runtime insert.
+
+Because `sys.executable` is unchanged, `model_cache_dir`/`engine_cache_dir`/base `lib/site-packages`
+all resolve to the shared install dir — `cache/models` shared, base runtime preserved. **Do not copy
+the engine into the venv dir:** that changes `sys.executable` → cache/site-packages resolve to the venv
+dir (wrong; also loses the engine runtime, and on Windows would require copying the `python3XX.dll` +
+`vcruntime`). The dev debug shim copies `python.exe` but **in the same dir**, so it's safe; venvs don't
+copy.
+
+Supporting `depends.py` changes: `uv pip install --target <venv_site>`; reuse the existing post-install
+cache reset (`importlib.invalidate_caches()` + `sys.path_importer_cache.pop`) on the venv path. **Verify:**
+the insert position (venv ahead of base site-packages but not breaking the engine framework dirs
+`rocketlib`/`ai`/`nodes`), and `uv --target` + `--no-build-isolation` behavior (`.pth`, console scripts,
+the pywin32 path hack).
+
+### 4.12 Response & failure merge-back
+A venv node's final response and any `objectFailed`/`completionError` must be shipped back and **merged
+into the root entry** the client reads (`data_conn.py:_close`), or venv-produced results/failures
+silently vanish. This is what allows an **end/return node to live in a venv** (§4.11 asymmetry).
+
+### 4.13 Edge cases
+- **Membership is `parentId`, not canvas geometry.** A node belongs to exactly one venv. Two boxes that
+  visually **intersect** still have unambiguous membership (the partitioner reads `parentId`); the UI
+  should prevent/warn on overlap. **Nested** isolated groups (venv-in-venv) are **rejected in v1**.
+- **Start/source node must stay in `main`** (rejected inside a venv in v1) — the client drives the root
+  pipe in the process it connects to. The guard belongs in `resolve_implied_source` (which does the
+  exactly-one-`Source` detection), not `_check_pipeline` (which only validates the named source exists).
+- **End/return node MAY be in a venv** — via response merge-back (§4.12). Asymmetric with the source
+  (input is driven in; output flows back).
+- **How many distinct environments drives the outcome:** no isolated groups → 1 process (today); some
+  in main + some in venvs → partition + hub; **all nodes in ONE venv** → **collapse** to a single
+  process running that venv's overlay (no bridge); ≥2 venvs with nothing in base → uncommon corner
+  (v1: require the source's env to be root, or a base-env source).
+- **Multi-source pipelines** are one pipeline with multiple lanes; constraints span the **whole
+  document** (§4.7). **Process-count note:** each source is its own task/process today, so a pipeline
+  with N sources and M venvs spawns **N × (1 + M)** processes (children are per-run, never shared across
+  source-tasks, §4.10). The per-env install lock covers the shared *disk* env; the process count itself
+  is the accepted v1 cost — revisit (shared children per pipeline) only if real pipelines hit limits.
+
+### 4.14 Non-pipeline entry points (engtest, CLI, ad-hoc, test harnesses)
+These have **no `project_id`**, so the scoping must degrade gracefully: `ROCKETRIDE_VENV_SITE` unset →
+overlay no-ops → use base; `depends.py` tolerates a missing `project_id`/`env_id` and falls back to a
+**default env** (or base). Concrete cases:
+
+- **`engtest`** (engine-lib Catch2 binary, links engLib → embeds Python) runs
+  `loadModule("nodes.webhook")`. Its `python::config` test asserts `sys.prefix == sys.executable dir ==
+  rootDir` — our **no-move-binary overlay preserves this** (the rejected copy-binary approach would
+  fail it → a free regression guard). Node modules import from `nodes/src` on `sys.path` (dev), so
+  module-load needs no install; only third-party deps need the env.
+- **`builder nodes:test`** runs **many** nodes' tests in one env today (works only because all nodes are
+  currently compatible). Once venvs allow incompatible nodes, a single pytest process (one
+  `site-packages`) can't host `torch 2.0` and `torch 2.1` tests → **per-node-scoped test envs**, reusing
+  the same `depends.py` env-dir primitive, with incompatible nodes in **separate worker processes**
+  pinned via `ROCKETRIDE_VENV_SITE` (composing with the planned pytest-xdist work). Declarative node
+  tests are already mini-pipelines (`nodes/test/framework/pipeline.py`) → run them through the same
+  partitioner. **Must land before the first incompatible node ships**, else the suite breaks.
+
+### 4.15 Compatibility & the venv master switch (`ROCKETRIDE_SERVER_USE_VENV`)
+The whole feature (venv runtime **and** per-environment scoping) is gated by one env var, so
+downstream/open-source consumers can pin today's behavior. **This is a permanent supported mode, not a
+migration flag.**
+
+- **Unset (default) = auto.** The partitioner inspects the *resolved* pipeline: an `isolated` group
+  present → venv runtime + per-env scoping; none present → today's single-process / global-glob
+  behavior. (This is already how §4.3/§4.13 behave — the default changes nothing for existing pipes.)
+- **`=0` = force off (legacy mode).** Never partition: any `isolated` group is **demoted to a plain
+  organizational group** (flattened into one process), and dependencies resolve via the **global-glob
+  `constraints.txt` path**. Byte-for-byte today's behavior; **never an error**, even if the document
+  contains isolated groups. This is the escape hatch for downstream consumers.
+- **`=1` = force on.** Enables the venv machinery and per-env scoping (still a no-op partition if the
+  pipeline genuinely has no isolated groups, but per-env `main` scoping applies).
+
+Open-source/default posture: with the var unset, a consumer who never creates an isolated group gets
+exactly today's engine; `=0` additionally guarantees legacy behavior even for documents authored
+elsewhere that carry `environment`.
+
+---
+
+## 5. Open questions — resolved (with residual verification noted)
+1. **Venv membership gate — RESOLVED.** `REMOTING`/`noremote` is a *network* gate; the `noremote` set
+   (local filesystem `core` source, DB nodes, `text_output`) exists because those nodes can't run on a
+   *remote host*. Venvs are **same-host**, so that reason doesn't apply — **do not reuse the network
+   `noremote` set.** v1 rule: **venv membership is unrestricted except the source node** (already forced
+   to `main`, §4.13); DB/filesystem/`text_output` nodes run fine in a venv. Define a venv-specific
+   capability only if a concrete node proves it needs the client's direct fd; none found so far.
+2. **AST variant discovery — RESOLVED via §4.8 correction (premise was wrong).** No
+   `requirements_pose`/`requirements_detection` variant files exist; `detect`/`pose_estimation` declare
+   no `requirements.txt` and never call `depends()`. Heavy deps are lazy, config-selected imports **two
+   hops inside `ai`** (`detection.py::_build_backend`), so a node-file AST walk **under-includes** and
+   the `depends()` backstop **doesn't fire** for them. Resolution: the walk must be **transitive through
+   `ai`** and **include all reachable config-branch backends' `requirements*.txt`** (§4.8). **A
+   throwaway prototype has now PROVEN this** on `detect`/`audio_transcribe`/`anonymize`: zero
+   under-includes, zero dynamic imports (§4.8 Prototype result). The remaining 2A prerequisite is
+   **precision** — the `ai.common.models` barrel `__init__` re-exports every submodule, so barrel-
+   importing nodes over-include the whole ML stack until the barrel goes lazy or nodes import submodules
+   by full path. Second axis: the walk (or a model-server-aware pruning of it) must account for
+   `--modelserver` mode, where the heavy `ai/**` deps aren't imported at all (§4.8 Model-server
+   dimension).
+3. **Non-isolated grouped pipelines — RESOLVED: they do NOT run today (verified).** `getProjectComponents`
+   nests group children into the group's `config.pipeline.components`; the engine (`stack.cpp`) reads
+   only top-level `components[]`; **no flattening pass exists** in `prepare_pipeline.py`, `pipeline.py`,
+   `task_engine.py`, or C++. Grouped children are silently dropped. → The partitioner **must** own
+   "flatten non-isolated groups" (already Phase-2B step 5); this also fixes an existing latent bug.
+4. **Partitioner + orchestration ownership — RESOLVED: both in `task_engine.py`; pure transform in
+   `pipeline.py`.** The engine subprocess is spawned in `task_engine.py` (`create_subprocess_exec`,
+   ~L1561; readiness ~L501-520; teardown `_terminated` ~L563). Put the partitioner as a **pure function
+   in `pipeline.py`** (sibling to `resolve_pipeline_env`/`resolve_implied_source`), invoked from
+   `Task._build_task` (~L355) before the task file is written. Venv-child spawn/lifecycle/channel
+   **mirror the existing engine-spawn pattern in `task_engine.py`**. `task_server.py` keeps the
+   active-task registry (`_task_control`/`TASK_CONTROL.project_id`), the **port broker**
+   (`assign_port`/`release_port`, already cross-called from `task_engine` ~L1500/1513), and auth/WS/DAP;
+   it gains only the minimal shared-resource entries a venv child needs (a registry row + a port).
+5. **Multi-process debug UX — DIRECTION set; detailed UX deferred to 2C.** Each venv child gets its own
+   `--debug_port` from the existing port broker (`assign_port`), exactly as the main engine does today.
+   The client attaches to **main**, which **advertises/multiplexes the child DAP endpoints** (it already
+   owns the per-child sockets as the hub, §4.6). Cross-cut single-stepping and unified breakpoint UX are
+   the genuinely open part → 2C.
+
+## 6. Risks & gating requirements
+- 🟠 **Metrics/billing multi-PID rollup (money bug) — driver-feasibility DE-RISKED; residual is
+  grouping.** **CPU/RAM** sum across the venv process tree (per-PID). For **GPU**: **concurrent pipelines
+  are already billed correctly today**, and each running pipeline is its own `engine.exe` PID — so the
+  billing path **already attributes GPU across multiple independent PIDs** on our real hardware. That is
+  empirical proof the driver-level per-PID capability exists, so the earlier "feasibility spike" is **no
+  longer needed**. Venvs therefore reduce to **bookkeeping**: sum a venv's child PIDs under the **parent
+  pipeline's** billing identity (the orchestrator already tracks which children it spawned) rather than
+  counting them as separate pipelines. Residual (still money-critical but **desk-checkable, no spike**):
+  confirm children are **grouped into the parent's bill** — not dropped (under-bill) nor double-counted
+  as standalone pipelines (over-bill).
+- 🟠 **Phase 2A blast radius = only pipelines where the scoped path is enabled** (`=1`, or auto with
+  isolated groups). Under the default (unset, no venvs) **nothing changes** — §4.15 semantics. The
+  radius becomes "every pipeline" only if/when a later release flips auto to scoped-by-default.
+- 🟠 **AST correctness is PROVEN; the residual is precision (2A prerequisite, §4.8 Prototype result).**
+  A throwaway static-AST walk over the three hardest nodes (`detect`/`audio_transcribe`/`anonymize`)
+  reached **every** ground-truth requirement file with **zero under-includes and zero dynamic imports**
+  — so a transitive walk (nested imports + correct relative-import resolution) is sound. The remaining
+  risk is **over-inclusion via the `ai.common.models` barrel `__init__`** (it statically re-exports every
+  submodule, so a barrel-importing node pulls the whole ML stack — reintroducing the torch conflict).
+  **2A prerequisite:** make the barrel lazy (PEP 562) or have nodes import submodules by full path (as
+  `detect` already does) — **sized: exactly 4 nodes** (`anonymize`, `audio_transcribe`,
+  `embedding_transformer`, `ocr`); 9 already safe. A whole-tree sweep (481 files) found only **1**
+  dynamic import (`preprocessor_code`, enumerable). Downgraded from 🔴 to 🟠 by the prototype; the
+  earlier "node-file-only AST under-includes" concern is subsumed by the transitive-walk requirement.
+- **Scoping should be model-server-aware (footprint optimization, §4.8).** Under `--modelserver` a
+  proxied node needs no `ai/**` heavy deps (facades take the `ModelClient` branch; `gpu_guard` blocks
+  `import torch`); pruning them shrinks venvs and removes most conflicts. Prerequisite: node
+  `requirements.txt` are model-server-blind today (`audio_transcribe`, `anonymize`). Note: model-server
+  mode does **not** remove the *compile-time* conflict (that glob union is flag-independent), so venvs
+  stay necessary.
+- 🟠 **Concurrent install race** — per-env lock (§4.10).
+- 🟠 **Large image/video crossings — being designed out by the cloud-store direction.** In the target
+  architecture AV bytes live in **cloud storage** (`ai..account.store`) and **only metadata / a URL
+  crosses node boundaries** → the venv bridge carries tiny pointers, not multi-MB buffers, and a venv
+  vision node **fetches from the store directly** (§4.5). So the throughput concern applies **only to any
+  interim** where AV still crosses over the bridge; there, a representative AV crossing must meet a
+  throughput target on the loopback WS bridge (2-hop hub multiplies buffer copies), with UI warning on a
+  heavy-lane boundary and shared-memory zero-copy as the v2 fallback. Store-fetch in the child needs
+  account context (secrets/`ROCKETRIDE_CLIENT_ID` propagation).
+- **Cross-env cyclic deadlock** — v1: detect env-cycles at partition and reject.
+- **Secrets scoping (a win):** partition runs on the *resolved* pipeline, so each child sub-document
+  carries only the secrets its own nodes reference (the `ocr` venv never sees the LLM key). Document how
+  account context / `ROCKETRIDE_CLIENT_ID` reaches each child.
+- **Backward compatibility:** old `.pipe` documents lack `environment` and must run unchanged (additive).
+- **Free upside:** separate processes = separate GILs → CPU-bound nodes in different venvs run *genuinely*
+  in parallel.
+
+---
+
+## 7. Phased implementation plan
+
+**Phase 1 — this design document.** (Done; pauses for review.)
+
+**Phase 2A — Foundation: per-environment requirement scoping (no venvs yet; independently shippable).**
+*Behind a feature flag with fallback to today's global-glob path (blast radius = every pipeline).*
+1. `depends.py` parameterization — `ensure_constraints()`/install take an **explicit requirement-file
+   set + env dir** (no global glob); uniform per-env build (main included); `uv --target
+   <venvs/<project_id>/<env_id>/site-packages>`; per-env constraints/lock/`requirements.hash`; the
+   `sys.path.insert` overlay hook; base = engine runtime only; default-env fallback when no `project_id`;
+   **env-key the module-global install state** (`_processed`/lock/progress/heartbeat), not just the path
+   helpers.
+2. **AST `ai/**` discovery** — once per init, cached; config-driven-variant + dynamic-import handling;
+   runtime `depends()` backstop with defined timing/failure.
+3. **Non-pipeline entry points** — `engtest` fallback; `builder nodes:test` per-node isolation (must
+   precede any incompatible node).
+   *Payoff (opt-in, per §4.15):* when the scoped path is enabled (`ROCKETRIDE_SERVER_USE_VENV=1`, or
+   auto with an isolated group present), the pipeline runs in a node-scoped "main" env → faster/smaller,
+   no gliner/whisper bloat. **If no venv is needed** — the pipeline contains no isolated groups and the
+   variable is unset — **it runs exactly as today**: one process, global-glob resolution, no behavior
+   change. De-risks the dependency-model change in isolation.
+   *Strategic note:* in **model-server deployments** the model servers already isolate the heavy
+   conflicting deps (each server owns its own env), so **most of the value lands in 2A alone**; the 2B
+   venv *runtime* is primarily for **internal / no-model-server mode**, where conflicting nodes share one
+   in-process interpreter. This sharpens sequencing: ship 2A broadly, prioritize 2B for internal-mode
+   users.
+- **Tests (§8.1–8.3):** AST-walk / resolution-rule / `depends`-parameterization / model-server-pruning
+  **unit tests**; the `vtest_alpha`/`vtest_beta` **fixture nodes**; the **no-venv-conflict-fails** and
+  **only-needed-installed (no-whisper)** acceptance tests; embedding-invariant regression.
+
+**Phase 2B — Venv runtime (the isolation feature), on top of 2A.**
+4. **Schema + UI:** the placeable Virtual Environment container + `config.environment`; validation
+   (source-in-group via `resolve_implied_source`, env-cycle, nested/overlap). Bridge nodes internal.
+5. **Partitioner:** generalize `prepare_pipeline.py` (flatten non-isolated; cut isolated; insert bridge
+   nodes; routing table; full-document node set).
+6. **Bridge: extract shared base + new `venv` node** (all 15 lanes; `image`/`video`/`audio`); network-
+   remote untouched.
+7. **Local spawn + transport (v1 = WS-over-loopback unchanged):** spawn the venv child (its overlay) and
+   point the existing `remote` WS bridge at it over loopback (Bearer token; raise the ~1 MB AV ceiling);
+   main-orchestrator hub routing. No layer-2 swap in v1.
+8. **Orchestrator** (`task_engine.py`): N children/run (sibling lifetime), channel wiring, readiness,
+   teardown-with-run, response/failure merge-back, monitor/trace/SSE fan-in, **metric aggregation across
+   child PIDs**, orphan-safe binding (OS process-tree: Windows Job Objects / Unix process groups),
+   install reporting, purge/delete + GC.
+- **Tests (§8):** partitioner **unit tests**; the **two-venv conflict-coexists** acceptance
+  (`vtest_alpha`/`vtest_beta` split across venvs); compat `=0` isolated-group **demotion**; purge /
+  delete / GC **lifecycle** (blocked while a run is active).
+
+**Phase 2C — Polish & scale.** Multi-process debug/observability across the cut; deploy-time pre-warm;
+the local-IPC transport seam (UDS/named-pipe/shared-mem, §4.5); v2 optimizations (direct venv↔venv mesh,
+shared-memory for AV).
+
+---
+
+## 8. Verification & testing
+Three layers; each test is tagged with the phase that first makes it runnable (**[2A]** = scoping only,
+**[2B]** = needs the venv runtime).
+
+### 8.1 Unit tests
+- **AST discovery walk** (`depends.py`) — promote the throwaway prototype (§4.8 Prototype result) to a
+  real unit test with a golden requirement-set per fixture: `detect`→{detection,vision,torch},
+  `audio_transcribe`→{whisper,torch}, `anonymize`→{gliner,torch}. Assert the two properties proven
+  necessary: (a) **nested/in-function** imports are followed; (b) **relative imports** resolve correctly
+  (`__init__` package vs module). Plus: `provider → path` resolution (aliases `chat`/`dropper`→`webhook`;
+  sub-package `remote`→`remote/client`; name≠dir; native no-`path` skip); dynamic `importlib` flagged;
+  **barrel-`__init__` over-inclusion guard** (full-path import stays tight, barrel import is detected). [2A]
+- **`depends.py` per-env parameterization** — env-keyed paths / lock / `_processed` / progress;
+  `requirements.hash` drift → reinstall; default-env fallback when no `project_id`; base =
+  engine-runtime-only. [2A]
+- **Compatibility switch** — `ROCKETRIDE_SERVER_USE_VENV` unset(auto) / `0`(force-off, isolated group
+  demoted to a plain group, global-glob) / `1`(force-on). [2A scoping paths; 2B demotion path]
+- **Model-server pruning** — a proxied node contributes only wrapper/networking deps, not `ai/**` heavy
+  files (§4.8). [2A]
+- **Partitioner** (`pipeline.py`) — flatten non-isolated groups; cut isolated → per-venv sub-doc +
+  bridge pair + routing table; env-cycle detection; **reject** cross-boundary invoke/control edges,
+  nested isolated groups, source-in-venv. Golden-file: authoring doc → expected N flat sub-docs. [2B]
+
+### 8.2 Test-fixture nodes (purpose-built, lightweight, decoupled from `ai/**`)
+Add a pair of **trivial pure-Python nodes** under the node-test tree (e.g.
+`nodes/test/fixtures/nodes/vtest_alpha`, `.../vtest_beta` — the extra `nodes/` mirrors the prod
+`nodes/src/nodes/` layout so `ProviderIndex` resolves them by the same rule). Each imports **only one tiny leaf package pinned to an
+exact, mutually-incompatible version** — e.g. `vtest_alpha` → `tabulate==0.8.10`, `vtest_beta` →
+`tabulate==0.9.0`. Pick a package **not used by the SDK or engine runtime** (`requests` would be a bad
+choice — the SDK depends on it, so the pin would collide with runtime deps and muddy the test).
+**They import nothing from `ai.*`**, so their requirements never touch `packages/ai`
+and the conflict is isolated to the venv-scoping mechanism — fast, deterministic, no GPU/torch. These
+**replace `torch 2.0/2.1`** as the conflict fixture. [created 2A; used by 8.3]
+
+### 8.3 Integration / acceptance
+- **Conflict → no venv → must NOT start (the core proof).** A pipeline with **both** `vtest_alpha` +
+  `vtest_beta` and **no** venv → the union constraints compile is **unsatisfiable** → the pipeline
+  **fails to start** with a clear error naming the conflicting `requests` pins ("Failed to compile
+  constraints"). [2A — the scoping/compile path alone surfaces this]
+- **Conflict → split across venvs → all good.** The same two nodes in **two separate venvs** → each env
+  compiles/install its single pin → the pipeline runs **end-to-end**, both `requests` versions
+  coexisting. Assert each overlay's `site-packages` holds the expected version (alpha-env→2.28.2,
+  beta-env→2.31.0) and the other is **absent**. [2B]
+- **Only-needed-installed (scoping).** (a) A pipeline using `vtest_alpha` only → its env has
+  `requests==2.28.2`, **not** the other pin and **not** `whisper`/`faster-whisper`/`torch`. (b) A
+  **no-audio** pipeline → `whisper`/`faster-whisper` **absent** from every env's install set; an audio
+  pipeline → **present** (the "if whisper isn't needed it isn't installed" check). (c) Assert the
+  **requirement-file set processed equals exactly the AST-reachable set**, not the global glob. [2A]
+- **Compatibility (`=0`).** A pipeline that **does** contain an isolated group still runs single-process
+  via the global-glob path (legacy mode), no error — the permanent opt-out (§4.15). [2B]
+- **Lifecycle.** Purge, delete-with-nodes, and pipeline-delete reclaim the right `venvs/...` dirs and are
+  **blocked while a run is active**. Image lanes cross a venv boundary (all-lane bridge). [2B]
+- **Embedding invariant.** `server:run-engtest` (`python::config` + `webhook`) and `builder nodes:test`
+  still pass — the no-move-binary overlay preserves `sys.prefix == exe dir == rootDir`. [2A]
+
+## 9. Critical files (for implementation)
+- **Reuse foundation:** `nodes/src/nodes/remote/client/prepare_pipeline.py` (transform → share/generalize);
+  `remote/base/IInstance.py` (extract the bridge base; the new `venv`/`venv_server` add all lanes; WS
+  `_send`/`_recv` live here = transport not separable in place); `packages/ai/src/ai/modules/remote/`
+  (WS transport, reuse over loopback). `REMOTING` in
+  `packages/client-python/src/rocketride/types/service.py` / services.json `noremote`.
+- `packages/ai/src/ai/modules/task/task_engine.py` — partitioner hook after `_check_pipeline`; spawn N
+  children; readiness; teardown; merge-back; metric/trace fan-in.
+- `packages/ai/src/ai/modules/task/task_server.py` — active-task registry (gate purge/GC); `project_id`.
+- `packages/ai/src/ai/modules/task/pipeline.py` — `resolve_implied_source` (source-in-venv guard).
+- `packages/ai/src/ai/modules/data/data_conn.py` — canonical lane serialization to reuse in the bridge.
+- **Testing:** `nodes/test/framework/pipeline.py` (declarative node tests are mini-pipelines → run
+  through the same partitioner); `builder nodes:test` (per-node isolation); `server:run-engtest`
+  (embedding invariant). New: `nodes/test/fixtures/nodes/vtest_alpha`/`vtest_beta` (the conflict fixture,
+  §8.2). **Implemented (2A increment 1):** `.../rocketlib-python/lib/ast_deps.py` (provider→module
+  resolution + transitive AST walk) with `test_ast_deps.py` — the §4.8 prototype is now a passing unit
+  test (13 tests green).
+- `packages/server/engine-lib/rocketlib-python/lib/depends.py` — `ensure_constraints` /
+  `_find_requirement_files` / `_get_combined_path` / `_get_constraints_path` / `_get_site_packages` /
+  `model_cache_dir` / `FileLock`; the AST **walk** (over the entry-module paths the partitioner
+  resolves — `depends.py` itself never reads the `.pipe`) + per-env parameterization + overlay hook
+  land here.
+- UI: `packages/shared-ui/src/components/canvas/util/graph.ts` (`getProjectComponents`),
+  `.../context/FlowGraphContext.tsx` (`onNodeDragStop`, `isValidConnection`),
+  `.../node/node-group/NodeGroup.tsx`, `packages/client-typescript/src/client/types/pipeline.ts`,
+  `apps/vscode/src/providers/views/Project/ProjectWebview.tsx`.
+- Reference only (no edits): `packages/server/engine-lib/engLib/store/stack.cpp`,
+  `.../endpoint/endpoint.pipes.cpp` — the `(from,to,lane)`/`(from,to,classType)` semantics the
+  partitioner must reproduce. `init.cpp` — embedded-Python init (isolated `PyConfig`; `setPaths`).
+  `.../store/services/services.cpp` (parses `protocol`→`logicalType` and `path`→`nodePath`) and
+  `.../store/python/python-global.cpp` (imports `serviceDef.nodePath`, not `nodes.<provider>`) — the
+  authoritative `provider → entry-module path` mapping the partitioner's AST discovery must reproduce
+  (§4.8 Resolution rule); `binder.hpp` — the `Binder::MethodNames` lane list (§4.4).
+  `packages/ai/src/ai/common/models/base.py` (`get_model_server_address`, `_ensure_dependencies`,
+  `ModelClient`) and `.../common/models/gpu_guard.py` (the `import torch` blocker) — the model-server
+  proxy/local branch the AST walk / model-server-aware pruning must model (§4.8 Model-server dimension);
+  `.../common/torch/__init__.py` and `ai/common/models/**/requirements_*.txt` — where the heavy `ai/**`
+  stack actually lives.

--- a/packages/server/design/virtual-environments.md
+++ b/packages/server/design/virtual-environments.md
@@ -355,6 +355,19 @@ variant — so the backstop is a narrow safety net, not the primary mechanism.
   walk without a matching walker change (`ast.walk` still traverses the `TYPE_CHECKING` re-export block,
   or under-includes if that block is removed). Measured effect: `audio_transcribe` **24 → 7** files,
   `anonymize` **23 → 5**, zero cross-family leaks.
+- **Residual: within-family over-inclusion (DEFERRED decision — revisit after the engine call-site).**
+  Cross-family isolation is exact — verified on the **real engine**: the `audio_transcribe` overlay
+  dropped **183 → 114** packages, no `rfdetr`/`gliner`/`easyocr`/`surya`/`timm`. But a node still pulls
+  **siblings within its own model family**, because the walk co-locates every `requirements*.txt` in a
+  reached `ai/` directory — e.g. `audio_transcribe` pulls `kokoro` (TTS, `audio` family), `detect` pulls
+  `rtmlib` (pose, `vision` family). Sound over-approximation, never under-includes; cosmetic (siblings
+  are small). To tighten later, pick one:
+  - **Option 1 (node-local):** the node imports the *specific* submodule
+    (`from ai.common.models.audio.whisper import Whisper`) instead of the family `__init__` → drops the
+    sibling for that node.
+  - **Option 2 (walker):** in `ast_deps`, for `ai/` model dirs collect only files named by
+    `_REQUIREMENTS_FILE` constants instead of blanket directory co-location → drops all siblings
+    globally, but must re-verify it never under-includes.
 - **Blast radius + generalization (whole node-tree sweeps, VERIFIED).** The barrel fix is **small and
   bounded: exactly 4 nodes** import via the barrel — `anonymize`, `audio_transcribe`,
   `embedding_transformer`, `ocr` — vs **9 already on full path** (`detect`, `ner`, `pose_estimation`,
@@ -412,6 +425,33 @@ imports live **exclusively in the local (no-model-server) branch**. Implications
 - `<exe>/cache/models/<name>` — **shared** model weights via `model_cache_dir`, resolved relative to
   `sys.executable`. The venv child runs the **same `engine.exe`, unmoved**, so it resolves the same
   `cache/models` automatically. Models are weights, not packages → not isolated per venv.
+
+**Constraints strategy: per-env, compiled independently of the global (VERIFIED live).** The single
+biggest lever venvs pull is *not sharing one constraint resolution*.
+
+- `<exe>/cache/constraints.txt` (**global**) is compiled from the `nodes/**`+`ai/**` globs and governs
+  **only** the base runtime and the legacy path (`ROCKETRIDE_SERVER_USE_VENV=0` / auto-without-venv).
+- `venvs/<project_id>/<env_id>/constraints.txt` (**per-env**) is compiled from **that env's
+  `combined.txt` alone — no global base** — so it resolves versions solely from the requirement files its
+  nodes reach. The scoped install **and** the runtime `depends()` calls active in that env both resolve
+  against the **env** constraints (never the global), so the overlay is internally consistent and no
+  global pin leaks in.
+- **Granularity is per-env, not per-project.** `venvs/<proj>/main`, `venvs/<proj>/<group>` each get their
+  own `constraints.txt`. This is exactly what lets an env with `torch 2.0` and another with `torch 2.1`
+  coexist — a shared per-project constraints file would collapse them into one resolution and defeat the
+  isolation venvs exist for.
+- **Why `ai` makes this essential:** `ai/**` modules carry their own pins (`torch/requirements.txt` →
+  `torch==2.10.0+cu128`, `requirements_detection.txt` → `rfdetr`, …). Under one global compile every pin
+  meets every other; per-env, only the pins of the `ai` modules an env's nodes actually reach (via the
+  AST walk) enter that env's constraints → fewer pins, fewer false conflicts, real conflicts isolated to
+  their env.
+- **Runtime `depends()` integration (implemented, live-verified):** while an overlay is active,
+  `depends()` installs via `uv --target <overlay>` and `-c <env constraints>` (not `-c cache/…`), so
+  node model-loads and the AST-miss backstop land **in the overlay at the env-resolved versions** (no
+  version churn), keeping base untouched.
+- **Residual (honest):** base *today* still receives `ai/**` at startup bootstrap (legacy behavior), so
+  it is not yet strictly runtime-only. Constraints are already fully per-env; physically stripping the
+  node/model deps out of base is the remaining Phase-2A-step-1 work (§4.7 blast radius).
 
 **Key by stable IDs; name is metadata.**
 

--- a/packages/server/engine-lib/engLib/store/core/endpoint/endpoint.cpp
+++ b/packages/server/engine-lib/engLib/store/core/endpoint/endpoint.cpp
@@ -67,6 +67,31 @@ Error IServiceEndpoint::beginEndpoint(OPEN_MODE _openMode) noexcept {
     // If we are actually starting the endpoint, we need to build
     // the global pipe and the connectoions
     if (!this->m_stackOnly) {
+        // Install this pipeline's dependencies into a per-environment overlay
+        // before buildGlobalPipe imports the node modules. No-op unless
+        // ROCKETRIDE_SERVER_USE_VENV enables scoping; a failure here (a version
+        // conflict between nodes) aborts the run by design.
+        if (ccode = callPython([&]() -> Error {
+                py::list providers;
+                auto &components = config.pipeline.components();
+                for (json::Value::ArrayIndex i = 0; i < components.size(); ++i)
+                    providers.append(
+                        std::string(components[i]["provider"].asString()));
+
+                auto &pipe = config.pipeline.root()["pipeline"];
+                py::object projectId = py::none();
+                if (pipe.isMember("project_id") &&
+                    pipe["project_id"].isString())
+                    projectId =
+                        py::str(std::string(pipe["project_id"].asString()));
+
+                auto mod = engine::python::loadModule("depends");
+                if (!mod) return mod.ccode();
+                (*mod).attr("ensure_env_scoped")(projectId, "main", providers);
+                return {};
+            }))
+            return ccode;
+
         // Build the global pipe
         if (ccode = buildGlobalPipe()) return ccode;
 

--- a/packages/server/engine-lib/rocketlib-python/lib/ast_deps.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/ast_deps.py
@@ -1,0 +1,461 @@
+# =============================================================================
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""AST-based per-environment dependency discovery for RocketRide venvs.
+
+Given the node providers an environment uses, resolve each provider to its entry
+module (via ``services*.json``'s ``path`` field), then *statically* walk the import
+graph — following nested/in-function imports and relative imports into the
+first-party ``nodes`` and ``ai`` packages — to collect exactly the
+``requirement*.txt`` files that environment needs. This is the pre-resolution
+layer that lets an env install only the deps its nodes actually reach, instead of
+globbing every node/ai requirement into one union.
+
+Design: ``packages/server/design/virtual-environments.md`` §4.8 (Resolution rule,
+Prototype result). Two properties proven necessary and encoded here:
+  1. nested / in-function imports are followed (``ast.walk``, not just module top);
+  2. relative imports resolve against the correct package (``__init__`` vs module).
+
+The walk is a *sound over-approximation*: within a shared package directory it may
+include sibling requirement files (the documented "barrel ``__init__``" precision
+issue, §4.8) but it never under-includes. It also flags dynamic ``importlib`` /
+``__import__`` calls it cannot resolve statically, so a caller can fall back to the
+runtime ``depends()`` backstop for those.
+
+Pure and self-contained (stdlib only, no engine imports) so it is unit- and
+sandbox-testable in isolation. Deployment-relative root resolution is intentionally
+*not* baked in — callers pass explicit ``nodes_src`` / ``ai_src`` roots.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from dataclasses import dataclass, field
+from glob import glob
+from typing import Iterable, Optional
+
+# Class names a node package re-exports; also the modules worth seeding a walk from.
+_ENTRY_BASENAMES = ('__init__.py', 'IGlobal.py', 'IInstance.py', 'IEndpoint.py')
+
+# First-party import roots we recurse INTO; anything else is a third-party leaf we
+# record (torch, rfdetr, ...) but never follow.
+_FIRST_PARTY = ('nodes', 'ai')
+
+# Stdlib / framework tops that are never pip requirements — pruned from third-party.
+_NON_REQUIREMENT_TOPS = frozenset(
+    {
+        'os',
+        'sys',
+        're',
+        'json',
+        'typing',
+        'asyncio',
+        'logging',
+        'abc',
+        'dataclasses',
+        'functools',
+        'enum',
+        'io',
+        'time',
+        'math',
+        'threading',
+        'collections',
+        'pathlib',
+        'contextlib',
+        'warnings',
+        'types',
+        'base64',
+        'hashlib',
+        'zlib',
+        'subprocess',
+        'tempfile',
+        'errno',
+        'concurrent',
+        'itertools',
+        'copy',
+        'inspect',
+        'importlib',
+        'traceback',
+        'uuid',
+        'random',
+        'struct',
+        'datetime',
+        'shutil',
+        'glob',
+        'string',
+        'rocketlib',
+        'depends',
+        '__future__',
+        'engLib',
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# JSONC (services*.json) parsing
+# ---------------------------------------------------------------------------
+
+
+def strip_jsonc(text: str) -> str:
+    """Strip ``//`` and ``/* */`` comments and trailing commas from JSONC text.
+
+    String-aware: a ``//`` inside a string literal (e.g. ``"webhook://"``) is
+    preserved. ``services*.json`` files are JSONC, so plain ``json.loads`` fails.
+
+    Args:
+        text: Raw JSONC document text.
+
+    Returns:
+        A string that is valid strict JSON.
+    """
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_str = False
+    while i < n:
+        ch = text[i]
+        if in_str:
+            out.append(ch)
+            if ch == '\\' and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_str = False
+            i += 1
+            continue
+        if ch == '"':
+            in_str = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == '/' and i + 1 < n and text[i + 1] == '/':
+            while i < n and text[i] != '\n':
+                i += 1
+            continue
+        if ch == '/' and i + 1 < n and text[i + 1] == '*':
+            i += 2
+            while i + 1 < n and not (text[i] == '*' and text[i + 1] == '/'):
+                i += 1
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return _strip_trailing_commas(''.join(out))
+
+
+def _strip_trailing_commas(text: str) -> str:
+    """Remove commas that immediately precede a ``}`` or ``]`` (string-aware)."""
+    out: list[str] = []
+    i, n = 0, len(text)
+    in_str = False
+    while i < n:
+        ch = text[i]
+        if in_str:
+            out.append(ch)
+            if ch == '\\' and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_str = False
+            i += 1
+            continue
+        if ch == '"':
+            in_str = True
+            out.append(ch)
+            i += 1
+            continue
+        if ch == ',':
+            j = i + 1
+            while j < n and text[j] in ' \t\r\n':
+                j += 1
+            if j < n and text[j] in '}]':
+                i += 1  # drop the comma
+                continue
+        out.append(ch)
+        i += 1
+    return ''.join(out)
+
+
+# ---------------------------------------------------------------------------
+# provider -> entry-module resolution (the services*.json 'path' mapping)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class NodeEntry:
+    """Resolution of one provider to the files that seed its dependency walk."""
+
+    provider: str
+    node_path: Optional[str]  # dotted module path from services.json, e.g. 'nodes.webhook'
+    entry_files: list[str]  # absolute .py files to seed the AST walk (empty if native)
+    native: bool = False  # provider has no 'path' -> no Python module (skip)
+
+
+class ProviderIndex:
+    """Maps a pipeline ``provider`` string to its Python entry module.
+
+    Reproduces the engine loader's mapping (``services*.json`` ``protocol`` ->
+    logical type, ``path`` -> module) rather than the naive ``nodes.<provider>``
+    guess, which is wrong for ~1/3 of providers (aliases, sub-package paths, name
+    != dir, native no-``path`` nodes). See design §4.8 Resolution rule.
+    """
+
+    def __init__(self, nodes_src: str):
+        """Build the index by scanning every ``services*.json`` under ``nodes_src``.
+
+        Args:
+            nodes_src: The ``nodes`` package source root (its child ``nodes/`` holds
+                the node packages), e.g. ``.../nodes/src``.
+        """
+        self._nodes_src = os.path.abspath(nodes_src)
+        # logicalType -> node_path ('nodes.webhook') or None for native nodes.
+        self._by_provider: dict[str, Optional[str]] = {}
+        self._scan()
+
+    def _scan(self) -> None:
+        pattern = os.path.join(self._nodes_src, 'nodes', '**', 'services*.json')
+        for path in glob(pattern, recursive=True):
+            try:
+                with open(path, 'r', encoding='utf-8') as fh:
+                    data = json.loads(strip_jsonc(fh.read()))
+            except (OSError, ValueError):
+                continue
+            protocol = data.get('protocol')
+            if not isinstance(protocol, str):
+                continue
+            logical = protocol.split('://', 1)[0].rstrip(':')
+            if not logical:
+                continue
+            node_path = data.get('path')
+            # First definition wins; multiple services*.json may share one dir.
+            self._by_provider.setdefault(logical, node_path if isinstance(node_path, str) else None)
+
+    def known(self) -> list[str]:
+        """Return all provider (logical-type) strings the index resolved."""
+        return sorted(self._by_provider)
+
+    def resolve(self, provider: str) -> Optional[NodeEntry]:
+        """Resolve one provider to its entry module files.
+
+        Args:
+            provider: The pipeline component ``provider`` (logical type).
+
+        Returns:
+            A ``NodeEntry`` (``native`` when the provider has no Python ``path``),
+            or ``None`` if the provider is unknown to the index.
+        """
+        if provider not in self._by_provider:
+            return None
+        node_path = self._by_provider[provider]
+        if not node_path:
+            return NodeEntry(provider=provider, node_path=None, entry_files=[], native=True)
+        pkg_dir = os.path.join(self._nodes_src, *node_path.split('.'))
+        entry_files = [
+            os.path.join(pkg_dir, base) for base in _ENTRY_BASENAMES if os.path.isfile(os.path.join(pkg_dir, base))
+        ]
+        return NodeEntry(provider=provider, node_path=node_path, entry_files=entry_files)
+
+
+# ---------------------------------------------------------------------------
+# the transitive AST walk
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class DiscoveryResult:
+    """Outcome of a dependency walk over one environment's node set."""
+
+    requirement_files: list[str] = field(default_factory=list)  # absolute paths
+    reached_modules: list[str] = field(default_factory=list)  # first-party dotted names
+    third_party: list[str] = field(default_factory=list)  # top-level pkg names (leaves)
+    dynamic_imports: list[str] = field(default_factory=list)  # unresolved importlib/__import__
+    unresolved_providers: list[str] = field(default_factory=list)
+
+
+def _module_to_file(dotted: str, roots: dict[str, str]) -> Optional[str]:
+    """Resolve a dotted first-party module to a ``.py`` file (module or package)."""
+    top = dotted.split('.', 1)[0]
+    base = roots.get(top)
+    if base is None:
+        return None
+    rel = os.path.join(*dotted.split('.'))
+    for cand in (os.path.join(base, rel + '.py'), os.path.join(base, rel, '__init__.py')):
+        if os.path.isfile(cand):
+            return cand
+    return None
+
+
+def _pkg_of(path: str, roots: dict[str, str]) -> str:
+    """Return the dotted *package* a file belongs to (``__init__`` vs module aware)."""
+    for base in roots.values():
+        if path.startswith(base):
+            rel = os.path.relpath(path, base).replace(os.sep, '.')
+            if rel.endswith('.__init__.py'):
+                return rel[: -len('.__init__.py')]  # pkg/__init__.py -> pkg
+            if rel.endswith('.py'):
+                return '.'.join(rel[:-3].split('.')[:-1])  # a.b.mod -> a.b
+    return ''
+
+
+def _import_targets(node: ast.AST, cur_file: str, roots: dict[str, str]) -> list[str]:
+    """Dotted module names an Import/ImportFrom refers to (relative resolved)."""
+    if isinstance(node, ast.Import):
+        return [alias.name for alias in node.names]
+    if isinstance(node, ast.ImportFrom):
+        if node.level:
+            anchor = _pkg_of(cur_file, roots).split('.')
+            for _ in range(node.level - 1):
+                anchor = anchor[:-1]
+            base = '.'.join(a for a in anchor if a)
+            if node.module:
+                return [f'{base}.{node.module}' if base else node.module]
+            return [base] if base else []
+        return [node.module] if node.module else []
+    return []
+
+
+def _string_consts(value: ast.AST) -> list[str]:
+    """Flatten str constants from a Constant / List / Tuple expression."""
+    if isinstance(value, ast.Constant) and isinstance(value.value, str):
+        return [value.value]
+    if isinstance(value, (ast.List, ast.Tuple)):
+        out: list[str] = []
+        for elt in value.elts:
+            out.extend(_string_consts(elt))
+        return out
+    return []
+
+
+def discover(entry_files: Iterable[str], roots: dict[str, str]) -> DiscoveryResult:
+    """Walk the import graph from ``entry_files`` and collect requirement files.
+
+    Args:
+        entry_files: Absolute ``.py`` paths to seed the walk (a node's entry
+            modules).
+        roots: ``{'nodes': <nodes src>, 'ai': <ai src>}`` first-party package roots.
+
+    Returns:
+        A ``DiscoveryResult``. ``requirement_files`` is the sound (over-approximating)
+        set of ``requirement*.txt`` paths reachable from the seeds.
+    """
+    seen: set[str] = set()
+    queue: list[str] = [os.path.abspath(f) for f in entry_files]
+    reqs: set[str] = set()
+    reached: set[str] = set()
+    third: set[str] = set()
+    dynamic: list[str] = []
+
+    def _add_req_dir(directory: str) -> None:
+        for rq in glob(os.path.join(directory, 'requirement*.txt')):
+            reqs.add(os.path.abspath(rq))
+
+    while queue:
+        cur = queue.pop()
+        if not cur or cur in seen or not os.path.isfile(cur):
+            continue
+        seen.add(cur)
+        cur_dir = os.path.dirname(cur)
+        _add_req_dir(cur_dir)  # a node's / ai module's co-located requirement*.txt
+        try:
+            tree = ast.parse(open(cur, encoding='utf-8').read())
+        except (OSError, SyntaxError, ValueError):
+            continue
+        for node in ast.walk(tree):
+            # calls: depends()/load_depends() string args + dynamic-import detection
+            if isinstance(node, ast.Call):
+                fn = getattr(node.func, 'attr', None) or getattr(node.func, 'id', None)
+                if fn in ('depends', 'load_depends'):
+                    for arg in node.args:
+                        for s in _string_consts(arg):
+                            if s.endswith('.txt'):
+                                cand = os.path.join(cur_dir, s)
+                                if os.path.isfile(cand):
+                                    reqs.add(os.path.abspath(cand))
+                if fn == 'import_module' and not (
+                    node.args and isinstance(node.args[0], ast.Constant) and isinstance(node.args[0].value, str)
+                ):
+                    dynamic.append(f'importlib.import_module(dynamic) @ {cur}')
+                if getattr(node.func, 'id', None) == '__import__' and not (
+                    node.args and isinstance(node.args[0], ast.Constant)
+                ):
+                    dynamic.append(f'__import__(dynamic) @ {cur}')
+            # *_REQUIREMENTS_FILE = 'requirements_x.txt' (or a list of them)
+            if isinstance(node, ast.Assign):
+                for tgt in node.targets:
+                    if isinstance(tgt, ast.Name) and 'REQUIREMENT' in tgt.id.upper():
+                        for s in _string_consts(node.value):
+                            if s.endswith('.txt'):
+                                cand = os.path.join(cur_dir, s)
+                                if os.path.isfile(cand):
+                                    reqs.add(os.path.abspath(cand))
+            # imports: recurse first-party, record third-party leaves
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                for mod in _import_targets(node, cur, roots):
+                    top = mod.split('.', 1)[0]
+                    if top in roots:
+                        if top == 'ai' and '.models' in ('.' + mod):
+                            reached.add(mod)
+                        nxt = _module_to_file(mod, roots)
+                        if nxt:
+                            queue.append(nxt)
+                    elif top and top not in _NON_REQUIREMENT_TOPS:
+                        third.add(top)
+
+    return DiscoveryResult(
+        requirement_files=sorted(reqs),
+        reached_modules=sorted(reached),
+        third_party=sorted(third),
+        dynamic_imports=sorted(set(dynamic)),
+    )
+
+
+def discover_for_providers(providers: Iterable[str], nodes_src: str, ai_src: str) -> DiscoveryResult:
+    """High-level: resolve providers and walk their combined dependency graph.
+
+    Args:
+        providers: The set of node ``provider`` strings used by one environment.
+        nodes_src: ``nodes`` package source root (e.g. ``.../nodes/src``).
+        ai_src: ``ai`` package source root (e.g. ``.../packages/ai/src``).
+
+    Returns:
+        A merged ``DiscoveryResult`` for the whole environment. Providers unknown
+        to the index (or native, no-``path`` nodes with no module) contribute no
+        files and, when unknown, are listed in ``unresolved_providers``.
+    """
+    index = ProviderIndex(nodes_src)
+    roots = {'nodes': os.path.abspath(nodes_src), 'ai': os.path.abspath(ai_src)}
+    seeds: list[str] = []
+    unresolved: list[str] = []
+    for provider in providers:
+        entry = index.resolve(provider)
+        if entry is None:
+            unresolved.append(provider)
+            continue
+        seeds.extend(entry.entry_files)
+    result = discover(seeds, roots)
+    result.unresolved_providers = sorted(set(unresolved))
+    return result

--- a/packages/server/engine-lib/rocketlib-python/lib/ast_deps.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/ast_deps.py
@@ -22,30 +22,24 @@
 # SOFTWARE.
 # =============================================================================
 
-"""AST-based per-environment dependency discovery for RocketRide venvs.
+"""AST-based per-environment dependency discovery.
 
-Given the node providers an environment uses, resolve each provider to its entry
-module (via ``services*.json``'s ``path`` field), then *statically* walk the import
-graph — following nested/in-function imports and relative imports into the
-first-party ``nodes`` and ``ai`` packages — to collect exactly the
-``requirement*.txt`` files that environment needs. This is the pre-resolution
-layer that lets an env install only the deps its nodes actually reach, instead of
-globbing every node/ai requirement into one union.
+Resolves each node ``provider`` to its entry module (via the ``path`` field of
+``services*.json``), then statically walks the import graph into the first-party
+``nodes`` and ``ai`` packages to collect exactly the ``requirement*.txt`` files that
+environment needs, instead of globbing every requirement in the tree.
 
-Design: ``packages/server/design/virtual-environments.md`` §4.8 (Resolution rule,
-Prototype result). Two properties proven necessary and encoded here:
-  1. nested / in-function imports are followed (``ast.walk``, not just module top);
-  2. relative imports resolve against the correct package (``__init__`` vs module).
+Two things the walk must get right: it follows nested/in-function imports, not just
+module-level ones, and resolves relative imports against the right package
+(``__init__`` vs regular module).
 
-The walk is a *sound over-approximation*: within a shared package directory it may
-include sibling requirement files (the documented "barrel ``__init__``" precision
-issue, §4.8) but it never under-includes. It also flags dynamic ``importlib`` /
-``__import__`` calls it cannot resolve statically, so a caller can fall back to the
-runtime ``depends()`` backstop for those.
+The result is a sound over-approximation — within a shared package directory it may
+pick up sibling requirement files, but it never under-includes. Dynamic
+``importlib``/``__import__`` calls that cannot be resolved statically are flagged so
+the caller can fall back to the runtime ``depends()`` backstop.
 
-Pure and self-contained (stdlib only, no engine imports) so it is unit- and
-sandbox-testable in isolation. Deployment-relative root resolution is intentionally
-*not* baked in — callers pass explicit ``nodes_src`` / ``ai_src`` roots.
+Stdlib only, with the package roots passed in explicitly, so it is testable in
+isolation.
 """
 
 from __future__ import annotations
@@ -218,10 +212,10 @@ class NodeEntry:
 class ProviderIndex:
     """Maps a pipeline ``provider`` string to its Python entry module.
 
-    Reproduces the engine loader's mapping (``services*.json`` ``protocol`` ->
-    logical type, ``path`` -> module) rather than the naive ``nodes.<provider>``
-    guess, which is wrong for ~1/3 of providers (aliases, sub-package paths, name
-    != dir, native no-``path`` nodes). See design §4.8 Resolution rule.
+    Reproduces the engine loader's mapping (``protocol`` -> logical type, ``path`` ->
+    module) rather than guessing ``nodes.<provider>``, which is wrong for roughly a
+    third of providers: aliases, sub-package paths, name != directory, and native
+    nodes with no ``path``.
     """
 
     def __init__(self, nodes_src: str):
@@ -445,12 +439,16 @@ def discover_for_providers(providers: Iterable[str], nodes_src: str, ai_src: str
         A merged ``DiscoveryResult`` for the whole environment. Providers unknown
         to the index (or native, no-``path`` nodes with no module) contribute no
         files and, when unknown, are listed in ``unresolved_providers``.
+
+    Duplicate providers (a pipeline may have many nodes of the same type, e.g. two
+    OpenAI or several Frame Grabber nodes) are collapsed up front, so each provider
+    is resolved and walked exactly once.
     """
     index = ProviderIndex(nodes_src)
     roots = {'nodes': os.path.abspath(nodes_src), 'ai': os.path.abspath(ai_src)}
     seeds: list[str] = []
     unresolved: list[str] = []
-    for provider in providers:
+    for provider in dict.fromkeys(providers):  # unique, first-seen order
         entry = index.resolve(provider)
         if entry is None:
             unresolved.append(provider)

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -65,6 +65,13 @@ REQUIREMENTS_GLOBS = [
     'ai/**/requirement*.txt',
 ]
 
+# Globs dropped from the startup compile when ROCKETRIDE_SERVER_USE_VENV forces scoping on:
+# node dependencies then come only from each environment's scoped install. Keeping them here
+# would require every node in the installation to be mutually satisfiable, so two nodes with
+# conflicting pins could not coexist at all — the engine would fail to start before any
+# per-environment logic runs.
+_SCOPED_EXCLUDED_GLOBS = frozenset({'nodes/**/requirement*.txt'})
+
 # Bootstrap tools install outside any constraint, so pin them or they float to 'latest' and a
 # later install downgrades them. Lockstep with packages/server/scripts/tasks.js.
 _BOOTSTRAP_TOOL_VERSIONS: dict[str, str] = {
@@ -643,11 +650,19 @@ def bootstrap():
 
 
 def _find_requirement_files() -> list[str]:
-    """Find all requirement files matching the glob patterns."""
+    """Find all requirement files matching the glob patterns.
+
+    With scoping forced on the node globs are skipped (see
+    :data:`_SCOPED_EXCLUDED_GLOBS`); in auto and legacy mode the set is unchanged.
+    """
     executable_dir = _get_executable_dir()
     found = []
 
-    for pattern in REQUIREMENTS_GLOBS:
+    patterns = REQUIREMENTS_GLOBS
+    if venv_env.use_venv_mode() == venv_env.USE_ON:
+        patterns = [p for p in patterns if p not in _SCOPED_EXCLUDED_GLOBS]
+
+    for pattern in patterns:
         full_pattern = os.path.join(executable_dir, pattern)
         matches = glob(full_pattern, recursive=True)
         for path in matches:
@@ -728,8 +743,9 @@ def _compile_constraints(constraints_path: str):
     )
 
     if result.returncode != 0:
-        error(f'Failed to compile constraints: {result.stderr}')
-        raise RuntimeError('Failed to compile constraints')
+        detail = (result.stderr or result.stdout or '').strip()
+        error(f'Failed to compile constraints: {detail}')
+        raise RuntimeError(f'Failed to compile constraints: {detail[:800]}')
 
     debug(f'Constraints compiled: {constraints_path}')
 

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -51,6 +51,10 @@ else:
 # engLib is built into engine.exe, always available
 from engLib import debug, monitorStatus, error
 
+# Sibling pure modules (stdlib-only, no engLib) for per-environment scoped installs (Phase 2A).
+import ast_deps
+import venv_env
+
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
@@ -1027,6 +1031,165 @@ def load_depends(current_file: str, requirements_file: str = 'requirements.txt')
     """
     requirements = os.path.join(os.path.dirname(os.path.realpath(current_file)), requirements_file)
     depends(requirements)
+
+
+# ---------------------------------------------------------------------------
+# Per-environment scoped install (Phase 2A — design 4.7 / 4.9 / 4.15)
+# ---------------------------------------------------------------------------
+
+
+def _compile_constraints_at(combined_path: str, constraints_path: str) -> None:
+    """Compile ``combined_path`` -> ``constraints_path`` for one environment.
+
+    Parameterized twin of :func:`_compile_constraints` that takes explicit paths
+    instead of the global cache locations, so each env compiles its own scoped set.
+    """
+    if not _uv_available():
+        raise RuntimeError('uv executable not found')
+    exe_dir = _get_executable_dir()
+    updateProgress('Compiling constraints...')
+    args = [
+        _uv_abs_path(),
+        'pip',
+        'compile',
+        combined_path,
+        '--output-file',
+        constraints_path,
+        '--python',
+        sys.executable,
+        '--index-strategy',
+        'unsafe-best-match',
+        '--no-build-isolation',
+        '--emit-index-url',
+    ]
+    result = subprocess.run(
+        args,
+        capture_output=True,
+        text=True,
+        check=False,
+        stdin=subprocess.PIPE,
+        encoding='utf-8',
+        errors='replace',
+        cwd=exe_dir,
+    )
+    if result.returncode != 0:
+        error(f'Failed to compile constraints: {result.stderr}')
+        raise RuntimeError('Failed to compile constraints')
+    debug(f'Constraints compiled: {constraints_path}')
+
+
+def _install_target(requirements_path: str, constraints_path: str, target_site: str) -> None:
+    """Install ``requirements_path`` into an overlay ``target_site`` (uv ``--target``).
+
+    Mirrors :func:`_install_requirements_inner` but lands packages in the env's
+    overlay ``site-packages`` instead of the base runtime.
+    """
+    with open(requirements_path, 'r', encoding='utf-8') as f:
+        has_deps = any(line.strip() and not line.strip().startswith('#') for line in f)
+    if not has_deps:
+        debug(f'  Empty scoped requirements, nothing to install: {requirements_path}')
+        return
+
+    exe_dir = _get_executable_dir()
+    excludes_rel = os.path.relpath(_write_excludes_file(), exe_dir)
+    argv = venv_env.build_install_argv(
+        uv_path=_uv_abs_path(),
+        python_exe=sys.executable,
+        requirements_path=requirements_path,
+        target_site=target_site,
+        excludes_path=excludes_rel,
+    )
+    argv.extend(_constraints_args(constraints_path, exe_dir))
+
+    _start_heartbeat()
+    try:
+        debug(f'Scoped install: {argv}')
+        proc = subprocess.Popen(
+            argv,
+            cwd=exe_dir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            encoding='utf-8',
+            errors='replace',
+            bufsize=1,
+        )
+        lines: list[str] = []
+        for line in proc.stdout:
+            line = line.rstrip()
+            lines.append(line)
+            updateProgress(line)
+        proc.wait()
+        if proc.returncode != 0:
+            tail = '\n'.join(lines[-10:])
+            error(f'Scoped install failed: {tail}')
+            raise RuntimeError(f'Failed scoped install into {target_site}\n{tail}')
+    finally:
+        _stop_heartbeat()
+
+    import importlib
+
+    importlib.invalidate_caches()
+    sys.path_importer_cache.pop(target_site, None)
+    debug(f'Scoped install complete: {target_site}')
+
+
+def ensure_env_scoped(
+    project_id: Optional[str],
+    env_id: Optional[str],
+    providers,
+    has_isolated_group: bool = False,
+) -> Optional[str]:
+    """Install only what a pipeline environment uses, into its own overlay.
+
+    Discovers the requirement-file set for ``providers`` (``ast_deps``), compiles +
+    installs it into ``venvs/<project_id>/<env_id>/site-packages`` (on drift), and
+    inserts that overlay ahead of the base runtime on ``sys.path``.
+
+    Gated by the ``ROCKETRIDE_SERVER_USE_VENV`` switch (§4.15): returns ``None``
+    when scoping does not apply, in which case the caller keeps today's global-glob
+    behavior (:func:`ensure_constraints` + base site-packages).
+
+    Args:
+        project_id: Pipe id (``config.pipeline.project_id``), or ``None`` -> default env.
+        env_id: ``'main'`` or a group id.
+        providers: The environment's node ``provider`` strings.
+        has_isolated_group: Whether the pipeline has an isolated group (auto mode).
+
+    Returns:
+        The overlay ``site-packages`` path (now on ``sys.path``), or ``None`` for the
+        legacy path.
+    """
+    exe_dir = _get_executable_dir()
+
+    def _discover(provs):
+        # In the deployed engine both packages sit directly under the exe dir.
+        return ast_deps.discover_for_providers(provs, exe_dir, exe_dir).requirement_files
+
+    def _compile_and_install(plan):
+        # Per-env lock (design 4.10): one lock per overlay, not the single global lock.
+        with FileLock(plan.paths.lock_file):
+            bootstrap()
+            _compile_constraints_at(plan.paths.combined, plan.paths.constraints)
+            _install_target(plan.paths.combined, plan.paths.constraints, plan.paths.site_packages)
+
+    def _overlay(site):
+        if site not in sys.path:
+            sys.path.insert(0, site)  # overlay precedence: venv wins over base (§4.11)
+        import importlib
+
+        importlib.invalidate_caches()
+
+    return venv_env.run_scoped_install(
+        exe_dir,
+        project_id,
+        env_id,
+        providers,
+        discover=_discover,
+        compile_and_install=_compile_and_install,
+        has_isolated_group=has_isolated_group,
+        on_overlay=_overlay,
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -51,7 +51,7 @@ else:
 # engLib is built into engine.exe, always available
 from engLib import debug, monitorStatus, error
 
-# Sibling pure modules (stdlib-only, no engLib) for per-environment scoped installs (Phase 2A).
+# Sibling stdlib-only modules backing the per-environment scoped install.
 import ast_deps
 import venv_env
 
@@ -82,6 +82,11 @@ def _tool_spec(name: str) -> str:
 
 # Track processed requirements to avoid redundant installs in same session
 _processed: set[str] = set()
+
+# Set while a per-environment overlay is active: runtime depends() then installs into the
+# overlay (uv --target) against the env's own constraints, leaving the base runtime alone.
+_active_overlay_site: Optional[str] = None
+_active_overlay_constraints: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -793,6 +798,23 @@ def _write_excludes_file() -> str:
     return excludes_path
 
 
+def _target_args() -> list[str]:
+    """``uv --target <overlay>`` when scoping is active, else ``[]``.
+
+    uv reads the target directory, so packages the scoped install already placed there
+    are reported as satisfied instead of being reinstalled into the base runtime.
+    """
+    return ['--target', _active_overlay_site] if _active_overlay_site else []
+
+
+def _effective_constraints(constraints_path: str) -> str:
+    """The env's constraints when scoping is active, else the given global one.
+
+    Keeps runtime installs pinned to the versions the scoped compile resolved.
+    """
+    return _active_overlay_constraints or constraints_path
+
+
 def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]:
     """
     Run uv pip install --dry-run and return list of packages that would be installed.
@@ -824,7 +846,8 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
     # See #1256.
     args.extend(['--excludes', os.path.relpath(_write_excludes_file(), exe_dir)])
 
-    args.extend(_constraints_args(constraints_path, exe_dir))
+    args.extend(_constraints_args(_effective_constraints(constraints_path), exe_dir))
+    args.extend(_target_args())
 
     debug(f'Dry-run: {args}')
     result = subprocess.run(
@@ -925,7 +948,8 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
     # Relative to cwd (exe_dir) — see the --excludes note in _install_dry_run (#1256).
     uv_args.extend(['--excludes', os.path.relpath(_write_excludes_file(), exe_dir)])
 
-    uv_args.extend(_constraints_args(constraints_path, exe_dir))
+    uv_args.extend(_constraints_args(_effective_constraints(constraints_path), exe_dir))
+    uv_args.extend(_target_args())
 
     # Run uv and stream output (heartbeat is already running from the caller)
     debug(f'Install: {uv_args}')
@@ -957,8 +981,8 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
     # Invalidate import caches so Python can find newly installed packages
     importlib.invalidate_caches()
 
-    # Clear path importer cache for site-packages to force re-scan
-    sys.path_importer_cache.pop(_get_site_packages(), None)
+    # Clear the path importer cache for the install target to force a re-scan
+    sys.path_importer_cache.pop(_active_overlay_site or _get_site_packages(), None)
 
     debug(f'Installed: {requirements_path}')
 
@@ -1034,15 +1058,15 @@ def load_depends(current_file: str, requirements_file: str = 'requirements.txt')
 
 
 # ---------------------------------------------------------------------------
-# Per-environment scoped install (Phase 2A — design 4.7 / 4.9 / 4.15)
+# Per-environment scoped install
 # ---------------------------------------------------------------------------
 
 
 def _compile_constraints_at(combined_path: str, constraints_path: str) -> None:
     """Compile ``combined_path`` -> ``constraints_path`` for one environment.
 
-    Parameterized twin of :func:`_compile_constraints` that takes explicit paths
-    instead of the global cache locations, so each env compiles its own scoped set.
+    Twin of :func:`_compile_constraints` taking explicit paths, so each env compiles
+    its own scoped set rather than the global one.
     """
     if not _uv_available():
         raise RuntimeError('uv executable not found')
@@ -1073,17 +1097,14 @@ def _compile_constraints_at(combined_path: str, constraints_path: str) -> None:
         cwd=exe_dir,
     )
     if result.returncode != 0:
-        error(f'Failed to compile constraints: {result.stderr}')
-        raise RuntimeError('Failed to compile constraints')
+        detail = (result.stderr or result.stdout or '').strip()
+        error(f'Failed to compile constraints: {detail}')
+        raise RuntimeError(f'Failed to compile constraints: {detail[:800]}')
     debug(f'Constraints compiled: {constraints_path}')
 
 
 def _install_target(requirements_path: str, constraints_path: str, target_site: str) -> None:
-    """Install ``requirements_path`` into an overlay ``target_site`` (uv ``--target``).
-
-    Mirrors :func:`_install_requirements_inner` but lands packages in the env's
-    overlay ``site-packages`` instead of the base runtime.
-    """
+    """Install ``requirements_path`` into the overlay ``target_site`` (uv ``--target``)."""
     with open(requirements_path, 'r', encoding='utf-8') as f:
         has_deps = any(line.strip() and not line.strip().startswith('#') for line in f)
     if not has_deps:
@@ -1142,40 +1163,38 @@ def ensure_env_scoped(
 ) -> Optional[str]:
     """Install only what a pipeline environment uses, into its own overlay.
 
-    Discovers the requirement-file set for ``providers`` (``ast_deps``), compiles +
-    installs it into ``venvs/<project_id>/<env_id>/site-packages`` (on drift), and
-    inserts that overlay ahead of the base runtime on ``sys.path``.
-
-    Gated by the ``ROCKETRIDE_SERVER_USE_VENV`` switch (§4.15): returns ``None``
-    when scoping does not apply, in which case the caller keeps today's global-glob
-    behavior (:func:`ensure_constraints` + base site-packages).
+    Discovers the requirement files reachable from ``providers``, compiles and installs
+    them into ``venvs/<project_id>/<env_id>/site-packages`` when they drifted, and puts
+    that overlay ahead of the base runtime on ``sys.path``.
 
     Args:
-        project_id: Pipe id (``config.pipeline.project_id``), or ``None`` -> default env.
+        project_id: Pipe id, or ``None`` for the shared default env.
         env_id: ``'main'`` or a group id.
         providers: The environment's node ``provider`` strings.
         has_isolated_group: Whether the pipeline has an isolated group (auto mode).
 
     Returns:
-        The overlay ``site-packages`` path (now on ``sys.path``), or ``None`` for the
-        legacy path.
+        The overlay ``site-packages`` path, or ``None`` when scoping does not apply —
+        the caller then keeps the global-glob behavior.
     """
     exe_dir = _get_executable_dir()
 
     def _discover(provs):
-        # In the deployed engine both packages sit directly under the exe dir.
+        # In the deployed engine both the nodes and ai packages sit under the exe dir.
         return ast_deps.discover_for_providers(provs, exe_dir, exe_dir).requirement_files
 
     def _compile_and_install(plan):
-        # Per-env lock (design 4.10): one lock per overlay, not the single global lock.
-        with FileLock(plan.paths.lock_file):
+        with FileLock(plan.paths.lock_file):  # one lock per overlay, not the global one
             bootstrap()
             _compile_constraints_at(plan.paths.combined, plan.paths.constraints)
             _install_target(plan.paths.combined, plan.paths.constraints, plan.paths.site_packages)
 
     def _overlay(site):
+        global _active_overlay_site, _active_overlay_constraints
         if site not in sys.path:
-            sys.path.insert(0, site)  # overlay precedence: venv wins over base (§4.11)
+            sys.path.insert(0, site)  # ahead of base so the overlay's versions win
+        _active_overlay_site = site
+        _active_overlay_constraints = venv_env.env_paths(os.path.dirname(site)).constraints
         import importlib
 
         importlib.invalidate_caches()

--- a/packages/server/engine-lib/rocketlib-python/lib/test_ast_deps.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/test_ast_deps.py
@@ -1,0 +1,150 @@
+# =============================================================================
+# MIT License — Copyright (c) 2026 Aparavi Software AG
+# (full text in ast_deps.py)
+# =============================================================================
+
+"""Unit tests for ``ast_deps`` — provider resolution + AST dependency discovery.
+
+Pure-logic tests (JSONC stripping, provider aliasing) run anywhere. The golden
+requirement-set tests need the real node/ai source tree and are skipped when the
+repo layout is not reachable from this file (e.g. an installed/packaged context).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import ast_deps as A
+
+# lib/ -> rocketlib-python -> engine-lib -> server -> packages -> repo root
+_REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), *([os.pardir] * 5)))
+_NODES_SRC = os.path.join(_REPO, 'nodes', 'src')
+_AI_SRC = os.path.join(_REPO, 'packages', 'ai', 'src')
+_FIXTURES = os.path.join(_REPO, 'nodes', 'test', 'fixtures')
+
+_HAVE_TREE = os.path.isdir(os.path.join(_NODES_SRC, 'nodes')) and os.path.isdir(os.path.join(_AI_SRC, 'ai'))
+_needs_tree = pytest.mark.skipif(not _HAVE_TREE, reason='node/ai source tree not reachable')
+
+
+# --- pure logic: JSONC stripping -------------------------------------------
+
+
+def test_strip_jsonc_preserves_scheme_in_strings():
+    src = '{ // a comment\n  "protocol": "webhook://", /* blk */ "path": "nodes.webhook" }'
+    import json
+
+    data = json.loads(A.strip_jsonc(src))
+    assert data['protocol'] == 'webhook://'  # the // inside the string survived
+    assert data['path'] == 'nodes.webhook'
+
+
+def test_strip_jsonc_trailing_commas():
+    import json
+
+    assert json.loads(A.strip_jsonc('{"a": 1, "b": [1, 2,], }')) == {'a': 1, 'b': [1, 2]}
+
+
+def test_string_consts_flatten():
+    import ast
+
+    node = ast.parse("X = ['a.txt', ('b.txt', 'c.txt')]").body[0].value
+    assert A._string_consts(node) == ['a.txt', 'b.txt', 'c.txt']
+
+
+# --- provider resolution (the services.json 'path' mapping) -----------------
+
+
+@_needs_tree
+def test_provider_aliases_share_one_dir():
+    idx = A.ProviderIndex(_NODES_SRC)
+    for prov in ('webhook', 'chat', 'dropper'):
+        entry = idx.resolve(prov)
+        assert entry is not None and entry.node_path == 'nodes.webhook'
+        assert any(f.endswith('IInstance.py') for f in entry.entry_files)
+
+
+@_needs_tree
+def test_provider_subpackage_path():
+    idx = A.ProviderIndex(_NODES_SRC)
+    assert idx.resolve('remote').node_path == 'nodes.remote.client'
+    assert idx.resolve('remote_server').node_path == 'nodes.remote.server'
+
+
+@_needs_tree
+def test_provider_name_not_equal_dir():
+    idx = A.ProviderIndex(_NODES_SRC)
+    assert idx.resolve('text-output').node_path == 'nodes.text_output'
+    assert idx.resolve('anonymize_text').node_path == 'nodes.anonymize'
+
+
+@_needs_tree
+def test_provider_native_and_unknown():
+    idx = A.ProviderIndex(_NODES_SRC)
+    for native in ('parse', 'filesys'):
+        entry = idx.resolve(native)
+        assert entry is not None and entry.native and entry.entry_files == []
+    assert idx.resolve('does_not_exist') is None
+
+
+# --- golden requirement sets (transitive walk correctness) ------------------
+
+
+@_needs_tree
+@pytest.mark.parametrize(
+    'provider, must_include',
+    [
+        ('detect', {'requirements_detection.txt', 'requirements_vision.txt'}),
+        ('audio_transcribe', {'requirements_whisper.txt'}),
+        ('anonymize_text', {'requirements_gliner.txt'}),
+    ],
+)
+def test_golden_requirement_sets(provider, must_include):
+    res = A.discover_for_providers([provider], _NODES_SRC, _AI_SRC)
+    assert not res.unresolved_providers
+    basenames = {os.path.basename(p) for p in res.requirement_files}
+    assert must_include <= basenames, f'{provider} missing {must_include - basenames}'
+    # torch is reached in every heavy vision/audio node's local branch
+    assert any('torch' in os.path.relpath(p, _REPO).replace(os.sep, '/') for p in res.requirement_files)
+    assert res.dynamic_imports == []  # none of these three use dynamic imports
+
+
+@_needs_tree
+def test_only_needed_excludes_unrelated_families():
+    # a detect-only env must not drag in audio (whisper) or NER (gliner) deps
+    res = A.discover_for_providers(['detect'], _NODES_SRC, _AI_SRC)
+    basenames = {os.path.basename(p) for p in res.requirement_files}
+    assert 'requirements_whisper.txt' not in basenames
+    assert 'requirements_gliner.txt' not in basenames
+
+
+@_needs_tree
+def test_dynamic_import_is_flagged():
+    # preprocessor_code uses importlib.import_module(modmap[lang]) — must be flagged
+    res = A.discover_for_providers(['preprocessor_code'], _NODES_SRC, _AI_SRC)
+    assert res.dynamic_imports, 'expected the dynamic importlib call to be flagged'
+
+
+# --- conflict fixture nodes (lightweight, decoupled from ai/*) --------------
+
+
+@pytest.mark.skipif(
+    not os.path.isdir(os.path.join(_FIXTURES, 'nodes', 'vtest_alpha')),
+    reason='vtest fixture nodes not present',
+)
+def test_fixture_nodes_pin_conflicting_versions_without_ai():
+    idx = A.ProviderIndex(_FIXTURES)
+    roots_ai = _AI_SRC if _HAVE_TREE else _FIXTURES
+    for prov, pin in (('vtest_alpha', 'tabulate==0.8.10'), ('vtest_beta', 'tabulate==0.9.0')):
+        entry = idx.resolve(prov)
+        assert entry is not None and not entry.native
+        res = A.discover([f for f in entry.entry_files], {'nodes': _FIXTURES, 'ai': roots_ai})
+        # the fixture's own requirements.txt is found ...
+        reqs = res.requirement_files
+        assert any(os.path.basename(r) == 'requirements.txt' for r in reqs)
+        contents = ''.join(open(r, encoding='utf-8').read() for r in reqs)
+        assert pin in contents
+        # ... and it pulls nothing from ai/*
+        assert res.reached_modules == []
+        assert 'tabulate' in res.third_party

--- a/packages/server/engine-lib/rocketlib-python/lib/test_venv_env.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/test_venv_env.py
@@ -150,3 +150,76 @@ def test_build_install_argv_targets_overlay():
 def test_build_install_argv_optional_flags_omitted():
     argv = V.build_install_argv('uv', 'py', 'r.txt', '/site')
     assert '-c' not in argv and '--excludes' not in argv
+
+
+# --- run_scoped_install orchestration (injected side effects) ---------------
+
+
+def _stub_discover(files):
+    def _d(providers):
+        _d.called_with = list(providers)
+        return files
+
+    _d.called_with = None
+    return _d
+
+
+def test_run_scoped_install_off_is_noop(tmp_path):
+    d = _stub_discover([])
+    calls = []
+    site = V.run_scoped_install(
+        str(tmp_path),
+        'p',
+        'main',
+        ['webhook'],
+        discover=d,
+        compile_and_install=lambda plan: calls.append('install'),
+        mode=V.USE_OFF,
+    )
+    assert site is None  # legacy/base path
+    assert d.called_with is None  # discover not even called
+    assert calls == []  # nothing installed
+
+
+def test_run_scoped_install_on_installs_and_overlays(tmp_path):
+    req = _req(tmp_path, 'r.txt', 'tabulate==0.8.10\n')
+    d = _stub_discover([req])
+    installed, overlaid = [], []
+    site = V.run_scoped_install(
+        str(tmp_path),
+        'proj-aaaa',
+        'main',
+        ['webhook', 'detect'],
+        discover=d,
+        compile_and_install=lambda plan: installed.append(plan.paths.site_packages),
+        on_overlay=overlaid.append,
+        mode=V.USE_ON,
+    )
+    assert site.endswith('site-packages')
+    assert d.called_with == ['webhook', 'detect']
+    assert installed == [site]  # compile+install ran (first run = drift)
+    assert overlaid == [site]  # overlay hook invoked with the overlay
+    assert os.path.isfile(V.env_paths(os.path.dirname(site)).hash_file)  # marked installed
+
+
+def test_run_scoped_install_skips_install_when_up_to_date(tmp_path):
+    req = _req(tmp_path, 'r.txt', 'tabulate==0.8.10\n')
+    d = _stub_discover([req])
+
+    def ci(plan):
+        open(plan.paths.constraints, 'w').close()  # simulate uv producing constraints
+        ci.n += 1
+
+    ci.n = 0
+    V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], discover=d, compile_and_install=ci, mode=V.USE_ON)
+    assert ci.n == 1
+    # unchanged reqs + constraints present -> no reinstall
+    V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], discover=d, compile_and_install=ci, mode=V.USE_ON)
+    assert ci.n == 1
+
+
+def test_run_scoped_install_auto_needs_isolated_group(tmp_path):
+    req = _req(tmp_path, 'r.txt', 'x\n')
+    base = dict(discover=_stub_discover([req]), compile_and_install=lambda plan: None, mode=V.USE_AUTO)
+    assert V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], has_isolated_group=False, **base) is None
+    assert V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], has_isolated_group=True, **base) is not None

--- a/packages/server/engine-lib/rocketlib-python/lib/test_venv_env.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/test_venv_env.py
@@ -1,0 +1,152 @@
+# =============================================================================
+# MIT License — Copyright (c) 2026 Aparavi Software AG
+# (full text in depends.py)
+# =============================================================================
+
+"""Unit tests for ``venv_env`` — per-env overlay layout, planning, and the switch.
+
+Pure/filesystem-only; no engine or ``uv`` needed. Uses ``tmp_path`` for overlays.
+"""
+
+from __future__ import annotations
+
+import os
+
+import venv_env as V
+
+
+# --- the ROCKETRIDE_SERVER_USE_VENV switch (§4.15) --------------------------
+
+
+def test_use_venv_mode_states():
+    assert V.use_venv_mode({}) == V.USE_AUTO  # unset
+    assert V.use_venv_mode({'ROCKETRIDE_SERVER_USE_VENV': '0'}) == V.USE_OFF
+    assert V.use_venv_mode({'ROCKETRIDE_SERVER_USE_VENV': '1'}) == V.USE_ON
+    assert V.use_venv_mode({'ROCKETRIDE_SERVER_USE_VENV': 'yes'}) == V.USE_AUTO  # unknown -> auto
+
+
+def test_scoping_enabled_semantics():
+    # off: never; on: always; auto: only with an isolated group
+    assert V.scoping_enabled(V.USE_OFF, has_isolated_group=True) is False
+    assert V.scoping_enabled(V.USE_ON, has_isolated_group=False) is True
+    assert V.scoping_enabled(V.USE_AUTO, has_isolated_group=True) is True
+    assert V.scoping_enabled(V.USE_AUTO, has_isolated_group=False) is False
+
+
+# --- id shortening + MAX_PATH friendliness (§4.9) ---------------------------
+
+
+def test_short_id_rules():
+    assert V.short_id(None) == V.DEFAULT_ID
+    assert V.short_id('') == V.DEFAULT_ID
+    assert V.short_id('----') == V.DEFAULT_ID  # all separators -> default
+    assert V.short_id('main') == 'main'  # short readable id kept
+    assert V.short_id('group_1') == 'group1'  # separators stripped
+    assert V.short_id('0d4f3caa-1234-5678-9abc') == '0d4f3caa'  # GUID -> first 8 hex
+    assert len(V.short_id('0d4f3caa-1234-5678-9abc')) == 8
+
+
+def test_env_dir_layout():
+    exe = os.path.join('X:', 'engine')
+    d = V.env_dir(exe, '0d4f3caa-1111-2222', 'group_7')
+    parts = d.replace('\\', '/').split('/')
+    assert parts[-3:] == ['venvs', '0d4f3caa', 'group7']
+    # missing project_id -> shared 'default'; missing env_id -> 'main'
+    assert V.env_dir(exe, None, None).replace('\\', '/').endswith('venvs/default/main')
+
+
+def test_env_paths_names():
+    p = V.env_paths(os.path.join('X:', 'e', 'venvs', 'p', 'main'))
+    assert os.path.basename(p.site_packages) == 'site-packages'
+    assert os.path.basename(p.combined) == 'combined.txt'
+    assert os.path.basename(p.constraints) == 'constraints.txt'
+    assert os.path.basename(p.hash_file) == 'requirements.hash'
+    assert os.path.basename(p.lock_file) == 'install.lock'
+
+
+# --- hash / combine ---------------------------------------------------------
+
+
+def _req(tmp_path, name, body):
+    f = tmp_path / name
+    f.write_text(body, encoding='utf-8')
+    return str(f)
+
+
+def test_requirements_hash_order_independent_and_content_sensitive(tmp_path):
+    a = _req(tmp_path, 'a.txt', 'tabulate==0.8.10\n')
+    b = _req(tmp_path, 'b.txt', 'six==1.16.0\n')
+    assert V.requirements_hash([a, b]) == V.requirements_hash([b, a])  # order-independent
+    h1 = V.requirements_hash([a])
+    (tmp_path / 'a.txt').write_text('tabulate==0.9.0\n', encoding='utf-8')  # content change
+    assert V.requirements_hash([a]) != h1
+
+
+def test_write_combined_concatenates_with_headers(tmp_path):
+    a = _req(tmp_path, 'a.txt', 'tabulate==0.8.10\n')
+    b = _req(tmp_path, 'b.txt', 'six==1.16.0\n')
+    out = str(tmp_path / 'combined.txt')
+    V.write_combined([a, b], out)
+    text = (tmp_path / 'combined.txt').read_text(encoding='utf-8')
+    assert 'tabulate==0.8.10' in text and 'six==1.16.0' in text
+    assert text.count('# Source:') == 2
+
+
+# --- plan_install drift + overlay creation ----------------------------------
+
+
+def test_plan_install_creates_overlay_and_detects_drift(tmp_path):
+    exe = str(tmp_path)
+    req = _req(tmp_path, 'r.txt', 'tabulate==0.8.10\n')
+
+    plan = V.plan_install(exe, 'proj-guid-aaaa', 'main', [req])
+    # overlay created, first run needs a rebuild, combined written
+    assert os.path.isdir(plan.paths.site_packages)
+    assert plan.needs_rebuild is True
+    assert os.path.isfile(plan.paths.combined)
+
+    # simulate a completed install: mark hash + create a constraints file
+    V.mark_installed(plan)
+    open(plan.paths.constraints, 'w').close()
+
+    # unchanged requirements -> no rebuild
+    plan2 = V.plan_install(exe, 'proj-guid-aaaa', 'main', [req])
+    assert plan2.needs_rebuild is False
+
+    # changed requirements -> rebuild again
+    (tmp_path / 'r.txt').write_text('tabulate==0.9.0\n', encoding='utf-8')
+    plan3 = V.plan_install(exe, 'proj-guid-aaaa', 'main', [req])
+    assert plan3.needs_rebuild is True
+
+
+def test_plan_install_default_env_when_no_project_id(tmp_path):
+    # §4.14: no project_id -> shared default overlay, still works
+    plan = V.plan_install(str(tmp_path), None, None, [])
+    assert plan.paths.env_dir.replace('\\', '/').endswith('venvs/default/main')
+    assert os.path.isdir(plan.paths.site_packages)
+
+
+# --- uv install argv (scoped via --target) ----------------------------------
+
+
+def test_build_install_argv_targets_overlay():
+    argv = V.build_install_argv(
+        uv_path='uv',
+        python_exe='py',
+        requirements_path='r.txt',
+        target_site='/venvs/p/main/site-packages',
+        constraints_path='c.txt',
+        excludes_path='ex.txt',
+    )
+    assert argv[:3] == ['uv', 'pip', 'install']
+    # target overlay + constraints + excludes all present, in order
+    assert argv[argv.index('--target') + 1] == '/venvs/p/main/site-packages'
+    assert argv[argv.index('-r') + 1] == 'r.txt'
+    assert argv[argv.index('-c') + 1] == 'c.txt'
+    assert '--no-build-isolation' in argv
+    assert argv[argv.index('--excludes') + 1] == 'ex.txt'
+
+
+def test_build_install_argv_optional_flags_omitted():
+    argv = V.build_install_argv('uv', 'py', 'r.txt', '/site')
+    assert '-c' not in argv and '--excludes' not in argv

--- a/packages/server/engine-lib/rocketlib-python/lib/venv_env.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/venv_env.py
@@ -1,0 +1,280 @@
+# =============================================================================
+# MIT License — Copyright (c) 2026 Aparavi Software AG
+# (full text in depends.py)
+# =============================================================================
+
+"""Per-environment overlay layout and scoped-install planning for RocketRide venvs.
+
+Implements the directory model and pre-install planning from design §4.9 / §4.7:
+every environment (``main`` or an isolated group) gets its own overlay under
+``<exe>/venvs/<proj>/<env>/`` holding ``site-packages/`` + a scoped
+``combined.txt`` / ``constraints.txt`` / ``requirements.hash`` + an install lock.
+Paths are keyed by **shortened** stable ids (first 8 chars) to stay under the
+Windows ``MAX_PATH`` limit (a 36-char GUID nested above deep torch/nvidia paths
+overflows 260).
+
+This module is **pure and engine-free** (stdlib only, no ``engLib``/``uv``, no
+subprocess, no ``sys.path`` mutation), so it is unit-testable in isolation and
+parameterized by explicit roots. The caller (``depends.py``) layers the actual
+``uv`` compile/install and the ``sys.path.insert`` overlay on top.
+
+The tiny hash/combine helpers here mirror ``depends.py`` on purpose to avoid
+importing it (which pulls ``engLib``); keep them in sync until ``depends.py`` is
+refactored to consume this module directly.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# env_id for the always-present base-of-the-pipeline environment.
+MAIN_ENV = 'main'
+# env / project id used when there is no project_id (engtest, CLI, ad-hoc — §4.14).
+DEFAULT_ID = 'default'
+
+_ID_MAX = 8  # chars kept from a long (GUID-like) id segment; short ids kept whole.
+
+
+# ---------------------------------------------------------------------------
+# the ROCKETRIDE_SERVER_USE_VENV master switch (§4.15)
+# ---------------------------------------------------------------------------
+
+# Resolved states of the switch.
+USE_AUTO = 'auto'  # unset: scope per-env only if the pipeline has an isolated group
+USE_OFF = 'off'  # '0': never partition/scope — today's global-glob behavior (legacy)
+USE_ON = 'on'  # '1': force the scoped/venv machinery on
+
+
+def use_venv_mode(env: Optional[dict] = None) -> str:
+    """Resolve the ``ROCKETRIDE_SERVER_USE_VENV`` switch to ``auto`` / ``off`` / ``on``.
+
+    Args:
+        env: Environment mapping to read (defaults to ``os.environ``); injectable
+            for tests.
+
+    Returns:
+        ``USE_OFF`` for ``'0'``, ``USE_ON`` for ``'1'``, ``USE_AUTO`` otherwise
+        (unset / any other value).
+    """
+    raw = (env if env is not None else os.environ).get('ROCKETRIDE_SERVER_USE_VENV')
+    if raw is None:
+        return USE_AUTO
+    raw = raw.strip()
+    if raw == '0':
+        return USE_OFF
+    if raw == '1':
+        return USE_ON
+    return USE_AUTO
+
+
+def scoping_enabled(mode: str, has_isolated_group: bool) -> bool:
+    """Whether per-environment scoping applies for this run.
+
+    ``off`` -> never (legacy global-glob); ``on`` -> always; ``auto`` -> only when
+    the pipeline opts in via an isolated group (§4.15).
+    """
+    if mode == USE_OFF:
+        return False
+    if mode == USE_ON:
+        return True
+    return has_isolated_group
+
+
+# ---------------------------------------------------------------------------
+# id shortening + directory layout (§4.9)
+# ---------------------------------------------------------------------------
+
+
+def short_id(identifier: Optional[str], length: int = _ID_MAX) -> str:
+    """Shorten a stable id to a filesystem-safe, MAX_PATH-friendly segment.
+
+    Long (GUID-like) ids are truncated to ``length`` chars; short readable ids
+    (``main``, ``group_1``) are kept whole (minus separators). ``None`` / empty ->
+    :data:`DEFAULT_ID`.
+
+    Collisions between two long ids sharing a prefix are the accepted MAX_PATH
+    trade-off (design §4.9); short group ids within one project stay distinct.
+    """
+    if not identifier:
+        return DEFAULT_ID
+    cleaned = re.sub(r'[^A-Za-z0-9]', '', str(identifier)).lower()
+    if not cleaned:
+        return DEFAULT_ID
+    return cleaned[:length] if len(cleaned) > length else cleaned
+
+
+def venv_root(exe_dir: str) -> str:
+    """The top-level ``venvs/`` directory (sibling of ``lib/`` and ``cache/``)."""
+    return os.path.join(exe_dir, 'venvs')
+
+
+def env_dir(exe_dir: str, project_id: Optional[str], env_id: Optional[str]) -> str:
+    """Overlay directory for one environment: ``<exe>/venvs/<proj>/<env>``.
+
+    ``project_id`` is the pipe id (``config.pipeline.project_id``); ``env_id`` is
+    ``main`` or a group node id. Both are shortened (§4.9). Missing ``project_id``
+    falls back to a shared ``default`` project (§4.14).
+    """
+    return os.path.join(venv_root(exe_dir), short_id(project_id), short_id(env_id or MAIN_ENV))
+
+
+@dataclass
+class EnvPaths:
+    """Resolved on-disk paths for one environment overlay."""
+
+    env_dir: str
+    site_packages: str
+    combined: str
+    constraints: str
+    hash_file: str
+    lock_file: str
+
+
+def env_paths(directory: str) -> EnvPaths:
+    """Return the standard file layout inside an environment overlay ``directory``."""
+    return EnvPaths(
+        env_dir=directory,
+        site_packages=os.path.join(directory, 'site-packages'),
+        combined=os.path.join(directory, 'combined.txt'),
+        constraints=os.path.join(directory, 'constraints.txt'),
+        hash_file=os.path.join(directory, 'requirements.hash'),
+        lock_file=os.path.join(directory, 'install.lock'),
+    )
+
+
+# ---------------------------------------------------------------------------
+# hash-drift planning (per-env; mirrors depends.py helpers)
+# ---------------------------------------------------------------------------
+
+
+def requirements_hash(req_files: list[str]) -> str:
+    """Fast content hash of a requirement-file set (path + size + mtime_ns).
+
+    Mirrors ``depends._compute_hash`` so a per-env overlay reuses the same drift
+    semantics without importing ``depends`` (which needs ``engLib``).
+    """
+    hasher = hashlib.md5()
+    for path in sorted(req_files):
+        stat = os.stat(path)
+        hasher.update(f'{path}:{stat.st_size}:{stat.st_mtime_ns}\n'.encode())
+    return hasher.hexdigest()
+
+
+def write_combined(req_files: list[str], combined_path: str) -> None:
+    """Concatenate ``req_files`` into ``combined_path`` (mirrors depends helper)."""
+    with open(combined_path, 'w', encoding='utf-8') as out:
+        for path in req_files:
+            out.write(f'# Source: {path}\n')
+            with open(path, 'r', encoding='utf-8') as inp:
+                out.write(inp.read())
+            out.write('\n')
+
+
+@dataclass
+class InstallPlan:
+    """Result of planning a scoped install for one environment."""
+
+    paths: EnvPaths
+    current_hash: str
+    needs_rebuild: bool
+
+
+def plan_install(
+    exe_dir: str,
+    project_id: Optional[str],
+    env_id: Optional[str],
+    req_files: list[str],
+    create: bool = True,
+) -> InstallPlan:
+    """Plan a scoped install: resolve the overlay, compute drift, write the combined file.
+
+    Does **no** subprocess work — it prepares everything the caller needs to run
+    ``uv`` (or to skip when the env is already up to date).
+
+    Args:
+        exe_dir: The engine executable directory (``dirname(sys.executable)``).
+        project_id: Pipe id, or ``None`` -> shared ``default`` project (§4.14).
+        env_id: ``main`` or a group id.
+        req_files: The environment's requirement-file set (from ``ast_deps``).
+        create: Create the overlay directory tree when ``True``.
+
+    Returns:
+        An :class:`InstallPlan`. ``needs_rebuild`` is ``True`` when the stored hash
+        differs (or the constraints file is missing); write the combined file only
+        then, run ``uv``, and finally :func:`mark_installed`.
+    """
+    paths = env_paths(env_dir(exe_dir, project_id, env_id))
+    if create:
+        os.makedirs(paths.site_packages, exist_ok=True)
+
+    current = requirements_hash(req_files) if req_files else ''
+    stored = _read_text(paths.hash_file)
+    needs = (current != stored) or not os.path.exists(paths.constraints)
+
+    if needs and create and req_files:
+        write_combined(req_files, paths.combined)
+
+    return InstallPlan(paths=paths, current_hash=current, needs_rebuild=needs)
+
+
+def mark_installed(plan: InstallPlan) -> None:
+    """Persist the plan's hash after a successful install (drift baseline)."""
+    with open(plan.paths.hash_file, 'w', encoding='utf-8') as fh:
+        fh.write(plan.current_hash)
+
+
+# ---------------------------------------------------------------------------
+# uv install-argv builder (scoped to the overlay via --target)
+# ---------------------------------------------------------------------------
+
+
+def build_install_argv(
+    uv_path: str,
+    python_exe: str,
+    requirements_path: str,
+    target_site: str,
+    constraints_path: Optional[str] = None,
+    excludes_path: Optional[str] = None,
+) -> list[str]:
+    """Construct the ``uv pip install --target`` argv for a per-env overlay.
+
+    Mirrors ``depends.py``'s install flags, adding ``--target`` so packages land
+    in the environment's overlay ``site-packages`` instead of the base runtime.
+    Pure (returns the list; the caller runs it) so it is unit-testable.
+    """
+    argv = [
+        uv_path,
+        'pip',
+        'install',
+        '--python',
+        python_exe,
+        '--target',
+        target_site,
+        '-r',
+        requirements_path,
+        '--index-strategy',
+        'unsafe-best-match',
+        '--no-build-isolation',
+    ]
+    if constraints_path:
+        argv += ['-c', constraints_path]
+    if excludes_path:
+        argv += ['--excludes', excludes_path]
+    return argv
+
+
+# ---------------------------------------------------------------------------
+# internal
+# ---------------------------------------------------------------------------
+
+
+def _read_text(path: str) -> Optional[str]:
+    try:
+        with open(path, 'r', encoding='utf-8') as fh:
+            return fh.read().strip()
+    except FileNotFoundError:
+        return None

--- a/packages/server/engine-lib/rocketlib-python/lib/venv_env.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/venv_env.py
@@ -268,6 +268,50 @@ def build_install_argv(
 
 
 # ---------------------------------------------------------------------------
+# scoped-install orchestration (side effects injected -> unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def run_scoped_install(
+    exe_dir: str,
+    project_id: Optional[str],
+    env_id: Optional[str],
+    providers,
+    *,
+    discover,
+    compile_and_install,
+    mode: Optional[str] = None,
+    has_isolated_group: bool = False,
+    on_overlay=None,
+) -> Optional[str]:
+    """Orchestrate a scoped per-environment install; return the overlay site-packages.
+
+    Pure control flow — every side effect is injected, so this is fully
+    unit-testable without an engine or ``uv``:
+
+    * ``discover(providers) -> list[str]`` — the env's requirement files (ast_deps).
+    * ``compile_and_install(plan)`` — run the uv compile + install ``--target``.
+    * ``on_overlay(site_packages)`` — e.g. ``sys.path.insert`` (optional).
+
+    Returns ``None`` when scoping does not apply for this run (the legacy/base
+    path — §4.15), otherwise the overlay ``site-packages`` path. Installs/rebuilds
+    only when the requirement set drifted (§4.9).
+    """
+    if mode is None:
+        mode = use_venv_mode()
+    if not scoping_enabled(mode, has_isolated_group):
+        return None
+    req_files = list(discover(providers))
+    plan = plan_install(exe_dir, project_id, env_id, req_files)
+    if plan.needs_rebuild:
+        compile_and_install(plan)
+        mark_installed(plan)
+    if on_overlay is not None:
+        on_overlay(plan.paths.site_packages)
+    return plan.paths.site_packages
+
+
+# ---------------------------------------------------------------------------
 # internal
 # ---------------------------------------------------------------------------
 

--- a/packages/server/engine-lib/rocketlib-python/lib/venv_env.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/venv_env.py
@@ -3,24 +3,17 @@
 # (full text in depends.py)
 # =============================================================================
 
-"""Per-environment overlay layout and scoped-install planning for RocketRide venvs.
+"""Per-environment overlay layout and scoped-install planning.
 
-Implements the directory model and pre-install planning from design §4.9 / §4.7:
-every environment (``main`` or an isolated group) gets its own overlay under
-``<exe>/venvs/<proj>/<env>/`` holding ``site-packages/`` + a scoped
-``combined.txt`` / ``constraints.txt`` / ``requirements.hash`` + an install lock.
-Paths are keyed by **shortened** stable ids (first 8 chars) to stay under the
-Windows ``MAX_PATH`` limit (a 36-char GUID nested above deep torch/nvidia paths
-overflows 260).
+Every environment (``main`` or an isolated group) gets its own overlay under
+``<exe>/venvs/<proj>/<env>/`` holding ``site-packages/`` plus its own
+``combined.txt`` / ``constraints.txt`` / ``requirements.hash`` and an install lock.
+Ids are shortened to stay under the Windows ``MAX_PATH`` limit.
 
-This module is **pure and engine-free** (stdlib only, no ``engLib``/``uv``, no
-subprocess, no ``sys.path`` mutation), so it is unit-testable in isolation and
-parameterized by explicit roots. The caller (``depends.py``) layers the actual
-``uv`` compile/install and the ``sys.path.insert`` overlay on top.
-
-The tiny hash/combine helpers here mirror ``depends.py`` on purpose to avoid
-importing it (which pulls ``engLib``); keep them in sync until ``depends.py`` is
-refactored to consume this module directly.
+Stdlib only — no engine, ``uv``, subprocess or ``sys.path`` mutation — so it is
+testable in isolation; ``depends.py`` layers the actual compile/install on top.
+The hash/combine helpers mirror ``depends.py`` to avoid importing it (that would
+pull in ``engLib``); keep them in sync.
 """
 
 from __future__ import annotations
@@ -33,14 +26,14 @@ from typing import Optional
 
 # env_id for the always-present base-of-the-pipeline environment.
 MAIN_ENV = 'main'
-# env / project id used when there is no project_id (engtest, CLI, ad-hoc — §4.14).
+# Used when there is no project_id (engtest, CLI, ad-hoc runs).
 DEFAULT_ID = 'default'
 
 _ID_MAX = 8  # chars kept from a long (GUID-like) id segment; short ids kept whole.
 
 
 # ---------------------------------------------------------------------------
-# the ROCKETRIDE_SERVER_USE_VENV master switch (§4.15)
+# the ROCKETRIDE_SERVER_USE_VENV switch
 # ---------------------------------------------------------------------------
 
 # Resolved states of the switch.
@@ -75,7 +68,7 @@ def scoping_enabled(mode: str, has_isolated_group: bool) -> bool:
     """Whether per-environment scoping applies for this run.
 
     ``off`` -> never (legacy global-glob); ``on`` -> always; ``auto`` -> only when
-    the pipeline opts in via an isolated group (§4.15).
+    the pipeline opts in via an isolated group.
     """
     if mode == USE_OFF:
         return False
@@ -85,7 +78,7 @@ def scoping_enabled(mode: str, has_isolated_group: bool) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# id shortening + directory layout (§4.9)
+# id shortening + directory layout
 # ---------------------------------------------------------------------------
 
 
@@ -97,7 +90,7 @@ def short_id(identifier: Optional[str], length: int = _ID_MAX) -> str:
     :data:`DEFAULT_ID`.
 
     Collisions between two long ids sharing a prefix are the accepted MAX_PATH
-    trade-off (design §4.9); short group ids within one project stay distinct.
+    trade-off; short group ids within one project stay distinct.
     """
     if not identifier:
         return DEFAULT_ID
@@ -116,8 +109,8 @@ def env_dir(exe_dir: str, project_id: Optional[str], env_id: Optional[str]) -> s
     """Overlay directory for one environment: ``<exe>/venvs/<proj>/<env>``.
 
     ``project_id`` is the pipe id (``config.pipeline.project_id``); ``env_id`` is
-    ``main`` or a group node id. Both are shortened (§4.9). Missing ``project_id``
-    falls back to a shared ``default`` project (§4.14).
+    ``main`` or a group node id. Both are shortened. Missing ``project_id`` falls
+    back to a shared ``default`` project.
     """
     return os.path.join(venv_root(exe_dir), short_id(project_id), short_id(env_id or MAIN_ENV))
 
@@ -192,12 +185,11 @@ def plan_install(
 ) -> InstallPlan:
     """Plan a scoped install: resolve the overlay, compute drift, write the combined file.
 
-    Does **no** subprocess work — it prepares everything the caller needs to run
-    ``uv`` (or to skip when the env is already up to date).
+    Prepares what the caller needs to run ``uv``, or to skip when already up to date.
 
     Args:
         exe_dir: The engine executable directory (``dirname(sys.executable)``).
-        project_id: Pipe id, or ``None`` -> shared ``default`` project (§4.14).
+        project_id: Pipe id, or ``None`` for the shared ``default`` project.
         env_id: ``main`` or a group id.
         req_files: The environment's requirement-file set (from ``ast_deps``).
         create: Create the overlay directory tree when ``True``.
@@ -286,22 +278,23 @@ def run_scoped_install(
 ) -> Optional[str]:
     """Orchestrate a scoped per-environment install; return the overlay site-packages.
 
-    Pure control flow — every side effect is injected, so this is fully
-    unit-testable without an engine or ``uv``:
+    Control flow only — the side effects are injected, so this is testable without an
+    engine or ``uv``: ``discover(providers)`` yields the env's requirement files,
+    ``compile_and_install(plan)`` runs uv, and the optional ``on_overlay(site)`` applies
+    the overlay.
 
-    * ``discover(providers) -> list[str]`` — the env's requirement files (ast_deps).
-    * ``compile_and_install(plan)`` — run the uv compile + install ``--target``.
-    * ``on_overlay(site_packages)`` — e.g. ``sys.path.insert`` (optional).
-
-    Returns ``None`` when scoping does not apply for this run (the legacy/base
-    path — §4.15), otherwise the overlay ``site-packages`` path. Installs/rebuilds
-    only when the requirement set drifted (§4.9).
+    Installs only when the requirement set drifted. Returns ``None`` when scoping does
+    not apply, leaving the caller on the base runtime.
     """
     if mode is None:
         mode = use_venv_mode()
     if not scoping_enabled(mode, has_isolated_group):
         return None
     req_files = list(discover(providers))
+    if not req_files:
+        # Nothing to scope (source-only endpoint, or all-native nodes): must not try to
+        # compile an absent combined file — leave the base runtime in place.
+        return None
     plan = plan_install(exe_dir, project_id, env_id, req_files)
     if plan.needs_rebuild:
         compile_and_install(plan)

--- a/packages/server/engine-lib/rocketlib-python/tests/conftest.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/conftest.py
@@ -1,0 +1,10 @@
+# =============================================================================
+# MIT License — Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Put ``lib/`` on sys.path so tests can import the modules under test."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'lib'))

--- a/packages/server/engine-lib/rocketlib-python/tests/test_ast_deps.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_ast_deps.py
@@ -1,13 +1,10 @@
 # =============================================================================
 # MIT License — Copyright (c) 2026 Aparavi Software AG
-# (full text in ast_deps.py)
 # =============================================================================
 
-"""Unit tests for ``ast_deps`` — provider resolution + AST dependency discovery.
+"""Tests for ``ast_deps`` — provider resolution and AST dependency discovery.
 
-Pure-logic tests (JSONC stripping, provider aliasing) run anywhere. The golden
-requirement-set tests need the real node/ai source tree and are skipped when the
-repo layout is not reachable from this file (e.g. an installed/packaged context).
+Tests needing the real node/ai source tree are skipped when it is not reachable.
 """
 
 from __future__ import annotations
@@ -18,7 +15,7 @@ import pytest
 
 import ast_deps as A
 
-# lib/ -> rocketlib-python -> engine-lib -> server -> packages -> repo root
+# tests/ -> rocketlib-python -> engine-lib -> server -> packages -> repo root
 _REPO = os.path.abspath(os.path.join(os.path.dirname(__file__), *([os.pardir] * 5)))
 _NODES_SRC = os.path.join(_REPO, 'nodes', 'src')
 _AI_SRC = os.path.join(_REPO, 'packages', 'ai', 'src')
@@ -26,17 +23,20 @@ _FIXTURES = os.path.join(_REPO, 'nodes', 'test', 'fixtures')
 
 _HAVE_TREE = os.path.isdir(os.path.join(_NODES_SRC, 'nodes')) and os.path.isdir(os.path.join(_AI_SRC, 'ai'))
 _needs_tree = pytest.mark.skipif(not _HAVE_TREE, reason='node/ai source tree not reachable')
+_needs_fixtures = pytest.mark.skipif(
+    not os.path.isdir(os.path.join(_FIXTURES, 'nodes', 'vtest_alpha')), reason='vtest fixtures not present'
+)
 
 
-# --- pure logic: JSONC stripping -------------------------------------------
+# --- JSONC parsing ----------------------------------------------------------
 
 
 def test_strip_jsonc_preserves_scheme_in_strings():
-    src = '{ // a comment\n  "protocol": "webhook://", /* blk */ "path": "nodes.webhook" }'
     import json
 
+    src = '{ // a comment\n  "protocol": "webhook://", /* blk */ "path": "nodes.webhook" }'
     data = json.loads(A.strip_jsonc(src))
-    assert data['protocol'] == 'webhook://'  # the // inside the string survived
+    assert data['protocol'] == 'webhook://'  # the // inside the string must survive
     assert data['path'] == 'nodes.webhook'
 
 
@@ -53,7 +53,7 @@ def test_string_consts_flatten():
     assert A._string_consts(node) == ['a.txt', 'b.txt', 'c.txt']
 
 
-# --- provider resolution (the services.json 'path' mapping) -----------------
+# --- provider -> module resolution ------------------------------------------
 
 
 @_needs_tree
@@ -88,7 +88,7 @@ def test_provider_native_and_unknown():
     assert idx.resolve('does_not_exist') is None
 
 
-# --- golden requirement sets (transitive walk correctness) ------------------
+# --- transitive walk --------------------------------------------------------
 
 
 @_needs_tree
@@ -105,14 +105,13 @@ def test_golden_requirement_sets(provider, must_include):
     assert not res.unresolved_providers
     basenames = {os.path.basename(p) for p in res.requirement_files}
     assert must_include <= basenames, f'{provider} missing {must_include - basenames}'
-    # torch is reached in every heavy vision/audio node's local branch
+    # torch is reached through each heavy node's local (non-model-server) branch
     assert any('torch' in os.path.relpath(p, _REPO).replace(os.sep, '/') for p in res.requirement_files)
-    assert res.dynamic_imports == []  # none of these three use dynamic imports
+    assert res.dynamic_imports == []
 
 
 @_needs_tree
 def test_only_needed_excludes_unrelated_families():
-    # a detect-only env must not drag in audio (whisper) or NER (gliner) deps
     res = A.discover_for_providers(['detect'], _NODES_SRC, _AI_SRC)
     basenames = {os.path.basename(p) for p in res.requirement_files}
     assert 'requirements_whisper.txt' not in basenames
@@ -121,30 +120,39 @@ def test_only_needed_excludes_unrelated_families():
 
 @_needs_tree
 def test_dynamic_import_is_flagged():
-    # preprocessor_code uses importlib.import_module(modmap[lang]) — must be flagged
+    # preprocessor_code resolves its module from a config-driven dict at runtime
     res = A.discover_for_providers(['preprocessor_code'], _NODES_SRC, _AI_SRC)
-    assert res.dynamic_imports, 'expected the dynamic importlib call to be flagged'
+    assert res.dynamic_imports
 
 
-# --- conflict fixture nodes (lightweight, decoupled from ai/*) --------------
+# --- conflict fixture nodes -------------------------------------------------
 
 
-@pytest.mark.skipif(
-    not os.path.isdir(os.path.join(_FIXTURES, 'nodes', 'vtest_alpha')),
-    reason='vtest fixture nodes not present',
-)
+@_needs_fixtures
 def test_fixture_nodes_pin_conflicting_versions_without_ai():
     idx = A.ProviderIndex(_FIXTURES)
     roots_ai = _AI_SRC if _HAVE_TREE else _FIXTURES
     for prov, pin in (('vtest_alpha', 'tabulate==0.8.10'), ('vtest_beta', 'tabulate==0.9.0')):
         entry = idx.resolve(prov)
         assert entry is not None and not entry.native
-        res = A.discover([f for f in entry.entry_files], {'nodes': _FIXTURES, 'ai': roots_ai})
-        # the fixture's own requirements.txt is found ...
-        reqs = res.requirement_files
-        assert any(os.path.basename(r) == 'requirements.txt' for r in reqs)
-        contents = ''.join(open(r, encoding='utf-8').read() for r in reqs)
+        res = A.discover(entry.entry_files, {'nodes': _FIXTURES, 'ai': roots_ai})
+        contents = ''.join(open(r, encoding='utf-8').read() for r in res.requirement_files)
         assert pin in contents
-        # ... and it pulls nothing from ai/*
         assert res.reached_modules == []
         assert 'tabulate' in res.third_party
+
+
+@_needs_fixtures
+def test_discover_for_providers_dedupes_repeated_providers(monkeypatch):
+    # a pipeline may hold many nodes of one type; each provider must resolve once
+    seen = []
+    orig = A.ProviderIndex.resolve
+
+    def counting(self, provider):
+        seen.append(provider)
+        return orig(self, provider)
+
+    monkeypatch.setattr(A.ProviderIndex, 'resolve', counting)
+    res = A.discover_for_providers(['vtest_alpha', 'vtest_alpha', 'vtest_beta', 'vtest_alpha'], _FIXTURES, _FIXTURES)
+    assert seen == ['vtest_alpha', 'vtest_beta']
+    assert {os.path.basename(r) for r in res.requirement_files} >= {'requirements.txt'}

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends_scoping.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends_scoping.py
@@ -1,0 +1,59 @@
+# =============================================================================
+# MIT License — Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Tests for the parts of ``depends`` that react to the scoping switch.
+
+``depends`` imports ``engLib``, so these run under the engine interpreter
+(``builder server:run-rocketlib-test``) and are skipped under a bare Python.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+try:
+    import depends as D
+
+    _HAVE_ENGLIB = True
+except ImportError:  # engLib is built into engine.exe
+    _HAVE_ENGLIB = False
+
+pytestmark = pytest.mark.skipif(not _HAVE_ENGLIB, reason='depends needs engLib (engine interpreter)')
+
+
+def _has_node_path(paths):
+    root = os.path.abspath(os.path.join(D._get_executable_dir(), 'nodes'))
+    return any(os.path.abspath(p).startswith(root + os.sep) for p in paths)
+
+
+def test_forced_scoping_drops_node_requirements(monkeypatch):
+    # With scoping forced on, node deps come from each env's scoped install; folding them
+    # into the startup compile would make two conflicting nodes unable to coexist at all.
+    monkeypatch.setenv('ROCKETRIDE_SERVER_USE_VENV', '1')
+    assert not _has_node_path(D._find_requirement_files())
+
+
+@pytest.mark.parametrize('value', ['0', None])
+def test_legacy_and_auto_keep_node_requirements(monkeypatch, value):
+    if value is None:
+        monkeypatch.delenv('ROCKETRIDE_SERVER_USE_VENV', raising=False)
+    else:
+        monkeypatch.setenv('ROCKETRIDE_SERVER_USE_VENV', value)
+    unscoped = D._find_requirement_files()
+    monkeypatch.setenv('ROCKETRIDE_SERVER_USE_VENV', '1')
+    assert set(D._find_requirement_files()) <= set(unscoped)
+    # Only meaningful while the installation actually ships node requirement files.
+    if os.path.isdir(os.path.join(D._get_executable_dir(), 'nodes')):
+        assert _has_node_path(unscoped)
+
+
+def test_ai_and_root_requirements_survive_forced_scoping(monkeypatch):
+    monkeypatch.setenv('ROCKETRIDE_SERVER_USE_VENV', '1')
+    exe_dir = os.path.abspath(D._get_executable_dir())
+    found = [os.path.abspath(p) for p in D._find_requirement_files()]
+    ai_root = os.path.join(exe_dir, 'ai')
+    if os.path.isdir(ai_root):
+        assert any(p.startswith(ai_root + os.sep) for p in found), 'base runtime must keep ai deps'

--- a/packages/server/engine-lib/rocketlib-python/tests/test_venv_env.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_venv_env.py
@@ -1,12 +1,8 @@
 # =============================================================================
 # MIT License — Copyright (c) 2026 Aparavi Software AG
-# (full text in depends.py)
 # =============================================================================
 
-"""Unit tests for ``venv_env`` — per-env overlay layout, planning, and the switch.
-
-Pure/filesystem-only; no engine or ``uv`` needed. Uses ``tmp_path`` for overlays.
-"""
+"""Tests for ``venv_env`` — overlay layout, install planning, and the venv switch."""
 
 from __future__ import annotations
 
@@ -15,43 +11,39 @@ import os
 import venv_env as V
 
 
-# --- the ROCKETRIDE_SERVER_USE_VENV switch (§4.15) --------------------------
+# --- ROCKETRIDE_SERVER_USE_VENV switch --------------------------------------
 
 
 def test_use_venv_mode_states():
-    assert V.use_venv_mode({}) == V.USE_AUTO  # unset
+    assert V.use_venv_mode({}) == V.USE_AUTO
     assert V.use_venv_mode({'ROCKETRIDE_SERVER_USE_VENV': '0'}) == V.USE_OFF
     assert V.use_venv_mode({'ROCKETRIDE_SERVER_USE_VENV': '1'}) == V.USE_ON
-    assert V.use_venv_mode({'ROCKETRIDE_SERVER_USE_VENV': 'yes'}) == V.USE_AUTO  # unknown -> auto
+    assert V.use_venv_mode({'ROCKETRIDE_SERVER_USE_VENV': 'yes'}) == V.USE_AUTO
 
 
 def test_scoping_enabled_semantics():
-    # off: never; on: always; auto: only with an isolated group
     assert V.scoping_enabled(V.USE_OFF, has_isolated_group=True) is False
     assert V.scoping_enabled(V.USE_ON, has_isolated_group=False) is True
     assert V.scoping_enabled(V.USE_AUTO, has_isolated_group=True) is True
     assert V.scoping_enabled(V.USE_AUTO, has_isolated_group=False) is False
 
 
-# --- id shortening + MAX_PATH friendliness (§4.9) ---------------------------
+# --- id shortening + layout -------------------------------------------------
 
 
 def test_short_id_rules():
     assert V.short_id(None) == V.DEFAULT_ID
     assert V.short_id('') == V.DEFAULT_ID
-    assert V.short_id('----') == V.DEFAULT_ID  # all separators -> default
-    assert V.short_id('main') == 'main'  # short readable id kept
-    assert V.short_id('group_1') == 'group1'  # separators stripped
-    assert V.short_id('0d4f3caa-1234-5678-9abc') == '0d4f3caa'  # GUID -> first 8 hex
-    assert len(V.short_id('0d4f3caa-1234-5678-9abc')) == 8
+    assert V.short_id('----') == V.DEFAULT_ID
+    assert V.short_id('main') == 'main'
+    assert V.short_id('group_1') == 'group1'
+    assert V.short_id('0d4f3caa-1234-5678-9abc') == '0d4f3caa'  # long ids truncated for MAX_PATH
 
 
 def test_env_dir_layout():
     exe = os.path.join('X:', 'engine')
     d = V.env_dir(exe, '0d4f3caa-1111-2222', 'group_7')
-    parts = d.replace('\\', '/').split('/')
-    assert parts[-3:] == ['venvs', '0d4f3caa', 'group7']
-    # missing project_id -> shared 'default'; missing env_id -> 'main'
+    assert d.replace('\\', '/').split('/')[-3:] == ['venvs', '0d4f3caa', 'group7']
     assert V.env_dir(exe, None, None).replace('\\', '/').endswith('venvs/default/main')
 
 
@@ -76,9 +68,9 @@ def _req(tmp_path, name, body):
 def test_requirements_hash_order_independent_and_content_sensitive(tmp_path):
     a = _req(tmp_path, 'a.txt', 'tabulate==0.8.10\n')
     b = _req(tmp_path, 'b.txt', 'six==1.16.0\n')
-    assert V.requirements_hash([a, b]) == V.requirements_hash([b, a])  # order-independent
+    assert V.requirements_hash([a, b]) == V.requirements_hash([b, a])
     h1 = V.requirements_hash([a])
-    (tmp_path / 'a.txt').write_text('tabulate==0.9.0\n', encoding='utf-8')  # content change
+    (tmp_path / 'a.txt').write_text('tabulate==0.9.0\n', encoding='utf-8')
     assert V.requirements_hash([a]) != h1
 
 
@@ -92,7 +84,7 @@ def test_write_combined_concatenates_with_headers(tmp_path):
     assert text.count('# Source:') == 2
 
 
-# --- plan_install drift + overlay creation ----------------------------------
+# --- install planning -------------------------------------------------------
 
 
 def test_plan_install_creates_overlay_and_detects_drift(tmp_path):
@@ -100,33 +92,26 @@ def test_plan_install_creates_overlay_and_detects_drift(tmp_path):
     req = _req(tmp_path, 'r.txt', 'tabulate==0.8.10\n')
 
     plan = V.plan_install(exe, 'proj-guid-aaaa', 'main', [req])
-    # overlay created, first run needs a rebuild, combined written
     assert os.path.isdir(plan.paths.site_packages)
     assert plan.needs_rebuild is True
     assert os.path.isfile(plan.paths.combined)
 
-    # simulate a completed install: mark hash + create a constraints file
+    # simulate a completed install: stored hash + constraints produced by uv
     V.mark_installed(plan)
     open(plan.paths.constraints, 'w').close()
+    assert V.plan_install(exe, 'proj-guid-aaaa', 'main', [req]).needs_rebuild is False
 
-    # unchanged requirements -> no rebuild
-    plan2 = V.plan_install(exe, 'proj-guid-aaaa', 'main', [req])
-    assert plan2.needs_rebuild is False
-
-    # changed requirements -> rebuild again
     (tmp_path / 'r.txt').write_text('tabulate==0.9.0\n', encoding='utf-8')
-    plan3 = V.plan_install(exe, 'proj-guid-aaaa', 'main', [req])
-    assert plan3.needs_rebuild is True
+    assert V.plan_install(exe, 'proj-guid-aaaa', 'main', [req]).needs_rebuild is True
 
 
 def test_plan_install_default_env_when_no_project_id(tmp_path):
-    # §4.14: no project_id -> shared default overlay, still works
     plan = V.plan_install(str(tmp_path), None, None, [])
     assert plan.paths.env_dir.replace('\\', '/').endswith('venvs/default/main')
     assert os.path.isdir(plan.paths.site_packages)
 
 
-# --- uv install argv (scoped via --target) ----------------------------------
+# --- uv install argv --------------------------------------------------------
 
 
 def test_build_install_argv_targets_overlay():
@@ -139,12 +124,11 @@ def test_build_install_argv_targets_overlay():
         excludes_path='ex.txt',
     )
     assert argv[:3] == ['uv', 'pip', 'install']
-    # target overlay + constraints + excludes all present, in order
     assert argv[argv.index('--target') + 1] == '/venvs/p/main/site-packages'
     assert argv[argv.index('-r') + 1] == 'r.txt'
     assert argv[argv.index('-c') + 1] == 'c.txt'
-    assert '--no-build-isolation' in argv
     assert argv[argv.index('--excludes') + 1] == 'ex.txt'
+    assert '--no-build-isolation' in argv
 
 
 def test_build_install_argv_optional_flags_omitted():
@@ -152,7 +136,7 @@ def test_build_install_argv_optional_flags_omitted():
     assert '-c' not in argv and '--excludes' not in argv
 
 
-# --- run_scoped_install orchestration (injected side effects) ---------------
+# --- run_scoped_install orchestration ---------------------------------------
 
 
 def _stub_discover(files):
@@ -176,9 +160,9 @@ def test_run_scoped_install_off_is_noop(tmp_path):
         compile_and_install=lambda plan: calls.append('install'),
         mode=V.USE_OFF,
     )
-    assert site is None  # legacy/base path
-    assert d.called_with is None  # discover not even called
-    assert calls == []  # nothing installed
+    assert site is None
+    assert d.called_with is None
+    assert calls == []
 
 
 def test_run_scoped_install_on_installs_and_overlays(tmp_path):
@@ -197,9 +181,9 @@ def test_run_scoped_install_on_installs_and_overlays(tmp_path):
     )
     assert site.endswith('site-packages')
     assert d.called_with == ['webhook', 'detect']
-    assert installed == [site]  # compile+install ran (first run = drift)
-    assert overlaid == [site]  # overlay hook invoked with the overlay
-    assert os.path.isfile(V.env_paths(os.path.dirname(site)).hash_file)  # marked installed
+    assert installed == [site]
+    assert overlaid == [site]
+    assert os.path.isfile(V.env_paths(os.path.dirname(site)).hash_file)
 
 
 def test_run_scoped_install_skips_install_when_up_to_date(tmp_path):
@@ -207,13 +191,11 @@ def test_run_scoped_install_skips_install_when_up_to_date(tmp_path):
     d = _stub_discover([req])
 
     def ci(plan):
-        open(plan.paths.constraints, 'w').close()  # simulate uv producing constraints
+        open(plan.paths.constraints, 'w').close()
         ci.n += 1
 
     ci.n = 0
     V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], discover=d, compile_and_install=ci, mode=V.USE_ON)
-    assert ci.n == 1
-    # unchanged reqs + constraints present -> no reinstall
     V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], discover=d, compile_and_install=ci, mode=V.USE_ON)
     assert ci.n == 1
 
@@ -223,3 +205,19 @@ def test_run_scoped_install_auto_needs_isolated_group(tmp_path):
     base = dict(discover=_stub_discover([req]), compile_and_install=lambda plan: None, mode=V.USE_AUTO)
     assert V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], has_isolated_group=False, **base) is None
     assert V.run_scoped_install(str(tmp_path), 'p', 'main', ['x'], has_isolated_group=True, **base) is not None
+
+
+def test_run_scoped_install_skips_when_no_requirements(tmp_path):
+    # nothing to scope (source-only / native-only env): must not compile an absent file
+    installed = []
+    site = V.run_scoped_install(
+        str(tmp_path),
+        'p',
+        'main',
+        ['dropper'],
+        discover=lambda provs: [],
+        compile_and_install=lambda plan: installed.append(1),
+        mode=V.USE_ON,
+    )
+    assert site is None
+    assert installed == []


### PR DESCRIPTION
## What this does

Resolves and installs a pipeline's Python dependencies **per environment** instead of unioning every node's requirements into one global resolution.

For each endpoint the engine now discovers, by static AST walk, exactly the `requirement*.txt` files the pipeline's nodes actually reach, compiles constraints for that set alone, and installs into an overlay at `venvs/<project_id>/<env_id>/site-packages` that goes ahead of the base runtime on `sys.path`.

Gated by `ROCKETRIDE_SERVER_USE_VENV`: unset = auto (today's behavior unless a pipeline opts in), `0` = legacy, `1` = forced on. The switch is set on the server process; the task subprocess inherits it.

## Why

Two nodes pinning incompatible versions of the same package could not coexist in one installation. The startup compile globbed `nodes/**` into a single resolution, so the conflict made `ensure_constraints()` unsatisfiable and killed the process at import of `ai/__init__` — the engine did not start at all, in every process. Scoping alone could not fix that, because the failure preceded it; hence the glob gating in this PR.

## Main changes

- `ast_deps.py` (new): `provider` → entry module via the `path` field of `services*.json` (the loader's real rule — `nodes.<provider>` is wrong for roughly a third of providers), then a transitive AST walk following nested/in-function imports and resolving relative imports against the right package.
- `venv_env.py` (new): overlay layout, drift planning, install-argv construction. Stdlib only, no engine imports, so it is testable in isolation.
- `depends.py`: per-env compile/install; while an overlay is active, runtime `depends()` calls install into it with the environment's own constraints; node globs leave the startup compile under `=1`.
- `endpoint.cpp`: collect the pipeline's providers and call `ensure_env_scoped` before `buildGlobalPipe` imports the node modules.
- 4 node modules now import `ai.common.models` submodules by full path, so the barrel `__init__` no longer drags the whole model universe into every walk.
- Tests moved out of `lib/` into `tests/`, where `server:run-rocketlib-test` expects them — `lib/` is synced wholesale into `dist/server`, so they were shipping with the distribution.

## Verification

34 unit tests (`builder server:run-rocketlib-test`), plus live runs on the real engine:

| | `=1` | `=0` / auto |
|---|---|---|
| pipeline | objectId returned | objectId returned |
| `venvs/` | `d1111111/main`, 18 sources, 115 packages | not created |
| startup compile | 29 sources, 0 node paths | 130 sources, 101 node paths |
| `--target` in install args | overlay | absent |

Conflict fixtures (`vtest_alpha` → `tabulate==0.8.10`, `vtest_beta` → `0.9.0`) in one pipeline: the engine starts, the conflict surfaces only in that environment's compile, the run aborts with the pins named, and **the server stays up**. The environment's combined file held 9 sources against the installation's 101, and the global one never saw `tabulate`.

## Known gaps (recorded in the design doc)

- `auto` does not isolate conflicts: the startup compile runs before any pipeline is known, so only `=1` delivers isolation in 2A.
- The base runtime still receives `ai/**` at startup, so it is not yet strictly runtime-only.
- A value placed in `<exe>/.env` silently has no effect — `load_dotenv` runs after `ai/__init__` has resolved dependencies. The fix belongs in the engine's load order.

Design: `packages/server/design/virtual-environments.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for isolated runtime environments, allowing pipeline components with conflicting dependencies to run independently.
  * Added automatic environment-specific dependency discovery, installation, caching, and lifecycle management.
  * Added configuration support to enable, disable, or automatically select isolated environments.

* **Bug Fixes**
  * Updated integrations for anonymization, transcription, embeddings, and OCR to use their current model packages.

* **Documentation**
  * Added design documentation covering virtual environment behavior and pipeline communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->