### PR TITLE
fix(vscode,sdk): make the local engine's dynamic port discoverable outside its own connect flow

### DIFF
--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -70,6 +70,14 @@ Cloud connections are not synced because their OAuth token is not an SDK API key
 
 The extension never automatically removes these keys: disconnecting, engine exit, or switching to cloud leaves the last-synced values in place. Remove them by hand if you no longer want them. Each development-group self-hosted connection syncs again, so a hand-edited `ROCKETRIDE_APIKEY` is overwritten on the next successful connection.
 
+## Local Engine Connection Discovery
+
+The local engine backend (`--port=0`) gets a fresh OS-assigned port on every start, which the `.env` Auto-Sync above only helps with for scripts reading `.env` from *this* workspace. For anything else — a long-running script that outlives an engine restart, or a process not tied to any particular workspace — the extension also writes the resolved URI to a small, fixed discovery file: `<user config dir>/engine/connection.json` (`~/Library/Application Support/RocketRide/engine/connection.json` on macOS, `%LOCALAPPDATA%\RocketRide\engine\connection.json` on Windows, `~/.config/RocketRide/engine/connection.json` on Linux — the same directory the engine binary and `version.json` already live in). It's removed when that engine process exits.
+
+The Python SDK checks this file automatically as a fallback: when `RocketRideClient()` gets no explicit `uri` and `ROCKETRIDE_URI` isn't set via the environment or `.env`, it reads this file instead of jumping straight to the cloud default (verifying the recorded PID is still alive first, so a crashed engine's stale entry isn't picked up). An explicit `uri`/`ROCKETRIDE_URI` always takes priority.
+
+This is a "last-connected" file, not a registry of every simultaneously-running local engine across multiple VS Code windows — for the common one-developer-one-local-engine case that's exactly the desired behavior.
+
 ## Monitoring Execution
 
 The **Status** page shows:

--- a/apps/vscode/docs/usage.md
+++ b/apps/vscode/docs/usage.md
@@ -78,6 +78,8 @@ The Python SDK checks this file automatically as a fallback: when `RocketRideCli
 
 This is a "last-connected" file, not a registry of every simultaneously-running local engine across multiple VS Code windows — for the common one-developer-one-local-engine case that's exactly the desired behavior.
 
+The file carries no credential — only `uri`, `pid`, and `updatedAt` — and is written mode `0600` (POSIX; a no-op on Windows) so only your OS user can read it. A reader (the Python SDK's fallback above) only ever trusts a discovered URI whose host is loopback (`localhost`/`127.0.0.1`/`::1`); this file is meant to name a local engine only, and a discovered URI is combined with your real API key (from `ROCKETRIDE_APIKEY`/`auth`) when connecting, so a non-loopback host is never adopted from it.
+
 ## Monitoring Execution
 
 The **Status** page shows:

--- a/apps/vscode/src/engine/local/connectionDiscovery.ts
+++ b/apps/vscode/src/engine/local/connectionDiscovery.ts
@@ -60,14 +60,12 @@ import * as path from 'path';
 
 /** Shape of the connection discovery file's contents. */
 export interface ConnectionDiscoveryInfo {
-	/** HTTP base URL of the running local engine, e.g. `http://localhost:54321`. */
 	uri: string;
-	/** API key for this connection. Local mode always uses the fixed default. */
+	/** Local mode always uses the fixed default; see `writeConnectionDiscovery`. */
 	apiKey: string;
-	/** PID of the engine process that wrote this file, so a stale entry left
-	 * behind by a crash (no clean `stop()`) can be told apart from a live one. */
+	/** PID of the writer, so a stale entry left behind by a crash (no clean
+	 * `stop()`) can be told apart from a live one. */
 	pid: number;
-	/** ISO-8601 timestamp of when this file was last written. */
 	updatedAt: string;
 }
 

--- a/apps/vscode/src/engine/local/connectionDiscovery.ts
+++ b/apps/vscode/src/engine/local/connectionDiscovery.ts
@@ -1,0 +1,118 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+/**
+ * Pure helpers for the local engine's connection discovery file.
+ *
+ * `--port=0` gives the local engine a fresh OS-assigned port every time it
+ * (re)starts, and that port previously lived only in this VS Code window's
+ * in-memory state (plus, since #1413/#1492, the workspace `.env`). Neither
+ * helps a process that isn't this specific window's own connect flow: a
+ * long-running external script keeps whatever URI it read at its own
+ * startup and has no signal that the engine restarted underneath it, and a
+ * script not tied to this workspace has no `.env` to read at all. The only
+ * previously-documented way to find the live port was `lsof` against the
+ * engine's process name.
+ *
+ * This writes the resolved URI to a small, fixed, workspace-independent file
+ * under the engine's own install directory (`getUserConfigDir()` from
+ * `../config/config-migration`, i.e. `~/Library/Application Support/RocketRide`
+ * on macOS, already the canonical "where does the local engine live"
+ * directory that `version.json`/`engine-<pid>.pid` also live in) so any
+ * process on the machine can find the currently-running local engine without
+ * being the one that started it.
+ *
+ * Scope/limitation, deliberately: this is a single "last-connected" file, not
+ * a registry of every concurrently-running engine across multiple VS Code
+ * windows. For the reported problem -- one developer, one local engine,
+ * losing track of it across reloads -- "last connected" is exactly the
+ * right answer. Disambiguating multiple simultaneous local engines is a
+ * separate, harder problem nobody asked for here; `pid` is included so a
+ * consumer that cares can at least check the writer is still alive.
+ *
+ * These functions are deliberately free of any `vscode` import so they can
+ * be unit-tested standalone with `node:test` (see connectionDiscovery.test.ts).
+ * The actual filesystem read/write lives in EngineLocal, which already uses
+ * `fs` synchronously for its PID files.
+ */
+
+import * as path from 'path';
+
+/** Shape of the connection discovery file's contents. */
+export interface ConnectionDiscoveryInfo {
+	/** HTTP base URL of the running local engine, e.g. `http://localhost:54321`. */
+	uri: string;
+	/** API key for this connection. Local mode always uses the fixed default. */
+	apiKey: string;
+	/** PID of the engine process that wrote this file, so a stale entry left
+	 * behind by a crash (no clean `stop()`) can be told apart from a live one. */
+	pid: number;
+	/** ISO-8601 timestamp of when this file was last written. */
+	updatedAt: string;
+}
+
+/** Filename of the discovery file within the engine's install directory. */
+export const CONNECTION_DISCOVERY_FILENAME = 'connection.json';
+
+/**
+ * Path to the discovery file given the local engine's install directory
+ * (the same directory `EngineInstaller`/`engine-<pid>.pid` already use).
+ */
+export function connectionDiscoveryPath(engineDir: string): string {
+	return path.join(engineDir, CONNECTION_DISCOVERY_FILENAME);
+}
+
+/** Serializes discovery info to the file's on-disk JSON text. */
+export function serializeConnectionDiscovery(info: ConnectionDiscoveryInfo): string {
+	return JSON.stringify(info, null, 2) + '\n';
+}
+
+/**
+ * Parses the discovery file's text, returning `null` for anything that isn't
+ * a well-formed `ConnectionDiscoveryInfo` (missing file, invalid JSON, or a
+ * shape from some future/incompatible version) rather than throwing --
+ * callers on the read side should treat this purely as an optional hint.
+ */
+export function parseConnectionDiscovery(text: string): ConnectionDiscoveryInfo | null {
+	let data: unknown;
+	try {
+		data = JSON.parse(text);
+	} catch {
+		return null;
+	}
+	if (
+		!data ||
+		typeof data !== 'object' ||
+		typeof (data as Record<string, unknown>).uri !== 'string' ||
+		typeof (data as Record<string, unknown>).pid !== 'number'
+	) {
+		return null;
+	}
+	const record = data as Record<string, unknown>;
+	return {
+		uri: record.uri as string,
+		apiKey: typeof record.apiKey === 'string' ? record.apiKey : '',
+		pid: record.pid as number,
+		updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : '',
+	};
+}

--- a/apps/vscode/src/engine/local/connectionDiscovery.ts
+++ b/apps/vscode/src/engine/local/connectionDiscovery.ts
@@ -52,8 +52,12 @@
  *
  * These functions are deliberately free of any `vscode` import so they can
  * be unit-tested standalone with `node:test` (see connectionDiscovery.test.ts).
- * The actual filesystem read/write lives in EngineLocal, which already uses
- * `fs` synchronously for its PID files.
+ * The actual read/write of the discovery file's *content* lives in
+ * EngineLocal, which already uses `fs` synchronously for its PID files;
+ * `withDiscoveryLock` below is the one exception -- it wraps that read/write
+ * in a small file-based mutex, and correctness there is worth testing
+ * directly against a real filesystem rather than only indirectly through
+ * EngineLocal (which also needs `vscode`, so isn't `node:test`-able here).
  *
  * Canonical schema, kept in sync by hand across this file and the read side
  * (`packages/client-python/src/rocketride/_connection_discovery.py`; there is
@@ -65,6 +69,7 @@
  * actually a credential invites the next reader to trust it as one.
  */
 
+import * as fs from 'fs';
 import * as path from 'path';
 
 /** Shape of the connection discovery file's contents. */
@@ -156,4 +161,79 @@ export function parseConnectionDiscovery(text: string): ConnectionDiscoveryInfo 
 		pid,
 		updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : '',
 	};
+}
+
+/** Suffix for the discovery file's advisory lock. */
+export const CONST_DISCOVERY_LOCK_SUFFIX = '.lock';
+
+/** Default `maxWaitMs` for `withDiscoveryLock`: how long to keep retrying to
+ * acquire the lock before giving up and skipping the operation (both write
+ * and remove are best-effort; a skipped one under contention is strictly
+ * safer than proceeding unprotected, since the bug this closes is two
+ * processes proceeding unprotected at once). */
+export const CONST_DISCOVERY_LOCK_MAX_WAIT_MS = 200;
+
+/** Default `staleMs` for `withDiscoveryLock`: a lock older than this is
+ * assumed abandoned by a process that crashed while holding it, and is
+ * broken rather than left to wedge every future writer/remover forever. */
+export const CONST_DISCOVERY_LOCK_STALE_MS = 5000;
+
+/**
+ * Best-effort synchronous mutex over the discovery file, so a write (on the
+ * engine becoming ready) and a check-then-delete (on exit) from two
+ * different `EngineLocal` processes -- e.g. two VS Code windows starting and
+ * stopping at nearly the same instant -- can't interleave. Without this, the
+ * gap between `removeConnectionDiscovery`'s read and its `unlinkSync` is
+ * exactly wide enough for a second window's write to land in it, and for the
+ * first window to then delete the second window's now-current entry.
+ *
+ * Uses exclusive file creation (`wx`, i.e. `O_CREAT | O_EXCL`) as the lock
+ * primitive: atomic on both POSIX and Windows, so no extra dependency or
+ * platform-specific code is needed. This only needs to coordinate our own
+ * cooperating processes -- a hostile actor doesn't play along with an
+ * advisory lock anyway; the loopback/proxy checks on the read side are what
+ * defend against an adversarial discovery file, not this.
+ *
+ * `maxWaitMs`/`staleMs` default to the `CONST_DISCOVERY_LOCK_*` constants
+ * above; both are parameters (rather than baked in) so tests can exercise
+ * the give-up and stale-lock-breaking paths without waiting on the real,
+ * production-sized durations.
+ *
+ * Returns `undefined` (without calling `fn`) if the lock couldn't be
+ * acquired within `maxWaitMs`.
+ */
+export function withDiscoveryLock<T>(discoveryFilePath: string, fn: () => T, { maxWaitMs = CONST_DISCOVERY_LOCK_MAX_WAIT_MS, staleMs = CONST_DISCOVERY_LOCK_STALE_MS } = {}): T | undefined {
+	const lockPath = `${discoveryFilePath}${CONST_DISCOVERY_LOCK_SUFFIX}`;
+	const deadline = Date.now() + maxWaitMs;
+	let fd: number | undefined;
+	while (fd === undefined) {
+		try {
+			fd = fs.openSync(lockPath, 'wx');
+		} catch (err) {
+			if ((err as NodeJS.ErrnoException).code !== 'EEXIST') return undefined; // e.g. directory gone
+			try {
+				if (Date.now() - fs.statSync(lockPath).mtimeMs > staleMs) {
+					fs.unlinkSync(lockPath); // Break an abandoned lock; loop and retry.
+				}
+			} catch {
+				/* raced with the holder finishing -- fine, loop and retry */
+			}
+			if (Date.now() >= deadline) return undefined;
+			// Brief synchronous pause between attempts rather than a hot spin --
+			// this whole function runs synchronously on the extension host's
+			// main thread, so a tight retry loop would burn CPU there for no
+			// benefit (contention this brief resolves in well under a tick).
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+		}
+	}
+	try {
+		return fn();
+	} finally {
+		fs.closeSync(fd);
+		try {
+			fs.unlinkSync(lockPath);
+		} catch {
+			/* already gone */
+		}
+	}
 }

--- a/apps/vscode/src/engine/local/connectionDiscovery.ts
+++ b/apps/vscode/src/engine/local/connectionDiscovery.ts
@@ -54,6 +54,15 @@
  * be unit-tested standalone with `node:test` (see connectionDiscovery.test.ts).
  * The actual filesystem read/write lives in EngineLocal, which already uses
  * `fs` synchronously for its PID files.
+ *
+ * Canonical schema, kept in sync by hand across this file and the read side
+ * (`packages/client-python/src/rocketride/_connection_discovery.py`; there is
+ * no TypeScript reader yet) -- see `ConnectionDiscoveryInfo` below for the
+ * fields and `parseConnectionDiscovery`/`isLoopbackDiscoveryUri` for exactly
+ * what a reader must validate before trusting a parsed file. There used to be
+ * a third field, `apiKey`, hardcoded to the local-mode default; it was
+ * removed (see #1851 review) because a credential-shaped field that is never
+ * actually a credential invites the next reader to trust it as one.
  */
 
 import * as path from 'path';
@@ -61,8 +70,6 @@ import * as path from 'path';
 /** Shape of the connection discovery file's contents. */
 export interface ConnectionDiscoveryInfo {
 	uri: string;
-	/** Local mode always uses the fixed default; see `writeConnectionDiscovery`. */
-	apiKey: string;
 	/** PID of the writer, so a stale entry left behind by a crash (no clean
 	 * `stop()`) can be told apart from a live one. */
 	pid: number;
@@ -85,11 +92,51 @@ export function serializeConnectionDiscovery(info: ConnectionDiscoveryInfo): str
 	return JSON.stringify(info, null, 2) + '\n';
 }
 
+/** True for an absolute `http(s)://` URI -- the only shape this file is ever
+ * meant to carry (a bare host:port or a `ws(s)://` URI is not a mistake this
+ * writer makes, so reject it rather than guess at normalizing it). */
+function isAbsoluteHttpUri(uri: string): boolean {
+	if (!uri) return false;
+	try {
+		return new URL(uri).protocol === 'http:' || new URL(uri).protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * True when `uri`'s host is loopback (`localhost`, `127.0.0.1`, or `::1`).
+ *
+ * Discovery only ever means "a local engine on this machine" -- the writer
+ * never emits anything else. A reader MUST call this (or the equivalent
+ * check on its own side) before adopting a discovered URI or any credential
+ * alongside it: without it, a discovery file naming an attacker-controlled
+ * host would redirect a client's real API key there. `new URL().hostname`
+ * canonicalizes alternate IPv4/IPv6 loopback spellings (octal/decimal
+ * octets, `::0:1`, etc.) to their standard form, so a plain equality check
+ * against the three spellings below is not fooled by those.
+ */
+export function isLoopbackDiscoveryUri(uri: string): boolean {
+	let hostname: string;
+	try {
+		hostname = new URL(uri).hostname;
+	} catch {
+		return false;
+	}
+	return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]';
+}
+
 /**
  * Parses the discovery file's text, returning `null` for anything that isn't
- * a well-formed `ConnectionDiscoveryInfo` (missing file, invalid JSON, or a
- * shape from some future/incompatible version) rather than throwing --
- * callers on the read side should treat this purely as an optional hint.
+ * a well-formed, structurally valid `ConnectionDiscoveryInfo` (missing file,
+ * invalid JSON, a shape from some future/incompatible version, a non-http(s)
+ * URI, or a non-positive/non-integer pid) rather than throwing -- callers on
+ * the read side should treat this purely as an optional hint.
+ *
+ * This only checks that the file is well-formed. It does NOT check that the
+ * URI is loopback -- callers must additionally call
+ * `isLoopbackDiscoveryUri()` before trusting the result for anything
+ * connection-relevant (see its doc comment).
  */
 export function parseConnectionDiscovery(text: string): ConnectionDiscoveryInfo | null {
 	let data: unknown;
@@ -98,19 +145,15 @@ export function parseConnectionDiscovery(text: string): ConnectionDiscoveryInfo 
 	} catch {
 		return null;
 	}
-	if (
-		!data ||
-		typeof data !== 'object' ||
-		typeof (data as Record<string, unknown>).uri !== 'string' ||
-		typeof (data as Record<string, unknown>).pid !== 'number'
-	) {
-		return null;
-	}
+	if (!data || typeof data !== 'object') return null;
 	const record = data as Record<string, unknown>;
+	const uri = record.uri;
+	const pid = record.pid;
+	if (typeof uri !== 'string' || !isAbsoluteHttpUri(uri)) return null;
+	if (typeof pid !== 'number' || !Number.isSafeInteger(pid) || pid <= 0) return null;
 	return {
-		uri: record.uri as string,
-		apiKey: typeof record.apiKey === 'string' ? record.apiKey : '',
-		pid: record.pid as number,
+		uri,
+		pid,
 		updatedAt: typeof record.updatedAt === 'string' ? record.updatedAt : '',
 	};
 }

--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -28,6 +28,7 @@ import { EngineBackend, type StatusEmitter, type EngineInfo, type EngineBackendS
 import type { ConnectionMode } from '../../config';
 import { getUserConfigDir } from '../config/config-migration';
 import { EngineInstaller } from '../shared/engine-installer';
+import { connectionDiscoveryPath, parseConnectionDiscovery, serializeConnectionDiscovery } from './connectionDiscovery';
 import type { ConnectionGroupConfig } from '../../config';
 import { getLogger } from '../../shared/util/output';
 import { icons } from '../../shared/util/icons';
@@ -320,6 +321,7 @@ export class EngineLocal extends EngineBackend {
 
 			child.on('exit', (code, signal) => {
 				this.removePidFile(myPidFile);
+				if (child.pid) this.removeConnectionDiscovery(child.pid);
 
 				if (!processReady && !processErrored) {
 					// Exited during startup — treat as error
@@ -350,6 +352,7 @@ export class EngineLocal extends EngineBackend {
 						this.actualPort = parseInt(match[1], 10);
 						processReady = true;
 							this.logger.output(`${icons.success} Engine ready (port ${this.actualPort})`);
+						if (child.pid) this.writeConnectionDiscovery(child.pid);
 						resolve();
 					}
 				}
@@ -424,6 +427,52 @@ export class EngineLocal extends EngineBackend {
 		if (expectedPath && this.pidFilePath !== expectedPath) return;
 		try { fs.unlinkSync(this.pidFilePath); } catch { /* already gone */ }
 		this.pidFilePath = undefined;
+	}
+
+	/**
+	 * Writes the connection discovery file so any process on the machine can
+	 * find this engine's resolved URI (see connectionDiscovery.ts). Best-effort
+	 * and non-fatal: a write failure here must never break an otherwise-
+	 * successful engine start.
+	 *
+	 * apiKey is hardcoded to the local-mode default ('MYAPIKEY', the same
+	 * fallback `ConnectionManager.connect()` uses when no explicit apiKey is
+	 * configured) rather than plumbed through from the caller: EngineLocal
+	 * only knows the port it started on, not which connection-group config
+	 * ultimately drives the client's actual auth. This file is a discovery
+	 * convenience, not an auth source of truth -- a dev who customized their
+	 * local API key away from the default already knows to configure it
+	 * explicitly on the consuming side too.
+	 */
+	private writeConnectionDiscovery(pid: number): void {
+		if (this.actualPort === undefined) return;
+		try {
+			fs.writeFileSync(
+				connectionDiscoveryPath(this.installer.dir),
+				serializeConnectionDiscovery({
+					uri: `http://localhost:${this.actualPort}`,
+					apiKey: 'MYAPIKEY',
+					pid,
+					updatedAt: new Date().toISOString(),
+				}),
+			);
+		} catch {
+			/* best-effort */
+		}
+	}
+
+	/** Removes the connection discovery file, but only if it's still this
+	 * process's own entry -- an already-running second local engine (a
+	 * different VS Code window) may have overwritten it with its own, and
+	 * this process stopping must not clobber that live entry. */
+	private removeConnectionDiscovery(pid: number): void {
+		const filePath = connectionDiscoveryPath(this.installer.dir);
+		try {
+			const info = parseConnectionDiscovery(fs.readFileSync(filePath, 'utf8'));
+			if (info && info.pid === pid) fs.unlinkSync(filePath);
+		} catch {
+			/* already gone, or never written (e.g. exited before becoming ready) */
+		}
 	}
 
 	// =========================================================================

--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -435,27 +435,33 @@ export class EngineLocal extends EngineBackend {
 	 * and non-fatal: a write failure here must never break an otherwise-
 	 * successful engine start.
 	 *
-	 * apiKey is hardcoded to the local-mode default ('MYAPIKEY', the same
-	 * fallback `ConnectionManager.connect()` uses when no explicit apiKey is
-	 * configured) rather than plumbed through from the caller: EngineLocal
-	 * only knows the port it started on, not which connection-group config
-	 * ultimately drives the client's actual auth. This file is a discovery
-	 * convenience, not an auth source of truth -- a dev who customized their
-	 * local API key away from the default already knows to configure it
-	 * explicitly on the consuming side too.
+	 * No credential lives in this file (see #1851 review: an earlier version
+	 * carried a hardcoded `apiKey`, which was removed -- a credential-shaped
+	 * field that never actually varies just invites a reader to trust it as
+	 * one). `mode: 0o600` is defence-in-depth so only this OS user can read
+	 * it, since it still influences which host a reader's *real* credential
+	 * gets sent to (see `isLoopbackDiscoveryUri` in connectionDiscovery.ts for
+	 * why a reader must independently constrain the host, not trust this file
+	 * blindly). `mode` is a POSIX permission bit and a no-op on Windows.
 	 */
 	private writeConnectionDiscovery(pid: number): void {
 		if (this.actualPort === undefined) return;
+		const filePath = connectionDiscoveryPath(this.installer.dir);
 		try {
 			fs.writeFileSync(
-				connectionDiscoveryPath(this.installer.dir),
+				filePath,
 				serializeConnectionDiscovery({
 					uri: `http://localhost:${this.actualPort}`,
-					apiKey: 'MYAPIKEY',
 					pid,
 					updatedAt: new Date().toISOString(),
 				}),
+				{ mode: 0o600 },
 			);
+			// `mode` above only applies when writeFileSync actually creates the
+			// file; an install upgrading from a version that wrote it 0644 would
+			// otherwise keep truncating-and-rewriting that same looser mode
+			// forever. chmod unconditionally, best-effort.
+			fs.chmodSync(filePath, 0o600);
 		} catch {
 			/* best-effort */
 		}

--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -28,7 +28,7 @@ import { EngineBackend, type StatusEmitter, type EngineInfo, type EngineBackendS
 import type { ConnectionMode } from '../../config';
 import { getUserConfigDir } from '../config/config-migration';
 import { EngineInstaller } from '../shared/engine-installer';
-import { connectionDiscoveryPath, parseConnectionDiscovery, serializeConnectionDiscovery } from './connectionDiscovery';
+import { connectionDiscoveryPath, parseConnectionDiscovery, serializeConnectionDiscovery, withDiscoveryLock } from './connectionDiscovery';
 import type { ConnectionGroupConfig } from '../../config';
 import { getLogger } from '../../shared/util/output';
 import { icons } from '../../shared/util/icons';
@@ -443,42 +443,57 @@ export class EngineLocal extends EngineBackend {
 	 * gets sent to (see `isLoopbackDiscoveryUri` in connectionDiscovery.ts for
 	 * why a reader must independently constrain the host, not trust this file
 	 * blindly). `mode` is a POSIX permission bit and a no-op on Windows.
+	 *
+	 * Runs under `withDiscoveryLock` (see its doc comment) so this can't
+	 * interleave with another window's `removeConnectionDiscovery`.
 	 */
 	private writeConnectionDiscovery(pid: number): void {
 		if (this.actualPort === undefined) return;
 		const filePath = connectionDiscoveryPath(this.installer.dir);
-		try {
-			fs.writeFileSync(
-				filePath,
-				serializeConnectionDiscovery({
-					uri: `http://localhost:${this.actualPort}`,
-					pid,
-					updatedAt: new Date().toISOString(),
-				}),
-				{ mode: 0o600 },
-			);
-			// `mode` above only applies when writeFileSync actually creates the
-			// file; an install upgrading from a version that wrote it 0644 would
-			// otherwise keep truncating-and-rewriting that same looser mode
-			// forever. chmod unconditionally, best-effort.
-			fs.chmodSync(filePath, 0o600);
-		} catch {
-			/* best-effort */
-		}
+		withDiscoveryLock(filePath, () => {
+			try {
+				fs.writeFileSync(
+					filePath,
+					serializeConnectionDiscovery({
+						uri: `http://localhost:${this.actualPort}`,
+						pid,
+						updatedAt: new Date().toISOString(),
+					}),
+					{ mode: 0o600 },
+				);
+				// `mode` above only applies when writeFileSync actually creates the
+				// file; an install upgrading from a version that wrote it 0644 would
+				// otherwise keep truncating-and-rewriting that same looser mode
+				// forever. chmod unconditionally, best-effort.
+				fs.chmodSync(filePath, 0o600);
+			} catch {
+				/* best-effort */
+			}
+		});
 	}
 
 	/** Removes the connection discovery file, but only if it's still this
 	 * process's own entry -- an already-running second local engine (a
 	 * different VS Code window) may have overwritten it with its own, and
-	 * this process stopping must not clobber that live entry. */
+	 * this process stopping must not clobber that live entry.
+	 *
+	 * The read-check-unlink here and the write in `writeConnectionDiscovery`
+	 * both run under `withDiscoveryLock`, so a second window's write can no
+	 * longer land in the gap between this function's read and its unlink --
+	 * without the lock, that gap is exactly wide enough for this process to
+	 * read the file before the second window overwrites it, then delete the
+	 * second window's now-current entry out from under it.
+	 */
 	private removeConnectionDiscovery(pid: number): void {
 		const filePath = connectionDiscoveryPath(this.installer.dir);
-		try {
-			const info = parseConnectionDiscovery(fs.readFileSync(filePath, 'utf8'));
-			if (info && info.pid === pid) fs.unlinkSync(filePath);
-		} catch {
-			/* already gone, or never written (e.g. exited before becoming ready) */
-		}
+		withDiscoveryLock(filePath, () => {
+			try {
+				const info = parseConnectionDiscovery(fs.readFileSync(filePath, 'utf8'));
+				if (info && info.pid === pid) fs.unlinkSync(filePath);
+			} catch {
+				/* already gone, or never written (e.g. exited before becoming ready) */
+			}
+		});
 	}
 
 	// =========================================================================

--- a/apps/vscode/src/engine/local/engine-local.ts
+++ b/apps/vscode/src/engine/local/engine-local.ts
@@ -164,7 +164,7 @@ export class EngineLocal extends EngineBackend {
 		this.emitStatus({
 			phase: 'ready',
 			message: 'Local engine ready',
-			uri: `http://localhost:${this.actualPort}`,
+			uri: `http://127.0.0.1:${this.actualPort}`,
 			version: installed?.tag,
 		});
 	}
@@ -194,7 +194,7 @@ export class EngineLocal extends EngineBackend {
 			this.emitStatus({
 				phase: 'ready',
 				message: 'Local engine ready',
-				uri: `http://localhost:${this.actualPort}`,
+				uri: `http://127.0.0.1:${this.actualPort}`,
 				version: installed?.tag,
 			});
 		} else {
@@ -446,6 +446,11 @@ export class EngineLocal extends EngineBackend {
 	 *
 	 * Runs under `withDiscoveryLock` (see its doc comment) so this can't
 	 * interleave with another window's `removeConnectionDiscovery`.
+	 *
+	 * `127.0.0.1`, not `localhost` -- same reasoning as the `--host` flag
+	 * above: the engine only binds that literal address, and a resolver that
+	 * prefers `::1` for `localhost` would have a reader try, and fail
+	 * against, a socket nothing is listening on.
 	 */
 	private writeConnectionDiscovery(pid: number): void {
 		if (this.actualPort === undefined) return;
@@ -455,7 +460,7 @@ export class EngineLocal extends EngineBackend {
 				fs.writeFileSync(
 					filePath,
 					serializeConnectionDiscovery({
-						uri: `http://localhost:${this.actualPort}`,
+						uri: `http://127.0.0.1:${this.actualPort}`,
 						pid,
 						updatedAt: new Date().toISOString(),
 					}),

--- a/apps/vscode/src/test/connectionDiscovery.test.ts
+++ b/apps/vscode/src/test/connectionDiscovery.test.ts
@@ -1,0 +1,96 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+	connectionDiscoveryPath,
+	parseConnectionDiscovery,
+	serializeConnectionDiscovery,
+	CONNECTION_DISCOVERY_FILENAME,
+	type ConnectionDiscoveryInfo,
+} from '../engine/local/connectionDiscovery';
+
+const INFO: ConnectionDiscoveryInfo = {
+	uri: 'http://localhost:54321',
+	apiKey: 'MYAPIKEY',
+	pid: 4242,
+	updatedAt: '2026-08-05T12:00:00.000Z',
+};
+
+// --- connectionDiscoveryPath --------------------------------------------------
+
+test('builds the discovery path under the given engine directory', () => {
+	assert.equal(
+		connectionDiscoveryPath('/Users/dev/Library/Application Support/RocketRide/engine'),
+		`/Users/dev/Library/Application Support/RocketRide/engine/${CONNECTION_DISCOVERY_FILENAME}`,
+	);
+});
+
+// --- serializeConnectionDiscovery / parseConnectionDiscovery round-trip ------
+
+test('round-trips a well-formed info object', () => {
+	const parsed = parseConnectionDiscovery(serializeConnectionDiscovery(INFO));
+	assert.deepEqual(parsed, INFO);
+});
+
+test('serialized output is valid, human-readable JSON ending in a newline', () => {
+	const text = serializeConnectionDiscovery(INFO);
+	assert.ok(text.endsWith('\n'));
+	assert.deepEqual(JSON.parse(text), INFO);
+});
+
+test('defaults a missing apiKey to an empty string on parse', () => {
+	const parsed = parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri, pid: INFO.pid }));
+	assert.deepEqual(parsed, { uri: INFO.uri, apiKey: '', pid: INFO.pid, updatedAt: '' });
+});
+
+// --- parseConnectionDiscovery must never throw on bad input ------------------
+
+test('returns null for invalid JSON', () => {
+	assert.equal(parseConnectionDiscovery('not json'), null);
+});
+
+test('returns null for JSON that is not an object', () => {
+	assert.equal(parseConnectionDiscovery('42'), null);
+	assert.equal(parseConnectionDiscovery('"a string"'), null);
+	assert.equal(parseConnectionDiscovery('null'), null);
+	assert.equal(parseConnectionDiscovery('[]'), null);
+});
+
+test('returns null when uri is missing or not a string', () => {
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ pid: 1 })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: 123, pid: 1 })), null);
+});
+
+test('returns null when pid is missing or not a number', () => {
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri, pid: '4242' })), null);
+});
+
+test('ignores unknown extra fields from a future file version', () => {
+	const parsed = parseConnectionDiscovery(
+		JSON.stringify({ ...INFO, someFutureField: 'ignore me' }),
+	);
+	assert.deepEqual(parsed, INFO);
+});

--- a/apps/vscode/src/test/connectionDiscovery.test.ts
+++ b/apps/vscode/src/test/connectionDiscovery.test.ts
@@ -23,14 +23,11 @@
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import {
-	connectionDiscoveryPath,
-	parseConnectionDiscovery,
-	serializeConnectionDiscovery,
-	isLoopbackDiscoveryUri,
-	CONNECTION_DISCOVERY_FILENAME,
-	type ConnectionDiscoveryInfo,
-} from '../engine/local/connectionDiscovery';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Worker } from 'node:worker_threads';
+import { connectionDiscoveryPath, parseConnectionDiscovery, serializeConnectionDiscovery, isLoopbackDiscoveryUri, withDiscoveryLock, CONNECTION_DISCOVERY_FILENAME, CONST_DISCOVERY_LOCK_SUFFIX, type ConnectionDiscoveryInfo } from '../engine/local/connectionDiscovery';
 
 const INFO: ConnectionDiscoveryInfo = {
 	uri: 'http://localhost:54321',
@@ -41,10 +38,11 @@ const INFO: ConnectionDiscoveryInfo = {
 // --- connectionDiscoveryPath --------------------------------------------------
 
 test('builds the discovery path under the given engine directory', () => {
-	assert.equal(
-		connectionDiscoveryPath('/Users/dev/Library/Application Support/RocketRide/engine'),
-		`/Users/dev/Library/Application Support/RocketRide/engine/${CONNECTION_DISCOVERY_FILENAME}`,
-	);
+	// path.join() (which connectionDiscoveryPath delegates to) uses '\' on
+	// Windows -- build the expectation the same way rather than hard-coding
+	// a POSIX separator that would fail there.
+	const engineDir = '/Users/dev/Library/Application Support/RocketRide/engine';
+	assert.equal(connectionDiscoveryPath(engineDir), path.join(engineDir, CONNECTION_DISCOVERY_FILENAME));
 });
 
 // --- serializeConnectionDiscovery / parseConnectionDiscovery round-trip ------
@@ -101,9 +99,7 @@ test('returns null when pid is missing, not a number, zero, negative, or fractio
 });
 
 test('ignores unknown extra fields from a future file version', () => {
-	const parsed = parseConnectionDiscovery(
-		JSON.stringify({ ...INFO, someFutureField: 'ignore me' }),
-	);
+	const parsed = parseConnectionDiscovery(JSON.stringify({ ...INFO, someFutureField: 'ignore me' }));
 	assert.deepEqual(parsed, INFO);
 });
 
@@ -135,4 +131,121 @@ test('rejects a non-loopback host', () => {
 test('rejects a malformed URI rather than throwing', () => {
 	assert.equal(isLoopbackDiscoveryUri('not a uri'), false);
 	assert.equal(isLoopbackDiscoveryUri(''), false);
+});
+
+// --- withDiscoveryLock ---------------------------------------------------------
+
+function withTempDiscoveryFile(fn: (filePath: string) => void): void {
+	const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rr-discovery-lock-'));
+	try {
+		fn(path.join(dir, CONNECTION_DISCOVERY_FILENAME));
+	} finally {
+		fs.rmSync(dir, { recursive: true, force: true });
+	}
+}
+
+test('runs fn and returns its result when the lock is free', () => {
+	withTempDiscoveryFile((filePath) => {
+		const result = withDiscoveryLock(filePath, () => 'ran');
+		assert.equal(result, 'ran');
+	});
+});
+
+test('removes the lock file after fn returns, so a later caller is not blocked', () => {
+	withTempDiscoveryFile((filePath) => {
+		withDiscoveryLock(filePath, () => undefined);
+		assert.equal(fs.existsSync(`${filePath}${CONST_DISCOVERY_LOCK_SUFFIX}`), false);
+
+		const second = withDiscoveryLock(filePath, () => 'second');
+		assert.equal(second, 'second');
+	});
+});
+
+test('removes the lock file even when fn throws', () => {
+	withTempDiscoveryFile((filePath) => {
+		assert.throws(() =>
+			withDiscoveryLock(filePath, () => {
+				throw new Error('boom');
+			})
+		);
+		assert.equal(fs.existsSync(`${filePath}${CONST_DISCOVERY_LOCK_SUFFIX}`), false);
+	});
+});
+
+test('skips fn and returns undefined when an already-held lock is not released in time', () => {
+	withTempDiscoveryFile((filePath) => {
+		// Simulate a concurrent holder: create the lock file ourselves and
+		// never release it.
+		const lockPath = `${filePath}${CONST_DISCOVERY_LOCK_SUFFIX}`;
+		fs.writeFileSync(lockPath, '');
+
+		let ran = false;
+		const result = withDiscoveryLock(filePath, () => (ran = true), { maxWaitMs: 20, staleMs: 60_000 });
+
+		assert.equal(result, undefined);
+		assert.equal(ran, false);
+	});
+});
+
+test('breaks a stale lock left behind by a crashed process, rather than skipping forever', () => {
+	withTempDiscoveryFile((filePath) => {
+		const lockPath = `${filePath}${CONST_DISCOVERY_LOCK_SUFFIX}`;
+		fs.writeFileSync(lockPath, '');
+		// Back-date the lock file so it reads as abandoned.
+		const old = new Date(Date.now() - 10_000);
+		fs.utimesSync(lockPath, old, old);
+
+		const result = withDiscoveryLock(filePath, () => 'ran-after-breaking-stale-lock', {
+			maxWaitMs: 200,
+			staleMs: 1000,
+		});
+
+		assert.equal(result, 'ran-after-breaking-stale-lock');
+	});
+});
+
+function sleepSyncMs(ms: number): void {
+	Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+test('an already-held lock blocks a second caller until it is released', () => {
+	// withDiscoveryLock is synchronous (Atomics.wait blocks the whole thread,
+	// including the timer queue), so a same-process setTimeout can't release
+	// a lock while a call is busy-waiting on it -- exercise the real
+	// cross-process case with a worker thread holding the lock instead.
+	withTempDiscoveryFile((filePath) => {
+		const lockPath = `${filePath}${CONST_DISCOVERY_LOCK_SUFFIX}`;
+		const holdMs = 150;
+
+		const worker = new Worker(
+			`
+			const fs = require('node:fs');
+			const { workerData } = require('node:worker_threads');
+			fs.writeFileSync(workerData.lockPath, '');
+			Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, workerData.holdMs);
+			fs.unlinkSync(workerData.lockPath);
+			`,
+			{ eval: true, workerData: { lockPath, holdMs } }
+		);
+
+		try {
+			// Poll for the worker to actually create the lock file (thread
+			// startup time varies) before this thread starts trying to acquire
+			// it -- a fixed sleep here would be flaky under CI load.
+			for (let waited = 0; !fs.existsSync(lockPath); waited += 5) {
+				assert.ok(waited < 2000, 'worker should have created the lock file by now');
+				sleepSyncMs(5);
+			}
+
+			// If withDiscoveryLock raced past the still-held lock instead of
+			// waiting for it, `wx` (exclusive create) would have thrown EEXIST
+			// immediately and it would give up well before the worker's
+			// `holdMs` release -- succeeding at all here means it genuinely
+			// waited.
+			const result = withDiscoveryLock(filePath, () => 'ran', { maxWaitMs: 2000, staleMs: 60_000 });
+			assert.equal(result, 'ran');
+		} finally {
+			worker.terminate();
+		}
+	});
 });

--- a/apps/vscode/src/test/connectionDiscovery.test.ts
+++ b/apps/vscode/src/test/connectionDiscovery.test.ts
@@ -27,13 +27,13 @@ import {
 	connectionDiscoveryPath,
 	parseConnectionDiscovery,
 	serializeConnectionDiscovery,
+	isLoopbackDiscoveryUri,
 	CONNECTION_DISCOVERY_FILENAME,
 	type ConnectionDiscoveryInfo,
 } from '../engine/local/connectionDiscovery';
 
 const INFO: ConnectionDiscoveryInfo = {
 	uri: 'http://localhost:54321',
-	apiKey: 'MYAPIKEY',
 	pid: 4242,
 	updatedAt: '2026-08-05T12:00:00.000Z',
 };
@@ -60,9 +60,14 @@ test('serialized output is valid, human-readable JSON ending in a newline', () =
 	assert.deepEqual(JSON.parse(text), INFO);
 });
 
-test('defaults a missing apiKey to an empty string on parse', () => {
+test('defaults a missing updatedAt to an empty string on parse', () => {
 	const parsed = parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri, pid: INFO.pid }));
-	assert.deepEqual(parsed, { uri: INFO.uri, apiKey: '', pid: INFO.pid, updatedAt: '' });
+	assert.deepEqual(parsed, { uri: INFO.uri, pid: INFO.pid, updatedAt: '' });
+});
+
+test('a serialized file no longer carries an apiKey field', () => {
+	const text = serializeConnectionDiscovery(INFO);
+	assert.equal(JSON.parse(text).apiKey, undefined);
 });
 
 // --- parseConnectionDiscovery must never throw on bad input ------------------
@@ -78,14 +83,21 @@ test('returns null for JSON that is not an object', () => {
 	assert.equal(parseConnectionDiscovery('[]'), null);
 });
 
-test('returns null when uri is missing or not a string', () => {
+test('returns null when uri is missing, not a string, or not an absolute http(s) URI', () => {
 	assert.equal(parseConnectionDiscovery(JSON.stringify({ pid: 1 })), null);
 	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: 123, pid: 1 })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: '', pid: 1 })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: 'localhost:54321', pid: 1 })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: 'ws://localhost:54321', pid: 1 })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: 'not a uri', pid: 1 })), null);
 });
 
-test('returns null when pid is missing or not a number', () => {
+test('returns null when pid is missing, not a number, zero, negative, or fractional', () => {
 	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri })), null);
 	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri, pid: '4242' })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri, pid: 0 })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri, pid: -4242 })), null);
+	assert.equal(parseConnectionDiscovery(JSON.stringify({ uri: INFO.uri, pid: 42.5 })), null);
 });
 
 test('ignores unknown extra fields from a future file version', () => {
@@ -93,4 +105,34 @@ test('ignores unknown extra fields from a future file version', () => {
 		JSON.stringify({ ...INFO, someFutureField: 'ignore me' }),
 	);
 	assert.deepEqual(parsed, INFO);
+});
+
+test('ignores a legacy apiKey field from a pre-#1851-fix file', () => {
+	const parsed = parseConnectionDiscovery(JSON.stringify({ ...INFO, apiKey: 'MYAPIKEY' }));
+	assert.deepEqual(parsed, INFO);
+});
+
+// --- isLoopbackDiscoveryUri ---------------------------------------------------
+
+test('accepts the standard loopback spellings', () => {
+	assert.ok(isLoopbackDiscoveryUri('http://localhost:54321'));
+	assert.ok(isLoopbackDiscoveryUri('http://127.0.0.1:54321'));
+	assert.ok(isLoopbackDiscoveryUri('http://[::1]:54321'));
+});
+
+test('accepts alternate loopback encodings that normalize to the standard form', () => {
+	assert.ok(isLoopbackDiscoveryUri('http://0177.0.0.1:54321')); // octal
+	assert.ok(isLoopbackDiscoveryUri('http://2130706433:54321')); // decimal
+	assert.ok(isLoopbackDiscoveryUri('http://127.1:54321')); // shortened
+	assert.ok(isLoopbackDiscoveryUri('http://[0:0:0:0:0:0:0:1]:54321')); // expanded IPv6
+});
+
+test('rejects a non-loopback host', () => {
+	assert.equal(isLoopbackDiscoveryUri('http://attacker.example.com:54321'), false);
+	assert.equal(isLoopbackDiscoveryUri('http://192.168.1.5:54321'), false);
+});
+
+test('rejects a malformed URI rather than throwing', () => {
+	assert.equal(isLoopbackDiscoveryUri('not a uri'), false);
+	assert.equal(isLoopbackDiscoveryUri(''), false);
 });

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -106,7 +106,7 @@ RocketRideClient(
 
 | Argument              | Type                      | Required | Description                                                                                                                                          |
 | --------------------- | ------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `uri`                 | `str`                     | Yes\*    | Server URI. \*Can be empty if `ROCKETRIDE_URI` is set in env/`.env`.                                                                                 |
+| `uri`                 | `str`                     | Yes\*    | Server URI. \*Can be empty -- see resolution order below.                                                                                            |
 | `auth`                | `str`                     | Yes\*    | API key. \*Can be empty if `ROCKETRIDE_APIKEY` is set.                                                                                               |
 | `env`                 | `dict`                    | No       | Override env; if omitted, `.env` is loaded. Use when passing config in code instead of env files.                                                    |
 | `module`              | `str`                     | No       | Client name for logging.                                                                                                                             |
@@ -120,7 +120,9 @@ RocketRideClient(
 | `on_protocol_message` | callable `(message: str)` | No       | Optional; for logging raw DAP messages. Helpful when debugging protocol issues.                                                                      |
 | `on_debug_message`    | callable `(message: str)` | No       | Optional; for debug output.                                                                                                                          |
 
-Raises `ValueError` if both `uri` and `ROCKETRIDE_URI` are empty or if `auth` is missing and not in env.
+**`uri` resolution order**, when the `uri` argument is empty: (1) `ROCKETRIDE_URI` from the environment/`.env`, if the key is *present* -- even set to `''`, which reaches step (4) below and raises, matching the behavior of an explicitly-empty `uri` argument; (2) otherwise, a locally-running engine's connection discovery file (written by the VS Code extension's local engine backend when `ROCKETRIDE_URI` is genuinely unset) -- only trusted when it names a loopback host (`localhost`/`127.0.0.1`/`::1`) and its recorded process is still alive; (3) otherwise, the default cloud service. `auth` resolves independently: the `auth` argument, then `ROCKETRIDE_APIKEY` -- discovery never supplies a credential.
+
+Raises `ValueError` if the resolved `uri` (from any of the above) is empty or malformed, or if `auth` is missing and not in env.
 
 **Example - client with persist and callbacks:**
 

--- a/packages/client-python/src/rocketride/_connection_discovery.py
+++ b/packages/client-python/src/rocketride/_connection_discovery.py
@@ -1,0 +1,128 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""
+Local engine connection discovery — reads the file the VS Code extension's
+local engine backend writes on startup.
+
+``--port=0`` gives the local engine a fresh OS-assigned port every restart.
+Previously the only way to find it without the VS Code extension's own
+connect flow was reading process listings by hand (e.g. ``lsof``). The
+extension (``apps/vscode/src/engine/local/engine-local.ts``, mirroring
+``connectionDiscovery.ts`` here) now writes the resolved URI to a small,
+fixed, workspace-independent JSON file under the engine's own install
+directory whenever it starts, and removes it when that same process exits.
+
+This module is the read side: a pure, best-effort lookup used as a fallback
+in :class:`RocketRideClient` when no explicit ``uri`` was given and
+``ROCKETRIDE_URI`` isn't set via the environment or a workspace ``.env``.
+Never raises -- a missing, malformed, or stale file just means "no hint
+available," not an error.
+"""
+
+import json
+import os
+import sys
+from typing import Optional, TypedDict
+
+
+class ConnectionDiscoveryInfo(TypedDict):
+    """Shape of the connection discovery file's contents."""
+
+    uri: str
+    apiKey: str
+    pid: int
+    updatedAt: str
+
+
+def get_user_config_dir() -> str:
+    """Per-user RocketRide config directory, matching the VS Code extension's
+    ``getUserConfigDir()`` (``apps/vscode/src/engine/config/config-migration.ts``)
+    exactly so both sides agree on where to look without any coordination:
+
+    - Windows: ``%LOCALAPPDATA%\\RocketRide``
+    - macOS:   ``~/Library/Application Support/RocketRide``
+    - Linux:   ``~/.config/RocketRide``
+    """
+    if sys.platform == 'win32':
+        base = os.environ.get('LOCALAPPDATA') or os.path.join(os.path.expanduser('~'), 'AppData', 'Local')
+        return os.path.join(base, 'RocketRide')
+    if sys.platform == 'darwin':
+        return os.path.join(os.path.expanduser('~'), 'Library', 'Application Support', 'RocketRide')
+    return os.path.join(os.path.expanduser('~'), '.config', 'RocketRide')
+
+
+def connection_discovery_path() -> str:
+    """Path to the local engine's connection discovery file."""
+    return os.path.join(get_user_config_dir(), 'engine', 'connection.json')
+
+
+def _is_process_alive(pid: int) -> bool:
+    """Best-effort liveness check. Never raises; unsupported platforms/errors
+    are treated as "can't tell," which callers take as "assume alive" so a
+    permissions error never hides an otherwise-usable hint.
+    """
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        # E.g. PermissionError on some platforms for a live process owned by
+        # another user -- can't confirm dead, so don't discard the hint.
+        return True
+    except Exception:
+        return True
+
+
+def read_connection_discovery(*, check_process_alive: bool = True) -> Optional[ConnectionDiscoveryInfo]:
+    """Reads and validates the connection discovery file, or returns ``None``.
+
+    Returns ``None`` (rather than raising) for: the file not existing, invalid
+    JSON, a shape missing ``uri``/``pid``, or -- when `check_process_alive` is
+    True (the default) -- a ``pid`` that's no longer running, e.g. a crashed
+    engine that never got to clean up its own entry on exit.
+    """
+    try:
+        with open(connection_discovery_path(), 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return None
+
+    if not isinstance(data, dict):
+        return None
+    uri = data.get('uri')
+    pid = data.get('pid')
+    if not isinstance(uri, str) or not uri or not isinstance(pid, int):
+        return None
+
+    if check_process_alive and not _is_process_alive(pid):
+        return None
+
+    api_key = data.get('apiKey')
+    updated_at = data.get('updatedAt')
+    return ConnectionDiscoveryInfo(
+        uri=uri,
+        apiKey=api_key if isinstance(api_key, str) else '',
+        pid=pid,
+        updatedAt=updated_at if isinstance(updated_at, str) else '',
+    )

--- a/packages/client-python/src/rocketride/_connection_discovery.py
+++ b/packages/client-python/src/rocketride/_connection_discovery.py
@@ -37,11 +37,28 @@ in :class:`RocketRideClient` when no explicit ``uri`` was given and
 ``ROCKETRIDE_URI`` isn't set via the environment or a workspace ``.env``.
 Never raises -- a missing, malformed, or stale file just means "no hint
 available," not an error.
+
+Canonical schema, kept in sync by hand across this file and the write side
+(``apps/vscode/src/engine/local/connectionDiscovery.ts``; there is no
+TypeScript reader yet) -- see :class:`ConnectionDiscoveryInfo` for the fields
+and ``read_connection_discovery`` for exactly what gets validated before a
+parsed file is trusted. There used to be a third field, ``apiKey``, hardcoded
+to the local-mode default; it was removed (see #1851 review) because a
+credential-shaped field that is never actually a credential invites the next
+reader to trust it as one.
+
+Security note: discovery only ever means "a local engine on this machine."
+A discovery file naming a non-loopback host is never trusted -- see
+``_is_loopback_host`` -- because adopting an arbitrary discovered URI would
+hand it whatever real credential the caller supplies via ``auth``/
+``ROCKETRIDE_APIKEY``, redirecting it to that host.
 """
 
+import ipaddress
 import json
 import os
 import sys
+import urllib.parse
 from typing import Optional, TypedDict
 
 
@@ -49,7 +66,6 @@ class ConnectionDiscoveryInfo(TypedDict):
     """Shape of the connection discovery file's contents."""
 
     uri: str
-    apiKey: str
     pid: int
     updatedAt: str
 
@@ -76,11 +92,60 @@ def connection_discovery_path() -> str:
     return os.path.join(get_user_config_dir(), 'engine', 'connection.json')
 
 
+def _is_absolute_http_uri(uri: str) -> bool:
+    """True for an absolute ``http(s)://`` URI -- the only shape the writer
+    ever produces (a bare ``host:port`` or a ``ws(s)://`` URI is not a
+    mistake it makes, so reject it rather than guess at normalizing it).
+    """
+    try:
+        parsed = urllib.parse.urlparse(uri)
+    except ValueError:
+        return False
+    return parsed.scheme in ('http', 'https') and bool(parsed.hostname)
+
+
+def _is_loopback_host(hostname: str) -> bool:
+    """True when ``hostname`` is ``localhost`` or a loopback IP address.
+
+    ``ipaddress.ip_address`` only accepts strict, unambiguous dotted-decimal
+    IPv4 (or standard IPv6) -- it rejects the octal/decimal/shortened
+    alternate spellings (e.g. ``0177.0.0.1``, ``2130706433``, ``127.1``) that
+    could otherwise be used to smuggle a non-loopback-looking string past a
+    naive string comparison. Anything that doesn't parse this strictly, or
+    that parses but isn't in the loopback range, is rejected -- deny by
+    default rather than try to enumerate every possible spelling.
+    """
+    if hostname.lower() == 'localhost':
+        return True
+    try:
+        return ipaddress.ip_address(hostname).is_loopback
+    except ValueError:
+        return False
+
+
+def is_loopback_discovery_uri(uri: str) -> bool:
+    """True when ``uri``'s host is loopback.
+
+    Discovery only ever means "a local engine on this machine" -- the writer
+    never emits anything else. This MUST be checked before adopting a
+    discovered URI or any credential alongside it: without it, a discovery
+    file naming an attacker-controlled host would redirect a client's real
+    API key there. See the module docstring's security note.
+    """
+    try:
+        hostname = urllib.parse.urlparse(uri).hostname
+    except ValueError:
+        return False
+    return bool(hostname) and _is_loopback_host(hostname)
+
+
 def _is_process_alive(pid: int) -> bool:
     """Best-effort liveness check. Never raises; unsupported platforms/errors
     are treated as "can't tell," which callers take as "assume alive" so a
     permissions error never hides an otherwise-usable hint.
     """
+    if sys.platform == 'win32':
+        return _is_process_alive_windows(pid)
     try:
         os.kill(pid, 0)
         return True
@@ -94,13 +159,50 @@ def _is_process_alive(pid: int) -> bool:
         return True
 
 
+def _is_process_alive_windows(pid: int) -> bool:
+    """Windows liveness check that never sends a signal.
+
+    ``os.kill(pid, 0)`` is a POSIX idiom; on Windows, ``os.kill()`` maps a
+    signal number to a real Win32 action (``GenerateConsoleCtrlEvent`` for
+    the CTRL_* values, of which 0 is one, or ``TerminateProcess`` otherwise)
+    rather than a no-op existence probe, so it cannot reliably distinguish
+    "alive" from "dead" here -- and in the worst case can affect a real,
+    unrelated process. Query the process's exit code via the Win32 API
+    directly instead, exactly like ``psutil``/similar libraries do.
+    """
+    import ctypes
+
+    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+    STILL_ACTIVE = 259
+    ERROR_INVALID_PARAMETER = 87
+
+    # `use_last_error=True` so `ctypes.get_last_error()` below reflects this
+    # call's `GetLastError()` (`ctypes.windll` doesn't track it).
+    kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)  # type: ignore[attr-defined]
+    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        # ERROR_INVALID_PARAMETER means no such process; anything else (e.g.
+        # access denied) -- can't confirm dead, assume alive.
+        return ctypes.get_last_error() != ERROR_INVALID_PARAMETER
+    try:
+        exit_code = ctypes.c_ulong()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return True
+        return exit_code.value == STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def read_connection_discovery(*, check_process_alive: bool = True) -> Optional[ConnectionDiscoveryInfo]:
     """Reads and validates the connection discovery file, or returns ``None``.
 
     Returns ``None`` (rather than raising) for: the file not existing, invalid
-    JSON, a shape missing ``uri``/``pid``, or -- when `check_process_alive` is
-    True (the default) -- a ``pid`` that's no longer running, e.g. a crashed
-    engine that never got to clean up its own entry on exit.
+    JSON, a shape missing/malformed ``uri``/``pid``, a ``uri`` that isn't an
+    absolute ``http(s)://`` loopback address (see ``is_loopback_discovery_uri``
+    -- this is a security boundary, not just shape validation), or -- when
+    `check_process_alive` is True (the default) -- a ``pid`` that's no longer
+    running, e.g. a crashed engine that never got to clean up its own entry
+    on exit.
     """
     try:
         with open(connection_discovery_path(), 'r', encoding='utf-8') as f:
@@ -112,17 +214,21 @@ def read_connection_discovery(*, check_process_alive: bool = True) -> Optional[C
         return None
     uri = data.get('uri')
     pid = data.get('pid')
-    if not isinstance(uri, str) or not uri or not isinstance(pid, int):
+    if not isinstance(uri, str) or not _is_absolute_http_uri(uri):
+        return None
+    # `bool` is a subclass of `int` in Python, so explicitly exclude it --
+    # otherwise a `pid: true` in the file would pass `isinstance(pid, int)`.
+    if isinstance(pid, bool) or not isinstance(pid, int) or pid <= 0:
+        return None
+    if not is_loopback_discovery_uri(uri):
         return None
 
     if check_process_alive and not _is_process_alive(pid):
         return None
 
-    api_key = data.get('apiKey')
     updated_at = data.get('updatedAt')
     return ConnectionDiscoveryInfo(
         uri=uri,
-        apiKey=api_key if isinstance(api_key, str) else '',
         pid=pid,
         updatedAt=updated_at if isinstance(updated_at, str) else '',
     )

--- a/packages/client-python/src/rocketride/_connection_discovery.py
+++ b/packages/client-python/src/rocketride/_connection_discovery.py
@@ -49,7 +49,7 @@ reader to trust it as one.
 
 Security note: discovery only ever means "a local engine on this machine."
 A discovery file naming a non-loopback host is never trusted -- see
-``_is_loopback_host`` -- because adopting an arbitrary discovered URI would
+``is_loopback_host`` -- because adopting an arbitrary discovered URI would
 hand it whatever real credential the caller supplies via ``auth``/
 ``ROCKETRIDE_APIKEY``, redirecting it to that host.
 """
@@ -104,8 +104,14 @@ def _is_absolute_http_uri(uri: str) -> bool:
     return parsed.scheme in ('http', 'https') and bool(parsed.hostname)
 
 
-def _is_loopback_host(hostname: str) -> bool:
+def is_loopback_host(hostname: str) -> bool:
     """True when ``hostname`` is ``localhost`` or a loopback IP address.
+
+    Public (not module-private) because it's also used outside discovery: see
+    ``TransportWebSocket.connect()``, which bypasses any configured proxy for
+    a loopback target -- an env-configured proxy would otherwise still see
+    (and could intercept) a ``ws://localhost:PORT`` connection and the real
+    credential sent over it, discovery-selected or not.
 
     ``ipaddress.ip_address`` only accepts strict, unambiguous dotted-decimal
     IPv4 (or standard IPv6) -- it rejects the octal/decimal/shortened
@@ -136,7 +142,7 @@ def is_loopback_discovery_uri(uri: str) -> bool:
         hostname = urllib.parse.urlparse(uri).hostname
     except ValueError:
         return False
-    return bool(hostname) and _is_loopback_host(hostname)
+    return bool(hostname) and is_loopback_host(hostname)
 
 
 def _is_process_alive(pid: int) -> bool:
@@ -179,6 +185,16 @@ def _is_process_alive_windows(pid: int) -> bool:
     # `use_last_error=True` so `ctypes.get_last_error()` below reflects this
     # call's `GetLastError()` (`ctypes.windll` doesn't track it).
     kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)  # type: ignore[attr-defined]
+    # `HANDLE` is pointer-sized (64 bits on 64-bit Windows); ctypes defaults an
+    # unset restype to `c_int` (32 bits), which would truncate the handle
+    # OpenProcess returns before GetExitCodeProcess/CloseHandle use it. Declare
+    # every signature explicitly rather than rely on the default.
+    kernel32.OpenProcess.restype = ctypes.c_void_p
+    kernel32.OpenProcess.argtypes = [ctypes.c_ulong, ctypes.c_int, ctypes.c_ulong]
+    kernel32.GetExitCodeProcess.restype = ctypes.c_int
+    kernel32.GetExitCodeProcess.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_ulong)]
+    kernel32.CloseHandle.restype = ctypes.c_int
+    kernel32.CloseHandle.argtypes = [ctypes.c_void_p]
     handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
     if not handle:
         # ERROR_INVALID_PARAMETER means no such process; anything else (e.g.

--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -44,6 +44,7 @@ Basic Usage:
 import os
 from functools import cached_property
 from .core import DAPClient, RocketRideException, CONST_DEFAULT_WEB_CLOUD
+from ._connection_discovery import read_connection_discovery
 from .account import AccountApi
 from .billing import BillingApi
 from .database import DatabaseApi
@@ -105,7 +106,9 @@ class RocketRideClient(
 
     Args:
         uri (str, optional): Service URI of the RocketRide server (e.g., "http://localhost:5565").
-            If not provided, uses ROCKETRIDE_URI environment variable or default service.
+            If not provided, uses ROCKETRIDE_URI environment variable; if that's also unset, falls
+            back to a locally-running engine's connection discovery file (written by the VS Code
+            extension's local engine backend) before defaulting to the cloud service.
         auth (str, optional): Your API key or access token for authentication.
             If not provided, uses ROCKETRIDE_APIKEY environment variable. Required at connect time.
         **kwargs: Additional configuration options like custom module name
@@ -144,7 +147,9 @@ class RocketRideClient(
 
         Args:
             uri: WebSocket URI of your RocketRide server (e.g., "ws://localhost:5565").
-                Optional; uses ROCKETRIDE_URI from env or .env if empty.
+                Optional; uses ROCKETRIDE_URI from env or .env if empty, then a local
+                engine's connection discovery file if that's also unset (see
+                _connection_discovery.py), then the default cloud service.
             auth: Your API key or access token. Optional; uses ROCKETRIDE_APIKEY from env or .env if empty.
             **kwargs: Additional options:
                 - env: Dictionary of environment variables to use instead of os.environ
@@ -198,14 +203,25 @@ class RocketRideClient(
             # Use the provided env dictionary; copy it so the caller's dict is not mutated
             self._env = dict(env)
 
-        # If we didn't get the URI, look at the env. If not there,
-        # use the default
+        # If we didn't get the URI, look at the env. If not there, check
+        # whether a local engine (started by the VS Code extension) left
+        # behind a connection discovery hint -- see _connection_discovery.py.
+        # Only consulted as a last resort, so an explicit uri/env value
+        # always wins and nothing changes for anyone not relying on it.
+        discovery_info = None
         if not uri:
-            uri = self._env.get('ROCKETRIDE_URI', CONST_DEFAULT_WEB_CLOUD)
+            uri = self._env.get('ROCKETRIDE_URI', '')
+            if not uri:
+                discovery_info = read_connection_discovery()
+                uri = discovery_info['uri'] if discovery_info else CONST_DEFAULT_WEB_CLOUD
 
-        # If no explicit auth credential was given, fall back to the environment variable
+        # If no explicit auth credential was given, fall back to the environment
+        # variable, then (only when the URI itself came from the discovery hint
+        # above) that same hint's API key.
         if not auth:
             auth = self._env.get('ROCKETRIDE_APIKEY', None)
+            if not auth and discovery_info:
+                auth = discovery_info['apiKey'] or None
 
         # Normalize the URI into a fully-formed WebSocket address
         from .mixins.connection import ConnectionMixin

--- a/packages/client-python/src/rocketride/client.py
+++ b/packages/client-python/src/rocketride/client.py
@@ -203,25 +203,29 @@ class RocketRideClient(
             # Use the provided env dictionary; copy it so the caller's dict is not mutated
             self._env = dict(env)
 
-        # If we didn't get the URI, look at the env. If not there, check
-        # whether a local engine (started by the VS Code extension) left
-        # behind a connection discovery hint -- see _connection_discovery.py.
-        # Only consulted as a last resort, so an explicit uri/env value
-        # always wins and nothing changes for anyone not relying on it.
-        discovery_info = None
+        # If we didn't get the URI, look at the env. An explicit
+        # ROCKETRIDE_URI -- even '' -- must behave exactly as it did before
+        # discovery existed (an explicit empty string reaches
+        # _get_websocket_uri() below and raises there), so check for the key's
+        # *presence* rather than truthiness: only a genuinely-unset env falls
+        # through to checking whether a local engine (started by the VS Code
+        # extension) left behind a connection discovery hint -- see
+        # _connection_discovery.py. Discovery is only ever consulted as this
+        # last resort, so an explicit uri/env value always wins and nothing
+        # changes for anyone not relying on it.
         if not uri:
-            uri = self._env.get('ROCKETRIDE_URI', '')
-            if not uri:
+            if 'ROCKETRIDE_URI' in self._env:
+                uri = self._env['ROCKETRIDE_URI']
+            else:
                 discovery_info = read_connection_discovery()
                 uri = discovery_info['uri'] if discovery_info else CONST_DEFAULT_WEB_CLOUD
 
         # If no explicit auth credential was given, fall back to the environment
-        # variable, then (only when the URI itself came from the discovery hint
-        # above) that same hint's API key.
+        # variable. Discovery never supplies a credential (see
+        # _connection_discovery.py) -- only ROCKETRIDE_APIKEY or an explicit
+        # auth ever sets it.
         if not auth:
             auth = self._env.get('ROCKETRIDE_APIKEY', None)
-            if not auth and discovery_info:
-                auth = discovery_info['apiKey'] or None
 
         # Normalize the URI into a fully-formed WebSocket address
         from .mixins.connection import ConnectionMixin

--- a/packages/client-python/src/rocketride/core/transport_websocket.py
+++ b/packages/client-python/src/rocketride/core/transport_websocket.py
@@ -55,8 +55,11 @@ Usage (Internal):
 
 import json
 import asyncio
+import inspect
+import urllib.parse
 from typing import Dict, Any, Union, Optional
 from .constants import CONST_DEFAULT_SERVICE, CONST_SOCKET_TIMEOUT, CONST_WS_PING_INTERVAL, CONST_WS_PING_TIMEOUT
+from .._connection_discovery import is_loopback_host
 
 # Optional dependency handling for websockets library
 try:
@@ -64,6 +67,13 @@ try:
     import websockets.exceptions
 except ImportError:
     websockets = None
+
+# `proxy=None` (explicitly disable proxy auto-detection) was added to
+# `websockets.connect()` well after this package's `websockets>=11.0.0` floor
+# -- check for it at import time rather than assume every installed version
+# has it, so an older-but-still-supported install degrades to prior behavior
+# (proxy env vars apply) instead of a `TypeError` on every connect.
+_WEBSOCKETS_SUPPORTS_PROXY_KWARG = bool(websockets) and 'proxy' in inspect.signature(websockets.connect).parameters
 
 # Optional dependency handling for FastAPI
 try:
@@ -374,16 +384,27 @@ class TransportWebSocket(TransportBase):
             # Convert ms to seconds for websockets library, or use default
             effective_open_timeout = timeout / 1000.0 if timeout is not None else CONST_SOCKET_TIMEOUT
 
+            connect_kwargs: Dict[str, Any] = {
+                'ping_interval': CONST_WS_PING_INTERVAL,
+                'ping_timeout': CONST_WS_PING_TIMEOUT,
+                'close_timeout': CONST_SOCKET_TIMEOUT,
+                'open_timeout': effective_open_timeout,
+                'max_size': 250 * 1024 * 1024,  # 250MB max message size
+                'compression': None,
+            }
+            # `websockets.connect()` honors HTTP_PROXY/HTTPS_PROXY/WS_PROXY by
+            # default (`proxy=True`) and only skips a proxy that NO_PROXY
+            # already excludes -- an env-configured proxy without a matching
+            # NO_PROXY entry would otherwise still see (and could terminate
+            # and impersonate) a loopback connection, and whatever credential
+            # rides the first DAP message over it. A URI naming a loopback
+            # host is never meant to leave this machine, discovered or not,
+            # so disable proxying outright rather than rely on NO_PROXY.
+            if _WEBSOCKETS_SUPPORTS_PROXY_KWARG and is_loopback_host(urllib.parse.urlparse(self._uri).hostname or ''):
+                connect_kwargs['proxy'] = None
+
             # Connect without auth on upgrade; first DAP message must be auth
-            self._websocket = await websockets.connect(
-                self._uri,
-                ping_interval=CONST_WS_PING_INTERVAL,
-                ping_timeout=CONST_WS_PING_TIMEOUT,
-                close_timeout=CONST_SOCKET_TIMEOUT,
-                open_timeout=effective_open_timeout,
-                max_size=250 * 1024 * 1024,  # 250MB max message size
-                compression=None,
-            )
+            self._websocket = await websockets.connect(self._uri, **connect_kwargs)
 
             self._connected = True
             self._draining = False

--- a/packages/client-python/src/rocketride/core/transport_websocket.py
+++ b/packages/client-python/src/rocketride/core/transport_websocket.py
@@ -68,12 +68,30 @@ try:
 except ImportError:
     websockets = None
 
-# `proxy=None` (explicitly disable proxy auto-detection) was added to
-# `websockets.connect()` well after this package's `websockets>=11.0.0` floor
-# -- check for it at import time rather than assume every installed version
-# has it, so an older-but-still-supported install degrades to prior behavior
-# (proxy env vars apply) instead of a `TypeError` on every connect.
-_WEBSOCKETS_SUPPORTS_PROXY_KWARG = bool(websockets) and 'proxy' in inspect.signature(websockets.connect).parameters
+
+def _detect_proxy_kwarg_support() -> bool:
+    """True if the installed `websockets.connect()` accepts `proxy=`.
+
+    `proxy=None` (explicitly disable proxy auto-detection) was added well
+    after this package's `websockets>=11.0.0` floor -- check for it at import
+    time rather than assume every installed version has it, so an
+    older-but-still-supported install degrades to prior behavior (proxy env
+    vars apply) instead of a `TypeError` on every connect.
+
+    `inspect.signature()` can itself raise (`ValueError`/`TypeError`) for a
+    callable it can't introspect; this module is imported by
+    `rocketride.core`, so an uncaught exception here would break importing
+    the whole SDK over what should only ever gate one optional kwarg.
+    """
+    if not websockets:
+        return False
+    try:
+        return 'proxy' in inspect.signature(websockets.connect).parameters
+    except (ValueError, TypeError):
+        return False
+
+
+_WEBSOCKETS_SUPPORTS_PROXY_KWARG = _detect_proxy_kwarg_support()
 
 # Optional dependency handling for FastAPI
 try:

--- a/packages/client-python/tests/test_client_env_loading.py
+++ b/packages/client-python/tests/test_client_env_loading.py
@@ -27,6 +27,7 @@ import unittest
 from unittest.mock import patch
 
 from rocketride.client import RocketRideClient
+from rocketride.core import CONST_DEFAULT_WEB_CLOUD
 from rocketride.mixins.connection import ConnectionMixin
 
 
@@ -48,3 +49,64 @@ class TestRocketRideClientEnvLoading(unittest.TestCase):
 
         self.assertEqual(client._uri, ConnectionMixin._get_websocket_uri('http://127.0.0.1:8765'))
         self.assertEqual(client._apikey, 'process-env-token')
+
+    def test_explicit_rocketride_uri_env_var_wins_over_connection_discovery(self) -> None:
+        """An explicit ROCKETRIDE_URI must never be overridden by the discovery
+        hint -- the fallback is a last resort, not a preference.
+        """
+        with (
+            patch.dict(os.environ, {'ROCKETRIDE_URI': 'http://127.0.0.1:8765'}, clear=True),
+            patch('rocketride.client.os.path.exists', return_value=False),
+            patch('rocketride.client.read_connection_discovery') as mock_discovery,
+        ):
+            client = RocketRideClient()
+
+        mock_discovery.assert_not_called()
+        self.assertEqual(client._uri, ConnectionMixin._get_websocket_uri('http://127.0.0.1:8765'))
+
+    def test_falls_back_to_connection_discovery_when_nothing_else_is_set(self) -> None:
+        """No explicit uri, no ROCKETRIDE_URI env/.env -- a local engine's
+        connection discovery hint should be used instead of jumping straight
+        to the cloud default.
+        """
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch('rocketride.client.os.path.exists', return_value=False),
+            patch(
+                'rocketride.client.read_connection_discovery',
+                return_value={'uri': 'http://localhost:54321', 'apiKey': 'MYAPIKEY', 'pid': 4242, 'updatedAt': ''},
+            ),
+        ):
+            client = RocketRideClient()
+
+        self.assertEqual(client._uri, ConnectionMixin._get_websocket_uri('http://localhost:54321'))
+        self.assertEqual(client._apikey, 'MYAPIKEY')
+
+    def test_explicit_auth_wins_over_the_discovered_api_key(self) -> None:
+        """The discovery hint's apiKey must only fill in when nothing else
+        provided one -- an explicitly-passed auth always wins.
+        """
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch('rocketride.client.os.path.exists', return_value=False),
+            patch(
+                'rocketride.client.read_connection_discovery',
+                return_value={'uri': 'http://localhost:54321', 'apiKey': 'MYAPIKEY', 'pid': 4242, 'updatedAt': ''},
+            ),
+        ):
+            client = RocketRideClient(auth='explicit-token')
+
+        self.assertEqual(client._apikey, 'explicit-token')
+
+    def test_falls_back_to_cloud_default_when_discovery_also_finds_nothing(self) -> None:
+        """No env, no .env, no live local engine -- must still land on the
+        documented cloud default, not raise or leave the URI empty.
+        """
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch('rocketride.client.os.path.exists', return_value=False),
+            patch('rocketride.client.read_connection_discovery', return_value=None),
+        ):
+            client = RocketRideClient()
+
+        self.assertEqual(client._uri, ConnectionMixin._get_websocket_uri(CONST_DEFAULT_WEB_CLOUD))

--- a/packages/client-python/tests/test_client_env_loading.py
+++ b/packages/client-python/tests/test_client_env_loading.py
@@ -30,6 +30,8 @@ from rocketride.client import RocketRideClient
 from rocketride.core import CONST_DEFAULT_WEB_CLOUD
 from rocketride.mixins.connection import ConnectionMixin
 
+DISCOVERED_INFO = {'uri': 'http://localhost:54321', 'pid': 4242, 'updatedAt': ''}
+
 
 class TestRocketRideClientEnvLoading(unittest.TestCase):
     def test_uses_process_environment_when_env_argument_is_not_provided(self) -> None:
@@ -72,27 +74,32 @@ class TestRocketRideClientEnvLoading(unittest.TestCase):
         with (
             patch.dict(os.environ, {}, clear=True),
             patch('rocketride.client.os.path.exists', return_value=False),
-            patch(
-                'rocketride.client.read_connection_discovery',
-                return_value={'uri': 'http://localhost:54321', 'apiKey': 'MYAPIKEY', 'pid': 4242, 'updatedAt': ''},
-            ),
+            patch('rocketride.client.read_connection_discovery', return_value=DISCOVERED_INFO),
         ):
             client = RocketRideClient()
 
         self.assertEqual(client._uri, ConnectionMixin._get_websocket_uri('http://localhost:54321'))
-        self.assertEqual(client._apikey, 'MYAPIKEY')
 
-    def test_explicit_auth_wins_over_the_discovered_api_key(self) -> None:
-        """The discovery hint's apiKey must only fill in when nothing else
-        provided one -- an explicitly-passed auth always wins.
+    def test_discovery_never_supplies_a_credential(self) -> None:
+        """Discovery only ever carries `uri`/`pid`/`updatedAt` -- auth comes
+        from an explicit `auth` or `ROCKETRIDE_APIKEY` only, never from the
+        discovery file (there is no `apiKey` field to read anymore; see the
+        #1851 review).
         """
         with (
             patch.dict(os.environ, {}, clear=True),
             patch('rocketride.client.os.path.exists', return_value=False),
-            patch(
-                'rocketride.client.read_connection_discovery',
-                return_value={'uri': 'http://localhost:54321', 'apiKey': 'MYAPIKEY', 'pid': 4242, 'updatedAt': ''},
-            ),
+            patch('rocketride.client.read_connection_discovery', return_value=DISCOVERED_INFO),
+        ):
+            client = RocketRideClient()
+
+        self.assertIsNone(client._apikey)
+
+    def test_explicit_auth_wins_over_env_and_is_unaffected_by_discovery(self) -> None:
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch('rocketride.client.os.path.exists', return_value=False),
+            patch('rocketride.client.read_connection_discovery', return_value=DISCOVERED_INFO),
         ):
             client = RocketRideClient(auth='explicit-token')
 
@@ -110,3 +117,35 @@ class TestRocketRideClientEnvLoading(unittest.TestCase):
             client = RocketRideClient()
 
         self.assertEqual(client._uri, ConnectionMixin._get_websocket_uri(CONST_DEFAULT_WEB_CLOUD))
+
+    def test_explicit_empty_rocketride_uri_env_var_still_raises(self) -> None:
+        """An explicitly-set `ROCKETRIDE_URI=''` must behave exactly as it did
+        on develop before discovery existed: it reaches `_get_websocket_uri()`
+        and raises there. Discovery is only consulted when ROCKETRIDE_URI is
+        genuinely absent, not when it's present-but-empty -- otherwise a typo'd
+        empty override would silently start talking to a different host
+        (discovery, then the cloud default) instead of failing loudly.
+        """
+        with (
+            patch.dict(os.environ, {'ROCKETRIDE_URI': ''}, clear=True),
+            patch('rocketride.client.os.path.exists', return_value=False),
+            patch('rocketride.client.read_connection_discovery') as mock_discovery,
+        ):
+            with self.assertRaises(ValueError):
+                RocketRideClient()
+
+        mock_discovery.assert_not_called()
+
+    def test_falls_back_to_discovery_when_rocketride_uri_is_genuinely_unset(self) -> None:
+        """The absent-vs-empty distinction cuts both ways: a genuinely unset
+        ROCKETRIDE_URI (the common case) must still reach discovery, not raise.
+        """
+        with (
+            patch.dict(os.environ, {}, clear=True),
+            patch('rocketride.client.os.path.exists', return_value=False),
+            patch('rocketride.client.read_connection_discovery', return_value=DISCOVERED_INFO) as mock_discovery,
+        ):
+            client = RocketRideClient()
+
+        mock_discovery.assert_called_once()
+        self.assertEqual(client._uri, ConnectionMixin._get_websocket_uri('http://localhost:54321'))

--- a/packages/client-python/tests/test_connection_discovery.py
+++ b/packages/client-python/tests/test_connection_discovery.py
@@ -1,0 +1,154 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the local engine connection discovery fallback."""
+
+import json
+import os
+import unittest
+from unittest.mock import mock_open, patch
+
+from rocketride._connection_discovery import (
+    connection_discovery_path,
+    get_user_config_dir,
+    read_connection_discovery,
+)
+
+VALID_INFO = {'uri': 'http://localhost:54321', 'apiKey': 'MYAPIKEY', 'pid': 4242, 'updatedAt': '2026-08-05T12:00:00Z'}
+
+
+class TestGetUserConfigDir(unittest.TestCase):
+    def test_matches_vscode_extension_layout_on_macos(self) -> None:
+        """Must agree byte-for-byte with getUserConfigDir() in
+        apps/vscode/src/engine/config/config-migration.ts -- both sides
+        compute this path independently, with no runtime coordination.
+        """
+        with patch('rocketride._connection_discovery.sys.platform', 'darwin'):
+            self.assertEqual(
+                get_user_config_dir(),
+                os.path.join(os.path.expanduser('~'), 'Library', 'Application Support', 'RocketRide'),
+            )
+
+    def test_matches_vscode_extension_layout_on_linux(self) -> None:
+        with patch('rocketride._connection_discovery.sys.platform', 'linux'):
+            self.assertEqual(get_user_config_dir(), os.path.join(os.path.expanduser('~'), '.config', 'RocketRide'))
+
+    def test_matches_vscode_extension_layout_on_windows(self) -> None:
+        with (
+            patch('rocketride._connection_discovery.sys.platform', 'win32'),
+            patch.dict(os.environ, {'LOCALAPPDATA': 'C:\\Users\\dev\\AppData\\Local'}, clear=False),
+        ):
+            self.assertEqual(get_user_config_dir(), os.path.join('C:\\Users\\dev\\AppData\\Local', 'RocketRide'))
+
+    def test_windows_falls_back_when_localappdata_unset(self) -> None:
+        with (
+            patch('rocketride._connection_discovery.sys.platform', 'win32'),
+            patch.dict(os.environ, {}, clear=True),
+        ):
+            self.assertEqual(
+                get_user_config_dir(),
+                os.path.join(os.path.expanduser('~'), 'AppData', 'Local', 'RocketRide'),
+            )
+
+    def test_discovery_path_is_under_engine_subdir(self) -> None:
+        """Same engine/ subdirectory version.json and engine-<pid>.pid already live in."""
+        self.assertEqual(
+            connection_discovery_path(),
+            os.path.join(get_user_config_dir(), 'engine', 'connection.json'),
+        )
+
+
+class TestReadConnectionDiscovery(unittest.TestCase):
+    def _with_file(self, content: str):
+        return patch('builtins.open', mock_open(read_data=content))
+
+    def test_returns_none_when_file_does_not_exist(self) -> None:
+        with patch('builtins.open', side_effect=FileNotFoundError):
+            self.assertIsNone(read_connection_discovery())
+
+    def test_returns_none_for_invalid_json(self) -> None:
+        with self._with_file('not json'):
+            self.assertIsNone(read_connection_discovery())
+
+    def test_returns_none_when_json_is_not_an_object(self) -> None:
+        for text in ('42', '"a string"', 'null', '[]'):
+            with self.subTest(text=text), self._with_file(text):
+                self.assertIsNone(read_connection_discovery())
+
+    def test_returns_none_when_uri_missing_or_wrong_type(self) -> None:
+        with self._with_file(json.dumps({'pid': 1})):
+            self.assertIsNone(read_connection_discovery())
+        with self._with_file(json.dumps({'uri': 123, 'pid': 1})):
+            self.assertIsNone(read_connection_discovery())
+        with self._with_file(json.dumps({'uri': '', 'pid': 1})):
+            self.assertIsNone(read_connection_discovery())
+
+    def test_returns_none_when_pid_missing_or_wrong_type(self) -> None:
+        with self._with_file(json.dumps({'uri': VALID_INFO['uri']})):
+            self.assertIsNone(read_connection_discovery())
+        with self._with_file(json.dumps({'uri': VALID_INFO['uri'], 'pid': '4242'})):
+            self.assertIsNone(read_connection_discovery())
+
+    def test_returns_info_for_a_well_formed_live_entry(self) -> None:
+        with (
+            self._with_file(json.dumps(VALID_INFO)),
+            patch('rocketride._connection_discovery._is_process_alive', return_value=True),
+        ):
+            self.assertEqual(read_connection_discovery(), VALID_INFO)
+
+    def test_returns_none_for_a_dead_pid_by_default(self) -> None:
+        """A crashed engine that never got to remove its own entry on exit
+        must not hand back a port nothing is listening on anymore.
+        """
+        with (
+            self._with_file(json.dumps(VALID_INFO)),
+            patch('rocketride._connection_discovery._is_process_alive', return_value=False),
+        ):
+            self.assertIsNone(read_connection_discovery())
+
+    def test_check_process_alive_false_skips_the_liveness_check(self) -> None:
+        with (
+            self._with_file(json.dumps(VALID_INFO)),
+            patch('rocketride._connection_discovery._is_process_alive', return_value=False) as mock_alive,
+        ):
+            result = read_connection_discovery(check_process_alive=False)
+        mock_alive.assert_not_called()
+        self.assertEqual(result, VALID_INFO)
+
+    def test_defaults_missing_apikey_and_updated_at_to_empty_string(self) -> None:
+        with (
+            self._with_file(json.dumps({'uri': VALID_INFO['uri'], 'pid': VALID_INFO['pid']})),
+            patch('rocketride._connection_discovery._is_process_alive', return_value=True),
+        ):
+            result = read_connection_discovery()
+        self.assertEqual(result, {'uri': VALID_INFO['uri'], 'apiKey': '', 'pid': VALID_INFO['pid'], 'updatedAt': ''})
+
+    def test_ignores_unknown_extra_fields(self) -> None:
+        with (
+            self._with_file(json.dumps({**VALID_INFO, 'someFutureField': 'ignore me'})),
+            patch('rocketride._connection_discovery._is_process_alive', return_value=True),
+        ):
+            self.assertEqual(read_connection_discovery(), VALID_INFO)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/packages/client-python/tests/test_connection_discovery.py
+++ b/packages/client-python/tests/test_connection_discovery.py
@@ -30,10 +30,11 @@ from unittest.mock import mock_open, patch
 from rocketride._connection_discovery import (
     connection_discovery_path,
     get_user_config_dir,
+    is_loopback_discovery_uri,
     read_connection_discovery,
 )
 
-VALID_INFO = {'uri': 'http://localhost:54321', 'apiKey': 'MYAPIKEY', 'pid': 4242, 'updatedAt': '2026-08-05T12:00:00Z'}
+VALID_INFO = {'uri': 'http://localhost:54321', 'pid': 4242, 'updatedAt': '2026-08-05T12:00:00Z'}
 
 
 class TestGetUserConfigDir(unittest.TestCase):
@@ -77,6 +78,31 @@ class TestGetUserConfigDir(unittest.TestCase):
         )
 
 
+class TestIsLoopbackDiscoveryUri(unittest.TestCase):
+    def test_accepts_standard_loopback_spellings(self) -> None:
+        for uri in ('http://localhost:54321', 'http://LOCALHOST:1', 'http://127.0.0.1:54321', 'http://[::1]:54321'):
+            with self.subTest(uri=uri):
+                self.assertTrue(is_loopback_discovery_uri(uri))
+
+    def test_rejects_non_loopback_hosts(self) -> None:
+        for uri in ('http://attacker.example.com:54321', 'http://192.168.1.5:54321', 'http://8.8.8.8:53'):
+            with self.subTest(uri=uri):
+                self.assertFalse(is_loopback_discovery_uri(uri))
+
+    def test_rejects_alternate_ip_encodings_rather_than_guess(self) -> None:
+        """`ipaddress.ip_address` deliberately doesn't accept these -- deny by
+        default rather than reimplement every alternate IPv4 spelling.
+        """
+        for uri in ('http://0177.0.0.1:1', 'http://2130706433:1', 'http://127.1:1'):
+            with self.subTest(uri=uri):
+                self.assertFalse(is_loopback_discovery_uri(uri))
+
+    def test_rejects_malformed_uri_without_raising(self) -> None:
+        for uri in ('not a uri', '', 'http://', '://'):
+            with self.subTest(uri=uri):
+                self.assertFalse(is_loopback_discovery_uri(uri))
+
+
 class TestReadConnectionDiscovery(unittest.TestCase):
     def _with_file(self, content: str):
         return patch('builtins.open', mock_open(read_data=content))
@@ -102,10 +128,39 @@ class TestReadConnectionDiscovery(unittest.TestCase):
         with self._with_file(json.dumps({'uri': '', 'pid': 1})):
             self.assertIsNone(read_connection_discovery())
 
+    def test_returns_none_when_uri_is_not_an_absolute_http_uri(self) -> None:
+        for uri in ('localhost:54321', 'ws://localhost:54321', 'not a uri', 'file:///etc/passwd'):
+            with self.subTest(uri=uri), self._with_file(json.dumps({'uri': uri, 'pid': 1})):
+                self.assertIsNone(read_connection_discovery())
+
     def test_returns_none_when_pid_missing_or_wrong_type(self) -> None:
         with self._with_file(json.dumps({'uri': VALID_INFO['uri']})):
             self.assertIsNone(read_connection_discovery())
         with self._with_file(json.dumps({'uri': VALID_INFO['uri'], 'pid': '4242'})):
+            self.assertIsNone(read_connection_discovery())
+
+    def test_returns_none_when_pid_is_a_bool(self) -> None:
+        """`bool` is a subclass of `int` in Python -- `pid: true` must not
+        pass as pid 1.
+        """
+        with self._with_file(json.dumps({'uri': VALID_INFO['uri'], 'pid': True})):
+            self.assertIsNone(read_connection_discovery())
+
+    def test_returns_none_when_pid_is_zero_or_negative(self) -> None:
+        for pid in (0, -4242):
+            with self.subTest(pid=pid), self._with_file(json.dumps({'uri': VALID_INFO['uri'], 'pid': pid})):
+                self.assertIsNone(read_connection_discovery())
+
+    def test_returns_none_for_a_non_loopback_uri_even_with_a_live_pid(self) -> None:
+        """The core of the fix: a discovery file naming an attacker-controlled
+        host must never be trusted, regardless of everything else being
+        well-formed and the pid being alive.
+        """
+        malicious = {'uri': 'http://attacker.example.com:5565', 'pid': 4242, 'updatedAt': ''}
+        with (
+            self._with_file(json.dumps(malicious)),
+            patch('rocketride._connection_discovery._is_process_alive', return_value=True),
+        ):
             self.assertIsNone(read_connection_discovery())
 
     def test_returns_info_for_a_well_formed_live_entry(self) -> None:
@@ -134,13 +189,23 @@ class TestReadConnectionDiscovery(unittest.TestCase):
         mock_alive.assert_not_called()
         self.assertEqual(result, VALID_INFO)
 
-    def test_defaults_missing_apikey_and_updated_at_to_empty_string(self) -> None:
+    def test_defaults_missing_updated_at_to_empty_string(self) -> None:
         with (
             self._with_file(json.dumps({'uri': VALID_INFO['uri'], 'pid': VALID_INFO['pid']})),
             patch('rocketride._connection_discovery._is_process_alive', return_value=True),
         ):
             result = read_connection_discovery()
-        self.assertEqual(result, {'uri': VALID_INFO['uri'], 'apiKey': '', 'pid': VALID_INFO['pid'], 'updatedAt': ''})
+        self.assertEqual(result, {'uri': VALID_INFO['uri'], 'pid': VALID_INFO['pid'], 'updatedAt': ''})
+
+    def test_ignores_a_legacy_api_key_field(self) -> None:
+        """A file written by a pre-#1851-fix extension still has `apiKey`;
+        the reader must not resurrect it onto the returned info.
+        """
+        with (
+            self._with_file(json.dumps({**VALID_INFO, 'apiKey': 'MYAPIKEY'})),
+            patch('rocketride._connection_discovery._is_process_alive', return_value=True),
+        ):
+            self.assertEqual(read_connection_discovery(), VALID_INFO)
 
     def test_ignores_unknown_extra_fields(self) -> None:
         with (
@@ -148,6 +213,91 @@ class TestReadConnectionDiscovery(unittest.TestCase):
             patch('rocketride._connection_discovery._is_process_alive', return_value=True),
         ):
             self.assertEqual(read_connection_discovery(), VALID_INFO)
+
+
+class TestIsProcessAliveWindows(unittest.TestCase):
+    """`_is_process_alive` dispatches to a ctypes-based probe on win32 instead
+    of `os.kill(pid, 0)`, which maps to a real Win32 action there rather than
+    a pure existence check.
+    """
+
+    def _mock_kernel32(self, *, open_handle, exit_code=None, get_exit_code_ok=True, last_error=0):
+        mock_dll = unittest.mock.MagicMock()
+        mock_dll.OpenProcess.return_value = open_handle
+
+        def _get_exit_code_process(_handle, ref):
+            if get_exit_code_ok:
+                ref._obj.value = exit_code
+            return 1 if get_exit_code_ok else 0
+
+        mock_dll.GetExitCodeProcess.side_effect = _get_exit_code_process
+        return mock_dll, last_error
+
+    def test_alive_when_still_active(self) -> None:
+        import ctypes
+
+        from rocketride._connection_discovery import _is_process_alive_windows
+
+        mock_dll, _ = self._mock_kernel32(open_handle=1234, exit_code=259)  # STILL_ACTIVE
+        with (
+            patch('rocketride._connection_discovery.sys.platform', 'win32'),
+            patch.object(ctypes, 'WinDLL', return_value=mock_dll, create=True),
+        ):
+            self.assertTrue(_is_process_alive_windows(4242))
+        mock_dll.CloseHandle.assert_called_once_with(1234)
+
+    def test_dead_when_exit_code_is_not_still_active(self) -> None:
+        import ctypes
+
+        from rocketride._connection_discovery import _is_process_alive_windows
+
+        mock_dll, _ = self._mock_kernel32(open_handle=1234, exit_code=0)
+        with (
+            patch('rocketride._connection_discovery.sys.platform', 'win32'),
+            patch.object(ctypes, 'WinDLL', return_value=mock_dll, create=True),
+        ):
+            self.assertFalse(_is_process_alive_windows(4242))
+
+    def test_dead_when_open_process_fails_with_invalid_parameter(self) -> None:
+        import ctypes
+
+        from rocketride._connection_discovery import _is_process_alive_windows
+
+        mock_dll = unittest.mock.MagicMock()
+        mock_dll.OpenProcess.return_value = 0
+        with (
+            patch('rocketride._connection_discovery.sys.platform', 'win32'),
+            patch.object(ctypes, 'WinDLL', return_value=mock_dll, create=True),
+            patch.object(ctypes, 'get_last_error', return_value=87, create=True),  # ERROR_INVALID_PARAMETER
+        ):
+            self.assertFalse(_is_process_alive_windows(4242))
+
+    def test_assumed_alive_when_open_process_fails_for_another_reason(self) -> None:
+        """E.g. access denied for a live process owned by another user --
+        can't confirm dead, so don't discard the hint.
+        """
+        import ctypes
+
+        from rocketride._connection_discovery import _is_process_alive_windows
+
+        mock_dll = unittest.mock.MagicMock()
+        mock_dll.OpenProcess.return_value = 0
+        with (
+            patch('rocketride._connection_discovery.sys.platform', 'win32'),
+            patch.object(ctypes, 'WinDLL', return_value=mock_dll, create=True),
+            patch.object(ctypes, 'get_last_error', return_value=5, create=True),  # ERROR_ACCESS_DENIED
+        ):
+            self.assertTrue(_is_process_alive_windows(4242))
+
+    def test_is_process_alive_dispatches_to_windows_probe_on_win32(self) -> None:
+        from rocketride._connection_discovery import _is_process_alive
+
+        with (
+            patch('rocketride._connection_discovery.sys.platform', 'win32'),
+            patch('rocketride._connection_discovery._is_process_alive_windows', return_value=True) as mock_probe,
+        ):
+            self.assertTrue(_is_process_alive(4242))
+        mock_probe.assert_called_once_with(4242)
 
 
 if __name__ == '__main__':

--- a/packages/client-python/tests/test_transport_websocket_proxy.py
+++ b/packages/client-python/tests/test_transport_websocket_proxy.py
@@ -31,6 +31,7 @@ proxy behavior untouched.
 """
 
 from contextlib import contextmanager
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -91,3 +92,28 @@ async def test_connect_omits_proxy_kwarg_on_older_websockets():
         await transport._receive_task
 
     assert 'proxy' not in mock_connect.call_args.kwargs
+
+
+def test_detect_proxy_kwarg_support_survives_uninspectable_connect():
+    """CodeRabbit on #1874: inspect.signature() can itself raise for a
+    callable it can't introspect. This module is imported by
+    rocketride.core, so an uncaught exception here would break importing the
+    whole SDK -- the detector must swallow it and default to False.
+    """
+    fake_websockets = SimpleNamespace(connect=lambda *a, **kw: None)
+    with (
+        patch.object(tw, 'websockets', fake_websockets),
+        patch.object(tw.inspect, 'signature', side_effect=ValueError('no signature found')),
+    ):
+        assert tw._detect_proxy_kwarg_support() is False
+
+    with (
+        patch.object(tw, 'websockets', fake_websockets),
+        patch.object(tw.inspect, 'signature', side_effect=TypeError('not a callable')),
+    ):
+        assert tw._detect_proxy_kwarg_support() is False
+
+
+def test_detect_proxy_kwarg_support_false_when_websockets_missing():
+    with patch.object(tw, 'websockets', None):
+        assert tw._detect_proxy_kwarg_support() is False

--- a/packages/client-python/tests/test_transport_websocket_proxy.py
+++ b/packages/client-python/tests/test_transport_websocket_proxy.py
@@ -1,0 +1,93 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression tests for TransportWebSocket's loopback proxy bypass.
+
+CodeRabbit on #1874: `websockets.connect()` honors HTTP_PROXY/HTTPS_PROXY/
+WS_PROXY by default, so a connection to a loopback URI (discovery-selected or
+not) could still be routed through a configured proxy, which could then
+intercept whatever credential rides the first DAP message. `connect()` must
+pass `proxy=None` for a loopback target, and leave a non-loopback target's
+proxy behavior untouched.
+"""
+
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from rocketride.core import transport_websocket as tw
+from rocketride.core.transport_websocket import TransportWebSocket
+
+
+@contextmanager
+def _connected(supports_proxy_kwarg: bool):
+    """Patches `websockets.connect` to hand back a fake socket without
+    starting a real background receive loop -- `_run_receive_task` is
+    stubbed out too, since the real one would spin tightly against an
+    AsyncMock socket's `recv()`, which is not what these tests are about.
+    """
+    fake_socket = AsyncMock()
+    with (
+        patch.object(tw, '_WEBSOCKETS_SUPPORTS_PROXY_KWARG', supports_proxy_kwarg),
+        patch.object(tw.websockets, 'connect', AsyncMock(return_value=fake_socket)) as mock_connect,
+        patch.object(TransportWebSocket, '_run_receive_task', AsyncMock(return_value=None)),
+    ):
+        yield mock_connect
+
+
+@pytest.mark.parametrize(
+    'uri',
+    [
+        'ws://localhost:54321',
+        'ws://127.0.0.1:54321',
+        'ws://[::1]:54321',
+    ],
+)
+async def test_connect_disables_proxy_for_loopback_uri(uri):
+    with _connected(supports_proxy_kwarg=True) as mock_connect:
+        transport = TransportWebSocket(uri)
+        await transport.connect()
+        await transport._receive_task
+
+    assert mock_connect.call_args.kwargs['proxy'] is None
+
+
+async def test_connect_leaves_proxy_default_for_non_loopback_uri():
+    with _connected(supports_proxy_kwarg=True) as mock_connect:
+        transport = TransportWebSocket('wss://cloud.rocketride.ai')
+        await transport.connect()
+        await transport._receive_task
+
+    assert 'proxy' not in mock_connect.call_args.kwargs
+
+
+async def test_connect_omits_proxy_kwarg_on_older_websockets():
+    """An installed websockets without `proxy` support must not receive the
+    kwarg at all -- passing it would raise TypeError on that version.
+    """
+    with _connected(supports_proxy_kwarg=False) as mock_connect:
+        transport = TransportWebSocket('ws://localhost:54321')
+        await transport.connect()
+        await transport._receive_task
+
+    assert 'proxy' not in mock_connect.call_args.kwargs


### PR DESCRIPTION
## Summary

Fixes #1851
- `--port=0` gives the local engine a fresh OS-assigned port every restart. Since #1413/PR #1492 the extension syncs that port into the workspace `.env` on each successful connect, but that only helps a script reading `.env` from the *same* workspace at its own startup — a long-running script that outlives an engine restart, or any process not tied to that specific workspace, has no way to notice or discover the new port short of grep-matching `lsof` against the engine's process name.
- Adds a small, fixed, workspace-independent connection discovery file (`<user config dir>/engine/connection.json` — reusing `getUserConfigDir()`, the same directory `version.json`/`engine-<pid>.pid` already live in) that `EngineLocal` writes when the engine becomes ready and removes when that same process exits, guarded by a stored `pid` so one window stopping can't clobber a different window's live entry.
- `RocketRideClient()` (Python SDK) now checks this file as a fallback when no explicit `uri` is given and `ROCKETRIDE_URI` isn't set via env/`.env`, verifying the recorded `pid` is still alive before trusting a stale entry left behind by a crash. An explicit `uri`/`ROCKETRIDE_URI` always wins — this is only consulted as a last resort before the cloud default.

**Design choice** (updated per review): the discovery file carries no credential at all — just `uri`/`pid`/`updatedAt`. An earlier version hardcoded an `apiKey` field to the local-mode default (`'MYAPIKEY'`), but a credential-shaped field that never actually varies just invites the next reader to trust it as a real one, so it's gone; auth only ever comes from an explicit `auth`/`ROCKETRIDE_APIKEY`, never from discovery. The file is also now written mode `0o600` and, since it still influences which host a reader's *real* credential gets sent to, a reader (the Python SDK fallback below) only ever trusts a discovered `uri` whose host is loopback (`localhost`/`127.0.0.1`/`::1`) — a discovery file naming any other host is ignored outright, closing off a local-file-write → credential-redirect path.

**Scope, deliberately**: a single "last-connected" file, not a registry of every concurrently-running local engine across multiple VS Code windows (the docstring in `engine-local.ts` mentions each window gets its own engine on its own port). For the reported problem — one developer, one local engine, losing track of it across reloads — "last connected" is exactly the right answer. Disambiguating several simultaneous local engines is a separate, harder problem nobody asked for here.

Only the Python SDK got the read-side fallback (matching the issue's own reproduction, which is Python). Happy to add the TypeScript SDK equivalent in a follow-up if wanted.

## Test plan
- [x] `apps/vscode/src/test/connectionDiscovery.test.ts` (15 cases, up from 9) — path construction, serialize/parse round-trip (apiKey no longer round-trips), `parseConnectionDiscovery` never throwing and now rejecting a non-http(s)/non-positive-integer-pid shape, plus `isLoopbackDiscoveryUri` accepting the standard and alternate-encoded loopback spellings and rejecting real hosts/malformed input. Compiled with `tsc --module commonjs` (same pre-existing gap as before: no wired-up runner for these `node:test` files in `builder`/CI) and run with `node --test`: 15/15 pass.
- [x] `packages/client-python/tests/test_connection_discovery.py` (29 cases, up from 15) — adds `TestIsLoopbackDiscoveryUri` (standard/alternate-encoded/non-loopback/malformed), `read_connection_discovery` rejecting a non-loopback URI even with a live pid (the core of the fix), a bool/zero/negative pid, and a new `TestIsProcessAliveWindows` exercising the ctypes-based Windows probe via a mocked `kernel32`.
- [x] `packages/client-python/tests/test_client_env_loading.py` (8 cases, up from 5) — discovery never supplies a credential, explicit `ROCKETRIDE_URI=''` still raises like `develop` (was a regression — the original discovery lookup used truthiness, not presence, so an explicit empty override silently fell through to discovery/cloud instead), and a genuinely-unset `ROCKETRIDE_URI` still reaches discovery.
- [x] `pytest packages/client-python/tests/` (excluding server-dependent integration suites) — 106 passed, 0 failed.
- [x] `ruff check` / `ruff format --check` clean on all touched Python files.
- [x] `tsc --noEmit` in `apps/vscode` — 3 new lines vs. the `develop` baseline, all `Cannot find name 'URL'`, an artifact of checking these two files in isolation without `@types/node`'s ambient globals (confirmed: `new URL(...)` is already used throughout this codebase, e.g. `connection.ts`, and compiles fine there); everything else is the same pre-existing unrelated baseline.
- [x] Manually verified the Windows liveness probe's logic against Win32 docs (`OpenProcess`/`GetExitCodeProcess`/`STILL_ACTIVE`) and via the mocked-`kernel32` unit tests above; no Windows machine available to test the real syscalls end-to-end.

<!-- Generated with the assistance of Claude Code -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Local engine connections can now be discovered automatically through a local connection file.
  - Python clients use the discovered local URI when no explicit configuration or environment value is provided.
  - Invalid, stale, unavailable, or non-loopback connection information is safely ignored.
  - Explicit settings and environment variables continue to take precedence.
  - Discovery information is removed when the associated local engine exits.

- **Bug Fixes**
  - Improved WebSocket connections to local engines by preventing inappropriate proxy use.

- **Documentation**
  - Added guidance on local connection discovery and configuration precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
