### PR TITLE
feat(capsule): node capsule launcher — install custom nodes at runtime (PoC)

### DIFF
--- a/apps/rocket-ui/src/providers/ProjectProvider.tsx
+++ b/apps/rocket-ui/src/providers/ProjectProvider.tsx
@@ -888,6 +888,15 @@ const ProjectProvider: React.FC<ProjectPageProps> = ({ uri, pipeline, isDirty, i
 					onOpenLink={handleOpenLink}
 					onSave={handleSave}
 					onExport={handleExport}
+					onUninstallNode={async (name: string) => {
+						if (!client) return;
+						try {
+							const res = await client.call<{ ok?: boolean; uninstalled?: string; error?: string }>('rrext_uninstall_node', { node: name });
+							window.alert(res?.ok ? `Node capsule uninstalled: ${res.uninstalled ?? name}. Reopen the pipeline to refresh the catalog.` : `Uninstall failed: ${res?.error ?? 'unknown error'}`);
+						} catch (err) {
+							window.alert(`Uninstall failed: ${err}`);
+						}
+					}}
 					envKeys={envKeys}
 				/>
 				{/* Deployment record drawer — keyed by identity so switching teams

--- a/apps/rocket-ui/src/providers/SidebarProvider.tsx
+++ b/apps/rocket-ui/src/providers/SidebarProvider.tsx
@@ -287,18 +287,62 @@ const SidebarProvider: React.FC = () => {
 	// --- Callbacks -----------------------------------------------------------
 
 	/**
+	 * Prompts for a .rrc capsule and installs it through the engine airlock.
+	 * Web counterpart of the VS Code `rocketride.node.installCapsule` command:
+	 * HTML file picker -> base64 -> rrext_install_node.
+	 */
+	const installCapsule = useCallback(() => {
+		if (!client || !isConnected) {
+			window.alert('Not connected to a RocketRide engine. Connect first.');
+			return;
+		}
+		const input = document.createElement('input');
+		input.type = 'file';
+		input.accept = '.rrc';
+		input.onchange = async () => {
+			const file = input.files?.[0];
+			if (!file) return;
+			try {
+				// readAsDataURL yields "data:...;base64,XXXX" — keep the payload after the comma.
+				const capsule = await new Promise<string>((resolve, reject) => {
+					const reader = new FileReader();
+					reader.onload = () => resolve(String(reader.result).split(',')[1] ?? '');
+					reader.onerror = () => reject(reader.error);
+					reader.readAsDataURL(file);
+				});
+				const res = await client.call<{ ok?: boolean; installed?: string; violations?: string[] }>('rrext_install_node', {
+					capsule,
+				});
+				if (res?.ok) {
+					window.alert(`Node capsule installed: ${res.installed}`);
+				} else {
+					window.alert(`Airlock rejected the capsule: ${(res?.violations ?? ['unknown reason']).join('; ')}`);
+				}
+			} catch (err) {
+				window.alert(`Failed to install node capsule: ${err}`);
+			}
+		};
+		input.click();
+	}, [client, isConnected]);
+
+	/**
 	 * Handles navigation button clicks.
 	 */
-	const handleNavigate = useCallback((target: string) => {
-		// getDocs() is null until RocketApp creates the Documents singleton.
-		const docs = getDocs();
-		if (!docs) return;
-		if (target === 'new') {
-			docs.createDocument(undefined, { project_id: crypto.randomUUID(), components: [] });
-		} else if (target === 'monitor') {
-			docs.openStaticDocument('monitor', 'Monitor');
-		}
-	}, []);
+	const handleNavigate = useCallback(
+		(target: string) => {
+			// getDocs() is null until RocketApp creates the Documents singleton.
+			const docs = getDocs();
+			if (!docs) return;
+			if (target === 'new') {
+				docs.createDocument(undefined, { project_id: crypto.randomUUID(), components: [] });
+			} else if (target === 'monitor') {
+				docs.openStaticDocument('monitor', 'Monitor');
+			} else if (target === 'installCapsule') {
+				installCapsule();
+			}
+		},
+		[installCapsule]
+	);
 
 	/**
 	 * Opens a file in the Documents singleton.

--- a/apps/rocket-ui/src/providers/SidebarProvider.tsx
+++ b/apps/rocket-ui/src/providers/SidebarProvider.tsx
@@ -38,7 +38,7 @@ import { getDocs } from '../docs';
 import { SidebarView } from 'shared/modules/sidebar/SidebarView';
 import { BxExport, useSidebarCollapsed } from 'shell';
 import { foldTaskEvent } from 'shared/modules/sidebar/taskFold';
-import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, SidebarMode } from 'shared/modules/sidebar/types';
+import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, SidebarMode, InstalledCapsule } from 'shared/modules/sidebar/types';
 import type { TaskLifecycleEvent } from 'shared/modules/sidebar/taskFold';
 import { loadProject, listProjectDir, isPipelineFile, pipelineExtension } from '../utils/projectStore';
 import { downloadJson } from '../utils/downloadFile';
@@ -286,6 +286,44 @@ const SidebarProvider: React.FC = () => {
 
 	// --- Callbacks -----------------------------------------------------------
 
+	// Action error state — shown as a dialog when an action fails (run/stop,
+	// and the node-capsule calls below).
+	const [actionError, setActionError] = useState<string | null>(null);
+
+	// --- Node capsules (Nodes tab) -------------------------------------------
+
+	const [capsules, setCapsules] = useState<InstalledCapsule[]>([]);
+	// Success notice for capsule actions (the error path uses actionError).
+	const [capsuleNotice, setCapsuleNotice] = useState<string | null>(null);
+
+	/**
+	 * Installed capsules, read from the services catalog: the engine tags the
+	 * ones it overlays from the caller's store with `source: 'capsule'`.
+	 */
+	const refreshCapsules = useCallback(async () => {
+		if (!client || !isConnected) {
+			setCapsules([]);
+			return;
+		}
+		try {
+			type CatalogEntry = { title?: string; source?: string };
+			const res = await client.call<{ services?: Record<string, CatalogEntry> }>('rrext_services', {});
+			const services: Record<string, CatalogEntry> = res?.services ?? {};
+			const installed = Object.entries(services)
+				.filter(([, def]) => def?.source === 'capsule')
+				.map(([name, def]) => ({ name, title: def?.title }));
+			setCapsules(installed);
+		} catch (err) {
+			// A catalog that cannot be read is not an error worth a dialog —
+			// the tab simply shows no capsules.
+			setCapsules([]);
+		}
+	}, [client, isConnected]);
+
+	useEffect(() => {
+		void refreshCapsules();
+	}, [refreshCapsules]);
+
 	/**
 	 * Prompts for a .rrc capsule and installs it through the engine airlock.
 	 * Web counterpart of the VS Code `rocketride.node.installCapsule` command:
@@ -293,7 +331,7 @@ const SidebarProvider: React.FC = () => {
 	 */
 	const installCapsule = useCallback(() => {
 		if (!client || !isConnected) {
-			window.alert('Not connected to a RocketRide engine. Connect first.');
+			setActionError('Not connected to a RocketRide engine. Connect first.');
 			return;
 		}
 		const input = document.createElement('input');
@@ -314,16 +352,57 @@ const SidebarProvider: React.FC = () => {
 					capsule,
 				});
 				if (res?.ok) {
-					window.alert(`Node capsule installed: ${res.installed}`);
+					setCapsuleNotice(`Node capsule installed: ${res.installed}`);
+					await refreshCapsules();
 				} else {
-					window.alert(`Airlock rejected the capsule: ${(res?.violations ?? ['unknown reason']).join('; ')}`);
+					setActionError(`Airlock rejected the capsule: ${(res?.violations ?? ['unknown reason']).join('; ')}`);
 				}
 			} catch (err) {
-				window.alert(`Failed to install node capsule: ${err}`);
+				setActionError(`Failed to install node capsule: ${err}`);
 			}
 		};
 		input.click();
-	}, [client, isConnected]);
+	}, [client, isConnected, refreshCapsules]);
+
+	/**
+	 * Export/uninstall from the Nodes tab. Export re-packs the installed node
+	 * server-side and hands the bytes back as base64, which the browser saves
+	 * through a temporary object URL (the only way to write a file from a page).
+	 */
+	const handleCapsuleAction = useCallback(
+		async (action: 'export' | 'uninstall', name: string) => {
+			if (!client) return;
+			try {
+				if (action === 'export') {
+					const res = await client.call<{ ok?: boolean; capsule?: string; filename?: string; error?: string }>('rrext_export_node', { node: name });
+					if (!res?.ok || !res.capsule) {
+						setActionError(`Export failed: ${res?.error ?? 'unknown error'}`);
+						return;
+					}
+					const bytes = Uint8Array.from(atob(res.capsule), (c) => c.charCodeAt(0));
+					const url = URL.createObjectURL(new Blob([bytes], { type: 'application/octet-stream' }));
+					const a = document.createElement('a');
+					a.href = url;
+					a.download = res.filename ?? `${name}.rrc`;
+					a.click();
+					URL.revokeObjectURL(url);
+					return;
+				}
+
+				const confirmed = await showConfirm('Uninstall node capsule', `Uninstall "${name}"? Pipelines using this node will stop working.`, 'Uninstall');
+				if (!confirmed) return;
+				const res = await client.call<{ ok?: boolean; error?: string }>('rrext_uninstall_node', { node: name });
+				if (!res?.ok) {
+					setActionError(`Uninstall failed: ${res?.error ?? 'unknown error'}`);
+					return;
+				}
+				await refreshCapsules();
+			} catch (err) {
+				setActionError(`Node capsule ${action} failed: ${err}`);
+			}
+		},
+		[client, refreshCapsules, showConfirm]
+	);
 
 	/**
 	 * Handles navigation button clicks.
@@ -433,9 +512,6 @@ const SidebarProvider: React.FC = () => {
 		[client]
 	);
 
-	// Action error state — shown as a dialog when run/stop fails
-	const [actionError, setActionError] = useState<string | null>(null);
-
 	/**
 	 * Handles run/stop actions on source components.
 	 */
@@ -515,10 +591,11 @@ const SidebarProvider: React.FC = () => {
 	return (
 		<>
 			<SidebarCollapsedGate>
-				<SidebarView connection={connection} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} activeFilePath={activeFilePath} onNavigate={handleNavigate} onOpenFile={handleOpenFile} onFileManage={handleFileManage} fileActions={[{ id: 'export', label: 'Export', icon: <BxExport size={16} />, onSelect: handleExportPipeline }]} onSourceAction={handleSourceAction} onOpenUnknownTask={handleOpenUnknownTask} onRefresh={refresh} showModeStrip sidebarMode={sidebarMode} onSidebarModeChange={setSidebarMode} />
+				<SidebarView connection={connection} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} activeFilePath={activeFilePath} onNavigate={handleNavigate} onOpenFile={handleOpenFile} onFileManage={handleFileManage} fileActions={[{ id: 'export', label: 'Export', icon: <BxExport size={16} />, onSelect: handleExportPipeline }]} onSourceAction={handleSourceAction} onOpenUnknownTask={handleOpenUnknownTask} onRefresh={refresh} capsules={capsules} onCapsuleAction={handleCapsuleAction} showModeStrip sidebarMode={sidebarMode} onSidebarModeChange={setSidebarMode} />
 			</SidebarCollapsedGate>
 			{confirmState && <ConfirmDialog title={confirmState.title} message={confirmState.message} confirmLabel={confirmState.confirmLabel} cancelLabel="Cancel" onConfirm={() => handleConfirmResult(true)} onCancel={() => handleConfirmResult(false)} />}
 			{actionError && <ConfirmDialog title="Pipeline Error" message={actionError} confirmLabel="OK" onConfirm={() => setActionError(null)} onCancel={() => setActionError(null)} />}
+			{capsuleNotice && <ConfirmDialog title="Node capsules" message={capsuleNotice} confirmLabel="OK" onConfirm={() => setCapsuleNotice(null)} onCancel={() => setCapsuleNotice(null)} />}
 		</>
 	);
 };

--- a/apps/shared/src/components/canvas/CanvasPanel.tsx
+++ b/apps/shared/src/components/canvas/CanvasPanel.tsx
@@ -136,6 +136,8 @@ export interface ICanvasPanelProps {
 	onSave?: () => void;
 	/** SaaS-only: export/download the current pipeline. Omitted hosts (VS Code) hide the button. */
 	onExport?: () => void;
+	/** Uninstalls a capsule-installed node by name (tunneled to FlowContainer). */
+	onUninstallNode?: (name: string) => void;
 
 	/** When true, the canvas is fully read-only: no editing, no adding nodes, no run/stop. */
 	isReadonly?: boolean;
@@ -148,7 +150,7 @@ export interface ICanvasPanelProps {
 // Component
 // =============================================================================
 
-export default function CanvasPanel({ oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, project, servicesJson, getNodeSchema, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, onContentChanged, onViewportChange, onUndo, onRedo, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, isReadonly = false, envKeys }: ICanvasPanelProps) {
+export default function CanvasPanel({ oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, project, servicesJson, getNodeSchema, taskStatuses, componentPipeCounts, totalPipes, handleValidatePipeline, onOpenLink, onContentChanged, onViewportChange, onUndo, onRedo, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, isReadonly = false, onUninstallNode, envKeys }: ICanvasPanelProps) {
 	// --- Build inventory from service catalog --------------------------------
 	const inventory = buildInventory(servicesJson);
 
@@ -207,7 +209,7 @@ export default function CanvasPanel({ oauth2RootUrl, oauthReturnUrl, onOpenExter
 					overflow: 'hidden',
 				}}
 			>
-				<FlowContainer oauth2RootUrl={oauth2RootUrl} oauthReturnUrl={oauthReturnUrl} onOpenExternal={onOpenExternal} pendingOAuthTokens={pendingOAuthTokens} clearPendingOAuthTokens={clearPendingOAuthTokens} project={project} servicesJson={servicesJson} getNodeSchema={getNodeSchema} inventory={inventory} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} handleValidatePipeline={handleValidatePipeline} onOpenLink={onOpenLink} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} onExport={onExport} isReadonly={isReadonly} envKeys={envKeys}>
+				<FlowContainer oauth2RootUrl={oauth2RootUrl} oauthReturnUrl={oauthReturnUrl} onOpenExternal={onOpenExternal} pendingOAuthTokens={pendingOAuthTokens} clearPendingOAuthTokens={clearPendingOAuthTokens} project={project} servicesJson={servicesJson} getNodeSchema={getNodeSchema} inventory={inventory} taskStatuses={taskStatuses} componentPipeCounts={componentPipeCounts} totalPipes={totalPipes} handleValidatePipeline={handleValidatePipeline} onOpenLink={onOpenLink} onContentChanged={onContentChanged} onViewportChange={onViewportChange} onUndo={onUndo} onRedo={onRedo} onRunPipeline={onRunPipeline} onStopPipeline={onStopPipeline} onOpenStatus={onOpenStatus} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={initialViewport} isDirty={isDirty} isNew={isNew} onSave={onSave} onExport={onExport} isReadonly={isReadonly} onUninstallNode={onUninstallNode} envKeys={envKeys}>
 					<FlowCanvas />
 				</FlowContainer>
 			</div>

--- a/apps/shared/src/components/canvas/components/FlowContainer.tsx
+++ b/apps/shared/src/components/canvas/components/FlowContainer.tsx
@@ -144,7 +144,8 @@ export interface IFlowContainerProps {
 	/** Called when the user triggers save from the canvas toolbar. */
 	onSave?: () => void;
 	onExport?: () => void;
-
+	/** Uninstalls a capsule-installed node by name (tunneled to the canvas). */
+	onUninstallNode?: (name: string) => void;
 
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
@@ -163,7 +164,7 @@ export interface IFlowContainerProps {
  * Uses `key` on the outer Box to force a clean re-mount when the project
  * ID changes, ensuring no stale graph state leaks between projects.
  */
-export default function FlowContainer({ project, oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, getNodeSchema, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys, children }: IFlowContainerProps): ReactElement {
+export default function FlowContainer({ project, oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, getNodeSchema, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, onUninstallNode, envKeys, children }: IFlowContainerProps): ReactElement {
 	return (
 		<ReactFlowProvider>
 			{/* Re-key on project ID to force clean re-mount between projects */}
@@ -204,6 +205,7 @@ export default function FlowContainer({ project, oauth2RootUrl, oauthReturnUrl, 
 					isNew={isNew}
 					onSave={onSave}
 					onExport={onExport}
+					onUninstallNode={onUninstallNode}
 					envKeys={envKeys}
 				>
 					{children}

--- a/apps/shared/src/components/canvas/components/panels/create-node/CreateNodePanel.tsx
+++ b/apps/shared/src/components/canvas/components/panels/create-node/CreateNodePanel.tsx
@@ -198,6 +198,17 @@ const styles = {
 		lineHeight: '14px',
 	} as CSSProperties,
 
+	// "Custom" pill for a capsule-installed node's icon tile: blue to set it apart
+	// from the yellow Experimental pill.
+	iconTileCustom: {
+		fontSize: '9px',
+		padding: '1px 4px',
+		borderRadius: '3px',
+		backgroundColor: 'var(--rr-color-info)',
+		color: 'var(--rr-fg-button)',
+		lineHeight: '14px',
+	} as CSSProperties,
+
 	sectionHeader: {
 		...commonStyles.labelUppercase,
 		display: 'flex',
@@ -257,6 +268,18 @@ const styles = {
 		lineHeight: '14px',
 	} as CSSProperties,
 
+	// "Custom" badge for a capsule-installed node in the list row (blue, vs the yellow Experimental).
+	customBadge: {
+		fontSize: '9px',
+		padding: '1px 4px',
+		borderRadius: '3px',
+		backgroundColor: 'var(--rr-color-info)',
+		color: 'var(--rr-fg-button)',
+		marginLeft: '4px',
+		flexShrink: 0,
+		lineHeight: '14px',
+	} as CSSProperties,
+
 	empty: {
 		padding: '16px',
 		textAlign: 'center' as const,
@@ -310,7 +333,7 @@ interface ICreateNodePanelProps {
  * @returns The DetailPanel drawer element.
  */
 export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): ReactElement {
-	const { inventory } = useFlowProject();
+	const { inventory, onUninstallNode } = useFlowProject();
 	const { addNode, setTempNode } = useFlowGraph();
 	// The one shared prefs accessor: drives the list/icon view-mode persistence
 	// below (the drawer width rides the same store via DetailPanel's persistKey).
@@ -532,6 +555,14 @@ export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): Rea
 															onClickItem(key);
 														}
 													}}
+													onContextMenu={
+														service.source === 'capsule' && onUninstallNode
+															? (e) => {
+																	e.preventDefault();
+																	if (window.confirm(`Uninstall custom node "${service.title ?? key}"? It will be removed from your store.`)) onUninstallNode(key);
+																}
+															: undefined
+													}
 													style={styles.iconTile}
 													title={service.title ?? key}
 													onMouseEnter={(e) => {
@@ -544,6 +575,7 @@ export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): Rea
 													{service.icon && <Icon name={service.icon} width={28} height={28} style={styles.iconTileIcon} />}
 													<span style={styles.iconTileTitle}>{service.title ?? key}</span>
 													{!!(service.capabilities && IServiceCapabilities.Experimental & service.capabilities) && <span style={styles.iconTileExperimental}>Experimental</span>}
+													{service.source === 'capsule' && <span style={styles.iconTileCustom}>Custom</span>}
 												</div>
 											))}
 										</div>
@@ -562,6 +594,14 @@ export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): Rea
 														onClickItem(key);
 													}
 												}}
+												onContextMenu={
+													service.source === 'capsule' && onUninstallNode
+														? (e) => {
+																e.preventDefault();
+																if (window.confirm(`Uninstall custom node "${service.title ?? key}"? It will be removed from your store.`)) onUninstallNode(key);
+															}
+														: undefined
+												}
 												style={styles.item}
 												onMouseEnter={(e) => {
 													(e.currentTarget as HTMLElement).style.backgroundColor = 'var(--rr-bg-list-hover)';
@@ -574,6 +614,7 @@ export default function CreateNodePanel({ onClose }: ICreateNodePanelProps): Rea
 												<span style={styles.itemTitle}>{service.title ?? key}</span>
 												{Array.isArray(service.classType) && service.classType.includes('tool') && <span style={styles.badge}>Tool</span>}
 												{!!(service.capabilities && IServiceCapabilities.Experimental & service.capabilities) && <span style={styles.experimentalBadge}>Experimental</span>}
+												{service.source === 'capsule' && <span style={styles.customBadge}>Custom</span>}
 											</div>
 										))
 									))}

--- a/apps/shared/src/components/canvas/context/FlowProjectContext.tsx
+++ b/apps/shared/src/components/canvas/context/FlowProjectContext.tsx
@@ -192,6 +192,9 @@ export interface IFlowProjectContext {
 	onSave?: () => void;
 	onExport?: () => void;
 
+	/** Uninstalls a capsule-installed node (source:capsule) by name; host wires the DAP call + catalog refresh. */
+	onUninstallNode?: (name: string) => void;
+
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
 }
@@ -265,6 +268,9 @@ export interface IFlowProjectProviderProps {
 	onSave?: () => void;
 	onExport?: () => void;
 
+	/** Uninstalls a capsule-installed node by name (host wires the DAP call + catalog refresh). */
+	onUninstallNode?: (name: string) => void;
+
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
 }
@@ -280,7 +286,7 @@ export interface IFlowProjectProviderProps {
  * The host application passes props that are tunneled through this context
  * so deeply nested components can access them without prop drilling.
  */
-export function FlowProjectProvider({ children, project: currentProject, isReadonly = false, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, getNodeSchema, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys }: IFlowProjectProviderProps): ReactElement {
+export function FlowProjectProvider({ children, project: currentProject, isReadonly = false, taskStatuses, componentPipeCounts, totalPipes, servicesJson: rawServicesJson, servicesJsonError, getNodeSchema, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, onUninstallNode, envKeys }: IFlowProjectProviderProps): ReactElement {
 	// --- Toolchain state ---------------------------------------------------
 
 	const [toolchainState, setToolchainState] = useState<IToolchainState>(DEFAULT_TOOLCHAIN_STATE);
@@ -395,6 +401,7 @@ export function FlowProjectProvider({ children, project: currentProject, isReado
 		isNew,
 		onSave,
 		onExport,
+		onUninstallNode,
 		envKeys,
 	}), [
 		currentProject, toolchainState, patchToolchainState, toggleDevMode,
@@ -404,7 +411,7 @@ export function FlowProjectProvider({ children, project: currentProject, isReado
 		oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens,
 		onOpenLink, googlePickerDeveloperKey, googlePickerClientId,
 		onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected,
-		isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys,
+		isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, onUninstallNode, envKeys,
 	]);
 
 	return <FlowProjectContext.Provider value={value}>{children}</FlowProjectContext.Provider>;

--- a/apps/shared/src/components/canvas/context/FlowProvider.tsx
+++ b/apps/shared/src/components/canvas/context/FlowProvider.tsx
@@ -121,6 +121,9 @@ export interface IFlowProviderProps {
 	onSave?: () => void;
 	onExport?: () => void;
 
+	/** Uninstalls a capsule-installed node by name (tunneled through to FlowProjectContext). */
+	onUninstallNode?: (name: string) => void;
+
 	/** Available ROCKETRIDE_* environment variable key names for autocomplete in config fields. */
 	envKeys?: string[];
 }
@@ -141,7 +144,7 @@ export interface IFlowProviderProps {
  * </ReactFlowProvider>
  * ```
  */
-export function FlowProvider({ children, project, projectId, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, getNodeSchema, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, envKeys }: IFlowProviderProps): ReactElement {
+export function FlowProvider({ children, project, projectId, isReadonly, taskStatuses, componentPipeCounts, totalPipes, servicesJson, servicesJsonError, getNodeSchema, inventory, inventoryConnectorTitleMap, handleValidatePipeline, onContentChanged, onViewportChange, onUndo, onRedo, oauth2RootUrl, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, onOpenLink, googlePickerDeveloperKey, googlePickerClientId, onRunPipeline, onStopPipeline, onOpenStatus, serverHost, isConnected, isSubscribed, initialViewport, isDirty, isNew, onSave, onExport, onUninstallNode, envKeys }: IFlowProviderProps): ReactElement {
 	return (
 		<FlowPreferencesProvider projectId={projectId} isReadonly={isReadonly}>
 			<FlowProjectProvider
@@ -179,6 +182,7 @@ export function FlowProvider({ children, project, projectId, isReadonly, taskSta
 				isNew={isNew}
 				onSave={onSave}
 				onExport={onExport}
+				onUninstallNode={onUninstallNode}
 				envKeys={envKeys}
 			>
 				<FlowGraphProvider>{children}</FlowGraphProvider>

--- a/apps/shared/src/modules/project/ProjectView.tsx
+++ b/apps/shared/src/modules/project/ProjectView.tsx
@@ -131,6 +131,8 @@ export interface IProjectViewProps {
 	onSave?: () => void;
 	/** SaaS-only: export/download the current pipeline. Forwarded to the canvas. */
 	onExport?: () => void;
+	/** Uninstalls a capsule-installed ("Custom") node by name; host wires the DAP call + catalog refresh. */
+	onUninstallNode?: (name: string) => void;
 	/**
 	 * @deprecated Unused since the environment-page restructure — each section
 	 * owns its replay window; there is no shared trace accumulator to clear.
@@ -295,7 +297,7 @@ function migrateViewMode(mode: string | undefined): ProjectViewMode {
 // COMPONENT
 // =============================================================================
 
-const ProjectView: React.FC<IProjectViewProps> = ({ project, documentTitle, servicesJson, isConnected, isSubscribed = true, statusMap, serverHost = '', isDirty = false, isNew = false, initialViewState, initialPrefs, onContentChanged, onValidate, getNodeSchema, onPipelineAction, onViewStateChange, onPrefsChange, onOpenLink, oauth2RootUrl = OAUTH_ROOT_URL, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, onSave, onExport, isReadonly = false, envKeys, onMissingEnvVars, liveLogEvents = [], openEventStream, fetchTimeline, fetchDeployLifecycle, teamDeployments = [], deployTeams = [], onDeployPublish, onDeployVersion, onOpenDeployment, onDeploySetDisabled, onDeploySetSchedule, onDeploySetSchedulePaused, onDeployPreviewSchedule, fetchDeployArtifact, onSaveDocument }) => {
+const ProjectView: React.FC<IProjectViewProps> = ({ project, documentTitle, servicesJson, isConnected, isSubscribed = true, statusMap, serverHost = '', isDirty = false, isNew = false, initialViewState, initialPrefs, onContentChanged, onValidate, getNodeSchema, onPipelineAction, onViewStateChange, onPrefsChange, onOpenLink, oauth2RootUrl = OAUTH_ROOT_URL, oauthReturnUrl, onOpenExternal, pendingOAuthTokens, clearPendingOAuthTokens, onSave, onExport, isReadonly = false, onUninstallNode, envKeys, onMissingEnvVars, liveLogEvents = [], openEventStream, fetchTimeline, fetchDeployLifecycle, teamDeployments = [], deployTeams = [], onDeployPublish, onDeployVersion, onOpenDeployment, onDeploySetDisabled, onDeploySetSchedule, onDeploySetSchedulePaused, onDeployPreviewSchedule, fetchDeployArtifact, onSaveDocument }) => {
 	// --- Local view state (initialized from props, managed locally) -----------
 
 	const [viewState, setViewState] = useState<ViewState>(() => ({
@@ -601,7 +603,7 @@ const ProjectView: React.FC<IProjectViewProps> = ({ project, documentTitle, serv
 		design: {
 			content: (
 				<div style={styles.canvasPadding}>
-					<PrefsProvider value={prefsApi}>{project && <CanvasPanel oauth2RootUrl={oauth2RootUrl} oauthReturnUrl={oauthReturnUrl} onOpenExternal={onOpenExternal} pendingOAuthTokens={pendingOAuthTokens} clearPendingOAuthTokens={clearPendingOAuthTokens} project={project} servicesJson={servicesJson} getNodeSchema={getNodeSchema ? handleGetNodeSchema : undefined} taskStatuses={statusMap} handleValidatePipeline={handleValidate} onContentChanged={isReadonly ? undefined : handleContentChanged} onViewportChange={handleViewportChange} onRunPipeline={isReadonly ? undefined : handleRunPipeline} onStopPipeline={isReadonly ? undefined : handleStopPipeline} onOpenLink={handleOpenLink} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={viewState.viewport} isDirty={isReadonly ? false : isDirty} isNew={isReadonly ? false : isNew} onSave={isReadonly ? undefined : handleSave} onExport={isReadonly ? undefined : onExport} isReadonly={isReadonly} envKeys={envKeys} />}</PrefsProvider>
+					<PrefsProvider value={prefsApi}>{project && <CanvasPanel oauth2RootUrl={oauth2RootUrl} oauthReturnUrl={oauthReturnUrl} onOpenExternal={onOpenExternal} pendingOAuthTokens={pendingOAuthTokens} clearPendingOAuthTokens={clearPendingOAuthTokens} project={project} servicesJson={servicesJson} getNodeSchema={getNodeSchema ? handleGetNodeSchema : undefined} taskStatuses={statusMap} handleValidatePipeline={handleValidate} onContentChanged={isReadonly ? undefined : handleContentChanged} onViewportChange={handleViewportChange} onRunPipeline={isReadonly ? undefined : handleRunPipeline} onStopPipeline={isReadonly ? undefined : handleStopPipeline} onOpenLink={handleOpenLink} serverHost={serverHost} isConnected={isConnected} isSubscribed={isSubscribed} initialViewport={viewState.viewport} isDirty={isReadonly ? false : isDirty} isNew={isReadonly ? false : isNew} onSave={isReadonly ? undefined : handleSave} onExport={isReadonly ? undefined : onExport} isReadonly={isReadonly} onUninstallNode={onUninstallNode} envKeys={envKeys} />}</PrefsProvider>
 				</div>
 			),
 		},

--- a/apps/shared/src/modules/sidebar/SidebarView.tsx
+++ b/apps/shared/src/modules/sidebar/SidebarView.tsx
@@ -21,7 +21,7 @@
 
 import React, { useState, useCallback, CSSProperties } from 'react';
 import { commonStyles } from 'shell';
-import { BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop, BxGridAlt } from 'shell';
+import { BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop, BxGridAlt, BxCloudUpload } from 'shell';
 import { SidebarMenu, TabControl, TabPanel } from 'shell';
 import { StatusBadge } from 'shell';
 import type { StatusVariant } from 'shell';
@@ -195,9 +195,13 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 		entries: [{ id: 'monitor', label: 'Monitor', icon: <BxDesktop size={16} />, disabled: !isConnected }],
 	};
 
-	// "+ New pipeline" belongs to the Pipelines tab body only.
+	// "+ New pipeline" belongs to the Pipelines tab body only, alongside the
+	// capsule installer (a node capsule is only useful to a pipeline).
 	const pipelinesNavMenu: ViewMenu = {
-		entries: [{ id: 'new', label: 'New pipeline', icon: <BxPlus size={16} /> }],
+		entries: [
+			{ id: 'new', label: 'New pipeline', icon: <BxPlus size={16} /> },
+			{ id: 'installCapsule', label: 'Install node capsule', icon: <BxCloudUpload size={16} />, disabled: !isConnected },
+		],
 	};
 
 	// The mode tabs — the stock TabControl menu. The Apps entry only exists
@@ -262,7 +266,7 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 					menu={pipelinesNavMenu}
 					activeId=""
 					onSelect={(id) => {
-						if (id === 'new') onNavigate(id);
+						if (id === 'new' || id === 'installCapsule') onNavigate(id);
 					}}
 				/>
 			</div>

--- a/apps/shared/src/modules/sidebar/SidebarView.tsx
+++ b/apps/shared/src/modules/sidebar/SidebarView.tsx
@@ -21,7 +21,7 @@
 
 import React, { useState, useCallback, CSSProperties } from 'react';
 import { commonStyles } from 'shell';
-import { BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop, BxGridAlt, BxCloudUpload } from 'shell';
+import { BxPlus, BxDesktop, BxChevronRight, BxChevronDown, BxStop, BxGridAlt, BxCloudUpload, BxExport, BxTrash } from 'shell';
 import { SidebarMenu, TabControl, TabPanel } from 'shell';
 import { StatusBadge } from 'shell';
 import type { StatusVariant } from 'shell';
@@ -174,7 +174,7 @@ const PIPELINE_CONFIG: ExplorerConfig = {
  * Maps ISidebarViewProps (pipeline-specific) to IExplorerProps (generic).
  * The Explorer component handles all file tree rendering internally.
  */
-export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscribed = true, entries, activeTasks, unknownTasks, headerSlot, onNavigate, onOpenFile, onFileManage, fileActions, onSourceAction, onRefresh, footerSlot, onOpenUnknownTask, activeFilePath, appBuilder, showModeStrip = false, sidebarMode = 'pipelines', onSidebarModeChange }) => {
+export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscribed = true, entries, activeTasks, unknownTasks, headerSlot, onNavigate, onOpenFile, onFileManage, fileActions, onSourceAction, onRefresh, footerSlot, onOpenUnknownTask, activeFilePath, appBuilder, capsules = [], onCapsuleAction, showModeStrip = false, sidebarMode = 'pipelines', onSidebarModeChange }) => {
 	const [hoveredRow, setHoveredRow] = useState<string | null>(null);
 	const [unknownExpanded, setUnknownExpanded] = useState(true);
 
@@ -195,13 +195,9 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 		entries: [{ id: 'monitor', label: 'Monitor', icon: <BxDesktop size={16} />, disabled: !isConnected }],
 	};
 
-	// "+ New pipeline" belongs to the Pipelines tab body only, alongside the
-	// capsule installer (a node capsule is only useful to a pipeline).
+	// "+ New pipeline" belongs to the Pipelines tab body only.
 	const pipelinesNavMenu: ViewMenu = {
-		entries: [
-			{ id: 'new', label: 'New pipeline', icon: <BxPlus size={16} /> },
-			{ id: 'installCapsule', label: 'Install node capsule', icon: <BxCloudUpload size={16} />, disabled: !isConnected },
-		],
+		entries: [{ id: 'new', label: 'New pipeline', icon: <BxPlus size={16} /> }],
 	};
 
 	// The mode tabs — the stock TabControl menu. The Apps entry only exists
@@ -266,7 +262,7 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 					menu={pipelinesNavMenu}
 					activeId=""
 					onSelect={(id) => {
-						if (id === 'new' || id === 'installCapsule') onNavigate(id);
+						if (id === 'new') onNavigate(id);
 					}}
 				/>
 			</div>
@@ -365,10 +361,48 @@ export const SidebarView: React.FC<ISidebarViewProps> = ({ connection, isSubscri
 		</div>
 	) : null;
 
-	// Nodes tab body: node-builder placeholder until the real surface lands.
+	// Nodes tab body: the node builder's capsule surface — import a .rrc, and
+	// export or uninstall the capsules already installed. Node authoring itself
+	// still lands here later.
+	const nodesNavMenu: ViewMenu = {
+		entries: [{ id: 'installCapsule', label: 'Import node capsule', icon: <BxCloudUpload size={16} />, disabled: !isConnected }],
+	};
+
 	const nodesPanel = (
 		<div style={S.panelColumn}>
-			<div style={S.comingSoon}>Coming soon...</div>
+			<div style={S.navSection}>
+				<SidebarMenu
+					menu={nodesNavMenu}
+					activeId=""
+					onSelect={(id) => {
+						if (id === 'installCapsule') onNavigate(id);
+					}}
+				/>
+			</div>
+
+			<div style={S.appsLabel}>Installed capsules</div>
+			{capsules.length === 0 ? (
+				<div style={S.comingSoon}>No node capsules installed</div>
+			) : (
+				<div style={S.appsList}>
+					{capsules.map((capsule) => (
+						<div key={capsule.name} style={{ ...S.row, ...hoverBg(`capsule-${capsule.name}`) }} onMouseEnter={() => setHoveredRow(`capsule-${capsule.name}`)} onMouseLeave={() => setHoveredRow(null)}>
+							<BxGridAlt size={16} />
+							<span style={S.rowName} title={capsule.name}>
+								{capsule.title || capsule.name}
+							</span>
+							{/* Actions stay mounted (not hover-gated) so they are
+							    reachable by keyboard, matching the Explorer rows. */}
+							<button style={S.actionBtn('var(--rr-text-secondary)')} title={`Export ${capsule.name} as .rrc`} disabled={!isConnected} onClick={() => onCapsuleAction?.('export', capsule.name)}>
+								<BxExport size={14} />
+							</button>
+							<button style={S.actionBtn('var(--rr-text-secondary)')} title={`Uninstall ${capsule.name}`} disabled={!isConnected} onClick={() => onCapsuleAction?.('uninstall', capsule.name)}>
+								<BxTrash size={14} />
+							</button>
+						</div>
+					))}
+				</div>
+			)}
 		</div>
 	);
 

--- a/apps/shared/src/modules/sidebar/types.ts
+++ b/apps/shared/src/modules/sidebar/types.ts
@@ -168,7 +168,7 @@ export interface ISidebarViewProps {
 	headerSlot?: ReactNode;
 
 	// ── Actions ─────────────────────────────────────────────────────────────
-	onNavigate: (target: 'new' | 'monitor' | 'deploy' | 'templates') => void;
+	onNavigate: (target: 'new' | 'monitor' | 'deploy' | 'templates' | 'installCapsule') => void;
 	/** Open a file in the editor. */
 	onOpenFile: (path: string) => void;
 	/**

--- a/apps/shared/src/modules/sidebar/types.ts
+++ b/apps/shared/src/modules/sidebar/types.ts
@@ -75,6 +75,14 @@ export interface UnknownTask {
 // APP BUILDER SIDEBAR (MY APPS)
 // =============================================================================
 
+/** One installed node capsule row in the Nodes sidebar mode. */
+export interface InstalledCapsule {
+	/** The node's name — its `local_nodes/<name>/` folder and catalog key. */
+	name: string;
+	/** Display title from the node's services.json; falls back to the name. */
+	title?: string;
+}
+
 /** One MY APPS row in the App Builder sidebar mode. */
 export interface AppListItem {
 	/** App id (the appManifest.id binding key, e.g. 'acme.brandy'). */
@@ -204,6 +212,20 @@ export interface ISidebarViewProps {
 	 * placeholder still rides along whenever the mode tabs render).
 	 */
 	appBuilder?: AppBuilderSidebar;
+
+	// ── Node builder (Nodes tab) ────────────────────────────────────────────
+	/**
+	 * Node capsules installed for the caller, listed under the Nodes tab.
+	 * Hosts read them from the services catalog (entries tagged
+	 * `source: 'capsule'`). Omitted → the tab shows its empty state.
+	 */
+	capsules?: InstalledCapsule[];
+	/**
+	 * Per-capsule action from the Nodes tab. The host owns the engine call and
+	 * whatever the platform needs around it (a download in the browser, a save
+	 * dialog in VS Code), plus refreshing the list afterwards.
+	 */
+	onCapsuleAction?: (action: 'export' | 'uninstall', name: string) => void;
 	/**
 	 * Force the mode tabs visible without appBuilder — Pipelines plus the
 	 * Nodes placeholder (the web host: more modes will land on that strip).

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -350,6 +350,18 @@
 				"icon": "$(cloud-upload)"
 			},
 			{
+				"command": "rocketride.node.exportCapsule",
+				"title": "Export Node Capsule (.rrc)",
+				"category": "RocketRide",
+				"icon": "$(cloud-download)"
+			},
+			{
+				"command": "rocketride.node.uninstallCapsule",
+				"title": "Uninstall Node Capsule",
+				"category": "RocketRide",
+				"icon": "$(trash)"
+			},
+			{
 				"command": "rocketride.sidebar.connection.connect",
 				"title": "Connect to Server",
 				"category": "RocketRide",

--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -2,7 +2,7 @@
 	"name": "rocketride",
 	"displayName": "RocketRide",
 	"description": "RocketRide extension for Visual Studio Code",
-	"version": "1.2.0",
+	"version": "1.2.4",
 	"publisher": "rocketride",
 	"repository": {
 		"type": "git",
@@ -32,6 +32,21 @@
 		"onStartupFinished"
 	],
 	"contributes": {
+		"languages": [
+			{
+				"id": "rocketride-capsule",
+				"aliases": [
+					"RocketRide Capsule"
+				],
+				"extensions": [
+					".rrc"
+				],
+				"icon": {
+					"light": "./rocketride-light-icon.png",
+					"dark": "./rocketride-dark-icon.png"
+				}
+			}
+		],
 		"customEditors": [
 			{
 				"viewType": "rocketride.PageProject",
@@ -329,6 +344,12 @@
 				"category": "RocketRide"
 			},
 			{
+				"command": "rocketride.node.installCapsule",
+				"title": "Install Node Capsule (.rrc)",
+				"category": "RocketRide",
+				"icon": "$(cloud-upload)"
+			},
+			{
 				"command": "rocketride.sidebar.connection.connect",
 				"title": "Connect to Server",
 				"category": "RocketRide",
@@ -579,6 +600,11 @@
 					"command": "rocketride.sidebar.files.createFile",
 					"when": "view == rocketride.provider.files",
 					"group": "navigation@2"
+				},
+				{
+					"command": "rocketride.node.installCapsule",
+					"when": "view == rocketride.provider.files",
+					"group": "navigation@3"
 				}
 			],
 			"view/item/context": [

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -490,6 +490,40 @@ function registerUtilityCommands(context: vscode.ExtensionContext): void {
 			await refreshAllProviders();
 			vscode.window.showInformationMessage('RocketRide views refreshed');
 		}),
+		vscode.commands.registerCommand('rocketride.node.installCapsule', async () => {
+			const logger = getLogger();
+			try {
+				const client = connectionManager?.getClient();
+				if (!client) {
+					vscode.window.showWarningMessage('Not connected to a RocketRide engine. Connect first.');
+					return;
+				}
+				const uris = await vscode.window.showOpenDialog({
+					canSelectMany: false,
+					openLabel: 'Install',
+					filters: { 'RocketRide Capsule': ['rrc'] },
+				});
+				if (!uris?.length) {
+					return;
+				}
+				const bytes = await vscode.workspace.fs.readFile(uris[0]);
+				const capsule = Buffer.from(bytes).toString('base64');
+				const res = await client.call<{ ok?: boolean; installed?: string; violations?: string[] }>(
+					'rrext_install_node',
+					{ capsule },
+				);
+				if (res?.ok) {
+					vscode.window.showInformationMessage(`Node capsule installed: ${res.installed}`);
+					await refreshAllProviders();
+				} else {
+					const why = (res?.violations ?? ['unknown reason']).join('; ');
+					vscode.window.showWarningMessage(`Airlock rejected the capsule: ${why}`);
+				}
+			} catch (err) {
+				logger.error(`[InstallCapsule] failed: ${err}`);
+				vscode.window.showErrorMessage(`Failed to install node capsule: ${err}`);
+			}
+		}),
 		vscode.commands.registerCommand('rocketride.agents.install', async () => {
 			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
 			if (!workspaceFolder) {

--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -524,6 +524,67 @@ function registerUtilityCommands(context: vscode.ExtensionContext): void {
 				vscode.window.showErrorMessage(`Failed to install node capsule: ${err}`);
 			}
 		}),
+		vscode.commands.registerCommand('rocketride.node.exportCapsule', async (node?: string) => {
+			const logger = getLogger();
+			try {
+				const client = connectionManager?.getClient();
+				if (!client) {
+					vscode.window.showWarningMessage('Not connected to a RocketRide engine. Connect first.');
+					return;
+				}
+				const name = node ?? (await pickInstalledCapsule(client, 'Export'));
+				if (!name) {
+					return;
+				}
+				// The engine re-packs from the store, so an edited node exports
+				// exactly what is installed rather than the original upload.
+				const res = await client.call<{ ok?: boolean; capsule?: string; filename?: string; error?: string }>('rrext_export_node', { node: name });
+				if (!res?.ok || !res.capsule) {
+					vscode.window.showWarningMessage(`Export failed: ${res?.error ?? 'unknown error'}`);
+					return;
+				}
+				const target = await vscode.window.showSaveDialog({
+					defaultUri: vscode.Uri.file(res.filename ?? `${name}.rrc`),
+					filters: { 'RocketRide Capsule': ['rrc'] },
+				});
+				if (!target) {
+					return;
+				}
+				await vscode.workspace.fs.writeFile(target, Buffer.from(res.capsule, 'base64'));
+				vscode.window.showInformationMessage(`Node capsule exported: ${target.fsPath}`);
+			} catch (err) {
+				logger.error(`[ExportCapsule] failed: ${err}`);
+				vscode.window.showErrorMessage(`Failed to export node capsule: ${err}`);
+			}
+		}),
+		vscode.commands.registerCommand('rocketride.node.uninstallCapsule', async (node?: string) => {
+			const logger = getLogger();
+			try {
+				const client = connectionManager?.getClient();
+				if (!client) {
+					vscode.window.showWarningMessage('Not connected to a RocketRide engine. Connect first.');
+					return;
+				}
+				const name = node ?? (await pickInstalledCapsule(client, 'Uninstall'));
+				if (!name) {
+					return;
+				}
+				const confirmed = await vscode.window.showWarningMessage(`Uninstall node capsule "${name}"? Pipelines using this node will stop working.`, { modal: true }, 'Uninstall');
+				if (confirmed !== 'Uninstall') {
+					return;
+				}
+				const res = await client.call<{ ok?: boolean; error?: string }>('rrext_uninstall_node', { node: name });
+				if (!res?.ok) {
+					vscode.window.showWarningMessage(`Uninstall failed: ${res?.error ?? 'unknown error'}`);
+					return;
+				}
+				vscode.window.showInformationMessage(`Node capsule uninstalled: ${name}`);
+				await refreshAllProviders();
+			} catch (err) {
+				logger.error(`[UninstallCapsule] failed: ${err}`);
+				vscode.window.showErrorMessage(`Failed to uninstall node capsule: ${err}`);
+			}
+		}),
 		vscode.commands.registerCommand('rocketride.agents.install', async () => {
 			const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
 			if (!workspaceFolder) {
@@ -644,6 +705,26 @@ function setupConnectionEventHandlers(): void {
 /**
  * Refreshes all data providers
  */
+/**
+ * Asks the user which installed capsule to act on.
+ *
+ * Only needed when a command is invoked from the palette — the sidebar rows
+ * pass the name directly. Returns undefined when nothing is installed or the
+ * user dismisses the pick.
+ */
+async function pickInstalledCapsule(client: { call<T>(command: string, args: Record<string, unknown>): Promise<T> }, action: string): Promise<string | undefined> {
+	const res = await client.call<{ services?: Record<string, { title?: string; source?: string }> }>('rrext_services', {});
+	const names = Object.entries(res?.services ?? {})
+		.filter(([, def]) => def?.source === 'capsule')
+		.map(([name, def]) => ({ label: def?.title || name, description: name }));
+	if (!names.length) {
+		vscode.window.showInformationMessage('No node capsules are installed.');
+		return undefined;
+	}
+	const picked = await vscode.window.showQuickPick(names, { placeHolder: `${action} which node capsule?` });
+	return picked?.description;
+}
+
 async function refreshAllProviders(): Promise<void> {
 	// SidebarProvider handles its own refresh via event listeners
 }

--- a/apps/vscode/src/providers/ProjectProvider.ts
+++ b/apps/vscode/src/providers/ProjectProvider.ts
@@ -522,6 +522,24 @@ export class ProjectProvider implements vscode.CustomTextEditorProvider {
 				return;
 			}
 			switch (data.type) {
+				case 'node:uninstallCapsule': {
+					const client = this.connectionManager.getClient();
+					if (!client) {
+						vscode.window.showWarningMessage('Not connected to a RocketRide engine.');
+						return;
+					}
+					try {
+						const res = await client.call<{ ok?: boolean; uninstalled?: string; error?: string }>('rrext_uninstall_node', { node: data.node });
+						if (res?.ok) {
+							vscode.window.showInformationMessage(`Node capsule uninstalled: ${res.uninstalled ?? data.node}. Reopen the pipeline to refresh the catalog.`);
+						} else {
+							vscode.window.showWarningMessage(`Uninstall failed: ${res?.error ?? 'unknown reason'}`);
+						}
+					} catch (err) {
+						vscode.window.showErrorMessage(`Uninstall failed: ${err}`);
+					}
+					return;
+				}
 				case 'view:ready': {
 					editorState.isReady = true;
 

--- a/apps/vscode/src/providers/SidebarProvider.ts
+++ b/apps/vscode/src/providers/SidebarProvider.ts
@@ -437,6 +437,8 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 		// Re-parse when service definitions arrive
 		const servicesUpdatedHandler = () => {
 			this.loadPipelineFiles();
+			// An installed/uninstalled capsule shows up as a catalog change.
+			this.sendCapsulesUpdate();
 		};
 		this.connectionManager.on('shell:servicesUpdated', servicesUpdatedHandler);
 
@@ -560,8 +562,31 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 				// them out-of-band so this update never awaits the catalog RPC
 				apps: this.appRows,
 				sidebarMode: this.sidebarMode,
+				// Node capsules (Nodes tab) — read off the same cached catalog
+				// the canvas uses, so this update costs no extra RPC.
+				capsules: this.buildCapsules(),
 			},
 		});
+	}
+
+	/**
+	 * Installed node capsules for the Nodes tab.
+	 *
+	 * The engine tags the entries it overlays from the caller's store with
+	 * `source: 'capsule'`, so the cached services catalog already carries
+	 * everything the list needs.
+	 */
+	private buildCapsules(): { name: string; title?: string }[] {
+		const { services } = this.connectionManager.getCachedServices();
+		return Object.entries(services ?? {})
+			.filter(([, def]) => (def as { source?: string })?.source === 'capsule')
+			.map(([name, def]) => ({ name, title: (def as { title?: string })?.title }));
+	}
+
+	/** Pushes just the capsule list (the catalog changed under a stable view). */
+	private sendCapsulesUpdate(): void {
+		if (!this._view) return;
+		this._view.webview.postMessage({ type: 'capsulesUpdate', capsules: this.buildCapsules() });
 	}
 
 	/** Sends only updated entries. */

--- a/apps/vscode/src/providers/types/projectTypes.ts
+++ b/apps/vscode/src/providers/types/projectTypes.ts
@@ -59,6 +59,7 @@ export type ProjectWebviewToHost =
 	| { type: 'project:openExternal'; url: string }
 	| { type: 'status:pipelineAction'; action: 'run' | 'stop' | 'restart'; source?: string }
 	| { type: 'status:missingEnvVars'; keys: string[] }
+	| { type: 'node:uninstallCapsule'; node: string }
 	| { type: 'trace:clear' }
 	// Embedded checkout requests (the Subscribe overlay).
 	| CheckoutRequestWebviewToHost

--- a/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
+++ b/apps/vscode/src/providers/views/Project/ProjectWebview.tsx
@@ -513,6 +513,13 @@ const ProjectWebview: React.FC = () => {
 		[sendMessage]
 	);
 
+	const handleUninstallNode = useCallback(
+		(name: string) => {
+			sendMessage({ type: 'node:uninstallCapsule', node: name });
+		},
+		[sendMessage]
+	);
+
 	const handleViewStateChange = useCallback(
 		(vs: ViewState) => {
 			// Keep local state current so the next run message carries the latest trace level
@@ -815,6 +822,7 @@ const ProjectWebview: React.FC = () => {
 				pendingOAuthTokens={pendingOAuthTokens}
 				clearPendingOAuthTokens={clearPendingOAuthTokens}
 				onSave={handleSave}
+				onUninstallNode={handleUninstallNode}
 				isReadonly={isReadonly}
 				envKeys={envKeys}
 				onMissingEnvVars={handleMissingEnvVars}

--- a/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
+++ b/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
@@ -301,6 +301,7 @@ const SidebarViewWebview: React.FC = () => {
 			const commands: Record<string, string> = {
 				new: 'rocketride.sidebar.files.createFile',
 				monitor: 'rocketride.page.monitor.open',
+				installCapsule: 'rocketride.node.installCapsule',
 			};
 			const cmd = commands[target];
 			if (cmd) sendMessage({ type: 'command', command: cmd });

--- a/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
+++ b/apps/vscode/src/providers/views/Sidebar/SidebarWebview.tsx
@@ -32,7 +32,7 @@ import { BxUser, BxCog, BxExport, BxLock, BxRocket } from 'shell';
 import { foldTaskEvent } from 'shared/modules/sidebar/taskFold';
 import { SidebarFooter } from 'shell';
 import type { SidebarFooterMenuItem } from 'shell';
-import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, AppListItem, SidebarMode } from 'shared/modules/sidebar/types';
+import type { ProjectEntry, ActiveTaskState, UnknownTask, ConnectionInfo, AppListItem, InstalledCapsule, SidebarMode } from 'shared/modules/sidebar/types';
 import { useMessaging } from '../hooks/useMessaging';
 
 // =============================================================================
@@ -92,12 +92,15 @@ type IncomingMessage =
 				unknownTasks: UnknownTask[];
 				// App Builder (MY APPS) — merged workspace ∪ server list
 				apps?: AppListItem[];
+				// Node capsules installed in the caller's store (Nodes tab).
+				capsules?: InstalledCapsule[];
 				/** Host-persisted sidebar mode (workspaceState). */
 				sidebarMode?: SidebarMode;
 			};
 	  }
 	| { type: 'entriesUpdate'; entries: HostProjectEntry[] }
 	| { type: 'appsUpdate'; apps: AppListItem[] }
+	| { type: 'capsulesUpdate'; capsules: InstalledCapsule[] }
 	| { type: 'taskEvent'; event: TaskEventBody }
 	| { type: 'statusUpdate'; projectId: string; sourceId: string; errors: string[]; warnings: string[] }
 	| { type: 'dashboardSnapshot'; tasks: DashboardTaskDTO[] };
@@ -127,6 +130,8 @@ const SidebarViewWebview: React.FC = () => {
 
 	// ── App Builder (MY APPS) ───────────────────────────────────────────────
 	const [apps, setApps] = useState<AppListItem[]>([]);
+	// ── Node capsules (Nodes tab) ───────────────────────────────────────────
+	const [capsules, setCapsules] = useState<InstalledCapsule[]>([]);
 	const [sidebarMode, setSidebarMode] = useState<SidebarMode>('pipelines');
 	// The host-persisted mode seeds the strip ONCE: an `update` composed
 	// before the persist round trip completed carries the previous value and
@@ -231,6 +236,7 @@ const SidebarViewWebview: React.FC = () => {
 					if ((msg.data as any).isSubscribed !== undefined) setSubscribed((msg.data as any).isSubscribed);
 					// App Builder list + host-persisted mode (seed once — see ref)
 					if (msg.data.apps) setApps(msg.data.apps);
+					if (msg.data.capsules) setCapsules(msg.data.capsules);
 					if (msg.data.sidebarMode && !sidebarModeSeededRef.current) {
 						sidebarModeSeededRef.current = true;
 						setSidebarMode(msg.data.sidebarMode);
@@ -243,6 +249,10 @@ const SidebarViewWebview: React.FC = () => {
 
 				case 'appsUpdate':
 					setApps(msg.apps);
+					break;
+
+				case 'capsulesUpdate':
+					setCapsules(msg.capsules);
 					break;
 
 				case 'taskEvent':
@@ -312,6 +322,16 @@ const SidebarViewWebview: React.FC = () => {
 	const onOpenFile = useCallback(
 		(path: string) => {
 			sendMessage({ type: 'openFile', fsPath: path });
+		},
+		[sendMessage]
+	);
+
+	// Capsule row actions run as host commands — the save dialog, the store
+	// call and the confirm prompt all belong to the extension side.
+	const onCapsuleAction = useCallback(
+		(action: 'export' | 'uninstall', name: string) => {
+			const command = action === 'export' ? 'rocketride.node.exportCapsule' : 'rocketride.node.uninstallCapsule';
+			sendMessage({ type: 'command', command, args: [name] });
 		},
 		[sendMessage]
 	);
@@ -477,7 +497,7 @@ const SidebarViewWebview: React.FC = () => {
 	// No headerSlot: the VS Code host has no home-app destination, so it injects no
 	// host-specific top nav. The "Home" button is a SaaS-shell concept owned by the
 	// web host (rocket-ui), intentionally absent from shared / this extension.
-	return <SidebarView connection={connection} isSubscribed={subscribed} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} onNavigate={onNavigate} onOpenFile={onOpenFile} onSourceAction={onSourceAction} onRefresh={onRefresh} footerSlot={footerSlot} onOpenUnknownTask={onOpenUnknownTask} appBuilder={{ apps, onNewApp, onOpenApp }} sidebarMode={sidebarMode} onSidebarModeChange={onSidebarModeChange} />;
+	return <SidebarView connection={connection} isSubscribed={subscribed} entries={entries} activeTasks={activeTasks} unknownTasks={unknownTasks} onNavigate={onNavigate} onOpenFile={onOpenFile} onSourceAction={onSourceAction} onRefresh={onRefresh} footerSlot={footerSlot} onOpenUnknownTask={onOpenUnknownTask} appBuilder={{ apps, onNewApp, onOpenApp }} capsules={capsules} onCapsuleAction={onCapsuleAction} sidebarMode={sidebarMode} onSidebarModeChange={onSidebarModeChange} />;
 };
 
 export default SidebarViewWebview;

--- a/packages/ai/src/ai/modules/task/commands/capsule_airlock.py
+++ b/packages/ai/src/ai/modules/task/commands/capsule_airlock.py
@@ -1,0 +1,293 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Capsule airlock — the mandatory secure-first gate for installable node capsules.
+
+A node capsule is a ``.rrc`` file (a ZIP) carrying a self-contained node:
+
+    <node>.rrc
+    ├── capsule.json              # manifest: name, protocol, version, sha256, declares[]
+    └── local_nodes/
+        └── <node>/
+            ├── services.json
+            ├── __init__.py, IGlobal.py, IInstance.py, <impl>.py
+            └── requirements.txt  (optional)
+
+Because installing a capsule means the engine will later EXECUTE its Python, the
+capsule is inspected here BEFORE anything is persisted or run. Nothing passes the
+airlock unless it is packaged for evaluation (plain source, no install-time code,
+declared intent) and clears the static scan. On any failure this raises
+``AirlockRejected`` and the caller must abort — no store write, no execution.
+"""
+
+import ast
+import hashlib
+import json
+import posixpath
+import re
+import zipfile
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+MANIFEST_NAME = 'capsule.json'
+NODES_ROOT = 'local_nodes'
+
+# Calls that have no legitimate use inside a declarative node and are rejected
+# outright (dynamic code execution / import escape hatches).
+FORBIDDEN_CALLS = frozenset({'eval', 'exec', 'compile', '__import__'})
+
+# Sensitive surfaces gated behind a DECLARED capability in capsule.json. A usage
+# that is not declared is a declared-vs-actual mismatch and rejects the capsule.
+CAPABILITY_MODULES = {
+    'network': frozenset({'socket', 'http', 'urllib', 'urllib3', 'requests', 'httpx', 'ftplib', 'smtplib', 'asyncio'}),
+    'subprocess': frozenset({'subprocess', 'multiprocessing', 'pty', 'os'}),
+    'filesystem': frozenset({'shutil', 'pathlib', 'tempfile', 'glob'}),
+}
+# os.system / os.popen / os.exec* specifically require 'subprocess'.
+OS_SUBPROCESS_ATTRS = frozenset({'system', 'popen', 'execv', 'execve', 'execvp', 'spawnv', 'spawnl', 'fork'})
+
+
+class AirlockRejected(Exception):
+    """Raised when a capsule fails validation. Carries the list of violations."""
+
+    def __init__(self, violations: List[str]):
+        self.violations = violations
+        super().__init__('; '.join(violations) if violations else 'capsule rejected')
+
+
+@dataclass
+class CapsuleInfo:
+    """Validated capsule metadata, returned only when the airlock passes."""
+
+    name: str
+    protocol: str
+    version: str
+    node_dir: str  # 'local_nodes/<node>'
+    services_json: dict
+    declares: List[str] = field(default_factory=list)
+    files: Dict[str, bytes] = field(default_factory=dict)  # arcname -> bytes
+
+
+def validate_capsule(zip_bytes: bytes) -> CapsuleInfo:
+    """
+    Run the full airlock over raw ``.rrc`` bytes.
+
+    Returns a ``CapsuleInfo`` on success. Raises ``AirlockRejected`` (with every
+    violation found) on any failure. The caller MUST NOT persist or execute a
+    capsule that did not return from here cleanly.
+    """
+    violations: List[str] = []
+
+    try:
+        zf = zipfile.ZipFile(_as_stream(zip_bytes))
+    except zipfile.BadZipFile:
+        raise AirlockRejected(['capsule is not a valid ZIP archive'])
+
+    names = zf.namelist()
+
+    # Zip-slip / absolute path guard: reject traversal before touching contents.
+    for name in names:
+        norm = posixpath.normpath(name)
+        if name.startswith('/') or norm.startswith('..') or posixpath.isabs(norm):
+            violations.append(f'unsafe path in capsule: {name!r}')
+    if violations:
+        raise AirlockRejected(violations)
+
+    # Manifest is required.
+    if MANIFEST_NAME not in names:
+        raise AirlockRejected([f'missing {MANIFEST_NAME} at capsule root'])
+    try:
+        manifest = json.loads(zf.read(MANIFEST_NAME).decode('utf-8'))
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise AirlockRejected([f'{MANIFEST_NAME} is not valid JSON: {exc}'])
+
+    name = manifest.get('name')
+    if not name or not isinstance(name, str) or not name.replace('_', '').isalnum():
+        violations.append('capsule.json: "name" must be an alphanumeric/underscore identifier')
+    declares = manifest.get('declares') or []
+    if not isinstance(declares, list):
+        violations.append('capsule.json: "declares" must be a list of capability strings')
+        declares = []
+
+    node_dir = f'{NODES_ROOT}/{name}' if name else None
+    services_path = f'{node_dir}/services.json' if node_dir else None
+    if not services_path or services_path not in names:
+        violations.append(f'missing node manifest at {services_path or "local_nodes/<name>/services.json"}')
+
+    # Everything the capsule ships must live under local_nodes/<name>/ (or be the
+    # manifest). No stray files, no code outside the declared node folder.
+    payload_files: Dict[str, bytes] = {}
+    for name_ in names:
+        if name_ == MANIFEST_NAME or name_.endswith('/'):
+            continue
+        if not node_dir or not name_.startswith(node_dir + '/'):
+            violations.append(f'file outside {node_dir or "local_nodes/<name>"}/: {name_!r}')
+            continue
+        payload_files[name_] = zf.read(name_)
+
+    # Packaged-for-evaluation: plain source only, no install-time execution hooks.
+    for arc in payload_files:
+        base = posixpath.basename(arc).lower()
+        if base.endswith(('.pyc', '.pyo', '.so', '.dylib', '.dll', '.pyd')):
+            violations.append(f'compiled/binary artifact not allowed: {arc!r}')
+        if base in ('setup.py', 'setup.cfg', 'pyproject.toml', 'conftest.py'):
+            violations.append(f'install-time hook not allowed: {arc!r}')
+
+    if violations:
+        raise AirlockRejected(violations)
+
+    # sha256: the evaluated bytes must equal the recorded bytes.
+    declared_sha = manifest.get('sha256')
+    if declared_sha:
+        actual = _payload_sha256(payload_files)
+        if actual != declared_sha:
+            raise AirlockRejected([f'sha256 mismatch: declared {declared_sha[:12]}…, computed {actual[:12]}…'])
+
+    # Static scan of every Python source in the capsule.
+    declared_caps = set(declares)
+    for arc, data in payload_files.items():
+        if not arc.endswith('.py'):
+            continue
+        try:
+            source = data.decode('utf-8')
+        except UnicodeDecodeError:
+            violations.append(f'{arc}: not valid UTF-8 source')
+            continue
+        try:
+            tree = ast.parse(source, filename=arc)
+        except SyntaxError as exc:
+            violations.append(f'{arc}: syntax error ({exc.msg})')
+            continue
+        violations.extend(_scan_python(tree, arc, declared_caps))
+
+    if violations:
+        raise AirlockRejected(violations)
+
+    services_json = load_relaxed_json(zf.read(services_path).decode('utf-8'))
+    protocol = services_json.get('protocol') or f'{name}://'
+    return CapsuleInfo(
+        name=name,
+        protocol=protocol,
+        version=str(manifest.get('version', '0.0.0')),
+        node_dir=node_dir,
+        services_json=services_json,
+        declares=list(declared_caps),
+        files=payload_files,
+    )
+
+
+def _scan_python(tree: ast.AST, arc: str, declared_caps: set) -> List[str]:
+    """Static AST scan: forbidden calls always reject; sensitive modules require a declared capability."""
+    out: List[str] = []
+    # Map module -> capability that must be declared to use it.
+    module_gate: Dict[str, str] = {}
+    for cap, mods in CAPABILITY_MODULES.items():
+        for mod in mods:
+            module_gate[mod] = cap
+
+    for node in ast.walk(tree):
+        # Imports of capability-gated modules.
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                top = alias.name.split('.')[0]
+                cap = module_gate.get(top)
+                if cap and cap not in declared_caps:
+                    out.append(f'{arc}:{node.lineno}: imports {top!r} but capsule does not declare "{cap}"')
+        elif isinstance(node, ast.ImportFrom):
+            top = (node.module or '').split('.')[0]
+            cap = module_gate.get(top)
+            if cap and cap not in declared_caps:
+                out.append(f'{arc}:{node.lineno}: imports from {top!r} but capsule does not declare "{cap}"')
+        # Calls: forbidden builtins + os.system-family.
+        elif isinstance(node, ast.Call):
+            fn = node.func
+            if isinstance(fn, ast.Name) and fn.id in FORBIDDEN_CALLS:
+                out.append(f'{arc}:{node.lineno}: forbidden call {fn.id}()')
+            elif isinstance(fn, ast.Attribute) and fn.attr in OS_SUBPROCESS_ATTRS:
+                if 'subprocess' not in declared_caps:
+                    out.append(f'{arc}:{node.lineno}: {fn.attr}() requires declared "subprocess"')
+    return out
+
+
+def load_relaxed_json(text: str):
+    """
+    Parse RocketRide's relaxed JSON. Node ``services.json`` files carry ``//`` and
+    ``/* */`` comments and trailing commas (the C++ engine tolerates them); strict
+    ``json`` does not, so strip those first — without touching string contents.
+    """
+    return json.loads(_strip_relaxed_json(text))
+
+
+def _strip_relaxed_json(text: str) -> str:
+    out = []
+    i, n = 0, len(text)
+    in_str = False
+    quote = ''
+    while i < n:
+        c = text[i]
+        if in_str:
+            out.append(c)
+            if c == '\\' and i + 1 < n:
+                out.append(text[i + 1])
+                i += 2
+                continue
+            if c == quote:
+                in_str = False
+            i += 1
+            continue
+        if c in ('"', "'"):
+            in_str = True
+            quote = c
+            out.append(c)
+        elif c == '/' and i + 1 < n and text[i + 1] == '/':
+            while i < n and text[i] != '\n':
+                i += 1
+            continue
+        elif c == '/' and i + 1 < n and text[i + 1] == '*':
+            i += 2
+            while i + 1 < n and not (text[i] == '*' and text[i + 1] == '/'):
+                i += 1
+            i += 2
+            continue
+        else:
+            out.append(c)
+        i += 1
+    # Drop trailing commas before a closing } or ].
+    return re.sub(r',(\s*[}\]])', r'\1', ''.join(out))
+
+
+def _payload_sha256(files: Dict[str, bytes]) -> str:
+    """Deterministic hash over the payload: names + bytes in sorted order."""
+    h = hashlib.sha256()
+    for arc in sorted(files):
+        h.update(arc.encode('utf-8'))
+        h.update(b'\0')
+        h.update(files[arc])
+        h.update(b'\0')
+    return h.hexdigest()
+
+
+def _as_stream(data: bytes):
+    import io
+
+    return io.BytesIO(data)

--- a/packages/ai/src/ai/modules/task/commands/capsule_pack.py
+++ b/packages/ai/src/ai/modules/task/commands/capsule_pack.py
@@ -38,13 +38,49 @@ import io
 import json
 import os
 import zipfile
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from .capsule_airlock import MANIFEST_NAME, NODES_ROOT, _payload_sha256, load_relaxed_json
 
 # Files that never belong in a capsule (build/runtime cruft).
 _SKIP_DIRS = frozenset({'__pycache__', '.git', '.mypy_cache', '.ruff_cache'})
 _SKIP_SUFFIX = ('.pyc', '.pyo')
+
+
+def pack_payload(
+    name: str, payload: Dict[str, bytes], protocol: str, version: str = '0.0.0', declares: Optional[List[str]] = None
+) -> bytes:
+    """
+    Build capsule bytes from an in-memory payload.
+
+    The packing half that needs no filesystem, so a caller holding the node's
+    files (e.g. read back from the user's store on export) reaches the exact
+    same format the airlock validates on the way in.
+
+    Args:
+        name: Node name — the ``local_nodes/<name>/`` folder inside the capsule.
+        payload: arcname -> bytes, each arcname already under ``local_nodes/<name>/``.
+        protocol: The node's protocol, recorded in the manifest.
+        version: Capsule version string, recorded in the manifest.
+        declares: Capability strings the node needs (network/subprocess/filesystem).
+
+    Returns:
+        The ``.rrc`` bytes, ready to send to ``rrext_install_node``.
+    """
+    manifest = {
+        'name': name,
+        'protocol': protocol,
+        'version': version,
+        'declares': list(declares or []),
+        'sha256': _payload_sha256(payload),
+    }
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=True))
+        for arc in sorted(payload):
+            zf.writestr(arc, payload[arc])
+    return buf.getvalue()
 
 
 def pack_node_dir(node_src_dir: str, version: str = '0.0.0', declares: Optional[List[str]] = None) -> bytes:
@@ -81,20 +117,7 @@ def pack_node_dir(node_src_dir: str, version: str = '0.0.0', declares: Optional[
             with open(abs_path, 'rb') as fh:
                 payload[f'{node_arc_root}/{rel}'] = fh.read()
 
-    manifest = {
-        'name': name,
-        'protocol': protocol,
-        'version': version,
-        'declares': list(declares or []),
-        'sha256': _payload_sha256(payload),
-    }
-
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=True))
-        for arc in sorted(payload):
-            zf.writestr(arc, payload[arc])
-    return buf.getvalue()
+    return pack_payload(name, payload, protocol, version=version, declares=declares)
 
 
 def _main() -> int:

--- a/packages/ai/src/ai/modules/task/commands/capsule_pack.py
+++ b/packages/ai/src/ai/modules/task/commands/capsule_pack.py
@@ -1,0 +1,118 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Capsule packer — turn a node folder into a ``.rrc`` capsule the airlock accepts.
+
+Mirrors the format defined in ``capsule_airlock``: a ZIP with ``capsule.json`` at
+the root and the node under ``local_nodes/<name>/``. The sha256 is computed with
+the SAME function the airlock verifies with, so a freshly packed capsule always
+passes the checksum gate.
+
+CLI:
+    python -m ai.modules.task.commands.capsule_pack \\
+        --node /path/to/claude_code_agent --out claude_code_agent.rrc \\
+        --declares network subprocess
+"""
+
+import io
+import json
+import os
+import zipfile
+from typing import List, Optional
+
+from .capsule_airlock import MANIFEST_NAME, NODES_ROOT, _payload_sha256, load_relaxed_json
+
+# Files that never belong in a capsule (build/runtime cruft).
+_SKIP_DIRS = frozenset({'__pycache__', '.git', '.mypy_cache', '.ruff_cache'})
+_SKIP_SUFFIX = ('.pyc', '.pyo')
+
+
+def pack_node_dir(node_src_dir: str, version: str = '0.0.0', declares: Optional[List[str]] = None) -> bytes:
+    """
+    Build capsule bytes from a node source folder.
+
+    Args:
+        node_src_dir: Path to the node folder (must contain services.json).
+        version: Capsule version string, recorded in the manifest.
+        declares: Capability strings the node needs (network/subprocess/filesystem).
+
+    Returns:
+        The ``.rrc`` bytes, ready to send to ``rrext_install_node``.
+    """
+    node_src_dir = os.path.abspath(node_src_dir)
+    name = os.path.basename(node_src_dir.rstrip('/'))
+    services_path = os.path.join(node_src_dir, 'services.json')
+    if not os.path.isfile(services_path):
+        raise ValueError(f'no services.json under {node_src_dir}')
+    with open(services_path, 'r', encoding='utf-8') as fh:
+        services = load_relaxed_json(fh.read())
+    protocol = services.get('protocol') or f'{name}://'
+
+    # Collect payload arcname -> bytes under local_nodes/<name>/.
+    node_arc_root = f'{NODES_ROOT}/{name}'
+    payload = {}
+    for root, dirs, files in os.walk(node_src_dir):
+        dirs[:] = [d for d in dirs if d not in _SKIP_DIRS]
+        for fname in files:
+            if fname.endswith(_SKIP_SUFFIX):
+                continue
+            abs_path = os.path.join(root, fname)
+            rel = os.path.relpath(abs_path, node_src_dir).replace(os.sep, '/')
+            with open(abs_path, 'rb') as fh:
+                payload[f'{node_arc_root}/{rel}'] = fh.read()
+
+    manifest = {
+        'name': name,
+        'protocol': protocol,
+        'version': version,
+        'declares': list(declares or []),
+        'sha256': _payload_sha256(payload),
+    }
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, 'w', zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr(MANIFEST_NAME, json.dumps(manifest, indent=2, sort_keys=True))
+        for arc in sorted(payload):
+            zf.writestr(arc, payload[arc])
+    return buf.getvalue()
+
+
+def _main() -> int:
+    import argparse
+
+    ap = argparse.ArgumentParser(description='Pack a node folder into a .rrc capsule')
+    ap.add_argument('--node', required=True, help='path to the node source folder')
+    ap.add_argument('--out', required=True, help='output .rrc path')
+    ap.add_argument('--version', default='0.0.0')
+    ap.add_argument('--declares', nargs='*', default=[], help='declared capabilities')
+    args = ap.parse_args()
+
+    data = pack_node_dir(args.node, version=args.version, declares=args.declares)
+    with open(args.out, 'wb') as fh:
+        fh.write(data)
+    print(f'wrote {args.out} ({len(data)} bytes)')
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(_main())

--- a/packages/ai/src/ai/modules/task/commands/cmd_install_node.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_install_node.py
@@ -1,0 +1,204 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+InstallNodeCommands: DAP handler for ``rrext_install_node`` — the capsule launcher.
+
+Installs a self-contained node capsule (``.rrc``) into the caller's store so it
+becomes usable in pipelines, without restarting the engine:
+
+    client (VSCode / SaaS web)  --rrext_install_node-->  engine
+        1. AIRLOCK (mandatory)  — validate_capsule(); reject before anything persists
+        2. STORE WRITE          — user's joined filesystem (#1686), local_nodes/<name>/
+        3. DEPENDS              — install the node's pinned requirements.txt
+        --> catalog overlay picks it up live (cmd_misc.on_rrext_services)
+        --> per-run child loads it from the store (task_engine node_path materialization)
+
+Secure-first: nothing is written to the store and no dependency is installed
+until the airlock passes.
+"""
+
+import asyncio
+import base64
+import posixpath
+from typing import Any, Dict
+
+from ai.common.dap.dap_conn import DAPConn
+
+from .capsule_airlock import AirlockRejected, CapsuleInfo, validate_capsule
+
+# Root (relative to the caller's file area) under which installed node capsules
+# live. Matches the capsule's internal ``local_nodes/`` layout and the path the
+# catalog overlay and per-run materializer read back from.
+STORE_NODES_ROOT = 'local_nodes'
+
+
+class InstallNodeCommands(DAPConn):
+    """DAP router for ``rrext_install_node`` — install a node capsule into the caller's store."""
+
+    def __init__(self, connection_id: int, server: 'TaskServer', transport, **kwargs) -> None:  # noqa: F821
+        """No per-command state; identity/store access come from the other TaskConn mixins."""
+        pass
+
+    async def on_rrext_install_node(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Install a node capsule for the authenticated caller.
+
+        Arguments (in ``request['arguments']``):
+            capsule (str): base64-encoded ``.rrc`` bytes (primary path), OR
+            path (str):    store path to an already-uploaded ``.rrc``.
+
+        Returns a DAP response whose body is either
+            {'ok': True, 'installed': <name>, 'protocol': <p>, 'version': <v>} or
+            {'ok': False, 'violations': [...]}  when the airlock rejects it.
+        """
+        args = request.get('arguments') or {}
+        try:
+            zip_bytes = await self._resolve_capsule_bytes(args)
+
+            # 1. AIRLOCK — mandatory gate. On rejection nothing else runs.
+            try:
+                info = validate_capsule(zip_bytes)
+            except AirlockRejected as rej:
+                self.debug_message(f'Capsule rejected by airlock: {rej.violations}')
+                return self.build_response(request, body={'ok': False, 'violations': rej.violations})
+
+            # 2. STORE WRITE — into the caller's joined filesystem (#1686).
+            await self._write_capsule_to_store(info)
+
+            # 3. DEPENDS — install the node's pinned requirements into the shared env.
+            await self._install_requirements(info)
+
+            self.debug_message(f'Installed node capsule {info.name!r} ({info.protocol})')
+            return self.build_response(
+                request,
+                body={'ok': True, 'installed': info.name, 'protocol': info.protocol, 'version': info.version},
+            )
+        except Exception as e:
+            self.debug_message(f'rrext_install_node failed: {e}')
+            raise
+
+    async def on_rrext_uninstall_node(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Uninstall a previously-installed node capsule for the authenticated caller.
+
+        Arguments (in ``request['arguments']``):
+            node (str): the installed node's name (its ``local_nodes/<name>/`` dir).
+
+        Removes the node's dir from the caller's store. The catalog overlay re-reads
+        the store on the next ``rrext_services``, so the node then disappears — no
+        cache to invalidate. Returns {'ok': True, 'uninstalled': <name>} or
+        {'ok': False, 'error': <why>}.
+        """
+        args = request.get('arguments') or {}
+        name = str(args.get('node') or '').strip()
+        # Confine the delete to a single dir directly under local_nodes/: reject
+        # empty, path separators and dot segments so it can never escape the root.
+        if not name or '/' in name or '\\' in name or name in ('.', '..'):
+            return self.build_response(request, body={'ok': False, 'error': 'invalid node name'})
+        try:
+            from ai.account import Store
+
+            fs = Store.file_store(self.request_context())
+            await fs.rmdir(f'{STORE_NODES_ROOT}/{name}', recursive=True)
+            self.debug_message(f'Uninstalled node capsule {name!r}')
+            return self.build_response(request, body={'ok': True, 'uninstalled': name})
+        except Exception as e:
+            self.debug_message(f'rrext_uninstall_node failed: {e}')
+            return self.build_response(request, body={'ok': False, 'error': str(e)})
+
+    # -------------------------------------------------------------------------
+
+    async def _resolve_capsule_bytes(self, args: Dict[str, Any]) -> bytes:
+        """Get the raw .rrc bytes from a base64 payload or an uploaded store path."""
+        b64 = args.get('capsule')
+        if b64:
+            try:
+                return base64.b64decode(b64)
+            except (ValueError, TypeError) as exc:
+                raise ValueError(f'"capsule" is not valid base64: {exc}')
+
+        path = args.get('path')
+        if path:
+            from ai.account import Store
+
+            fs = Store.file_store(self.request_context())
+            meta = await fs.open_read(path)
+            handle = meta['handle']
+            chunks = bytearray()
+            offset = 0
+            try:
+                while True:
+                    chunk = await fs.read_chunk(handle, offset)
+                    if not chunk:
+                        break
+                    chunks.extend(chunk)
+                    offset += len(chunk)
+            finally:
+                await fs.close_read(handle)
+            return bytes(chunks)
+
+        raise ValueError('rrext_install_node requires "capsule" (base64) or "path"')
+
+    async def _write_capsule_to_store(self, info: CapsuleInfo) -> None:
+        """Persist the validated capsule files under the caller's ``local_nodes/<name>/``."""
+        from ai.account import Store
+
+        fs = Store.file_store(self.request_context())
+
+        # Replace any prior install of this node so re-uploads are idempotent.
+        node_dir = f'{STORE_NODES_ROOT}/{info.name}'
+        try:
+            await fs.rmdir(node_dir, recursive=True)
+        except Exception:
+            pass  # first install: nothing to remove
+
+        made: set = set()
+        for arc in sorted(info.files):
+            parent = posixpath.dirname(arc)
+            if parent and parent not in made:
+                await fs.mkdir(parent)
+                made.add(parent)
+            handle = await fs.open_write(arc)
+            try:
+                await fs.write_chunk(handle, info.files[arc])
+            finally:
+                await fs.close_write(handle)
+
+    async def _install_requirements(self, info: CapsuleInfo) -> None:
+        """Install the node's pinned requirements.txt (if any) into the shared engine env."""
+        req_arc = f'{info.node_dir}/requirements.txt'
+        req_bytes = info.files.get(req_arc)
+        if not req_bytes or not req_bytes.strip():
+            return
+
+        import os
+        import tempfile
+
+        from depends import depends  # type: ignore
+
+        with tempfile.TemporaryDirectory(prefix=f'capsule-{info.name}-') as tmp:
+            req_path = os.path.join(tmp, 'requirements.txt')
+            with open(req_path, 'wb') as fh:
+                fh.write(req_bytes)
+            # depends() is synchronous (bootstraps uv/pip); keep the loop free.
+            await asyncio.get_event_loop().run_in_executor(None, depends, req_path)

--- a/packages/ai/src/ai/modules/task/commands/cmd_install_node.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_install_node.py
@@ -39,17 +39,38 @@ until the airlock passes.
 
 import asyncio
 import base64
+import json
 import posixpath
 from typing import Any, Dict
 
 from ai.common.dap.dap_conn import DAPConn
 
-from .capsule_airlock import AirlockRejected, CapsuleInfo, validate_capsule
+from .capsule_airlock import NODES_ROOT, AirlockRejected, CapsuleInfo, validate_capsule
 
 # Root (relative to the caller's file area) under which installed node capsules
 # live. Matches the capsule's internal ``local_nodes/`` layout and the path the
 # catalog overlay and per-run materializer read back from.
 STORE_NODES_ROOT = 'local_nodes'
+
+# The installed copy of the capsule's manifest, kept beside the node's files.
+# The store holds the node payload only, so without this the capsule's version
+# and declared capabilities would be lost and no export could rebuild the
+# original. Dot-prefixed and skipped when re-packing, so it never becomes part
+# of the payload it describes.
+STORE_MANIFEST_NAME = '.capsule.json'
+
+
+def _safe_node_name(raw: Any) -> str:
+    """
+    Narrow a caller-supplied node name to a single dir under ``local_nodes/``.
+
+    Rejects empty, path separators and dot segments, so a name can never escape
+    the root. Returns '' when the name is unusable.
+    """
+    name = str(raw or '').strip()
+    if not name or '/' in name or '\\' in name or name in ('.', '..'):
+        return ''
+    return name
 
 
 class InstallNodeCommands(DAPConn):
@@ -110,10 +131,9 @@ class InstallNodeCommands(DAPConn):
         {'ok': False, 'error': <why>}.
         """
         args = request.get('arguments') or {}
-        name = str(args.get('node') or '').strip()
-        # Confine the delete to a single dir directly under local_nodes/: reject
-        # empty, path separators and dot segments so it can never escape the root.
-        if not name or '/' in name or '\\' in name or name in ('.', '..'):
+        # Confine the delete to a single dir directly under local_nodes/.
+        name = _safe_node_name(args.get('node'))
+        if not name:
             return self.build_response(request, body={'ok': False, 'error': 'invalid node name'})
         try:
             from ai.account import Store
@@ -126,7 +146,115 @@ class InstallNodeCommands(DAPConn):
             self.debug_message(f'rrext_uninstall_node failed: {e}')
             return self.build_response(request, body={'ok': False, 'error': str(e)})
 
+    async def on_rrext_export_node(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Re-pack an installed node capsule so the caller can save it as a ``.rrc``.
+
+        The round-trip half of ``rrext_install_node``: reads the node back out of
+        the caller's store, rebuilds the manifest from the copy kept at install
+        time (see STORE_MANIFEST_NAME), and re-packs. The result passes the
+        airlock again — the checksum is recomputed over the payload that is
+        actually there, so a node edited in place exports as a valid capsule.
+
+        Arguments (in ``request['arguments']``):
+            node (str): the installed node's name.
+
+        Returns {'ok': True, 'node': <name>, 'filename': '<name>.rrc',
+        'capsule': <base64>} or {'ok': False, 'error': <why>}.
+        """
+        args = request.get('arguments') or {}
+        name = _safe_node_name(args.get('node'))
+        if not name:
+            return self.build_response(request, body={'ok': False, 'error': 'invalid node name'})
+        try:
+            from ai.account import Store
+
+            from .capsule_airlock import load_relaxed_json
+            from .capsule_pack import pack_payload
+
+            fs = Store.file_store(self.request_context())
+            node_dir = f'{STORE_NODES_ROOT}/{name}'
+            files = await self._read_store_tree(fs, node_dir)
+            if not files:
+                return self.build_response(request, body={'ok': False, 'error': f'node {name!r} is not installed'})
+
+            # The manifest is metadata ABOUT the payload, so it is stripped
+            # before packing and re-emitted by pack_payload().
+            manifest_raw = files.pop(STORE_MANIFEST_NAME, None)
+            manifest = json.loads(manifest_raw.decode('utf-8')) if manifest_raw else {}
+
+            services_raw = files.get('services.json')
+            services = load_relaxed_json(services_raw.decode('utf-8')) if services_raw else {}
+            protocol = manifest.get('protocol') or services.get('protocol') or f'{name}://'
+
+            payload = {f'{NODES_ROOT}/{name}/{rel}': data for rel, data in files.items()}
+            capsule = await asyncio.get_event_loop().run_in_executor(
+                None,
+                lambda: pack_payload(
+                    name,
+                    payload,
+                    protocol,
+                    version=str(manifest.get('version') or '0.0.0'),
+                    declares=list(manifest.get('declares') or []),
+                ),
+            )
+            self.debug_message(f'Exported node capsule {name!r} ({len(capsule)} bytes)')
+            return self.build_response(
+                request,
+                body={
+                    'ok': True,
+                    'node': name,
+                    'filename': f'{name}.rrc',
+                    'capsule': base64.b64encode(capsule).decode('ascii'),
+                },
+            )
+        except Exception as e:
+            self.debug_message(f'rrext_export_node failed: {e}')
+            return self.build_response(request, body={'ok': False, 'error': str(e)})
+
     # -------------------------------------------------------------------------
+
+    async def _read_store_tree(self, fs, root: str) -> Dict[str, bytes]:
+        """
+        Read every file under a store directory, keyed by path relative to it.
+
+        Walks depth-first through ``list_dir`` (which only reports immediate
+        children). A missing root yields an empty dict rather than raising —
+        the caller reports it as "not installed".
+        """
+        out: Dict[str, bytes] = {}
+        try:
+            listing = await fs.list_dir(root)
+        except Exception:
+            return out
+        for entry in listing.get('entries', []) if isinstance(listing, dict) else []:
+            child = entry.get('name') if isinstance(entry, dict) else entry
+            if not child:
+                continue
+            path = f'{root}/{child}'
+            if isinstance(entry, dict) and entry.get('type') == 'dir':
+                for rel, data in (await self._read_store_tree(fs, path)).items():
+                    out[f'{child}/{rel}'] = data
+            else:
+                out[child] = await self._read_store_bytes(fs, path)
+        return out
+
+    async def _read_store_bytes(self, fs, path: str) -> bytes:
+        """Read a whole store file through the chunked handle API."""
+        meta = await fs.open_read(path)
+        handle = meta['handle']
+        data = bytearray()
+        offset = 0
+        try:
+            while True:
+                chunk = await fs.read_chunk(handle, offset)
+                if not chunk:
+                    break
+                data.extend(chunk)
+                offset += len(chunk)
+        finally:
+            await fs.close_read(handle)
+        return bytes(data)
 
     async def _resolve_capsule_bytes(self, args: Dict[str, Any]) -> bytes:
         """Get the raw .rrc bytes from a base64 payload or an uploaded store path."""
@@ -172,15 +300,25 @@ class InstallNodeCommands(DAPConn):
         except Exception:
             pass  # first install: nothing to remove
 
+        # The node's payload, plus the manifest that describes it (see
+        # STORE_MANIFEST_NAME) so an export can rebuild an equivalent capsule.
+        manifest = json.dumps(
+            {'name': info.name, 'protocol': info.protocol, 'version': info.version, 'declares': list(info.declares)},
+            indent=2,
+            sort_keys=True,
+        ).encode('utf-8')
+        to_write = dict(info.files)
+        to_write[f'{node_dir}/{STORE_MANIFEST_NAME}'] = manifest
+
         made: set = set()
-        for arc in sorted(info.files):
+        for arc in sorted(to_write):
             parent = posixpath.dirname(arc)
             if parent and parent not in made:
                 await fs.mkdir(parent)
                 made.add(parent)
             handle = await fs.open_write(arc)
             try:
-                await fs.write_chunk(handle, info.files[arc])
+                await fs.write_chunk(handle, to_write[arc])
             finally:
                 await fs.close_write(handle)
 

--- a/packages/ai/src/ai/modules/task/commands/cmd_misc.py
+++ b/packages/ai/src/ai/modules/task/commands/cmd_misc.py
@@ -135,9 +135,18 @@ class MiscCommands(DAPConn):
             args = request.get('arguments', {})
             service = args.get('service', None)
 
+            # Installed node capsules the caller owns, read live from the store so
+            # the palette reflects them WITHOUT an engine restart (m_services is
+            # init-only). Each is tagged source:"capsule" so the UI distinguishes it.
+            overlay = await self._installed_capsule_services()
+
             if service:
                 # Retrieve the full cached entry (config schema included)
                 schema = await services_catalog.get_service(service)
+
+                # Fall back to an installed capsule before declaring not-found.
+                if not schema and service in overlay:
+                    schema = overlay[service]
 
                 # Validate the service exists
                 if not schema:
@@ -145,6 +154,22 @@ class MiscCommands(DAPConn):
             else:
                 # The cached summary view: display fields + inline icons
                 schema = await services_catalog.get_summary()
+                if isinstance(schema, dict) and overlay:
+                    # The client groups the flat 'services' map by classType, so the
+                    # capsules are merged INTO it (built-ins win on key collision) and
+                    # each capsule's SVG joins the shared icons table under its own id.
+                    services = dict(schema.get('services') or {})
+                    icons = dict(schema.get('icons') or {})
+                    for provider, definition in overlay.items():
+                        if provider in services:
+                            continue
+                        svg = definition.pop('iconSvg', None)
+                        if svg:
+                            icon_id = f'capsule:{provider}'
+                            icons[icon_id] = svg
+                            definition['icon'] = icon_id
+                        services[provider] = definition
+                    schema = {**schema, 'services': services, 'icons': icons}
 
             # Return successful response with service definition(s)
             return self.build_response(request, body=schema)
@@ -155,6 +180,79 @@ class MiscCommands(DAPConn):
 
             # Re-raise to let DAP error handling create proper error response
             raise
+
+    async def _installed_capsule_services(self) -> Dict[str, Any]:
+        """
+        Read the caller's installed node capsules from the store and return their
+        service definitions keyed by node name, each tagged ``source:"capsule"``.
+
+        Best-effort and non-fatal: any error (unauthenticated, empty store, read
+        failure) yields an empty overlay so the built-in catalog is never broken.
+        """
+        from .capsule_airlock import load_relaxed_json
+        from .cmd_install_node import STORE_NODES_ROOT
+
+        try:
+            from ai.account import Store
+
+            ctx = self.request_context()
+            fs = Store.file_store(ctx)
+            listing = await fs.list_dir(STORE_NODES_ROOT)
+        except Exception as e:
+            self.debug_message(f'capsule overlay: no installed nodes ({e})')
+            return {}
+
+        overlay: Dict[str, Any] = {}
+        for entry in listing.get('entries', []) if isinstance(listing, dict) else []:
+            name = entry.get('name') if isinstance(entry, dict) else entry
+            if not name:
+                continue
+            try:
+                text = await self._read_store_text(fs, f'{STORE_NODES_ROOT}/{name}/services.json')
+                definition = load_relaxed_json(text)
+                definition['source'] = 'capsule'
+                # The client's buildInventory() skips entries without a truthy
+                # ``Pipe`` ({schema, ui}) — that map is produced by the C++ init
+                # transform, which the persistent engine can't run post-init. Give
+                # the node a Pipe built from its declared fields so it shows in the
+                # catalog; the per-run child loads the REAL node (ports/config)
+                # from --node_path at execution time.
+                if not definition.get('Pipe'):
+                    fields = definition.get('fields') if isinstance(definition.get('fields'), dict) else {}
+                    definition['Pipe'] = {'schema': {'type': 'object', 'properties': fields}, 'ui': {}}
+                # Carry the node's icon SVG text so the caller can park it in the
+                # response's icons table. A capsule's icon is a filename relative to
+                # its store folder, which resolves to nothing on the client; the
+                # served table is the only path that renders it.
+                icon = definition.get('icon')
+                if isinstance(icon, str) and icon.lower().endswith('.svg'):
+                    try:
+                        definition['iconSvg'] = await self._read_store_text(fs, f'{STORE_NODES_ROOT}/{name}/{icon}')
+                        definition.pop('icon', None)
+                    except Exception as e:
+                        self.debug_message(f'capsule overlay: icon read failed for {name!r} ({e})')
+                        definition.pop('icon', None)
+                overlay[name] = definition
+            except Exception as e:
+                self.debug_message(f'capsule overlay: skip {name!r} ({e})')
+        return overlay
+
+    async def _read_store_text(self, fs, path: str) -> str:
+        """Read a whole store file as UTF-8 text via the handle API."""
+        meta = await fs.open_read(path)
+        handle = meta['handle']
+        data = bytearray()
+        offset = 0
+        try:
+            while True:
+                chunk = await fs.read_chunk(handle, offset)
+                if not chunk:
+                    break
+                data.extend(chunk)
+                offset += len(chunk)
+        finally:
+            await fs.close_read(handle)
+        return bytes(data).decode('utf-8')
 
     async def on_rrext_validate(self, request: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/packages/ai/src/ai/modules/task/task_conn.py
+++ b/packages/ai/src/ai/modules/task/task_conn.py
@@ -77,6 +77,7 @@ from .commands.cmd_public import PublicCommands
 from .commands.cmd_deploy import DeployCommands
 from .commands.cmd_log import LogCommands
 from .commands.cmd_store import StoreCommands
+from .commands.cmd_install_node import InstallNodeCommands
 from ai.account.models import AccountInfo, RequestContext, resolve_task_permissions, resolve_team_permissions
 from ai.common.account import AccountPipelineValidation
 
@@ -108,6 +109,7 @@ class TaskConn(
     DeployCommands,
     LogCommands,
     StoreCommands,
+    InstallNodeCommands,
     DAPConn,
 ):
     """
@@ -199,6 +201,7 @@ class TaskConn(
         DeployCommands.__init__(self, connection_id, server, transport, **kwargs)
         LogCommands.__init__(self, connection_id, server, transport, **kwargs)
         StoreCommands.__init__(self, connection_id, server, transport, **kwargs)
+        InstallNodeCommands.__init__(self, connection_id, server, transport, **kwargs)
 
         # Store connection identifier for tracking and logging
         self._connection_id = connection_id

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -358,6 +358,9 @@ class Task(DAPBase):
 
         # Lifecycle state
         self._tmpfile = None
+        # Per-run dir where installed node capsules are materialized for the
+        # task subprocess to scan via --node_path (removed on cleanup).
+        self._node_path_dir = None
         self._stop_requested = False
         # WHY the stop was requested ('user' | 'ttl'); None until requested.
         # A ttl-window expiry is SUCCESS (the run stayed up exactly as
@@ -632,6 +635,93 @@ class Task(DAPBase):
         if not self.client_id:
             return ''
         return validate_storage_root(f'users/{self.client_id}/files')
+
+    async def _materialize_installed_nodes(self, parent_node_path):
+        """
+        Materialize the caller's installed node capsules into a per-run directory
+        the task subprocess scans via --node_path.
+
+        Copies the parent engine's workspace nodes first (if any), then overlays
+        the caller's installed capsules from the store (capsules win on name
+        collision). Returns the dir to pass as --node_path, or None when the
+        caller has no installed capsules (caller then keeps the parent's path).
+        """
+        if not self.client_id:
+            return None
+        try:
+            from ai.account import RequestContext, Store
+
+            fs = Store.file_store(RequestContext.internal('capsule-materialize'), client_id=self.client_id)
+            listing = await fs.list_dir('local_nodes')
+        except Exception as e:
+            self.debug_message(f'no installed capsules to materialize: {e}')
+            return None
+
+        names = []
+        for entry in listing.get('entries', []) if isinstance(listing, dict) else []:
+            name = entry.get('name') if isinstance(entry, dict) else entry
+            if name and 'dirmarker' not in name:
+                names.append(name)
+        if not names:
+            return None
+
+        node_dir = tempfile.mkdtemp(prefix=f'capsule-nodes-{self.id}-')
+        self._node_path_dir = node_dir
+        dst_root = os.path.join(node_dir, 'local_nodes')
+        os.makedirs(dst_root, exist_ok=True)
+
+        # Parent workspace nodes first; installed capsules override by name.
+        if parent_node_path:
+            parent_local = os.path.join(parent_node_path, 'local_nodes')
+            if os.path.isdir(parent_local):
+                for name in os.listdir(parent_local):
+                    src = os.path.join(parent_local, name)
+                    if os.path.isdir(src):
+                        shutil.copytree(src, os.path.join(dst_root, name), dirs_exist_ok=True)
+
+        for name in names:
+            try:
+                await self._copy_store_tree(fs, f'local_nodes/{name}', os.path.join(dst_root, name))
+            except Exception as e:
+                self.debug_message(f'capsule materialize: skip {name!r} ({e})')
+
+        return node_dir
+
+    async def _copy_store_tree(self, fs, store_path, dst_dir):
+        """Recursively copy a store subtree to a local directory."""
+        os.makedirs(dst_dir, exist_ok=True)
+        listing = await fs.list_dir(store_path)
+        for entry in listing.get('entries', []) if isinstance(listing, dict) else []:
+            name = entry.get('name') if isinstance(entry, dict) else entry
+            if not name or 'dirmarker' in name:
+                continue
+            child_store = f'{store_path}/{name}'
+            child_dst = os.path.join(dst_dir, name)
+            try:
+                data = await self._read_store_bytes(fs, child_store)
+            except Exception:
+                # Not a readable file — treat as a subdirectory and recurse.
+                await self._copy_store_tree(fs, child_store, child_dst)
+                continue
+            with open(child_dst, 'wb') as fh:
+                fh.write(data)
+
+    async def _read_store_bytes(self, fs, path):
+        """Read a whole store file as bytes via the handle API."""
+        meta = await fs.open_read(path)
+        handle = meta['handle']
+        data = bytearray()
+        offset = 0
+        try:
+            while True:
+                chunk = await fs.read_chunk(handle, offset)
+                if not chunk:
+                    break
+                data.extend(chunk)
+                offset += len(chunk)
+        finally:
+            await fs.close_read(handle)
+        return bytes(data)
 
     async def _write_task_file(self, pipeline: Dict[str, Any]) -> str:
         """
@@ -917,6 +1007,11 @@ class Task(DAPBase):
                 except OSError as e:
                     self.debug_message(f'Could not remove temporary file: {self._tmpfile} - {e}')
                 self._tmpfile = None
+
+            # Clean up the per-run materialized node capsules dir.
+            if self._node_path_dir:
+                shutil.rmtree(self._node_path_dir, ignore_errors=True)
+                self._node_path_dir = None
         except Exception as e:
             self.debug_message(f'Error cleaning up temporary file: {e}')
 
@@ -2124,13 +2219,23 @@ class Task(DAPBase):
                         child_args.append(arg)
                         break
 
-            # Inherit parent engine's --node_path so workspace-local nodes load
-            # in the task subprocess too (Opt reads argv only, not the env).
+            # Point the task subprocess at workspace-local AND user-installed
+            # nodes. The child scans <node_path>/local_nodes in C++ init (argv
+            # only, not env), and only one --node_path wins — so if the caller
+            # has installed capsules we materialize them (merged over the parent
+            # engine's workspace nodes) into a per-run dir and point there;
+            # otherwise we just inherit the parent engine's --node_path.
             if not any(a.startswith('--node_path=') for a in child_args):
+                parent_node_path = None
                 for arg in startup_args():
                     if arg.startswith('--node_path='):
-                        child_args.append(arg)
+                        parent_node_path = arg[len('--node_path=') :]
                         break
+                capsule_node_path = await self._materialize_installed_nodes(parent_node_path)
+                if capsule_node_path:
+                    child_args.append(f'--node_path={capsule_node_path}')
+                elif parent_node_path:
+                    child_args.append(f'--node_path={parent_node_path}')
 
             await self._send_status_update()
 

--- a/packages/shell/src/types/project.ts
+++ b/packages/shell/src/types/project.ts
@@ -182,6 +182,9 @@ export interface IService {
 	/** Icon filename or URL for the node header (e.g. "openai.svg"). */
 	icon?: string;
 
+	/** Provenance marker: 'capsule' for nodes installed at runtime via a .rrc (rrext_install_node). */
+	source?: string;
+
 	/** Bitmask of actions this service supports. */
 	actions?: number;
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/c0d941f0-4740-45a1-8b54-7f3584487415



## Summary

- Node **capsule launcher**: package a custom node as a single `.rrc` file, upload it from VSCode (or the SaaS sidebar), validate it through a **secure-first airlock**, persist it in the per-user store (#1686), and surface it **live in the node catalog without restarting the engine** — then use it in a running pipeline.
- Installed capsules are **materialized into the per-run child `node_path`** (#1434) at execution time; nothing is stored or run until the airlock validates.
- Client-agnostic: the install action lives in shared-ui, so it works in both VSCode and the SaaS web sidebar.

## Type

feature (PoC) — runtime installation of custom nodes.

## Testing

Working end-to-end on the remote lab (upload → airlock → store → live catalog → run). This is a **draft** opened to evaluate the change surface, not a merge candidate yet.

- [ ] Tests added or updated <!-- PoC; tests to follow -->
- [x] Tested locally / on the remote lab
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (n/a — additive)

## Linked Discussion

<!-- PoC discussed here (format, components, config limitations), not an issue: -->

Discussion: https://github.com/rocketride-org/rocketride-server/discussions/1781

**Note:** rebased onto `develop` so the diff is only the capsule surface (~870 lines / 12 files); deploy-2 is already in `develop`. Main follow-up before production: fix `Config.getNodeConfig` to strip the node prefix for installed capsules (see discussion, limitation #1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Install, export, and uninstall custom node capsules (`.rrc`) from Rocket UI and VS Code.
  * View installed capsules in the Nodes sidebar and project view, with custom styling and confirmation before removal.
  * VS Code recognizes capsule files and provides dedicated capsule management commands.
* **Security**
  * Capsules are validated for structure, integrity, permissions, and unsafe code before installation.
* **Compatibility**
  * Installed capsules are available to task runs and their services appear in the service catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->