### PR TITLE
fix(agent_crewai): manager synthesizes delegate findings instead of returning one raw output

### DIFF
--- a/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
+++ b/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
@@ -346,22 +346,25 @@ class CrewManager(CrewBase):
             context, crew.akickoff(inputs={'user_request': prompt} if prompt else {})
         )
 
-        # Result extraction: prefer the last completed task's output (clean result)
-        # over result.raw, which in hierarchical mode contains the full manager
-        # ReAct trace (all delegations + observations concatenated).
+        # Result extraction: `tasks_output` holds one raw entry per delegate
+        # Task and nothing in CrewAI combines them, so the manager's own
+        # synthesis step has to happen here, explicitly, through its own LLM
+        # channel -- otherwise "the manager's answer" is just whichever single
+        # delegate's output happens to be picked, which defeats the entire
+        # point of a manager (see the goal/backstory above).
         tasks_out = getattr(result, 'tasks_output', None) or []
-        final_text = ''
-        for task_out in reversed(tasks_out):
-            candidate = safe_str(getattr(task_out, 'raw', None))
-            if not candidate:
-                continue
-            stripped = _strip_react_preamble(candidate)
-            if stripped:
-                final_text = stripped
-                break
+        final_text = self._synthesize_delegate_findings(
+            context=context,
+            tasks_out=tasks_out,
+            sub_tasks=sub_tasks,
+            manager_backstory=manager_backstory,
+            manager_goal=ig.goal or _MGR_GOAL,
+        )
 
         if not final_text:
-            # Fall back to result.raw with the same ReAct stripping.
+            # No delegate produced usable output (or the synthesis call itself
+            # came back empty) -- fall back to result.raw, ReAct-stripped, same
+            # as before this method existed.
             raw = (
                 safe_str(getattr(result, 'raw', None))
                 or safe_str(getattr(getattr(result, 'result', None), 'raw', None))
@@ -370,3 +373,46 @@ class CrewManager(CrewBase):
             final_text = _strip_react_preamble(raw)
 
         return final_text, result
+
+    def _synthesize_delegate_findings(
+        self,
+        *,
+        context: AgentContext,
+        tasks_out: List[Any],
+        sub_tasks: List[Any],
+        manager_backstory: str,
+        manager_goal: str,
+    ) -> str:
+        """Combine every delegate's clean task output into the manager's own answer.
+
+        `tasks_out` and `sub_tasks` are positional (`crew.tasks` executes in
+        the order it was given `sub_tasks`, and `tasks_output` is appended in
+        execution order), so zipping them pairs each raw output with the
+        delegate that produced it -- used only to label findings by role.
+
+        Returns ``''`` when no delegate produced usable output, so the caller
+        falls back to `result.raw`.
+        """
+        findings = []
+        for sub_task, task_out in zip(sub_tasks, tasks_out):
+            candidate = safe_str(getattr(task_out, 'raw', None))
+            if not candidate:
+                continue
+            stripped = _strip_react_preamble(candidate)
+            if not stripped:
+                continue
+            role = getattr(getattr(sub_task, 'agent', None), 'role', None) or 'Sub-agent'
+            findings.append(f'### {role}\n{stripped}')
+
+        if not findings:
+            return ''
+
+        synthesis_prompt = (
+            f'{manager_backstory}\n\n'
+            f'Your goal: {manager_goal}\n\n'
+            "Your team has finished. Below is each sub-agent's finding for this "
+            'request. Write your own final answer that satisfies your goal by '
+            'synthesizing these findings together -- never return one finding '
+            'verbatim as the final answer.\n\n' + '\n\n'.join(findings)
+        )
+        return safe_str(self.call_llm(context, synthesis_prompt, role=_MGR_ROLE)).strip()

--- a/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
+++ b/nodes/src/nodes/agent_crewai/crewai_manager/manager.py
@@ -37,9 +37,9 @@ tool path), not via the `crewai` channel.
 from __future__ import annotations
 
 import json
-from typing import Any, List
+from typing import Any, List, Tuple
 
-from rocketlib import debug
+from rocketlib import debug, error, warning
 
 from ai.common.agent import AgentContext
 from ai.common.agent._internal.host import AgentHostServices
@@ -105,6 +105,41 @@ def _strip_react_preamble(text: str) -> str:
         #    clean error.
         return ''
     return text
+
+
+def _finalize_answer(findings: List[str], final_text: str, result: Any) -> str:
+    """Assemble the manager's final answer, falling back to `result.raw` only
+    when there is truly nothing else to use.
+
+    Ladder:
+      1. `final_text` -- the synthesis output -- when synthesis produced
+         usable text.
+      2. The raw `findings`, joined, when synthesis produced nothing (the
+         call returned empty, or raised) but at least one delegate did.
+      3. `result.raw`, ReAct-stripped -- only when no delegate produced
+         usable output at all.
+
+    Rung 3 must never be reached while any finding exists: in hierarchical
+    mode `result.raw` is the last delegate task's own raw output (see the
+    comment at the `_synthesize_delegate_findings` call site), so falling
+    back to it while findings are available would silently reintroduce
+    #1848 -- one subagent's answer presented as the manager's, with nothing
+    to distinguish it from a real synthesis at the point of use.
+
+    A free function (not a method) so it's testable with plain values,
+    without a `CrewManager` instance or any CrewAI/LLM machinery -- this is
+    exactly the seam #1848's regression lives on.
+    """
+    if final_text:
+        return final_text
+    if findings:
+        return '\n\n'.join(findings)
+    raw = (
+        safe_str(getattr(result, 'raw', None))
+        or safe_str(getattr(getattr(result, 'result', None), 'raw', None))
+        or safe_str(result)
+    )
+    return _strip_react_preamble(raw)
 
 
 _MGR_ROLE = 'Manager'
@@ -352,8 +387,22 @@ class CrewManager(CrewBase):
         # channel -- otherwise "the manager's answer" is just whichever single
         # delegate's output happens to be picked, which defeats the entire
         # point of a manager (see the goal/backstory above).
+        #
+        # Checked whether CrewAI already exposes a distinct manager-authored
+        # answer instead of a delegate's raw output (crewai==1.15.10, within
+        # our >=1.14.1,<2 pin): `CrewOutput` (crewai/crews/crew_output.py)
+        # only carries `raw`, `pydantic`, `json_dict`, `tasks_output`, and
+        # `token_usage` -- no separate manager field. `Crew._create_crew_output`
+        # (crewai/crew.py) builds `raw` from
+        # `[t for t in task_outputs if t.raw][-1].raw`, and `task_outputs` is
+        # one entry per item in the `tasks` list `Crew(...)` was given --
+        # which above is `sub_tasks`, not a separate manager task (hierarchical
+        # mode delegates the given tasks; it does not add its own). So
+        # `result.raw` provably IS one delegate's raw output, not a manager
+        # synthesis -- there is no free alternative to the LLM-based synthesis
+        # below in this CrewAI version.
         tasks_out = getattr(result, 'tasks_output', None) or []
-        final_text = self._synthesize_delegate_findings(
+        findings, final_text = self._synthesize_delegate_findings(
             context=context,
             tasks_out=tasks_out,
             sub_tasks=sub_tasks,
@@ -361,18 +410,7 @@ class CrewManager(CrewBase):
             manager_goal=ig.goal or _MGR_GOAL,
         )
 
-        if not final_text:
-            # No delegate produced usable output (or the synthesis call itself
-            # came back empty) -- fall back to result.raw, ReAct-stripped, same
-            # as before this method existed.
-            raw = (
-                safe_str(getattr(result, 'raw', None))
-                or safe_str(getattr(getattr(result, 'result', None), 'raw', None))
-                or safe_str(result)
-            )
-            final_text = _strip_react_preamble(raw)
-
-        return final_text, result
+        return _finalize_answer(findings, final_text, result), result
 
     def _synthesize_delegate_findings(
         self,
@@ -382,7 +420,7 @@ class CrewManager(CrewBase):
         sub_tasks: List[Any],
         manager_backstory: str,
         manager_goal: str,
-    ) -> str:
+    ) -> Tuple[List[str], str]:
         """Combine every delegate's clean task output into the manager's own answer.
 
         `tasks_out` and `sub_tasks` are positional (`crew.tasks` executes in
@@ -390,10 +428,27 @@ class CrewManager(CrewBase):
         execution order), so zipping them pairs each raw output with the
         delegate that produced it -- used only to label findings by role.
 
-        Returns ``''`` when no delegate produced usable output, so the caller
-        falls back to `result.raw`.
+        Returns ``(findings, final_text)``. ``findings`` is every usable,
+        role-labeled delegate output found (``[]`` if none were); the caller
+        (`_finalize_answer`) uses it as the fallback when synthesis produces
+        nothing, so the delegate work already paid for is never silently
+        discarded. ``final_text`` is the synthesis output, or ``''`` when
+        there was nothing to synthesize (no findings), exactly one finding
+        (see below), or the synthesis call itself produced nothing or failed.
+
+        With exactly one finding there is nothing to synthesize -- asking the
+        model to "combine" a single finding only risks paraphrasing away
+        detail it already got right, at the cost of an extra LLM round trip
+        for no benefit. Returned verbatim (its ``### <role>`` label stripped)
+        instead, without calling the LLM. This does not reopen #1848: that
+        bug is dropping N-1 of N findings, which cannot happen when N=1.
+
+        With two or more findings, synthesis is an unconditional extra LLM
+        round trip per manager run (the same cost the `planning` flag above
+        opts out of by default) -- accepted here because combining findings
+        is the manager's actual job, unlike planning.
         """
-        findings = []
+        findings: List[str] = []
         for sub_task, task_out in zip(sub_tasks, tasks_out):
             candidate = safe_str(getattr(task_out, 'raw', None))
             if not candidate:
@@ -405,7 +460,10 @@ class CrewManager(CrewBase):
             findings.append(f'### {role}\n{stripped}')
 
         if not findings:
-            return ''
+            return [], ''
+
+        if len(findings) == 1:
+            return findings, findings[0].split('\n', 1)[1]
 
         synthesis_prompt = (
             f'{manager_backstory}\n\n'
@@ -415,4 +473,28 @@ class CrewManager(CrewBase):
             'synthesizing these findings together -- never return one finding '
             'verbatim as the final answer.\n\n' + '\n\n'.join(findings)
         )
-        return safe_str(self.call_llm(context, synthesis_prompt, role=_MGR_ROLE)).strip()
+        try:
+            final_text = safe_str(self.call_llm(context, synthesis_prompt, role=_MGR_ROLE)).strip()
+        except Exception as e:
+            # A provider hiccup here must not lose the N delegate runs already
+            # paid for -- degrade to the unsynthesized findings via
+            # `_finalize_answer` rather than letting this propagate out of
+            # `_run` (which would discard `findings` along with everything else).
+            error(
+                'agent_crewai_manager synthesis call_llm failed run_id={} type={} message={}'.format(
+                    context.run_id, type(e).__name__, str(e)
+                )
+            )
+            return findings, ''
+
+        if not final_text:
+            # Not an error -- e.g. the model returned an empty completion --
+            # but still worth a log line: `_finalize_answer` recovers using
+            # `findings`, so this would otherwise be as silent as the bug
+            # #1848 reports.
+            warning(
+                'agent_crewai_manager synthesis produced no usable text from {} finding(s) run_id={}; '
+                'falling back to unsynthesized findings'.format(len(findings), context.run_id)
+            )
+
+        return findings, final_text

--- a/nodes/test/agent_crewai/test_manager_synthesis.py
+++ b/nodes/test/agent_crewai/test_manager_synthesis.py
@@ -1,0 +1,290 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression tests for the hierarchical manager's result synthesis.
+
+A Manager wired to three subagents was returning a single subagent's raw,
+unedited task output as its final answer -- identifiable by that subagent's
+own persona leaking through -- instead of a synthesis of all three. Reordering
+the wired subagents surfaced a *different* subagent's raw output, with no
+correlation to position.
+
+Root cause: ``CrewManager._run``'s result-extraction step walked
+``result.tasks_output`` (one raw entry per delegate Task) and returned the
+first non-empty, ReAct-stripped candidate found scanning *backwards* -- i.e.
+whichever single delegate's output happened to survive stripping last in
+iteration order. Nothing anywhere combined multiple ``tasks_output`` entries,
+and no manager-authored synthesis step existed to extract instead.
+
+These tests exercise ``_synthesize_delegate_findings`` -- the extracted method
+that now performs that synthesis pass -- directly, in isolation from CrewAI's
+real hierarchical delegation loop. Scripting that loop (the manager's LLM
+would have to emit precisely-formatted ReAct delegation actions for CrewAI to
+actually invoke ``DelegateWorkTool``) is exactly what ``test_manager_tool_scoping.py``
+already opted out of for its own scope; same trade-off applied here.
+
+Import setup mirrors ``test_llm_contract.py``: ``crewai_manager.manager`` pulls
+``rocketlib``, ``crewai`` and several ``ai.common`` submodules that need
+pywin32/the compiled engine to import for real, so this stubs those seams
+around the import. The stubs are scoped and torn down afterwards so a full
+``builder nodes:test`` run, where the real modules are present, is unaffected.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import pytest
+
+# Point at nodes/src/nodes, not nodes/src: importing through the `nodes` package
+# would execute nodes/src/nodes/__init__.py, which pulls the engine-only `depends`.
+_NODES_DIR = Path(__file__).resolve().parents[2] / 'src' / 'nodes'
+if str(_NODES_DIR) not in sys.path:
+    sys.path.insert(0, str(_NODES_DIR))
+
+_STUB_MODULE_NAMES = (
+    'rocketlib',
+    'crewai',
+    'ai',
+    'ai.common',
+    'ai.common.agent',
+    'ai.common.agent._internal',
+    'ai.common.agent._internal.host',
+    'ai.common.agent.types',
+    'ai.common.schema',
+    'ai.common.utils',
+    'ai.common.config',
+)
+
+
+def _build_stubs() -> dict:
+    mod_rocketlib = types.ModuleType('rocketlib')
+    mod_rocketlib.ToolDescriptor = dict
+    mod_rocketlib.debug = lambda *a, **k: None
+    # Package __init__.py also pulls in IInstance.py / IGlobal.py (sibling
+    # node-facing classes, unrelated to _synthesize_delegate_findings), which
+    # need these additional rocketlib/ai.common seams to import.
+    mod_rocketlib.IInstanceBase = object
+    mod_rocketlib.IGlobalBase = object
+    mod_rocketlib.OPEN_MODE = types.SimpleNamespace(CONFIG='CONFIG')
+    mod_rocketlib.tool_function = lambda **kwargs: lambda fn: fn
+
+    # No `crewai.crew` / `crewai.tools` submodules: the import-time compatibility
+    # patches in crewai_base wrap their imports in try/except and no-op without them.
+    mod_crewai = types.ModuleType('crewai')
+    mod_crewai.BaseLLM = type('_StubBaseLLM', (), {'__init__': lambda self, **k: None})
+
+    mod_ai = types.ModuleType('ai')
+    mod_ai_common = types.ModuleType('ai.common')
+
+    mod_agent = types.ModuleType('ai.common.agent')
+
+    class AgentBase:
+        pass
+
+    class AgentContext:
+        pass
+
+    mod_agent.AgentBase = AgentBase
+    mod_agent.AgentContext = AgentContext
+
+    mod_agent_internal = types.ModuleType('ai.common.agent._internal')
+    mod_agent_internal_host = types.ModuleType('ai.common.agent._internal.host')
+    mod_agent_internal_host.AgentHostServices = object
+
+    mod_agent_types = types.ModuleType('ai.common.agent.types')
+    mod_agent_types.AgentRunResult = object
+    mod_agent_types.AGENT_TOOL_INPUT_SCHEMA = {}
+    mod_agent_types.AGENT_TOOL_OUTPUT_SCHEMA = {}
+
+    mod_schema = types.ModuleType('ai.common.schema')
+    mod_schema.Question = object
+
+    mod_utils = types.ModuleType('ai.common.utils')
+    mod_utils.safe_str = lambda v: '' if v is None else str(v)
+
+    mod_config = types.ModuleType('ai.common.config')
+    mod_config.Config = type('Config', (), {'getNodeConfig': staticmethod(lambda *a, **k: {})})
+
+    return {
+        'rocketlib': mod_rocketlib,
+        'crewai': mod_crewai,
+        'ai': mod_ai,
+        'ai.common': mod_ai_common,
+        'ai.common.agent': mod_agent,
+        'ai.common.agent._internal': mod_agent_internal,
+        'ai.common.agent._internal.host': mod_agent_internal_host,
+        'ai.common.agent.types': mod_agent_types,
+        'ai.common.schema': mod_schema,
+        'ai.common.utils': mod_utils,
+        'ai.common.config': mod_config,
+    }
+
+
+@contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    original = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    sys.modules.update(_build_stubs())
+    try:
+        yield
+    finally:
+        for name, module in original.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+with _scoped_stubs():
+    manager_module = importlib.import_module('agent_crewai.crewai_manager.manager')
+
+CrewManager = manager_module.CrewManager
+
+
+@pytest.fixture(autouse=True)
+def _stubbed_crewai():
+    with _scoped_stubs():
+        yield
+
+
+def _make_manager(call_llm_return: str = '') -> Any:
+    """A CrewManager instance with __init__ bypassed and call_llm stubbed.
+
+    __init__ resolves node config via the engine's Config/iGlobal seams,
+    which this test has no need to stand up -- _synthesize_delegate_findings
+    only touches `self.call_llm`.
+    """
+    manager = object.__new__(CrewManager)
+    manager.call_llm = MagicMock(return_value=call_llm_return)
+    return manager
+
+
+def _task_out(raw: str) -> Any:
+    return MagicMock(raw=raw)
+
+
+def _sub_task(role: str) -> Any:
+    task = MagicMock()
+    task.agent.role = role
+    return task
+
+
+class TestSynthesizeDelegateFindings:
+    def test_combines_all_delegate_findings_not_just_one(self):
+        """The exact bug: with 3 subagents, all 3 must feed the synthesis call."""
+        manager = _make_manager(call_llm_return='The synthesized answer.')
+        sub_tasks = [_sub_task('Research Subagent'), _sub_task('Writer Subagent'), _sub_task('Critic Subagent')]
+        tasks_out = [
+            _task_out('Final Answer: research finding'),
+            _task_out('Final Answer: draft finding'),
+            _task_out('Final Answer: critique finding'),
+        ]
+
+        result = manager._synthesize_delegate_findings(
+            context=MagicMock(),
+            tasks_out=tasks_out,
+            sub_tasks=sub_tasks,
+            manager_backstory='You are the manager.',
+            manager_goal='Coordinate the team.',
+        )
+
+        assert result == 'The synthesized answer.'
+        prompt_sent = manager.call_llm.call_args.args[1]
+        assert 'research finding' in prompt_sent
+        assert 'draft finding' in prompt_sent
+        assert 'critique finding' in prompt_sent
+        assert 'Research Subagent' in prompt_sent
+        assert 'Writer Subagent' in prompt_sent
+        assert 'Critic Subagent' in prompt_sent
+
+    def test_result_is_the_synthesis_not_any_single_finding_verbatim(self):
+        """Guards the reported symptom directly: a subagent's raw text must
+        never be byte-identical to the returned final answer.
+        """
+        manager = _make_manager(call_llm_return='Combined: all three checks passed.')
+        sub_tasks = [_sub_task('A'), _sub_task('B')]
+        tasks_out = [_task_out('Final Answer: A said X'), _task_out('Final Answer: B said Y')]
+
+        result = manager._synthesize_delegate_findings(
+            context=MagicMock(),
+            tasks_out=tasks_out,
+            sub_tasks=sub_tasks,
+            manager_backstory='backstory',
+            manager_goal='goal',
+        )
+
+        assert result not in ('A said X', 'B said Y')
+
+    def test_order_of_wired_subagents_does_not_change_which_findings_are_used(self):
+        """Reordering inputs must not drop a finding -- only relabel it."""
+        manager_forward = _make_manager(call_llm_return='synthesized')
+        manager_reversed = _make_manager(call_llm_return='synthesized')
+
+        sub_tasks = [_sub_task('First'), _sub_task('Second')]
+        tasks_out = [_task_out('Final Answer: one'), _task_out('Final Answer: two')]
+
+        manager_forward._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+        manager_reversed._synthesize_delegate_findings(
+            context=MagicMock(),
+            tasks_out=list(reversed(tasks_out)),
+            sub_tasks=list(reversed(sub_tasks)),
+            manager_backstory='b',
+            manager_goal='g',
+        )
+
+        forward_prompt = manager_forward.call_llm.call_args.args[1]
+        reversed_prompt = manager_reversed.call_llm.call_args.args[1]
+        for prompt in (forward_prompt, reversed_prompt):
+            assert 'one' in prompt
+            assert 'two' in prompt
+
+    def test_skips_delegates_with_empty_or_unstrippable_output(self):
+        manager = _make_manager(call_llm_return='synthesized')
+        sub_tasks = [_sub_task('Empty'), _sub_task('Real')]
+        tasks_out = [_task_out(''), _task_out('Final Answer: the only real finding')]
+
+        result = manager._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+
+        assert result == 'synthesized'
+        prompt_sent = manager.call_llm.call_args.args[1]
+        assert 'the only real finding' in prompt_sent
+
+    def test_no_usable_delegate_output_returns_empty_without_calling_llm(self):
+        """Lets the caller fall back to result.raw instead of synthesizing nothing."""
+        manager = _make_manager(call_llm_return='should not be used')
+        sub_tasks = [_sub_task('A')]
+        tasks_out = [_task_out('')]
+
+        result = manager._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+
+        assert result == ''
+        manager.call_llm.assert_not_called()
+
+    def test_mismatched_lengths_do_not_crash(self):
+        """More task outputs than known sub_tasks (or vice versa) must not raise."""
+        manager = _make_manager(call_llm_return='synthesized')
+        sub_tasks: List[Any] = [_sub_task('Only one known')]
+        tasks_out = [_task_out('Final Answer: one'), _task_out('Final Answer: two')]
+
+        result = manager._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+
+        assert result == 'synthesized'

--- a/nodes/test/agent_crewai/test_manager_synthesis.py
+++ b/nodes/test/agent_crewai/test_manager_synthesis.py
@@ -146,7 +146,7 @@ def _scoped_stubs() -> Iterator[None]:
                 sys.modules[name] = module
 
 
-def _import_manager_module() -> Any:
+def _import_manager_module(module_name: str = 'agent_crewai.crewai_manager.manager') -> Any:
     """Import crewai_manager.manager under the stubs, then evict every
     agent_crewai* module the import pulled in from sys.modules.
 
@@ -158,13 +158,26 @@ def _import_manager_module() -> Any:
     stub-tainted copy instead of a fresh one. Evicting them here doesn't
     invalidate the `manager_module`/`CrewManager` references already bound
     below; sys.modules only governs future imports, not held references.
+
+    The eviction runs in `finally` rather than after the import: Python's
+    import machinery caches each parent package in `sys.modules` as soon as
+    it succeeds, before moving on to the next component of a dotted import.
+    So a failure partway through (e.g. `manager` itself raising after
+    `agent_crewai` and `agent_crewai.crewai_manager` already imported fine)
+    would leave those already-succeeded parents stub-tainted and uncleaned
+    if eviction only ran on the success path. `module_name` is a parameter
+    (default the real target) so tests can force that exact partial-success-
+    then-failure shape with a nonexistent submodule name, without needing to
+    break the stubs themselves.
     """
     before = set(sys.modules)
-    with _scoped_stubs():
-        module = importlib.import_module('agent_crewai.crewai_manager.manager')
-    for name in list(sys.modules):
-        if name not in before and (name == 'agent_crewai' or name.startswith('agent_crewai.')):
-            del sys.modules[name]
+    try:
+        with _scoped_stubs():
+            module = importlib.import_module(module_name)
+    finally:
+        for name in list(sys.modules):
+            if name not in before and (name == 'agent_crewai' or name.startswith('agent_crewai.')):
+                del sys.modules[name]
     return module
 
 
@@ -176,6 +189,33 @@ CrewManager = manager_module.CrewManager
 def _stubbed_crewai():
     with _scoped_stubs():
         yield
+
+
+class TestImportManagerModuleCleanup:
+    """_import_manager_module's cleanup must run even when the import itself
+    raises -- otherwise whatever agent_crewai* packages DID finish importing
+    before the failure (agent_crewai, agent_crewai.crewai_manager -- neither
+    needs the missing submodule below) would stay cached under their real
+    names, stub-tainted, for a later import elsewhere in the same session to
+    pick up. A nonexistent submodule name forces exactly that partial-
+    success-then-failure shape reliably, without needing to break the stubs.
+    """
+
+    def test_evicts_agent_crewai_modules_even_when_import_raises(self):
+        # Compare against a before-snapshot, not "no agent_crewai* names at
+        # all": sibling test files (test_llm_contract.py, test_tool_schema.py)
+        # import agent_crewai.crewai_base under their own stubs and -- by
+        # their own design -- don't evict it afterward, so it may already be
+        # cached (stub-tainted, but not this test's problem) depending on
+        # collection order. What this test owns is that THIS call doesn't add
+        # any new leaks beyond whatever was already there.
+        before = {name for name in sys.modules if name == 'agent_crewai' or name.startswith('agent_crewai.')}
+
+        with pytest.raises(ModuleNotFoundError):
+            _import_manager_module('agent_crewai.crewai_manager.nonexistent_module_for_test')
+
+        after = {name for name in sys.modules if name == 'agent_crewai' or name.startswith('agent_crewai.')}
+        assert after == before
 
 
 def _make_manager(call_llm_return: str = '') -> Any:

--- a/nodes/test/agent_crewai/test_manager_synthesis.py
+++ b/nodes/test/agent_crewai/test_manager_synthesis.py
@@ -146,9 +146,29 @@ def _scoped_stubs() -> Iterator[None]:
                 sys.modules[name] = module
 
 
-with _scoped_stubs():
-    manager_module = importlib.import_module('agent_crewai.crewai_manager.manager')
+def _import_manager_module() -> Any:
+    """Import crewai_manager.manager under the stubs, then evict every
+    agent_crewai* module the import pulled in from sys.modules.
 
+    Without this, `agent_crewai`, `agent_crewai.crewai_base`, and
+    `agent_crewai.crewai_manager*` would stay cached under their real names
+    but built against these fakes -- a later import of the same names
+    elsewhere in the same pytest session (e.g. a real `builder nodes:test`
+    run where the genuine dependencies are present) would silently get this
+    stub-tainted copy instead of a fresh one. Evicting them here doesn't
+    invalidate the `manager_module`/`CrewManager` references already bound
+    below; sys.modules only governs future imports, not held references.
+    """
+    before = set(sys.modules)
+    with _scoped_stubs():
+        module = importlib.import_module('agent_crewai.crewai_manager.manager')
+    for name in list(sys.modules):
+        if name not in before and (name == 'agent_crewai' or name.startswith('agent_crewai.')):
+            del sys.modules[name]
+    return module
+
+
+manager_module = _import_manager_module()
 CrewManager = manager_module.CrewManager
 
 

--- a/nodes/test/agent_crewai/test_manager_synthesis.py
+++ b/nodes/test/agent_crewai/test_manager_synthesis.py
@@ -226,6 +226,16 @@ class TestImportManagerModuleCleanup:
             leaked = [name for name in sys.modules if name == 'agent_crewai' or name.startswith('agent_crewai.')]
             assert leaked == [], 'the failing import must not leave any agent_crewai* modules cached'
         finally:
+            # update(saved) alone only adds back what was popped above -- it
+            # doesn't remove anything else. If the assertion above is what
+            # fails (i.e. this test is doing its job and catching a real
+            # eviction regression), whatever leaked would stay leaked after
+            # cleanup too, contaminating later tests. Strip every current
+            # agent_crewai* entry first so restoring `saved` lands on
+            # exactly the pre-test state either way.
+            for name in list(sys.modules):
+                if (name == 'agent_crewai' or name.startswith('agent_crewai.')) and name not in saved:
+                    del sys.modules[name]
             sys.modules.update(saved)
 
 

--- a/nodes/test/agent_crewai/test_manager_synthesis.py
+++ b/nodes/test/agent_crewai/test_manager_synthesis.py
@@ -202,20 +202,31 @@ class TestImportManagerModuleCleanup:
     """
 
     def test_evicts_agent_crewai_modules_even_when_import_raises(self):
-        # Compare against a before-snapshot, not "no agent_crewai* names at
-        # all": sibling test files (test_llm_contract.py, test_tool_schema.py)
-        # import agent_crewai.crewai_base under their own stubs and -- by
-        # their own design -- don't evict it afterward, so it may already be
-        # cached (stub-tainted, but not this test's problem) depending on
-        # collection order. What this test owns is that THIS call doesn't add
-        # any new leaks beyond whatever was already there.
-        before = {name for name in sys.modules if name == 'agent_crewai' or name.startswith('agent_crewai.')}
+        # Force a clean slate first. Sibling test files (test_llm_contract.py,
+        # test_tool_schema.py) import agent_crewai.crewai_base under their own
+        # stubs and -- by their own design -- don't evict it afterward, so
+        # depending on collection order agent_crewai/agent_crewai.crewai_manager
+        # could already be cached when this test runs. If they were, the
+        # failing import below would find them present and add nothing new,
+        # so even a finally-less (unfixed) _import_manager_module would show
+        # "no new leaks" -- passing vacuously without eviction ever running.
+        # Popping any existing agent_crewai* entries first guarantees the
+        # failing import has to freshly (re)create agent_crewai and
+        # agent_crewai.crewai_manager, so this test actually exercises
+        # eviction rather than coincidentally finding nothing to evict.
+        saved = {
+            name: sys.modules.pop(name)
+            for name in list(sys.modules)
+            if name == 'agent_crewai' or name.startswith('agent_crewai.')
+        }
+        try:
+            with pytest.raises(ModuleNotFoundError):
+                _import_manager_module('agent_crewai.crewai_manager.nonexistent_module_for_test')
 
-        with pytest.raises(ModuleNotFoundError):
-            _import_manager_module('agent_crewai.crewai_manager.nonexistent_module_for_test')
-
-        after = {name for name in sys.modules if name == 'agent_crewai' or name.startswith('agent_crewai.')}
-        assert after == before
+            leaked = [name for name in sys.modules if name == 'agent_crewai' or name.startswith('agent_crewai.')]
+            assert leaked == [], 'the failing import must not leave any agent_crewai* modules cached'
+        finally:
+            sys.modules.update(saved)
 
 
 def _make_manager(call_llm_return: str = '') -> Any:

--- a/nodes/test/agent_crewai/test_manager_synthesis.py
+++ b/nodes/test/agent_crewai/test_manager_synthesis.py
@@ -72,6 +72,8 @@ def _build_stubs() -> dict:
     mod_rocketlib = types.ModuleType('rocketlib')
     mod_rocketlib.ToolDescriptor = dict
     mod_rocketlib.debug = lambda *a, **k: None
+    mod_rocketlib.error = lambda *a, **k: None
+    mod_rocketlib.warning = lambda *a, **k: None
     # Package __init__.py also pulls in IInstance.py / IGlobal.py (sibling
     # node-facing classes, unrelated to _synthesize_delegate_findings), which
     # need these additional rocketlib/ai.common seams to import.
@@ -239,7 +241,7 @@ class TestImportManagerModuleCleanup:
             sys.modules.update(saved)
 
 
-def _make_manager(call_llm_return: str = '') -> Any:
+def _make_manager(call_llm_return: str = '', call_llm_side_effect: Any = None) -> Any:
     """A CrewManager instance with __init__ bypassed and call_llm stubbed.
 
     __init__ resolves node config via the engine's Config/iGlobal seams,
@@ -247,7 +249,7 @@ def _make_manager(call_llm_return: str = '') -> Any:
     only touches `self.call_llm`.
     """
     manager = object.__new__(CrewManager)
-    manager.call_llm = MagicMock(return_value=call_llm_return)
+    manager.call_llm = MagicMock(return_value=call_llm_return, side_effect=call_llm_side_effect)
     return manager
 
 
@@ -263,7 +265,11 @@ def _sub_task(role: str) -> Any:
 
 class TestSynthesizeDelegateFindings:
     def test_combines_all_delegate_findings_not_just_one(self):
-        """The exact bug: with 3 subagents, all 3 must feed the synthesis call."""
+        """The exact bug: with 3 subagents, all 3 must feed the synthesis call,
+        and the returned text must be the synthesis, not any one finding
+        verbatim (folds in the former standalone verbatim-check test -- same
+        seam, this one already asserts the stronger claim).
+        """
         manager = _make_manager(call_llm_return='The synthesized answer.')
         sub_tasks = [_sub_task('Research Subagent'), _sub_task('Writer Subagent'), _sub_task('Critic Subagent')]
         tasks_out = [
@@ -272,7 +278,7 @@ class TestSynthesizeDelegateFindings:
             _task_out('Final Answer: critique finding'),
         ]
 
-        result = manager._synthesize_delegate_findings(
+        findings, result = manager._synthesize_delegate_findings(
             context=MagicMock(),
             tasks_out=tasks_out,
             sub_tasks=sub_tasks,
@@ -281,6 +287,8 @@ class TestSynthesizeDelegateFindings:
         )
 
         assert result == 'The synthesized answer.'
+        assert result not in ('research finding', 'draft finding', 'critique finding')
+        assert len(findings) == 3
         prompt_sent = manager.call_llm.call_args.args[1]
         assert 'research finding' in prompt_sent
         assert 'draft finding' in prompt_sent
@@ -288,24 +296,6 @@ class TestSynthesizeDelegateFindings:
         assert 'Research Subagent' in prompt_sent
         assert 'Writer Subagent' in prompt_sent
         assert 'Critic Subagent' in prompt_sent
-
-    def test_result_is_the_synthesis_not_any_single_finding_verbatim(self):
-        """Guards the reported symptom directly: a subagent's raw text must
-        never be byte-identical to the returned final answer.
-        """
-        manager = _make_manager(call_llm_return='Combined: all three checks passed.')
-        sub_tasks = [_sub_task('A'), _sub_task('B')]
-        tasks_out = [_task_out('Final Answer: A said X'), _task_out('Final Answer: B said Y')]
-
-        result = manager._synthesize_delegate_findings(
-            context=MagicMock(),
-            tasks_out=tasks_out,
-            sub_tasks=sub_tasks,
-            manager_backstory='backstory',
-            manager_goal='goal',
-        )
-
-        assert result not in ('A said X', 'B said Y')
 
     def test_order_of_wired_subagents_does_not_change_which_findings_are_used(self):
         """Reordering inputs must not drop a finding -- only relabel it."""
@@ -333,17 +323,21 @@ class TestSynthesizeDelegateFindings:
             assert 'two' in prompt
 
     def test_skips_delegates_with_empty_or_unstrippable_output(self):
-        manager = _make_manager(call_llm_return='synthesized')
+        """The empty delegate must not reach the survivor count: with only
+        one usable delegate left, the single-finding short-circuit applies
+        (see TestSingleFindingShortCircuit), so no LLM call happens here.
+        """
+        manager = _make_manager(call_llm_return='should not be used')
         sub_tasks = [_sub_task('Empty'), _sub_task('Real')]
         tasks_out = [_task_out(''), _task_out('Final Answer: the only real finding')]
 
-        result = manager._synthesize_delegate_findings(
+        findings, result = manager._synthesize_delegate_findings(
             context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
         )
 
-        assert result == 'synthesized'
-        prompt_sent = manager.call_llm.call_args.args[1]
-        assert 'the only real finding' in prompt_sent
+        assert findings == ['### Real\nthe only real finding']
+        assert result == 'the only real finding'
+        manager.call_llm.assert_not_called()
 
     def test_no_usable_delegate_output_returns_empty_without_calling_llm(self):
         """Lets the caller fall back to result.raw instead of synthesizing nothing."""
@@ -351,21 +345,140 @@ class TestSynthesizeDelegateFindings:
         sub_tasks = [_sub_task('A')]
         tasks_out = [_task_out('')]
 
-        result = manager._synthesize_delegate_findings(
+        findings, result = manager._synthesize_delegate_findings(
             context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
         )
 
+        assert findings == []
         assert result == ''
         manager.call_llm.assert_not_called()
 
     def test_mismatched_lengths_do_not_crash(self):
-        """More task outputs than known sub_tasks (or vice versa) must not raise."""
-        manager = _make_manager(call_llm_return='synthesized')
-        sub_tasks: List[Any] = [_sub_task('Only one known')]
-        tasks_out = [_task_out('Final Answer: one'), _task_out('Final Answer: two')]
+        """More task outputs than known sub_tasks (or vice versa) must not raise.
 
-        result = manager._synthesize_delegate_findings(
+        Two sub_tasks against three task outputs so zip's truncation to two
+        pairs still leaves two findings -- keeping this test on the
+        synthesis path, distinct from the single-finding short-circuit.
+        """
+        manager = _make_manager(call_llm_return='synthesized')
+        sub_tasks: List[Any] = [_sub_task('First known'), _sub_task('Second known')]
+        tasks_out = [
+            _task_out('Final Answer: one'),
+            _task_out('Final Answer: two'),
+            _task_out('Final Answer: unmatched, no sub_task for this one'),
+        ]
+
+        findings, result = manager._synthesize_delegate_findings(
             context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
         )
 
+        assert len(findings) == 2
         assert result == 'synthesized'
+
+
+class TestSingleFindingShortCircuit:
+    """#1855 review (asclearuc): with exactly one usable delegate finding,
+    synthesizing "together" is meaningless -- return it verbatim (label
+    stripped) without spending an LLM call that can only paraphrase it worse.
+    """
+
+    def test_single_finding_returned_verbatim_without_calling_llm(self):
+        manager = _make_manager(call_llm_return='should not be used')
+        sub_tasks = [_sub_task('Solo Subagent')]
+        tasks_out = [_task_out('Final Answer: the only finding')]
+
+        findings, result = manager._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+
+        assert findings == ['### Solo Subagent\nthe only finding']
+        assert result == 'the only finding'
+        manager.call_llm.assert_not_called()
+
+    def test_does_not_reopen_1848_dropping_findings(self):
+        """#1848 is dropping N-1 of N findings. With N=1 there is nothing to
+        drop, so returning the sole finding verbatim is not a regression.
+        """
+        manager = _make_manager()
+        sub_tasks = [_sub_task('Only One')]
+        tasks_out = [_task_out('Final Answer: complete and correct answer')]
+
+        findings, result = manager._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+
+        assert result == 'complete and correct answer'
+        assert len(findings) == 1
+
+
+class TestSynthesisFailureModes:
+    """#1855 review (asclearuc), MUST-fix item: an empty or failed synthesis
+    call must not discard the delegate findings it had in hand -- `_run`
+    (via `_finalize_answer`) falls back to them, never straight to
+    `result.raw`, which would silently reintroduce #1848 on a new path.
+    """
+
+    def test_empty_synthesis_still_returns_the_findings(self):
+        """call_llm returning '' (e.g. an empty model completion) must not
+        lose the findings the caller needs for its own fallback.
+        """
+        manager = _make_manager(call_llm_return='')
+        sub_tasks = [_sub_task('A'), _sub_task('B')]
+        tasks_out = [_task_out('Final Answer: finding A'), _task_out('Final Answer: finding B')]
+
+        findings, result = manager._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+
+        assert result == ''
+        assert len(findings) == 2
+
+    def test_call_llm_raising_still_returns_the_findings(self):
+        """A provider hiccup (rate limit, timeout, 5xx) inside call_llm must
+        degrade to an empty synthesis, not propagate and lose the findings.
+        """
+        manager = _make_manager(call_llm_side_effect=RuntimeError('rate limited'))
+        sub_tasks = [_sub_task('A'), _sub_task('B')]
+        tasks_out = [_task_out('Final Answer: finding A'), _task_out('Final Answer: finding B')]
+
+        findings, result = manager._synthesize_delegate_findings(
+            context=MagicMock(), tasks_out=tasks_out, sub_tasks=sub_tasks, manager_backstory='b', manager_goal='g'
+        )
+
+        assert result == ''
+        assert len(findings) == 2
+
+
+class TestFinalizeAnswer:
+    """Direct tests of `_finalize_answer`'s fallback ladder -- the seam
+    #1855's regression actually lives on, and (before this PR) had no
+    coverage: it is a free function taking plain values, so these need no
+    CrewManager instance, LLM, or CrewAI machinery at all.
+    """
+
+    def test_prefers_final_text_when_present(self):
+        result = manager_module._finalize_answer(['### A\nfinding a'], 'the synthesis', MagicMock(raw='raw trace'))
+        assert result == 'the synthesis'
+
+    def test_falls_back_to_joined_findings_when_final_text_empty(self):
+        """The core regression pin: an empty synthesis with findings on hand
+        must use the findings, never `result.raw` -- reaching `result.raw`
+        here would silently reintroduce #1848.
+        """
+        findings = ['### A\nfinding a', '### B\nfinding b']
+        fake_result = MagicMock(raw='Thought: ...\nFinal Answer: finding b')
+
+        result = manager_module._finalize_answer(findings, '', fake_result)
+
+        assert result == '### A\nfinding a\n\n### B\nfinding b'
+        assert result != 'finding b'
+
+    def test_falls_back_to_result_raw_only_when_no_findings_exist(self):
+        """The pre-#1848 behavior, kept as the last resort for the genuinely
+        no-usable-output case (no delegate produced anything at all).
+        """
+        fake_result = MagicMock(raw='Thought: ...\nFinal Answer: only usable text')
+
+        result = manager_module._finalize_answer([], '', fake_result)
+
+        assert result == 'only usable text'


### PR DESCRIPTION
## Summary
- `CrewManager._run`'s result-extraction step walked `result.tasks_output` (one raw entry per delegate `Task`) and returned the first non-empty, ReAct-stripped candidate found scanning **backwards** — i.e. whichever single delegate's output happened to survive stripping last in iteration order. Nothing anywhere combined multiple `tasks_output` entries, and no manager-authored synthesis step existed to extract instead.
- With 3 wired subagents, the pipeline silently dropped 2 of them: the "final answer" was one subagent's raw output verbatim (its own persona/voice leaking through), not a synthesis. Reordering the wired subagents surfaced a *different* subagent's output, uncorrelated with position — exactly the reported symptom.
- Extracts the fix into `_synthesize_delegate_findings`: collects every delegate's clean output, labels each by role, and runs them back through the manager's own LLM (using its configured goal/backstory/instructions) for an explicit synthesis pass. Falls back to the previous `result.raw` behavior only when no delegate produced usable output.

Fixes #1848

## Test plan
- [x] `pytest nodes/test/agent_crewai/` — 83 passed (77 pre-existing + 6 new), same 4 pre-existing environment-only failures in `test_stop_words.py` (missing `ai` package on `sys.path` outside `./builder test`) reproduced identically on `develop` before this change, confirming they're unrelated.
- [x] New `test_manager_synthesis.py` covers: all N delegate findings reach the synthesis prompt (not just one), the returned answer is never byte-identical to any single finding, reordering wired subagents doesn't drop a finding, empty/unstrippable delegate outputs are skipped, no-usable-output falls back without calling the LLM, and mismatched list lengths don't crash.
- [x] `ruff check` / `ruff format --check` clean on touched files.
- [ ] Not run against a full `crew.akickoff()` with the real CrewAI hierarchical delegation loop — same scope decision `test_manager_tool_scoping.py` already made: scripting the manager's LLM to emit precisely-formatted ReAct delegation actions that make CrewAI actually invoke `DelegateWorkTool` isn't practical to fake reliably, so the fix is tested at the result-extraction/synthesis seam directly instead.

<!-- Generated with the assistance of Claude Code -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crew manager results by combining findings from all available delegates instead of displaying only the last completed result.
  * Findings are now labeled by delegate role and remain consistent regardless of completion order.
  * Empty, invalid, or incomplete delegate outputs are safely excluded.
  * Preserved fallback results when synthesis cannot produce usable text.
  * Improved handling of mismatched or partial delegate results for more reliable output.
  * Synthesized results are no longer limited to verbatim delegate responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->