### PR TITLE
release: bump to 3.4.0 and cut CHANGELOG (from stage)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,293 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]: since 2026-06-08
+## [Unreleased] — since 2026-07-22
+
+## [3.4.0] - 2026-07-22
+
+### Added
+
+- #429 Add Exa search node and working sample pipeline [FRONTIER TOWER HACKATHON]
+- **agent** — Crewai orchestrator
+- **agent** — Extract task engine and cmd_data from feat/base-ui
+- **agent_deepagent** — Concurrent subagent fan-out via async LangGraph
+- **agent_llamaindex** — Single-agent node using LlamaIndex ReAct loop
+- **aparavi** — AQL node, multi-tab chat app, auth page removal, reconnect fix
+- **audio_tts** — Add Kokoro-only Text To Speech node (RR-411)
+- **billing** — Promo codes — SDK methods, CheckoutModal promo box, host wiring (#1475)
+- **billing-3** — Billing, validation, shell infra, and SDK sync
+- **billing-4** — Profiler visualizations, waitlist gate, subscribe CTA, canvas edge refactor
+- **billing-6** — Admin app support, build tooling, profiler security
+- **build** — Fedora / RHEL-family (dnf) build-from-source support
+- **build** — Upgrade to Rsbuild v2, Module Federation v2, Rslib v0.22
+- **check-externals** — CI framework to detect 3rd-party Python interface drift
+- **checkout** — Round monthly-equivalent price up to whole dollars
+- **ci** — Experimental-release workflow for non-develop builds
+- **cloud_tts** — OpenAI + ElevenLabs cloud TTS on a shared engine (RR-411)
+- **dap** — Add BillingCommands mixin — stub for rrext_account_billing
+- **database** — Add QuestionType.DIALECT for engine discovery
+- **database** — Add QuestionType.EXECUTE for direct SQL/Cypher execution
+- **depends** — Add load_depends() helper
+- **deploy** — Deployment infrastructure
+- **discord** — Add live CI check status and PR state tracking to embed
+- **docs** — Add and update documentation for each node
+- **docs** — Co-located, build-integrated documentation site
+- **docs** — Docs-site star caching & UX robustness (RR-1218)
+- **engine** — Add docker-compose and healthcheck for local development
+- **engine** — Add Kubernetes Helm chart for production deployment
+- **engine** — Load workspace-local nodes via --node_path
+- **engine** — Support for experimental capability
+- **llm** — Add GMI Cloud LLM connector
+- **llm** — Stream model reasoning over the 'thinking' SSE lane
+- **llm_minimax** — Add MiniMax M3 model profile
+- **mcp** — Add MCP Resources and Prompts to RocketRide MCP server
+- **node** — Add ClickHouse database node (db_postgres clone)
+- **node** — Add llm_nebius as a branded preset of llm_openai_api
+- **node** — Add Mem0 long-term memory tool
+- **node** — Add Supabase as a branded preset of db_postgres
+- **node** — Add tool_tavily web-search agent tool
+- **nodes** — Add anomaly detection node for pipeline output monitoring
+- **nodes** — Add ArangoDB db_arango node
+- **nodes** — Add Baidu Qianfan ERNIE LLM node
+- **nodes** — Add Cohere Rerank pipeline node
+- **nodes** — Add DeepL translate + write tool node (tool_deepl)
+- **nodes** — Add Exa semantic web search node for real-time data enrichment
+- **nodes** — Add GitHub tool
+- **nodes** — Add guardrails node for AI safety with input/output validation
+- **nodes** — Add Kimi (Moonshot) LLM node + model-sync registration
+- **nodes** — Add Landing.ai ADE document-extraction nodes (Parse + Extract)
+- **nodes** — Add persistent cross-session memory node with Redis and in-memory backends
+- **nodes** — Add self-contained Git tool node (#654)
+- **nodes** — Add shared Google access/scope resolver (RR-1054)
+- **nodes** — Add Telegram Bot source node
+- **nodes** — Add tool interface for vector DB operations
+- **nodes** — Add v0 by Vercel tool node for UI generation
+- **nodes** — Add video embedding node for semantic search and RAG pipelines
+- **nodes** — Config - add deprecation pathway for deprecated profiles
+- **nodes** — Emit profile token limits in generated tables, fix Anthropic drift (RR-1220)
+- **nodes** — Improve Milvus vector DB node — address all TODOs
+- **nodes** — New node - openai compatible
+- **nodes** — Parallelize nodes:test with pytest-xdist
+- **nodes, ai** — Add graph base class; make FalkorDB a real graph node
+- **phase3** — Capabilities probe, shared connection UI, settings overhaul
+- **profiler** — Replace cProfile with yappi, snakeviz-style UI
+- **registerApp** — Pass requiredPermissions array through to apps.json
+- **shared-ui** — Chat module
+- **shared-ui** — Replace MUI with plain CSS/HTML, add runtime theme system with light/dark JSON tokens
+- **shell** — Branded waitlist button, loading screen, OAuth-loop guard
+- **shell-ui** — Apply saved theme on init to prevent tan loading flash
+- **store** — Handle-based streaming I/O for file store
+- **sync** — Stamp capabilities.reasoning from OpenRouter
+- **task** — Scheduled pipeline deployments (deploy v2)
+- **tool** — Add DAP tool subcommand for direct @tool_function invocation
+- **tool_apify** — Expose Apify Actors as an agent tool
+- **tool_daytona** — Run agent code in an isolated Daytona cloud sandbox
+- **tool_falkordb** — Query FalkorDB graphs with Cypher as an agent tool
+- **tools** — Add automated LLM model sync tool and update provider profiles
+- **tools** — Replace tool declarations @tool_function decorators on IInstanceBase
+- **ui** — Unify sidebar footer, add engine progress log
+- **vision** — 7-node suite — RF-DETR, Mask2Former, DA-V2, BlazeFace + more
+- **vscode** — Add Parameters tab to set pipeline trace level
+- **vscode** — Change play button to show actionable text instead of current state
+- **vscode** — ETag-based conditional requests for GitHub releases API
+- **vscode** — Improve stop button feedback in Pipeline Observability screen
+- **vscode,engine** — Add server monitor
+- Add Bland AI voice call tool node
+- Add MiniMax LLM node
+- Filesystem Tool
+- Pipeline tool
+- Save button in canvas toolbar with dirty-state tracking
+- Shared-ui migration, ProjectView architecture, agent framework overhaul
+- Tool subcommand API, Qdrant fixes, chat provider flexibility
+
+### Fixed
+
+- **agent** — CrewAI reliability — stop, trace, config shape (RR-1363)
+- **ai** — Cap matplotlib<3.11 — 3.11.0 ft2font aborts model server on detection load
+- **ai** — Install test deps via depends() so engine constraints apply
+- **ai** — Map server RR_* env vars to ROCKETRIDE_* for sys.admin pipelines
+- **ai** — Preserve parallel tool-call identity in transcript replay
+- **ai** — Return generic auth errors, log exception details server-side
+- **ai** — Stub matplotlib.pyplot before rfdetr import (ft2font aborts engine)
+- **audio** — Force docopt/num2words to wheels for Windows engine install (#1358)
+- **autoinstall** — Align clang to distro default — unblocks repo-wide Ubuntu CI
+- **autoinstall** — Detect root + cover libc++ runtime in compiler-unix.sh
+- **autoinstall** — Make gnupg apt install non-interactive
+- **billing/shell** — Resilient event bus + plan-aware checkout/upgrade UI
+- **build** — Add missing libuuid vcpkg config template
+- **build** — Fail the build when Linux dependency install fails
+- **build** — Gate server:compile-tests on persisted download state
+- **build** — Include shell-ui and apps.json in release packages, fix restart token
+- **build** — Make Breakpad symbol generation non-fatal
+- **build** — Make cc/c++ symlinking idempotent and fail gracefully without sudo
+- **build** — Restore cmake >= 3.19 version gate
+- **builder** — Prevent deadlock when conditional skips a dedup branch
+- **canvas** — Forward drag events through CreateNodePanel backdrop
+- **canvas** — Improve QuickAdd popup label copy
+- **canvas** — Pipeline render-loop fix + sidebar logo home nav
+- **checkout** — Carry validated promo into preselected-plan checkout (#1604)
+- **checkout** — Open plan CTA links externally in the VS Code extension
+- **chroma** — Exclude soft-deleted documents from default searches
+- **ci** — Add build passthrough for docs-only PRs
+- **ci** — Add id-token: write to nightly docker job to unblock prereleases
+- **ci** — Add id-token: write to release docker job (preemptive fix)
+- **ci** — Allow Nightly workflow_dispatch from stage and main
+- **ci** — Block shell injection in _build.yaml via env-var indirection
+- **ci** — Drop artifact retention to 1 day to fit in 0.5 GB storage cap
+- **ci** — Grant nightly workflow workflows:write to publish prereleases
+- **ci** — Match GraphQL github-actions author login in marker search
+- **ci** — Pin all actions to immutable commit hash
+- **ci** — Pin cryptography at build + UV_LINK_MODE=copy to stop Windows nodes:test _rust.pyd lock
+- **ci** — Prevent duplicate Discord posts on discussion edits
+- **ci** — Push release/prerelease tags via WORKFLOW_PAT (repo+workflow scope)
+- **ci** — Scope nightly.yaml writes to per-job permissions
+- **ci** — Stop Discord discussions notifier from posting blank bot comments
+- **ci** — Stop Discord notifier from posting blank bot comments
+- **ci** — Use literal ROCKETRIDE_APIKEY in Test step instead of secret
+- **ci/cd, nodes** — Full tests
+- **cli** — Catch ValueError from json5.loads, not non-existent json5.JSONError (#1379)
+- **cli** — Implement signal handlers for graceful shutdown (RR-655)
+- **client-python** — Bound truncate_filename for small widths (#1385)
+- **client-python** — Break drain cycle causing RecursionError on disconnect
+- **client-python** — Clean pending DAP request on send failure
+- **client-python** — Remove token='*' from restart command
+- **client-ts** — Preserve user-specified port in normalizeUri
+- **clients** — Pipe errors (Python + TS), SSE rollback, getTaskStatus timeout
+- **connection** — Handle missing hostname in URI parsing
+- **core** — _message_tasks set is accessed from multiple async contexts without a lock
+- **crewai** — Patch async compatibility issues for CrewAI 1.14.x hierarchical crews
+- **dap** — Don't let an oversized subprocess stdout line kill the pipeline task
+- **database** — Bound Neo4j EXECUTE rows, parse allow_execute strictly
+- **database** — Gate EXECUTE path, bound results, validate SDK inputs
+- **deepagent** — Avoid transformers dependency for token counting
+- **depends** — Bootstrap setuptools alongside wheel
+- **depends,whisper** — Unicode encoding + whisper GPU probe in server mode
+- **deps** — Restore libc fields in pnpm-lock.yaml
+- **deps** — Update pnpm-lock.yaml for lucide-react dependency
+- **discord-discussions** — Normalize webhook base, at-most-once POST
+- **docker** — Provision /opt/data and use /version for healthcheck
+- **docs** — Documenation update
+- **docs** — Trigger workflow on README.md changes to keep llms.txt current
+- **docs** — Update source connector docs
+- **easyocr** — Unwrap DataParallel to prevent SIGABRT under concurrent load
+- **engine** — Forward --node_path to task subprocess so workspace-local nodes load
+- **engine** — In-process clients connect to wrong port when engine binds to OS-assigned port
+- **engine** — Pass uv --excludes relative to cwd so spaced install paths resolve
+- **engine** — Pass uv -c constraints relative to cwd so spaced install paths resolve
+- **engine** — Progress sidecar for depends.py, remove dry-run, exclude crewai-cli
+- **git** — Lefthook sequential
+- **guardrails** — Reject '|' in email TLD char class
+- **home-ui** — SaaS pipeline export, host-slot sidebar refactor & shell/canvas polish
+- **icons** — Add auto-currentcolor theming and fix node icon assets
+- **icons** — Preserve original colors for Baidu Qianfan node icon
+- **llm** — Clear correct _chat reference in endGlobal across all LLM nodes
+- **llm_anthropic** — Drop temperature, removed on Opus 4.7+
+- **llm_ollama** — Auto-configure reasoning models (temperature + reasoning_effort)
+- **milvus** — Apply retrieval_score_threshold filter in searchSemantic (#642)
+- **mixins** — Error handling for missing pipeline configuration files
+- **nodes** — Add input validation/sanitization to LLM chat drivers
+- **nodes** — Add rate limiting to tool_http_request node
+- **nodes** — Agent keyword search returns nothing (RR-1363)
+- **nodes** — Bootstrap deps in agent_rocketride and drop transformers from llm_anthropic
+- **nodes** — Correct GMI Cloud Gemini model IDs (#996)
+- **nodes** — Enforce LF for .md files and harden doc generator on Windows
+- **nodes** — Improve error handling in remote node execution
+- **nodes** — Openai - add latest openai models
+- **nodes** — Reclassify FalkorDB as database, not store (classType) [stage]
+- **nodes** — Remove caption + face_detection nodes ahead of release
+- **nodes** — Remove deprecated gemini models
+- **nodes** — Remove llm_vertex, fix llm_gemini key handling, migrate vision nodes to LLMBase
+- **nodes** — Remove redundant full-res image encode/decode round-trips
+- **nodes** — User-configured interval ignored in frame grabber
+- **ocr** — Support img2table 2.0 OCRInstance API rewrite
+- **profiler-ui** — Rehydrate report on mount so split panes keep the chart
+- **qdrant** — Correct score-space mismatch and isDeleted filter
+- **release** — Drop orphaned TWINE_USERNAME/PASSWORD lines inside MCP PyPI run block
+- **release** — Durable CHANGELOG-sourced GitHub Release notes
+- **rocketlib** — Satisfy ruff D204/Q000 in __init__.pyi stub
+- **scripts** — Guard state.js dot-paths against prototype pollution
+- **scripts** — Resolve undefined BUILD_ROOT and DIST_DIR in licenses.js
+- **scripts** — Skip pytest tasks when target dir has no test files
+- **sdk** — Align CreditBalance type with backend camelCase wire shape
+- **security** — Expand sensitive field redaction patterns in VS Code logger
+- **security** — Explicit branch check on nightly workflow_run trigger
+- **security** — Prevent arbitrary module injection via /use endpoint (RCE)
+- **security** — Prevent filter expression injection in Milvus vector store
+- **security** — Require authentication for profiler endpoints and escape HTML output
+- **security** — Restrict environment variable expansion in pipeline configs
+- **security** — Switch SQL safety check from blacklist to whitelist approach
+- **security** — Use pathlib.is_relative_to for path traversal checks
+- **security** — Use secure temporary file creation in task engine
+- **shared-ui** — Explorer empty-state create + annotation double-click editor
+- **shared-ui** — Use named React hook imports in Account panels
+- **shell-ui** — Clear pending app on abandoned OAuth back-nav
+- **shell-ui** — Force prompt=login on web sign-in so users can switch accounts
+- **shell-ui** — Logout flow + guest overlays, monitor branding
+- **shell-ui** — Only show Aparavi AQL Settings in sidebar when the AQL app is installed
+- **shell-ui** — Scope app settings to installed apps; keep global Settings always visible
+- **shell-ui** — Surface MF app load failures instead of hanging on "Loading..."
+- **sidebar** — Wire docs link to browser and update announcements
+- **store/azure** — Allow wildcard (*) in the Azure blob endpoint
+- **store/services** — Respect explicit default in combo field provider resolution
+- **task** — Use singular `organization` in pk_/tk_ account info
+- **template** — Route RAG chat query through embedding before vector store
+- **test** — Fix parallel test server isolation — remove shared ctx.port fallback
+- **test** — Resolve flaky timeouts and hanging in concurrent pipeline tests
+- **test** — Skip HF-downloading embedding nodes in default CI lane (#1120)
+- **test,build** — Unblock test-full pipelines + saas overlay consolidation
+- **test/mocks** — Resolve Python truthiness and isinstance traps
+- **tests** — Make test_tool_v0 mock import-order independent
+- **text-output** — Correct text output handling
+- **tika** — Extract media from standalone files and large archives
+- **tool_git** — Eliminate pytest-xdist race in path-traversal tests
+- **tool_http_request** — Insert path-param values literally (#1369)
+- **ui** — Address PR #1191 CodeRabbit review comments
+- **ui** — Fix icons and coloring for bland, gmi, and trash bin
+- **ui** — Resolve dark mode icon and edge visibility in flow builder (…
+- **vision** — Optimize the vision suite — downscale-for-inference, fast PNG, GPU onnxruntime
+- **vscode** — Add osx python path for Python-EaaS debugger
+- **vscode** — Add Product Hunt badge as PNG — marketplace rejects SVGs
+- **vscode** — Allow GitHub raw host in webview CSP so announcements load
+- **vscode** — Bake dedicated NATIVE Zitadel app client_id for cloud login (#89)
+- **vscode** — Bake production server URL and Stripe key into the VSIX
+- **vscode** — Loop-strip HTML tags in firstSentence to handle nesting
+- **vscode** — Project editor missing status events and stale serverHost
+- **vscode** — Realign view:ready handshake — chat webview blank screen
+- **vscode** — Register canvas-played pipelines in sidebar menu
+- **vscode** — Remove Product Hunt SVG badge from VS Code README — marketplace rejects SVGs
+- **vscode** — Sidebar polish, env variables, autocomplete, and startup fixes
+- **weaviate** — Pin grpcio-health-checking<1.80 to match protobuf runtime
+- **whisper** — Add version guard to GPU probe for ctranslate2 4.7.x + CUDA 12.8
+- **whisper** — Bound version guard to < 4.8 + guard explicit CUDA devices
+- **workflows** — Add retry/backoff to Discord webhook calls
+- Address CodeRabbit review - score assignment and first-chunk aliasing
+- Address PR #1148 CodeRabbit review comments
+- Address PR #1149 CodeRabbit review comments
+- Align client-python requires-python with monorepo target (py310)
+- Guard against falsy-value traps in psycopg2, chromadb, weaviate mocks
+- LLM providers small clean-up
+- MF stability, ModelClient SDK refactor, settings UX, billing, and UI polish
+- Normalize_tool_input function receives list of params to drop
+- Replace mutable default arguments with None
+- SDK connect error callback type
+- Use chunk reference in _processFullTables to resolve chunkId scoping bug
+
+### Changed
+
+- **ai.common** — Consolidate node helpers; drop dead code
+- **database** — Hoist max_execute_rows default to a single constant per module
+- **database** — Reference DEFAULT_MAX_EXECUTE_ROWS in get_data limits
+- **engine, nodes** — Extract duplicate helper from tool nodes
+- **icons** — Move SVGs to node dirs, auto-tint monochromes
+- **nodes** — Ruff format llm_vision_gemini + llm_vision_openai
+- **objstore** — Paginate S3 scan and share a cached scanner client
+- **tools** — Nest `sync_models` under `tools/sync_models/`
+- **vscode** — Restructure engine management with ioControl pattern
+- Migrate llm providers to ai.common.LLMBase
+
+### Maintenance
+
+- 65 chore, 23 docs, 12 CI, 3 test and 55 uncategorised commits are omitted from the list above.
 
 ## [3.3.0] - 2026-06-08
 

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "rocketride",
 	"displayName": "RocketRide",
 	"description": "RocketRide extension for Visual Studio Code",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"publisher": "rocketride",
 	"repository": {
 		"type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride-server",
-	"version": "3.3.1",
+	"version": "3.4.0",
 	"description": "RocketRide Server - A high-performance data processing engine with modular nodes, AI capabilities, and cross-platform clients",
 	"private": true,
 	"license": "MIT",

--- a/packages/client-mcp/pyproject.toml
+++ b/packages/client-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride-mcp"
-version = "1.3.0"
+version = "1.4.0"
 description = "RocketRide MCP stdio server that streams local files to RocketRide EaaS"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rocketride"
-version = "1.3.0"
+version = "1.4.0"
 description = "RocketRide Pipeline Python Client SDK"
 readme = "README.md"
 authors = [

--- a/packages/client-typescript/package.json
+++ b/packages/client-typescript/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "rocketride",
-	"version": "1.3.0",
+	"version": "1.4.0",
 	"author": "RocketRide, Inc.",
 	"license": "MIT",
 	"description": "TypeScript client for RocketRide data processing and AI services",


### PR DESCRIPTION
Version bump + CHANGELOG cut for **3.4.0**, cut from `stage`.

**Why from stage and not develop:** `develop` is 62 commits ahead of `stage`, and those have not been through stage validation. This cut ships only the **445 commits that have** — that is what `stage` is for. develop's extra work rides the next cut. (Supersedes #1653, which took the develop route.)

| Package | released | → new |
|---|---|---|
| Server | 3.3.1 | **3.4.0** |
| TypeScript client | 1.3.0 | **1.4.0** |
| Python client | 1.3.0 | **1.4.0** |
| MCP client | 1.3.0 | **1.4.0** |
| VS Code extension | 1.3.0 | **1.4.0** |

Versions are computed from the **already-released** versions, so nothing collides with an existing tag.

**CHANGELOG:** the cut section came out empty (nothing had accumulated in `[Unreleased]` since 2026-06-08), which would have produced empty GitHub Release notes for all five packages. Populated from the 445 commits in `main..stage`: **92 Added, 169 Fixed, 10 Changed**; chore/docs/CI/test summarised.

Merging this into `stage` publishes nothing. The release fires on `stage → main`.

Context: no stable release since 2026-07-07 (v3.3.1) — 15 days.
