### PR TITLE
fix(ocr): documents lane called a non-callable reader and dropped its text

### DIFF
--- a/nodes/src/nodes/ocr/IInstance.py
+++ b/nodes/src/nodes/ocr/IInstance.py
@@ -190,14 +190,18 @@ class IInstance(IInstanceBase):
             image_data = base64.b64decode(doc.page_content)
 
             # Read the text by OCR model
-            text = self.IGlobal.reader(image_data)
+            with self.IGlobal.readerLock:
+                text = self.IGlobal.reader.read(image_data)
+
+            if isinstance(text, list):
+                text = ' '.join(text)
 
             # Read the tables by OCR model , invoke writeTable
             self.extract_tables_from_image(image_data, self.instance.writeTable)
 
             # If we have a listener on our text lane, write the text to it
             if self.instance.hasListener('text'):
-                self.writeText(text)
+                self.instance.writeText(text)
 
             # If we have a listener on our documents lane, create a new
             # text document and add it to the list

--- a/nodes/test/ocr/test_write_documents.py
+++ b/nodes/test/ocr/test_write_documents.py
@@ -1,0 +1,259 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Tests for the OCR node's ``documents`` input lane (``IInstance.writeDocuments``).
+
+Guards two defects that survived since the initial commit because the fulltest
+feeds ``image/png``, which ``_determine_lane`` routes to the ``image`` lane:
+
+- ``self.IGlobal.reader(image_data)`` — neither ``Reader`` nor ``ReaderBase``
+  defines ``__call__``, so it raised ``TypeError`` on the first document.
+- ``self.writeText(text)`` — that is ``IInstanceBase``'s inbound handler, whose
+  body is ``pass``. The emitter is ``self.instance.writeText``.
+
+``IInstance.py`` is loaded by file path under a synthetic parent package so its
+``from .IGlobal import IGlobal`` resolves without the engine venv.
+
+Usage:
+    ./builder.cmd nodes:test --pytest-pattern=ocr --verbose
+"""
+
+import base64
+import contextlib
+import importlib.util
+import sys
+import threading
+import types
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+_PKG = '_ocr_pkg_under_test'
+
+_STUB_NAMES = (
+    'rocketlib',
+    'ai',
+    'ai.common',
+    'ai.common.schema',
+    'ai.common.avi',
+    'ai.common.avi.descriptor',
+    'numpy',
+    'PIL',
+    'PIL.Image',
+    _PKG,
+    f'{_PKG}.IGlobal',
+)
+
+
+class _AVI_ACTION:
+    BEGIN, WRITE, END = 0, 1, 2
+
+
+class _Entry:
+    pass
+
+
+class _Doc:
+    """Stand-in for ``ai.common.schema.Doc``."""
+
+    def __init__(self, type: str, page_content: str, metadata: dict | None = None) -> None:
+        self.type = type
+        self.page_content = page_content
+        self.metadata = metadata or {}
+
+    def model_copy(self) -> '_Doc':
+        return _Doc(self.type, self.page_content, dict(self.metadata))
+
+
+class _IInstanceBase:
+    """Stand-in for ``rocketlib.IInstanceBase``.
+
+    ``writeText`` mirrors the real inbound handler, which is a ``pass`` body —
+    here it records instead, so a test can prove it is not used as an emitter.
+    """
+
+    def writeText(self, text) -> None:
+        self.inbound_writeText.append(text)
+
+    def preventDefault(self) -> str:
+        return 'prevented'
+
+
+def _install_min_stubs() -> None:
+    def _mk(name: str, **attrs: object) -> None:
+        m = types.ModuleType(name)
+        for k, v in attrs.items():
+            setattr(m, k, v)
+        sys.modules[name] = m
+
+    _mk('rocketlib', IInstanceBase=_IInstanceBase, AVI_ACTION=_AVI_ACTION, Entry=_Entry)
+
+    ai = types.ModuleType('ai')
+    ai.__path__ = []
+    sys.modules['ai'] = ai
+    for name in ('ai.common', 'ai.common.avi'):
+        m = types.ModuleType(name)
+        m.__path__ = []
+        sys.modules[name] = m
+
+    _mk('ai.common.schema', Doc=_Doc)
+    _mk('ai.common.avi.descriptor', rename_ext=lambda metadata, ext: metadata)
+    _mk('numpy', array=lambda *a, **kw: None)
+
+    pil = types.ModuleType('PIL')
+    pil.__path__ = []
+    sys.modules['PIL'] = pil
+    pil_image = types.ModuleType('PIL.Image')
+    pil_image.open = lambda *a, **kw: None
+    sys.modules['PIL.Image'] = pil_image
+    pil.Image = pil_image
+
+    # Synthetic parent so IInstance.py's `from .IGlobal import IGlobal` resolves
+    pkg = types.ModuleType(_PKG)
+    pkg.__path__ = []
+    sys.modules[_PKG] = pkg
+    _mk(f'{_PKG}.IGlobal', IGlobal=object)
+
+
+@contextlib.contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    """Install stub modules for the duration of the block, restoring on exit."""
+    snapshot = {name: sys.modules.get(name) for name in _STUB_NAMES}
+    _install_min_stubs()
+    try:
+        yield
+    finally:
+        for name, mod in snapshot.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+
+
+_iinstance_path = Path(__file__).parent.parent.parent / 'src' / 'nodes' / 'ocr' / 'IInstance.py'
+
+with _scoped_stubs():
+    _spec = importlib.util.spec_from_file_location(f'{_PKG}.IInstance', _iinstance_path)
+    assert _spec is not None and _spec.loader is not None
+    _iinstance_mod = importlib.util.module_from_spec(_spec)
+    _iinstance_mod.__package__ = _PKG
+    sys.modules[f'{_PKG}.IInstance'] = _iinstance_mod
+    _spec.loader.exec_module(_iinstance_mod)
+    sys.modules.pop(f'{_PKG}.IInstance', None)
+
+IInstance = _iinstance_mod.IInstance
+
+
+class _StubReader:
+    """Stand-in for ``ocr.Reader``. Deliberately defines no ``__call__``."""
+
+    def __init__(self, result) -> None:
+        self.result = result
+        self.calls: list[bytes] = []
+
+    def read(self, image_data):
+        self.calls.append(bytes(image_data))
+        return self.result
+
+
+class _StubIGlobal:
+    def __init__(self, reader: _StubReader) -> None:
+        self.reader = reader
+        self.readerLock = threading.Lock()
+        # no `table_ocr` attribute, so extract_tables_from_image returns early
+
+
+class _StubInstance:
+    def __init__(self, lanes: tuple[str, ...]) -> None:
+        self._lanes = lanes
+        self.texts: list = []
+        self.documents: list = []
+
+    def hasListener(self, lane: str) -> bool:
+        return lane in self._lanes
+
+    def writeText(self, text) -> None:
+        self.texts.append(text)
+
+    def writeTable(self, table) -> None:
+        pass
+
+    def writeDocuments(self, docs) -> None:
+        self.documents.append(docs)
+
+
+PNG_BYTES = b'\x89PNG\r\n\x1a\n-not-a-real-png-but-opaque-to-the-node'
+
+
+def _make(lanes: tuple[str, ...] = ('text',), result='hello world'):
+    node = IInstance.__new__(IInstance)
+    node.inbound_writeText = []
+    node.IGlobal = _StubIGlobal(_StubReader(result))
+    node.instance = _StubInstance(lanes)
+    return node
+
+
+def _doc() -> _Doc:
+    return _Doc(type='Image', page_content=base64.b64encode(PNG_BYTES).decode())
+
+
+class TestReaderIsInvokedCorrectly:
+    def test_calls_read_not_the_instance(self) -> None:
+        node = _make()
+        node.writeDocuments([_doc()])
+
+        assert node.IGlobal.reader.calls == [PNG_BYTES]
+
+    def test_reader_is_not_callable(self) -> None:
+        """The old code did reader(image_data); nothing in the MRO allows that."""
+        reader = _StubReader('x')
+        assert not callable(reader)
+        with pytest.raises(TypeError, match='not callable'):
+            reader(PNG_BYTES)
+
+
+class TestTextIsEmitted:
+    def test_text_goes_to_the_emitter(self) -> None:
+        node = _make(result='hello world')
+        node.writeDocuments([_doc()])
+
+        assert node.instance.texts == ['hello world']
+
+    def test_inbound_handler_is_not_used_as_emitter(self) -> None:
+        """self.writeText is IInstanceBase's inbound handler — a `pass` body."""
+        node = _make()
+        node.writeDocuments([_doc()])
+
+        assert node.inbound_writeText == [], 'text was sent to the inbound handler and lost'
+
+    def test_no_text_lane_means_no_emit(self) -> None:
+        node = _make(lanes=())
+        node.writeDocuments([_doc()])
+
+        assert node.instance.texts == []
+
+    def test_list_result_is_joined(self) -> None:
+        node = _make(result=['hello', 'world'])
+        node.writeDocuments([_doc()])
+
+        assert node.instance.texts == ['hello world']
+
+
+class TestDocumentsLane:
+    def test_emits_converted_documents(self) -> None:
+        node = _make(lanes=('documents',), result='extracted')
+        assert node.writeDocuments([_doc()]) == 'prevented'
+
+        assert len(node.instance.documents) == 1
+        (txtdoc,) = node.instance.documents[0]
+        assert txtdoc.type == 'Document'
+        assert txtdoc.page_content == 'extracted'
+
+    def test_rejects_non_image_documents(self) -> None:
+        node = _make()
+        with pytest.raises(ValueError, match='must be "image"'):
+            node.writeDocuments([_Doc(type='Document', page_content='')])


### PR DESCRIPTION
## Summary

- `IInstance.py:193` called `self.IGlobal.reader(image_data)`. Neither `Reader` nor `ReaderBase` defines `__call__` — verified at runtime: `TypeError: 'Reader' object is not callable`. It raised on the first document. Now `reader.read(...)` under `readerLock`, matching the image path at line 167.
- `IInstance.py:200` emitted via `self.writeText`, which resolves to `IInstanceBase.writeText` (`filters.py:956-958`) — the *inbound* handler, body `pass`. The text was discarded with no error. Now `self.instance.writeText`, matching line 178.
- List results are joined to a string, matching the image path at lines 172-173.

The lock is deliberate: `readerLock` is created once on `IGlobal` (`IGlobal.py:372`) and guards the single shared `reader`, and `writeDocuments` is dispatched from the same `asyncio.to_thread(write_sync)` pool as `writeImage` (`data_conn.py:655`, `:718`, `:754`), so the two lanes can genuinely overlap. Without it this would be the only unguarded `reader.read` call site. `extract_tables_from_image` stays outside the lock, matching line 170.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

New `nodes/test/ocr/test_write_documents.py` — 8 tests. `IInstance.py` is loaded by file path under a synthetic parent package so its `from .IGlobal import IGlobal` resolves without the engine venv; `numpy`/`PIL` are stubbed so the file cannot silently skip on a tree where Pillow is not installed.

Verified against unmodified `develop`: **6 of the 8 fail**. The 2 that pass there do not depend on the fix — one asserts the stub reader is not callable, the other checks the non-image `ValueError`, which short-circuits before the defect.

`nodes/test/ocr`: 18 passed, 1 skipped (pre-existing, requires img2table < 2.0). Ruff clean.

`./builder test` is unticked for the same reason as #1796 and #1799: the only failure is the saas-overlay `saas:test`, which dies importing its own conftest on a missing `alembic` — not part of this repo's `./builder test`, and unrelated to this change.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (n/a)
- [ ] Breaking changes documented (n/a — this lane raised `TypeError` on first use, so nothing can depend on the previous behaviour)

## Notes

Touches `IInstance.py`, as does #1799, but in disjoint regions (lines 190-204 here vs 29/49/120-124 there), so they should auto-merge in either order.

## Linked Issue

Fixes #1800


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved OCR document processing by using the reader’s supported read operation.
  - Combined multi-part OCR results into a single text output.
  - Ensured text and document results are emitted through the appropriate output channels.
  - Added validation to reject unsupported non-image documents.

- **Tests**
  - Added coverage for OCR text extraction, document conversion, listener handling, and prevented results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->