### PR TITLE
fix(docs): unblock docs deploys broken by tool_google_workspace's docs/ variant dir

### DIFF
--- a/packages/docs/content-static/examples/rag-pipeline.md
+++ b/packages/docs/content-static/examples/rag-pipeline.md
@@ -125,6 +125,6 @@ back the answer.
 ## Next steps
 
 - Swap `embedding_openai` for [`embedding_transformer`](/nodes/embedding_transformer) to run embeddings locally without an API key.
-- Swap `qdrant` for [`pinecone`](/nodes/pinecone) or [`milvus`](/nodes/milvus) without changing the rest of the pipeline.
+- Swap `qdrant` for [`pinecone`](/nodes/store_pinecone) or [`milvus`](/nodes/store_milvus) without changing the rest of the pipeline.
 - Add a [`guardrails`](/nodes/guardrails) node between the LLM and response to validate outputs.
 - See the [Qdrant integration guide](/integrations/qdrant) for configuration details.

--- a/packages/docs/content-static/examples/webhook-pipeline.md
+++ b/packages/docs/content-static/examples/webhook-pipeline.md
@@ -126,6 +126,6 @@ Then wire `llm_1` to receive from `prompt_1` instead of `source_1`.
 
 ## Next steps
 
-- Add a [`qdrant`](/nodes/qdrant) store between source and LLM to build the full [RAG pipeline](/examples/rag-pipeline).
+- Add a [`qdrant`](/nodes/store_qdrant) store between source and LLM to build the full [RAG pipeline](/examples/rag-pipeline).
 - Replace `llm_openai` with [`llm_anthropic`](/nodes/llm_anthropic) or [`llm_ollama`](/nodes/llm_ollama) — the rest of the pipeline is unchanged.
 - See the [Anthropic integration guide](/integrations/anthropic) for model profile options.

--- a/packages/docs/content-static/integrations/neo4j.md
+++ b/packages/docs/content-static/integrations/neo4j.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 # Neo4j
 
-The `db_neo4j` node answers natural-language questions against a Neo4j graph
+The `graph_neo4j` node answers natural-language questions against a Neo4j graph
 database by translating them to Cypher with a connected LLM. It plays two roles:
 a **pipeline node** that takes questions on the `questions` lane and emits
 results downstream, and an **agent tool** that exposes graph retrieval directly
@@ -122,6 +122,6 @@ fast rather than mid-pipeline.
 
 ## Related
 
-- [`db_neo4j` node reference](/nodes/db_neo4j)
+- [`graph_neo4j` node reference](/nodes/graph_neo4j)
 - [Qdrant integration](/integrations/qdrant) — vector retrieval for RAG
 - [Concepts: Agents & Tools](/concepts/agents-tools-skills)

--- a/packages/docs/content-static/integrations/qdrant.md
+++ b/packages/docs/content-static/integrations/qdrant.md
@@ -111,7 +111,7 @@ annotated `.pipe` file.
 
 ## Related
 
-- [`qdrant` node reference](/nodes/qdrant)
+- [`qdrant` node reference](/nodes/store_qdrant)
 - [RAG Pipeline example](/examples/rag-pipeline)
 - [Anthropic integration](/integrations/anthropic) — pairing with Anthropic Claude models
 - [Concepts: Performance](/concepts/performance) — batching and chunk size tuning

--- a/packages/docs/scripts/lib/gather.js
+++ b/packages/docs/scripts/lib/gather.js
@@ -23,7 +23,11 @@ const { allDocIds, docTitles, isValidMount, mountSlots, NODES_DIR } = require('.
 const NODES_GLOB = 'nodes/src/nodes/*/README.md';
 const GENERATED_START = '<!-- ROCKETRIDE:GENERATED:PARAMS START -->';
 const DOCS_GLOB = '{nodes,packages,apps}/**/docs/**/*.{md,mdx}';
-const IGNORE = ['**/node_modules/**', '**/build/**', '**/dist/**', 'packages/docs/**'];
+// Node sources and node tests are excluded from the package-mount pass: their
+// markdown is handled by the nodes contributor above, and a node directory may
+// legitimately be *named* docs (tool_google_workspace's Google Docs variant),
+// which would otherwise match DOCS_GLOB and abort the build as unmounted.
+const IGNORE = ['**/node_modules/**', '**/build/**', '**/dist/**', 'packages/docs/**', 'nodes/src/nodes/**', 'nodes/test/**'];
 
 const PLACEHOLDER_NOTE = '> **Placeholder.** Generated stub for the documentation spine. Real content lands in a later phase.';
 

--- a/packages/docs/scripts/lib/gather.js
+++ b/packages/docs/scripts/lib/gather.js
@@ -23,10 +23,12 @@ const { allDocIds, docTitles, isValidMount, mountSlots, NODES_DIR } = require('.
 const NODES_GLOB = 'nodes/src/nodes/*/README.md';
 const GENERATED_START = '<!-- ROCKETRIDE:GENERATED:PARAMS START -->';
 const DOCS_GLOB = '{nodes,packages,apps}/**/docs/**/*.{md,mdx}';
-// Node sources and node tests are excluded from the package-mount pass: their
-// markdown is handled by the nodes contributor above, and a node directory may
-// legitimately be *named* docs (tool_google_workspace's Google Docs variant),
-// which would otherwise match DOCS_GLOB and abort the build as unmounted.
+// Node sources and node tests are excluded from the package-mount pass: node
+// markdown is the nodes contributor's domain (staged when the node's top-level
+// README carries the generated markers, and not otherwise), and a node
+// directory may legitimately be *named* docs (tool_google_workspace's Google
+// Docs variant), which would otherwise match DOCS_GLOB and abort the build as
+// unmounted.
 const IGNORE = ['**/node_modules/**', '**/build/**', '**/dist/**', 'packages/docs/**', 'nodes/src/nodes/**', 'nodes/test/**'];
 
 const PLACEHOLDER_NOTE = '> **Placeholder.** Generated stub for the documentation spine. Real content lands in a later phase.';


### PR DESCRIPTION
## Summary

- Exclude `nodes/src/nodes/**` and `nodes/test/**` from docs:gather's package-mount glob. The Google Docs variant directory `nodes/src/nodes/tool_google_workspace/docs/` matched `{nodes,packages,apps}/**/docs/**` purely by name, had no declared mount, and aborted every docs build since 2026-07-17. Node-internal markdown is staged by the dedicated nodes contributor pass, so the package-mount pass never needs to look there.
- Fix the four spine pages that still linked pre-rename node routes (`/nodes/qdrant`, `/nodes/pinecone`, `/nodes/milvus`, `/nodes/db_neo4j`) from the #1636/#1611 renames. The revived build's broken-links check fails on them; they now point at the canonical `store_*`/`graph_*` routes (public redirects for the old URLs already exist in `redirects.ts`). Also updates the neo4j page's node name from `db_neo4j` to `graph_neo4j` to match.

## Type

fix (docs build)

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`./builder docs:build` now compiles clean end to end (gather -> index -> compile): 170 pages staged including all 118 node docs, Docusaurus broken-links check green. Before the fix, `docs:gather` aborted with the unmounted-file error on every run, exactly as in CI (e.g. run 30577925738).

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1756

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Pinecone, Milvus, and Qdrant links to point to their current node documentation.
  * Corrected Neo4j references to use the current graph node name.
  * Improved documentation generation by excluding node source and test paths from package documentation discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->