### PR TITLE
fix(google-workspace): stop reporting connection_ok when nothing was checked

### DIFF
--- a/nodes/src/nodes/tool_google_workspace/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/IInstance.py
@@ -91,14 +91,27 @@ class GoogleToolInstanceBase(IInstanceBase):
             'connection_ok': self._svc() is not None,
             'access': getattr(access, 'tier', None),
             'requiredScopes': list(getattr(access, 'scopes', []) or []),
+            # What was actually exercised, so a caller can tell a verified
+            # answer from an assumed one. Without this, `connection_ok: true`
+            # meant "we hold a plausible credential" while everyone read it as
+            # "this node works" — see #1694, where it sat next to a 403 saying
+            # the API was disabled and sent the reporter off re-authenticating.
+            'checked': ['client', 'scopes'],
         }
         service = self._svc()
         if probe is not None and service is not None:
             try:
                 probe(service)
+                out['checked'].append('api')
             except Exception as exc:
                 out['connection_ok'] = False
                 out['error'] = str(exc)[:200]
+                # Google distinguishes accessNotConfigured (API disabled) from
+                # forbidden (permission) from rateLimitExceeded, and that word
+                # alone names the fix. Losing it costs the reader the diagnosis.
+                reason = getattr(exc, 'reason', None) or getattr(exc, '_get_reason', lambda: None)()
+                if reason:
+                    out['errorReason'] = str(reason).strip()[:120]
         try:
             cfg = Config.getNodeConfig(self.IGlobal.glb.logicalType, self.IGlobal.glb.connConfig)
             auth_type = (cfg.get('authType') or 'service').strip()
@@ -116,4 +129,15 @@ class GoogleToolInstanceBase(IInstanceBase):
                         out['error'] = f'invalid user token data: {str(exc)[:160]}'
         except Exception:
             pass  # config lookup diagnostics must never raise
+
+        # No live call was made, so `connection_ok` here only means the
+        # credential looks usable. Say so rather than letting it read as proof:
+        # a disabled API, an exhausted quota, disabled billing and an org-policy
+        # block are all invisible to a client-and-scopes check.
+        if 'api' not in out['checked'] and out['connection_ok']:
+            out['connection_ok'] = 'unknown'
+            out['note'] = (
+                'Credential and scopes look correct; no API call was made, so this '
+                'does not confirm the service is reachable or enabled.'
+            )
         return out

--- a/nodes/src/nodes/tool_google_workspace/drive/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/drive/IInstance.py
@@ -162,7 +162,7 @@ class IInstance(GoogleToolInstanceBase):
     )
     def check_connection(self, args: dict) -> dict:
         """Check Drive connection status and whether granted OAuth scopes cover the access tier. Read-only."""
-        return self._check_connection_impl()
+        return self._check_connection_impl(probe=lambda s: execute(s.about().get(fields='user')))
 
     # =======================================================================
     # FILES — read

--- a/nodes/src/nodes/tool_google_workspace/gmail/IInstance.py
+++ b/nodes/src/nodes/tool_google_workspace/gmail/IInstance.py
@@ -146,7 +146,7 @@ class IInstance(GoogleToolInstanceBase):
     )
     def check_connection(self, args: dict) -> dict:
         """Check Gmail connection status and whether granted OAuth scopes cover the configured access tier. Read-only."""
-        return self._check_connection_impl()
+        return self._check_connection_impl(probe=lambda s: execute(s.users().getProfile(userId='me')))
 
     # =======================================================================
     # MESSAGES — read

--- a/nodes/src/nodes/tool_google_workspace/google_client.py
+++ b/nodes/src/nodes/tool_google_workspace/google_client.py
@@ -147,6 +147,50 @@ def resolve_token_uri(svc: GoogleService, token_uri: object) -> str:
     return token_uri
 
 
+class GoogleApiError(ValueError):
+    """A failed Google API call, carrying the structured reason Google returned.
+
+    Subclasses ``ValueError`` deliberately: ``execute()`` has always raised
+    ``ValueError`` and callers catch it, so this stays backward-compatible
+    while giving them something to read.
+
+    Exists because the structured reason was being thrown away. ``execute()``
+    wrapped ``HttpError`` in a plain ``ValueError``, so by the time a caller
+    looked, ``getattr(exc, 'reason')`` found nothing — the word that names the
+    fix (``accessNotConfigured`` = the API is switched off in the project,
+    versus ``insufficientPermissions`` = wrong scopes) survived only inside a
+    prose message. Two different problems, two different fixes, one
+    indistinguishable string.
+    """
+
+    def __init__(self, message: str, *, status: int | None = None, reason: str | None = None):
+        super().__init__(message)
+        self.status = status
+        self.reason = reason
+
+
+def _error_reason(exc: Exception) -> str | None:
+    """First ``error.errors[].reason`` from a Google error body, if there is one.
+
+    Same body shape ``_is_rate_limit_403`` already parses. Returns None rather
+    than guessing when the body is absent, non-JSON, or carries no reason —
+    an absent reason must not read as a diagnosis.
+    """
+    content = getattr(exc, 'content', b'') or b''
+    if isinstance(content, bytes):
+        content = content.decode('utf-8', 'replace')
+    try:
+        errors = (json.loads(content).get('error') or {}).get('errors') or []
+        for item in errors:
+            if isinstance(item, dict) and item.get('reason'):
+                return str(item['reason'])
+    except (ValueError, AttributeError, TypeError):
+        pass
+    # googleapiclient sets .reason on HttpError itself; fall back to it.
+    direct = getattr(exc, 'reason', None)
+    return str(direct) if direct else None
+
+
 def _is_rate_limit_403(exc: Exception) -> bool:
     """True when a 403 is a transient rate/quota limit (safe to retry) vs a permission error."""
     status = getattr(getattr(exc, 'resp', None), 'status', None)
@@ -417,12 +461,18 @@ def execute(svc: GoogleService, request: Any, *, binary: bool = False) -> Any:
                 _time.sleep(base_delay * (2**attempt))
                 continue
             detail = getattr(exc, 'reason', None) or str(exc)
+            # Parse the structured reason HERE, while the HttpError is still in
+            # hand. Once we wrap it, the body is gone from the caller's view.
+            reason = _error_reason(exc)
+            code = int(status) if status else None
             if status and int(status) == 403:
-                raise ValueError(
+                raise GoogleApiError(
                     f'{svc.product} API 403: {detail}. If this is a scope error, disconnect '
                     'and reconnect your Google account with the required access tier. If it is a '
-                    'sharing/ownership error, the account may lack permission on that resource.'
+                    'sharing/ownership error, the account may lack permission on that resource.',
+                    status=code,
+                    reason=reason,
                 ) from exc
             prefix = f'{svc.product} API {status}: ' if status else f'{svc.product} request failed: '
-            raise ValueError(f'{prefix}{detail}') from exc
+            raise GoogleApiError(f'{prefix}{detail}', status=code, reason=reason) from exc
     raise RuntimeError('execute: retry loop exhausted unexpectedly')  # unreachable

--- a/nodes/test/tool_google_workspace/docs/test_docs.py
+++ b/nodes/test/tool_google_workspace/docs/test_docs.py
@@ -260,11 +260,16 @@ def test_default_tier_is_write():
     assert access.can_write is True
 
 
-def test_check_connection_reports_ok():
+def test_check_connection_reports_unknown_without_api_probe():
     inst = _make()
     out = inst.check_connection({})
     assert isinstance(out, dict)
-    assert out['connection_ok'] is True
+    # 'unknown', not True: docs/sheets make no API probe, and a client-and-scopes
+    # check cannot see a disabled API, an exhausted quota, disabled billing or an
+    # org-policy block. Reporting True there is the false green this change removes.
+    assert out['connection_ok'] == 'unknown'
+    assert 'api' not in out['checked']
+    assert 'note' in out
     assert out['access'] == 'write'
     assert any('documents' in s for s in out['requiredScopes'])
 

--- a/nodes/test/tool_google_workspace/drive/test_drive.py
+++ b/nodes/test/tool_google_workspace/drive/test_drive.py
@@ -742,6 +742,78 @@ def test_check_connection_reports_ok():
     assert any('drive' in s for s in out['requiredScopes'])
 
 
+class _FakeHttpError(Exception):
+    """Shaped like googleapiclient.errors.HttpError: ``.resp.status`` + ``.content``.
+
+    The real ``execute()`` reads exactly those two, so a fake carrying them
+    travels the same code path a live 403 does.
+    """
+
+    def __init__(self, status: int, body: dict):
+        super().__init__(f'{status} {body.get("error", {}).get("message", "")}')
+        self.resp = types.SimpleNamespace(status=status)
+        self.content = json.dumps(body).encode()
+
+
+def test_check_connection_probe_failure_reports_error_and_reason():
+    """A failing probe must flip connection_ok AND name the reason.
+
+    This is the branch the whole PR exists for and it was the one branch with
+    no test: the success path and the no-probe ``unknown`` path were covered,
+    the failure path was not.
+
+    ``accessNotConfigured`` (the Drive API is switched off in the project) and
+    ``insufficientPermissions`` (wrong scopes) are different problems with
+    different fixes. Reporting only ``connection_ok: false`` sends the reader
+    to re-authenticate when the real answer is "enable the API" — which is
+    exactly what happened in #1694.
+
+    The failure is injected at the TRANSPORT (the fake request's ``execute()``),
+    not by replacing ``execute()`` itself. That distinction is the test: stubbing
+    ``execute`` would skip the very wrapper that has to preserve the reason, and
+    the test would pass while proving nothing.
+    """
+    err = _FakeHttpError(
+        403,
+        {
+            'error': {
+                'code': 403,
+                'message': 'Google Drive API has not been used in project 123 before or it is disabled.',
+                'errors': [{'reason': 'accessNotConfigured', 'message': 'Access Not Configured.'}],
+            }
+        },
+    )
+    # check_connection's probe is about().get(...), whose terminal method is 'get'.
+    inst = _make(results={'get': err})
+
+    out = inst.check_connection({})
+
+    assert out['connection_ok'] is False
+    assert out['error']
+    # The probe was attempted but must NOT be claimed as checked — a failed
+    # check is not a completed one.
+    assert 'api' not in out['checked']
+    # The point of the fix: the structured reason survives execute()'s wrapper.
+    assert out.get('errorReason') == 'accessNotConfigured'
+
+
+def test_check_connection_probe_failure_without_reason_omits_the_field():
+    """No structured reason means no ``errorReason`` — absence beats a guess.
+
+    A transport error carries no Google error body. Emitting an empty or
+    invented reason would be worse than omitting it: the field is read as a
+    diagnosis, so it must appear only when Google actually supplied one.
+    """
+    inst = _make(results={'get': ConnectionError('connection reset by peer')})
+
+    out = inst.check_connection({})
+
+    assert out['connection_ok'] is False
+    assert out['error']
+    assert 'api' not in out['checked']
+    assert 'errorReason' not in out
+
+
 # ---------------------------------------------------------------------------
 # Error mapping
 # ---------------------------------------------------------------------------

--- a/nodes/test/tool_google_workspace/drive/test_drive.py
+++ b/nodes/test/tool_google_workspace/drive/test_drive.py
@@ -186,6 +186,13 @@ class FakeDrive:
     def changes(self):
         return _Node(self, 'changes')
 
+    def about(self):
+        # check_connection's liveness probe calls about().get(fields='user').
+        # Without this the probe raises AttributeError and the node reports
+        # connection_ok=False — which is correct behaviour for an unreachable
+        # API, and exactly why the diagnostic must be exercised, not assumed.
+        return _Node(self, 'about')
+
     def call_for(self, op):
         """Return the kwargs of the FIRST recorded call to terminal method ``op``."""
         return next((kw for n, kw in self.calls if n == op), None)
@@ -727,6 +734,10 @@ def test_check_connection_reports_ok():
     inst = _make()
     out = inst.check_connection({})
     assert out['connection_ok'] is True
+    # True is only honest when an API call actually happened; assert the probe
+    # ran rather than trusting the boolean on its own.
+    assert 'api' in out['checked']
+    assert inst.IGlobal.service.call_for('get') is not None
     assert out['access'] == 'write'
     assert any('drive' in s for s in out['requiredScopes'])
 

--- a/nodes/test/tool_google_workspace/sheets/test_sheets.py
+++ b/nodes/test/tool_google_workspace/sheets/test_sheets.py
@@ -310,10 +310,14 @@ def test_default_tier_is_write():
 # ---------------------------------------------------------------------------
 
 
-def test_check_connection_reports_ok():
+def test_check_connection_reports_unknown_without_api_probe():
     inst = _make()
     out = inst.check_connection({})
-    assert out['connection_ok'] is True
+    # 'unknown', not True: sheets makes no API probe, so the credential looking
+    # correct is not evidence the service is reachable. See IInstance.check_connection.
+    assert out['connection_ok'] == 'unknown'
+    assert 'api' not in out['checked']
+    assert 'note' in out
     assert out['access'] == 'write'
     assert any('spreadsheets' in s for s in out['requiredScopes'])
 


### PR DESCRIPTION
Josh hit this on the Gmail node. One response contained both:

```
connection_ok: true
Gmail API 403 — "Gmail API has not been used in project 841282965419 … or it is disabled"
```

Both lines are ours, and they contradict each other. He re-authenticated — which could never have helped — because the tool told him the connection was fine.

## Why it passed

`connection_ok` came from three things, **none of which touch the API**:

1. a client object was constructed — local;
2. the live `probe` is **optional** and this service supplied none;
3. `token_scope_report` inspects the scopes the token *claims* — local.

So it answered *"do we hold a plausible credential"* while every reader takes it as *"this node works"*. A disabled API is invisible to all three — as are an exhausted quota, disabled billing, and an org-policy block.

## Changes

- **`checked: [...]`** — reports what was actually exercised, so a verified answer is distinguishable from an assumed one.
- **`connection_ok: unknown`** (with a note) when no live call was made, instead of `true`. *A green light nobody checked is worse than no light*, because it redirects the debugging effort — precisely what happened here.
- **`errorReason`** surfaces Googles reason verbatim: `accessNotConfigured` (API disabled) vs `forbidden` (permission) vs `rateLimitExceeded`. That one word names the fix.
- **gmail** → probes `users().getProfile(userId=me)`; **drive** → probes `about().get(fields=user)`. (calendar already probed `calendarList().list`.)

## sheets and docs deliberately get no probe

Both would need a real spreadsheet/document id. Probing with a fabricated one returns **404 on a perfectly healthy API** — a false negative, which is the same disease pointing the other way. I wrote those probes first, then removed them: shipping a check that reports "broken" for a working service would have been worse than the bug being fixed.

They now honestly report `unknown`. Giving them a genuine probe means a caller-supplied id or a create-then-delete, neither of which belongs in a read-only diagnostic.

## Verification

- All five modules compile; ruff check and format clean.
- `execute` confirmed present in the `.client` import list of **both** gmail and drive — checked rather than assumed, since a missing import would `NameError` only at call time. Calendars existing probe was the pattern.

**Not verified:** a live call against Google. There are no credentials in my environment, so the probes behaviour on a real 403 is unexercised — the first real `check_connection` is the actual test.

Closes #1694.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Workspace connection diagnostics by distinguishing verified credentials and scopes from confirmed API reachability.
  * Drive and Gmail checks now perform live service probes.
  * When reachability cannot be confirmed, results report `unknown` with a clarifying note.
  * Errors may now include more specific Google API reasons.
* **Tests**
  * Expanded coverage for uncertain connectivity, successful probes, and API failure scenarios across Workspace services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->