### PR TITLE
fix(check-externals): disable NLTK's CWE-427 import guard so its stdlib import resolves

### DIFF
--- a/tools/contract_checks/scripts/tasks.js
+++ b/tools/contract_checks/scripts/tasks.js
@@ -91,8 +91,12 @@ function makeRunChecksAction(options = {}) {
 
             await execCommand(ENGINE, cliArgs, {
                 task,
+                // NLTK 3.9.4's import guard (nltk/inisec.py) blocks any NLTK-triggered import
+                // that resolves under the CWD. Here cwd=dist/server holds the engine's frozen
+                // stdlib, so NLTK importing optparse trips it as a false positive. Its
+                // off-switch disables the guard so the stdlib import resolves normally.
                 cwd: path.join(DIST_ROOT, 'server'),
-                env: { ...process.env },
+                env: { ...process.env, NLTK_DISABLE_IMPORT_SECURITY: '1' },
             });
         },
     };


### PR DESCRIPTION
## Summary

- `check-externals` runs the engine with `cwd=dist/server`, under which the engine's frozen stdlib lives (`dist/server/lib/python3.12/`). NLTK 3.9.4 ships an early import hook (`nltk/inisec.py`, `NLTKSafeImportFinder`) that, as a CWE-427 mitigation, blocks any NLTK-triggered import whose module resolves **under the CWD**. Importing `nltk` pulls `nltk.sem.boxer`, which does `from optparse import OptionParser`, and `optparse` resolves under `dist/server` → the guard false-blocks a plain stdlib import.
- Fix: set `NLTK_DISABLE_IMPORT_SECURITY=1` (NLTK's documented off-switch) on the check-externals engine spawn. This is a controlled CI import check — the CWD is the engine's own runtime, not an untrusted location — so turning off NLTK's CWD-import guard here is safe.
- Nothing of ours (test or guard) is removed. The guard's `PYTHONSAFEPATH`/`-P` hint is a no-op for the already-running interpreter, which is why the fix uses the off-switch rather than safe-path.

**The fix comes straight from NLTK's own `inisec.py` docstring** (dumped from the failing CI import), which documents both the mechanism and the remedy:

> The meta-path finder inspects the call stack whenever a module is resolved from the current working directory (CWD). If any ancestor frame belongs to `nltk`, the import is blocked.

> The hook can be disabled entirely by setting `NLTK_DISABLE_IMPORT_SECURITY=1`.

## Type

fix (CI) — `check-externals` has been failing on `develop` (the `nltk` check) independent of any feature branch.

## Testing

- CI `check-externals` is now green: **474 passed, 33 skipped, 0 failed** (was 473 passed, 1 failed).
- Root cause confirmed by dumping the failing import's traceback + `sys.meta_path` + `nltk/inisec.py` source from CI: the block originates in `nltk/inisec.py`'s `find_spec`, not Python's `safe_path`.

- [ ] Tests added or updated <!-- CI-config fix; validated by the check-externals job -->
- [x] Tested locally (root cause) + confirmed green on CI (Linux)
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (none — CI-only, additive env)

## Linked Issue

<!-- Pre-existing check-externals failure on develop (nltk / optparse), not a feature issue: -->

Fixes the pre-existing `check-externals` `nltk` failure on `develop`.
