### PR TITLE
fix(guardrails): make pii_leak findings triageable and stop two false positives

### DIFF
--- a/nodes/src/nodes/guardrails/guardrails_engine.py
+++ b/nodes/src/nodes/guardrails/guardrails_engine.py
@@ -191,13 +191,56 @@ class GuardrailsEngine:
     # -------------------------------------------------------------------------
     PII_PATTERNS: Dict[str, re.Pattern] = {
         'email': re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b'),
-        'phone_us': re.compile(r'\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b'),
+        # A bare run of ten digits is NOT a phone number. Every separator and the
+        # country code were optional here, so the pattern reduced to "ten digits" --
+        # and Unix timestamps, order ids and database keys are ten digits routinely.
+        # A Slack message ts like 1785525294.884619 matched, so one run over Slack
+        # content reported 124 phone numbers, every one of them a message id. A
+        # guardrail that fires every run teaches people to ignore it, which is worse
+        # than not having one. Real numbers carry formatting, so require at least one
+        # of: a +1 prefix, a parenthesised area code, or separators between groups.
+        'phone_us': re.compile(
+            r'(?:'
+            r'\+1[-.\s]?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}'  # +1 (415) 555-0142
+            r'|\(\d{3}\)\s?\d{3}[-.\s]?\d{4}'  # (415) 555-0142
+            r'|\b\d{3}[-.\s]\d{3}[-.\s]\d{4}\b'  # 415-555-0142
+            r')'
+        ),
         'ssn': re.compile(r'\b(?!000|666|9\d{2})\d{3}[-\s]?(?!00)\d{2}[-\s]?(?!0000)\d{4}\b'),
         'credit_card': re.compile(
             r'\b(?:4\d{3}|5[1-5]\d{2}|3[47]\d{2}|6(?:011|5\d{2}))[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b'
         ),
         'ip_address': re.compile(r'\b(?:(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\.){3}(?:25[0-5]|2[0-4]\d|[01]?\d\d?)\b'),
     }
+
+    #: Addresses that are never personal information, so they must not be reported
+    #: as a PII leak. Loopback and the unspecified address identify no one -- a
+    #: service URL like http://127.0.0.1:8791/health in an output is not a privacy
+    #: incident. Routable and private ranges are still reported, since those can
+    #: genuinely leak topology.
+    NON_PII_IP_PREFIXES = ('127.', '0.0.0.0')
+
+    @staticmethod
+    def _mask(value: Any) -> str:
+        """A recognisable but non-leaking sample of a match.
+
+        First two and last two characters, middle replaced. ``4111...1111`` stays
+        identifiably a card; ``17...19`` stays identifiably a timestamp. Short
+        values are masked entirely, since two of four characters is most of the
+        value.
+        """
+        text = str(value)
+        if len(text) <= 6:
+            return '*' * len(text)
+        return f'{text[:2]}{"*" * (len(text) - 4)}{text[-2:]}'
+
+    @classmethod
+    def _pii_matches(cls, name: str, pattern: re.Pattern, text: str) -> List[Any]:
+        """Matches for one PII type, minus the shapes that are never personal."""
+        found = pattern.findall(text)
+        if name == 'ip_address':
+            found = [m for m in found if not str(m).startswith(cls.NON_PII_IP_PREFIXES)]
+        return found
 
     def __init__(self, config: Dict[str, Any]):
         """Initialize the guardrails engine with configuration.
@@ -468,9 +511,15 @@ class GuardrailsEngine:
         """
         found_pii = []
         for pii_type, pattern in self.PII_PATTERNS.items():
-            matches = pattern.findall(text)
+            matches = self._pii_matches(pii_type, pattern, text)
             if matches:
-                found_pii.append(f'{pii_type}: {len(matches)} occurrence(s)')
+                # Include a masked sample. "credit_card: 1 occurrence(s)" says
+                # something was found but not what, so the only way to act on it is
+                # to re-derive the whole input and re-run the regex by hand. Every
+                # other rule in this file already names what it matched. Enough to
+                # recognise a false positive (a timestamp, an id, a UUID), never
+                # enough to be the leak.
+                found_pii.append(f'{pii_type}: {len(matches)} occurrence(s) [{self._mask(matches[0])}]')
 
         if found_pii:
             return {

--- a/nodes/test/guardrails/test_pii_precision.py
+++ b/nodes/test/guardrails/test_pii_precision.py
@@ -1,0 +1,191 @@
+"""Precision of the ``pii_leak`` rule, and whether its warning can be acted on.
+
+Two failure modes reinforce each other: rules that fire on things that are not
+PII make triage necessary, and a warning that reports only a count makes triage
+impossible. These tests pin both directions -- the false positives must stop,
+and the real detections must keep working.
+
+The module bootstrap below is duplicated from ``test_all.py`` rather than
+imported from it, so this file stands alone and does not couple to a sibling
+test module's private helpers.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_ENGINE_PATH = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'guardrails', 'guardrails_engine.py')
+
+
+def _load_engine_module():
+    """Load guardrails_engine.py as a standalone module."""
+    # Stub rocketlib only while loading; restore so it never leaks to sibling tests.
+    _saved_rl = sys.modules.get('rocketlib')
+    _rocketlib_stub = types.ModuleType('rocketlib')
+    _rocketlib_stub.warning = lambda msg, *a, **kw: None
+    sys.modules['rocketlib'] = _rocketlib_stub
+    spec = importlib.util.spec_from_file_location('guardrails_engine_pii', _ENGINE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        if _saved_rl is not None:
+            sys.modules['rocketlib'] = _saved_rl
+        else:
+            sys.modules.pop('rocketlib', None)
+
+
+_engine = _load_engine_module()
+Engine = _engine.GuardrailsEngine
+
+
+def hits(kind, text):
+    """Matches of one PII pattern, through the same filter the rule uses."""
+    return Engine._pii_matches(kind, Engine.PII_PATTERNS[kind], text)
+
+
+# ---------------------------------------------------------------------------
+# phone_us must not fire on bare ten-digit ids
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'label, text',
+    [
+        ('slack message ts', '1785525294.884619'),
+        ('epoch seconds', 'order 1737049182 shipped'),
+        ('bare ten digits', 'reference 4155550142 attached'),
+        ('database key', 'row id 9876543210'),
+        ('two ids in a sentence', 'linking 1785525294 to 1737049182'),
+    ],
+)
+def test_a_bare_run_of_ten_digits_is_not_a_phone_number(label, text):
+    """Unix timestamps, order ids and database keys are ten digits routinely.
+
+    The old pattern made every separator and the country code optional, so it
+    reduced to "ten digits". One run over Slack content reported 124 phone
+    numbers, every one of them a message id.
+    """
+    assert hits('phone_us', text) == [], label
+
+
+# ---------------------------------------------------------------------------
+# ...but real phone numbers must still be caught
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'label, text',
+    [
+        ('parenthesised', 'call (415) 555-0142 today'),
+        ('dashed', 'call 415-555-0142 today'),
+        ('dotted', 'call 415.555.0142 today'),
+        ('spaced', 'call 415 555 0142 today'),
+        ('international', 'call +1 415 555 0142 today'),
+        ('international dashed', 'call +1-415-555-0142 today'),
+    ],
+)
+def test_a_formatted_phone_number_is_still_detected(label, text):
+    """Formatting is what separates a phone number from an id."""
+    assert hits('phone_us', text), label
+
+
+def test_a_parenthesised_number_is_captured_whole():
+    """The old pattern's unbalanced parens matched '415) 555-0142'."""
+    assert hits('phone_us', 'call (415) 555-0142') == ['(415) 555-0142']
+
+
+# ---------------------------------------------------------------------------
+# ip_address must not fire on addresses that identify nobody
+# ---------------------------------------------------------------------------
+
+
+def test_a_loopback_address_is_not_personal_information():
+    """A service URL in an output is not a privacy incident."""
+    assert hits('ip_address', 'GET http://127.0.0.1:8791/health') == []
+
+
+def test_the_unspecified_address_is_not_personal_information():
+    assert hits('ip_address', 'listening on 0.0.0.0:8080') == []
+
+
+@pytest.mark.parametrize('text', ['from 203.0.113.44', 'host 192.168.1.8', 'gateway 10.0.0.1'])
+def test_a_routable_or_private_address_is_still_detected(text):
+    """Those can genuinely leak topology, so they keep firing."""
+    assert hits('ip_address', text)
+
+
+# ---------------------------------------------------------------------------
+# the other three patterns must be unaffected by the filter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    'kind, text',
+    [
+        ('email', 'write to alex@example.com please'),
+        ('ssn', 'ssn 123-45-6789 on file'),
+        ('credit_card', 'card 4111 1111 1111 1111 expires soon'),
+    ],
+)
+def test_the_remaining_patterns_pass_through_unchanged(kind, text):
+    """_pii_matches only filters ip_address; everything else is a passthrough."""
+    assert hits(kind, text)
+
+
+# ---------------------------------------------------------------------------
+# the warning has to be actionable
+# ---------------------------------------------------------------------------
+
+
+def test_a_pii_warning_names_enough_to_diagnose_it():
+    """A bare count cannot be triaged.
+
+    Every other rule in guardrails_engine already names what it matched --
+    prompt injection quotes the match, blocked topics quote the topic,
+    hallucination quotes the sentence. pii_leak reported only a number, so the
+    only way to judge a finding was to re-derive the input and re-run the regex
+    by hand.
+    """
+    engine = Engine({})
+    result = engine.check_pii_leak('card 4111 1111 1111 1111 on file')
+
+    assert result['passed'] is False
+    assert 'credit_card' in result['details']
+    # a sample is present, and it is not the raw value
+    assert '[' in result['details'] and ']' in result['details']
+    assert '4111 1111 1111 1111' not in result['details']
+
+
+def test_the_mask_never_reproduces_the_value():
+    """Enough to recognise a false positive, never enough to be the leak."""
+    masked = Engine._mask('4111111111111111')
+    assert masked.startswith('41')
+    assert masked.endswith('11')
+    assert '*' in masked
+    assert masked != '4111111111111111'
+    assert len(masked) == len('4111111111111111')
+
+
+def test_short_values_are_masked_completely():
+    """Two of four characters is most of the value, so show none of it."""
+    assert Engine._mask('abcd') == '****'
+    assert Engine._mask('123456') == '******'
+
+
+def test_a_timestamp_stays_recognisable_through_the_mask():
+    """The mask has to make a false positive identifiable, or it defeats itself."""
+    masked = Engine._mask('1785525294')
+    assert masked.startswith('17')
+    assert masked.endswith('94')
+
+
+def test_clean_text_still_passes():
+    engine = Engine({})
+    result = engine.check_pii_leak('the quarterly report is attached')
+    assert result['passed'] is True

--- a/nodes/test/guardrails/test_pii_precision.py
+++ b/nodes/test/guardrails/test_pii_precision.py
@@ -111,6 +111,7 @@ def test_a_loopback_address_is_not_personal_information():
 
 
 def test_the_unspecified_address_is_not_personal_information():
+    """0.0.0.0 is a bind wildcard, not a host, so it identifies nobody."""
     assert hits('ip_address', 'listening on 0.0.0.0:8080') == []
 
 
@@ -186,6 +187,7 @@ def test_a_timestamp_stays_recognisable_through_the_mask():
 
 
 def test_clean_text_still_passes():
+    """Text with no PII must report passed, with no sample to include."""
     engine = Engine({})
     result = engine.check_pii_leak('the quarterly report is attached')
     assert result['passed'] is True


### PR DESCRIPTION
## Summary

- Adds a masked sample to the `pii_leak` details, so a finding can be triaged without re-deriving the input and re-running the regex by hand.
- Tightens `phone_us` so a bare run of ten digits (Unix timestamps, order ids, database keys) is no longer a phone number.
- Stops reporting loopback and unspecified IPs as PII.

## Type

fix

Three problems that compound. The rules fire constantly, which makes triage necessary; the warning is a bare count, which makes triage impossible.

**1 — the warning could not be acted on.** `check_pii_leak` produced `PII detected: credit_card: 1 occurrence(s)`. `pii_leak` was the only rule in the file that reports a count with no sample:

| line | rule | details |
|---|---|---|
| `:241` | prompt injection | ``matched pattern near "{match.group(0)[:80]}"`` |
| `:295` | blocked topic | ``Blocked topic detected: "{topic}"`` |
| `:423` | hallucination | ``"{ungrounded[0][:80]}..."`` |
| `:473` | **pii_leak** | **count only** |

**2 — `phone_us` reduced to "ten digits".** Every separator and the country code were optional. In one run over Slack content this reported **124 phone numbers**, all of them message ids. A guardrail that fires every run teaches people to ignore it, which is worse than not having one.

**3 — loopback was a privacy incident.** `127.0.0.1` and `0.0.0.0` identify nobody. Routable and private ranges still fire, since those can leak topology.

Measured against the pristine engine, before → after:

| input | before | after |
|---|---|---|
| `phone_us` on `1785525294.884619` (Slack ts) | `['1785525294']` | `[]` |
| `ip_address` on `http://127.0.0.1:8791/health` | `['127.0.0.1']` | `[]` |
| `phone_us` on `call (415) 555-0142` | `['415) 555-0142']` ← stray paren | `['(415) 555-0142']` |
| `phone_us` on `call 415-555-0142` | detected | detected |
| `ip_address` on `from 203.0.113.44` | detected | detected |
| details for a real card | `credit_card: 1 occurrence(s)` | `credit_card: 1 occurrence(s) [41***************11]` |

The parenthesised-capture fix is incidental — the old pattern's `\(?`/`\)?` were unbalanced, so it swallowed the closing paren but not the opening one.

Note the `ssn` pattern immediately above already carries negative lookaheads for invalid prefixes, so precision is clearly a value in this file. `phone_us` and `ip_address` just never got the same treatment — #1372 (`reject '|' in email TLD char class`, from #1371) is the last change to `PII_PATTERNS` and it touched only `email`.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`nodes/test/guardrails/test_pii_precision.py` — 25 tests, pinning both directions: the false positives must stop **and** real detections must keep working.

```
test/guardrails/test_pii_precision.py .........................   25 passed
```

Regression — the existing suite is untouched:

```
test/guardrails/test_all.py ...........................................   92 passed
```

Every claim above was measured by loading the pristine `origin/develop` engine module side by side with this branch's, which is where the before/after table comes from.

The bootstrap in the new test file is duplicated from `test_all.py` rather than imported. That is deliberate: **#1793 is currently modifying `test_all.py`**, and importing its private `_load_engine_module` would couple this PR to an in-flight one. It also keeps the file runnable on its own.

`./builder nodes:test` was not run in full — it needs a built engine and a running task server, which I don't have provisioned. This test needs neither (it loads the module by path, stubbing `rocketlib` only during load and restoring it, exactly as `test_all.py` does), so CI picks it up unchanged.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

`nodes/src/nodes/guardrails/README.md` is deliberately untouched: `:75` documents *which* patterns exist (`email`, `phone_us`, `ssn`, `credit_card`, `ip_address`) and that list is unchanged, and the config surface is unchanged. It also avoids a needless collision with #1793, which edits that file. Happy to add a note about the sample format if you'd prefer it documented.

Behaviour change worth being explicit about: `phone_us` now **misses** unformatted 10-digit sequences that are genuinely phone numbers written without separators. That is the intended trade — the alternative is the current state, where the rule is ignored.

## Linked Issue

Fixes #1824


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved personally identifiable information detection to reduce false positives from unformatted phone numbers and loopback or unspecified IP addresses.
  * Continued detecting formatted phone numbers, routable and private IP addresses, email addresses, Social Security numbers, and credit-card numbers.
  * Added masked examples to PII violation warnings for clearer, safer guidance while protecting sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->