### PR TITLE
fix plan gate missing plans denial

### DIFF
--- a/packages/ai/src/ai/common/account/pipeline_validation.py
+++ b/packages/ai/src/ai/common/account/pipeline_validation.py
@@ -15,7 +15,8 @@ class AccountPipelineValidation:
 
         # Check if user has required plan for pipeline
         if len(required_plans):
-            account_plans = set(getattr(account_info, 'plans', []))
+            # AccountInfo has no plans field today; missing or None fails closed.
+            account_plans = set(getattr(account_info, 'plans', None) or [])
             for required_plan in required_plans:
                 if required_plan not in account_plans:
                     return False

--- a/packages/ai/src/ai/common/account/pipeline_validation.py
+++ b/packages/ai/src/ai/common/account/pipeline_validation.py
@@ -1,11 +1,13 @@
-from typing import Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List
 from collections import deque
-from ai.web import AccountInfo
 from rocketlib import getServiceDefinition
+
+if TYPE_CHECKING:
+    from ai.web import AccountInfo
 
 
 class AccountPipelineValidation:
-    def validate(self, account_info: AccountInfo, pipeline: Dict[str, Any]) -> bool:
+    def validate(self, account_info: 'AccountInfo', pipeline: Dict[str, Any]) -> bool:
         """
         Validate the user has the correct plan for a pipeline.
         """
@@ -13,7 +15,7 @@ class AccountPipelineValidation:
 
         # Check if user has required plan for pipeline
         if len(required_plans):
-            account_plans = set(account_info.plans)
+            account_plans = set(getattr(account_info, 'plans', []))
             for required_plan in required_plans:
                 if required_plan not in account_plans:
                     return False

--- a/packages/ai/tests/_engine_stubs.py
+++ b/packages/ai/tests/_engine_stubs.py
@@ -7,9 +7,7 @@ from types import ModuleType
 from typing import Any, Optional
 
 
-def import_with_engine_stubs(
-    module_name: str, rocketlib_attrs: Optional[dict[str, Any]] = None
-) -> ModuleType:
+def import_with_engine_stubs(module_name: str, rocketlib_attrs: Optional[dict[str, Any]] = None) -> ModuleType:
     """Import a module with temporary stubs and restore the import state."""
     stubs: dict[str, ModuleType] = {
         'depends': types.ModuleType('depends'),

--- a/packages/ai/tests/_engine_stubs.py
+++ b/packages/ai/tests/_engine_stubs.py
@@ -4,13 +4,12 @@ import sys
 import types
 from importlib import import_module
 from types import ModuleType
-from typing import Any
+from typing import Any, Optional
 
 
-_MISSING = object()
-
-
-def import_with_engine_stubs(module_name: str, rocketlib_attrs: dict[str, Any] | None = None) -> ModuleType:
+def import_with_engine_stubs(
+    module_name: str, rocketlib_attrs: Optional[dict[str, Any]] = None
+) -> ModuleType:
     """Import a module with temporary stubs and restore the import state."""
     stubs: dict[str, ModuleType] = {
         'depends': types.ModuleType('depends'),
@@ -20,14 +19,30 @@ def import_with_engine_stubs(module_name: str, rocketlib_attrs: dict[str, Any] |
     for key, value in (rocketlib_attrs or {}).items():
         setattr(stubs['rocketlib'], key, value)
 
-    saved = {name: sys.modules.get(name, _MISSING) for name in (*stubs, module_name)}
+    saved_modules = sys.modules.copy()
+    saved_parents = {}
+    parts = module_name.split('.')
+    for index in range(1, len(parts)):
+        parent_name = '.'.join(parts[:index])
+        parent = saved_modules.get(parent_name)
+        if parent is not None:
+            saved_parents[parent_name] = (parent, parent.__dict__.copy())
+
     sys.modules.update(stubs)
     sys.modules.pop(module_name, None)
     try:
         return import_module(module_name)
     finally:
-        for name, module in saved.items():
-            if module is _MISSING:
-                sys.modules.pop(name, None)
-            else:
+        # Importing a submodule also mutates its already-loaded parent package
+        # (for example, by assigning ``parent.child``). Restore both the module
+        # registry and those parent dictionaries so this helper is collection-order
+        # independent and leaves no dangling references behind.
+        current_names = set(sys.modules)
+        for name in current_names - saved_modules.keys():
+            sys.modules.pop(name, None)
+        for name, module in saved_modules.items():
+            if sys.modules.get(name) is not module:
                 sys.modules[name] = module
+        for parent, saved_dict in saved_parents.values():
+            parent.__dict__.clear()
+            parent.__dict__.update(saved_dict)

--- a/packages/ai/tests/_engine_stubs.py
+++ b/packages/ai/tests/_engine_stubs.py
@@ -1,0 +1,33 @@
+"""Helpers for importing source modules without dist/server engine modules."""
+
+import sys
+import types
+from importlib import import_module
+from types import ModuleType
+from typing import Any
+
+
+_MISSING = object()
+
+
+def import_with_engine_stubs(module_name: str, rocketlib_attrs: dict[str, Any] | None = None) -> ModuleType:
+    """Import a module with temporary stubs and restore the import state."""
+    stubs: dict[str, ModuleType] = {
+        'depends': types.ModuleType('depends'),
+        'rocketlib': types.ModuleType('rocketlib'),
+    }
+    stubs['depends'].depends = lambda *_args, **_kwargs: None  # type: ignore[attr-defined]
+    for key, value in (rocketlib_attrs or {}).items():
+        setattr(stubs['rocketlib'], key, value)
+
+    saved = {name: sys.modules.get(name, _MISSING) for name in (*stubs, module_name)}
+    sys.modules.update(stubs)
+    sys.modules.pop(module_name, None)
+    try:
+        return import_module(module_name)
+    finally:
+        for name, module in saved.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module

--- a/packages/ai/tests/ai/common/account/test_pipeline_validation.py
+++ b/packages/ai/tests/ai/common/account/test_pipeline_validation.py
@@ -15,31 +15,16 @@ External deps:
   a provider id, or None if unknown. Tests patch it via monkeypatch.
 """
 
-import importlib.util
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
+from _engine_stubs import import_with_engine_stubs
 
-def _load_import_helper():
-    path = Path(__file__).parents[2] / 'modules/task/conftest.py'
-    spec = importlib.util.spec_from_file_location('task_conftest_import_helper', path)
-    assert spec is not None
-    module = importlib.util.module_from_spec(spec)
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module.import_with_engine_stubs
-
-
-def _import_pipeline_validation():
-    return _load_import_helper()(
-        'ai.common.account.pipeline_validation',
-        {'getServiceDefinition': lambda _provider_id: None},
-    )
-
-
-pv = _import_pipeline_validation()
+pv = import_with_engine_stubs(
+    'ai.common.account.pipeline_validation',
+    {'getServiceDefinition': lambda _provider_id: None},
+)
 
 
 # ---------------------------------------------------------------------------
@@ -160,6 +145,17 @@ def test_validate_rejects_account_without_plans_field(patch_service_definitions)
     }
     validator = pv.AccountPipelineValidation()
     assert validator.validate(SimpleNamespace(), pipeline) is False
+
+
+def test_validate_rejects_account_with_none_plans(patch_service_definitions):
+    """An account with plans=None should deny required plans, not crash."""
+    patch_service_definitions['providerA'] = {'plans': ['pro']}
+    pipeline = {
+        'source': 'a',
+        'components': [{'id': 'a', 'provider': 'providerA', 'input': []}],
+    }
+    validator = pv.AccountPipelineValidation()
+    assert validator.validate(SimpleNamespace(plans=None), pipeline) is False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/account/test_pipeline_validation.py
+++ b/packages/ai/tests/ai/common/account/test_pipeline_validation.py
@@ -21,6 +21,7 @@ import pytest
 
 from tests._engine_stubs import import_with_engine_stubs
 
+
 @pytest.fixture
 def pv():
     """Import the validator with engine dependencies stubbed per test."""
@@ -28,8 +29,6 @@ def pv():
         'ai.common.account.pipeline_validation',
         {'getServiceDefinition': lambda _provider_id: None},
     )
-
-
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/account/test_pipeline_validation.py
+++ b/packages/ai/tests/ai/common/account/test_pipeline_validation.py
@@ -19,12 +19,17 @@ from types import SimpleNamespace
 
 import pytest
 
-from _engine_stubs import import_with_engine_stubs
+from tests._engine_stubs import import_with_engine_stubs
 
-pv = import_with_engine_stubs(
-    'ai.common.account.pipeline_validation',
-    {'getServiceDefinition': lambda _provider_id: None},
-)
+@pytest.fixture
+def pv():
+    """Import the validator with engine dependencies stubbed per test."""
+    return import_with_engine_stubs(
+        'ai.common.account.pipeline_validation',
+        {'getServiceDefinition': lambda _provider_id: None},
+    )
+
+
 
 
 # ---------------------------------------------------------------------------
@@ -47,7 +52,7 @@ def _account(plans):
 
 
 @pytest.fixture
-def patch_service_definitions(monkeypatch):
+def patch_service_definitions(monkeypatch, pv):
     """
     Patch ``rocketlib.getServiceDefinition`` with a mapping-driven fake.
 
@@ -75,20 +80,20 @@ def patch_service_definitions(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_validate_empty_pipeline_passes(patch_service_definitions):
+def test_validate_empty_pipeline_passes(patch_service_definitions, pv):
     """A pipeline with no source / components requires no plans, so any account passes."""
     validator = pv.AccountPipelineValidation()
     assert validator.validate(_account([]), {}) is True
 
 
-def test_validate_pipeline_without_components_passes(patch_service_definitions):
+def test_validate_pipeline_without_components_passes(patch_service_definitions, pv):
     """Source without components yields no required plans."""
     validator = pv.AccountPipelineValidation()
     pipeline = {'source': 'src', 'components': []}
     assert validator.validate(_account([]), pipeline) is True
 
 
-def test_validate_passes_when_account_has_all_required_plans(patch_service_definitions):
+def test_validate_passes_when_account_has_all_required_plans(patch_service_definitions, pv):
     """Account with all the required plans passes."""
     patch_service_definitions['providerA'] = {'plans': ['pro']}
     patch_service_definitions['providerB'] = {'plans': ['enterprise']}
@@ -109,7 +114,7 @@ def test_validate_passes_when_account_has_all_required_plans(patch_service_defin
 # ---------------------------------------------------------------------------
 
 
-def test_validate_rejects_when_missing_required_plan(patch_service_definitions):
+def test_validate_rejects_when_missing_required_plan(patch_service_definitions, pv):
     """Missing one required plan is enough to reject."""
     patch_service_definitions['providerA'] = {'plans': ['pro']}
     patch_service_definitions['providerB'] = {'plans': ['enterprise']}
@@ -125,7 +130,7 @@ def test_validate_rejects_when_missing_required_plan(patch_service_definitions):
     assert validator.validate(_account(['pro']), pipeline) is False
 
 
-def test_validate_rejects_when_account_has_no_plans(patch_service_definitions):
+def test_validate_rejects_when_account_has_no_plans(patch_service_definitions, pv):
     """An empty account.plans list cannot satisfy any required plan."""
     patch_service_definitions['providerA'] = {'plans': ['pro']}
     pipeline = {
@@ -136,7 +141,7 @@ def test_validate_rejects_when_account_has_no_plans(patch_service_definitions):
     assert validator.validate(_account([]), pipeline) is False
 
 
-def test_validate_rejects_account_without_plans_field(patch_service_definitions):
+def test_validate_rejects_account_without_plans_field(patch_service_definitions, pv):
     """An account object without plans should deny required plans, not crash."""
     patch_service_definitions['providerA'] = {'plans': ['pro']}
     pipeline = {
@@ -147,7 +152,7 @@ def test_validate_rejects_account_without_plans_field(patch_service_definitions)
     assert validator.validate(SimpleNamespace(), pipeline) is False
 
 
-def test_validate_rejects_account_with_none_plans(patch_service_definitions):
+def test_validate_rejects_account_with_none_plans(patch_service_definitions, pv):
     """An account with plans=None should deny required plans, not crash."""
     patch_service_definitions['providerA'] = {'plans': ['pro']}
     pipeline = {
@@ -163,7 +168,7 @@ def test_validate_rejects_account_with_none_plans(patch_service_definitions):
 # ---------------------------------------------------------------------------
 
 
-def test_required_plans_only_includes_reachable_nodes(patch_service_definitions):
+def test_required_plans_only_includes_reachable_nodes(patch_service_definitions, pv):
     """BFS starts from ``source``; nodes outside the source's reach are ignored."""
     patch_service_definitions['providerA'] = {'plans': ['plan-a']}
     patch_service_definitions['providerB'] = {'plans': ['plan-b']}
@@ -184,7 +189,7 @@ def test_required_plans_only_includes_reachable_nodes(patch_service_definitions)
     assert plans == {'plan-a', 'plan-b'}
 
 
-def test_required_plans_handles_branching_graph(patch_service_definitions):
+def test_required_plans_handles_branching_graph(patch_service_definitions, pv):
     """A diamond graph (a -> b, a -> c, b/c -> d) collects every node's plans once."""
     patch_service_definitions['pA'] = {'plans': ['a']}
     patch_service_definitions['pB'] = {'plans': ['b', 'shared']}
@@ -205,7 +210,7 @@ def test_required_plans_handles_branching_graph(patch_service_definitions):
     assert plans == {'a', 'b', 'c', 'd', 'shared'}
 
 
-def test_required_plans_handles_unknown_node_id(patch_service_definitions):
+def test_required_plans_handles_unknown_node_id(patch_service_definitions, pv):
     """A child reference whose target id is missing from `nodes` is silently skipped."""
     patch_service_definitions['pA'] = {'plans': ['a']}
     pipeline = {
@@ -222,7 +227,7 @@ def test_required_plans_handles_unknown_node_id(patch_service_definitions):
     assert plans == {'a'}
 
 
-def test_required_plans_handles_provider_without_plans_key(patch_service_definitions):
+def test_required_plans_handles_provider_without_plans_key(patch_service_definitions, pv):
     """A schema with no 'plans' key is treated as contributing nothing (not crashing)."""
     patch_service_definitions['pA'] = {}  # no 'plans' field at all
     pipeline = {
@@ -234,14 +239,14 @@ def test_required_plans_handles_provider_without_plans_key(patch_service_definit
     assert plans == set()
 
 
-def test_required_plans_no_source_returns_empty(patch_service_definitions):
+def test_required_plans_no_source_returns_empty(patch_service_definitions, pv):
     """Without a 'source' field there are no required plans."""
     pipeline = {'components': [{'id': 'x', 'provider': 'pA'}]}
     validator = pv.AccountPipelineValidation()
     assert validator._get_pipeline_required_plans(pipeline) == set()
 
 
-def test_required_plans_visited_set_prevents_revisit(monkeypatch):
+def test_required_plans_visited_set_prevents_revisit(monkeypatch, pv):
     """A node referenced from multiple parents is only visited once (cycle/dup safety)."""
     schemas = {'pA': {'plans': ['pA']}, 'pB': {'plans': ['pB']}}
     call_count: dict = {}

--- a/packages/ai/tests/ai/common/account/test_pipeline_validation.py
+++ b/packages/ai/tests/ai/common/account/test_pipeline_validation.py
@@ -15,29 +15,28 @@ External deps:
   a provider id, or None if unknown. Tests patch it via monkeypatch.
 """
 
-import importlib
-import sys
-import types
+import importlib.util
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 
-_MISSING = object()
+def _load_import_helper():
+    path = Path(__file__).parents[2] / 'modules/task/conftest.py'
+    spec = importlib.util.spec_from_file_location('task_conftest_import_helper', path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.import_with_engine_stubs
 
 
 def _import_pipeline_validation():
-    saved = {name: sys.modules.get(name, _MISSING) for name in ('depends', 'rocketlib')}
-    sys.modules.setdefault('depends', types.SimpleNamespace(depends=lambda *_args, **_kwargs: None))
-    sys.modules.setdefault('rocketlib', types.SimpleNamespace(getServiceDefinition=lambda _provider_id: None))
-    try:
-        return importlib.import_module('ai.common.account.pipeline_validation')
-    finally:
-        for name, module in saved.items():
-            if module is _MISSING:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = module
+    return _load_import_helper()(
+        'ai.common.account.pipeline_validation',
+        {'getServiceDefinition': lambda _provider_id: None},
+    )
 
 
 pv = _import_pipeline_validation()

--- a/packages/ai/tests/ai/common/account/test_pipeline_validation.py
+++ b/packages/ai/tests/ai/common/account/test_pipeline_validation.py
@@ -8,19 +8,39 @@ True only if the supplied account has every required plan.
 
 External deps:
 
-- ``ai.web.AccountInfo`` — only used as a type hint; the real ``ai.web``
-  package is loaded normally so the import succeeds. Tests pass a
-  ``SimpleNamespace`` with a ``plans`` attribute at the call site; the
-  identity of ``AccountInfo`` is never inspected at runtime.
+- ``ai.web.AccountInfo`` — only used as a type hint. Tests pass a
+  ``SimpleNamespace`` at the call site; the identity of ``AccountInfo`` is
+  never inspected at runtime.
 - ``rocketlib.getServiceDefinition(provider)`` — returns the schema dict for
   a provider id, or None if unknown. Tests patch it via monkeypatch.
 """
 
+import importlib
+import sys
+import types
 from types import SimpleNamespace
 
 import pytest
 
-from ai.common.account import pipeline_validation as pv
+
+_MISSING = object()
+
+
+def _import_pipeline_validation():
+    saved = {name: sys.modules.get(name, _MISSING) for name in ('depends', 'rocketlib')}
+    sys.modules.setdefault('depends', types.SimpleNamespace(depends=lambda *_args, **_kwargs: None))
+    sys.modules.setdefault('rocketlib', types.SimpleNamespace(getServiceDefinition=lambda _provider_id: None))
+    try:
+        return importlib.import_module('ai.common.account.pipeline_validation')
+    finally:
+        for name, module in saved.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+pv = _import_pipeline_validation()
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +150,17 @@ def test_validate_rejects_when_account_has_no_plans(patch_service_definitions):
     }
     validator = pv.AccountPipelineValidation()
     assert validator.validate(_account([]), pipeline) is False
+
+
+def test_validate_rejects_account_without_plans_field(patch_service_definitions):
+    """An account object without plans should deny required plans, not crash."""
+    patch_service_definitions['providerA'] = {'plans': ['pro']}
+    pipeline = {
+        'source': 'a',
+        'components': [{'id': 'a', 'provider': 'providerA', 'input': []}],
+    }
+    validator = pv.AccountPipelineValidation()
+    assert validator.validate(SimpleNamespace(), pipeline) is False
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/modules/task/conftest.py
+++ b/packages/ai/tests/ai/modules/task/conftest.py
@@ -34,6 +34,9 @@ when the import is unavailable.
 
 import sys
 import types
+from importlib import import_module
+from types import ModuleType
+from typing import Any
 
 
 def _stub_module(name: str, **attrs) -> None:
@@ -51,12 +54,38 @@ def _stub_module(name: str, **attrs) -> None:
     sys.modules[name] = module
 
 
-# dist/server dependency-bootstrap: a no-op satisfies the source tree.
-_stub_module('depends', depends=lambda *_args, **_kwargs: None)
+if __name__ != 'task_conftest_import_helper':
+    # dist/server dependency-bootstrap: a no-op satisfies the source tree.
+    _stub_module('depends', depends=lambda *_args, **_kwargs: None)
 
-# dist/server shared logging/args helpers used by task_engine and friends.
-_stub_module(
-    'rocketlib',
-    debug=lambda *_args, **_kwargs: None,
-    args=types.SimpleNamespace(),
-)
+    # dist/server shared logging/args helpers used by task_engine and friends.
+    _stub_module(
+        'rocketlib',
+        debug=lambda *_args, **_kwargs: None,
+        args=types.SimpleNamespace(),
+    )
+
+
+_MISSING = object()
+
+
+def import_with_engine_stubs(module_name: str, rocketlib_attrs: dict[str, Any] | None = None) -> ModuleType:
+    """Import ``module_name`` with temporary source-tree stubs for engine-only modules."""
+    stubs: dict[str, ModuleType] = {
+        'depends': types.ModuleType('depends'),
+        'rocketlib': types.ModuleType('rocketlib'),
+    }
+    stubs['depends'].depends = lambda *_args, **_kwargs: None  # type: ignore[attr-defined]
+    for key, value in (rocketlib_attrs or {}).items():
+        setattr(stubs['rocketlib'], key, value)
+
+    saved = {name: sys.modules.get(name, _MISSING) for name in stubs}
+    sys.modules.update(stubs)
+    try:
+        return import_module(module_name)
+    finally:
+        for name, module in saved.items():
+            if module is _MISSING:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module

--- a/packages/ai/tests/ai/modules/task/conftest.py
+++ b/packages/ai/tests/ai/modules/task/conftest.py
@@ -34,9 +34,6 @@ when the import is unavailable.
 
 import sys
 import types
-from importlib import import_module
-from types import ModuleType
-from typing import Any
 
 
 def _stub_module(name: str, **attrs) -> None:
@@ -54,38 +51,12 @@ def _stub_module(name: str, **attrs) -> None:
     sys.modules[name] = module
 
 
-if __name__ != 'task_conftest_import_helper':
-    # dist/server dependency-bootstrap: a no-op satisfies the source tree.
-    _stub_module('depends', depends=lambda *_args, **_kwargs: None)
+# dist/server dependency-bootstrap: a no-op satisfies the source tree.
+_stub_module('depends', depends=lambda *_args, **_kwargs: None)
 
-    # dist/server shared logging/args helpers used by task_engine and friends.
-    _stub_module(
-        'rocketlib',
-        debug=lambda *_args, **_kwargs: None,
-        args=types.SimpleNamespace(),
-    )
-
-
-_MISSING = object()
-
-
-def import_with_engine_stubs(module_name: str, rocketlib_attrs: dict[str, Any] | None = None) -> ModuleType:
-    """Import ``module_name`` with temporary source-tree stubs for engine-only modules."""
-    stubs: dict[str, ModuleType] = {
-        'depends': types.ModuleType('depends'),
-        'rocketlib': types.ModuleType('rocketlib'),
-    }
-    stubs['depends'].depends = lambda *_args, **_kwargs: None  # type: ignore[attr-defined]
-    for key, value in (rocketlib_attrs or {}).items():
-        setattr(stubs['rocketlib'], key, value)
-
-    saved = {name: sys.modules.get(name, _MISSING) for name in stubs}
-    sys.modules.update(stubs)
-    try:
-        return import_module(module_name)
-    finally:
-        for name, module in saved.items():
-            if module is _MISSING:
-                sys.modules.pop(name, None)
-            else:
-                sys.modules[name] = module
+# dist/server shared logging/args helpers used by task_engine and friends.
+_stub_module(
+    'rocketlib',
+    debug=lambda *_args, **_kwargs: None,
+    args=types.SimpleNamespace(),
+)

--- a/packages/ai/tests/test_engine_stubs.py
+++ b/packages/ai/tests/test_engine_stubs.py
@@ -1,0 +1,45 @@
+"""Regression tests for the temporary engine import helper."""
+
+import importlib
+import sys
+import types
+
+from tests._engine_stubs import import_with_engine_stubs
+
+
+def _write_package(tmp_path, package_name, child_source):
+    package = tmp_path / package_name
+    package.mkdir()
+    (package / '__init__.py').write_text('')
+    (package / 'child.py').write_text(child_source)
+    return package
+
+
+def test_import_with_engine_stubs_restores_modules_and_parent_attributes(tmp_path, monkeypatch):
+    """Temporary imports must not leak modules or child attributes."""
+    _write_package(tmp_path, 'test_helper_parent', 'VALUE = 1\n')
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    parent = importlib.import_module('test_helper_parent')
+    original_child = types.ModuleType('test_helper_parent.child')
+    parent.child = original_child
+    monkeypatch.setitem(sys.modules, 'test_helper_parent.child', original_child)
+
+    imported = import_with_engine_stubs('test_helper_parent.child')
+
+    assert imported is not original_child
+    assert sys.modules['test_helper_parent'] is parent
+    assert sys.modules['test_helper_parent.child'] is original_child
+    assert parent.child is original_child
+
+
+def test_import_with_engine_stubs_removes_transitive_modules(tmp_path, monkeypatch):
+    """Modules created by a temporary import disappear after it returns."""
+    package = _write_package(tmp_path, 'test_helper_transitive', 'import test_helper_transitive.extra\n')
+    (package / 'extra.py').write_text('VALUE = 1\n')
+    monkeypatch.syspath_prepend(str(tmp_path))
+
+    import_with_engine_stubs('test_helper_transitive.child')
+
+    assert 'test_helper_transitive.child' not in sys.modules
+    assert 'test_helper_transitive.extra' not in sys.modules


### PR DESCRIPTION
fixes #1672

changes:
- treat missing `account_info.plans` as no entitlements instead of raising `AttributeError`
- keep the `ai.web.AccountInfo` import type-check-only so the validator does not load the web server at runtime
- add a regression for account objects without a `plans` field
- scope the source-tree import stubs used by the focused test and restore `sys.modules` after importing the validator

## Fail-closed semantics (design note)

`AccountInfo` currently carries no `plans` field at all, and no `services.json` declares a `plans` key. By design, the plan gate fails closed: whenever a pipeline declares required plans that cannot be proven satisfied, the account is denied. Today that branch is inert (no pipeline declares plans); the moment an entitlement source is wired up, `set(getattr(account_info, 'plans', None) or [])` in `AccountPipelineValidation.validate` is the single place that changes. Confirmed in review discussion with @kgarg2468.

## Review follow-ups (kgarg2468)

- `plans=None` can no longer crash: `getattr(..., None) or []` covers both missing-attribute and explicit-`None`, pinned by a `SimpleNamespace(plans=None)` regression test.
- The import-stub helper is extracted to `packages/ai/tests/_engine_stubs.py` and imported as `tests._engine_stubs` (fixes the collection `ModuleNotFoundError`), and the module-level import is gone: `pv` is a per-test fixture.
- The stub restore is now collection-order independent: it snapshots the whole `sys.modules` registry plus already-loaded parent package `__dict__`s and unwinds everything the temporary import pulled in (`ai`, `ai.common`, `ai.common.account`), with regression tests in `packages/ai/tests/test_engine_stubs.py`.

CodeRabbit:
- addressed the import-stub persistence thread; it is now resolved/outdated after commit `3eaa268b`

verification:
- `PYTHONPATH=packages/ai/src .venv/bin/pytest packages/ai/tests/ai/common/account/test_pipeline_validation.py packages/ai/tests/test_engine_stubs.py` (15 passed)
- `git diff --check`
- `ruff check` (0.16.x) on all changed files
- `ruff format --check` (0.16.x) on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account validation now safely handles missing or empty plan information without raising errors.
  * Existing required-plan validation behavior remains unchanged.

* **Tests**
  * Added coverage for accounts without plan information and accounts with null plan values.
  * Improved validation test reliability and coverage for related edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->