### PR TITLE
fix(store_chroma): connect to Chroma Cloud with TLS, token auth, and tenant/database

### DIFF
--- a/nodes/src/nodes/store_chroma/README.md
+++ b/nodes/src/nodes/store_chroma/README.md
@@ -38,7 +38,7 @@ Documents must pass through an embedding node before reaching this node; chunks 
 | Profile | Description                                                                                            |
 | ------- | ------------------------------------------------------------------------------------------------------ |
 | `local` | Your own ChromaDB server. Connects with plain `HttpClient(host, port)`, no authentication.             |
-| `cloud` | ChromaDB Cloud. Requires `host` and `apikey`; authenticates using ChromaDB's `TokenAuthClientProvider`. |
+| `cloud` | ChromaDB Cloud or any TLS-protected remote server. Connects over TLS and sends the `apikey` in the `x-chroma-token` header; ChromaDB Cloud additionally requires `tenant` and `database`. |
 
 ---
 
@@ -82,7 +82,13 @@ No authentication is required. The node connects with `chromadb.HttpClient(host,
 
 ### Cloud profile
 
-Set `profile` to `cloud`, provide the ChromaDB Cloud `host` and your `apikey`. The node authenticates using `chromadb.auth.token_authn.TokenAuthClientProvider` configured via ChromaDB's `Settings` object.
+Set the profile to `cloud` and provide:
+
+- `host`: the server hostname (defaults to `api.trychroma.com` for ChromaDB Cloud)
+- `apikey`: sent with every request in the `x-chroma-token` header
+- `tenant` and `database`: required by ChromaDB Cloud accounts, optional for self-hosted multi-tenant servers
+
+The connection always uses TLS; ChromaDB Cloud only serves HTTPS, and a plain HTTP request against the TLS port hangs or is rejected with "illegal request line". Every HTTP session the chromadb client creates is given a 30s connect / 120s request timeout, so an unresponsive connection surfaces as an error instead of hanging the pipeline (the client library itself defaults to no timeout).
 
 ---
 

--- a/nodes/src/nodes/store_chroma/README.md
+++ b/nodes/src/nodes/store_chroma/README.md
@@ -84,7 +84,7 @@ No authentication is required. The node connects with `chromadb.HttpClient(host,
 
 Set the profile to `cloud` and provide:
 
-- `host`: the server hostname (defaults to `api.trychroma.com` for ChromaDB Cloud)
+- `host`: the server hostname (`api.trychroma.com` for ChromaDB Cloud)
 - `apikey`: sent with every request in the `x-chroma-token` header
 - `tenant` and `database`: required by ChromaDB Cloud accounts, optional for self-hosted multi-tenant servers
 

--- a/nodes/src/nodes/store_chroma/README.md
+++ b/nodes/src/nodes/store_chroma/README.md
@@ -109,6 +109,7 @@ The `port` field accepts either a number or a string. Enter a plain integer such
 | `chroma.profile` | `string` | **Type of chroma host**<br/>Connect to... | `"local"` |
 | `chroma.provider` | `string` |  | const: `"chroma"` |
 | `chroma.serverName` | `string` | **Tool Server Name**<br/>Namespace for agent-facing tool names, e.g. 'chroma' exposes tools as chroma.search / chroma.upsert / chroma.delete. Change this when running multiple Chroma nodes in the same pipeline so their tool names do not collide. | `"chroma"` |
+| `chroma.ssl` | `boolean` | **Use TLS**<br/>Connect over HTTPS. Required for Chroma Cloud, which serves HTTPS only. Turn it off for a self-hosted server reached over plain HTTP. | `true` |
 | `chroma.tenant` | `string` | **Tenant**<br/>Chroma Cloud tenant id (required for Chroma Cloud, optional for self-hosted multi-tenant servers) | `""` |
 | `vector.cloud.host` |  | Enter the server IP address e.g. <your-instance-url> |  |
 | `vector.cloud.port` | `number,string` | Port number. Enter a plain integer such as 443, or an env-var placeholder like ${ROCKETRIDE_CHROMA_PORT}. Placeholders resolve to a string at run time, so this field accepts both a number and a string; the node coerces the value to an integer before connecting, so either form works. | `"443"` |

--- a/nodes/src/nodes/store_chroma/README.md
+++ b/nodes/src/nodes/store_chroma/README.md
@@ -105,13 +105,15 @@ The `port` field accepts either a number or a string. Enter a plain integer such
 
 | Field | Type | Description | Default |
 |---|---|---|---|
-| `chroma.profile` | `string` | **Type of chroma host**<br/>Connect to... | `"cloud"` |
+| `chroma.database` | `string` | **Database**<br/>Chroma Cloud database name (required for Chroma Cloud, optional for self-hosted multi-tenant servers) | `""` |
+| `chroma.profile` | `string` | **Type of chroma host**<br/>Connect to... | `"local"` |
 | `chroma.provider` | `string` |  | const: `"chroma"` |
 | `chroma.serverName` | `string` | **Tool Server Name**<br/>Namespace for agent-facing tool names, e.g. 'chroma' exposes tools as chroma.search / chroma.upsert / chroma.delete. Change this when running multiple Chroma nodes in the same pipeline so their tool names do not collide. | `"chroma"` |
+| `chroma.tenant` | `string` | **Tenant**<br/>Chroma Cloud tenant id (required for Chroma Cloud, optional for self-hosted multi-tenant servers) | `""` |
 | `vector.cloud.host` |  | Enter the server IP address e.g. <your-instance-url> |  |
 | `vector.cloud.port` | `number,string` | Port number. Enter a plain integer such as 443, or an env-var placeholder like ${ROCKETRIDE_CHROMA_PORT}. Placeholders resolve to a string at run time, so this field accepts both a number and a string; the node coerces the value to an integer before connecting, so either form works. | `"443"` |
 | `vector.local.host` |  |  | `"localhost"` |
-| `vector.local.port` | `number,string` | Port number. Enter a plain integer such as 8000, or an env-var placeholder like ${ROCKETRIDE_CHROMA_PORT}. Placeholders resolve to a string at run time, so this field accepts both a number and a string; the node coerces the value to an integer before connecting, so either form works. | `"8330"` |
+| `vector.local.port` | `number,string` | Port number. Enter a plain integer such as 8000, or an env-var placeholder like ${ROCKETRIDE_CHROMA_PORT}. Placeholders resolve to a string at run time, so this field accepts both a number and a string; the node coerces the value to an integer before connecting, so either form works. | `"8000"` |
 
 ## Dependencies
 

--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -32,7 +32,7 @@ import chromadb
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase
 from ai.common.config import Config
-from rocketlib import debug
+from rocketlib import debug, warning
 import uuid
 import numpy as np
 import json
@@ -126,7 +126,13 @@ class Store(DocumentStoreBase):
         # issues its first request while HttpClient() is still constructing,
         # so one unresponsive connection hangs the whole pipeline forever.
         # Give every session created by chromadb's transport module a default
-        # timeout; the patch is confined to that module's namespace.
+        # timeout.
+        #
+        # Scope: the replacement only shadows the `httpx` name inside
+        # chromadb.api.fastapi, which is where this client builds its sessions.
+        # Nothing else in the process sees it, and any explicit timeout the
+        # caller passes is preserved. chromadb-client exposes no supported
+        # timeout setting, which is why the default is installed this way.
         try:
             import httpx
             import chromadb.api.fastapi as _chroma_fastapi
@@ -145,8 +151,13 @@ class Store(DocumentStoreBase):
 
                 _chroma_fastapi.httpx = _HttpxShim()
                 _chroma_fastapi._rocketrideTimeoutShim = True
-        except Exception:
-            pass
+        except Exception as exc:
+            # This is hardening against an upstream default, not a feature, so a
+            # failure here must not stop the node from connecting: if chromadb
+            # reorganises its transport module the store still works, just
+            # without the timeout. Say so rather than failing silently, because
+            # the symptom otherwise is a pipeline that hangs with no explanation.
+            warning(f'chroma: HTTP timeout shim not applied ({exc}); an unresponsive server may hang requests')
 
         # The Chroma client connects eagerly (identity/tenant validation on construction),
         # so an incompatible/old server surfaces here as a cryptic error (e.g.

--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -29,7 +29,6 @@ depends(requirements)
 
 from typing import List, Dict, Any, Callable, cast
 import chromadb
-from chromadb.config import Settings
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase
 from ai.common.config import Config
@@ -101,10 +100,20 @@ class Store(DocumentStoreBase):
         if self.apikey is not None:
             self.apikey = self.apikey.strip()
 
+        # Chroma Cloud multi-tenancy - both are required by Chroma Cloud
+        # accounts and optional for self-hosted servers
+        self.tenant = (config.get('tenant') or '').strip() or None
+        self.database = (config.get('database') or '').strip() or None
+
         self.renderChunkSize = config.get('renderChunkSize', self.renderChunkSize)
         self.payload_limit = config.get('payloadLimit', self.payload_limit)
 
-        profile = config.get('profile', 'local')
+        # The merged node config carries the profile selection in 'mode':
+        # getNodeConfig consumes the 'profile' key while merging the selected
+        # profile's contents, so 'profile' is absent when configured through
+        # a service/autopipe config and the cloud branch was never taken.
+        # Keep 'profile' as a fallback for direct configurations.
+        profile = config.get('mode') or config.get('profile') or 'local'
 
         # check if the similarity matches qdrant configuration options
         similarity = config.get('similarity', 'cosine')
@@ -112,6 +121,32 @@ class Store(DocumentStoreBase):
             self.similarity = similarity
         else:
             raise Exception('The metric you provided in the config.json does not match required chroma configurations')
+
+        # The chromadb client builds its httpx session with timeout=None and
+        # issues its first request while HttpClient() is still constructing,
+        # so one unresponsive connection hangs the whole pipeline forever.
+        # Give every session created by chromadb's transport module a default
+        # timeout; the patch is confined to that module's namespace.
+        try:
+            import httpx
+            import chromadb.api.fastapi as _chroma_fastapi
+
+            if not getattr(_chroma_fastapi, '_rocketrideTimeoutShim', False):
+
+                class _HttpxShim:
+                    class Client(httpx.Client):
+                        def __init__(self, *args, **kwargs):
+                            if kwargs.get('timeout', 'unset') in (None, 'unset'):
+                                kwargs['timeout'] = httpx.Timeout(120.0, connect=30.0)
+                            super().__init__(*args, **kwargs)
+
+                    def __getattr__(self, name):
+                        return getattr(httpx, name)
+
+                _chroma_fastapi.httpx = _HttpxShim()
+                _chroma_fastapi._rocketrideTimeoutShim = True
+        except Exception:
+            pass
 
         # The Chroma client connects eagerly (identity/tenant validation on construction),
         # so an incompatible/old server surfaces here as a cryptic error (e.g.
@@ -121,13 +156,22 @@ class Store(DocumentStoreBase):
             if profile == 'local':
                 self.client = chromadb.HttpClient(host=self.host, port=self.port)
             else:
+                # Cloud / remote server. TLS is required: Chroma Cloud only
+                # serves HTTPS, and a plain HTTP request against the TLS port
+                # hangs or is rejected with "illegal request line". The API
+                # key travels in the x-chroma-token header, and Chroma Cloud
+                # additionally requires the tenant and database.
+                kwargs: Dict[str, Any] = {}
+                if self.tenant:
+                    kwargs['tenant'] = self.tenant
+                if self.database:
+                    kwargs['database'] = self.database
                 self.client = chromadb.HttpClient(
                     host=self.host,
                     port=self.port,
-                    settings=Settings(
-                        chroma_client_auth_provider='chromadb.auth.token_authn.TokenAuthClientProvider',
-                        chroma_client_auth_credentials=self.apikey,
-                    ),
+                    ssl=True,
+                    headers={'x-chroma-token': self.apikey} if self.apikey else None,
+                    **kwargs,
                 )
         except Exception as e:
             self.client = None

--- a/nodes/src/nodes/store_chroma/chroma.py
+++ b/nodes/src/nodes/store_chroma/chroma.py
@@ -32,7 +32,7 @@ import chromadb
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase
 from ai.common.config import Config
-from rocketlib import debug, warning
+from rocketlib import debug
 import uuid
 import numpy as np
 import json
@@ -77,6 +77,18 @@ class Store(DocumentStoreBase):
     client: chromadb.HttpClient
     collectionObj: chromadb.Collection | None = None
 
+    @staticmethod
+    def _coerceBool(value: Any) -> bool:
+        """Read a boolean that may arrive as a string from an env-var placeholder."""
+        if isinstance(value, bool):
+            return value
+        text = str(value).strip().lower()
+        if text in ('false', '0', 'no', 'off'):
+            return False
+        # An unresolved '${...}' placeholder is not a deliberate 'off', so it
+        # keeps the safe default rather than silently dropping TLS.
+        return True
+
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
         """
         Initialize the chroma vector store.
@@ -105,6 +117,10 @@ class Store(DocumentStoreBase):
         self.tenant = (config.get('tenant') or '').strip() or None
         self.database = (config.get('database') or '').strip() or None
 
+        # TLS for the cloud/remote profile. Defaults on, since Chroma Cloud is
+        # HTTPS-only; a self-hosted server behind plain HTTP turns it off.
+        self.ssl = self._coerceBool(config.get('ssl', True))
+
         self.renderChunkSize = config.get('renderChunkSize', self.renderChunkSize)
         self.payload_limit = config.get('payloadLimit', self.payload_limit)
 
@@ -122,43 +138,6 @@ class Store(DocumentStoreBase):
         else:
             raise Exception('The metric you provided in the config.json does not match required chroma configurations')
 
-        # The chromadb client builds its httpx session with timeout=None and
-        # issues its first request while HttpClient() is still constructing,
-        # so one unresponsive connection hangs the whole pipeline forever.
-        # Give every session created by chromadb's transport module a default
-        # timeout.
-        #
-        # Scope: the replacement only shadows the `httpx` name inside
-        # chromadb.api.fastapi, which is where this client builds its sessions.
-        # Nothing else in the process sees it, and any explicit timeout the
-        # caller passes is preserved. chromadb-client exposes no supported
-        # timeout setting, which is why the default is installed this way.
-        try:
-            import httpx
-            import chromadb.api.fastapi as _chroma_fastapi
-
-            if not getattr(_chroma_fastapi, '_rocketrideTimeoutShim', False):
-
-                class _HttpxShim:
-                    class Client(httpx.Client):
-                        def __init__(self, *args, **kwargs):
-                            if kwargs.get('timeout', 'unset') in (None, 'unset'):
-                                kwargs['timeout'] = httpx.Timeout(120.0, connect=30.0)
-                            super().__init__(*args, **kwargs)
-
-                    def __getattr__(self, name):
-                        return getattr(httpx, name)
-
-                _chroma_fastapi.httpx = _HttpxShim()
-                _chroma_fastapi._rocketrideTimeoutShim = True
-        except Exception as exc:
-            # This is hardening against an upstream default, not a feature, so a
-            # failure here must not stop the node from connecting: if chromadb
-            # reorganises its transport module the store still works, just
-            # without the timeout. Say so rather than failing silently, because
-            # the symptom otherwise is a pipeline that hangs with no explanation.
-            warning(f'chroma: HTTP timeout shim not applied ({exc}); an unresponsive server may hang requests')
-
         # The Chroma client connects eagerly (identity/tenant validation on construction),
         # so an incompatible/old server surfaces here as a cryptic error (e.g.
         # KeyError('_type')). Wrap it so the user gets an actionable message instead of a
@@ -167,11 +146,15 @@ class Store(DocumentStoreBase):
             if profile == 'local':
                 self.client = chromadb.HttpClient(host=self.host, port=self.port)
             else:
-                # Cloud / remote server. TLS is required: Chroma Cloud only
-                # serves HTTPS, and a plain HTTP request against the TLS port
-                # hangs or is rejected with "illegal request line". The API
-                # key travels in the x-chroma-token header, and Chroma Cloud
-                # additionally requires the tenant and database.
+                # Cloud / remote server. Chroma Cloud only serves HTTPS, and a
+                # plain HTTP request against the TLS port hangs or is rejected
+                # with "illegal request line" -- so TLS is the default. It stays
+                # configurable because this profile also covers a self-hosted
+                # server reached over plain HTTP with token auth, which the
+                # removed Settings path supported and which would otherwise lose
+                # its only working configuration.
+                # The API key travels in the x-chroma-token header, and Chroma
+                # Cloud additionally requires the tenant and database.
                 kwargs: Dict[str, Any] = {}
                 if self.tenant:
                     kwargs['tenant'] = self.tenant
@@ -180,7 +163,7 @@ class Store(DocumentStoreBase):
                 self.client = chromadb.HttpClient(
                     host=self.host,
                     port=self.port,
-                    ssl=True,
+                    ssl=self.ssl,
                     headers={'x-chroma-token': self.apikey} if self.apikey else None,
                     **kwargs,
                 )

--- a/nodes/src/nodes/store_chroma/services.json
+++ b/nodes/src/nodes/store_chroma/services.json
@@ -147,7 +147,7 @@
 			"cloud": {
 				"mode": "cloud",
 				"title": "ChromaDB Cloud Server",
-				"host": "api.trychroma.com",
+				"host": "",
 				"port": "443",
 				"apikey": "",
 				"tenant": "",

--- a/nodes/src/nodes/store_chroma/services.json
+++ b/nodes/src/nodes/store_chroma/services.json
@@ -147,9 +147,11 @@
 			"cloud": {
 				"mode": "cloud",
 				"title": "ChromaDB Cloud Server",
-				"host": "",
+				"host": "api.trychroma.com",
 				"port": "443",
 				"apikey": "",
+				"tenant": "",
+				"database": "",
 				"collection": "ROCKETRIDE",
 				"serverName": "chroma"
 			}
@@ -188,9 +190,21 @@
 			"default": "chroma",
 			"minLength": 1
 		},
+		"chroma.tenant": {
+			"title": "Tenant",
+			"description": "Chroma Cloud tenant id (required for Chroma Cloud, optional for self-hosted multi-tenant servers)",
+			"type": "string",
+			"default": ""
+		},
+		"chroma.database": {
+			"title": "Database",
+			"description": "Chroma Cloud database name (required for Chroma Cloud, optional for self-hosted multi-tenant servers)",
+			"type": "string",
+			"default": ""
+		},
 		"chroma.cloud": {
 			"object": "cloud",
-			"properties": ["vector.cloud.host", "vector.cloud.port", "vector.apikey", "vector.collection", "chroma.serverName"]
+			"properties": ["vector.cloud.host", "vector.cloud.port", "vector.apikey", "chroma.tenant", "chroma.database", "vector.collection", "chroma.serverName"]
 		},
 		"chroma.local": {
 			"object": "local",

--- a/nodes/src/nodes/store_chroma/services.json
+++ b/nodes/src/nodes/store_chroma/services.json
@@ -196,6 +196,13 @@
 			"type": "string",
 			"default": ""
 		},
+		"chroma.ssl": {
+			"title": "Use TLS",
+			"description": "Connect over HTTPS. Required for Chroma Cloud, which serves HTTPS only. Turn it off for a self-hosted server reached over plain HTTP.",
+			"type": "boolean",
+			"default": true,
+			"optional": true
+		},
 		"chroma.database": {
 			"title": "Database",
 			"description": "Chroma Cloud database name (required for Chroma Cloud, optional for self-hosted multi-tenant servers)",
@@ -204,7 +211,7 @@
 		},
 		"chroma.cloud": {
 			"object": "cloud",
-			"properties": ["vector.cloud.host", "vector.cloud.port", "vector.apikey", "chroma.tenant", "chroma.database", "vector.collection", "chroma.serverName"]
+			"properties": ["vector.cloud.host", "vector.cloud.port", "vector.apikey", "chroma.tenant", "chroma.database", "vector.collection", "chroma.serverName", "chroma.ssl"]
 		},
 		"chroma.local": {
 			"object": "local",

--- a/nodes/test/store_chroma/test_cloud_connection.py
+++ b/nodes/test/store_chroma/test_cloud_connection.py
@@ -45,6 +45,11 @@ _STUB_MODULE_NAMES = (
 #: Every kwarg the store hands to chromadb.HttpClient, newest call last.
 _CLIENT_CALLS: list[dict] = []
 
+#: The stub transport module the shim patches. Held here rather than re-imported
+#: in the tests: the stubs are scoped to loading `chroma.py` and are gone by the
+#: time a test body runs, and the real chromadb is not installed.
+_FASTAPI_STUB: types.ModuleType | None = None
+
 
 def _install_stubs() -> None:
     """Stub the third-party packages `chroma.py` imports at module scope."""
@@ -75,6 +80,9 @@ def _install_stubs() -> None:
     sys.modules['chromadb.api'] = chromadb_api
     sys.modules['chromadb.api.fastapi'] = chromadb_fastapi
 
+    global _FASTAPI_STUB
+    _FASTAPI_STUB = chromadb_fastapi
+
     numpy_mod = types.ModuleType('numpy')
     numpy_mod.exp = math.exp
     numpy_mod.int64 = int
@@ -96,27 +104,34 @@ def _scoped_stubs() -> Iterator[None]:
 
 
 def _load_module():
+    """Import `chroma.py`. The caller must already hold the stub context."""
     nodes_root = Path(__file__).resolve().parent.parent.parent
     chroma_py = nodes_root / 'src' / 'nodes' / 'store_chroma' / 'chroma.py'
-    with _scoped_stubs():
-        spec = importlib.util.spec_from_file_location('chroma_cloud_under_test', chroma_py)
-        assert spec is not None and spec.loader is not None
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
-        return module
+    spec = importlib.util.spec_from_file_location('chroma_cloud_under_test', chroma_py)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _connect(monkeypatch: pytest.MonkeyPatch, config: dict) -> dict:
-    """Build a Store with `config` and return the kwargs it passed to HttpClient."""
-    module = _load_module()
+    """Build a Store with `config` and return the kwargs it passed to HttpClient.
+
+    Both the import and the construction run inside the stub context: the shim
+    installs itself while the Store is being built, so `chromadb.api.fastapi`
+    has to still be the stub at that point, not just while importing.
+    """
     _CLIENT_CALLS.clear()
+    with _scoped_stubs():
+        module = _load_module()
 
-    # getNodeConfig merges the selected profile and is exercised elsewhere; here
-    # the point is what the store does with the config it ends up holding.
-    monkeypatch.setattr(module.Config, 'getNodeConfig', staticmethod(lambda *_a, **_k: config))
-    monkeypatch.setattr(module.DocumentStoreBase, '__init__', lambda self, *_a, **_k: None)
+        # getNodeConfig merges the selected profile and is exercised elsewhere;
+        # here the point is what the store does with the config it holds.
+        monkeypatch.setattr(module.Config, 'getNodeConfig', staticmethod(lambda *_a, **_k: config))
+        monkeypatch.setattr(module.DocumentStoreBase, '__init__', lambda self, *_a, **_k: None)
 
-    module.Store('chroma', {}, {})
+        module.Store('chroma', {}, {})
+
     assert _CLIENT_CALLS, 'the store never constructed a client'
     return _CLIENT_CALLS[-1]
 
@@ -199,50 +214,54 @@ class TestTimeoutShim:
 
     def test_a_session_built_with_no_timeout_gets_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        import chromadb.api.fastapi as patched
-
-        client = patched.httpx.Client()
+        assert _FASTAPI_STUB is not None
+        client = _FASTAPI_STUB.httpx.Client()
         assert client.timeout.connect == 30.0
         assert client.timeout.read == 120.0
 
     def test_an_explicit_timeout_is_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        import chromadb.api.fastapi as patched
         import httpx
 
-        client = patched.httpx.Client(timeout=httpx.Timeout(5.0))
+        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
+        assert _FASTAPI_STUB is not None
+        client = _FASTAPI_STUB.httpx.Client(timeout=httpx.Timeout(5.0))
         assert client.timeout.read == 5.0
 
     def test_the_shim_is_applied_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Re-wrapping on every Store would nest the subclass without bound.
         _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        import chromadb.api.fastapi as patched
-
-        first = patched.httpx
+        assert _FASTAPI_STUB is not None
+        first_module = _FASTAPI_STUB
+        first_httpx = first_module.httpx
         _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        assert patched.httpx is first
+        # A second Store rebuilds the stub module, so assert on the one it saw.
+        assert first_module.httpx is first_httpx
 
     def test_other_httpx_names_still_resolve(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # The shim only shadows Client; everything else falls through to httpx.
-        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        import chromadb.api.fastapi as patched
         import httpx
 
-        assert patched.httpx.Timeout is httpx.Timeout
+        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
+        assert _FASTAPI_STUB is not None
+        assert _FASTAPI_STUB.httpx.Timeout is httpx.Timeout
 
     def test_a_store_still_connects_when_the_shim_cannot_apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # Hardening, not a feature: if chromadb reorganises its transport module
         # the store must still connect, just without the default timeout.
-        module = _load_module()
         _CLIENT_CALLS.clear()
-        monkeypatch.setattr(
-            module.Config,
-            'getNodeConfig',
-            staticmethod(lambda *_a, **_k: {'mode': 'local', 'host': 'localhost'}),
-        )
-        monkeypatch.setattr(module.DocumentStoreBase, '__init__', lambda self, *_a, **_k: None)
-        monkeypatch.delitem(sys.modules, 'chromadb.api.fastapi', raising=False)
-        monkeypatch.setattr(sys.modules['chromadb.api'], 'fastapi', None, raising=False)
+        with _scoped_stubs():
+            module = _load_module()
+            monkeypatch.setattr(
+                module.Config,
+                'getNodeConfig',
+                staticmethod(lambda *_a, **_k: {'mode': 'local', 'host': 'localhost'}),
+            )
+            monkeypatch.setattr(module.DocumentStoreBase, '__init__', lambda self, *_a, **_k: None)
+            # Take the transport module away, which is what a reorganised
+            # chromadb looks like from here.
+            monkeypatch.delitem(sys.modules, 'chromadb.api.fastapi', raising=False)
+            monkeypatch.delattr(sys.modules['chromadb.api'], 'fastapi', raising=False)
 
-        module.Store('chroma', {}, {})
+            module.Store('chroma', {}, {})
+
         assert _CLIENT_CALLS, 'a failed shim must not stop the store connecting'

--- a/nodes/test/store_chroma/test_cloud_connection.py
+++ b/nodes/test/store_chroma/test_cloud_connection.py
@@ -5,7 +5,7 @@
 
 """How the Chroma store reaches Chroma Cloud.
 
-Three defects stacked here and each is silent in its own way, so each gets a
+Two defects stacked here and each is silent in its own way, so each gets a
 test that fails if the fix is undone:
 
 - the cloud branch was never taken, because ``getNodeConfig`` consumes the
@@ -14,9 +14,6 @@ test that fails if the fix is undone:
 - authentication moved off the removed ``Settings`` / ``TokenAuthClientProvider``
   path onto the ``x-chroma-token`` header, and Chroma Cloud additionally wants
   the tenant and database;
-- chromadb builds its httpx session with ``timeout=None``, so an unresponsive
-  server hangs the pipeline with no error to read.
-
 Loads ``chroma.py`` the way the sibling suites do, stubbing only the
 third-party packages.
 """
@@ -44,11 +41,6 @@ _STUB_MODULE_NAMES = (
 
 #: Every kwarg the store hands to chromadb.HttpClient, newest call last.
 _CLIENT_CALLS: list[dict] = []
-
-#: The stub transport module the shim patches. Held here rather than re-imported
-#: in the tests: the stubs are scoped to loading `chroma.py` and are gone by the
-#: time a test body runs, and the real chromadb is not installed.
-_FASTAPI_STUB: types.ModuleType | None = None
 
 
 def _install_stubs() -> None:
@@ -79,9 +71,6 @@ def _install_stubs() -> None:
     chromadb_api.fastapi = chromadb_fastapi
     sys.modules['chromadb.api'] = chromadb_api
     sys.modules['chromadb.api.fastapi'] = chromadb_fastapi
-
-    global _FASTAPI_STUB
-    _FASTAPI_STUB = chromadb_fastapi
 
     numpy_mod = types.ModuleType('numpy')
     numpy_mod.exp = math.exp
@@ -209,59 +198,25 @@ class TestTenantAndDatabase:
         assert 'tenant' not in kwargs
 
 
-class TestTimeoutShim:
-    """The shim cannot be reviewed by reading, so pin what it does."""
+class TestTlsIsConfigurable:
+    """Chroma Cloud is HTTPS-only, but this profile also covers plain-HTTP servers."""
 
-    def test_a_session_built_with_no_timeout_gets_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        assert _FASTAPI_STUB is not None
-        client = _FASTAPI_STUB.httpx.Client()
-        assert client.timeout.connect == 30.0
-        assert client.timeout.read == 120.0
+    def test_tls_is_on_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'k'})
+        assert kwargs['ssl'] is True
 
-    def test_an_explicit_timeout_is_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        import httpx
+    def test_tls_can_be_turned_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A self-hosted server behind plain HTTP with token auth worked before
+        # the Settings path was removed; it must keep working.
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'k', 'ssl': False})
+        assert kwargs['ssl'] is False
 
-        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        assert _FASTAPI_STUB is not None
-        client = _FASTAPI_STUB.httpx.Client(timeout=httpx.Timeout(5.0))
-        assert client.timeout.read == 5.0
+    def test_the_string_false_from_an_env_var_turns_it_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'k', 'ssl': 'false'})
+        assert kwargs['ssl'] is False
 
-    def test_the_shim_is_applied_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Re-wrapping on every Store would nest the subclass without bound.
-        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        assert _FASTAPI_STUB is not None
-        first_module = _FASTAPI_STUB
-        first_httpx = first_module.httpx
-        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        # A second Store rebuilds the stub module, so assert on the one it saw.
-        assert first_module.httpx is first_httpx
-
-    def test_other_httpx_names_still_resolve(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # The shim only shadows Client; everything else falls through to httpx.
-        import httpx
-
-        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
-        assert _FASTAPI_STUB is not None
-        assert _FASTAPI_STUB.httpx.Timeout is httpx.Timeout
-
-    def test_a_store_still_connects_when_the_shim_cannot_apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Hardening, not a feature: if chromadb reorganises its transport module
-        # the store must still connect, just without the default timeout.
-        _CLIENT_CALLS.clear()
-        with _scoped_stubs():
-            module = _load_module()
-            monkeypatch.setattr(
-                module.Config,
-                'getNodeConfig',
-                staticmethod(lambda *_a, **_k: {'mode': 'local', 'host': 'localhost'}),
-            )
-            monkeypatch.setattr(module.DocumentStoreBase, '__init__', lambda self, *_a, **_k: None)
-            # Take the transport module away, which is what a reorganised
-            # chromadb looks like from here.
-            monkeypatch.delitem(sys.modules, 'chromadb.api.fastapi', raising=False)
-            monkeypatch.delattr(sys.modules['chromadb.api'], 'fastapi', raising=False)
-
-            module.Store('chroma', {}, {})
-
-        assert _CLIENT_CALLS, 'a failed shim must not stop the store connecting'
+    def test_an_unresolved_placeholder_keeps_tls_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # '${...}' is a missing env var, not a deliberate opt-out, so it must not
+        # silently downgrade the connection to plaintext.
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'k', 'ssl': '${ROCKETRIDE_CHROMA_SSL}'})
+        assert kwargs['ssl'] is True

--- a/nodes/test/store_chroma/test_cloud_connection.py
+++ b/nodes/test/store_chroma/test_cloud_connection.py
@@ -1,0 +1,248 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""How the Chroma store reaches Chroma Cloud.
+
+Three defects stacked here and each is silent in its own way, so each gets a
+test that fails if the fix is undone:
+
+- the cloud branch was never taken, because ``getNodeConfig`` consumes the
+  ``profile`` key while merging that profile's contents, so the store only ever
+  saw ``local``;
+- authentication moved off the removed ``Settings`` / ``TokenAuthClientProvider``
+  path onto the ``x-chroma-token`` header, and Chroma Cloud additionally wants
+  the tenant and database;
+- chromadb builds its httpx session with ``timeout=None``, so an unresponsive
+  server hangs the pipeline with no error to read.
+
+Loads ``chroma.py`` the way the sibling suites do, stubbing only the
+third-party packages.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_STUB_MODULE_NAMES = (
+    'chromadb',
+    'chromadb.config',
+    'chromadb.api',
+    'chromadb.api.fastapi',
+    'numpy',
+    'chroma_cloud_under_test',
+)
+
+#: Every kwarg the store hands to chromadb.HttpClient, newest call last.
+_CLIENT_CALLS: list[dict] = []
+
+
+def _install_stubs() -> None:
+    """Stub the third-party packages `chroma.py` imports at module scope."""
+    chromadb = types.ModuleType('chromadb')
+
+    class _HttpClient:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            _CLIENT_CALLS.append(dict(kwargs))
+
+    chromadb.HttpClient = _HttpClient
+    chromadb.Collection = object
+    sys.modules['chromadb'] = chromadb
+
+    chromadb_config = types.ModuleType('chromadb.config')
+
+    class Settings:
+        def __init__(self, *_a: object, **_k: object) -> None:
+            pass
+
+    chromadb_config.Settings = Settings
+    sys.modules['chromadb.config'] = chromadb_config
+
+    # The timeout shim reaches for chromadb.api.fastapi and replaces the httpx
+    # name inside it, so the module has to exist for the shim to apply.
+    chromadb_api = types.ModuleType('chromadb.api')
+    chromadb_fastapi = types.ModuleType('chromadb.api.fastapi')
+    chromadb_api.fastapi = chromadb_fastapi
+    sys.modules['chromadb.api'] = chromadb_api
+    sys.modules['chromadb.api.fastapi'] = chromadb_fastapi
+
+    numpy_mod = types.ModuleType('numpy')
+    numpy_mod.exp = math.exp
+    numpy_mod.int64 = int
+    sys.modules['numpy'] = numpy_mod
+
+
+@contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    original = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    _install_stubs()
+    try:
+        yield
+    finally:
+        for name in _STUB_MODULE_NAMES:
+            if original.get(name) is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original[name]
+
+
+def _load_module():
+    nodes_root = Path(__file__).resolve().parent.parent.parent
+    chroma_py = nodes_root / 'src' / 'nodes' / 'store_chroma' / 'chroma.py'
+    with _scoped_stubs():
+        spec = importlib.util.spec_from_file_location('chroma_cloud_under_test', chroma_py)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+def _connect(monkeypatch: pytest.MonkeyPatch, config: dict) -> dict:
+    """Build a Store with `config` and return the kwargs it passed to HttpClient."""
+    module = _load_module()
+    _CLIENT_CALLS.clear()
+
+    # getNodeConfig merges the selected profile and is exercised elsewhere; here
+    # the point is what the store does with the config it ends up holding.
+    monkeypatch.setattr(module.Config, 'getNodeConfig', staticmethod(lambda *_a, **_k: config))
+    monkeypatch.setattr(module.DocumentStoreBase, '__init__', lambda self, *_a, **_k: None)
+
+    module.Store('chroma', {}, {})
+    assert _CLIENT_CALLS, 'the store never constructed a client'
+    return _CLIENT_CALLS[-1]
+
+
+class TestProfileResolution:
+    """Which branch runs: `getNodeConfig` eats `profile`, so `mode` carries it."""
+
+    def test_mode_cloud_takes_the_cloud_branch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'api.trychroma.com', 'apikey': 'k'})
+        assert kwargs.get('ssl') is True
+
+    def test_profile_cloud_still_works_for_direct_configs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A config that reaches the node without going through profile merging
+        # still has `profile`, so it stays a fallback rather than being dropped.
+        kwargs = _connect(monkeypatch, {'profile': 'cloud', 'host': 'api.trychroma.com', 'apikey': 'k'})
+        assert kwargs.get('ssl') is True
+
+    def test_absent_selection_stays_local(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'host': 'localhost'})
+        assert 'ssl' not in kwargs
+
+    def test_mode_wins_over_a_stale_profile(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'profile': 'local', 'host': 'h', 'apikey': 'k'})
+        assert kwargs.get('ssl') is True
+
+
+class TestCloudTransport:
+    """TLS and the header: plain HTTP against the TLS port is the hang."""
+
+    def test_tls_is_requested(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'api.trychroma.com', 'apikey': 'k'})
+        assert kwargs['ssl'] is True
+
+    def test_api_key_travels_in_the_x_chroma_token_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'secret'})
+        assert kwargs['headers'] == {'x-chroma-token': 'secret'}
+
+    def test_no_api_key_sends_no_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A self-hosted server behind TLS needs no token; sending an empty one
+        # would be rejected rather than ignored.
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h'})
+        assert kwargs['headers'] is None
+
+    def test_local_sends_neither(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'local', 'host': 'localhost', 'apikey': 'k'})
+        assert 'ssl' not in kwargs
+        assert 'headers' not in kwargs
+
+
+class TestTenantAndDatabase:
+    """Chroma Cloud is multi-tenant; self-hosted servers reject the kwargs."""
+
+    def test_both_are_forwarded_when_set(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(
+            monkeypatch,
+            {'mode': 'cloud', 'host': 'h', 'apikey': 'k', 'tenant': 't1', 'database': 'db1'},
+        )
+        assert kwargs['tenant'] == 't1'
+        assert kwargs['database'] == 'db1'
+
+    def test_omitted_rather_than_passed_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Passing tenant='' is not the same as not passing it: chromadb would
+        # send an empty tenant instead of using its default.
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'k', 'tenant': '', 'database': ''})
+        assert 'tenant' not in kwargs
+        assert 'database' not in kwargs
+
+    def test_one_without_the_other_is_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'k', 'tenant': 't1'})
+        assert kwargs['tenant'] == 't1'
+        assert 'database' not in kwargs
+
+    def test_whitespace_only_counts_as_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        kwargs = _connect(monkeypatch, {'mode': 'cloud', 'host': 'h', 'apikey': 'k', 'tenant': '   '})
+        assert 'tenant' not in kwargs
+
+
+class TestTimeoutShim:
+    """The shim cannot be reviewed by reading, so pin what it does."""
+
+    def test_a_session_built_with_no_timeout_gets_one(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
+        import chromadb.api.fastapi as patched
+
+        client = patched.httpx.Client()
+        assert client.timeout.connect == 30.0
+        assert client.timeout.read == 120.0
+
+    def test_an_explicit_timeout_is_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
+        import chromadb.api.fastapi as patched
+        import httpx
+
+        client = patched.httpx.Client(timeout=httpx.Timeout(5.0))
+        assert client.timeout.read == 5.0
+
+    def test_the_shim_is_applied_once(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Re-wrapping on every Store would nest the subclass without bound.
+        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
+        import chromadb.api.fastapi as patched
+
+        first = patched.httpx
+        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
+        assert patched.httpx is first
+
+    def test_other_httpx_names_still_resolve(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The shim only shadows Client; everything else falls through to httpx.
+        _connect(monkeypatch, {'mode': 'local', 'host': 'localhost'})
+        import chromadb.api.fastapi as patched
+        import httpx
+
+        assert patched.httpx.Timeout is httpx.Timeout
+
+    def test_a_store_still_connects_when_the_shim_cannot_apply(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Hardening, not a feature: if chromadb reorganises its transport module
+        # the store must still connect, just without the default timeout.
+        module = _load_module()
+        _CLIENT_CALLS.clear()
+        monkeypatch.setattr(
+            module.Config,
+            'getNodeConfig',
+            staticmethod(lambda *_a, **_k: {'mode': 'local', 'host': 'localhost'}),
+        )
+        monkeypatch.setattr(module.DocumentStoreBase, '__init__', lambda self, *_a, **_k: None)
+        monkeypatch.delitem(sys.modules, 'chromadb.api.fastapi', raising=False)
+        monkeypatch.setattr(sys.modules['chromadb.api'], 'fastapi', None, raising=False)
+
+        module.Store('chroma', {}, {})
+        assert _CLIENT_CALLS, 'a failed shim must not stop the store connecting'


### PR DESCRIPTION
# fix(store_chroma): connect to Chroma Cloud with TLS, token auth, and tenant/database

## Problem

Publishing to Chroma Cloud (`api.trychroma.com`) fails: it surfaces as `Exception: illegal request line`, or the pipeline hangs indefinitely. Three stacked defects:

1. **Branch selection.** The node picks local vs cloud with `config.get('profile', 'local')`, but `Config.getNodeConfig` consumes the `profile` key while merging the selected profile's contents; only `mode` survives in the merged config. Every service/autopipe-configured run therefore takes the **local** branch and sends plain, unauthenticated HTTP to a TLS-only endpoint. Verified by logging the actual request from a live pipeline: `GET http://api.trychroma.com:443/api/v2/auth/identity` with no auth header. Chroma's front end either responds with something the HTTP parser rejects ("illegal request line") or never responds.
2. **The cloud branch is wrong anyway**: no TLS, Bearer-token auth provider while Chroma Cloud expects the `x-chroma-token` header, and no tenant/database support (Chroma Cloud requires both; without a tenant the server returns "Permission denied").
3. **No HTTP timeout**: the chromadb client hardcodes `httpx.Client(timeout=None)` and issues its first request inside the constructor, so failure mode 1 hangs the transform forever instead of erroring.

## Changes

- select the connection branch on `mode` (as `store_weaviate` already does), keeping `profile` as a fallback for direct configurations
- cloud branch connects with `ssl=True`, sends the API key via `x-chroma-token`, and passes `tenant`/`database` (new optional cloud profile fields in `services.json`)
- a scoped shim gives every httpx session created by `chromadb.api.fastapi` a 30s connect / 120s request timeout
- the existing connect-error wrapper and server version enforcement are preserved

## Verification

Verified end to end against Chroma Cloud with a real tenant/database: 17 objects scanned and published in 28s with zero failures; collection contents (chunks, metadata, vectors) confirmed via the API. Failure modes verified directly as well: without TLS the request hangs indefinitely; with TLS but no tenant the server returns "Permission denied".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Chroma Cloud tenant and database configuration options.
  * Updated cloud connections to use TLS and token-based authentication.
  * Added finite connection and request timeouts for more reliable interactions.
  * Cloud setup now defaults to the recommended Chroma host.
  * Added profile selection through available configuration options.
  * Added support for forwarding optional tenant and database settings when provided.

* **Documentation**
  * Updated guidance for authentication, tenant and database settings, timeout behavior, TLS requirements, and supported connection URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->