### PR TITLE
fix(auth): log why has_permission denies instead of swallowing silently

### DIFF
--- a/packages/ai/src/ai/modules/task/task_conn.py
+++ b/packages/ai/src/ai/modules/task/task_conn.py
@@ -59,9 +59,9 @@ This design provides a single connection point while maintaining separation
 of concerns through specialized command handler classes.
 """
 
+import logging
 import time
 from typing import TYPE_CHECKING, Dict, Any, Union, Optional
-from rocketlib import debug
 from rocketride import EVENT_TYPE
 from ai.common.dap import DAPConn, TransportBase
 from ai.constants import CONST_AUTH_MAX_ATTEMPTS_PER_CONN
@@ -387,7 +387,20 @@ class TaskConn(
             # (AccountInfo carries a single org). Deny — but never silently: without this
             # line the caller sees a bare "Permission 'x' denied" and the real cause, an
             # unresolvable default team, is invisible in the logs.
-            debug(
+            #
+            # stdlib logging, not rocketlib.debug()/warning(). Two reasons, both checked
+            # against the running cloud ALB rather than assumed:
+            #   * debug() is gated on the engine trace level, and prod runs without one
+            #     (`./engine ./ai/eaas.py --saas --host=0.0.0.0 --port=5565 ...`).
+            #   * rocketlib output goes to the engine job log, which is delivered to the
+            #     connected client — not to container stdout. The prod ALB's log is
+            #     uvicorn access lines and nothing else, so neither call would have been
+            #     visible to us. Denying a client and then reporting the reason only to
+            #     that same client is not observability.
+            # uvicorn configures root logging, so this lands on stdout and reaches
+            # CloudWatch. Volume is bounded by actual denials, and a flood of these is
+            # itself the signal — that is exactly the shape #373 had.
+            logging.getLogger(__name__).warning(
                 f'[auth] has_permission: cannot resolve defaultTeam '
                 f'{self._account_info.defaultTeam!r} for user {self._account_info.userId!r} '
                 f'-> denying {perm!r} ({exc})'

--- a/packages/ai/src/ai/modules/task/task_conn.py
+++ b/packages/ai/src/ai/modules/task/task_conn.py
@@ -61,6 +61,7 @@ of concerns through specialized command handler classes.
 
 import time
 from typing import TYPE_CHECKING, Dict, Any, Union, Optional
+from rocketlib import debug
 from rocketride import EVENT_TYPE
 from ai.common.dap import DAPConn, TransportBase
 from ai.constants import CONST_AUTH_MAX_ATTEMPTS_PER_CONN
@@ -381,7 +382,16 @@ class TaskConn(
             return False
         try:
             perms = resolve_team_permissions(self._account_info, self._account_info.defaultTeam)
-        except PermissionError:
+        except PermissionError as exc:
+            # The session's defaultTeam is not resolvable inside account_info.organization
+            # (AccountInfo carries a single org). Deny — but never silently: without this
+            # line the caller sees a bare "Permission 'x' denied" and the real cause, an
+            # unresolvable default team, is invisible in the logs.
+            debug(
+                f'[auth] has_permission: cannot resolve defaultTeam '
+                f'{self._account_info.defaultTeam!r} for user {self._account_info.userId!r} '
+                f'-> denying {perm!r} ({exc})'
+            )
             return False
         if isinstance(perm, str):
             perm = [perm]

--- a/packages/ai/tests/ai/modules/task/test_task_conn.py
+++ b/packages/ai/tests/ai/modules/task/test_task_conn.py
@@ -306,8 +306,16 @@ def test_has_permission_logs_why_it_denied(monkeypatch, caplog):
     with caplog.at_level(logging.WARNING, logger=tc_mod.__name__):
         assert conn.has_permission('task.control') is False
 
-    assert caplog.records, 'denial produced no log record at all'
-    message = ' '.join(r.getMessage() for r in caplog.records)
+    # Pin the record down before reading it. Joining every captured record would
+    # let an unrelated log satisfy these field checks, and would keep passing if
+    # the denial were downgraded to debug or raised to error — either of which
+    # changes whether we actually see it in CloudWatch, which is the entire point.
+    records = [r for r in caplog.records if r.name == tc_mod.__name__ and r.levelno == logging.WARNING]
+    assert len(records) == 1, (
+        f'expected exactly one WARNING from {tc_mod.__name__}, got {[(r.name, r.levelname) for r in caplog.records]}'
+    )
+
+    message = records[0].getMessage()
     for expected in ('team-1', 'user-1', 'task.control', 'not in organization'):
         assert expected in message, f'denial log omits {expected!r}: {message}'
 

--- a/packages/ai/tests/ai/modules/task/test_task_conn.py
+++ b/packages/ai/tests/ai/modules/task/test_task_conn.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import logging
+
 import pytest
 
 from ai.modules.task.task_conn import TaskConn
@@ -282,6 +284,32 @@ def test_has_permission_swallows_permission_error(monkeypatch):
 
     conn = _make_conn(account_info=_make_account_info())
     assert conn.has_permission('task.control') is False
+
+
+def test_has_permission_logs_why_it_denied(monkeypatch, caplog):
+    """
+    The denial must say WHO, WHICH TEAM, WHICH PERMISSION and WHAT FAILED.
+
+    Asserting only the False return is not enough: that assertion passes just as
+    happily with the logging deleted, which is how the #373 incident stayed
+    invisible for a day. The silent-denial path is the whole reason this log
+    exists, so the test has to fail if the message goes away or loses a field.
+    """
+    from ai.modules.task import task_conn as tc_mod
+
+    def _raise(info, team):
+        raise PermissionError('team-1 not in organization')
+
+    monkeypatch.setattr(tc_mod, 'resolve_team_permissions', _raise)
+
+    conn = _make_conn(account_info=_make_account_info(user_id='user-1', default_team='team-1'))
+    with caplog.at_level(logging.WARNING, logger=tc_mod.__name__):
+        assert conn.has_permission('task.control') is False
+
+    assert caplog.records, 'denial produced no log record at all'
+    message = ' '.join(r.getMessage() for r in caplog.records)
+    for expected in ('team-1', 'user-1', 'task.control', 'not in organization'):
+        assert expected in message, f'denial log omits {expected!r}: {message}'
 
 
 def test_verify_permission_raises_on_missing(monkeypatch):


### PR DESCRIPTION
## What
`TaskConn.has_permission` caught `PermissionError` from `resolve_team_permissions` and returned a bare `False`. Now it logs the reason first. **Behaviour is unchanged — it still denies.**

## Why
`resolve_team_permissions` raises when the session's `defaultTeam` isn't inside `account_info.organization` (AccountInfo carries a **single** org). The swallow meant the caller only saw `Permission 'x' denied`, with the actual cause — an unresolvable default team — invisible.

That is exactly what happened in saas **#373**: the admin Dashboard hung on *"Loading Dashboard Data"* with `Permission 'task.monitor' denied` for a user who **genuinely held** `task.monitor`. With no log line, it took ~2 days to trace.

## Related
- Root cause fix (backend): rocketride-saas **#374** — reconciles `default_team` to the session's selected org.
- Incident: rocketride-saas **#373**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for permission checks by logging a warning when default team permissions can’t be resolved.
  * Permission access continues to be denied safely when permission verification fails, with the warning detailing the user, team, requested permissions, and the denial reason.
* **Tests**
  * Added unit test coverage to confirm a single warning is emitted when permission resolution raises a `PermissionError`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->