### PR TITLE
feat(nodes): add a FalkorDB URL connection profile to graph_falkordb

### DIFF
--- a/nodes/src/nodes/graph_falkordb/IGlobal.py
+++ b/nodes/src/nodes/graph_falkordb/IGlobal.py
@@ -338,12 +338,27 @@ def _url_without_password(url: str) -> str:
 
 
 def _redact(target: str) -> str:
-    """Strip credentials from a URL before it reaches a log line."""
+    """Strip credentials from a URL before it reaches a log line.
+
+    Masks both places a URL carries a password: the ``user:password@host``
+    authority and the ``password=`` query that ``unix://`` URLs use.
+    """
     scheme, sep, rest = target.partition('://')
     if not sep:
         return target
-    credentials, at, host = rest.rpartition('@')
-    return f'{scheme}://***@{host}' if at and credentials else target
+
+    authority, question, query = rest.partition('?')
+    credentials, at, host = authority.rpartition('@')
+    if at and credentials:
+        authority = f'***@{host}'
+
+    if query:
+        params = parse_qsl(query, keep_blank_values=True)
+        if any(k == 'password' for k, _ in params):
+            # safe='*' keeps the mask readable instead of percent-escaping it.
+            query = urlencode([(k, '***' if k == 'password' else v) for k, v in params], safe='*')
+
+    return f'{scheme}://{authority}{question}{query}'
 
 
 def _type_name(value: Any) -> str:

--- a/nodes/src/nodes/graph_falkordb/IGlobal.py
+++ b/nodes/src/nodes/graph_falkordb/IGlobal.py
@@ -34,6 +34,7 @@ from the base class.
 from __future__ import annotations
 
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from redis.exceptions import RedisError
 
@@ -244,11 +245,17 @@ class IGlobal(GraphGlobalBase):
     def _connect(cls, config: Dict[str, Any]) -> FalkorDB:
         """Open a client from whichever profile is configured: URL or host/port."""
         url = _connection_url(config)
-        # In the URL profile every credential travels in the URL itself; a separate
-        # password field would only conflict with one already embedded there.
-        if url:
+        if not url:
+            return FalkorDB(**cls._client_kwargs(config))
+
+        # Do NOT strip the password — whitespace is valid in passwords.
+        password = str(config.get('password') or '')
+        if not password:
             return FalkorDB.from_url(url)
-        return FalkorDB(**cls._client_kwargs(config))
+
+        # A filled-in password field is the one that counts, so drop whatever the
+        # URL embeds: redis-py would otherwise prefer the URL and ignore the field.
+        return FalkorDB.from_url(_url_without_password(url), password=password)
 
     @staticmethod
     def _client_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:
@@ -300,6 +307,34 @@ def _connection_url(config: Dict[str, Any]) -> str:
             f'Unsupported FalkorDB URL scheme in "{_redact(url)}": expected one of {", ".join(URL_SCHEMES)}'
         )
     return url
+
+
+def _url_without_password(url: str) -> str:
+    """Return the URL with any embedded password removed, username kept.
+
+    Covers both places a URL can carry one: the authority (``user:pass@host``)
+    and the ``password=`` query parameter that ``unix://`` URLs use.
+    """
+    parts = urlsplit(url)
+
+    # Split the authority by hand rather than through parts.username, which
+    # unquotes percent-escapes that must survive into the rebuilt URL.
+    netloc = parts.netloc
+    if '@' in netloc:
+        credentials, _, host = netloc.rpartition('@')
+        user = credentials.split(':', 1)[0]
+        netloc = f'{user}@{host}' if user else host
+
+    query = parts.query
+    if query:
+        query = urlencode([(k, v) for k, v in parse_qsl(query, keep_blank_values=True) if k != 'password'])
+
+    rebuilt = urlunsplit((parts.scheme, netloc, parts.path, query, parts.fragment))
+    # urlunsplit drops the '//' when the authority is empty, turning a unix:///path
+    # socket URL into unix:/path. Put it back so the scheme still parses.
+    if not netloc and url.startswith(f'{parts.scheme}://'):
+        rebuilt = f'{parts.scheme}://{rebuilt[len(parts.scheme) + 1 :]}'
+    return rebuilt
 
 
 def _redact(target: str) -> str:

--- a/nodes/src/nodes/graph_falkordb/IGlobal.py
+++ b/nodes/src/nodes/graph_falkordb/IGlobal.py
@@ -244,16 +244,11 @@ class IGlobal(GraphGlobalBase):
     def _connect(cls, config: Dict[str, Any]) -> FalkorDB:
         """Open a client from whichever profile is configured: URL or host/port."""
         url = _connection_url(config)
-        if not url:
-            return FalkorDB(**cls._client_kwargs(config))
-
-        kwargs: Dict[str, Any] = {}
-        # redis-py lets the URL's own credentials win over keyword arguments, so
-        # the password field only fills in a URL that carries none.
-        password = str(config.get('password') or '')
-        if password:
-            kwargs['password'] = password
-        return FalkorDB.from_url(url, **kwargs)
+        # In the URL profile every credential travels in the URL itself; a separate
+        # password field would only conflict with one already embedded there.
+        if url:
+            return FalkorDB.from_url(url)
+        return FalkorDB(**cls._client_kwargs(config))
 
     @staticmethod
     def _client_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:

--- a/nodes/src/nodes/graph_falkordb/IGlobal.py
+++ b/nodes/src/nodes/graph_falkordb/IGlobal.py
@@ -46,6 +46,8 @@ from falkordb import FalkorDB
 
 DEFAULT_PORT = 6379
 DEFAULT_GRAPH = 'agent'
+# Schemes falkordb-py accepts: falkor(s):// are its own aliases for redis(s)://.
+URL_SCHEMES = ('falkor://', 'falkors://', 'redis://', 'rediss://', 'unix://')
 DEFAULT_TIMEOUT_MS = 30000
 DEFAULT_ROW_CAP = 250
 
@@ -87,7 +89,7 @@ class IGlobal(GraphGlobalBase):
             config, 'query_timeout_ms', DEFAULT_TIMEOUT_MS, min_value=100, max_value=600000
         )
 
-        self.client = FalkorDB(**self._client_kwargs(config))
+        self.client = self._connect(config)
         # Round-trip now so a wrong host or password fails at pipeline start
         # rather than on the first tool call.
         self.client.list_graphs()
@@ -101,17 +103,24 @@ class IGlobal(GraphGlobalBase):
 
     def _probe_connection(self, config: Dict[str, Any]) -> None:
         """Save-time probe: connect and list graphs, reporting failures as warnings."""
-        host = str(config.get('host') or '').strip()
-        if not host:
-            warning('host is required')
+        try:
+            target = _connection_url(config)
+        except ValueError as e:
+            warning(str(e))
             return
+
+        if not target:
+            target = str(config.get('host') or '').strip()
+            if not target:
+                warning('host is required')
+                return
 
         client = None
         try:
-            client = FalkorDB(**self._client_kwargs(config))
+            client = self._connect(config)
             client.list_graphs()
         except RedisError as e:
-            warning(f'Could not connect to FalkorDB at {host}: {e}')
+            warning(f'Could not connect to FalkorDB at {_redact(target)}: {e}')
         except Exception as e:
             warning(str(e))
         finally:
@@ -231,6 +240,21 @@ class IGlobal(GraphGlobalBase):
         result = graph.ro_query(cypher, timeout=self.query_timeout_ms)
         return [str(row[0]) for row in (result.result_set or []) if row]
 
+    @classmethod
+    def _connect(cls, config: Dict[str, Any]) -> FalkorDB:
+        """Open a client from whichever profile is configured: URL or host/port."""
+        url = _connection_url(config)
+        if not url:
+            return FalkorDB(**cls._client_kwargs(config))
+
+        kwargs: Dict[str, Any] = {}
+        # redis-py lets the URL's own credentials win over keyword arguments, so
+        # the password field only fills in a URL that carries none.
+        password = str(config.get('password') or '')
+        if password:
+            kwargs['password'] = password
+        return FalkorDB.from_url(url, **kwargs)
+
     @staticmethod
     def _client_kwargs(config: Dict[str, Any]) -> Dict[str, Any]:
         """Build the FalkorDB() kwargs from node config."""
@@ -263,6 +287,33 @@ class IGlobal(GraphGlobalBase):
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
+
+
+def _connection_url(config: Dict[str, Any]) -> str:
+    """Return the validated connection URL, or '' when the node uses host/port.
+
+    The URL profile sets ``mode`` to ``url``; an empty URL there is a
+    misconfiguration rather than a fallback to localhost.
+    """
+    url = str(config.get('url') or '').strip()
+    if not url:
+        if str(config.get('mode') or '').strip().lower() == 'url':
+            raise ValueError('FalkorDB URL is required, e.g. falkor://user:password@host:6379')
+        return ''
+    if not url.startswith(URL_SCHEMES):
+        raise ValueError(
+            f'Unsupported FalkorDB URL scheme in "{_redact(url)}": expected one of {", ".join(URL_SCHEMES)}'
+        )
+    return url
+
+
+def _redact(target: str) -> str:
+    """Strip credentials from a URL before it reaches a log line."""
+    scheme, sep, rest = target.partition('://')
+    if not sep:
+        return target
+    credentials, at, host = rest.rpartition('@')
+    return f'{scheme}://***@{host}' if at and credentials else target
 
 
 def _type_name(value: Any) -> str:

--- a/nodes/src/nodes/graph_falkordb/README.md
+++ b/nodes/src/nodes/graph_falkordb/README.md
@@ -41,9 +41,9 @@ the FalkorDB Browser offers between *Manual Configuration* and *FalkorDB URL*:
 - **FalkorDB URL (connection string)** — profile `url`. Paste the connection string from the
   FalkorDB Cloud console, e.g.
   `falkor://falkordb@r-6jissuruar.instance-ytljliglb.us-east-1.aws.cloud:53939`. Schemes
-  accepted: `falkor://`, `falkors://` (TLS), `redis://`, `rediss://`, `unix://`. Credentials may
-  be embedded (`falkor://user:password@host:port`) or left out of the URL and typed into
-  `password`, which keeps the secret in the node's encrypted field instead of in the URL.
+  accepted: `falkor://`, `falkors://` (TLS), `redis://`, `rediss://`, `unix://`. Credentials
+  travel in the URL itself (`falkor://user:password@host:port`); this profile has no separate
+  password field, so there is nothing that can disagree with what the URL already carries.
 
 Every other setting below is available in both profiles. Pipelines saved before the URL profile
 existed keep working unchanged: they already use the `default` profile.
@@ -55,9 +55,9 @@ existed keep working unchanged: they already use the `default` profile.
 | `host` | manual | string | Default `localhost`. FalkorDB host, e.g. `localhost` or `your-instance.falkordb.cloud`. |
 | `port` | manual | integer | Default 6379 (1–65535). FalkorDB port (Redis protocol). |
 | `username` | manual | string | Default empty. Username, e.g. `default` for FalkorDB Cloud. Leave empty for no auth. |
+| `password` | manual | string | Default empty. Password for the FalkorDB instance. Leave empty for no auth. |
 | `tls` | manual | boolean | Default false. Connect with TLS (for FalkorDB Cloud TLS endpoints). |
-| `url` | url | string | Connection string, e.g. `falkor://user:password@host:6379`. Required in this profile. |
-| `password` | both | string | Default empty. Password for the FalkorDB instance. Leave empty for no auth, or when the URL already carries it. |
+| `url` | url | string | Connection string, e.g. `falkor://user:password@host:6379`. Required in this profile; it carries the credentials too. |
 
 ### Shared fields
 

--- a/nodes/src/nodes/graph_falkordb/README.md
+++ b/nodes/src/nodes/graph_falkordb/README.md
@@ -33,13 +33,36 @@ agent's context.
 
 ## Configuration
 
+The node connects in one of two ways, picked with the **Connection** selector — the same choice
+the FalkorDB Browser offers between *Manual Configuration* and *FalkorDB URL*:
+
+- **Manual configuration (host and port)** — profile `default`. Fill in `host`, `port`,
+  `username`, `password` and `tls` yourself.
+- **FalkorDB URL (connection string)** — profile `url`. Paste the connection string from the
+  FalkorDB Cloud console, e.g.
+  `falkor://falkordb@r-6jissuruar.instance-ytljliglb.us-east-1.aws.cloud:53939`. Schemes
+  accepted: `falkor://`, `falkors://` (TLS), `redis://`, `rediss://`, `unix://`. Credentials may
+  be embedded (`falkor://user:password@host:port`) or left out of the URL and typed into
+  `password`, which keeps the secret in the node's encrypted field instead of in the URL.
+
+Every other setting below is available in both profiles. Pipelines saved before the URL profile
+existed keep working unchanged: they already use the `default` profile.
+
+### Connection fields
+
+| Field | Profile | Type | Description |
+|---|---|---|---|
+| `host` | manual | string | Default `localhost`. FalkorDB host, e.g. `localhost` or `your-instance.falkordb.cloud`. |
+| `port` | manual | integer | Default 6379 (1–65535). FalkorDB port (Redis protocol). |
+| `username` | manual | string | Default empty. Username, e.g. `default` for FalkorDB Cloud. Leave empty for no auth. |
+| `tls` | manual | boolean | Default false. Connect with TLS (for FalkorDB Cloud TLS endpoints). |
+| `url` | url | string | Connection string, e.g. `falkor://user:password@host:6379`. Required in this profile. |
+| `password` | both | string | Default empty. Password for the FalkorDB instance. Leave empty for no auth, or when the URL already carries it. |
+
+### Shared fields
+
 | Field | Type | Description |
 |---|---|---|
-| `host` | string | Default `localhost`. FalkorDB host, e.g. `localhost` or `your-instance.falkordb.cloud`. |
-| `port` | integer | Default 6379 (1–65535). FalkorDB port (Redis protocol). |
-| `username` | string | Default empty. Username, e.g. `default` for FalkorDB Cloud. Leave empty for no auth. |
-| `password` | string | Default empty. Password for the FalkorDB instance. Leave empty for no auth. |
-| `tls` | boolean | Default false. Connect with TLS (for FalkorDB Cloud TLS endpoints). |
 | `graph` | string | Default `agent`. Graph queried when the agent does not pass one explicitly. |
 | `db_description` | string | Default empty. What this graph holds, in your own words. Given to the LLM so it writes better Cypher. |
 | `allow_writes` | boolean | Default false. Permit `CREATE`/`MERGE`/`SET`/`DELETE` in `query`. When off, queries run via `GRAPH.RO_QUERY` and the server rejects write clauses. |
@@ -109,8 +132,8 @@ read-only path.
 docker run -p 6379:6379 -it --rm falkordb/falkordb:latest
 ```
 
-Point the node at `localhost:6379` and ask the agent to `MATCH` away, or to `CREATE` with
-**Allow Writes** turned on.
+Point the node at `localhost:6379` (manual profile) or at `falkor://localhost:6379` (URL
+profile) and ask the agent to `MATCH` away, or to `CREATE` with **Allow Writes** turned on.
 
 ---
 

--- a/nodes/src/nodes/graph_falkordb/README.md
+++ b/nodes/src/nodes/graph_falkordb/README.md
@@ -41,9 +41,11 @@ the FalkorDB Browser offers between *Manual Configuration* and *FalkorDB URL*:
 - **FalkorDB URL (connection string)** — profile `url`. Paste the connection string from the
   FalkorDB Cloud console, e.g.
   `falkor://falkordb@r-6jissuruar.instance-ytljliglb.us-east-1.aws.cloud:53939`. Schemes
-  accepted: `falkor://`, `falkors://` (TLS), `redis://`, `rediss://`, `unix://`. Credentials
-  travel in the URL itself (`falkor://user:password@host:port`); this profile has no separate
-  password field, so there is nothing that can disagree with what the URL already carries.
+  accepted: `falkor://`, `falkors://` (TLS), `redis://`, `rediss://`, `unix://`. The password may
+  be embedded (`falkor://user:password@host:port`) or left out of the URL and typed into
+  `password`, which keeps the secret in the node's encrypted field instead of in the URL. When
+  `password` is filled in it is the one used: any password the URL embeds is stripped before the
+  connection is opened, so the two can never silently disagree.
 
 Every other setting below is available in both profiles. Pipelines saved before the URL profile
 existed keep working unchanged: they already use the `default` profile.
@@ -55,9 +57,9 @@ existed keep working unchanged: they already use the `default` profile.
 | `host` | manual | string | Default `localhost`. FalkorDB host, e.g. `localhost` or `your-instance.falkordb.cloud`. |
 | `port` | manual | integer | Default 6379 (1–65535). FalkorDB port (Redis protocol). |
 | `username` | manual | string | Default empty. Username, e.g. `default` for FalkorDB Cloud. Leave empty for no auth. |
-| `password` | manual | string | Default empty. Password for the FalkorDB instance. Leave empty for no auth. |
 | `tls` | manual | boolean | Default false. Connect with TLS (for FalkorDB Cloud TLS endpoints). |
-| `url` | url | string | Connection string, e.g. `falkor://user:password@host:6379`. Required in this profile; it carries the credentials too. |
+| `url` | url | string | Connection string, e.g. `falkor://user@host:6379`. Required in this profile. |
+| `password` | both | string | Default empty. Stored encrypted. When set it replaces any password embedded in the URL. Leave empty for no auth, or to use the one the URL carries. |
 
 ### Shared fields
 

--- a/nodes/src/nodes/graph_falkordb/README.md
+++ b/nodes/src/nodes/graph_falkordb/README.md
@@ -155,15 +155,21 @@ pytest nodes/test/test_graph_falkordb.py -v
 
 | Field | Type | Description | Default |
 |---|---|---|---|
-| `tool_falkordb.allow_writes` | `boolean` | **Allow Writes**<br/>Permit CREATE/MERGE/SET/DELETE. When off, queries run via GRAPH.RO_QUERY and the server rejects write clauses. | `false` |
-| `tool_falkordb.graph` | `string` | **Default Graph**<br/>Graph queried when the agent does not pass one explicitly. | `"agent"` |
-| `tool_falkordb.host` | `string` | **Host**<br/>FalkorDB host, e.g. localhost or your-instance.falkordb.cloud. | `"localhost"` |
-| `tool_falkordb.max_rows` | `integer` | **Max Rows**<br/>Upper cap on rows returned to the agent per query. | `250` |
-| `tool_falkordb.password` | `string` | **Password**<br/>Password for the FalkorDB instance. Leave empty for no auth. | `""` |
-| `tool_falkordb.port` | `integer` | **Port**<br/>FalkorDB port (Redis protocol). | `6379` |
-| `tool_falkordb.query_timeout_ms` | `integer` | **Query Timeout (ms)**<br/>Server-side timeout for a single query. | `30000` |
-| `tool_falkordb.tls` | `boolean` | **TLS**<br/>Connect with TLS (FalkorDB Cloud TLS endpoints). | `false` |
-| `tool_falkordb.username` | `string` | **Username**<br/>Username, e.g. "default" for FalkorDB Cloud. Leave empty for no auth. | `""` |
+| `graph_falkordb.allow_execute` | `boolean` | **Allow Execute**<br/>Enable the execute tool, which runs raw Cypher with no LLM translation and no read-only gate. Leave OFF unless a trusted application explicitly needs to issue Cypher directly. | `false` |
+| `graph_falkordb.allow_writes` | `boolean` | **Allow Writes**<br/>Permit CREATE/MERGE/SET/DELETE in the query tool. When off, queries run via GRAPH.RO_QUERY and the server itself rejects write clauses. | `false` |
+| `graph_falkordb.db_description` | `string` | **Graph Description**<br/>What is this graph used for? Describe its content and domain, this helps the LLM generate more accurate Cypher queries. | `""` |
+| `graph_falkordb.graph` | `string` | **Default Graph**<br/>A FalkorDB server hosts many graphs. This is the one queried when the caller does not name another. | `"agent"` |
+| `graph_falkordb.host` | `string` | **Host**<br/>FalkorDB host, e.g. localhost or your-instance.falkordb.cloud. | `"localhost"` |
+| `graph_falkordb.max_attempts` | `integer` | **Max Validation Attempts**<br/>Maximum number of times to re-ask the LLM if EXPLAIN rejects the generated Cypher query. | `5` |
+| `graph_falkordb.max_execute_rows` | `integer` | **Max Execute Rows**<br/>Upper cap on rows returned by the execute tool. The query fails if exceeded, so one statement cannot exhaust worker memory. | `25000` |
+| `graph_falkordb.max_rows` | `integer` | **Max Rows**<br/>Upper cap on rows returned per query. Results beyond it are cut and flagged as truncated. | `250` |
+| `graph_falkordb.password` | `string` | **Password**<br/>Password for the FalkorDB instance. Stored encrypted. When set it is the one used, replacing any password embedded in the FalkorDB URL. Leave empty for no auth, or to use the one the URL already carries. | `""` |
+| `graph_falkordb.port` | `integer` | **Port**<br/>FalkorDB port (Redis protocol). FalkorDB Cloud assigns a per-instance port. | `6379` |
+| `graph_falkordb.profile` | `string` | **Connection**<br/>How this node connects to FalkorDB | `"default"` |
+| `graph_falkordb.query_timeout_ms` | `integer` | **Query Timeout (ms)**<br/>Server-side timeout for a single query. | `30000` |
+| `graph_falkordb.tls` | `boolean` | **TLS**<br/>Connect with TLS. Required by FalkorDB Cloud TLS endpoints. | `false` |
+| `graph_falkordb.url` | `string` | **FalkorDB URL**<br/>Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. The URL may carry credentials, so it is stored encrypted; the password can also be left out of it and typed in the Password field below, which then replaces whatever the URL embeds. | `""` |
+| `graph_falkordb.username` | `string` | **Username**<br/>Username, e.g. "default" for FalkorDB Cloud. Leave empty for no auth. | `""` |
 
 ## Dependencies
 
@@ -172,5 +178,5 @@ pytest nodes/test/test_graph_falkordb.py -v
 
 ## Source
 
-[<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true" style="vertical-align:-0.15em;margin-right:0.35em"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> View source](https://github.com/rocketride-org/rocketride-server/tree/develop/nodes/src/nodes/tool_falkordb)
+[<svg viewBox="0 0 16 16" width="15" height="15" fill="currentColor" aria-hidden="true" style="vertical-align:-0.15em;margin-right:0.35em"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg> View source](https://github.com/rocketride-org/rocketride-server/tree/develop/nodes/src/nodes/graph_falkordb)
 <!-- ROCKETRIDE:GENERATED:PARAMS END -->

--- a/nodes/src/nodes/graph_falkordb/services.json
+++ b/nodes/src/nodes/graph_falkordb/services.json
@@ -134,7 +134,7 @@
 			"default": "",
 			"secure": true,
 			"optional": true,
-			"description": "Password for the FalkorDB instance. Leave empty for no auth, or when the FalkorDB URL already carries it.",
+			"description": "Password for the FalkorDB instance. Leave empty for no auth.",
 			"ui": {
 				"ui:widget": "password"
 			}
@@ -143,7 +143,7 @@
 			"type": "string",
 			"title": "FalkorDB URL",
 			"default": "",
-			"description": "Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. Credentials may be embedded as falkor://user:password@host:port, or left out and typed in the Password field below."
+			"description": "Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. Credentials travel in the URL itself: falkor://user:password@host:port."
 		},
 		"graph_falkordb.tls": {
 			"type": "boolean",
@@ -222,7 +222,7 @@
 		},
 		"graph_falkordb.urlProfile": {
 			"object": "url",
-			"properties": ["graph_falkordb.url", "graph_falkordb.password", "graph_falkordb.graph", "graph_falkordb.db_description", "graph_falkordb.allow_writes", "graph_falkordb.allow_execute", "graph_falkordb.max_attempts", "graph_falkordb.max_rows", "graph_falkordb.max_execute_rows", "graph_falkordb.query_timeout_ms"]
+			"properties": ["graph_falkordb.url", "graph_falkordb.graph", "graph_falkordb.db_description", "graph_falkordb.allow_writes", "graph_falkordb.allow_execute", "graph_falkordb.max_attempts", "graph_falkordb.max_rows", "graph_falkordb.max_execute_rows", "graph_falkordb.query_timeout_ms"]
 		},
 		"graph_falkordb.profile": {
 			"type": "string",

--- a/nodes/src/nodes/graph_falkordb/services.json
+++ b/nodes/src/nodes/graph_falkordb/services.json
@@ -134,7 +134,7 @@
 			"default": "",
 			"secure": true,
 			"optional": true,
-			"description": "Password for the FalkorDB instance. Leave empty for no auth.",
+			"description": "Password for the FalkorDB instance. Stored encrypted. When set it is the one used, replacing any password embedded in the FalkorDB URL. Leave empty for no auth, or to use the one the URL already carries.",
 			"ui": {
 				"ui:widget": "password"
 			}
@@ -143,7 +143,7 @@
 			"type": "string",
 			"title": "FalkorDB URL",
 			"default": "",
-			"description": "Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. Credentials travel in the URL itself: falkor://user:password@host:port."
+			"description": "Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. The password may be embedded (falkor://user:password@host:port) or left out of the URL and typed in the Password field below, which keeps it encrypted."
 		},
 		"graph_falkordb.tls": {
 			"type": "boolean",
@@ -222,7 +222,7 @@
 		},
 		"graph_falkordb.urlProfile": {
 			"object": "url",
-			"properties": ["graph_falkordb.url", "graph_falkordb.graph", "graph_falkordb.db_description", "graph_falkordb.allow_writes", "graph_falkordb.allow_execute", "graph_falkordb.max_attempts", "graph_falkordb.max_rows", "graph_falkordb.max_execute_rows", "graph_falkordb.query_timeout_ms"]
+			"properties": ["graph_falkordb.url", "graph_falkordb.password", "graph_falkordb.graph", "graph_falkordb.db_description", "graph_falkordb.allow_writes", "graph_falkordb.allow_execute", "graph_falkordb.max_attempts", "graph_falkordb.max_rows", "graph_falkordb.max_execute_rows", "graph_falkordb.query_timeout_ms"]
 		},
 		"graph_falkordb.profile": {
 			"type": "string",

--- a/nodes/src/nodes/graph_falkordb/services.json
+++ b/nodes/src/nodes/graph_falkordb/services.json
@@ -143,7 +143,11 @@
 			"type": "string",
 			"title": "FalkorDB URL",
 			"default": "",
-			"description": "Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. The password may be embedded (falkor://user:password@host:port) or left out of the URL and typed in the Password field below, which keeps it encrypted."
+			"secure": true,
+			"description": "Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. The URL may carry credentials, so it is stored encrypted; the password can also be left out of it and typed in the Password field below, which then replaces whatever the URL embeds.",
+			"ui": {
+				"ui:widget": "password"
+			}
 		},
 		"graph_falkordb.tls": {
 			"type": "boolean",

--- a/nodes/src/nodes/graph_falkordb/services.json
+++ b/nodes/src/nodes/graph_falkordb/services.json
@@ -85,9 +85,17 @@
 		// Define the values that will be merged into any profile configuration
 		// specified, unless the profile is 'absolute'
 		"default": "default",
-		// Defines profiles used with the "profile": key
+		// Defines profiles used with the "profile": key. "default" keeps its name
+		// so pipelines saved before the URL profile existed still resolve.
 		"profiles": {
 			"default": {
+				"title": "Manual configuration (host and port)",
+				"mode": "manual",
+				"graph": "agent"
+			},
+			"url": {
+				"title": "FalkorDB URL (connection string)",
+				"mode": "url",
 				"graph": "agent"
 			}
 		}
@@ -126,10 +134,16 @@
 			"default": "",
 			"secure": true,
 			"optional": true,
-			"description": "Password for the FalkorDB instance. Leave empty for no auth.",
+			"description": "Password for the FalkorDB instance. Leave empty for no auth, or when the FalkorDB URL already carries it.",
 			"ui": {
 				"ui:widget": "password"
 			}
+		},
+		"graph_falkordb.url": {
+			"type": "string",
+			"title": "FalkorDB URL",
+			"default": "",
+			"description": "Connection string as shown in the FalkorDB Cloud console, e.g. falkor://falkordb@r-xxxx.instance-yyyy.cloud:53939. Use falkors:// for TLS. Credentials may be embedded as falkor://user:password@host:port, or left out and typed in the Password field below."
 		},
 		"graph_falkordb.tls": {
 			"type": "boolean",
@@ -196,6 +210,36 @@
 			"minimum": 100,
 			"maximum": 600000,
 			"description": "Server-side timeout for a single query."
+		},
+		//
+		// The two connection profiles. Everything the driver reads must be listed
+		// inside the profile object: the resolved config is the profile section
+		// merged with connConfig[profile], so top-level keys are not seen.
+		//
+		"graph_falkordb.default": {
+			"object": "default",
+			"properties": ["graph_falkordb.host", "graph_falkordb.port", "graph_falkordb.username", "graph_falkordb.password", "graph_falkordb.tls", "graph_falkordb.graph", "graph_falkordb.db_description", "graph_falkordb.allow_writes", "graph_falkordb.allow_execute", "graph_falkordb.max_attempts", "graph_falkordb.max_rows", "graph_falkordb.max_execute_rows", "graph_falkordb.query_timeout_ms"]
+		},
+		"graph_falkordb.urlProfile": {
+			"object": "url",
+			"properties": ["graph_falkordb.url", "graph_falkordb.password", "graph_falkordb.graph", "graph_falkordb.db_description", "graph_falkordb.allow_writes", "graph_falkordb.allow_execute", "graph_falkordb.max_attempts", "graph_falkordb.max_rows", "graph_falkordb.max_execute_rows", "graph_falkordb.query_timeout_ms"]
+		},
+		"graph_falkordb.profile": {
+			"type": "string",
+			"title": "Connection",
+			"description": "How this node connects to FalkorDB",
+			"default": "default",
+			"enum": ["*>preconfig.profiles.*.title"],
+			"conditional": [
+				{
+					"value": "default",
+					"properties": ["graph_falkordb.default"]
+				},
+				{
+					"value": "url",
+					"properties": ["graph_falkordb.urlProfile"]
+				}
+			]
 		}
 	},
 	//
@@ -211,7 +255,7 @@
 		{
 			"section": "Pipe",
 			"title": "FalkorDB",
-			"properties": ["type", "graph_falkordb.host", "graph_falkordb.port", "graph_falkordb.username", "graph_falkordb.password", "graph_falkordb.tls", "graph_falkordb.graph", "graph_falkordb.db_description", "graph_falkordb.allow_writes", "graph_falkordb.allow_execute", "graph_falkordb.max_attempts", "graph_falkordb.max_rows", "graph_falkordb.max_execute_rows", "graph_falkordb.query_timeout_ms"]
+			"properties": ["type", "graph_falkordb.profile"]
 		}
 	]
 }

--- a/nodes/test/test_graph_falkordb.py
+++ b/nodes/test/test_graph_falkordb.py
@@ -686,18 +686,12 @@ def test_manual_profile_connects_with_host_and_port(recording_client):
 
 
 def test_url_profile_connects_from_url(recording_client):
-    url = 'falkor://falkordb@r-6jissuruar.instance-ytljliglb.us-east-1.aws.cloud:53939'
+    url = 'falkor://falkordb:s3cret@r-6jissuruar.instance-ytljliglb.us-east-1.aws.cloud:53939'
     _glb_mod.IGlobal._connect({'mode': 'url', 'url': f'  {url}  '})
 
+    # The URL carries every credential; nothing else may be passed alongside it.
     assert recording_client.last_url == url
-    # No password field set -> nothing may override the URL's own credentials.
     assert recording_client.last_kwargs == {}
-
-
-def test_url_profile_password_field_fills_in_a_url_without_one(recording_client):
-    _glb_mod.IGlobal._connect({'mode': 'url', 'url': 'falkors://falkordb@host:53939', 'password': 'secret'})
-
-    assert recording_client.last_kwargs == {'password': 'secret'}
 
 
 @pytest.mark.parametrize('url', ['http://host:6379', 'host:6379', 'bolt://host:7687'])

--- a/nodes/test/test_graph_falkordb.py
+++ b/nodes/test/test_graph_falkordb.py
@@ -764,6 +764,21 @@ def test_probe_does_not_leak_url_credentials(monkeypatch, recording_client):
     assert 'falkor://***@host:53939' in messages[0]
 
 
+def test_probe_does_not_leak_unix_socket_password(monkeypatch, recording_client):
+    """A unix:// URL carries its password in the query string, not the authority."""
+    messages = []
+    monkeypatch.setattr(_glb_mod, 'warning', messages.append)
+    monkeypatch.setattr(
+        recording_client, 'from_url', classmethod(lambda cls, url, **kw: (_ for _ in ()).throw(_StubRedisError('nope')))
+    )
+
+    glb = _FakeGlobal(_FakeGraph())
+    glb._probe_connection({'mode': 'url', 'url': 'unix:///tmp/f.sock?db=0&password=s3cret'})
+
+    assert messages and 's3cret' not in messages[0]
+    assert 'unix:///tmp/f.sock?db=0&password=***' in messages[0]
+
+
 def test_probe_reports_missing_host_on_manual_profile(monkeypatch):
     messages = []
     monkeypatch.setattr(_glb_mod, 'warning', messages.append)

--- a/nodes/test/test_graph_falkordb.py
+++ b/nodes/test/test_graph_falkordb.py
@@ -689,9 +689,40 @@ def test_url_profile_connects_from_url(recording_client):
     url = 'falkor://falkordb:s3cret@r-6jissuruar.instance-ytljliglb.us-east-1.aws.cloud:53939'
     _glb_mod.IGlobal._connect({'mode': 'url', 'url': f'  {url}  '})
 
-    # The URL carries every credential; nothing else may be passed alongside it.
+    # No password field set -> the URL is passed through untouched.
     assert recording_client.last_url == url
     assert recording_client.last_kwargs == {}
+
+
+def test_password_field_replaces_the_one_embedded_in_the_url(recording_client):
+    """The field is the single source of truth: redis-py must not prefer the URL."""
+    _glb_mod.IGlobal._connect({'mode': 'url', 'url': 'falkor://falkordb:stale@host:53939', 'password': 'current'})
+
+    assert recording_client.last_url == 'falkor://falkordb@host:53939'
+    assert recording_client.last_kwargs == {'password': 'current'}
+
+
+def test_password_field_fills_in_a_url_without_credentials(recording_client):
+    _glb_mod.IGlobal._connect({'mode': 'url', 'url': 'falkor://falkordb@host:53939', 'password': 'secret'})
+
+    assert recording_client.last_url == 'falkor://falkordb@host:53939'
+    assert recording_client.last_kwargs == {'password': 'secret'}
+
+
+@pytest.mark.parametrize(
+    ('url', 'expected'),
+    [
+        # The username survives, percent-escapes and all; only the password goes.
+        ('falkor://us%3Aer:p%40ss@host:6379', 'falkor://us%3Aer@host:6379'),
+        # No username either — an authority that is only a password.
+        ('falkor://:pw@host:6379', 'falkor://host:6379'),
+        # unix:// carries its password in the query string instead.
+        ('unix:///tmp/f.sock?db=0&password=pw', 'unix:///tmp/f.sock?db=0'),
+        ('falkor://host:6379', 'falkor://host:6379'),
+    ],
+)
+def test_url_without_password_strips_only_the_password(url, expected):
+    assert _glb_mod._url_without_password(url) == expected
 
 
 @pytest.mark.parametrize('url', ['http://host:6379', 'host:6379', 'bolt://host:7687'])

--- a/nodes/test/test_graph_falkordb.py
+++ b/nodes/test/test_graph_falkordb.py
@@ -638,6 +638,116 @@ def test_affected_rows_reported_for_write_that_also_returns_rows():
     assert out['affected_rows'] == 2  # ...and the write is still counted
 
 
+# ---------------------------------------------------------------------------
+# Connection profiles: manual (host/port) and URL
+# ---------------------------------------------------------------------------
+
+
+class _RecordingFalkorDB:
+    """Captures how the driver was asked to connect, without opening a socket."""
+
+    last_kwargs = None
+    last_url = None
+
+    def __init__(self, **kwargs):
+        _RecordingFalkorDB.last_kwargs = kwargs
+        _RecordingFalkorDB.last_url = None
+
+    @classmethod
+    def from_url(cls, url, **kwargs):
+        instance = cls.__new__(cls)
+        _RecordingFalkorDB.last_url = url
+        _RecordingFalkorDB.last_kwargs = kwargs
+        return instance
+
+
+@pytest.fixture
+def recording_client(monkeypatch):
+    monkeypatch.setattr(_glb_mod, 'FalkorDB', _RecordingFalkorDB)
+    _RecordingFalkorDB.last_kwargs = None
+    _RecordingFalkorDB.last_url = None
+    return _RecordingFalkorDB
+
+
+def test_manual_profile_connects_with_host_and_port(recording_client):
+    """The pre-existing profile must keep building the client from host/port."""
+    _glb_mod.IGlobal._connect(
+        {'mode': 'manual', 'host': 'localhost', 'port': 6379, 'username': 'u', 'password': 'p', 'tls': True}
+    )
+
+    assert recording_client.last_url is None
+    assert recording_client.last_kwargs == {
+        'host': 'localhost',
+        'port': 6379,
+        'username': 'u',
+        'password': 'p',
+        'ssl': True,
+    }
+
+
+def test_url_profile_connects_from_url(recording_client):
+    url = 'falkor://falkordb@r-6jissuruar.instance-ytljliglb.us-east-1.aws.cloud:53939'
+    _glb_mod.IGlobal._connect({'mode': 'url', 'url': f'  {url}  '})
+
+    assert recording_client.last_url == url
+    # No password field set -> nothing may override the URL's own credentials.
+    assert recording_client.last_kwargs == {}
+
+
+def test_url_profile_password_field_fills_in_a_url_without_one(recording_client):
+    _glb_mod.IGlobal._connect({'mode': 'url', 'url': 'falkors://falkordb@host:53939', 'password': 'secret'})
+
+    assert recording_client.last_kwargs == {'password': 'secret'}
+
+
+@pytest.mark.parametrize('url', ['http://host:6379', 'host:6379', 'bolt://host:7687'])
+def test_url_profile_rejects_unsupported_schemes(url):
+    with pytest.raises(ValueError, match='Unsupported FalkorDB URL scheme'):
+        _glb_mod._connection_url({'mode': 'url', 'url': url})
+
+
+def test_url_profile_requires_a_url():
+    """An empty URL in the URL profile must fail, not silently hit localhost."""
+    with pytest.raises(ValueError, match='FalkorDB URL is required'):
+        _glb_mod._connection_url({'mode': 'url', 'url': ''})
+
+
+def test_manual_profile_has_no_url():
+    assert _glb_mod._connection_url({'mode': 'manual', 'host': 'localhost'}) == ''
+
+
+def test_legacy_flat_config_still_uses_host_port(recording_client):
+    """Pipelines saved before profiles existed carry no 'mode' key at all."""
+    _glb_mod.IGlobal._connect({'host': 'db.internal', 'port': 6380})
+
+    assert recording_client.last_url is None
+    assert recording_client.last_kwargs == {'host': 'db.internal', 'port': 6380}
+
+
+def test_probe_does_not_leak_url_credentials(monkeypatch, recording_client):
+    """A failed probe is logged: the password in the URL must not reach the log."""
+    messages = []
+    monkeypatch.setattr(_glb_mod, 'warning', messages.append)
+    monkeypatch.setattr(
+        recording_client, 'from_url', classmethod(lambda cls, url, **kw: (_ for _ in ()).throw(_StubRedisError('nope')))
+    )
+
+    glb = _FakeGlobal(_FakeGraph())
+    glb._probe_connection({'mode': 'url', 'url': 'falkor://falkordb:s3cret@host:53939'})
+
+    assert messages and 's3cret' not in messages[0]
+    assert 'falkor://***@host:53939' in messages[0]
+
+
+def test_probe_reports_missing_host_on_manual_profile(monkeypatch):
+    messages = []
+    monkeypatch.setattr(_glb_mod, 'warning', messages.append)
+
+    _FakeGlobal(_FakeGraph())._probe_connection({'mode': 'manual', 'host': ''})
+
+    assert messages == ['host is required']
+
+
 def test_reflect_schema_failure_does_not_break_begin(monkeypatch):
     """A driver error during reflection degrades the schema, it does not crash the node."""
     glb = _FakeGlobal(_FakeGraph())


### PR DESCRIPTION

<img width="386" height="664" alt="Captura de pantalla 2026-08-03 a las 15 58 48" src="https://github.com/user-attachments/assets/57ad47b4-4ac8-40f3-a29d-4da1c1e01db1" />

## Summary

- Add a second connection profile to `graph_falkordb`, **FalkorDB URL (connection string)**, next to the existing manual host/port one — the same choice the FalkorDB Browser offers between *Manual Configuration* and *FalkorDB URL*. A FalkorDB Cloud user can now paste `falkor://falkordb@r-xxxx.instance-yyyy.us-east-1.aws.cloud:53939` instead of taking it apart by hand.
- The manual profile keeps its existing key name `default`, so every `.pipe` already on disk (they write `"profile": "default"`) resolves unchanged. No migration, no `IServices::VERSION` bump.
- The URL profile keeps the encrypted `password` field, and makes it authoritative: a `.pipe` is usually committed, so that is where the secret belongs. When the field is set, any password embedded in the URL is stripped before connecting — redis-py would otherwise silently prefer the URL and ignore the field. Leave the field empty and the URL's own credentials stay in charge.
- Any connection target that reaches a warning is redacted (`falkor://***@host:53939`), so a password in the URL never lands in a log line.

### How it works

`services.json` declares the two profiles under `preconfig.profiles` and a conditional `profile` field that swaps the form between them, following the `store_qdrant` pattern. `IGlobal._connect()` opens the client through `FalkorDB.from_url()` when a URL is configured and through host/port otherwise; schemes are validated (`falkor://`, `falkors://`, `redis://`, `rediss://`, `unix://`) and an empty URL inside the URL profile is an error rather than a silent fallback to localhost.

`_url_without_password()` handles both places a URL can carry a password — the `user:pass@host` authority and the `password=` query parameter of a `unix://` socket URL — while keeping a percent-escaped username intact and preserving the empty authority of `unix:///path` that `urlunsplit` would otherwise drop.

## Type

feature

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

16 new tests in `nodes/test/test_graph_falkordb.py` cover both profiles: manual host/port kwargs, URL pass-through, the password field replacing an embedded password and filling in a URL without one, the URL-rewriting edge cases above, rejected schemes, an empty URL in the URL profile, a legacy flat config with no `mode` key, and that a password in the URL never reaches a warning.

```
./dist/server/engine -m pytest nodes/test/test_graph_falkordb.py nodes/test/test_contracts.py
374 passed
```

**Verified against live servers**, driving the real node through `beginGlobal()` so the profile is resolved from this `services.json` by `Config.getNodeConfig` — not a stub.

Against a FalkorDB Cloud instance, all three ways the credentials can be supplied:

| URL | password field | result |
|---|---|---|
| no password embedded | set | connects: `list_graphs`, reflected schema, `query` tool return rows |
| **wrong** password embedded | set (correct) | connects — the field wins, which is the whole point of the override |
| correct password embedded | empty | connects |

And against a password-protected FalkorDB container, both profiles side by side: `list_graphs`, schema reflection (`Person`, `KNOWS`) and the `query` tool return identical results through the URL profile and through the manual one.

`ruff check` and `ruff format` are clean (also enforced by the pre-commit hooks). Not run: the full `./builder test` suite.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

No breaking change: the manual profile keeps the key `default` precisely so saved pipelines keep resolving. `README.md` documents both profiles; the generated `ROCKETRIDE:GENERATED:PARAMS` block is left untouched (it is regenerated by `nodes:docs-generate` and is already stale from the `tool_falkordb` rename).

## Linked Issue

Fixes #1785


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added FalkorDB connection profiles for manual host/port or URL-based configuration.
  * Added support for FalkorDB, Redis, secure Redis, and Unix socket URLs.
  * Added password handling with secure credential precedence.
  * Added a connection-profile selector in the Pipe UI.
* **Bug Fixes**
  * Improved connection validation and startup checks.
  * Connection warnings now redact credentials.
  * Preserved support for legacy host/port configurations.
* **Documentation**
  * Updated setup guidance with both supported connection methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->