### PR TITLE
fix(memory_persistent): prevent double-forward of questions and answers

### DIFF
--- a/nodes/src/nodes/memory_persistent/IInstance.py
+++ b/nodes/src/nodes/memory_persistent/IInstance.py
@@ -21,7 +21,11 @@ from .IGlobal import IGlobal
 
 
 class IInstance(IInstanceBase):
-    """Pipeline instance for the memory_persistent node."""
+    """Pipeline instance for the memory_persistent node.
+
+    preventDefault() raises immediately, so no code may follow it — anything
+    added after a preventDefault() call is unreachable at runtime.
+    """
 
     IGlobal: IGlobal
     _current_session_id: str | None = None

--- a/nodes/src/nodes/memory_persistent/IInstance.py
+++ b/nodes/src/nodes/memory_persistent/IInstance.py
@@ -40,6 +40,7 @@ class IInstance(IInstanceBase):
         store = self.IGlobal.store
         if store is None:
             self.instance.writeQuestions(question)
+            self.preventDefault()
             return
 
         # Deep copy to prevent mutation of the original question
@@ -63,6 +64,7 @@ class IInstance(IInstanceBase):
                 self._current_session_id = None
                 debug(f'Ignoring invalid session_id in question metadata: {session_id!r}')
                 self.instance.writeQuestions(question)
+                self.preventDefault()
                 return
 
             # Load all keys from the session
@@ -81,8 +83,11 @@ class IInstance(IInstanceBase):
                     question.metadata['memory_context'] = memory_context
                     debug(f'Attached {len(memory_context)} memory keys to question for session {session_id}')
 
-        # Forward the (possibly enriched) question downstream
+        # Forward the (possibly enriched) question downstream. preventDefault()
+        # suppresses the engine's automatic default forward, which would
+        # otherwise deliver the question a second time (the unenriched original).
         self.instance.writeQuestions(question)
+        self.preventDefault()
 
     def writeAnswers(self, answer: Answer) -> None:
         """Store answer text in session memory for future retrieval, then forward.
@@ -93,6 +98,7 @@ class IInstance(IInstanceBase):
         store = self.IGlobal.store
         if store is None:
             self.instance.writeAnswers(answer)
+            self.preventDefault()
             return
 
         # Deep copy to prevent mutation
@@ -116,6 +122,7 @@ class IInstance(IInstanceBase):
             except ValueError:
                 debug(f'Ignoring invalid session_id in answer metadata: {session_id!r}')
                 self.instance.writeAnswers(answer)
+                self.preventDefault()
                 return
 
             # Store the answer text
@@ -127,5 +134,8 @@ class IInstance(IInstanceBase):
 
             debug(f'Stored answer in session {session_id}')
 
-        # Forward the answer downstream
+        # Forward the answer downstream. preventDefault() suppresses the
+        # engine's automatic default forward, which would otherwise deliver
+        # the answer a second time (a separate deep-copied object).
         self.instance.writeAnswers(answer)
+        self.preventDefault()

--- a/nodes/test/memory_persistent/test_node.py
+++ b/nodes/test/memory_persistent/test_node.py
@@ -804,7 +804,10 @@ class TestIInstanceLifecycle:
         inst.instance = MagicMock()
         # The real IInstanceBase.preventDefault() raises APERR by design (it's
         # meant to be caught by the C++ engine); stub it so unit tests can call
-        # writeQuestions/writeAnswers without a running engine.
+        # writeQuestions/writeAnswers without a running engine. Note: unlike the
+        # real one, this stub does not raise, so code placed after a
+        # preventDefault() call will appear to run here but never runs in the
+        # engine.
         inst.preventDefault = MagicMock()
         return inst
 

--- a/nodes/test/memory_persistent/test_node.py
+++ b/nodes/test/memory_persistent/test_node.py
@@ -813,12 +813,14 @@ class TestIInstanceLifecycle:
         question = MagicMock()
         inst.writeQuestions(question)
         inst.instance.writeQuestions.assert_called_once()
+        inst.preventDefault.assert_called_once_with()
 
     def test_write_answers_forwards_without_store(self):
         inst = self._make_instance(store=None)
         answer = MagicMock()
         inst.writeAnswers(answer)
         inst.instance.writeAnswers.assert_called_once()
+        inst.preventDefault.assert_called_once_with()
 
     def test_write_questions_enriches_with_memory(self):
         store = PersistentMemoryStore(backend='memory')
@@ -831,6 +833,7 @@ class TestIInstanceLifecycle:
 
         inst.writeQuestions(question)
         inst.instance.writeQuestions.assert_called_once()
+        inst.preventDefault.assert_called_once_with()
 
         # The forwarded question should have memory_context
         forwarded = inst.instance.writeQuestions.call_args[0][0]
@@ -858,6 +861,7 @@ class TestIInstanceLifecycle:
 
         inst.writeAnswers(answer)
         inst.instance.writeAnswers.assert_called_once()
+        inst.preventDefault.assert_called_once_with()
 
         # Check that answer was stored
         result = store.get('test-sess', 'last_answer')
@@ -883,6 +887,7 @@ class TestIInstanceLifecycle:
         assert result['ok'] is True
         assert result['value'] == 'Follow-up answer'
         assert store.get('test-sess', 'answer_count')['value'] == 1
+        assert inst.preventDefault.call_count == 2
 
     def test_write_answers_increments_count(self):
         store = PersistentMemoryStore(backend='memory')
@@ -920,6 +925,7 @@ class TestIInstanceLifecycle:
 
         inst.writeQuestions(question)
         inst.instance.writeQuestions.assert_called_once()
+        inst.preventDefault.assert_called_once_with()
 
     def test_write_answers_no_session_id(self):
         store = PersistentMemoryStore(backend='memory')
@@ -929,6 +935,7 @@ class TestIInstanceLifecycle:
 
         inst.writeAnswers(answer)
         inst.instance.writeAnswers.assert_called_once()
+        inst.preventDefault.assert_called_once_with()
 
     def test_deep_copy_prevents_question_mutation(self):
         store = PersistentMemoryStore(backend='memory')

--- a/nodes/test/memory_persistent/test_node.py
+++ b/nodes/test/memory_persistent/test_node.py
@@ -802,6 +802,10 @@ class TestIInstanceLifecycle:
         inst.IGlobal = MagicMock()
         inst.IGlobal.store = store
         inst.instance = MagicMock()
+        # The real IInstanceBase.preventDefault() raises APERR by design (it's
+        # meant to be caught by the C++ engine); stub it so unit tests can call
+        # writeQuestions/writeAnswers without a running engine.
+        inst.preventDefault = MagicMock()
         return inst
 
     def test_write_questions_forwards_without_store(self):


### PR DESCRIPTION
## Summary

- `writeQuestions`/`writeAnswers` explicitly forwarded via `self.instance.write*()` without calling `preventDefault()`, so the engine's automatic default action also ran afterward, delivering every question and answer twice
- For questions this was worse than a plain duplicate: enrichment happens on a deep copy, so downstream received one copy with `memory_context` attached and one without
- Added `return self.preventDefault()` on every explicit-forward path in both methods (all six exits). `preventDefault()` raises, and that is what suppresses the engine's default forward, so it is the last statement on each path. The `_make_instance` test fixture stubs `preventDefault` so the unit tests can call the handlers directly; delivery counts are checked in `nodes/test/test_lane_forward_once_nodes.py`, whose stub raises like the real one.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Ran `./builder nodes:test` (not the full `./builder test`) via the real compiled engine: **2162 passed, 64 skipped, 0 failed**.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — N/A, no breaking changes

## Linked Issue

Fixes #1638


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate delivery when forwarding questions or answers.
  * Improved handling when storage is unavailable or sessions are invalid.
  * Ensured forwarded data is not automatically delivered again.
  * Prevented invalid session identifiers from enriching or persisting forwarded data.

* **Tests**
  * Added coverage for question and answer forwarding across session and no-session scenarios.
  * Added regression coverage for delivery deduplication and stored-answer handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
