### PR TITLE
fix(llm_anthropic): disable extended thinking at the node (interim stop-gap)

### DIFF
--- a/nodes/src/nodes/llm_anthropic/anthropic.py
+++ b/nodes/src/nodes/llm_anthropic/anthropic.py
@@ -36,6 +36,14 @@ from ai.common.llm_native_stream import build_anthropic_thinking_kwargs, gate_mo
 from langchain_anthropic import ChatAnthropic
 
 
+# Interim: extended thinking is disabled at the node until the normalized provider adapter
+# lands (RFC #1679). With thinking on, Anthropic returns typed content blocks (thinking + text)
+# that the agent / expectJson path cannot consume (incident #1658; flatten defense-in-depth in
+# #1659). We gate activation here rather than flipping capabilities.reasoning, because that flag
+# is stamped by tools/sync_models and re-stamps to true on the next sync. Flip back to re-enable.
+_EXTENDED_THINKING_ENABLED = False
+
+
 def _estimate_token_ids(text: str) -> list:
     """Estimate token ids at ~4 chars/token."""
     return [0] * max(1, (len(text) + 3) // 4)
@@ -77,7 +85,7 @@ class Chat(ChatBase):
             'max_tokens': self._modelOutputTokens,
             'custom_get_token_ids': _estimate_token_ids,
         }
-        if self._is_reasoning:
+        if self._is_reasoning and _EXTENDED_THINKING_ENABLED:
             kwargs.update(build_anthropic_thinking_kwargs(model_gate, self._modelOutputTokens))
 
         self._extended_thinking = bool(kwargs.get('thinking'))


### PR DESCRIPTION
## Description

Interim stop-gap for the Anthropic-on-agents incident (#1658). Enabling extended thinking makes
Anthropic reasoning models return content as typed blocks (thinking + text), which the agent /
expectJson path cannot consume. This gates thinking activation behind a node-level constant
(`_EXTENDED_THINKING_ENABLED = False`) so it never turns on.

Gated at the node rather than by flipping `capabilities.reasoning`, because that flag is stamped
by `tools/sync_models` (`stamp_reasoning.py`) and re-stamps to true on the next sync, so a
services.json edit would not hold. Confirmed with Ariel that the node gate gives better control and
does not clash with the adapter RFC.

## Testing

Verified on a develop build (langchain-anthropic 1.5.0, which reproduces the crash), with ChatBase
left clean (no flatten):
- Anthropic content now comes back as `str` (thinking off).
- Anthropic agents pass on rocketride, crewai, and llamaindex (crash before, pass after) with the
  node gate as the only change.

## Linked issue

Fixes #1680

## Related

- #1659 flatten defense-in-depth (draft, to merge when thinking is re-enabled)
- #1679 normalized provider adapter, the long-term fix (Ariel)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Anthropic extended-thinking mode by default to prevent unintended reasoning output and typed thinking blocks.
  * Preserved standard streaming behavior unless extended thinking is explicitly enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->