### PR TITLE
fix pgvector compose image

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -56,7 +56,7 @@ services:
 
   # ── PostgreSQL + pgvector ────────────────────────────────────────────────
   postgres:
-    image: ankane/pgvector:v0.8.0
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-rocketride}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}


### PR DESCRIPTION
fixes #1684

what changed:
- replaced the removed `ankane/pgvector:v0.8.0` image with `pgvector/pgvector:pg16` in `docker/docker-compose.yml`

why:
the documented docker stack fails at image pull time because the old pgvector image tag no longer resolves.

checks:
- `docker compose -f docker/docker-compose.yml config`
- `docker manifest inspect pgvector/pgvector:pg16`

breaking changes: none
