### PR TITLE
fix(shared-ui): keep a finished run's diagnostics visible in the Errors pane

### DIFF
--- a/packages/shared-ui/src/modules/project/components/SourcePanel.tsx
+++ b/packages/shared-ui/src/modules/project/components/SourcePanel.tsx
@@ -532,8 +532,18 @@ export const SourcePanel: React.FC<ISourcePanelProps> = ({ source, runKind, proj
 	const handlePillChange = useCallback((id: string) => setPill(id as SourcePill), []);
 
 	// --- Pane rendering -------------------------------------------------------
-	const errorItems = cleared ? [] : (paneStatus?.errors ?? []);
-	const warningItems = cleared ? [] : (paneStatus?.warnings ?? []);
+	// Errors/Warnings are a SNAPSHOT of the task's problems, not an accumulating
+	// window, so they must not vanish the moment a run ends. `cleared` is
+	// `!track.active`, and `active` means "inside a chapter that has not ended"
+	// (useTaskEvents.ts:646) — so gating these on it emptied both lists as soon
+	// as endTime was set, and the pane reported "No errors or warnings" about
+	// arrays it had just discarded. Outside a track, fall back to the task's own
+	// status. Replay still blanks, because there the question genuinely is "what
+	// was true at this position". The accumulating panes below stay on `cleared`,
+	// where that gate is correct.
+	const snapshotStatus = cleared ? (isReplay ? undefined : liveTaskStatus) : paneStatus;
+	const errorItems = snapshotStatus?.errors ?? [];
+	const warningItems = snapshotStatus?.warnings ?? [];
 	const [flowViewMode, setFlowViewMode] = useState<'pipeline' | 'component'>('pipeline');
 
 	/** Render the pane for the active pill. */
@@ -589,7 +599,7 @@ export const SourcePanel: React.FC<ISourcePanelProps> = ({ source, runKind, proj
 				);
 			case 'errors':
 				return errorItems.length === 0 && warningItems.length === 0 ? (
-					<EmptyState title="No errors or warnings" description="Problems raised by the pipeline appear here while it runs or when replaying a recorded run." />
+					<EmptyState title="No errors or warnings" description="Problems raised by the pipeline appear here while it runs, after it finishes, and when replaying a recorded run." />
 				) : (
 					<>
 						{errorItems.length > 0 && <Errors title="Errors" items={errorItems} type="error" />}


### PR DESCRIPTION
## Summary

- Errors and Warnings now fall back to the task's own status outside a live track, so a finished run's diagnostics stay readable instead of vanishing the moment it ends.
- Updates the empty-state copy, which currently documents the behaviour being fixed.

## Type

fix

`errorItems` and `warningItems` were gated on `cleared`, which is `!track.active`. `active` is not "a run exists" — `useTaskEvents.ts:646`:

```ts
return { chapter, active: chapter.endTime == null || position < chapter.endTime };
```

It means "the position sits inside a chapter that has **not ended**". So as soon as a run finished and `endTime` was set, `cleared` went true and both arrays were emptied one line before render:

```ts
const errorItems   = cleared ? [] : (paneStatus?.errors ?? []);   // :534
const warningItems = cleared ? [] : (paneStatus?.warnings ?? []); // :535
```

The pane then displayed **"No errors or warnings"** about arrays it had just discarded. A run that failed thirty seconds ago reported having raised nothing.

The strongest evidence that this is a mismatch rather than a deliberate choice is the pane's own empty-state text:

> Problems raised by the pipeline appear here **while it runs or when replaying a recorded run.**

That is a correct description of a *streaming accumulating window*, and the wrong description for a *status snapshot* — which is what Errors and Warnings are. Updated in this PR to match the fixed behaviour.

Diagnostics raised when a node is **configured** rather than run have no chapter at all, so the same gate discarded them permanently. That case follows from the same mechanism.

Scope is deliberately narrow: gating on `cleared` is **correct** for the accumulating panes and they are left alone — tokens (`:562`) and `StatusPane` (`:629`) still use it. Replay still blanks, because there the question genuinely is "what was true at this position".

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

```
tsc --noEmit -p packages/shared-ui/tsconfig.json     0 errors
node --import tsx --test scripts/*.test.mjs          28 passed
```

No test added, and I want to be straight about why rather than let the unchecked box pass silently: `SourcePanel` is a 700-line component whose state comes from `useTaskEvents`, a live event-stream hook. Asserting this behaviour properly means driving that hook through a run's full lifecycle — open chapter, events, `endTime` set — and there is no existing harness for it (`packages/shared-ui`'s suite is `scripts/*.test.mjs` plus a handful of `*.test.tsx`, none of which mount this component). Building one is a larger piece of work than the three-line fix and I did not want to bundle it in. If you would like it, I am happy to do it as a follow-up — say the word.

**Also worth stating plainly: this was traced by reading the source, not by instrumenting a live session.** The completed-run case follows directly from `active`'s definition and I am confident in it; the configure-time case is inferred from the same mechanism rather than separately observed.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

Separate finding, deliberately **not** fixed here — `ProjectView.tsx:570` passes `liveTaskStatus={runKind === 'dev' ? statusMap[src.id] : undefined}`, so the **DEPLOY** tab has no live status at all regardless of this gate. It is a different cause and belongs in its own change (and #1782 is already touching that file). Flagging it because it will look like this bug when tested.

## Linked Issue

Fixes #1832


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Error and warning panes now keep showing live task status after a run finishes.
  - Replay mode continues to behave as position-specific.
  - Updated the empty-state message to make it clear that issues remain visible after completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->