### PR TITLE
fix(ai): keep GLiNER inference params out of model identity

### DIFF
--- a/packages/ai/src/ai/common/models/gliner/gliner.py
+++ b/packages/ai/src/ai/common/models/gliner/gliner.py
@@ -38,9 +38,9 @@ class GLiNERLoader(BaseLoader):
     _REQUIREMENTS_FILE = os.path.join(os.path.dirname(__file__), 'requirements_gliner.txt')
 
     # No identity defaults. `threshold`, `flat_ner` and `multi_label` are inference-time
-    # arguments applied per call in inference(), not load-time ones — load() builds the
-    # model with from_pretrained(model_name) alone. Folding them in here made two GLiNER
-    # instances differing only in threshold load separate copies of identical weights.
+    # arguments applied per call in inference(), not load-time ones. Folding them in here
+    # made two GLiNER instances differing only in threshold load separate copies of
+    # identical weights.
 
     @staticmethod
     def load(
@@ -48,6 +48,9 @@ class GLiNERLoader(BaseLoader):
         device: Optional[str] = None,
         allocate_gpu: Optional[callable] = None,
         exclude_gpus: Optional[List[int]] = None,
+        threshold: Optional[float] = None,
+        flat_ner: Optional[bool] = None,
+        multi_label: Optional[bool] = None,
         **kwargs,
     ) -> Tuple[Any, Dict[str, Any], int]:
         """
@@ -62,10 +65,19 @@ class GLiNERLoader(BaseLoader):
             device: Device for local mode ('cuda:0', 'cpu', etc.)
             allocate_gpu: Callback for server mode (memory_gb, exclude_gpus) -> (gpu_index, device_str)
             exclude_gpus: GPUs to exclude (server mode)
-            **kwargs: Additional arguments for GLiNER
+            threshold: Accepted and ignored. Inference-time only — see inference().
+            flat_ner: Accepted and ignored. Inference-time only — see inference().
+            multi_label: Accepted and ignored. Inference-time only — see inference().
+            **kwargs: Additional arguments forwarded to GLiNER.from_pretrained()
+                (e.g. `revision`)
 
         Returns:
             Tuple of (model_object, metadata_dict, gpu_index)
+
+        Note:
+            The three inference params are named explicitly so they are absorbed rather
+            than forwarded: an older client can still put them in `loader_options`, and
+            passing them through to `from_pretrained()` would raise.
         """
         GLiNERLoader._ensure_dependencies()
         GLiNERLoader._patch_mecab()
@@ -77,7 +89,7 @@ class GLiNERLoader(BaseLoader):
         if allocate_gpu:
             # === SERVER MODE: CPU-first for accurate memory measurement ===
             logger.info(f'Loading GLiNER {model_name} to CPU...')
-            model = GLiNERModel.from_pretrained(model_name)
+            model = GLiNERModel.from_pretrained(model_name, **kwargs)
             model.to('cpu')
             model.eval()
 
@@ -98,7 +110,7 @@ class GLiNERLoader(BaseLoader):
                 device = 'cuda:0' if torch.cuda.is_available() else 'cpu'
 
             logger.info(f'Loading GLiNER {model_name} to {device}')
-            model = GLiNERModel.from_pretrained(model_name)
+            model = GLiNERModel.from_pretrained(model_name, **kwargs)
             model.to(device)
             model.eval()
 

--- a/packages/ai/src/ai/common/models/gliner/gliner.py
+++ b/packages/ai/src/ai/common/models/gliner/gliner.py
@@ -36,11 +36,11 @@ class GLiNERLoader(BaseLoader):
 
     LOADER_TYPE: str = 'gliner'
     _REQUIREMENTS_FILE = os.path.join(os.path.dirname(__file__), 'requirements_gliner.txt')
-    _DEFAULTS: dict = {
-        'threshold': 0.5,
-        'flat_ner': True,
-        'multi_label': False,
-    }
+
+    # No identity defaults. `threshold`, `flat_ner` and `multi_label` are inference-time
+    # arguments applied per call in inference(), not load-time ones — load() builds the
+    # model with from_pretrained(model_name) alone. Folding them in here made two GLiNER
+    # instances differing only in threshold load separate copies of identical weights.
 
     @staticmethod
     def load(
@@ -324,10 +324,14 @@ class GLiNER:
         Args:
             model_name_or_path: Model name or path
             device: Device ('server', 'cuda', 'cpu', 'cuda:N', or None for auto)
-            threshold: Confidence threshold for entity detection
-            flat_ner: Whether to use flat NER (no nested entities)
-            multi_label: Whether to allow multiple labels per span
+            threshold: Default confidence threshold, applied per call
+            flat_ner: Default flat-NER setting, applied per call
+            multi_label: Default multi-label setting, applied per call
             **kwargs: Additional arguments for model loading
+
+        The three inference defaults above are applied at predict time and can be
+        overridden per call in predict_entities(). They are not part of model identity,
+        so instances differing only in these values share one copy on the model server.
         """
         self.model_name = model_name_or_path
         self.device = device
@@ -360,11 +364,14 @@ class GLiNER:
             )
 
     def _init_proxy(self) -> None:
-        """Initialize proxy connection and load model on server."""
+        """Initialize proxy connection and load model on server.
+
+        `threshold`, `flat_ner` and `multi_label` are deliberately not sent: they are
+        inference-time arguments, re-sent per request by _predict_remote(), and
+        generate_model_id() hashes loader options into model identity — so including
+        them would load a separate identical copy of the weights per distinct value.
+        """
         loader_options = {
-            'threshold': self.threshold,
-            'flat_ner': self.flat_ner,
-            'multi_label': self.multi_label,
             **self.kwargs,
         }
         self._client.load_model(

--- a/packages/ai/src/ai/common/models/gliner/gliner.py
+++ b/packages/ai/src/ai/common/models/gliner/gliner.py
@@ -41,6 +41,12 @@ class GLiNERLoader(BaseLoader):
     # arguments applied per call in inference(), not load-time ones. Folding them in here
     # made two GLiNER instances differing only in threshold load separate copies of
     # identical weights.
+    #
+    # They are excluded from the identity hash for the same reason. load() absorbs and
+    # ignores them, so they cannot change the loaded weights — but an older client that
+    # still sends them in loader_options would otherwise hash to a different model_id
+    # and duplicate those weights for the length of a rolling upgrade.
+    _SERVER_PARAMS = BaseLoader._SERVER_PARAMS | {'threshold', 'flat_ner', 'multi_label'}
 
     @staticmethod
     def load(

--- a/packages/ai/tests/ai/common/models/test_gliner.py
+++ b/packages/ai/tests/ai/common/models/test_gliner.py
@@ -3,6 +3,7 @@
 import sys
 import types
 
+from ai.common.models.base import BaseLoader
 from ai.common.models.gliner.gliner import GLiNERLoader, GLiNER
 import ai.common.models.gliner.gliner as glinermod
 
@@ -26,8 +27,13 @@ class _FakeGLiNERModel:
         return self
 
 
-def _load_with_fake_upstream(monkeypatch, **load_kwargs):
-    """Run GLiNERLoader.load() against a fake upstream package, on CPU."""
+def _load_with_fake_upstream(monkeypatch, server_mode=False, **load_kwargs):
+    """Run GLiNERLoader.load() against a fake upstream package.
+
+    load() has two branches with their own from_pretrained() call: local (a
+    device) and server (an allocate_gpu callback, CPU-first for memory
+    measurement). `server_mode` picks the branch so both get covered.
+    """
     _FakeGLiNERModel.last_from_pretrained = ()
 
     fake_pkg = types.ModuleType('gliner')
@@ -38,7 +44,10 @@ def _load_with_fake_upstream(monkeypatch, **load_kwargs):
     monkeypatch.setattr(GLiNERLoader, '_patch_mecab', staticmethod(lambda: None))
     monkeypatch.setattr(GLiNERLoader, '_get_memory_footprint', staticmethod(lambda model: 1.0))
 
-    GLiNERLoader.load(MODEL, device='cpu', **load_kwargs)
+    if server_mode:
+        GLiNERLoader.load(MODEL, allocate_gpu=lambda memory_gb, exclude: (0, 'cpu'), **load_kwargs)
+    else:
+        GLiNERLoader.load(MODEL, device='cpu', **load_kwargs)
     return _FakeGLiNERModel.last_from_pretrained
 
 
@@ -63,9 +72,51 @@ def test_load_absorbs_inference_params_instead_of_forwarding(monkeypatch):
     assert kwargs == {'revision': 'abc'}
 
 
+def test_server_mode_load_forwards_and_absorbs_the_same_way(monkeypatch):
+    """The allocate_gpu branch has its own from_pretrained() call — cover it too."""
+    model_name, kwargs = _load_with_fake_upstream(
+        monkeypatch,
+        server_mode=True,
+        threshold=0.3,
+        flat_ner=False,
+        multi_label=True,
+        revision='abc',
+    )
+
+    assert model_name == MODEL
+    assert kwargs == {'revision': 'abc'}
+
+
 def test_model_id_is_stable():
     a = GLiNERLoader.generate_model_id(MODEL)
     assert a == GLiNERLoader.generate_model_id(MODEL)  # same identity -> shared server copy
+
+
+def test_model_id_ignores_inference_params():
+    """Identity must not move for params load() absorbs and ignores.
+
+    The facade no longer sends these, but an older client on a newer server
+    still will. Without the exclusion each distinct threshold would hash to its
+    own model_id and load another copy of identical weights — the very waste
+    this change removes.
+    """
+    base = GLiNERLoader.generate_model_id(MODEL)
+
+    assert GLiNERLoader.generate_model_id(MODEL, threshold=0.3) == base
+    assert GLiNERLoader.generate_model_id(MODEL, threshold=0.9) == base
+    assert GLiNERLoader.generate_model_id(MODEL, flat_ner=False) == base
+    assert GLiNERLoader.generate_model_id(MODEL, multi_label=True) == base
+    assert GLiNERLoader.generate_model_id(MODEL, threshold=0.3, flat_ner=False, multi_label=True) == base
+
+
+def test_identity_exclusion_is_not_widened():
+    """Guard against over-broad filtering: only the three inference params are added."""
+    assert GLiNERLoader._SERVER_PARAMS == BaseLoader._SERVER_PARAMS | {'threshold', 'flat_ner', 'multi_label'}
+
+
+def test_model_id_still_splits_on_genuine_load_params():
+    """`revision` does reach from_pretrained(), so it must keep splitting identity."""
+    assert GLiNERLoader.generate_model_id(MODEL, revision='abc') != GLiNERLoader.generate_model_id(MODEL)
 
 
 def test_model_id_splits_on_model_name():

--- a/packages/ai/tests/ai/common/models/test_gliner.py
+++ b/packages/ai/tests/ai/common/models/test_gliner.py
@@ -1,0 +1,99 @@
+"""Unit tests for the GLiNER loader + facade (no torch/gliner needed)."""
+
+from ai.common.models.gliner.gliner import GLiNERLoader, GLiNER
+import ai.common.models.gliner.gliner as glinermod
+
+MODEL = 'urchade/gliner_small-v2.1'
+
+
+def test_model_id_is_stable():
+    a = GLiNERLoader.generate_model_id(MODEL)
+    assert a == GLiNERLoader.generate_model_id(MODEL)  # same identity -> shared server copy
+
+
+def test_model_id_splits_on_model_name():
+    """Sanity guard: the model itself must still drive identity."""
+    assert GLiNERLoader.generate_model_id(MODEL) != GLiNERLoader.generate_model_id('urchade/gliner_large-v2.1')
+
+
+class _FakeClient:
+    """Captures what the facade sends to the model server."""
+
+    captured: dict = {}
+
+    def __init__(self, addr):
+        self.metadata = {}
+
+    def load_model(self, model_name, model_type, loader_options=None):
+        _FakeClient.captured['load'] = (model_name, model_type, loader_options)
+
+    def send_command(self, command, args):
+        _FakeClient.captured['infer'] = (command, args)
+        return {'result': [{'entities': [{'text': 'Google', 'label': 'organization'}]}]}
+
+    def disconnect(self):
+        pass
+
+
+def _proxy_gliner(monkeypatch, **kwargs) -> GLiNER:
+    _FakeClient.captured = {}
+    monkeypatch.setattr(glinermod, 'get_model_server_address', lambda: 'localhost:5590')
+    monkeypatch.setattr(glinermod, 'ModelClient', _FakeClient)
+    return GLiNER(MODEL, **kwargs)
+
+
+def test_facade_proxy_does_not_send_inference_params(monkeypatch):
+    """threshold/flat_ner/multi_label are inference-time, so they must not reach loader_options."""
+    model = _proxy_gliner(monkeypatch, threshold=0.3, flat_ner=False, multi_label=True)
+
+    assert model._proxy_mode is True
+    model_name, model_type, loader_options = _FakeClient.captured['load']
+    assert model_name == MODEL and model_type == 'gliner'
+    # load_model is called with None when there is nothing left to send.
+    sent = loader_options or {}
+    assert 'threshold' not in sent
+    assert 'flat_ner' not in sent
+    assert 'multi_label' not in sent
+
+
+def test_differing_thresholds_send_identical_load_payloads(monkeypatch):
+    """Acceptance criterion: GLiNER(m, threshold=0.3) and GLiNER(m, threshold=0.5) share an id.
+
+    Asserted on the payloads rather than by hashing them: identical loader_options give an
+    identical model_id by construction, whereas comparing two computed ids here would just
+    compare generate_model_id(MODEL) with itself.
+    """
+    _proxy_gliner(monkeypatch, threshold=0.3)
+    low = _FakeClient.captured['load'][2]
+
+    _proxy_gliner(monkeypatch, threshold=0.5)
+    high = _FakeClient.captured['load'][2]
+
+    assert low == high
+    assert not (low or {})  # threshold was the only difference, and it is no longer sent
+
+
+def test_real_load_kwargs_still_reach_loader_options(monkeypatch):
+    """Guard against over-broad filtering: genuine load kwargs must still be forwarded."""
+    _proxy_gliner(monkeypatch, threshold=0.3, revision='abc')
+
+    assert _FakeClient.captured['load'][2] == {'revision': 'abc'}
+
+
+def test_inference_params_are_still_sent_per_request(monkeypatch):
+    """Removing them from load must not lose them — they belong on the inference call."""
+    model = _proxy_gliner(monkeypatch, threshold=0.3, flat_ner=False, multi_label=True)
+    model.predict_entities('John works at Google', ['person', 'organization'])
+
+    _, args = _FakeClient.captured['infer']
+    assert args['threshold'] == 0.3
+    assert args['flat_ner'] is False
+    assert args['multi_label'] is True
+
+
+def test_per_call_override_beats_the_instance_default(monkeypatch):
+    model = _proxy_gliner(monkeypatch, threshold=0.3)
+    model.predict_entities('John works at Google', ['person'], threshold=0.9)
+
+    _, args = _FakeClient.captured['infer']
+    assert args['threshold'] == 0.9

--- a/packages/ai/tests/ai/common/models/test_gliner.py
+++ b/packages/ai/tests/ai/common/models/test_gliner.py
@@ -1,9 +1,66 @@
 """Unit tests for the GLiNER loader + facade (no torch/gliner needed)."""
 
+import sys
+import types
+
 from ai.common.models.gliner.gliner import GLiNERLoader, GLiNER
 import ai.common.models.gliner.gliner as glinermod
 
 MODEL = 'urchade/gliner_small-v2.1'
+
+
+class _FakeGLiNERModel:
+    """Stand-in for the upstream gliner.GLiNER class."""
+
+    last_from_pretrained: tuple = ()
+
+    @classmethod
+    def from_pretrained(cls, model_name, **kwargs):
+        cls.last_from_pretrained = (model_name, kwargs)
+        return cls()
+
+    def to(self, device):
+        return self
+
+    def eval(self):
+        return self
+
+
+def _load_with_fake_upstream(monkeypatch, **load_kwargs):
+    """Run GLiNERLoader.load() against a fake upstream package, on CPU."""
+    _FakeGLiNERModel.last_from_pretrained = ()
+
+    fake_pkg = types.ModuleType('gliner')
+    fake_pkg.GLiNER = _FakeGLiNERModel
+    monkeypatch.setitem(sys.modules, 'gliner', fake_pkg)
+
+    monkeypatch.setattr(GLiNERLoader, '_ensure_dependencies', staticmethod(lambda: None))
+    monkeypatch.setattr(GLiNERLoader, '_patch_mecab', staticmethod(lambda: None))
+    monkeypatch.setattr(GLiNERLoader, '_get_memory_footprint', staticmethod(lambda model: 1.0))
+
+    GLiNERLoader.load(MODEL, device='cpu', **load_kwargs)
+    return _FakeGLiNERModel.last_from_pretrained
+
+
+def test_load_forwards_genuine_kwargs_to_from_pretrained(monkeypatch):
+    """`revision` must actually reach the weights, not just the model id."""
+    model_name, kwargs = _load_with_fake_upstream(monkeypatch, revision='abc')
+
+    assert model_name == MODEL
+    assert kwargs == {'revision': 'abc'}
+
+
+def test_load_absorbs_inference_params_instead_of_forwarding(monkeypatch):
+    """An older client may still send these in loader_options; they must not reach load."""
+    _, kwargs = _load_with_fake_upstream(
+        monkeypatch,
+        threshold=0.3,
+        flat_ner=False,
+        multi_label=True,
+        revision='abc',
+    )
+
+    assert kwargs == {'revision': 'abc'}
 
 
 def test_model_id_is_stable():


### PR DESCRIPTION
## Summary

- `threshold`, `flat_ner` and `multi_label` are inference-time arguments — applied per call in `GLiNERLoader.inference()` and already re-sent per request by both `_predict_local()` and `_predict_remote()`. They were still placed in `loader_options` and `_DEFAULTS`, and `generate_model_id()` hashes those into model identity, so two GLiNER instances differing only in threshold loaded separate copies of identical weights.
- `load()` never consumed them at all: it builds the model with `from_pretrained(model_name)` alone, so they fell into `**kwargs` and were silently dropped. Removing them changes nothing at load time.
- They stay on the facade signature — unlike Surya's dead `languages` in #1095, these are genuinely functional as per-call defaults, overridable in `predict_entities()`.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

New `packages/ai/tests/ai/common/models/test_gliner.py` (7 cases) — none existed. Differing thresholds produce identical load payloads, genuine load kwargs are still forwarded, the params are still sent per inference request, and per-call overrides still beat instance defaults.

48/48 pass across `packages/ai/tests/ai/common/models/`; `ruff check` and `ruff format` clean.

**Please treat CI as the real signal.** No built engine locally, so I ran the suite with `engLib`/`depends` stubbed rather than under `./builder ai:test`. The committed tests need no stubs.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none

## Notes for review

Second of three in the same bug class — inference-time params leaking into load-time model identity. #1095 (Surya) is [#1749](https://github.com/rocketride-org/rocketride-server/pull/1749), #1094 (Whisper) follows.

One deliberate difference from #1749: there I also excluded the param from identity via `_SERVER_PARAMS`, because Surya's `languages` is *dead* — it has no effect at all, so ignoring it is unambiguously right. Here the three params are *functional*, just per-request, so this PR does the narrower fix the issue asks for: stop sending them at load, keep sending them per call. A caller that passes `threshold` directly to the loader still splits identity, which seems like correct signalling rather than something to silently swallow. Happy to align the two either way once you've called the `_SERVER_PARAMS` question on #1749.

## Linked Issue

Fixes #1093


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GLiNER model loading so threshold, flat NER, and multi-label settings apply per inference request rather than during model setup.
  * Inference settings no longer create separate model instances; per-call overrides take precedence over defaults.
  * Preserved model loading options such as revision to ensure the intended model version is used.
* **Tests**
  * Added coverage for local and server loading, stable model handling, option forwarding, and per-request inference overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->