### PR TITLE
chore(release): make the release train fail loudly

### DIFF
--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -1,0 +1,119 @@
+# =============================================================================
+# Release back-merge
+#
+# Version bumps land on `stage` and `main` and were never brought back to
+# `develop`. The result is silent drift: after v3.3.1 shipped, `develop` still
+# read 3.3.0 and the VS Code extension still read 1.2.0, so the nightly
+# prereleases published *below* the shipped stable line — `vscode-v1.2.0-prerelease`
+# appeared after stable `v1.3.0`. Every release made the gap worse.
+#
+# This opens a back-merge pull request as soon as a release finishes, so the
+# drift closes on the same day it is created rather than accumulating until
+# someone trips over it.
+#
+# It opens a PR rather than pushing: `develop` is protected and the merge can
+# conflict, and a conflicted back-merge is a thing a human should look at.
+# =============================================================================
+
+name: Release back-merge
+
+on:
+  workflow_run:
+    workflows: ['Release']
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backmerge:
+    name: Open main → develop back-merge
+    # Only after a release that actually succeeded.
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Is develop already up to date?
+        id: check
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main develop
+          BEHIND=$(git rev-list --count origin/develop..origin/main)
+          echo "behind=$BEHIND" >> "$GITHUB_OUTPUT"
+          if [ "$BEHIND" -eq 0 ]; then
+            echo "develop already contains main — nothing to back-merge."
+          fi
+
+      - name: Create the back-merge branch
+        if: steps.check.outputs.behind != '0'
+        id: branch
+        run: |
+          set -euo pipefail
+          BRANCH="chore/backmerge-main-$(git rev-parse --short origin/main)"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Branch $BRANCH already exists — a back-merge is already in flight."
+            exit 0
+          fi
+          echo "exists=false" >> "$GITHUB_OUTPUT"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH" origin/develop
+
+          # A conflict here is expected and fine: past releases were squashed into
+          # main, so the branches share little history. Push the branch anyway and
+          # let the PR carry the conflict markers to a human.
+          if git merge --no-edit origin/main; then
+            echo "conflicts=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "conflicts=true" >> "$GITHUB_OUTPUT"
+            git merge --abort
+            git checkout -b "$BRANCH" origin/develop 2>/dev/null || true
+          fi
+
+          git push -u origin "$BRANCH"
+
+      - name: Open the pull request
+        if: steps.check.outputs.behind != '0' && steps.branch.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          BEHIND: ${{ steps.check.outputs.behind }}
+          CONFLICTS: ${{ steps.branch.outputs.conflicts }}
+        run: |
+          set -euo pipefail
+          {
+            echo "Brings the release commit on \`main\` back into \`develop\`."
+            echo
+            echo "\`develop\` is **$BEHIND commits** behind \`main\`."
+            echo
+            echo "Without this, \`develop\` keeps the pre-release version numbers while"
+            echo "\`main\` carries the released ones, and the nightly prereleases publish"
+            echo "*below* the shipped stable line. That is exactly how"
+            echo "\`vscode-v1.2.0-prerelease\` came out after stable \`v1.3.0\`."
+            if [ "$CONFLICTS" = "true" ]; then
+              echo
+              echo "> **The automatic merge conflicted**, so this branch is a plain copy of"
+              echo "> \`develop\`. Merge \`main\` into it by hand. Conflicts are expected:"
+              echo "> releases are squashed into \`main\`, so the branches share little history."
+            fi
+            echo
+            echo "_Opened automatically by \`release-backmerge\` after a successful release._"
+          } > /tmp/backmerge-body.md
+
+          gh pr create \
+            --base develop --head "$BRANCH" \
+            --title "chore: back-merge main into develop after release" \
+            --body-file /tmp/backmerge-body.md \
+            --label "release" || true

--- a/.github/workflows/release-stall-check.yml
+++ b/.github/workflows/release-stall-check.yml
@@ -1,0 +1,143 @@
+# =============================================================================
+# Release stall check
+#
+# The release train fails silently. `Release` only fires on a push to `main`,
+# and the `stage -> main` cut is a manual pull request. If nobody opens it,
+# nothing breaks and nothing complains: `develop -> stage` keeps flowing and
+# prereleases keep publishing off `develop`, so from the outside the project
+# looks like it is shipping. In July 2026 that state ran for 15 days with 445
+# commits sitting on `stage` before anyone noticed.
+#
+# This job makes the silence audible: once a weekday it measures how far `main`
+# trails `stage` and, past either threshold, opens (or refreshes) a single
+# tracking issue. It never opens a second one.
+# =============================================================================
+
+name: Release stall check
+
+on:
+  schedule:
+    # 15:00 UTC on weekdays — after EU standup, before US midday.
+    - cron: '0 15 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Days main may trail stage before this is a stall'
+        required: false
+        default: '7'
+      max_commits:
+        description: 'Commits main may trail stage before this is a stall'
+        required: false
+        default: '50'
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Is main trailing stage?
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history — we compare branches)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+
+      - name: Measure the gap
+        id: gap
+        env:
+          MAX_AGE_DAYS: ${{ inputs.max_age_days || '7' }}
+          MAX_COMMITS: ${{ inputs.max_commits || '50' }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet origin main stage
+
+          BEHIND=$(git rev-list --count origin/main..origin/stage)
+          LAST_RELEASE_TS=$(git log -1 --format=%ct origin/main)
+          AGE_DAYS=$(( ( $(date -u +%s) - LAST_RELEASE_TS ) / 86400 ))
+          LAST_RELEASE_DATE=$(git log -1 --format=%cs origin/main)
+
+          echo "behind=$BEHIND"       >> "$GITHUB_OUTPUT"
+          echo "age_days=$AGE_DAYS"   >> "$GITHUB_OUTPUT"
+          echo "last_date=$LAST_RELEASE_DATE" >> "$GITHUB_OUTPUT"
+
+          if [ "$BEHIND" -gt "$MAX_COMMITS" ] || [ "$AGE_DAYS" -gt "$MAX_AGE_DAYS" ]; then
+            echo "stalled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stalled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "### Release train"
+            echo ""
+            echo "| | |"
+            echo "|---|---|"
+            echo "| \`main\` last moved | $LAST_RELEASE_DATE (${AGE_DAYS}d ago) |"
+            echo "| Commits on \`stage\` not in \`main\` | $BEHIND |"
+            echo "| Thresholds | ${MAX_AGE_DAYS}d / ${MAX_COMMITS} commits |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or refresh the tracking issue
+        if: steps.gap.outputs.stalled == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const behind  = '${{ steps.gap.outputs.behind }}';
+            const ageDays = '${{ steps.gap.outputs.age_days }}';
+            const lastDate = '${{ steps.gap.outputs.last_date }}';
+            const marker = '<!-- release-stall-check -->';
+
+            const body = [
+              marker,
+              `\`main\` last moved on **${lastDate}** — **${ageDays} days ago** — and **${behind} commits** are sitting on \`stage\` unreleased.`,
+              '',
+              'Nothing is broken. `Release` only fires on a push to `main`, and the `stage → main` cut is a manual pull request — so a stalled train looks identical to a healthy one from the outside.',
+              '',
+              'To cut a release, see `RELEASE.md` → *How to release a new version*.',
+              '',
+              '_This issue is opened and refreshed automatically by `release-stall-check`. It closes itself once `main` catches up._',
+            ].join('\n');
+
+            const existing = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'release-stall',
+            });
+            const issue = existing.find(i => (i.body || '').includes(marker));
+
+            if (issue) {
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: issue.number, body,
+              });
+              core.notice(`Refreshed #${issue.number} — main is ${ageDays}d / ${behind} commits behind stage.`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner, repo: context.repo.repo,
+                title: `Release train stalled — main is ${ageDays} days behind stage`,
+                body, labels: ['release-stall'],
+              });
+              core.notice(`Opened #${created.data.number}.`);
+            }
+
+      - name: Close the tracking issue once main catches up
+        if: steps.gap.outputs.stalled == 'false'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const marker = '<!-- release-stall-check -->';
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner, repo: context.repo.repo,
+              state: 'open', labels: 'release-stall',
+            });
+            for (const i of open.filter(i => (i.body || '').includes(marker))) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: i.number,
+                body: '`main` has caught up with `stage`. Closing.',
+              });
+              await github.rest.issues.update({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: i.number, state: 'closed',
+              });
+            }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -177,10 +177,15 @@ Each package is published independently:
 1. **Bump the version** in the appropriate file(s) on the `develop` branch.
 2. **Cut the changelog** in the *same* pull request, so the cut rides the normal `develop → stage → main` promotion:
    ```bash
+   # Fill [Unreleased] from commit history first — it is maintained by hand and
+   # in practice it is empty. Hand-written entries are preserved.
+   node scripts/release/generate-unreleased.mjs origin/main origin/stage
+
    # Archive [Unreleased] -> [<server-version>] - <today> and open a fresh [Unreleased].
    node scripts/release/cut-changelog.mjs            # uses the root package.json version + today
    # or pin explicitly:  node scripts/release/cut-changelog.mjs 3.2.0 2026-06-05
    ```
+   Do not skip the first command. The v3.4.0 cut came out **empty** because nothing had been added to `[Unreleased]` since 8 June, which would have shipped blank release notes for all five packages across 445 commits.
    This is what makes the stable GitHub Release notes scoped to the release (see [Release Notes](#release-notes)). Do this in the version-bump PR, **never** auto-commit a cut to `main` from CI (it would re-trigger the release workflow and diverge `main`'s changelog from `develop`).
 3. **Commit and push** to `develop`, then **merge `develop` into `stage`** once the change is ready to be validated:
    ```bash
@@ -190,13 +195,42 @@ Each package is published independently:
    ```
    The next nightly build will create a prerelease with the new version from `stage`.
 4. **Verify the prerelease** by downloading artifacts from the GitHub Releases page.
-5. **Merge `stage` into `main`**:
-   ```bash
-   git checkout main
-   git merge stage
-   git push origin main
-   ```
+5. **Promote `stage` to `main`** — see [Promoting stage to main](#promoting-stage-to-main) below. A plain `git merge stage` will not work.
 6. The release workflow triggers automatically and publishes all packages with new versions.
+7. **Merge the back-merge PR.** `release-backmerge` opens one automatically once the release succeeds. Until it lands, `develop` still carries the old version numbers and the nightly prereleases publish *below* the shipped stable line.
+
+### Promoting stage to main
+
+**A direct `stage → main` merge does not work, and the reason is structural.** Past releases were squash-merged into `main`, so `main` and `stage` share almost no commits. Git treats nearly everything as divergent: the July 2026 attempt produced **105 conflicts**, none of them real. This gets worse with every squashed release.
+
+Until that is changed, promote through a dedicated branch whose *content* is `stage` and whose *parent* is `main`:
+
+```bash
+git fetch origin main stage
+git checkout -B release-to-main-<version> origin/main
+git read-tree -u --reset origin/stage      # working tree becomes stage's, parent stays main
+git commit -m "release: v<version> — stage → main"
+git push -u origin release-to-main-<version>
+# then open a PR against main
+```
+
+**Before doing this, confirm nothing on `main` is about to be dropped** — `main` may hold hotfixes that never came back:
+
+```bash
+# Files that exist on main but not on stage. Each one needs an explanation.
+git diff --diff-filter=D --name-only origin/main origin/stage
+
+# Spot-check the files past hotfixes touched; identical output means stage already has the fix.
+git diff origin/main:<path> origin/stage:<path>
+```
+
+In the v3.4.0 promotion this surfaced `nodes/src/nodes/tool_falkordb/`, present on `main` and absent from `stage` — deliberately reworked into `graph_falkordb`, so dropping it was correct. Verify, do not assume.
+
+### If the release train stalls
+
+`Release` only fires on a push to `main`, and the `stage → main` cut is a manual pull request. Nothing breaks when it is skipped: `develop → stage` keeps flowing and prereleases keep publishing, so a stalled train is indistinguishable from a healthy one. In July 2026 that ran for 15 days with 445 commits on `stage`.
+
+The `release-stall-check` workflow now measures the gap on weekdays and opens a tracking issue past 7 days or 50 commits. It closes the issue when `main` catches up.
 
 ### Releasing a single package
 

--- a/scripts/release/generate-unreleased.mjs
+++ b/scripts/release/generate-unreleased.mjs
@@ -1,0 +1,163 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+/**
+ * Fill the CHANGELOG "[Unreleased]" section from commit history.
+ *
+ * Why this exists: `[Unreleased]` is maintained by hand, and in practice nobody
+ * maintains it. In July 2026 the v3.4.0 cut came out **empty** — nothing had been
+ * added since 8 June — which would have shipped blank GitHub Release notes for
+ * all five packages across 445 commits of real work. Release notes that depend on
+ * discipline are release notes that end up empty.
+ *
+ * Run this immediately BEFORE `cut-changelog.mjs` in the version-bump PR:
+ *
+ *   node scripts/release/generate-unreleased.mjs origin/main origin/stage
+ *   node scripts/release/cut-changelog.mjs
+ *
+ * Conventional-commit prefixes map to Keep a Changelog sections:
+ *   feat                      -> Added
+ *   fix                       -> Fixed
+ *   perf / refactor / style   -> Changed
+ * Everything else (chore, docs, ci, test, build) is counted, not listed — the
+ * notes are for people consuming the packages, not for the commit log.
+ *
+ * Anything already written under [Unreleased] by hand is preserved: generated
+ * entries are appended below it, never on top of it. Curated prose beats
+ * generated prose, so we never throw it away.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+const CHANGELOG = 'CHANGELOG.md';
+
+const [, , fromRef = 'origin/main', toRef = 'origin/stage'] = process.argv;
+
+const SECTION_FOR = {
+  feat: 'Added',
+  fix: 'Fixed',
+  perf: 'Changed',
+  refactor: 'Changed',
+  style: 'Changed',
+};
+const ORDER = ['Added', 'Fixed', 'Changed'];
+
+function subjects(from, to) {
+  const out = execFileSync(
+    'git',
+    ['log', '--no-merges', '--format=%s', `${from}..${to}`],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  return out.split('\n').filter(Boolean);
+}
+
+function build(lines) {
+  const groups = new Map(ORDER.map((s) => [s, []]));
+  const counts = new Map();
+  const seen = new Set();
+
+  for (const raw of lines) {
+    // Drop the trailing "(#1234)" GitHub adds on squash merges.
+    const subject = raw.replace(/\s*\(#\d+\)\s*$/, '').trim();
+    const m = subject.match(/^(\w+)(\(([^)]*)\))?!?:\s*(.+)$/);
+    if (!m) {
+      counts.set('uncategorised', (counts.get('uncategorised') ?? 0) + 1);
+      continue;
+    }
+    const [, type, , scope, rest] = m;
+    const kind = type.toLowerCase();
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+
+    const section = SECTION_FOR[kind];
+    if (!section) continue;
+
+    const text = rest.charAt(0).toUpperCase() + rest.slice(1);
+    const entry = scope ? `- **${scope}** — ${text}` : `- ${text}`;
+    const key = entry.toLowerCase();
+    if (seen.has(key)) continue; // the same fix cherry-picked twice reads as noise
+    seen.add(key);
+    groups.get(section).push(entry);
+  }
+
+  const parts = [];
+  for (const section of ORDER) {
+    const items = groups.get(section);
+    if (!items.length) continue;
+    items.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+    parts.push(`### ${section}`, '', ...items, '');
+  }
+
+  const omitted = ['chore', 'docs', 'ci', 'test', 'build', 'uncategorised']
+    .map((k) => [k, counts.get(k) ?? 0])
+    .filter(([, n]) => n > 0);
+
+  if (omitted.length) {
+    parts.push(
+      '### Maintenance',
+      '',
+      `- ${omitted.map(([k, n]) => `${n} ${k}`).join(', ')} commits are omitted from the list above.`,
+      '',
+    );
+  }
+
+  return { body: parts.join('\n'), counts, groups };
+}
+
+const changelog = readFileSync(CHANGELOG, 'utf8');
+const header = changelog.match(/^## \[Unreleased\].*$/m);
+if (!header) {
+  console.error('No "## [Unreleased]" heading in CHANGELOG.md — nothing to fill.');
+  process.exit(1);
+}
+
+const start = header.index + header[0].length;
+const nextHeading = changelog.slice(start).search(/^## \[/m);
+const end = nextHeading === -1 ? changelog.length : start + nextHeading;
+const existing = changelog.slice(start, end).trim();
+
+const lines = subjects(fromRef, toRef);
+if (!lines.length) {
+  console.error(`No commits in ${fromRef}..${toRef} — leaving CHANGELOG untouched.`);
+  process.exit(0);
+}
+
+const { body, counts, groups } = build(lines);
+if (!body.trim()) {
+  console.error('No user-facing commits (feat/fix/perf/refactor/style) — leaving CHANGELOG untouched.');
+  process.exit(0);
+}
+
+const kept = existing ? `${existing}\n\n` : '';
+const updated =
+  changelog.slice(0, start) + '\n\n' + kept + body.trimEnd() + '\n\n' + changelog.slice(end);
+
+writeFileSync(CHANGELOG, updated);
+
+const n = (s) => groups.get(s).length;
+console.log(
+  `Filled [Unreleased] from ${fromRef}..${toRef}: ` +
+    `${n('Added')} Added, ${n('Fixed')} Fixed, ${n('Changed')} Changed ` +
+    `(${lines.length} commits scanned).`,
+);
+if (existing) console.log('Existing hand-written entries were preserved above the generated ones.');


### PR DESCRIPTION
Today's v3.4.0 cut hit three separate failures in the release process. **None of them announced itself** — that is the common thread, and it is what this PR addresses.

### 1 · `release-stall-check` — make the silence audible

`Release` only fires on a push to `main`, and the `stage → main` cut is a manual pull request. Skipping it breaks nothing: `develop → stage` keeps flowing and prereleases keep publishing off `develop`, so from the outside a stalled train is indistinguishable from a healthy one.

It ran **15 days with 445 commits sitting on `stage`** before anyone noticed, and only because someone asked why there had been no extension release.

Weekday job, measures how far `main` trails `stage`, opens **one** tracking issue past 7 days or 50 commits, closes it when `main` catches up. Thresholds are dispatch inputs.

### 2 · `release-backmerge` — stop the version drift at the source

Version bumps land on `stage` and `main` and never return to `develop`. So `develop` keeps the pre-release numbers while `main` carries the released ones, and the nightly prereleases publish **below** the shipped stable line — that is exactly how `vscode-v1.2.0-prerelease` came out *after* stable `v1.3.0`.

Every release made the gap wider. This opens a back-merge PR as soon as a release succeeds. It opens a PR rather than pushing, because `develop` is protected and the merge can legitimately conflict — a conflicted back-merge deserves a human.

### 3 · `generate-unreleased.mjs` — release notes that don't depend on discipline

`[Unreleased]` is maintained by hand, and in practice nobody maintains it. The v3.4.0 cut came out **empty** (nothing since 8 June), which would have shipped blank GitHub Release notes for all five packages across 445 commits of real work.

Fills `[Unreleased]` from commit history using the conventional-commit prefixes. Hand-written entries are **preserved above** the generated ones — curated prose beats generated prose.

Verified against the real range: `92 Added, 169 Fixed, 10 Changed` from 437 commits, and a hand-written entry survives a second run.

### 4 · `RELEASE.md` — write down what I had to rediscover

A direct `stage → main` merge **does not work**: past releases were squashed into `main`, so the branches share almost no history and git reports **105 conflicts**, none of them real. The documented step 5 (`git merge stage`) cannot succeed as written.

Now documented: the dedicated `release-to-main-<version>` branch (content of `stage`, parent `main`), plus the pre-flight check for hotfixes that live only on `main` — which in this release surfaced `tool_falkordb`, correctly dropped because it had been reworked into `graph_falkordb`.

---

**Not addressed here, needs a decision rather than code:** whether to stop squashing `stage → main` (which would end the divergence permanently), and who owns the cut and on what cadence.
