### PR TITLE
fix(docs): normalize Discord invite links to a single code

### DIFF
--- a/apps/hello-ui/src/HomeApp.tsx
+++ b/apps/hello-ui/src/HomeApp.tsx
@@ -51,7 +51,7 @@ const { useWorkspace, ConnectionManager } = getShellApi();
 // CONSTANTS
 // =============================================================================
 
-const DISCORD_URL = 'https://discord.gg/rocketride';
+const DISCORD_URL = 'https://discord.gg/PMXrtenMsY';
 
 /** Honor the OS "reduce motion" setting for card hover transitions. */
 const REDUCE_MOTION =

--- a/apps/vscode/docs/index.md
+++ b/apps/vscode/docs/index.md
@@ -14,7 +14,7 @@ sidebar_position: 1
 <p align="center">
   <a href="https://marketplace.visualstudio.com/items?itemName=RocketRide.rocketride"><img src="https://img.shields.io/visual-studio-marketplace/v/RocketRide.rocketride?color=222223&label=Marketplace" alt="VS Code Marketplace" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server"><img src="https://img.shields.io/github/stars/rocketride-org/rocketride-server?style=flat&color=238636&label=GitHub&logo=github&logoColor=white" alt="GitHub" /></a>
-  <a href="https://discord.gg/9hr3tdZmEG"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://discord.gg/PMXrtenMsY"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server/blob/develop/LICENSE"><img src="https://img.shields.io/badge/License-MIT-41b6e6" alt="MIT License" /></a>
 </p>
 
@@ -86,7 +86,7 @@ Need inspiration? Check out [awesome-rocketride](https://github.com/rocketride-o
 ## Links
 
 - [Documentation](https://docs.rocketride.org/)
-- [Discord](https://discord.gg/9hr3tdZmEG)
+- [Discord](https://discord.gg/PMXrtenMsY)
 - [GitHub](https://github.com/rocketride-org/rocketride-server)
 - [Contributing](https://github.com/rocketride-org/rocketride-server/blob/develop/CONTRIBUTING.md)
 - [Security](https://github.com/rocketride-org/rocketride-server/blob/develop/SECURITY.md)

--- a/packages/client-mcp/docs/index.md
+++ b/packages/client-mcp/docs/index.md
@@ -17,7 +17,7 @@ title: "MCP Server"
 <p align="center">
   <a href="https://pypi.org/project/rocketride-mcp/"><img src="https://img.shields.io/pypi/v/rocketride-mcp?color=222223&label=PyPI" alt="PyPI" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server"><img src="https://img.shields.io/github/stars/rocketride-org/rocketride-server?style=flat&color=238636&label=GitHub&logo=github&logoColor=white" alt="GitHub" /></a>
-  <a href="https://discord.gg/9hr3tdZmEG"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://discord.gg/PMXrtenMsY"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server/blob/develop/LICENSE"><img src="https://img.shields.io/badge/License-MIT-41b6e6" alt="MIT License" /></a>
 </p>
 
@@ -344,7 +344,7 @@ Set these environment variables (required; no config file is used):
 
 - [Documentation](https://docs.rocketride.org/)
 - [GitHub](https://github.com/rocketride-org/rocketride-server)
-- [Discord](https://discord.gg/9hr3tdZmEG)
+- [Discord](https://discord.gg/PMXrtenMsY)
 - [Contributing](https://github.com/rocketride-org/rocketride-server/blob/develop/CONTRIBUTING.md)
 
 ## License

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -14,7 +14,7 @@ title: Python
 <p align="center">
   <a href="https://pypi.org/project/rocketride/"><img src="https://img.shields.io/pypi/v/rocketride?color=222223&label=PyPI" alt="PyPI" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server"><img src="https://img.shields.io/github/stars/rocketride-org/rocketride-server?style=flat&color=238636&label=GitHub&logo=github&logoColor=white" alt="GitHub" /></a>
-  <a href="https://discord.gg/9hr3tdZmEG"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://discord.gg/PMXrtenMsY"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server/blob/develop/LICENSE"><img src="https://img.shields.io/badge/License-MIT-41b6e6" alt="MIT License" /></a>
 </p>
 
@@ -679,7 +679,7 @@ All commands accept `--uri` and `--apikey` flags, or read from environment varia
 
 - [Documentation](https://docs.rocketride.org/)
 - [GitHub](https://github.com/rocketride-org/rocketride-server)
-- [Discord](https://discord.gg/9hr3tdZmEG)
+- [Discord](https://discord.gg/PMXrtenMsY)
 - [Contributing](https://github.com/rocketride-org/rocketride-server/blob/develop/CONTRIBUTING.md)
 
 ## License

--- a/packages/client-typescript/docs/guide/index.md
+++ b/packages/client-typescript/docs/guide/index.md
@@ -15,7 +15,7 @@ title: TypeScript
 <p align="center">
   <a href="https://www.npmjs.com/package/rocketride"><img src="https://img.shields.io/npm/v/rocketride?color=222223&label=NPM" alt="npm" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server"><img src="https://img.shields.io/github/stars/rocketride-org/rocketride-server?style=flat&color=238636&label=GitHub&logo=github&logoColor=white" alt="GitHub" /></a>
-  <a href="https://discord.gg/9hr3tdZmEG"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
+  <a href="https://discord.gg/PMXrtenMsY"><img src="https://img.shields.io/badge/Discord-Join-370b7a?logo=discord&logoColor=white" alt="Discord" /></a>
   <a href="https://github.com/rocketride-org/rocketride-server/blob/develop/LICENSE"><img src="https://img.shields.io/badge/License-MIT-41b6e6" alt="MIT License" /></a>
 </p>
 
@@ -548,7 +548,7 @@ await client.disconnect();
 
 - [Documentation](https://docs.rocketride.org/)
 - [GitHub](https://github.com/rocketride-org/rocketride-server)
-- [Discord](https://discord.gg/9hr3tdZmEG)
+- [Discord](https://discord.gg/PMXrtenMsY)
 - [Contributing](https://github.com/rocketride-org/rocketride-server/blob/develop/CONTRIBUTING.md)
 
 ## License

--- a/packages/docs/content-static/index.mdx
+++ b/packages/docs/content-static/index.mdx
@@ -48,7 +48,7 @@ RocketRide sits one layer below your application and your agent framework. It ha
   <span className="rr-side-card__body">Run on Docker, on-prem, or one-click deploy to RocketRide Cloud.</span>
 </a>
 
-<a className="rr-side-card" href="https://discord.gg/9hr3tdZmEG">
+<a className="rr-side-card" href="https://discord.gg/PMXrtenMsY">
   <span className="rr-side-card__head"><SiDiscord className="rr-card-icon" /><span className="rr-side-card__title">Discord Community</span></span>
   <span className="rr-side-card__body">Join the Discord, ask questions, show what you built.</span>
 </a>

--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -114,7 +114,7 @@ const config: Config = {
 			},
 			items: [
 				{ to: '/', label: 'Home', position: 'left', className: 'navbar__link--colored' },
-				{ type: 'custom-discord', href: 'https://discord.gg/9hr3tdZmEG', label: 'Discord', position: 'right' },
+				{ type: 'custom-discord', href: 'https://discord.gg/PMXrtenMsY', label: 'Discord', position: 'right' },
 				{ type: 'custom-githubStars', href: 'https://github.com/rocketride-org/rocketride-server', label: 'GitHub', position: 'right' },
 			],
 		},

--- a/packages/docs/src/theme/Footer/index.tsx
+++ b/packages/docs/src/theme/Footer/index.tsx
@@ -85,7 +85,7 @@ const SOCIALS: SocialLink[] = [
 	},
 	{
 		label: 'Discord',
-		href: 'https://discord.gg/9hr3tdZmEG',
+		href: 'https://discord.gg/PMXrtenMsY',
 		icon: (
 			<svg viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
 				<path


### PR DESCRIPTION
Closes #1745.

The repo referenced three different Discord invites. This standardizes every reference on `discord.gg/PMXrtenMsY` — the code already used in the top-level `README.md` and the `docs/README-*.md` client readmes.

### Changes (8 files, 12 occurrences)
- `discord.gg/9hr3tdZmEG` → `PMXrtenMsY` — docs-site config/footer + co-located `docs/index.md` (vscode, client-mcp, client-python, client-typescript), `packages/docs/content-static/index.mdx`
- `discord.gg/rocketride` → `PMXrtenMsY` — `apps/hello-ui/src/HomeApp.tsx` placeholder

### Out of scope
CI webhook URLs (`discord.com/api/webhooks/...`) are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Discord invitation links across the OSS landing page, documentation site, VS Code guides, MCP Server docs, Python docs, and TypeScript docs.
  - Refreshed Discord links in navigation, footers, badges, and community cards to ensure they point to the current invite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->