### PR TITLE
fix(ai): name the cause when a reasoning model is cut off mid-<think>

### DIFF
--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -17,7 +17,7 @@ from typing import Dict, Any, Callable, Optional
 from rocketlib import debug, warning
 from ai.common.schema import Answer, Question
 from ai.common.config import Config
-from ai.common.util import parseJson
+from ai.common.util import ThinkTruncatedError, parseJson
 from ai.common.validation import (
     validate_model_name,
     validate_max_tokens,
@@ -601,7 +601,19 @@ class ChatBase:
                     answer.setAnswer(parsed_response)
                     return answer
 
-                except (json.JSONDecodeError, ValueError):
+                # Listed before the generic arm below, which would otherwise swallow it —
+                # ThinkTruncatedError IS a ValueError.
+                except ThinkTruncatedError as e:
+                    # Not a formatting mistake: the model never reached the JSON because it
+                    # ran out of output budget mid-reasoning. The repair prompt tells it to
+                    # "examine your JSON", which is the wrong instruction, and a resample
+                    # rarely fits a budget that has already overflowed. So surface the cause
+                    # now instead of buying two more model calls to arrive at a message that
+                    # no longer names it.
+                    debug(f'Error: {e}')
+                    raise
+
+                except (json.JSONDecodeError, ValueError) as e:
                     # JSON parsing failed
                     if retry_count < max_retries - 1:
                         debug(f'JSON validation failed on attempt {retry_count + 1}, retrying...')
@@ -610,10 +622,15 @@ class ChatBase:
                         # This will again use chat_string with full network retry logic
                         response = self.chat_string(question.getPrompt(has_previous_json_failed=True))
                     else:
-                        # Max retries reached, raise ValueError
-                        error_msg = f'Failed to get valid JSON response after {max_retries + 1} attempts. Last response: {response[:200]}...'
+                        # Max retries reached, raise ValueError. Carry the last parse error:
+                        # without it the caller sees only a truncated response and has to
+                        # guess what was wrong with it.
+                        error_msg = (
+                            f'Failed to get valid JSON response after {max_retries + 1} attempts. '
+                            f'Cause: {e}. Last response: {response[:200]}...'
+                        )
                         debug(f'Error: {error_msg}')
-                        raise ValueError(error_msg)
+                        raise ValueError(error_msg) from e
 
         else:
             # Create the answer and assign the text

--- a/packages/ai/src/ai/common/util.py
+++ b/packages/ai/src/ai/common/util.py
@@ -46,6 +46,17 @@ def parseJson(value: str) -> Any:
         # so fence detection below is not confused by content inside the think block.
         value = re.sub(r'<think>.*?</think>', '', value, flags=re.DOTALL).strip()
 
+        # An UNCLOSED block means the model ran out of output budget while still
+        # reasoning, so it never reached the JSON at all. The regex above cannot match
+        # it, and the generic "Expecting value: line 1 column 1" that follows sends you
+        # looking at the schema instead of at modelOutputTokens. Checked after the
+        # substitution so a complete block followed by a truncated one is caught too.
+        if value.startswith('<think>') and '</think>' not in value:
+            raise ValueError(
+                'model was cut off inside a <think> block and never emitted JSON; '
+                'raise modelOutputTokens, or disable reasoning for this call'
+            )
+
         # If the LLM wrapped the response in a ```json fence, strip the opening marker.
         # We only check the beginning of the string so we don't accidentally strip ``` sequences
         # that appear inside JSON string values (e.g. a chartjs fenced code block in an "answer" field).

--- a/packages/ai/src/ai/common/util.py
+++ b/packages/ai/src/ai/common/util.py
@@ -49,21 +49,38 @@ class ThinkTruncatedError(ValueError):
 
 
 def _holdsCompleteJson(value: str) -> bool:
-    """True when a complete JSON value can be decoded somewhere in ``value``.
+    """True when ``value`` ENDS in a complete JSON object or array.
 
     Used to tell a model that never reached its JSON apart from one that emitted it and
-    merely dropped a closing tag. Testing for a bare '{' or '[' is not enough: reasoning
-    about a JSON answer routinely writes one ("the schema is {title, body}"), so the
-    character alone would call almost every real truncation a success.
+    merely dropped a closing tag. Two things this deliberately is not:
+
+    A bare '{' or '[' test is too loose -- reasoning about a JSON answer routinely writes
+    one ("the schema is {title, body}"), so the character alone would call almost every
+    real truncation a success.
+
+    Decoding *anywhere* is also too loose. A model drafting its answer mid-reasoning
+    ('I will return {"title": "X"} and then add the') leaves a fragment that decodes
+    perfectly but is still followed by prose, and it is still a truncation. So the
+    decoded value must run to the end, give or take whitespace and a closing fence.
+
+    Only objects and arrays count as starts. ``parseJson`` accepts a bare scalar, but no
+    model answers an expectJson prompt with one, whereas reasoning that happens to break
+    off on a number or on the word "true" is an ordinary truncation -- honouring scalars
+    would trade a real case for an imaginary one.
     """
+    tail = value.strip()
+    if tail.endswith('```'):
+        tail = tail[:-3].rstrip()
+
     decoder = json.JSONDecoder()
-    for i, ch in enumerate(value):
+    for i, ch in enumerate(tail):
         if ch in '{[':
             try:
-                decoder.raw_decode(value, i)
+                _, end = decoder.raw_decode(tail, i)
             except ValueError:
                 continue
-            return True
+            if not tail[end:].strip():
+                return True
     return False
 
 

--- a/packages/ai/src/ai/common/util.py
+++ b/packages/ai/src/ai/common/util.py
@@ -66,12 +66,21 @@ def parseJson(value: str) -> Any:
         # looking at the schema instead of at modelOutputTokens. Checked after the
         # substitution so a complete block followed by a truncated one is caught too.
         #
-        # Both clauses carry weight. re.sub is a single left-to-right pass, so deleting an
-        # inner pair can splice a fresh one into the remainder that the pass has already
-        # moved past: '<thi<think>x</think>nk>a</think>{...}' leaves '<think>a</think>{...}',
-        # which opens with <think> but is not a truncation. The closing-tag test is what
-        # keeps that from being reported as a budget problem.
-        if value.startswith('<think>') and '</think>' not in value:
+        # All three clauses carry weight.
+        #
+        # re.sub is a single left-to-right pass, so deleting an inner pair can splice a
+        # fresh one into the remainder that the pass has already moved past:
+        # '<thi<think>x</think>nk>a</think>{...}' leaves '<think>a</think>{...}', which
+        # opens with <think> but is not a truncation. The closing-tag test excludes that.
+        #
+        # A missing </think> is not by itself proof of a budget overflow -- a model can
+        # emit its JSON and simply drop the closing tag, e.g. when the tag is consumed as
+        # a stop sequence. '<think>reasoning\n{"a": 1}' is that shape. Blaming
+        # modelOutputTokens there sends the operator to a setting that will not help, so
+        # require the remainder to hold no object or array opener before claiming the
+        # model never reached the JSON. When one is present this falls through to the
+        # ordinary parse error, which is what such input got before this check existed.
+        if value.startswith('<think>') and '</think>' not in value and '{' not in value and '[' not in value:
             raise ThinkTruncatedError(
                 'model was cut off inside a <think> block and never emitted JSON; '
                 'raise modelOutputTokens, or disable reasoning for this call'

--- a/packages/ai/src/ai/common/util.py
+++ b/packages/ai/src/ai/common/util.py
@@ -48,6 +48,25 @@ class ThinkTruncatedError(ValueError):
     """
 
 
+def _holdsCompleteJson(value: str) -> bool:
+    """True when a complete JSON value can be decoded somewhere in ``value``.
+
+    Used to tell a model that never reached its JSON apart from one that emitted it and
+    merely dropped a closing tag. Testing for a bare '{' or '[' is not enough: reasoning
+    about a JSON answer routinely writes one ("the schema is {title, body}"), so the
+    character alone would call almost every real truncation a success.
+    """
+    decoder = json.JSONDecoder()
+    for i, ch in enumerate(value):
+        if ch in '{[':
+            try:
+                decoder.raw_decode(value, i)
+            except ValueError:
+                continue
+            return True
+    return False
+
+
 def parseJson(value: str) -> Any:
     """
     Parse a string and return a json value.
@@ -75,12 +94,12 @@ def parseJson(value: str) -> Any:
         #
         # A missing </think> is not by itself proof of a budget overflow -- a model can
         # emit its JSON and simply drop the closing tag, e.g. when the tag is consumed as
-        # a stop sequence. '<think>reasoning\n{"a": 1}' is that shape. Blaming
-        # modelOutputTokens there sends the operator to a setting that will not help, so
-        # require the remainder to hold no object or array opener before claiming the
-        # model never reached the JSON. When one is present this falls through to the
-        # ordinary parse error, which is what such input got before this check existed.
-        if value.startswith('<think>') and '</think>' not in value and '{' not in value and '[' not in value:
+        # a stop sequence. '<think>reasoning\n{"a": 1}' is that shape, and blaming
+        # modelOutputTokens there sends the operator to a setting that will not help.
+        # So ask whether a JSON value can actually be DECODED, not merely whether a brace
+        # appears -- reasoning that mentions '{title, body}' or 'compare [A, B]' is a
+        # truncation like any other, and a character test would wave it through.
+        if value.startswith('<think>') and '</think>' not in value and not _holdsCompleteJson(value):
             raise ThinkTruncatedError(
                 'model was cut off inside a <think> block and never emitted JSON; '
                 'raise modelOutputTokens, or disable reasoning for this call'

--- a/packages/ai/src/ai/common/util.py
+++ b/packages/ai/src/ai/common/util.py
@@ -34,6 +34,20 @@ def safeString(value: str) -> str:
     return str(value).strip().replace('"', "'")
 
 
+class ThinkTruncatedError(ValueError):
+    """Raised by ``parseJson`` when all that arrived is an unterminated ``<think>`` block.
+
+    The model exhausted its output budget while still reasoning and never reached the
+    JSON, so re-prompting it for "valid JSON" cannot help -- the fix is
+    ``modelOutputTokens``, or turning reasoning off for the call. ``ChatBase.chat``
+    catches this specifically and fails fast rather than spending its repair retries
+    on a budget problem.
+
+    Subclasses ``ValueError`` so callers that already handle a parse failure that way
+    are unaffected.
+    """
+
+
 def parseJson(value: str) -> Any:
     """
     Parse a string and return a json value.
@@ -51,8 +65,14 @@ def parseJson(value: str) -> Any:
         # it, and the generic "Expecting value: line 1 column 1" that follows sends you
         # looking at the schema instead of at modelOutputTokens. Checked after the
         # substitution so a complete block followed by a truncated one is caught too.
+        #
+        # Both clauses carry weight. re.sub is a single left-to-right pass, so deleting an
+        # inner pair can splice a fresh one into the remainder that the pass has already
+        # moved past: '<thi<think>x</think>nk>a</think>{...}' leaves '<think>a</think>{...}',
+        # which opens with <think> but is not a truncation. The closing-tag test is what
+        # keeps that from being reported as a budget problem.
         if value.startswith('<think>') and '</think>' not in value:
-            raise ValueError(
+            raise ThinkTruncatedError(
                 'model was cut off inside a <think> block and never emitted JSON; '
                 'raise modelOutputTokens, or disable reasoning for this call'
             )

--- a/packages/ai/tests/ai/common/test_chat_expect_json_retries.py
+++ b/packages/ai/tests/ai/common/test_chat_expect_json_retries.py
@@ -27,13 +27,19 @@ Run with::
 
 from __future__ import annotations
 
-from typing import List
+import json
 
 import pytest
 
 from ai.common.chat import ChatBase
 from ai.common.schema import Question
 from ai.common.util import ThinkTruncatedError
+
+# A reasoning model that hit its output budget before emitting any JSON.
+TRUNCATED = '<think>The user wants a JSON summary. Let me work through the fields one at a'
+
+# The CRITICAL instruction question.py appends once a parse has already failed.
+REPAIR_MARKER = 'previous response returned invalid JSON'
 
 
 def _question() -> Question:
@@ -43,13 +49,13 @@ def _question() -> Question:
     return q
 
 
-def _chat_returning(*responses: str) -> tuple[ChatBase, List[str]]:
+def _chat_returning(*responses: str) -> tuple[ChatBase, list[str]]:
     """A ChatBase whose ``chat_string`` yields ``responses`` in order, recording prompts.
 
     The last response repeats if the loop asks for more than were supplied, so a test
     that expects a single call does not accidentally pass on an IndexError.
     """
-    prompts: List[str] = []
+    prompts: list[str] = []
     chat = ChatBase.__new__(ChatBase)
 
     def _chat_string(prompt: str, **_kwargs) -> str:
@@ -58,9 +64,6 @@ def _chat_returning(*responses: str) -> tuple[ChatBase, List[str]]:
 
     chat.chat_string = _chat_string
     return chat, prompts
-
-
-TRUNCATED = '<think>The user wants a JSON summary. Let me work through the fields one at a'
 
 
 class TestTruncatedThinkBlock:
@@ -93,7 +96,32 @@ class TestTruncatedThinkBlock:
         with pytest.raises(ThinkTruncatedError):
             chat.chat(_question())
 
-        assert not any('previous response returned invalid JSON' in p for p in prompts)
+        assert not any(REPAIR_MARKER in p for p in prompts)
+
+    def test_a_truncation_discovered_on_a_retry_also_fails_fast(self):
+        """The guard is inside the loop, so it holds on attempt 2 as well as attempt 1.
+
+        This is the likelier production shape: the first answer is merely malformed, the
+        repair prompt makes the model reason *harder* about getting the JSON right, and
+        that is what pushes it over the output budget. Stopping here costs two calls
+        rather than three, and still names the budget.
+        """
+        chat, prompts = _chat_returning('not json at all', TRUNCATED)
+
+        with pytest.raises(ThinkTruncatedError, match='modelOutputTokens'):
+            chat.chat(_question())
+
+        assert len(prompts) == 2
+        assert REPAIR_MARKER in prompts[1]
+
+    def test_is_not_reported_as_exhausted_retries(self):
+        """The dedicated arm has to come first — the subclass IS a ValueError."""
+        chat, _ = _chat_returning(TRUNCATED)
+
+        with pytest.raises(ValueError) as excinfo:
+            chat.chat(_question())
+
+        assert 'Failed to get valid JSON response' not in str(excinfo.value)
 
 
 class TestOrdinaryBadJson:
@@ -105,7 +133,7 @@ class TestOrdinaryBadJson:
             chat.chat(_question())
 
         assert len(prompts) == 3
-        assert 'previous response returned invalid JSON' in prompts[1]
+        assert REPAIR_MARKER in prompts[1]
 
     def test_the_final_error_carries_the_parse_failure(self):
         """The exhausted-retries message used to drop what was wrong with the response."""
@@ -115,16 +143,7 @@ class TestOrdinaryBadJson:
             chat.chat(_question())
 
         assert 'Expecting value' in str(excinfo.value)
-        assert excinfo.value.__cause__ is not None
-
-    def test_a_truncated_think_error_is_not_reported_as_exhausted_retries(self):
-        """The dedicated arm has to come first — the subclass IS a ValueError."""
-        chat, _ = _chat_returning(TRUNCATED)
-
-        with pytest.raises(ValueError) as excinfo:
-            chat.chat(_question())
-
-        assert 'Failed to get valid JSON response' not in str(excinfo.value)
+        assert isinstance(excinfo.value.__cause__, json.JSONDecodeError)
 
 
 class TestValidJson:

--- a/packages/ai/tests/ai/common/test_chat_expect_json_retries.py
+++ b/packages/ai/tests/ai/common/test_chat_expect_json_retries.py
@@ -1,0 +1,143 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""What ``ChatBase.chat``'s ``expectJson`` loop does with each kind of parse failure.
+
+This is the only production path through ``parseJson``, so it decides whether a
+diagnosis made there reaches anyone. Two failures arrive at the same ``except`` and
+must not be treated alike:
+
+- **Bad JSON** — the model can plausibly do better on a resample, so re-prompt it.
+- **A truncated ``<think>`` block** — the model never reached the JSON because it ran
+  out of output budget. The repair prompt ("examine your JSON and ensure it is
+  complete") describes a problem that does not exist, a resample rarely fits a budget
+  that already overflowed, and each attempt is a paid model call. Worse, the generic
+  message raised after the loop replaces the one that named ``modelOutputTokens``.
+
+``chat`` reads no instance state beyond ``self.chat_string``, so it is exercised over a
+bare ``__new__`` instance with that one method stubbed — the pattern established in
+``test_chat_return_contract.py``.
+
+Run with::
+
+    pytest packages/ai/tests/ai/common/test_chat_expect_json_retries.py -v
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from ai.common.chat import ChatBase
+from ai.common.schema import Question
+from ai.common.util import ThinkTruncatedError
+
+
+def _question() -> Question:
+    """A minimal JSON-expecting question."""
+    q = Question(expectJson=True)
+    q.addQuestion('summarize this')
+    return q
+
+
+def _chat_returning(*responses: str) -> tuple[ChatBase, List[str]]:
+    """A ChatBase whose ``chat_string`` yields ``responses`` in order, recording prompts.
+
+    The last response repeats if the loop asks for more than were supplied, so a test
+    that expects a single call does not accidentally pass on an IndexError.
+    """
+    prompts: List[str] = []
+    chat = ChatBase.__new__(ChatBase)
+
+    def _chat_string(prompt: str, **_kwargs) -> str:
+        prompts.append(prompt)
+        return responses[min(len(prompts) - 1, len(responses) - 1)]
+
+    chat.chat_string = _chat_string
+    return chat, prompts
+
+
+TRUNCATED = '<think>The user wants a JSON summary. Let me work through the fields one at a'
+
+
+class TestTruncatedThinkBlock:
+    def test_fails_fast_without_spending_a_retry(self):
+        """One model call, then the error — not three."""
+        chat, prompts = _chat_returning(TRUNCATED)
+
+        with pytest.raises(ThinkTruncatedError):
+            chat.chat(_question())
+
+        assert len(prompts) == 1
+
+    def test_the_cause_survives_to_the_caller(self):
+        """The whole point of the diagnosis: it is still readable at the top.
+
+        Swallowed into the retry loop, it became ``Failed to get valid JSON response
+        after N attempts``, which names nothing. ``LLMBase.writeQuestions`` renders
+        whatever escapes here as ``**LLM error** — {type}: {message}``, so this is the
+        text a user ends up seeing.
+        """
+        chat, _ = _chat_returning(TRUNCATED)
+
+        with pytest.raises(ThinkTruncatedError, match='modelOutputTokens'):
+            chat.chat(_question())
+
+    def test_the_repair_prompt_is_never_sent(self):
+        """The repair instruction misdescribes a budget overflow, so it must not be asked."""
+        chat, prompts = _chat_returning(TRUNCATED)
+
+        with pytest.raises(ThinkTruncatedError):
+            chat.chat(_question())
+
+        assert not any('previous response returned invalid JSON' in p for p in prompts)
+
+
+class TestOrdinaryBadJson:
+    def test_still_retries_the_full_budget(self):
+        """Unchanged behaviour for the failure a resample can actually fix."""
+        chat, prompts = _chat_returning('not json at all')
+
+        with pytest.raises(ValueError):
+            chat.chat(_question())
+
+        assert len(prompts) == 3
+        assert 'previous response returned invalid JSON' in prompts[1]
+
+    def test_the_final_error_carries_the_parse_failure(self):
+        """The exhausted-retries message used to drop what was wrong with the response."""
+        chat, _ = _chat_returning('not json at all')
+
+        with pytest.raises(ValueError, match='Cause:') as excinfo:
+            chat.chat(_question())
+
+        assert 'Expecting value' in str(excinfo.value)
+        assert excinfo.value.__cause__ is not None
+
+    def test_a_truncated_think_error_is_not_reported_as_exhausted_retries(self):
+        """The dedicated arm has to come first — the subclass IS a ValueError."""
+        chat, _ = _chat_returning(TRUNCATED)
+
+        with pytest.raises(ValueError) as excinfo:
+            chat.chat(_question())
+
+        assert 'Failed to get valid JSON response' not in str(excinfo.value)
+
+
+class TestValidJson:
+    def test_returns_on_the_first_attempt(self):
+        chat, prompts = _chat_returning('{"answer": 42}')
+
+        answer = chat.chat(_question())
+
+        assert answer.getJson() == {'answer': 42}
+        assert len(prompts) == 1
+
+    def test_a_fenced_response_after_a_complete_think_block_parses(self):
+        """The closed-block path must keep working; only the unterminated one is fatal."""
+        chat, _ = _chat_returning('<think>reasoning</think>\n```json\n{"x": "y"}\n```')
+
+        assert chat.chat(_question()).getJson() == {'x': 'y'}

--- a/packages/ai/tests/ai/common/test_util.py
+++ b/packages/ai/tests/ai/common/test_util.py
@@ -153,6 +153,28 @@ def test_parse_json_does_not_misreport_a_spliced_think_pair():
         util.parseJson(raw)
 
 
+@pytest.mark.parametrize(
+    'raw',
+    [
+        '<think>let me reason about the fields\n{"a": 1}',
+        '<think>reasoning\n```json\n{"a": 1}\n```',
+        '<think>listing them\n[1, 2, 3]',
+    ],
+    ids=['bare-object', 'fenced-object', 'array'],
+)
+def test_parse_json_does_not_blame_budget_when_json_actually_arrived(raw):
+    """A missing ``</think>`` is not by itself a budget overflow.
+
+    A model can finish its reasoning, emit the JSON, and simply drop the closing tag --
+    which happens when the tag is consumed as a stop sequence. The response is still
+    unparseable, but ``modelOutputTokens`` is not the fix, and saying so sends the
+    operator to a setting that cannot help. These fall through to the ordinary parse
+    error instead, exactly as they did before the truncation check existed.
+    """
+    with pytest.raises(json.JSONDecodeError):
+        util.parseJson(raw)
+
+
 def test_parse_json_keeps_inner_backticks_in_string_value():
     """Triple-backticks inside a JSON string value must NOT be treated as fences."""
     raw = '{"answer": "see ```python\\nprint(1)\\n``` here"}'

--- a/packages/ai/tests/ai/common/test_util.py
+++ b/packages/ai/tests/ai/common/test_util.py
@@ -160,8 +160,21 @@ def test_parse_json_does_not_misreport_a_spliced_think_pair():
         '<think>The schema is {title, body}, so I will start with the',
         '<think>Fields {a, b} and options [x, y]; taking them in',
         '<think>I need to emit {"title": ... but first let me check the',
+        '<think>consider {"a": 1}; that shape works, so next I will',
+        '<think>I will return {"title": "X"} and then add the',
+        '<think>I will use option 2',
+        '<think>the flag should be true',
     ],
-    ids=['bracket', 'brace', 'both', 'partial-json'],
+    ids=[
+        'bracket',
+        'brace',
+        'both',
+        'partial-json',
+        'embedded-fragment',
+        'drafted-then-cut',
+        'ends-on-number',
+        'ends-on-keyword',
+    ],
 )
 def test_parse_json_names_a_truncation_whose_reasoning_mentions_brackets(raw):
     """Reasoning that merely MENTIONS a brace is still a truncation.

--- a/packages/ai/tests/ai/common/test_util.py
+++ b/packages/ai/tests/ai/common/test_util.py
@@ -156,6 +156,28 @@ def test_parse_json_does_not_misreport_a_spliced_think_pair():
 @pytest.mark.parametrize(
     'raw',
     [
+        '<think>Compare [A, B] and decide which one the user meant',
+        '<think>The schema is {title, body}, so I will start with the',
+        '<think>Fields {a, b} and options [x, y]; taking them in',
+        '<think>I need to emit {"title": ... but first let me check the',
+    ],
+    ids=['bracket', 'brace', 'both', 'partial-json'],
+)
+def test_parse_json_names_a_truncation_whose_reasoning_mentions_brackets(raw):
+    """Reasoning that merely MENTIONS a brace is still a truncation.
+
+    A model reasoning its way toward JSON routinely writes one -- "the schema is
+    {title, body}" is an ordinary sentence in that chain. Testing for the character
+    would wave through most real truncations, which is the exact failure #1822
+    reports. The test is whether a complete JSON value can be *decoded*.
+    """
+    with pytest.raises(util.ThinkTruncatedError, match='modelOutputTokens'):
+        util.parseJson(raw)
+
+
+@pytest.mark.parametrize(
+    'raw',
+    [
         '<think>let me reason about the fields\n{"a": 1}',
         '<think>reasoning\n```json\n{"a": 1}\n```',
         '<think>listing them\n[1, 2, 3]',

--- a/packages/ai/tests/ai/common/test_util.py
+++ b/packages/ai/tests/ai/common/test_util.py
@@ -104,6 +104,26 @@ def test_parse_json_strips_think_then_fence():
     assert util.parseJson(raw) == {'x': 'y'}
 
 
+def test_parse_json_names_a_truncated_think_block():
+    """A model cut off mid-reasoning must be told apart from bad JSON.
+
+    The strip regex needs a closing ``</think>``, so a truncated block reaches
+    ``json.loads`` intact and fails at character zero. That generic message is
+    indistinguishable from a bad schema or a model returning prose, which have
+    entirely different fixes -- this one is ``modelOutputTokens``.
+    """
+    raw = '<think>The user wants a JSON summary. Let me work through the fields one at a'
+    with pytest.raises(ValueError, match='modelOutputTokens'):
+        util.parseJson(raw)
+
+
+def test_parse_json_names_a_truncated_think_block_after_a_complete_one():
+    """The check runs after the substitution, so a trailing truncated block is caught."""
+    raw = '<think>first thought</think><think>second one, cut off mid-'
+    with pytest.raises(ValueError, match='cut off inside a <think> block'):
+        util.parseJson(raw)
+
+
 def test_parse_json_keeps_inner_backticks_in_string_value():
     """Triple-backticks inside a JSON string value must NOT be treated as fences."""
     raw = '{"answer": "see ```python\\nprint(1)\\n``` here"}'

--- a/packages/ai/tests/ai/common/test_util.py
+++ b/packages/ai/tests/ai/common/test_util.py
@@ -14,6 +14,8 @@ Covers the four pure helpers used across the LLM drivers:
 with the engine binary, so the import resolves at test time without mocking.
 """
 
+import json
+
 import pytest
 
 from ai.common import util
@@ -113,14 +115,41 @@ def test_parse_json_names_a_truncated_think_block():
     entirely different fixes -- this one is ``modelOutputTokens``.
     """
     raw = '<think>The user wants a JSON summary. Let me work through the fields one at a'
-    with pytest.raises(ValueError, match='modelOutputTokens'):
+    with pytest.raises(util.ThinkTruncatedError, match='modelOutputTokens'):
         util.parseJson(raw)
 
 
 def test_parse_json_names_a_truncated_think_block_after_a_complete_one():
     """The check runs after the substitution, so a trailing truncated block is caught."""
     raw = '<think>first thought</think><think>second one, cut off mid-'
-    with pytest.raises(ValueError, match='cut off inside a <think> block'):
+    with pytest.raises(util.ThinkTruncatedError, match='cut off inside a <think> block'):
+        util.parseJson(raw)
+
+
+def test_truncated_think_error_is_still_a_value_error():
+    """The dedicated type is what ``chat.py`` branches on; ``ValueError`` is what keeps
+    every other caller working.
+
+    ``ChatBase.chat`` needs to fail fast on a budget truncation without string-matching
+    the message, but the handlers that predate this class catch ``ValueError`` -- so the
+    subclass relationship is part of the contract, not an implementation detail.
+    """
+    assert issubclass(util.ThinkTruncatedError, ValueError)
+    with pytest.raises(ValueError):
+        util.parseJson('<think>cut off mid-')
+
+
+def test_parse_json_does_not_misreport_a_spliced_think_pair():
+    """A ``<think>`` opener the substitution left behind is not automatically a truncation.
+
+    ``re.sub`` is a single left-to-right pass, so deleting an inner pair can splice a new
+    one into text the pass has already moved past. The result opens with ``<think>`` while
+    still carrying its closing tag -- a malformed response, but *not* a budget problem, and
+    naming ``modelOutputTokens`` here would send the reader somewhere useless. The
+    closing-tag half of the guard is what draws that line.
+    """
+    raw = '<thi<think>x</think>nk>a</think>{"a": 1}'
+    with pytest.raises(json.JSONDecodeError):
         util.parseJson(raw)
 
 


### PR DESCRIPTION
## Summary

- `parseJson` now raises a specific error when a reasoning model is cut off inside an unterminated `<think>` block, instead of letting it fall through to a generic `Expecting value: line 1 column 1`.
- Adds two tests beside the existing think-block coverage.

## Type

fix

The strip regex requires a closing tag:

```python
value = re.sub(r'<think>.*?</think>', '', value, flags=re.DOTALL).strip()
```

When a model exhausts its output budget mid-reasoning there is no `</think>`, the substitution is a no-op, and the still-wrapped text reaches `json.loads`, which fails on the first character:

```
JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

Every part of that message is true and none of it is actionable — it is indistinguishable from a bad schema, malformed JSON, or a model returning prose. Those have entirely different fixes. This one is `modelOutputTokens` (`chat.py:100`, default 4096) or disabling reasoning for the call.

Two things make it worse than an ordinary unclear error:

- **It is intermittent by construction.** Whether reasoning fits in budget depends on the input, so the same pipeline succeeds on most documents and fails on the long ones — which reads as a data problem, not a configuration one.
- **The closed-block case works perfectly** (`parseJson('<think>reasoning</think>{"a": 1}')` → `{'a': 1}`), so the mechanism looks sound right up until it isn't.

`parseJson` has 9 call sites across `packages/ai/src/ai/common/`, mostly `chat.py`, so this reaches any node asking a reasoning model for structured output.

The check runs **after** the substitution rather than before. That also covers a complete block followed by a truncated one (`<think>a</think><think>b`) — the first is removed and the remainder is caught. Second test pins that.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Two tests added next to the existing `test_parse_json_strips_think_block` (`:95`) and `test_parse_json_strips_think_then_fence` (`:101`), verified in both directions:

```
# this branch — all parseJson tests, existing ones included
test_parse_json_plain                                            PASSED
test_parse_json_strips_json_fence                                PASSED
test_parse_json_strips_plain_fence                               PASSED
test_parse_json_strips_think_block                               PASSED
test_parse_json_strips_think_then_fence                          PASSED
test_parse_json_names_a_truncated_think_block                    PASSED
test_parse_json_names_a_truncated_think_block_after_a_complete_one  PASSED
test_parse_json_keeps_inner_backticks_in_string_value            PASSED
test_parse_json_invalid_raises                                   PASSED
                                                                 9 passed

# same two tests against pristine origin/develop
test_parse_json_names_a_truncated_think_block                    FAILED
test_parse_json_names_a_truncated_think_block_after_a_complete_one  FAILED
                                                                 2 failed
```

`ruff check` and `ruff format --check` pass on both files.

On how I ran them: `./builder ai:test` needs a built engine, since `util.py` does `from engLib import debug` and `packages/ai/tests/conftest.py` pulls `rocketlib` — both C-extensions bundled with the engine binary, which I don't have provisioned here. I ran the module with `--noconftest` and small `engLib`/`depends` stubs, which is the pattern the repo already documents for standalone AI test files (`test_config_shapes.py` and `test_pipeflow.py` both say to run with `--noconftest`). Nothing in these tests touches the engine — they exercise a pure string function — so CI's `ai:test` should pick them up unchanged under the real interpreter.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

Behaviour change is narrow: input that previously raised `JSONDecodeError` now raises `ValueError` with a specific message. Both are `ValueError` subclasses, so callers catching `ValueError` (as `test_parse_json_invalid_raises` deliberately does) are unaffected.

## Linked Issue

Fixes #1822


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete reasoning blocks in AI responses.
  * Reports dedicated errors when responses are truncated before valid JSON can be parsed.
  * Prevents unnecessary repair attempts for truncated responses while preserving failure details.
  * Maintains retry behavior for ordinary malformed JSON responses.

* **Tests**
  * Added coverage for truncated reasoning blocks, malformed JSON, retry behavior, and valid direct or fenced JSON responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->