### PR TITLE
feat(ci): keep Discord forum tags live (re-apply on state/label change via bot)

### DIFF
--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -56,6 +56,7 @@ jobs:
           command -v discord_applied_tags   >/dev/null 2>&1 || discord_applied_tags()   { printf '[]'; }
           command -v extract_discord_thread >/dev/null 2>&1 || extract_discord_thread() { :; }
           command -v discord_archive_thread >/dev/null 2>&1 || discord_archive_thread() { :; }
+          command -v discord_set_tags       >/dev/null 2>&1 || discord_set_tags()       { :; }
 
           NUMBER="${{ github.event.discussion.number }}"
           OWNER="${REPO%/*}"
@@ -340,6 +341,10 @@ jobs:
           FINAL_THREAD_ID="${DISCORD_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${WINNER_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${NEW_THREAD_ID:-}"
+          # Keep forum tags live (open/closed, answered/unanswered, category,
+          # label changes). Webhooks can't edit applied_tags after creation, so
+          # the bot re-applies them each event, before archiving.
+          discord_set_tags "$FINAL_THREAD_ID" "$APPLIED_TAGS"
           if [ "$IS_CLOSED" = "true" ]; then
             discord_archive_thread "$FINAL_THREAD_ID" true
           else

--- a/.github/workflows/discord-discussions.yml
+++ b/.github/workflows/discord-discussions.yml
@@ -55,8 +55,7 @@ jobs:
           # automatically once this merges to the default branch.
           command -v discord_applied_tags   >/dev/null 2>&1 || discord_applied_tags()   { printf '[]'; }
           command -v extract_discord_thread >/dev/null 2>&1 || extract_discord_thread() { :; }
-          command -v discord_archive_thread >/dev/null 2>&1 || discord_archive_thread() { :; }
-          command -v discord_set_tags       >/dev/null 2>&1 || discord_set_tags()       { :; }
+          command -v discord_sync_thread    >/dev/null 2>&1 || discord_sync_thread()    { :; }
 
           NUMBER="${{ github.event.discussion.number }}"
           OWNER="${REPO%/*}"
@@ -336,17 +335,17 @@ jobs:
             fi
           fi
 
-          # ── Mirror closed/open state onto the forum thread (archive) ─────
-          # No-op unless DISCORD_GITHUB_BOT_TOKEN is set.
+          # ── Sync forum thread: archive flag + live tags in ONE PATCH ─────
+          # No-op unless DISCORD_GITHUB_BOT_TOKEN is set. archived + applied_tags
+          # are set together so re-tagging also works on reopen and on threads
+          # Discord auto-archived by inactivity (an applied_tags edit on an
+          # already-archived thread is rejected with 400). Tags cover state,
+          # answer status, category, and labels.
           FINAL_THREAD_ID="${DISCORD_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${WINNER_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${NEW_THREAD_ID:-}"
-          # Keep forum tags live (open/closed, answered/unanswered, category,
-          # label changes). Webhooks can't edit applied_tags after creation, so
-          # the bot re-applies them each event, before archiving.
-          discord_set_tags "$FINAL_THREAD_ID" "$APPLIED_TAGS"
           if [ "$IS_CLOSED" = "true" ]; then
-            discord_archive_thread "$FINAL_THREAD_ID" true
+            discord_sync_thread "$FINAL_THREAD_ID" true "$APPLIED_TAGS"
           else
-            discord_archive_thread "$FINAL_THREAD_ID" false
+            discord_sync_thread "$FINAL_THREAD_ID" false "$APPLIED_TAGS"
           fi

--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -53,8 +53,7 @@ jobs:
           # automatically once this merges to the default branch.
           command -v discord_applied_tags   >/dev/null 2>&1 || discord_applied_tags()   { printf '[]'; }
           command -v extract_discord_thread >/dev/null 2>&1 || extract_discord_thread() { :; }
-          command -v discord_archive_thread >/dev/null 2>&1 || discord_archive_thread() { :; }
-          command -v discord_set_tags       >/dev/null 2>&1 || discord_set_tags()       { :; }
+          command -v discord_sync_thread    >/dev/null 2>&1 || discord_sync_thread()    { :; }
 
           NUMBER="${{ github.event.issue.number }}"
 
@@ -230,18 +229,17 @@ jobs:
             fi
           fi
 
-          # ── Mirror closed/open state onto the forum thread (archive) ─────
-          # No-op unless DISCORD_GITHUB_BOT_TOKEN is set. Prefer the stored thread id,
-          # then the race winner's, then a freshly created one.
+          # ── Sync forum thread: archive flag + live tags in ONE PATCH ─────
+          # No-op unless DISCORD_GITHUB_BOT_TOKEN is set. Prefer the stored thread
+          # id, then the race winner's, then a freshly created one. archived +
+          # applied_tags are set together so re-tagging also works on reopen and
+          # on threads Discord auto-archived by inactivity (an applied_tags edit
+          # on an already-archived thread is rejected with 400).
           FINAL_THREAD_ID="${DISCORD_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${WINNER_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${NEW_THREAD_ID:-}"
-          # Keep forum tags live (open→closed, label changes). Webhooks can't edit
-          # applied_tags after creation, so the bot re-applies them each event.
-          # Done before archiving, while the thread is still active.
-          discord_set_tags "$FINAL_THREAD_ID" "$APPLIED_TAGS"
           if [ "$STATE" = "open" ]; then
-            discord_archive_thread "$FINAL_THREAD_ID" false
+            discord_sync_thread "$FINAL_THREAD_ID" false "$APPLIED_TAGS"
           else
-            discord_archive_thread "$FINAL_THREAD_ID" true
+            discord_sync_thread "$FINAL_THREAD_ID" true "$APPLIED_TAGS"
           fi

--- a/.github/workflows/discord-issues.yml
+++ b/.github/workflows/discord-issues.yml
@@ -54,6 +54,7 @@ jobs:
           command -v discord_applied_tags   >/dev/null 2>&1 || discord_applied_tags()   { printf '[]'; }
           command -v extract_discord_thread >/dev/null 2>&1 || extract_discord_thread() { :; }
           command -v discord_archive_thread >/dev/null 2>&1 || discord_archive_thread() { :; }
+          command -v discord_set_tags       >/dev/null 2>&1 || discord_set_tags()       { :; }
 
           NUMBER="${{ github.event.issue.number }}"
 
@@ -235,6 +236,10 @@ jobs:
           FINAL_THREAD_ID="${DISCORD_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${WINNER_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${NEW_THREAD_ID:-}"
+          # Keep forum tags live (open→closed, label changes). Webhooks can't edit
+          # applied_tags after creation, so the bot re-applies them each event.
+          # Done before archiving, while the thread is still active.
+          discord_set_tags "$FINAL_THREAD_ID" "$APPLIED_TAGS"
           if [ "$STATE" = "open" ]; then
             discord_archive_thread "$FINAL_THREAD_ID" false
           else

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -74,8 +74,7 @@ jobs:
           # automatically once this merges to the default branch.
           command -v discord_applied_tags   >/dev/null 2>&1 || discord_applied_tags()   { printf '[]'; }
           command -v extract_discord_thread >/dev/null 2>&1 || extract_discord_thread() { :; }
-          command -v discord_archive_thread >/dev/null 2>&1 || discord_archive_thread() { :; }
-          command -v discord_set_tags       >/dev/null 2>&1 || discord_set_tags()       { :; }
+          command -v discord_sync_thread    >/dev/null 2>&1 || discord_sync_thread()    { :; }
 
           # ── Resolve PR number ────────────────────────────────────────────
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
@@ -332,18 +331,17 @@ jobs:
             fi
           fi
 
-          # ── Mirror closed/merged state onto the forum thread (archive) ───
-          # No-op unless DISCORD_GITHUB_BOT_TOKEN is set. Closed AND merged PRs both
-          # have PR_STATE=closed, so both archive; reopened PRs unarchive.
+          # ── Sync forum thread: archive flag + live tags in ONE PATCH ─────
+          # No-op unless DISCORD_GITHUB_BOT_TOKEN is set. Closed AND merged PRs
+          # both have PR_STATE=closed, so both archive; reopened PRs unarchive.
+          # archived + applied_tags are set together so re-tagging also works on
+          # reopen and on threads Discord auto-archived by inactivity (an
+          # applied_tags edit on an already-archived thread is rejected with 400).
           FINAL_THREAD_ID="${DISCORD_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${WINNER_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${NEW_THREAD_ID:-}"
-          # Keep forum tags live (open→closed→merged/draft, label changes).
-          # Webhooks can't edit applied_tags after creation, so the bot re-applies
-          # them each event. Done before archiving, while the thread is still active.
-          discord_set_tags "$FINAL_THREAD_ID" "$APPLIED_TAGS"
           if [ "$PR_STATE" = "open" ]; then
-            discord_archive_thread "$FINAL_THREAD_ID" false
+            discord_sync_thread "$FINAL_THREAD_ID" false "$APPLIED_TAGS"
           else
-            discord_archive_thread "$FINAL_THREAD_ID" true
+            discord_sync_thread "$FINAL_THREAD_ID" true "$APPLIED_TAGS"
           fi

--- a/.github/workflows/discord-pr.yml
+++ b/.github/workflows/discord-pr.yml
@@ -75,6 +75,7 @@ jobs:
           command -v discord_applied_tags   >/dev/null 2>&1 || discord_applied_tags()   { printf '[]'; }
           command -v extract_discord_thread >/dev/null 2>&1 || extract_discord_thread() { :; }
           command -v discord_archive_thread >/dev/null 2>&1 || discord_archive_thread() { :; }
+          command -v discord_set_tags       >/dev/null 2>&1 || discord_set_tags()       { :; }
 
           # ── Resolve PR number ────────────────────────────────────────────
           if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_target" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
@@ -337,6 +338,10 @@ jobs:
           FINAL_THREAD_ID="${DISCORD_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${WINNER_THREAD_ID:-}"
           [ -z "$FINAL_THREAD_ID" ] && FINAL_THREAD_ID="${NEW_THREAD_ID:-}"
+          # Keep forum tags live (open→closed→merged/draft, label changes).
+          # Webhooks can't edit applied_tags after creation, so the bot re-applies
+          # them each event. Done before archiving, while the thread is still active.
+          discord_set_tags "$FINAL_THREAD_ID" "$APPLIED_TAGS"
           if [ "$PR_STATE" = "open" ]; then
             discord_archive_thread "$FINAL_THREAD_ID" false
           else

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -180,12 +180,18 @@ discord_sync_thread() {
   else
     body="{\"archived\": ${archived}, \"applied_tags\": ${tags}}"
   fi
+  # Route through discord_curl (not a hand-rolled curl call) so this PATCH gets
+  # the same 429/5xx retry as the create path. Safe here because the PATCH sets
+  # an absolute target state (archived + full applied_tags replace), so it's
+  # idempotent and retry-safe — unlike the create POST, this must NOT pass
+  # --no-retry-5xx.
   local status
-  status=$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 10 --max-time 30 -X PATCH \
+  discord_curl -X PATCH \
     -H "Authorization: Bot ${DISCORD_GITHUB_BOT_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "$body" \
-    "https://discord.com/api/v10/channels/${thread_id}") || status=""
+    "https://discord.com/api/v10/channels/${thread_id}" >/dev/null 2>&1 || true
+  status=$(cat "$DISCORD_STATUS_FILE" 2>/dev/null || echo "")
   # Best-effort: never fail the job, but surface non-2xx (e.g. missing Manage
   # Threads → 403, bad payload → 400) so it's diagnosable in the run log.
   case "$status" in

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -168,3 +168,22 @@ discord_archive_thread() {
     -d "{\"archived\": ${archived}}" \
     "https://discord.com/api/v10/channels/${thread_id}" || true
 }
+
+# ── Live forum tag sync ──────────────────────────────────────────────────
+# discord_set_tags <thread_id> <applied_tags_json> — re-apply a forum thread's
+# tags so they track the current state/labels (open→closed→merged, label adds).
+# Webhooks can only set applied_tags at creation, so keeping them live needs a
+# BOT token with Manage Threads/Posts. No-op unless DISCORD_GITHUB_BOT_TOKEN is
+# set, a thread id is known, and the tag list is non-empty (an empty list means
+# the channel has no tag config — never clobber it to untagged). Best-effort.
+discord_set_tags() {
+  local thread_id="$1" tags="$2"
+  [ -z "${DISCORD_GITHUB_BOT_TOKEN:-}" ] && return 0
+  [ -z "$thread_id" ] && return 0
+  { [ -z "$tags" ] || [ "$tags" = "[]" ]; } && return 0
+  curl -sS -o /dev/null --connect-timeout 10 --max-time 30 -X PATCH \
+    -H "Authorization: Bot ${DISCORD_GITHUB_BOT_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{\"applied_tags\": ${tags}}" \
+    "https://discord.com/api/v10/channels/${thread_id}" || true
+}

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -174,9 +174,17 @@ discord_sync_thread() {
   else
     body="{\"archived\": ${archived}, \"applied_tags\": ${tags}}"
   fi
-  curl -sS -o /dev/null --connect-timeout 10 --max-time 30 -X PATCH \
+  local status
+  status=$(curl -sS -o /dev/null -w '%{http_code}' --connect-timeout 10 --max-time 30 -X PATCH \
     -H "Authorization: Bot ${DISCORD_GITHUB_BOT_TOKEN}" \
     -H "Content-Type: application/json" \
     -d "$body" \
-    "https://discord.com/api/v10/channels/${thread_id}" || true
+    "https://discord.com/api/v10/channels/${thread_id}") || status=""
+  # Best-effort: never fail the job, but surface non-2xx (e.g. missing Manage
+  # Threads → 403, bad payload → 400) so it's diagnosable in the run log.
+  case "$status" in
+    2??) : ;;
+    *) echo "::warning::Discord thread sync returned '${status:-no response}' for thread ${thread_id} (archive/tags not applied)" >&2 ;;
+  esac
+  return 0
 }

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -170,7 +170,13 @@ discord_sync_thread() {
   [ -z "${DISCORD_GITHUB_BOT_TOKEN:-}" ] && return 0
   [ -z "$thread_id" ] && return 0
   if [ -z "$tags" ] || [ "$tags" = "[]" ]; then
+    # Omitting the key (never sending applied_tags:[]) is deliberate: an empty
+    # resolve can mean "no tag config for this channel" OR "config present but
+    # nothing matched" (e.g. a state/label name missing from the ids map).
+    # Either way, leaving existing tags untouched is safer than clobbering them
+    # to empty on a config typo — but warn so a real misconfiguration is visible.
     body="{\"archived\": ${archived}}"
+    echo "::warning::Discord thread sync: no tags resolved for thread ${thread_id} — leaving existing tags untouched (check discord-forum-tags.json if this is unexpected)" >&2
   else
     body="{\"archived\": ${archived}, \"applied_tags\": ${tags}}"
   fi

--- a/.github/workflows/scripts/discord-helper.sh
+++ b/.github/workflows/scripts/discord-helper.sh
@@ -150,40 +150,33 @@ discord_applied_tags() {
     | .[0:5]'
 }
 
-# ── Forum thread archiving ───────────────────────────────────────────────
-# discord_archive_thread <thread_id> <true|false> — archive/unarchive a forum
-# thread so its Discord state mirrors the GitHub issue/PR/discussion (closed →
-# archived, reopened → unarchived). Forum threads can only be (un)archived with
-# a BOT token that has Manage Threads — webhooks cannot do it — so this is a
-# no-op (returns 0) unless DISCORD_GITHUB_BOT_TOKEN is set and a thread id is known.
-# Best-effort: archiving is cosmetic (the embed already reflects state), so a
-# transient failure must never abort the calling workflow.
-discord_archive_thread() {
-  local thread_id="$1" archived="$2"
+# ── Forum thread sync (archive state + tags in one PATCH) ────────────────
+# discord_sync_thread <thread_id> <archived:true|false> <applied_tags_json>
+# — mirror the GitHub state onto the forum thread: set the archived flag AND
+# re-apply applied_tags so tags track state/labels (open→closed→merged, label
+# adds). Both are set in a SINGLE PATCH on purpose: Discord rejects an
+# applied_tags edit on an already-archived thread (400), so setting tags and
+# then (un)archiving in separate calls fails on reopen or on threads Discord
+# auto-archived by inactivity. Combining them works from any state.
+#
+# Forum threads can only be edited with a BOT token that has Manage Threads/
+# Posts — webhooks cannot — so this is a no-op unless DISCORD_GITHUB_BOT_TOKEN
+# and a thread id are set. If <applied_tags_json> is empty ("" or "[]") only the
+# archived flag is sent (an empty list means the channel has no tag config, so
+# never clobber it to untagged). Best-effort: a transient failure never aborts
+# the calling workflow (the embed already reflects state).
+discord_sync_thread() {
+  local thread_id="$1" archived="$2" tags="$3" body
   [ -z "${DISCORD_GITHUB_BOT_TOKEN:-}" ] && return 0
   [ -z "$thread_id" ] && return 0
+  if [ -z "$tags" ] || [ "$tags" = "[]" ]; then
+    body="{\"archived\": ${archived}}"
+  else
+    body="{\"archived\": ${archived}, \"applied_tags\": ${tags}}"
+  fi
   curl -sS -o /dev/null --connect-timeout 10 --max-time 30 -X PATCH \
     -H "Authorization: Bot ${DISCORD_GITHUB_BOT_TOKEN}" \
     -H "Content-Type: application/json" \
-    -d "{\"archived\": ${archived}}" \
-    "https://discord.com/api/v10/channels/${thread_id}" || true
-}
-
-# ── Live forum tag sync ──────────────────────────────────────────────────
-# discord_set_tags <thread_id> <applied_tags_json> — re-apply a forum thread's
-# tags so they track the current state/labels (open→closed→merged, label adds).
-# Webhooks can only set applied_tags at creation, so keeping them live needs a
-# BOT token with Manage Threads/Posts. No-op unless DISCORD_GITHUB_BOT_TOKEN is
-# set, a thread id is known, and the tag list is non-empty (an empty list means
-# the channel has no tag config — never clobber it to untagged). Best-effort.
-discord_set_tags() {
-  local thread_id="$1" tags="$2"
-  [ -z "${DISCORD_GITHUB_BOT_TOKEN:-}" ] && return 0
-  [ -z "$thread_id" ] && return 0
-  { [ -z "$tags" ] || [ "$tags" = "[]" ]; } && return 0
-  curl -sS -o /dev/null --connect-timeout 10 --max-time 30 -X PATCH \
-    -H "Authorization: Bot ${DISCORD_GITHUB_BOT_TOKEN}" \
-    -H "Content-Type: application/json" \
-    -d "{\"applied_tags\": ${tags}}" \
+    -d "$body" \
     "https://discord.com/api/v10/channels/${thread_id}" || true
 }


### PR DESCRIPTION
## Summary

- Discord forum tags were a **creation-time snapshot** — a PR stayed tagged `open` forever, and later label changes never appeared (webhooks can't edit `applied_tags` after creation).
- Re-apply tags on **every event** using the bot token (which now has **Manage Posts**): new helper `discord_set_tags`, called in all three notifiers before the archive step with the `APPLIED_TAGS` the workflow already computes.
- State tags now move **open→closed→merged/draft/answered** and label tags stay in sync.

## Type

feature (CI)

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

- YAML parses (3 workflows); `shellcheck` clean on the helper.
- **Live-tested** against the real PR forum channel: created a post tagged `open`, ran `discord_set_tags` → tag became `merged` (`200`); empty-list guard verified (does **not** clear tags on an unconfigured channel); cleaned up.
- Reuses `DISCORD_GITHUB_BOT_TOKEN`; no new secret. Webhook still does all posting/patching.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included

## Dependency

Depends on **#1530** (marker-lookup fix) — without it the notifier never reaches the update path, so the live re-tag can't fire. #1530 should merge first. Also requires the bot to have **Manage Posts + View Channel** on the forum channels (already granted).

## Linked Issue

Closes #1721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Discord forum thread synchronization so archived/open state and applied tags are updated together, keeping thread tags aligned with GitHub issue/discussion/PR status.
  * Ensures reopen scenarios reapply the correct tag data alongside unarchiving.
  * Added safer, backward-compatible synchronization behavior to prevent workflow failures when the latest sync helper isn’t available, and avoids overwriting existing tags when no tag data is provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->