### PR TITLE
fix pinecone transform sub-key

### DIFF
--- a/nodes/src/nodes/store_pinecone/IGlobal.py
+++ b/nodes/src/nodes/store_pinecone/IGlobal.py
@@ -25,6 +25,7 @@
 # This class controls the data shared between all threads for the task
 # ------------------------------------------------------------------------------
 
+import hashlib
 import os
 import re
 from typing import Any, Dict
@@ -95,8 +96,9 @@ class IGlobal(StoreGlobalBase):
         return Store(logical_type, conn_config, bag)
 
     def _sub_key(self) -> str:
-        """Return the transform sub-key: host/port/collection."""
-        return f'{self.store.host}/{self.store.port}/{self.store.collection}'
+        """Return the transform sub-key without leaking the Pinecone API key."""
+        account = hashlib.sha256((self.store.apikey or '').encode()).hexdigest()[:12]
+        return f'{account}/{self.store.profile}/{self.store.collection}'
 
     def _probe_connection(self, config: Dict[str, Any]) -> None:
         """

--- a/nodes/src/nodes/store_pinecone/README.md
+++ b/nodes/src/nodes/store_pinecone/README.md
@@ -99,7 +99,7 @@ The tool path runs on the control plane and does not pass through the pipeline's
 
 Set `apikey` to your Pinecone API key. The key is used during both config validation (HTTP client) and runtime data operations (gRPC client). There are no additional auth modes - Pinecone uses API-key-only authentication.
 
-Changing the API key, profile, or index changes the transform key used to track ingested objects. Existing Pinecone pipelines may re-ingest once after upgrading from versions that used the legacy host/port/collection key.
+Changing the API key, profile, or collection changes the transform key used to track ingested objects. Existing Pinecone pipelines may re-ingest once after upgrading from versions that used the legacy host/port/collection key.
 
 ---
 

--- a/nodes/src/nodes/store_pinecone/README.md
+++ b/nodes/src/nodes/store_pinecone/README.md
@@ -99,7 +99,7 @@ The tool path runs on the control plane and does not pass through the pipeline's
 
 Set `apikey` to your Pinecone API key. The key is used during both config validation (HTTP client) and runtime data operations (gRPC client). There are no additional auth modes - Pinecone uses API-key-only authentication.
 
-Changing the API key, profile, or collection changes the transform key used to track ingested objects. Existing Pinecone pipelines may re-ingest once after upgrading from versions that used the legacy host/port/collection key.
+Changing the API key, profile, or collection changes the transform key used to track ingested objects. The legacy transform key was derived from the host/port/collection tuple, so existing Pinecone pipelines may re-ingest once after upgrading from that format.
 
 ---
 

--- a/nodes/src/nodes/store_pinecone/README.md
+++ b/nodes/src/nodes/store_pinecone/README.md
@@ -99,6 +99,8 @@ The tool path runs on the control plane and does not pass through the pipeline's
 
 Set `apikey` to your Pinecone API key. The key is used during both config validation (HTTP client) and runtime data operations (gRPC client). There are no additional auth modes - Pinecone uses API-key-only authentication.
 
+Changing the API key, profile, or index changes the transform key used to track ingested objects. Existing Pinecone pipelines may re-ingest once after upgrading from versions that used the legacy host/port/collection key.
+
 ---
 
 <!-- ROCKETRIDE:GENERATED:PARAMS START -->

--- a/nodes/test/store_pinecone/test_transform_sub_key.py
+++ b/nodes/test/store_pinecone/test_transform_sub_key.py
@@ -1,0 +1,59 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+class StoreGlobalBase:
+    pass
+
+
+ai = ModuleType('ai')
+ai_common = ModuleType('ai.common')
+ai_common_store = ModuleType('ai.common.store')
+ai_common_store.StoreGlobalBase = StoreGlobalBase
+rocketlib = ModuleType('rocketlib')
+rocketlib.warning = lambda message: None
+
+path = Path(__file__).parents[2] / 'src/nodes/store_pinecone/IGlobal.py'
+spec = importlib.util.spec_from_file_location('store_pinecone_IGlobal', path)
+assert spec is not None
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+stubs = {
+    'ai': ai,
+    'ai.common': ai_common,
+    'ai.common.store': ai_common_store,
+    'rocketlib': rocketlib,
+}
+originals = {name: sys.modules.get(name) for name in stubs}
+sys.modules.update(stubs)
+try:
+    spec.loader.exec_module(module)
+finally:
+    for name, original in originals.items():
+        if original is None:
+            del sys.modules[name]
+        else:
+            sys.modules[name] = original
+IGlobal = module.IGlobal
+
+
+def _sub_key(apikey: str, profile: str = 'serverless-dense', collection: str = 'shared-index') -> str:
+    glb = IGlobal.__new__(IGlobal)
+    glb.store = SimpleNamespace(apikey=apikey, profile=profile, collection=collection)
+    return glb._sub_key()
+
+
+def test_sub_key_distinguishes_accounts_without_leaking_api_key() -> None:
+    first = _sub_key('pcsk_first_secret')
+    second = _sub_key('pcsk_second_secret')
+
+    assert first != second
+    assert first.endswith('/serverless-dense/shared-index')
+    assert 'pcsk_first_secret' not in first
+    assert 'pcsk_second_secret' not in second
+
+
+def test_sub_key_includes_profile_and_collection() -> None:
+    assert _sub_key('pcsk_secret', 'pod-based', 'other-index').endswith('/pod-based/other-index')


### PR DESCRIPTION
fixes #1664

## changes
- key Pinecone transform state by hash(api key), profile, and index
- keep raw API key material out of transform tags
- document the one-time re-ingest behavior after the key changes, using the accurate legacy host/port/collection wording from CodeRabbit review

## CodeRabbit
- addressed the README migration-note wording thread by replacing the misleading index-only legacy description with `legacy host/port/collection key`

## verification
- `PYTHONPATH=nodes/src:nodes/test:packages/server/engine-lib/rocketlib-python/lib /home/ericwang/Projects/upstream-contributions/rocketride-issue1638/.venv/bin/python -m pytest nodes/test/store_pinecone/test_transform_sub_key.py -q` -> 2 passed
- `/home/ericwang/Projects/upstream-contributions/rocketride-issue1638/.venv/bin/python -m ruff check nodes/src/nodes/store_pinecone/IGlobal.py nodes/test/store_pinecone/test_transform_sub_key.py`
- `/home/ericwang/Projects/upstream-contributions/rocketride-issue1638/.venv/bin/python -m ruff format --check nodes/src/nodes/store_pinecone/IGlobal.py nodes/test/store_pinecone/test_transform_sub_key.py`
- `git diff --check`
- pre-commit hook: `gitleaks`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pinecone transform key generation to avoid exposing API keys and provide a consistent format.
  * Transform keys now vary reliably when API keys, profiles, or collections change.
* **Documentation**
  * Clarified that configuration changes update the transform key and may require one-time re-ingestion after upgrading.
* **Tests**
  * Added automated coverage for transform key derivation and API key protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->