### PR TITLE
fix(ai): send Whisper `language` per request instead of at load

### DIFF
--- a/packages/ai/src/ai/common/models/audio/whisper.py
+++ b/packages/ai/src/ai/common/models/audio/whisper.py
@@ -51,8 +51,8 @@ class WhisperLoader(BaseLoader):
         See _DEFAULTS for default values applied before hashing.
 
         `language` is deliberately excluded: faster-whisper models are multilingual and
-        `language` is a transcribe()-time decode hint, so folding it in loaded one
-        identical copy of the weights per language. `compute_type` stays — precision
+        `language` is a transcribe()-time decode hint, so folding it into identity loads
+        an identical copy of the weights per language. `compute_type` stays — precision
         genuinely changes the loaded weights.
 
     Performance Note:
@@ -447,6 +447,7 @@ class WhisperLoader(BaseLoader):
         raw_output: List[Dict[str, Any]],
         batch_size: int,
         output_fields: List[str],
+        language: Optional[str] = None,
         **kwargs,
     ) -> List[Dict[str, Any]]:
         """
@@ -457,6 +458,9 @@ class WhisperLoader(BaseLoader):
             raw_output: Output from inference()
             batch_size: Expected batch size
             output_fields: Fields to extract (e.g., ['$text', '$segments'])
+            language: Language resolved for this request. Used only as a fallback for
+                results that don't already carry one; falls back to the loaded value
+                when not supplied, preserving the previous behaviour.
             **kwargs: Additional parameters (ignored)
 
         Returns:
@@ -464,17 +468,20 @@ class WhisperLoader(BaseLoader):
         """
         from ..extract import extract_outputs
 
-        # Get language from metadata
-        if hasattr(model, 'metadata'):
-            language = model.metadata.get('language', 'en')
-        elif isinstance(model, dict):
-            language = model.get('language', 'en')
-        else:
-            language = 'en'
+        # Fall back to the loaded language only when the caller didn't resolve one.
+        if language is None:
+            if hasattr(model, 'metadata'):
+                language = model.metadata.get('language', 'en')
+            elif isinstance(model, dict):
+                language = model.get('language', 'en')
+            else:
+                language = 'en'
 
         results = []
         for output in raw_output:
-            output_with_lang = {**output, 'language': language}
+            # Fallback first, so a language already on the output — the one the decoder
+            # actually detected — is preserved rather than overwritten.
+            output_with_lang = {'language': language, **output}
             extracted = extract_outputs(output_with_lang, output_fields)
             results.append(extracted)
 
@@ -682,7 +689,13 @@ class Whisper:
 
         # Postprocess phase — extract requested output fields
         t0 = time.perf_counter()
-        results = WhisperLoader.postprocess(self._model, raw_output, 1, self.output_fields)
+        results = WhisperLoader.postprocess(
+            self._model,
+            raw_output,
+            1,
+            self.output_fields,
+            language=language,
+        )
         t_post = (time.perf_counter() - t0) * 1000
 
         # Report all perf counters — same keys as model server response

--- a/packages/ai/src/ai/common/models/audio/whisper.py
+++ b/packages/ai/src/ai/common/models/audio/whisper.py
@@ -47,8 +47,13 @@ class WhisperLoader(BaseLoader):
     - MIT licensed - no restrictions
 
     Model Identity (for sharing):
-        model_name + language + compute_type
+        model_name + compute_type
         See _DEFAULTS for default values applied before hashing.
+
+        `language` is deliberately excluded: faster-whisper models are multilingual and
+        `language` is a transcribe()-time decode hint, so folding it in loaded one
+        identical copy of the weights per language. `compute_type` stays — precision
+        genuinely changes the loaded weights.
 
     Performance Note:
         - Typical throughput: ~8-15 req/s depending on model size and audio length
@@ -61,9 +66,9 @@ class WhisperLoader(BaseLoader):
     _model_locks: Dict[int, threading.Lock] = {}
     _locks_lock = threading.Lock()
 
-    # Defaults applied before hashing (ensures consistent model IDs)
+    # Defaults applied before hashing (ensures consistent model IDs).
+    # `language` is not here — it is a per-request decode hint, not a load param.
     _DEFAULTS = {
-        'language': 'en',
         'compute_type': 'float16',
     }
 
@@ -338,6 +343,7 @@ class WhisperLoader(BaseLoader):
         preprocessed: Dict[str, Any],
         metadata: Optional[Dict] = None,
         stream: Optional[Any] = None,
+        language: Optional[str] = None,
     ) -> List[Dict[str, Any]]:
         """
         Run Whisper transcription.
@@ -349,6 +355,9 @@ class WhisperLoader(BaseLoader):
             preprocessed: Output from preprocess()
             metadata: Optional metadata dict
             stream: Optional CUDA stream (not used)
+            language: Per-request decode language. Falls back to the value carried on
+                preprocessed/the bundle, so callers that do not pass it keep the
+                previous load-time behaviour.
 
         Returns:
             List of transcription results with segments
@@ -362,7 +371,9 @@ class WhisperLoader(BaseLoader):
             models = model
 
         whisper_model = models['model']
-        language = preprocessed.get('language', models.get('language', 'en'))
+        # Per-request language wins; fall back to whatever the model was loaded with.
+        if language is None:
+            language = preprocessed.get('language', models.get('language', 'en'))
 
         # Get lock for this model instance (faster-whisper is NOT thread-safe)
         model_lock = WhisperLoader._get_model_lock(id(whisper_model))
@@ -599,9 +610,14 @@ class Whisper:
             )
 
     def _init_proxy(self) -> None:
-        """Initialize proxy connection and load model on server."""
+        """Initialize proxy connection and load model on server.
+
+        `language` is deliberately not sent: faster-whisper models are multilingual and
+        it is a decode-time hint, sent per request by _transcribe_remote(). Including it
+        here made generate_model_id() load one identical copy of the weights per
+        language. `compute_type` stays — it genuinely changes the loaded weights.
+        """
         loader_options = {
-            'language': self.language,
             'compute_type': self.compute_type,
         }
         if self.kwargs:
@@ -620,6 +636,7 @@ class Whisper:
         beam_size: int = 5,
         vad_filter: bool = True,
         vad_parameters: Optional[Dict[str, Any]] = None,
+        language: Optional[str] = None,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -630,6 +647,7 @@ class Whisper:
             beam_size: Beam size for decoding
             vad_filter: Enable voice activity detection (Silero VAD)
             vad_parameters: VAD parameters dict
+            language: Override the instance's default decode language for this call
             **kwargs: Additional transcription arguments
 
         Returns:
@@ -641,14 +659,16 @@ class Whisper:
         # Count inference call — perf timing handled per-mode below
         metrics.counter('gpu_inference_count', 1)
 
+        language = language if language is not None else self.language
+
         if self._proxy_mode:
             # Model server mode — ModelClient.send_command handles perf timing
-            return self._transcribe_remote(audio, beam_size, vad_filter, vad_parameters, **kwargs)
+            return self._transcribe_remote(audio, beam_size, vad_filter, vad_parameters, language, **kwargs)
         else:
             # Local mode — time each phase
-            return self._transcribe_local(audio, **kwargs)
+            return self._transcribe_local(audio, language, **kwargs)
 
-    def _transcribe_local(self, audio: bytes, **kwargs) -> Dict[str, Any]:
+    def _transcribe_local(self, audio: bytes, language: str, **kwargs) -> Dict[str, Any]:
         """Execute local transcription with perf timing."""
         # Preprocess phase — convert raw PCM bytes to model input format
         t0 = time.perf_counter()
@@ -657,7 +677,7 @@ class Whisper:
 
         # GPU inference phase — run transcription model
         t0 = time.perf_counter()
-        raw_output = WhisperLoader.inference(self._model, preprocessed, self._metadata)
+        raw_output = WhisperLoader.inference(self._model, preprocessed, self._metadata, language=language)
         t_gpu = (time.perf_counter() - t0) * 1000
 
         # Postprocess phase — extract requested output fields
@@ -685,9 +705,14 @@ class Whisper:
         beam_size: int,
         vad_filter: bool,
         vad_parameters: Optional[Dict[str, Any]],
+        language: str,
         **kwargs,
     ) -> Dict[str, Any]:
-        """Execute remote transcription via model server."""
+        """Execute remote transcription via model server.
+
+        `language` travels with the request rather than the load, so every language
+        shares one server-side copy of the weights.
+        """
         result = self._client.send_command(
             'rrext_ms_inference',
             {
@@ -695,6 +720,7 @@ class Whisper:
                 'beam_size': beam_size,
                 'vad_filter': vad_filter,
                 'vad_parameters': vad_parameters,
+                'language': language,
                 'output_fields': self.output_fields,
                 **kwargs,
             },

--- a/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
+++ b/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
@@ -1,0 +1,115 @@
+"""Unit tests for Whisper model identity and per-request language (no torch/faster-whisper)."""
+
+from ai.common.models.audio.whisper import WhisperLoader, Whisper
+import ai.common.models.audio.whisper as whispermod
+
+
+def test_model_id_is_stable():
+    a = WhisperLoader.generate_model_id('tiny')
+    assert a == WhisperLoader.generate_model_id('tiny')  # same identity -> shared server copy
+
+
+def test_language_is_no_longer_a_load_identity_default():
+    """`language` is a decode hint, so it is not folded into identity as a load default.
+
+    This is the narrow fix the issue asks for: the facade stops *sending* it (see
+    test_facade_proxy_does_not_send_language). A caller that passes `language` straight
+    to the loader still splits identity, which is intentional — unlike Surya's dead
+    `languages`, this parameter is functional, so an explicit load-time value is a
+    deliberate act rather than something to silently ignore.
+    """
+    assert WhisperLoader._DEFAULTS == {'compute_type': 'float16'}
+
+
+def test_model_id_still_splits_on_compute_type():
+    """compute_type genuinely changes the loaded weights, so it must remain identity."""
+    fp16 = WhisperLoader.generate_model_id('tiny', compute_type='float16')
+    int8 = WhisperLoader.generate_model_id('tiny', compute_type='int8')
+
+    assert fp16 != int8
+
+
+def test_model_id_still_splits_on_model_name():
+    assert WhisperLoader.generate_model_id('tiny') != WhisperLoader.generate_model_id('large-v3')
+
+
+class _FakeClient:
+    """Captures what the facade sends to the model server."""
+
+    captured: dict = {}
+
+    def __init__(self, addr):
+        self.metadata = {}
+
+    def load_model(self, model_name, model_type, loader_options=None):
+        _FakeClient.captured['load'] = (model_name, model_type, loader_options)
+
+    def send_command(self, command, args):
+        _FakeClient.captured['infer'] = (command, args)
+        return {'result': [{'text': 'hallo welt'}]}
+
+    def disconnect(self):
+        pass
+
+
+def _proxy_whisper(monkeypatch, **kwargs) -> Whisper:
+    _FakeClient.captured = {}
+    monkeypatch.setattr(whispermod, 'get_model_server_address', lambda: 'localhost:5590')
+    monkeypatch.setattr(whispermod, 'ModelClient', _FakeClient)
+    return Whisper('tiny', **kwargs)
+
+
+def test_facade_proxy_does_not_send_language(monkeypatch):
+    model = _proxy_whisper(monkeypatch, language='de')
+
+    assert model._proxy_mode is True
+    model_name, model_type, loader_options = _FakeClient.captured['load']
+    assert model_name == 'tiny' and model_type == 'whisper'
+    assert 'language' not in loader_options
+    assert loader_options['compute_type'] == 'float16'  # real load param still sent
+
+
+def test_differing_languages_send_identical_load_payloads(monkeypatch):
+    """Acceptance criterion: Whisper('tiny', language='en'/'de') share one model_id."""
+    _proxy_whisper(monkeypatch, language='en')
+    en = _FakeClient.captured['load'][2]
+
+    _proxy_whisper(monkeypatch, language='de')
+    de = _FakeClient.captured['load'][2]
+
+    # Identical loader_options -> identical identity by construction.
+    assert en == de
+
+
+def test_language_travels_with_the_request(monkeypatch):
+    """Removing it from load must not lose it — it belongs on the transcribe call."""
+    model = _proxy_whisper(monkeypatch, language='de')
+    model.transcribe(b'\x00\x01' * 2000)
+
+    _, args = _FakeClient.captured['infer']
+    assert args['language'] == 'de'
+
+
+def test_per_call_language_overrides_the_instance_default(monkeypatch):
+    model = _proxy_whisper(monkeypatch, language='de')
+    model.transcribe(b'\x00\x01' * 2000, language='fr')
+
+    _, args = _FakeClient.captured['infer']
+    assert args['language'] == 'fr'
+
+
+def test_inference_falls_back_to_loaded_language_when_not_passed():
+    """Back-compat: an older caller that omits `language` keeps the previous behaviour."""
+    captured = {}
+
+    class _FakeWhisperModel:
+        def transcribe(self, audio, **kw):
+            captured.update(kw)
+            return iter(()), type('Info', (), {'language': kw.get('language')})()
+
+    bundle = {'model': _FakeWhisperModel(), 'language': 'ja'}
+    preprocessed = {'audios': [[0.0] * 2000], 'batch_size': 1, 'language': 'ja'}
+
+    WhisperLoader.inference(bundle, preprocessed)
+
+    assert captured['language'] == 'ja'

--- a/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
+++ b/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
@@ -98,18 +98,62 @@ def test_per_call_language_overrides_the_instance_default(monkeypatch):
     assert args['language'] == 'fr'
 
 
-def test_inference_falls_back_to_loaded_language_when_not_passed():
-    """Back-compat: an older caller that omits `language` keeps the previous behaviour."""
-    captured = {}
+class _FakeWhisperModel:
+    """Records the decode kwargs faster-whisper would have received."""
 
-    class _FakeWhisperModel:
-        def transcribe(self, audio, **kw):
-            captured.update(kw)
-            return iter(()), type('Info', (), {'language': kw.get('language')})()
+    def __init__(self):
+        self.captured = {}
 
-    bundle = {'model': _FakeWhisperModel(), 'language': 'ja'}
-    preprocessed = {'audios': [[0.0] * 2000], 'batch_size': 1, 'language': 'ja'}
+    def transcribe(self, audio, **kw):
+        self.captured.update(kw)
+        return iter(()), type('Info', (), {'language': kw.get('language')})()
 
-    WhisperLoader.inference(bundle, preprocessed)
 
-    assert captured['language'] == 'ja'
+def _run_inference(bundle_language=None, preprocessed_language=None, language=None):
+    model = _FakeWhisperModel()
+    bundle = {'model': model}
+    if bundle_language is not None:
+        bundle['language'] = bundle_language
+
+    preprocessed = {'audios': [[0.0] * 2000], 'batch_size': 1}
+    if preprocessed_language is not None:
+        preprocessed['language'] = preprocessed_language
+
+    WhisperLoader.inference(bundle, preprocessed, language=language)
+    return model.captured
+
+
+def test_inference_falls_back_to_bundle_language():
+    """Back-compat: with nothing on preprocessed, the loaded bundle value is used."""
+    assert _run_inference(bundle_language='ja')['language'] == 'ja'
+
+
+def test_inference_falls_back_to_preprocessed_language():
+    """preprocess() carries the loaded language forward; it beats the bundle value."""
+    assert _run_inference(bundle_language='ja', preprocessed_language='ko')['language'] == 'ko'
+
+
+def test_inference_prefers_the_per_request_language():
+    """An explicit per-request language wins over both fallbacks."""
+    captured = _run_inference(bundle_language='ja', preprocessed_language='ko', language='fr')
+    assert captured['language'] == 'fr'
+
+
+def test_postprocess_does_not_clobber_the_request_language():
+    """Regression: decoding in `fr` must not be reported as the loaded `de`."""
+    bundle = {'model': _FakeWhisperModel(), 'language': 'de'}
+    raw_output = [{'segments': [], 'text': 'bonjour', 'language': 'fr'}]
+
+    results = WhisperLoader.postprocess(bundle, raw_output, 1, ['$text', 'language'], language='fr')
+
+    assert results[0]['language'] == 'fr'
+
+
+def test_postprocess_still_falls_back_to_loaded_language():
+    """Callers that don't resolve a language keep the previous metadata-derived value."""
+    bundle = {'model': _FakeWhisperModel(), 'language': 'de'}
+    raw_output = [{'segments': [], 'text': 'hallo'}]
+
+    results = WhisperLoader.postprocess(bundle, raw_output, 1, ['$text', 'language'])
+
+    assert results[0]['language'] == 'de'


### PR DESCRIPTION
## Summary

- faster-whisper models (`tiny`/`base`/`large-v3`) are multilingual; `language` is a `transcribe()`-time decode hint. The facade put it in `loader_options`, and `generate_model_id()` hashes those into identity — so transcribing in K languages loaded K identical copies of the same weights.
- `transcribe()`/`_transcribe_local()` never passed it per call, so the value only took effect at load. That omission is precisely what forced the per-language copies, so this PR adds the per-request plumbing rather than just deleting the key.
- `compute_type` stays a load param in both `loader_options` and `_DEFAULTS` — precision genuinely changes the loaded weights.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

New `packages/ai/tests/ai/common/models/audio/test_whisper_identity.py` (9 cases): `compute_type` and `model_name` still split identity, differing languages send identical load payloads, `language` travels with the request, per-call override wins, and an `inference()` call that omits `language` still falls back to the loaded value.

50/50 pass across `packages/ai/tests/ai/common/models/` (including the existing `test_whisper.py`); `ruff check` and `ruff format` clean.

**Please treat CI as the real signal.** No built engine locally, so I ran the suite with `engLib`/`depends` stubbed rather than under `./builder ai:test`.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none; `transcribe()` gains an optional keyword

## Notes for review

Third of three in the same bug class. #1095 (Surya) is [#1749](https://github.com/rocketride-org/rocketride-server/pull/1749), #1093 (GLiNER) is [#1750](https://github.com/rocketride-org/rocketride-server/pull/1750).

**This is the one that actually fires today.** `nodes/src/nodes/audio_transcribe/IGlobal.py:110` constructs `Whisper(...)` with a user-configured `language`, so two transcribe nodes on different languages currently load two copies of identical weights. (Surya's equivalent was latent — nothing in-tree passed it.)

**The riskiest change of the three**, since it adds behaviour rather than removing it. Two things worth checking:

1. **Server-side dispatch.** `_transcribe_remote()` now sends `'language'` with the request and `WhisperLoader.inference()` accepts it. I couldn't verify the `rrext_ms_inference` handler from this checkout — it isn't vendored here — so I followed the pattern already shipped by `GLiNERLoader.inference()` (threshold/flat_ner/multi_label) and `PoseEstimatorLoader.inference()` (threshold/max_persons), both of which send the same keys through `send_command`. If that assumption is wrong, remote transcription would silently fall back to the loaded language, so it's worth a maintainer's eye.
2. **Back-compat fallback.** `inference()` resolves `language or preprocessed[...] or bundle[...] or 'en'`, so any caller that doesn't pass it keeps the old behaviour. The only in-tree caller (`audio_transcribe`) doesn't pass it to `transcribe()`, so it picks up the instance default and continues to work unchanged.

`transcribe()` gained `language` as a keyword before `**kwargs`. The only caller passes everything by keyword, so nothing positional breaks.

## Linked Issue

Fixes #1094


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-call language selection for Whisper transcription across local and remote processing.
  * Explicit per-call language overrides instance or default settings.
* **Bug Fixes**
  * Improved model reuse by preventing language from creating duplicate model loads.
  * Preserved language detected during decoding when processing results.
* **Tests**
  * Added coverage for model identity, request handling, and language fallback and override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->