### PR TITLE
fix Google Workspace connection probes

### DIFF
--- a/nodes/src/nodes/tool_google_workspace/drive/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/drive/IInstance.py
@@ -156,13 +156,13 @@ class IInstance(GoogleToolInstanceBase):
         description=(
             'Check the Google Drive connection and verify that the granted OAuth scopes cover the '
             "node's configured access tier. Call this when a Drive operation fails with a scope or "
-            'permission error. Returns connection_ok: true when the required scopes are present.'
+            'permission error. Returns connection_ok: true when the API probe succeeds and the required scopes are present.'
         ),
         input_schema={'type': 'object', 'properties': {}, 'required': []},
     )
     def check_connection(self, args: dict) -> dict:
         """Check Drive connection status and whether granted OAuth scopes cover the access tier. Read-only."""
-        return self._check_connection_impl()
+        return self._check_connection_impl(probe=lambda s: execute(s.about().get(fields='user')))
 
     # =======================================================================
     # FILES — read

--- a/nodes/src/nodes/tool_google_workspace/gmail/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/gmail/IInstance.py
@@ -148,7 +148,10 @@ class IInstance(GoogleToolInstanceBase):
         """Check Gmail connection status and whether granted OAuth scopes cover the configured access tier. Read-only."""
 
         def probe(s):
-            if _GMAIL_SETTINGS_SCOPE in self._access().scopes:
+            scopes = set(self._access().scopes)
+            if _GMAIL_SETTINGS_SHARING_SCOPE in scopes:
+                return execute(s.users().settings().sendAs().list(userId=USER_ID))
+            if _GMAIL_SETTINGS_SCOPE in scopes:
                 return execute(s.users().settings().getPop(userId=USER_ID))
             return execute(s.users().getProfile(userId=USER_ID))
 

--- a/nodes/src/nodes/tool_google_workspace/gmail/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/gmail/IInstance.py
@@ -140,13 +140,19 @@ class IInstance(GoogleToolInstanceBase):
             "Check the Gmail connection status and verify that the OAuth token's granted scopes "
             "cover the node's configured access tier. Call this when a Gmail operation fails with "
             'a scope or permission error, or before attempting settings-level operations for the '
-            'first time. Returns connection_ok: true when all required scopes are present.'
+            'first time. Returns connection_ok: true when the API probe succeeds and all required scopes are present.'
         ),
         input_schema={'type': 'object', 'properties': {}, 'required': []},
     )
     def check_connection(self, args: dict) -> dict:
         """Check Gmail connection status and whether granted OAuth scopes cover the configured access tier. Read-only."""
-        return self._check_connection_impl()
+
+        def probe(s):
+            if _GMAIL_SETTINGS_SCOPE in self._access().scopes:
+                return execute(s.users().settings().getPop(userId=USER_ID))
+            return execute(s.users().getProfile(userId=USER_ID))
+
+        return self._check_connection_impl(probe=probe)
 
     # =======================================================================
     # MESSAGES — read

--- a/nodes/test/tool_google_workspace/drive/test_drive.py
+++ b/nodes/test/tool_google_workspace/drive/test_drive.py
@@ -186,6 +186,9 @@ class FakeDrive:
     def changes(self):
         return _Node(self, 'changes')
 
+    def about(self):
+        return _Node(self, 'about')
+
     def call_for(self, op):
         """Return the kwargs of the FIRST recorded call to terminal method ``op``."""
         return next((kw for n, kw in self.calls if n == op), None)
@@ -729,6 +732,14 @@ def test_check_connection_reports_ok():
     assert out['connection_ok'] is True
     assert out['access'] == 'write'
     assert any('drive' in s for s in out['requiredScopes'])
+    assert inst.IGlobal.service.call_for('get')['fields'] == 'user'
+
+
+def test_check_connection_reports_drive_api_probe_failure():
+    inst = _make(results={'get': RuntimeError('Drive API disabled')})
+    out = inst.check_connection({})
+    assert out['connection_ok'] is False
+    assert 'Drive API disabled' in out['error']
 
 
 # ---------------------------------------------------------------------------

--- a/nodes/test/tool_google_workspace/gmail/test_gmail.py
+++ b/nodes/test/tool_google_workspace/gmail/test_gmail.py
@@ -615,6 +615,21 @@ def test_check_connection_ok_with_full_scope(monkeypatch):
     assert result['authType'] == 'user'
 
 
+def test_check_connection_settings_sharing_uses_settings_probe(monkeypatch):
+    """A settings-sharing token is checked through a settings API, not getProfile."""
+    mocks = Path(__file__).resolve().parents[2] / 'mocks'
+    monkeypatch.syspath_prepend(str(mocks))
+    inst = _inst_with_token(
+        'settings_sharing',
+        {'access_token': 'tok', 'scope': 'https://www.googleapis.com/auth/gmail.settings.basic https://www.googleapis.com/auth/gmail.settings.sharing'},
+    )
+    _patch_config(monkeypatch, inst)
+    result = inst.check_connection({})
+    assert result['connection_ok']
+    assert inst.IGlobal.service.call_for('list')['userId'] == 'me'
+    assert not any(name == 'getProfile' for name, _ in inst.IGlobal.service.calls)
+
+
 def test_check_connection_reports_gmail_api_probe_failure(monkeypatch):
     """check_connection reports disabled/unreachable Gmail API as not OK."""
     mocks = Path(__file__).resolve().parents[2] / 'mocks'

--- a/nodes/test/tool_google_workspace/gmail/test_gmail.py
+++ b/nodes/test/tool_google_workspace/gmail/test_gmail.py
@@ -624,6 +624,7 @@ def test_check_connection_settings_sharing_uses_settings_probe(monkeypatch):
         {
             'access_token': 'tok',
             'scope': (
+                'https://www.googleapis.com/auth/gmail.modify '
                 'https://www.googleapis.com/auth/gmail.settings.basic '
                 'https://www.googleapis.com/auth/gmail.settings.sharing'
             ),

--- a/nodes/test/tool_google_workspace/gmail/test_gmail.py
+++ b/nodes/test/tool_google_workspace/gmail/test_gmail.py
@@ -621,7 +621,13 @@ def test_check_connection_settings_sharing_uses_settings_probe(monkeypatch):
     monkeypatch.syspath_prepend(str(mocks))
     inst = _inst_with_token(
         'settings_sharing',
-        {'access_token': 'tok', 'scope': 'https://www.googleapis.com/auth/gmail.settings.basic https://www.googleapis.com/auth/gmail.settings.sharing'},
+        {
+            'access_token': 'tok',
+            'scope': (
+                'https://www.googleapis.com/auth/gmail.settings.basic '
+                'https://www.googleapis.com/auth/gmail.settings.sharing'
+            ),
+        },
     )
     _patch_config(monkeypatch, inst)
     result = inst.check_connection({})

--- a/nodes/test/tool_google_workspace/gmail/test_gmail.py
+++ b/nodes/test/tool_google_workspace/gmail/test_gmail.py
@@ -569,9 +569,9 @@ def test_thread_modify_requires_labels():
 # ---------------------------------------------------------------------------
 
 
-def _inst_with_token(access_tier: str, token: dict | None) -> 'IInstance.IInstance':
+def _inst_with_token(access_tier: str, token: dict | None, results: dict | None = None) -> 'IInstance.IInstance':
     """Return an IInstance whose IGlobal.glb simulates a persisted user token."""
-    inst = make_inst(access_tier)
+    inst = make_inst(access_tier, results=results)
     token_json = json.dumps(token) if token is not None else ''
     inst.IGlobal.glb = types.SimpleNamespace(logicalType='tool_gmail', connConfig={})
     inst.IGlobal._token_cfg = {'authType': 'user', 'userToken': token_json}
@@ -597,6 +597,7 @@ def test_check_connection_missing_scope(monkeypatch):
     _patch_config(monkeypatch, inst)
     result = inst.check_connection({})
     assert not result['connection_ok']
+    assert inst.IGlobal.service.call_for('getPop')['userId'] == 'me'
     assert any('gmail.settings.basic' in s for s in result['missingScopes'])
     assert result['authType'] == 'user'
 
@@ -609,8 +610,24 @@ def test_check_connection_ok_with_full_scope(monkeypatch):
     _patch_config(monkeypatch, inst)
     result = inst.check_connection({})
     assert result['connection_ok']
+    assert inst.IGlobal.service.call_for('getPop')['userId'] == 'me'
     assert result.get('missingScopes', []) == []
     assert result['authType'] == 'user'
+
+
+def test_check_connection_reports_gmail_api_probe_failure(monkeypatch):
+    """check_connection reports disabled/unreachable Gmail API as not OK."""
+    mocks = Path(__file__).resolve().parents[2] / 'mocks'
+    monkeypatch.syspath_prepend(str(mocks))
+    inst = _inst_with_token(
+        'settings',
+        {'access_token': 'tok', 'scope': 'https://mail.google.com/'},
+        results={'getPop': RuntimeError('Gmail API disabled')},
+    )
+    _patch_config(monkeypatch, inst)
+    result = inst.check_connection({})
+    assert result['connection_ok'] is False
+    assert 'Gmail API disabled' in result['error']
 
 
 def test_check_connection_readonly_satisfied_by_modify(monkeypatch):


### PR DESCRIPTION
fixes #1694

## changes
- add live connection probes for Google Workspace Gmail and Drive nodes
- keep existing missing-scope diagnostics in the shared connection checker
- use the Gmail settings API for settings-tier Gmail probes

## verification
- `PYTHONPATH=nodes/src:nodes/test:packages/server/engine-lib/rocketlib-python/lib /home/ericwang/Projects/upstream-contributions/rocketride-issue1638/.venv/bin/python -m pytest nodes/test/tool_google_workspace/gmail/test_gmail.py nodes/test/tool_google_workspace/drive/test_drive.py -q`
- `PYTHONPATH=nodes/src:nodes/test:packages/server/engine-lib/rocketlib-python/lib /home/ericwang/Projects/upstream-contributions/rocketride-issue1638/.venv/bin/python -m pytest nodes/test/tool_google_workspace/gmail/test_gmail.py -q`
- `/home/ericwang/Projects/upstream-contributions/rocketride-issue1638/.venv/bin/python -m ruff check nodes/src/nodes/tool_google_workspace/drive/IInstance.py nodes/src/nodes/tool_google_workspace/gmail/IInstance.py nodes/test/tool_google_workspace/drive/test_drive.py nodes/test/tool_google_workspace/gmail/test_gmail.py`
- `/home/ericwang/Projects/upstream-contributions/rocketride-issue1638/.venv/bin/python -m ruff format --check nodes/src/nodes/tool_google_workspace/drive/IInstance.py nodes/src/nodes/tool_google_workspace/gmail/IInstance.py nodes/test/tool_google_workspace/drive/test_drive.py nodes/test/tool_google_workspace/gmail/test_gmail.py`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Drive and Gmail connection checks by verifying API availability and required permissions.
  * Added service-specific Gmail checks for settings and sending permissions.
  * Connection diagnostics now report clear failure details when an API probe fails.

* **Tests**
  * Expanded coverage for Drive and Gmail connection verification, permission handling, authentication details, service-specific probes, and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->