### PR TITLE
docs: update rocketride docs links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://docs.rocketride.ai
+    url: https://docs.rocketride.org
     about: Check the docs for guides, API references, and examples.
   - name: Wiki
     url: https://github.com/rocketride-org/rocketride-server/wiki

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -4,7 +4,7 @@ Looking for help with RocketRide? Here's where to go.
 
 ## Documentation
 
-- **[Documentation site](https://docs.rocketride.ai)**: guides, tutorials, API reference
+- **[Documentation site](https://docs.rocketride.org)**: guides, tutorials, API reference
 - **[Build system docs](docs/README-builder.md)**: building from source
 - **[Client library docs](docs/README-clients.md)**: TypeScript, Python, MCP SDKs
 


### PR DESCRIPTION
fixes #1534

## changes
- update the issue-template documentation link to `docs.rocketride.org`
- update the support documentation link to the same domain

## verification
- `rg -n "docs\.rocketride\.ai" .github docs README* || true`
- `git diff --check`
- `curl -I -L --max-time 20 https://docs.rocketride.org`