### PR TITLE
fix(deps): sync onnxruntime pin in constraints.lock with #1725

### DIFF
--- a/nodes/src/nodes/constraints.lock
+++ b/nodes/src/nodes/constraints.lock
@@ -870,14 +870,14 @@ oauthlib==3.3.1
     # via requests-oauthlib
 obstore==0.8.2
     # via daytona
-onnxruntime==1.20.1
+onnxruntime==1.22.0
     # via
     #   -r nodes/src/nodes/anonymize/requirements.txt
     #   -r nodes/src/nodes/audio_transcribe/requirements.txt
     #   chromadb
     #   faster-whisper
     #   gliner
-onnxruntime-gpu==1.20.1 ; sys_platform != 'darwin'
+onnxruntime-gpu==1.22.0 ; sys_platform != 'darwin'
     # via
     #   -r nodes/src/nodes/anonymize/requirements.txt
     #   -r nodes/src/nodes/audio_transcribe/requirements.txt


### PR DESCRIPTION
fixes #1754

## changes
- bump `onnxruntime`/`onnxruntime-gpu` from `1.20.1` to `1.22.0` in `nodes/src/nodes/constraints.lock`, matching the version #1725 already moved all five consuming requirements files to (`onnxruntime-gpu==1.20.1` was never published on PyPI — only `1.20.0`/`1.20.2` exist for the `-gpu` variant — so the lock was unsatisfiable, not merely stale)

## verification
- `curl -s https://pypi.org/pypi/onnxruntime-gpu/json | python3 -c "import json,sys; print(sorted(json.load(sys.stdin)['releases'].keys()))"` -> confirms `1.20.1` absent, `1.22.0` present
- `uv pip install --python <py3.12 venv> --dry-run -c nodes/src/nodes/constraints.lock "onnxruntime-gpu==1.22.0" "onnxruntime==1.22.0"` -> resolves, 10 packages
- `uv pip compile -c nodes/src/nodes/constraints.lock nodes/src/nodes/anonymize/requirements.txt nodes/src/nodes/audio_transcribe/requirements.txt --python <py3.12 venv>` -> resolves cleanly against the updated lock
- `git diff --check`