### PR TITLE
fix: flatten Anthropic typed-block content on the non-streaming path

### DIFF
--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -38,6 +38,32 @@ def _stop_kwargs() -> dict:
     return {'stop': stop} if stop else {}
 
 
+def _flatten_content(content: Any) -> str:
+    """Normalize an LLM response's ``content`` to plain answer text.
+
+    OpenAI-style providers return a ``str``; Anthropic (and LangChain v1) return a list
+    of typed blocks, where ``text`` blocks are the visible answer and ``thinking`` /
+    ``reasoning`` blocks are internal and must not leak into the answer. The non-streaming
+    path returned this list verbatim, so ``expectJson`` agent calls hit
+    ``parseJson(list)`` → ``.strip()`` and crashed; other agents surfaced the raw blocks.
+    This mirrors the block handling already applied on the streaming path in
+    ``chat_string`` and always yields a ``str``.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get('type') == 'text':
+                parts.append(block.get('text', '') or '')
+        return ''.join(parts)
+    if content is None:
+        return ''
+    return str(content)
+
+
 def _make_think_tag_splitter():
     """Split ``<think>...</think>`` CoT out of the content stream (Ollama, Perplexity).
 
@@ -242,8 +268,10 @@ class ChatBase:
         # so non-agent callers (and backends/mocks without a stop param) are unaffected.
         results = self._llm.invoke(prompt, **_stop_kwargs())
 
-        # Return the results
-        return results.content
+        # Return the results. Flatten typed-block content (Anthropic / LangChain v1) to a
+        # str — this path feeds parseJson() for expectJson agent calls, which would crash
+        # on a raw list.
+        return _flatten_content(results.content)
 
     def getTokens(self, value: str) -> int:
         """
@@ -497,8 +525,7 @@ class ChatBase:
             # the full fallback would arrive on top of the partial we already streamed.
             if emitted is None or not emitted['any']:
                 results = self._llm.invoke(prompt, **_stop_kwargs())
-                content = getattr(results, 'content', '') or ''
-                content_text = content if isinstance(content, str) else str(content)
+                content_text = _flatten_content(getattr(results, 'content', ''))
                 text_parts = [content_text]
                 # Push the fallback answer through on_chunk so the open UI bubble
                 # gets the visible text (the caller dedupes the final pipeline result).
@@ -717,8 +744,9 @@ class ChatBase:
                     answer.setAnswer(parsed_response)
                     return answer
 
-                except (json.JSONDecodeError, ValueError):
-                    # JSON parsing failed
+                except (json.JSONDecodeError, ValueError, AttributeError, TypeError):
+                    # JSON parsing failed (AttributeError/TypeError guard against a
+                    # non-str response reaching parseJson) — retry instead of killing the wave
                     if retry_count < max_retries - 1:
                         debug(f'JSON validation failed on attempt {retry_count + 1}, retrying...')
 

--- a/packages/ai/tests/ai/common/test_chat_content.py
+++ b/packages/ai/tests/ai/common/test_chat_content.py
@@ -1,0 +1,139 @@
+"""Unit tests for ``chat._flatten_content``.
+
+Pins the fix for the agent crash on Anthropic (and LangChain v1) responses: those
+providers return ``content`` as a list of typed blocks, not a ``str``. The non-streaming
+path returned that list verbatim, so ``expectJson`` agent calls hit ``parseJson(list)`` →
+``.strip()`` and crashed (``'list' object has no attribute 'strip'``), while other agents
+surfaced the raw blocks (leaking internal ``thinking`` text and Anthropic ``signature``
+values into the answer). ``_flatten_content`` normalizes any content shape to plain answer
+text, keeping only ``text`` blocks and dropping ``thinking`` / ``reasoning`` blocks.
+
+Loaded by file path with chat.py's engine/sibling imports stubbed so no engine runtime is
+needed — run with ``pytest --noconftest``.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+_CHAT_PATH = Path(__file__).resolve().parents[3] / 'src' / 'ai' / 'common' / 'chat.py'
+
+
+def _load_flatten_content():
+    """Load chat.py by path with its engine/sibling imports stubbed."""
+    stub_names = (
+        'rocketlib',
+        'ai',
+        'ai.common',
+        'ai.common.schema',
+        'ai.common.config',
+        'ai.common.util',
+        'ai.common.validation',
+        'ai.common.llm_native_stream',
+    )
+    saved = {k: sys.modules.get(k) for k in stub_names}
+
+    rl = types.ModuleType('rocketlib')
+    rl.debug = lambda *a, **k: None
+    rl.warning = lambda *a, **k: None
+
+    ai_pkg = types.ModuleType('ai')
+    ai_pkg.__path__ = []
+    common_pkg = types.ModuleType('ai.common')
+    common_pkg.__path__ = []
+
+    schema = types.ModuleType('ai.common.schema')
+    schema.Answer = type('Answer', (), {})
+    schema.Question = type('Question', (), {})
+
+    config = types.ModuleType('ai.common.config')
+    config.Config = type('Config', (), {})
+
+    util = types.ModuleType('ai.common.util')
+    util.parseJson = lambda value: value
+
+    validation = types.ModuleType('ai.common.validation')
+    validation.validate_model_name = lambda *a, **k: None
+    validation.validate_max_tokens = lambda *a, **k: None
+    validation.validate_prompt = lambda prompt, *a, **k: prompt
+
+    native = types.ModuleType('ai.common.llm_native_stream')
+    native.STOP_SEQUENCES_VAR = contextvars.ContextVar('STOP_SEQUENCES_VAR', default=None)
+    native.dispatch_native_chat_stream = lambda *a, **k: None
+
+    sys.modules.update(
+        {
+            'rocketlib': rl,
+            'ai': ai_pkg,
+            'ai.common': common_pkg,
+            'ai.common.schema': schema,
+            'ai.common.config': config,
+            'ai.common.util': util,
+            'ai.common.validation': validation,
+            'ai.common.llm_native_stream': native,
+        }
+    )
+
+    try:
+        spec = importlib.util.spec_from_file_location('rr_chat_undertest', _CHAT_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod._flatten_content
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+_flatten_content = _load_flatten_content()
+
+
+class TestFlattenContent:
+    def test_plain_string_passthrough(self):
+        assert _flatten_content('hello world') == 'hello world'
+
+    def test_none_returns_empty_string(self):
+        assert _flatten_content(None) == ''
+
+    def test_anthropic_blocks_keep_only_text(self):
+        # The exact shape that crashed the agent: a thinking block + a text block.
+        content = [
+            {'type': 'thinking', 'thinking': 'internal reasoning', 'signature': 'ErQC...'},
+            {'type': 'text', 'text': 'Hello!'},
+        ]
+        assert _flatten_content(content) == 'Hello!'
+
+    def test_thinking_and_signature_never_leak(self):
+        out = _flatten_content(
+            [
+                {'type': 'thinking', 'thinking': 'do not leak me', 'signature': 'sig'},
+                {'type': 'text', 'text': 'visible answer'},
+            ]
+        )
+        assert 'do not leak me' not in out
+        assert 'sig' not in out
+
+    def test_reasoning_block_dropped(self):
+        content = [
+            {'type': 'text', 'text': 'A'},
+            {'type': 'reasoning', 'reasoning': 'chain of thought'},
+            {'type': 'text', 'text': 'B'},
+        ]
+        assert _flatten_content(content) == 'AB'
+
+    def test_bare_string_blocks_joined(self):
+        assert _flatten_content(['foo', 'bar']) == 'foobar'
+
+    def test_result_is_always_a_stripable_string(self):
+        # The original bug was parseJson calling .strip() on a list. Whatever the shape,
+        # the result must be a str so downstream .strip()/parse never raises.
+        for content in ('x', None, [{'type': 'text', 'text': 'y'}], [{'type': 'thinking', 'thinking': 'z'}], 123):
+            result = _flatten_content(content)
+            assert isinstance(result, str)
+            result.strip()  # must not raise


### PR DESCRIPTION
## Description

Defense-in-depth fix for agents breaking when the Anthropic LLM has extended thinking on.

When thinking is enabled, Anthropic returns content as a list of typed blocks (thinking +
text) instead of a string. Agents ask with `expectJson`, which disables streaming and routes
to the non-streaming path; that path returned `results.content` verbatim, so the block list
reached `parseJson(...).strip()` and crashed the wave (`'list' object has no attribute 'strip'`).
Other agents surfaced the raw blocks, leaking internal thinking text and signatures.

`_flatten_content()` normalizes any content shape to plain answer text (keep `text` blocks,
drop `thinking` / `reasoning`), mirroring the streaming path. It is identity for strings, so
providers that already return a string are unchanged. Used on both non-streaming `invoke`
sites, and the retry `except` is widened so a non-str response retries instead of killing the
wave.

## Root cause and scope

The trigger was #987 (47d7e6dd) setting `reasoning = true` on the Anthropic models, which turns
on thinking. It is not a LangChain change (old and new both return a block list with thinking
on). 16 of 18 Anthropic models currently break; only Haiku still works, and only because the
mode table blanket-rejects it. Reproduced on 5/5 agent frameworks. OpenAI is unaffected
(reasoning handled separately, content stays a string).

This PR is the defense-in-depth layer and is needed regardless of the model set. The
root-cause fix, scoping thinking activation to the call context plus correcting the per-model
mode table, is a separate follow-up (Ariel).

## Linked issue

Fixes #1658

## Testing

- New `packages/ai/tests/ai/common/test_chat_content.py` (7 cases): string passthrough,
  `None` -> `''`, Anthropic `[thinking, text]` -> text only, thinking/signature never leak,
  reasoning blocks dropped, bare-string blocks joined, and "result is always a stripable str".
- `pytest tests/ai/common/test_chat_content.py --noconftest` -> 7 passed.
- Verified on a fresh develop build (langchain-anthropic 1.5.0, the version that reproduces
  the crash) across all five agent frameworks (rocketride, deepagent, crewai, langchain,
  llamaindex): Anthropic passes 5/5 (crash before, pass after), and OpenAI passes 5/5 with
  no change, confirming the shared-path flatten does not affect other providers.

