### PR TITLE
chore(n8n-nodes): token auth for the first publish only

### DIFF
--- a/.github/workflows/n8n-nodes-release.yml
+++ b/.github/workflows/n8n-nodes-release.yml
@@ -67,7 +67,33 @@ jobs:
           npm run lint
           npm test
 
-      - name: Publish to npm (OIDC trusted publishing + provenance)
+      # TEMPORARY — remove once the package exists on the registry.
+      #
+      # Trusted publishing cannot be configured for a package that has never
+      # been published: `npm trust github n8n-nodes-rocketride ...` returns
+      # 404 POST /-/package/n8n-nodes-rocketride/trust. So the FIRST publish
+      # has to authenticate with a token.
+      #
+      # Provenance is unaffected by how we authenticate — it comes from
+      # `id-token: write` plus `--provenance`, which are already here. That
+      # matters because n8n Cloud requires provenance as of 1 May 2026, so a
+      # local `npm publish` would produce a package unusable where it is meant
+      # to be installed.
+      #
+      # AFTER THE FIRST SUCCESSFUL RUN:
+      #   1. npm trust github n8n-nodes-rocketride --file n8n-nodes-release.yml \
+      #        --repo rocketride-org/rocketride-server --env release
+      #   2. delete the NPM_TOKEN secret
+      #   3. revert this commit — the step below returns to tokenless OIDC
+      - name: Publish to npm (token auth for first publish + provenance)
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          if [ -z "${NODE_AUTH_TOKEN}" ]; then
+            echo "::error::NPM_TOKEN is not set. This workflow is in its first-publish"
+            echo "::error::configuration and needs a one-time granular token scoped to"
+            echo "::error::n8n-nodes-rocketride. See the comment above this step."
+            exit 1
+          fi
           # npm 11.19.0 supports OIDC trusted publishing and npm trust configuration (npm trust requires >= 11.15.0).
           npm publish --provenance --access public


### PR DESCRIPTION
Unblocks the first release of `n8n-nodes-rocketride` (from #1255). **Temporary by design — revert after one successful run.**

## Why a token, when we deliberately moved off tokens

Trusted publishing has to be attached to a package that already exists. Verified against the registry today:

```
npm trust github n8n-nodes-rocketride --file n8n-nodes-release.yml \
  --repo rocketride-org/rocketride-server --env release

→ npm error 404 Not Found - POST /-/package/n8n-nodes-rocketride/trust
```

The 2FA prompt appears *before* that call, so the command looks like it is working right up until it isn't. The package must exist first. Chicken and egg, and the token is the only way out of it.

## Why not just publish from a laptop

Because the result would be unusable where the package is meant to be installed:

```
n8n-node release --publish
▲ Publishing directly from your machine will not include npm provenance,
  which is required for n8n Cloud starting May 1 2026.
```

**Provenance does not depend on how we authenticate.** It comes from `id-token: write` plus `--provenance`, both already in this workflow and untouched here. So a CI publish with token auth still produces a fully attested package; only the *auth* method is temporarily different.

## What this changes

One step. Adds `NODE_AUTH_TOKEN` from a new `NPM_TOKEN` secret, plus a guard that fails with a clear message if the secret is missing rather than erroring deep inside npm.

## Sequence

1. Create a **granular** npm token scoped to publish `n8n-nodes-rocketride`, store it as the `NPM_TOKEN` secret in this repo — it should never pass through chat or a terminal transcript
2. Merge this
3. `git tag n8n-nodes-v0.1.0 && git push origin n8n-nodes-v0.1.0` — CI builds, lints, tests, publishes with provenance
4. `npm trust github n8n-nodes-rocketride --file n8n-nodes-release.yml --repo rocketride-org/rocketride-server --env release` — now succeeds, the package exists
5. Delete the `NPM_TOKEN` secret
6. Revert this commit

Steps 4–6 are the point of the exercise; leaving the token in place would undo #1077.

## Note on the package name

`n8n-nodes-rocketride` is unscoped, so the first publisher owns it. Publishing from CI under the `rocketride` org account keeps it with the company rather than an individual — worth confirming that is the account the token is minted from.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package publishing authentication for the initial release.
  * Added validation to clearly report when the required publishing credential is missing.
  * Kept provenance publishing enabled.
* **Documentation**
  * Documented the temporary token-based publishing setup and the planned return to trusted publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->