### PR TITLE
fix(llm_qwen): correct stale and invalid DashScope model profiles

### DIFF
--- a/nodes/src/nodes/llm_qwen/README.md
+++ b/nodes/src/nodes/llm_qwen/README.md
@@ -86,7 +86,7 @@ DashScope has no `:thinking` model variants — reasoning is controlled with the
 
 The default is `us`. An unrecognised value falls back to the US endpoint.
 
-Setting `base_url` overrides this table entirely, which is how you reach a DashScope host Alibaba Cloud serves outside the three above — another Alibaba Cloud region, for instance. It is available on every profile, including `custom`. Leave it empty to use the regional endpoint.
+Setting `base_url` overrides this table entirely, which is how you reach a DashScope host Alibaba Cloud serves outside the three above — another Alibaba Cloud region, for instance. It is available on every live profile, including `custom`; the deprecated profiles above do not expose it. Leave it empty to use the regional endpoint.
 
 Note: DashScope API keys are not interchangeable between regions. A key issued for one region will fail authentication against another region's endpoint.
 

--- a/nodes/src/nodes/llm_qwen/README.md
+++ b/nodes/src/nodes/llm_qwen/README.md
@@ -41,26 +41,23 @@ Profiles come in two kinds.
 
 **Stable aliases** always resolve to DashScope's current snapshot for their tier, so they do not go stale as new generations ship. Prefer these unless you need to pin a specific release:
 
-| Profile                   | Model         | Context tokens | Output tokens |
-|---------------------------|---------------|----------------|---------------|
-| Qwen Flash *(default)*    | `qwen-flash`  | 131,072        | 4,096         |
-| Qwen Plus                 | `qwen-plus`   | 1,000,000      | 32,768        |
-| Qwen Max                  | `qwen-max`    | 32,768         | 8,192         |
-| Qwen Turbo                | `qwen-turbo`  | 131,072        | 8,192         |
+| Profile                          | Model         | Context tokens | Output tokens |
+|----------------------------------|---------------|----------------|---------------|
+| Qwen Flash (latest) *(default)*  | `qwen-flash`  | 131,072        | 4,096         |
+| Qwen Plus (latest)               | `qwen-plus`   | 1,000,000      | 32,768        |
+| Qwen Max (latest)                | `qwen-max`    | 32,768         | 8,192         |
+| Qwen Turbo (latest)              | `qwen-turbo`  | 131,072        | 8,192         |
 
 **Pinned releases** name a specific model version:
 
 | Profile                | Model                  | Context tokens | Output tokens |
 |------------------------|------------------------|----------------|---------------|
-| Qwen3.8 Max (preview)  | `qwen3.8-max-preview`  | 983,616        | 131,072       |
 | Qwen3.7 Max            | `qwen3.7-max`          | 1,000,000      | 65,536        |
 | Qwen3.7 Plus           | `qwen3.7-plus`         | 1,000,000      | 65,536        |
 | Qwen3.6 Flash          | `qwen3.6-flash`        | 1,000,000      | 65,536        |
 | Qwen Plus 0728         | `qwen-plus-2025-07-28` | 1,000,000      | 32,768        |
 
 Choose `custom` to set the model name and context length manually.
-
-> **Qwen3.8 Max is a preview model.** Access is limited and it may be served from an endpoint other than the standard compatible-mode hosts. If the profile fails to validate, set `base_url` to the endpoint shown in your Alibaba Cloud console.
 
 ### Deprecated profiles
 
@@ -89,7 +86,7 @@ DashScope has no `:thinking` model variants — reasoning is controlled with the
 
 The default is `us`. An unrecognised value falls back to the US endpoint.
 
-Setting `base_url` overrides this table entirely, which is how you reach an endpoint Alibaba Cloud serves outside the three hosts above. Leave it empty to use the regional endpoint.
+Setting `base_url` overrides this table entirely, which is how you reach a DashScope host Alibaba Cloud serves outside the three above — another Alibaba Cloud region, for instance. It is available on every profile, including `custom`. Leave it empty to use the regional endpoint.
 
 Note: DashScope API keys are not interchangeable between regions. A key issued for one region will fail authentication against another region's endpoint.
 

--- a/nodes/src/nodes/llm_qwen/README.md
+++ b/nodes/src/nodes/llm_qwen/README.md
@@ -119,7 +119,7 @@ Profiles are maintained by the model sync tool, see [tools/sync_models](../../..
 python tools/sync_models/src/sync_models.py --provider llm_qwen --enable-discovery --apply
 ```
 
-Discovery requires `ROCKETRIDE_QWEN_KEY`. Without it the sync falls back to OpenRouter, which lists HuggingFace-style IDs that DashScope does not accept — the source of the deprecated profiles above. The stable aliases are listed in `protected_profiles` so a non-authoritative source cannot deprecate them.
+Discovery — adding profiles — requires `ROCKETRIDE_QWEN_KEY`. Without it the command above still runs, but only enriches profiles that already exist: OpenRouter and LiteLLM can supply token counts, and neither may add a profile unless you also pass `--allow-fallback-discovery`. Avoid that flag here — it lets OpenRouter contribute the HuggingFace-style IDs DashScope does not accept, which is what the deprecated profiles above are. The stable aliases are listed in `protected_profiles` so a non-authoritative source cannot deprecate them.
 
 ---
 

--- a/nodes/src/nodes/llm_qwen/README.md
+++ b/nodes/src/nodes/llm_qwen/README.md
@@ -6,7 +6,7 @@ A RocketRide LLM node that connects Alibaba Cloud Qwen models to a pipeline via 
 
 Provides Qwen chat completions to the pipeline. Used primarily as an `llm` invoke connection by agents and other nodes that need an LLM, and can also be used directly via lanes.
 
-Uses **LangChain's `ChatOpenAI`** client pointed at DashScope's OpenAI-compatible endpoint. The regional endpoint is resolved from the `region` field at startup. Temperature is fixed at `0`, and `max_tokens` is taken from the profile's `modelOutputTokens`.
+Uses **LangChain's `ChatOpenAI`** client pointed at DashScope's OpenAI-compatible endpoint. The endpoint is resolved at startup from the `base_url` field if set, otherwise from the `region` field. Temperature is fixed at `0`, and `max_tokens` is taken from the profile's `modelOutputTokens`.
 
 When the node configuration is validated, the node performs a live 1-token test request against the API to verify the key, model, and region actually work. Failures surface as configuration warnings with the provider's error message.
 
@@ -29,6 +29,7 @@ The main setting is the **profile** (model selection, default `qwen-flash`). Eac
 | `profile`          | enum, `qwen-flash`  | Qwen AI model selection (see profiles below, or `custom`)                |
 | `apikey`           | string              | DashScope API key. Must start with `sk-`.                                |
 | `region`           | enum, `us`          | DashScope regional endpoint: `us`, `intl`, or `cn` (see regions below)   |
+| `base_url`         | string, empty       | Optional endpoint override, wins over `region` (see regions below)       |
 | `model`            | string              | Qwen model name (custom profile only)                                    |
 | `modelTotalTokens` | number              | Maximum context length in tokens (custom profile only, must be > 0)      |
 
@@ -36,19 +37,43 @@ The main setting is the **profile** (model selection, default `qwen-flash`). Eac
 
 ## Profiles
 
-| Profile                         | Model                           | Context tokens | Output tokens |
-|---------------------------------|---------------------------------|----------------|---------------|
-| Qwen Flash *(default)*          | `qwen-flash`                    | 131,072        | 4,096         |
-| Qwen Plus                       | `qwen-plus`                     | 1,000,000      | 32,768        |
-| Qwen2.5 72B Instruct            | `qwen-2.5-72b-instruct`         | 32,768         | 16,384        |
-| Qwen2.5 7B Instruct             | `qwen-2.5-7b-instruct`          | 32,768         | 32,768        |
-| Qwen2.5 Coder 32B Instruct      | `qwen-2.5-coder-32b-instruct`   | 32,768         | 4,096         |
-| Qwen-Max                        | `qwen-max`                      | 32,768         | 8,192         |
-| Qwen Plus 0728                  | `qwen-plus-2025-07-28`          | 1,000,000      | 32,768        |
-| Qwen Plus 0728 (thinking)       | `qwen-plus-2025-07-28:thinking` | 1,000,000      | 32,768        |
-| Qwen-Turbo                      | `qwen-turbo`                    | 131,072        | 8,192         |
+Profiles come in two kinds.
+
+**Stable aliases** always resolve to DashScope's current snapshot for their tier, so they do not go stale as new generations ship. Prefer these unless you need to pin a specific release:
+
+| Profile                   | Model         | Context tokens | Output tokens |
+|---------------------------|---------------|----------------|---------------|
+| Qwen Flash *(default)*    | `qwen-flash`  | 131,072        | 4,096         |
+| Qwen Plus                 | `qwen-plus`   | 1,000,000      | 32,768        |
+| Qwen Max                  | `qwen-max`    | 32,768         | 8,192         |
+| Qwen Turbo                | `qwen-turbo`  | 131,072        | 8,192         |
+
+**Pinned releases** name a specific model version:
+
+| Profile                | Model                  | Context tokens | Output tokens |
+|------------------------|------------------------|----------------|---------------|
+| Qwen3.8 Max (preview)  | `qwen3.8-max-preview`  | 983,616        | 131,072       |
+| Qwen3.7 Max            | `qwen3.7-max`          | 1,000,000      | 65,536        |
+| Qwen3.7 Plus           | `qwen3.7-plus`         | 1,000,000      | 65,536        |
+| Qwen3.6 Flash          | `qwen3.6-flash`        | 1,000,000      | 65,536        |
+| Qwen Plus 0728         | `qwen-plus-2025-07-28` | 1,000,000      | 32,768        |
 
 Choose `custom` to set the model name and context length manually.
+
+> **Qwen3.8 Max is a preview model.** Access is limited and it may be served from an endpoint other than the standard compatible-mode hosts. If the profile fails to validate, set `base_url` to the endpoint shown in your Alibaba Cloud console.
+
+### Deprecated profiles
+
+These remain selectable so saved pipelines keep loading, but DashScope rejects their model IDs. They were introduced by OpenRouter fallback discovery in the model sync and carry OpenRouter/HuggingFace IDs rather than DashScope ones. Migrate to a profile above.
+
+| Profile                    | Model                           | Why it fails                                        |
+|----------------------------|---------------------------------|-----------------------------------------------------|
+| Qwen2.5 72B Instruct       | `qwen-2.5-72b-instruct`         | DashScope uses `qwen2.5-72b-instruct`               |
+| Qwen2.5 7B Instruct        | `qwen-2.5-7b-instruct`          | DashScope uses `qwen2.5-7b-instruct`                |
+| Qwen2.5 Coder 32B Instruct | `qwen-2.5-coder-32b-instruct`   | DashScope uses `qwen2.5-coder-32b-instruct`         |
+| Qwen Plus 0728 (thinking)  | `qwen-plus-2025-07-28:thinking` | `:thinking` is OpenRouter variant syntax            |
+
+DashScope has no `:thinking` model variants — reasoning is controlled with the `enable_thinking` request parameter instead.
 
 ---
 
@@ -63,6 +88,8 @@ Choose `custom` to set the model name and context length manually.
 | `cn`   | China (Beijing) | `https://dashscope.aliyuncs.com/compatible-mode/v1`       |
 
 The default is `us`. An unrecognised value falls back to the US endpoint.
+
+Setting `base_url` overrides this table entirely, which is how you reach an endpoint Alibaba Cloud serves outside the three hosts above. Leave it empty to use the regional endpoint.
 
 Note: DashScope API keys are not interchangeable between regions. A key issued for one region will fail authentication against another region's endpoint.
 
@@ -87,9 +114,22 @@ Rate-limit and connection errors are classified as retryable by the shared chat 
 
 ---
 
+## Keeping the model list current
+
+Profiles are maintained by the model sync tool, see [tools/sync_models](../../../../tools/sync_models/README.md):
+
+```bash
+python tools/sync_models/src/sync_models.py --provider llm_qwen --enable-discovery --apply
+```
+
+Discovery requires `ROCKETRIDE_QWEN_KEY`. Without it the sync falls back to OpenRouter, which lists HuggingFace-style IDs that DashScope does not accept — the source of the deprecated profiles above. The stable aliases are listed in `protected_profiles` so a non-authoritative source cannot deprecate them.
+
+---
+
 ## Upstream docs
 
 - [DashScope API reference](https://help.aliyun.com/zh/dashscope/)
+- [Alibaba Cloud Model Studio models](https://www.alibabacloud.com/help/en/model-studio/models)
 
 ---
 

--- a/nodes/src/nodes/llm_qwen/qwen_client.py
+++ b/nodes/src/nodes/llm_qwen/qwen_client.py
@@ -61,9 +61,13 @@ class Chat(ChatBase):
         if not apikey or not apikey.startswith('sk-'):
             raise ValueError('Invalid DashScope API key. Key must start with "sk-".')
 
-        # Resolve regional endpoint
-        region = config.get('region', 'us')
-        base_url = DASHSCOPE_REGIONS.get(region, DASHSCOPE_REGIONS['us'])
+        # Resolve the endpoint, an explicit base_url wins over the regional map
+        # so a profile can reach a host outside the compatible-mode endpoints
+        base_url = (config.get('base_url') or '').strip()
+
+        if not base_url:
+            region = config.get('region', 'us')
+            base_url = DASHSCOPE_REGIONS.get(region, DASHSCOPE_REGIONS['us'])
 
         # Get the llm using OpenAI-compatible endpoint
         self._llm = ChatOpenAI(

--- a/nodes/src/nodes/llm_qwen/services.json
+++ b/nodes/src/nodes/llm_qwen/services.json
@@ -47,7 +47,7 @@
 	// Optional:
 	//		Description to of this driver
 	//
-	"description": ["A component that connects to Alibaba Cloud's Qwen large language models via the ", "DashScope API. It supports tasks such as text generation, summarization, question ", "answering, and chat-based interactions. With access to models like Qwen Plus ", "and Qwen Flash, this component enables high-quality, context-aware responses. Configurable ", "with API keys, it allows seamless integration into AI-driven workflows with scalable ", "performance."],
+	"description": ["A component that connects to Alibaba Cloud's Qwen large language models via the ", "DashScope API. It supports tasks such as text generation, summarization, question ", "answering, and chat-based interactions. With access to models like Qwen Max, Qwen Plus ", "and Qwen Flash, this component enables high-quality, context-aware responses. Configurable ", "with API keys, it allows seamless integration into AI-driven workflows with scalable ", "performance."],
 	//
 	// Optional:
 	//	  The icon is the icon to display in the UI for this node
@@ -79,9 +79,77 @@
 		// specified, unless the profile is 'absolute'
 		"default": "qwen-flash",
 		// Defines profiles used with the "profile": key
+		//
+		// Two kinds of profile live here:
+		//
+		//   * Stable aliases (qwen-max, qwen-plus, qwen-flash, qwen-turbo) always
+		//     resolve to DashScope's current snapshot for that tier, so they never
+		//     go stale. They are listed in protected_profiles in
+		//     tools/sync_models/src/sync_models.config.json so a non-authoritative
+		//     source cannot deprecate them.
+		//   * Pinned generation IDs (qwen3.x) name a specific model release.
+		//
 		"profiles": {
+			"qwen3-8-max-preview": {
+				"title": "Qwen3.8 Max (preview)",
+				"model": "qwen3.8-max-preview",
+				"modelSource": "manual",
+				"modelTotalTokens": 983616, // manual
+				"modelOutputTokens": 131072, // manual
+				"region": "intl",
+				"base_url": "",
+				"apikey": "",
+				"capabilities": {
+					"reasoning": true
+				}
+			},
+			"qwen3-7-max": {
+				"title": "Qwen3.7 Max",
+				"model": "qwen3.7-max",
+				"modelSource": "manual",
+				"modelTotalTokens": 1000000, // openrouter
+				"modelOutputTokens": 65536, // openrouter
+				"region": "us",
+				"apikey": "",
+				"capabilities": {
+					"reasoning": true
+				}
+			},
+			"qwen3-7-plus": {
+				"title": "Qwen3.7 Plus",
+				"model": "qwen3.7-plus",
+				"modelSource": "manual",
+				"modelTotalTokens": 1000000, // openrouter
+				"modelOutputTokens": 65536, // openrouter
+				"region": "us",
+				"apikey": "",
+				"capabilities": {
+					"reasoning": true
+				}
+			},
+			"qwen3-6-flash": {
+				"title": "Qwen3.6 Flash",
+				"model": "qwen3.6-flash",
+				"modelSource": "manual",
+				"modelTotalTokens": 1000000, // openrouter
+				"modelOutputTokens": 65536, // openrouter
+				"region": "us",
+				"apikey": "",
+				"capabilities": {
+					"reasoning": true
+				}
+			},
+			"qwen-max": {
+				"title": "Qwen Max (latest)",
+				"model": "qwen-max",
+				"modelSource": "manual",
+				"modelTotalTokens": 32768, // manual
+				"modelOutputTokens": 8192, // manual
+				"region": "us",
+				"apikey": ""
+			},
 			"qwen-plus": {
-				"title": "Qwen Plus",
+				"title": "Qwen Plus (latest)",
 				"model": "qwen-plus",
 				"modelSource": "manual",
 				"modelTotalTokens": 1000000, // openrouter
@@ -93,7 +161,7 @@
 				}
 			},
 			"qwen-flash": {
-				"title": "Qwen Flash",
+				"title": "Qwen Flash (latest)",
 				"model": "qwen-flash",
 				"modelSource": "manual",
 				"modelTotalTokens": 131072, // manual
@@ -101,71 +169,69 @@
 				"region": "us",
 				"apikey": ""
 			},
+			"qwen-turbo": {
+				"title": "Qwen Turbo (latest)",
+				"model": "qwen-turbo",
+				"modelSource": "manual",
+				"modelTotalTokens": 131072, // manual
+				"modelOutputTokens": 8192, // manual
+				"region": "us",
+				"apikey": ""
+			},
+			"qwen-plus-2025-07-28": {
+				"title": "Qwen Plus 0728",
+				"model": "qwen-plus-2025-07-28",
+				"modelSource": "manual",
+				"modelTotalTokens": 1000000, // openrouter
+				"modelOutputTokens": 32768, // openrouter
+				"region": "us",
+				"apikey": "",
+				"capabilities": {
+					"reasoning": true
+				}
+			},
 			"qwen-2-5-72b-instruct": {
 				"title": "Qwen2.5 72B Instruct",
 				"model": "qwen-2.5-72b-instruct",
 				"modelSource": "openrouter",
-				"modelTotalTokens": 131072, // openrouter
+				"modelTotalTokens": 32768, // openrouter
 				"modelOutputTokens": 16384, // openrouter
+				"deprecated": true,
+				"migration": "Not a valid DashScope model ID (this is an OpenRouter alias; DashScope uses qwen2.5-72b-instruct). Select Qwen Plus or a qwen3.x profile.",
 				"apikey": ""
 			},
 			"qwen-2-5-7b-instruct": {
-				"title": "Qwen: Qwen2.5 7B Instruct",
+				"title": "Qwen2.5 7B Instruct",
 				"model": "qwen-2.5-7b-instruct",
 				"modelSource": "openrouter",
-				"modelTotalTokens": 131072, // openrouter
+				"modelTotalTokens": 32768, // openrouter
 				"modelOutputTokens": 32768, // openrouter
+				"deprecated": true,
+				"migration": "Not a valid DashScope model ID (this is an OpenRouter alias; DashScope uses qwen2.5-7b-instruct). Select Qwen Flash or a qwen3.x profile.",
 				"apikey": ""
 			},
 			"qwen-2-5-coder-32b-instruct": {
 				"title": "Qwen2.5 Coder 32B Instruct",
 				"model": "qwen-2.5-coder-32b-instruct",
 				"modelSource": "openrouter",
-				"modelTotalTokens": 128000, // openrouter
+				"modelTotalTokens": 32768, // openrouter
 				"modelOutputTokens": 32768, // openrouter
-				"apikey": ""
-			},
-			"qwen-max": {
-				"title": "Qwen: Qwen-Max ",
-				"model": "qwen-max",
-				"modelSource": "openrouter",
-				"modelTotalTokens": 32768, // manual
-				"modelOutputTokens": 8192, // manual
 				"deprecated": true,
-				"migration": "Model no longer listed in OpenRouter. Please select a current model.",
+				"migration": "Not a valid DashScope model ID (this is an OpenRouter alias; DashScope uses qwen2.5-coder-32b-instruct). Select a qwen3.x profile.",
 				"apikey": ""
-			},
-			"qwen-plus-2025-07-28": {
-				"title": "Qwen: Qwen Plus 0728",
-				"model": "qwen-plus-2025-07-28",
-				"modelSource": "openrouter",
-				"modelTotalTokens": 1000000, // openrouter
-				"modelOutputTokens": 32768, // openrouter
-				"apikey": "",
-				"capabilities": {
-					"reasoning": true
-				}
 			},
 			"qwen-plus-2025-07-28-thinking": {
-				"title": "Qwen: Qwen Plus 0728 (thinking)",
+				"title": "Qwen Plus 0728 (thinking)",
 				"model": "qwen-plus-2025-07-28:thinking",
 				"modelSource": "openrouter",
 				"modelTotalTokens": 1000000, // openrouter
 				"modelOutputTokens": 32768, // openrouter
+				"deprecated": true,
+				"migration": "The ':thinking' suffix is OpenRouter variant syntax and is rejected by DashScope, which controls reasoning with the enable_thinking parameter. Select Qwen Plus 0728 or a qwen3.x profile.",
 				"apikey": "",
 				"capabilities": {
 					"reasoning": true
 				}
-			},
-			"qwen-turbo": {
-				"title": "Qwen: Qwen-Turbo",
-				"model": "qwen-turbo",
-				"modelSource": "openrouter",
-				"modelTotalTokens": 131072, // manual
-				"modelOutputTokens": 8192, // manual
-				"deprecated": true,
-				"migration": "Model no longer listed in OpenRouter. Please select a current model.",
-				"apikey": ""
 			}
 		}
 	},
@@ -206,11 +272,59 @@
 				]
 			]
 		},
+		"qwen.base_url": {
+			"type": "string",
+			"title": "Base URL override",
+			"default": "",
+			"description": "Optional. Overrides the endpoint selected by Region. Leave empty to use the regional endpoint. Set this when a model is served from an endpoint other than the standard compatible-mode hosts."
+		},
 		"qwen.custom": {
 			"object": "custom",
 			"properties": [
 				"model",
 				"modelTotalTokens",
+				"llm.cloud.apikey",
+				"qwen.region",
+				"qwen.base_url",
+				"llm.cloud.modelSource"
+			]
+		},
+		"qwen.qwen3-8-max-preview": {
+			"object": "qwen3-8-max-preview",
+			"properties": [
+				"llm.cloud.apikey",
+				"qwen.region",
+				"qwen.base_url",
+				"llm.cloud.modelSource"
+			]
+		},
+		"qwen.qwen3-7-max": {
+			"object": "qwen3-7-max",
+			"properties": [
+				"llm.cloud.apikey",
+				"qwen.region",
+				"llm.cloud.modelSource"
+			]
+		},
+		"qwen.qwen3-7-plus": {
+			"object": "qwen3-7-plus",
+			"properties": [
+				"llm.cloud.apikey",
+				"qwen.region",
+				"llm.cloud.modelSource"
+			]
+		},
+		"qwen.qwen3-6-flash": {
+			"object": "qwen3-6-flash",
+			"properties": [
+				"llm.cloud.apikey",
+				"qwen.region",
+				"llm.cloud.modelSource"
+			]
+		},
+		"qwen.qwen-max": {
+			"object": "qwen-max",
+			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
 				"llm.cloud.modelSource"
@@ -226,6 +340,22 @@
 		},
 		"qwen.qwen-flash": {
 			"object": "qwen-flash",
+			"properties": [
+				"llm.cloud.apikey",
+				"qwen.region",
+				"llm.cloud.modelSource"
+			]
+		},
+		"qwen.qwen-turbo": {
+			"object": "qwen-turbo",
+			"properties": [
+				"llm.cloud.apikey",
+				"qwen.region",
+				"llm.cloud.modelSource"
+			]
+		},
+		"qwen.qwen-plus-2025-07-28": {
+			"object": "qwen-plus-2025-07-28",
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
@@ -256,32 +386,8 @@
 				"llm.cloud.modelSource"
 			]
 		},
-		"qwen.qwen-max": {
-			"object": "qwen-max",
-			"properties": [
-				"llm.cloud.apikey",
-				"qwen.region",
-				"llm.cloud.modelSource"
-			]
-		},
-		"qwen.qwen-plus-2025-07-28": {
-			"object": "qwen-plus-2025-07-28",
-			"properties": [
-				"llm.cloud.apikey",
-				"qwen.region",
-				"llm.cloud.modelSource"
-			]
-		},
 		"qwen.qwen-plus-2025-07-28-thinking": {
 			"object": "qwen-plus-2025-07-28-thinking",
-			"properties": [
-				"llm.cloud.apikey",
-				"qwen.region",
-				"llm.cloud.modelSource"
-			]
-		},
-		"qwen.qwen-turbo": {
-			"object": "qwen-turbo",
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
@@ -304,6 +410,36 @@
 					]
 				},
 				{
+					"value": "qwen3-8-max-preview",
+					"properties": [
+						"qwen.qwen3-8-max-preview"
+					]
+				},
+				{
+					"value": "qwen3-7-max",
+					"properties": [
+						"qwen.qwen3-7-max"
+					]
+				},
+				{
+					"value": "qwen3-7-plus",
+					"properties": [
+						"qwen.qwen3-7-plus"
+					]
+				},
+				{
+					"value": "qwen3-6-flash",
+					"properties": [
+						"qwen.qwen3-6-flash"
+					]
+				},
+				{
+					"value": "qwen-max",
+					"properties": [
+						"qwen.qwen-max"
+					]
+				},
+				{
 					"value": "qwen-plus",
 					"properties": [
 						"qwen.qwen-plus"
@@ -313,6 +449,18 @@
 					"value": "qwen-flash",
 					"properties": [
 						"qwen.qwen-flash"
+					]
+				},
+				{
+					"value": "qwen-turbo",
+					"properties": [
+						"qwen.qwen-turbo"
+					]
+				},
+				{
+					"value": "qwen-plus-2025-07-28",
+					"properties": [
+						"qwen.qwen-plus-2025-07-28"
 					]
 				},
 				{
@@ -334,27 +482,9 @@
 					]
 				},
 				{
-					"value": "qwen-max",
-					"properties": [
-						"qwen.qwen-max"
-					]
-				},
-				{
-					"value": "qwen-plus-2025-07-28",
-					"properties": [
-						"qwen.qwen-plus-2025-07-28"
-					]
-				},
-				{
 					"value": "qwen-plus-2025-07-28-thinking",
 					"properties": [
 						"qwen.qwen-plus-2025-07-28-thinking"
-					]
-				},
-				{
-					"value": "qwen-turbo",
-					"properties": [
-						"qwen.qwen-turbo"
 					]
 				}
 			]

--- a/nodes/src/nodes/llm_qwen/services.json
+++ b/nodes/src/nodes/llm_qwen/services.json
@@ -90,19 +90,6 @@
 		//   * Pinned generation IDs (qwen3.x) name a specific model release.
 		//
 		"profiles": {
-			"qwen3-8-max-preview": {
-				"title": "Qwen3.8 Max (preview)",
-				"model": "qwen3.8-max-preview",
-				"modelSource": "manual",
-				"modelTotalTokens": 983616, // manual
-				"modelOutputTokens": 131072, // manual
-				"region": "intl",
-				"base_url": "",
-				"apikey": "",
-				"capabilities": {
-					"reasoning": true
-				}
-			},
 			"qwen3-7-max": {
 				"title": "Qwen3.7 Max",
 				"model": "qwen3.7-max",
@@ -110,6 +97,7 @@
 				"modelTotalTokens": 1000000, // openrouter
 				"modelOutputTokens": 65536, // openrouter
 				"region": "us",
+				"base_url": "",
 				"apikey": "",
 				"capabilities": {
 					"reasoning": true
@@ -122,6 +110,7 @@
 				"modelTotalTokens": 1000000, // openrouter
 				"modelOutputTokens": 65536, // openrouter
 				"region": "us",
+				"base_url": "",
 				"apikey": "",
 				"capabilities": {
 					"reasoning": true
@@ -134,6 +123,7 @@
 				"modelTotalTokens": 1000000, // openrouter
 				"modelOutputTokens": 65536, // openrouter
 				"region": "us",
+				"base_url": "",
 				"apikey": "",
 				"capabilities": {
 					"reasoning": true
@@ -146,6 +136,7 @@
 				"modelTotalTokens": 32768, // manual
 				"modelOutputTokens": 8192, // manual
 				"region": "us",
+				"base_url": "",
 				"apikey": ""
 			},
 			"qwen-plus": {
@@ -155,6 +146,7 @@
 				"modelTotalTokens": 1000000, // openrouter
 				"modelOutputTokens": 32768, // openrouter
 				"region": "us",
+				"base_url": "",
 				"apikey": "",
 				"capabilities": {
 					"reasoning": true
@@ -167,6 +159,7 @@
 				"modelTotalTokens": 131072, // manual
 				"modelOutputTokens": 4096, // manual
 				"region": "us",
+				"base_url": "",
 				"apikey": ""
 			},
 			"qwen-turbo": {
@@ -176,6 +169,7 @@
 				"modelTotalTokens": 131072, // manual
 				"modelOutputTokens": 8192, // manual
 				"region": "us",
+				"base_url": "",
 				"apikey": ""
 			},
 			"qwen-plus-2025-07-28": {
@@ -185,11 +179,17 @@
 				"modelTotalTokens": 1000000, // openrouter
 				"modelOutputTokens": 32768, // openrouter
 				"region": "us",
+				"base_url": "",
 				"apikey": "",
 				"capabilities": {
 					"reasoning": true
 				}
 			},
+			//
+			// The profiles below were introduced by OpenRouter fallback discovery and
+			// carry OpenRouter/HuggingFace model IDs that the DashScope API rejects.
+			// They are deprecated rather than deleted so saved pipelines keep loading.
+			//
 			"qwen-2-5-72b-instruct": {
 				"title": "Qwen2.5 72B Instruct",
 				"model": "qwen-2.5-72b-instruct",
@@ -276,7 +276,10 @@
 			"type": "string",
 			"title": "Base URL override",
 			"default": "",
-			"description": "Optional. Overrides the endpoint selected by Region. Leave empty to use the regional endpoint. Set this when a model is served from an endpoint other than the standard compatible-mode hosts."
+			"description": "Optional. Overrides the endpoint selected by Region. Leave empty to use the regional endpoint. Set this to reach a DashScope host other than the three listed above, for example another Alibaba Cloud region.",
+			"ui": {
+				"ui:placeholder": "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+			}
 		},
 		"qwen.custom": {
 			"object": "custom",
@@ -289,20 +292,12 @@
 				"llm.cloud.modelSource"
 			]
 		},
-		"qwen.qwen3-8-max-preview": {
-			"object": "qwen3-8-max-preview",
-			"properties": [
-				"llm.cloud.apikey",
-				"qwen.region",
-				"qwen.base_url",
-				"llm.cloud.modelSource"
-			]
-		},
 		"qwen.qwen3-7-max": {
 			"object": "qwen3-7-max",
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -311,6 +306,7 @@
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -319,6 +315,7 @@
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -327,6 +324,7 @@
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -335,6 +333,7 @@
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -343,6 +342,7 @@
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -351,6 +351,7 @@
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -359,6 +360,7 @@
 			"properties": [
 				"llm.cloud.apikey",
 				"qwen.region",
+				"qwen.base_url",
 				"llm.cloud.modelSource"
 			]
 		},
@@ -407,12 +409,6 @@
 					"value": "custom",
 					"properties": [
 						"qwen.custom"
-					]
-				},
-				{
-					"value": "qwen3-8-max-preview",
-					"properties": [
-						"qwen.qwen3-8-max-preview"
 					]
 				},
 				{

--- a/tools/sync_models/src/sync_models.config.json
+++ b/tools/sync_models/src/sync_models.config.json
@@ -363,18 +363,26 @@
 			"auth_header": "Authorization",
 			"auth_prefix": "Bearer",
 			"smoke_test": "chat",
+			// "qwen-" alone excludes every current model: DashScope names the modern
+			// families qwen3-max, qwen3.6-plus, qwen3.7-max, qwen3.8-max-preview —
+			// all of which start with "qwen3", not "qwen-". Match on the bare vendor
+			// name so new generations are picked up without another config change.
 			"model_filter": {
-				"include_prefixes": ["qwen-"],
+				"include_prefixes": ["qwen"],
 				"exclude_prefixes": [],
-				"exclude_patterns": ["embed", "vision", "audio", "vl"]
+				"exclude_patterns": ["embed", "vision", "audio", "vl", "omni", "ocr", "asr", "tts"]
 			},
-			// qwen-flash and qwen-plus are DashScope short aliases. OpenRouter uses
-			// full HuggingFace IDs (qwen-2.5-7b-instruct etc.) and doesn't list these
-			// aliases — protect them so the OpenRouter fallback won't deprecate them.
+			// qwen-max, qwen-plus, qwen-flash and qwen-turbo are DashScope stable
+			// aliases that always resolve to the current snapshot. OpenRouter lists
+			// full HuggingFace IDs (qwen-2.5-7b-instruct etc.) and not these aliases,
+			// so without protection the OpenRouter fallback deprecates working models
+			// — which is exactly what happened to qwen-max and qwen-turbo.
 			"protected_profiles": [
 				["custom", "2126-04-09"],
-				["qwen-plus", "2026-10-09"],
-				["qwen-flash", "2026-10-09"]
+				["qwen-max", "2126-04-09"],
+				["qwen-plus", "2126-04-09"],
+				["qwen-flash", "2126-04-09"],
+				["qwen-turbo", "2126-04-09"]
 			],
 			"token_limit_overrides": {
 				// "qwen-plus": 131072,


### PR DESCRIPTION
Closes #1710

## What

The `llm_qwen` model list is stale and partly invalid. This fixes the root cause in the sync config, retires the profiles DashScope rejects, restores two models that were falsely deprecated, and adds the current generation.

## Why the list went stale

`tools/sync_models/src/sync_models.config.json` filtered discovery on `include_prefixes: ["qwen-"]`. Current DashScope models are `qwen3-max`, `qwen3.6-plus`, `qwen3.7-max`, `qwen3.8-max-preview` — all begin with `qwen3`, not `qwen-`, so every one was dropped before discovery. The weekly `sync-models.yml` run could only ever churn token counts on stale profiles.

Before:

```
$ python tools/sync_models/src/sync_models.py --provider llm_qwen --enable-discovery --allow-fallback-discovery
  ~ qwen-2-5-72b-instruct          modelTotalTokens: 131072 → 32768
  ~ qwen-2-5-7b-instruct           modelTotalTokens: 131072 → 32768
  ~ qwen-2-5-coder-32b-instruct    modelTotalTokens: 128000 → 32768
```

Nothing added. After widening the prefix, the tool sees the modern families and supplies authoritative token data, which is where the `qwen3.x` numbers in this PR come from:

```
$ python tools/sync_models/src/sync_models.py --provider llm_qwen --apply
  ~ qwen3-6-flash                  capabilities.reasoning: False → True
  ~ qwen3-6-flash                  modelOutputTokens: 32768 → 65536
  ~ qwen3-7-max                    modelOutputTokens: 32768 → 65536
  ~ qwen3-7-plus                   modelOutputTokens: 32768 → 65536
```

## Changes

**`tools/sync_models/src/sync_models.config.json`**
- `include_prefixes` → `["qwen"]` so new generations need no further config change
- `exclude_patterns` gains `omni`, `ocr`, `asr`, `tts` to keep non-chat families out of a text-generation node
- All four stable aliases added to `protected_profiles` with a far-future expiry

**`nodes/src/nodes/llm_qwen/services.json`**
- Added `qwen3.8-max-preview`, `qwen3.7-max`, `qwen3.7-plus`, `qwen3.6-flash`
- Un-deprecated `qwen-max` and `qwen-turbo`
- Deprecated the four invalid profiles with accurate migration messages
- New optional `base_url` field

**`nodes/src/nodes/llm_qwen/qwen_client.py`**
- `base_url`, when set, wins over the region map

**`nodes/src/nodes/llm_qwen/README.md`**
- Profiles table rebuilt and split into stable aliases vs pinned releases, plus a deprecated table explaining why each ID fails

### On the invalid profiles

These carried `"modelSource": "openrouter"` and are OpenRouter/HuggingFace IDs, not DashScope IDs — selecting one produced a runtime error rather than a config-time warning:

| Profile | `model` | Problem |
|---|---|---|
| `qwen-2-5-72b-instruct` | `qwen-2.5-72b-instruct` | DashScope uses `qwen2.5-72b-instruct` |
| `qwen-2-5-7b-instruct` | `qwen-2.5-7b-instruct` | same |
| `qwen-2-5-coder-32b-instruct` | `qwen-2.5-coder-32b-instruct` | same |
| `qwen-plus-2025-07-28-thinking` | `qwen-plus-2025-07-28:thinking` | `:thinking` is OpenRouter variant syntax; DashScope uses `enable_thinking` |

This is the **Loose discovery** risk called out in `tools/sync_models/README.md`. They are deprecated rather than deleted so saved pipelines keep loading — happy to switch to outright removal if you'd prefer.

`qwen-max` and `qwen-turbo` were flagged `deprecated` with *"Model no longer listed in OpenRouter"*. Both are current DashScope stable aliases, deprecated only because a non-authoritative source stopped listing them.

## Testing

- `pytest tools/sync_models/test/test_sync_logic.py` — 41 passed
- `ruff check` / `ruff format --check` on `nodes/src/nodes/llm_qwen/` — clean
- Both edited `services*.json` / config files parse as JSON5; profile keys, `fields` entries, and `conditional` values verified to cross-reference consistently, and `preconfig.default` resolves

## Please verify before merge

**I do not have a `ROCKETRIDE_QWEN_KEY`,** so provider-source discovery and smoke tests could not run. Specifically worth a maintainer's eyes:

1. **`qwen3.8-max-preview`** — added per request. Alibaba's primary docs did not confirm this ID, its token limits (983,616 / 131,072), or its endpoint; those come from secondary reporting of the 2026-07-19 WAIC preview announcement. Access appears to be limited-availability and it may be served from a host outside the three compatible-mode endpoints, which is what the new `base_url` field is there for. **If you can't confirm it, dropping this one profile is fine** — the rest of the PR stands without it.
2. **Stable-alias token limits** (`qwen-max`, `qwen-flash`, `qwen-turbo`) are carried over from the existing file, not re-derived. They are conservative rather than wrong, but a real sync would tighten them.
3. Running `sync_models.py --provider llm_qwen --enable-discovery --apply` with a key will confirm every ID against the native API and smoke-test the additions. I'll happily fold in whatever it reports.

## Note on the generated docs block

`nodes:docs-generate` deliberately no-ops off `main`/`stage`/`develop`, so the `ROCKETRIDE:GENERATED:PARAMS` block in the README does not yet list the new `qwen.base_url` field. It regenerates on merge. Left untouched rather than hand-edited, per the co-located documentation rule.

## Out of scope

The README's `## Profiles` table is hand-written and nothing keeps it in step with `services.json` — the generated block emits only Schema, Dependencies and Source. That is why it had drifted (it disagreed with `services.json` on three context windows and omitted both deprecation flags). **15 `llm_*` nodes share this**, so it wants its own change rather than riding along here. Filed as a note in #1710; happy to open a separate issue if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `base_url` option to override the Qwen OpenAI-compatible endpoint; it takes precedence over region.
  * Refreshed Qwen profiles with new “latest” aliases (Max/Plus/Flash/Turbo) and pinned `qwen3-*` releases.
* **Documentation**
  * Updated Qwen documentation to reflect `base_url` vs region behavior, reorganized profile catalog, and clarified deprecated-profile availability and migration guidance.
  * Added instructions for keeping the Qwen model list current via the model sync tool.
* **Bug Fixes**
  * Improved Qwen model discovery by widening vendor matching and filtering additional unsupported families, plus updated protected profile rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->