### PR TITLE
fix(ai): SQL base EXPLAIN-exhaustion isValid + real-bool crash

### DIFF
--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -245,6 +245,11 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             return {'sql': sql_query, 'valid': True}
         elif is_valid and sql_query:
             return {'error': 'Generated query contains unsafe SQL', 'sql': sql_query, 'valid': False}
+        elif result.get('error'):
+            # EXPLAIN rejected the query on every attempt -- surface the real
+            # database error instead of the rejected SQL, so callers can tell
+            # this apart from a genuinely off-topic question.
+            return {'error': result['error'], 'valid': False}
         else:
             return {'answer': sql_query, 'valid': False}
 
@@ -574,10 +579,13 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
 
             # Execute the query only when the LLM flagged it as valid SQL and
             # the safety check passes; otherwise return the LLM's text response.
+            # When EXPLAIN rejected the query on every attempt, prefer the real
+            # database error over the rejected SQL text, which reads as prose
+            # and would be indistinguishable from a genuine off-topic answer.
             if is_valid_query and sql_query and is_sql_safe(sql_query):
                 result = self._executeSQLQuery(sql_query)
             else:
-                result = sql_query
+                result = query_json.get('error') or sql_query
 
             if 'text' in lanes:
                 self.instance.writeText(str(result))

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -238,7 +238,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         limit = args.get('limit', 250)
         result = self._buildSQLQuery(question, limit=limit)
 
-        is_valid = parse_bool(result.get('isValid'))
+        is_valid = parse_bool(result.get('isValid', False))
         sql_query = result.get('query', '')
 
         if is_valid and sql_query and is_sql_safe(sql_query):
@@ -345,8 +345,9 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         Calls ``_buildSQLQueryOnce`` to ask the LLM, then runs ``EXPLAIN`` on
         the result.  If EXPLAIN rejects the query the error is fed back to the
         LLM and another attempt is made, up to ``IGlobal.max_validation_attempts``
-        times.  Returns the last LLM response regardless of whether validation
-        ultimately succeeded.
+        times.  Returns the last LLM response if EXPLAIN eventually accepts it;
+        if every attempt is rejected, the result is forced to ``isValid: False``
+        with the last EXPLAIN error carried in ``error``.
         """
         previous_sql: str | None = None
         last_error: str | None = None
@@ -355,7 +356,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         for attempt in range(self.IGlobal.max_validation_attempts):
             result = self._buildSQLQueryOnce(question_text, limit=limit, previous_sql=previous_sql, error=last_error)
 
-            is_valid = parse_bool(result.get('isValid'))
+            is_valid = parse_bool(result.get('isValid', False))
             sql_query = result.get('query', '')
 
             # If the LLM decided the question isn't a DB query, or the safety
@@ -574,7 +575,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         try:
             # Ask the LLM to translate the natural-language question into SQL.
             query_json = self._buildSQLQuery(question_text)
-            is_valid_query = parse_bool(query_json.get('isValid'))
+            is_valid_query = parse_bool(query_json.get('isValid', False))
             sql_query = query_json.get('query')
 
             # Execute the query only when the LLM flagged it as valid SQL and

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -599,12 +599,18 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             error(f'Error handling question: {e}')
 
     def _emitError(self, message: str, lanes) -> None:
-        """Emit a validation/safety error to the wired lanes, never a rejected query as prose."""
+        """Emit a validation/safety error to the wired lanes, never a rejected query as prose.
+
+        The answers lane wraps the message as ``{'error': message}`` JSON (matching
+        graph_instance_base.py), so a real prose answer and an error are structurally
+        distinguishable one lane down -- both would otherwise be indistinguishable
+        plain strings.
+        """
         if 'text' in lanes:
             self.instance.writeText(message)
         if 'answers' in lanes:
             answer = Answer()
-            answer.setAnswer(message)
+            answer.setAnswer(json.dumps({'error': message}))
             self.instance.writeAnswers(answer)
 
     def _emit(self, result, lanes, *, executed: bool) -> None:

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -575,35 +575,56 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         try:
             # Ask the LLM to translate the natural-language question into SQL.
             query_json = self._buildSQLQuery(question_text)
-            is_valid_query = parse_bool(query_json.get('isValid', False))
             sql_query = query_json.get('query')
+            is_valid_query = parse_bool(query_json.get('isValid', False))
 
-            # Execute the query only when the LLM flagged it as valid SQL and
-            # the safety check passes; otherwise return the LLM's text response.
-            # When EXPLAIN rejected the query on every attempt, prefer the real
-            # database error over the rejected SQL text, which reads as prose
-            # and would be indistinguishable from a genuine off-topic answer.
-            if is_valid_query and sql_query and is_sql_safe(sql_query):
-                result = self._executeSQLQuery(sql_query)
-            else:
-                result = query_json.get('error') or sql_query
+            # The EXPLAIN repair loop gave up: `query` still holds the rejected
+            # SQL, not an answer. Emit the error instead of printing it as prose.
+            if query_json.get('error'):
+                self._emitError(query_json['error'], lanes)
+                return
+            # The LLM claimed valid SQL but it fails the safety gate: same rule
+            # -- surface the rejection, never emit the unsafe SQL as prose/data.
+            if is_valid_query and sql_query and not is_sql_safe(sql_query):
+                self._emitError('Generated query contains unsafe SQL', lanes)
+                return
 
-            if 'text' in lanes:
-                self.instance.writeText(str(result))
+            executed = is_valid_query and bool(sql_query)
+            # When the LLM decides it isn't a DB question, `sql_query` holds its prose answer.
+            result = self._executeSQLQuery(sql_query) if executed else sql_query
 
-            if 'table' in lanes and is_valid_query and result:
-                self.instance.writeTable(self._formatResultAsMarkdown(result))
-
-            if 'answers' in lanes:
-                answer = Answer()
-                if is_valid_query and result:
-                    answer.setAnswer(self._formatResultAsMarkdown(result))
-                else:
-                    answer.setAnswer(str(result))
-                self.instance.writeAnswers(answer)
+            self._emit(result, lanes, executed=executed)
 
         except Exception as e:
             error(f'Error handling question: {e}')
+
+    def _emitError(self, message: str, lanes) -> None:
+        """Emit a validation/safety error to the wired lanes, never a rejected query as prose."""
+        if 'text' in lanes:
+            self.instance.writeText(message)
+        if 'answers' in lanes:
+            answer = Answer()
+            answer.setAnswer(message)
+            self.instance.writeAnswers(answer)
+
+    def _emit(self, result, lanes, *, executed: bool) -> None:
+        """Write a query result to whichever of the text/table/answers lanes are wired.
+
+        ``executed`` distinguishes real query results from a rejected/prose
+        fallback -- the table lane and the answers lane's markdown formatting
+        must key off whether the query actually ran, not just whether the LLM
+        claimed the SQL was valid.
+        """
+        if 'text' in lanes:
+            self.instance.writeText(str(result))
+
+        if 'table' in lanes and executed and result:
+            self.instance.writeTable(self._formatResultAsMarkdown(result))
+
+        if 'answers' in lanes:
+            answer = Answer()
+            answer.setAnswer(self._formatResultAsMarkdown(result) if executed and result else str(result))
+            self.instance.writeAnswers(answer)
 
     def writeTable(self, markdown: str) -> None:
         """Handle incoming markdown table data — parse and insert into the database."""

--- a/packages/ai/src/ai/common/database/db_instance_base.py
+++ b/packages/ai/src/ai/common/database/db_instance_base.py
@@ -47,6 +47,7 @@ from sqlalchemy.exc import NoSuchTableError, SQLAlchemyError
 
 from ai.common.schema import Answer, Question, QuestionType
 from ai.common.table import Table
+from ai.common.utils import parse_bool
 from rocketlib.types import IInvokeLLM
 
 from .db_global_base import DEFAULT_MAX_EXECUTE_ROWS, DatabaseGlobalBase
@@ -237,7 +238,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         limit = args.get('limit', 250)
         result = self._buildSQLQuery(question, limit=limit)
 
-        is_valid = result.get('isValid', '').lower() == 'true'
+        is_valid = parse_bool(result.get('isValid'))
         sql_query = result.get('query', '')
 
         if is_valid and sql_query and is_sql_safe(sql_query):
@@ -349,7 +350,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         for attempt in range(self.IGlobal.max_validation_attempts):
             result = self._buildSQLQueryOnce(question_text, limit=limit, previous_sql=previous_sql, error=last_error)
 
-            is_valid = result.get('isValid', '').lower() == 'true'
+            is_valid = parse_bool(result.get('isValid'))
             sql_query = result.get('query', '')
 
             # If the LLM decided the question isn't a DB query, or the safety
@@ -370,9 +371,13 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
             previous_sql = sql_query
             last_error = explain_error
 
-        warning(
-            f'SQL validation failed after {self.IGlobal.max_validation_attempts} attempt(s); returning last result.'
-        )
+        warning(f'SQL validation failed after {self.IGlobal.max_validation_attempts} attempt(s); rejecting the query.')
+        # Every EXPLAIN attempt failed. Force isValid False so callers (get_sql,
+        # get_data, writeQuestions) don't execute a query the database already
+        # refused; keep the last query for context and carry the EXPLAIN error
+        # so callers can tell this apart from a non-SQL question.
+        result['isValid'] = False
+        result['error'] = last_error or 'SQL validation failed'
         return result
 
     def _buildSQLQueryOnce(
@@ -564,7 +569,7 @@ class DatabaseInstanceBase(IInstanceBase, ABC):
         try:
             # Ask the LLM to translate the natural-language question into SQL.
             query_json = self._buildSQLQuery(question_text)
-            is_valid_query = query_json.get('isValid', '').lower() == 'true'
+            is_valid_query = parse_bool(query_json.get('isValid'))
             sql_query = query_json.get('query')
 
             # Execute the query only when the LLM flagged it as valid SQL and

--- a/packages/ai/tests/ai/common/database/test_db_base.py
+++ b/packages/ai/tests/ai/common/database/test_db_base.py
@@ -291,6 +291,25 @@ def test_build_sql_query_accepts_real_json_bool_isvalid():
     assert parse_bool(result.get('isValid')) is True
 
 
+def test_get_sql_surfaces_explain_error_not_rejected_sql():
+    """get_sql() must return the EXPLAIN error, not the rejected SQL as prose.
+
+    Before this fix, the invalid branch always returned {'answer': sql_query,
+    'valid': False}, so a caller could not tell an EXPLAIN rejection (rejected
+    SQL text) apart from a genuinely off-topic question (LLM prose answer).
+    """
+    fake_global = _FakeGlobal(explain_error='column "userz" does not exist')
+    inst = _sql_instance(fake_global)
+    inst._buildSQLQueryOnce = lambda question_text, *, limit, previous_sql, error: {
+        'isValid': 'true',
+        'query': 'SELECT * FROM userz',
+    }
+
+    result = inst.get_sql({'question': 'all users'})
+
+    assert result == {'error': 'column "userz" does not exist', 'valid': False}
+
+
 # ---------------------------------------------------------------------------
 # _tableExists (engine-backed)
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/database/test_db_base.py
+++ b/packages/ai/tests/ai/common/database/test_db_base.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
 
 from ai.common.database.db_global_base import DatabaseGlobalBase
 from ai.common.database.db_instance_base import DatabaseInstanceBase
+from ai.common.schema import Question
 from ai.common.utils import parse_bool
 
 
@@ -308,6 +309,52 @@ def test_get_sql_surfaces_explain_error_not_rejected_sql():
     result = inst.get_sql({'question': 'all users'})
 
     assert result == {'error': 'column "userz" does not exist', 'valid': False}
+
+
+class _FakeInstance:
+    """Minimal stand-in for IFilterInstance: records what each lane receives."""
+
+    def __init__(self, lanes):
+        self._lanes = lanes
+        self.text_written = None
+        self.answer_written = None
+
+    def getListeners(self):
+        return list(self._lanes)
+
+    def writeText(self, text):
+        self.text_written = text
+
+    def writeTable(self, markdown):
+        pass
+
+    def writeAnswers(self, answer):
+        self.answer_written = answer
+
+
+def test_write_questions_surfaces_explain_error_not_rejected_sql():
+    """writeQuestions() must report the EXPLAIN error on text/answer lanes, not the rejected SQL.
+
+    Mirrors the get_sql() fix: writeQuestions() has its own separate fallback
+    path (db_instance_base.py) that must not regress to emitting the rejected
+    SQL as if it were the LLM's prose answer.
+    """
+    fake_global = _FakeGlobal(explain_error='syntax error near FROM')
+    inst = _sql_instance(fake_global)
+    inst._buildSQLQueryOnce = lambda question_text, *, limit, previous_sql, error: {
+        'isValid': 'true',
+        'query': 'SELECT * FROM',
+    }
+    fake_instance = _FakeInstance(lanes=['text', 'answers'])
+    inst.instance = fake_instance
+
+    question = Question()
+    question.addQuestion('all users')
+
+    inst.writeQuestions(question)
+
+    assert fake_instance.text_written == 'syntax error near FROM'
+    assert fake_instance.answer_written.getText() == 'syntax error near FROM'
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/database/test_db_base.py
+++ b/packages/ai/tests/ai/common/database/test_db_base.py
@@ -317,6 +317,7 @@ class _FakeInstance:
     def __init__(self, lanes):
         self._lanes = lanes
         self.text_written = None
+        self.table_written = None
         self.answer_written = None
 
     def getListeners(self):
@@ -326,7 +327,7 @@ class _FakeInstance:
         self.text_written = text
 
     def writeTable(self, markdown):
-        pass
+        self.table_written = markdown
 
     def writeAnswers(self, answer):
         self.answer_written = answer
@@ -357,7 +358,7 @@ def test_write_questions_surfaces_explain_error_not_rejected_sql(is_valid_value)
     inst.writeQuestions(question)
 
     assert fake_instance.text_written == 'syntax error near FROM'
-    assert fake_instance.answer_written.getText() == 'syntax error near FROM'
+    assert fake_instance.answer_written.getJson() == {'error': 'syntax error near FROM'}
 
 
 @pytest.mark.parametrize('is_valid_value', [True, 'true'])
@@ -399,7 +400,10 @@ def test_write_questions_emits_error_for_unsafe_sql_not_as_data():
     fails the safety gate, the old code still let the rejected SQL fall
     through to _formatResultAsMarkdown on the table/answers lanes -- keyed off
     is_valid_query rather than whether anything was actually executed -- so
-    the rejected SQL went out dressed up as a one-cell table of "data".
+    the rejected SQL went out dressed up as a one-cell table of "data". Also
+    asserts the table lane stayed silent -- the test name promises that, but
+    _FakeInstance.writeTable() previously discarded its argument instead of
+    recording it, so a regression here would have passed unnoticed.
     """
     fake_global = _FakeGlobal()
     inst = _sql_instance(fake_global)
@@ -416,7 +420,8 @@ def test_write_questions_emits_error_for_unsafe_sql_not_as_data():
     inst.writeQuestions(question)
 
     assert fake_instance.text_written == 'Generated query contains unsafe SQL'
-    assert fake_instance.answer_written.getText() == 'Generated query contains unsafe SQL'
+    assert fake_instance.answer_written.getJson() == {'error': 'Generated query contains unsafe SQL'}
+    assert fake_instance.table_written is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/database/test_db_base.py
+++ b/packages/ai/tests/ai/common/database/test_db_base.py
@@ -391,6 +391,34 @@ def test_write_questions_executes_query_when_valid(is_valid_value):
     assert fake_instance.text_written == str([{'answer': 42}])
 
 
+def test_write_questions_emits_error_for_unsafe_sql_not_as_data():
+    """writeQuestions() must emit unsafe SQL as an error, not as formatted table/answer data.
+
+    Regression for the partial mirror caught in review: is_valid_query alone
+    doesn't mean the query ran. When the LLM claims isValid=true but the SQL
+    fails the safety gate, the old code still let the rejected SQL fall
+    through to _formatResultAsMarkdown on the table/answers lanes -- keyed off
+    is_valid_query rather than whether anything was actually executed -- so
+    the rejected SQL went out dressed up as a one-cell table of "data".
+    """
+    fake_global = _FakeGlobal()
+    inst = _sql_instance(fake_global)
+    inst._buildSQLQueryOnce = lambda question_text, *, limit, previous_sql, error: {
+        'isValid': 'true',
+        'query': 'DELETE FROM users',
+    }
+    fake_instance = _FakeInstance(lanes=['text', 'table', 'answers'])
+    inst.instance = fake_instance
+
+    question = Question()
+    question.addQuestion('delete all users')
+
+    inst.writeQuestions(question)
+
+    assert fake_instance.text_written == 'Generated query contains unsafe SQL'
+    assert fake_instance.answer_written.getText() == 'Generated query contains unsafe SQL'
+
+
 # ---------------------------------------------------------------------------
 # _tableExists (engine-backed)
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/database/test_db_base.py
+++ b/packages/ai/tests/ai/common/database/test_db_base.py
@@ -332,17 +332,20 @@ class _FakeInstance:
         self.answer_written = answer
 
 
-def test_write_questions_surfaces_explain_error_not_rejected_sql():
+@pytest.mark.parametrize('is_valid_value', [True, 'true'])
+def test_write_questions_surfaces_explain_error_not_rejected_sql(is_valid_value):
     """writeQuestions() must report the EXPLAIN error on text/answer lanes, not the rejected SQL.
 
     Mirrors the get_sql() fix: writeQuestions() has its own separate fallback
     path (db_instance_base.py) that must not regress to emitting the rejected
-    SQL as if it were the LLM's prose answer.
+    SQL as if it were the LLM's prose answer. Parametrized over a real JSON
+    boolean and the string 'true' so a regression in isValid parsing inside
+    this specific caller would also be caught.
     """
     fake_global = _FakeGlobal(explain_error='syntax error near FROM')
     inst = _sql_instance(fake_global)
     inst._buildSQLQueryOnce = lambda question_text, *, limit, previous_sql, error: {
-        'isValid': 'true',
+        'isValid': is_valid_value,
         'query': 'SELECT * FROM',
     }
     fake_instance = _FakeInstance(lanes=['text', 'answers'])

--- a/packages/ai/tests/ai/common/database/test_db_base.py
+++ b/packages/ai/tests/ai/common/database/test_db_base.py
@@ -360,6 +360,37 @@ def test_write_questions_surfaces_explain_error_not_rejected_sql(is_valid_value)
     assert fake_instance.answer_written.getText() == 'syntax error near FROM'
 
 
+@pytest.mark.parametrize('is_valid_value', [True, 'true'])
+def test_write_questions_executes_query_when_valid(is_valid_value):
+    """writeQuestions() must execute and emit results when EXPLAIN accepts the
+    query on the first attempt, for both a real JSON boolean and the string
+    'true'.
+
+    The EXPLAIN-exhaustion test above always ends with isValid forced to
+    False by _buildSQLQuery, so it can't distinguish True from 'true' -- both
+    parametrized cases hit the same overwritten value. This test exercises
+    the success path instead, where EXPLAIN accepts the query immediately and
+    the LLM's isValid value passes through _buildSQLQuery unchanged.
+    """
+    fake_global = _FakeGlobal()
+    fake_global._validateQuery = lambda sql: (True, None)  # EXPLAIN accepts it first try
+    inst = _sql_instance(fake_global)
+    inst._buildSQLQueryOnce = lambda question_text, *, limit, previous_sql, error: {
+        'isValid': is_valid_value,
+        'query': 'SELECT 1',
+    }
+    inst._executeSQLQuery = lambda sql: [{'answer': 42}]
+    fake_instance = _FakeInstance(lanes=['text'])
+    inst.instance = fake_instance
+
+    question = Question()
+    question.addQuestion('the answer')
+
+    inst.writeQuestions(question)
+
+    assert fake_instance.text_written == str([{'answer': 42}])
+
+
 # ---------------------------------------------------------------------------
 # _tableExists (engine-backed)
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/database/test_db_base.py
+++ b/packages/ai/tests/ai/common/database/test_db_base.py
@@ -35,6 +35,7 @@ from sqlalchemy import (
 
 from ai.common.database.db_global_base import DatabaseGlobalBase
 from ai.common.database.db_instance_base import DatabaseInstanceBase
+from ai.common.utils import parse_bool
 
 
 # ---------------------------------------------------------------------------
@@ -216,6 +217,78 @@ def test_sanitize_row_list_input():
 def test_sanitize_row_scalar_input():
     """A scalar value is sanitized directly (not wrapped in a list)."""
     assert DatabaseInstanceBase._sanitize_row(42) == 42
+
+
+# ---------------------------------------------------------------------------
+# _buildSQLQuery (EXPLAIN exhaustion + isValid parsing) — regression for #1601
+# ---------------------------------------------------------------------------
+
+
+class _TestableInstance(DatabaseInstanceBase):
+    """Concrete DatabaseInstanceBase that satisfies the two abstract methods."""
+
+    def _db_display_name(self):
+        """Human-readable name used in tool descriptions."""
+        return 'TestDB'
+
+    def _db_dialect(self):
+        """Machine-readable dialect identifier."""
+        return 'testdb'
+
+
+class _FakeGlobal:
+    """Stub IGlobal: every EXPLAIN attempt rejects the query."""
+
+    def __init__(self, max_attempts=2, explain_error='syntax error near FROM'):
+        self.max_validation_attempts = max_attempts
+        self._explain_error = explain_error
+
+    def _validateQuery(self, sql):
+        return False, self._explain_error
+
+
+def _sql_instance(fake_global):
+    inst = _TestableInstance.__new__(_TestableInstance)
+    inst.IGlobal = fake_global
+    return inst
+
+
+def test_build_sql_query_marks_invalid_after_explain_exhaustion():
+    """Every EXPLAIN attempt failing must flip isValid to False, not leave the LLM's 'true'.
+
+    Before the fix, exhaustion returned the last LLM response unchanged, so
+    get_sql/get_data/writeQuestions executed a statement the database had
+    already refused on every attempt.
+    """
+    inst = _sql_instance(_FakeGlobal())
+    inst._buildSQLQueryOnce = lambda question_text, *, limit, previous_sql, error: {
+        'isValid': 'true',
+        'query': 'SELECT * FROM users',
+    }
+
+    result = inst._buildSQLQuery('all users')
+
+    assert parse_bool(result.get('isValid')) is False
+    assert result.get('error')  # the EXPLAIN error is carried for the caller
+
+
+def test_build_sql_query_accepts_real_json_bool_isvalid():
+    """A real JSON bool from the LLM must not crash isValid parsing.
+
+    Before the fix, `result.get('isValid', '').lower()` raised AttributeError
+    the moment the LLM returned a real bool instead of the string 'true'.
+    """
+    fake_global = _FakeGlobal()
+    fake_global._validateQuery = lambda sql: (True, None)
+    inst = _sql_instance(fake_global)
+    inst._buildSQLQueryOnce = lambda question_text, *, limit, previous_sql, error: {
+        'isValid': True,  # real bool, not the string 'true'
+        'query': 'SELECT 1',
+    }
+
+    result = inst._buildSQLQuery('anything')  # must not raise AttributeError
+
+    assert parse_bool(result.get('isValid')) is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Mirrors the fix already applied to the graph base (#1584): after every EXPLAIN attempt fails, isValid is now forced to False with the error carried, instead of silently returning the LLM's last isValid: true. isValid parsing now goes through ai.common.utils.parse_bool instead of .lower() == 'true', which crashed on a real JSON boolean.

Fixes #1601

## Why this matters

Without this fix, a query the database already rejected could still get executed downstream (masked as a generic error), and any LLM response using a real JSON boolean for 'isValid' (instead of the string "true") would crash the request entirely.

## Summary

- '_buildSQLQuery': after every EXPLAIN attempt is rejected, set 'isValid=False' and carry the EXPLAIN error, instead of returning the last LLM response unchanged (which still had `isValid: true`)
- Replaced all three 'result.get('isValid', '').lower() == 'true'' call sites ('get_sql', '_buildSQLQuery', 'writeQuestions') with 'ai.common.utils.parse_bool(...)', so a real JSON boolean from the LLM no longer raises `AttributeError`
- Added two regression tests in 'test_db_base.py' covering both cases

## Type

Bug fix

## Testing

- Added 'test_build_sql_query_marks_invalid_after_explain_exhaustion' and 'test_build_sql_query_accepts_real_json_bool_isvalid' to 'packages/ai/tests/ai/common/database/test_db_base.py'
- Ran './builder ai:test' locally — all tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interpretation of SQL validation results, including boolean values in different formats.
  * When SQL validation exhausts all attempts, the query is now marked invalid and returns the final validation error instead of rejected SQL.
  * Prevented invalid SQL from being presented as a successful answer.

* **Tests**
  * Added regression coverage for validation exhaustion, boolean validation results, and surfaced validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->