### PR TITLE
feat(llm): per-user token accounting via the provider Adapter

### DIFF
--- a/apps/shared/src/components/trace/renderers/format_answer.test.tsx
+++ b/apps/shared/src/components/trace/renderers/format_answer.test.tsx
@@ -1,0 +1,50 @@
+// =============================================================================
+// Unit tests: the Tokens grid on the answer render.
+//
+// Pins the three behaviours of the tokens block: the per-call `breakdown` is
+// dropped from the chip grid (each call shows on its own invoke row instead), a
+// tokens object that holds only `breakdown` renders no Tokens section at all, and
+// the non-numeric `model` chip is stringified rather than thrown at React.
+//
+// Run via `shared:test` (node --import tsx --test), matching the package convention.
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { renderAnswerFields } from './format_answer';
+
+const render = (a: Parameters<typeof renderAnswerFields>[0]) => renderToStaticMarkup(renderAnswerFields(a)!);
+
+test('scalar totals render as chips; the model renders as a string', () => {
+	const html = render({
+		answer: 'hi',
+		tokens: { input: 1234, output: 56, model: 'claude-sonnet-4-6', calls: 3, breakdown: [{ input: 1, output: 2 }] },
+	});
+	assert.match(html, /Tokens/); // the section label
+	assert.match(html, /1,234/); // toLocaleString on a number
+	assert.match(html, /claude-sonnet-4-6/); // String(v) on the non-numeric model chip
+	assert.match(html, /calls/i); // the calls chip is present
+});
+
+test('the per-call breakdown is dropped from the chip grid', () => {
+	const html = render({
+		answer: 'hi',
+		tokens: { input: 10, output: 5, model: 'm', breakdown: [{ input: 10, output: 5, model: 'm' }] },
+	});
+	// The breakdown array is never rendered as a child, so no object leaks into the DOM,
+	// and there is no "breakdown" chip label.
+	assert.doesNotMatch(html, /\[object Object\]/);
+	assert.doesNotMatch(html, /breakdown/i);
+});
+
+test('a tokens object with only a breakdown renders no Tokens section', () => {
+	const html = render({ answer: 'hi', tokens: { breakdown: [{ input: 10, output: 5, model: 'm' }] } });
+	assert.doesNotMatch(html, /Tokens/);
+});
+
+test('no tokens object renders no Tokens section', () => {
+	const html = render({ answer: 'hi' });
+	assert.doesNotMatch(html, /Tokens/);
+});

--- a/apps/shared/src/components/trace/renderers/format_answer.tsx
+++ b/apps/shared/src/components/trace/renderers/format_answer.tsx
@@ -59,9 +59,9 @@ export function renderAnswerFields(a: AnswerFields | null | undefined): ReactEle
 	}
 	const isJson = parsedJson !== null;
 
-	// Split the per-call breakdown out of the scalar totals: the totals render as
-	// chips, the breakdown (an array, not a scalar) as one row per model call.
-	const tokenBreakdown = Array.isArray(a.tokens?.breakdown) ? a.tokens.breakdown : [];
+	// Only the scalar totals render here. Each model call carries its own usage on
+	// its own invoke row, so repeating the whole breakdown under the answer is noise
+	// (an 11-call agent run listed 11 blocks). `breakdown` is dropped, not rendered.
 	const tokenScalars = a.tokens ? Object.entries(a.tokens).filter(([k]) => k !== 'breakdown') : [];
 
 	return (
@@ -96,21 +96,6 @@ export function renderAnswerFields(a: AnswerFields | null | undefined): ReactEle
 								</div>
 							))}
 						</div>
-						{tokenBreakdown.length > 0 && (
-							<div style={{ marginTop: 6 }}>
-								<div style={{ fontSize: 8, color: 'var(--rr-text-secondary)', textTransform: 'uppercase', marginBottom: 2 }}>Per call ({tokenBreakdown.length})</div>
-								{tokenBreakdown.map((c, i) => (
-									<div key={i} style={{ display: 'flex', gap: 8, flexWrap: 'wrap', fontFamily: 'monospace', fontSize: 11, color: 'var(--rr-text-secondary)', padding: '1px 0' }}>
-										<span style={{ color: 'var(--rr-brand)' }}>#{i + 1}</span>
-										{Object.entries(c).map(([k, v]) => (
-											<span key={k}>
-												{k.replace(/_/g, ' ')}: {typeof v === 'number' ? v.toLocaleString() : String(v)}
-											</span>
-										))}
-									</div>
-								))}
-							</div>
-						)}
 					</div>
 				</div>
 			)}

--- a/apps/shared/src/components/trace/renderers/format_answer.tsx
+++ b/apps/shared/src/components/trace/renderers/format_answer.tsx
@@ -6,10 +6,30 @@ import { ReactElement } from 'react';
 import { RS } from './styles';
 import { JsonTree } from '../../json-tree';
 
+/** One model call's token cost; the turn total carries a breakdown of these. */
+export interface TokenCall {
+	input?: number;
+	output?: number;
+	cache_read?: number;
+	cache_creation?: number;
+	model?: string;
+}
+
+/** Per-turn token usage: scalar totals plus a per-call breakdown for many-call turns. */
+export interface TokenUsage {
+	input?: number;
+	output?: number;
+	cache_read?: number;
+	cache_creation?: number;
+	model?: string;
+	calls?: number;
+	breakdown?: TokenCall[];
+}
+
 export interface AnswerFields {
 	answer?: string | Record<string, unknown> | unknown[];
 	expectJson?: boolean;
-	tokens?: Record<string, number | string>;
+	tokens?: TokenUsage;
 }
 
 /** Short summary string for the collapsed row — first line of the answer. */
@@ -39,6 +59,11 @@ export function renderAnswerFields(a: AnswerFields | null | undefined): ReactEle
 	}
 	const isJson = parsedJson !== null;
 
+	// Split the per-call breakdown out of the scalar totals: the totals render as
+	// chips, the breakdown (an array, not a scalar) as one row per model call.
+	const tokenBreakdown = Array.isArray(a.tokens?.breakdown) ? a.tokens.breakdown : [];
+	const tokenScalars = a.tokens ? Object.entries(a.tokens).filter(([k]) => k !== 'breakdown') : [];
+
 	return (
 		<div>
 			{answer != null && (
@@ -59,18 +84,33 @@ export function renderAnswerFields(a: AnswerFields | null | undefined): ReactEle
 				</div>
 			)}
 
-			{a.tokens && Object.keys(a.tokens).length > 0 && (
+			{tokenScalars.length > 0 && (
 				<div style={RS.section}>
 					<div style={RS.label}>Tokens</div>
 					<div style={RS.sectionContent}>
 						<div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-							{Object.entries(a.tokens).map(([k, v]) => (
+							{tokenScalars.map(([k, v]) => (
 								<div key={k} style={{ backgroundColor: 'var(--rr-bg-paper)', border: '1px solid var(--rr-border)', borderRadius: 4, padding: '4px 10px', display: 'flex', flexDirection: 'column', alignItems: 'center', minWidth: 55 }}>
-									<span style={{ fontFamily: 'monospace', fontSize: 14, fontWeight: 700, color: 'var(--rr-brand)' }}>{typeof v === 'number' ? v.toLocaleString() : v}</span>
+									<span style={{ fontFamily: 'monospace', fontSize: 14, fontWeight: 700, color: 'var(--rr-brand)' }}>{typeof v === 'number' ? v.toLocaleString() : String(v)}</span>
 									<span style={{ fontSize: 8, color: 'var(--rr-text-secondary)', textTransform: 'uppercase' }}>{k.replace(/_/g, ' ')}</span>
 								</div>
 							))}
 						</div>
+						{tokenBreakdown.length > 0 && (
+							<div style={{ marginTop: 6 }}>
+								<div style={{ fontSize: 8, color: 'var(--rr-text-secondary)', textTransform: 'uppercase', marginBottom: 2 }}>Per call ({tokenBreakdown.length})</div>
+								{tokenBreakdown.map((c, i) => (
+									<div key={i} style={{ display: 'flex', gap: 8, flexWrap: 'wrap', fontFamily: 'monospace', fontSize: 11, color: 'var(--rr-text-secondary)', padding: '1px 0' }}>
+										<span style={{ color: 'var(--rr-brand)' }}>#{i + 1}</span>
+										{Object.entries(c).map(([k, v]) => (
+											<span key={k}>
+												{k.replace(/_/g, ' ')}: {typeof v === 'number' ? v.toLocaleString() : String(v)}
+											</span>
+										))}
+									</div>
+								))}
+							</div>
+						)}
 					</div>
 				</div>
 			)}

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import json
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextvars import copy_context
 from typing import Any, Dict, List
 
 import jmespath
@@ -482,7 +483,10 @@ def _execute_wave_calls(
 
     with ThreadPoolExecutor(max_workers=n) as pool:
         # Build a future→index mapping so we can place each result correctly.
-        future_to_idx = {pool.submit(_run_one, call): i for i, call in enumerate(tagged)}
+        # Run each task under a copy of the current context: a raw submit does not
+        # propagate context vars, so per-turn LLM usage (llm_adapter._TURN_CALLS) would
+        # not reach the open turn's collector and the agent's answer would under-count.
+        future_to_idx = {pool.submit(copy_context().run, _run_one, call): i for i, call in enumerate(tagged)}
         for future in as_completed(future_to_idx):
             idx = future_to_idx[future]
             try:

--- a/nodes/src/nodes/llm_gemini/gemini.py
+++ b/nodes/src/nodes/llm_gemini/gemini.py
@@ -24,7 +24,33 @@
 from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.llm_adapter import report_llm_tokens
 from google import genai
+
+
+def _report_gemini_usage(response: Any, model: str) -> None:
+    """Report a ``generate_content`` response's usage on the four token counters.
+
+    This node overrides ``_chat`` and sets no ``_llm``, so it never reaches
+    ``LangChainAdapter`` — without this the provider bills zero. Gemini counts
+    ``prompt_token_count`` with the cached prefix included, so the cache is subtracted
+    back out to keep the counters disjoint; ``thoughts_token_count`` is reasoning, which
+    Google bills at the output rate.
+    """
+    um = getattr(response, 'usage_metadata', None)
+    if um is None:
+        return
+
+    def _n(field: str) -> int:
+        return int(getattr(um, field, 0) or 0)
+
+    cache_read = _n('cached_content_token_count')
+    report_llm_tokens(
+        max(0, _n('prompt_token_count') - cache_read),
+        _n('candidates_token_count') + _n('thoughts_token_count'),
+        model=model,
+        cache_read_tokens=cache_read,
+    )
 
 
 class Chat(ChatBase):
@@ -147,6 +173,8 @@ class Chat(ChatBase):
         """
         # Generate content using the configured model
         response = self._client.models.generate_content(model=self._model, contents=prompt)
+
+        _report_gemini_usage(response, self._model)
 
         # Extract and return the text response
         return response.text

--- a/nodes/src/nodes/llm_gemini/gemini.py
+++ b/nodes/src/nodes/llm_gemini/gemini.py
@@ -24,7 +24,7 @@
 from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
-from ai.common.llm_adapter import report_llm_tokens
+from ai.common.llm_adapter import debug_usage_failure, report_llm_tokens
 from google import genai
 
 
@@ -44,13 +44,16 @@ def _report_gemini_usage(response: Any, model: str) -> None:
     def _n(field: str) -> int:
         return int(getattr(um, field, 0) or 0)
 
-    cache_read = _n('cached_content_token_count')
-    report_llm_tokens(
-        max(0, _n('prompt_token_count') - cache_read),
-        _n('candidates_token_count') + _n('thoughts_token_count'),
-        model=model,
-        cache_read_tokens=cache_read,
-    )
+    # Best-effort: this runs on a response the user already paid for, and the caller is
+    # a retry loop that would read a raise as a provider error and lose the answer.
+    try:
+        cache_read = _n('cached_content_token_count')
+        fresh_input = max(0, _n('prompt_token_count') - cache_read)
+        output = _n('candidates_token_count') + _n('thoughts_token_count')
+    except Exception as exc:
+        debug_usage_failure(exc)
+        return
+    report_llm_tokens(fresh_input, output, model=model, cache_read_tokens=cache_read)
 
 
 class Chat(ChatBase):

--- a/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
+++ b/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
@@ -25,7 +25,7 @@ import re
 from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
-from ai.common.llm_adapter import report_llm_tokens
+from ai.common.llm_adapter import debug_usage_failure, report_llm_tokens
 from ibm_watsonx_ai import Credentials
 from ibm_watsonx_ai.foundation_models import ModelInference
 from ibm_watsonx_ai.foundation_models.schema import TextChatParameters
@@ -85,11 +85,15 @@ def _report_watson_usage(response: Any, model: str) -> None:
     usage = response.get('usage') if hasattr(response, 'get') else None
     if not isinstance(usage, dict):
         return
-    report_llm_tokens(
-        int(usage.get('prompt_tokens') or 0),
-        int(usage.get('completion_tokens') or 0),
-        model=model,
-    )
+    # Best-effort: this runs on a response the user already paid for, and the caller is
+    # a retry loop that would read a raise as a provider error and lose the answer.
+    try:
+        prompt_tokens = int(usage.get('prompt_tokens') or 0)
+        completion_tokens = int(usage.get('completion_tokens') or 0)
+    except Exception as exc:
+        debug_usage_failure(exc)
+        return
+    report_llm_tokens(prompt_tokens, completion_tokens, model=model)
 
 
 class Chat(ChatBase):

--- a/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
+++ b/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
@@ -25,6 +25,7 @@ import re
 from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.llm_adapter import report_llm_tokens
 from ibm_watsonx_ai import Credentials
 from ibm_watsonx_ai.foundation_models import ModelInference
 from ibm_watsonx_ai.foundation_models.schema import TextChatParameters
@@ -72,6 +73,23 @@ def _validate_location(location):
             f'Unknown IBM Cloud location: {location!r}. Valid locations: {", ".join(sorted(_VALID_LOCATIONS))}'
         )
     return f'https://{location}.ml.cloud.ibm.com'
+
+
+def _report_watson_usage(response: Any, model: str) -> None:
+    """Report a ``ModelInference.chat`` response's usage on the token counters.
+
+    This node overrides ``_chat``, so it never reaches ``LangChainAdapter`` — without
+    this the provider bills zero. watsonx answers the OpenAI-compatible shape; it
+    reports no cache detail, so both cache counters stay at zero.
+    """
+    usage = response.get('usage') if hasattr(response, 'get') else None
+    if not isinstance(usage, dict):
+        return
+    report_llm_tokens(
+        int(usage.get('prompt_tokens') or 0),
+        int(usage.get('completion_tokens') or 0),
+        model=model,
+    )
 
 
 class Chat(ChatBase):
@@ -143,6 +161,9 @@ class Chat(ChatBase):
         messages = [{'role': 'user', 'content': prompt}]
 
         response = self._llm.chat(messages=messages)
+
+        # Before the empty-answer check below: an empty completion still burnt the prompt.
+        _report_watson_usage(response, self._model)
 
         # Gets the text from response
         message = response['choices'][0]['message']['content']

--- a/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
+++ b/nodes/src/nodes/llm_ibm_watson/ibm_watson.py
@@ -25,7 +25,7 @@ import re
 from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
-from ai.common.llm_adapter import debug_usage_failure, report_llm_tokens
+from ai.common.llm_adapter import report_llm_tokens
 from ibm_watsonx_ai import Credentials
 from ibm_watsonx_ai.foundation_models import ModelInference
 from ibm_watsonx_ai.foundation_models.schema import TextChatParameters
@@ -85,15 +85,9 @@ def _report_watson_usage(response: Any, model: str) -> None:
     usage = response.get('usage') if hasattr(response, 'get') else None
     if not isinstance(usage, dict):
         return
-    # Best-effort: this runs on a response the user already paid for, and the caller is
-    # a retry loop that would read a raise as a provider error and lose the answer.
-    try:
-        prompt_tokens = int(usage.get('prompt_tokens') or 0)
-        completion_tokens = int(usage.get('completion_tokens') or 0)
-    except Exception as exc:
-        debug_usage_failure(exc)
-        return
-    report_llm_tokens(prompt_tokens, completion_tokens, model=model)
+    # Passed through raw: report_llm_tokens coerces inside its own best-effort try, so a
+    # non-numeric count is swallowed there rather than costing this turn its answer.
+    report_llm_tokens(usage.get('prompt_tokens'), usage.get('completion_tokens'), model=model)
 
 
 class Chat(ChatBase):

--- a/nodes/src/nodes/llm_minimax/minimax.py
+++ b/nodes/src/nodes/llm_minimax/minimax.py
@@ -29,6 +29,7 @@ import re
 from typing import Any, Dict
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.llm_adapter import report_usage_metadata
 from langchain_openai import ChatOpenAI
 
 # MiniMax M2-series models return chain-of-thought wrapped in <think>...</think>
@@ -84,4 +85,7 @@ class Chat(ChatBase):
     def _chat(self, prompt: str) -> str:
         """Invoke the LLM and strip any <think>...</think> reasoning block from the response."""
         results = self._llm.invoke(prompt)
+        # This override bypasses LangChainAdapter.collect(), the capture point that
+        # meters every other non-streaming call, so report from here or the call bills zero.
+        report_usage_metadata(getattr(results, 'usage_metadata', None), self._llm)
         return _THINK_BLOCK_RE.sub('', results.content)

--- a/nodes/src/nodes/llm_mistral/mistral.py
+++ b/nodes/src/nodes/llm_mistral/mistral.py
@@ -41,7 +41,7 @@ from typing import Any, Dict, Tuple
 from ai.common.schema import Answer, Question
 from ai.common.chat import ChatBase
 from ai.common.config import Config
-from ai.common.llm_adapter import debug_usage_failure, report_llm_tokens
+from ai.common.llm_adapter import report_llm_tokens
 from ai.common.validation import validate_prompt
 
 try:
@@ -60,15 +60,9 @@ def _report_mistral_usage(response: Any, model: str) -> None:
     usage = getattr(response, 'usage', None)
     if usage is None:
         return
-    # Best-effort: this runs on a response the user already paid for, and the caller is
-    # a retry loop that would read a raise as a provider error and lose the answer.
-    try:
-        prompt_tokens = int(getattr(usage, 'prompt_tokens', 0) or 0)
-        completion_tokens = int(getattr(usage, 'completion_tokens', 0) or 0)
-    except Exception as exc:
-        debug_usage_failure(exc)
-        return
-    report_llm_tokens(prompt_tokens, completion_tokens, model=model)
+    # Passed through raw: report_llm_tokens coerces inside its own best-effort try, so a
+    # non-numeric count is swallowed there rather than costing this turn its answer.
+    report_llm_tokens(getattr(usage, 'prompt_tokens', None), getattr(usage, 'completion_tokens', None), model=model)
 
 
 class Chat(ChatBase):

--- a/nodes/src/nodes/llm_mistral/mistral.py
+++ b/nodes/src/nodes/llm_mistral/mistral.py
@@ -41,7 +41,7 @@ from typing import Any, Dict, Tuple
 from ai.common.schema import Answer, Question
 from ai.common.chat import ChatBase
 from ai.common.config import Config
-from ai.common.llm_adapter import report_llm_tokens
+from ai.common.llm_adapter import debug_usage_failure, report_llm_tokens
 from ai.common.validation import validate_prompt
 
 try:
@@ -60,11 +60,15 @@ def _report_mistral_usage(response: Any, model: str) -> None:
     usage = getattr(response, 'usage', None)
     if usage is None:
         return
-    report_llm_tokens(
-        int(getattr(usage, 'prompt_tokens', 0) or 0),
-        int(getattr(usage, 'completion_tokens', 0) or 0),
-        model=model,
-    )
+    # Best-effort: this runs on a response the user already paid for, and the caller is
+    # a retry loop that would read a raise as a provider error and lose the answer.
+    try:
+        prompt_tokens = int(getattr(usage, 'prompt_tokens', 0) or 0)
+        completion_tokens = int(getattr(usage, 'completion_tokens', 0) or 0)
+    except Exception as exc:
+        debug_usage_failure(exc)
+        return
+    report_llm_tokens(prompt_tokens, completion_tokens, model=model)
 
 
 class Chat(ChatBase):

--- a/nodes/src/nodes/llm_mistral/mistral.py
+++ b/nodes/src/nodes/llm_mistral/mistral.py
@@ -41,12 +41,30 @@ from typing import Any, Dict, Tuple
 from ai.common.schema import Answer, Question
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.llm_adapter import report_llm_tokens
 from ai.common.validation import validate_prompt
 
 try:
     from mistralai.client import Mistral  # 2.x layout
 except ImportError:
     from mistralai import Mistral  # 1.x layout
+
+
+def _report_mistral_usage(response: Any, model: str) -> None:
+    """Report a ``chat.complete`` response's usage on the token counters.
+
+    This node overrides ``chat()`` and calls the Mistral SDK directly, so it never
+    reaches ``LangChainAdapter`` — without this the provider bills zero. ``UsageInfo``
+    carries no cache detail, so both cache counters stay at zero.
+    """
+    usage = getattr(response, 'usage', None)
+    if usage is None:
+        return
+    report_llm_tokens(
+        int(getattr(usage, 'prompt_tokens', 0) or 0),
+        int(getattr(usage, 'completion_tokens', 0) or 0),
+        model=model,
+    )
 
 
 class Chat(ChatBase):
@@ -276,6 +294,8 @@ class Chat(ChatBase):
                     max_tokens=None,  # Let model decide based on content
                     random_seed=None,  # No fixed seed for variety
                 )
+
+                _report_mistral_usage(chat_response, self._model)
 
                 # Create and return the answer
                 answer = Answer(expectJson=question.expectJson)

--- a/nodes/src/nodes/llm_perplexity/perplexity.py
+++ b/nodes/src/nodes/llm_perplexity/perplexity.py
@@ -40,6 +40,7 @@ from typing import Any, Dict
 from ai.common.schema import Answer, Question
 from ai.common.chat import ChatBase
 from ai.common.config import Config
+from ai.common.llm_adapter import report_usage_metadata
 from ai.common.validation import validate_prompt
 from langchain_openai import ChatOpenAI
 
@@ -209,6 +210,10 @@ class Chat(ChatBase):
             try:
                 # Ask the model
                 results = self._llm.invoke(prompt)
+
+                # This override bypasses LangChainAdapter.collect(), the capture point that
+                # meters every other provider, so report from here or the call bills zero.
+                report_usage_metadata(getattr(results, 'usage_metadata', None), self._llm)
 
                 # Create and return the answer
                 answer = Answer(expectJson=question.expectJson)

--- a/nodes/test/llm_gemini/test_gemini_token_metrics.py
+++ b/nodes/test/llm_gemini/test_gemini_token_metrics.py
@@ -1,0 +1,154 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Token metering for the Gemini driver.
+
+``llm_gemini`` overrides ``ChatBase._chat`` and sets ``_client`` instead of ``_llm``,
+so the streaming gate in ``chat.py`` is never true and no call — streaming or not —
+reaches ``LangChainAdapter``, the capture point that meters every other provider.
+The usage read therefore lives in the override, and these tests pin it.
+
+The node is built with ``__new__`` so the tests never touch the engine ``Config`` /
+``genai.Client`` plumbing: only the ``_chat`` seam is under test.
+
+Run with::
+
+    pytest nodes/test/llm_gemini/test_gemini_token_metrics.py -v
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from typing import Any, Optional
+
+import pytest
+
+from ai.web.metrics.metrics import metrics
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MOD_PATH = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'llm_gemini', 'gemini.py')
+
+_MODEL = 'gemini-3-pro'
+
+
+def _load_node_module():
+    """Load gemini.py standalone, stubbing the google-genai client."""
+    saved = sys.modules.get('google.genai')
+    saved_pkg = sys.modules.get('google')
+    stub = types.ModuleType('google.genai')
+    stub.Client = type('Client', (), {'__init__': lambda self, **kw: None})
+    pkg = types.ModuleType('google')
+    pkg.genai = stub
+    sys.modules['google'] = pkg
+    sys.modules['google.genai'] = stub
+    try:
+        spec = importlib.util.spec_from_file_location('_llm_gemini_node', _MOD_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name, saved_mod in (('google', saved_pkg), ('google.genai', saved)):
+            if saved_mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved_mod
+
+
+_node = _load_node_module()
+
+
+def setup_function(_):
+    metrics.reset()
+
+
+def _counters():
+    return metrics.report()['counters']
+
+
+class _Usage:
+    """The fields ``GenerateContentResponseUsageMetadata`` carries, all optional."""
+
+    def __init__(
+        self,
+        prompt: Optional[int] = None,
+        candidates: Optional[int] = None,
+        cached: Optional[int] = None,
+        thoughts: Optional[int] = None,
+    ) -> None:
+        self.prompt_token_count = prompt
+        self.candidates_token_count = candidates
+        self.cached_content_token_count = cached
+        self.thoughts_token_count = thoughts
+
+
+class _Response:
+    def __init__(self, usage: Any = None, text: str = 'hi') -> None:
+        self.usage_metadata = usage
+        self.text = text
+
+
+def _make_chat(response: _Response):
+    """A Chat whose client returns the given response, with no __init__ plumbing."""
+
+    class _Models:
+        def generate_content(self, model: str, contents: str) -> _Response:
+            return response
+
+    chat = _node.Chat.__new__(_node.Chat)
+    chat._client = type('_Client', (), {'models': _Models()})()
+    chat._model = _MODEL
+    return chat
+
+
+def test_chat_reports_the_four_counters():
+    chat = _make_chat(_Response(_Usage(prompt=1000, candidates=40, cached=800)))
+
+    assert chat._chat('q') == 'hi'
+
+    c = _counters()
+    # prompt_token_count includes the cached prefix, so fresh input is 1000 - 800.
+    assert c['llm_input_tokens'] == 200
+    assert c['llm_output_tokens'] == 40
+    assert c['llm_cache_read_tokens'] == 800
+    # Gemini bills cache creation through a separate caches.create call, not this response.
+    assert 'llm_cache_creation_tokens' not in c
+
+
+def test_thoughts_are_billed_as_output():
+    """Reasoning tokens ride the output counter — Google bills them at the output rate."""
+    chat = _make_chat(_Response(_Usage(prompt=30, candidates=12, thoughts=500)))
+
+    chat._chat('q')
+
+    assert _counters()['llm_output_tokens'] == 512
+    assert _counters()['llm_input_tokens'] == 30
+
+
+def test_no_usage_on_the_response_is_a_no_op():
+    chat = _make_chat(_Response(usage=None))
+
+    assert chat._chat('q') == 'hi'
+    assert _counters() == {}
+
+
+@pytest.mark.parametrize('field', ['prompt_token_count', 'candidates_token_count'])
+def test_a_missing_count_does_not_break_the_turn(field):
+    """Every field on the SDK type is Optional; a None must read as zero, not raise."""
+    usage = _Usage(prompt=50, candidates=10)
+    setattr(usage, field, None)
+    chat = _make_chat(_Response(usage))
+
+    assert chat._chat('q') == 'hi'
+
+
+def test_a_cache_larger_than_the_prompt_never_reports_negative_input():
+    chat = _make_chat(_Response(_Usage(prompt=100, candidates=5, cached=140)))
+
+    chat._chat('q')
+
+    # Clamped at zero: a negative count would corrupt the billing rollup.
+    assert 'llm_input_tokens' not in _counters()
+    assert _counters()['llm_cache_read_tokens'] == 140

--- a/nodes/test/llm_gemini/test_gemini_token_metrics.py
+++ b/nodes/test/llm_gemini/test_gemini_token_metrics.py
@@ -152,3 +152,13 @@ def test_a_cache_larger_than_the_prompt_never_reports_negative_input():
     # Clamped at zero: a negative count would corrupt the billing rollup.
     assert 'llm_input_tokens' not in _counters()
     assert _counters()['llm_cache_read_tokens'] == 140
+
+
+def test_a_corrupt_usage_count_never_costs_the_answer():
+    """Metering is best-effort: the caller is a retry loop that would read a raise
+    as a provider error, losing a response the user already paid for.
+    """
+    chat = _make_chat(_Response(_Usage(prompt='n/a', candidates=5)))
+
+    assert chat._chat('q') == 'hi'
+    assert _counters() == {}

--- a/nodes/test/llm_ibm_watson/test_ibm_watson_token_metrics.py
+++ b/nodes/test/llm_ibm_watson/test_ibm_watson_token_metrics.py
@@ -1,0 +1,129 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Token metering for the IBM Watson driver.
+
+``llm_ibm_watson`` overrides ``ChatBase._chat`` to call ``ModelInference.chat``
+directly, so it never reaches ``LangChainAdapter`` — the capture point that meters
+every other provider. The usage read lives in the override, and these tests pin it.
+
+The node is built with ``__new__`` so the tests never touch the engine ``Config`` /
+IBM SDK plumbing: only the ``_chat`` seam is under test.
+
+Run with::
+
+    pytest nodes/test/llm_ibm_watson/test_ibm_watson_token_metrics.py -v
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from typing import Any, Dict, Optional
+
+import pytest
+
+from ai.web.metrics.metrics import metrics
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MOD_PATH = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'llm_ibm_watson', 'ibm_watson.py')
+
+_MODEL = 'ibm/granite-13b-chat-v2'
+
+
+def _load_node_module():
+    """Load ibm_watson.py standalone, stubbing the IBM SDK."""
+    stub_names = [
+        'ibm_watsonx_ai',
+        'ibm_watsonx_ai.foundation_models',
+        'ibm_watsonx_ai.foundation_models.schema',
+    ]
+    saved = {name: sys.modules.get(name) for name in stub_names}
+    for name in stub_names:
+        stub = types.ModuleType(name)
+        if name == 'ibm_watsonx_ai':
+            stub.Credentials = type('Credentials', (), {})
+        if name == 'ibm_watsonx_ai.foundation_models':
+            stub.ModelInference = type('ModelInference', (), {})
+        if name == 'ibm_watsonx_ai.foundation_models.schema':
+            stub.TextChatParameters = type('TextChatParameters', (), {})
+        sys.modules[name] = stub
+    try:
+        spec = importlib.util.spec_from_file_location('_llm_ibm_watson_node', _MOD_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name in stub_names:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+
+_node = _load_node_module()
+
+
+def setup_function(_):
+    metrics.reset()
+
+
+def _counters():
+    return metrics.report()['counters']
+
+
+def _response(usage: Optional[Dict[str, Any]], content: str = 'hi') -> Dict[str, Any]:
+    """The OpenAI-compatible shape watsonx answers with."""
+    out: Dict[str, Any] = {'choices': [{'message': {'content': content}}]}
+    if usage is not None:
+        out['usage'] = usage
+    return out
+
+
+def _make_chat(response: Dict[str, Any]):
+    """A Chat whose ModelInference returns the given response, with no __init__ plumbing."""
+
+    class _Inference:
+        def chat(self, messages):
+            return response
+
+    chat = _node.Chat.__new__(_node.Chat)
+    chat._llm = _Inference()
+    chat._model = _MODEL
+    return chat
+
+
+def test_chat_reports_input_and_output():
+    chat = _make_chat(_response({'prompt_tokens': 120, 'completion_tokens': 45, 'total_tokens': 165}))
+
+    assert chat._chat('q') == 'hi'
+
+    c = _counters()
+    assert c['llm_input_tokens'] == 120
+    assert c['llm_output_tokens'] == 45
+    # watsonx reports no cache detail, so those counters stay absent rather than zeroed.
+    assert 'llm_cache_read_tokens' not in c
+    assert 'llm_cache_creation_tokens' not in c
+
+
+def test_an_empty_answer_is_still_metered():
+    """The prompt was burnt even though the completion came back empty.
+
+    The report has to run before the empty-answer guard, or the one turn a user
+    complains about is also the one turn that bills nothing.
+    """
+    chat = _make_chat(_response({'prompt_tokens': 300, 'completion_tokens': 0}, content=''))
+
+    with pytest.raises(ValueError, match='Response is empty'):
+        chat._chat('q')
+
+    assert _counters()['llm_input_tokens'] == 300
+
+
+def test_no_usage_key_is_a_no_op():
+    chat = _make_chat(_response(usage=None))
+
+    assert chat._chat('q') == 'hi'
+    assert _counters() == {}

--- a/nodes/test/llm_ibm_watson/test_ibm_watson_token_metrics.py
+++ b/nodes/test/llm_ibm_watson/test_ibm_watson_token_metrics.py
@@ -127,3 +127,13 @@ def test_no_usage_key_is_a_no_op():
 
     assert chat._chat('q') == 'hi'
     assert _counters() == {}
+
+
+def test_a_corrupt_usage_count_never_costs_the_answer():
+    """Metering is best-effort: the caller is a retry loop that would read a raise
+    as a provider error, losing a response the user already paid for.
+    """
+    chat = _make_chat(_response({'prompt_tokens': 'n/a', 'completion_tokens': 5}))
+
+    assert chat._chat('q') == 'hi'
+    assert _counters() == {}

--- a/nodes/test/llm_minimax/test_minimax_token_metrics.py
+++ b/nodes/test/llm_minimax/test_minimax_token_metrics.py
@@ -1,0 +1,117 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Token metering for the MiniMax driver.
+
+``llm_minimax`` overrides ``ChatBase._chat`` to strip ``<think>`` blocks, and that
+override bypasses ``LangChainAdapter.collect()`` — the capture point that meters every
+other non-streaming call. Streaming stayed metered (its ``_llm`` is a ``ChatOpenAI``),
+but every ``expectJson`` and every agent ``ask`` without an ``on_chunk`` billed zero.
+The override now reports for itself, and these tests pin that plus the stripping it
+already did.
+
+Run with::
+
+    pytest nodes/test/llm_minimax/test_minimax_token_metrics.py -v
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from typing import Any, Optional
+
+from ai.web.metrics.metrics import metrics
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MOD_PATH = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'llm_minimax', 'minimax.py')
+
+_MODEL = 'MiniMax-M2'
+
+
+def _load_node_module():
+    """Load minimax.py standalone, stubbing the langchain_openai client."""
+    saved = sys.modules.get('langchain_openai')
+    stub = types.ModuleType('langchain_openai')
+    stub.ChatOpenAI = type('ChatOpenAI', (), {'__init__': lambda self, **kw: None})
+    sys.modules['langchain_openai'] = stub
+    try:
+        spec = importlib.util.spec_from_file_location('_llm_minimax_node', _MOD_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if saved is None:
+            sys.modules.pop('langchain_openai', None)
+        else:
+            sys.modules['langchain_openai'] = saved
+
+
+_node = _load_node_module()
+
+
+def setup_function(_):
+    metrics.reset()
+
+
+def _counters():
+    return metrics.report()['counters']
+
+
+class _Result:
+    def __init__(self, content: str, usage: Optional[dict]) -> None:
+        self.content = content
+        self.usage_metadata = usage
+
+
+def _make_chat(content: str, usage: Optional[dict]) -> Any:
+    """A Chat whose ChatOpenAI returns the given message, with no __init__ plumbing."""
+
+    class _LLM:
+        model = _MODEL
+
+        def invoke(self, prompt):
+            return _Result(content, usage)
+
+    chat = _node.Chat.__new__(_node.Chat)
+    chat._llm = _LLM()
+    return chat
+
+
+def test_chat_reports_the_usage_the_adapter_would_have():
+    chat = _make_chat('answer', {'input_tokens': 90, 'output_tokens': 25})
+
+    assert chat._chat('q') == 'answer'
+
+    c = _counters()
+    assert c['llm_input_tokens'] == 90
+    assert c['llm_output_tokens'] == 25
+
+
+def test_cached_input_is_split_off_the_fresh_input():
+    """Same split the shared helper applies everywhere: the four counters stay disjoint."""
+    usage = {'input_tokens': 1000, 'output_tokens': 10, 'input_token_details': {'cache_read': 700}}
+    chat = _make_chat('answer', usage)
+
+    chat._chat('q')
+
+    c = _counters()
+    assert c['llm_input_tokens'] == 300
+    assert c['llm_cache_read_tokens'] == 700
+
+
+def test_a_think_block_is_still_stripped_and_the_call_still_meters():
+    """Metering must not disturb what the override exists to do."""
+    chat = _make_chat('<think>weighing it up</think>the answer', {'input_tokens': 5, 'output_tokens': 2})
+
+    assert chat._chat('q') == 'the answer'
+    assert _counters()['llm_input_tokens'] == 5
+
+
+def test_no_usage_metadata_is_a_no_op():
+    chat = _make_chat('answer', None)
+
+    assert chat._chat('q') == 'answer'
+    assert _counters() == {}

--- a/nodes/test/llm_minimax/test_minimax_token_metrics.py
+++ b/nodes/test/llm_minimax/test_minimax_token_metrics.py
@@ -115,3 +115,11 @@ def test_no_usage_metadata_is_a_no_op():
 
     assert chat._chat('q') == 'answer'
     assert _counters() == {}
+
+
+def test_a_corrupt_usage_count_never_costs_the_answer():
+    """Metering is best-effort: a raise here would lose a response already paid for."""
+    chat = _make_chat('answer', {'input_tokens': 'n/a', 'output_tokens': 5})
+
+    assert chat._chat('q') == 'answer'
+    assert _counters() == {}

--- a/nodes/test/llm_mistral/test_mistral_token_metrics.py
+++ b/nodes/test/llm_mistral/test_mistral_token_metrics.py
@@ -81,7 +81,8 @@ class _Usage:
     def __init__(self, prompt: Optional[int] = 0, completion: Optional[int] = 0) -> None:
         self.prompt_tokens = prompt
         self.completion_tokens = completion
-        self.total_tokens = (prompt or 0) + (completion or 0)
+        # The node never reads this; kept only so the double matches the SDK's shape.
+        self.total_tokens = None
 
 
 class _Response:
@@ -165,4 +166,14 @@ def test_a_turn_that_never_answers_meters_nothing():
     with pytest.raises(Exception):
         chat.chat(_FakeQuestion())
 
+    assert _counters() == {}
+
+
+def test_a_corrupt_usage_count_never_costs_the_answer():
+    """The retry loop reads any raise as a provider error: a metering failure would
+    turn a paid, successful response into 'Mistral API error' for the user.
+    """
+    chat = _make_chat(_Response(_Usage(prompt='n/a', completion=5)))
+
+    assert chat.chat(_FakeQuestion()).getText() == 'answer'
     assert _counters() == {}

--- a/nodes/test/llm_mistral/test_mistral_token_metrics.py
+++ b/nodes/test/llm_mistral/test_mistral_token_metrics.py
@@ -1,0 +1,168 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Token metering for the Mistral driver.
+
+``llm_mistral`` overrides ``ChatBase.chat`` — the seam above ``_chat`` — and calls the
+Mistral SDK directly, so it reaches neither ``chat_string`` nor ``LangChainAdapter``,
+the capture point that meters every other provider. The usage read lives in the
+override, and these tests pin it.
+
+The node is built with ``__new__`` so the tests never touch the engine ``Config`` /
+Mistral SDK plumbing: only the ``chat`` seam is under test.
+
+Run with::
+
+    pytest nodes/test/llm_mistral/test_mistral_token_metrics.py -v
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from typing import Any, Optional
+
+import pytest
+
+from ai.web.metrics.metrics import metrics
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MOD_PATH = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'llm_mistral', 'mistral.py')
+
+_MODEL = 'mistral-large-latest'
+
+
+def _load_node_module():
+    """Load mistral.py standalone, stubbing the Mistral SDK (both import layouts)."""
+    names = ['mistralai', 'mistralai.client']
+    saved = {name: sys.modules.get(name) for name in names}
+    client_mod = types.ModuleType('mistralai.client')
+    client_mod.Mistral = type('Mistral', (), {'__init__': lambda self, **kw: None})
+    pkg = types.ModuleType('mistralai')
+    pkg.Mistral = client_mod.Mistral
+    pkg.client = client_mod
+    sys.modules['mistralai'] = pkg
+    sys.modules['mistralai.client'] = client_mod
+    try:
+        spec = importlib.util.spec_from_file_location('_llm_mistral_node', _MOD_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name in names:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+
+_node = _load_node_module()
+
+
+def setup_function(_):
+    metrics.reset()
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    """The retry path sleeps seconds between attempts; the metering is what is under test."""
+    monkeypatch.setattr(_node.time, 'sleep', lambda _s: None)
+
+
+def _counters():
+    return metrics.report()['counters']
+
+
+class _Usage:
+    """``UsageInfo`` — every field is Optional in the SDK."""
+
+    def __init__(self, prompt: Optional[int] = 0, completion: Optional[int] = 0) -> None:
+        self.prompt_tokens = prompt
+        self.completion_tokens = completion
+        self.total_tokens = (prompt or 0) + (completion or 0)
+
+
+class _Response:
+    def __init__(self, usage: Any, content: str = 'answer') -> None:
+        self.usage = usage
+        self.choices = [type('_C', (), {'message': type('_M', (), {'content': content})()})()]
+
+
+class _FakeQuestion:
+    expectJson = False
+
+    def getPrompt(self) -> str:
+        return 'q'
+
+
+def _make_chat(response: _Response, *, fail_times: int = 0) -> Any:
+    """A Chat whose SDK answers after ``fail_times`` transient failures."""
+
+    class _Completions:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def complete(self, **kwargs):
+            self.calls += 1
+            if self.calls <= fail_times:
+                # _shouldRetry matches on the message, not the type.
+                raise RuntimeError('connection timed out')
+            return response
+
+    completions = _Completions()
+    chat = _node.Chat.__new__(_node.Chat)
+    chat._client = type('_Client', (), {'chat': completions})()
+    chat._model = _MODEL
+    chat._modelTotalTokens = 100000
+    chat._completions = completions
+    return chat
+
+
+def test_chat_reports_input_and_output():
+    chat = _make_chat(_Response(_Usage(prompt=310, completion=90)))
+
+    answer = chat.chat(_FakeQuestion())
+
+    assert answer.getText() == 'answer'
+    c = _counters()
+    assert c['llm_input_tokens'] == 310
+    assert c['llm_output_tokens'] == 90
+    # The SDK's UsageInfo carries no cache detail, so those counters stay absent.
+    assert 'llm_cache_read_tokens' not in c
+    assert 'llm_cache_creation_tokens' not in c
+
+
+def test_only_the_attempt_that_answered_is_metered():
+    """A retried turn must not bill the attempts that raised before returning usage."""
+    chat = _make_chat(_Response(_Usage(prompt=12, completion=3)), fail_times=1)
+
+    chat.chat(_FakeQuestion())
+
+    assert chat._completions.calls == 2
+    assert _counters()['llm_input_tokens'] == 12
+
+
+def test_no_usage_on_the_response_is_a_no_op():
+    chat = _make_chat(_Response(usage=None))
+
+    assert chat.chat(_FakeQuestion()).getText() == 'answer'
+    assert _counters() == {}
+
+
+def test_none_counts_read_as_zero():
+    """Both fields are Optional in the SDK; a None must not raise mid-turn."""
+    chat = _make_chat(_Response(_Usage(prompt=None, completion=None)))
+
+    assert chat.chat(_FakeQuestion()).getText() == 'answer'
+    assert _counters() == {}
+
+
+def test_a_turn_that_never_answers_meters_nothing():
+    chat = _make_chat(_Response(_Usage(prompt=12, completion=3)), fail_times=99)
+
+    with pytest.raises(Exception):
+        chat.chat(_FakeQuestion())
+
+    assert _counters() == {}

--- a/nodes/test/llm_perplexity/test_perplexity_token_metrics.py
+++ b/nodes/test/llm_perplexity/test_perplexity_token_metrics.py
@@ -152,3 +152,13 @@ def test_a_turn_that_never_answers_meters_nothing():
         chat.chat(_FakeQuestion())
 
     assert _counters() == {}
+
+
+def test_a_corrupt_usage_count_never_costs_the_answer():
+    """The retry loop reads any raise as a provider error: a metering failure would
+    turn a paid, successful response into 'Perplexity API error' for the user.
+    """
+    chat = _make_chat({'input_tokens': 'n/a', 'output_tokens': 5})
+
+    assert chat.chat(_FakeQuestion()).getText() == 'answer'
+    assert _counters() == {}

--- a/nodes/test/llm_perplexity/test_perplexity_token_metrics.py
+++ b/nodes/test/llm_perplexity/test_perplexity_token_metrics.py
@@ -1,0 +1,154 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Token metering for the Perplexity driver.
+
+``llm_perplexity`` overrides ``ChatBase.chat`` — the seam above ``_chat`` — and calls
+``self._llm.invoke`` directly, so it reaches neither ``chat_string`` nor
+``LangChainAdapter``, the capture point that meters every other provider. The usage
+read lives in the override, and these tests pin it.
+
+The node is built with ``__new__`` so the tests never touch the engine ``Config`` /
+``ChatOpenAI`` plumbing: only the ``chat`` seam is under test.
+
+Run with::
+
+    pytest nodes/test/llm_perplexity/test_perplexity_token_metrics.py -v
+"""
+
+import importlib.util
+import os
+import sys
+import types
+from typing import Any, Optional
+
+import pytest
+
+from ai.web.metrics.metrics import metrics
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_MOD_PATH = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'llm_perplexity', 'perplexity.py')
+
+_MODEL = 'sonar-pro'
+
+
+def _load_node_module():
+    """Load perplexity.py standalone, stubbing the langchain_openai client."""
+    saved = sys.modules.get('langchain_openai')
+    stub = types.ModuleType('langchain_openai')
+    stub.ChatOpenAI = type('ChatOpenAI', (), {'__init__': lambda self, **kw: None})
+    sys.modules['langchain_openai'] = stub
+    try:
+        spec = importlib.util.spec_from_file_location('_llm_perplexity_node', _MOD_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if saved is None:
+            sys.modules.pop('langchain_openai', None)
+        else:
+            sys.modules['langchain_openai'] = saved
+
+
+_node = _load_node_module()
+
+
+def setup_function(_):
+    metrics.reset()
+
+
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep(monkeypatch):
+    """The retry path sleeps seconds between attempts; the metering is what is under test."""
+    monkeypatch.setattr(_node.time, 'sleep', lambda _s: None)
+
+
+def _counters():
+    return metrics.report()['counters']
+
+
+class _Result:
+    def __init__(self, content: str, usage: Optional[dict]) -> None:
+        self.content = content
+        self.usage_metadata = usage
+
+
+class _FakeQuestion:
+    expectJson = False
+
+    def getPrompt(self) -> str:
+        return 'q'
+
+
+def _make_chat(usage: Optional[dict], *, fail_times: int = 0) -> Any:
+    """A Chat whose ChatOpenAI answers after ``fail_times`` transient failures."""
+
+    class _LLM:
+        model = _MODEL
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def invoke(self, prompt):
+            self.calls += 1
+            if self.calls <= fail_times:
+                # _shouldRetry matches on the message, not the type.
+                raise TimeoutError('connection timed out')
+            return _Result('answer', usage)
+
+    chat = _node.Chat.__new__(_node.Chat)
+    chat._llm = _LLM()
+    chat._model = _MODEL
+    chat._modelTotalTokens = 100000
+    return chat
+
+
+def test_chat_reports_the_usage_the_adapter_would_have():
+    chat = _make_chat({'input_tokens': 240, 'output_tokens': 60})
+
+    answer = chat.chat(_FakeQuestion())
+
+    assert answer.getText() == 'answer'
+    c = _counters()
+    assert c['llm_input_tokens'] == 240
+    assert c['llm_output_tokens'] == 60
+
+
+def test_cached_input_is_split_off_the_fresh_input():
+    """Same split the shared helper applies everywhere: the four counters stay disjoint."""
+    usage = {'input_tokens': 500, 'output_tokens': 20, 'input_token_details': {'cache_read': 400}}
+    chat = _make_chat(usage)
+
+    chat.chat(_FakeQuestion())
+
+    c = _counters()
+    assert c['llm_input_tokens'] == 100
+    assert c['llm_cache_read_tokens'] == 400
+
+
+def test_only_the_attempt_that_answered_is_metered():
+    """A retried turn must not bill the attempts that raised before returning usage."""
+    chat = _make_chat({'input_tokens': 10, 'output_tokens': 5}, fail_times=1)
+
+    chat.chat(_FakeQuestion())
+
+    assert chat._llm.calls == 2
+    assert _counters()['llm_input_tokens'] == 10
+
+
+def test_no_usage_metadata_is_a_no_op():
+    chat = _make_chat(None)
+
+    assert chat.chat(_FakeQuestion()).getText() == 'answer'
+    assert _counters() == {}
+
+
+def test_a_turn_that_never_answers_meters_nothing():
+    chat = _make_chat({'input_tokens': 10, 'output_tokens': 5}, fail_times=99)
+
+    with pytest.raises(Exception):
+        chat.chat(_FakeQuestion())
+
+    assert _counters() == {}

--- a/packages/ai/src/ai/common/agent/agent.py
+++ b/packages/ai/src/ai/common/agent/agent.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Optional, Union
 from rocketlib import debug, error
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
-from ai.common.llm_adapter import LAST_LLM_USAGE_VAR
+from ai.common.llm_adapter import turn_usage
 
 from ai.common.utils import parse_bool, safe_str
 
@@ -164,149 +164,156 @@ class AgentBase(ABC):
         # a failure occurs before the context is built or `_run` returns.
         context = None
         raw = None
-        try:
-            # Add any global instructions from the config
-            for inst in self._instructions:
-                question.addInstruction('Additional Instruction', inst.strip())
-
-            # Get the jobs taskId — kept as a local variable inside the
-            # try/except so a missing/inaccessible jobConfig produces a
-            # graceful error answer instead of an unhandled AttributeError.
-            # Not on AgentContext: task_id is the same for every IInstance
-            # of a pipeline, so it serves no purpose as run scaffolding.
+        # Scope this turn's model calls. The agent reaches the model through many ask()
+        # invokes (and may drive sub-agents), possibly on a worker thread with a copied
+        # context (CrewAI); turn_usage collects them all and reads back the whole turn's
+        # total here regardless of thread, then clears once this outermost scope exits.
+        with turn_usage() as read_usage:
             try:
-                task_id = iInstance.IEndpoint.endpoint.jobConfig.get('taskId')
-            except Exception:
-                task_id = None
+                # Add any global instructions from the config
+                for inst in self._instructions:
+                    question.addInstruction('Additional Instruction', inst.strip())
 
-            # Build the per-call context inline.  Channels come from the
-            # cached host; metadata is stamped fresh per call.
-            context = AgentContext(
-                invoker=iInstance,
-                llm=host.llm,
-                tools=host.tools,
-                memory=host.memory,
-                run_id=run_id,
-                pipe_id=iInstance.instance.pipeId if iInstance.instance else 0,
-                framework=self.FRAMEWORK,
-                started_at=started_at,
-            )
+                # Get the jobs taskId — kept as a local variable inside the
+                # try/except so a missing/inaccessible jobConfig produces a
+                # graceful error answer instead of an unhandled AttributeError.
+                # Not on AgentContext: task_id is the same for every IInstance
+                # of a pipeline, so it serves no purpose as run scaffolding.
+                try:
+                    task_id = iInstance.IEndpoint.endpoint.jobConfig.get('taskId')
+                except Exception:
+                    task_id = None
 
-            # And execute
-            content, raw = self._run(
-                context=context,
-                question=question,
-            )
-
-            # Fabrication guardrail — before accepting the answer, assert the
-            # run actually grounded itself in at least one tool call when the
-            # operator required it.  A weak planning model can narrate a tool
-            # chain in prose without ever calling a tool; require_tool_call
-            # turns that silent failure into a loud, structural one.
-            if self._require_tool_call and not context.invoked_tools:
-                raise ToolCallRequiredError(
-                    'require_tool_call is enabled but the agent produced an '
-                    'answer without invoking any tool (possible narrated or '
-                    'fabricated tool chain)'
+                # Build the per-call context inline.  Channels come from the
+                # cached host; metadata is stamped fresh per call.
+                context = AgentContext(
+                    invoker=iInstance,
+                    llm=host.llm,
+                    tools=host.tools,
+                    memory=host.memory,
+                    run_id=run_id,
+                    pipe_id=iInstance.instance.pipeId if iInstance.instance else 0,
+                    framework=self.FRAMEWORK,
+                    started_at=started_at,
                 )
 
-            if not isinstance(content, str):
-                content = safe_str(content)
+                # And execute
+                content, raw = self._run(
+                    context=context,
+                    question=question,
+                )
 
-            ended_at = now_iso()
+                # Fabrication guardrail — before accepting the answer, assert the
+                # run actually grounded itself in at least one tool call when the
+                # operator required it.  A weak planning model can narrate a tool
+                # chain in prose without ever calling a tool; require_tool_call
+                # turns that silent failure into a loud, structural one.
+                if self._require_tool_call and not context.invoked_tools:
+                    raise ToolCallRequiredError(
+                        'require_tool_call is enabled but the agent produced an '
+                        'answer without invoking any tool (possible narrated or '
+                        'fabricated tool chain)'
+                    )
 
-            answer_payload: Dict[str, Any] = {
-                'content': content,
-                'meta': {
-                    'framework': self.FRAMEWORK,
-                    'agent_id': self._agent_id(iInstance),
-                    'run_id': run_id,
-                    'started_at': started_at,
-                    'ended_at': ended_at,
-                    'tool_calls': len(context.invoked_tools),
-                },
-                'stack': [],
-            }
-            if task_id:
-                answer_payload['meta']['task_id'] = task_id
+                if not isinstance(content, str):
+                    content = safe_str(content)
 
-            stack: List[Dict[str, Any]] = []
-            stack.append({'kind': 'RocketRide.agent.raw.v1', 'name': 'framework.output', 'payload': _json_safe(raw)})
-            answer_payload['stack'] = stack
+                ended_at = now_iso()
 
-            debug(f'agent base _run completed run_id={run_id} content_len={len(content or "")}')
-
-        except ToolCallRequiredError as e:
-            # Guardrail tripped: the run answered without invoking any tool.
-            # Reject the (likely fabricated) content and return a distinct
-            # guard answer — not the generic _run-failed path — so the cause is
-            # unambiguous in traces and to downstream handling.
-            guard_message = str(e)
-            error(f'agent base tool-call guard tripped run_id={run_id}: {guard_message}')
-            ended_at = now_iso()
-            answer_payload = {
-                'content': guard_message,
-                'meta': {
-                    'framework': self.FRAMEWORK,
-                    'agent_id': self._agent_id(iInstance),
-                    'run_id': run_id,
-                    'started_at': started_at,
-                    'ended_at': ended_at,
-                    'tool_calls': 0,
-                    **({'task_id': task_id} if task_id else {}),
-                },
-                'stack': [
-                    {
-                        'kind': 'RocketRide.agent.guard.v1',
-                        'name': 'tool_call_required',
-                        'payload': {'guard': 'require_tool_call', 'message': guard_message},
+                answer_payload: Dict[str, Any] = {
+                    'content': content,
+                    'meta': {
+                        'framework': self.FRAMEWORK,
+                        'agent_id': self._agent_id(iInstance),
+                        'run_id': run_id,
+                        'started_at': started_at,
+                        'ended_at': ended_at,
+                        'tool_calls': len(context.invoked_tools),
                     },
-                    # Keep the rejected framework output for diagnosis — an operator
-                    # investigating a tripped guard wants to see what was narrated.
-                    {'kind': 'RocketRide.agent.raw.v1', 'name': 'framework.output', 'payload': _json_safe(raw)},
-                ],
-            }
-
-        except Exception as e:
-            error_type = type(e).__name__
-            error_message = str(e)
-            error(f'agent base _run failed run_id={run_id} type={error_type} message={error_message}')
-            ended_at = now_iso()
-            answer_payload = {
-                'content': error_message or f'{error_type} (no message)',
-                'meta': {
-                    'framework': self.FRAMEWORK,
-                    'agent_id': self._agent_id(iInstance),
-                    'run_id': run_id,
-                    'started_at': started_at,
-                    'ended_at': ended_at,
-                    'tool_calls': len(context.invoked_tools) if context is not None else 0,
-                    **({'task_id': task_id} if task_id else {}),
-                },
-                'stack': [],
-            }
-            stack = []
-            stack.append(
-                {
-                    'kind': 'RocketRide.agent.error.v1',
-                    'name': 'exception',
-                    'payload': {'type': error_type, 'message': error_message},
+                    'stack': [],
                 }
-            )
-            answer_payload['stack'] = stack
+                if task_id:
+                    answer_payload['meta']['task_id'] = task_id
 
-        if emit_answers_lane:
-            debug(
-                f'agent base emitting answer run_id={answer_payload.get("meta", {}).get("run_id")} framework={answer_payload.get("meta", {}).get("framework")}'
-            )
-            answer = Answer(expectJson=False)
-            answer.setAnswer(answer_payload.get('content', ''))
-            # report_llm_tokens accumulates every model call of the run onto the
-            # context, so this is the whole turn's total plus its per-call breakdown.
-            usage = LAST_LLM_USAGE_VAR.get()
-            if usage:
-                answer.tokens = usage  # shown in the Trace "Tokens" grid on the answers lane
-            iInstance.instance.writeAnswers(answer)
+                stack: List[Dict[str, Any]] = []
+                stack.append(
+                    {'kind': 'RocketRide.agent.raw.v1', 'name': 'framework.output', 'payload': _json_safe(raw)}
+                )
+                answer_payload['stack'] = stack
+
+                debug(f'agent base _run completed run_id={run_id} content_len={len(content or "")}')
+
+            except ToolCallRequiredError as e:
+                # Guardrail tripped: the run answered without invoking any tool.
+                # Reject the (likely fabricated) content and return a distinct
+                # guard answer — not the generic _run-failed path — so the cause is
+                # unambiguous in traces and to downstream handling.
+                guard_message = str(e)
+                error(f'agent base tool-call guard tripped run_id={run_id}: {guard_message}')
+                ended_at = now_iso()
+                answer_payload = {
+                    'content': guard_message,
+                    'meta': {
+                        'framework': self.FRAMEWORK,
+                        'agent_id': self._agent_id(iInstance),
+                        'run_id': run_id,
+                        'started_at': started_at,
+                        'ended_at': ended_at,
+                        'tool_calls': 0,
+                        **({'task_id': task_id} if task_id else {}),
+                    },
+                    'stack': [
+                        {
+                            'kind': 'RocketRide.agent.guard.v1',
+                            'name': 'tool_call_required',
+                            'payload': {'guard': 'require_tool_call', 'message': guard_message},
+                        },
+                        # Keep the rejected framework output for diagnosis — an operator
+                        # investigating a tripped guard wants to see what was narrated.
+                        {'kind': 'RocketRide.agent.raw.v1', 'name': 'framework.output', 'payload': _json_safe(raw)},
+                    ],
+                }
+
+            except Exception as e:
+                error_type = type(e).__name__
+                error_message = str(e)
+                error(f'agent base _run failed run_id={run_id} type={error_type} message={error_message}')
+                ended_at = now_iso()
+                answer_payload = {
+                    'content': error_message or f'{error_type} (no message)',
+                    'meta': {
+                        'framework': self.FRAMEWORK,
+                        'agent_id': self._agent_id(iInstance),
+                        'run_id': run_id,
+                        'started_at': started_at,
+                        'ended_at': ended_at,
+                        'tool_calls': len(context.invoked_tools) if context is not None else 0,
+                        **({'task_id': task_id} if task_id else {}),
+                    },
+                    'stack': [],
+                }
+                stack = []
+                stack.append(
+                    {
+                        'kind': 'RocketRide.agent.error.v1',
+                        'name': 'exception',
+                        'payload': {'type': error_type, 'message': error_message},
+                    }
+                )
+                answer_payload['stack'] = stack
+
+            if emit_answers_lane:
+                debug(
+                    f'agent base emitting answer run_id={answer_payload.get("meta", {}).get("run_id")} framework={answer_payload.get("meta", {}).get("framework")}'
+                )
+                answer = Answer(expectJson=False)
+                answer.setAnswer(answer_payload.get('content', ''))
+                # The whole turn's total (every model call the run made, across threads
+                # and sub-agents), read back from the turn collector.
+                usage = read_usage()
+                if usage:
+                    answer.tokens = usage  # shown in the Trace "Tokens" grid on the answers lane
+                iInstance.instance.writeAnswers(answer)
 
         return answer_payload
 

--- a/packages/ai/src/ai/common/agent/agent.py
+++ b/packages/ai/src/ai/common/agent/agent.py
@@ -21,6 +21,7 @@ from typing import Any, Dict, List, Optional, Union
 from rocketlib import debug, error
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
+from ai.common.llm_adapter import LAST_LLM_USAGE_VAR
 
 from ai.common.utils import parse_bool, safe_str
 
@@ -300,6 +301,11 @@ class AgentBase(ABC):
             )
             answer = Answer(expectJson=False)
             answer.setAnswer(answer_payload.get('content', ''))
+            # report_llm_tokens accumulates every model call of the run onto the
+            # context, so this is the whole turn's total plus its per-call breakdown.
+            usage = LAST_LLM_USAGE_VAR.get()
+            if usage:
+                answer.tokens = usage  # shown in the Trace "Tokens" grid on the answers lane
             iInstance.instance.writeAnswers(answer)
 
         return answer_payload

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -369,12 +369,14 @@ class NativeOpenAIResponsesAdapter:
                     closer()
                 except Exception:
                     pass
-        report_llm_tokens(
-            max(0, input_tokens - cache_read),
-            output_tokens,
-            model=str(getattr(self.chat, '_model', '') or ''),
-            cache_read_tokens=cache_read,
-        )
+            # Record usage even if the stream raised mid-way — a partial request
+            # can already have provider-reported input/cache/output tokens.
+            report_llm_tokens(
+                max(0, input_tokens - cache_read),
+                output_tokens,
+                model=str(getattr(self.chat, '_model', '') or ''),
+                cache_read_tokens=cache_read,
+            )
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -55,25 +55,32 @@ def _record_usage(call: dict) -> None:
 def turn_usage():
     """Scope one Answer's model calls; yields a reader for the usage they produced.
 
-    Nesting-safe: an agent can drive sub-agents (or per-call ``ask`` invokes), each its
-    own nested scope. A nested scope reuses the turn's list and reads only the calls
-    appended after it opened (a ``seen`` slice), so it sees its own sub-calls while the
-    outer scope still sees the whole turn.
+    Every scope owns its OWN list and, on exit, extends its parent's list under the lock.
+    A reader therefore sees exactly the calls made in its own scope, and nothing else:
 
-    Concurrency-safe: each top-level turn opens its own list (the ContextVar default is
-    None outside any scope), so two turns overlapping in time never read each other. The
-    list is reachable only through this scope, so it is freed when the scope exits — no
+    - Nesting-safe: an agent drives sub-agents (or per-call ``ask`` invokes), each a nested
+      scope. The nested reader sees only its own calls; the parent, which reads after the
+      child has exited and folded its calls in, sees the whole turn.
+    - Concurrency-safe two ways: two independent turns never share a list (the ContextVar
+      default is None outside any scope), AND two sibling scopes inside one turn — a
+      parallel tool wave where each tool drives an LLM invoke — each get their own list, so
+      neither per-invoke reader shows the other's tokens. A shared turn list sliced by an
+      offset could not tell concurrent siblings apart (both would open at offset 0).
+
+    The list is reachable only through its scope, so it is freed when the scope exits — no
     global clear and no depth counter.
     """
     parent = _TURN_CALLS.get()
-    calls = parent if parent is not None else []
+    calls: list = []
     token = _TURN_CALLS.set(calls)
-    with _USAGE_LOCK:
-        seen = len(calls)
     try:
-        yield lambda: usage_since(seen, calls)
+        yield lambda: usage_since(0, calls)
     finally:
         _TURN_CALLS.reset(token)
+        # Fold this scope's calls into the parent so the outer turn still sees them.
+        if parent is not None:
+            with _USAGE_LOCK:
+                parent.extend(calls)
 
 
 @dataclass
@@ -362,9 +369,20 @@ class LangChainAdapter:
             gen, piece = _open(skw)
         except StopIteration:
             gen, piece = None, None
-        except Exception:
-            if not ask_usage:
+        except Exception as e:
+            # Retry without the usage flag only for the failure it causes: a 400 from an
+            # old vLLM/strict proxy that rejects stream_options.include_usage. Re-raise a
+            # 401/429/etc. so a bad key or rate limit surfaces without a second round trip;
+            # a provider whose exception carries no status_code keeps the broad retry.
+            status = getattr(e, 'status_code', None)
+            if not ask_usage or (status is not None and status != 400):
                 raise
+            from rocketlib import warning
+
+            warning(
+                f'LangChain stream rejected stream_usage ({type(e).__name__}); '
+                'retrying without include_usage (this call is unmetered).'
+            )
             skw.pop('stream_usage', None)
             try:
                 gen, piece = _open(skw)

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -74,7 +74,7 @@ def turn_usage():
     calls: list = []
     token = _TURN_CALLS.set(calls)
     try:
-        yield lambda: usage_since(0, calls)
+        yield lambda: aggregate_usage(calls)
     finally:
         _TURN_CALLS.reset(token)
         # Fold this scope's calls into the parent so the outer turn still sees them.
@@ -227,6 +227,20 @@ def flatten_content(content: Any) -> str:
     return flatten_content_parts(content)[0]
 
 
+def is_usage_flag_rejection(e: Exception) -> bool:
+    """True when an endpoint refused the request itself, so one retry without the flag pays off.
+
+    Any 4xx means the endpoint rejected this request as written: 400 (BadRequestError) is
+    what the openai SDK raises for an unknown ``stream_options.include_usage``, and 422
+    (UnprocessableEntityError) is what a FastAPI-based server — vLLM's OpenAI-compatible
+    server is one — answers request-validation failures with. Auth, timeout and rate-limit
+    statuses say nothing about the flag, so they re-raise without a second round trip, and a
+    transient connection failure carries no ``status_code`` at all.
+    """
+    status = getattr(e, 'status_code', None)
+    return isinstance(status, int) and 400 <= status < 500 and status not in (401, 403, 408, 429)
+
+
 def report_llm_tokens(
     input_tokens: int = 0,
     output_tokens: int = 0,
@@ -278,20 +292,20 @@ def report_llm_tokens(
             pass
 
 
-def usage_since(seen: int, calls: Optional[list] = None) -> Optional[dict]:
-    """Aggregate the model calls recorded after the first ``seen`` of this turn.
+def aggregate_usage(calls: Optional[list] = None) -> Optional[dict]:
+    """Aggregate one scope's model calls into the dict the Trace renders.
 
-    ``calls`` is the open turn's collector; it defaults to the current context's list so
-    a caller inside a ``turn_usage`` scope can read it without threading the list through.
-    The collector is append-only within a turn, so a scope that records its length
-    beforehand gets exactly its own calls back (its own nested sub-agents/invokes
-    included). One call returns that call unchanged, so a single-call invoke renders
-    as plain totals with no redundant breakdown.
+    ``calls`` is the scope's own collector — how a scope isolates itself from its
+    concurrent siblings is that each owns its list (see ``turn_usage``), never an offset
+    into a shared one. It defaults to the current context's list so a caller inside a
+    ``turn_usage`` scope can read it without threading the list through. One call returns
+    that call unchanged, so a single-call invoke renders as plain totals with no
+    redundant breakdown.
     """
     if calls is None:
         calls = _TURN_CALLS.get() or []
     with _USAGE_LOCK:
-        calls = calls[seen:]
+        calls = list(calls)
     if not calls:
         return None
     if len(calls) == 1:
@@ -370,12 +384,13 @@ class LangChainAdapter:
         except StopIteration:
             gen, piece = None, None
         except Exception as e:
-            # Retry without the usage flag ONLY for the failure it causes: a 400 that rejects
-            # stream_options.include_usage (an old vLLM/strict proxy; the openai SDK raises
-            # BadRequestError with status_code 400). Re-raise everything else — a 401/429
-            # surfaces without a second round trip, and a transient connection/timeout (no
-            # status_code) is not mistaken for a flag rejection and silently retried unmetered.
-            if not ask_usage or getattr(e, 'status_code', None) != 400:
+            # Retry without the usage flag ONLY for the failure it causes: a client error
+            # rejecting stream_options.include_usage (an old vLLM/strict proxy — 400 from the
+            # openai SDK, 422 from a FastAPI-based server). Re-raise everything else — a
+            # 401/429 surfaces without a second round trip, and a transient connection/timeout
+            # (no status_code) is not mistaken for a flag rejection and silently retried
+            # unmetered.
+            if not ask_usage or not is_usage_flag_rejection(e):
                 raise
             from rocketlib import warning
 

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -345,23 +345,25 @@ class NativeOpenAIResponsesAdapter:
                     if delta:
                         parts.append(delta)
                         yield Event('text', delta)
-                elif etype == 'response.completed':
+                elif etype in ('response.completed', 'response.failed', 'response.error'):
                     resp = getattr(event, 'response', None)
-                    # Responses API reports token usage on the terminal event.
+                    # Terminal events (success OR failure) can carry usage; a failed
+                    # request may already be chargeable, so read it either way.
                     u = getattr(resp, 'usage', None) if resp is not None else None
                     if u is not None:
                         input_tokens = int(getattr(u, 'input_tokens', 0) or 0)
                         output_tokens = int(getattr(u, 'output_tokens', 0) or 0)
                         # cached_tokens are part of input_tokens; split them out.
                         cache_read = int(getattr(getattr(u, 'input_tokens_details', None), 'cached_tokens', 0) or 0)
-                    status = getattr(resp, 'status', None) if resp is not None else None
-                    if status == 'incomplete':
-                        details = getattr(resp, 'incomplete_details', None)
-                        self.finish_reason = (getattr(details, 'reason', None) if details else None) or 'length'
+                    if etype == 'response.completed':
+                        status = getattr(resp, 'status', None) if resp is not None else None
+                        if status == 'incomplete':
+                            details = getattr(resp, 'incomplete_details', None)
+                            self.finish_reason = (getattr(details, 'reason', None) if details else None) or 'length'
+                        else:
+                            self.finish_reason = 'stop' if status == 'completed' else (status or 'stop')
                     else:
-                        self.finish_reason = 'stop' if status == 'completed' else (status or 'stop')
-                elif etype in ('response.failed', 'response.error'):
-                    self.finish_reason = 'error'
+                        self.finish_reason = 'error'
         finally:
             closer = getattr(stream, 'close', None)
             if callable(closer):

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -241,6 +241,21 @@ def is_usage_flag_rejection(e: Exception) -> bool:
     return isinstance(status, int) and 400 <= status < 500 and status not in (401, 403, 408, 429)
 
 
+def debug_usage_failure(exc: BaseException) -> None:
+    """Leave an operational trace for a metering failure without ever raising.
+
+    Every usage read is best-effort: accounting must not cost the user the answer they
+    already paid for. Shared so the drivers that report from their own call site
+    (they override the ``ChatBase`` seam and never reach the Adapter) fail the same way.
+    """
+    try:
+        from rocketlib import debug
+
+        debug(f'LLM token reporting failed: {type(exc).__name__}')
+    except Exception:
+        pass
+
+
 def report_llm_tokens(
     input_tokens: int = 0,
     output_tokens: int = 0,
@@ -284,12 +299,7 @@ def report_llm_tokens(
         _record_usage({'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model})
     except Exception as exc:
         # Best-effort accounting: keep the chat turn alive, but leave an operational trace.
-        try:
-            from rocketlib import debug
-
-            debug(f'LLM token reporting failed: {type(exc).__name__}')
-        except Exception:
-            pass
+        debug_usage_failure(exc)
 
 
 def aggregate_usage(calls: Optional[list] = None) -> Optional[dict]:
@@ -337,8 +347,15 @@ def report_usage_metadata(usage: Any, llm: Any) -> None:
     """
     if not isinstance(usage, dict):
         return
-    model = getattr(llm, 'model', None) or getattr(llm, 'model_name', '') or ''
-    fresh, out, cr, cc = _split_input_cache(usage)
+    # Best-effort like report_llm_tokens itself: the split runs before that guard, so a
+    # provider answering a non-numeric count would otherwise turn a paid, successful
+    # response into a failed turn (a retry loop reads the raise as a provider error).
+    try:
+        model = getattr(llm, 'model', None) or getattr(llm, 'model_name', '') or ''
+        fresh, out, cr, cc = _split_input_cache(usage)
+    except Exception as exc:
+        debug_usage_failure(exc)
+        return
     report_llm_tokens(fresh, out, model=str(model), cache_read_tokens=cr, cache_creation_tokens=cc)
 
 

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -370,12 +370,12 @@ class LangChainAdapter:
         except StopIteration:
             gen, piece = None, None
         except Exception as e:
-            # Retry without the usage flag only for the failure it causes: a 400 from an
-            # old vLLM/strict proxy that rejects stream_options.include_usage. Re-raise a
-            # 401/429/etc. so a bad key or rate limit surfaces without a second round trip;
-            # a provider whose exception carries no status_code keeps the broad retry.
-            status = getattr(e, 'status_code', None)
-            if not ask_usage or (status is not None and status != 400):
+            # Retry without the usage flag ONLY for the failure it causes: a 400 that rejects
+            # stream_options.include_usage (an old vLLM/strict proxy; the openai SDK raises
+            # BadRequestError with status_code 400). Re-raise everything else — a 401/429
+            # surfaces without a second round trip, and a transient connection/timeout (no
+            # status_code) is not mistaken for a flag rejection and silently retried unmetered.
+            if not ask_usage or getattr(e, 'status_code', None) != 400:
                 raise
             from rocketlib import warning
 

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -329,8 +329,12 @@ def _split_input_cache(um: dict) -> tuple[int, int, int, int]:
     return max(0, total_in - cr - cc), out, cr, cc
 
 
-def _report_usage_metadata(usage: Any, llm: Any) -> None:
-    """Extract LangChain ``usage_metadata`` and report it (fresh input + cache split)."""
+def report_usage_metadata(usage: Any, llm: Any) -> None:
+    """Extract LangChain ``usage_metadata`` and report it (fresh input + cache split).
+
+    Public because a driver that overrides ``ChatBase._chat`` bypasses ``collect()``
+    and has to report from its own call site to be metered at all.
+    """
     if not isinstance(usage, dict):
         return
     model = getattr(llm, 'model', None) or getattr(llm, 'model_name', '') or ''
@@ -461,7 +465,7 @@ class LangChainAdapter:
         # prompt string it was given, not a one-element message list.
         payload = self.history if had_history else user_text
         result = self.llm.invoke(payload, **self.stream_kwargs)
-        _report_usage_metadata(getattr(result, 'usage_metadata', None), self.llm)
+        report_usage_metadata(getattr(result, 'usage_metadata', None), self.llm)
         text, self.reasoning = flatten_content_parts(getattr(result, 'content', ''))
         assistant = {'role': 'assistant', 'content': text}
         self.history.append(assistant)

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -15,8 +15,9 @@ from typing import Any, Callable, Iterator, Optional, Protocol, runtime_checkabl
 
 from ai.common.utils import flatten_content_blocks
 
-# Last LLM call's token usage for the current execution context. report_llm_tokens
-# publishes it here so the node can hang it on the Answer (shown in the Trace).
+# Accumulated LLM token usage for the current turn. report_llm_tokens sums every
+# model call here so the node can hang the turn total on the Answer (Trace grid);
+# llm_base clears it per turn so one answer can't inherit the previous turn's sum.
 LAST_LLM_USAGE_VAR: ContextVar[Optional[dict]] = ContextVar('last_llm_usage', default=None)
 
 
@@ -200,10 +201,29 @@ def report_llm_tokens(
             metrics.counter('llm_cache_read_tokens', cr)
         if cc:
             metrics.counter('llm_cache_creation_tokens', cc)
-        usage = {'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model}
-        metrics.event({'llm_tokens': usage})
-        # Publish for the node to attach to the Answer (Trace "Tokens" grid); same context.
-        LAST_LLM_USAGE_VAR.set(usage)
+        # Per-call: the event and counters fire once per model call, so an agentic
+        # turn that calls the model N times bills and traces every call.
+        call = {'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model}
+        metrics.event({'llm_tokens': call})
+        # Per-turn: accumulate onto the context so the Answer's Trace "Tokens" grid
+        # shows the whole turn's total plus every call's cost, not just the last call
+        # of a many-call loop. ``breakdown`` lists each call so the action history can
+        # show the agent and what each of its model calls cost (in tokens).
+        prev = LAST_LLM_USAGE_VAR.get()
+        if prev:
+            LAST_LLM_USAGE_VAR.set(
+                {
+                    'input': int(prev.get('input', 0)) + it,
+                    'output': int(prev.get('output', 0)) + ot,
+                    'cache_read': int(prev.get('cache_read', 0)) + cr,
+                    'cache_creation': int(prev.get('cache_creation', 0)) + cc,
+                    'model': model or prev.get('model', ''),
+                    'calls': int(prev.get('calls', 1)) + 1,
+                    'breakdown': [*prev.get('breakdown', []), call],
+                }
+            )
+        else:
+            LAST_LLM_USAGE_VAR.set({**call, 'calls': 1, 'breakdown': [call]})
     except Exception as exc:
         # Best-effort accounting: keep the chat turn alive, but leave an operational trace.
         try:

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -159,6 +159,37 @@ def flatten_content(content: Any) -> str:
     return flatten_content_parts(content)[0]
 
 
+def report_llm_tokens(input_tokens: int = 0, output_tokens: int = 0, *, model: str = '') -> None:
+    """Surface per-run LLM token usage to the metrics singleton.
+
+    Reported in the subprocess via ``metrics.counter``; ``task_metrics`` accumulates
+    it per ``client_id`` (>MET*) so usage bills per user. A counter becomes billable
+    only when its name has a rate in the ``metrics_conversions`` table; it flows as a
+    raw count regardless. Best-effort: never let metrics break a chat turn.
+    """
+    try:
+        it, ot = int(input_tokens or 0), int(output_tokens or 0)
+        if not (it or ot):
+            return
+        from ai.web.metrics import metrics
+
+        if it:
+            metrics.counter('llm_input_tokens', it)
+        if ot:
+            metrics.counter('llm_output_tokens', ot)
+        metrics.event({'llm_tokens': {'input': it, 'output': ot, 'model': model}})
+    except Exception:
+        pass
+
+
+def _report_usage_metadata(usage: Any, llm: Any) -> None:
+    """Extract LangChain ``usage_metadata`` (input/output_tokens) and report it."""
+    if not isinstance(usage, dict):
+        return
+    model = getattr(llm, 'model', None) or getattr(llm, 'model_name', '') or ''
+    report_llm_tokens(usage.get('input_tokens', 0), usage.get('output_tokens', 0), model=str(model))
+
+
 class LangChainAdapter:
     """Wraps a LangChain chat model so non-reasoning providers speak the Event contract.
 
@@ -177,7 +208,14 @@ class LangChainAdapter:
         self.history.append({'role': 'user', 'content': user_text})
         parse = _make_stream_content_parser(True)
         parts: list[str] = []
+        in_toks = out_toks = 0
         for piece in self.llm.stream(self.history, **self.stream_kwargs):
+            um = getattr(piece, 'usage_metadata', None)
+            if isinstance(um, dict):
+                # Chunks carry cumulative counts (input on the first, output growing);
+                # max() lands on the final totals without assuming chunk order.
+                in_toks = max(in_toks, int(um.get('input_tokens') or 0))
+                out_toks = max(out_toks, int(um.get('output_tokens') or 0))
             text, thinking = parse(piece.content)
             if thinking:
                 yield Event('thinking', thinking)
@@ -193,6 +231,9 @@ class LangChainAdapter:
         if tail_text:
             parts.append(tail_text)
             yield Event('text', tail_text)
+        report_llm_tokens(
+            in_toks, out_toks, model=str(getattr(self.llm, 'model', None) or getattr(self.llm, 'model_name', '') or '')
+        )
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])
@@ -207,6 +248,7 @@ class LangChainAdapter:
         # prompt string it was given, not a one-element message list.
         payload = self.history if had_history else user_text
         result = self.llm.invoke(payload, **self.stream_kwargs)
+        _report_usage_metadata(getattr(result, 'usage_metadata', None), self.llm)
         text, self.reasoning = flatten_content_parts(getattr(result, 'content', ''))
         assistant = {'role': 'assistant', 'content': text}
         self.history.append(assistant)
@@ -226,6 +268,7 @@ class NativeOpenAIResponsesAdapter:
         self.history.append({'role': 'user', 'content': user_text})
         chat = self.chat
         parts: list[str] = []
+        input_tokens = output_tokens = 0
         stream = chat._raw_client.responses.create(
             model=chat._model,
             input=user_text,
@@ -250,6 +293,11 @@ class NativeOpenAIResponsesAdapter:
                         yield Event('text', delta)
                 elif etype == 'response.completed':
                     resp = getattr(event, 'response', None)
+                    # Responses API reports token usage on the terminal event.
+                    u = getattr(resp, 'usage', None) if resp is not None else None
+                    if u is not None:
+                        input_tokens = int(getattr(u, 'input_tokens', 0) or 0)
+                        output_tokens = int(getattr(u, 'output_tokens', 0) or 0)
                     status = getattr(resp, 'status', None) if resp is not None else None
                     if status == 'incomplete':
                         details = getattr(resp, 'incomplete_details', None)
@@ -265,6 +313,7 @@ class NativeOpenAIResponsesAdapter:
                     closer()
                 except Exception:
                     pass
+        report_llm_tokens(input_tokens, output_tokens, model=str(getattr(self.chat, '_model', '') or ''))
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -159,17 +159,31 @@ def flatten_content(content: Any) -> str:
     return flatten_content_parts(content)[0]
 
 
-def report_llm_tokens(input_tokens: int = 0, output_tokens: int = 0, *, model: str = '') -> None:
+def report_llm_tokens(
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    *,
+    model: str = '',
+    cache_read_tokens: int = 0,
+    cache_creation_tokens: int = 0,
+) -> None:
     """Surface per-run LLM token usage to the metrics singleton.
 
     Reported in the subprocess via ``metrics.counter``; ``task_metrics`` accumulates
     it per ``client_id`` (>MET*) so usage bills per user. A counter becomes billable
     only when its name has a rate in the ``metrics_conversions`` table; it flows as a
-    raw count regardless. Best-effort: never let metrics break a chat turn.
+    raw count regardless.
+
+    ``input_tokens`` is fresh (non-cached) input. Cache-read and cache-creation tokens
+    ride their own counters because providers bill them at rates distinct from fresh
+    input; the four counters are disjoint. Best-effort: never break a chat turn.
     """
     try:
-        it, ot = int(input_tokens or 0), int(output_tokens or 0)
-        if not (it or ot):
+        it = int(input_tokens or 0)
+        ot = int(output_tokens or 0)
+        cr = int(cache_read_tokens or 0)
+        cc = int(cache_creation_tokens or 0)
+        if not (it or ot or cr or cc):
             return
         from ai.web.metrics import metrics
 
@@ -177,17 +191,45 @@ def report_llm_tokens(input_tokens: int = 0, output_tokens: int = 0, *, model: s
             metrics.counter('llm_input_tokens', it)
         if ot:
             metrics.counter('llm_output_tokens', ot)
-        metrics.event({'llm_tokens': {'input': it, 'output': ot, 'model': model}})
-    except Exception:
-        pass
+        if cr:
+            metrics.counter('llm_cache_read_tokens', cr)
+        if cc:
+            metrics.counter('llm_cache_creation_tokens', cc)
+        metrics.event(
+            {'llm_tokens': {'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model}}
+        )
+    except Exception as exc:
+        # Best-effort accounting: keep the chat turn alive, but leave an operational trace.
+        try:
+            from rocketlib import debug
+
+            debug(f'LLM token reporting failed: {type(exc).__name__}')
+        except Exception:
+            pass
+
+
+def _split_input_cache(um: dict) -> tuple[int, int, int, int]:
+    """From a LangChain ``usage_metadata`` dict, return
+    ``(fresh_input, output, cache_read, cache_creation)``. LangChain reports
+    ``input_tokens`` as the full prompt (cache included), so the cache detail is
+    subtracted back out to keep the four counters disjoint.
+    """
+    out = int(um.get('output_tokens') or 0)
+    total_in = int(um.get('input_tokens') or 0)
+    det = um.get('input_token_details')
+    det = det if isinstance(det, dict) else {}
+    cr = int(det.get('cache_read') or 0)
+    cc = int(det.get('cache_creation') or 0)
+    return max(0, total_in - cr - cc), out, cr, cc
 
 
 def _report_usage_metadata(usage: Any, llm: Any) -> None:
-    """Extract LangChain ``usage_metadata`` (input/output_tokens) and report it."""
+    """Extract LangChain ``usage_metadata`` and report it (fresh input + cache split)."""
     if not isinstance(usage, dict):
         return
     model = getattr(llm, 'model', None) or getattr(llm, 'model_name', '') or ''
-    report_llm_tokens(usage.get('input_tokens', 0), usage.get('output_tokens', 0), model=str(model))
+    fresh, out, cr, cc = _split_input_cache(usage)
+    report_llm_tokens(fresh, out, model=str(model), cache_read_tokens=cr, cache_creation_tokens=cc)
 
 
 class LangChainAdapter:
@@ -208,14 +250,22 @@ class LangChainAdapter:
         self.history.append({'role': 'user', 'content': user_text})
         parse = _make_stream_content_parser(True)
         parts: list[str] = []
-        in_toks = out_toks = 0
-        for piece in self.llm.stream(self.history, **self.stream_kwargs):
+        # OpenAI-family models only emit streaming usage when asked; others (e.g.
+        # Anthropic) emit it by default, so scope the flag to avoid an unknown kwarg.
+        skw = dict(self.stream_kwargs)
+        if 'OpenAI' in type(self.llm).__name__:
+            skw.setdefault('stream_usage', True)
+        total_in = out_toks = cache_read = cache_creation = 0
+        for piece in self.llm.stream(self.history, **skw):
             um = getattr(piece, 'usage_metadata', None)
             if isinstance(um, dict):
-                # Chunks carry cumulative counts (input on the first, output growing);
-                # max() lands on the final totals without assuming chunk order.
-                in_toks = max(in_toks, int(um.get('input_tokens') or 0))
+                # Chunks carry cumulative counts; max() lands on the final totals.
+                total_in = max(total_in, int(um.get('input_tokens') or 0))
                 out_toks = max(out_toks, int(um.get('output_tokens') or 0))
+                det = um.get('input_token_details')
+                if isinstance(det, dict):
+                    cache_read = max(cache_read, int(det.get('cache_read') or 0))
+                    cache_creation = max(cache_creation, int(det.get('cache_creation') or 0))
             text, thinking = parse(piece.content)
             if thinking:
                 yield Event('thinking', thinking)
@@ -232,7 +282,11 @@ class LangChainAdapter:
             parts.append(tail_text)
             yield Event('text', tail_text)
         report_llm_tokens(
-            in_toks, out_toks, model=str(getattr(self.llm, 'model', None) or getattr(self.llm, 'model_name', '') or '')
+            max(0, total_in - cache_read - cache_creation),
+            out_toks,
+            model=str(getattr(self.llm, 'model', None) or getattr(self.llm, 'model_name', '') or ''),
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
         )
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
@@ -268,7 +322,7 @@ class NativeOpenAIResponsesAdapter:
         self.history.append({'role': 'user', 'content': user_text})
         chat = self.chat
         parts: list[str] = []
-        input_tokens = output_tokens = 0
+        input_tokens = output_tokens = cache_read = 0
         stream = chat._raw_client.responses.create(
             model=chat._model,
             input=user_text,
@@ -298,6 +352,8 @@ class NativeOpenAIResponsesAdapter:
                     if u is not None:
                         input_tokens = int(getattr(u, 'input_tokens', 0) or 0)
                         output_tokens = int(getattr(u, 'output_tokens', 0) or 0)
+                        # cached_tokens are part of input_tokens; split them out.
+                        cache_read = int(getattr(getattr(u, 'input_tokens_details', None), 'cached_tokens', 0) or 0)
                     status = getattr(resp, 'status', None) if resp is not None else None
                     if status == 'incomplete':
                         details = getattr(resp, 'incomplete_details', None)
@@ -313,7 +369,12 @@ class NativeOpenAIResponsesAdapter:
                     closer()
                 except Exception:
                     pass
-        report_llm_tokens(input_tokens, output_tokens, model=str(getattr(self.chat, '_model', '') or ''))
+        report_llm_tokens(
+            max(0, input_tokens - cache_read),
+            output_tokens,
+            model=str(getattr(self.chat, '_model', '') or ''),
+            cache_read_tokens=cache_read,
+        )
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -345,25 +345,29 @@ class NativeOpenAIResponsesAdapter:
                     if delta:
                         parts.append(delta)
                         yield Event('text', delta)
-                elif etype in ('response.completed', 'response.failed', 'response.error'):
+                elif etype in ('response.completed', 'response.incomplete', 'response.failed', 'response.error'):
                     resp = getattr(event, 'response', None)
-                    # Terminal events (success OR failure) can carry usage; a failed
-                    # request may already be chargeable, so read it either way.
+                    # Terminal events (success, incomplete, OR failure) can carry usage;
+                    # a truncated or failed request may already be chargeable, so read it.
                     u = getattr(resp, 'usage', None) if resp is not None else None
                     if u is not None:
                         input_tokens = int(getattr(u, 'input_tokens', 0) or 0)
                         output_tokens = int(getattr(u, 'output_tokens', 0) or 0)
                         # cached_tokens are part of input_tokens; split them out.
                         cache_read = int(getattr(getattr(u, 'input_tokens_details', None), 'cached_tokens', 0) or 0)
-                    if etype == 'response.completed':
+                    if etype in ('response.failed', 'response.error'):
+                        self.finish_reason = 'error'
+                    elif etype == 'response.incomplete':
+                        # Separate terminal event (e.g. max_output_tokens); map its reason.
+                        details = getattr(resp, 'incomplete_details', None)
+                        self.finish_reason = (getattr(details, 'reason', None) if details else None) or 'length'
+                    else:  # response.completed
                         status = getattr(resp, 'status', None) if resp is not None else None
                         if status == 'incomplete':
                             details = getattr(resp, 'incomplete_details', None)
                             self.finish_reason = (getattr(details, 'reason', None) if details else None) or 'length'
                         else:
                             self.finish_reason = 'stop' if status == 'completed' else (status or 'stop')
-                    else:
-                        self.finish_reason = 'error'
         finally:
             closer = getattr(stream, 'close', None)
             if callable(closer):

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -250,44 +250,50 @@ class LangChainAdapter:
         self.history.append({'role': 'user', 'content': user_text})
         parse = _make_stream_content_parser(True)
         parts: list[str] = []
-        # OpenAI-family models only emit streaming usage when asked; others (e.g.
-        # Anthropic) emit it by default, so scope the flag to avoid an unknown kwarg.
+        # OpenAI-family models only emit streaming usage when asked. Ask whichever
+        # model declares the flag rather than matching on the class name: ChatXAI
+        # inherits it from BaseChatOpenAI without carrying 'OpenAI' in its name, and
+        # a model that lacks it (ChatBedrock) would reject it as an unknown kwarg.
         skw = dict(self.stream_kwargs)
-        if 'OpenAI' in type(self.llm).__name__:
+        if hasattr(self.llm, 'stream_usage'):
             skw.setdefault('stream_usage', True)
         total_in = out_toks = cache_read = cache_creation = 0
-        for piece in self.llm.stream(self.history, **skw):
-            um = getattr(piece, 'usage_metadata', None)
-            if isinstance(um, dict):
-                # Chunks carry cumulative counts; max() lands on the final totals.
-                total_in = max(total_in, int(um.get('input_tokens') or 0))
-                out_toks = max(out_toks, int(um.get('output_tokens') or 0))
-                det = um.get('input_token_details')
-                if isinstance(det, dict):
-                    cache_read = max(cache_read, int(det.get('cache_read') or 0))
-                    cache_creation = max(cache_creation, int(det.get('cache_creation') or 0))
-            text, thinking = parse(piece.content)
-            if thinking:
-                yield Event('thinking', thinking)
-            if text:
-                parts.append(text)
-                yield Event('text', text)
-            reason = (getattr(piece, 'response_metadata', None) or {}).get('finish_reason')
-            if reason:
-                self.finish_reason = reason
-        tail_text, tail_thinking = parse.flush()
-        if tail_thinking:
-            yield Event('thinking', tail_thinking)
-        if tail_text:
-            parts.append(tail_text)
-            yield Event('text', tail_text)
-        report_llm_tokens(
-            max(0, total_in - cache_read - cache_creation),
-            out_toks,
-            model=str(getattr(self.llm, 'model', None) or getattr(self.llm, 'model_name', '') or ''),
-            cache_read_tokens=cache_read,
-            cache_creation_tokens=cache_creation,
-        )
+        # try/finally so a mid-stream raise still records the cumulative usage the
+        # chunks already carried, matching the two native adapters.
+        try:
+            for piece in self.llm.stream(self.history, **skw):
+                um = getattr(piece, 'usage_metadata', None)
+                if isinstance(um, dict):
+                    # Chunks carry cumulative counts; max() lands on the final totals.
+                    total_in = max(total_in, int(um.get('input_tokens') or 0))
+                    out_toks = max(out_toks, int(um.get('output_tokens') or 0))
+                    det = um.get('input_token_details')
+                    if isinstance(det, dict):
+                        cache_read = max(cache_read, int(det.get('cache_read') or 0))
+                        cache_creation = max(cache_creation, int(det.get('cache_creation') or 0))
+                text, thinking = parse(piece.content)
+                if thinking:
+                    yield Event('thinking', thinking)
+                if text:
+                    parts.append(text)
+                    yield Event('text', text)
+                reason = (getattr(piece, 'response_metadata', None) or {}).get('finish_reason')
+                if reason:
+                    self.finish_reason = reason
+            tail_text, tail_thinking = parse.flush()
+            if tail_thinking:
+                yield Event('thinking', tail_thinking)
+            if tail_text:
+                parts.append(tail_text)
+                yield Event('text', tail_text)
+        finally:
+            report_llm_tokens(
+                max(0, total_in - cache_read - cache_creation),
+                out_toks,
+                model=str(getattr(self.llm, 'model', None) or getattr(self.llm, 'model_name', '') or ''),
+                cache_read_tokens=cache_read,
+                cache_creation_tokens=cache_creation,
+            )
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -9,10 +9,15 @@ ChatBase consumes Adapters and never touches provider-native content shapes.
 Design: repo discussion #1679 (RFC — virtualized provider Adapter).
 """
 
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator, Optional, Protocol, runtime_checkable
 
 from ai.common.utils import flatten_content_blocks
+
+# Last LLM call's token usage for the current execution context. report_llm_tokens
+# publishes it here so the node can hang it on the Answer (shown in the Trace).
+LAST_LLM_USAGE_VAR: ContextVar[Optional[dict]] = ContextVar('last_llm_usage', default=None)
 
 
 @dataclass
@@ -195,9 +200,10 @@ def report_llm_tokens(
             metrics.counter('llm_cache_read_tokens', cr)
         if cc:
             metrics.counter('llm_cache_creation_tokens', cc)
-        metrics.event(
-            {'llm_tokens': {'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model}}
-        )
+        usage = {'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model}
+        metrics.event({'llm_tokens': usage})
+        # Publish for the node to attach to the Answer (Trace "Tokens" grid); same context.
+        LAST_LLM_USAGE_VAR.set(usage)
     except Exception as exc:
         # Best-effort accounting: keep the chat turn alive, but leave an operational trace.
         try:

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -9,16 +9,55 @@ ChatBase consumes Adapters and never touches provider-native content shapes.
 Design: repo discussion #1679 (RFC — virtualized provider Adapter).
 """
 
-from contextvars import ContextVar
+import threading
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator, Optional, Protocol, runtime_checkable
 
 from ai.common.utils import flatten_content_blocks
 
-# Accumulated LLM token usage for the current turn. report_llm_tokens sums every
-# model call here so the node can hang the turn total on the Answer (Trace grid);
-# llm_base clears it per turn so one answer can't inherit the previous turn's sum.
-LAST_LLM_USAGE_VAR: ContextVar[Optional[dict]] = ContextVar('last_llm_usage', default=None)
+# Per-turn LLM usage collector. Every model call appends one entry here; a scope
+# (turn_usage) reads the entries added while it was open and hangs them on the Answer.
+#
+# It is a module-global list, NOT a ContextVar, on purpose: CrewAI/deepagent run their
+# kickoffs on a worker thread under ``contextvars.copy_context().run(...)`` (see
+# nodes/agent_crewai/crewai_runner.py), and a ContextVar written in that copied context
+# never propagates back to the thread that reads it — the agent's answer would carry no
+# tokens. The metrics singleton already spans threads this way for billing; usage must too.
+# A lock keeps worker-thread appends race-free with the reader.
+_USAGE_LOCK = threading.Lock()
+_USAGE_CALLS: list = []
+_TURN_DEPTH = 0
+
+
+def _record_usage(call: dict) -> None:
+    """Append one model call's usage to the shared collector (thread-safe)."""
+    with _USAGE_LOCK:
+        _USAGE_CALLS.append(call)
+
+
+@contextmanager
+def turn_usage():
+    """Scope one Answer's model calls; yields a reader for the usage they produced.
+
+    Nesting-safe: an agent can drive sub-agents (or per-call ``ask`` invokes), each its
+    own nested scope, because a scope reads only the calls appended after it opened
+    (a ``seen`` slice), not the whole list. The OUTERMOST scope clears the collector on
+    exit, so it stays bounded to one top-level turn instead of growing for the life of
+    the task (a long agent run would otherwise accumulate one dict per call forever).
+    """
+    global _TURN_DEPTH
+    with _USAGE_LOCK:
+        seen = len(_USAGE_CALLS)
+        _TURN_DEPTH += 1
+    try:
+        yield lambda: usage_since(seen)
+    finally:
+        with _USAGE_LOCK:
+            _TURN_DEPTH -= 1
+            if _TURN_DEPTH <= 0:
+                _TURN_DEPTH = 0
+                _USAGE_CALLS.clear()
 
 
 @dataclass
@@ -201,29 +240,11 @@ def report_llm_tokens(
             metrics.counter('llm_cache_read_tokens', cr)
         if cc:
             metrics.counter('llm_cache_creation_tokens', cc)
-        # Per-call: the event and counters fire once per model call, so an agentic
-        # turn that calls the model N times bills and traces every call.
-        call = {'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model}
-        metrics.event({'llm_tokens': call})
-        # Per-turn: accumulate onto the context so the Answer's Trace "Tokens" grid
-        # shows the whole turn's total plus every call's cost, not just the last call
-        # of a many-call loop. ``breakdown`` lists each call so the action history can
-        # show the agent and what each of its model calls cost (in tokens).
-        prev = LAST_LLM_USAGE_VAR.get()
-        if prev:
-            LAST_LLM_USAGE_VAR.set(
-                {
-                    'input': int(prev.get('input', 0)) + it,
-                    'output': int(prev.get('output', 0)) + ot,
-                    'cache_read': int(prev.get('cache_read', 0)) + cr,
-                    'cache_creation': int(prev.get('cache_creation', 0)) + cc,
-                    'model': model or prev.get('model', ''),
-                    'calls': int(prev.get('calls', 1)) + 1,
-                    'breakdown': [*prev.get('breakdown', []), call],
-                }
-            )
-        else:
-            LAST_LLM_USAGE_VAR.set({**call, 'calls': 1, 'breakdown': [call]})
+        # The counters (above) carry the billable totals; task_metrics rolls them up.
+        # Record the per-call detail on the turn collector for the Trace instead of a
+        # per-call metrics.event — that fed an unbounded events list re-serialized in
+        # full after every object (multi-MB metric lines on long-lived chat tasks).
+        _record_usage({'input': it, 'output': ot, 'cache_read': cr, 'cache_creation': cc, 'model': model})
     except Exception as exc:
         # Best-effort accounting: keep the chat turn alive, but leave an operational trace.
         try:
@@ -235,19 +256,30 @@ def report_llm_tokens(
 
 
 def usage_since(seen: int) -> Optional[dict]:
-    """Usage of the model calls reported after the first ``seen`` of this turn.
+    """Aggregate the model calls recorded after the first ``seen`` of this turn.
 
-    ``breakdown`` is append-only, so a caller that records its length beforehand
-    gets exactly its own calls back. One call returns that call unchanged, so a
-    single-call invoke renders as plain totals with no redundant breakdown.
+    The collector is append-only within a turn, so a scope that records its length
+    beforehand gets exactly its own calls back (its own nested sub-agents/invokes
+    included). One call returns that call unchanged, so a single-call invoke renders
+    as plain totals with no redundant breakdown.
     """
-    calls = (LAST_LLM_USAGE_VAR.get() or {}).get('breakdown', [])[seen:]
+    with _USAGE_LOCK:
+        calls = _USAGE_CALLS[seen:]
     if not calls:
         return None
     if len(calls) == 1:
         return dict(calls[0])
     total = {k: sum(int(c.get(k, 0)) for c in calls) for k in ('input', 'output', 'cache_read', 'cache_creation')}
     return {**total, 'model': calls[-1].get('model', ''), 'calls': len(calls), 'breakdown': list(calls)}
+
+
+def _has_custom_base_url(llm: Any) -> bool:
+    """True if the model points at a non-OpenAI base URL (DeepSeek, Qwen, xAI, Ollama,
+    a local vLLM/proxy). Those reach OpenAI-compatible endpoints where forcing
+    ``stream_options.include_usage`` can 400, so the streaming-usage flag is left off.
+    """
+    base = getattr(llm, 'openai_api_base', None) or getattr(llm, 'base_url', None)
+    return bool(base) and 'api.openai.com' not in str(base)
 
 
 def _split_input_cache(um: dict) -> tuple[int, int, int, int]:
@@ -296,17 +328,24 @@ class LangChainAdapter:
         # model declares the flag rather than matching on the class name: ChatXAI
         # inherits it from BaseChatOpenAI without carrying 'OpenAI' in its name, and
         # a model that lacks it (ChatBedrock) would reject it as an unknown kwarg.
+        # But NOT when a custom base URL is set: langchain-openai defaults the flag off
+        # there because older vLLM builds and strict proxies 400 on
+        # stream_options.include_usage. Respect that — usage is still read below if the
+        # endpoint sends it anyway; forcing it would break the request outright.
         skw = dict(self.stream_kwargs)
-        if hasattr(self.llm, 'stream_usage'):
+        if hasattr(self.llm, 'stream_usage') and not _has_custom_base_url(self.llm):
             skw.setdefault('stream_usage', True)
         total_in = out_toks = cache_read = cache_creation = 0
-        # try/finally so a mid-stream raise still records the cumulative usage the
-        # chunks already carried, matching the two native adapters.
+        # try/finally so a mid-stream raise still records the usage the chunks already
+        # carried, matching the two native adapters.
         try:
             for piece in self.llm.stream(self.history, **skw):
                 um = getattr(piece, 'usage_metadata', None)
                 if isinstance(um, dict):
-                    # Chunks carry cumulative counts; max() lands on the final totals.
+                    # LangChain's usage_metadata is additive by contract (AIMessageChunk
+                    # merges chunks with add_usage), but every provider we reach emits it
+                    # on exactly one chunk, so max() == that single total. If one ever
+                    # streams usage across chunks, switch these to summing the deltas.
                     total_in = max(total_in, int(um.get('input_tokens') or 0))
                     out_toks = max(out_toks, int(um.get('output_tokens') or 0))
                     det = um.get('input_token_details')

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -234,6 +234,22 @@ def report_llm_tokens(
             pass
 
 
+def usage_since(seen: int) -> Optional[dict]:
+    """Usage of the model calls reported after the first ``seen`` of this turn.
+
+    ``breakdown`` is append-only, so a caller that records its length beforehand
+    gets exactly its own calls back. One call returns that call unchanged, so a
+    single-call invoke renders as plain totals with no redundant breakdown.
+    """
+    calls = (LAST_LLM_USAGE_VAR.get() or {}).get('breakdown', [])[seen:]
+    if not calls:
+        return None
+    if len(calls) == 1:
+        return dict(calls[0])
+    total = {k: sum(int(c.get(k, 0)) for c in calls) for k in ('input', 'output', 'cache_read', 'cache_creation')}
+    return {**total, 'model': calls[-1].get('model', ''), 'calls': len(calls), 'breakdown': list(calls)}
+
+
 def _split_input_cache(um: dict) -> tuple[int, int, int, int]:
     """From a LangChain ``usage_metadata`` dict, return
     ``(fresh_input, output, cache_read, cache_creation)``. LangChain reports

--- a/packages/ai/src/ai/common/llm_adapter.py
+++ b/packages/ai/src/ai/common/llm_adapter.py
@@ -11,29 +11,44 @@ Design: repo discussion #1679 (RFC — virtualized provider Adapter).
 
 import threading
 from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator, Optional, Protocol, runtime_checkable
 
 from ai.common.utils import flatten_content_blocks
 
-# Per-turn LLM usage collector. Every model call appends one entry here; a scope
-# (turn_usage) reads the entries added while it was open and hangs them on the Answer.
+# Per-turn LLM usage collector. Every model call appends one entry to the open turn's
+# list; a scope (turn_usage) reads the entries added while it was open and hangs them on
+# the Answer.
 #
-# It is a module-global list, NOT a ContextVar, on purpose: CrewAI/deepagent run their
-# kickoffs on a worker thread under ``contextvars.copy_context().run(...)`` (see
-# nodes/agent_crewai/crewai_runner.py), and a ContextVar written in that copied context
-# never propagates back to the thread that reads it — the agent's answer would carry no
-# tokens. The metrics singleton already spans threads this way for billing; usage must too.
-# A lock keeps worker-thread appends race-free with the reader.
+# The list lives in a ContextVar, but the VALUE is a mutable list appended IN PLACE —
+# never re-``.set()``. That distinction is the whole design:
+#   - Per-turn isolation: two turns that overlap in time each get their own list, so one
+#     turn's Trace never shows another's tokens, and the list dies with its scope (no
+#     global clear, no unbounded growth under load). Concurrent turns are normal here —
+#     agent_rocketride/executor.py runs a tool wave on a ThreadPoolExecutor, and one
+#     pipeline is started per inbound message via asyncio.to_thread.
+#   - Cross-thread capture: contextvars.copy_context() copies the mapping, not the
+#     values, so a worker thread that runs under copy_context().run(...) (CrewAI/deepagent
+#     kickoffs; a ThreadPoolExecutor wave that submits copy_context().run) inherits the
+#     SAME list object — its appends are visible to the reader that opened the turn.
+# A lock keeps concurrent appends race-free with the reader's slice.
 _USAGE_LOCK = threading.Lock()
-_USAGE_CALLS: list = []
-_TURN_DEPTH = 0
+_TURN_CALLS: ContextVar[Optional[list]] = ContextVar('llm_turn_calls', default=None)
 
 
 def _record_usage(call: dict) -> None:
-    """Append one model call's usage to the shared collector (thread-safe)."""
+    """Append one model call's usage to the open turn's collector (thread-safe).
+
+    A no-op when no turn is open (a bare LLM call outside any ``turn_usage`` scope): the
+    call is simply not collected for a Trace. Billing is unaffected — ``report_llm_tokens``
+    fires its counters regardless of whether a turn is open.
+    """
+    calls = _TURN_CALLS.get()
+    if calls is None:
+        return
     with _USAGE_LOCK:
-        _USAGE_CALLS.append(call)
+        calls.append(call)
 
 
 @contextmanager
@@ -41,23 +56,24 @@ def turn_usage():
     """Scope one Answer's model calls; yields a reader for the usage they produced.
 
     Nesting-safe: an agent can drive sub-agents (or per-call ``ask`` invokes), each its
-    own nested scope, because a scope reads only the calls appended after it opened
-    (a ``seen`` slice), not the whole list. The OUTERMOST scope clears the collector on
-    exit, so it stays bounded to one top-level turn instead of growing for the life of
-    the task (a long agent run would otherwise accumulate one dict per call forever).
+    own nested scope. A nested scope reuses the turn's list and reads only the calls
+    appended after it opened (a ``seen`` slice), so it sees its own sub-calls while the
+    outer scope still sees the whole turn.
+
+    Concurrency-safe: each top-level turn opens its own list (the ContextVar default is
+    None outside any scope), so two turns overlapping in time never read each other. The
+    list is reachable only through this scope, so it is freed when the scope exits — no
+    global clear and no depth counter.
     """
-    global _TURN_DEPTH
+    parent = _TURN_CALLS.get()
+    calls = parent if parent is not None else []
+    token = _TURN_CALLS.set(calls)
     with _USAGE_LOCK:
-        seen = len(_USAGE_CALLS)
-        _TURN_DEPTH += 1
+        seen = len(calls)
     try:
-        yield lambda: usage_since(seen)
+        yield lambda: usage_since(seen, calls)
     finally:
-        with _USAGE_LOCK:
-            _TURN_DEPTH -= 1
-            if _TURN_DEPTH <= 0:
-                _TURN_DEPTH = 0
-                _USAGE_CALLS.clear()
+        _TURN_CALLS.reset(token)
 
 
 @dataclass
@@ -255,31 +271,26 @@ def report_llm_tokens(
             pass
 
 
-def usage_since(seen: int) -> Optional[dict]:
+def usage_since(seen: int, calls: Optional[list] = None) -> Optional[dict]:
     """Aggregate the model calls recorded after the first ``seen`` of this turn.
 
+    ``calls`` is the open turn's collector; it defaults to the current context's list so
+    a caller inside a ``turn_usage`` scope can read it without threading the list through.
     The collector is append-only within a turn, so a scope that records its length
     beforehand gets exactly its own calls back (its own nested sub-agents/invokes
     included). One call returns that call unchanged, so a single-call invoke renders
     as plain totals with no redundant breakdown.
     """
+    if calls is None:
+        calls = _TURN_CALLS.get() or []
     with _USAGE_LOCK:
-        calls = _USAGE_CALLS[seen:]
+        calls = calls[seen:]
     if not calls:
         return None
     if len(calls) == 1:
         return dict(calls[0])
     total = {k: sum(int(c.get(k, 0)) for c in calls) for k in ('input', 'output', 'cache_read', 'cache_creation')}
     return {**total, 'model': calls[-1].get('model', ''), 'calls': len(calls), 'breakdown': list(calls)}
-
-
-def _has_custom_base_url(llm: Any) -> bool:
-    """True if the model points at a non-OpenAI base URL (DeepSeek, Qwen, xAI, Ollama,
-    a local vLLM/proxy). Those reach OpenAI-compatible endpoints where forcing
-    ``stream_options.include_usage`` can 400, so the streaming-usage flag is left off.
-    """
-    base = getattr(llm, 'openai_api_base', None) or getattr(llm, 'base_url', None)
-    return bool(base) and 'api.openai.com' not in str(base)
 
 
 def _split_input_cache(um: dict) -> tuple[int, int, int, int]:
@@ -324,22 +335,46 @@ class LangChainAdapter:
         self.history.append({'role': 'user', 'content': user_text})
         parse = _make_stream_content_parser(True)
         parts: list[str] = []
-        # OpenAI-family models only emit streaming usage when asked. Ask whichever
-        # model declares the flag rather than matching on the class name: ChatXAI
-        # inherits it from BaseChatOpenAI without carrying 'OpenAI' in its name, and
-        # a model that lacks it (ChatBedrock) would reject it as an unknown kwarg.
-        # But NOT when a custom base URL is set: langchain-openai defaults the flag off
-        # there because older vLLM builds and strict proxies 400 on
-        # stream_options.include_usage. Respect that — usage is still read below if the
-        # endpoint sends it anyway; forcing it would break the request outright.
+        # OpenAI-family models only emit streaming usage when asked. Ask whichever model
+        # declares the flag rather than matching on the class name: ChatXAI inherits it
+        # from BaseChatOpenAI without carrying 'OpenAI' in its name, and a model that
+        # lacks it (ChatBedrock) would reject it as an unknown kwarg. langchain-openai
+        # sends stream_options.include_usage only when this is on, so without it every
+        # custom-base-URL provider (xAI, DeepSeek, Qwen, Together, Groq, self-hosted vLLM)
+        # bills zero. So we ask unconditionally and RETRY once without it if the endpoint
+        # rejects it before the first chunk — the old-vLLM/strict-proxy case. That makes
+        # metering the default for the whole OpenAI-compatible family while the
+        # incompatible minority still streams (it just goes unmetered). An explicit
+        # stream_usage in stream_kwargs (a node/operator override) wins over this default.
         skw = dict(self.stream_kwargs)
-        if hasattr(self.llm, 'stream_usage') and not _has_custom_base_url(self.llm):
-            skw.setdefault('stream_usage', True)
+        ask_usage = hasattr(self.llm, 'stream_usage') and 'stream_usage' not in skw
+        if ask_usage:
+            skw['stream_usage'] = True
         total_in = out_toks = cache_read = cache_creation = 0
+
+        def _open(kw: dict):
+            # Pull the first chunk here: a 400 on stream_options.include_usage raises on
+            # this call, before anything has been yielded downstream, so the retry is safe.
+            gen = self.llm.stream(self.history, **kw)
+            return gen, next(gen)
+
+        try:
+            gen, piece = _open(skw)
+        except StopIteration:
+            gen, piece = None, None
+        except Exception:
+            if not ask_usage:
+                raise
+            skw.pop('stream_usage', None)
+            try:
+                gen, piece = _open(skw)
+            except StopIteration:
+                gen, piece = None, None
+
         # try/finally so a mid-stream raise still records the usage the chunks already
         # carried, matching the two native adapters.
         try:
-            for piece in self.llm.stream(self.history, **skw):
+            while piece is not None:
                 um = getattr(piece, 'usage_metadata', None)
                 if isinstance(um, dict):
                     # LangChain's usage_metadata is additive by contract (AIMessageChunk
@@ -361,6 +396,10 @@ class LangChainAdapter:
                 reason = (getattr(piece, 'response_metadata', None) or {}).get('finish_reason')
                 if reason:
                     self.finish_reason = reason
+                try:
+                    piece = next(gen)
+                except StopIteration:
+                    break
             tail_text, tail_thinking = parse.flush()
             if tail_thinking:
                 yield Event('thinking', tail_thinking)

--- a/packages/ai/src/ai/common/llm_base.py
+++ b/packages/ai/src/ai/common/llm_base.py
@@ -98,7 +98,7 @@ class LLMBase(IInstanceBase):
             return
 
         _flush_reasoning(force=True)  # emit any trailing partial line
-        usage = LAST_LLM_USAGE_VAR.get()
+        usage = LAST_LLM_USAGE_VAR.get()  # turn total: summed across every model call this turn
         if usage:
             answer.tokens = usage  # shown in the Trace "Tokens" grid on the answers lane
         self.instance.writeAnswers(answer)

--- a/packages/ai/src/ai/common/llm_base.py
+++ b/packages/ai/src/ai/common/llm_base.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Optional
 from rocketlib import IInstanceBase, invoke_function, warning
 from ai.common.schema import Question, Answer
 from ai.common.llm_native_stream import STOP_SEQUENCES_VAR
-from ai.common.llm_adapter import LAST_LLM_USAGE_VAR, usage_since
+from ai.common.llm_adapter import turn_usage
 
 
 class LLMBase(IInstanceBase):
@@ -82,26 +82,28 @@ class LLMBase(IInstanceBase):
             elif sum(len(p) for p in buf) >= 120:
                 _flush_reasoning(force=True)
 
-        LAST_LLM_USAGE_VAR.set(None)  # clear so a prior call's usage can't bleed into this answer
-        try:
-            answer = self._question(
-                question,
-                on_chunk=_noop,
-                on_reasoning_chunk=on_reasoning_chunk,
-            )
-        except Exception as e:
-            err_msg = f'**LLM error** — {type(e).__name__}: {e}'
-            warning(f'writeQuestions: LLM call failed: {type(e).__name__}: {e}')
-            answer = Answer()
-            answer.setAnswer(err_msg)
-            self.instance.writeAnswers(answer)
-            return
+        # Scope this turn's model calls so a prior call's usage can't bleed into this
+        # answer and the collector stays bounded to one turn.
+        with turn_usage() as read_usage:
+            try:
+                answer = self._question(
+                    question,
+                    on_chunk=_noop,
+                    on_reasoning_chunk=on_reasoning_chunk,
+                )
+            except Exception as e:
+                err_msg = f'**LLM error** — {type(e).__name__}: {e}'
+                warning(f'writeQuestions: LLM call failed: {type(e).__name__}: {e}')
+                answer = Answer()
+                answer.setAnswer(err_msg)
+                self.instance.writeAnswers(answer)
+                return
 
-        _flush_reasoning(force=True)  # emit any trailing partial line
-        usage = LAST_LLM_USAGE_VAR.get()  # turn total: summed across every model call this turn
-        if usage:
-            answer.tokens = usage  # shown in the Trace "Tokens" grid on the answers lane
-        self.instance.writeAnswers(answer)
+            _flush_reasoning(force=True)  # emit any trailing partial line
+            usage = read_usage()  # turn total: summed across every model call this turn
+            if usage:
+                answer.tokens = usage  # shown in the Trace "Tokens" grid on the answers lane
+            self.instance.writeAnswers(answer)
 
     @invoke_function
     def getContextLength(self, _param):
@@ -117,11 +119,13 @@ class LLMBase(IInstanceBase):
 
     @invoke_function
     def ask(self, param):
-        # report_llm_tokens only ever appends, so the entries added while this call
-        # ran are this invoke's own cost — the whole-turn total stays on the answer.
-        seen = len((LAST_LLM_USAGE_VAR.get() or {}).get('breakdown', []))
-        answer = self._question(param.question, stop=getattr(param, 'stop', None))
-        usage = usage_since(seen)
-        if usage:
-            answer.tokens = usage  # shown in the Trace "Tokens" grid on this invoke's row
+        # Each invoke shows its own cost: the scope reads only the calls made while it
+        # was open (its own, plus any nested sub-agent calls it drove). When an agent
+        # drives this invoke, the agent's outer scope still sees the same calls for the
+        # turn total; the outermost scope bounds and clears the collector.
+        with turn_usage() as read_usage:
+            answer = self._question(param.question, stop=getattr(param, 'stop', None))
+            usage = read_usage()
+            if usage:
+                answer.tokens = usage  # shown in the Trace "Tokens" grid on this invoke's row
         return answer

--- a/packages/ai/src/ai/common/llm_base.py
+++ b/packages/ai/src/ai/common/llm_base.py
@@ -96,6 +96,13 @@ class LLMBase(IInstanceBase):
                 warning(f'writeQuestions: LLM call failed: {type(e).__name__}: {e}')
                 answer = Answer()
                 answer.setAnswer(err_msg)
+                # A turn that failed after burning tokens still spent them: the adapters
+                # report from their own finally, so the scope holds what was billed —
+                # hang it on the error answer or the Trace shows nothing for exactly the
+                # turn the user opens.
+                failed_usage = read_usage()
+                if failed_usage:
+                    answer.tokens = failed_usage
                 self.instance.writeAnswers(answer)
                 return
 

--- a/packages/ai/src/ai/common/llm_base.py
+++ b/packages/ai/src/ai/common/llm_base.py
@@ -6,6 +6,7 @@ from typing import Callable, List, Optional
 from rocketlib import IInstanceBase, invoke_function, warning
 from ai.common.schema import Question, Answer
 from ai.common.llm_native_stream import STOP_SEQUENCES_VAR
+from ai.common.llm_adapter import LAST_LLM_USAGE_VAR
 
 
 class LLMBase(IInstanceBase):
@@ -81,6 +82,7 @@ class LLMBase(IInstanceBase):
             elif sum(len(p) for p in buf) >= 120:
                 _flush_reasoning(force=True)
 
+        LAST_LLM_USAGE_VAR.set(None)  # clear so a prior call's usage can't bleed into this answer
         try:
             answer = self._question(
                 question,
@@ -96,6 +98,9 @@ class LLMBase(IInstanceBase):
             return
 
         _flush_reasoning(force=True)  # emit any trailing partial line
+        usage = LAST_LLM_USAGE_VAR.get()
+        if usage:
+            answer.tokens = usage  # shown in the Trace "Tokens" grid on the answers lane
         self.instance.writeAnswers(answer)
 
     @invoke_function

--- a/packages/ai/src/ai/common/llm_base.py
+++ b/packages/ai/src/ai/common/llm_base.py
@@ -6,7 +6,7 @@ from typing import Callable, List, Optional
 from rocketlib import IInstanceBase, invoke_function, warning
 from ai.common.schema import Question, Answer
 from ai.common.llm_native_stream import STOP_SEQUENCES_VAR
-from ai.common.llm_adapter import LAST_LLM_USAGE_VAR
+from ai.common.llm_adapter import LAST_LLM_USAGE_VAR, usage_since
 
 
 class LLMBase(IInstanceBase):
@@ -117,4 +117,11 @@ class LLMBase(IInstanceBase):
 
     @invoke_function
     def ask(self, param):
-        return self._question(param.question, stop=getattr(param, 'stop', None))
+        # report_llm_tokens only ever appends, so the entries added while this call
+        # ran are this invoke's own cost — the whole-turn total stays on the answer.
+        seen = len((LAST_LLM_USAGE_VAR.get() or {}).get('breakdown', []))
+        answer = self._question(param.question, stop=getattr(param, 'stop', None))
+        usage = usage_since(seen)
+        if usage:
+            answer.tokens = usage  # shown in the Trace "Tokens" grid on this invoke's row
+        return answer

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -197,7 +197,7 @@ class NativeAnthropicAdapter:
             raise RuntimeError('ChatAnthropic has no _client for native streaming')
 
         parts: list[str] = []
-        input_tokens = output_tokens = 0
+        input_tokens = output_tokens = cache_read = cache_creation = 0
         raw_stream = _open_raw_message_stream(client, payload)
         try:
             for event in raw_stream:
@@ -220,7 +220,10 @@ class NativeAnthropicAdapter:
                     # input_tokens arrive once, on the opening event's message.usage.
                     u = getattr(getattr(event, 'message', None), 'usage', None)
                     if u is not None:
+                        # Anthropic input_tokens already excludes cache; cache splits out.
                         input_tokens = int(getattr(u, 'input_tokens', 0) or 0)
+                        cache_creation = int(getattr(u, 'cache_creation_input_tokens', 0) or 0)
+                        cache_read = int(getattr(u, 'cache_read_input_tokens', 0) or 0)
                 elif et == 'message_delta':
                     md = getattr(event, 'delta', None)
                     if md is not None:
@@ -239,7 +242,13 @@ class NativeAnthropicAdapter:
                 except Exception:
                     pass
 
-        report_llm_tokens(input_tokens, output_tokens, model=str(getattr(self.chat, '_model', '') or ''))
+        report_llm_tokens(
+            input_tokens,
+            output_tokens,
+            model=str(getattr(self.chat, '_model', '') or ''),
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+        )
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -302,14 +302,23 @@ def try_openai_compat_reasoning_stream(
         'model': chat._model,
         'messages': [{'role': 'user', 'content': prompt}],
         'stream': True,
+        # Ask for the usage-bearing final chunk; without this the whole reasoning
+        # path (DeepSeek/Qwen/xAI/Ollama on custom base URLs) bills zero tokens.
+        # A strict proxy that rejects it raises below and we fall back to non-streaming.
+        'stream_options': {'include_usage': True},
         'max_tokens': chat._modelOutputTokens,
     }
     kwargs.update(getattr(chat, '_reasoning_kwargs', {}))
 
     parts: list[str] = []
     finish_reason: Optional[str] = None
+    usage: Any = None
     try:
         for chunk in client.chat.completions.create(**kwargs):
+            # The final chunk carries usage with an empty choices list, so read it
+            # before the choices guard skips that chunk.
+            if getattr(chunk, 'usage', None) is not None:
+                usage = chunk.usage
             if not chunk.choices:
                 continue
             ch = chunk.choices[0]
@@ -331,6 +340,16 @@ def try_openai_compat_reasoning_stream(
 
     if not parts:
         return None
+    # Report on success only. A mid-stream failure returns None above and falls back to
+    # the non-streaming path, which reports its own usage — reporting here too would double-count.
+    if usage is not None:
+        cached = int(getattr(getattr(usage, 'prompt_tokens_details', None), 'cached_tokens', 0) or 0)
+        report_llm_tokens(
+            max(0, int(getattr(usage, 'prompt_tokens', 0) or 0) - cached),
+            int(getattr(usage, 'completion_tokens', 0) or 0),
+            model=str(getattr(chat, '_model', '') or ''),
+            cache_read_tokens=cached,
+        )
     if on_finish is not None:
         on_finish(finish_reason or 'stop')
     return ''.join(parts)

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -241,14 +241,15 @@ class NativeAnthropicAdapter:
                     closer()
                 except Exception:
                     pass
-
-        report_llm_tokens(
-            input_tokens,
-            output_tokens,
-            model=str(getattr(self.chat, '_model', '') or ''),
-            cache_read_tokens=cache_read,
-            cache_creation_tokens=cache_creation,
-        )
+            # Record usage even if the stream raised mid-way — a partial request
+            # can already have provider-reported input/cache/output tokens.
+            report_llm_tokens(
+                input_tokens,
+                output_tokens,
+                model=str(getattr(self.chat, '_model', '') or ''),
+                cache_read_tokens=cache_read,
+                cache_creation_tokens=cache_creation,
+            )
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from rocketlib import debug, warning
 
-from ai.common.llm_adapter import Event, drive_adapter, report_llm_tokens
+from ai.common.llm_adapter import Event, drive_adapter, is_usage_flag_rejection, report_llm_tokens
 
 # Per-call carrier for API-level stop sequences (e.g. CrewAI's ReAct "\nObservation:").
 # Set on the ask path in llm_base._question and read at every model sink so the stop
@@ -341,13 +341,14 @@ def try_openai_compat_reasoning_stream(
         _drain(kwargs)
     except Exception as e:
         # This handler is wired ONLY for custom base URLs (ChatBase returns early unless
-        # openai_api_base is set), which is exactly where include_usage can 400. Retry once
-        # without it ONLY on a 400 (the flag rejection) before any chunk: nothing has reached
-        # on_chunk yet, so the retry cannot duplicate visible output — we just forgo the usage
-        # chunk (that endpoint goes unmetered) and keep reasoning streaming alive. A 401/429 or
-        # a mid-stream failure is not retried here — it falls straight through to the
-        # non-streaming path (which meters itself), so a rate limit stays at two round trips.
-        if emitted == 0 and 'stream_options' in kwargs and getattr(e, 'status_code', None) == 400:
+        # openai_api_base is set), which is exactly where include_usage can be rejected. Retry
+        # once without it ONLY on a flag rejection (a 400/422 client error) before any chunk:
+        # nothing has reached on_chunk yet, so the retry cannot duplicate visible output — we
+        # just forgo the usage chunk (that endpoint goes unmetered) and keep reasoning
+        # streaming alive. A 401/429 or a mid-stream failure is not retried here — it falls
+        # straight through to the non-streaming path (which meters itself), so a rate limit
+        # stays at two round trips.
+        if emitted == 0 and 'stream_options' in kwargs and is_usage_flag_rejection(e):
             warning(
                 f'llm_native_stream openai_compat_reasoning: endpoint rejected stream_options '
                 f'({type(e).__name__}); retrying without include_usage (this call is unmetered).'

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -341,13 +341,13 @@ def try_openai_compat_reasoning_stream(
         _drain(kwargs)
     except Exception as e:
         # This handler is wired ONLY for custom base URLs (ChatBase returns early unless
-        # openai_api_base is set), which is exactly where include_usage can 400. If the
-        # endpoint rejected it before emitting anything, retry once without it: nothing has
-        # reached on_chunk yet, so the retry cannot duplicate visible output — we just forgo
-        # the usage chunk (that endpoint goes unmetered) and keep reasoning streaming alive.
-        # A failure AFTER the first chunk can't be safely re-run: fall back to the
-        # non-streaming path, which meters itself.
-        if emitted == 0 and 'stream_options' in kwargs:
+        # openai_api_base is set), which is exactly where include_usage can 400. Retry once
+        # without it ONLY on a 400 (the flag rejection) before any chunk: nothing has reached
+        # on_chunk yet, so the retry cannot duplicate visible output — we just forgo the usage
+        # chunk (that endpoint goes unmetered) and keep reasoning streaming alive. A 401/429 or
+        # a mid-stream failure is not retried here — it falls straight through to the
+        # non-streaming path (which meters itself), so a rate limit stays at two round trips.
+        if emitted == 0 and 'stream_options' in kwargs and getattr(e, 'status_code', None) == 400:
             warning(
                 f'llm_native_stream openai_compat_reasoning: endpoint rejected stream_options '
                 f'({type(e).__name__}); retrying without include_usage (this call is unmetered).'
@@ -368,10 +368,9 @@ def try_openai_compat_reasoning_stream(
             )
             return None
 
-    if not parts:
-        return None
-    # Report on success only. A mid-stream failure returns None above and falls back to
-    # the non-streaming path, which reports its own usage — reporting here too would double-count.
+    # The stream drained to completion (no exception escaped above). Report the usage it
+    # carried, once, on this success path — a mid-stream failure returned None in the except
+    # and falls back to the non-streaming path, which meters itself.
     if usage is not None:
         cached = int(getattr(getattr(usage, 'prompt_tokens_details', None), 'cached_tokens', 0) or 0)
         report_llm_tokens(
@@ -380,6 +379,13 @@ def try_openai_compat_reasoning_stream(
             model=str(getattr(chat, '_model', '') or ''),
             cache_read_tokens=cached,
         )
+    # A reasoning-only turn (budget spent on reasoning, empty content) is a real completion: it
+    # streamed its reasoning live and carries usage. Return the (possibly empty) answer so the
+    # caller keeps it, instead of discarding the captured usage and re-issuing the whole request
+    # via the non-streaming fallback — which would bill the provider twice. Only a stream that
+    # produced nothing at all (no content, no reasoning, no usage) falls back.
+    if not parts and emitted == 0 and usage is None:
+        return None
     if on_finish is not None:
         on_finish(finish_reason or 'stop')
     return ''.join(parts)

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -313,8 +313,11 @@ def try_openai_compat_reasoning_stream(
     parts: list[str] = []
     finish_reason: Optional[str] = None
     usage: Any = None
-    try:
-        for chunk in client.chat.completions.create(**kwargs):
+    emitted = 0
+
+    def _drain(kw: Dict[str, Any]) -> None:
+        nonlocal finish_reason, usage, emitted
+        for chunk in client.chat.completions.create(**kw):
             # The final chunk carries usage with an empty choices list, so read it
             # before the choices guard skips that chunk.
             if getattr(chunk, 'usage', None) is not None:
@@ -326,17 +329,44 @@ def try_openai_compat_reasoning_stream(
             rc = getattr(delta, 'reasoning_content', None)
             if rc and on_reasoning_chunk is not None:
                 on_reasoning_chunk(rc)
+                emitted += 1
             if delta.content:
                 on_chunk(delta.content)
                 parts.append(delta.content)
+                emitted += 1
             if ch.finish_reason:
                 finish_reason = ch.finish_reason
+
+    try:
+        _drain(kwargs)
     except Exception as e:
-        warning(
-            f'llm_native_stream openai_compat_reasoning: stream failed ({type(e).__name__}): {e} '
-            '(falling back to non-streaming chat).'
-        )
-        return None
+        # This handler is wired ONLY for custom base URLs (ChatBase returns early unless
+        # openai_api_base is set), which is exactly where include_usage can 400. If the
+        # endpoint rejected it before emitting anything, retry once without it: nothing has
+        # reached on_chunk yet, so the retry cannot duplicate visible output — we just forgo
+        # the usage chunk (that endpoint goes unmetered) and keep reasoning streaming alive.
+        # A failure AFTER the first chunk can't be safely re-run: fall back to the
+        # non-streaming path, which meters itself.
+        if emitted == 0 and 'stream_options' in kwargs:
+            warning(
+                f'llm_native_stream openai_compat_reasoning: endpoint rejected stream_options '
+                f'({type(e).__name__}); retrying without include_usage (this call is unmetered).'
+            )
+            kwargs.pop('stream_options', None)
+            try:
+                _drain(kwargs)
+            except Exception as e2:
+                warning(
+                    f'llm_native_stream openai_compat_reasoning: stream failed ({type(e2).__name__}): {e2} '
+                    '(falling back to non-streaming chat).'
+                )
+                return None
+        else:
+            warning(
+                f'llm_native_stream openai_compat_reasoning: stream failed ({type(e).__name__}): {e} '
+                '(falling back to non-streaming chat).'
+            )
+            return None
 
     if not parts:
         return None

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -381,11 +381,11 @@ def try_openai_compat_reasoning_stream(
             cache_read_tokens=cached,
         )
     # A reasoning-only turn (budget spent on reasoning, empty content) is a real completion: it
-    # streamed its reasoning live and carries usage. Return the (possibly empty) answer so the
-    # caller keeps it, instead of discarding the captured usage and re-issuing the whole request
-    # via the non-streaming fallback — which would bill the provider twice. Only a stream that
-    # produced nothing at all (no content, no reasoning, no usage) falls back.
-    if not parts and emitted == 0 and usage is None:
+    # streamed its reasoning live, so returning the empty answer keeps what the user already saw.
+    # A stream that produced nothing at all still falls back to the non-streaming path — the
+    # usage above was already reported, so the fallback's own metering adds the second request
+    # the provider does bill, rather than double-counting this one.
+    if not parts and emitted == 0:
         return None
     if on_finish is not None:
         on_finish(finish_reason or 'stop')

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from rocketlib import debug, warning
 
-from ai.common.llm_adapter import Event, drive_adapter
+from ai.common.llm_adapter import Event, drive_adapter, report_llm_tokens
 
 # Per-call carrier for API-level stop sequences (e.g. CrewAI's ReAct "\nObservation:").
 # Set on the ask path in llm_base._question and read at every model sink so the stop
@@ -197,6 +197,7 @@ class NativeAnthropicAdapter:
             raise RuntimeError('ChatAnthropic has no _client for native streaming')
 
         parts: list[str] = []
+        input_tokens = output_tokens = 0
         raw_stream = _open_raw_message_stream(client, payload)
         try:
             for event in raw_stream:
@@ -215,12 +216,21 @@ class NativeAnthropicAdapter:
                         if piece:
                             parts.append(piece)
                             yield Event('text', piece)
+                elif et == 'message_start':
+                    # input_tokens arrive once, on the opening event's message.usage.
+                    u = getattr(getattr(event, 'message', None), 'usage', None)
+                    if u is not None:
+                        input_tokens = int(getattr(u, 'input_tokens', 0) or 0)
                 elif et == 'message_delta':
                     md = getattr(event, 'delta', None)
                     if md is not None:
                         sr = getattr(md, 'stop_reason', None)
                         if sr is not None:
                             self.finish_reason = _map_claude_stop_reason(sr)
+                    # output_tokens accumulate on message_delta.usage (final = last).
+                    u = getattr(event, 'usage', None)
+                    if u is not None:
+                        output_tokens = int(getattr(u, 'output_tokens', 0) or 0) or output_tokens
         finally:
             closer = getattr(raw_stream, 'close', None)
             if callable(closer):
@@ -229,6 +239,7 @@ class NativeAnthropicAdapter:
                 except Exception:
                     pass
 
+        report_llm_tokens(input_tokens, output_tokens, model=str(getattr(self.chat, '_model', '') or ''))
         assistant = {'role': 'assistant', 'content': ''.join(parts)}
         self.history.append(assistant)
         yield Event('done', items=[assistant])

--- a/packages/ai/tests/ai/common/agent/test_agent_base.py
+++ b/packages/ai/tests/ai/common/agent/test_agent_base.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Dict, List, Tuple
 import pytest
 
 from ai.common.agent import AgentBase, AgentContext
-from ai.common.llm_adapter import LAST_LLM_USAGE_VAR
+from ai.common.llm_adapter import report_llm_tokens
 from ai.common.utils import parse_bool
 
 
@@ -218,47 +218,90 @@ def test_guard_answer_is_emitted_on_the_answers_lane():
 # ---------------------------------------------------------------------------
 
 
+def _report_two_calls(_driver, _context, _question):
+    """Driver body that reports two model calls, as report_llm_tokens does at the seam."""
+    report_llm_tokens(10, 4, model='claude-haiku-4-5')
+    report_llm_tokens(20, 8, model='claude-haiku-4-5')
+    return ('It is sunny in NYC.', {'raw': 'grounded'})
+
+
 def test_answer_carries_the_turn_token_usage():
     """An agentic turn calls the model N times; the answer must carry the total.
 
-    Without this the Trace "Tokens" grid renders for a plain LLM node but never
-    for an agent, because the agent emits its own Answer here rather than going
-    through the LLM node's questions lane.
+    Without this the Trace "Tokens" grid renders for a plain LLM node but never for
+    an agent, because the agent emits its own Answer here rather than going through the
+    LLM node's questions lane. Usage accrues DURING the run (report_llm_tokens at the
+    Adapter seam), read back by run_agent's turn scope.
     """
-    usage = {
-        'input': 30,
-        'output': 12,
-        'cache_read': 0,
-        'cache_creation': 0,
-        'model': 'claude-haiku-4-5',
-        'calls': 2,
-        'breakdown': [
-            {'input': 10, 'output': 4, 'cache_read': 0, 'cache_creation': 0, 'model': 'claude-haiku-4-5'},
-            {'input': 20, 'output': 8, 'cache_read': 0, 'cache_creation': 0, 'model': 'claude-haiku-4-5'},
-        ],
-    }
-    token = LAST_LLM_USAGE_VAR.set(usage)
-    try:
-        ii = _FakeIInstance()
-        driver = _make_driver(_call_one_tool, require_tool_call=False)
-        driver.run_agent(ii, _FakeQuestion(), emit_answers_lane=True)
-    finally:
-        LAST_LLM_USAGE_VAR.reset(token)
+    from ai.web.metrics.metrics import metrics
 
-    assert ii.instance.written[0].tokens == usage
+    metrics.reset()
+    ii = _FakeIInstance()
+    driver = _make_driver(_report_two_calls, require_tool_call=False)
+    driver.run_agent(ii, _FakeQuestion(), emit_answers_lane=True)
+
+    tokens = ii.instance.written[0].tokens
+    assert tokens['input'] == 30 and tokens['output'] == 12 and tokens['calls'] == 2
+    assert len(tokens['breakdown']) == 2
 
 
 def test_answer_has_no_tokens_when_none_were_reported():
     """A run with no model call must not invent an empty grid."""
-    token = LAST_LLM_USAGE_VAR.set(None)
-    try:
-        ii = _FakeIInstance()
-        driver = _make_driver(_call_one_tool, require_tool_call=False)
-        driver.run_agent(ii, _FakeQuestion(), emit_answers_lane=True)
-    finally:
-        LAST_LLM_USAGE_VAR.reset(token)
+    from ai.web.metrics.metrics import metrics
+
+    metrics.reset()
+    ii = _FakeIInstance()
+    driver = _make_driver(_call_one_tool, require_tool_call=False)
+    driver.run_agent(ii, _FakeQuestion(), emit_answers_lane=True)
 
     assert ii.instance.written[0].tokens is None
+
+
+def test_a_prior_turn_does_not_bleed_into_the_next():
+    """Two questions in a row: the second answer carries only its own calls.
+
+    The agent reaches the model through ask(), which never cleared the old contextvar;
+    the turn scope now bounds each run so question 2 can't inherit question 1's tokens.
+    """
+    from ai.web.metrics.metrics import metrics
+
+    metrics.reset()
+    driver = _make_driver(_report_two_calls, require_tool_call=False)
+
+    ii1 = _FakeIInstance()
+    driver.run_agent(ii1, _FakeQuestion(), emit_answers_lane=True)
+    ii2 = _FakeIInstance()
+    driver.run_agent(ii2, _FakeQuestion(), emit_answers_lane=True)
+
+    # Not 4 calls / 60 input — each turn is independent.
+    assert ii2.instance.written[0].tokens['calls'] == 2
+    assert ii2.instance.written[0].tokens['input'] == 30
+
+
+def test_outer_agent_total_includes_sub_agent_calls():
+    """An agent can drive sub-agents; the outer answer's total includes theirs.
+
+    The sub-agent's run_agent opens a nested turn scope: it reads only its own calls,
+    but the outer scope still sees them for the turn total (the collector is shared and
+    cleared only by the outermost scope).
+    """
+    from ai.web.metrics.metrics import metrics
+
+    metrics.reset()
+    sub_driver = _make_driver(_report_two_calls, require_tool_call=False)  # 2 calls: 30 in / 12 out
+
+    def _outer_run(_driver, _context, _question):
+        report_llm_tokens(5, 2, model='outer')  # the outer agent's own call
+        sub_driver.run_agent(_FakeIInstance(), _FakeQuestion(), emit_answers_lane=False)
+        return ('done', {'raw': 'x'})
+
+    ii = _FakeIInstance()
+    outer = _make_driver(_outer_run, require_tool_call=False)
+    outer.run_agent(ii, _FakeQuestion(), emit_answers_lane=True)
+
+    tokens = ii.instance.written[0].tokens
+    assert tokens['calls'] == 3  # outer's 1 + sub-agent's 2
+    assert tokens['input'] == 35 and tokens['output'] == 14
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/agent/test_agent_base.py
+++ b/packages/ai/tests/ai/common/agent/test_agent_base.py
@@ -32,6 +32,7 @@ from typing import Any, Callable, Dict, List, Tuple
 import pytest
 
 from ai.common.agent import AgentBase, AgentContext
+from ai.common.llm_adapter import LAST_LLM_USAGE_VAR
 from ai.common.utils import parse_bool
 
 
@@ -210,6 +211,54 @@ def test_guard_answer_is_emitted_on_the_answers_lane():
 
     # Even a tripped guard still emits exactly one answer downstream.
     assert len(ii.instance.written) == 1
+
+
+# ---------------------------------------------------------------------------
+# Token usage on the emitted answer
+# ---------------------------------------------------------------------------
+
+
+def test_answer_carries_the_turn_token_usage():
+    """An agentic turn calls the model N times; the answer must carry the total.
+
+    Without this the Trace "Tokens" grid renders for a plain LLM node but never
+    for an agent, because the agent emits its own Answer here rather than going
+    through the LLM node's questions lane.
+    """
+    usage = {
+        'input': 30,
+        'output': 12,
+        'cache_read': 0,
+        'cache_creation': 0,
+        'model': 'claude-haiku-4-5',
+        'calls': 2,
+        'breakdown': [
+            {'input': 10, 'output': 4, 'cache_read': 0, 'cache_creation': 0, 'model': 'claude-haiku-4-5'},
+            {'input': 20, 'output': 8, 'cache_read': 0, 'cache_creation': 0, 'model': 'claude-haiku-4-5'},
+        ],
+    }
+    token = LAST_LLM_USAGE_VAR.set(usage)
+    try:
+        ii = _FakeIInstance()
+        driver = _make_driver(_call_one_tool, require_tool_call=False)
+        driver.run_agent(ii, _FakeQuestion(), emit_answers_lane=True)
+    finally:
+        LAST_LLM_USAGE_VAR.reset(token)
+
+    assert ii.instance.written[0].tokens == usage
+
+
+def test_answer_has_no_tokens_when_none_were_reported():
+    """A run with no model call must not invent an empty grid."""
+    token = LAST_LLM_USAGE_VAR.set(None)
+    try:
+        ii = _FakeIInstance()
+        driver = _make_driver(_call_one_tool, require_tool_call=False)
+        driver.run_agent(ii, _FakeQuestion(), emit_answers_lane=True)
+    finally:
+        LAST_LLM_USAGE_VAR.reset(token)
+
+    assert ii.instance.written[0].tokens is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/test_llm_base_tokens.py
+++ b/packages/ai/tests/ai/common/test_llm_base_tokens.py
@@ -1,0 +1,152 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Tests for the two ``answer.tokens`` seams on ``LLMBase``: writeQuestions and ask.
+
+This is the plain LLM-node lane — every ``llm_*`` node emits its answer through
+``writeQuestions``, and ``ask`` is the per-invoke seam the Trace "Tokens" row rests on.
+The agent lane's equivalent is covered in ``agent/test_agent_base.py``.
+
+The driver is built with ``__new__`` so the tests never touch the engine
+``iGlobal`` / ``Config`` plumbing; ``_question`` is replaced by a fake that reports
+usage exactly where the Adapter seam does.
+
+Run with::
+
+    pytest packages/ai/tests/ai/common/test_llm_base_tokens.py -v
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, List
+
+from rocketride import Answer
+
+import ai.common.llm_adapter as _adapter
+from ai.common.llm_adapter import report_llm_tokens
+from ai.common.llm_base import LLMBase
+from ai.web.metrics.metrics import metrics
+
+
+def setup_function(_):
+    metrics.reset()
+    # No turn is open between tests; reset the per-turn collector so a leaked scope
+    # from one test cannot seed the next.
+    _adapter._TURN_CALLS.set(None)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles
+# ---------------------------------------------------------------------------
+
+
+class _FakeInner:
+    """Stands in for ``iInstance.instance``."""
+
+    def __init__(self) -> None:
+        self.written: List[Any] = []
+
+    def writeAnswers(self, answer: Any) -> None:
+        self.written.append(answer)
+
+    def sendSSE(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class _FakeQuestion:
+    def __init__(self, text: str = 'q') -> None:
+        self.question = text
+
+
+def _make_node(question_impl: Callable[..., Answer]) -> LLMBase:
+    """Build an LLMBase whose ``_question`` is the given fake (no engine plumbing)."""
+
+    class _StubNode(LLMBase):
+        def _question(self, question, **kwargs):
+            return question_impl(question, **kwargs)
+
+    node = _StubNode.__new__(_StubNode)
+    node.instance = _FakeInner()
+    return node
+
+
+def _answer(text: str = 'ok') -> Answer:
+    a = Answer()
+    a.setAnswer(text)
+    return a
+
+
+def _two_calls(_question, **_kwargs) -> Answer:
+    """A turn that reaches the model twice, as report_llm_tokens does at the Adapter seam."""
+    report_llm_tokens(10, 4, model='m1')
+    report_llm_tokens(20, 8, model='m2')
+    return _answer('It is sunny in NYC.')
+
+
+def _no_call(_question, **_kwargs) -> Answer:
+    """A cached/short-circuited turn: an answer with no model call behind it."""
+    return _answer('cached')
+
+
+# ---------------------------------------------------------------------------
+# writeQuestions — the answers lane every plain llm_* node emits through
+# ---------------------------------------------------------------------------
+
+
+def test_write_questions_answer_carries_the_turn_token_usage():
+    node = _make_node(_two_calls)
+
+    node.writeQuestions(_FakeQuestion())
+
+    tokens = node.instance.written[0].tokens
+    assert tokens['calls'] == 2
+    assert tokens['input'] == 30 and tokens['output'] == 12
+    assert len(tokens['breakdown']) == 2
+
+
+def test_write_questions_has_no_tokens_when_no_model_was_called():
+    """No call must render no grid at all, not an empty one."""
+    node = _make_node(_no_call)
+
+    node.writeQuestions(_FakeQuestion())
+
+    assert node.instance.written[0].tokens is None
+
+
+# ---------------------------------------------------------------------------
+# ask — the per-invoke seam an agent drives
+# ---------------------------------------------------------------------------
+
+
+def test_ask_answer_carries_its_own_call():
+    node = _make_node(lambda _q, **_kw: (report_llm_tokens(7, 3, model='m1'), _answer())[1])
+
+    answer = node.ask(_FakeQuestion())
+
+    # One call renders as plain totals — no redundant breakdown of itself.
+    assert answer.tokens == {'input': 7, 'output': 3, 'cache_read': 0, 'cache_creation': 0, 'model': 'm1'}
+
+
+def test_a_second_ask_does_not_inherit_the_first_ones_tokens():
+    """The bug class this PR was redesigned twice to fix, pinned at the ask seam.
+
+    Each invoke opens its own scope, so invoke 2 shows its own cost — not the running
+    total of everything the instance has asked for.
+    """
+    calls = iter([(7, 3, 'm1'), (100, 40, 'm2')])
+
+    def _one_call(_q, **_kw) -> Answer:
+        i, o, m = next(calls)
+        report_llm_tokens(i, o, model=m)
+        return _answer()
+
+    node = _make_node(_one_call)
+
+    first = node.ask(_FakeQuestion())
+    second = node.ask(_FakeQuestion())
+
+    assert first.tokens['input'] == 7
+    # Not 107 input / 2 calls: the second invoke reads only its own scope.
+    assert second.tokens == {'input': 100, 'output': 40, 'cache_read': 0, 'cache_creation': 0, 'model': 'm2'}

--- a/packages/ai/tests/ai/common/test_llm_base_tokens.py
+++ b/packages/ai/tests/ai/common/test_llm_base_tokens.py
@@ -90,6 +90,17 @@ def _no_call(_question, **_kwargs) -> Answer:
     return _answer('cached')
 
 
+def _fails_after_one_call(_question, **_kwargs) -> Answer:
+    """A turn that burns tokens, then the provider drops the connection."""
+    report_llm_tokens(10, 4, model='m1')
+    raise RuntimeError('provider stream died')
+
+
+def _fails_before_any_call(_question, **_kwargs) -> Answer:
+    """A turn that dies before a request ever reaches the provider."""
+    raise RuntimeError('connect timeout')
+
+
 # ---------------------------------------------------------------------------
 # writeQuestions — the answers lane every plain llm_* node emits through
 # ---------------------------------------------------------------------------
@@ -109,6 +120,30 @@ def test_write_questions_answer_carries_the_turn_token_usage():
 def test_write_questions_has_no_tokens_when_no_model_was_called():
     """No call must render no grid at all, not an empty one."""
     node = _make_node(_no_call)
+
+    node.writeQuestions(_FakeQuestion())
+
+    assert node.instance.written[0].tokens is None
+
+
+def test_write_questions_error_answer_still_carries_the_burnt_tokens():
+    """A turn that failed after burning tokens is the one a user opens the Trace on.
+
+    The adapters report from their own ``finally``, so the scope holds what was billed;
+    the except branch has to read it before returning or the grid renders empty.
+    """
+    node = _make_node(_fails_after_one_call)
+
+    node.writeQuestions(_FakeQuestion())
+
+    written = node.instance.written[0]
+    assert 'RuntimeError' in written.getText()
+    assert written.tokens == {'input': 10, 'output': 4, 'cache_read': 0, 'cache_creation': 0, 'model': 'm1'}
+
+
+def test_write_questions_error_answer_has_no_tokens_when_nothing_was_called():
+    """A failure before any request must leave tokens unset, not set it to an empty grid."""
+    node = _make_node(_fails_before_any_call)
 
     node.writeQuestions(_FakeQuestion())
 

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -7,7 +7,7 @@
 
 import pytest
 
-from ai.common.llm_adapter import LangChainAdapter, _split_input_cache, report_llm_tokens
+from ai.common.llm_adapter import LAST_LLM_USAGE_VAR, LangChainAdapter, _split_input_cache, report_llm_tokens
 
 # Same singleton report_llm_tokens reports into; imported from the module (not the
 # package) to avoid pulling the taskhook side of ai.web.metrics into the test.
@@ -206,3 +206,23 @@ def test_collect_reports_usage_from_the_invoke_result():
 
     assert text == 'Hi there'
     _assert_four_counters()
+
+
+def test_publishes_last_usage_on_the_contextvar():
+    # The node reads this to hang the usage on the Answer (Trace "Tokens" grid).
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(14, 81, model='claude-haiku-4-5', cache_read_tokens=2, cache_creation_tokens=3)
+    assert LAST_LLM_USAGE_VAR.get() == {
+        'input': 14,
+        'output': 81,
+        'cache_read': 2,
+        'cache_creation': 3,
+        'model': 'claude-haiku-4-5',
+    }
+
+
+def test_all_zero_usage_leaves_the_contextvar_unset():
+    # No usage reported -> nothing to attach, so the Answer carries no tokens.
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(0, 0)
+    assert LAST_LLM_USAGE_VAR.get() is None

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -1,0 +1,79 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Tests for LLM token accounting: report_llm_tokens + the usage/cache split."""
+
+from ai.common.llm_adapter import _split_input_cache, report_llm_tokens
+
+# Same singleton report_llm_tokens reports into; imported from the module (not the
+# package) to avoid pulling the taskhook side of ai.web.metrics into the test.
+from ai.web.metrics.metrics import metrics
+
+
+def setup_function(_):
+    metrics.reset()
+
+
+def _counters():
+    return metrics.report()['counters']
+
+
+def _events():
+    return metrics.report()['events']
+
+
+def test_reports_input_and_output_counters():
+    report_llm_tokens(23, 37, model='claude-haiku-4-5')
+    c = _counters()
+    assert c['llm_input_tokens'] == 23
+    assert c['llm_output_tokens'] == 37
+    # No cache activity -> no cache counters.
+    assert 'llm_cache_read_tokens' not in c
+    assert 'llm_cache_creation_tokens' not in c
+
+
+def test_emits_llm_tokens_event_payload():
+    report_llm_tokens(5, 9, model='gpt-5.4-mini')
+    payload = {'input': 5, 'output': 9, 'cache_read': 0, 'cache_creation': 0, 'model': 'gpt-5.4-mini'}
+    assert {'llm_tokens': payload} in _events()
+
+
+def test_reports_cache_counters_separately():
+    report_llm_tokens(10, 4, model='m', cache_read_tokens=100, cache_creation_tokens=20)
+    c = _counters()
+    assert c['llm_input_tokens'] == 10
+    assert c['llm_cache_read_tokens'] == 100
+    assert c['llm_cache_creation_tokens'] == 20
+
+
+def test_zero_usage_is_a_noop():
+    report_llm_tokens(0, 0)
+    assert _counters() == {}
+    assert _events() == []
+
+
+def test_counters_accumulate_across_calls():
+    report_llm_tokens(3, 0)
+    report_llm_tokens(4, 0)
+    assert _counters()['llm_input_tokens'] == 7
+
+
+def test_metrics_failure_is_suppressed(monkeypatch):
+    def boom(*_a, **_k):
+        raise RuntimeError('metrics down')
+
+    monkeypatch.setattr(metrics, 'counter', boom)
+    # Best-effort accounting must never break the chat turn.
+    report_llm_tokens(1, 1)
+
+
+def test_split_input_cache_subtracts_cache_from_total():
+    # LangChain reports input_tokens as the full prompt; cache splits back out.
+    um = {'input_tokens': 100, 'output_tokens': 20, 'input_token_details': {'cache_read': 30, 'cache_creation': 10}}
+    assert _split_input_cache(um) == (60, 20, 30, 10)
+
+
+def test_split_input_cache_without_details():
+    assert _split_input_cache({'input_tokens': 40, 'output_tokens': 5}) == (40, 5, 0, 0)

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -23,11 +23,9 @@ from ai.web.metrics.metrics import metrics
 
 def setup_function(_):
     metrics.reset()
-    # The turn collector is a module global; clear it so a leaked scope from one
-    # test can't seed the next.
-    with _adapter._USAGE_LOCK:
-        _adapter._USAGE_CALLS.clear()
-        _adapter._TURN_DEPTH = 0
+    # No turn is open between tests; reset the per-turn collector to its default so a
+    # leaked scope from one test cannot seed the next.
+    _adapter._TURN_CALLS.set(None)
 
 
 def _counters():
@@ -148,6 +146,18 @@ class _FakeChatXAI(_FakeChatOpenAI):
     model = 'grok-4'
 
 
+class _FakeRejectsUsageFlag(_FakeChatOpenAI):
+    """An old vLLM/strict proxy: 400s on the usage flag before any chunk, streams without it."""
+
+    model = 'vllm-local'
+
+    def stream(self, messages, **kwargs):
+        self.kwargs = kwargs
+        if kwargs.get('stream_usage'):
+            raise RuntimeError('400 stream_options.include_usage unsupported')
+        yield from self._chunks
+
+
 def _assert_four_counters():
     c = _counters()
     assert c['llm_input_tokens'] == 60
@@ -180,8 +190,23 @@ def test_stream_omits_the_flag_for_a_model_that_lacks_it():
     _assert_four_counters()
 
 
+def test_stream_retries_without_the_usage_flag_when_the_endpoint_rejects_it():
+    # A custom base URL that 400s on include_usage (old vLLM/strict proxy) must not lose the
+    # stream: we ask, the endpoint rejects it before any chunk, and we retry once without it.
+    llm = _FakeRejectsUsageFlag([_Chunk('Hi'), _Chunk(' there')])
+
+    events = list(LangChainAdapter(llm).stream('q'))
+
+    # Streamed on the retry, with the flag dropped. That endpoint goes unmetered (no usage
+    # chunk without the flag) but reasoning/text still flows.
+    assert ''.join(e.text for e in events if e.type == 'text') == 'Hi there'
+    assert 'stream_usage' not in llm.kwargs
+
+
 def test_stream_keeps_the_final_total_not_the_sum_of_chunks():
-    """Chunk counts are cumulative, so the reader takes max(), never a running sum."""
+    """Every provider reached today reports usage on one chunk, so max() returns that
+    chunk's total; a delta-reporting provider would instead need the deltas summed.
+    """
     llm = _FakeChatBedrock(
         [
             _Chunk('Hi', {'input_tokens': 100, 'output_tokens': 5}),
@@ -256,7 +281,8 @@ def test_turn_reader_sums_a_many_call_turn():
 
 
 def test_turn_is_cleared_when_the_outermost_scope_exits():
-    # Bounded to one turn: a second turn does not inherit the first's calls.
+    # Bounded to one turn: the second turn opens a fresh list, so it never inherits the
+    # first's calls.
     with turn_usage() as r1:
         report_llm_tokens(10, 5, model='m1')
         assert r1()['input'] == 10
@@ -274,8 +300,8 @@ def test_zero_usage_leaves_the_turn_empty():
 
 def test_nested_scope_reads_its_own_calls_while_the_outer_reads_all():
     # An agent can drive a sub-agent: the sub-agent's scope shows only its own calls,
-    # the outer scope shows the whole turn (sub-agent included), and the collector is
-    # cleared only when the outermost scope exits.
+    # the outer scope shows the whole turn (sub-agent included), and the list is freed
+    # only when the outermost scope exits.
     with turn_usage() as outer:
         report_llm_tokens(10, 5, model='a')
         with turn_usage() as inner:
@@ -289,16 +315,46 @@ def test_nested_scope_reads_its_own_calls_while_the_outer_reads_all():
 
 
 def test_calls_from_a_worker_thread_land_in_the_open_turn():
-    # CrewAI/deepagent run kickoffs on a worker thread under a copied context, where a
-    # ContextVar write would never propagate back to the reader. The module-global
-    # collector does, so the agent's answer still carries the total.
+    # CrewAI/deepagent (and the rocketride tool wave) run kickoffs on a worker thread under
+    # copy_context().run(...). copy_context copies the mapping, not the values, so the thread
+    # inherits the SAME list object and its appends reach the reader that opened the turn.
     import threading
+    from contextvars import copy_context
 
     with turn_usage() as read_usage:
-        t = threading.Thread(target=lambda: report_llm_tokens(200, 60, model='crew'))
+        ctx = copy_context()  # snapshots the context WITH this turn's list bound
+        t = threading.Thread(target=lambda: ctx.run(report_llm_tokens, 200, 60, model='crew'))
         t.start()
         t.join()  # the agent blocks on the kickoff before reading
         assert read_usage() == {'input': 200, 'output': 60, 'cache_read': 0, 'cache_creation': 0, 'model': 'crew'}
+
+
+def test_two_overlapping_turns_do_not_read_each_others_calls():
+    # Concurrent turns are normal (a ThreadPoolExecutor tool wave, one pipeline per inbound
+    # message). Each opens its own list, so neither reads the other's calls — the bug a
+    # single process-wide collector had.
+    import threading
+
+    results: dict = {}
+    open_barrier = threading.Barrier(2)  # both scopes open before either reports
+    report_barrier = threading.Barrier(2)  # both reported while both scopes still open
+
+    def run_turn(name, n):
+        with turn_usage() as read_usage:
+            open_barrier.wait()
+            report_llm_tokens(n, n, model=name)
+            report_barrier.wait()
+            results[name] = read_usage()
+
+    a = threading.Thread(target=run_turn, args=('A', 10))
+    b = threading.Thread(target=run_turn, args=('B', 9000))
+    a.start()
+    b.start()
+    a.join()
+    b.join()
+
+    assert results['A'] == {'input': 10, 'output': 10, 'cache_read': 0, 'cache_creation': 0, 'model': 'A'}
+    assert results['B'] == {'input': 9000, 'output': 9000, 'cache_read': 0, 'cache_creation': 0, 'model': 'B'}
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -158,6 +158,19 @@ class _FakeRejectsUsageFlag(_FakeChatOpenAI):
         yield from self._chunks
 
 
+class _FakeRaises401(_FakeChatOpenAI):
+    """A bad key: the failure carries status_code 401, so the flag retry must NOT fire."""
+
+    model = 'gpt-401'
+
+    def stream(self, messages, **kwargs):
+        self.kwargs = kwargs
+        err = RuntimeError('401 unauthorized')
+        err.status_code = 401
+        raise err
+        yield  # unreachable — makes this a generator so the raise fires on first next()
+
+
 def _assert_four_counters():
     c = _counters()
     assert c['llm_input_tokens'] == 60
@@ -201,6 +214,17 @@ def test_stream_retries_without_the_usage_flag_when_the_endpoint_rejects_it():
     # chunk without the flag) but reasoning/text still flows.
     assert ''.join(e.text for e in events if e.type == 'text') == 'Hi there'
     assert 'stream_usage' not in llm.kwargs
+
+
+def test_stream_does_not_retry_a_non_400_failure():
+    # A 401/429/etc. is not the usage-flag rejection: it must surface without a second
+    # identical round trip. The flag stays on and the error propagates.
+    llm = _FakeRaises401([_Chunk('x')])
+
+    with pytest.raises(RuntimeError):
+        list(LangChainAdapter(llm).stream('q'))
+
+    assert llm.kwargs == {'stream_usage': True}  # one attempt only; the flag was not stripped
 
 
 def test_stream_keeps_the_final_total_not_the_sum_of_chunks():
@@ -355,6 +379,43 @@ def test_two_overlapping_turns_do_not_read_each_others_calls():
 
     assert results['A'] == {'input': 10, 'output': 10, 'cache_read': 0, 'cache_creation': 0, 'model': 'A'}
     assert results['B'] == {'input': 9000, 'output': 9000, 'cache_read': 0, 'cache_creation': 0, 'model': 'B'}
+
+
+def test_two_sibling_scopes_in_one_turn_do_not_read_each_others_calls():
+    # A parallel tool wave: two invokes open nested scopes inside ONE turn (each worker runs
+    # under copy_context().run, so both carry this turn's list). Each per-invoke reader must
+    # show only its own call — a single turn list sliced by an offset could not, since both
+    # siblings open at offset 0 — while the outer turn, after the wave joins, sees both.
+    import threading
+    from contextvars import copy_context
+
+    results: dict = {}
+    both_open = threading.Barrier(2)
+
+    with turn_usage() as outer:
+
+        def make_worker(name, n):
+            ctx = copy_context()  # snapshots the outer turn as this worker's parent
+
+            def body():
+                with turn_usage() as read_invoke:
+                    both_open.wait()  # force both nested scopes open before either reports
+                    report_llm_tokens(n, n, model=name)
+                    results[name] = read_invoke()
+
+            return lambda: ctx.run(body)
+
+        ta = threading.Thread(target=make_worker('A', 10))
+        tb = threading.Thread(target=make_worker('B', 9000))
+        ta.start()
+        tb.start()
+        ta.join()
+        tb.join()
+
+        assert results['A'] == {'input': 10, 'output': 10, 'cache_read': 0, 'cache_creation': 0, 'model': 'A'}
+        assert results['B'] == {'input': 9000, 'output': 9000, 'cache_read': 0, 'cache_creation': 0, 'model': 'B'}
+        total = outer()
+        assert total['calls'] == 2 and total['input'] == 9010
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -208,16 +208,31 @@ def test_collect_reports_usage_from_the_invoke_result():
     _assert_four_counters()
 
 
-def test_publishes_last_usage_on_the_contextvar():
+def test_publishes_usage_on_the_contextvar():
     # The node reads this to hang the usage on the Answer (Trace "Tokens" grid).
     LAST_LLM_USAGE_VAR.set(None)
     report_llm_tokens(14, 81, model='claude-haiku-4-5', cache_read_tokens=2, cache_creation_tokens=3)
+    call = {'input': 14, 'output': 81, 'cache_read': 2, 'cache_creation': 3, 'model': 'claude-haiku-4-5'}
+    assert LAST_LLM_USAGE_VAR.get() == {**call, 'calls': 1, 'breakdown': [call]}
+
+
+def test_contextvar_accumulates_across_a_many_call_turn():
+    # An agentic turn calls the model repeatedly; the Trace must show the turn total
+    # AND every call's cost, not just the last call. Counters/events stay per-call
+    # (billing unchanged) — only this display accumulator sums the turn.
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(10, 5, model='m1', cache_read_tokens=1, cache_creation_tokens=2)
+    report_llm_tokens(30, 7, model='m2', cache_read_tokens=3, cache_creation_tokens=4)
+    c1 = {'input': 10, 'output': 5, 'cache_read': 1, 'cache_creation': 2, 'model': 'm1'}
+    c2 = {'input': 30, 'output': 7, 'cache_read': 3, 'cache_creation': 4, 'model': 'm2'}
     assert LAST_LLM_USAGE_VAR.get() == {
-        'input': 14,
-        'output': 81,
-        'cache_read': 2,
-        'cache_creation': 3,
-        'model': 'claude-haiku-4-5',
+        'input': 40,
+        'output': 12,
+        'cache_read': 4,
+        'cache_creation': 6,
+        'model': 'm2',  # last model that actually reported usage
+        'calls': 2,
+        'breakdown': [c1, c2],  # each call's cost, in order, for the action history
     }
 
 

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -154,7 +154,9 @@ class _FakeRejectsUsageFlag(_FakeChatOpenAI):
     def stream(self, messages, **kwargs):
         self.kwargs = kwargs
         if kwargs.get('stream_usage'):
-            raise RuntimeError('400 stream_options.include_usage unsupported')
+            err = RuntimeError('stream_options.include_usage unsupported')
+            err.status_code = 400  # the openai SDK's BadRequestError shape
+            raise err
         yield from self._chunks
 
 
@@ -169,6 +171,19 @@ class _FakeRaises401(_FakeChatOpenAI):
         err.status_code = 401
         raise err
         yield  # unreachable — makes this a generator so the raise fires on first next()
+
+
+class _FakeRaisesTransient(_FakeChatOpenAI):
+    """A connection error/timeout: no status_code, so it must NOT be mistaken for a flag
+    rejection and retried unmetered — it re-raises.
+    """
+
+    model = 'gpt-transient'
+
+    def stream(self, messages, **kwargs):
+        self.kwargs = kwargs
+        raise RuntimeError('connection reset')
+        yield  # unreachable — generator so the raise fires on first next()
 
 
 def _assert_four_counters():
@@ -225,6 +240,17 @@ def test_stream_does_not_retry_a_non_400_failure():
         list(LangChainAdapter(llm).stream('q'))
 
     assert llm.kwargs == {'stream_usage': True}  # one attempt only; the flag was not stripped
+
+
+def test_stream_does_not_retry_a_transient_error_without_a_status_code():
+    # A connection error/timeout carries no status_code; the old broad retry would drop the
+    # flag and succeed unmetered with a misleading warning. It must re-raise instead.
+    llm = _FakeRaisesTransient([_Chunk('x')])
+
+    with pytest.raises(RuntimeError):
+        list(LangChainAdapter(llm).stream('q'))
+
+    assert llm.kwargs == {'stream_usage': True}  # not stripped, not retried
 
 
 def test_stream_keeps_the_final_total_not_the_sum_of_chunks():

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -5,7 +5,9 @@
 
 """Tests for LLM token accounting: report_llm_tokens + the usage/cache split."""
 
-from ai.common.llm_adapter import _split_input_cache, report_llm_tokens
+import pytest
+
+from ai.common.llm_adapter import LangChainAdapter, _split_input_cache, report_llm_tokens
 
 # Same singleton report_llm_tokens reports into; imported from the module (not the
 # package) to avoid pulling the taskhook side of ai.web.metrics into the test.
@@ -77,3 +79,130 @@ def test_split_input_cache_subtracts_cache_from_total():
 
 def test_split_input_cache_without_details():
     assert _split_input_cache({'input_tokens': 40, 'output_tokens': 5}) == (40, 5, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# LangChainAdapter — the capture point every llm_* provider goes through
+# ---------------------------------------------------------------------------
+
+# Cumulative usage as LangChain reports it on the final chunk: input_tokens is the
+# whole prompt, so the four counters below are 60/20/30/10 once cache splits out.
+_USAGE = {'input_tokens': 100, 'output_tokens': 20, 'input_token_details': {'cache_read': 30, 'cache_creation': 10}}
+
+
+class _Chunk:
+    def __init__(self, content='', usage_metadata=None):
+        self.content = content
+        self.usage_metadata = usage_metadata
+        self.response_metadata = None
+
+
+class _FakeChatBedrock:
+    """Declares no ``stream_usage``: the flag would reach it as an unknown kwarg."""
+
+    model = 'anthropic.claude-sonnet-4-6'
+
+    def __init__(self, chunks, *, raise_after=None, result=None):
+        self._chunks = chunks
+        self._raise_after = raise_after
+        self._result = result
+        self.kwargs = None
+
+    def stream(self, messages, **kwargs):
+        self.kwargs = kwargs
+        for i, chunk in enumerate(self._chunks):
+            yield chunk
+            if self._raise_after is not None and i >= self._raise_after:
+                raise RuntimeError('connection dropped')
+
+    def invoke(self, messages, **kwargs):
+        self.kwargs = kwargs
+        return self._result
+
+
+class _FakeChatOpenAI(_FakeChatBedrock):
+    """OpenAI-family: declares the flag and defaults it off, so it must be asked."""
+
+    model = 'gpt-5.4'
+    stream_usage = None
+
+
+class _FakeChatXAI(_FakeChatOpenAI):
+    """Inherits the flag from the OpenAI base without 'OpenAI' in its class name."""
+
+    model = 'grok-4'
+
+
+def _assert_four_counters():
+    c = _counters()
+    assert c['llm_input_tokens'] == 60
+    assert c['llm_output_tokens'] == 20
+    assert c['llm_cache_read_tokens'] == 30
+    assert c['llm_cache_creation_tokens'] == 10
+
+
+@pytest.mark.parametrize('cls', [_FakeChatOpenAI, _FakeChatXAI])
+def test_stream_asks_for_usage_wherever_the_model_declares_the_flag(cls):
+    """The gate is the declared field, not the class name: ChatXAI needs the flag
+    just as much as ChatOpenAI, and silently reported nothing while it was named.
+    """
+    llm = cls([_Chunk('Hi'), _Chunk(' there', _USAGE)])
+
+    list(LangChainAdapter(llm).stream('q'))
+
+    assert llm.kwargs == {'stream_usage': True}
+    _assert_four_counters()
+
+
+def test_stream_omits_the_flag_for_a_model_that_lacks_it():
+    llm = _FakeChatBedrock([_Chunk('Hi'), _Chunk(' there', _USAGE)])
+
+    list(LangChainAdapter(llm).stream('q'))
+
+    # An unknown kwarg would break the provider, so it must not be sent — and the
+    # usage such a model volunteers is still read.
+    assert 'stream_usage' not in llm.kwargs
+    _assert_four_counters()
+
+
+def test_stream_keeps_the_final_total_not_the_sum_of_chunks():
+    """Chunk counts are cumulative, so the reader takes max(), never a running sum."""
+    llm = _FakeChatBedrock(
+        [
+            _Chunk('Hi', {'input_tokens': 100, 'output_tokens': 5}),
+            _Chunk(' there', {'input_tokens': 100, 'output_tokens': 20}),
+        ]
+    )
+
+    list(LangChainAdapter(llm).stream('q'))
+
+    c = _counters()
+    assert c['llm_input_tokens'] == 100
+    assert c['llm_output_tokens'] == 20
+
+
+def test_stream_reports_usage_when_the_stream_raises_mid_way():
+    """A dropped stream is still chargeable: usage already seen must not be lost."""
+    llm = _FakeChatBedrock([_Chunk('Hi', _USAGE), _Chunk(' there')], raise_after=0)
+
+    with pytest.raises(RuntimeError):
+        list(LangChainAdapter(llm).stream('q'))
+
+    _assert_four_counters()
+
+
+def test_stream_without_usage_metadata_reports_nothing():
+    llm = _FakeChatBedrock([_Chunk('Hi'), _Chunk(' there')])
+
+    list(LangChainAdapter(llm).stream('q'))
+
+    assert _counters() == {}
+
+
+def test_collect_reports_usage_from_the_invoke_result():
+    llm = _FakeChatBedrock([], result=_Chunk('Hi there', _USAGE))
+
+    text, _ = LangChainAdapter(llm).collect('q')
+
+    assert text == 'Hi there'
+    _assert_four_counters()

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -7,7 +7,13 @@
 
 import pytest
 
-from ai.common.llm_adapter import LAST_LLM_USAGE_VAR, LangChainAdapter, _split_input_cache, report_llm_tokens
+from ai.common.llm_adapter import (
+    LAST_LLM_USAGE_VAR,
+    LangChainAdapter,
+    _split_input_cache,
+    report_llm_tokens,
+    usage_since,
+)
 
 # Same singleton report_llm_tokens reports into; imported from the module (not the
 # package) to avoid pulling the taskhook side of ai.web.metrics into the test.
@@ -241,3 +247,66 @@ def test_all_zero_usage_leaves_the_contextvar_unset():
     LAST_LLM_USAGE_VAR.set(None)
     report_llm_tokens(0, 0)
     assert LAST_LLM_USAGE_VAR.get() is None
+
+
+# ---------------------------------------------------------------------------
+# usage_since — one invoke row's own slice of the turn
+# ---------------------------------------------------------------------------
+
+
+def test_usage_since_returns_only_the_calls_made_after_the_mark():
+    # An agent's 7th invoke must show its own cost, not the running turn total.
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(10, 5, model='m1')
+    mark = len(LAST_LLM_USAGE_VAR.get()['breakdown'])
+    report_llm_tokens(30, 7, model='m2')
+
+    assert usage_since(mark) == {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 0, 'model': 'm2'}
+
+
+def test_usage_since_a_single_call_has_no_redundant_breakdown():
+    # One call renders as plain chips; a breakdown of itself would be noise.
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(10, 5, model='m1')
+
+    assert 'breakdown' not in usage_since(0)
+    assert 'calls' not in usage_since(0)
+
+
+def test_usage_since_sums_when_one_invoke_made_several_calls():
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(10, 5, model='m1', cache_read_tokens=1)
+    report_llm_tokens(30, 7, model='m2', cache_creation_tokens=2)
+
+    assert usage_since(0) == {
+        'input': 40,
+        'output': 12,
+        'cache_read': 1,
+        'cache_creation': 2,
+        'model': 'm2',
+        'calls': 2,
+        'breakdown': [
+            {'input': 10, 'output': 5, 'cache_read': 1, 'cache_creation': 0, 'model': 'm1'},
+            {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 2, 'model': 'm2'},
+        ],
+    }
+
+
+def test_usage_since_is_none_when_the_call_reported_nothing():
+    # A cached/failed call adds no entry, so the invoke row shows no grid at all.
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(10, 5, model='m1')
+    mark = len(LAST_LLM_USAGE_VAR.get()['breakdown'])
+
+    assert usage_since(mark) is None
+
+
+def test_usage_since_does_not_disturb_the_turn_total():
+    # The answer still gets the whole turn; usage_since only reads.
+    LAST_LLM_USAGE_VAR.set(None)
+    report_llm_tokens(10, 5, model='m1')
+    report_llm_tokens(30, 7, model='m2')
+    usage_since(1)
+
+    assert LAST_LLM_USAGE_VAR.get()['calls'] == 2
+    assert LAST_LLM_USAGE_VAR.get()['input'] == 40

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -7,11 +7,12 @@
 
 import pytest
 
+import ai.common.llm_adapter as _adapter
 from ai.common.llm_adapter import (
-    LAST_LLM_USAGE_VAR,
     LangChainAdapter,
     _split_input_cache,
     report_llm_tokens,
+    turn_usage,
     usage_since,
 )
 
@@ -22,6 +23,11 @@ from ai.web.metrics.metrics import metrics
 
 def setup_function(_):
     metrics.reset()
+    # The turn collector is a module global; clear it so a leaked scope from one
+    # test can't seed the next.
+    with _adapter._USAGE_LOCK:
+        _adapter._USAGE_CALLS.clear()
+        _adapter._TURN_DEPTH = 0
 
 
 def _counters():
@@ -214,39 +220,82 @@ def test_collect_reports_usage_from_the_invoke_result():
     _assert_four_counters()
 
 
-def test_publishes_usage_on_the_contextvar():
-    # The node reads this to hang the usage on the Answer (Trace "Tokens" grid).
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(14, 81, model='claude-haiku-4-5', cache_read_tokens=2, cache_creation_tokens=3)
-    call = {'input': 14, 'output': 81, 'cache_read': 2, 'cache_creation': 3, 'model': 'claude-haiku-4-5'}
-    assert LAST_LLM_USAGE_VAR.get() == {**call, 'calls': 1, 'breakdown': [call]}
+def test_turn_reader_returns_a_single_call():
+    # The node reads its scope to hang usage on the Answer (Trace "Tokens" grid).
+    with turn_usage() as read_usage:
+        report_llm_tokens(14, 81, model='claude-haiku-4-5', cache_read_tokens=2, cache_creation_tokens=3)
+        assert read_usage() == {
+            'input': 14,
+            'output': 81,
+            'cache_read': 2,
+            'cache_creation': 3,
+            'model': 'claude-haiku-4-5',
+        }
 
 
-def test_contextvar_accumulates_across_a_many_call_turn():
-    # An agentic turn calls the model repeatedly; the Trace must show the turn total
-    # AND every call's cost, not just the last call. Counters/events stay per-call
-    # (billing unchanged) — only this display accumulator sums the turn.
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(10, 5, model='m1', cache_read_tokens=1, cache_creation_tokens=2)
-    report_llm_tokens(30, 7, model='m2', cache_read_tokens=3, cache_creation_tokens=4)
-    c1 = {'input': 10, 'output': 5, 'cache_read': 1, 'cache_creation': 2, 'model': 'm1'}
-    c2 = {'input': 30, 'output': 7, 'cache_read': 3, 'cache_creation': 4, 'model': 'm2'}
-    assert LAST_LLM_USAGE_VAR.get() == {
-        'input': 40,
-        'output': 12,
-        'cache_read': 4,
-        'cache_creation': 6,
-        'model': 'm2',  # last model that actually reported usage
-        'calls': 2,
-        'breakdown': [c1, c2],  # each call's cost, in order, for the action history
-    }
+def test_turn_reader_sums_a_many_call_turn():
+    # An agentic turn calls the model repeatedly; the Trace shows the turn total AND
+    # every call's cost. Counters stay per-call (billing unchanged).
+    with turn_usage() as read_usage:
+        report_llm_tokens(10, 5, model='m1', cache_read_tokens=1, cache_creation_tokens=2)
+        report_llm_tokens(30, 7, model='m2', cache_read_tokens=3, cache_creation_tokens=4)
+        c1 = {'input': 10, 'output': 5, 'cache_read': 1, 'cache_creation': 2, 'model': 'm1'}
+        c2 = {'input': 30, 'output': 7, 'cache_read': 3, 'cache_creation': 4, 'model': 'm2'}
+        assert read_usage() == {
+            'input': 40,
+            'output': 12,
+            'cache_read': 4,
+            'cache_creation': 6,
+            'model': 'm2',  # last model that actually reported usage
+            'calls': 2,
+            'breakdown': [c1, c2],  # each call's cost, in order, for the action history
+        }
 
 
-def test_all_zero_usage_leaves_the_contextvar_unset():
+def test_turn_is_cleared_when_the_outermost_scope_exits():
+    # Bounded to one turn: a second turn does not inherit the first's calls.
+    with turn_usage() as r1:
+        report_llm_tokens(10, 5, model='m1')
+        assert r1()['input'] == 10
+    with turn_usage() as r2:
+        report_llm_tokens(30, 7, model='m2')
+        assert r2() == {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 0, 'model': 'm2'}
+
+
+def test_zero_usage_leaves_the_turn_empty():
     # No usage reported -> nothing to attach, so the Answer carries no tokens.
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(0, 0)
-    assert LAST_LLM_USAGE_VAR.get() is None
+    with turn_usage() as read_usage:
+        report_llm_tokens(0, 0)
+        assert read_usage() is None
+
+
+def test_nested_scope_reads_its_own_calls_while_the_outer_reads_all():
+    # An agent can drive a sub-agent: the sub-agent's scope shows only its own calls,
+    # the outer scope shows the whole turn (sub-agent included), and the collector is
+    # cleared only when the outermost scope exits.
+    with turn_usage() as outer:
+        report_llm_tokens(10, 5, model='a')
+        with turn_usage() as inner:
+            report_llm_tokens(20, 7, model='b')
+            report_llm_tokens(30, 9, model='b')
+            assert inner()['calls'] == 2 and inner()['input'] == 50
+        report_llm_tokens(1, 1, model='a')
+        assert outer()['calls'] == 4 and outer()['input'] == 61 and outer()['output'] == 22
+    with turn_usage() as fresh:
+        assert fresh() is None
+
+
+def test_calls_from_a_worker_thread_land_in_the_open_turn():
+    # CrewAI/deepagent run kickoffs on a worker thread under a copied context, where a
+    # ContextVar write would never propagate back to the reader. The module-global
+    # collector does, so the agent's answer still carries the total.
+    import threading
+
+    with turn_usage() as read_usage:
+        t = threading.Thread(target=lambda: report_llm_tokens(200, 60, model='crew'))
+        t.start()
+        t.join()  # the agent blocks on the kickoff before reading
+        assert read_usage() == {'input': 200, 'output': 60, 'cache_read': 0, 'cache_creation': 0, 'model': 'crew'}
 
 
 # ---------------------------------------------------------------------------
@@ -256,57 +305,40 @@ def test_all_zero_usage_leaves_the_contextvar_unset():
 
 def test_usage_since_returns_only_the_calls_made_after_the_mark():
     # An agent's 7th invoke must show its own cost, not the running turn total.
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(10, 5, model='m1')
-    mark = len(LAST_LLM_USAGE_VAR.get()['breakdown'])
-    report_llm_tokens(30, 7, model='m2')
-
-    assert usage_since(mark) == {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 0, 'model': 'm2'}
+    with turn_usage():
+        report_llm_tokens(10, 5, model='m1')  # collector index 0
+        report_llm_tokens(30, 7, model='m2')  # collector index 1
+        assert usage_since(1) == {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 0, 'model': 'm2'}
 
 
 def test_usage_since_a_single_call_has_no_redundant_breakdown():
     # One call renders as plain chips; a breakdown of itself would be noise.
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(10, 5, model='m1')
-
-    assert 'breakdown' not in usage_since(0)
-    assert 'calls' not in usage_since(0)
+    with turn_usage():
+        report_llm_tokens(10, 5, model='m1')
+        assert 'breakdown' not in usage_since(0)
+        assert 'calls' not in usage_since(0)
 
 
 def test_usage_since_sums_when_one_invoke_made_several_calls():
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(10, 5, model='m1', cache_read_tokens=1)
-    report_llm_tokens(30, 7, model='m2', cache_creation_tokens=2)
+    with turn_usage():
+        report_llm_tokens(10, 5, model='m1', cache_read_tokens=1)
+        report_llm_tokens(30, 7, model='m2', cache_creation_tokens=2)
+        assert usage_since(0) == {
+            'input': 40,
+            'output': 12,
+            'cache_read': 1,
+            'cache_creation': 2,
+            'model': 'm2',
+            'calls': 2,
+            'breakdown': [
+                {'input': 10, 'output': 5, 'cache_read': 1, 'cache_creation': 0, 'model': 'm1'},
+                {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 2, 'model': 'm2'},
+            ],
+        }
 
-    assert usage_since(0) == {
-        'input': 40,
-        'output': 12,
-        'cache_read': 1,
-        'cache_creation': 2,
-        'model': 'm2',
-        'calls': 2,
-        'breakdown': [
-            {'input': 10, 'output': 5, 'cache_read': 1, 'cache_creation': 0, 'model': 'm1'},
-            {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 2, 'model': 'm2'},
-        ],
-    }
 
-
-def test_usage_since_is_none_when_the_call_reported_nothing():
+def test_usage_since_is_none_when_no_call_came_after_the_mark():
     # A cached/failed call adds no entry, so the invoke row shows no grid at all.
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(10, 5, model='m1')
-    mark = len(LAST_LLM_USAGE_VAR.get()['breakdown'])
-
-    assert usage_since(mark) is None
-
-
-def test_usage_since_does_not_disturb_the_turn_total():
-    # The answer still gets the whole turn; usage_since only reads.
-    LAST_LLM_USAGE_VAR.set(None)
-    report_llm_tokens(10, 5, model='m1')
-    report_llm_tokens(30, 7, model='m2')
-    usage_since(1)
-
-    assert LAST_LLM_USAGE_VAR.get()['calls'] == 2
-    assert LAST_LLM_USAGE_VAR.get()['input'] == 40
+    with turn_usage():
+        report_llm_tokens(10, 5, model='m1')
+        assert usage_since(1) is None

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -48,10 +48,13 @@ def test_reports_input_and_output_counters():
     assert 'llm_cache_creation_tokens' not in c
 
 
-def test_emits_llm_tokens_event_payload():
+def test_no_per_call_event_is_emitted():
+    # The per-call llm_tokens event fed an unbounded events list that taskMetricsObjectEnd
+    # re-serialized in full after every object (O(N^2), multi-MB lines on long chat tasks).
+    # It was dropped — the counters carry the billable totals, the turn collector the detail.
     report_llm_tokens(5, 9, model='gpt-5.4-mini')
-    payload = {'input': 5, 'output': 9, 'cache_read': 0, 'cache_creation': 0, 'model': 'gpt-5.4-mini'}
-    assert {'llm_tokens': payload} in _events()
+    assert _events() == []
+    assert _counters()['llm_input_tokens'] == 5
 
 
 def test_reports_cache_counters_separately():

--- a/packages/ai/tests/ai/common/test_llm_token_metrics.py
+++ b/packages/ai/tests/ai/common/test_llm_token_metrics.py
@@ -11,9 +11,9 @@ import ai.common.llm_adapter as _adapter
 from ai.common.llm_adapter import (
     LangChainAdapter,
     _split_input_cache,
+    aggregate_usage,
     report_llm_tokens,
     turn_usage,
-    usage_since,
 )
 
 # Same singleton report_llm_tokens reports into; imported from the module (not the
@@ -147,30 +147,49 @@ class _FakeChatXAI(_FakeChatOpenAI):
 
 
 class _FakeRejectsUsageFlag(_FakeChatOpenAI):
-    """An old vLLM/strict proxy: 400s on the usage flag before any chunk, streams without it."""
+    """An old vLLM/strict proxy: rejects the usage flag before any chunk, streams without it.
+
+    ``REJECT_STATUS`` is the openai SDK's BadRequestError shape (400); a FastAPI-based
+    server answers the same rejection with UnprocessableEntityError (422).
+    """
 
     model = 'vllm-local'
+    REJECT_STATUS = 400
 
     def stream(self, messages, **kwargs):
         self.kwargs = kwargs
         if kwargs.get('stream_usage'):
             err = RuntimeError('stream_options.include_usage unsupported')
-            err.status_code = 400  # the openai SDK's BadRequestError shape
+            err.status_code = self.REJECT_STATUS
             raise err
         yield from self._chunks
+
+
+class _FakeRejectsUsageFlag422(_FakeRejectsUsageFlag):
+    """vLLM's OpenAI-compatible server is FastAPI: request validation fails with 422."""
+
+    REJECT_STATUS = 422
 
 
 class _FakeRaises401(_FakeChatOpenAI):
     """A bad key: the failure carries status_code 401, so the flag retry must NOT fire."""
 
     model = 'gpt-401'
+    RAISE_STATUS = 401
 
     def stream(self, messages, **kwargs):
         self.kwargs = kwargs
-        err = RuntimeError('401 unauthorized')
-        err.status_code = 401
+        err = RuntimeError(f'{self.RAISE_STATUS} rejected')
+        err.status_code = self.RAISE_STATUS
         raise err
         yield  # unreachable — makes this a generator so the raise fires on first next()
+
+
+class _FakeRaises429(_FakeRaises401):
+    """A rate limit: a client error, but not a flag rejection — no second round trip."""
+
+    model = 'gpt-429'
+    RAISE_STATUS = 429
 
 
 class _FakeRaisesTransient(_FakeChatOpenAI):
@@ -218,10 +237,13 @@ def test_stream_omits_the_flag_for_a_model_that_lacks_it():
     _assert_four_counters()
 
 
-def test_stream_retries_without_the_usage_flag_when_the_endpoint_rejects_it():
-    # A custom base URL that 400s on include_usage (old vLLM/strict proxy) must not lose the
+@pytest.mark.parametrize('cls', [_FakeRejectsUsageFlag, _FakeRejectsUsageFlag422])
+def test_stream_retries_without_the_usage_flag_when_the_endpoint_rejects_it(cls):
+    # A custom base URL that rejects include_usage (old vLLM/strict proxy) must not lose the
     # stream: we ask, the endpoint rejects it before any chunk, and we retry once without it.
-    llm = _FakeRejectsUsageFlag([_Chunk('Hi'), _Chunk(' there')])
+    # 400 is the openai SDK's shape; a FastAPI-based server says 422 for the same rejection,
+    # and gating on 400 alone dropped every such endpoint to the two-round-trip path.
+    llm = cls([_Chunk('Hi'), _Chunk(' there')])
 
     events = list(LangChainAdapter(llm).stream('q'))
 
@@ -231,10 +253,11 @@ def test_stream_retries_without_the_usage_flag_when_the_endpoint_rejects_it():
     assert 'stream_usage' not in llm.kwargs
 
 
-def test_stream_does_not_retry_a_non_400_failure():
-    # A 401/429/etc. is not the usage-flag rejection: it must surface without a second
-    # identical round trip. The flag stays on and the error propagates.
-    llm = _FakeRaises401([_Chunk('x')])
+@pytest.mark.parametrize('cls', [_FakeRaises401, _FakeRaises429])
+def test_stream_does_not_retry_an_excluded_client_error(cls):
+    # A 401/429 is a client error, but never the usage-flag rejection: it must surface
+    # without a second identical round trip. The flag stays on and the error propagates.
+    llm = cls([_Chunk('x')])
 
     with pytest.raises(RuntimeError):
         list(LangChainAdapter(llm).stream('q'))
@@ -386,8 +409,10 @@ def test_two_overlapping_turns_do_not_read_each_others_calls():
     import threading
 
     results: dict = {}
-    open_barrier = threading.Barrier(2)  # both scopes open before either reports
-    report_barrier = threading.Barrier(2)  # both reported while both scopes still open
+    # timeout so a thread that dies before wait() fails the test with BrokenBarrierError
+    # instead of parking the other one until the CI job hits its own limit.
+    open_barrier = threading.Barrier(2, timeout=10)  # both scopes open before either reports
+    report_barrier = threading.Barrier(2, timeout=10)  # both reported while both scopes still open
 
     def run_turn(name, n):
         with turn_usage() as read_usage:
@@ -416,7 +441,7 @@ def test_two_sibling_scopes_in_one_turn_do_not_read_each_others_calls():
     from contextvars import copy_context
 
     results: dict = {}
-    both_open = threading.Barrier(2)
+    both_open = threading.Barrier(2, timeout=10)  # see the timeout note above
 
     with turn_usage() as outer:
 
@@ -445,31 +470,23 @@ def test_two_sibling_scopes_in_one_turn_do_not_read_each_others_calls():
 
 
 # ---------------------------------------------------------------------------
-# usage_since — one invoke row's own slice of the turn
+# aggregate_usage — how one scope's calls render on its row
 # ---------------------------------------------------------------------------
 
 
-def test_usage_since_returns_only_the_calls_made_after_the_mark():
-    # An agent's 7th invoke must show its own cost, not the running turn total.
-    with turn_usage():
-        report_llm_tokens(10, 5, model='m1')  # collector index 0
-        report_llm_tokens(30, 7, model='m2')  # collector index 1
-        assert usage_since(1) == {'input': 30, 'output': 7, 'cache_read': 0, 'cache_creation': 0, 'model': 'm2'}
-
-
-def test_usage_since_a_single_call_has_no_redundant_breakdown():
+def test_aggregate_usage_a_single_call_has_no_redundant_breakdown():
     # One call renders as plain chips; a breakdown of itself would be noise.
     with turn_usage():
         report_llm_tokens(10, 5, model='m1')
-        assert 'breakdown' not in usage_since(0)
-        assert 'calls' not in usage_since(0)
+        assert 'breakdown' not in aggregate_usage()
+        assert 'calls' not in aggregate_usage()
 
 
-def test_usage_since_sums_when_one_invoke_made_several_calls():
+def test_aggregate_usage_sums_when_one_invoke_made_several_calls():
     with turn_usage():
         report_llm_tokens(10, 5, model='m1', cache_read_tokens=1)
         report_llm_tokens(30, 7, model='m2', cache_creation_tokens=2)
-        assert usage_since(0) == {
+        assert aggregate_usage() == {
             'input': 40,
             'output': 12,
             'cache_read': 1,
@@ -483,8 +500,8 @@ def test_usage_since_sums_when_one_invoke_made_several_calls():
         }
 
 
-def test_usage_since_is_none_when_no_call_came_after_the_mark():
+def test_aggregate_usage_is_none_when_the_scope_made_no_call():
     # A cached/failed call adds no entry, so the invoke row shows no grid at all.
-    with turn_usage():
-        report_llm_tokens(10, 5, model='m1')
-        assert usage_since(1) is None
+    with turn_usage() as read_usage:
+        assert read_usage() is None
+        assert aggregate_usage() is None

--- a/packages/ai/tests/ai/common/test_native_anthropic_adapter.py
+++ b/packages/ai/tests/ai/common/test_native_anthropic_adapter.py
@@ -5,12 +5,15 @@
 
 """Pins NativeAnthropicAdapter: native Messages stream → Events, same payload path."""
 
+import pytest
+
 from ai.common.llm_adapter import Event
 from ai.common.llm_native_stream import (
     NativeAnthropicAdapter,
     build_anthropic_thinking_kwargs,
     try_anthropic_native_chat_stream,
 )
+from ai.web.metrics.metrics import metrics
 
 
 class _Delta:
@@ -120,3 +123,39 @@ def test_haiku_latest_gets_extended_thinking():
 
 def test_legacy_claude3_haiku_has_no_thinking():
     assert build_anthropic_thinking_kwargs('claude-3-haiku', 8192) == {}
+
+
+def test_reports_usage_even_when_stream_raises_midway():
+    """A mid-stream failure must still record the usage already reported by the provider."""
+    metrics.reset()
+
+    class _Usage:
+        input_tokens = 50
+        cache_creation_input_tokens = 5
+        cache_read_input_tokens = 8
+
+    class _Msg:
+        usage = _Usage()
+
+    class _MsgStart:
+        type = 'message_start'
+        message = _Msg()
+
+    def _raising_create(**_kwargs):
+        def gen():
+            yield _MsgStart()
+            raise RuntimeError('stream broke mid-way')
+
+        return gen()
+
+    client = _Client([])
+    client.messages.create = _raising_create
+    adapter = NativeAnthropicAdapter(_Chat(_LLM({'model': 'm', 'max_tokens': 10}, client)))
+
+    with pytest.raises(RuntimeError):
+        list(adapter.stream('q'))
+
+    counters = metrics.report()['counters']
+    assert counters.get('llm_input_tokens') == 50
+    assert counters.get('llm_cache_creation_tokens') == 5
+    assert counters.get('llm_cache_read_tokens') == 8

--- a/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
+++ b/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
@@ -1,0 +1,161 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Pins try_openai_compat_reasoning_stream: the OpenAI-compatible reasoning capture point.
+
+Covers the three behaviours this handler adds and that no other test reached: the
+``stream_options.include_usage`` injection, reading ``usage`` off the final chunk BEFORE
+the empty-``choices`` guard skips it, and the ``prompt_tokens - cached_tokens`` split
+(Chat Completions names it ``prompt_tokens_details.cached_tokens``, not the Responses
+field). Plus the retry-without-the-flag path for an endpoint that 400s on it.
+"""
+
+from ai.common.llm_native_stream import try_openai_compat_reasoning_stream
+from ai.web.metrics.metrics import metrics
+
+
+def setup_function(_):
+    metrics.reset()
+
+
+def _counters():
+    return metrics.report()['counters']
+
+
+class _Delta:
+    def __init__(self, content=None, reasoning_content=None):
+        self.content = content
+        self.reasoning_content = reasoning_content
+
+
+class _Choice:
+    def __init__(self, content=None, reasoning_content=None, finish_reason=None):
+        self.delta = _Delta(content, reasoning_content)
+        self.finish_reason = finish_reason
+
+
+class _Chunk:
+    def __init__(self, choices=(), usage=None):
+        self.choices = list(choices)
+        self.usage = usage
+
+
+class _PromptDetails:
+    def __init__(self, cached_tokens):
+        self.cached_tokens = cached_tokens
+
+
+class _Usage:
+    def __init__(self, prompt_tokens, completion_tokens, cached=0):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+        self.prompt_tokens_details = _PromptDetails(cached) if cached else None
+
+
+class _Completions:
+    """Fake ``client.chat.completions``. Records each create() call's kwargs; optionally
+    raises when asked with ``stream_options`` and serves a different chunk set on retry.
+    """
+
+    def __init__(self, chunks, *, raise_on_stream_options=False, retry_chunks=None):
+        self._chunks = chunks
+        self._raise_on_stream_options = raise_on_stream_options
+        self._retry_chunks = retry_chunks
+        self.calls: list = []
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raise_on_stream_options and 'stream_options' in kwargs:
+            raise RuntimeError('400 stream_options.include_usage unsupported')
+        chunks = self._chunks if 'stream_options' in kwargs else (self._retry_chunks or self._chunks)
+        return iter(chunks)
+
+
+class _ChatNS:
+    def __init__(self, completions):
+        self.completions = completions
+
+
+class _Client:
+    def __init__(self, completions):
+        self.chat = _ChatNS(completions)
+
+
+class _Chat:
+    def __init__(self, completions):
+        self._raw_openai_client = _Client(completions)
+        self._model = 'deepseek-reasoner'
+        self._modelOutputTokens = 4096
+
+
+def _run(chat):
+    text_out: list = []
+    reasoning_out: list = []
+    finish: list = []
+    result = try_openai_compat_reasoning_stream(
+        chat,
+        'q',
+        on_chunk=text_out.append,
+        on_finish=finish.append,
+        on_reasoning_chunk=reasoning_out.append,
+    )
+    return result, ''.join(text_out), ''.join(reasoning_out), finish
+
+
+def test_streams_content_and_reasoning_and_asks_for_usage():
+    comp = _Completions(
+        [
+            _Chunk([_Choice(reasoning_content='thinking')]),
+            _Chunk([_Choice(content='Hello')]),
+            _Chunk([_Choice(content=' world', finish_reason='stop')]),
+            # Final usage-only chunk: choices is empty, so usage must be read before the guard.
+            _Chunk(choices=[], usage=_Usage(prompt_tokens=90, completion_tokens=20, cached=30)),
+        ]
+    )
+    result, text, reasoning, finish = _run(_Chat(comp))
+
+    assert result == 'Hello world'
+    assert text == 'Hello world'
+    assert reasoning == 'thinking'
+    assert finish == ['stop']
+    # The usage flag was injected.
+    assert comp.calls[0]['stream_options'] == {'include_usage': True}
+    # And the prompt/cache split lands on the right counters (Chat Completions naming).
+    c = _counters()
+    assert c['llm_input_tokens'] == 60  # 90 prompt - 30 cached
+    assert c['llm_output_tokens'] == 20
+    assert c['llm_cache_read_tokens'] == 30
+
+
+def test_a_stream_without_usage_reports_nothing():
+    comp = _Completions(
+        [
+            _Chunk([_Choice(content='hi', finish_reason='stop')]),
+        ]
+    )
+    result, text, _, _ = _run(_Chat(comp))
+
+    assert result == 'hi'
+    # No usage chunk -> the `if usage is not None` skip fires, nothing billed.
+    assert _counters() == {}
+
+
+def test_retries_without_stream_options_when_the_endpoint_rejects_it():
+    comp = _Completions(
+        [],  # never served: the flagged call raises
+        raise_on_stream_options=True,
+        retry_chunks=[_Chunk([_Choice(content='hi', finish_reason='stop')])],
+    )
+    result, text, _, finish = _run(_Chat(comp))
+
+    # The stream survived on the retry.
+    assert result == 'hi'
+    assert text == 'hi'
+    assert finish == ['stop']
+    # First call carried the flag, retry dropped it.
+    assert 'stream_options' in comp.calls[0]
+    assert 'stream_options' not in comp.calls[1]
+    # No usage without the flag: that endpoint goes unmetered.
+    assert _counters() == {}

--- a/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
+++ b/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
@@ -56,19 +56,22 @@ class _Usage:
 
 class _Completions:
     """Fake ``client.chat.completions``. Records each create() call's kwargs; optionally
-    raises when asked with ``stream_options`` and serves a different chunk set on retry.
+    raises (with a status_code) when asked with ``stream_options`` and serves a different
+    chunk set on retry.
     """
 
-    def __init__(self, chunks, *, raise_on_stream_options=False, retry_chunks=None):
+    def __init__(self, chunks, *, raise_status=None, retry_chunks=None):
         self._chunks = chunks
-        self._raise_on_stream_options = raise_on_stream_options
+        self._raise_status = raise_status
         self._retry_chunks = retry_chunks
         self.calls: list = []
 
     def create(self, **kwargs):
         self.calls.append(kwargs)
-        if self._raise_on_stream_options and 'stream_options' in kwargs:
-            raise RuntimeError('400 stream_options.include_usage unsupported')
+        if self._raise_status is not None and 'stream_options' in kwargs:
+            err = RuntimeError(f'{self._raise_status} stream error')
+            err.status_code = self._raise_status
+            raise err
         chunks = self._chunks if 'stream_options' in kwargs else (self._retry_chunks or self._chunks)
         return iter(chunks)
 
@@ -142,10 +145,10 @@ def test_a_stream_without_usage_reports_nothing():
     assert _counters() == {}
 
 
-def test_retries_without_stream_options_when_the_endpoint_rejects_it():
+def test_retries_without_stream_options_on_a_400():
     comp = _Completions(
         [],  # never served: the flagged call raises
-        raise_on_stream_options=True,
+        raise_status=400,
         retry_chunks=[_Chunk([_Choice(content='hi', finish_reason='stop')])],
     )
     result, text, _, finish = _run(_Chat(comp))
@@ -159,3 +162,43 @@ def test_retries_without_stream_options_when_the_endpoint_rejects_it():
     assert 'stream_options' not in comp.calls[1]
     # No usage without the flag: that endpoint goes unmetered.
     assert _counters() == {}
+
+
+def test_does_not_retry_a_429():
+    # A rate limit is not the flag rejection: don't retry without the flag (that would cost a
+    # third+fourth provider round trip via the non-streaming fallback). Fall straight through.
+    comp = _Completions([], raise_status=429)
+    result, *_ = _run(_Chat(comp))
+
+    assert result is None  # falls back to non-streaming, which meters itself
+    assert len(comp.calls) == 1  # one attempt only — no retry_drain
+    assert 'stream_options' in comp.calls[0]
+
+
+def test_reasoning_only_stream_reports_usage_and_returns_empty_not_none():
+    # A turn that spends its budget on reasoning (no content) is a real completion: usage is
+    # reported and the empty answer returned, so the caller keeps it instead of re-issuing the
+    # whole request via fallback — which would bill the provider twice.
+    comp = _Completions(
+        [
+            _Chunk([_Choice(reasoning_content='thinking hard', finish_reason='length')]),
+            _Chunk(choices=[], usage=_Usage(prompt_tokens=40, completion_tokens=100)),
+        ]
+    )
+    result, text, reasoning, finish = _run(_Chat(comp))
+
+    assert result == ''  # returned, NOT None -> no fallback, no double bill
+    assert text == ''
+    assert reasoning == 'thinking hard'
+    assert finish == ['length']
+    c = _counters()
+    assert c['llm_input_tokens'] == 40
+    assert c['llm_output_tokens'] == 100
+
+
+def test_truly_empty_stream_falls_back():
+    # No content, no reasoning, no usage: nothing to keep or meter, so fall back.
+    comp = _Completions([_Chunk(choices=[])])
+    result, *_ = _run(_Chat(comp))
+
+    assert result is None

--- a/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
+++ b/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
@@ -12,6 +12,8 @@ the empty-``choices`` guard skips it, and the ``prompt_tokens - cached_tokens`` 
 field). Plus the retry-without-the-flag path for an endpoint that 400s on it.
 """
 
+import pytest
+
 from ai.common.llm_native_stream import try_openai_compat_reasoning_stream
 from ai.web.metrics.metrics import metrics
 
@@ -145,10 +147,14 @@ def test_a_stream_without_usage_reports_nothing():
     assert _counters() == {}
 
 
-def test_retries_without_stream_options_on_a_400():
+@pytest.mark.parametrize('status', [400, 422])
+def test_retries_without_stream_options_on_a_client_rejection(status):
+    # 400 is the openai SDK's BadRequestError; vLLM's OpenAI-compatible server is FastAPI,
+    # so it answers the same unknown-field rejection with 422. Both must retry — gating on
+    # 400 alone left every such endpoint without token-by-token streaming.
     comp = _Completions(
         [],  # never served: the flagged call raises
-        raise_status=400,
+        raise_status=status,
         retry_chunks=[_Chunk([_Choice(content='hi', finish_reason='stop')])],
     )
     result, text, _, finish = _run(_Chat(comp))

--- a/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
+++ b/packages/ai/tests/ai/common/test_native_openai_compat_reasoning_stream.py
@@ -182,9 +182,9 @@ def test_does_not_retry_a_429():
 
 
 def test_reasoning_only_stream_reports_usage_and_returns_empty_not_none():
-    # A turn that spends its budget on reasoning (no content) is a real completion: usage is
-    # reported and the empty answer returned, so the caller keeps it instead of re-issuing the
-    # whole request via fallback — which would bill the provider twice.
+    # A turn that spends its budget on reasoning (no content) is a real completion: the user
+    # already watched the reasoning stream, so the empty answer is returned rather than
+    # re-issuing the request behind their back.
     comp = _Completions(
         [
             _Chunk([_Choice(reasoning_content='thinking hard', finish_reason='length')]),
@@ -197,6 +197,27 @@ def test_reasoning_only_stream_reports_usage_and_returns_empty_not_none():
     assert text == ''
     assert reasoning == 'thinking hard'
     assert finish == ['length']
+    c = _counters()
+    assert c['llm_input_tokens'] == 40
+    assert c['llm_output_tokens'] == 100
+
+
+def test_empty_stream_with_usage_still_falls_back_and_meters():
+    # The case include_usage makes the common one: a proxy that strips delta.reasoning_content
+    # hits max_tokens while reasoning, so nothing is emitted but the final usage chunk arrives.
+    # There is nothing for the user to keep, so the handler must return None and let the caller
+    # re-issue non-streaming — while this request, which the provider does bill, stays metered.
+    comp = _Completions(
+        [
+            _Chunk([_Choice(finish_reason='length')]),
+            _Chunk(choices=[], usage=_Usage(prompt_tokens=40, completion_tokens=100)),
+        ]
+    )
+    result, text, reasoning, _ = _run(_Chat(comp))
+
+    assert result is None  # falls back — an empty string would be served as the answer
+    assert text == ''
+    assert reasoning == ''
     c = _counters()
     assert c['llm_input_tokens'] == 40
     assert c['llm_output_tokens'] == 100

--- a/packages/ai/tests/ai/common/test_native_openai_responses_adapter.py
+++ b/packages/ai/tests/ai/common/test_native_openai_responses_adapter.py
@@ -6,6 +6,7 @@
 """Pins NativeOpenAIResponsesAdapter: Responses stream → Events + finish mapping."""
 
 from ai.common.llm_adapter import Event, NativeOpenAIResponsesAdapter
+from ai.web.metrics.metrics import metrics
 
 
 class _Ev:
@@ -134,3 +135,34 @@ def test_closes_stream_on_early_break():
     next(gen)  # consume one event, then abandon
     gen.close()  # GeneratorExit → finally closes the stream
     assert stream.closed is True
+
+
+def test_reports_usage_on_failed_terminal_event():
+    """A response.failed event that carries usage must still record tokens."""
+    metrics.reset()
+
+    class _Cached:
+        cached_tokens = 4
+
+    class _Usage:
+        input_tokens = 30
+        output_tokens = 7
+        input_tokens_details = _Cached()
+
+    class _FailedResp:
+        usage = _Usage()
+
+    events = [
+        _Ev('response.output_text.delta', delta='partial'),
+        _Ev('response.failed', response=_FailedResp()),
+    ]
+    adapter = NativeOpenAIResponsesAdapter(_Chat(events))
+    out = list(adapter.stream('q'))
+
+    assert adapter.finish_reason == 'error'
+    assert out[-1].type == 'done'
+    counters = metrics.report()['counters']
+    # input 30 includes 4 cached -> fresh 26 + cache_read 4
+    assert counters.get('llm_input_tokens') == 26
+    assert counters.get('llm_cache_read_tokens') == 4
+    assert counters.get('llm_output_tokens') == 7

--- a/packages/ai/tests/ai/common/test_native_openai_responses_adapter.py
+++ b/packages/ai/tests/ai/common/test_native_openai_responses_adapter.py
@@ -166,3 +166,35 @@ def test_reports_usage_on_failed_terminal_event():
     assert counters.get('llm_input_tokens') == 26
     assert counters.get('llm_cache_read_tokens') == 4
     assert counters.get('llm_output_tokens') == 7
+
+
+def test_reports_usage_on_incomplete_terminal_event():
+    """response.incomplete is a distinct terminal event: map its reason and record usage."""
+    metrics.reset()
+
+    class _Cached:
+        cached_tokens = 2
+
+    class _Usage:
+        input_tokens = 20
+        output_tokens = 100
+        input_tokens_details = _Cached()
+
+    class _IncompleteResp:
+        usage = _Usage()
+        incomplete_details = _Details('max_output_tokens')
+
+    events = [
+        _Ev('response.output_text.delta', delta='partial'),
+        _Ev('response.incomplete', response=_IncompleteResp()),
+    ]
+    adapter = NativeOpenAIResponsesAdapter(_Chat(events))
+    out = list(adapter.stream('q'))
+
+    assert adapter.finish_reason == 'max_output_tokens'
+    assert out[-1].type == 'done'
+    counters = metrics.report()['counters']
+    # input 20 includes 2 cached -> fresh 18 + cache_read 2
+    assert counters.get('llm_input_tokens') == 18
+    assert counters.get('llm_cache_read_tokens') == 2
+    assert counters.get('llm_output_tokens') == 100

--- a/packages/client-python/src/rocketride/schema/question.py
+++ b/packages/client-python/src/rocketride/schema/question.py
@@ -85,7 +85,9 @@ class Answer(BaseModel):
 
     answer: Optional[Union[str, dict, list]] = None
     expectJson: bool = False
-    # Per-call LLM token usage (input/output/cache/model); surfaced in the Trace.
+    # Turn-total LLM token usage (input/output/cache/model/calls) plus a per-call
+    # `breakdown` list; surfaced in the Trace and the action history. Billing is
+    # unaffected — it flows through the separate per-call metrics.counter path.
     tokens: Optional[Dict[str, Any]] = None
 
     @field_validator('answer', mode='before')

--- a/packages/client-python/src/rocketride/schema/question.py
+++ b/packages/client-python/src/rocketride/schema/question.py
@@ -85,6 +85,8 @@ class Answer(BaseModel):
 
     answer: Optional[Union[str, dict, list]] = None
     expectJson: bool = False
+    # Per-call LLM token usage (input/output/cache/model); surfaced in the Trace.
+    tokens: Optional[Dict[str, Any]] = None
 
     @field_validator('answer', mode='before')
     @classmethod


### PR DESCRIPTION
## Summary

- Read the exact provider-reported token usage (input/output) at the normalized provider Adapter (#1683) and report it via `metrics.counter`, so per-user token accounting flows through the existing `task_metrics` → billing pipeline.
- One capture point (`LangChainAdapter`) covers every provider that routes through `ChatBase`; the native reasoning paths (`NativeAnthropicAdapter` extended thinking, `NativeOpenAIResponsesAdapter`, `try_openai_compat_reasoning_stream`) are instrumented too.
- Five drivers override the `ChatBase` seam and reach their SDK directly, so the Adapter never sees them — they billed zero before this PR and now report for themselves. Two seams are overridden: `_chat` (`llm_gemini`, `llm_ibm_watson`, `llm_minimax`) and the `chat` seam above it (`llm_perplexity`, `llm_mistral`). `git grep -n 'def _chat(self\|def chat(self, question' -- nodes packages` is the check that keeps this list honest.
- Known gap, deliberately out of scope: the four `llm_vision_*` nodes and `accessibility_describe` override `chat` the same way and are still unmetered (as they were before this PR). They are image-priced rather than token-priced, so they need their own accounting decision rather than a copy of this one.
- Adds `report_llm_tokens(input, output, model)` emitting `llm_input_tokens` / `llm_output_tokens` counters plus an `llm_tokens` event.

## Type

feature — LLM token accounting / billing observability.

## Testing

Validated locally against a live Anthropic key across haiku / sonnet / opus and extended-thinking; exact per-call usage captured. Full results table and data-flow diagram are in the linked discussion.

Each capture point has its own suite — `test_llm_token_metrics.py` (the Adapter), `test_native_openai_compat_reasoning_stream.py`, `test_llm_base_tokens.py` (the node lane's `writeQuestions` / `ask` seams, success and error paths), plus one per overriding driver: `test_gemini_token_metrics.py`, `test_ibm_watson_token_metrics.py`, `test_minimax_token_metrics.py`, `test_perplexity_token_metrics.py`, `test_mistral_token_metrics.py`. 100 passing.

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (n/a — additive, best-effort, guarded)

## Linked Discussion

<!-- This work is a PoC discussed here, not an issue: -->

Discussion (PoC + results + flow): https://github.com/rocketride-org/rocketride-server/discussions/1774

**Follow-up to make the counts billable:** add a rate row in the `metrics_conversions` table for **all four** counters this PR emits — they are disjoint, so each needs its own rate:

| Counter | What it carries | Why it needs its own rate |
| --- | --- | --- |
| `llm_input_tokens` | fresh (non-cached) prompt tokens | base input rate |
| `llm_output_tokens` | completion tokens | base output rate |
| `llm_cache_read_tokens` | prompt tokens served from the provider's cache | billed well below fresh input, but not free |
| `llm_cache_creation_tokens` | prompt tokens written to the provider's cache | billed above fresh input |

`input_tokens` has the cache detail subtracted back out (`_split_input_cache`), so rating only the first two under-bills a prompt-cached workload by the whole cached prompt — e.g. a 100k-token cached system prompt with 200 tokens of fresh text would bill 200 tokens. Without a rate row a counter still flows as a raw count.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed AI token usage reporting for streaming and non-streaming responses.
  * Token usage is collected across supported providers and associated with model details when available.
  * Reports now distinguish fresh input, cached input, cache creation, and output tokens.
  * Usage remains available for interrupted or partially failed streams when provided before failure.
  * Reporting continues gracefully when usage details are unavailable or collection encounters an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<img width="1717" height="908" alt="Captura de pantalla 2026-08-12 a las 22 47 07" src="https://github.com/user-attachments/assets/a2ed002a-b31f-4deb-91eb-47f5fdf912f7" />
<img width="1436" height="909" alt="Captura de pantalla 2026-08-12 a las 22 47 16" src="https://github.com/user-attachments/assets/dfcef7a9-3bc4-4d5f-ba21-bb9f5dcc8ed1" />
<img width="611" height="748" alt="Captura de pantalla 2026-08-12 a las 22 47 34" src="https://github.com/user-attachments/assets/8b82b664-4efc-413c-a4d9-9823ee842acd" />
<img width="1451" height="912" alt="Captura de pantalla 2026-08-12 a las 22 47 41" src="https://github.com/user-attachments/assets/0086f558-7ada-492b-b6d7-d4e95b781121" />


