### PR TITLE
fix(vscode,docs): gitignore .env in scaffolded projects; finish the docs.rocketride.org rename

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Documentation
-    url: https://docs.rocketride.ai
+    url: https://docs.rocketride.org
     about: Check the docs for guides, API references, and examples.
   - name: Wiki
     url: https://github.com/rocketride-org/rocketride-server/wiki

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -4,7 +4,7 @@ Looking for help with RocketRide? Here's where to go.
 
 ## Documentation
 
-- **[Documentation site](https://docs.rocketride.ai)**: guides, tutorials, API reference
+- **[Documentation site](https://docs.rocketride.org)**: guides, tutorials, API reference
 - **[Build system docs](docs/README-builder.md)**: building from source
 - **[Client library docs](docs/README-clients.md)**: TypeScript, Python, MCP SDKs
 

--- a/apps/vscode/src/agents/agent-manager.ts
+++ b/apps/vscode/src/agents/agent-manager.ts
@@ -27,7 +27,7 @@
  * Coordinates installing RocketRide documentation and agent stubs into
  * user workspaces. Handles:
  *   1. Copying docs from extension bundle → .rocketride/docs/
- *   2. Ensuring .rocketride/ is in .gitignore
+ *   2. Ensuring .rocketride/ and .env are in .gitignore
  *   3. Detecting which coding agents are present
  *   4. Delegating to per-agent installers
  */
@@ -44,9 +44,18 @@ import { WindsurfInstaller } from './windsurf-installer';
 import { CopilotInstaller } from './copilot-installer';
 import { ClaudeMdInstaller } from './claude-md-installer';
 import { AgentsMdInstaller } from './agents-md-installer';
+import { appendGitignoreEntries } from '../shared/util/gitignoreEntries';
 
 const DOCS_DIR = '.rocketride/docs';
-const GITIGNORE_ENTRY = '.rocketride/';
+/**
+ * Entries the extension keeps in the workspace `.gitignore`.
+ *
+ * `.env` is here because connecting to a self-hosted engine writes a real
+ * `ROCKETRIDE_APIKEY` into it (see `Connection.syncEnvFile`), so a fresh
+ * project would otherwise be one `git add .` away from committing a live key.
+ * The pattern is the exact name, so a committed `.env.example` is unaffected.
+ */
+const GITIGNORE_ENTRIES = ['.rocketride/', '.env'] as const;
 
 /** Doc files shipped in the extension's docs/ directory. */
 const DOC_FILES = ['ROCKETRIDE_README.md', 'ROCKETRIDE_QUICKSTART.md', 'ROCKETRIDE_PIPELINE_RULES.md', 'ROCKETRIDE_COMPONENT_REFERENCE.md', 'ROCKETRIDE_COMMON_MISTAKES.md', 'ROCKETRIDE_python_API.md', 'ROCKETRIDE_typescript_API.md', 'ROCKETRIDE_OBSERVABILITY.md'];
@@ -306,8 +315,9 @@ export class AgentManager {
 	}
 
 	/**
-	 * Ensure .rocketride/ is listed in .gitignore.
-	 * Creates .gitignore if it doesn't exist. Appends if entry is missing.
+	 * Ensure every entry in GITIGNORE_ENTRIES is listed in .gitignore.
+	 * Creates .gitignore if it doesn't exist. Appends only the missing entries,
+	 * so an entry the user already covers is never duplicated.
 	 */
 	async ensureGitignore(workspaceRoot: vscode.Uri): Promise<void> {
 		const gitignoreUri = vscode.Uri.joinPath(workspaceRoot, '.gitignore');
@@ -320,13 +330,11 @@ export class AgentManager {
 			// .gitignore doesn't exist — will create
 		}
 
-		// Check if already present (exact line match)
-		const lines = content.split('\n');
-		if (lines.some((line) => line.trim() === GITIGNORE_ENTRY)) {
+		const newContent = appendGitignoreEntries(content, GITIGNORE_ENTRIES);
+		if (newContent === null) {
 			return;
 		}
 
-		const newContent = content.trimEnd() + (content ? '\n' : '') + GITIGNORE_ENTRY + '\n';
 		await vscode.workspace.fs.writeFile(gitignoreUri, Buffer.from(newContent, 'utf8'));
 	}
 

--- a/apps/vscode/src/shared/util/gitignoreEntries.ts
+++ b/apps/vscode/src/shared/util/gitignoreEntries.ts
@@ -44,11 +44,18 @@ export function missingGitignoreEntries(content: string, entries: readonly strin
  * `content` with any missing entries appended, or `null` when nothing is
  * missing (so the caller can skip the write entirely rather than rewriting a
  * byte-identical file).
+ *
+ * The user's existing text is preserved byte-for-byte, including any blank
+ * lines they left at the end — this file is hand-edited, and silently
+ * reformatting someone's `.gitignore` while adding one line to it is the kind
+ * of thing that makes a tool untrustworthy. A separating newline is added only
+ * when the content does not already end in one.
  */
 export function appendGitignoreEntries(content: string, entries: readonly string[]): string | null {
 	const missing = missingGitignoreEntries(content, entries);
 	if (missing.length === 0) {
 		return null;
 	}
-	return content.trimEnd() + (content ? '\n' : '') + missing.join('\n') + '\n';
+	const separator = content === '' || content.endsWith('\n') ? '' : '\n';
+	return content + separator + missing.join('\n') + '\n';
 }

--- a/apps/vscode/src/shared/util/gitignoreEntries.ts
+++ b/apps/vscode/src/shared/util/gitignoreEntries.ts
@@ -1,0 +1,54 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+/**
+ * Pure `.gitignore` entry reconciliation, kept out of `agent-manager.ts` so it
+ * is testable without the `vscode` module (same seam as `envFile.ts`).
+ */
+
+/**
+ * Which of `entries` are not already listed in `content`.
+ *
+ * Matching is on exact trimmed lines. That is deliberate: a user whose
+ * `.gitignore` already says `*.env` or `**\/.env` has a broader rule than we
+ * would add, and second-guessing it risks writing a narrower duplicate. The
+ * cost of the strict comparison is an occasional redundant line, which is
+ * harmless; the cost of being clever is fighting the user's own config.
+ */
+export function missingGitignoreEntries(content: string, entries: readonly string[]): string[] {
+	const present = new Set(content.split('\n').map((line) => line.trim()));
+	return entries.filter((entry) => !present.has(entry));
+}
+
+/**
+ * `content` with any missing entries appended, or `null` when nothing is
+ * missing (so the caller can skip the write entirely rather than rewriting a
+ * byte-identical file).
+ */
+export function appendGitignoreEntries(content: string, entries: readonly string[]): string | null {
+	const missing = missingGitignoreEntries(content, entries);
+	if (missing.length === 0) {
+		return null;
+	}
+	return content.trimEnd() + (content ? '\n' : '') + missing.join('\n') + '\n';
+}

--- a/apps/vscode/src/test/gitignoreEntries.test.ts
+++ b/apps/vscode/src/test/gitignoreEntries.test.ts
@@ -48,6 +48,19 @@ test('tolerates a missing trailing newline', () => {
 	assert.equal(appendGitignoreEntries('node_modules/', ENTRIES), 'node_modules/\n.rocketride/\n.env\n');
 });
 
+test('whitespace-only content does not gain a leading blank line', () => {
+	// Regression: trimming the content but testing the UNtrimmed string for the
+	// separator emitted a leading newline here.
+	assert.equal(appendGitignoreEntries('   ', ENTRIES), '   \n.rocketride/\n.env\n');
+});
+
+test("preserves the user's trailing blank lines verbatim", () => {
+	// A hand-edited .gitignore is the user's file. Adding one entry must not
+	// silently reformat the rest of it.
+	const existing = 'node_modules/\n\n\n';
+	assert.equal(appendGitignoreEntries(existing, ENTRIES), `${existing}.rocketride/\n.env\n`);
+});
+
 test('matches entries despite surrounding whitespace', () => {
 	assert.deepEqual(missingGitignoreEntries('  .env  \n', ENTRIES), ['.rocketride/']);
 });

--- a/apps/vscode/src/test/gitignoreEntries.test.ts
+++ b/apps/vscode/src/test/gitignoreEntries.test.ts
@@ -1,0 +1,66 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { appendGitignoreEntries, missingGitignoreEntries } from '../shared/util/gitignoreEntries';
+
+const ENTRIES = ['.rocketride/', '.env'] as const;
+
+test('creates both entries in an empty .gitignore', () => {
+	assert.equal(appendGitignoreEntries('', ENTRIES), '.rocketride/\n.env\n');
+});
+
+test('appends only the missing entry', () => {
+	assert.equal(appendGitignoreEntries('.rocketride/\n', ENTRIES), '.rocketride/\n.env\n');
+});
+
+test('returns null when nothing is missing, so the caller can skip the write', () => {
+	assert.equal(appendGitignoreEntries('.rocketride/\n.env\n', ENTRIES), null);
+});
+
+test('preserves existing user content and trailing-newline shape', () => {
+	const existing = '# my project\nnode_modules/\ndist/\n';
+	assert.equal(appendGitignoreEntries(existing, ENTRIES), `${existing}.rocketride/\n.env\n`);
+});
+
+test('tolerates a missing trailing newline', () => {
+	assert.equal(appendGitignoreEntries('node_modules/', ENTRIES), 'node_modules/\n.rocketride/\n.env\n');
+});
+
+test('matches entries despite surrounding whitespace', () => {
+	assert.deepEqual(missingGitignoreEntries('  .env  \n', ENTRIES), ['.rocketride/']);
+});
+
+test('does not treat .env.example as covering .env', () => {
+	// .env.example is meant to be COMMITTED, so it must never be mistaken for
+	// the ignore rule that protects the real key.
+	assert.deepEqual(missingGitignoreEntries('.env.example\n', ['.env']), ['.env']);
+});
+
+test('a broader user pattern is not rewritten, only supplemented', () => {
+	// Strict line matching means `*.env` does not suppress our `.env` entry.
+	// The redundant line is harmless; silently trusting a pattern we did not
+	// write would be worse.
+	assert.deepEqual(missingGitignoreEntries('*.env\n', ['.env']), ['.env']);
+});

--- a/docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md
+++ b/docs/agents/ROCKETRIDE_COMPONENT_REFERENCE.md
@@ -438,7 +438,7 @@ Any string value in `config` can use `${ROCKETRIDE_<name>}` to inject values fro
    ROCKETRIDE_QDRANT_PORT=6333
    ```
 
-2. **Update `env.example`** with the same variable names but placeholder values. This file can be safely committed to the repo so other developers know what to configure:
+2. **Update `.env.example`** with the same variable names but placeholder values. Unlike `.env` — which holds the real key and must stay gitignored — this file is safe to commit so other developers know what to configure:
    ```env
    ROCKETRIDE_OPENAI_KEY=your-openai-api-key-here
    ROCKETRIDE_QDRANT_HOST=localhost

--- a/docs/agents/ROCKETRIDE_README.md
+++ b/docs/agents/ROCKETRIDE_README.md
@@ -44,8 +44,9 @@ Before writing ANY RocketRide code, you MUST:
 - [ ] If you are creating a python project, create a virtual environment
 - [ ] Create the pipeline file(s) using `.pipe` extension (e.g., `chat.pipe`, `ingestion.pipe`)
 - [ ] On connect to a self-hosted engine (local/docker/service/onprem), the extension auto-populates `.env` with the live `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`; for cloud, set `ROCKETRIDE_APIKEY` manually
-- [ ] Create an `env.example` file documenting any custom variables used in your pipeline files
-- [ ] Open the `.env` file in the workspace editor (as a tab) so the user can verify settings and add custom variables (e.g., `ROCKETRIDE_INPUT_PATH`, `ROCKETRIDE_OUTPUT_PATH`, etc.)
+- [ ] Make sure `.env` is listed in `.gitignore` — it holds a real `ROCKETRIDE_APIKEY`. Commit only the example file
+- [ ] Create a `.env.example` file documenting any custom variables used in your pipeline files, with placeholder values
+- [ ] Confirm the variable names the pipeline expects are present in `.env` (e.g., `ROCKETRIDE_INPUT_PATH`, `ROCKETRIDE_OUTPUT_PATH`) and tell the user which ones they still need to fill in
 - [ ] Always install the appropriate RocketRide client:
   - **Python:** `pip install rocketride`
   - **TypeScript (npm):** `npm install rocketride`

--- a/packages/client-python/src/rocketride/__init__.py
+++ b/packages/client-python/src/rocketride/__init__.py
@@ -51,7 +51,7 @@ Quick Start:
     finally:
         await client.disconnect()
 
-For more information, see the documentation at https://docs.rocketride.ai
+For more information, see the documentation at https://docs.rocketride.org
 """
 
 # Package metadata — __version__ is populated at runtime from the installed


### PR DESCRIPTION
Closes #1201. Closes #1534.

## #1201 — `.env` holds a real key and wasn't gitignored

Connecting to a self-hosted engine writes a live `ROCKETRIDE_APIKEY` into the workspace `.env` (`Connection.syncEnvFile`, `apps/vscode/src/connection/connection.ts:280`), but `ensureGitignore` only ever added `.rocketride/`. A fresh scaffolded project was one `git add .` from committing that key.

- `ensureGitignore` now reconciles a **list** of entries (`.rocketride/`, `.env`) and appends only what's missing, so re-running never duplicates a line.
- The pure reconciliation moved to `apps/vscode/src/shared/util/gitignoreEntries.ts`. That directory is `vscode`-free, so it's unit-testable — the same seam `envFile.ts` already uses for exactly this reason. `agent-manager.ts` imports `vscode` at module scope and can't be loaded under `node:test`.
- Matching is on **exact trimmed lines**. A user who already wrote `*.env` keeps their own rule and gets one redundant line at worst; silently trusting a pattern we didn't write seemed worse than that. Both cases are tested.
- `.env` does **not** match `.env.example`, so the example file stays committable. Also tested, since that's the property the whole "commit only the example" instruction rests on.

Docs, per the issue's follow-ups:
- new checklist step: make sure `.env` is gitignored, commit only the example
- `env.example` → `.env.example` (`ROCKETRIDE_README.md`, and `ROCKETRIDE_COMPONENT_REFERENCE.md:441`)
- replaced "open `.env` as a visible tab" with confirming the variable names the pipeline actually expects

The issue mentions the `packages/agents-core` copy from #1034/#1110 and a `docs-sync.ts` — neither exists on `develop` yet, so there's nothing to mirror. Whoever lands those will want to carry `GITIGNORE_ENTRIES` across.

## #1534 — three `.ai` references, not one

The issue names `.github/ISSUE_TEMPLATE/config.yml`. Two others were still live:

- `.github/SUPPORT.md:7`
- `packages/client-python/src/rocketride/__init__.py:54` — the `rocketride` package docstring, which ships to PyPI and is the most user-visible of the three

`grep -rn "docs.rocketride.ai"` is now empty.

## On #1200 — I think it's already fixed, please close

Not touched here, because the behaviour it reports as removed is **back**. #1200 says #803 deleted the extension's `.env` handling, so the checklist line is false. On `develop`:

- `Connection.syncEnvFile` (`connection.ts:280`) writes `ROCKETRIDE_URI` / `ROCKETRIDE_APIKEY` into the workspace `.env`
- `resolveConnectionEnv` (`shared/util/envFile.ts:163`) gates it: **`development` group only**, self-hosted modes only, cloud skipped because an OAuth token isn't a usable SDK key

The current checklist line — *"On connect to a self-hosted engine (local/docker/service/onprem), the extension auto-populates `.env` … for cloud, set `ROCKETRIDE_APIKEY` manually"* — matches that exactly. Rewriting it per #1200 to say the agent must create `.env` itself would make the doc wrong.

One nuance the line leaves out, if you want it tightened: only the **`development`** connection group writes `.env` — the `deployment` group deliberately never touches it. Happy to add that in a follow-up.

## Verification

- `npx tsx --test src/test/gitignoreEntries.test.ts` → **8 passed**
- `npx tsc --noEmit -p apps/vscode/tsconfig.json` → **0 errors**
- `npx prettier --check` on all changed TS → clean
- `grep -rn "docs.rocketride.ai"` → no matches

I don't have the engine build locally, so `builder` targets haven't been run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated documentation, support, issue template, and package links to the new `docs.rocketride.org` site.
  * Clarified environment variable setup, including `.env` and `.env.example` requirements.
  * Added guidance to verify all pipeline-required environment variables.

* **Bug Fixes**
  * Projects now automatically exclude both `.rocketride/` and `.env` from version control.
  * Improved `.gitignore` updates to preserve existing content, formatting, and avoid unnecessary rewrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->