### PR TITLE
docs(agents): PIPELINE_RULES Rule 1 overstates the source constraint

### DIFF
--- a/docs/agents/ROCKETRIDE_PIPELINE_RULES.md
+++ b/docs/agents/ROCKETRIDE_PIPELINE_RULES.md
@@ -47,7 +47,7 @@ Complete reference for building RocketRide pipelines across any project.
 }
 ```
 
-**Field ordering matters:** `components` must come first. The `project_id`, `viewport`, and `version` fields go at the bottom. The `source` field is optional: the VS Code extension manages it automatically.
+**Field ordering matters:** `components` must come first. The `project_id`, `viewport`, and `version` fields go at the bottom. The `source` field is optional **only when the pipeline has exactly one source-kind component**, in which case it is inferred; the VS Code extension sets it for you. With more than one, it must be set explicitly — see Rule 1.
 
 ---
 
@@ -111,7 +111,8 @@ Complete reference for building RocketRide pipelines across any project.
 
 - ID of the entry point component where data enters the pipeline
 - Managed automatically by the VS Code extension
-- When writing pipelines by hand, you can omit this field, the extension will add it
+- When writing pipelines by hand you can omit it **only if exactly one component is source-kind** — it is then inferred, and the extension will add it
+- With more than one source-kind component, inference raises `Pipeline has multiple source components, please specify one explicitly`, so the field is required
 
 ---
 
@@ -369,9 +370,10 @@ ROCKETRIDE_COLLECTION_NAME=documents
 
 ### Rule 1: Source Components
 
-- Every pipeline must declare exactly one `source` **field**, naming the component where execution starts
+- Every pipeline has exactly one **entry point** — the component where execution starts — named by the `source` field
+- A pipeline may contain more than one source-**kind** component (an ingest branch and a query branch, say). Only the entry point is started; run another by passing `source=` explicitly
+- The `source` field is optional **only when exactly one component is source-kind**, in which case it is inferred. With more than one, `resolve_implied_source` raises `Pipeline has multiple source components, please specify one explicitly` — so `source` must be set
 - The `source` field must reference that component's `id`
-- A pipeline may contain more than one source-kind component (an ingest branch and a query branch, say), but only the one named by `source` is started by `client.use()`. Start the others by passing `source=` explicitly
 - Source components typically don't have an `input` array
 - Examples: webhook, chat, dropper
 
@@ -387,6 +389,7 @@ Example:
 
 ```json
 {
+	"source": "webhook_1",
 	"components": [
 		{ "id": "webhook_1", "provider": "webhook", "config": { "hideForm": true, "mode": "Source", "parameters": {}, "type": "webhook" } },
 		{ "id": "parse_1", "provider": "parse", "config": {}, "input": [{ "lane": "tags", "from": "webhook_1" }] },
@@ -746,6 +749,7 @@ Before deploying a pipeline:
 
 ```json
 {
+	"source": "webhook_1",
 	"components": [
 		{
 			"id": "webhook_1",
@@ -769,6 +773,7 @@ Before deploying a pipeline:
 
 ```json
 {
+	"source": "chat_1",
 	"components": [
 		{ "id": "chat_1", "provider": "chat", "config": { "hideForm": true, "mode": "Source", "parameters": {}, "type": "chat" } },
 		{ "id": "embedding_1", "provider": "embedding_transformer", "config": { "profile": "miniLM", "parameters": {} }, "input": [{ "lane": "questions", "from": "chat_1" }] },

--- a/docs/agents/ROCKETRIDE_PIPELINE_RULES.md
+++ b/docs/agents/ROCKETRIDE_PIPELINE_RULES.md
@@ -369,8 +369,9 @@ ROCKETRIDE_COLLECTION_NAME=documents
 
 ### Rule 1: Source Components
 
-- Every pipeline must have exactly one source component
-- The `source` field must reference this component's `id`
+- Every pipeline must declare exactly one `source` **field**, naming the component where execution starts
+- The `source` field must reference that component's `id`
+- A pipeline may contain more than one source-kind component (an ingest branch and a query branch, say), but only the one named by `source` is started by `client.use()`. Start the others by passing `source=` explicitly
 - Source components typically don't have an `input` array
 - Examples: webhook, chat, dropper
 

--- a/docs/agents/ROCKETRIDE_PIPELINE_RULES.md
+++ b/docs/agents/ROCKETRIDE_PIPELINE_RULES.md
@@ -389,12 +389,12 @@ Example:
 
 ```json
 {
-	"source": "webhook_1",
 	"components": [
 		{ "id": "webhook_1", "provider": "webhook", "config": { "hideForm": true, "mode": "Source", "parameters": {}, "type": "webhook" } },
 		{ "id": "parse_1", "provider": "parse", "config": {}, "input": [{ "lane": "tags", "from": "webhook_1" }] },
 		{ "id": "response_1", "provider": "response_text", "config": { "laneName": "text" }, "input": [{ "lane": "text", "from": "parse_1" }] }
 	],
+	"source": "webhook_1",
 	"project_id": "85be2a13-ad93-49ed-a1e1-4b0f763ca618",
 	"viewport": { "x": 0, "y": 0, "zoom": 1 },
 	"version": 1
@@ -749,7 +749,6 @@ Before deploying a pipeline:
 
 ```json
 {
-	"source": "webhook_1",
 	"components": [
 		{
 			"id": "webhook_1",
@@ -763,6 +762,7 @@ Before deploying a pipeline:
 			"input": [{ "lane": "text", "from": "webhook_1" }]
 		}
 	],
+	"source": "webhook_1",
 	"project_id": "85be2a13-ad93-49ed-a1e1-4b0f763ca618",
 	"viewport": { "x": 0, "y": 0, "zoom": 1 },
 	"version": 1
@@ -773,7 +773,6 @@ Before deploying a pipeline:
 
 ```json
 {
-	"source": "chat_1",
 	"components": [
 		{ "id": "chat_1", "provider": "chat", "config": { "hideForm": true, "mode": "Source", "parameters": {}, "type": "chat" } },
 		{ "id": "embedding_1", "provider": "embedding_transformer", "config": { "profile": "miniLM", "parameters": {} }, "input": [{ "lane": "questions", "from": "chat_1" }] },
@@ -781,6 +780,7 @@ Before deploying a pipeline:
 		{ "id": "llm_1", "provider": "llm_openai", "config": { "profile": "openai-5-2", "openai-5-2": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }, "parameters": {} }, "input": [{ "lane": "questions", "from": "qdrant_1" }] },
 		{ "id": "response_1", "provider": "response_answers", "config": { "laneName": "answers" }, "input": [{ "lane": "answers", "from": "llm_1" }] }
 	],
+	"source": "chat_1",
 	"project_id": "85be2a13-ad93-49ed-a1e1-4b0f763ca618",
 	"viewport": { "x": 0, "y": 0, "zoom": 1 },
 	"version": 1

--- a/examples/rag-pipeline.pipe
+++ b/examples/rag-pipeline.pipe
@@ -1,5 +1,4 @@
 {
-	"source": "chat_1",
 	"components": [
 		{
 			"id": "webhook_1",
@@ -111,6 +110,7 @@
 			"ui": { "position": { "x": 1120, "y": 500 }, "measured": { "width": 150, "height": 66 }, "nodeType": "default", "formDataValid": true }
 		}
 	],
+	"source": "chat_1",
 	"project_id": "1327e7c0-8479-4ab7-a319-c4dc944daeb5",
 	"viewport": { "x": 0, "y": 0, "zoom": 1 },
 	"version": 1

--- a/examples/rag-pipeline.pipe
+++ b/examples/rag-pipeline.pipe
@@ -1,4 +1,5 @@
 {
+	"source": "chat_1",
 	"components": [
 		{
 			"id": "webhook_1",


### PR DESCRIPTION
## Summary

- Rewrites `PIPELINE_RULES.md` Rule 1, which stated "every pipeline must have exactly one source component" — conflating one `source` **field** with one source-**kind** component. The engine only enforces the former.
- Adds the missing `"source": "chat_1"` to `examples/rag-pipeline.pipe`, which declared two source-mode components and no `source` field, leaving the implied-source fallback with two candidates and no tiebreak.

## Type

docs (plus a one-line data fix to an example)

The claim is checked against the engine rather than asserted. `PipelineConfig::validate()` in `packages/server/engine-lib/engLib/store/pipeline/pipeline_config.cpp` documents its own rule list in the header comment; the only source-related entries are:

```
 *   3. "pipeline.source" must be a string.
 *  11. The value of "pipeline.source" must reference a valid component id.
```

implemented at `:155-169`. Nothing counts `"mode": "Source"` components, and `grep -rin "exactly one source\|multiple sources\|source count" packages/server` returns no matches.

Three things in-tree already depend on multiple source components being legal:

| | Evidence |
|---|---|
| Engine fixtures | `packages/server/test/pipelines/chat-ingest.json` and `chat-ui.json` each declare **two** `"mode": "Source"` components; `chat-ingest.json` sets `"source": "webhook_1"` while declaring both |
| Example corpus | `examples/incorrect/README.md` defines its failure modes relative to "a second start" (`:9`, `:21`, `:22`), and `:28` states that `tool_pipe` invoked from **two starts** "is valid, so it is not here" |
| VS Code UI | `apps/vscode/src/providers/SidebarProvider.ts:44` types the field as an array, `sources?: { id: string; name: string; provider?: string }[]`, built at `:473` from `pf.sourceComponents` |

This is worth correcting rather than leaving as a loose phrasing because `docs/agents/` is the **agent-facing** documentation — an assistant reading Rule 1 will refuse to generate, or will "fix", a valid two-source pipeline.

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

No tests: the change is documentation plus one key in an example `.pipe`. Verified instead that the example is still valid and now self-consistent:

```
python3 -c "import json; d=json.load(open('examples/rag-pipeline.pipe')); \
  print(d['source'], d['source'] in [c['id'] for c in d['components']])"
# -> chat_1 True
```

`./builder test` was not run — the diff touches only `docs/agents/**` and `examples/**`, neither of which is in CI's `changes` path filter, so the build job is skipped for this PR by design.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1812


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pipelines can now include multiple source components.
  - The configured top-level source starts automatically, while other source components can be selected explicitly.
  - Pipelines with a single source component can infer the source automatically.
  - Updated the RAG pipeline example with an explicit source configuration.

- **Documentation**
  - Clarified source-component selection and pipeline startup rules.
  - Added source configuration examples for linear, minimal, and RAG pipelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->