### PR TITLE
docs: remove stale claim about VS Code extension auto-writing .env

### DIFF
--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -66,7 +66,7 @@ The extension host reads these from the workspace settings and passes them to th
 
 The extension does not write or sync a workspace `.env` file. You must create `.env` yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. The RocketRide **Python SDK** reads the workspace `.env` automatically from its process working directory; the TypeScript SDK and CLIs read only process environment variables, so export the values first (for example, `set -a; source .env`).
 
-Server-managed env (org/team/user secrets) is configured separately from the **Environment** page and merged server-side during pipeline execution — it does not require a local `.env` file.
+Server-managed env (org/team/user secrets) is configured on the **Environment** page, separately from the local `.env` file, and merged server-side during pipeline execution — it does not require a local `.env` file.
 
 ## Monitoring Execution
 

--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -62,13 +62,11 @@ Trace verbosity, the idle timeout (TTL), task arguments, and debug output for pi
 
 The extension host reads these from the workspace settings and passes them to the engine on each `run`/`restart` (the `status:pipelineAction` message carries only the action and source). The engine process itself starts with no extra flags — these settings apply per task, not to the server.
 
-## `.env` Auto-Sync
+## Environment Variables
 
-After a successful engine connection, the extension syncs the workspace `.env` only for the **development** connection group using a self-hosted mode (local, Docker, service, or direct/on-prem connection). It writes the resolved `ROCKETRIDE_URI` (including a dynamic local port when applicable) and `ROCKETRIDE_APIKEY`, preserves existing comments and variables, and does not rewrite the file when its contents are already current. The RocketRide **Python SDK** reads the workspace `.env` automatically from its process working directory; the TypeScript SDK and CLIs read only process environment variables, so export the values first (for example, `set -a; source .env`).
+The extension does not write or sync a workspace `.env` file. You must create `.env` yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. The RocketRide **Python SDK** reads the workspace `.env` automatically from its process working directory; the TypeScript SDK and CLIs read only process environment variables, so export the values first (for example, `set -a; source .env`).
 
-Cloud connections are not synced because their OAuth token is not an SDK API key. Deployment connections, workspaces with no folder open, and unreadable `.env` files are also skipped; a sync failure never affects the connection itself. Keep `.env` gitignored.
-
-The extension never automatically removes these keys: disconnecting, engine exit, or switching to cloud leaves the last-synced values in place. Remove them by hand if you no longer want them. Each development-group self-hosted connection syncs again, so a hand-edited `ROCKETRIDE_APIKEY` is overwritten on the next successful connection.
+Server-managed env (org/team/user secrets) is configured separately from the **Environment** page and merged server-side during pipeline execution — it does not require a local `.env` file.
 
 ## Monitoring Execution
 

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ### Step 1: Set Up the `.env` File
 
-The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the **Environment** page, separately from the local `.env` file.
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` for the Python and TypeScript clients. MCP uses `ROCKETRIDE_AUTH` instead. Server-managed env (org/team/user secrets) is configured on the **Environment** page, separately from the local `.env` file.
 
 ```env
 # live engine address
@@ -111,7 +111,7 @@ python main.py
 
 ### Step 1: Set Up the `.env` File
 
-The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the **Environment** page, separately from the local `.env` file.
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` for the Python and TypeScript clients. MCP uses `ROCKETRIDE_AUTH` instead. Server-managed env (org/team/user secrets) is configured on the **Environment** page, separately from the local `.env` file.
 
 ```env
 # live engine address

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ### Step 1: Set Up the `.env` File
 
-The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the Environment page, separately from the local `.env` file.
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the **Environment** page, separately from the local `.env` file.
 
 ```env
 # live engine address
@@ -111,7 +111,7 @@ python main.py
 
 ### Step 1: Set Up the `.env` File
 
-The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the Environment page, separately from the local `.env` file.
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the **Environment** page, separately from the local `.env` file.
 
 ```env
 # live engine address

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -4,7 +4,7 @@
 
 ### Step 1: Set Up the `.env` File
 
-The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured separately from the Environment page.
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the Environment page, separately from the local `.env` file.
 
 ```env
 # live engine address
@@ -17,7 +17,7 @@ ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** For self-hosted engines in the development connection group, the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. Add any additional custom variables as needed. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
+> **Note:** Add any additional custom variables as needed. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
 
 ### Step 2: Install Client
 
@@ -111,7 +111,7 @@ python main.py
 
 ### Step 1: Set Up the `.env` File
 
-The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured separately from the Environment page.
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured on the Environment page, separately from the local `.env` file.
 
 ```env
 # live engine address
@@ -124,7 +124,7 @@ ROCKETRIDE_INPUT_PATH=/data/input
 ROCKETRIDE_OUTPUT_PATH=/data/output
 ```
 
-> **Note:** For self-hosted engines in the development connection group, the extension re-syncs `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` on every connect while leaving your other variables untouched. For cloud, provide your own API key. The TypeScript client reads `process.env`; it does not load `.env` itself, so load the file when starting the process as shown below. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
+> **Note:** The TypeScript client reads `process.env`; it does not load `.env` itself, so load the file when starting the process as shown below. Because `.env` can contain credentials, add it to `.gitignore` and never commit it.
 
 ### Step 2: Install Client
 
@@ -293,7 +293,7 @@ await client.disconnect();
 
 1. Hardcode `uri` or `auth` in the constructor (load `ROCKETRIDE_*` values into the process environment instead)
 2. Use variables in `project_id` field (must be literal GUID)
-3. Hand-edit `ROCKETRIDE_URI`/`ROCKETRIDE_APIKEY` for a self-hosted engine in the development connection group — the extension re-syncs them on connect (change them via extension settings; for cloud, set `ROCKETRIDE_APIKEY` manually)
+3. Assume the extension writes or syncs `.env` for you — it doesn't; create and maintain it yourself
 4. Skip `connect()` or `disconnect()`
 5. Use non-ROCKETRIDE\_\* variables in pipelines
 6. Use `.json` extension for pipeline files (use `.pipe`)

--- a/docs/agents/ROCKETRIDE_QUICKSTART.md
+++ b/docs/agents/ROCKETRIDE_QUICKSTART.md
@@ -4,11 +4,10 @@
 
 ### Step 1: Set Up the `.env` File
 
-When you connect to a **self-hosted engine** (local, docker, service, or on-prem) using the extension's **development connection group**, the extension auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured separately from the Environment page.
 
 ```env
-# Development-group self-hosted engines: auto-filled on connect (local uses the real dynamic port).
-# live engine address (auto-filled)
+# live engine address
 ROCKETRIDE_URI=http://localhost:54123
 # self-hosted default; set your own for cloud
 ROCKETRIDE_APIKEY=MYAPIKEY
@@ -112,11 +111,10 @@ python main.py
 
 ### Step 1: Set Up the `.env` File
 
-When you connect to a **self-hosted engine** (local, docker, service, or on-prem) using the extension's **development connection group**, the extension auto-populates `.env` in your workspace with the live server URI and key — preserving any other variables you've added. In **local** mode the engine listens on a dynamically assigned port, so the extension writes the *actual* resolved address (not a fixed port). In **cloud** mode, set `ROCKETRIDE_APIKEY` yourself (cloud sign-in uses a short-lived OAuth token, which is not a usable SDK key).
+The extension does not write `.env` for you — create it yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`. Server-managed env (org/team/user secrets) is configured separately from the Environment page.
 
 ```env
-# Development-group self-hosted engines: auto-filled on connect (local uses the real dynamic port).
-# live engine address (auto-filled)
+# live engine address
 ROCKETRIDE_URI=http://localhost:54123
 # self-hosted default; set your own for cloud
 ROCKETRIDE_APIKEY=MYAPIKEY
@@ -284,7 +282,7 @@ await client.disconnect();
 ### Always Do This:
 
 1. Configure server URL in extension settings (`rocketride.hostUrl` and API key)
-2. When the extension's development connection group connects to a self-hosted engine, it auto-populates `.env` with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (for cloud, set `ROCKETRIDE_APIKEY` manually)
+2. Create `.env` yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` — the extension does not write this file
 3. Use empty constructor: `RocketRideClient()` or `new RocketRideClient()`
 4. Use literal GUID for `project_id` - generate a new one per pipeline
 5. Use `${ROCKETRIDE_*}` variables in component `config` fields

--- a/docs/agents/ROCKETRIDE_README.md
+++ b/docs/agents/ROCKETRIDE_README.md
@@ -43,7 +43,7 @@ Before writing ANY RocketRide code, you MUST:
 - [ ] Read ROCKETRIDE_PIPELINE_RULES.md, ROCKETRIDE_COMPONENT_REFERENCE.md and ROCKETRIDE_COMMON_MISTAKES.md
 - [ ] If you are creating a python project, create a virtual environment
 - [ ] Create the pipeline file(s) using `.pipe` extension (e.g., `chat.pipe`, `ingestion.pipe`)
-- [ ] On connect to a self-hosted engine (local/docker/service/onprem), the extension auto-populates `.env` with the live `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY`; for cloud, set `ROCKETRIDE_APIKEY` manually
+- [ ] Create the `.env` file yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (the extension no longer writes this file; server-managed env is configured separately from the Environment page)
 - [ ] Create an `env.example` file documenting any custom variables used in your pipeline files
 - [ ] Open the `.env` file in the workspace editor (as a tab) so the user can verify settings and add custom variables (e.g., `ROCKETRIDE_INPUT_PATH`, `ROCKETRIDE_OUTPUT_PATH`, etc.)
 - [ ] Always install the appropriate RocketRide client:

--- a/docs/agents/ROCKETRIDE_README.md
+++ b/docs/agents/ROCKETRIDE_README.md
@@ -43,7 +43,7 @@ Before writing ANY RocketRide code, you MUST:
 - [ ] Read ROCKETRIDE_PIPELINE_RULES.md, ROCKETRIDE_COMPONENT_REFERENCE.md and ROCKETRIDE_COMMON_MISTAKES.md
 - [ ] If you are creating a python project, create a virtual environment
 - [ ] Create the pipeline file(s) using `.pipe` extension (e.g., `chat.pipe`, `ingestion.pipe`)
-- [ ] Create the `.env` file yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (the extension no longer writes this file; server-managed env is configured on the **Environment** page, separately from the local `.env` file)
+- [ ] Create the `.env` file yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` for the Python and TypeScript clients (`ROCKETRIDE_AUTH` for MCP) (the extension no longer writes this file; server-managed env is configured on the **Environment** page, separately from the local `.env` file)
 - [ ] Create an `env.example` file documenting any custom variables used in your pipeline files
 - [ ] Open the `.env` file in the workspace editor (as a tab) so the user can verify settings and add custom variables (e.g., `ROCKETRIDE_INPUT_PATH`, `ROCKETRIDE_OUTPUT_PATH`, etc.)
 - [ ] Always install the appropriate RocketRide client:

--- a/docs/agents/ROCKETRIDE_README.md
+++ b/docs/agents/ROCKETRIDE_README.md
@@ -43,7 +43,7 @@ Before writing ANY RocketRide code, you MUST:
 - [ ] Read ROCKETRIDE_PIPELINE_RULES.md, ROCKETRIDE_COMPONENT_REFERENCE.md and ROCKETRIDE_COMMON_MISTAKES.md
 - [ ] If you are creating a python project, create a virtual environment
 - [ ] Create the pipeline file(s) using `.pipe` extension (e.g., `chat.pipe`, `ingestion.pipe`)
-- [ ] Create the `.env` file yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (the extension no longer writes this file; server-managed env is configured separately from the Environment page)
+- [ ] Create the `.env` file yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (the extension no longer writes this file; server-managed env is configured on the Environment page, separately from the local `.env` file)
 - [ ] Create an `env.example` file documenting any custom variables used in your pipeline files
 - [ ] Open the `.env` file in the workspace editor (as a tab) so the user can verify settings and add custom variables (e.g., `ROCKETRIDE_INPUT_PATH`, `ROCKETRIDE_OUTPUT_PATH`, etc.)
 - [ ] Always install the appropriate RocketRide client:

--- a/docs/agents/ROCKETRIDE_README.md
+++ b/docs/agents/ROCKETRIDE_README.md
@@ -43,7 +43,7 @@ Before writing ANY RocketRide code, you MUST:
 - [ ] Read ROCKETRIDE_PIPELINE_RULES.md, ROCKETRIDE_COMPONENT_REFERENCE.md and ROCKETRIDE_COMMON_MISTAKES.md
 - [ ] If you are creating a python project, create a virtual environment
 - [ ] Create the pipeline file(s) using `.pipe` extension (e.g., `chat.pipe`, `ingestion.pipe`)
-- [ ] Create the `.env` file yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (the extension no longer writes this file; server-managed env is configured on the Environment page, separately from the local `.env` file)
+- [ ] Create the `.env` file yourself with `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` (the extension no longer writes this file; server-managed env is configured on the **Environment** page, separately from the local `.env` file)
 - [ ] Create an `env.example` file documenting any custom variables used in your pipeline files
 - [ ] Open the `.env` file in the workspace editor (as a tab) so the user can verify settings and add custom variables (e.g., `ROCKETRIDE_INPUT_PATH`, `ROCKETRIDE_OUTPUT_PATH`, etc.)
 - [ ] Always install the appropriate RocketRide client:


### PR DESCRIPTION
fixes #1200

## changes
- `docs/agents/ROCKETRIDE_README.md`: replace the "extension auto-populates `.env`" checklist step with instructions to create `.env` manually (the extension no longer writes it; server-managed env now lives on the Environment page)
- `docs/agents/ROCKETRIDE_QUICKSTART.md`: fix the same stale claim duplicated across the Python and TypeScript quickstart sections (prose + `.env` code-block comments) and the "Key Patterns" checklist
- `apps/vscode/docs/usage.md`: rewrite the `.env` Auto-Sync section, which described the removed watcher/sync behavior in detail, to reflect that the extension no longer touches `.env`

Background: PR #803 (commit c5cde38f) removed the VS Code extension's `.env` file handling (~350 lines, including the workspace watcher). Env is now managed server-side via `client.account.setEnv` / the Environment page. These docs still described the old auto-populate/auto-sync behavior, which never happens anymore.

## verification
- `rg -rniE "extension.*(auto-populat|auto-writ|writes.*\.env|creates/updates.*\.env|syncs the workspace.*\.env)|auto-filled" --include='*.md' .` → no matches
- `git diff --check` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated setup guidance to clarify that users must create and maintain their own `.env` file.
  - Documented required `ROCKETRIDE_URI` and `ROCKETRIDE_APIKEY` variables for Python and TypeScript clients, plus `ROCKETRIDE_AUTH` for MCP.
  - Clarified that the extension no longer creates or synchronizes workspace `.env` files.
  - Explained how SDKs and CLIs load environment variables.
  - Clarified that server-managed secrets are configured separately and applied during execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->