### PR TITLE
fix(ai): resolve ${ROCKETRIDE_*} placeholders in node config

### DIFF
--- a/packages/ai/src/ai/common/config.py
+++ b/packages/ai/src/ai/common/config.py
@@ -4,6 +4,7 @@ import os
 import difflib
 from typing import Dict, Any
 from rocketlib import getServiceDefinition, IJson, warning
+from ai.common.env_resolve import resolve_env_placeholders
 
 
 # Fields the catalogue keeps about a profile, which a pipeline never sets. Kept out
@@ -307,14 +308,31 @@ class Config:
 
         config = merge(userConfig, defaultConfig)
 
-        # Output the computed configuration. Array/object values arrive from
-        # the engine as IJson, not list/dict (see #1839 defect 2), so a node
-        # that does isinstance(value, list) on its own declared field falls
-        # through to its default and silently ignores what was configured.
-        # IJson.toDict recursively normalizes to native list/dict and is a
-        # no-op on values that are already native, so this is safe to apply
-        # unconditionally rather than pushing the conversion onto every node.
-        return IJson.toDict(config)
+        # Normalize before resolving. Array/object values arrive from the
+        # engine as IJson, not list/dict (see #1839 defect 2), so a node that
+        # does isinstance(value, list) on its own declared field falls through
+        # to its default and silently ignores what was configured. IJson.toDict
+        # recursively normalizes to native list/dict and is a no-op on values
+        # that are already native, so this is safe to apply unconditionally
+        # rather than pushing the conversion onto every node.
+        config = IJson.toDict(config)
+
+        # Resolve any ${ROCKETRIDE_*} placeholders (e.g. an apikey field set
+        # via the env-var autocomplete) that reached this layer still
+        # unresolved, so callers never send a literal placeholder to a
+        # provider SDK. Backstop for callers (e.g. the engine's live
+        # validateConfig probe) that don't pre-resolve the pipeline.
+        #
+        # Must run AFTER IJson.toDict: resolve_env_placeholders round-trips
+        # through json.dumps, and a raw IJson value reaches it as an
+        # unserializable type ("Object of type IJson is not JSON
+        # serializable"). toDict yields plain dict/list/scalars, so the
+        # round-trip is safe here.
+        rocketrideEnv = {k: v for k, v in os.environ.items() if k.startswith('ROCKETRIDE_')}
+        config = resolve_env_placeholders(config, rocketrideEnv)
+
+        # Output the computed configuration
+        return config
 
     @staticmethod
     def getProviderConfig(providerConfig: Dict[str, any]):

--- a/packages/ai/src/ai/common/env_resolve.py
+++ b/packages/ai/src/ai/common/env_resolve.py
@@ -1,0 +1,67 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Shared ``${VAR}`` placeholder resolution for RocketRide configs.
+
+Kept dependency-free (stdlib only) so it can be imported from both the task
+orchestration layer (``ai.modules.task.pipeline``) and low-level node config
+loading (``ai.common.config``) without pulling in the web server stack.
+"""
+
+import json
+import re
+from typing import Any, Dict
+
+# Only environment variables with this prefix are permitted to resolve.
+# All other env vars are blocked to prevent exfiltration of secrets via ${VAR} expansion.
+ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
+
+
+def resolve_env_placeholders(value: Dict[str, Any], env: Dict[str, str]) -> Dict[str, Any]:
+    """Replace ``${KEY}`` placeholders in a dict with environment values.
+
+    Only variables whose names start with :data:`ALLOWED_ENV_PREFIX` are
+    resolved. All other references are replaced with ``<REDACTED>`` to
+    prevent secret exfiltration.
+
+    Args:
+        value: Dictionary that may contain ``${KEY}`` placeholders anywhere
+            in its (possibly nested) string values.
+        env: Environment dict to resolve placeholders against.
+
+    Returns:
+        New dictionary with resolved environment variables.
+    """
+    value_str = json.dumps(value)
+
+    def replacer(match: re.Match) -> str:
+        env_var = match.group(1)
+        if env_var.startswith(ALLOWED_ENV_PREFIX):
+            resolved = env.get(env_var, match.group(0))
+            if resolved == match.group(0):
+                return resolved  # placeholder not found — keep as-is
+            return json.dumps(resolved)[1:-1]  # escape but strip outer quotes
+        return '<REDACTED>'
+
+    resolved_str = re.sub(r'\$\{([^}]+)\}', replacer, value_str)
+    return json.loads(resolved_str)

--- a/packages/ai/src/ai/modules/task/pipeline.py
+++ b/packages/ai/src/ai/modules/task/pipeline.py
@@ -1,20 +1,19 @@
 """Pipeline utility functions for source resolution and variable substitution."""
 
-import json
-import re
 from typing import Dict, Any, Optional
 
-# Only environment variables with this prefix are permitted to resolve in pipelines.
-# All other env vars are blocked to prevent exfiltration of secrets via ${VAR} expansion.
-ALLOWED_ENV_PREFIX = 'ROCKETRIDE_'
+from ai.common.env_resolve import resolve_env_placeholders
+
+# Re-exported for backwards compatibility with callers that import it from here.
+from ai.common.env_resolve import ALLOWED_ENV_PREFIX  # noqa: F401
 
 
 def resolve_pipeline_env(pipeline: Dict[str, Any], env: Dict[str, str]) -> Dict[str, Any]:
     """Replace ``${KEY}`` placeholders in a pipeline dict with environment values.
 
-    Only variables whose names start with :data:`ALLOWED_ENV_PREFIX` are
-    resolved.  All other references are replaced with ``<REDACTED>`` to
-    prevent secret exfiltration.
+    Only variables whose names start with ``ROCKETRIDE_`` are resolved. All
+    other references are replaced with ``<REDACTED>`` to prevent secret
+    exfiltration. Delegates to :func:`ai.common.env_resolve.resolve_env_placeholders`.
 
     Args:
         pipeline: Pipeline configuration dictionary.
@@ -23,19 +22,7 @@ def resolve_pipeline_env(pipeline: Dict[str, Any], env: Dict[str, str]) -> Dict[
     Returns:
         New dictionary with resolved environment variables.
     """
-    pipeline_str = json.dumps(pipeline)
-
-    def replacer(match: re.Match) -> str:
-        env_var = match.group(1)
-        if env_var.startswith(ALLOWED_ENV_PREFIX):
-            value = env.get(env_var, match.group(0))
-            if value == match.group(0):
-                return value  # placeholder not found — keep as-is
-            return json.dumps(value)[1:-1]  # escape but strip outer quotes
-        return '<REDACTED>'
-
-    resolved_str = re.sub(r'\$\{([^}]+)\}', replacer, pipeline_str)
-    return json.loads(resolved_str)
+    return resolve_env_placeholders(pipeline, env)
 
 
 def resolve_implied_source(pipeline: Dict[str, Any]) -> Optional[str]:

--- a/packages/ai/tests/ai/common/test_config_env_resolve.py
+++ b/packages/ai/tests/ai/common/test_config_env_resolve.py
@@ -45,7 +45,16 @@ def _load_config():
     class _IJson:
         @staticmethod
         def toDict(x):
-            return dict(x) if isinstance(x, dict) else x
+            # Mirrors rocketlib.IJson.toDict: recursive, and a no-op on values
+            # that are already native. getNodeConfig runs this immediately
+            # before resolve_env_placeholders (which round-trips through
+            # json.dumps), so a shallow stub here would not exercise the same
+            # normalization the engine relies on.
+            if isinstance(x, dict):
+                return {k: _IJson.toDict(v) for k, v in x.items()}
+            if isinstance(x, list):
+                return [_IJson.toDict(v) for v in x]
+            return x
 
     rl.IJson = _IJson
     rl.warning = lambda *a, **k: None
@@ -76,8 +85,14 @@ class TestApiKeyPlaceholderResolution:
             assert cfg['apikey'] == 'sk-ant-real-key'
 
     def test_missing_placeholder_left_as_is(self):
-        cfg = Config.getNodeConfig('llm_anthropic', {'apikey': '${ROCKETRIDE_MISSING_KEY}'})
-        assert cfg['apikey'] == '${ROCKETRIDE_MISSING_KEY}'
+        # Clear the variable rather than merely not setting it: the assertion is
+        # that an *unset* var keeps its placeholder, so a runner that happens to
+        # export ROCKETRIDE_MISSING_KEY would otherwise turn this green test red
+        # (or, worse, mask a regression) depending on ambient environment.
+        with patch.dict(os.environ):
+            os.environ.pop('ROCKETRIDE_MISSING_KEY', None)
+            cfg = Config.getNodeConfig('llm_anthropic', {'apikey': '${ROCKETRIDE_MISSING_KEY}'})
+            assert cfg['apikey'] == '${ROCKETRIDE_MISSING_KEY}'
 
     def test_disallowed_var_redacted_not_leaked(self):
         with patch.dict(os.environ, {'AWS_SECRET_ACCESS_KEY': 'super-secret'}):

--- a/packages/ai/tests/ai/common/test_config_env_resolve.py
+++ b/packages/ai/tests/ai/common/test_config_env_resolve.py
@@ -1,0 +1,92 @@
+"""Unit tests for ${ROCKETRIDE_*} placeholder resolution in Config.getNodeConfig.
+
+Pins the fix for issue #1105: an apikey field set via the env-var autocomplete
+(e.g. "${ROCKETRIDE_ANTHROPIC_KEY}") must never reach a node's validateConfig()/
+beginGlobal() as a literal, unresolved string -- callers that skip pipeline-level
+resolution (e.g. the engine's live validateConfig probe) previously sent the raw
+placeholder to the provider SDK, producing a silent 401.
+
+Loaded by file path with rocketlib/json5 stubbed so no engine runtime is needed --
+mirrors the approach in test_config_shapes.py.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+_CONFIG_PATH = Path(__file__).resolve().parents[3] / 'src' / 'ai' / 'common' / 'config.py'
+
+_SERVICE = {
+    'preconfig': {
+        'default': 'default',
+        'profiles': {
+            'default': {'apikey': '', 'model': 'claude'},
+        },
+    }
+}
+
+
+def _load_config():
+    """Load config.py with rocketlib/json5 stubbed; patch getServiceDefinition."""
+    saved = {k: sys.modules.get(k) for k in ('rocketlib', 'json5')}
+
+    rl = types.ModuleType('rocketlib')
+
+    class _IJson:
+        @staticmethod
+        def toDict(x):
+            return dict(x) if isinstance(x, dict) else x
+
+    rl.IJson = _IJson
+    rl.warning = lambda *a, **k: None
+    rl.getServiceDefinition = lambda logical_type: _SERVICE
+    sys.modules['rocketlib'] = rl
+    sys.modules['json5'] = types.ModuleType('json5')
+
+    try:
+        spec = importlib.util.spec_from_file_location('rr_real_config_env_resolve', _CONFIG_PATH)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod.Config
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+Config = _load_config()
+
+
+class TestApiKeyPlaceholderResolution:
+    def test_allowed_placeholder_resolves(self):
+        with patch.dict(os.environ, {'ROCKETRIDE_ANTHROPIC_KEY': 'sk-ant-real-key'}):
+            cfg = Config.getNodeConfig('llm_anthropic', {'apikey': '${ROCKETRIDE_ANTHROPIC_KEY}'})
+            assert cfg['apikey'] == 'sk-ant-real-key'
+
+    def test_missing_placeholder_left_as_is(self):
+        cfg = Config.getNodeConfig('llm_anthropic', {'apikey': '${ROCKETRIDE_MISSING_KEY}'})
+        assert cfg['apikey'] == '${ROCKETRIDE_MISSING_KEY}'
+
+    def test_disallowed_var_redacted_not_leaked(self):
+        with patch.dict(os.environ, {'AWS_SECRET_ACCESS_KEY': 'super-secret'}):
+            cfg = Config.getNodeConfig('llm_anthropic', {'apikey': '${AWS_SECRET_ACCESS_KEY}'})
+            assert cfg['apikey'] == '<REDACTED>'
+
+    def test_plain_apikey_unchanged(self):
+        cfg = Config.getNodeConfig('llm_anthropic', {'apikey': 'sk-ant-literal'})
+        assert cfg['apikey'] == 'sk-ant-literal'
+
+    def test_nested_profile_shape_resolves(self):
+        with patch.dict(os.environ, {'ROCKETRIDE_ANTHROPIC_KEY': 'sk-ant-real-key'}):
+            cfg = Config.getNodeConfig(
+                'llm_anthropic',
+                {'profile': 'default', 'default': {'apikey': '${ROCKETRIDE_ANTHROPIC_KEY}'}},
+            )
+            assert cfg['apikey'] == 'sk-ant-real-key'

--- a/packages/ai/tests/ai/common/test_config_env_resolve.py
+++ b/packages/ai/tests/ai/common/test_config_env_resolve.py
@@ -13,11 +13,16 @@ mirrors the approach in test_config_shapes.py.
 from __future__ import annotations
 
 import importlib.util
+import json
 import os
 import sys
+import threading
 import types
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 _CONFIG_PATH = Path(__file__).resolve().parents[3] / 'src' / 'ai' / 'common' / 'config.py'
 
@@ -90,3 +95,75 @@ class TestApiKeyPlaceholderResolution:
                 {'profile': 'default', 'default': {'apikey': '${ROCKETRIDE_ANTHROPIC_KEY}'}},
             )
             assert cfg['apikey'] == 'sk-ant-real-key'
+
+
+# ==============================================================================
+# End-to-end repro: the resolved key must reach the *actual outgoing HTTP
+# request*, not just the in-memory config dict. This drives the real
+# `anthropic` SDK the same way nodes/src/nodes/llm_anthropic/IGlobal.py's
+# validateConfig() does (Anthropic(api_key=apikey).messages.create(...)),
+# pointed at a local mock server instead of the real API, and inspects the
+# captured x-api-key header. No network access or real API key required.
+# ==============================================================================
+
+
+class _CaptureHandler(BaseHTTPRequestHandler):
+    # self.headers (email.message.Message) is case-insensitive on .get();
+    # store the lookup result directly rather than a plain dict(), which
+    # would preserve the wire casing ("X-Api-Key") and break a lowercase lookup.
+    captured_api_key: str | None = None
+
+    def do_POST(self):  # noqa: N802 (BaseHTTPRequestHandler API)
+        _CaptureHandler.captured_api_key = self.headers.get('x-api-key')
+        body = json.dumps(
+            {
+                'id': 'msg_test',
+                'type': 'message',
+                'role': 'assistant',
+                'content': [{'type': 'text', 'text': 'hi'}],
+                'model': 'claude-3-haiku-20240307',
+                'stop_reason': 'end_turn',
+                'stop_sequence': None,
+                'usage': {'input_tokens': 1, 'output_tokens': 1},
+            }
+        ).encode()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.send_header('Content-Length', str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):  # noqa: A002 (silence request logging)
+        pass
+
+
+@pytest.fixture
+def mock_anthropic_server():
+    server = HTTPServer(('127.0.0.1', 0), _CaptureHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join()
+
+
+class TestResolvedApiKeyReachesOutgoingRequest:
+    def test_placeholder_never_sent_as_x_api_key(self, mock_anthropic_server):
+        from anthropic import Anthropic
+
+        with patch.dict(os.environ, {'ROCKETRIDE_ANTHROPIC_KEY': 'sk-ant-test-repro-secret'}):
+            # Same lookup every LLM node performs in validateConfig()/beginGlobal().
+            cfg = Config.getNodeConfig('llm_anthropic', {'apikey': '${ROCKETRIDE_ANTHROPIC_KEY}'})
+            apikey = cfg['apikey']
+
+            port = mock_anthropic_server.server_address[1]
+            client = Anthropic(api_key=apikey, base_url=f'http://127.0.0.1:{port}')
+            client.messages.create(
+                model='claude-3-haiku-20240307', max_tokens=1, messages=[{'role': 'user', 'content': 'Hi'}]
+            )
+
+        sent_key = _CaptureHandler.captured_api_key
+        assert sent_key == 'sk-ant-test-repro-secret'
+        assert sent_key != '${ROCKETRIDE_ANTHROPIC_KEY}'

--- a/packages/ai/tests/requirements.txt
+++ b/packages/ai/tests/requirements.txt
@@ -16,7 +16,10 @@ time_machine
 # (collection time), before any depends() runs, so they must be pre-installed
 # here. Unpinned to track the source packages' own (unpinned) declarations.
 #   pillow -> from PIL import Image (tests/ai/common/image, .../models/vision)
+#   anthropic -> from anthropic import Anthropic (tests/ai/common/test_config_env_resolve.py);
+#                declared by nodes/src/nodes/llm_anthropic, which ai tests never import
 pillow
+anthropic
 
 # AI module dependencies — each sub-package declares its own deps and
 # installs them via depends() at import time. Listing them here pre-installs


### PR DESCRIPTION
## Summary

- `Config.getNodeConfig()` fed every LLM node's `apikey` field (and every other config
  field) straight to the provider SDK without resolving `${ROCKETRIDE_*}` placeholders. A
  key entered via the env-var autocomplete (as the docs recommend) was sent literally,
  producing a silent `401 invalid x-api-key` on the live `validateConfig` probe and any
  other caller that reaches this layer without pre-resolving the pipeline first.
- `resolve_pipeline_env()` was the only existing resolver, but it is invoked from just two
  call sites in the `packages/ai` orchestration layer (`modules/task/commands/cmd_misc.py`,
  `modules/task/task_engine.py`) — never from the engine's live single-component validate
  path or its `ConfigureService` pre-flight check, both of which call
  `Config.getNodeConfig()` directly.
- Fix: resolve `${ROCKETRIDE_*}` placeholders against `os.environ` directly inside
  `Config.getNodeConfig()` as a backstop, so it applies regardless of which upstream caller
  reaches this function. The substitution logic was extracted from `resolve_pipeline_env`
  into a new dependency-free `ai.common.env_resolve` module (importing
  `ai.modules.task.pipeline` from `ai.common.config` transitively pulled in the web server
  stack via `ai.modules.task/__init__.py`, breaking an unrelated existing test).
  `ALLOWED_ENV_PREFIX` is still re-exported from `ai.modules.task.pipeline`, so the
  `ROCKETRIDE_`-only allowlist and the `<REDACTED>` exfiltration guard are unchanged and
  existing importers keep working.

Re-opened here against `rocketride-org/rocketride-server:develop` — the original PR was
mistakenly filed against my own fork's `develop`. Rebased onto current `develop`
(`11389361`) with no conflicts; both files it touches are unchanged upstream since the
original branch point.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes — ran the affected Python suites rather than the full
      monorepo build (see below); nothing outside `packages/ai` is touched.

New unit tests in `packages/ai/tests/ai/common/test_config_env_resolve.py` cover:
placeholder resolves, missing var kept as placeholder, disallowed var redacted (not
leaked), plain literal key unchanged, nested-profile config shape resolves.

The same file adds a real-SDK repro: it drives the actual `anthropic` package the way
`IGlobal.validateConfig()` does (`Anthropic(api_key=apikey).messages.create(...)`), pointed
at a local mock HTTP server, and asserts the env-resolved value — not the literal
`${ROCKETRIDE_ANTHROPIC_KEY}` string — is what lands in the outgoing `x-api-key` header. No
live API key or network access needed; it closes the loop between config resolution and the
actual request that produced the reported 401.

`anthropic` is declared in `packages/ai/tests/requirements.txt` because it is otherwise
only declared by `nodes/src/nodes/llm_anthropic` and installed lazily via `depends()` on
first import of that node — `ai:run-pytest` installs the ai test requirements and nothing
else, so without this the repro would `ImportError` at collection in a clean environment.
It sits alongside `pillow`, listed there for the same reason.

Local runs (Windows, engine interpreter):

- `packages/ai/tests/ai/common/test_config_env_resolve.py` — 6 passed
- `packages/ai/tests/ai/common` + `packages/ai/tests/ai/modules/task` — **1274 passed,
  2 skipped** (both pre-existing Windows-only skips in `test_temp_file_security.py`). This
  includes `test_env_var_exfil.py`, the regression guard for the logic moved into
  `env_resolve.py`.
- `ruff check` / `ruff format --check` clean on all touched and added files.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a, no public contract change: `getNodeConfig()` is
      internal and the `${ROCKETRIDE_*}` behaviour it now honours is already the documented
      contract.
- [x] Breaking changes documented (if applicable) — none.

## Linked Issue

Fixes #1105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving approved environment-variable placeholders in nested AI configuration.
  * Resolved values are safely escaped before being used in outgoing API requests.
  * Unrecognized or disallowed placeholders are protected from accidental exposure.

* **Bug Fixes**
  * Ensured configured API keys are correctly applied to provider requests.

* **Tests**
  * Added coverage for nested configurations, missing and restricted variables, and provider request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->