### PR TITLE
fix(events-ui): filter event monitor tokens

### DIFF
--- a/apps/events-ui/src/hooks/useEventCapture.ts
+++ b/apps/events-ui/src/hooks/useEventCapture.ts
@@ -183,9 +183,6 @@ export function useEventCapture(): IUseEventCaptureResult {
 		if (!config.active) return;
 		// Only DAP events carry a capturable body.
 		if (event.type !== 'event') return;
-		// Token filter: a concrete token must match; '*' captures every task.
-		if (config.token !== '*' && event.token !== config.token) return;
-
 		// Record the event into the ring buffer and the metric accumulators.
 		const captured: CapturedEvent = {
 			id: nextIdRef.current++,


### PR DESCRIPTION
fixes #1629

## changes
- remove the redundant client-side `event.token` filter from Event Monitor capture
- keep the existing server-side `addMonitor({ token })` subscription scope as the source of truth

## note
- related #1630 removes the same stale check from the older `EventsApp.tsx` path; this PR applies the fix to the current `useEventCapture` hook path

## verification
- `git diff --check`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @rocketride/events-ui build`