### PR TITLE
docs: point a commit link at the current org, not the pre-rebrand one

### DIFF
--- a/tools/contract_checks/README.md
+++ b/tools/contract_checks/README.md
@@ -4,7 +4,7 @@ Catches breaking API changes in upstream Python packages **before** they ship to
 
 ## Why this exists
 
-In May 2026, `img2table 2.0` moved `OCRInstance` from `img2table.ocr.base` to `img2table.ocr._types`. Our OCR node started failing in production with `No module named 'img2table.ocr.base'`. The fix landed in [commit c4aa67921](https://github.com/aparavi/rocketride-server/commit/c4aa67921), but only **after** the breakage shipped, we found out from a customer.
+In May 2026, `img2table 2.0` moved `OCRInstance` from `img2table.ocr.base` to `img2table.ocr._types`. Our OCR node started failing in production with `No module named 'img2table.ocr.base'`. The fix landed in [commit c4aa67921](https://github.com/rocketride-org/rocketride-server/commit/c4aa67921), but only **after** the breakage shipped, we found out from a customer.
 
 This tool catches the next one in CI instead.
 


### PR DESCRIPTION
`tools/contract_checks/README.md` links the fix commit under the pre-rebrand org:

```
https://github.com/aparavi/rocketride-server/commit/c4aa67921   -> 404
https://github.com/rocketride-org/rocketride-server/commit/...  -> 200
```

Verified both just now. One-line change, and the only occurrence of an old-org URL repo-wide (`grep -rn "github.com/aparavi"` returns exactly this line).

Other `Aparavi` mentions in the tree are **not** rebrand residue and are deliberately untouched: `nodes/src/nodes/aparavi_aql/` documents the Aparavi data-governance platform, which is a real third-party system this node queries.

Worth noting the docs audit in #1718 cannot catch this class — it resolves paths inside the repo and never fetches an external URL. Dead external links are exactly what a rebrand leaves behind, so that gap is worth closing separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the production incident reference link to point to the correct repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->