### PR TITLE
fix(client-python): import NotRequired from typing_extensions so Python 3.10 works

### DIFF
--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "websockets>=11.0.0",
     "aiofiles>=23.0.0",
     "pydantic>=2.0.0",
+    "typing_extensions>=4.0.0",
 ]
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/client-python/src/rocketride/types/billing.py
+++ b/packages/client-python/src/rocketride/types/billing.py
@@ -36,7 +36,9 @@ Types Defined:
     PromoRedemption: Result of redeeming a credit-grant code.
 """
 
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, TypedDict
+
+from typing_extensions import NotRequired
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Imports `NotRequired` from `typing_extensions` instead of `typing`, so `import rocketride` works on Python 3.10 — the floor the package declares.
- Declares `typing_extensions` explicitly in `dependencies`; it was only present transitively via `pydantic`.

## Type

fix

`pyproject.toml:45` declares `requires-python = ">=3.10"` and ships the `Programming Language :: Python :: 3.10` classifier (`:23`), but `types/billing.py:39` imported `typing.NotRequired`, which is **3.11+** (PEP 655). The import is unconditional and `types/__init__.py:190` pulls `billing` in unconditionally, so this was total failure to import, not a partial degradation. It is live on PyPI 1.3.0 — `pip install` succeeds, `import rocketride` raises.

The 3.10 floor looks deliberate rather than accidental, which is why this is a compatibility shim and not a floor bump: #434 → PR #491 moved it from `>=3.8` to `>=3.10` on purpose, the root `pyproject.toml` sets ruff `target-version = "py310"`, and `scripts/compiler-unix.sh` hard-fails below 3.10 while advertising *"Ubuntu 22.04 or newer (has Python 3.10+)"* as supported.

`billing.py` is the only offender — it holds all 17 `NotRequired` uses, and a sweep of `packages/client-python/src/` for `Required`, `Self`, `LiteralString`, `TypeVarTuple`, `Unpack`, `assert_never` and `override` found no other 3.11+ construct.

**On declaring the dependency rather than leaning on it:** `typing_extensions` resolves today only because `pydantic>=2.0.0` requires it (`pip show pydantic` → `Requires: annotated-types, pydantic-core, typing-extensions`). That is not something this package declares or controls, so it is now explicit.

**No behaviour change on modern Pythons.** `typing_extensions` re-exports the stdlib object, verified on 3.13.5:

```python
>>> from typing_extensions import NotRequired
>>> import typing; NotRequired is typing.NotRequired
True
```

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Verified in both directions against a real CPython **3.10.6**, using the actual shipped source:

```
# before — origin/develop
git archive origin/develop packages/client-python/src | tar -x -C /tmp/rr
python3.10 -c "import sys; sys.path.insert(0,'/tmp/rr/.../src'); import rocketride"
ImportError: cannot import name 'NotRequired' from 'typing'

# after — this branch
python3.10 -c "import sys; sys.path.insert(0,'<worktree>/.../src'); import rocketride"
import rocketride OK on 3.10.6

# and NotRequired actually resolves through the shim
>>> billing.NotRequired.__module__
'typing_extensions'
```

Plus a `TypedDict` using `NotRequired` constructed successfully on both 3.10.6 and 3.13.5.

No tests added: the failure is an import-time version incompatibility, and asserting it properly needs an interpreter matrix rather than a unit test. Which leads to —

**Why CI did not catch this, and a suggestion.** The only `python-version:` pins across the workflows are `'3.12'`; there is no version matrix. The client-python tests run under the engine's *embedded* interpreter (`packages/client-python/scripts/tasks.js` → `scripts/lib/pytest.js` → `dist/server/engine -m pytest`), never the runner's Python. The only PR-level Python gate is `ruff check`, whose selected rules (`E,F,Q,D`) cannot flag a version-incompatible stdlib import. A single `python3.10 -c "import rocketride"` step would make the declared floor a tested claim rather than a documented one — happy to open that separately if you want it.

`./builder test` was not run — it needs a built engine and a running task server, which I don't have provisioned here.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

Overlap check: #1736, #1612 and #1581 also touch `packages/client-python/pyproject.toml`, but all three edit line 61 onward (`optional-dependencies`, `urls`, `package-data`). This PR edits `dependencies` at `:41-44` — no shared hunks.

## Linked Issue

Fixes #1820


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for Python environments by updating typing support.
  * Resolved compatibility issues affecting billing type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->