### PR TITLE
fix(nodes): point each service's Documentation menu link at its docs page

### DIFF
--- a/nodes/src/nodes/accessibility_describe/services.json
+++ b/nodes/src/nodes/accessibility_describe/services.json
@@ -9,7 +9,7 @@
 	"prefix": "accessibility_describe",
 	"description": ["An accessibility-focused image analysis node that generates scene descriptions ", "optimized for blind and visually impaired users. Powered by Google Gemini Vision, ", "it provides structured descriptions including spatial layout (clock positions), ", "hazard detection, text reading (OCR), people detection, and navigation guidance. ", "Designed for real-time assistive technology applications like smart glasses."],
 	"icon": "accessibility-describe.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/accessibility_describe",
 	"tile": ["Model: ${parameters.accessibility_describe.profile}"],
 	"lanes": {
 		"image": ["text"]

--- a/nodes/src/nodes/agent_crewai/services.agent.json
+++ b/nodes/src/nodes/agent_crewai/services.agent.json
@@ -9,7 +9,7 @@
 	"prefix": "agent",
 	"description": ["Standalone single-agent CrewAI node.", "Can be invoked as a tool (`<nodeId>.run_agent`) by other agents.", "For multi-agent delegation, use a CrewAI Manager + CrewAI Subagent nodes."],
 	"icon": "crewai.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/agent_crewai/crewai_agent",
 	"invoke": {
 		"llm": {
 			"description": "LLM used by the agent",

--- a/nodes/src/nodes/agent_crewai/services.manager.json
+++ b/nodes/src/nodes/agent_crewai/services.manager.json
@@ -9,6 +9,7 @@
 	"prefix": "agent",
 	"description": ["Multi-agent manager using CrewAI hierarchical process.", "Fans out to connected CrewAI Subagent nodes, assembles a Crew, and synthesizes their outputs.", "Can be invoked as a tool (`<nodeId>.run_agent`) for nested orchestration."],
 	"icon": "crewai.svg",
+	"documentation": "https://docs.rocketride.org/nodes/agent_crewai/crewai_manager",
 	"invoke": {
 		"llm": {
 			"description": "LLM used by the manager agent",

--- a/nodes/src/nodes/agent_crewai/services.subagent.json
+++ b/nodes/src/nodes/agent_crewai/services.subagent.json
@@ -9,7 +9,7 @@
 	"prefix": "agent",
 	"description": ["Managed CrewAI sub-agent. Must be wired into a CrewAI Manager via the crewai channel.", "Cannot be invoked directly, has no questions lane."],
 	"icon": "crewai.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/agent_crewai/crewai_subagent",
 	"invoke": {
 		"llm": {
 			"description": "LLM used by this sub-agent when delegated to",

--- a/nodes/src/nodes/agent_deepagent/services.agent.json
+++ b/nodes/src/nodes/agent_deepagent/services.agent.json
@@ -9,7 +9,7 @@
 	"prefix": "agent",
 	"description": ["Single-agent execution using Deep Agents.", "Adds strategic planning, persistent state, and long-context management on top of LangChain.", "Connect Deep Agent Subagent nodes via the deepagent invoke channel for hierarchical delegation.", "Can be invoked as a tool (`<nodeId>.run_agent`) by other agents."],
 	"icon": "deepagent.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/agent_deepagent/deepagent_agent",
 	"invoke": {
 		"llm": {
 			"description": "LLM used by the agent",

--- a/nodes/src/nodes/agent_deepagent/services.subagent.json
+++ b/nodes/src/nodes/agent_deepagent/services.subagent.json
@@ -9,7 +9,7 @@
 	"prefix": "agent",
 	"description": ["Managed Deep Agent subagent. Must be wired into a Deep Agent node via the deepagent channel.", "Cannot be invoked directly, has no questions lane."],
 	"icon": "deepagent.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/agent_deepagent/deepagent_subagent",
 	"invoke": {
 		"llm": {
 			"description": "LLM used by this sub-agent when delegated to",

--- a/nodes/src/nodes/agent_langchain/services.json
+++ b/nodes/src/nodes/agent_langchain/services.json
@@ -9,7 +9,7 @@
 	"prefix": "agent",
 	"description": ["Single-agent execution using LangChain.", "Can be invoked as a tool (`<nodeId>.run_agent`) for hierarchical agent orchestration."],
 	"icon": "langchain.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/agent_langchain",
 	"invoke": {
 		"llm": {
 			"description": "LLM used by the agent",

--- a/nodes/src/nodes/agent_llamaindex/services.json
+++ b/nodes/src/nodes/agent_llamaindex/services.json
@@ -50,7 +50,7 @@
 	//		The icon to display in the UI for this node
 	//
 	"icon": "llamaindex.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/agent_llamaindex",
 	//
 	// Optional:
 	//		Control-plane channels this agent invokes: an LLM (required) and

--- a/nodes/src/nodes/agent_rocketride/services.json
+++ b/nodes/src/nodes/agent_rocketride/services.json
@@ -9,7 +9,7 @@
 	"prefix": "agent",
 	"description": ["Wave-planning agent built natively on the RocketRide architecture.", "Plans each step as a wave of parallel tool calls, uses keyed memory to stay token-efficient,", "and requests tool schemas on demand instead of loading them all upfront.", "Can be invoked as a tool (`<nodeId>.run_agent`) for hierarchical agent orchestration."],
 	"icon": "rocketride.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/agent_rocketride",
 	"invoke": {
 		"llm": {
 			"description": "LLM used by the agent for planning and synthesis",

--- a/nodes/src/nodes/anomaly_detector/services.json
+++ b/nodes/src/nodes/anomaly_detector/services.json
@@ -51,6 +51,7 @@
 	//		The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
+	"documentation": "https://docs.rocketride.org/nodes/anomaly_detector",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/anonymize/services.json
+++ b/nodes/src/nodes/anonymize/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/anonymize",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/answer_documents/services.json
+++ b/nodes/src/nodes/answer_documents/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/answer_documents",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/aparavi_aql/services.json
+++ b/nodes/src/nodes/aparavi_aql/services.json
@@ -46,6 +46,7 @@
 	//		The prefix map when added/removed when converting URLs <=> paths
 	//
 	"prefix": "aparavi",
+	"documentation": "https://docs.rocketride.org/nodes/aparavi_aql",
 	//
 	// Optional:
 	//		Description of this driver

--- a/nodes/src/nodes/audio_player/services.json
+++ b/nodes/src/nodes/audio_player/services.json
@@ -54,7 +54,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "audio-player.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/audio_player",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/audio_transcribe/services.json
+++ b/nodes/src/nodes/audio_transcribe/services.json
@@ -54,7 +54,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "audio-transcribe.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/audio_transcribe",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/audio_tts/services.json
+++ b/nodes/src/nodes/audio_tts/services.json
@@ -53,6 +53,7 @@
 	//	  The icon to display in the UI for this node
 	//
 	"icon": "audio-player.svg",
+	"documentation": "https://docs.rocketride.org/nodes/audio_tts",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/autopipe/services.json
+++ b/nodes/src/nodes/autopipe/services.json
@@ -43,6 +43,7 @@
 	//		The prefix map when added/removed when convertting URLs <=> paths
 	//
 	"prefix": "Autopipe",
+	"documentation": "https://docs.rocketride.org/nodes/autopipe",
 	//
 	// Optional:
 	//		Description to of this driver

--- a/nodes/src/nodes/core/services.filesys.json
+++ b/nodes/src/nodes/core/services.filesys.json
@@ -40,7 +40,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "file-system.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/core",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/core/services.hash.json
+++ b/nodes/src/nodes/core/services.hash.json
@@ -35,7 +35,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "hash.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/core/hash",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/core/services.indexer.json
+++ b/nodes/src/nodes/core/services.indexer.json
@@ -31,6 +31,7 @@
 	//		The prefix map when added/removed when convertting URLs <=> paths
 	//
 	"prefix": "Indexer",
+	"documentation": "https://docs.rocketride.org/nodes/core",
 	//
 	//	Optional:
 	//		Profile section are configuration optoins used by the driver

--- a/nodes/src/nodes/core/services.null.json
+++ b/nodes/src/nodes/core/services.null.json
@@ -34,6 +34,7 @@
 	//		The prefix map when added/removed when convertting URLs <=> paths
 	//
 	"prefix": "Null",
+	"documentation": "https://docs.rocketride.org/nodes/core",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/core/services.parse.json
+++ b/nodes/src/nodes/core/services.parse.json
@@ -35,7 +35,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "parse.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/core/parser",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/core/services.zip.json
+++ b/nodes/src/nodes/core/services.zip.json
@@ -36,6 +36,7 @@
 	//		The prefix map when added/removed when convertting URLs <=> paths
 	//
 	"prefix": "Zip",
+	"documentation": "https://docs.rocketride.org/nodes/core",
 	//
 	// Optional:
 	//		Local fields definitions - these define fields only for the

--- a/nodes/src/nodes/currency_convert_explicit/services.json
+++ b/nodes/src/nodes/currency_convert_explicit/services.json
@@ -50,7 +50,7 @@
 	//		The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/currency_convert_explicit",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/db_clickhouse/services.json
+++ b/nodes/src/nodes/db_clickhouse/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "clickhouse.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/db_clickhouse",
 	//
 	// Optional:
 	//		Defines the invoke connections that may/must be connected

--- a/nodes/src/nodes/db_mysql/services.json
+++ b/nodes/src/nodes/db_mysql/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "mysql.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/db_mysql",
 	//
 	//
 	// Optional:

--- a/nodes/src/nodes/db_postgres/services.json
+++ b/nodes/src/nodes/db_postgres/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "postgres.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/db_postgres",
 	//
 	// Optional:
 	//		Defines the invoke connections that may/must be connected

--- a/nodes/src/nodes/db_postgres/services.supabase.json
+++ b/nodes/src/nodes/db_postgres/services.supabase.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "supabase.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/db_postgres",
 	//
 	// Optional:
 	//		Defines the invoke connections that may/must be connected

--- a/nodes/src/nodes/dictionary/services.json
+++ b/nodes/src/nodes/dictionary/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "dictionary.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/dictionary",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/embedding_image/services.json
+++ b/nodes/src/nodes/embedding_image/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "embedding-image.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/embedding_image",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/embedding_openai/services.json
+++ b/nodes/src/nodes/embedding_openai/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "openai.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/embedding_openai",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/embedding_transformer/services.json
+++ b/nodes/src/nodes/embedding_transformer/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "embedding-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/embedding_transformer",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/embedding_video/services.json
+++ b/nodes/src/nodes/embedding_video/services.json
@@ -53,6 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "embedding-video.svg",
+	"documentation": "https://docs.rocketride.org/nodes/embedding_video",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/extract_data/services.json
+++ b/nodes/src/nodes/extract_data/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/extract_data",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/extract_facts/services.json
+++ b/nodes/src/nodes/extract_facts/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/extract_facts",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/frame_grabber/services.json
+++ b/nodes/src/nodes/frame_grabber/services.json
@@ -54,7 +54,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "frame_grabber.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/frame_grabber",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/graph_arango/services.json
+++ b/nodes/src/nodes/graph_arango/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "arango.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/graph_arango",
 	//
 	// Optional:
 	//		Defines the invoke connections that may/must be connected

--- a/nodes/src/nodes/graph_falkordb/services.json
+++ b/nodes/src/nodes/graph_falkordb/services.json
@@ -55,7 +55,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "falkordb.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/graph_falkordb",
 	"tile": [],
 	//
 	// Optional:

--- a/nodes/src/nodes/graph_hydradb/services.json
+++ b/nodes/src/nodes/graph_hydradb/services.json
@@ -42,7 +42,7 @@
 	// Optional: The UI icon (co-located svg)
 	//
 	"icon": "hydradb.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/graph_hydradb",
 	//
 	// Optional: Lanes - this MVP is a pure agent-tool surface, so no data-flow lanes.
 	//

--- a/nodes/src/nodes/graph_neo4j/services.json
+++ b/nodes/src/nodes/graph_neo4j/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "neo4j.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/graph_neo4j",
 	//
 	// Optional:
 	//		Defines the invoke connections that may/must be connected

--- a/nodes/src/nodes/guardrails/services.json
+++ b/nodes/src/nodes/guardrails/services.json
@@ -64,6 +64,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-guard.svg",
+	"documentation": "https://docs.rocketride.org/nodes/guardrails",
 	//
 	// Optional:
 	//	 The tile is the displayable name of this node

--- a/nodes/src/nodes/image_cleanup/services.json
+++ b/nodes/src/nodes/image_cleanup/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "image_cleanup.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/image_cleanup",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/llamaparse/services.json
+++ b/nodes/src/nodes/llamaparse/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "llamaindex_icon.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llamaparse",
 
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_anthropic/services.json
+++ b/nodes/src/nodes/llm_anthropic/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "anthropic.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_anthropic",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_baidu_qianfan/services.json
+++ b/nodes/src/nodes/llm_baidu_qianfan/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "baidu-qianfan.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_baidu_qianfan",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_bedrock/services.json
+++ b/nodes/src/nodes/llm_bedrock/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "bedrock.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_bedrock",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_deepseek/services.json
+++ b/nodes/src/nodes/llm_deepseek/services.json
@@ -61,7 +61,7 @@
 	//              profile (model name)
 	//
 	"icon": "deepseek.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_deepseek",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_gemini/services.json
+++ b/nodes/src/nodes/llm_gemini/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "gemini.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_gemini",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/llm_gmi_cloud/services.json
+++ b/nodes/src/nodes/llm_gmi_cloud/services.json
@@ -53,7 +53,7 @@
 	//		The icon is the icon to display in the UI for this node
 	//
 	"icon": "gmi_cloud.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_gmi_cloud",
 	//
 	//
 	// Optional:

--- a/nodes/src/nodes/llm_kimi/services.json
+++ b/nodes/src/nodes/llm_kimi/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "kimi.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_kimi",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_minimax/services.json
+++ b/nodes/src/nodes/llm_minimax/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "minimax.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_minimax",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_mistral/services.json
+++ b/nodes/src/nodes/llm_mistral/services.json
@@ -9,7 +9,7 @@
 	"prefix": "llm",
 	"description": ["A component that connects to Mistral AI's advanced language models for natural language processing. ", "Supports a wide range of models from large (256K context) to small (32K context), including specialized ", "models for reasoning and technical tasks. Features high-quality chat completions with robust error handling ", "and automatic token management."],
 	"icon": "mistral.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_mistral",
 	"tile": ["Model: ${parameters.llm_mistral.profile}"],
 	"lanes": {
 		"questions": ["answers"]

--- a/nodes/src/nodes/llm_ollama/services.json
+++ b/nodes/src/nodes/llm_ollama/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "ollama.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_ollama",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_openai/services.json
+++ b/nodes/src/nodes/llm_openai/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "openai.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_openai",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/llm_openai_api/services.json
+++ b/nodes/src/nodes/llm_openai_api/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "openai.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_openai_api",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/llm_openai_api/services.nebius.json
+++ b/nodes/src/nodes/llm_openai_api/services.nebius.json
@@ -50,7 +50,7 @@
 	//		The icon to display in the UI for this node
 	//
 	"icon": "nebius.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_openai_api",
 	//
 	// Optional:
 	//		Rendering hints to the UI which indicate which config fields to surface

--- a/nodes/src/nodes/llm_perplexity/services.json
+++ b/nodes/src/nodes/llm_perplexity/services.json
@@ -9,7 +9,7 @@
 	"prefix": "llm",
 	"description": ["A component that connects to Perplexity AI's Sonar models for advanced natural language ", "processing with real-time web search capabilities. It supports tasks such as research, ", "question answering, and chat-based interactions with access to current web information. ", "Configurable with API keys and multiple model options including reasoning and deep research ", "models for comprehensive, fact-based responses."],
 	"icon": "perplexity.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_perplexity",
 	"tile": ["Model: ${parameters.llm_perplexity.profile}"],
 	"lanes": {
 		"questions": ["answers"]

--- a/nodes/src/nodes/llm_qwen/services.json
+++ b/nodes/src/nodes/llm_qwen/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "qwen.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_qwen",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_vision_gemini/services.json
+++ b/nodes/src/nodes/llm_vision_gemini/services.json
@@ -9,7 +9,7 @@
 	"prefix": "image_vision_gemini",
 	"description": ["A component that connects to Google Gemini's vision-capable models for image analysis, ", "OCR, visual understanding, and scene description. Supports Gemini 2.5 and 3.x models ", "with multimodal capabilities. Features robust error handling, automatic image processing, ", "and flexible prompt configuration for a wide range of vision use cases."],
 	"icon": "gemini.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_vision_gemini",
 	"tile": ["Model: ${parameters.image_vision_gemini.profile}"],
 	"lanes": {
 		"image": ["text"],

--- a/nodes/src/nodes/llm_vision_mistral/services.json
+++ b/nodes/src/nodes/llm_vision_mistral/services.json
@@ -9,7 +9,7 @@
 	"prefix": "image_vision_mistral",
 	"description": ["A component that connects to Mistral AI's vision-capable models for image analysis, ", "OCR, and visual understanding tasks. Supports all Mistral vision models including ", "Mistral Large 3, Medium 3.1, Small 3.2, and Ministral models. Features robust error ", "handling, automatic image processing, and flexible prompt configuration for various use cases."],
 	"icon": "mistral-vision.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_vision_mistral",
 	"tile": ["Model: ${parameters.image_vision_mistral.profile}"],
 	"lanes": {
 		"image": ["text"],

--- a/nodes/src/nodes/llm_vision_ollama/services.json
+++ b/nodes/src/nodes/llm_vision_ollama/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "ollama.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_vision_ollama",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/llm_vision_openai/services.json
+++ b/nodes/src/nodes/llm_vision_openai/services.json
@@ -9,7 +9,7 @@
 	"prefix": "image_vision_openai",
 	"description": ["A component that connects to OpenAI's vision-capable models for image analysis, ", "OCR, visual understanding, and scene description. Supports GPT-4.1 and GPT-4o model families ", "with multimodal capabilities. Features robust error handling, automatic image processing, ", "and flexible prompt configuration for a wide range of vision use cases."],
 	"icon": "openai.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_vision_openai",
 	"tile": ["Model: ${parameters.image_vision_openai.profile}"],
 	"lanes": {
 		"image": ["text"],

--- a/nodes/src/nodes/llm_xai/services.json
+++ b/nodes/src/nodes/llm_xai/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "xai.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/llm_xai",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/local_text_output/services.json
+++ b/nodes/src/nodes/local_text_output/services.json
@@ -51,7 +51,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "text-output.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/local_text_output",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/memory_internal/services.json
+++ b/nodes/src/nodes/memory_internal/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.memory_internal",
 	"prefix": "memory",
 	"icon": "memory.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/memory_internal",
 	"description": ["Run-scoped keyed memory store exposed as agent tools.", "Provides put, get, peek, list, and clear operations so agents can", "persist intermediate results across planning waves without bloating", "the LLM context window."],
 	"lanes": {},
 	"preconfig": {

--- a/nodes/src/nodes/memory_persistent/services.json
+++ b/nodes/src/nodes/memory_persistent/services.json
@@ -8,6 +8,7 @@
 	"path": "nodes.memory_persistent",
 	"prefix": "memory",
 	"icon": "memory.svg",
+	"documentation": "https://docs.rocketride.org/nodes/memory_persistent",
 	"description": [
 		"A persistent cross-session memory node that retains data across pipeline",
 		"invocations. Supports Redis for production and in-memory backends for",

--- a/nodes/src/nodes/ner/services.json
+++ b/nodes/src/nodes/ner/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/ner",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/normalize_facts/services.json
+++ b/nodes/src/nodes/normalize_facts/services.json
@@ -50,7 +50,7 @@
 	//		The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/normalize_facts",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/ocr/services.json
+++ b/nodes/src/nodes/ocr/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "ocr.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/ocr",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/preprocessor_code/services.json
+++ b/nodes/src/nodes/preprocessor_code/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "preprocessor-code.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/preprocessor_code",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/preprocessor_langchain/services.json
+++ b/nodes/src/nodes/preprocessor_langchain/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "preprocessor-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/preprocessor_langchain",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/preprocessor_llm/services.json
+++ b/nodes/src/nodes/preprocessor_llm/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "preprocessor-llm.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/preprocessor_llm",
 	//
 	//
 	//

--- a/nodes/src/nodes/prompt/services.json
+++ b/nodes/src/nodes/prompt/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "prompt.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/prompt",
 	//
 	//
 	// Optional:

--- a/nodes/src/nodes/question/services.json
+++ b/nodes/src/nodes/question/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "question.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/question",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/reducto/services.json
+++ b/nodes/src/nodes/reducto/services.json
@@ -54,7 +54,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "reducto.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/reducto",
 
 	//
 	// Required:

--- a/nodes/src/nodes/remote/services.client.json
+++ b/nodes/src/nodes/remote/services.client.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "remote.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/remote",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/remote/services.server.json
+++ b/nodes/src/nodes/remote/services.server.json
@@ -48,6 +48,7 @@
 	//		The prefix map when added/removed when convertting URLs <=> paths
 	//
 	"prefix": "Remote Server",
+	"documentation": "https://docs.rocketride.org/nodes/remote",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/response/services.answers.json
+++ b/nodes/src/nodes/response/services.answers.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.audio.json
+++ b/nodes/src/nodes/response/services.audio.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.documents.json
+++ b/nodes/src/nodes/response/services.documents.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.image.json
+++ b/nodes/src/nodes/response/services.image.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.json
+++ b/nodes/src/nodes/response/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/response/services.json.json
+++ b/nodes/src/nodes/response/services.json.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.questions.json
+++ b/nodes/src/nodes/response/services.questions.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.table.json
+++ b/nodes/src/nodes/response/services.table.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.text.json
+++ b/nodes/src/nodes/response/services.text.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/response/services.video.json
+++ b/nodes/src/nodes/response/services.video.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-infrastructure.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/response",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/rocketride_graph/services.json
+++ b/nodes/src/nodes/rocketride_graph/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "rocketride_graph.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/rocketride_graph",
 	//
 	// Optional:
 	//		Defines the invoke connections that may/must be connected

--- a/nodes/src/nodes/rocketride_sql/services.json
+++ b/nodes/src/nodes/rocketride_sql/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "rocketride_sql.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/rocketride_sql",
 	//
 	// Optional:
 	//		Defines the invoke connections that may/must be connected

--- a/nodes/src/nodes/rocketride_vector/services.json
+++ b/nodes/src/nodes/rocketride_vector/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "rocketride_vector.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/rocketride_vector",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/schema_validate/services.json
+++ b/nodes/src/nodes/schema_validate/services.json
@@ -50,7 +50,7 @@
 	//		The icon is the icon to display in the UI for this node
 	//
 	"icon": "util-text.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/schema_validate",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/search_exa/services.json
+++ b/nodes/src/nodes/search_exa/services.json
@@ -48,7 +48,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "exa.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/search_exa",
 	//
 	// Optional:
 	//		Description to of this driver

--- a/nodes/src/nodes/store_astra/services.json
+++ b/nodes/src/nodes/store_astra/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "astra_db.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_astra",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/store_atlas/services.json
+++ b/nodes/src/nodes/store_atlas/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "mongodb.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_atlas",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/store_chroma/services.json
+++ b/nodes/src/nodes/store_chroma/services.json
@@ -54,7 +54,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "chroma.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_chroma",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/store_elasticsearch/services.elasticsearch.json
+++ b/nodes/src/nodes/store_elasticsearch/services.elasticsearch.json
@@ -9,7 +9,7 @@
 	"prefix": "Elasticsearch Vector Store",
 	"description": ["A vector database component for Elasticsearch, enabling efficient storage and ", "retrieval of vector embeddings. It supports similarity search, filtering, ", "and management of vector data with high performance. Supports Elastic Cloud ", "Serverless, Elastic Cloud Hosted, and self-managed Elasticsearch deployments."],
 	"icon": "elasticsearch.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_elasticsearch/elasticsearch",
 	"tile": ["Host/Port: ${parameters.elasticsearch.${profile}.host}:${parameters.elasticsearch.${profile}.port}", "Index: ${parameters.elasticsearch.${profile}.index}"],
 	"lanes": {
 		"text": [],

--- a/nodes/src/nodes/store_elasticsearch/services.opensearch.json
+++ b/nodes/src/nodes/store_elasticsearch/services.opensearch.json
@@ -19,7 +19,7 @@
 	"prefix": "OpenSearch Index",
 	"description": ["An OpenSearch node that supports classic BM25 search and vector search ", "for ingestion and retrieval workflows. Works with self-managed OpenSearch."],
 	"icon": "opensearch.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_elasticsearch/opensearch",
 	"tile": ["Host: ${parameters.opensearch.host}"],
 	"lanes": {
 		"text": [],

--- a/nodes/src/nodes/store_milvus/services.json
+++ b/nodes/src/nodes/store_milvus/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "milvus.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_milvus",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/store_pinecone/services.json
+++ b/nodes/src/nodes/store_pinecone/services.json
@@ -59,7 +59,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "pinecone.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_pinecone",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/store_postgres/services.json
+++ b/nodes/src/nodes/store_postgres/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "postgres.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_postgres",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/store_qdrant/services.json
+++ b/nodes/src/nodes/store_qdrant/services.json
@@ -54,7 +54,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "qdrant.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_qdrant",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/store_weaviate/services.json
+++ b/nodes/src/nodes/store_weaviate/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "weaviate.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/store_weaviate",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/summarization/services.json
+++ b/nodes/src/nodes/summarization/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "summaries.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/summarization",
 	//
 	//
 	//  Optional:

--- a/nodes/src/nodes/telegram/services.json
+++ b/nodes/src/nodes/telegram/services.json
@@ -53,6 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "telegram.svg",
+	"documentation": "https://docs.rocketride.org/nodes/telegram",
 	//
 	// Optional:
 	//	 The tile is the displayable name of this node

--- a/nodes/src/nodes/text_output/services.json
+++ b/nodes/src/nodes/text_output/services.json
@@ -47,7 +47,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "text-output.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/text_output",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/thumbnail/services.json
+++ b/nodes/src/nodes/thumbnail/services.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "thumbnail.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/thumbnail",
 	//
 	//
 	//	Optional:

--- a/nodes/src/nodes/tool_apify/services.json
+++ b/nodes/src/nodes/tool_apify/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_apify",
 	"prefix": "apify",
 	"icon": "apify.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_apify",
 	"description": ["Exposes Apify Actors as agent tools.", "Provides run_actor (run an Actor and return its dataset) and get_dataset_items."],
 	"tile": [],
 	"lanes": {},

--- a/nodes/src/nodes/tool_bland_ai/services.json
+++ b/nodes/src/nodes/tool_bland_ai/services.json
@@ -8,6 +8,7 @@
 	"path": "nodes.tool_bland_ai",
 	"prefix": "bland",
 	"icon": "bland-ai.svg",
+	"documentation": "https://docs.rocketride.org/nodes/tool_bland_ai",
 	"description": ["Make and manage AI-powered phone calls via Bland AI.", "The agent can initiate outbound calls, retrieve call transcripts, and analyze completed calls.", "Requires a Bland AI API key from https://www.bland.ai"],
 	"tile": ["Tool: ${parameters.bland_ai.serverName}"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_chartjs/services.json
+++ b/nodes/src/nodes/tool_chartjs/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_chartjs",
 	"prefix": "chartjs",
 	"icon": "chartjs.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_chartjs",
 	"description": ["Generates Chart.js v4 chart configurations from data using the pipeline LLM.", "The agent provides raw data and an optional chart type or description.", "Returns a ```chartjs fenced code block ready for rendering in the chat UI."],
 	"tile": ["Tool: ${parameters.tool_chartjs.serverName}.generate_chart"],
 	"invoke": {

--- a/nodes/src/nodes/tool_daytona/services.json
+++ b/nodes/src/nodes/tool_daytona/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_daytona",
 	"prefix": "daytona",
 	"icon": "daytona.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_daytona",
 	"description": ["Gives agents an isolated Daytona cloud sandbox for running code and shell commands.", "Provides run_code, run_command, upload_file and download_file on one shared ephemeral sandbox."],
 	"tile": [],
 	"lanes": {},

--- a/nodes/src/nodes/tool_deepl/services.json
+++ b/nodes/src/nodes/tool_deepl/services.json
@@ -45,6 +45,7 @@
 	//		The icon to display in the UI for this node.
 	//
 	"icon": "deepl.svg",
+	"documentation": "https://docs.rocketride.org/nodes/tool_deepl",
 	//
 	// Optional:
 	//		Description of this node shown in the pipeline builder.

--- a/nodes/src/nodes/tool_exa_search/services.json
+++ b/nodes/src/nodes/tool_exa_search/services.json
@@ -45,6 +45,7 @@
 	//		The icon to display in the UI for this node.
 	//
 	"icon": "exa.svg",
+	"documentation": "https://docs.rocketride.org/nodes/tool_exa_search",
 	//
 	// Optional:
 	//		Description of this node shown in the pipeline builder.

--- a/nodes/src/nodes/tool_filesystem/services.source.json
+++ b/nodes/src/nodes/tool_filesystem/services.source.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_filesystem",
 	"prefix": "fs",
 	"icon": "file-system.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_filesystem",
 	"description": ["File Store source. Streams files from the account-scoped RocketRide file store into the pipeline as raw objects for downstream processing.", "Point it at a file to process just that file, or at a folder to process every file in it; enable 'Recursive' to also descend into subfolders.", "Paths are relative to the task's storage anchor, resolved automatically from the running task."],
 	"tile": ["Path: ${parameters.filesystem.path}"],
 	"lanes": {

--- a/nodes/src/nodes/tool_filesystem/services.store.json
+++ b/nodes/src/nodes/tool_filesystem/services.store.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_filesystem",
 	"prefix": "fs",
 	"icon": "file-system.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_filesystem",
 	"description": ["File Store pipeline sink. Persists incoming lane data (documents, text, tables, and streamed image/audio/video) to the account-scoped RocketRide file store (the same store exposed via the client SDK's fs_* methods).", "All writes are scoped to the task's storage anchor (the owning user's file tree for development runs, the task's team subtree for deployed runs), resolved automatically from the running task.", "For each persisted file a JSON reference {path, url?} is emitted on the json lane; the signed url is included when 'Emit download URL' is enabled."],
 	"lanes": {
 		"documents": ["json"],

--- a/nodes/src/nodes/tool_filesystem/services.tool.json
+++ b/nodes/src/nodes/tool_filesystem/services.tool.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_filesystem",
 	"prefix": "fs",
 	"icon": "file-system.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_filesystem",
 	"description": ["File system tool for agents. Reads, writes, deletes, lists, and creates directories within the account-scoped RocketRide file store (the same store exposed via the client SDK's fs_* methods).", "All operations are scoped to the task's storage anchor (the owning user's file tree for development runs, the task's team subtree for deployed runs), resolved automatically from the running task.", "Per-operation toggles (allowRead, allowWrite, allowDelete, allowList, allowMkdir, allowStat) gate which methods the agent can call."],
 	"lanes": {},
 	"preconfig": {

--- a/nodes/src/nodes/tool_firecrawl/services.json
+++ b/nodes/src/nodes/tool_firecrawl/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_firecrawl",
 	"prefix": "firecrawl",
 	"icon": "firecrawl.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_firecrawl",
 	"description": ["Exposes Firecrawl web-scraping operations as agent tools.", "Provides scrape_url (single page) and map_url (site structure discovery)."],
 	"tile": [],
 	"lanes": {},

--- a/nodes/src/nodes/tool_git/services.json
+++ b/nodes/src/nodes/tool_git/services.json
@@ -58,7 +58,7 @@
 	// Optional:
 	//		Link rendered behind the node's docs button.
 	//
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_git",
 	//
 	// Optional:
 	//		Description shown in the node palette and node info pane.

--- a/nodes/src/nodes/tool_github/services.json
+++ b/nodes/src/nodes/tool_github/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_github",
 	"prefix": "github",
 	"icon": "github.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_github",
 	"description": ["Exposes GitHub repository operations as agent tools.", "Covers files, issues, pull requests, reviews, releases, workflows, orgs, users,", "code search, and commit history."],
 	"tile": ["GitHub${parameters.github.defaultRepo ? ': ' + parameters.github.defaultRepo : ''}"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_gohighlevel/services.json
+++ b/nodes/src/nodes/tool_gohighlevel/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_gohighlevel",
 	"prefix": "gohighlevel",
 	"icon": "gohighlevel.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_gohighlevel",
 	"description": ["Exposes the GoHighLevel (LeadConnector) v2 REST API as agent tools.", "Covers contacts, notes, tasks, opportunities, pipelines, conversations, messages,", "calendars, appointments, custom fields, custom values, tags, businesses and users."],
 	"tile": ["GoHighLevel${parameters.gohighlevel.locationId ? ': ' + parameters.gohighlevel.locationId : ''}"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_guild/services.json
+++ b/nodes/src/nodes/tool_guild/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_guild",
 	"prefix": "guild",
 	"icon": "guild.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_guild",
 	"description": ["Run Guild.ai agents from a RocketRide pipeline or an agent.", "As a pipeline step, lane input is sent to a configured Guild agent as a session and its answer flows downstream; as a tool, an agent can start Guild sessions and inspect their status and transcript.", "Guild is the control plane for AI agents — RocketRide prepares the data, a governed Guild agent performs the action."],
 	"tile": ["Guild${parameters.tool_guild.agent ? ': ' + parameters.tool_guild.agent : ''}"],
 	"lanes": {

--- a/nodes/src/nodes/tool_http_request/services.json
+++ b/nodes/src/nodes/tool_http_request/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_http_request",
 	"prefix": "http",
 	"icon": "http.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_http_request",
 	"description": ["Makes HTTP requests to any API endpoint, like curl for agents.", "The agent provides the full request (method, URL, headers, body, auth).", "The node enforces security guardrails: only whitelisted URLs and enabled HTTP methods are permitted."],
 	"tile": ["Tool: ${parameters.http_request.serverName}.http_request"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_mcp_client/services.json
+++ b/nodes/src/nodes/tool_mcp_client/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_mcp_client",
 	"prefix": "mcp",
 	"icon": "mcp.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_mcp_client",
 	"description": ["Connects to an external MCP server and exposes its tools for agent tool-calling.", "Transports: STDIO (local subprocess), Streamable HTTP (modern), and legacy HTTP+SSE."],
 	"tile": ["Transport: ${parameters.mcp_client.transport}"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_oura/services.json
+++ b/nodes/src/nodes/tool_oura/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_oura",
 	"prefix": "oura",
 	"icon": "oura.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_oura",
 	"description": ["Exposes Oura Ring health data as read-only agent tools.", "Covers daily sleep, readiness, activity, stress, resilience, SpO2, heart rate,", "workouts, sessions, tags, VO2 max, cardiovascular age, battery level, and personal info."],
 	"tile": ["Oura Ring"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_pipe/services.json
+++ b/nodes/src/nodes/tool_pipe/services.json
@@ -9,6 +9,7 @@
 	"prefix": "tool_pipe",
 	"description": ["Exposes an inline pipeline as an agent tool.", "Connect this node's output lanes to any pipeline nodes on the same canvas.", "When an agent calls the tool, the input is routed to every connected output lane.", "End each connected branch with a response node to return results."],
 	"icon": "pipetool.svg",
+	"documentation": "https://docs.rocketride.org/nodes/tool_pipe",
 	"tile": ["run_pipe"],
 	"lanes": {
 		"_source": ["text", "questions", "documents", "table", "answers"]

--- a/nodes/src/nodes/tool_pipedrive/services.json
+++ b/nodes/src/nodes/tool_pipedrive/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_pipedrive",
 	"prefix": "pipedrive",
 	"icon": "pipedrive.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_pipedrive",
 	"description": ["Exposes the Pipedrive CRM REST API v1 as agent tools.", "Covers deals, persons, organizations, activities, pipelines, stages, notes, leads,", "products, files, users, teams, goals, projects, and every other v1 resource."],
 	"tile": ["Pipedrive${parameters.pipedrive.companyDomain ? ': ' + parameters.pipedrive.companyDomain : ''}"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_python/services.json
+++ b/nodes/src/nodes/tool_python/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_python",
 	"prefix": "python",
 	"icon": "python.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_python",
 	"description": ["Executes Python code in a restricted in-process sandbox via exec().", "Only whitelisted modules can be imported. Dangerous builtins are removed."],
 	"tile": ["Tool: python.execute"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_slack/services.json
+++ b/nodes/src/nodes/tool_slack/services.json
@@ -8,7 +8,7 @@
 	"path": "nodes.tool_slack",
 	"prefix": "slack",
 	"icon": "slack.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/tool_slack",
 	"description": ["Exposes Slack workspace operations as agent tools.", "Post messages to channels or threads, list public channels, read channel history,", "and verify the connection. Authenticates with a bot token, or an incoming-webhook", "URL for zero-scope post-only setups."],
 	"tile": ["Slack${parameters.slack.webhookUrl ? ' (webhook)' : ''}"],
 	"lanes": {},

--- a/nodes/src/nodes/tool_tavily/services.json
+++ b/nodes/src/nodes/tool_tavily/services.json
@@ -45,6 +45,7 @@
 	//		The icon to display in the UI for this node.
 	//
 	"icon": "tavily.svg",
+	"documentation": "https://docs.rocketride.org/nodes/tool_tavily",
 	//
 	// Optional:
 	//		Description of this node shown in the pipeline builder.

--- a/nodes/src/nodes/tool_v0/services.json
+++ b/nodes/src/nodes/tool_v0/services.json
@@ -57,6 +57,7 @@
 	//		The icon to display in the UI for this node
 	//
 	"icon": "vercel.svg",
+	"documentation": "https://docs.rocketride.org/nodes/tool_v0",
 	//
 	// Optional:
 	//		Description of this driver

--- a/nodes/src/nodes/twelvelabs/services.json
+++ b/nodes/src/nodes/twelvelabs/services.json
@@ -53,7 +53,7 @@
 	//		The icon is the icon to display in the UI for this node
 	//
 	"icon": "twelvelabs.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/twelvelabs",
 	//
 	// Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/vectorizer/services.json
+++ b/nodes/src/nodes/vectorizer/services.json
@@ -48,6 +48,7 @@
 	//     The prefix map when added/removed when convertting URLs <=> paths
 	//
 	"prefix": "Vectorizer",
+	"documentation": "https://docs.rocketride.org/nodes/vectorizer",
 	//
 	//	Optional:
 	//		As a pipe component, define what this pipe component takes

--- a/nodes/src/nodes/webhook/services.chat.json
+++ b/nodes/src/nodes/webhook/services.chat.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "chat.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/webhook/chat",
 	//
 	//
 	// Optional:

--- a/nodes/src/nodes/webhook/services.dropper.json
+++ b/nodes/src/nodes/webhook/services.dropper.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "dropper.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/webhook/dropper",
 	//
 	//
 	// Optional:

--- a/nodes/src/nodes/webhook/services.tools.json
+++ b/nodes/src/nodes/webhook/services.tools.json
@@ -54,7 +54,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "webhook.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/webhook/tools",
 	//
 	//  Optional:
 	//      Rendering hints to the UI which indicate which fields of

--- a/nodes/src/nodes/webhook/services.webhook.json
+++ b/nodes/src/nodes/webhook/services.webhook.json
@@ -53,7 +53,7 @@
 	//	  The icon is the icon to display in the UI for this node
 	//
 	"icon": "webhook.svg",
-	"documentation": "https://docs.rocketride.org",
+	"documentation": "https://docs.rocketride.org/nodes/webhook/webhook",
 	//
 	//
 	//  Optional:

--- a/nodes/test/test_contracts.py
+++ b/nodes/test/test_contracts.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Dict, List, Any, Optional, Tuple
 from dataclasses import dataclass, field
 from unittest.mock import Mock, MagicMock
+from urllib.parse import urlsplit
 
 # Add nodes/src to path for imports
 NODES_SRC = Path(__file__).parent.parent / 'src' / 'nodes'
@@ -231,6 +232,7 @@ def get_python_lanes() -> List[Tuple[ServiceConfig, LaneDefinition]]:
 # below hold the `documentation` field to it.
 
 DOCS_SITE = 'https://docs.rocketride.org'
+DOCS_HOST = 'docs.rocketride.org'
 GENERATED_MARKER = '<!-- ROCKETRIDE:GENERATED:PARAMS START -->'
 
 
@@ -768,26 +770,39 @@ class TestDocumentationLinks:
             )
             return
 
-        assert isinstance(doc, str) and doc.startswith('https://'), (
+        assert isinstance(doc, str), f'{service.test_id}: documentation must be a string, got {doc!r}'
+        parts = urlsplit(doc)
+        host = (parts.hostname or '').lower()
+        assert parts.scheme == 'https' and host, (
             f'{service.test_id}: documentation must be an absolute https URL, got {doc!r}'
         )
 
-        if doc.rstrip('/') == DOCS_SITE:
-            # Bare docs root: only tolerated while the node has no page to link.
-            assert route is None, (
-                f'{service.test_id}: documentation points at the docs site root but the '
-                f'node has a dedicated page; use "{DOCS_SITE}{route}"'
+        if host == DOCS_HOST:
+            # Classify by hostname, not string prefix, so root URLs dressed up
+            # with a query or fragment cannot slip past as "external".
+            path = parts.path.rstrip('/')
+            if not path:
+                # Bare docs root: only tolerated while the node has no page to link.
+                assert route is None, (
+                    f'{service.test_id}: documentation points at the docs site root but the '
+                    f'node has a dedicated page; use "{DOCS_SITE}{route}"'
+                )
+            else:
+                assert route is not None, (
+                    f'{service.test_id}: documentation points at a docs site path but the node '
+                    f'has no staged docs page (README.md with generated markers); '
+                    f'author the doc or drop the field'
+                )
+                assert path == route, (
+                    f'{service.test_id}: documentation is {doc} but the staged docs route is {DOCS_SITE}{route}'
+                )
+        else:
+            # External vendor docs are a deliberate choice and allowed, but a
+            # lookalike or typo'd RocketRide domain is an authoring error.
+            assert 'rocketride' not in host, (
+                f'{service.test_id}: documentation host {host!r} looks like a mistyped '
+                f'RocketRide docs domain; the docs site is {DOCS_SITE}'
             )
-        elif doc.startswith(DOCS_SITE + '/'):
-            assert route is not None, (
-                f'{service.test_id}: documentation points at a docs site path but the node '
-                f'has no staged docs page (README.md with generated markers); '
-                f'author the doc or drop the field'
-            )
-            assert doc == DOCS_SITE + route, (
-                f'{service.test_id}: documentation is {doc} but the staged docs route is {DOCS_SITE}{route}'
-            )
-        # Any other https URL is a deliberate external reference (vendor docs); allowed.
 
 
 # Note: Functional tests (actual node input/output testing via pipelines)

--- a/nodes/test/test_contracts.py
+++ b/nodes/test/test_contracts.py
@@ -238,9 +238,8 @@ GENERATED_MARKER = '<!-- ROCKETRIDE:GENERATED:PARAMS START -->'
 
 def service_slug(file_path: Path) -> str:
     """Slug of a services file: services.json -> '', services.parse.json -> 'parse'."""
-    stem = file_path.name
-    stem = re.sub(r'\.json$', '', stem)
-    return re.sub(r'^services\.?', '', stem)
+    name = get_service_name(file_path)
+    return '' if name == 'default' else name
 
 
 def variant_owner(variant: str, slugs: List[str]) -> Optional[str]:

--- a/nodes/test/test_contracts.py
+++ b/nodes/test/test_contracts.py
@@ -220,6 +220,68 @@ def get_python_lanes() -> List[Tuple[ServiceConfig, LaneDefinition]]:
 
 
 # ============================================================================
+# Documentation Link Discovery
+# ============================================================================
+# The docs site stages one page per node from its co-located README
+# (packages/docs/scripts/lib/gather.js): /nodes/<dir> when the top-level
+# README.md carries the generated markers, plus /nodes/<dir>/<variant> for
+# each variant subdirectory holding a README.md. The canvas opens each
+# service's `documentation` URL verbatim from services*.json, so these
+# helpers derive the route a service's page will be staged at and the tests
+# below hold the `documentation` field to it.
+
+DOCS_SITE = 'https://docs.rocketride.org'
+GENERATED_MARKER = '<!-- ROCKETRIDE:GENERATED:PARAMS START -->'
+
+
+def service_slug(file_path: Path) -> str:
+    """Slug of a services file: services.json -> '', services.parse.json -> 'parse'."""
+    stem = file_path.name
+    stem = re.sub(r'\.json$', '', stem)
+    return re.sub(r'^services\.?', '', stem)
+
+
+def variant_owner(variant: str, slugs: List[str]) -> Optional[str]:
+    """Owning service slug for a variant directory.
+
+    Mirrors variantDescription() in gather.js: exact match, then
+    endswith('_' + slug), then startswith(slug); within a tier the longest
+    slug wins, so overlapping slugs (parse/parser) resolve deterministically.
+    """
+    if variant in slugs:
+        return variant
+    for pred in (lambda s: variant.endswith('_' + s), lambda s: variant.startswith(s)):
+        best, best_len = None, -1
+        for slug in slugs:
+            if slug and pred(slug) and len(slug) > best_len:
+                best, best_len = slug, len(slug)
+        if best is not None:
+            return best
+    return None
+
+
+def expected_docs_route(service: ServiceConfig) -> Optional[str]:
+    """Docs-site route the service's page is staged at, or None when no page exists."""
+    node_dir = NODES_SRC / service.node_name
+    readme = node_dir / 'README.md'
+    if not readme.exists() or GENERATED_MARKER not in readme.read_text(encoding='utf-8'):
+        return None  # legacy or missing README: gather.js stages nothing for this node
+    slugs = [service_slug(p) for p in sorted(node_dir.glob('service*.json'))]
+    slug = service_slug(service.file_path)
+    if slug:
+        for variant_dir in sorted(node_dir.iterdir()):
+            if variant_dir.is_dir() and (variant_dir / 'README.md').exists():
+                if variant_owner(variant_dir.name, slugs) == slug:
+                    return f'/nodes/{service.node_name}/{variant_dir.name}'
+    return f'/nodes/{service.node_name}'
+
+
+def get_registerable_services() -> List[ServiceConfig]:
+    """Services that declare a protocol (palette-visible; excludes field fragments)."""
+    return [s for s in get_all_services() if s.protocol]
+
+
+# ============================================================================
 # Output Capture
 # ============================================================================
 
@@ -681,6 +743,51 @@ class TestNodeLanes:
         }
         for output in lane.outputs:
             assert output in valid_lanes, f"{service.test_id}:{lane.lane}: Unknown output lane '{output}'"
+
+
+class TestDocumentationLinks:
+    """Hold each service's `documentation` URL to the node's real docs page.
+
+    The canvas "Documentation" menu entry opens this URL verbatim, so a bare
+    site root is only acceptable while the node has no staged docs page at
+    all. Once a node gains a README with the generated markers, this test
+    starts requiring the deep link, keeping future nodes correct by
+    construction.
+    """
+
+    @pytest.mark.parametrize('service', get_registerable_services(), ids=lambda s: s.test_id)
+    def test_documentation_url(self, service: ServiceConfig):
+        """Verify the documentation URL matches the staged docs route."""
+        doc = service.raw_data.get('documentation')
+        route = expected_docs_route(service)
+
+        if doc is None:
+            assert route is None, (
+                f'{service.test_id}: has a docs page but no documentation URL; '
+                f'add "documentation": "{DOCS_SITE}{route}" to {service.file_path.name}'
+            )
+            return
+
+        assert isinstance(doc, str) and doc.startswith('https://'), (
+            f'{service.test_id}: documentation must be an absolute https URL, got {doc!r}'
+        )
+
+        if doc.rstrip('/') == DOCS_SITE:
+            # Bare docs root: only tolerated while the node has no page to link.
+            assert route is None, (
+                f'{service.test_id}: documentation points at the docs site root but the '
+                f'node has a dedicated page; use "{DOCS_SITE}{route}"'
+            )
+        elif doc.startswith(DOCS_SITE + '/'):
+            assert route is not None, (
+                f'{service.test_id}: documentation points at a docs site path but the node '
+                f'has no staged docs page (README.md with generated markers); '
+                f'author the doc or drop the field'
+            )
+            assert doc == DOCS_SITE + route, (
+                f'{service.test_id}: documentation is {doc} but the staged docs route is {DOCS_SITE}{route}'
+            )
+        # Any other https URL is a deliberate external reference (vendor docs); allowed.
 
 
 # Note: Functional tests (actual node input/output testing via pipelines)

--- a/nodes/test/test_contracts.py
+++ b/nodes/test/test_contracts.py
@@ -777,6 +777,9 @@ class TestDocumentationLinks:
         )
 
         if host == DOCS_HOST:
+            assert parts.port in (None, 443), (
+                f'{service.test_id}: documentation uses unsupported HTTPS port {parts.port!r}; use port 443'
+            )
             # Classify by hostname, not string prefix, so root URLs dressed up
             # with a query or fragment cannot slip past as "external".
             path = parts.path.rstrip('/')


### PR DESCRIPTION
## Summary

- Point every service definition's `documentation` URL at the node's actual docs page instead of the docs site root: 105 root links replaced with deep links, 20 missing fields added, following the exact staging rules from `packages/docs/scripts/lib/gather.js` (`/nodes/<dir>`, variant pages `/nodes/<dir>/<variant>` matched exact > `endsWith('_'+slug)` > `startsWith(slug)`). The canvas three-dot menu's **Documentation** entry opens this URL verbatim, so this fixes the menu for every node in the cloud builder and the VS Code extension.
- Keep the 7 deliberate external vendor links (`rerank_cohere`, `tool_cognee`, `tool_mem0`, `tool_xtrace_memory`, `tool_mcp_client.butterbase`, `landing_ai` x2) unchanged. Services whose node has no staged docs page keep the root link (or no link) until their doc is authored; the full list is in #1755.
- Add `TestDocumentationLinks` to `nodes/test/test_contracts.py`: derives the expected route per service from the repo layout and fails when a service points at the root while a page exists, points at a nonexistent `docs.rocketride.org` path, or omits the field while a page exists. Future nodes are held to the correct link automatically, and authoring a README for a currently pageless node flips the requirement on for it.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes (full suite not run locally; contract suite passes, see below)

- Full contract suite: 462 passed (`pytest nodes/test/test_contracts.py`), including 148 new documentation-link checks.
- Mutation check: reverting one service to the root URL makes the new test fail with an actionable message naming the expected URL.
- All 125 deep links verified against the `.manifest.json` produced by a local `builder docs:gather` run.
- Edits preserve JSONC comments and formatting; every touched file re-parses.

Note: some of the linked pages 404 on the live site right now because docs deploys have been broken since 2026-07-17. #1757 (fixes #1756) unblocks the deploy; once it lands, the next docs build publishes every route these links target. The two PRs are independent to merge, in any order.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1755

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated node documentation links to point directly to relevant, node-specific guides.
  * Added missing documentation links across agents, tools, databases, integrations, media services, and core nodes.

* **Tests**
  * Added validation to ensure documentation links use secure URLs and correspond to available documentation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->