### PR TITLE
fix(storage): version the /task/fetch claim so pre-upgrade tokens cannot be reinterpreted

### DIFF
--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -46,17 +46,11 @@ MAX_READ_SIZE = 100 * 1024 * 1024  # 100 MB
 # ctx conn_id is non-empty — '' means "unowned", used by tests.
 MAX_HANDLES_PER_CONNECTION = 64
 
-# Generation marker for the /task/fetch capability claim (get_url below,
-# consumed by ai.modules.task.fetch). BUMP THIS whenever the meaning of any
-# claim changes, and teach the handler to refuse the older generation.
-#
-# Tokens live up to an hour, which outlasts a deploy, so both generations
-# meet at every upgrade. v1 (pre-#1686) carried the WIRE path and the handler
-# re-resolved it under the caller's namespace; v2 carries the RESOLVED
-# physical path and the handler serves it verbatim. The payloads are
-# otherwise identical in shape, so without this marker a v1 claim is
-# indistinguishable from a v2 one and gets read as a store-root-relative
-# path — reaching another user's, team's or org's files (issue #1767).
+# Generation of the /task/fetch claim (issue #1767). v1 carried the WIRE
+# path and the handler re-resolved it; v2 carries the RESOLVED physical path
+# and the handler serves it verbatim. Tokens outlive a deploy, so both meet
+# at every upgrade — BUMP THIS whenever a claim's meaning changes, and the
+# handler will refuse the older generation instead of misreading it.
 FETCH_CLAIM_VERSION = 2
 
 # Characters forbidden inside any single path segment. ':' blocks Windows
@@ -1135,11 +1129,6 @@ class FileStore:
         # because its internal identity has no name dictionary and no org
         # context, so a name-based '@/Team/<name>' or '@/Org' wire path
         # could never resolve there (it would 500 instead of serving).
-        #
-        # 'v' states WHICH of those two meanings this claim carries. It is
-        # what lets the handler refuse a v1 token minted by a pre-#1686
-        # server during the upgrade window, instead of reading its wire path
-        # as a physical one (see FETCH_CLAIM_VERSION).
         payload = {
             'sub': self._client_id,
             'path': full_path,

--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -46,6 +46,19 @@ MAX_READ_SIZE = 100 * 1024 * 1024  # 100 MB
 # ctx conn_id is non-empty — '' means "unowned", used by tests.
 MAX_HANDLES_PER_CONNECTION = 64
 
+# Generation marker for the /task/fetch capability claim (get_url below,
+# consumed by ai.modules.task.fetch). BUMP THIS whenever the meaning of any
+# claim changes, and teach the handler to refuse the older generation.
+#
+# Tokens live up to an hour, which outlasts a deploy, so both generations
+# meet at every upgrade. v1 (pre-#1686) carried the WIRE path and the handler
+# re-resolved it under the caller's namespace; v2 carries the RESOLVED
+# physical path and the handler serves it verbatim. The payloads are
+# otherwise identical in shape, so without this marker a v1 claim is
+# indistinguishable from a v2 one and gets read as a store-root-relative
+# path — reaching another user's, team's or org's files (issue #1767).
+FETCH_CLAIM_VERSION = 2
+
 # Characters forbidden inside any single path segment. ':' blocks Windows
 # drive-letter syntax (C:\...) from leaking through after the '\\' -> '/'
 # conversion in _validate_path.
@@ -1122,9 +1135,15 @@ class FileStore:
         # because its internal identity has no name dictionary and no org
         # context, so a name-based '@/Team/<name>' or '@/Org' wire path
         # could never resolve there (it would 500 instead of serving).
+        #
+        # 'v' states WHICH of those two meanings this claim carries. It is
+        # what lets the handler refuse a v1 token minted by a pre-#1686
+        # server during the upgrade window, instead of reading its wire path
+        # as a physical one (see FETCH_CLAIM_VERSION).
         payload = {
             'sub': self._client_id,
             'path': full_path,
+            'v': FETCH_CLAIM_VERSION,
             'exp': int(time.time()) + expires_in,
         }
         # Carry the download filename in the signed claim so /task/fetch can set
@@ -1176,5 +1195,6 @@ __all__ = [
     'MAX_CHUNK_SIZE',
     'MAX_READ_SIZE',
     'MAX_HANDLES_PER_CONNECTION',
+    'FETCH_CLAIM_VERSION',
     'DIR_MARKER',
 ]

--- a/packages/ai/src/ai/modules/task/fetch.py
+++ b/packages/ai/src/ai/modules/task/fetch.py
@@ -48,6 +48,9 @@ async def handle_fetch(request: Request):
         - ``sub``: userId that the URL was issued to (audit trail only)
         - ``path``: RESOLVED physical store path (the capability — scope
           resolution and authorization ran at issuance, in FileStore.get_url)
+        - ``v``: claim generation, which states what ``path`` MEANS. Only
+          ``FETCH_CLAIM_VERSION`` is served; anything else is refused (see
+          the version gate below)
         - ``exp``: expiration timestamp (standard JWT claim)
     """
     # ── Extract and validate JWT ─────────────────────────────────────────
@@ -73,6 +76,25 @@ async def handle_fetch(request: Request):
     download_name = payload.get('download_name')
     if not user_id or not path:
         return JSONResponse({'error': 'Token missing required claims'}, status_code=400)
+
+    # ── Claim generation gate ────────────────────────────────────────────
+    # `path` means something DIFFERENT per generation, and both generations
+    # are in flight at once during an upgrade (tokens outlive a deploy by
+    # design — up to an hour). A v1 claim is a WIRE path from a pre-#1686
+    # server, which that server's handler resolved and scoped to the user;
+    # reading it here, where the claim is served as a store-root-relative
+    # physical path, would hand out another user's / team's / org's files.
+    #
+    # Refusing is the right trade over trying to resolve v1: the worst case
+    # is that URLs minted in the hour before an upgrade need one more click.
+    #
+    # Deferred import: ai.account instantiates the Account singleton on
+    # import, and this module is imported during bootstrap (same reason
+    # Store is imported inside the function below).
+    from ai.account.file_store import FETCH_CLAIM_VERSION
+
+    if payload.get('v') != FETCH_CLAIM_VERSION:
+        return JSONResponse({'error': 'Token format no longer supported'}, status_code=401)
 
     # ── Map the signed store path to its filesystem location ─────────────
     # The `path` claim is the RESOLVED physical store path: authorization

--- a/packages/ai/src/ai/modules/task/fetch.py
+++ b/packages/ai/src/ai/modules/task/fetch.py
@@ -71,32 +71,15 @@ async def handle_fetch(request: Request):
     except jwt.InvalidTokenError as e:
         return JSONResponse({'error': f'Invalid token: {e}'}, status_code=401)
 
-    # ── Claim generation gate ────────────────────────────────────────────
-    # FIRST, before any other claim is read: `v` states how to interpret the
-    # REST of the payload, so validating fields whose meaning is not yet
-    # established is backwards. A future generation may not even carry the
-    # same claim set, and an unsupported one must fail closed as 401 rather
-    # than fall out of an earlier check with a different status.
-    #
-    # `path` means something DIFFERENT per generation, and both generations
-    # are in flight at once during an upgrade (tokens outlive a deploy by
-    # design — up to an hour). A v1 claim is a WIRE path from a pre-#1686
-    # server, which that server's handler resolved and scoped to the user;
-    # reading it here, where the claim is served as a store-root-relative
-    # physical path, would hand out another user's / team's / org's files.
-    #
-    # Refusing is the right trade over trying to resolve v1: the worst case
-    # is that URLs minted in the hour before an upgrade need one more click.
-    #
-    # Deferred import: ai.account instantiates the Account singleton on
-    # import, and this module is imported during bootstrap (same reason
-    # Store is imported inside the function below).
-    from ai.account.file_store import FETCH_CLAIM_VERSION
+    # Gate on generation before reading anything else: `v` says how to
+    # interpret the rest of the payload. A v1 claim (pre-#1686) holds a WIRE
+    # path; served under today's meaning it would be a store-root-relative
+    # physical path into another user's tree — see FETCH_CLAIM_VERSION.
+    from ai.account.file_store import FETCH_CLAIM_VERSION  # deferred: Account singleton
 
     if payload.get('v') != FETCH_CLAIM_VERSION:
         return JSONResponse({'error': 'Token format no longer supported'}, status_code=401)
 
-    # Everything below reads the payload under THIS generation's rules.
     user_id = payload.get('sub')
     path = payload.get('path')
     download_name = payload.get('download_name')

--- a/packages/ai/src/ai/modules/task/fetch.py
+++ b/packages/ai/src/ai/modules/task/fetch.py
@@ -71,13 +71,13 @@ async def handle_fetch(request: Request):
     except jwt.InvalidTokenError as e:
         return JSONResponse({'error': f'Invalid token: {e}'}, status_code=401)
 
-    user_id = payload.get('sub')
-    path = payload.get('path')
-    download_name = payload.get('download_name')
-    if not user_id or not path:
-        return JSONResponse({'error': 'Token missing required claims'}, status_code=400)
-
     # ── Claim generation gate ────────────────────────────────────────────
+    # FIRST, before any other claim is read: `v` states how to interpret the
+    # REST of the payload, so validating fields whose meaning is not yet
+    # established is backwards. A future generation may not even carry the
+    # same claim set, and an unsupported one must fail closed as 401 rather
+    # than fall out of an earlier check with a different status.
+    #
     # `path` means something DIFFERENT per generation, and both generations
     # are in flight at once during an upgrade (tokens outlive a deploy by
     # design — up to an hour). A v1 claim is a WIRE path from a pre-#1686
@@ -95,6 +95,13 @@ async def handle_fetch(request: Request):
 
     if payload.get('v') != FETCH_CLAIM_VERSION:
         return JSONResponse({'error': 'Token format no longer supported'}, status_code=401)
+
+    # Everything below reads the payload under THIS generation's rules.
+    user_id = payload.get('sub')
+    path = payload.get('path')
+    download_name = payload.get('download_name')
+    if not user_id or not path:
+        return JSONResponse({'error': 'Token missing required claims'}, status_code=400)
 
     # ── Map the signed store path to its filesystem location ─────────────
     # The `path` claim is the RESOLVED physical store path: authorization

--- a/packages/ai/tests/ai/account/test_store_auth.py
+++ b/packages/ai/tests/ai/account/test_store_auth.py
@@ -705,6 +705,12 @@ class TestSignedFetchUrls:
             ('v1 (no marker)', {'sub': 'user-1', 'path': 'users/victim/files/secret.txt'}),
             # A newer generation must fail closed on today's handler too.
             ('newer generation', {'sub': 'user-1', 'path': 'users/user-1/files/q1.csv', 'v': 99}),
+            # ORDERING: the generation gate runs before the required-claim
+            # check, so a wrong-generation claim is refused as 401 even when
+            # it is ALSO missing 'sub'/'path' — 'v' says how to read the rest
+            # of the payload, so it cannot be validated second.
+            ('wrong generation, no sub', {'path': 'users/victim/files/secret.txt'}),
+            ('wrong generation, no path', {'sub': 'user-1'}),
         ],
     )
     async def test_handler_refuses_other_claim_generations(self, label, claim):

--- a/packages/ai/tests/ai/account/test_store_auth.py
+++ b/packages/ai/tests/ai/account/test_store_auth.py
@@ -685,3 +685,51 @@ class TestSignedFetchUrls:
         fs = _fs(store, _account())
         with pytest.raises(PermissionError):
             await fs.get_url('@/Org/q1.csv')
+
+    @pytest.mark.asyncio
+    async def test_claim_states_its_generation(self, store):
+        # The marker is what makes the two meanings of 'path' separable.
+        from ai.account.file_store import FETCH_CLAIM_VERSION
+
+        fs = _fs(store, _account())
+        url = await fs.get_url('reports/q1.csv')
+        assert self._claim(url)['v'] == FETCH_CLAIM_VERSION
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ('label', 'claim'),
+        [
+            # A pre-#1686 token: no marker, and 'path' is the WIRE spelling.
+            # Served under today's meaning it is a store-root-relative
+            # PHYSICAL path — i.e. straight into another user's tree.
+            ('v1 (no marker)', {'sub': 'user-1', 'path': 'users/victim/files/secret.txt'}),
+            # A newer generation must fail closed on today's handler too.
+            ('newer generation', {'sub': 'user-1', 'path': 'users/user-1/files/q1.csv', 'v': 99}),
+        ],
+    )
+    async def test_handler_refuses_other_claim_generations(self, label, claim):
+        """Issue #1767: tokens outlive a deploy, so both generations meet at
+        every upgrade. A claim that is not THIS generation must be refused,
+        never read under the current meaning of 'path'.
+
+        The gate runs before anything is resolved or served, so these never
+        reach the store; that the current generation gets PAST it is what
+        the rest of this class covers.
+        """
+        import time
+        from types import SimpleNamespace
+
+        import jwt
+
+        from ai.modules.task.fetch import handle_fetch
+
+        token = jwt.encode(
+            {**claim, 'exp': int(time.time()) + 600},
+            'test-signing-key',
+            algorithm='HS256',
+        )
+        # handle_fetch reads only request.query_params — no ASGI plumbing.
+        request = SimpleNamespace(query_params={'token': token})
+
+        response = await handle_fetch(request)
+        assert response.status_code == 401, label

--- a/packages/ai/tests/ai/account/test_store_auth.py
+++ b/packages/ai/tests/ai/account/test_store_auth.py
@@ -688,7 +688,6 @@ class TestSignedFetchUrls:
 
     @pytest.mark.asyncio
     async def test_claim_states_its_generation(self, store):
-        # The marker is what makes the two meanings of 'path' separable.
         from ai.account.file_store import FETCH_CLAIM_VERSION
 
         fs = _fs(store, _account())
@@ -699,28 +698,17 @@ class TestSignedFetchUrls:
     @pytest.mark.parametrize(
         ('label', 'claim'),
         [
-            # A pre-#1686 token: no marker, and 'path' is the WIRE spelling.
-            # Served under today's meaning it is a store-root-relative
-            # PHYSICAL path — i.e. straight into another user's tree.
-            ('v1 (no marker)', {'sub': 'user-1', 'path': 'users/victim/files/secret.txt'}),
-            # A newer generation must fail closed on today's handler too.
+            ('v1 — wire path, no marker', {'sub': 'user-1', 'path': 'users/victim/files/secret.txt'}),
             ('newer generation', {'sub': 'user-1', 'path': 'users/user-1/files/q1.csv', 'v': 99}),
-            # ORDERING: the generation gate runs before the required-claim
-            # check, so a wrong-generation claim is refused as 401 even when
-            # it is ALSO missing 'sub'/'path' — 'v' says how to read the rest
-            # of the payload, so it cannot be validated second.
+            # The gate precedes the required-claim check, so these are 401 and not 400.
             ('wrong generation, no sub', {'path': 'users/victim/files/secret.txt'}),
             ('wrong generation, no path', {'sub': 'user-1'}),
         ],
     )
     async def test_handler_refuses_other_claim_generations(self, label, claim):
-        """Issue #1767: tokens outlive a deploy, so both generations meet at
-        every upgrade. A claim that is not THIS generation must be refused,
-        never read under the current meaning of 'path'.
-
-        The gate runs before anything is resolved or served, so these never
-        reach the store; that the current generation gets PAST it is what
-        the rest of this class covers.
+        """Issue #1767: tokens outlive a deploy, so both generations meet at every
+        upgrade. Anything but the current one must be refused, never read under
+        today's meaning of 'path'.
         """
         import time
         from types import SimpleNamespace
@@ -729,13 +717,8 @@ class TestSignedFetchUrls:
 
         from ai.modules.task.fetch import handle_fetch
 
-        token = jwt.encode(
-            {**claim, 'exp': int(time.time()) + 600},
-            'test-signing-key',
-            algorithm='HS256',
-        )
-        # handle_fetch reads only request.query_params — no ASGI plumbing.
-        request = SimpleNamespace(query_params={'token': token})
+        token = jwt.encode({**claim, 'exp': int(time.time()) + 600}, 'test-signing-key', algorithm='HS256')
+        request = SimpleNamespace(query_params={'token': token})  # handle_fetch reads only query_params
 
         response = await handle_fetch(request)
         assert response.status_code == 401, label


### PR DESCRIPTION
Closes #1767.

## Summary

#1686 changed what the `path` claim in a `/task/fetch` token **means** — from the wire spelling the handler re-resolved and scoped to the caller, to the resolved physical store path the handler now serves verbatim. The payload kept the same three keys and gained no generation marker.

Signed URLs live up to an hour, which outlasts a deploy, so both generations are in flight at every upgrade and `handle_fetch` cannot tell them apart. A v1 claim read under the v2 meaning is a store-root-relative **physical** path.

## Why that reaches other people's files

- `FilesystemStore._get_full_path` only guards escaping the store **root** — `users/`, `teams/`, `orgs/` and the `.logs` / `.deployments` system trees all live inside it.
- `sub` is no longer used for scoping; it is read once for an emptiness check.
- Issuance never constrained *which* path could be signed: the old `_full_path()` accepted any own-namespace spelling, and the filesystem backend's `get_url` returns `None` unconditionally, so every call reached the JWT branch with no existence check.

Bounded — filesystem backend only (S3/Azure return presigned URLs and never reach this endpoint), and the window closes an hour after a rollout. It opens at *every* upgrade that changes a claim's meaning, which is why the marker is the durable fix rather than a one-off.

## Change

```python
# get_url
payload = {'sub': ..., 'path': full_path, 'v': FETCH_CLAIM_VERSION, 'exp': ...}
```

```python
# handle_fetch — before anything is resolved or served
if payload.get('v') != FETCH_CLAIM_VERSION:
    return JSONResponse({'error': 'Token format no longer supported'}, status_code=401)
```

Refusing beats trying to resolve v1: the worst case is that URLs minted in the hour before an upgrade need one more click. `FETCH_CLAIM_VERSION` is shared rather than a literal in two files, so bumping it is one edit and the reason to bump lives next to it.

## Tests

`TestSignedFetchUrls` gains a generation assertion on a real minted claim, plus a parametrized case driving `handle_fetch` with a v1 (no marker) and a v99 claim, both asserting 401.

## Verification — please run CI

My checkout has no built dist (`depends`, `fastapi` and `ruff` are all absent), so **I could not run the pytest suite**. What I did instead:

- syntax-checked all three files;
- loaded the real `handle_fetch` by path with only fastapi stubbed and the genuine `FETCH_CLAIM_VERSION` imported, then drove it:

```
claim                                       expect   got  result
v1 - pre-#1686, wire path, no marker           401   401  PASS
v99 - newer generation                         401   401  PASS
v2 - current generation                        404   404  PASS  (past the gate, no such file)
```

The suite and `ruff` still need a real run — treat CI as the gate, not this.

## Docs

No co-located doc update: the SDK contract (`fs_get_url` / `fsGetUrl`) is unchanged in signature and behaviour. The claim shape is internal to the `get_url` ↔ `/task/fetch` pair, not a documented surface.

## Delivery note

The saas repo pins `rocketride-server` at `baea4ab5` — the #1686 merge — so this fix does not reach the deployed product until that submodule pointer is bumped after this merges. Flagging for sequencing; the pointer bump is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * Added version validation for signed file-fetch requests.
  * Requests with missing or unsupported security claim versions are rejected before file access.
  * Newly generated fetch links include the current claim version.

* **Bug Fixes**
  * Prevented incompatible or outdated fetch tokens from reaching file path resolution.

* **Tests**
  * Added coverage for valid claim versions and rejection of unsupported token formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->