### PR TITLE
fix(vscode): tell the user when the env-var pre-flight check could not run

### DIFF
--- a/apps/vscode/src/shared/util/envVarCheck.ts
+++ b/apps/vscode/src/shared/util/envVarCheck.ts
@@ -10,17 +10,16 @@
  * references in a pipeline, then compares against the server's known env keys.
  * If any are missing, opens the Variables page with the missing keys pre-filled
  * so the user can set values before re-running.
+ *
+ * The decision itself lives in `envVarDecision.ts`, which imports neither
+ * `vscode` nor the logger so it can be asserted directly. This module is the
+ * side effects.
  */
 
 import * as vscode from 'vscode';
 import type { RocketRideClient } from 'rocketride';
-
-/** Extract all unique ROCKETRIDE_* variable names referenced in a pipeline. */
-function extractPipelineEnvVars(pipeline: Record<string, unknown>): string[] {
-	const str = JSON.stringify(pipeline);
-	const matches = str.matchAll(/\$\{(ROCKETRIDE_[^}]+)\}/g);
-	return [...new Set([...matches].map((m) => m[1]))];
-}
+import { decideEnvVars, extractPipelineEnvVars } from './envVarDecision';
+import { getLogger } from './output';
 
 /**
  * Opens the Variables page and pre-fills the missing keys as empty entries.
@@ -40,21 +39,37 @@ async function openWithMissingKeys(missingKeys: string[]): Promise<void> {
  * Used by the sidebar run path which doesn't go through the webview.
  */
 export async function checkMissingEnvVars(client: RocketRideClient, pipeline: Record<string, unknown>): Promise<string[]> {
-	const referencedVars = extractPipelineEnvVars(pipeline);
-	if (referencedVars.length === 0) return [];
+	const referenced = extractPipelineEnvVars(pipeline);
+	// Nothing to verify — skip the round-trip entirely, as before.
+	if (referenced.length === 0) return [];
 
-	let knownKeys: string[];
+	let keys: string[] | Error;
 	try {
-		knownKeys = await client.account.getEnvironmentKeys();
-	} catch {
+		keys = await client.account.getEnvironmentKeys();
+	} catch (error: unknown) {
+		keys = error instanceof Error ? error : new Error(String(error));
+	}
+
+	const decision = decideEnvVars(referenced, keys);
+
+	if (decision.kind === 'unverified') {
+		// Permissive on purpose — a transient failure should not block a run that
+		// would have been fine. What changed is that it is no longer SILENT: this
+		// used to return an empty list, which the caller cannot tell apart from
+		// "all variables defined", so the gate vanished without a word.
+		getLogger().error(
+			`envVarCheck: could not read environment keys (${decision.reason}); running without the pre-flight check`
+		);
+		vscode.window.showWarningMessage(
+			`Could not verify environment variables (${decision.reason}). Running without the pre-flight check — an undefined variable will reach the pipeline as a literal \${ROCKETRIDE_*} placeholder.`
+		);
 		return [];
 	}
 
-	const missing = referencedVars.filter((v) => !knownKeys.includes(v));
-	if (missing.length === 0) return [];
+	if (decision.kind === 'ok') return [];
 
-	await openWithMissingKeys(missing);
-	return missing;
+	await openWithMissingKeys(decision.missingKeys);
+	return decision.missingKeys;
 }
 
 /**

--- a/apps/vscode/src/shared/util/envVarDecision.ts
+++ b/apps/vscode/src/shared/util/envVarDecision.ts
@@ -1,0 +1,49 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/**
+ * The decision half of the pre-run environment variable check.
+ *
+ * Split out from `envVarCheck.ts` so it imports neither `vscode` nor the logger
+ * and can be asserted directly. `envVarCheck.ts` keeps the side effects.
+ *
+ * The distinction this module exists to preserve: "every variable is defined"
+ * and "the key list could not be fetched" are different answers. Collapsing
+ * them into one empty array is what let a transient API failure switch the
+ * pre-flight check off without saying so.
+ */
+
+/** Extract all unique ROCKETRIDE_* variable names referenced in a pipeline. */
+export function extractPipelineEnvVars(pipeline: Record<string, unknown>): string[] {
+	const str = JSON.stringify(pipeline);
+	const matches = str.matchAll(/\$\{(ROCKETRIDE_[^}]+)\}/g);
+	return [...new Set([...matches].map((m) => m[1]))];
+}
+
+/** The three genuinely different outcomes of the check. */
+export type EnvVarDecision =
+	| { kind: 'ok' }
+	| { kind: 'missing'; missingKeys: string[] }
+	| { kind: 'unverified'; reason: string };
+
+/**
+ * Decide what the pre-run check should do.
+ *
+ * @param referenced Variable names the pipeline refers to.
+ * @param knownKeys  The server's known keys, or the Error that prevented reading them.
+ */
+export function decideEnvVars(referenced: string[], knownKeys: string[] | Error): EnvVarDecision {
+	// Nothing referenced: nothing to verify, so a failed fetch would not have
+	// mattered either. Checked first so an unrelated outage does not produce a
+	// warning about a pipeline that uses no variables.
+	if (referenced.length === 0) return { kind: 'ok' };
+
+	if (knownKeys instanceof Error) {
+		return { kind: 'unverified', reason: knownKeys.message || 'unknown error' };
+	}
+
+	const missingKeys = referenced.filter((v) => !knownKeys.includes(v));
+	return missingKeys.length === 0 ? { kind: 'ok' } : { kind: 'missing', missingKeys };
+}

--- a/apps/vscode/src/test/envVarDecision.test.ts
+++ b/apps/vscode/src/test/envVarDecision.test.ts
@@ -1,0 +1,76 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { decideEnvVars, extractPipelineEnvVars } from '../shared/util/envVarDecision';
+
+test('extractPipelineEnvVars finds each ROCKETRIDE_ reference once', () => {
+	const pipeline = {
+		a: { key: '${ROCKETRIDE_ANTHROPIC_KEY}' },
+		b: { key: '${ROCKETRIDE_ANTHROPIC_KEY}', other: '${ROCKETRIDE_SLACK_TOKEN}' },
+	};
+	assert.deepEqual(extractPipelineEnvVars(pipeline).sort(), ['ROCKETRIDE_ANTHROPIC_KEY', 'ROCKETRIDE_SLACK_TOKEN']);
+});
+
+test('extractPipelineEnvVars ignores non-ROCKETRIDE placeholders', () => {
+	assert.deepEqual(extractPipelineEnvVars({ a: '${HOME}', b: '${PATH}' }), []);
+});
+
+test('all referenced variables defined is ok', () => {
+	const d = decideEnvVars(['ROCKETRIDE_A'], ['ROCKETRIDE_A', 'ROCKETRIDE_B']);
+	assert.equal(d.kind, 'ok');
+});
+
+test('an undefined variable is reported as missing', () => {
+	const d = decideEnvVars(['ROCKETRIDE_A', 'ROCKETRIDE_B'], ['ROCKETRIDE_A']);
+	assert.equal(d.kind, 'missing');
+	assert.deepEqual(d.kind === 'missing' ? d.missingKeys : [], ['ROCKETRIDE_B']);
+});
+
+test('a failed key fetch is unverified, not ok', () => {
+	const d = decideEnvVars(['ROCKETRIDE_A'], new Error('ECONNREFUSED'));
+	assert.equal(d.kind, 'unverified');
+	assert.match(d.kind === 'unverified' ? d.reason : '', /ECONNREFUSED/);
+});
+
+test('ok and unverified are never the same value', () => {
+	// This is the whole bug. checkMissingEnvVars used to return [] for both, and
+	// the caller gates the run on that array being empty -- so a transient API
+	// failure switched the pre-flight check off and looked exactly like a clean
+	// pass. If these two ever compare equal again, the gate has silently
+	// collapsed.
+	const verified = decideEnvVars(['ROCKETRIDE_A'], ['ROCKETRIDE_A']);
+	const couldNotCheck = decideEnvVars(['ROCKETRIDE_A'], new Error('boom'));
+	assert.notDeepEqual(verified, couldNotCheck);
+	assert.equal(verified.kind, 'ok');
+	assert.equal(couldNotCheck.kind, 'unverified');
+});
+
+test('a pipeline referencing nothing is ok even when the fetch failed', () => {
+	// Nothing to verify, so the outage did not cost anything -- do not warn about
+	// a pipeline that uses no variables.
+	const d = decideEnvVars([], new Error('ECONNREFUSED'));
+	assert.equal(d.kind, 'ok');
+});


### PR DESCRIPTION
## Summary

- The pre-run env-var check no longer disappears silently when `getEnvironmentKeys()` fails. It stays permissive, but logs and warns instead of pretending it passed.
- Extracts the decision into a pure `envVarDecision.ts` that imports neither `vscode` nor the logger, so the invariant can be asserted directly.

## Type

fix

`checkMissingEnvVars` had a bare `catch { return []; }`. The caller gates the run on that array — `SidebarProvider.ts:521-522`:

```ts
const missing = await checkMissingEnvVars(client, pipelineJson);
if (missing.length > 0) return;
```

So `[]` means **proceed**, and it was returned in two entirely different situations: every variable is defined, or the key list could not be read at all. No log line, no message — from the user's side the gate simply was not there. The one thing that would have made it diagnosable, the underlying error, was discarded by the bare `catch`.

What happens next is the part that makes this worth fixing rather than leaving as a nicety. `resolve_pipeline_env` keeps the placeholder as-is when a key is absent (`packages/ai/src/ai/modules/task/pipeline.py:31-33`):

```python
value = env.get(env_var, match.group(0))
if value == match.group(0):
    return value  # placeholder not found — keep as-is
```

so the literal `${ROCKETRIDE_ANTHROPIC_KEY}` is handed to the node as its API key and surfaces much later as a provider error. That is **#1105** (*"API key from .env (`${ROCKETRIDE_ANTHROPIC_KEY}`) not resolved — 401 invalid x-api-key"*), still open — and preventing exactly that confusion is what this gate exists for.

**Staying permissive on a fetch failure is deliberate and unchanged.** A transient error should not block a run that would have been fine. `unverified` still returns `[]`. What changed is that it says so.

Three outcomes are now distinct:

| outcome | returns | side effect |
|---|---|---|
| `ok` | `[]` | none |
| `missing` | the keys | opens the Variables page, pre-filled |
| `unverified` | `[]` | `getLogger().error(...)` + a warning naming the reason |

The early return when a pipeline references no variables is preserved, so there is no new round-trip for pipelines that use none.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`apps/vscode/src/test/envVarDecision.test.ts` — 7 tests, `node:test` + `node:assert/strict`, matching `envFile.test.ts` and `connectionModeAuth.test.ts`.

```
# tests 7
# pass 7
# fail 0
```

The load-bearing one is `ok and unverified are never the same value` — that collapse *is* the bug, so it is asserted rather than described.

Type-checked against the real extension `tsconfig.json`: **zero errors in the changed files.** (`tsc --noEmit -p apps/vscode/tsconfig.json` does report 28 pre-existing errors in `ProjectProvider.ts` on my machine, all from a stale local `node_modules` predating #1764's deploy-API change — none in `envVar*`, and none introduced here.)

**Please be aware the new test does not actually run in CI, and neither do the existing ones.** `apps/vscode/package.json` has no `scripts` block at all, there is no `.vscode-test.mjs` or `.mocharc`, and nothing under `apps/vscode/scripts/` or `scripts/` references `src/test`. So `envFile.test.ts`, `connectionModeAuth.test.ts` and `extension.test.ts` are equally dormant. I have deliberately **not** wired up a runner here — that is separate infrastructure, it would drag `apps/vscode/package.json` into a bug-fix PR, and it deserves its own change. I kept `envVarDecision.ts` a pure function so the test is at least trivially runnable by hand (`npx tsx --test apps/vscode/src/test/envVarDecision.test.ts`). Happy to open a follow-up for the runner if that's wanted.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

The public signature of `checkMissingEnvVars` is unchanged — same parameters, same `Promise<string[]>`, same meaning for the caller.

## Linked Issue

Fixes #1829


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment-variable validation for pipelines.
  * Missing variables now open the Variables page only when their absence is confirmed.
  * Verification failures display a warning instead of incorrectly reporting variables as missing.
  * Pipelines without environment-variable references complete successfully without unnecessary checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->