### PR TITLE
fix(nodes): decode OCR images when the AVI buffer is a bytearray

### DIFF
--- a/nodes/src/nodes/ocr/ocr.py
+++ b/nodes/src/nodes/ocr/ocr.py
@@ -206,8 +206,11 @@ class Reader(ReaderBase):
         Returns:
             Image as PNG bytes
         """
-        if isinstance(image_data, bytes):
-            return image_data
+        # bytearray/memoryview are the accumulator types used by the AVI image lane;
+        # they are not instances of bytes, so match them explicitly rather than
+        # letting them fall through to the stringify fallback below.
+        if isinstance(image_data, (bytes, bytearray, memoryview)):
+            return bytes(image_data)
 
         if isinstance(image_data, np.ndarray):
             # Handle grayscale images


### PR DESCRIPTION
## Summary

- The OCR node failed on **every** image format with `UnidentifiedImageError: cannot identify image file <_io.BytesIO object at ...>`. The image lane accumulates AVI stream chunks into a `bytearray` (`nodes/src/nodes/ocr/IInstance.py:132`), but `Reader._to_bytes` matched only `bytes` — and `bytearray` is not a `bytes` subclass, so images fell through to the `str(image_data).encode('utf-8')` fallback and reached the OCR engine as a Python repr string (`"bytearray(b'\x89PNG...')"`).
- Fix: match `bytearray`/`memoryview` explicitly and normalise with `bytes()`, mirroring the existing convention in `ai.common.utils.image_utils.image_to_bytes`.
- Regression from #1525 (`36d0131d`), which changed the `BEGIN` branch from seeding the buffer with the incoming `bytes` chunk to starting an empty `bytearray`. **OCR was the only node affected** — the other 10 image nodes touched by that change either read via `Image.open(BytesIO(...))` (which accepts any buffer) or coerce with `bytes()` explicitly.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Verified end-to-end against a live pipeline (`dropper → parse → ocr → response_text`): instrumenting `writeImage` confirmed the node receives the complete, valid image (3424 bytes, intact PNG magic, IHDR 240x160), proving the whole upstream chain — Tika, JNI, the AVI binder, the descriptor payload — was already correct and the fault was local to `_to_bytes`.

Reproduced the failure and confirmed the fix in isolation:

```python
acc = bytearray(); acc += open('image.png','rb').read()
isinstance(acc, bytes)                       # False  <- the bug
Image.open(BytesIO(str(acc).encode()))       # UnidentifiedImageError
Image.open(BytesIO(bytes(acc)))              # PNG    <- after fix
```

`ruff check` and `ruff format --check` pass (also enforced by the pre-commit hook). `./builder test` was **not** run locally — leaving that to CI.

No regression test is included. `nodes/test/ocr/` currently covers only `ModelServerOCR`'s img2table shim and nothing in `ocr.py`. A minimal test that would have caught this:

```python
def test_to_bytes_accepts_bytearray_and_memoryview():
    r = Reader.__new__(Reader)  # skip engine-dependent __init__
    png = b'\x89PNG\r\n\x1a\n'
    assert r._to_bytes(png) == png
    assert r._to_bytes(bytearray(png)) == png          # regression guard
    assert r._to_bytes(memoryview(bytearray(png))) == png
```

Happy to add it here if reviewers prefer it in-scope.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a, no public contract change
- [x] Breaking changes documented (if applicable) — none

## Follow-ups (not in this PR)

- The `str(image_data).encode('utf-8')` fallback at the end of `_to_bytes` is what turned a type mismatch into a plausible-looking garbage buffer instead of an error, hiding the bug and surfacing it several layers downstream. Making it `raise TypeError` would have failed loudly on the first image.
- Two latent instances of the same pattern: `transport_tcpip.py:768` (a `bytearray` in the DAP `data` field hits `json.dumps` and raises), and `audio_transcribe/IGlobal.py:73-88` (`_audio_to_pcm_bytes` falls through to `return b''` on a `bytearray` — silent empty audio). Neither appears reachable today.
- `nodes/src/nodes/ocr/IInstance.py:193` calls `self.IGlobal.reader(image_data)` rather than `.read(...)`; `ReaderBase` defines no `__call__`, so that lane would raise `TypeError`. Pre-existing and unrelated.

## Linked Issue

No issue filed for this yet — flagging rather than inventing a number, since the template requires a real one. Happy to open one and link it.

Fixes #

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR image processing to accept `bytearray` and `memoryview` inputs.
  * Preserved support for existing byte and image formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->