### PR TITLE
fix(deps): bump onnxruntime-gpu 1.20.1 → 1.20.2 (release pulled from PyPI)

### DIFF
--- a/nodes/src/nodes/anonymize/requirements.txt
+++ b/nodes/src/nodes/anonymize/requirements.txt
@@ -1,5 +1,5 @@
 gliner
 # onnxruntime is an indirect dep (via gliner), not imported here.
 # Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
-onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime-gpu==1.20.2; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/nodes/src/nodes/audio_transcribe/requirements.txt
+++ b/nodes/src/nodes/audio_transcribe/requirements.txt
@@ -7,5 +7,5 @@ huggingface-hub
 tqdm
 # onnxruntime is an indirect dep (via faster-whisper), not imported here.
 # Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
-onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime-gpu==1.20.2; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/nodes/src/nodes/constraints.lock
+++ b/nodes/src/nodes/constraints.lock
@@ -877,7 +877,7 @@ onnxruntime==1.20.1
     #   chromadb
     #   faster-whisper
     #   gliner
-onnxruntime-gpu==1.20.1 ; sys_platform != 'darwin'
+onnxruntime-gpu==1.20.2 ; sys_platform != 'darwin'
     # via
     #   -r nodes/src/nodes/anonymize/requirements.txt
     #   -r nodes/src/nodes/audio_transcribe/requirements.txt

--- a/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
+++ b/packages/ai/src/ai/common/models/audio/requirements_whisper.txt
@@ -6,5 +6,5 @@ faster-whisper
 numpy
 # onnxruntime is an indirect dep (via faster-whisper), not imported here.
 # Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
-onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime-gpu==1.20.2; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'

--- a/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
+++ b/packages/ai/src/ai/common/models/gliner/requirements_gliner.txt
@@ -4,6 +4,6 @@ gliner
 python-mecab-ko
 # onnxruntime is an indirect dep (via gliner), not imported here.
 # Pin 1.20.1 to match the one shared install (rtmlib needs exactly that).
-onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime-gpu==1.20.2; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'
 

--- a/packages/ai/src/ai/common/models/vision/requirements_pose.txt
+++ b/packages/ai/src/ai/common/models/vision/requirements_pose.txt
@@ -5,6 +5,6 @@
 rtmlib>=0.0.13
 # onnxruntime is an indirect dep (via rtmlib), not imported here.
 # Pin 1.20.1 — the version rtmlib needs.
-onnxruntime-gpu==1.20.1; platform_system != 'Darwin'
+onnxruntime-gpu==1.20.2; platform_system != 'Darwin'
 onnxruntime==1.20.1; platform_system == 'Darwin'
 Pillow


### PR DESCRIPTION
## Summary

- `onnxruntime-gpu` 1.20.1 was removed from PyPI (its release file list is now empty), so the engine's constraints compile fails with *no solution found* and every Ubuntu/Windows build in CI is red — first observed on #1668, but it breaks all non-Darwin CI repo-wide.
- Bump the pin to **1.20.2** (nearest surviving 1.20.x release) in the five `requirements*.txt` files that carry it. macOS is unaffected (`platform_system != 'Darwin'` marker), and the plain CPU `onnxruntime==1.20.1` (Darwin) still exists on PyPI, so it is left untouched.
- The committed `nodes/src/nodes/constraints.lock` entry is hand-bumped to match so engine installs don't see a requirements↔constraints conflict; the `lock-node-deps` workflow re-solves and recommits the full lockfile on merge to develop (this PR also triggers its lint gate since it touches `nodes/src/nodes/**/requirements.txt`).

## Type

fix (CI / dependencies)

## Testing

- [ ] Tests added or updated — n/a, version pin only
- [x] Tested locally — verified via the PyPI JSON API that 1.20.1 has zero files while 1.20.2 is available; the failing CI step (`uv pip compile` in `depends.py`) resolves once the pin points at an existing release
- [ ] `./builder test` passes — exercised by CI on this PR (the previously failing constraints compile runs in the Build jobs)

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a
- [ ] Breaking changes documented (if applicable) — n/a

## Linked Issue

Fixes #1728

🤖 Generated with [Claude Code](https://claude.com/claude-code)