### PR TITLE
fix: bind engine to explicit 127.0.0.1 instead of ambiguous localhost name

### DIFF
--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -153,7 +153,13 @@ export class EngineLocal extends EngineBackend {
 		const args = [
 			'--autoterm',        // Exit when VS Code closes (stdin monitoring)
 			'./ai/eaas.py',
-			'--host=localhost',
+			// Bind an explicit address, never the name 'localhost'. Where it resolves
+			// to both ::1 and 127.0.0.1, asyncio binds one socket per address family
+			// and --port=0 gives each its own ephemeral port, but only the first
+			// socket's port is reported — so the engine can advertise a port nothing
+			// accepts over IPv4 and look dead while being healthy. The service
+			// launchers already pass 127.0.0.1 for this reason.
+			'--host=127.0.0.1',
 			'--port=0',          // Dynamic port assignment
 			...effectiveArgs,
 		];

--- a/scripts/lib/server.js
+++ b/scripts/lib/server.js
@@ -64,8 +64,15 @@ async function startServer(options) {
 	// --port=0 lets the OS assign a free port; we parse the actual port from
 	// Uvicorn's stdout to avoid the race between findFreePort() releasing the
 	// port and the engine binding to it (same pattern as engine-manager.ts).
+	// --host=127.0.0.1 is deliberate: never bind the *name* 'localhost'. Where it
+	// resolves to both ::1 and 127.0.0.1 (any container - a bare host usually maps
+	// only IPv4), asyncio binds one socket per address family and --port=0 gives
+	// each its own ephemeral port, while only the first socket's port is logged.
+	// We parse that port and hand it to the tests, so whenever IPv6 sorts first
+	// the tests dial a port nothing listens on over IPv4 and every request fails
+	// with ECONNREFUSED against a healthy engine.
 	const scriptArgs = script.split(/\s+/);
-	const serverArgs = ['--autoterm', ...scriptArgs, '--port=0', ...args];
+	const serverArgs = ['--autoterm', ...scriptArgs, '--host=127.0.0.1', '--port=0', ...args];
 	if (basePort) {
 		serverArgs.push(`--base_port=${basePort}`);
 	}


### PR DESCRIPTION
## Summary

- Bind the engine to an explicit `127.0.0.1` instead of the name `localhost`. Where that name resolves to **both** `::1` and `127.0.0.1` — typical inside a container — asyncio binds one socket per address family, and with `--port=0` each socket gets its **own ephemeral port** while only the first is advertised. Whenever IPv6 sorts first, clients dial a port nothing listens on over IPv4 and get an instant `ECONNREFUSED` from a perfectly healthy engine, which is why the TypeScript client integration tests fail periodically.
- Apply the same fix to `engine-local.ts`, which spawned **every VS Code window's** engine with `--host=localhost --port=0` — the same broken combination, so a user's engine could advertise a port nothing accepts and appear dead while healthy. Windows prefers IPv6 for `localhost` and is most exposed. The service launchers already pass `127.0.0.1`; this was the last caller using the ambiguous name and the only one pairing it with `--port=0`.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

Root cause and fix verified against the real engine running in a container:

```text
--host=localhost   → advertised=46697, ipv4_socket=46697, ipv6_socket=38073
                     dial 127.0.0.1:38073 → REFUSED     ← the observed symptom
--host=127.0.0.1   → 1 socket, 1 port, always reachable (3/3 runs)
```

Cross-distro test sweep with the fix applied: all relevant legs green, `73 passed` each, **0 `ECONNREFUSED`** — two of those legs were red on the preceding sweep. (The `almalinux` leg fails for an unrelated `libc++` loader issue.)

No automated test added: reproducing this requires a container whose `/etc/hosts` maps `localhost` to both address families, plus a `getaddrinfo` ordering race. That is not something to assert reliably in the suite. The fix is structural — with an explicit address only one socket exists, so the mismatch is impossible rather than merely unlikely.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1623


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved local engine connectivity by consistently binding services to the IPv4 loopback address.
  * Reduced connection failures caused by differences in how systems resolve `localhost`.
  * Preserved automatic assignment of available ports for local processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->