### PR TITLE
fix(nodes): unpin laser-sdk to >=0.0.2 in tool_laserdata_memory

### DIFF
--- a/nodes/src/nodes/tool_laserdata_memory/requirements.txt
+++ b/nodes/src/nodes/tool_laserdata_memory/requirements.txt
@@ -1,5 +1,1 @@
-# rc20+ speaks only Apache Iggy's VSR cluster protocol. LaserData Cloud
-# deployments created on/after 2026-07-31 serve VSR (verified live: full
-# memory round-trip on rc21); older deployments must be recreated, and a
-# local server must be a VSR-enabled build (e.g. laserdata/laser-stack).
-laser-sdk==0.0.1rc21
+laser-sdk>=0.0.2


### PR DESCRIPTION
## Summary

Follow-up to #1760. Replaces the exact `laser-sdk==0.0.1rc21` pin (and its rationale comment) with a single unadorned floor: `laser-sdk>=0.0.2`.

The exact pin was justified when it shipped, for two reasons that have both since lapsed:

- **Protocol split**: SDKs from rc20 onward speak only Apache Iggy's VSR cluster protocol while LaserData Cloud still spoke classic — rc19 (later rc21) was load-bearing. Cloud deployments created on/after 2026-07-31 serve VSR, so any current SDK works.
- **rc-only package**: `laser-sdk` had no stable release, and pip refuses pre-releases for an unpinned requirement — a bare line literally would not install. PyPI now has stable `0.0.1` and `0.0.2`.

The floor stays at `0.0.2` (rather than fully bare) so the resolver can never pick `0.0.1`, whose protocol era is ambiguous relative to the VSR cutover. This matches the repo convention: node requirements are unpinned or ranged by default, with exact pins reserved for documented incompatibilities. Operational context (VSR-only SDKs; pre-2026-07-31 Cloud deployments must be recreated; local servers need a VSR build) lives in the node's README and PR history rather than the requirements file.

## Verification

- **Live smoke test** against LaserData Cloud (`RocketTest`, AWS us-west-1) on `laser-sdk==0.0.2` as resolved by the new specifier: `remember` → `recall` (id present) → `improve` → `forget` → `recall` (tombstoned) — full round-trip PASS.
- **Contract checks**: `./builder check-externals:run --pattern=laserdata` → 2 passed, 0 skipped, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the laser SDK requirement to support newer compatible releases.
  * Removed outdated deployment compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->