### PR TITLE
fix(nodes, test): scope core-module stubs so they don't leak across tests

### DIFF
--- a/nodes/test/_sys_modules_guard.py
+++ b/nodes/test/_sys_modules_guard.py
@@ -1,0 +1,118 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression guard for sys.modules isolation in node tests (see #1640).
+
+Node tests stub rocketlib/ai/pydantic/etc so a node imports without the engine.
+Those stubs are installed at IMPORT time, and pytest imports every test module
+during collection — before any test runs. So the check runs at collection time
+(right after each module is imported): snapshot the guarded modules in
+``pytest_collectstart`` (just before the import) and compare in
+``pytest_collectreport`` (just after). A teardown-time check would blame whichever
+module happens to finish while a later module's leak is already in sys.modules.
+
+Each detected leak is undone so one offender does not cascade into N false
+failures. Leaks are recorded and the run is failed at session finish — raising
+inside a collection hook gives pytest INTERNALERROR and kills the run.
+"""
+
+from __future__ import annotations
+
+import sys
+from typing import Any, Dict, List, Tuple
+
+_GUARDED_CORE_MODULES = (
+    'rocketlib',
+    'ai',
+    'ai.common',
+    'ai.common.config',
+    'ai.common.utils',
+    'ai.common.schema',
+    'ai.common.store',
+    'pydantic',
+    'requests',
+    'requests.exceptions',
+    'tenacity',
+)
+
+# nodeid -> {module name: object present before the module was imported}
+_core_baseline: Dict[str, Dict[str, Any]] = {}
+# (nodeid, [leaked module names]) recorded during collection
+_core_leaks: List[Tuple[str, List[str]]] = []
+
+
+def _is_stub_module(mod) -> bool:
+    """True when mod is a hand-built stub/MagicMock, not the real imported module.
+
+    A real module (or non-empty namespace package) is loaded from disk and carries
+    a __file__ or a non-empty __path__. Hand-built stubs — types.ModuleType (even
+    ones marked with __path__ = [] or built via module_from_spec), or MagicMock —
+    carry neither.
+    """
+    if mod is None:
+        return False
+    if type(mod).__name__ in ('MagicMock', 'Mock', 'NonCallableMagicMock'):
+        return True
+    if getattr(mod, '__file__', None) is not None:
+        return False
+    return not getattr(mod, '__path__', None)
+
+
+def check_after_import(nodeid: str) -> List[str]:
+    """Compare guarded modules against the snapshot; record + undo any leaked stub.
+
+    Returns the list of leaked module names (empty if clean). Pure helper so the
+    guard is unit-testable without a full pytest sub-session.
+    """
+    base = _core_baseline.pop(nodeid, None)
+    if base is None:
+        return []
+    leaked = [
+        name
+        for name in _GUARDED_CORE_MODULES
+        if sys.modules.get(name) is not base[name] and _is_stub_module(sys.modules.get(name))
+    ]
+    if not leaked:
+        return []
+    _core_leaks.append((nodeid, leaked))
+    # Undo the leak so one offender does not cascade into every later module.
+    for name in _GUARDED_CORE_MODULES:
+        if base[name] is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = base[name]
+    return leaked
+
+
+# ---------------------------------------------------------------------------
+# pytest hooks (registered by importing them into conftest.py)
+# ---------------------------------------------------------------------------
+
+
+def pytest_collectstart(collector):
+    """Snapshot the guarded modules just before a test module is imported."""
+    if type(collector).__name__ == 'Module':
+        _core_baseline[collector.nodeid] = {name: sys.modules.get(name) for name in _GUARDED_CORE_MODULES}
+
+
+def pytest_collectreport(report):
+    """Right after a test module is imported, record and undo any stub it left behind."""
+    check_after_import(report.nodeid)
+
+
+def pytest_terminal_summary(terminalreporter):
+    """Report leaked core-module stubs (see #1640)."""
+    for nodeid, leaked in _core_leaks:
+        terminalreporter.write_line(
+            f'sys.modules leak: {nodeid} left stub core modules {leaked}. '
+            'Snapshot and restore sys.modules around the node import (save/restore pattern).',
+            red=True,
+        )
+
+
+def pytest_sessionfinish(session, exitstatus):  # noqa: ARG001
+    """Fail the run when any test module leaked a core-module stub."""
+    if _core_leaks:
+        session.exitstatus = 1

--- a/nodes/test/atlas/test_isdeleted_filter.py
+++ b/nodes/test/atlas/test_isdeleted_filter.py
@@ -16,7 +16,6 @@ Usage:
 import importlib
 import importlib.util
 import sys
-import types
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -63,19 +62,11 @@ class DocFilter:
 
 
 # ---------------------------------------------------------------------------
-# Stub out ai.common.* so atlas.py can import without the full AI package
-# ---------------------------------------------------------------------------
-
-
-# Mock pydantic at module level (atlas.py imports ValidationError)
-mock_pydantic = types.ModuleType('pydantic')
-mock_pydantic.ValidationError = Exception
-sys.modules.setdefault('pydantic', mock_pydantic)
-
-# ---------------------------------------------------------------------------
 # Load atlas.py directly by file path (bypasses atlas/__init__.py)
 # ---------------------------------------------------------------------------
 
+# Do NOT stub pydantic: atlas.py imports ai.common.store -> rocketlib, and
+# rocketlib.types needs the real pydantic (BaseModel, ConfigDict, Field).
 _atlas_path = Path(__file__).parent.parent.parent / 'src' / 'nodes' / 'atlas' / 'atlas.py'
 _spec = importlib.util.spec_from_file_location('_atlas_direct', _atlas_path)
 atlas_mod = importlib.util.module_from_spec(_spec)

--- a/nodes/test/cloud_tts/test_cloud_tts.py
+++ b/nodes/test/cloud_tts/test_cloud_tts.py
@@ -31,30 +31,41 @@ _SERVICES = ['services.tts_openai.json', 'services.tts_elevenlabs.json']
 def _load_iglobal():
     """Import nodes/cloud_tts/IGlobal.py standalone, stubbing engine-only deps.
 
-    Uses setdefault so a real engine runtime (dist/server on sys.path in CI) is
-    used when present, and the stubs kick in only when it is not.
+    Stubs the engine-only modules only while the node imports, then restores
+    sys.modules so the rocketlib/ai stubs never leak to sibling tests.
     """
+    # Save prior state so the stubs are scoped to the import below.
+    _core = ('rocketlib', 'ai', 'ai.common', 'ai.common.config')
+    _saved = {name: sys.modules.get(name) for name in _core}
+
     rocketlib = types.ModuleType('rocketlib')
     rocketlib.IGlobalBase = type('IGlobalBase', (), {})
     rocketlib.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
-    sys.modules.setdefault('rocketlib', rocketlib)
+    sys.modules['rocketlib'] = rocketlib
 
-    sys.modules.setdefault('ai', types.ModuleType('ai'))
-    sys.modules.setdefault('ai.common', types.ModuleType('ai.common'))
+    sys.modules['ai'] = types.ModuleType('ai')
+    sys.modules['ai.common'] = types.ModuleType('ai.common')
     ai_cfg = types.ModuleType('ai.common.config')
     ai_cfg.Config = type('Config', (), {})
-    sys.modules.setdefault('ai.common.config', ai_cfg)
+    sys.modules['ai.common.config'] = ai_cfg
 
     # Synthetic package so IGlobal's `from . import openai_tts, elevenlabs_tts` resolves.
     pkg = types.ModuleType('cloud_tts')
     pkg.__path__ = [str(_DIR)]
     sys.modules['cloud_tts'] = pkg
-    for name in ('openai_tts', 'elevenlabs_tts', 'IGlobal'):
-        spec = importlib.util.spec_from_file_location(f'cloud_tts.{name}', _DIR / f'{name}.py')
-        module = importlib.util.module_from_spec(spec)
-        sys.modules[f'cloud_tts.{name}'] = module
-        spec.loader.exec_module(module)
-    return sys.modules['cloud_tts.IGlobal']
+    try:
+        for name in ('openai_tts', 'elevenlabs_tts', 'IGlobal'):
+            spec = importlib.util.spec_from_file_location(f'cloud_tts.{name}', _DIR / f'{name}.py')
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[f'cloud_tts.{name}'] = module
+            spec.loader.exec_module(module)
+        return sys.modules['cloud_tts.IGlobal']
+    finally:
+        for name, mod in _saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
 
 
 _ig = _load_iglobal()

--- a/nodes/test/cloud_tts/test_cloud_tts.py
+++ b/nodes/test/cloud_tts/test_cloud_tts.py
@@ -44,7 +44,9 @@ def _load_iglobal():
     sys.modules['rocketlib'] = rocketlib
 
     sys.modules['ai'] = types.ModuleType('ai')
+    sys.modules['ai'].__path__ = []  # mark as package so sub-imports resolve
     sys.modules['ai.common'] = types.ModuleType('ai.common')
+    sys.modules['ai.common'].__path__ = []
     ai_cfg = types.ModuleType('ai.common.config')
     ai_cfg.Config = type('Config', (), {})
     sys.modules['ai.common.config'] = ai_cfg

--- a/nodes/test/conftest.py
+++ b/nodes/test/conftest.py
@@ -84,9 +84,12 @@ def _is_stub_module(mod) -> bool:
     return getattr(mod, '__spec__', None) is None and getattr(mod, '__file__', None) is None
 
 
-@pytest.fixture(autouse=True)
+# Module-scoped: checked once per test module, after its module-scoped fixtures
+# have torn down. A per-test check would false-positive on tests that legitimately
+# stub a core module in a scope='module' fixture and restore it at module teardown.
+@pytest.fixture(scope='module', autouse=True)
 def _guard_core_module_stubs(request):
-    """Fail a test that left a stub core module in sys.modules without restoring it."""
+    """Fail a test module that left a stub core module in sys.modules without restoring it."""
     yield
     leaked = [name for name in _GUARDED_CORE_MODULES if _is_stub_module(sys.modules.get(name))]
     if leaked:

--- a/nodes/test/conftest.py
+++ b/nodes/test/conftest.py
@@ -50,53 +50,16 @@ except ImportError:
     pass  # dotenv is optional
 
 
-# ---------------------------------------------------------------------------
-# Regression guard for sys.modules isolation (see #1640).
-# Node tests stub rocketlib/ai/pydantic/etc so a node imports without the
-# engine. If a test installs such a stub and does not restore sys.modules, the
-# stub leaks and breaks unrelated tests under a different collection order.
-# This guard fails the offending test instead of letting the leak spread.
-# ---------------------------------------------------------------------------
-
-_GUARDED_CORE_MODULES = (
-    'rocketlib',
-    'ai',
-    'ai.common',
-    'ai.common.config',
-    'ai.common.utils',
-    'ai.common.schema',
-    'ai.common.store',
-    'pydantic',
-    'requests',
-    'requests.exceptions',
-    'tenacity',
+# The sys.modules isolation guard (see #1640) lives in _sys_modules_guard so it is
+# unit-testable in isolation. conftest is imported before pytest puts its own dir
+# on sys.path, so add it here; importing the hooks registers them with pytest.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _sys_modules_guard import (  # noqa: E402,F401
+    pytest_collectreport,
+    pytest_collectstart,
+    pytest_sessionfinish,
+    pytest_terminal_summary,
 )
-
-
-def _is_stub_module(mod) -> bool:
-    """True when mod is a hand-built stub/MagicMock, not the real imported module."""
-    if mod is None:
-        return False
-    if type(mod).__name__ in ('MagicMock', 'Mock', 'NonCallableMagicMock'):
-        return True
-    # Real modules and namespace packages carry a __spec__ or __file__; bare
-    # types.ModuleType stubs built in tests carry neither.
-    return getattr(mod, '__spec__', None) is None and getattr(mod, '__file__', None) is None
-
-
-# Module-scoped: checked once per test module, after its module-scoped fixtures
-# have torn down. A per-test check would false-positive on tests that legitimately
-# stub a core module in a scope='module' fixture and restore it at module teardown.
-@pytest.fixture(scope='module', autouse=True)
-def _guard_core_module_stubs(request):
-    """Fail a test module that left a stub core module in sys.modules without restoring it."""
-    yield
-    leaked = [name for name in _GUARDED_CORE_MODULES if _is_stub_module(sys.modules.get(name))]
-    if leaked:
-        pytest.fail(
-            f'{request.node.nodeid} left stub core modules in sys.modules: {leaked}. '
-            'Snapshot and restore sys.modules around the node import (save/restore pattern).'
-        )
 
 
 # =============================================================================

--- a/nodes/test/conftest.py
+++ b/nodes/test/conftest.py
@@ -50,6 +50,52 @@ except ImportError:
     pass  # dotenv is optional
 
 
+# ---------------------------------------------------------------------------
+# Regression guard for sys.modules isolation (see #1640).
+# Node tests stub rocketlib/ai/pydantic/etc so a node imports without the
+# engine. If a test installs such a stub and does not restore sys.modules, the
+# stub leaks and breaks unrelated tests under a different collection order.
+# This guard fails the offending test instead of letting the leak spread.
+# ---------------------------------------------------------------------------
+
+_GUARDED_CORE_MODULES = (
+    'rocketlib',
+    'ai',
+    'ai.common',
+    'ai.common.config',
+    'ai.common.utils',
+    'ai.common.schema',
+    'ai.common.store',
+    'pydantic',
+    'requests',
+    'requests.exceptions',
+    'tenacity',
+)
+
+
+def _is_stub_module(mod) -> bool:
+    """True when mod is a hand-built stub/MagicMock, not the real imported module."""
+    if mod is None:
+        return False
+    if type(mod).__name__ in ('MagicMock', 'Mock', 'NonCallableMagicMock'):
+        return True
+    # Real modules and namespace packages carry a __spec__ or __file__; bare
+    # types.ModuleType stubs built in tests carry neither.
+    return getattr(mod, '__spec__', None) is None and getattr(mod, '__file__', None) is None
+
+
+@pytest.fixture(autouse=True)
+def _guard_core_module_stubs(request):
+    """Fail a test that left a stub core module in sys.modules without restoring it."""
+    yield
+    leaked = [name for name in _GUARDED_CORE_MODULES if _is_stub_module(sys.modules.get(name))]
+    if leaked:
+        pytest.fail(
+            f'{request.node.nodeid} left stub core modules in sys.modules: {leaked}. '
+            'Snapshot and restore sys.modules around the node import (save/restore pattern).'
+        )
+
+
 # =============================================================================
 # Test Configuration
 # =============================================================================

--- a/nodes/test/guardrails/test_all.py
+++ b/nodes/test/guardrails/test_all.py
@@ -58,15 +58,21 @@ _ENGINE_PATH = os.path.join(_GUARDRAILS_DIR, 'guardrails_engine.py')
 
 def _load_engine_module():
     """Load guardrails_engine.py as a standalone module."""
-    # Stub rocketlib so the module can be loaded without the runtime
-    if 'rocketlib' not in sys.modules:
-        _rocketlib_stub = types.ModuleType('rocketlib')
-        _rocketlib_stub.warning = lambda msg, *a, **kw: None
-        sys.modules['rocketlib'] = _rocketlib_stub
+    # Stub rocketlib only while loading; restore so it never leaks to sibling tests.
+    _saved_rl = sys.modules.get('rocketlib')
+    _rocketlib_stub = types.ModuleType('rocketlib')
+    _rocketlib_stub.warning = lambda msg, *a, **kw: None
+    sys.modules['rocketlib'] = _rocketlib_stub
     spec = importlib.util.spec_from_file_location('guardrails_engine', _ENGINE_PATH)
     mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
+    try:
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if _saved_rl is not None:
+            sys.modules['rocketlib'] = _saved_rl
+        else:
+            sys.modules.pop('rocketlib', None)
 
 
 _engine_mod = _load_engine_module()

--- a/nodes/test/qdrant/test_search_threshold.py
+++ b/nodes/test/qdrant/test_search_threshold.py
@@ -25,7 +25,7 @@ class _FakeDocumentStoreBase:
         return True
 
 
-for _name in (
+_STUB_NAMES = (
     'numpy',
     'qdrant_client',
     'qdrant_client.models',
@@ -38,17 +38,28 @@ for _name in (
     'ai.common',
     'ai.common.schema',
     'ai.common.config',
-):
-    sys.modules.setdefault(_name, MagicMock())
+)
 
-_store_mod = MagicMock()
-_store_mod.DocumentStoreBase = _FakeDocumentStoreBase
-sys.modules['ai.common.store'] = _store_mod
+# Snapshot every name we touch (setdefault set + ai.common.store), then restore
+# in finally so these stubs never leak to sibling tests run in the same process.
+_saved = {_name: sys.modules.get(_name) for _name in (*_STUB_NAMES, 'ai.common.store')}
+try:
+    for _name in _STUB_NAMES:
+        sys.modules.setdefault(_name, MagicMock())
+    _store_mod = MagicMock()
+    _store_mod.DocumentStoreBase = _FakeDocumentStoreBase
+    sys.modules['ai.common.store'] = _store_mod
 
-_spec = importlib.util.spec_from_file_location('_qdrant_store', str(NODES_SRC / 'qdrant' / 'qdrant.py'))
-_qdrant_mod = importlib.util.module_from_spec(_spec)
-_spec.loader.exec_module(_qdrant_mod)
-Store = _qdrant_mod.Store
+    _spec = importlib.util.spec_from_file_location('_qdrant_store', str(NODES_SRC / 'qdrant' / 'qdrant.py'))
+    _qdrant_mod = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_qdrant_mod)
+    Store = _qdrant_mod.Store
+finally:
+    for _name, _mod in _saved.items():
+        if _mod is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _mod
 
 
 def _make_store(similarity: str) -> Store:

--- a/nodes/test/qdrant/test_search_threshold.py
+++ b/nodes/test/qdrant/test_search_threshold.py
@@ -45,7 +45,7 @@ _STUB_NAMES = (
 _saved = {_name: sys.modules.get(_name) for _name in (*_STUB_NAMES, 'ai.common.store')}
 try:
     for _name in _STUB_NAMES:
-        sys.modules.setdefault(_name, MagicMock())
+        sys.modules[_name] = MagicMock()
     _store_mod = MagicMock()
     _store_mod.DocumentStoreBase = _FakeDocumentStoreBase
     sys.modules['ai.common.store'] = _store_mod

--- a/nodes/test/test_anomaly_detector.py
+++ b/nodes/test/test_anomaly_detector.py
@@ -10,12 +10,20 @@ import os
 import sys
 import types
 
+# Stub rocketlib only while importing detector, then restore so it never leaks.
+_saved_rl = sys.modules.get('rocketlib')
 rocketlib = types.ModuleType('rocketlib')
 rocketlib.debug = lambda *a, **kw: None
-sys.modules.setdefault('rocketlib', rocketlib)
+sys.modules['rocketlib'] = rocketlib
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes', 'anomaly_detector'))
-from detector import AnomalyDetector
+try:
+    from detector import AnomalyDetector
+finally:
+    if _saved_rl is not None:
+        sys.modules['rocketlib'] = _saved_rl
+    else:
+        sys.modules.pop('rocketlib', None)
 
 
 def _make_detector(**overrides):

--- a/nodes/test/test_anomaly_detector.py
+++ b/nodes/test/test_anomaly_detector.py
@@ -18,7 +18,7 @@ sys.modules['rocketlib'] = rocketlib
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes', 'anomaly_detector'))
 try:
-    from detector import AnomalyDetector
+    from detector import AnomalyDetector  # noqa: E402
 finally:
     if _saved_rl is not None:
         sys.modules['rocketlib'] = _saved_rl

--- a/nodes/test/test_currency_convert_explicit.py
+++ b/nodes/test/test_currency_convert_explicit.py
@@ -10,13 +10,20 @@ import sys
 import types
 
 # convert.py has no rocketlib import, but stub it defensively so importing the
-# node package stays isolated from the native engine.
+# node package stays isolated; restore after so the stub never leaks.
+_saved_rl = sys.modules.get('rocketlib')
 rocketlib = types.ModuleType('rocketlib')
 rocketlib.debug = lambda *a, **kw: None
-sys.modules.setdefault('rocketlib', rocketlib)
+sys.modules['rocketlib'] = rocketlib
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src', 'nodes', 'currency_convert_explicit'))
-from convert import NODE_OP, convert_fact, convert_payload  # noqa: E402
+try:
+    from convert import NODE_OP, convert_fact, convert_payload  # noqa: E402
+finally:
+    if _saved_rl is not None:
+        sys.modules['rocketlib'] = _saved_rl
+    else:
+        sys.modules.pop('rocketlib', None)
 
 
 CFG = {

--- a/nodes/test/test_db_hydradb.py
+++ b/nodes/test/test_db_hydradb.py
@@ -150,10 +150,9 @@ def node():
     _GET.bodies_by_path = None
     _GET.side_effect = None
     _WARNINGS.clear()
-    Config = _install_stubs()
-    client_mod, iglobal_mod, iinstance_mod = _load_package()
-    yield SimpleNamespace(Config=Config, client_mod=client_mod, iglobal_mod=iglobal_mod, iinstance_mod=iinstance_mod)
-    for name in [
+    # Snapshot the modules we stub so teardown restores the prior state, not just
+    # pops it — a real rocketlib/requests already loaded is put back, not deleted.
+    _managed = [
         'db_hydradb',
         'db_hydradb.hydradb_client',
         'db_hydradb.IGlobal',
@@ -164,8 +163,16 @@ def node():
         'ai.common.config',
         'ai.common.utils',
         'requests',
-    ]:
-        sys.modules.pop(name, None)
+    ]
+    _saved = {name: sys.modules.get(name) for name in _managed}
+    Config = _install_stubs()
+    client_mod, iglobal_mod, iinstance_mod = _load_package()
+    yield SimpleNamespace(Config=Config, client_mod=client_mod, iglobal_mod=iglobal_mod, iinstance_mod=iinstance_mod)
+    for name in _managed:
+        if _saved[name] is not None:
+            sys.modules[name] = _saved[name]
+        else:
+            sys.modules.pop(name, None)
 
 
 def _make_instance(iinstance_mod, client):

--- a/nodes/test/test_db_hydradb.py
+++ b/nodes/test/test_db_hydradb.py
@@ -165,14 +165,18 @@ def node():
         'requests',
     ]
     _saved = {name: sys.modules.get(name) for name in _managed}
-    Config = _install_stubs()
-    client_mod, iglobal_mod, iinstance_mod = _load_package()
-    yield SimpleNamespace(Config=Config, client_mod=client_mod, iglobal_mod=iglobal_mod, iinstance_mod=iinstance_mod)
-    for name in _managed:
-        if _saved[name] is not None:
-            sys.modules[name] = _saved[name]
-        else:
-            sys.modules.pop(name, None)
+    try:
+        Config = _install_stubs()
+        client_mod, iglobal_mod, iinstance_mod = _load_package()
+        yield SimpleNamespace(
+            Config=Config, client_mod=client_mod, iglobal_mod=iglobal_mod, iinstance_mod=iinstance_mod
+        )
+    finally:
+        for name in _managed:
+            if _saved[name] is not None:
+                sys.modules[name] = _saved[name]
+            else:
+                sys.modules.pop(name, None)
 
 
 def _make_instance(iinstance_mod, client):

--- a/nodes/test/test_sys_modules_guard.py
+++ b/nodes/test/test_sys_modules_guard.py
@@ -1,0 +1,100 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Tests for the sys.modules isolation guard itself (see #1640).
+
+The guard has to name the module that actually leaked, undo the leak so it does
+not cascade, and not blame an innocent module that restores correctly. These
+exercise the collection-time helper directly.
+"""
+
+import importlib.util
+import json
+import sys
+import types
+
+import pytest
+
+import _sys_modules_guard as guard
+
+
+class Module:
+    """Stand-in for pytest's Module collector; only its class name matters to the guard."""
+
+    def __init__(self, nodeid):
+        """Record the collector nodeid."""
+        self.nodeid = nodeid
+
+
+@pytest.fixture(autouse=True)
+def _isolate_guard_state():
+    """Run each test on clean guard state, then restore what real collection recorded.
+
+    The guard's state is module-global and already holds any leaks found while
+    collecting the real suite; snapshot and restore it so these tests never mask
+    a genuine leak.
+    """
+    saved_baseline = dict(guard._core_baseline)
+    saved_leaks = list(guard._core_leaks)
+    guard._core_baseline.clear()
+    guard._core_leaks.clear()
+    yield
+    guard._core_baseline.clear()
+    guard._core_baseline.update(saved_baseline)
+    guard._core_leaks.clear()
+    guard._core_leaks.extend(saved_leaks)
+
+
+def test_guard_flags_and_undoes_a_leaked_stub():
+    """A module that stubs a core module at import and never restores is flagged and undone."""
+    saved = sys.modules.get('rocketlib')
+    nodeid = 'nodes/test/fake_leaker.py'
+    guard.pytest_collectstart(Module(nodeid))
+    sys.modules['rocketlib'] = types.ModuleType('rocketlib')  # leak at import time
+    try:
+        assert guard.check_after_import(nodeid) == ['rocketlib']
+        assert guard._core_leaks == [(nodeid, ['rocketlib'])]
+        assert sys.modules.get('rocketlib') is saved  # leak undone
+    finally:
+        if saved is None:
+            sys.modules.pop('rocketlib', None)
+        else:
+            sys.modules['rocketlib'] = saved
+
+
+def test_guard_ignores_a_module_that_restores():
+    """A module that leaves sys.modules unchanged is not flagged."""
+    nodeid = 'nodes/test/clean.py'
+    guard.pytest_collectstart(Module(nodeid))
+    assert guard.check_after_import(nodeid) == []
+    assert guard._core_leaks == []
+
+
+def test_guard_blames_the_leaker_not_an_earlier_clean_module():
+    """A later module's leak is attributed to it, never to an earlier clean module."""
+    guard.pytest_collectstart(Module('nodes/test/clean.py'))
+    assert guard.check_after_import('nodes/test/clean.py') == []
+
+    saved = sys.modules.get('rocketlib')
+    guard.pytest_collectstart(Module('nodes/test/leaker.py'))
+    sys.modules['rocketlib'] = types.ModuleType('rocketlib')
+    try:
+        guard.check_after_import('nodes/test/leaker.py')
+        assert [n for n, _ in guard._core_leaks] == ['nodes/test/leaker.py']
+    finally:
+        if saved is None:
+            sys.modules.pop('rocketlib', None)
+        else:
+            sys.modules['rocketlib'] = saved
+
+
+def test_is_stub_module_detects_stub_built_via_module_from_spec():
+    """A stub with a __spec__ but no __file__ is still a stub (guard heuristic)."""
+    spec = importlib.util.spec_from_loader('fake_core', loader=None)
+    mod = importlib.util.module_from_spec(spec)  # carries __spec__, no __file__
+    assert guard._is_stub_module(mod) is True
+    # a real module loaded from disk (has __file__) is not a stub
+    assert guard._is_stub_module(json) is False
+    assert guard._is_stub_module(None) is False

--- a/nodes/test/tool_filesystem/test_read_size_cap.py
+++ b/nodes/test/tool_filesystem/test_read_size_cap.py
@@ -43,9 +43,6 @@ def _install_rocketlib_stub() -> None:
     decorator that stamps ``__tool_meta__`` on the wrapped method) — both
     are surface used by ``IInstance.py`` at import time.
     """
-    if 'rocketlib' in sys.modules:
-        return
-
     stub = types.ModuleType('rocketlib')
 
     class _IInstanceBase:
@@ -111,15 +108,23 @@ def _install_tool_filesystem_pkg_stub() -> None:
     sys.modules['tool_filesystem.IGlobal'] = iglobal_mod
 
 
+# Stub rocketlib only while importing the node, then restore so it never leaks.
+_saved_rl = sys.modules.get('rocketlib')
 _install_rocketlib_stub()
 _install_tool_filesystem_pkg_stub()
 
-from tool_filesystem.IInstance import (  # noqa: E402  — must follow sys.modules setup
-    DEFAULT_READ_LIMIT,
-    MAX_READ_LIMIT,
-    IInstance,
-)
-from tool_filesystem.IGlobal import IGlobal  # noqa: E402
+try:
+    from tool_filesystem.IInstance import (  # noqa: E402  — must follow sys.modules setup
+        DEFAULT_READ_LIMIT,
+        MAX_READ_LIMIT,
+        IInstance,
+    )
+    from tool_filesystem.IGlobal import IGlobal  # noqa: E402
+finally:
+    if _saved_rl is not None:
+        sys.modules['rocketlib'] = _saved_rl
+    else:
+        sys.modules.pop('rocketlib', None)
 
 
 # ---------------------------------------------------------------------------

--- a/nodes/test/tool_mem0/test_tools.py
+++ b/nodes/test/tool_mem0/test_tools.py
@@ -71,6 +71,9 @@ def _ensure_ai_common() -> None:
     """Install fresh ``ai.common.*`` stubs so the node imports without the engine."""
     for name in ('ai', 'ai.common', 'ai.common.utils', 'ai.common.config'):
         sys.modules[name] = types.ModuleType(name)
+    # Mark containers as packages so sub-imports resolve even if not pre-inserted.
+    sys.modules['ai'].__path__ = []
+    sys.modules['ai.common'].__path__ = []
     sys.modules['ai.common.utils'].normalize_tool_input = _passthrough
 
     class _Config:

--- a/nodes/test/tool_mem0/test_tools.py
+++ b/nodes/test/tool_mem0/test_tools.py
@@ -33,7 +33,9 @@ _NODE_DIR = Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 't
 
 
 # ---------------------------------------------------------------------------
-# Composable import scaffolding (augments existing stubs, never clobbers)
+# Import scaffolding: build FRESH stubs unconditionally. Never read the object
+# already in sys.modules — the _saved_core save/restore below repones the real
+# one, so a fresh stub can't leak even without the engine loaded.
 # ---------------------------------------------------------------------------
 
 
@@ -49,19 +51,14 @@ def _tool_function(**_meta):
 
 
 def _ensure_rocketlib() -> None:
-    """Install a minimal rocketlib stub so the node imports without the engine."""
-    mod = sys.modules.get('rocketlib') or types.ModuleType('rocketlib')
-    if not hasattr(mod, 'IInstanceBase'):
-        mod.IInstanceBase = type('IInstanceBase', (), {})
-    if not hasattr(mod, 'IGlobalBase'):
-        mod.IGlobalBase = type('IGlobalBase', (), {})
-    if not hasattr(mod, 'tool_function'):
-        mod.tool_function = _tool_function
-    if not hasattr(mod, 'OPEN_MODE'):
-        mod.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
+    """Install a fresh rocketlib stub so the node imports without the engine."""
+    mod = types.ModuleType('rocketlib')
+    mod.IInstanceBase = type('IInstanceBase', (), {})
+    mod.IGlobalBase = type('IGlobalBase', (), {})
+    mod.tool_function = _tool_function
+    mod.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
     for name in ('debug', 'error', 'warning'):
-        if not hasattr(mod, name):
-            setattr(mod, name, lambda *a, **k: None)
+        setattr(mod, name, lambda *a, **k: None)
     sys.modules['rocketlib'] = mod
 
 
@@ -71,29 +68,24 @@ def _passthrough(args, tool_name=None):
 
 
 def _ensure_ai_common() -> None:
-    """Create minimal ``ai.common.*`` stubs only when absent (never overwrite)."""
+    """Install fresh ``ai.common.*`` stubs so the node imports without the engine."""
     for name in ('ai', 'ai.common', 'ai.common.utils', 'ai.common.config'):
-        if name not in sys.modules:
-            sys.modules[name] = types.ModuleType(name)
-    if not hasattr(sys.modules['ai.common.utils'], 'normalize_tool_input'):
-        sys.modules['ai.common.utils'].normalize_tool_input = _passthrough
-    if not hasattr(sys.modules['ai.common.config'], 'Config'):
+        sys.modules[name] = types.ModuleType(name)
+    sys.modules['ai.common.utils'].normalize_tool_input = _passthrough
 
-        class _Config:
-            """Minimal Config stub returning an empty node config."""
+    class _Config:
+        """Minimal Config stub returning an empty node config."""
 
-            @staticmethod
-            def getNodeConfig(*_a, **_k):
-                """Return an empty config dict."""
-                return {}
+        @staticmethod
+        def getNodeConfig(*_a, **_k):
+            """Return an empty config dict."""
+            return {}
 
-        sys.modules['ai.common.config'].Config = _Config
+    sys.modules['ai.common.config'].Config = _Config
 
 
 def _ensure_requests() -> None:
-    """Stub ``requests`` if unavailable — the HTTP layer is patched out anyway."""
-    if 'requests' in sys.modules:
-        return
+    """Install a fresh ``requests`` stub — the HTTP layer is patched out anyway."""
     mod = types.ModuleType('requests')
     mod.RequestException = type('RequestException', (Exception,), {})
     exc = types.ModuleType('requests.exceptions')
@@ -106,9 +98,7 @@ def _ensure_requests() -> None:
 
 
 def _ensure_tenacity() -> None:
-    """Stub ``tenacity`` if unavailable — the retry layer is patched out in tests."""
-    if 'tenacity' in sys.modules:
-        return
+    """Install a fresh ``tenacity`` stub — the retry layer is patched out in tests."""
     mod = types.ModuleType('tenacity')
     mod.Retrying = lambda **_kw: lambda fn, *a, **k: fn(*a, **k)
     mod.stop_after_attempt = lambda *a, **k: None
@@ -126,21 +116,42 @@ def _ensure_pkg() -> None:
         sys.modules['tool_mem0'] = pkg
 
 
+# Stub engine-only deps just long enough to import the node, then restore
+# sys.modules so these stubs never leak to sibling tests.
+_CORE_STUBS = (
+    'rocketlib',
+    'ai',
+    'ai.common',
+    'ai.common.utils',
+    'ai.common.config',
+    'requests',
+    'requests.exceptions',
+    'tenacity',
+)
+_saved_core = {_name: sys.modules.get(_name) for _name in _CORE_STUBS}
+
 _ensure_rocketlib()
 _ensure_ai_common()
 _ensure_requests()
 _ensure_tenacity()
 _ensure_pkg()
 
-from tool_mem0 import IInstance as IInstanceMod  # noqa: E402
-from tool_mem0.IInstance import (  # noqa: E402
-    IInstance,
-    _coerce_messages,
-    _event_id_of,
-    _shape_add,
-    _shape_results,
-)
-from tool_mem0.IGlobal import IGlobal  # noqa: E402
+try:
+    from tool_mem0 import IInstance as IInstanceMod  # noqa: E402
+    from tool_mem0.IInstance import (  # noqa: E402
+        IInstance,
+        _coerce_messages,
+        _event_id_of,
+        _shape_add,
+        _shape_results,
+    )
+    from tool_mem0.IGlobal import IGlobal  # noqa: E402
+finally:
+    for _name, _mod in _saved_core.items():
+        if _mod is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _mod
 
 
 # ---------------------------------------------------------------------------

--- a/nodes/test/tool_mem0/test_tools.py
+++ b/nodes/test/tool_mem0/test_tools.py
@@ -34,7 +34,7 @@ _NODE_DIR = Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 't
 
 # ---------------------------------------------------------------------------
 # Import scaffolding: build FRESH stubs unconditionally. Never read the object
-# already in sys.modules — the _saved_core save/restore below repones the real
+# already in sys.modules — the _saved_core save/restore below restores the real
 # one, so a fresh stub can't leak even without the engine loaded.
 # ---------------------------------------------------------------------------
 

--- a/nodes/test/tool_xtrace_memory/test_tools.py
+++ b/nodes/test/tool_xtrace_memory/test_tools.py
@@ -29,7 +29,9 @@ _NODE_DIR = Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 't
 
 
 # ---------------------------------------------------------------------------
-# Composable import scaffolding (augments existing stubs, never clobbers)
+# Import scaffolding: build FRESH stubs unconditionally. Never read the object
+# already in sys.modules — the _saved_core save/restore below repones the real
+# one, so a fresh stub can't leak even without the engine loaded.
 # ---------------------------------------------------------------------------
 
 
@@ -42,18 +44,13 @@ def _tool_function(**_meta):
 
 
 def _ensure_rocketlib() -> None:
-    mod = sys.modules.get('rocketlib') or types.ModuleType('rocketlib')
-    if not hasattr(mod, 'IInstanceBase'):
-        mod.IInstanceBase = type('IInstanceBase', (), {})
-    if not hasattr(mod, 'IGlobalBase'):
-        mod.IGlobalBase = type('IGlobalBase', (), {})
-    if not hasattr(mod, 'tool_function'):
-        mod.tool_function = _tool_function
-    if not hasattr(mod, 'OPEN_MODE'):
-        mod.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
+    mod = types.ModuleType('rocketlib')
+    mod.IInstanceBase = type('IInstanceBase', (), {})
+    mod.IGlobalBase = type('IGlobalBase', (), {})
+    mod.tool_function = _tool_function
+    mod.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
     for name in ('debug', 'error', 'warning'):
-        if not hasattr(mod, name):
-            setattr(mod, name, lambda *a, **k: None)
+        setattr(mod, name, lambda *a, **k: None)
     sys.modules['rocketlib'] = mod
 
 
@@ -62,35 +59,30 @@ def _passthrough(args, tool_name=None):
 
 
 def _ensure_ai_common() -> None:
-    """Create minimal ``ai.common.*`` stubs only when absent.
+    """Install fresh ``ai.common.*`` stubs so the node imports without the engine.
 
-    Never overwrites a real/existing module attribute — that would pollute
-    other node tests in the same session. Deterministic behavior for THIS
-    node is pinned locally after import (see below), not globally here.
+    Deterministic behavior for THIS node is pinned locally after import (see
+    below); the fresh stubs never leak thanks to the _saved_core restore.
     """
     for name in ('ai', 'ai.common', 'ai.common.utils', 'ai.common.config'):
-        if name not in sys.modules:
-            sys.modules[name] = types.ModuleType(name)
-    if not hasattr(sys.modules['ai.common.utils'], 'normalize_tool_input'):
-        sys.modules['ai.common.utils'].normalize_tool_input = _passthrough
-    if not hasattr(sys.modules['ai.common.config'], 'Config'):
+        sys.modules[name] = types.ModuleType(name)
+    sys.modules['ai.common.utils'].normalize_tool_input = _passthrough
 
-        class _Config:
-            @staticmethod
-            def getNodeConfig(*_a, **_k):
-                return {}
+    class _Config:
+        @staticmethod
+        def getNodeConfig(*_a, **_k):
+            return {}
 
-        sys.modules['ai.common.config'].Config = _Config
+    sys.modules['ai.common.config'].Config = _Config
 
 
 def _ensure_requests() -> None:
-    """Stub ``requests`` if unavailable — the HTTP layer is patched out anyway."""
-    if 'requests' in sys.modules:
-        return
+    """Install a fresh ``requests`` stub — the HTTP layer is patched out anyway."""
     mod = types.ModuleType('requests')
     mod.RequestException = type('RequestException', (Exception,), {})
     exc = types.ModuleType('requests.exceptions')
     exc.Timeout = type('Timeout', (mod.RequestException,), {})
+    exc.HTTPError = type('HTTPError', (mod.RequestException,), {})
     mod.exceptions = exc
     mod.request = lambda *a, **k: None
     sys.modules['requests'] = mod
@@ -98,9 +90,7 @@ def _ensure_requests() -> None:
 
 
 def _ensure_tenacity() -> None:
-    """Stub ``tenacity`` if unavailable — the retry layer is patched out in tests."""
-    if 'tenacity' in sys.modules:
-        return
+    """Install a fresh ``tenacity`` stub — the retry layer is patched out in tests."""
     mod = types.ModuleType('tenacity')
     # Retrying(...)(fn) just calls fn once; tests patch _request_with_retry anyway.
     mod.Retrying = lambda **_kw: lambda fn, *a, **k: fn(*a, **k)
@@ -117,15 +107,36 @@ def _ensure_pkg() -> None:
         sys.modules['tool_xtrace_memory'] = pkg
 
 
+# Stub engine-only deps just long enough to import the node, then restore
+# sys.modules so these stubs never leak to sibling tests.
+_CORE_STUBS = (
+    'rocketlib',
+    'ai',
+    'ai.common',
+    'ai.common.utils',
+    'ai.common.config',
+    'requests',
+    'requests.exceptions',
+    'tenacity',
+)
+_saved_core = {_name: sys.modules.get(_name) for _name in _CORE_STUBS}
+
 _ensure_rocketlib()
 _ensure_ai_common()
 _ensure_requests()
 _ensure_tenacity()
 _ensure_pkg()
 
-from tool_xtrace_memory import IInstance as IInstanceMod  # noqa: E402
-from tool_xtrace_memory.IInstance import IInstance, _coerce_messages  # noqa: E402
-from tool_xtrace_memory.IGlobal import IGlobal, _split_group_ids  # noqa: E402
+try:
+    from tool_xtrace_memory import IInstance as IInstanceMod  # noqa: E402
+    from tool_xtrace_memory.IInstance import IInstance, _coerce_messages  # noqa: E402
+    from tool_xtrace_memory.IGlobal import IGlobal, _split_group_ids  # noqa: E402
+finally:
+    for _name, _mod in _saved_core.items():
+        if _mod is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _mod
 
 # Pin the input normalizer locally so behavior is deterministic regardless of
 # whatever ``ai.common.utils`` resolved to in this session (real or MagicMock).

--- a/nodes/test/tool_xtrace_memory/test_tools.py
+++ b/nodes/test/tool_xtrace_memory/test_tools.py
@@ -30,7 +30,7 @@ _NODE_DIR = Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 't
 
 # ---------------------------------------------------------------------------
 # Import scaffolding: build FRESH stubs unconditionally. Never read the object
-# already in sys.modules — the _saved_core save/restore below repones the real
+# already in sys.modules — the _saved_core save/restore below restores the real
 # one, so a fresh stub can't leak even without the engine loaded.
 # ---------------------------------------------------------------------------
 

--- a/nodes/test/tool_xtrace_memory/test_tools.py
+++ b/nodes/test/tool_xtrace_memory/test_tools.py
@@ -66,6 +66,9 @@ def _ensure_ai_common() -> None:
     """
     for name in ('ai', 'ai.common', 'ai.common.utils', 'ai.common.config'):
         sys.modules[name] = types.ModuleType(name)
+    # Mark containers as packages so sub-imports resolve even if not pre-inserted.
+    sys.modules['ai'].__path__ = []
+    sys.modules['ai.common'].__path__ = []
     sys.modules['ai.common.utils'].normalize_tool_input = _passthrough
 
     class _Config:


### PR DESCRIPTION
## Summary

- Several node tests installed stubs for core modules (`rocketlib` + submodules, `pydantic`, and their `ai.common.*`/`requests`/`tenacity` companions) into `sys.modules` at import time and never restored them. The stub stayed global for the rest of the pytest session and leaked into unrelated tests that import the real module.
- Wrap each stub so it lives only while the node code is imported, and restore `sys.modules` in a `finally`. Switch `setdefault` to direct assignment so a stub left contaminated by another test can't be reused.
- No test logic or assertions changed — only the stub lifecycle.

## Type

test / bug fix (test isolation)

## Testing

- [x] Tests updated (stub save/restore added; behaviour unchanged)
- [ ] Tested locally (lint green: ruff; full suite runs in CI — no engine locally)
- [ ] `./builder test` passes (runs in CI on this PR)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — N/A
- [x] Breaking changes documented — none; test-only, no runtime behaviour changes

## Linked Issue

Fixes #1640

<sub>Context: this unblocks #1636 (node-family renames), which does nothing to these tests but reorders pytest collection and surfaces the leak. With isolation fixed here, any reorder stays green.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Test Reliability**
  * Improved test isolation by scoping dependency stubs to each test’s import window and restoring prior `sys.modules` state afterward.
  * Applied a consistent save-install-restore pattern across node and tool tests to prevent mock/module leakage between tests.
  * Updated dynamic imports to avoid persistent stub injection while keeping existing assertions unchanged.
  * Added an automatic pytest regression guard that detects leaked stubbed core modules and fails the test to enforce correct isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->