### PR TITLE
fix memory_persistent double forwarding

### DIFF
--- a/nodes/src/nodes/memory_persistent/IInstance.py
+++ b/nodes/src/nodes/memory_persistent/IInstance.py
@@ -40,7 +40,7 @@ class IInstance(IInstanceBase):
         store = self.IGlobal.store
         if store is None:
             self.instance.writeQuestions(question)
-            return
+            return self.preventDefault()
 
         # Deep copy to prevent mutation of the original question
         question = copy.deepcopy(question)
@@ -63,7 +63,7 @@ class IInstance(IInstanceBase):
                 self._current_session_id = None
                 debug(f'Ignoring invalid session_id in question metadata: {session_id!r}')
                 self.instance.writeQuestions(question)
-                return
+                return self.preventDefault()
 
             # Load all keys from the session
             keys_result = store.list_keys(session_id)
@@ -83,6 +83,7 @@ class IInstance(IInstanceBase):
 
         # Forward the (possibly enriched) question downstream
         self.instance.writeQuestions(question)
+        return self.preventDefault()
 
     def writeAnswers(self, answer: Answer) -> None:
         """Store answer text in session memory for future retrieval, then forward.
@@ -93,7 +94,7 @@ class IInstance(IInstanceBase):
         store = self.IGlobal.store
         if store is None:
             self.instance.writeAnswers(answer)
-            return
+            return self.preventDefault()
 
         # Deep copy to prevent mutation
         answer = copy.deepcopy(answer)
@@ -116,7 +117,7 @@ class IInstance(IInstanceBase):
             except ValueError:
                 debug(f'Ignoring invalid session_id in answer metadata: {session_id!r}')
                 self.instance.writeAnswers(answer)
-                return
+                return self.preventDefault()
 
             # Store the answer text
             answer_text = answer.getText() if hasattr(answer, 'getText') else str(answer)
@@ -129,3 +130,4 @@ class IInstance(IInstanceBase):
 
         # Forward the answer downstream
         self.instance.writeAnswers(answer)
+        return self.preventDefault()

--- a/nodes/test/memory_persistent/test_node.py
+++ b/nodes/test/memory_persistent/test_node.py
@@ -802,6 +802,7 @@ class TestIInstanceLifecycle:
         inst.IGlobal = MagicMock()
         inst.IGlobal.store = store
         inst.instance = MagicMock()
+        inst.preventDefault = MagicMock()
         return inst
 
     def test_write_questions_forwards_without_store(self):
@@ -809,12 +810,14 @@ class TestIInstanceLifecycle:
         question = MagicMock()
         inst.writeQuestions(question)
         inst.instance.writeQuestions.assert_called_once()
+        inst.preventDefault.assert_called_once()
 
     def test_write_answers_forwards_without_store(self):
         inst = self._make_instance(store=None)
         answer = MagicMock()
         inst.writeAnswers(answer)
         inst.instance.writeAnswers.assert_called_once()
+        inst.preventDefault.assert_called_once()
 
     def test_write_questions_enriches_with_memory(self):
         store = PersistentMemoryStore(backend='memory')
@@ -827,6 +830,7 @@ class TestIInstanceLifecycle:
 
         inst.writeQuestions(question)
         inst.instance.writeQuestions.assert_called_once()
+        inst.preventDefault.assert_called_once()
 
         # The forwarded question should have memory_context
         forwarded = inst.instance.writeQuestions.call_args[0][0]
@@ -854,6 +858,7 @@ class TestIInstanceLifecycle:
 
         inst.writeAnswers(answer)
         inst.instance.writeAnswers.assert_called_once()
+        inst.preventDefault.assert_called_once()
 
         # Check that answer was stored
         result = store.get('test-sess', 'last_answer')


### PR DESCRIPTION
fixes #1638

changes:
- call `preventDefault()` after every explicit `writeQuestions` / `writeAnswers` forward in `memory_persistent`
- assert the lane is claimed in the existing lifecycle tests

verification:
- `git diff --check`
- `.venv/bin/python -m ruff check nodes/src/nodes/memory_persistent/IInstance.py nodes/test/memory_persistent/test_node.py`
- `.venv/bin/python -m ruff format --check nodes/src/nodes/memory_persistent/IInstance.py nodes/test/memory_persistent/test_node.py`
- scoped engine-stub runner: `PYTHONPATH=nodes/src .venv/bin/python - <<PY ... pytest.main(["nodes/test/memory_persistent/test_node.py", "-q"]) ... PY` -> 87 passed

notes:
- direct pytest cannot collect in this checkout until `depends`, `rocketlib`, and `ai.common.*` are supplied by the engine environment; the scoped runner stubs only those import-time engine modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling so delegated question and answer operations consistently prevent duplicate default processing.
  * Ensured invalid session and forwarding scenarios follow the same handling behavior.

* **Tests**
  * Added coverage verifying default processing is prevented during question and answer lifecycle operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->