### PR TITLE
ci(release): let an experimental build publish its container, safely — hackathon blocker

### DIFF
--- a/.github/workflows/_docker.yaml
+++ b/.github/workflows/_docker.yaml
@@ -21,6 +21,16 @@ on:
         required: false
         type: boolean
         default: false
+      tag_suffix:
+        description: >-
+          Custom tag suffix for builds that must NOT touch the shared tags —
+          experimental / workshop / hotfix branches. When set, the image is
+          published ONLY as <version>-<suffix> and `latest` is deliberately
+          skipped, so a branch build cannot become what everything else
+          resolves to. Empty preserves the previous behaviour exactly.
+        required: false
+        type: string
+        default: ''
 
 jobs:
   docker:
@@ -71,9 +81,18 @@ jobs:
           file: docker/Dockerfile.engine
           push: true
           platforms: linux/amd64
+          # Three mutually exclusive shapes, in priority order:
+          #   tag_suffix set   -> <version>-<suffix>   and NO latest
+          #   prerelease true  -> <version>-prerelease and no latest
+          #   otherwise        -> <version>            and latest
+          # The suffix wins over `prerelease` on purpose: a suffixed build is
+          # by definition one that must not land on a shared tag, and that
+          # intent should not depend on the caller also getting `prerelease`
+          # right. `latest` is withheld for the same reason — an experimental
+          # branch silently becoming `latest` is the worst outcome available.
           tags: |
-            ghcr.io/${{ github.repository_owner }}/rocketride-engine:${{ inputs.server_version }}${{ inputs.prerelease && '-prerelease' || '' }}
-            ${{ inputs.prerelease == false && format('ghcr.io/{0}/rocketride-engine:latest', github.repository_owner) || '' }}
+            ghcr.io/${{ github.repository_owner }}/rocketride-engine:${{ inputs.server_version }}${{ inputs.tag_suffix != '' && format('-{0}', inputs.tag_suffix) || (inputs.prerelease && '-prerelease' || '') }}
+            ${{ (inputs.prerelease == false && inputs.tag_suffix == '') && format('ghcr.io/{0}/rocketride-engine:latest', github.repository_owner) || '' }}
 
       # Cosign keyless signing via GitHub OIDC. Signs the image manifest by
       # digest, which covers every tag pointing at it. Verification:

--- a/.github/workflows/experimental-release.yaml
+++ b/.github/workflows/experimental-release.yaml
@@ -178,3 +178,41 @@ jobs:
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Publish the engine container too, under the run's own suffix.
+  #
+  # WHY THIS EXISTS. Until now the only workflows that produced an engine
+  # container were prerelease.yaml (auto, develop) and release.yaml (full
+  # release, publishes to npm/PyPI/Marketplace). So there was NO way to get a
+  # branch build into the cloud: the first overwrites the shared
+  # `<version>-prerelease` tag that every other build resolves to, and the
+  # second publishes to the public registries. Both are wrong for a workshop
+  # or hotfix branch, which left "put this branch in front of users" with no
+  # safe route at all.
+  #
+  # With tag_suffix the image lands on `<version>-<suffix>` and nothing else —
+  # `latest` is skipped by _docker.yaml. Nothing shared is touched, so this
+  # cannot disturb develop's pipeline.
+  #
+  # Only when the run actually includes the server; a vscode-only workshop
+  # build has no engine to publish.
+  docker:
+    name: Docker
+    if: ${{ contains(inputs.products, 'server') }}
+    needs: [init, build]
+    uses: ./.github/workflows/_docker.yaml
+    permissions:
+      contents: read
+      packages: write
+      # id-token: write is REQUIRED even though nothing here signs directly —
+      # _docker.yaml's job declares it for cosign keyless signing, and GitHub
+      # validates at workflow start that the caller covers every permission the
+      # reusable job declares. Omitting it fails the whole run before any step
+      # executes (that is what broke every nightly after #929).
+      id-token: write
+    with:
+      ref: ${{ inputs.ref }}
+      server_version: ${{ needs.init.outputs.server_version }}
+      tag_suffix: ${{ inputs.tag_suffix }}
+    secrets: inherit
+


### PR DESCRIPTION
**Blocker for tomorrow's joint hackathon (FalkorDB / LaserData / Guild.ai, 9:30 PDT).** The two new nodes are merged and an engine branch containing them is built and verified — but there is currently **no safe way to publish a branch build's container**, so they cannot reach the cloud.

## The gap

Only two workflows produce the engine image:

| workflow | what it does | why it is wrong for a branch |
|---|---|---|
| `prerelease.yaml` | auto on `develop` | hard-codes the `-prerelease` tag that **everything else resolves to**, and its cleanup step deletes develop's release tags |
| `release.yaml` | the real release | also publishes to npm, PyPI and the VS Code Marketplace |

`experimental-release.yaml` exists for exactly this case — build from an arbitrary ref under a custom suffix, no registry publishing, no prerelease cleanup — but it stops at binaries and a GitHub Release. It never publishes an image.

So "ship this branch to the cloud" has been a choice between clobbering a shared tag and doing a full public release. Neither is acceptable, which is why it has simply not been done.

## The change

`_docker.yaml` gains an optional `tag_suffix`:

```
tag_suffix set   ->  <version>-<suffix>     no latest
prerelease true  ->  <version>-prerelease   no latest    (unchanged)
neither          ->  <version> + latest                  (unchanged)
```

Both existing callers pass no suffix, so **`prerelease.yaml` and `release.yaml` behave exactly as before.**

Two deliberate choices worth stating:

- **The suffix wins over `prerelease`.** A suffixed build is by definition one that must not land on a shared tag; that intent should not depend on the caller also getting `prerelease` right.
- **`latest` is withheld whenever a suffix is set.** An experimental branch quietly becoming `latest` is the worst outcome this change could produce, so it is excluded structurally rather than by convention.

`experimental-release.yaml` then calls it, gated on the run actually including the server — a vscode-only workshop build has no engine to publish.

## One thing that will look redundant and is not

The new job declares `id-token: write` while signing nothing itself. `_docker.yaml`'s job declares it for cosign keyless signing, and GitHub validates **at workflow start** that the caller covers every permission the callee declares. Omitting it fails the whole run before a single step executes — that is what produced the `startup_failure` on every nightly after #929. The comment is in the file so the next person does not rediscover it.

## Verification, and what is not yet proven

Both files parse, and I worked the tag expression through all three shapes by hand rather than eyeballing it:

```
suffix='hackathon', prerelease=false  ->  3.3.0-hackathon   latest: no
suffix='',          prerelease=true   ->  3.3.0-prerelease  latest: no
suffix='',          prerelease=false  ->  3.3.0             latest: yes
```

**What is not proven is the expression under GitHub's own evaluator** — that only a real run settles. Running it is my very next step, and I will report the tag it actually produced rather than assume the table above holds. If it does not, this PR is wrong and I would rather say so than have someone find out from a mis-tagged image.
