### PR TITLE
style(docs): ruff format markdown code blocks (clear CI debt)

### DIFF
--- a/docs/README-mcp-client.md
+++ b/docs/README-mcp-client.md
@@ -159,15 +159,15 @@ In Claude Desktop or any MCP-compatible client, resources are listed automatical
 
 ```python
 # Example: read the pipeline list resource
-result = await session.read_resource("rocketride://pipelines")
+result = await session.read_resource('rocketride://pipelines')
 # Returns: {"pipelines": [{"name": "my-pipeline", "description": "..."}, ...]}
 
 # Example: check server status
-result = await session.read_resource("rocketride://status")
+result = await session.read_resource('rocketride://status')
 # Returns: {"connected": true, "pipeline_count": 3, "pipelines": ["pipe-a", "pipe-b", "pipe-c"]}
 
 # Example: list available node types
-result = await session.read_resource("rocketride://nodes")
+result = await session.read_resource('rocketride://nodes')
 # Returns: {"nodes": [{"name": "llm-openai", "type": "processor"}, ...]}
 ```
 
@@ -236,10 +236,9 @@ This generates the message: _"Evaluate the output quality of the RocketRide pipe
 prompts = await session.list_prompts()
 
 # Get a rendered prompt
-result = await session.get_prompt("analyze-document", arguments={
-    "pipeline": "my-pipeline",
-    "query": "Summarize the key findings"
-})
+result = await session.get_prompt(
+    'analyze-document', arguments={'pipeline': 'my-pipeline', 'query': 'Summarize the key findings'}
+)
 # result.messages[0].content.text contains the rendered message
 ```
 

--- a/docs/README-nodes.md
+++ b/docs/README-nodes.md
@@ -283,6 +283,7 @@ standalone catalog nodes.
    from .IInstance import IInstance
    from .IGlobal import IGlobal
 
+
    # nodes/src/nodes/my_node/my_node.py
    class MyNode:
        def __init__(self, config):

--- a/docs/README-python-client.md
+++ b/docs/README-python-client.md
@@ -23,13 +23,15 @@ pip install rocketride
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    async with RocketRideClient(uri="https://api.rocketride.ai", auth="my-key") as client:
-        result = await client.use(filepath="pipeline.pipe")
-        token = result["token"]
-        out = await client.send(token, "Hello, pipeline!", objinfo={"name": "input.txt"}, mimetype="text/plain")
+    async with RocketRideClient(uri='https://api.rocketride.ai', auth='my-key') as client:
+        result = await client.use(filepath='pipeline.pipe')
+        token = result['token']
+        out = await client.send(token, 'Hello, pipeline!', objinfo={'name': 'input.txt'}, mimetype='text/plain')
         print(out)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -132,11 +134,11 @@ Raises `ValueError` if both `uri` and `ROCKETRIDE_URI` are empty or if `auth` is
 
 ```python
 client = RocketRideClient(
-    uri="https://api.rocketride.ai",
-    auth="my-key",
+    uri='https://api.rocketride.ai',
+    auth='my-key',
     persist=True,
     max_retry_time=300000,
-    on_connect_error=lambda msg: print("Connect error:", msg),
+    on_connect_error=lambda msg: print('Connect error:', msg),
     on_event=handle_event,
 )
 ```
@@ -153,10 +155,10 @@ client = RocketRideClient(
 **Example:**
 
 ```python
-async with RocketRideClient(uri="wss://api.rocketride.ai", auth=os.environ["ROCKETRIDE_APIKEY"]) as client:
-    result = await client.use(filepath="pipeline.pipe")
-    token = result["token"]
-    await client.send(token, "Hello, pipeline!")
+async with RocketRideClient(uri='wss://api.rocketride.ai', auth=os.environ['ROCKETRIDE_APIKEY']) as client:
+    result = await client.use(filepath='pipeline.pipe')
+    token = result['token']
+    await client.send(token, 'Hello, pipeline!')
 ```
 
 ### Connection
@@ -182,14 +184,14 @@ async with RocketRideClient(uri="wss://api.rocketride.ai", auth=os.environ["ROCK
 
 ```python
 # Two-step (build then request)
-req = client.build_request("rrext_monitor", token=token, arguments={"types": ["apaevt_status_upload"]})
+req = client.build_request('rrext_monitor', token=token, arguments={'types': ['apaevt_status_upload']})
 res = await client.request(req, timeout=5000)
 
 # One-step with dap_request
-res = await client.dap_request("rrext_services", {}, timeout=5000)
+res = await client.dap_request('rrext_services', {}, timeout=5000)
 
 if client.did_fail(res):
-    raise RuntimeError(res.get("message", "Request failed"))
+    raise RuntimeError(res.get('message', 'Request failed'))
 ```
 
 ### Pipeline execution
@@ -215,13 +217,13 @@ if client.did_fail(res):
 **Example - send a string:**
 
 ```python
-result = await client.send(token, "Hello, pipeline!", objinfo={"name": "greeting.txt"}, mimetype="text/plain")
+result = await client.send(token, 'Hello, pipeline!', objinfo={'name': 'greeting.txt'}, mimetype='text/plain')
 ```
 
 **Example - stream with a pipe:**
 
 ```python
-pipe = await client.pipe(token, mime_type="application/json")
+pipe = await client.pipe(token, mime_type='application/json')
 await pipe.open()
 await pipe.write(b'{"key": "value1"}')
 await pipe.write(b'{"key": "value2"}')
@@ -356,14 +358,14 @@ from rocketride.core.exceptions import PipeException, ExecutionException
 
 try:
     async with RocketRideClient(uri=uri, auth=auth) as client:
-        result = await client.use(filepath="pipeline.pipe")
-        await client.send(result["token"], data)
+        result = await client.use(filepath='pipeline.pipe')
+        await client.send(result['token'], data)
 except AuthenticationException:
-    print("Bad credentials")
+    print('Bad credentials')
 except ExecutionException as e:
-    print(f"Pipeline failed: {e}")
+    print(f'Pipeline failed: {e}')
 except PipeException as e:
-    print(f"Data transfer error: {e}")
+    print(f'Data transfer error: {e}')
 ```
 
 ---
@@ -376,15 +378,17 @@ except PipeException as e:
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    client = RocketRideClient(uri="https://api.rocketride.ai", auth="my-key")
+    client = RocketRideClient(uri='https://api.rocketride.ai', auth='my-key')
     await client.connect()
-    result = await client.use(filepath="pipeline.pipe")
-    token = result["token"]
-    out = await client.send(token, "Hello, pipeline!", objinfo={"name": "input.txt"}, mimetype="text/plain")
+    result = await client.use(filepath='pipeline.pipe')
+    token = result['token']
+    out = await client.send(token, 'Hello, pipeline!', objinfo={'name': 'input.txt'}, mimetype='text/plain')
     print(out)
     await client.terminate(token)
     await client.disconnect()
+
 
 asyncio.run(main())
 ```
@@ -395,14 +399,16 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    async with RocketRideClient(uri="wss://api.rocketride.ai", auth="my-key") as client:
-        result = await client.use(pipeline={"pipeline": my_pipeline_config})
-        token = result["token"]
+    async with RocketRideClient(uri='wss://api.rocketride.ai', auth='my-key') as client:
+        result = await client.use(pipeline={'pipeline': my_pipeline_config})
+        token = result['token']
         await client.send(token, '{"data": 1}')
         status = await client.get_task_status(token)
         print(status)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -413,19 +419,21 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
     client = RocketRideClient(
-        uri="https://api.rocketride.ai",
-        auth="my-key",
+        uri='https://api.rocketride.ai',
+        auth='my-key',
         persist=True,
         max_retry_time=300000,
-        on_connected=lambda info: print("Connected:", info),
-        on_disconnected=lambda reason, has_error: print("Disconnected:", reason, has_error),
-        on_connect_error=lambda msg: print("Connect error:", msg),
-        on_event=lambda e: print(e.get("event"), e.get("body")),
+        on_connected=lambda info: print('Connected:', info),
+        on_disconnected=lambda reason, has_error: print('Disconnected:', reason, has_error),
+        on_connect_error=lambda msg: print('Connect error:', msg),
+        on_event=lambda e: print(e.get('event'), e.get('body')),
     )
     await client.connect()
     # Later: use(), send_files(), etc. If connection drops, client retries; do not call disconnect() in on_disconnected.
+
 
 asyncio.run(main())
 ```
@@ -437,29 +445,31 @@ import asyncio
 from pathlib import Path
 from rocketride import RocketRideClient
 
-async def main():
-    client = RocketRideClient(uri="https://api.rocketride.ai", auth="my-key")
-    await client.connect()
-    result = await client.use(filepath="vectorize.pipe")
-    token = result["token"]
-    await client.set_events(token, ["apaevt_status_upload", "apaevt_status_processing"])
 
-    files = ["doc1.md", "doc2.md", ("doc3.json", {"tag": "export"}, "application/json")]
+async def main():
+    client = RocketRideClient(uri='https://api.rocketride.ai', auth='my-key')
+    await client.connect()
+    result = await client.use(filepath='vectorize.pipe')
+    token = result['token']
+    await client.set_events(token, ['apaevt_status_upload', 'apaevt_status_processing'])
+
+    files = ['doc1.md', 'doc2.md', ('doc3.json', {'tag': 'export'}, 'application/json')]
     upload_results = await client.send_files(files, token)
     for r in upload_results:
-        if r["action"] == "complete":
-            print("OK", r["filepath"])
+        if r['action'] == 'complete':
+            print('OK', r['filepath'])
         else:
-            print("Failed", r["filepath"], r.get("error"))
+            print('Failed', r['filepath'], r.get('error'))
 
     while True:
         status = await client.get_task_status(token)
-        print(f"Progress: {status.get('completedCount', 0)}/{status.get('totalCount', 0)}")
-        if status.get("completed"):
+        print(f'Progress: {status.get("completedCount", 0)}/{status.get("totalCount", 0)}')
+        if status.get('completed'):
             break
         await asyncio.sleep(2)
     await client.terminate(token)
     await client.disconnect()
+
 
 asyncio.run(main())
 ```
@@ -470,13 +480,14 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    async with RocketRideClient(uri="https://api.rocketride.ai", auth="my-key") as client:
-        result = await client.use(filepath="ingest.pipe")
-        token = result["token"]
-        pipe = await client.pipe(token, objinfo={"name": "large.csv"}, mime_type="text/csv")
+    async with RocketRideClient(uri='https://api.rocketride.ai', auth='my-key') as client:
+        result = await client.use(filepath='ingest.pipe')
+        token = result['token']
+        pipe = await client.pipe(token, objinfo={'name': 'large.csv'}, mime_type='text/csv')
         await pipe.open()
-        with open("large.csv", "rb") as f:
+        with open('large.csv', 'rb') as f:
             while True:
                 chunk = f.read(64 * 1024)
                 if not chunk:
@@ -485,6 +496,7 @@ async def main():
         result = await pipe.close()
         print(result)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -496,24 +508,26 @@ import asyncio
 from rocketride import RocketRideClient
 from rocketride.schema import Question, Answer
 
+
 async def main():
-    async with RocketRideClient(uri="https://api.rocketride.ai", auth="my-key") as client:
-        result = await client.use(filepath="chat_pipeline.pipe")
-        token = result["token"]
+    async with RocketRideClient(uri='https://api.rocketride.ai', auth='my-key') as client:
+        result = await client.use(filepath='chat_pipeline.pipe')
+        token = result['token']
         question = Question(expectJson=True)
-        question.addInstruction("Format", "Return a JSON object with keys: summary, keywords.")
-        question.addExample("Summarize X", {"summary": "...", "keywords": ["a", "b"]})
-        question.addQuestion("Summarize the main points and list keywords.")
+        question.addInstruction('Format', 'Return a JSON object with keys: summary, keywords.')
+        question.addExample('Summarize X', {'summary': '...', 'keywords': ['a', 'b']})
+        question.addQuestion('Summarize the main points and list keywords.')
         response = await client.chat(token=token, question=question)
-        answer_text = response.get("data", {}).get("answer") or (response.get("answers") or [None])[0]
+        answer_text = response.get('data', {}).get('answer') or (response.get('answers') or [None])[0]
         answer = Answer(expectJson=True)
-        answer.setAnswer(answer_text or "")
+        answer.setAnswer(answer_text or '')
         if answer.isJson():
             structured = answer.getJson()
         else:
             structured = answer.getText()
         print(structured)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -524,19 +538,21 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    client = RocketRideClient(uri="https://api.rocketride.ai", auth="my-key")
+    client = RocketRideClient(uri='https://api.rocketride.ai', auth='my-key')
     await client.connect()
     services = await client.get_services()
-    print("Available:", list(services.keys()))
-    ocr = await client.get_service("ocr")
+    print('Available:', list(services.keys()))
+    ocr = await client.get_service('ocr')
     if ocr:
-        print("OCR schema:", ocr.get("schema"))
-    req = client.build_request("rrext_ping", token=my_token)
+        print('OCR schema:', ocr.get('schema'))
+    req = client.build_request('rrext_ping', token=my_token)
     res = await client.request(req, timeout=5000)
     if client.did_fail(res):
-        raise RuntimeError(res.get("message", "Ping failed"))
+        raise RuntimeError(res.get('message', 'Ping failed'))
     await client.disconnect()
+
 
 asyncio.run(main())
 ```

--- a/docs/agents/ROCKETRIDE_COMMON_MISTAKES.md
+++ b/docs/agents/ROCKETRIDE_COMMON_MISTAKES.md
@@ -27,12 +27,7 @@ A comprehensive guide to avoiding common pitfalls when building RocketRide pipel
 
 ```python
 # Pipeline has custom laneName
-{
-  "provider": "response_answers",
-  "config": {
-    "lanes": [{"laneId": "answers", "laneName": "chat_response"}]
-  }
-}
+{'provider': 'response_answers', 'config': {'lanes': [{'laneId': 'answers', 'laneName': 'chat_response'}]}}
 
 # But code expects default key
 response = await client.chat(token=token, question=question)
@@ -358,7 +353,7 @@ for key, lane_type in result_types.items():
 if answer_key and answer_key in response and len(response[answer_key]) > 0:
     answer = response[answer_key][0]
 else:
-    answer = "No answer received"
+    answer = 'No answer received'
 ```
 
 **Simpler Solution (if you know you're using defaults):**
@@ -366,7 +361,7 @@ else:
 ```python
 # Use .get() with defaults
 answers = response.get('answers', [])
-answer = answers[0] if answers else "No answer received"
+answer = answers[0] if answers else 'No answer received'
 ```
 
 **Understanding result_types:**
@@ -378,7 +373,7 @@ response = {
     'chat_response': ['The answer...'],  # Actual data
     'result_types': {'chat_response': 'answers'},  # Maps 'chat_response' → 'answers' lane
     'name': 'Question 1',
-    'objectId': '...'
+    'objectId': '...',
 }
 
 # result_types tells you:
@@ -405,7 +400,7 @@ def extract_answer(response: dict) -> str:
 
     # Fallback: try default 'answers' key
     answers = response.get('answers', [])
-    return answers[0] if answers else "No answer received"
+    return answers[0] if answers else 'No answer received'
 ```
 
 **Best Practice (TypeScript):**
@@ -445,7 +440,7 @@ function extractAnswer(response: any): string {
 
 ```python
 # Python: Chat pipeline but using send()
-response = await client.send(token, "Hello")  # ERROR: Chat source expects Question objects
+response = await client.send(token, 'Hello')  # ERROR: Chat source expects Question objects
 ```
 
 ```typescript
@@ -463,7 +458,7 @@ The `send()` method is for raw data (webhook/dropper sources), not for conversat
 from rocketride.schema import Question
 
 question = Question()
-question.addQuestion("Hello")
+question.addQuestion('Hello')
 response = await client.chat(token=token, question=question)  # CORRECT: Correct for chat source
 ```
 
@@ -588,6 +583,7 @@ await client.connect()
 result = await client.use(filepath='chat.pipe')  # CORRECT: Start once
 token = result['token']
 
+
 async def ask_question(question_text):
     # Just use the existing pipeline
     question = Question()
@@ -595,9 +591,10 @@ async def ask_question(question_text):
     response = await client.chat(token=token, question=question)  # CORRECT: Reuse token
     return response
 
+
 # Ask many questions
-answer1 = await ask_question("What is AI?")
-answer2 = await ask_question("Tell me more")
+answer1 = await ask_question('What is AI?')
+answer2 = await ask_question('Tell me more')
 
 # Disconnect when done
 await client.disconnect()
@@ -843,7 +840,7 @@ ROCKETRIDE_QDRANT_HOST=localhost
 # Python: Blocking the event loop with synchronous input()
 async def chat_loop():
     while True:
-        user_input = input("You: ")  # ERROR: BLOCKS the entire event loop!
+        user_input = input('You: ')  # ERROR: BLOCKS the entire event loop!
         response = await client.chat(token=token, question=question)
         print(response)
 ```
@@ -890,13 +887,15 @@ from concurrent.futures import ThreadPoolExecutor
 # Create a thread pool for blocking I/O
 _input_executor = ThreadPoolExecutor(max_workers=1)
 
-async def async_input(prompt: str = "") -> str:
+
+async def async_input(prompt: str = '') -> str:
     """
     Non-blocking async input that doesn't block the event loop.
     This allows websocket ping/pong keepalive to work properly.
     """
     loop = asyncio.get_event_loop()
     return await loop.run_in_executor(_input_executor, input, prompt)
+
 
 # Use it in your async code
 async def chat_loop():
@@ -908,7 +907,7 @@ async def chat_loop():
 
     while True:
         # CORRECT: Non-blocking input - event loop stays responsive
-        user_input = await async_input("You: ")
+        user_input = await async_input('You: ')
 
         if user_input.lower() == 'quit':
             break
@@ -918,7 +917,7 @@ async def chat_loop():
 
         # Event loop can process websocket messages while waiting
         response = await client.chat(token=token, question=question)
-        print(f"Bot: {response['answers'][0]}")
+        print(f'Bot: {response["answers"][0]}')
 
     await client.disconnect()
 ```
@@ -1001,9 +1000,9 @@ Both Python and TypeScript/Node.js have other blocking operations that must be a
 
 ```python
 # ERROR: BLOCKING - Don't use these in async functions
-time.sleep(5)           # Use: await asyncio.sleep(5)
-open('file.txt').read() # Use: async with aiofiles.open('file.txt') as f
-requests.get(url)       # Use: async with aiohttp.ClientSession()
+time.sleep(5)  # Use: await asyncio.sleep(5)
+open('file.txt').read()  # Use: async with aiofiles.open('file.txt') as f
+requests.get(url)  # Use: async with aiohttp.ClientSession()
 ```
 
 **TypeScript:**

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -67,6 +67,7 @@ Pipeline files **must** use the `.pipe` extension.
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
     # Client reads configuration from .env automatically
     client = RocketRideClient()
@@ -74,27 +75,28 @@ async def main():
     try:
         # Connect to server
         await client.connect()
-        print("Connected to RocketRide server")
+        print('Connected to RocketRide server')
 
         # Start pipeline
         result = await client.use(filepath='pipeline.pipe')
         token = result['token']
-        print(f"Pipeline started with token: {token}")
+        print(f'Pipeline started with token: {token}')
 
         # Send data
-        await client.send(token, "Hello, RocketRide!")
-        print("Data sent successfully")
+        await client.send(token, 'Hello, RocketRide!')
+        print('Data sent successfully')
 
         # Check status
         status = await client.get_task_status(token)
-        print(f"Pipeline state: {status['state']}")
+        print(f'Pipeline state: {status["state"]}')
 
     finally:
         # Always disconnect
         await client.disconnect()
-        print("Disconnected")
+        print('Disconnected')
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     asyncio.run(main())
 ```
 
@@ -238,6 +240,7 @@ import asyncio
 from rocketride import RocketRideClient
 from rocketride.schema import Question
 
+
 async def main():
     client = RocketRideClient()
     await client.connect()
@@ -245,11 +248,13 @@ async def main():
     token = result['token']
 
     q = Question()
-    q.addQuestion("Hello, how are you?")
+    q.addQuestion('Hello, how are you?')
     response = await client.chat(token=token, question=q)
-    print("Answer:", response.get('answers', [None])[0])
+    print('Answer:', response.get('answers', [None])[0])
 
     await client.disconnect()
+
+
 asyncio.run(main())
 ```
 

--- a/docs/agents/ROCKETRIDE_python_API.md
+++ b/docs/agents/ROCKETRIDE_python_API.md
@@ -75,10 +75,7 @@ You can override `.env` settings by passing parameters directly to the construct
 
 ```python
 # Override for testing or special cases
-client = RocketRideClient(
-    uri='https://api.rocketride.ai',
-    auth='your-api-key'
-)
+client = RocketRideClient(uri='https://api.rocketride.ai', auth='your-api-key')
 ```
 
 ### Environment Variable Substitution in Pipelines
@@ -212,10 +209,10 @@ pipeline = {
     'components': [
         {'id': 'input', 'provider': 'webhook', 'config': {}},
         {'id': 'process', 'provider': 'transform', 'config': {}, 'input': [{'lane': 'text', 'from': 'input'}]},
-        {'id': 'output', 'provider': 'response_text', 'config': {}, 'input': [{'lane': 'text', 'from': 'process'}]}
+        {'id': 'output', 'provider': 'response_text', 'config': {}, 'input': [{'lane': 'text', 'from': 'process'}]},
     ],
     'source': 'input',
-    'project_id': '{guid}'  # Replace with your unique GUID
+    'project_id': '{guid}',  # Replace with your unique GUID
 }
 
 # Start pipeline
@@ -251,26 +248,30 @@ async with RocketRideClient() as client:
 ```python
 from rocketride import RocketRideClient
 
+
 # Declare connection callbacks
 async def on_connected(info: str) -> None:
     print(f'Connected: {info}')
+
 
 async def on_disconnected(reason: str, has_error: bool) -> None:
     if has_error:
         print(f'Connection lost: {reason}')
 
+
 async def on_connect_error(error: str) -> None:
     print(f'Connection attempt failed: {error}')
+
 
 # Create client with automatic reconnection enabled
 client = RocketRideClient(
     uri='https://api.rocketride.ai',
     auth='your-api-key',
-    persist=True,                # Enable automatic reconnection (exponential backoff)
-    max_retry_time=60000,        # Stop retrying after 60 seconds (None = retry forever)
+    persist=True,  # Enable automatic reconnection (exponential backoff)
+    max_retry_time=60000,  # Stop retrying after 60 seconds (None = retry forever)
     on_connected=on_connected,
     on_disconnected=on_disconnected,
-    on_connect_error=on_connect_error
+    on_connect_error=on_connect_error,
 )
 
 # Connect to server
@@ -287,10 +288,7 @@ await client.disconnect()
 ```python
 from rocketride import RocketRideClient
 
-client = RocketRideClient(
-    uri='https://api.rocketride.ai',
-    auth='your-api-key'
-)
+client = RocketRideClient(uri='https://api.rocketride.ai', auth='your-api-key')
 
 await client.connect()
 
@@ -323,16 +321,15 @@ async with await client.pipe(token=myToken, mime_type='application/json') as pip
 ```python
 from rocketride import RocketRideClient
 
+
 # Declare event handler
 async def handle_events(event):
     if event['event'] == 'apaevt_status_upload':
         body = event['body']
-        print(f"{body['filepath']}: {body['action']} - {body['bytes_sent']}/{body['file_size']} bytes")
+        print(f'{body["filepath"]}: {body["action"]} - {body["bytes_sent"]}/{body["file_size"]} bytes')
 
-client = RocketRideClient(
-    auth='your-api-key',
-    on_event=handle_events
-)
+
+client = RocketRideClient(auth='your-api-key', on_event=handle_events)
 
 await client.connect()
 
@@ -341,18 +338,15 @@ files = ['doc1.pdf', 'data.csv', 'report.docx']
 results = await client.send_files(files, token)
 
 # With metadata and MIME types
-files = [
-    ('report.pdf', {'department': 'finance'}),
-    ('data.csv', {'type': 'sales_data'}, 'text/csv')
-]
+files = [('report.pdf', {'department': 'finance'}), ('data.csv', {'type': 'sales_data'}, 'text/csv')]
 results = await client.send_files(files, token)
 
 # Process results
 for result in results:
     if result['action'] == 'complete':
-        print(f"✓ {result['filepath']}: {result['upload_time']:.2f}s")
+        print(f'✓ {result["filepath"]}: {result["upload_time"]:.2f}s')
     else:
-        print(f"✗ {result['filepath']}: {result['error']}")
+        print(f'✗ {result["filepath"]}: {result["error"]}')
 
 await client.disconnect()
 ```
@@ -569,8 +563,7 @@ Create a streaming data pipe for sending large datasets.
 **Callback signature:**
 
 ```python
-async def on_sse(type: str, data: dict) -> None:
-    ...
+async def on_sse(type: str, data: dict) -> None: ...
 ```
 
 - `type` (str): The SSE event type
@@ -581,8 +574,10 @@ async def on_sse(type: str, data: dict) -> None:
 ```python
 from rocketride.schema import Question
 
+
 async def handle_sse(type: str, data: dict) -> None:
     print(f'[{type}] {data}')
+
 
 question = Question()
 question.addQuestion('Summarize the document.')
@@ -722,22 +717,22 @@ Add one or more documents to the question context.
 pipeline = {
     'components': [
         {
-            'id': str,              # Unique component identifier
-            'provider': str,        # Component type (e.g., 'webhook', 'response', 'ai_chat')
-            'name': str,            # Human-readable name (optional)
-            'description': str,     # Component description (optional)
-            'config': dict,         # Component-specific configuration
-            'ui': dict,             # UI-specific configuration (optional)
-            'input': [              # Input connections (optional)
+            'id': str,  # Unique component identifier
+            'provider': str,  # Component type (e.g., 'webhook', 'response', 'ai_chat')
+            'name': str,  # Human-readable name (optional)
+            'description': str,  # Component description (optional)
+            'config': dict,  # Component-specific configuration
+            'ui': dict,  # UI-specific configuration (optional)
+            'input': [  # Input connections (optional)
                 {
-                    'lane': str,    # Data lane/channel name
-                    'from': str     # Source component ID
+                    'lane': str,  # Data lane/channel name
+                    'from': str,  # Source component ID
                 }
-            ]
+            ],
         }
     ],
-    'source': str,                  # Entry point component ID
-    'project_id': str               # Project identifier
+    'source': str,  # Entry point component ID
+    'project_id': str,  # Project identifier
 }
 ```
 
@@ -745,13 +740,13 @@ pipeline = {
 
 ```python
 {
-    'action': str,           # 'open', 'write', 'close', 'complete', or 'error'
-    'filepath': str,         # Original filename
-    'bytes_sent': int,       # Bytes transmitted
-    'file_size': int,        # Total file size
-    'upload_time': float,    # Time taken in seconds
-    'result': dict,          # Processing result (on complete, optional)
-    'error': str             # Error message (on error, optional)
+    'action': str,  # 'open', 'write', 'close', 'complete', or 'error'
+    'filepath': str,  # Original filename
+    'bytes_sent': int,  # Bytes transmitted
+    'file_size': int,  # Total file size
+    'upload_time': float,  # Time taken in seconds
+    'result': dict,  # Processing result (on complete, optional)
+    'error': str,  # Error message (on error, optional)
 }
 ```
 
@@ -759,9 +754,9 @@ pipeline = {
 
 ```python
 {
-    'name': str,             # Result identifier (UUID)
-    'location': str,         # Storage location (optional)
-    'result_types': dict,    # Result type mapping (optional)
+    'name': str,  # Result identifier (UUID)
+    'location': str,  # Storage location (optional)
+    'result_types': dict,  # Result type mapping (optional)
     # Additional dynamic fields based on result_types
 }
 ```
@@ -770,9 +765,9 @@ pipeline = {
 
 ```python
 {
-    'state': str,            # 'running', 'completed', 'failed', 'terminated'
-    'progress': float,       # Progress percentage 0-100 (optional)
-    'message': str,          # Status message (optional)
+    'state': str,  # 'running', 'completed', 'failed', 'terminated'
+    'progress': float,  # Progress percentage 0-100 (optional)
+    'message': str,  # Status message (optional)
     # Additional status fields
 }
 ```
@@ -819,6 +814,7 @@ await client.connect()
 result = await client.use(filepath='chat_pipeline.pipe')
 token = result['token']
 
+
 async def my_chat(my_question: str) -> str:
     # Simple question
     question = Question()
@@ -835,6 +831,7 @@ async def my_chat(my_question: str) -> str:
     answer = response['answers'][0]
     return answer
 
+
 # Use the function
 answer = await my_chat('What are the main themes in these documents?')
 print(answer)
@@ -845,13 +842,11 @@ print(answer)
 ```python
 from rocketride.schema import Question
 
+
 async def extract(source_document: str):
     question = Question(expectJson=True)
     question.addQuestion('Extract email addresses and phone numbers')
-    question.addExample(
-        'Find contacts',
-        {'emails': ['john@company.com'], 'phones': ['555-1234']}
-    )
+    question.addExample('Find contacts', {'emails': ['john@company.com'], 'phones': ['555-1234']})
     question.addContext(source_document)
 
     response = await client.chat(token=token, question=question)
@@ -861,6 +856,7 @@ async def extract(source_document: str):
         structured_answer = response['answers'][0]
         return structured_answer
     return {}
+
 
 # Use the function
 result = await extract('Contact us at john@company.com or 555-1234')
@@ -901,6 +897,7 @@ response = await client.chat(token='chat-token', question=question)
 ```python
 from rocketride import RocketRideClient
 
+
 async def process_documents():
     async with RocketRideClient() as client:  # Configuration from .env
         # Start document processing pipeline
@@ -921,6 +918,7 @@ async def process_documents():
 import json
 from rocketride import RocketRideClient
 
+
 async def stream_sensor_data(data_generator):
     async with RocketRideClient() as client:  # Configuration from .env
         result = await client.use(filepath='sensor_processor.pipe')
@@ -932,7 +930,7 @@ async def stream_sensor_data(data_generator):
                 data = {
                     'timestamp': sensor_reading.timestamp,
                     'temperature': sensor_reading.temp,
-                    'humidity': sensor_reading.humidity
+                    'humidity': sensor_reading.humidity,
                 }
                 await pipe.write(json.dumps(data).encode())
             result = await pipe.close()
@@ -948,6 +946,7 @@ async def stream_sensor_data(data_generator):
 ```python
 from typing import Dict, Any
 
+
 async def handle_events(event: Dict[str, Any]) -> None:
     event_type = event['event']
     body = event['body']
@@ -957,16 +956,14 @@ async def handle_events(event: Dict[str, Any]) -> None:
             progress = (body['bytes_sent'] / body['file_size']) * 100
             print(f'Upload progress: {progress:.1f}%')
 
+
 # Create client with event handler
 client = RocketRideClient(on_event=handle_events)  # Configuration from .env
 
 await client.connect()
 
 # Subscribe to specific events
-await client.set_events(token, [
-    'apaevt_status_upload',
-    'apaevt_status_processing'
-])
+await client.set_events(token, ['apaevt_status_upload', 'apaevt_status_processing'])
 ```
 
 #### Connection Event Handlers
@@ -975,17 +972,16 @@ await client.set_events(token, [
 async def on_connected(info: str) -> None:
     print(f'Connected to {info}')
 
+
 async def on_disconnected(reason: str, has_error: bool) -> None:
     if has_error:
         print(f'Connection lost: {reason}')
     else:
         print('Disconnected gracefully')
 
+
 client = RocketRideClient(
-    uri='https://api.rocketride.ai',
-    auth='api_key',
-    on_connected=on_connected,
-    on_disconnected=on_disconnected
+    uri='https://api.rocketride.ai', auth='api_key', on_connected=on_connected, on_disconnected=on_disconnected
 )
 ```
 
@@ -1014,6 +1010,7 @@ while True:
 # Declare an EventCallback function
 async def event_notification(event: Dict[str, Any]) -> None:
     print(event)
+
 
 # Create the client
 client = RocketRideClient(

--- a/packages/client-mcp/docs/index.md
+++ b/packages/client-mcp/docs/index.md
@@ -233,15 +233,15 @@ In Claude Desktop or any MCP-compatible client, resources are listed automatical
 
 ```python
 # Example: read the pipeline list resource
-result = await session.read_resource("rocketride://pipelines")
+result = await session.read_resource('rocketride://pipelines')
 # Returns: {"pipelines": [{"name": "my-pipeline", "description": "..."}, ...]}
 
 # Example: check server status
-result = await session.read_resource("rocketride://status")
+result = await session.read_resource('rocketride://status')
 # Returns: {"connected": true, "pipeline_count": 3, "pipelines": ["pipe-a", "pipe-b", "pipe-c"]}
 
 # Example: list available node types
-result = await session.read_resource("rocketride://nodes")
+result = await session.read_resource('rocketride://nodes')
 # Returns: {"nodes": [{"name": "llm_openai", "type": "processor"}, ...]}
 ```
 
@@ -310,10 +310,9 @@ This generates the message: _"Evaluate the output quality of the RocketRide pipe
 prompts = await session.list_prompts()
 
 # Get a rendered prompt
-result = await session.get_prompt("analyze-document", arguments={
-    "pipeline": "my-pipeline",
-    "query": "Summarize the key findings"
-})
+result = await session.get_prompt(
+    'analyze-document', arguments={'pipeline': 'my-pipeline', 'query': 'Summarize the key findings'}
+)
 # result.messages[0].content.text contains the rendered message
 ```
 

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -28,13 +28,15 @@ pip install rocketride
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    async with RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key") as client:
-        result = await client.use(filepath="pipeline.pipe")
-        token = result["token"]
-        out = await client.send(token, "Hello, pipeline!", objinfo={"name": "input.txt"}, mimetype="text/plain")
+    async with RocketRideClient(uri='https://cloud.rocketride.ai', auth='my-key') as client:
+        result = await client.use(filepath='pipeline.pipe')
+        token = result['token']
+        out = await client.send(token, 'Hello, pipeline!', objinfo={'name': 'input.txt'}, mimetype='text/plain')
         print(out)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -124,11 +126,11 @@ Raises `ValueError` if both `uri` and `ROCKETRIDE_URI` are empty or if `auth` is
 
 ```python
 client = RocketRideClient(
-    uri="https://cloud.rocketride.ai",
-    auth="my-key",
+    uri='https://cloud.rocketride.ai',
+    auth='my-key',
     persist=True,
     max_retry_time=300000,
-    on_connect_error=lambda msg: print("Connect error:", msg),
+    on_connect_error=lambda msg: print('Connect error:', msg),
     on_event=handle_event,
 )
 ```
@@ -145,10 +147,10 @@ client = RocketRideClient(
 **Example:**
 
 ```python
-async with RocketRideClient(uri="wss://cloud.rocketride.ai", auth=os.environ["ROCKETRIDE_APIKEY"]) as client:
-    result = await client.use(filepath="pipeline.json")
-    token = result["token"]
-    await client.send(token, "Hello, pipeline!")
+async with RocketRideClient(uri='wss://cloud.rocketride.ai', auth=os.environ['ROCKETRIDE_APIKEY']) as client:
+    result = await client.use(filepath='pipeline.json')
+    token = result['token']
+    await client.send(token, 'Hello, pipeline!')
 ```
 
 ### Connection
@@ -175,14 +177,14 @@ async with RocketRideClient(uri="wss://cloud.rocketride.ai", auth=os.environ["RO
 
 ```python
 # Two-step (build then request)
-req = client.build_request("rrext_monitor", token=token, arguments={"types": ["apaevt_status_upload"]})
+req = client.build_request('rrext_monitor', token=token, arguments={'types': ['apaevt_status_upload']})
 res = await client.request(req, timeout=5000)
 
 # One-step with dap_request
-res = await client.dap_request("rrext_services", {}, timeout=5000)
+res = await client.dap_request('rrext_services', {}, timeout=5000)
 
 if client.did_fail(res):
-    raise RuntimeError(res.get("message", "Request failed"))
+    raise RuntimeError(res.get('message', 'Request failed'))
 ```
 
 ### Pipeline execution
@@ -208,13 +210,13 @@ if client.did_fail(res):
 **Example - send a string:**
 
 ```python
-result = await client.send(token, "Hello, pipeline!", objinfo={"name": "greeting.txt"}, mimetype="text/plain")
+result = await client.send(token, 'Hello, pipeline!', objinfo={'name': 'greeting.txt'}, mimetype='text/plain')
 ```
 
 **Example - stream with a pipe:**
 
 ```python
-pipe = await client.pipe(token, mime_type="application/json")
+pipe = await client.pipe(token, mime_type='application/json')
 await pipe.open()
 await pipe.write(b'{"key": "value1"}')
 await pipe.write(b'{"key": "value2"}')
@@ -264,31 +266,31 @@ Read, write, and manage files in your account's server-side store. All paths are
 
 ```python
 # Strings and JSON (wrappers manage the handle for you)
-await client.fs_write_string("notes/todo.txt", "buy milk")
-text = await client.fs_read_string("notes/todo.txt")
-await client.fs_write_json("config/app.json", {"debug": True})
-cfg = await client.fs_read_json("config/app.json")
+await client.fs_write_string('notes/todo.txt', 'buy milk')
+text = await client.fs_read_string('notes/todo.txt')
+await client.fs_write_json('config/app.json', {'debug': True})
+cfg = await client.fs_read_json('config/app.json')
 
 # Browse and inspect
-listing = await client.fs_list_dir("reports")
-for entry in listing["entries"]:
-    print(entry["name"], entry["type"])
+listing = await client.fs_list_dir('reports')
+for entry in listing['entries']:
+    print(entry['name'], entry['type'])
 
 # Streaming binary upload via a write handle (4 MB chunks)
-info = await client.fs_open("uploads/video.mp4", "w")
-handle = info["handle"]
+info = await client.fs_open('uploads/video.mp4', 'w')
+handle = info['handle']
 try:
-    with open("video.mp4", "rb") as f:
+    with open('video.mp4', 'rb') as f:
         while chunk := f.read(4_194_304):
             await client.fs_write(handle, chunk)
 finally:
-    await client.fs_close(handle, "w")
+    await client.fs_close(handle, 'w')
 
 # Inline URL for streaming in a browser (<video>/<img> src)
-stream_url = await client.fs_get_url("uploads/video.mp4", expires_in=600)
+stream_url = await client.fs_get_url('uploads/video.mp4', expires_in=600)
 
 # Force a download with a friendly filename (works cross-origin on S3/Azure too)
-download_url = await client.fs_get_url("uploads/video.mp4", download_name="my video.mp4")
+download_url = await client.fs_get_url('uploads/video.mp4', download_name='my video.mp4')
 ```
 
 ### Events
@@ -331,10 +333,10 @@ Accessed via `client.deploy`. A deployment persists a pipeline on the server and
 **Example:**
 
 ```python
-record = await client.deploy.add(my_pipeline, schedule="*/15 * * * *")
+record = await client.deploy.add(my_pipeline, schedule='*/15 * * * *')
 for rec in await client.deploy.list():
-    print(rec["pipeline"]["project_id"], rec["schedule"], rec["state"])
-await client.deploy.update(project_id, schedule="manual")  # pause scheduled runs
+    print(rec['pipeline']['project_id'], rec['schedule'], rec['state'])
+await client.deploy.update(project_id, schedule='manual')  # pause scheduled runs
 await client.deploy.remove(project_id)
 ```
 
@@ -444,14 +446,14 @@ from rocketride.core.exceptions import PipeException, ExecutionException
 
 try:
     async with RocketRideClient(uri=uri, auth=auth) as client:
-        result = await client.use(filepath="pipeline.json")
-        await client.send(result["token"], data)
+        result = await client.use(filepath='pipeline.json')
+        await client.send(result['token'], data)
 except AuthenticationException:
-    print("Bad credentials")
+    print('Bad credentials')
 except ExecutionException as e:
-    print(f"Pipeline failed: {e}")
+    print(f'Pipeline failed: {e}')
 except PipeException as e:
-    print(f"Data transfer error: {e}")
+    print(f'Data transfer error: {e}')
 ```
 
 ---
@@ -464,15 +466,17 @@ except PipeException as e:
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    client = RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key")
+    client = RocketRideClient(uri='https://cloud.rocketride.ai', auth='my-key')
     await client.connect()
-    result = await client.use(filepath="pipeline.json")
-    token = result["token"]
-    out = await client.send(token, "Hello, pipeline!", objinfo={"name": "input.txt"}, mimetype="text/plain")
+    result = await client.use(filepath='pipeline.json')
+    token = result['token']
+    out = await client.send(token, 'Hello, pipeline!', objinfo={'name': 'input.txt'}, mimetype='text/plain')
     print(out)
     await client.terminate(token)
     await client.disconnect()
+
 
 asyncio.run(main())
 ```
@@ -483,14 +487,16 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    async with RocketRideClient(uri="wss://cloud.rocketride.ai", auth="my-key") as client:
-        result = await client.use(pipeline={"pipeline": my_pipeline_config})
-        token = result["token"]
+    async with RocketRideClient(uri='wss://cloud.rocketride.ai', auth='my-key') as client:
+        result = await client.use(pipeline={'pipeline': my_pipeline_config})
+        token = result['token']
         await client.send(token, '{"data": 1}')
         status = await client.get_task_status(token)
         print(status)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -501,19 +507,21 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
     client = RocketRideClient(
-        uri="https://cloud.rocketride.ai",
-        auth="my-key",
+        uri='https://cloud.rocketride.ai',
+        auth='my-key',
         persist=True,
         max_retry_time=300000,
-        on_connected=lambda info: print("Connected:", info),
-        on_disconnected=lambda reason, has_error: print("Disconnected:", reason, has_error),
-        on_connect_error=lambda msg: print("Connect error:", msg),
-        on_event=lambda e: print(e.get("event"), e.get("body")),
+        on_connected=lambda info: print('Connected:', info),
+        on_disconnected=lambda reason, has_error: print('Disconnected:', reason, has_error),
+        on_connect_error=lambda msg: print('Connect error:', msg),
+        on_event=lambda e: print(e.get('event'), e.get('body')),
     )
     await client.connect()
     # Later: use(), send_files(), etc. If connection drops, client retries; do not call disconnect() in on_disconnected.
+
 
 asyncio.run(main())
 ```
@@ -525,29 +533,31 @@ import asyncio
 from pathlib import Path
 from rocketride import RocketRideClient
 
-async def main():
-    client = RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key")
-    await client.connect()
-    result = await client.use(filepath="vectorize.json")
-    token = result["token"]
-    await client.set_events(token, ["apaevt_status_upload", "apaevt_status_processing"])
 
-    files = ["doc1.md", "doc2.md", ("doc3.json", {"tag": "export"}, "application/json")]
+async def main():
+    client = RocketRideClient(uri='https://cloud.rocketride.ai', auth='my-key')
+    await client.connect()
+    result = await client.use(filepath='vectorize.json')
+    token = result['token']
+    await client.set_events(token, ['apaevt_status_upload', 'apaevt_status_processing'])
+
+    files = ['doc1.md', 'doc2.md', ('doc3.json', {'tag': 'export'}, 'application/json')]
     upload_results = await client.send_files(files, token)
     for r in upload_results:
-        if r["action"] == "complete":
-            print("OK", r["filepath"])
+        if r['action'] == 'complete':
+            print('OK', r['filepath'])
         else:
-            print("Failed", r["filepath"], r.get("error"))
+            print('Failed', r['filepath'], r.get('error'))
 
     while True:
         status = await client.get_task_status(token)
-        print(f"Progress: {status.get('completedCount', 0)}/{status.get('totalCount', 0)}")
-        if status.get("completed"):
+        print(f'Progress: {status.get("completedCount", 0)}/{status.get("totalCount", 0)}')
+        if status.get('completed'):
             break
         await asyncio.sleep(2)
     await client.terminate(token)
     await client.disconnect()
+
 
 asyncio.run(main())
 ```
@@ -558,13 +568,14 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    async with RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key") as client:
-        result = await client.use(filepath="ingest.json")
-        token = result["token"]
-        pipe = await client.pipe(token, objinfo={"name": "large.csv"}, mime_type="text/csv")
+    async with RocketRideClient(uri='https://cloud.rocketride.ai', auth='my-key') as client:
+        result = await client.use(filepath='ingest.json')
+        token = result['token']
+        pipe = await client.pipe(token, objinfo={'name': 'large.csv'}, mime_type='text/csv')
         await pipe.open()
-        with open("large.csv", "rb") as f:
+        with open('large.csv', 'rb') as f:
             while True:
                 chunk = f.read(64 * 1024)
                 if not chunk:
@@ -573,6 +584,7 @@ async def main():
         result = await pipe.close()
         print(result)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -584,19 +596,21 @@ import asyncio
 from rocketride import RocketRideClient
 from rocketride.schema import Question, Answer
 
+
 async def main():
-    async with RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key") as client:
-        result = await client.use(filepath="chat_pipeline.json")
-        token = result["token"]
+    async with RocketRideClient(uri='https://cloud.rocketride.ai', auth='my-key') as client:
+        result = await client.use(filepath='chat_pipeline.json')
+        token = result['token']
         question = Question(expectJson=True)
-        question.addInstruction("Format", "Return a JSON object with keys: summary, keywords.")
-        question.addExample("Summarize X", {"summary": "...", "keywords": ["a", "b"]})
-        question.addQuestion("Summarize the main points and list keywords.")
+        question.addInstruction('Format', 'Return a JSON object with keys: summary, keywords.')
+        question.addExample('Summarize X', {'summary': '...', 'keywords': ['a', 'b']})
+        question.addQuestion('Summarize the main points and list keywords.')
         response = await client.chat(token=token, question=question)
-        answer_text = response.get("data", {}).get("answer") or (response.get("answers") or [None])[0]
+        answer_text = response.get('data', {}).get('answer') or (response.get('answers') or [None])[0]
         structured = Answer().parseJson(answer_text) if answer_text else None
         print(structured)
         await client.terminate(token)
+
 
 asyncio.run(main())
 ```
@@ -607,19 +621,21 @@ asyncio.run(main())
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    client = RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key")
+    client = RocketRideClient(uri='https://cloud.rocketride.ai', auth='my-key')
     await client.connect()
     services = await client.get_services()
-    print("Available:", list(services.keys()))
-    ocr = await client.get_service("ocr")
+    print('Available:', list(services.keys()))
+    ocr = await client.get_service('ocr')
     if ocr:
-        print("OCR schema:", ocr.get("schema"))
-    req = client.build_request("rrext_ping", token=my_token)
+        print('OCR schema:', ocr.get('schema'))
+    req = client.build_request('rrext_ping', token=my_token)
     res = await client.request(req, timeout=5000)
     if client.did_fail(res):
-        raise RuntimeError(res.get("message", "Ping failed"))
+        raise RuntimeError(res.get('message', 'Ping failed'))
     await client.disconnect()
+
 
 asyncio.run(main())
 ```

--- a/packages/client-typescript/docs/guide/methods/deploy.md
+++ b/packages/client-typescript/docs/guide/methods/deploy.md
@@ -82,10 +82,12 @@ Returned by `add()`, `status()`, and (as an array) `list()`:
 import asyncio
 from rocketride import RocketRideClient
 
+
 async def main():
-    async with RocketRideClient(uri="https://cloud.rocketride.ai", auth="my-key") as client:
-        record = await client.deploy.add(my_pipeline, schedule="*/15 * * * *")
-        print(record["pipeline"]["project_id"], record["state"])
+    async with RocketRideClient(uri='https://cloud.rocketride.ai', auth='my-key') as client:
+        record = await client.deploy.add(my_pipeline, schedule='*/15 * * * *')
+        print(record['pipeline']['project_id'], record['state'])
+
 
 asyncio.run(main())
 ```
@@ -103,14 +105,14 @@ console.log(record.pipeline!.project_id, record.state);
 Switch the schedule to `"manual"`; switch back to a cron expression to resume:
 
 ```python
-await client.deploy.update(project_id, schedule="manual")
+await client.deploy.update(project_id, schedule='manual')
 ```
 
 ### Inspect and clean up
 
 ```python
 for rec in await client.deploy.list():
-    print(rec["pipeline"]["project_id"], rec["schedule"], rec["state"])
+    print(rec['pipeline']['project_id'], rec['schedule'], rec['state'])
 
 await client.deploy.remove(project_id)
 ```
@@ -136,9 +138,9 @@ If a scheduled run is still in progress when the next tick comes due, that tick 
 
 ```python
 try:
-    await client.deploy.add(pipeline, schedule="*/15 * * * *")
+    await client.deploy.add(pipeline, schedule='*/15 * * * *')
 except RuntimeError as e:
-    print(f"Deploy failed: {e}")
+    print(f'Deploy failed: {e}')
 ```
 
 ## **API Endpoints**

--- a/packages/client-typescript/docs/guide/methods/send.md
+++ b/packages/client-typescript/docs/guide/methods/send.md
@@ -71,6 +71,7 @@ async with RocketRideClient(auth='your-api-key') as client:
 
     # Send JSON data
     import json
+
     response = await client.send(
         token,
         json.dumps({'name': 'John', 'age': 30}),
@@ -172,9 +173,9 @@ async with RocketRideClient(auth='your-api-key') as client:
 
     for r in results:
         if r['action'] == 'complete':
-            print(f"Uploaded {r['filepath']} in {r['upload_time']:.2f}s")
+            print(f'Uploaded {r["filepath"]} in {r["upload_time"]:.2f}s')
         else:
-            print(f"Failed {r['filepath']}: {r['error']}")
+            print(f'Failed {r["filepath"]}: {r["error"]}')
 
     # With metadata and MIME types
     files = [
@@ -202,7 +203,8 @@ async def handle_events(event):
         body = event['body']
         if body['action'] == 'write':
             pct = (body['bytes_sent'] / body['file_size']) * 100
-            print(f"{body['filepath']}: {pct:.1f}%")
+            print(f'{body["filepath"]}: {pct:.1f}%')
+
 
 client = RocketRideClient(auth='your-api-key', on_event=handle_events)
 ```

--- a/packages/client-typescript/docs/guide/methods/use.md
+++ b/packages/client-typescript/docs/guide/methods/use.md
@@ -26,7 +26,7 @@ The method returns a **token** that you use for all subsequent operations on tha
 
 ```python
 result = await client.use(
-    filepath="pipeline.json",   # or pipeline={...}
+    filepath='pipeline.json',  # or pipeline={...}
     token=None,
     source=None,
     threads=None,
@@ -133,10 +133,13 @@ config = {
     'source': 'webhook_1',
     'components': [
         {'id': 'webhook_1', 'provider': 'webhook', 'config': {}},
-        {'id': 'llm_1', 'provider': 'llm_openai', 'config': {'model': 'gpt-4'},
-         'input': [{'from': 'webhook_1', 'lane': 'output'}]},
-        {'id': 'response_1', 'provider': 'response', 'config': {},
-         'input': [{'from': 'llm_1', 'lane': 'answer'}]},
+        {
+            'id': 'llm_1',
+            'provider': 'llm_openai',
+            'config': {'model': 'gpt-4'},
+            'input': [{'from': 'webhook_1', 'lane': 'output'}],
+        },
+        {'id': 'response_1', 'provider': 'response', 'config': {}, 'input': [{'from': 'llm_1', 'lane': 'answer'}]},
     ],
 }
 result = await client.use(pipeline=config)

--- a/packages/client-typescript/docs/guide/methods/validate.md
+++ b/packages/client-typescript/docs/guide/methods/validate.md
@@ -66,10 +66,18 @@ async with RocketRideClient(auth='your-api-key') as client:
         'source': 'webhook_1',
         'components': [
             {'id': 'webhook_1', 'provider': 'webhook', 'config': {}},
-            {'id': 'processor_1', 'provider': 'ai_chat', 'config': {'model': 'gpt-4'},
-             'input': [{'from': 'webhook_1', 'lane': 'output'}]},
-            {'id': 'response_1', 'provider': 'response', 'config': {},
-             'input': [{'from': 'processor_1', 'lane': 'answer'}]},
+            {
+                'id': 'processor_1',
+                'provider': 'ai_chat',
+                'config': {'model': 'gpt-4'},
+                'input': [{'from': 'webhook_1', 'lane': 'output'}],
+            },
+            {
+                'id': 'response_1',
+                'provider': 'response',
+                'config': {},
+                'input': [{'from': 'processor_1', 'lane': 'answer'}],
+            },
         ],
     }
 

--- a/tools/contract_checks/README.md
+++ b/tools/contract_checks/README.md
@@ -139,19 +139,25 @@ Real examples from this repo:
 # nodes/src/nodes/llm_anthropic/anthropic.py — optional monkey-patch
 try:
     import langchain_core.utils.tokenization as _tok  # contract-check: ignore  optional monkey-patch path; outer except handles absence
+
     ...
 except Exception:
     pass
 
 # nodes/src/nodes/llm_mistral/IGlobal.py — falls back to built-in Exception
 try:
-    from mistralai.exceptions import MistralException  # contract-check: ignore  optional, falls back to built-in Exception
+    from mistralai.exceptions import (
+        MistralException,
+    )  # contract-check: ignore  optional, falls back to built-in Exception
 except Exception:
     MistralException = Exception
 
 # nodes/src/nodes/pinecone/IGlobal.py — moved between pinecone versions
 try:
-    from pinecone.core.client.exceptions import ApiException as _ApiException  # contract-check: ignore  optional, path moved between pinecone versions; outer handler covers absence
+    from pinecone.core.client.exceptions import (
+        ApiException as _ApiException,
+    )  # contract-check: ignore  optional, path moved between pinecone versions; outer handler covers absence
+
     ...
 except Exception:
     pass
@@ -282,7 +288,7 @@ MANIFEST = ComponentManifest(
     heavy_classes=(
         HeavyClass(
             qualname='somesdk.Client',
-            construct='Client(api_key="x")',     # MUST be side-effect-free
+            construct='Client(api_key="x")',  # MUST be side-effect-free
             attr_chains=(
                 'users.list',
                 'users.get',
@@ -372,11 +378,13 @@ For single imports, the inline `# contract-check: ignore` comment is usually a b
 Edit [`tools/contract_checks/src/contract_checks/trees.py`](src/contract_checks/trees.py) and append one `Tree` entry to `SCANNED_TREES`:
 
 ```python
-Tree(
-    name='my-new-tree',
-    root=REPO_ROOT / 'path' / 'to' / 'python' / 'source',
-    internal_packages=frozenset({'my_internal_package'}),
-),
+(
+    Tree(
+        name='my-new-tree',
+        root=REPO_ROOT / 'path' / 'to' / 'python' / 'source',
+        internal_packages=frozenset({'my_internal_package'}),
+    ),
+)
 ```
 
 No other change is needed, the CLI's tree iteration loop picks up the new entry automatically on the next run, and the install hook recursively finds every `requirement*.txt` under `root` on its own (no per-tree requirements config).


### PR DESCRIPTION
## What

`ruff format` on 13 documentation files. **Docs only — no source code changed.**

## Why

The `Ruff` CI check runs `ruff format --check` with `docstring-code-format = true`, so it reformats the ```python code fences embedded in our markdown docs. 13 doc files carried unformatted snippets and were **failing the check on any PR that ran it** — e.g. Rod's #1661 was blocked by this even though 12 of the 13 files were nothing to do with that PR.

Formatting them here on `develop` clears the debt at the source so the gate stops red-flagging unrelated PRs.

## Verification

- `ruff@0.16.0 format --check` → clean (matches the CI-pinned version)
- `ruff@0.16.0 check` → All checks passed
- Only `.md` files touched (confirmed no `.py`/`.ts`/source in the diff)

Trivial + mechanical; safe to fast-approve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Standardized Python code examples with consistent quoting, indentation, and formatting.
  - Improved readability across SDK, MCP, pipeline, deployment, and validation guides.
  - Corrected examples for safer response handling, connection reuse, and non-blocking async usage.
  - Fixed a broken code-block layout in the Python SDK documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->