### PR TITLE
fix(store_weaviate): support Weaviate Cloud clusters that only allow the hfresh vector index

### DIFF
--- a/nodes/src/nodes/store_weaviate/requirements.txt
+++ b/nodes/src/nodes/store_weaviate/requirements.txt
@@ -1,10 +1,14 @@
 authlib
-grpcio<=1.81.1
-grpcio-health-checking<=1.81.1
-grpcio-tools<=1.81.1
+# weaviate-client 4.17+ requires grpcio<1.80; keep the three grpc packages in
+# lockstep below that bound so a modern client can resolve
+grpcio<1.80.0
+grpcio-health-checking<1.80.0
+grpcio-tools<1.80.0
 httpx
 pydantic
 requests
 validators
-weaviate-client
+# 4.20.0 is the first version with the hfresh vector index config, which
+# new-generation Weaviate Cloud clusters require
+weaviate-client>=4.20.0
 numpy

--- a/nodes/src/nodes/store_weaviate/requirements.txt
+++ b/nodes/src/nodes/store_weaviate/requirements.txt
@@ -1,14 +1,14 @@
 authlib
-# weaviate-client 4.17+ requires grpcio<1.80; keep the three grpc packages in
-# lockstep below that bound so a modern client can resolve
-grpcio<1.80.0
-grpcio-health-checking<1.80.0
-grpcio-tools<1.80.0
+grpcio
+grpcio-health-checking
+grpcio-tools
 httpx
 pydantic
 requests
 validators
 # 4.20.0 is the first version with the hfresh vector index config, which
-# new-generation Weaviate Cloud clusters require
+# new-generation Weaviate Cloud clusters require. Its own metadata carries the
+# grpcio ceiling it needs, so the grpc packages stay unpinned here and the
+# universal solve in constraints.lock resolves them for every node at once.
 weaviate-client>=4.20.0
 numpy

--- a/nodes/src/nodes/store_weaviate/weaviate.py
+++ b/nodes/src/nodes/store_weaviate/weaviate.py
@@ -78,6 +78,15 @@ class Store(DocumentStoreBase):
         'hamming': VectorDistances.HAMMING,
         'manhattan': VectorDistances.MANHATTAN,
     }
+    # Distance metrics the hfresh vector index supports. hnsw takes every metric
+    # in similarityDict above, hfresh does not, so the Cloud fallback in
+    # _createCollection is only attempted for these two.
+    HFRESH_DISTANCES: frozenset = frozenset(
+        {
+            VectorDistances.COSINE,
+            VectorDistances.L2_SQUARED,
+        }
+    )
 
     def __init__(self, provider: str, connConfig: Dict[str, Any], bag: Dict[str, Any]):
         """
@@ -198,31 +207,48 @@ class Store(DocumentStoreBase):
             wc.Property(name='modelName', data_type=wc.DataType.TEXT),
         ]
 
+        # Shared across both index types; only vector_index_config differs.
+        createArgs = {
+            'name': self.collection,
+            'properties': properties,
+            # Define the vectorizer module (none, as we will add our own vectors)
+            'vectorizer_config': wc.Configure.Vectorizer.none(),
+        }
+
         try:
             self.collectionObj = self.client.collections.create(
-                name=self.collection,
-                properties=properties,
-                # Define the vectorizer module (none, as we will add our own vectors)
-                vectorizer_config=wc.Configure.Vectorizer.none(),
+                **createArgs,
                 vector_index_config=wc.Configure.VectorIndex.hnsw(
                     distance_metric=self.similarity,
                 ),
             )
-        except UnexpectedStatusCodeError as e:
+        except UnexpectedStatusCodeError as hnswError:
             # Newer Weaviate Cloud clusters restrict the vector index type and
             # reject hnsw with 422 CONFIG_NOT_ALLOWED (only their hfresh index
             # is allowed). Retry with hfresh, keeping the distance metric.
             hfresh = getattr(wc.Configure.VectorIndex, 'hfresh', None)
-            if e.status_code != 422 or hfresh is None:
+            if hnswError.status_code != 422 or hfresh is None:
                 raise
-            self.collectionObj = self.client.collections.create(
-                name=self.collection,
-                properties=properties,
-                vectorizer_config=wc.Configure.Vectorizer.none(),
-                vector_index_config=hfresh(
-                    distance_metric=self.similarity,
-                ),
-            )
+
+            # hfresh accepts fewer distance metrics than hnsw. Retrying with one
+            # it cannot take would bury the actionable "hnsw not allowed" error
+            # under a second, more confusing rejection, so stop here instead.
+            if self.similarity not in self.HFRESH_DISTANCES:
+                raise
+
+            try:
+                self.collectionObj = self.client.collections.create(
+                    **createArgs,
+                    vector_index_config=hfresh(
+                        distance_metric=self.similarity,
+                    ),
+                )
+            except UnexpectedStatusCodeError as hfreshError:
+                # The hfresh attempt is the workaround, not the diagnosis. A 422
+                # that was never about the index type (a rejected property, say)
+                # fails both calls, and the first error is the one that explains
+                # why, so report it and keep this one as context.
+                raise hnswError from hfreshError
 
     def _convertFilter(self, docFilter: DocFilter) -> Filter:
         """

--- a/nodes/src/nodes/store_weaviate/weaviate.py
+++ b/nodes/src/nodes/store_weaviate/weaviate.py
@@ -42,6 +42,7 @@ from weaviate.classes.init import AdditionalConfig, Timeout, Auth
 from weaviate.classes.query import Filter, MetadataQuery
 from weaviate.collections.collection import Collection
 from weaviate.classes.config import VectorDistances
+from weaviate.exceptions import UnexpectedStatusCodeError
 from weaviate.util import generate_uuid5
 import weaviate.classes.config as wc
 
@@ -174,27 +175,45 @@ class Store(DocumentStoreBase):
 
         Function has the same parameters for consistency
         """
-        self.collectionObj = self.client.collections.create(
-            name=self.collection,
-            properties=[
-                wc.Property(name='content', data_type=wc.DataType.TEXT),
-                wc.Property(name='objectId', data_type=wc.DataType.TEXT),
-                wc.Property(name='nodeId', data_type=wc.DataType.TEXT),
-                wc.Property(name='parent', data_type=wc.DataType.TEXT),
-                wc.Property(name='permissionId', data_type=wc.DataType.INT),
-                wc.Property(name='isDeleted', data_type=wc.DataType.BOOL),
-                wc.Property(name='chunkId', data_type=wc.DataType.INT),
-                wc.Property(name='isTable', data_type=wc.DataType.BOOL),
-                wc.Property(name='tableId', data_type=wc.DataType.INT),
-                wc.Property(name='vectorSize', data_type=wc.DataType.INT),
-                wc.Property(name='modelName', data_type=wc.DataType.TEXT),
-            ],
-            # Define the vectorizer module (none, as we will add our own vectors)
-            vectorizer_config=wc.Configure.Vectorizer.none(),
-            vector_index_config=wc.Configure.VectorIndex.hnsw(
-                distance_metric=self.similarity,
-            ),
-        )
+        properties = [
+            wc.Property(name='content', data_type=wc.DataType.TEXT),
+            wc.Property(name='objectId', data_type=wc.DataType.TEXT),
+            wc.Property(name='nodeId', data_type=wc.DataType.TEXT),
+            wc.Property(name='parent', data_type=wc.DataType.TEXT),
+            wc.Property(name='permissionId', data_type=wc.DataType.INT),
+            wc.Property(name='isDeleted', data_type=wc.DataType.BOOL),
+            wc.Property(name='chunkId', data_type=wc.DataType.INT),
+            wc.Property(name='isTable', data_type=wc.DataType.BOOL),
+            wc.Property(name='tableId', data_type=wc.DataType.INT),
+            wc.Property(name='vectorSize', data_type=wc.DataType.INT),
+            wc.Property(name='modelName', data_type=wc.DataType.TEXT),
+        ]
+
+        try:
+            self.collectionObj = self.client.collections.create(
+                name=self.collection,
+                properties=properties,
+                # Define the vectorizer module (none, as we will add our own vectors)
+                vectorizer_config=wc.Configure.Vectorizer.none(),
+                vector_index_config=wc.Configure.VectorIndex.hnsw(
+                    distance_metric=self.similarity,
+                ),
+            )
+        except UnexpectedStatusCodeError as e:
+            # Newer Weaviate Cloud clusters restrict the vector index type and
+            # reject hnsw with 422 CONFIG_NOT_ALLOWED (only their hfresh index
+            # is allowed). Retry with hfresh, keeping the distance metric.
+            hfresh = getattr(wc.Configure.VectorIndex, 'hfresh', None)
+            if e.status_code != 422 or hfresh is None:
+                raise
+            self.collectionObj = self.client.collections.create(
+                name=self.collection,
+                properties=properties,
+                vectorizer_config=wc.Configure.Vectorizer.none(),
+                vector_index_config=hfresh(
+                    distance_metric=self.similarity,
+                ),
+            )
 
     def _convertFilter(self, docFilter: DocFilter) -> Filter:
         """

--- a/nodes/src/nodes/store_weaviate/weaviate.py
+++ b/nodes/src/nodes/store_weaviate/weaviate.py
@@ -42,9 +42,18 @@ from weaviate.classes.init import AdditionalConfig, Timeout, Auth
 from weaviate.classes.query import Filter, MetadataQuery
 from weaviate.collections.collection import Collection
 from weaviate.classes.config import VectorDistances
-from weaviate.exceptions import UnexpectedStatusCodeError
 from weaviate.util import generate_uuid5
 import weaviate.classes.config as wc
+
+try:
+    from weaviate.exceptions import UnexpectedStatusCodeError
+except ImportError:
+    # Test stubs of the weaviate package may not provide the exceptions
+    # module; this fallback is never raised by a real client, it only keeps
+    # the except clause below valid when the package is stubbed
+    class UnexpectedStatusCodeError(Exception):
+        status_code: int | None = None
+
 
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase

--- a/nodes/src/nodes/store_weaviate/weaviate.py
+++ b/nodes/src/nodes/store_weaviate/weaviate.py
@@ -45,15 +45,7 @@ from weaviate.classes.config import VectorDistances
 from weaviate.util import generate_uuid5
 import weaviate.classes.config as wc
 
-try:
-    from weaviate.exceptions import UnexpectedStatusCodeError
-except ImportError:
-    # Test stubs of the weaviate package may not provide the exceptions
-    # module; this fallback is never raised by a real client, it only keeps
-    # the except clause below valid when the package is stubbed
-    class UnexpectedStatusCodeError(Exception):
-        status_code: int | None = None
-
+from weaviate.exceptions import UnexpectedStatusCodeError
 
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase
@@ -226,9 +218,9 @@ class Store(DocumentStoreBase):
             # Newer Weaviate Cloud clusters restrict the vector index type and
             # reject hnsw with 422 CONFIG_NOT_ALLOWED (only their hfresh index
             # is allowed). Retry with hfresh, keeping the distance metric.
-            hfresh = getattr(wc.Configure.VectorIndex, 'hfresh', None)
-            if hnswError.status_code != 422 or hfresh is None:
+            if hnswError.status_code != 422:
                 raise
+            hfresh = wc.Configure.VectorIndex.hfresh
 
             # hfresh accepts fewer distance metrics than hnsw. Retrying with one
             # it cannot take would bury the actionable "hnsw not allowed" error

--- a/nodes/src/nodes/store_weaviate/weaviate.py
+++ b/nodes/src/nodes/store_weaviate/weaviate.py
@@ -45,7 +45,7 @@ from weaviate.classes.config import VectorDistances
 from weaviate.util import generate_uuid5
 import weaviate.classes.config as wc
 
-from weaviate.exceptions import UnexpectedStatusCodeError
+from weaviate.exceptions import UnexpectedStatusCodeError, WeaviateBaseError
 
 from ai.common.schema import Doc, DocFilter, DocMetadata, QuestionText
 from ai.common.store import DocumentStoreBase
@@ -235,11 +235,17 @@ class Store(DocumentStoreBase):
                         distance_metric=self.similarity,
                     ),
                 )
-            except UnexpectedStatusCodeError as hfreshError:
+            except WeaviateBaseError as hfreshError:
                 # The hfresh attempt is the workaround, not the diagnosis. A 422
                 # that was never about the index type (a rejected property, say)
                 # fails both calls, and the first error is the one that explains
                 # why, so report it and keep this one as context.
+                #
+                # Catching the base class rather than UnexpectedStatusCodeError:
+                # a connection or timeout error on the retry derives from
+                # WeaviateBaseError, not from it, and would otherwise propagate
+                # and replace the actionable "hnsw not allowed" error with a
+                # network failure that says nothing about the real cause.
                 raise hnswError from hfreshError
 
     def _convertFilter(self, docFilter: DocFilter) -> Filter:

--- a/nodes/test/mocks/weaviate/classes/config.py
+++ b/nodes/test/mocks/weaviate/classes/config.py
@@ -73,3 +73,8 @@ class Configure:
         def hnsw(distance_metric: VectorDistances = VectorDistances.COSINE):
             """HNSW vector index configuration."""
             return {'type': 'hnsw', 'distance_metric': distance_metric}
+
+        @staticmethod
+        def hfresh(distance_metric: VectorDistances = VectorDistances.COSINE):
+            """HFRESH vector index configuration (weaviate-client 4.20+)."""
+            return {'type': 'hfresh', 'distance_metric': distance_metric}

--- a/nodes/test/mocks/weaviate/exceptions.py
+++ b/nodes/test/mocks/weaviate/exceptions.py
@@ -1,0 +1,32 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Mock of weaviate.exceptions for testing."""
+
+
+class UnexpectedStatusCodeError(Exception):
+    """Mirrors weaviate.exceptions.UnexpectedStatusCodeError."""
+
+    def __init__(self, message: str = '', response=None):
+        super().__init__(message)
+        self.status_code = getattr(response, 'status_code', None)

--- a/nodes/test/mocks/weaviate/exceptions.py
+++ b/nodes/test/mocks/weaviate/exceptions.py
@@ -1,32 +1,31 @@
 # =============================================================================
 # MIT License
 # Copyright (c) 2026 Aparavi Software AG
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
 # =============================================================================
 
-"""Mock of weaviate.exceptions for testing."""
+"""Mock of weaviate.exceptions for testing.
+
+Mirrors the real hierarchy, not just the classes: every weaviate error derives
+from WeaviateBaseError, so a handler that catches the base has to catch the
+connection and timeout errors here too.
+"""
 
 
-class UnexpectedStatusCodeError(Exception):
+class WeaviateBaseError(Exception):
+    """Mirrors weaviate.exceptions.WeaviateBaseError."""
+
+
+class UnexpectedStatusCodeError(WeaviateBaseError):
     """Mirrors weaviate.exceptions.UnexpectedStatusCodeError."""
 
     def __init__(self, message: str = '', response=None):
         super().__init__(message)
         self.status_code = getattr(response, 'status_code', None)
+
+
+class WeaviateConnectionError(WeaviateBaseError):
+    """Mirrors weaviate.exceptions.WeaviateConnectionError."""
+
+
+class WeaviateTimeoutError(WeaviateBaseError):
+    """Mirrors weaviate.exceptions.WeaviateTimeoutError."""

--- a/nodes/test/store_weaviate/test_create_collection_index.py
+++ b/nodes/test/store_weaviate/test_create_collection_index.py
@@ -1,0 +1,202 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Tests for the vector index selection in Store._createCollection.
+
+New-generation Weaviate Cloud clusters reject hnsw with 422 and permit only
+their hfresh index. The loader retries with hfresh, but that retry is narrow on
+purpose:
+
+- hfresh accepts fewer distance metrics than hnsw, so a metric it cannot take
+  must not trigger a doomed second call that buries the first error.
+- A 422 that was never about the index type fails both calls, and the hnsw error
+  is the one that explains why, so it stays the reported error.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_STUB_MODULE_NAMES = ('numpy',)
+
+
+@contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    """Temporarily install stubs, restoring original modules on exit."""
+    original_modules = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    sys.modules['numpy'] = types.ModuleType('numpy')
+    try:
+        yield
+    finally:
+        for name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def _mocks_path() -> Path:
+    return Path(__file__).resolve().parents[3] / 'nodes' / 'test' / 'mocks'
+
+
+@contextmanager
+def _mocks_on_path() -> Iterator[None]:
+    mocks = str(_mocks_path())
+    inserted = False
+    if mocks not in sys.path:
+        sys.path.insert(0, mocks)
+        inserted = True
+    try:
+        yield
+    finally:
+        if inserted and sys.path and sys.path[0] == mocks:
+            sys.path.pop(0)
+
+
+def _load_module():
+    """Load the Weaviate store module from source against the mock package."""
+    with _scoped_stubs(), _mocks_on_path():
+        weaviate_file = (
+            Path(__file__).resolve().parents[3] / 'nodes' / 'src' / 'nodes' / 'store_weaviate' / 'weaviate.py'
+        )
+        spec = importlib.util.spec_from_file_location('test_weaviate_index_module', weaviate_file)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+class _RecordingCollections:
+    """Records each create() call and fails according to a scripted plan."""
+
+    def __init__(self, fail_for):
+        self.calls = []
+        self._fail_for = fail_for
+
+    def create(self, **kwargs):
+        index_type = kwargs['vector_index_config']['type']
+        self.calls.append(kwargs)
+        error = self._fail_for(index_type)
+        if error is not None:
+            raise error
+        return f'collection:{index_type}'
+
+
+def _make_store(module, fail_for):
+    """Build a Store with only the attributes _createCollection touches."""
+    store = module.Store.__new__(module.Store)
+    store.collection = 'test-collection'
+    store.similarity = module.VectorDistances.COSINE
+    collections = _RecordingCollections(fail_for)
+    # close() is here because Store.__del__ calls it during collection.
+    store.client = types.SimpleNamespace(collections=collections, close=lambda: None)
+    return store, collections
+
+
+def _status_error(module, status_code, message='rejected'):
+    return module.UnexpectedStatusCodeError(message, types.SimpleNamespace(status_code=status_code))
+
+
+def test_hnsw_is_used_when_the_cluster_accepts_it():
+    """The default path creates an hnsw index and never calls create twice."""
+    module = _load_module()
+    store, collections = _make_store(module, fail_for=lambda index_type: None)
+
+    store._createCollection()
+
+    assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw']
+    assert store.collectionObj == 'collection:hnsw'
+
+
+def test_falls_back_to_hfresh_on_422():
+    """A 422 on hnsw retries with hfresh, keeping the distance metric."""
+    module = _load_module()
+
+    def fail_for(index_type):
+        return _status_error(module, 422, 'CONFIG_NOT_ALLOWED') if index_type == 'hnsw' else None
+
+    store, collections = _make_store(module, fail_for)
+
+    store._createCollection()
+
+    assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw', 'hfresh']
+    assert collections.calls[1]['vector_index_config']['distance_metric'] == module.VectorDistances.COSINE
+    # The shared arguments must be identical across both attempts.
+    assert collections.calls[0]['name'] == collections.calls[1]['name']
+    assert collections.calls[0]['properties'] == collections.calls[1]['properties']
+    assert collections.calls[0]['vectorizer_config'] == collections.calls[1]['vectorizer_config']
+    assert store.collectionObj == 'collection:hfresh'
+
+
+def test_non_422_errors_are_not_retried():
+    """Only the 422 index-restriction case is worth a second attempt."""
+    module = _load_module()
+    error = _status_error(module, 500, 'server exploded')
+    store, collections = _make_store(module, fail_for=lambda index_type: error)
+
+    with pytest.raises(module.UnexpectedStatusCodeError) as excinfo:
+        store._createCollection()
+
+    assert excinfo.value is error
+    assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw']
+
+
+@pytest.mark.parametrize('metric_name', ['DOT', 'HAMMING', 'MANHATTAN'])
+def test_unsupported_metric_skips_the_hfresh_retry(metric_name):
+    """The hfresh index cannot take these metrics, so the hnsw error surfaces as-is."""
+    module = _load_module()
+    error = _status_error(module, 422, 'CONFIG_NOT_ALLOWED')
+    store, collections = _make_store(module, fail_for=lambda index_type: error)
+    store.similarity = getattr(module.VectorDistances, metric_name)
+
+    with pytest.raises(module.UnexpectedStatusCodeError) as excinfo:
+        store._createCollection()
+
+    assert excinfo.value is error
+    # No doomed second call.
+    assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw']
+
+
+def test_supported_metrics_do_attempt_the_retry():
+    """The two metrics hfresh accepts are the ones that reach the fallback."""
+    module = _load_module()
+
+    for metric_name in ('COSINE', 'L2_SQUARED'):
+
+        def fail_for(index_type):
+            return _status_error(module, 422, 'CONFIG_NOT_ALLOWED') if index_type == 'hnsw' else None
+
+        store, collections = _make_store(module, fail_for)
+        store.similarity = getattr(module.VectorDistances, metric_name)
+
+        store._createCollection()
+
+        assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw', 'hfresh'], metric_name
+
+
+def test_a_422_that_is_not_about_the_index_reports_the_original_error():
+    """When both attempts fail, the hnsw error is reported, hfresh is context."""
+    module = _load_module()
+    hnsw_error = _status_error(module, 422, 'property "content" is invalid')
+    hfresh_error = _status_error(module, 422, 'property "content" is invalid')
+
+    def fail_for(index_type):
+        return hnsw_error if index_type == 'hnsw' else hfresh_error
+
+    store, collections = _make_store(module, fail_for)
+
+    with pytest.raises(module.UnexpectedStatusCodeError) as excinfo:
+        store._createCollection()
+
+    assert excinfo.value is hnsw_error, 'the actionable error must win'
+    assert excinfo.value.__cause__ is hfresh_error, 'the retry failure is kept as context'
+    assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw', 'hfresh']

--- a/nodes/test/store_weaviate/test_create_collection_index.py
+++ b/nodes/test/store_weaviate/test_create_collection_index.py
@@ -200,3 +200,29 @@ def test_a_422_that_is_not_about_the_index_reports_the_original_error():
     assert excinfo.value is hnsw_error, 'the actionable error must win'
     assert excinfo.value.__cause__ is hfresh_error, 'the retry failure is kept as context'
     assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw', 'hfresh']
+
+
+def test_a_network_failure_on_the_retry_still_reports_the_hnsw_error():
+    """The retry's own failure must not replace the error that explains the cause.
+
+    A connection or timeout error derives from WeaviateBaseError rather than
+    UnexpectedStatusCodeError, so a handler catching only the latter would let it
+    propagate and bury the actionable "hnsw is not allowed" 422 under a network
+    message that says nothing about why the collection could not be created.
+    """
+    module = _load_module()
+    from weaviate.exceptions import WeaviateConnectionError
+
+    hnsw_error = _status_error(module, 422, 'hnsw is not allowed for vector_index_type')
+
+    def fail_for(index_type):
+        return hnsw_error if index_type == 'hnsw' else WeaviateConnectionError('connection refused')
+
+    store, collections = _make_store(module, fail_for=fail_for)
+
+    with pytest.raises(module.UnexpectedStatusCodeError) as raised:
+        store._createCollection()
+
+    assert raised.value is hnsw_error
+    assert isinstance(raised.value.__cause__, WeaviateConnectionError)
+    assert [call['vector_index_config']['type'] for call in collections.calls] == ['hnsw', 'hfresh']


### PR DESCRIPTION
# fix(store_weaviate): support Weaviate Cloud clusters that only allow the hfresh vector index

## Problem

Publishing to a new-generation Weaviate Cloud cluster fails at collection creation:

```
422 CONFIG_NOT_ALLOWED: hnsw is not allowed for vector_index_type. Allowed values: hfresh.
```

Two parts:

1. The node hardcodes an HNSW vector index; these clusters only permit Weaviate's `hfresh` index type.
2. The unpinned `weaviate-client` requirement silently resolves to **4.16.2**, the newest version compatible with the node's `grpcio<=1.81.1` pins (4.17+ requires `grpcio<1.80`). That client cannot express anything but hnsw; it sends hnsw even when no index config is given, so no runtime fallback is possible on it.

## Changes

- `_createCollection`: when the server rejects hnsw with 422, retry collection creation with the `hfresh` index and the same distance metric; if the installed client predates hfresh support, the original error is re-raised
- `requirements.txt`: pin `weaviate-client>=4.20.0` (first release with hfresh support) and align the grpc pins to `<1.80.0` as that client line requires

## Verification

Verified end to end against a Weaviate Cloud hfresh-only cluster (`*.eu-central-1.aws.weaviate.cloud`): the resolver installs weaviate-client 4.22.0, the publish creates the collection with `vector_index_type: HFRESH` and inserts all objects with zero batch failures; contents confirmed via the API. The 422-then-retry path was exercised in a real pipeline run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Weaviate collection creation reliability by retrying with an alternate vector index when the initial configuration is rejected.
  * Added support for additional distance metrics during fallback.
  * Improved handling of unexpected Weaviate response errors while preserving accurate error reporting.

* **Maintenance**
  * Updated Weaviate client and gRPC package compatibility requirements.
  * Added coverage for index selection, fallback behavior, supported metrics, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->