### PR TITLE
fix(depends): allow a CPU-only dependency resolve, opt-in

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -650,8 +650,27 @@ def _find_requirement_files() -> list[str]:
 
 
 def _compute_hash(file_paths: list[str]) -> str:
-    """Compute a fast hash from file metadata (mtime + size)."""
+    """Compute a fast hash from file metadata (mtime + size) AND the resolve mode.
+
+    The resolve mode is part of the key because it changes the OUTPUT for
+    identical inputs: with ``ROCKETRIDE_CPU_ONLY_DEPS`` set, the combined
+    requirements gain a ``--extra-index-url .../cpu`` line and resolve to the
+    CPU ``torch`` instead of the CUDA one. Hashing only the requirement files
+    would make the flag a no-op on any host that already built
+    ``constraints.txt`` — the early return in ``ensure_constraints()`` fires,
+    ``_combine_requirements()`` never re-runs, and the resolve stays CUDA while
+    reporting success. Unsetting the flag afterwards would likewise fail to
+    restore GPU.
+
+    Worse, ``_write_excludes_file()`` is rewritten on every call and *does*
+    honour the flag, so a stale cache lets the two disagree: excludes saying
+    ``onnxruntime-gpu`` while constraints still pin CUDA ``torch``.
+
+    Seeding here rather than at the call site keeps the invariant with the
+    thing it protects — any future caller inherits it.
+    """
     hasher = hashlib.md5()
+    hasher.update(f'cpu_only={_cpu_only()}\n'.encode())
     for path in sorted(file_paths):
         stat = os.stat(path)
         entry = f'{path}:{stat.st_size}:{stat.st_mtime_ns}\n'

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -674,9 +674,34 @@ def _save_hash(hash_file: str, hash_value: str):
         f.write(hash_value)
 
 
+def _cpu_only() -> bool:
+    """True when this host should resolve CPU-only wheels.
+
+    Opt-in via ``ROCKETRIDE_CPU_ONLY_DEPS=1``. Deliberately NOT auto-detected:
+    guessing "no GPU visible, therefore CPU" would silently downgrade a machine
+    whose driver simply is not loaded yet, and a silent downgrade of an
+    inference host is far worse than an oversized install.
+    """
+    return os.environ.get('ROCKETRIDE_CPU_ONLY_DEPS', '').strip().lower() in ('1', 'true', 'yes')
+
+
 def _combine_requirements(file_paths: list[str], output_path: str):
     """Concatenate all requirement files into one."""
     with open(output_path, 'w', encoding='utf-8') as out:
+        if _cpu_only():
+            # PyPI's default `torch` wheel is the CUDA build, which drags in
+            # ~13 nvidia-* packages plus triton. On the cloud ALB that measured
+            # 6.6 GB of the pod's 8.2 GB site-packages — on an m7i-flex.large
+            # with no GPU, no /dev/nvidia*, and no models (inference goes out to
+            # the H100). It was downloaded and written on every pod start and
+            # never once executed. See rocketride-server #1697.
+            #
+            # Pointing at the CPU index makes torch resolve to +cpu (~200 MB)
+            # and the nvidia-* packages are never selected at all. Verified with
+            # `uv pip compile` over the four nodes that pull torch transitively:
+            # 119 packages / 13 nvidia-* -> 105 packages / 0 nvidia-*.
+            out.write('# CPU-only resolve: ROCKETRIDE_CPU_ONLY_DEPS is set.\n')
+            out.write('--extra-index-url https://download.pytorch.org/whl/cpu\n\n')
         for path in file_paths:
             out.write(f'# Source: {path}\n')
             with open(path, 'r', encoding='utf-8') as inp:
@@ -782,8 +807,17 @@ def _write_excludes_file() -> str:
     """
     excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
     excludes = 'uv\n'
-    if platform.system() != 'Darwin':
+    # The onnxruntime exclusion keys on OS, which is not the question being
+    # asked. "Not a Mac" was used as a proxy for "has CUDA", and it is wrong on
+    # every Linux box without a GPU — including the cloud ALB, where it forces
+    # the GPU build and blocks the CPU one from ever being installed. Excluding
+    # it there would defeat the CPU-only resolve above, so honour that flag.
+    if platform.system() != 'Darwin' and not _cpu_only():
         excludes += 'onnxruntime\n'
+    elif _cpu_only():
+        # Mirror image: on a CPU-only host the GPU build is the one that must
+        # not win, for the same clobbering reason the original comment gives.
+        excludes += 'onnxruntime-gpu\n'
     with open(excludes_path, 'w', encoding='utf-8') as f:
         f.write(excludes)
     return excludes_path


### PR DESCRIPTION
The cloud ALB carries **6.6 GB of CUDA it cannot execute** — `nvidia` 4.3G, `torch` 1.7G, `triton` 639M: 80% of its 8.2 GB site-packages. The pod is an `m7i-flex.large` with no GPU capacity and no `/dev/nvidia*`, and it holds no models — inference goes out to the H100. That runtime is downloaded and written **on every pod start** and has never once run. It is the root of the DiskPressure incidents (#1697).

Adds `ROCKETRIDE_CPU_ONLY_DEPS`. When set, the compile input gains `--extra-index-url https://download.pytorch.org/whl/cpu`, so `torch` resolves to `+cpu` (~200 MB) and the `nvidia-*` packages are never selected.

## Three things had to line up — I knew about two

1. `torch` — no node declares it; it arrives transitively via gliner / transformers / accelerate, and PyPIs default wheel is the CUDA build.
2. `anonymize` declares `onnxruntime-gpu; platform_system != Darwin`.
3. **This file excluded plain `onnxruntime` on every non-Darwin host** — which would have defeated a fix to (2) outright. The CPU build could not be installed even if something asked for it.

**(3) I found while implementing, not while diagnosing**, and it is the one worth reviewing: `"not a Mac"` was being used as a proxy for `"has CUDA"`, which is wrong on every Linux box without a GPU. The exclusion now honours the flag, and on a CPU-only host excludes the *GPU* build instead — same clobbering logic, correct direction.

## Opt-in, deliberately not auto-detected

Inferring "no GPU visible, therefore CPU" would **silently downgrade** a host whose driver simply has not loaded yet. A silent downgrade of an inference machine is far worse than an oversized install. The cloud sets the flag; self-hosted users with a GPU are untouched — which is the point, and why this is not a hardcoded CPU default in node requirements.

## Verification — what is proven and what is not

**Proven**
- The resolve: `uv pip compile` over the four torch-pulling nodes, targeting `x86_64-manylinux2014`/cp312 — **119 packages / 13 `nvidia-*`** on the default index, **105 / 0** with this exact flag. No conflicts.
- The line the code emits is byte-identical to the flag I resolved with.

**Not proven**
- That `_combine_requirements()` runs correctly here. The module imports engine dependencies I dont have locally, so **both branches of the flag are unexercised** — I read the diff rather than ran it.
- That the four nodes still *work* on `torch+cpu`. `torch+cpu` raises when CUDA is actually requested, **not at import**, so a green resolve is not evidence.

**Do not set the flag in the cloud until that functional run is done.** The saving (8.2 GB → ~1.8 GB, node 84% → ~15-20%) is worth having, and not worth guessing at.

Refs #1697.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an opt-in CPU-only dependency installation mode.
  - CPU-only mode directs PyTorch installation toward CPU wheels instead of CUDA-enabled builds.
  - Updated runtime package selection to install the appropriate ONNX Runtime package for CPU-only environments.
  - Dependency constraints are automatically refreshed when the CPU-only setting changes, ensuring installations reflect the selected hardware configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->