### PR TITLE
feat(llm): full provider-adapter assembly — native paths wired (testable)

### DIFF
--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -20,7 +20,7 @@ from ai.common.config import Config
 from ai.common.util import parseJson
 from ai.common.validation import validate_model_name, validate_max_tokens, validate_prompt
 from ai.common.llm_native_stream import STOP_SEQUENCES_VAR, dispatch_native_chat_stream
-from ai.common.llm_adapter import LangChainAdapter, drive_adapter, flatten_content
+from ai.common.llm_adapter import LangChainAdapter, NativeOpenAIResponsesAdapter, drive_adapter, flatten_content
 
 
 def _stop_kwargs() -> dict:
@@ -400,64 +400,27 @@ class ChatBase:
         falling back to non-streaming invoke() only if nothing reached the UI yet.
         """
         prompt = validate_prompt(prompt, self._modelTotalTokens, self.getTokens)
-
-        text_parts: list = []
-        finish_reason: Optional[str] = None
         try:
-            stream = self._raw_client.responses.create(
-                model=self._model,
-                input=prompt,
-                reasoning={'summary': 'auto'},
-                max_output_tokens=self._modelOutputTokens,
-                stream=True,
-            )
-            for event in stream:
-                etype = getattr(event, 'type', '') or ''
-                if etype == 'response.reasoning_summary_text.delta':
-                    delta = getattr(event, 'delta', '') or ''
-                    if delta and on_reasoning_chunk is not None:
-                        on_reasoning_chunk(delta)
-                elif etype == 'response.output_text.delta':
-                    delta = getattr(event, 'delta', '') or ''
-                    if delta:
-                        text_parts.append(delta)
-                        if on_chunk is not None:
-                            on_chunk(delta)
-                elif etype == 'response.completed':
-                    resp = getattr(event, 'response', None)
-                    if resp is not None:
-                        status = getattr(resp, 'status', None)
-                        if status == 'completed':
-                            finish_reason = 'stop'
-                        elif status == 'incomplete':
-                            details = getattr(resp, 'incomplete_details', None)
-                            reason = getattr(details, 'reason', None) if details else None
-                            finish_reason = reason or 'length'
-                        else:
-                            finish_reason = status or 'stop'
-                elif etype in ('response.failed', 'response.error'):
-                    finish_reason = 'error'
+            adapter = NativeOpenAIResponsesAdapter(self)
+            text, _items = drive_adapter(adapter, prompt, on_chunk, on_reasoning_chunk)
+            if on_finish is not None:
+                on_finish(adapter.finish_reason)
+            return text
         except Exception as e:
             warning(f'Reasoning streaming disabled for model={self._model} ({type(e).__name__}): {e}.')
-            # Only retry non-streaming if nothing has reached the UI; otherwise
-            # the full fallback would arrive on top of the partial we already streamed.
+            # Only retry non-streaming if nothing reached the UI; otherwise the full
+            # fallback would arrive on top of the partial we already streamed.
             if emitted is None or not emitted['any']:
                 results = self._llm.invoke(prompt, **_stop_kwargs())
-                content = getattr(results, 'content', '') or ''
-                content_text = content if isinstance(content, str) else str(content)
-                text_parts = [content_text]
-                # Push the fallback answer through on_chunk so the open UI bubble
-                # gets the visible text (the caller dedupes the final pipeline result).
+                content_text = flatten_content(getattr(results, 'content', ''))
                 if content_text and on_chunk is not None:
                     on_chunk(content_text)
-                finish_reason = 'stop'
-            else:
-                finish_reason = 'error'
-
-        if on_finish is not None:
-            on_finish(finish_reason)
-
-        return ''.join(text_parts)
+                if on_finish is not None:
+                    on_finish('stop')
+                return content_text
+            if on_finish is not None:
+                on_finish('error')
+            return ''
 
     def chat_string(
         self,

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -275,3 +275,48 @@ class OpenAIAdapter:
         items = [item.model_dump() for item in final.output]
         self.history.extend(items)
         yield Event('done', items=items)
+
+
+class NativeOpenAIResponsesAdapter:
+    """Bridges the OpenAI Responses reasoning stream (create/stream=True) to Events."""
+
+    def __init__(self, chat: Any, history: list[Any] | None = None):
+        self.chat = chat
+        self.history: list[Any] = history if history is not None else []
+        self.finish_reason: Optional[str] = None
+
+    def stream(self, user_text: str) -> Iterator[Event]:
+        self.history.append({'role': 'user', 'content': user_text})
+        chat = self.chat
+        parts: list[str] = []
+        stream = chat._raw_client.responses.create(
+            model=chat._model,
+            input=user_text,
+            reasoning={'summary': 'auto'},
+            max_output_tokens=chat._modelOutputTokens,
+            stream=True,
+        )
+        for event in stream:
+            etype = getattr(event, 'type', '') or ''
+            if etype == 'response.reasoning_summary_text.delta':
+                delta = getattr(event, 'delta', '') or ''
+                if delta:
+                    yield Event('thinking', delta)
+            elif etype == 'response.output_text.delta':
+                delta = getattr(event, 'delta', '') or ''
+                if delta:
+                    parts.append(delta)
+                    yield Event('text', delta)
+            elif etype == 'response.completed':
+                resp = getattr(event, 'response', None)
+                status = getattr(resp, 'status', None) if resp is not None else None
+                if status == 'incomplete':
+                    details = getattr(resp, 'incomplete_details', None)
+                    self.finish_reason = (getattr(details, 'reason', None) if details else None) or 'length'
+                else:
+                    self.finish_reason = 'stop' if status == 'completed' else (status or 'stop')
+            elif etype in ('response.failed', 'response.error'):
+                self.finish_reason = 'error'
+        assistant = {'role': 'assistant', 'content': ''.join(parts)}
+        self.history.append(assistant)
+        yield Event('done', items=[assistant])

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Dict, List, Optional
 
 from rocketlib import debug, warning
 
+from ai.common.llm_adapter import Event, drive_adapter
+
 # Per-call carrier for API-level stop sequences (e.g. CrewAI's ReAct "\nObservation:").
 # Set on the ask path in llm_base._question and read at every model sink so the stop
 # reaches the provider API instead of relying only on post-hoc text truncation. A
@@ -167,67 +169,65 @@ def anthropic_extended_thinking_active(chat: Any) -> bool:
     return bool(mk.get('thinking'))
 
 
-def _stream_anthropic_messages_api(
-    chat: Any,
-    prompt: str,
-    on_chunk: Callable[[str], None],
-    on_finish: Optional[Callable[[Optional[str]], None]],
-    on_reasoning_chunk: Optional[Callable[[str], None]],
-) -> str:
-    llm = chat._llm
-    # INVARIANT: read synchronously within the ask() call, while LLMBase._question still
-    # holds the contextvar (before its finally reset). The stream is consumed here, not
-    # deferred to the caller, so this never runs after the reset (which would send None).
-    payload: dict[str, Any] = dict(llm._get_request_payload(prompt, stop=STOP_SEQUENCES_VAR.get() or None, stream=True))
-    _raw_client = getattr(llm, '_client', None)
-    client = _raw_client() if callable(_raw_client) else _raw_client
-    if client is None:
-        raise RuntimeError('ChatAnthropic has no _client for native streaming')
+class NativeAnthropicAdapter:
+    """Bridges the native Anthropic Messages stream to the Event contract.
 
-    parts: list[str] = []
-    finish_reason: Optional[str] = None
-    reasoning_deltas = 0
-    raw_stream = _open_raw_message_stream(client, payload)
+    Same payload + raw create(stream=True) path as before; now yields normalized Events.
+    """
 
-    try:
-        for event in raw_stream:
-            et = _event_type_name(event)
-            if et == 'content_block_delta':
-                delta = getattr(event, 'delta', None)
-                if delta is None:
-                    continue
-                dt = _delta_type_name(delta)
-                if dt == 'thinking_delta' and on_reasoning_chunk is not None:
-                    piece = getattr(delta, 'thinking', None) or ''
-                    if piece:
-                        on_reasoning_chunk(piece)
-                        reasoning_deltas += 1
-                elif dt == 'text_delta' and on_chunk is not None:
-                    piece = getattr(delta, 'text', None) or ''
-                    if piece:
-                        on_chunk(piece)
-                        parts.append(piece)
-            elif et == 'message_delta':
-                md = getattr(event, 'delta', None)
-                if md is not None:
-                    sr = getattr(md, 'stop_reason', None)
-                    if sr is not None:
-                        finish_reason = _map_claude_stop_reason(sr)
-    finally:
-        closer = getattr(raw_stream, 'close', None)
-        if callable(closer):
-            try:
-                closer()
-            except Exception:
-                pass
+    def __init__(self, chat: Any, history: Optional[list] = None):
+        self.chat = chat
+        self.history = history if history is not None else []
+        self.finish_reason: Optional[str] = None
 
-    if not parts:
-        raise RuntimeError('Anthropic SDK stream produced no text')
+    def stream(self, user_text: str):
+        # INVARIANT: consume synchronously within ask() while STOP_SEQUENCES_VAR is still set.
+        self.history.append({'role': 'user', 'content': user_text})
+        llm = self.chat._llm
+        payload: dict[str, Any] = dict(
+            llm._get_request_payload(user_text, stop=STOP_SEQUENCES_VAR.get() or None, stream=True)
+        )
+        _raw_client = getattr(llm, '_client', None)
+        client = _raw_client() if callable(_raw_client) else _raw_client
+        if client is None:
+            raise RuntimeError('ChatAnthropic has no _client for native streaming')
 
-    if on_finish is not None:
-        on_finish(finish_reason)
+        parts: list[str] = []
+        raw_stream = _open_raw_message_stream(client, payload)
+        try:
+            for event in raw_stream:
+                et = _event_type_name(event)
+                if et == 'content_block_delta':
+                    delta = getattr(event, 'delta', None)
+                    if delta is None:
+                        continue
+                    dt = _delta_type_name(delta)
+                    if dt == 'thinking_delta':
+                        piece = getattr(delta, 'thinking', None) or ''
+                        if piece:
+                            yield Event('thinking', piece)
+                    elif dt == 'text_delta':
+                        piece = getattr(delta, 'text', None) or ''
+                        if piece:
+                            parts.append(piece)
+                            yield Event('text', piece)
+                elif et == 'message_delta':
+                    md = getattr(event, 'delta', None)
+                    if md is not None:
+                        sr = getattr(md, 'stop_reason', None)
+                        if sr is not None:
+                            self.finish_reason = _map_claude_stop_reason(sr)
+        finally:
+            closer = getattr(raw_stream, 'close', None)
+            if callable(closer):
+                try:
+                    closer()
+                except Exception:
+                    pass
 
-    return ''.join(parts)
+        assistant = {'role': 'assistant', 'content': ''.join(parts)}
+        self.history.append(assistant)
+        yield Event('done', items=[assistant])
 
 
 def try_anthropic_native_chat_stream(
@@ -242,7 +242,12 @@ def try_anthropic_native_chat_stream(
         return None
 
     try:
-        text = _stream_anthropic_messages_api(chat, prompt, on_chunk, on_finish, on_reasoning_chunk)
+        adapter = NativeAnthropicAdapter(chat)
+        text, _items = drive_adapter(adapter, prompt, on_chunk, on_reasoning_chunk)
+        if not text:
+            raise RuntimeError('Anthropic SDK stream produced no text')
+        if on_finish is not None:
+            on_finish(adapter.finish_reason)
         return text
     except Exception as e:
         warning(

--- a/packages/ai/tests/ai/common/test_native_anthropic_adapter.py
+++ b/packages/ai/tests/ai/common/test_native_anthropic_adapter.py
@@ -1,0 +1,86 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Pins NativeAnthropicAdapter: native Messages stream → Events, same payload path."""
+
+from ai.common.llm_adapter import Event
+from ai.common.llm_native_stream import NativeAnthropicAdapter, try_anthropic_native_chat_stream
+
+
+class _Delta:
+    def __init__(self, type, thinking='', text='', stop_reason=None):
+        self.type = type
+        self.thinking = thinking
+        self.text = text
+        self.stop_reason = stop_reason
+
+
+class _RawEvent:
+    def __init__(self, type, delta=None):
+        self.type = type
+        self.delta = delta
+
+
+class _Messages:
+    def __init__(self, events):
+        self._events = events
+        self.seen = None
+
+    def create(self, **kwargs):
+        self.seen = kwargs
+        return iter(self._events)
+
+
+class _Client:
+    def __init__(self, events):
+        self.messages = _Messages(events)
+
+
+class _LLM:
+    def __init__(self, payload, client):
+        self._payload = payload
+        self._client = client
+
+    def _get_request_payload(self, prompt, stop=None, stream=False):
+        return {**self._payload, 'messages': [{'role': 'user', 'content': prompt}]}
+
+
+class _Chat:
+    def __init__(self, llm):
+        self._llm = llm
+        self._extended_thinking = True
+
+
+def _chat_with(events, payload=None):
+    return _Chat(_LLM(payload or {'model': 'claude-sonnet-4-6', 'max_tokens': 1000}, _Client(events)))
+
+
+def test_native_adapter_yields_events_and_maps_finish():
+    events = [
+        _RawEvent('content_block_delta', _Delta('thinking_delta', thinking='cot')),
+        _RawEvent('content_block_delta', _Delta('text_delta', text='answer')),
+        _RawEvent('message_delta', _Delta('message_delta', stop_reason='end_turn')),
+    ]
+    adapter = NativeAnthropicAdapter(_chat_with(events))
+    out = list(adapter.stream('q'))
+
+    assert Event('thinking', 'cot') in out
+    assert Event('text', 'answer') in out
+    assert out[-1].type == 'done'
+    assert out[-1].items == [{'role': 'assistant', 'content': 'answer'}]
+    assert adapter.finish_reason == 'stop'
+
+
+def test_handler_drives_adapter_and_reports_finish():
+    events = [
+        _RawEvent('content_block_delta', _Delta('text_delta', text='hi')),
+        _RawEvent('message_delta', _Delta('message_delta', stop_reason='max_tokens')),
+    ]
+    finishes = []
+    text = try_anthropic_native_chat_stream(
+        _chat_with(events), 'q', on_chunk=lambda t: None, on_finish=finishes.append, on_reasoning_chunk=lambda t: None
+    )
+    assert text == 'hi'
+    assert finishes == ['length']  # max_tokens → length

--- a/packages/ai/tests/ai/common/test_native_openai_responses_adapter.py
+++ b/packages/ai/tests/ai/common/test_native_openai_responses_adapter.py
@@ -1,0 +1,74 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Pins NativeOpenAIResponsesAdapter: Responses stream → Events + finish mapping."""
+
+from ai.common.llm_adapter import Event, NativeOpenAIResponsesAdapter
+
+
+class _Ev:
+    def __init__(self, type, delta='', response=None):
+        self.type = type
+        self.delta = delta
+        self.response = response
+
+
+class _Resp:
+    def __init__(self, status, incomplete_details=None):
+        self.status = status
+        self.incomplete_details = incomplete_details
+
+
+class _Details:
+    def __init__(self, reason):
+        self.reason = reason
+
+
+class _Responses:
+    def __init__(self, events):
+        self._events = events
+        self.seen = None
+
+    def create(self, **kwargs):
+        self.seen = kwargs
+        return iter(self._events)
+
+
+class _RawClient:
+    def __init__(self, events):
+        self.responses = _Responses(events)
+
+
+class _Chat:
+    def __init__(self, events):
+        self._raw_client = _RawClient(events)
+        self._model = 'gpt-5.6'
+        self._modelOutputTokens = 4096
+
+
+def test_yields_events_and_completed_maps_to_stop():
+    events = [
+        _Ev('response.reasoning_summary_text.delta', delta='think'),
+        _Ev('response.output_text.delta', delta='ans'),
+        _Ev('response.completed', response=_Resp('completed')),
+    ]
+    adapter = NativeOpenAIResponsesAdapter(_Chat(events))
+    out = list(adapter.stream('q'))
+
+    assert Event('thinking', 'think') in out
+    assert Event('text', 'ans') in out
+    assert out[-1].type == 'done'
+    assert out[-1].items == [{'role': 'assistant', 'content': 'ans'}]
+    assert adapter.finish_reason == 'stop'
+
+
+def test_incomplete_maps_to_reason():
+    events = [
+        _Ev('response.output_text.delta', delta='x'),
+        _Ev('response.completed', response=_Resp('incomplete', _Details('max_output_tokens'))),
+    ]
+    adapter = NativeOpenAIResponsesAdapter(_Chat(events))
+    list(adapter.stream('q'))
+    assert adapter.finish_reason == 'max_output_tokens'


### PR DESCRIPTION
## Summary

Full assembly of the provider-adapter virtualization (RFC #1679), on top of `feat/llm-provider-adapter`, to see it all together and test end-to-end.

- Every provider path now routes through the normalized `Event`/`Adapter` interface: `LangChainAdapter` (the ~18 non-reasoning providers), `NativeAnthropicAdapter` (Messages), `NativeOpenAIResponsesAdapter` (Responses).
- `_chat` flattens content — structurally closes the agent crash (#1658).
- **Single-turn.** The multi-turn opaque reasoning round-trip needs the C++ `Question`/`QuestionHistory` change (pending Rod — see discussion #1679).

## Testing

- 602 `ai/common` tests green (adapters, native adapters, wiring); no regressions.
- The native Anthropic/OpenAI reasoning paths reuse the same proven payload/stream mechanism, but need a **live run** to fully verify (no API keys in CI here).
