### PR TITLE
fix(ai,nodes): make Whisper decode params, node config and model identity actually reach their targets

### DIFF
--- a/nodes/src/nodes/audio_transcribe/IGlobal.py
+++ b/nodes/src/nodes/audio_transcribe/IGlobal.py
@@ -120,9 +120,8 @@ class IGlobal(IGlobalBase):
             compute_type=compute_type,
         )
 
-        # Transcribe()'s own defaults; IInstance passes these through (#1809).
+        # Transcribe()'s own default; IInstance passes it through (#1809).
         self.chunk_duration = int(config.get('chunk_duration', 60))
-        self.max_chunk_duration = int(config.get('max_chunk_duration', 120))
 
         # Cast to the types VadOptions declares — JSON does not distinguish 5 from 5.0.
         self._whisper_beam_size = int(config.get('beam_size', 5))

--- a/nodes/src/nodes/audio_transcribe/IGlobal.py
+++ b/nodes/src/nodes/audio_transcribe/IGlobal.py
@@ -120,6 +120,10 @@ class IGlobal(IGlobalBase):
             compute_type=compute_type,
         )
 
+        # Transcribe()'s own defaults; IInstance passes these through (#1809).
+        self.chunk_duration = int(config.get('chunk_duration', 60))
+        self.max_chunk_duration = int(config.get('max_chunk_duration', 120))
+
         # Cast to the types VadOptions declares — JSON does not distinguish 5 from 5.0.
         self._whisper_beam_size = int(config.get('beam_size', 5))
         self._whisper_vad_filter = bool(config.get('vad_filter', True))

--- a/nodes/src/nodes/audio_transcribe/IGlobal.py
+++ b/nodes/src/nodes/audio_transcribe/IGlobal.py
@@ -53,16 +53,22 @@ class IGlobal(IGlobalBase):
         if not audio_bytes:
             return []
 
+        vad_parameters = {
+            'threshold': self._whisper_threshold,
+            'min_silence_duration_ms': self._whisper_min_silence_duration_ms,
+            'speech_pad_ms': self._whisper_speech_pad_ms,
+        }
+        # 0 = no limit: upstream's default is inf, which JSON cannot express, so omit the
+        # key. This key only — threshold=0 and speech_pad_ms=0 are real values.
+        if self._whisper_max_speech_duration_s:
+            vad_parameters['max_speech_duration_s'] = self._whisper_max_speech_duration_s
+
         with self.transcribe_lock:
             result = self._whisper.transcribe(
                 audio_bytes,
-                beam_size=5,
-                vad_filter=True,
-                vad_parameters={
-                    'threshold': self._whisper_threshold,
-                    'min_silence_duration_ms': self._whisper_min_silence_duration_ms,
-                    'max_speech_duration_s': self._whisper_max_speech_duration_s,
-                },
+                beam_size=self._whisper_beam_size,
+                vad_filter=self._whisper_vad_filter,
+                vad_parameters=vad_parameters,
             )
 
         segments = result.get('$segments') or []
@@ -114,9 +120,14 @@ class IGlobal(IGlobalBase):
             compute_type=compute_type,
         )
 
-        self._whisper_threshold = config.get('vad_threshold', 0.5)
-        self._whisper_min_silence_duration_ms = config.get('vad_min_silence_duration_ms', 500)
-        self._whisper_max_speech_duration_s = config.get('vad_max_speech_duration_s', 20)
+        # Cast to the types VadOptions declares — JSON does not distinguish 5 from 5.0.
+        self._whisper_beam_size = int(config.get('beam_size', 5))
+        self._whisper_vad_filter = bool(config.get('vad_filter', True))
+        self._whisper_threshold = float(config.get('vad_threshold', 0.5))
+        self._whisper_min_silence_duration_ms = int(config.get('vad_min_silence_duration_ms', 500))
+        self._whisper_speech_pad_ms = int(config.get('vad_speech_pad_ms', 400))
+        # Was 20, but it never reached the decoder — 0 is what actually runs today.
+        self._whisper_max_speech_duration_s = float(config.get('vad_max_speech_duration_s', 0))
 
         debug(f'    Audio transcribe: model={self.model_name}, language={language}')
 

--- a/nodes/src/nodes/audio_transcribe/IInstance.py
+++ b/nodes/src/nodes/audio_transcribe/IInstance.py
@@ -105,7 +105,6 @@ class IInstance(IInstanceBase):
             segment_callback=self._segment_callback,
             transcribe=self.IGlobal.transcribe,
             chunk_duration=self.IGlobal.chunk_duration,
-            max_chunk_duration=self.IGlobal.max_chunk_duration,
         )
 
     def open(self, object: Entry):

--- a/nodes/src/nodes/audio_transcribe/IInstance.py
+++ b/nodes/src/nodes/audio_transcribe/IInstance.py
@@ -104,6 +104,8 @@ class IInstance(IInstanceBase):
         self._transcribe = Transcribe(
             segment_callback=self._segment_callback,
             transcribe=self.IGlobal.transcribe,
+            chunk_duration=self.IGlobal.chunk_duration,
+            max_chunk_duration=self.IGlobal.max_chunk_duration,
         )
 
     def open(self, object: Entry):

--- a/nodes/src/nodes/audio_transcribe/README.md
+++ b/nodes/src/nodes/audio_transcribe/README.md
@@ -28,10 +28,6 @@ When a `documents` listener is attached, the node also emits one document per me
 | Field | Type | Description |
 |---|---|---|
 | `model` | string | Default "base". The Whisper model to use for transcription |
-| `silence_threshold` | number | Default 0.25. The silence threshold to detect silence in speech (in seconds) |
-| `min_seconds` | number | Default 240. The minimum seconds of audio to process in a batch and looking for silence |
-| `max_seconds` | number | Default 300. The maximum seconds of audio to buffer to process |
-| `vad_level` | number | Default 1. The VAD level to use for silence detection (0-3) |
 | `beam_size` | number | Default 5. Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate |
 | `vad_filter` | boolean | Default true. Use Whisper's built-in Silero VAD to drop non-speech before transcribing |
 | `vad_threshold` | number | Default 0.5. Silero speech probability above which audio counts as speech (0-1) |
@@ -45,14 +41,21 @@ node's defaults rather than replacing them, so setting one leaves the others alo
 `vad_threshold` and `vad_speech_pad_ms` accept `0` as a real value; only
 `vad_max_speech_duration_s` treats `0` specially, as "no limit".
 
-### VAD levels
+### Removed fields
 
-| Level | Behaviour |
-|-------|-----------|
-| `0`   | Most permissive: detects the most audio as speech (risk: includes noise) |
-| `1`   | Slightly more aggressive: skips minor background noise (default) |
-| `2`   | Balanced: moderate filtering of non-speech |
-| `3`   | Most aggressive: filters aggressively, may cut off quiet or short speech |
+`silence_threshold`, `min_seconds`, `max_seconds` and `vad_level` were declared but read
+by nothing, and are gone as of #1809. They predate the move to faster-whisper's built-in
+Silero VAD:
+
+| Removed | Replacement |
+|---|---|
+| `vad_level` (webrtcvad 0-3 aggressiveness) | `vad_threshold` (Silero 0-1 speech probability) |
+| `silence_threshold` (seconds) | `vad_min_silence_duration_ms` |
+| `min_seconds` / `max_seconds` | none — buffering is fixed at 60 s, forced flush at 120 s |
+
+Configs that still carry them keep working: nothing validates node config keys, so the
+unknown values are ignored. There is no automatic translation to the replacements, since
+that would change transcripts for anyone who had set them.
 
 ---
 
@@ -70,7 +73,9 @@ node's defaults rather than replacing them, so setting one leaves the others alo
 
 ## Profiles
 
-The node ships one profile per model size (`tiny`, `base`, `small`, `medium`, `large-v3`) plus `default`, which is an alias for `base`. Every profile uses the same defaults: `language: en`, `silence_threshold: 0.25`, `min_seconds: 240`, `max_seconds: 300`, `vad_level: 1`. Only the model differs between profiles.
+The node ships one profile per model size (`tiny`, `base`, `small`, `medium`, `large-v3`) plus `default`, which is an alias for `base`. Only the model and `language: en` differ; everything else comes from the field defaults.
+
+Before #1809 the profiles set `mode`, but the node reads `model` — so every profile silently loaded `base`, whichever one you picked. Selecting a profile now actually selects that model.
 
 ---
 

--- a/nodes/src/nodes/audio_transcribe/README.md
+++ b/nodes/src/nodes/audio_transcribe/README.md
@@ -4,7 +4,7 @@ A RocketRide audio filter node that transcribes spoken audio or video to text us
 
 ## What it does
 
-Receives an audio or video stream, extracts the audio track as 16 kHz mono PCM, buffers it in 60-second chunks (forced flush at 120 seconds, both configurable — see `chunk_duration` and `max_chunk_duration`), and runs Whisper with built-in voice activity detection (VAD). Segments are merged until they end in terminal punctuation (`.`, `?`, `!`), so output arrives as whole sentences, each carrying the timestamp of its first segment.
+Receives an audio or video stream, extracts the audio track as 16 kHz mono PCM, buffers it in 60-second chunks (configurable — see `chunk_duration`), and runs Whisper with built-in voice activity detection (VAD). Segments are merged until they end in terminal punctuation (`.`, `?`, `!`), so output arrives as whole sentences, each carrying the timestamp of its first segment.
 
 Uses `ai.common.models.Whisper`: transcription routes to the model server when the engine is started with `--modelserver`, otherwise it runs locally via `faster-whisper`. No API key is required either way. Decoding and VAD are configurable per request — see `beam_size` and the `vad_*` fields below; the defaults reproduce the behaviour this node had before they were exposed. Transcription calls are serialized through a global lock so a single loaded model is shared safely across instances.
 
@@ -29,7 +29,6 @@ When a `documents` listener is attached, the node also emits one document per me
 |---|---|---|
 | `model` | string | Default "base". The Whisper model to use for transcription |
 | `chunk_duration` | number | Default 60. Seconds of audio to buffer before sending a chunk to Whisper |
-| `max_chunk_duration` | number | Default 120. Hard limit before a chunk is flushed even without a pause |
 | `beam_size` | number | Default 5. Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate |
 | `vad_filter` | boolean | Default true. Use Whisper's built-in Silero VAD to drop non-speech before transcribing |
 | `vad_threshold` | number | Default 0.5. Silero speech probability above which audio counts as speech (0-1) |
@@ -53,7 +52,7 @@ Silero VAD:
 |---|---|
 | `vad_level` (webrtcvad 0-3 aggressiveness) | `vad_threshold` (Silero 0-1 speech probability) |
 | `silence_threshold` (seconds) | `vad_min_silence_duration_ms` |
-| `min_seconds` / `max_seconds` | `chunk_duration` / `max_chunk_duration`, which are actually wired up |
+| `min_seconds` / `max_seconds` | `chunk_duration`, which is actually wired up. There is no second, higher threshold: it would only mean something with a silence test between the two, and pause handling belongs to Whisper's VAD |
 
 Configs that still carry them keep working: nothing validates node config keys, so the
 unknown values are ignored. There is no automatic translation to the replacements, since

--- a/nodes/src/nodes/audio_transcribe/README.md
+++ b/nodes/src/nodes/audio_transcribe/README.md
@@ -6,7 +6,7 @@ A RocketRide audio filter node that transcribes spoken audio or video to text us
 
 Receives an audio or video stream, extracts the audio track as 16 kHz mono PCM, buffers it in 60-second chunks (forced flush at 120 seconds), and runs Whisper with built-in voice activity detection (VAD). Segments are merged until they end in terminal punctuation (`.`, `?`, `!`), so output arrives as whole sentences, each carrying the timestamp of its first segment.
 
-Uses `ai.common.models.Whisper`: transcription routes to the model server when the engine is started with `--modelserver`, otherwise it runs locally via `faster-whisper`. No API key is required either way. Whisper is invoked with `beam_size=5` and `vad_filter=True`, and transcription calls are serialized through a global lock so a single loaded model is shared safely across instances.
+Uses `ai.common.models.Whisper`: transcription routes to the model server when the engine is started with `--modelserver`, otherwise it runs locally via `faster-whisper`. No API key is required either way. Decoding and VAD are configurable per request — see `beam_size` and the `vad_*` fields below; the defaults reproduce the behaviour this node had before they were exposed. Transcription calls are serialized through a global lock so a single loaded model is shared safely across instances.
 
 Models are downloaded from HuggingFace on first use. GPU is used automatically when available (`compute_type` defaults to `float16`).
 
@@ -32,7 +32,18 @@ When a `documents` listener is attached, the node also emits one document per me
 | `min_seconds` | number | Default 240. The minimum seconds of audio to process in a batch and looking for silence |
 | `max_seconds` | number | Default 300. The maximum seconds of audio to buffer to process |
 | `vad_level` | number | Default 1. The VAD level to use for silence detection (0-3) |
+| `beam_size` | number | Default 5. Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate |
+| `vad_filter` | boolean | Default true. Use Whisper's built-in Silero VAD to drop non-speech before transcribing |
+| `vad_threshold` | number | Default 0.5. Silero speech probability above which audio counts as speech (0-1) |
+| `vad_min_silence_duration_ms` | number | Default 500. Silence this long ends a speech chunk |
+| `vad_speech_pad_ms` | number | Default 400. Padding added to each side of a detected speech chunk |
+| `vad_max_speech_duration_s` | number | Default 0. Split speech chunks longer than this. 0 means no limit |
 | `profile` | string | Default "default".  |
+
+The five `vad_*` fields map onto faster-whisper's `VadOptions`. They are merged over the
+node's defaults rather than replacing them, so setting one leaves the others alone. Note
+`vad_threshold` and `vad_speech_pad_ms` accept `0` as a real value; only
+`vad_max_speech_duration_s` treats `0` specially, as "no limit".
 
 ### VAD levels
 
@@ -76,12 +87,18 @@ Defaults to English (`en`). Change the `language` config value to transcribe oth
 
 | Field | Type | Description | Default |
 |---|---|---|---|
+| `transcribe.beam_size` | `number` | **Beam Size**<br/>Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate | `5` |
 | `transcribe.max_seconds` | `number` | **Maximum Seconds**<br/>The maximum seconds of audio to buffer to process | `300` |
 | `transcribe.min_seconds` | `number` | **Minimum Seconds**<br/>The minimum seconds of audio to process in a batch and looking for silence | `240` |
 | `transcribe.model` | `string` | **Model**<br/>The Whisper model to use for transcription | `"base"` |
 | `transcribe.profile` | `string` |  | `"default"` |
 | `transcribe.silence_threshold` | `number` | **Silence Threshold**<br/>The silence threshold to detect silence in speech (in seconds) | `0.25` |
+| `transcribe.vad_filter` | `boolean` | **VAD Filter**<br/>Use Whisper's built-in Silero VAD to drop non-speech before transcribing | `true` |
 | `transcribe.vad_level` | `number` | **VAD Level**<br/>The VAD level to use for silence detection (0-3) | `1` |
+| `transcribe.vad_max_speech_duration_s` | `number` | **VAD Maximum Speech (s)**<br/>Split speech chunks longer than this. 0 means no limit | `0` |
+| `transcribe.vad_min_silence_duration_ms` | `number` | **VAD Minimum Silence (ms)**<br/>Silence this long ends a speech chunk | `500` |
+| `transcribe.vad_speech_pad_ms` | `number` | **VAD Speech Padding (ms)**<br/>Padding added to each side of a detected speech chunk | `400` |
+| `transcribe.vad_threshold` | `number` | **VAD Speech Threshold**<br/>Silero speech probability above which audio counts as speech (0-1) | `0.5` |
 
 ## Dependencies
 
@@ -91,7 +108,8 @@ Defaults to English (`en`). Change the `language` config value to transcribe oth
 - `tokenizers`
 - `huggingface-hub`
 - `tqdm`
-- `onnxruntime`
+- `onnxruntime-gpu` `==1.22.0; platform_system != 'Darwin'`
+- `onnxruntime` `==1.22.0; platform_system == 'Darwin'`
 
 ## Source
 

--- a/nodes/src/nodes/audio_transcribe/README.md
+++ b/nodes/src/nodes/audio_transcribe/README.md
@@ -4,7 +4,7 @@ A RocketRide audio filter node that transcribes spoken audio or video to text us
 
 ## What it does
 
-Receives an audio or video stream, extracts the audio track as 16 kHz mono PCM, buffers it in 60-second chunks (forced flush at 120 seconds), and runs Whisper with built-in voice activity detection (VAD). Segments are merged until they end in terminal punctuation (`.`, `?`, `!`), so output arrives as whole sentences, each carrying the timestamp of its first segment.
+Receives an audio or video stream, extracts the audio track as 16 kHz mono PCM, buffers it in 60-second chunks (forced flush at 120 seconds, both configurable — see `chunk_duration` and `max_chunk_duration`), and runs Whisper with built-in voice activity detection (VAD). Segments are merged until they end in terminal punctuation (`.`, `?`, `!`), so output arrives as whole sentences, each carrying the timestamp of its first segment.
 
 Uses `ai.common.models.Whisper`: transcription routes to the model server when the engine is started with `--modelserver`, otherwise it runs locally via `faster-whisper`. No API key is required either way. Decoding and VAD are configurable per request — see `beam_size` and the `vad_*` fields below; the defaults reproduce the behaviour this node had before they were exposed. Transcription calls are serialized through a global lock so a single loaded model is shared safely across instances.
 
@@ -28,6 +28,8 @@ When a `documents` listener is attached, the node also emits one document per me
 | Field | Type | Description |
 |---|---|---|
 | `model` | string | Default "base". The Whisper model to use for transcription |
+| `chunk_duration` | number | Default 60. Seconds of audio to buffer before sending a chunk to Whisper |
+| `max_chunk_duration` | number | Default 120. Hard limit before a chunk is flushed even without a pause |
 | `beam_size` | number | Default 5. Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate |
 | `vad_filter` | boolean | Default true. Use Whisper's built-in Silero VAD to drop non-speech before transcribing |
 | `vad_threshold` | number | Default 0.5. Silero speech probability above which audio counts as speech (0-1) |
@@ -51,7 +53,7 @@ Silero VAD:
 |---|---|
 | `vad_level` (webrtcvad 0-3 aggressiveness) | `vad_threshold` (Silero 0-1 speech probability) |
 | `silence_threshold` (seconds) | `vad_min_silence_duration_ms` |
-| `min_seconds` / `max_seconds` | none — buffering is fixed at 60 s, forced flush at 120 s |
+| `min_seconds` / `max_seconds` | `chunk_duration` / `max_chunk_duration`, which are actually wired up |
 
 Configs that still carry them keep working: nothing validates node config keys, so the
 unknown values are ignored. There is no automatic translation to the replacements, since

--- a/nodes/src/nodes/audio_transcribe/services.json
+++ b/nodes/src/nodes/audio_transcribe/services.json
@@ -168,6 +168,20 @@
 			],
 			"default": "base"
 		},
+		// Buffering, passed to Transcribe(). Defaults are its own constants, which ran
+		// unconditionally before — min_seconds/max_seconds never reached it (#1809).
+		"transcribe.chunk_duration": {
+			"type": "number",
+			"title": "Chunk Duration (s)",
+			"description": "Seconds of audio to buffer before sending a chunk to Whisper",
+			"default": 60
+		},
+		"transcribe.max_chunk_duration": {
+			"type": "number",
+			"title": "Maximum Chunk Duration (s)",
+			"description": "Hard limit before a chunk is flushed even without a pause",
+			"default": 120
+		},
 		// Decode-time parameters, forwarded per request (#1809). Defaults mirror what
 		// the node already sent.
 		"transcribe.beam_size": {
@@ -208,7 +222,7 @@
 		},
 		"transcribe.default": {
 			"object": "default",
-			"properties": ["transcribe.model", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+			"properties": ["transcribe.model", "transcribe.chunk_duration", "transcribe.max_chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
 		},
 		"transcribe.profile": {
 			"hidden": true,

--- a/nodes/src/nodes/audio_transcribe/services.json
+++ b/nodes/src/nodes/audio_transcribe/services.json
@@ -176,12 +176,6 @@
 			"description": "Seconds of audio to buffer before sending a chunk to Whisper",
 			"default": 60
 		},
-		"transcribe.max_chunk_duration": {
-			"type": "number",
-			"title": "Maximum Chunk Duration (s)",
-			"description": "Hard limit before a chunk is flushed even without a pause",
-			"default": 120
-		},
 		// Decode-time parameters, forwarded per request (#1809). Defaults mirror what
 		// the node already sent.
 		"transcribe.beam_size": {
@@ -222,7 +216,7 @@
 		},
 		"transcribe.default": {
 			"object": "default",
-			"properties": ["transcribe.model", "transcribe.chunk_duration", "transcribe.max_chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+			"properties": ["transcribe.model", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
 		},
 		"transcribe.profile": {
 			"hidden": true,

--- a/nodes/src/nodes/audio_transcribe/services.json
+++ b/nodes/src/nodes/audio_transcribe/services.json
@@ -76,54 +76,32 @@
 		// specified, unless the profile is 'absolute'
 		"default": "default",
 		// Defines profiles used with the "profile": key
+		// "model", not "mode": IGlobal reads config.get('model'), so every profile
+		// silently loaded base regardless of its name (#1809).
 		"profiles": {
 			"default": {
-				"mode": "base",
-				"language": "en",
-				"silence_threshold": 0.25,
-				"min_seconds": 240,
-				"max_seconds": 300,
-				"vad_level": 1
+				"model": "base",
+				"language": "en"
 			},
 			"tiny": {
-				"mode": "tiny",
-				"language": "en",
-				"silence_threshold": 0.25,
-				"min_seconds": 240,
-				"max_seconds": 300,
-				"vad_level": 1
+				"model": "tiny",
+				"language": "en"
 			},
 			"base": {
-				"mode": "base",
-				"language": "en",
-				"silence_threshold": 0.25,
-				"min_seconds": 240,
-				"max_seconds": 300,
-				"vad_level": 1
+				"model": "base",
+				"language": "en"
 			},
 			"small": {
-				"mode": "small",
-				"language": "en",
-				"silence_threshold": 0.25,
-				"min_seconds": 240,
-				"max_seconds": 300,
-				"vad_level": 1
+				"model": "small",
+				"language": "en"
 			},
 			"medium": {
-				"mode": "medium",
-				"language": "en",
-				"silence_threshold": 0.25,
-				"min_seconds": 240,
-				"max_seconds": 300,
-				"vad_level": 1
+				"model": "medium",
+				"language": "en"
 			},
 			"large-v3": {
-				"mode": "large-v3",
-				"language": "en",
-				"silence_threshold": 0.25,
-				"min_seconds": 240,
-				"max_seconds": 300,
-				"vad_level": 1
+				"model": "large-v3",
+				"language": "en"
 			}
 		}
 	},
@@ -139,7 +117,9 @@
 				"expect": {
 					"text": {
 						"beginsWith": "Where East meets West in the divided",
-						"contains": "Mr Gorbachev, open this gate.\nMr Gorbachev, tear down this wall.\n",
+						// No "Mr": small and tiny write "Mr." where the larger models write
+						// "Mr", and the difference says nothing about transcription quality.
+						"contains": "Gorbachev, tear down this wall.\n",
 						"endsWith": "as many again were arrested.\n\n\n"
 					}
 				}
@@ -160,7 +140,8 @@
 					"video": "video/BBC - Tear down this wall.mp4",
 					"expect": {
 						"text": {
-							"contains": "Mr Gorbachev, tear down this wall."
+							// See the note in "test" above — no "Mr", so every model size matches.
+						"contains": "Gorbachev, tear down this wall."
 						}
 					}
 				}
@@ -186,36 +167,6 @@
 				["large-v3", "Large v3 - Slowest, Highest accuracy"]
 			],
 			"default": "base"
-		},
-		"transcribe.silence_threshold": {
-			"type": "number",
-			"title": "Silence Threshold",
-			"description": "The silence threshold to detect silence in speech (in seconds)",
-			"default": 0.25
-		},
-		"transcribe.min_seconds": {
-			"type": "number",
-			"title": "Minimum Seconds",
-			"description": "The minimum seconds of audio to process in a batch and looking for silence",
-			"default": 240
-		},
-		"transcribe.max_seconds": {
-			"type": "number",
-			"title": "Maximum Seconds",
-			"description": "The maximum seconds of audio to buffer to process",
-			"default": 300
-		},
-		"transcribe.vad_level": {
-			"type": "number",
-			"title": "VAD Level",
-			"description": "The VAD level to use for silence detection (0-3)",
-			"default": 1,
-			"enum": [
-				[0, "Most permissive - detects the most audio as speech (risk: includes noise"],
-				[1, "Slightly more aggressive - skips minor background noise."],
-				[2, "Balanced - moderate filtering of non-speech (default in many tools)."],
-				[3, "Most aggressive - filters aggressively, may cut off quiet or short speech."]
-			]
 		},
 		// Decode-time parameters, forwarded per request (#1809). Defaults mirror what
 		// the node already sent.
@@ -257,7 +208,7 @@
 		},
 		"transcribe.default": {
 			"object": "default",
-			"properties": ["transcribe.model", "transcribe.silence_threshold", "transcribe.min_seconds", "transcribe.max_seconds", "transcribe.vad_level", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+			"properties": ["transcribe.model", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
 		},
 		"transcribe.profile": {
 			"hidden": true,

--- a/nodes/src/nodes/audio_transcribe/services.json
+++ b/nodes/src/nodes/audio_transcribe/services.json
@@ -217,9 +217,47 @@
 				[3, "Most aggressive - filters aggressively, may cut off quiet or short speech."]
 			]
 		},
+		// Decode-time parameters, forwarded per request (#1809). Defaults mirror what
+		// the node already sent.
+		"transcribe.beam_size": {
+			"type": "number",
+			"title": "Beam Size",
+			"description": "Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate",
+			"default": 5
+		},
+		"transcribe.vad_filter": {
+			"type": "boolean",
+			"title": "VAD Filter",
+			"description": "Use Whisper's built-in Silero VAD to drop non-speech before transcribing",
+			"default": true
+		},
+		"transcribe.vad_threshold": {
+			"type": "number",
+			"title": "VAD Speech Threshold",
+			"description": "Silero speech probability above which audio counts as speech (0-1)",
+			"default": 0.5
+		},
+		"transcribe.vad_min_silence_duration_ms": {
+			"type": "number",
+			"title": "VAD Minimum Silence (ms)",
+			"description": "Silence this long ends a speech chunk",
+			"default": 500
+		},
+		"transcribe.vad_speech_pad_ms": {
+			"type": "number",
+			"title": "VAD Speech Padding (ms)",
+			"description": "Padding added to each side of a detected speech chunk",
+			"default": 400
+		},
+		"transcribe.vad_max_speech_duration_s": {
+			"type": "number",
+			"title": "VAD Maximum Speech (s)",
+			"description": "Split speech chunks longer than this. 0 means no limit",
+			"default": 0
+		},
 		"transcribe.default": {
 			"object": "default",
-			"properties": ["transcribe.model", "transcribe.silence_threshold", "transcribe.min_seconds", "transcribe.max_seconds", "transcribe.vad_level"]
+			"properties": ["transcribe.model", "transcribe.silence_threshold", "transcribe.min_seconds", "transcribe.max_seconds", "transcribe.vad_level", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
 		},
 		"transcribe.profile": {
 			"hidden": true,

--- a/nodes/src/nodes/audio_transcribe/transcribe.py
+++ b/nodes/src/nodes/audio_transcribe/transcribe.py
@@ -45,9 +45,7 @@ class Transcribe(AudioReader):
     SAMPLE_RATE = 16000  # Required input sample rate for Whisper
     CHANNELS = 1  # Mono audio
     CHUNK_DURATION = 60  # Send audio to Whisper every 60 seconds
-    MAX_CHUNK_DURATION = 120  # Maximum chunk duration before forcing transcription
     CHUNK_SAMPLES = SAMPLE_RATE * CHUNK_DURATION
-    MAX_CHUNK_SAMPLES = SAMPLE_RATE * MAX_CHUNK_DURATION
 
     def __init__(
         self,
@@ -60,7 +58,6 @@ class Transcribe(AudioReader):
         """
         # Get the optional parameters from kwargs
         chunk_duration: int = kwargs.get('chunk_duration', self.CHUNK_DURATION)
-        max_chunk_duration: int = kwargs.get('max_chunk_duration', self.MAX_CHUNK_DURATION)
 
         # The whisper model is passed to us
         self._transcribe = transcribe
@@ -70,7 +67,6 @@ class Transcribe(AudioReader):
 
         # Buffering parameters
         self._chunk_samples = chunk_duration * self.SAMPLE_RATE
-        self._max_chunk_samples = max_chunk_duration * self.SAMPLE_RATE
 
         # Audio extractor that calls onData on each decoded PCM chunk
         super().__init__(
@@ -166,11 +162,12 @@ class Transcribe(AudioReader):
         self._audio_chunks.append(chunk)
         self._total_samples += len(chunk) // 2  # 2 bytes per int16 sample
 
-        # Check if we should flush
-        # Flush every 60 seconds, or force flush at 120 seconds max
+        # One threshold, cut unconditionally. There used to be a second, higher one
+        # guarded by `elif`, which could never fire — reaching it meant already passing
+        # this one. A second threshold only means something with a "cut here, it is
+        # quiet" test between the two, and this class has no silence detection: pause
+        # handling is delegated to Whisper's built-in VAD, per the class docstring.
         if self._total_samples >= self._chunk_samples:
-            self._flush_audio()
-        elif self._total_samples >= self._max_chunk_samples:
             self._flush_audio()
 
     def outputText(self, text: str):

--- a/nodes/test/audio_transcribe/test_decode_params.py
+++ b/nodes/test/audio_transcribe/test_decode_params.py
@@ -18,6 +18,7 @@ and the knob is dead on arrival — which is the very bug #1809 is about.
 
 from __future__ import annotations
 
+import ast
 import importlib.util
 import os
 import sys
@@ -40,7 +41,7 @@ _VAD_FIELD_TO_DECODE_KEY = {
     'vad_speech_pad_ms': 'speech_pad_ms',
     'vad_max_speech_duration_s': 'max_speech_duration_s',
 }
-_NEW_FIELDS = ['beam_size', 'vad_filter', *_VAD_FIELD_TO_DECODE_KEY]
+_NEW_FIELDS = ['beam_size', 'vad_filter', 'chunk_duration', 'max_chunk_duration', *_VAD_FIELD_TO_DECODE_KEY]
 
 # Read by nothing; superseded by the vad_* fields or by fixed buffering constants.
 _DEAD_FIELDS = ['silence_threshold', 'min_seconds', 'max_seconds', 'vad_level']
@@ -240,6 +241,8 @@ def test_services_json_defaults_match_the_python_fallbacks():
     """A UI default that disagrees with the runtime fallback changes behaviour on save."""
     fields = _parse_services_json()['fields']
     expected = {
+        'transcribe.chunk_duration': 60,
+        'transcribe.max_chunk_duration': 120,
         'transcribe.beam_size': 5,
         'transcribe.vad_filter': True,
         'transcribe.vad_threshold': 0.5,
@@ -250,6 +253,57 @@ def test_services_json_defaults_match_the_python_fallbacks():
 
     for name, default in expected.items():
         assert fields[name]['default'] == default, f'{name} default drifted from IGlobal'
+
+
+def _class_attrs(path, class_name):
+    """Read a class's literal attributes without importing it (relative imports)."""
+    tree = ast.parse(open(path, encoding='utf-8').read())
+    cls = next(n for n in ast.walk(tree) if isinstance(n, ast.ClassDef) and n.name == class_name)
+    return {
+        t.id: n.value.value
+        for n in cls.body
+        if isinstance(n, ast.Assign) and isinstance(n.value, ast.Constant)
+        for t in n.targets
+        if isinstance(t, ast.Name)
+    }
+
+
+def test_iglobal_reads_buffering_from_config():
+    IGlobal, holder = _load_iglobal()
+    holder['raw'] = {'chunk_duration': 30, 'max_chunk_duration': 90}
+
+    ig = IGlobal.__new__(IGlobal)
+    ig.glb = types.SimpleNamespace(logicalType='audio_transcribe://', connConfig={})
+    ig.beginGlobal()
+
+    assert ig.chunk_duration == 30
+    assert ig.max_chunk_duration == 90
+
+
+def test_buffering_defaults_reproduce_transcribe_constants():
+    """The defaults must equal what Transcribe ran unconditionally before it was wired."""
+    consts = _class_attrs(os.path.join(_NODE_DIR, 'transcribe.py'), 'Transcribe')
+    fields = _parse_services_json()['fields']
+
+    assert fields['transcribe.chunk_duration']['default'] == consts['CHUNK_DURATION']
+    assert fields['transcribe.max_chunk_duration']['default'] == consts['MAX_CHUNK_DURATION']
+
+
+def test_iinstance_passes_buffering_to_transcribe():
+    """IInstance built Transcribe() with no kwargs, so the config never reached it.
+
+    Static check: IInstance imports rocketlib and ai.common.avi, so the stub harness
+    above cannot load it.
+    """
+    tree = ast.parse(open(os.path.join(_NODE_DIR, 'IInstance.py'), encoding='utf-8').read())
+    call = next(
+        n
+        for n in ast.walk(tree)
+        if isinstance(n, ast.Call) and isinstance(n.func, ast.Name) and n.func.id == 'Transcribe'
+    )
+    passed = {kw.arg for kw in call.keywords}
+
+    assert {'chunk_duration', 'max_chunk_duration'} <= passed, f'Transcribe() only gets {sorted(passed)}'
 
 
 def test_dead_fields_are_gone():

--- a/nodes/test/audio_transcribe/test_decode_params.py
+++ b/nodes/test/audio_transcribe/test_decode_params.py
@@ -41,7 +41,7 @@ _VAD_FIELD_TO_DECODE_KEY = {
     'vad_speech_pad_ms': 'speech_pad_ms',
     'vad_max_speech_duration_s': 'max_speech_duration_s',
 }
-_NEW_FIELDS = ['beam_size', 'vad_filter', 'chunk_duration', 'max_chunk_duration', *_VAD_FIELD_TO_DECODE_KEY]
+_NEW_FIELDS = ['beam_size', 'vad_filter', 'chunk_duration', *_VAD_FIELD_TO_DECODE_KEY]
 
 # Read by nothing; superseded by the vad_* fields or by fixed buffering constants.
 _DEAD_FIELDS = ['silence_threshold', 'min_seconds', 'max_seconds', 'vad_level']
@@ -242,7 +242,6 @@ def test_services_json_defaults_match_the_python_fallbacks():
     fields = _parse_services_json()['fields']
     expected = {
         'transcribe.chunk_duration': 60,
-        'transcribe.max_chunk_duration': 120,
         'transcribe.beam_size': 5,
         'transcribe.vad_filter': True,
         'transcribe.vad_threshold': 0.5,
@@ -270,14 +269,13 @@ def _class_attrs(path, class_name):
 
 def test_iglobal_reads_buffering_from_config():
     IGlobal, holder = _load_iglobal()
-    holder['raw'] = {'chunk_duration': 30, 'max_chunk_duration': 90}
+    holder['raw'] = {'chunk_duration': 30}
 
     ig = IGlobal.__new__(IGlobal)
     ig.glb = types.SimpleNamespace(logicalType='audio_transcribe://', connConfig={})
     ig.beginGlobal()
 
     assert ig.chunk_duration == 30
-    assert ig.max_chunk_duration == 90
 
 
 def test_buffering_defaults_reproduce_transcribe_constants():
@@ -286,7 +284,6 @@ def test_buffering_defaults_reproduce_transcribe_constants():
     fields = _parse_services_json()['fields']
 
     assert fields['transcribe.chunk_duration']['default'] == consts['CHUNK_DURATION']
-    assert fields['transcribe.max_chunk_duration']['default'] == consts['MAX_CHUNK_DURATION']
 
 
 def test_iinstance_passes_buffering_to_transcribe():
@@ -303,7 +300,98 @@ def test_iinstance_passes_buffering_to_transcribe():
     )
     passed = {kw.arg for kw in call.keywords}
 
-    assert {'chunk_duration', 'max_chunk_duration'} <= passed, f'Transcribe() only gets {sorted(passed)}'
+    assert 'chunk_duration' in passed, f'Transcribe() only gets {sorted(passed)}'
+
+
+def _load_transcribe():
+    """Load transcribe.py behind stubs.
+
+    It does `from .IGlobal import IGlobal`, so the module must be loaded inside a
+    package; a synthetic one pointed at the node directory is enough.
+    """
+    saved = {}
+    pkg_name = '_audio_transcribe_pkg'
+
+    class FakeAudioReader:
+        def __init__(self, **kwargs):
+            pass
+
+        def start(self):
+            pass
+
+        def getTimestamp(self):
+            return 0.0
+
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [_NODE_DIR]
+    iglobal_stub = types.ModuleType(f'{pkg_name}.IGlobal')
+    iglobal_stub.IGlobal = object
+
+    stubs = {
+        pkg_name: pkg,
+        f'{pkg_name}.IGlobal': iglobal_stub,
+        'ai': types.ModuleType('ai'),
+        'ai.common': types.ModuleType('ai.common'),
+        'ai.common.avi': types.ModuleType('ai.common.avi'),
+        'ai.common.avi.audio': types.ModuleType('ai.common.avi.audio'),
+        'rocketlib': types.ModuleType('rocketlib'),
+    }
+    stubs['ai.common.avi.audio'].AudioReader = FakeAudioReader
+    stubs['rocketlib'].debug = lambda *a, **kw: None
+
+    for name, stub in stubs.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = stub
+
+    mod_name = f'{pkg_name}.transcribe'
+    try:
+        spec = importlib.util.spec_from_file_location(mod_name, os.path.join(_NODE_DIR, 'transcribe.py'))
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod.Transcribe
+    finally:
+        sys.modules.pop(mod_name, None)
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+
+def test_audio_is_flushed_once_chunk_duration_is_reached():
+    """The behavioural gap the checks above leave open.
+
+    Nothing here used to observe an actual flush, which is how a second, unreachable
+    threshold survived: any buffer long enough to hit it has already hit this one, so
+    `elif` never ran and its config field was inert. Feeding real bytes catches that.
+    """
+    Transcribe = _load_transcribe()
+    flushed = []
+
+    node = Transcribe(
+        segment_callback=lambda segments: None,
+        transcribe=lambda audio: flushed.append(len(audio)) or [],
+        chunk_duration=2,
+    )
+    node.start()
+
+    one_second = b'\x00\x01' * Transcribe.SAMPLE_RATE  # int16 mono
+
+    node.onData(one_second)
+    assert flushed == [], 'flushed before reaching chunk_duration'
+
+    node.onData(one_second)
+    assert len(flushed) == 1, 'no flush at chunk_duration'
+    assert flushed[0] == 2 * Transcribe.SAMPLE_RATE * 2  # 2 s of int16
+
+    # _flush_audio() zeroes the counter, so the next second starts a fresh chunk.
+    node.onData(one_second)
+    assert len(flushed) == 1
+
+    # There is deliberately no higher threshold: without a "cut here, it is quiet"
+    # test between the two it can never fire, and this class has no silence detection.
+    assert not hasattr(Transcribe, 'MAX_CHUNK_DURATION')
 
 
 def test_dead_fields_are_gone():

--- a/nodes/test/audio_transcribe/test_decode_params.py
+++ b/nodes/test/audio_transcribe/test_decode_params.py
@@ -1,0 +1,249 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Engine-glue tests for audio_transcribe's per-request decode parameters (#1809).
+
+Mirrors the direct-instance harness used by schema_validate/test_engine_glue.py and
+currency_convert_explicit/test_isjson_gate.py: rocketlib and ai.common.* are stubbed,
+IGlobal.py is loaded from source via importlib, the IGlobal is built with
+__new__ + beginGlobal(), and ai.common.models.Whisper is a recorder. No server, no
+model, no GPU.
+
+Guards the half of #1809 the integration runs cannot see. A misspelled field name or a
+stale default falls back silently: the transcript does not move, nodes:test stays green,
+and the knob is dead on arrival — which is the very bug #1809 is about.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_NODE_DIR = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'audio_transcribe')
+_SERVICES_JSON = os.path.join(_NODE_DIR, 'services.json')
+_DISCOVERY_PY = os.path.join(_HERE, '..', 'framework', 'discovery.py')
+
+# Exactly what the node sent before #1809, and must keep sending when nothing is set.
+_BASELINE_VAD = {'threshold': 0.5, 'min_silence_duration_ms': 500, 'speech_pad_ms': 400}
+
+# services.json field name -> the faster-whisper key it must arrive as.
+_VAD_FIELD_TO_DECODE_KEY = {
+    'vad_threshold': 'threshold',
+    'vad_min_silence_duration_ms': 'min_silence_duration_ms',
+    'vad_speech_pad_ms': 'speech_pad_ms',
+    'vad_max_speech_duration_s': 'max_speech_duration_s',
+}
+_NEW_FIELDS = ['beam_size', 'vad_filter', *_VAD_FIELD_TO_DECODE_KEY]
+
+
+class _FakeWhisper:
+    """Stands in for ai.common.models.Whisper, recording the decode kwargs."""
+
+    def __init__(self, model_name, output_fields=None, language=None, compute_type=None, **kwargs):
+        self.calls = []
+
+    def transcribe(self, audio, **kw):
+        self.calls.append(kw)
+        return {'$segments': []}
+
+    def disconnect(self):
+        pass
+
+
+def _load_iglobal():
+    """Load IGlobal.py from source behind stubs. Returns (IGlobal, config_holder)."""
+    saved = {}
+    config_holder = {'raw': {}}
+
+    class FakeIGlobalBase:
+        glb = None
+
+    stubs = {
+        'rocketlib': types.ModuleType('rocketlib'),
+        'ai': types.ModuleType('ai'),
+        'ai.common': types.ModuleType('ai.common'),
+        'ai.common.config': types.ModuleType('ai.common.config'),
+        'ai.common.models': types.ModuleType('ai.common.models'),
+    }
+    stubs['rocketlib'].IGlobalBase = FakeIGlobalBase
+    stubs['rocketlib'].debug = lambda *a, **kw: None
+    stubs['ai.common.config'].Config = type(
+        'FakeConfig', (), {'getNodeConfig': staticmethod(lambda lt, cc: config_holder['raw'])}
+    )
+    stubs['ai.common.models'].Whisper = _FakeWhisper
+
+    for name, stub in stubs.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = stub
+
+    # Loads standalone — the package __init__ would drag in IInstance.
+    mod_name = '_audio_transcribe_iglobal_under_test'
+    try:
+        spec = importlib.util.spec_from_file_location(mod_name, os.path.join(_NODE_DIR, 'IGlobal.py'))
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod.IGlobal, config_holder
+    finally:
+        sys.modules.pop(mod_name, None)
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+
+def _decode_kwargs(raw_config):
+    """Build an IGlobal from a node config and return the kwargs it hands Whisper."""
+    IGlobal, holder = _load_iglobal()
+    holder['raw'] = raw_config
+
+    ig = IGlobal.__new__(IGlobal)
+    ig.glb = types.SimpleNamespace(logicalType='audio_transcribe://', connConfig={})
+    ig.beginGlobal()
+    ig.transcribe(b'\x00\x01' * 2000)
+
+    return ig._whisper.calls[-1]
+
+
+def _parse_services_json():
+    """Parse via the repo's JSONC reader — services.json has comments and trailing commas."""
+    spec = importlib.util.spec_from_file_location('_audio_transcribe_discovery', _DISCOVERY_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod._parse_service_json(_SERVICES_JSON)
+
+
+# -----------------------------------------------------------------------------
+# What an unconfigured node sends
+# -----------------------------------------------------------------------------
+
+
+def test_empty_config_reproduces_todays_call():
+    """The 'output unchanged' claim, made executable.
+
+    Also the only direct guard on the vad_max_speech_duration_s 20 -> 0 change.
+    """
+    kw = _decode_kwargs({})
+
+    assert kw['beam_size'] == 5
+    assert kw['vad_filter'] is True
+    assert kw['vad_parameters'] == _BASELINE_VAD
+    assert 'max_speech_duration_s' not in kw['vad_parameters']
+
+
+# -----------------------------------------------------------------------------
+# Config -> decoder wiring
+# -----------------------------------------------------------------------------
+
+
+def test_beam_size_and_vad_filter_come_from_config():
+    kw = _decode_kwargs({'beam_size': 1, 'vad_filter': False})
+
+    assert kw['beam_size'] == 1
+    assert kw['vad_filter'] is False
+
+
+@pytest.mark.parametrize(
+    'field,value',
+    [
+        ('vad_threshold', 0.25),
+        ('vad_min_silence_duration_ms', 250),
+        ('vad_speech_pad_ms', 100),
+        ('vad_max_speech_duration_s', 30),
+    ],
+)
+def test_each_vad_field_arrives_under_its_faster_whisper_name(field, value):
+    """Fails when the IGlobal side of the name mapping is misspelled."""
+    vad = _decode_kwargs({field: value})['vad_parameters']
+
+    assert vad[_VAD_FIELD_TO_DECODE_KEY[field]] == value
+
+
+def test_several_keys_at_once():
+    kw = _decode_kwargs({'beam_size': 3, 'vad_filter': False, 'vad_threshold': 0.7, 'vad_max_speech_duration_s': 15})
+
+    assert kw['beam_size'] == 3
+    assert kw['vad_filter'] is False
+    assert kw['vad_parameters']['threshold'] == 0.7
+    assert kw['vad_parameters']['max_speech_duration_s'] == 15
+    assert kw['vad_parameters']['min_silence_duration_ms'] == 500  # untouched default
+
+
+# -----------------------------------------------------------------------------
+# The 0 sentinel, and the keys it must not affect
+# -----------------------------------------------------------------------------
+
+
+def test_max_speech_duration_of_zero_omits_the_key():
+    """0 means no limit: faster-whisper's real default is inf, which JSON cannot express."""
+    vad = _decode_kwargs({'vad_max_speech_duration_s': 0})['vad_parameters']
+
+    assert 'max_speech_duration_s' not in vad
+
+
+def test_max_speech_duration_when_set_is_sent():
+    vad = _decode_kwargs({'vad_max_speech_duration_s': 20})['vad_parameters']
+
+    assert vad['max_speech_duration_s'] == 20
+
+
+def test_zero_is_kept_on_every_other_vad_key():
+    """The falsy-means-omit rule is for max_speech_duration_s ONLY.
+
+    A `{k: v for k, v in ... if v}` sweep would silently restore 0.5 and 400 here.
+    """
+    vad = _decode_kwargs({'vad_threshold': 0, 'vad_speech_pad_ms': 0})['vad_parameters']
+
+    assert vad['threshold'] == 0
+    assert vad['speech_pad_ms'] == 0
+
+
+def test_types_match_what_vadoptions_declares():
+    """JSON does not distinguish 5 from 5.0, and CTranslate2 wants an int beam size."""
+    kw = _decode_kwargs({'beam_size': 5.0, 'vad_min_silence_duration_ms': 500.0})
+
+    assert kw['beam_size'] == 5
+    assert isinstance(kw['beam_size'], int)
+    assert isinstance(kw['vad_parameters']['min_silence_duration_ms'], int)
+
+
+# -----------------------------------------------------------------------------
+# services.json — the side the tests above bypass
+# -----------------------------------------------------------------------------
+
+
+def test_services_json_declares_every_field_iglobal_reads():
+    """Every other test hands IGlobal a config dict, so a typo in the JSON would leave
+    the knob unreachable from the UI with the whole file still green.
+    """
+    service = _parse_services_json()
+    fields = service['fields']
+    properties = fields['transcribe.default']['properties']
+
+    for name in _NEW_FIELDS:
+        assert f'transcribe.{name}' in fields, f'{name} missing from services.json fields'
+        assert f'transcribe.{name}' in properties, f'{name} missing from transcribe.default'
+
+
+def test_services_json_defaults_match_the_python_fallbacks():
+    """A UI default that disagrees with the runtime fallback changes behaviour on save."""
+    fields = _parse_services_json()['fields']
+    expected = {
+        'transcribe.beam_size': 5,
+        'transcribe.vad_filter': True,
+        'transcribe.vad_threshold': 0.5,
+        'transcribe.vad_min_silence_duration_ms': 500,
+        'transcribe.vad_speech_pad_ms': 400,
+        'transcribe.vad_max_speech_duration_s': 0,
+    }
+
+    for name, default in expected.items():
+        assert fields[name]['default'] == default, f'{name} default drifted from IGlobal'

--- a/nodes/test/audio_transcribe/test_decode_params.py
+++ b/nodes/test/audio_transcribe/test_decode_params.py
@@ -42,6 +42,9 @@ _VAD_FIELD_TO_DECODE_KEY = {
 }
 _NEW_FIELDS = ['beam_size', 'vad_filter', *_VAD_FIELD_TO_DECODE_KEY]
 
+# Read by nothing; superseded by the vad_* fields or by fixed buffering constants.
+_DEAD_FIELDS = ['silence_threshold', 'min_seconds', 'max_seconds', 'vad_level']
+
 
 class _FakeWhisper:
     """Stands in for ai.common.models.Whisper, recording the decode kwargs."""
@@ -247,3 +250,29 @@ def test_services_json_defaults_match_the_python_fallbacks():
 
     for name, default in expected.items():
         assert fields[name]['default'] == default, f'{name} default drifted from IGlobal'
+
+
+def test_dead_fields_are_gone():
+    """Nothing reads these, so declaring them offers knobs that silently do nothing."""
+    service = _parse_services_json()
+    fields = service['fields']
+    properties = fields['transcribe.default']['properties']
+
+    for name in _DEAD_FIELDS:
+        key = f'transcribe.{name}'
+        assert key not in fields, f'{name} is declared again but nothing reads it'
+        assert key not in properties, f'{name} is back in transcribe.default'
+
+    for profile, values in service['preconfig']['profiles'].items():
+        leftovers = sorted(set(values) & set(_DEAD_FIELDS))
+        assert not leftovers, f'profile {profile} still carries {leftovers}'
+
+
+def test_every_profile_selects_its_own_model():
+    """Profiles used to set "mode" while IGlobal reads "model", so all six loaded base."""
+    profiles = _parse_services_json()['preconfig']['profiles']
+
+    for name, values in profiles.items():
+        assert 'mode' not in values, f'profile {name} still sets "mode", which nothing reads'
+        expected = 'base' if name == 'default' else name
+        assert values.get('model') == expected, f'profile {name} selects {values.get("model")!r}'

--- a/packages/ai/src/ai/common/models/audio/whisper.py
+++ b/packages/ai/src/ai/common/models/audio/whisper.py
@@ -55,6 +55,9 @@ class WhisperLoader(BaseLoader):
         an identical copy of the weights per language. `compute_type` stays — precision
         genuinely changes the loaded weights.
 
+        `beam_size`, `vad_filter` and `vad_parameters` are excluded for the same reason —
+        all three are decode-time (#1809).
+
     Performance Note:
         - Typical throughput: ~8-15 req/s depending on model size and audio length
     """
@@ -70,6 +73,13 @@ class WhisperLoader(BaseLoader):
     # `language` is not here — it is a per-request decode hint, not a load param.
     _DEFAULTS = {
         'compute_type': 'float16',
+    }
+
+    # Merged under a caller's vad_parameters. Unlike _DEFAULTS, never reaches identity.
+    _VAD_DEFAULTS = {
+        'threshold': 0.5,
+        'min_silence_duration_ms': 500,
+        'speech_pad_ms': 400,
     }
 
     # Cached result of GPU compatibility probe (None = not yet tested)
@@ -344,6 +354,11 @@ class WhisperLoader(BaseLoader):
         metadata: Optional[Dict] = None,
         stream: Optional[Any] = None,
         language: Optional[str] = None,
+        beam_size: int = 5,
+        # Upstream defaults this to False; True is ours. Flipping it turns VAD off for
+        # every existing caller.
+        vad_filter: bool = True,
+        vad_parameters: Optional[Dict[str, Any]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Run Whisper transcription.
@@ -358,6 +373,12 @@ class WhisperLoader(BaseLoader):
             language: Per-request decode language. Falls back to the value carried on
                 preprocessed/the bundle, so callers that do not pass it keep the
                 previous load-time behaviour.
+            beam_size: Per-request beam size.
+            vad_filter: Per-request VAD toggle.
+            vad_parameters: Merged over _VAD_DEFAULTS rather than replacing them, so
+                setting one key leaves the others at our defaults. A nested None means
+                "unset"; 0 is a real value. Mapping only — unlike upstream, not a
+                VadOptions.
 
         Returns:
             List of transcription results with segments
@@ -374,6 +395,13 @@ class WhisperLoader(BaseLoader):
         # Per-request language wins; fall back to whatever the model was loaded with.
         if language is None:
             language = preprocessed.get('language', models.get('language', 'en'))
+
+        # Merge, not replace: setting only `threshold` must keep our 500ms min-silence
+        # instead of inheriting upstream's 2000ms. `is None`, not truthiness — 0 is real.
+        vad_options = {
+            **WhisperLoader._VAD_DEFAULTS,
+            **{k: v for k, v in (vad_parameters or {}).items() if v is not None},
+        }
 
         # Get lock for this model instance (faster-whisper is NOT thread-safe)
         model_lock = WhisperLoader._get_model_lock(id(whisper_model))
@@ -394,13 +422,9 @@ class WhisperLoader(BaseLoader):
                     segments_gen, info = whisper_model.transcribe(
                         audio,
                         language=language,
-                        beam_size=5,
-                        vad_filter=True,
-                        vad_parameters={
-                            'threshold': 0.5,
-                            'min_silence_duration_ms': 500,
-                            'speech_pad_ms': 400,
-                        },
+                        beam_size=beam_size,
+                        vad_filter=vad_filter,
+                        vad_parameters=vad_options,
                     )
 
                     # Convert generator to list and build result
@@ -653,7 +677,8 @@ class Whisper:
             audio: Raw PCM int16 bytes (16kHz mono)
             beam_size: Beam size for decoding
             vad_filter: Enable voice activity detection (Silero VAD)
-            vad_parameters: VAD parameters dict
+            vad_parameters: VAD settings, merged over WhisperLoader._VAD_DEFAULTS rather
+                than replacing them. Mapping only; a VadOptions is not accepted.
             language: Override the instance's default decode language for this call
             **kwargs: Additional transcription arguments
 
@@ -673,9 +698,17 @@ class Whisper:
             return self._transcribe_remote(audio, beam_size, vad_filter, vad_parameters, language, **kwargs)
         else:
             # Local mode — time each phase
-            return self._transcribe_local(audio, language, **kwargs)
+            return self._transcribe_local(audio, beam_size, vad_filter, vad_parameters, language, **kwargs)
 
-    def _transcribe_local(self, audio: bytes, language: str, **kwargs) -> Dict[str, Any]:
+    def _transcribe_local(
+        self,
+        audio: bytes,
+        beam_size: int,
+        vad_filter: bool,
+        vad_parameters: Optional[Dict[str, Any]],
+        language: str,
+        **kwargs,
+    ) -> Dict[str, Any]:
         """Execute local transcription with perf timing."""
         # Preprocess phase — convert raw PCM bytes to model input format
         t0 = time.perf_counter()
@@ -684,7 +717,15 @@ class Whisper:
 
         # GPU inference phase — run transcription model
         t0 = time.perf_counter()
-        raw_output = WhisperLoader.inference(self._model, preprocessed, self._metadata, language=language)
+        raw_output = WhisperLoader.inference(
+            self._model,
+            preprocessed,
+            self._metadata,
+            language=language,
+            beam_size=beam_size,
+            vad_filter=vad_filter,
+            vad_parameters=vad_parameters,
+        )
         t_gpu = (time.perf_counter() - t0) * 1000
 
         # Postprocess phase — extract requested output fields

--- a/packages/ai/src/ai/common/models/audio/whisper.py
+++ b/packages/ai/src/ai/common/models/audio/whisper.py
@@ -55,8 +55,8 @@ class WhisperLoader(BaseLoader):
         an identical copy of the weights per language. `compute_type` stays — precision
         genuinely changes the loaded weights.
 
-        `beam_size`, `vad_filter` and `vad_parameters` are excluded for the same reason —
-        all three are decode-time (#1809).
+        `beam_size`, `vad_filter`, `vad_parameters` and `word_timestamps` are excluded
+        for the same reason — all four are decode-time (#1809).
 
     Performance Note:
         - Typical throughput: ~8-15 req/s depending on model size and audio length
@@ -359,6 +359,7 @@ class WhisperLoader(BaseLoader):
         # every existing caller.
         vad_filter: bool = True,
         vad_parameters: Optional[Dict[str, Any]] = None,
+        word_timestamps: bool = False,
     ) -> List[Dict[str, Any]]:
         """
         Run Whisper transcription.
@@ -379,6 +380,9 @@ class WhisperLoader(BaseLoader):
                 setting one key leaves the others at our defaults. A nested None means
                 "unset"; 0 is a real value. Mapping only — unlike upstream, not a
                 VadOptions.
+            word_timestamps: Populate each segment's `words`. Off by default, matching
+                upstream — turning it on costs an alignment pass and moves segment
+                boundaries. The `words` block below was unreachable until this existed.
 
         Returns:
             List of transcription results with segments
@@ -425,6 +429,7 @@ class WhisperLoader(BaseLoader):
                         beam_size=beam_size,
                         vad_filter=vad_filter,
                         vad_parameters=vad_options,
+                        word_timestamps=word_timestamps,
                     )
 
                     # Convert generator to list and build result
@@ -668,6 +673,7 @@ class Whisper:
         vad_filter: bool = True,
         vad_parameters: Optional[Dict[str, Any]] = None,
         language: Optional[str] = None,
+        word_timestamps: bool = False,
         **kwargs,
     ) -> Dict[str, Any]:
         """
@@ -680,6 +686,9 @@ class Whisper:
             vad_parameters: VAD settings, merged over WhisperLoader._VAD_DEFAULTS rather
                 than replacing them. Mapping only; a VadOptions is not accepted.
             language: Override the instance's default decode language for this call
+            word_timestamps: Populate each segment's `words` with per-word timings.
+                Off by default; turning it on costs an alignment pass and shifts
+                segment boundaries.
             **kwargs: Additional transcription arguments
 
         Returns:
@@ -695,10 +704,14 @@ class Whisper:
 
         if self._proxy_mode:
             # Model server mode — ModelClient.send_command handles perf timing
-            return self._transcribe_remote(audio, beam_size, vad_filter, vad_parameters, language, **kwargs)
+            return self._transcribe_remote(
+                audio, beam_size, vad_filter, vad_parameters, language, word_timestamps, **kwargs
+            )
         else:
             # Local mode — time each phase
-            return self._transcribe_local(audio, beam_size, vad_filter, vad_parameters, language, **kwargs)
+            return self._transcribe_local(
+                audio, beam_size, vad_filter, vad_parameters, language, word_timestamps, **kwargs
+            )
 
     def _transcribe_local(
         self,
@@ -707,6 +720,7 @@ class Whisper:
         vad_filter: bool,
         vad_parameters: Optional[Dict[str, Any]],
         language: str,
+        word_timestamps: bool = False,
         **kwargs,
     ) -> Dict[str, Any]:
         """Execute local transcription with perf timing."""
@@ -725,6 +739,7 @@ class Whisper:
             beam_size=beam_size,
             vad_filter=vad_filter,
             vad_parameters=vad_parameters,
+            word_timestamps=word_timestamps,
         )
         t_gpu = (time.perf_counter() - t0) * 1000
 
@@ -760,6 +775,7 @@ class Whisper:
         vad_filter: bool,
         vad_parameters: Optional[Dict[str, Any]],
         language: str,
+        word_timestamps: bool = False,
         **kwargs,
     ) -> Dict[str, Any]:
         """Execute remote transcription via model server.
@@ -775,6 +791,7 @@ class Whisper:
                 'vad_filter': vad_filter,
                 'vad_parameters': vad_parameters,
                 'language': language,
+                'word_timestamps': word_timestamps,
                 'output_fields': self.output_fields,
                 **kwargs,
             },

--- a/packages/ai/src/ai/common/models/audio/whisper.py
+++ b/packages/ai/src/ai/common/models/audio/whisper.py
@@ -56,7 +56,12 @@ class WhisperLoader(BaseLoader):
         genuinely changes the loaded weights.
 
         `beam_size`, `vad_filter`, `vad_parameters` and `word_timestamps` are excluded
-        for the same reason — all four are decode-time (#1809).
+        for the same reason — all four are decode-time (#1809). The exclusion is
+        enforced by _SERVER_PARAMS, so it holds even when an old client sends them.
+
+        Anything else in `**kwargs` is treated as a genuine WhisperModel option and
+        forwarded to it, so `revision` or `download_root` change both the weights and
+        the identity, as they should.
 
     Performance Note:
         - Typical throughput: ~8-15 req/s depending on model size and audio length
@@ -73,6 +78,18 @@ class WhisperLoader(BaseLoader):
     # `language` is not here — it is a per-request decode hint, not a load param.
     _DEFAULTS = {
         'compute_type': 'float16',
+    }
+
+    # Excluded from the identity hash, not merely omitted by the facade: an older client
+    # that still sends these in loader_options would otherwise hash to a different
+    # model_id and duplicate the weights for the length of a rolling upgrade. Same
+    # reasoning as GLiNER's #1750; load() absorbs them and never applies them.
+    _SERVER_PARAMS = BaseLoader._SERVER_PARAMS | {
+        'language',
+        'beam_size',
+        'vad_filter',
+        'vad_parameters',
+        'word_timestamps',
     }
 
     # Merged under a caller's vad_parameters. Unlike _DEFAULTS, never reaches identity.
@@ -163,6 +180,14 @@ class WhisperLoader(BaseLoader):
         exclude_gpus: Optional[List[int]] = None,
         language: str = 'en',
         compute_type: str = 'float16',
+        # Named so they are absorbed rather than forwarded to WhisperModel(), which does
+        # not accept them and would raise. An older client can still put them in
+        # loader_options; forwarding **kwargs blindly would trade one bug for a worse
+        # one (#1750). Everything else in **kwargs is a genuine WhisperModel option.
+        beam_size: Optional[int] = None,
+        vad_filter: Optional[bool] = None,
+        vad_parameters: Optional[Dict[str, Any]] = None,
+        word_timestamps: Optional[bool] = None,
         **kwargs,
     ) -> Tuple[Dict[str, Any], Dict[str, Any], int]:
         """
@@ -179,7 +204,12 @@ class WhisperLoader(BaseLoader):
             exclude_gpus: GPUs to exclude (server mode)
             language: Language code for transcription (default: 'en')
             compute_type: Precision type (float16, int8, float32)
-            **kwargs: Additional arguments (ignored for compatibility)
+            beam_size: Absorbed, not applied — decode-time, see the class docstring
+            vad_filter: Absorbed, not applied
+            vad_parameters: Absorbed, not applied
+            word_timestamps: Absorbed, not applied
+            **kwargs: Forwarded to WhisperModel() as genuine loader options
+                (revision, download_root, cpu_threads, …)
 
         Returns:
             Tuple of (model_bundle, metadata_dict, gpu_index)
@@ -266,6 +296,7 @@ class WhisperLoader(BaseLoader):
                     model_name,
                     device='cpu',
                     compute_type=compute_type,
+                    **kwargs,
                 )
             else:
                 # Extract real device index from torch_device (e.g., 'cuda:0' -> 0)
@@ -276,6 +307,7 @@ class WhisperLoader(BaseLoader):
                     device='cuda',
                     device_index=real_device_index,
                     compute_type=compute_type,
+                    **kwargs,
                 )
         except Exception as e:
             logger.error(f'Failed to load whisper model: {e}')
@@ -612,7 +644,9 @@ class Whisper:
             device: Device ('server', 'cuda', 'cpu', 'cuda:N', or None for auto)
             language: Language code for transcription
             compute_type: Compute type ('float16', 'int8', etc.)
-            **kwargs: Additional arguments (ignored for compatibility)
+            **kwargs: Loader options, forwarded to WhisperModel() and part of model
+                identity. Decode parameters do not belong here — pass them to
+                transcribe() instead; sent here they are absorbed and ignored.
         """
         self.model_name = model_name
         self.output_fields = output_fields or ['$text']

--- a/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
+++ b/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
@@ -4,6 +4,9 @@ Covers `language` (#1751) plus `beam_size` / `vad_filter` / `vad_parameters` (#1
 No torch, no faster-whisper, no model download.
 """
 
+import sys
+import types
+
 import pytest
 
 from ai.common.models.audio.whisper import WhisperLoader, Whisper
@@ -379,6 +382,63 @@ def test_decode_parameters_never_reach_loader_options(monkeypatch):
 
     _, _, loader_options = _FakeClient.captured['load']
     assert loader_options == {'compute_type': 'float16'}
+
+
+@pytest.mark.parametrize(
+    'param,value',
+    [
+        ('language', 'de'),
+        ('beam_size', 10),
+        ('vad_filter', False),
+        ('vad_parameters', {'threshold': 0.1}),
+        ('word_timestamps', True),
+    ],
+)
+def test_decode_params_in_loader_options_do_not_split_identity(param, value):
+    """An old client may still send these at load; they must not duplicate the weights.
+
+    Enforced by _SERVER_PARAMS, so it holds even though the facade no longer sends them.
+    """
+    assert WhisperLoader.generate_model_id('tiny', **{param: value}) == WhisperLoader.generate_model_id('tiny')
+
+
+def test_genuine_loader_options_still_split_identity():
+    """The other half: revision changes the weights, so it must change the id."""
+    assert WhisperLoader.generate_model_id('tiny', revision='abc') != WhisperLoader.generate_model_id('tiny')
+
+
+class _RecordingWhisperModel:
+    """Captures what load() hands the faster-whisper constructor."""
+
+    captured = {}
+
+    def __init__(self, model_name, **kw):
+        _RecordingWhisperModel.captured = {'model_name': model_name, **kw}
+
+
+def _load_with(monkeypatch, **loader_options):
+    fake = types.ModuleType('faster_whisper')
+    fake.WhisperModel = _RecordingWhisperModel
+    monkeypatch.setitem(sys.modules, 'faster_whisper', fake)
+    monkeypatch.setattr(WhisperLoader, 'model_gpu_gb', staticmethod(lambda *a, **k: 0.0), raising=False)
+
+    WhisperLoader.load('tiny', device='cpu', **loader_options)
+    return _RecordingWhisperModel.captured
+
+
+def test_load_absorbs_decode_params_instead_of_forwarding_them(monkeypatch):
+    """WhisperModel() does not accept them — forwarding blindly would raise."""
+    captured = _load_with(monkeypatch, beam_size=10, vad_filter=False, word_timestamps=True)
+
+    for name in ('beam_size', 'vad_filter', 'vad_parameters', 'word_timestamps'):
+        assert name not in captured
+
+
+def test_load_forwards_genuine_loader_options(monkeypatch):
+    """Before this, revision changed the model id but never reached the constructor."""
+    captured = _load_with(monkeypatch, revision='abc123')
+
+    assert captured['revision'] == 'abc123'
 
 
 def test_facade_puts_all_four_on_the_wire(monkeypatch):

--- a/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
+++ b/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
@@ -417,10 +417,20 @@ class _RecordingWhisperModel:
 
 
 def _load_with(monkeypatch, **loader_options):
-    fake = types.ModuleType('faster_whisper')
-    fake.WhisperModel = _RecordingWhisperModel
-    monkeypatch.setitem(sys.modules, 'faster_whisper', fake)
-    monkeypatch.setattr(WhisperLoader, 'model_gpu_gb', staticmethod(lambda *a, **k: 0.0), raising=False)
+    """Run load() with nothing real behind it — see this module's docstring.
+
+    load() resolves dependencies and imports torch before it ever touches
+    faster-whisper, so stubbing only the latter would still need both installed.
+    """
+    fake_whisper = types.ModuleType('faster_whisper')
+    fake_whisper.WhisperModel = _RecordingWhisperModel
+    monkeypatch.setitem(sys.modules, 'faster_whisper', fake_whisper)
+
+    fake_torch = types.ModuleType('ai.common.torch')
+    fake_torch.torch = types.SimpleNamespace(cuda=types.SimpleNamespace(is_available=lambda: False))
+    monkeypatch.setitem(sys.modules, 'ai.common.torch', fake_torch)
+
+    monkeypatch.setattr(WhisperLoader, '_ensure_dependencies', staticmethod(lambda *a, **k: None))
 
     WhisperLoader.load('tiny', device='cpu', **loader_options)
     return _RecordingWhisperModel.captured

--- a/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
+++ b/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
@@ -280,6 +280,38 @@ def test_vad_defaults_are_never_mutated():
 
 
 # -----------------------------------------------------------------------------
+# word_timestamps (#1809)
+# -----------------------------------------------------------------------------
+
+
+def test_word_timestamps_defaults_to_false():
+    """Matches upstream; turning it on costs an alignment pass and moves boundaries."""
+    assert _run_inference().captured['word_timestamps'] is False
+
+
+def test_word_timestamps_is_forwarded():
+    assert _run_inference(word_timestamps=True).captured['word_timestamps'] is True
+
+
+class _WordyWhisperModel:
+    """Yields a segment carrying word timings, as faster-whisper does when asked."""
+
+    def transcribe(self, audio, **kw):
+        word = type('W', (), {'word': ' hi', 'start': 0.1, 'end': 0.4, 'probability': 0.9})()
+        segment = type('S', (), {'start': 0.0, 'end': 0.5, 'text': ' hi', 'words': [word]})()
+        return iter((segment,)), type('Info', (), {'language': 'en'})()
+
+
+def test_words_reach_the_result():
+    """seg_dict['words'] was unreachable before #1809 — nothing ever passed the flag."""
+    preprocessed = {'audios': [[0.0] * 2000], 'batch_size': 1}
+
+    results = WhisperLoader.inference({'model': _WordyWhisperModel()}, preprocessed, word_timestamps=True)
+
+    assert results[0]['segments'][0]['words'] == [{'word': ' hi', 'start': 0.1, 'end': 0.4, 'probability': 0.9}]
+
+
+# -----------------------------------------------------------------------------
 # Cross-cutting (#1809)
 # -----------------------------------------------------------------------------
 
@@ -341,20 +373,25 @@ def test_decode_parameters_never_reach_loader_options(monkeypatch):
     whatever it is handed — it does not ignore them.
     """
     model = _proxy_whisper(monkeypatch)
-    model.transcribe(b'\x00\x01' * 2000, beam_size=10, vad_filter=False, vad_parameters={'threshold': 0.1})
+    model.transcribe(
+        b'\x00\x01' * 2000, beam_size=10, vad_filter=False, vad_parameters={'threshold': 0.1}, word_timestamps=True
+    )
 
     _, _, loader_options = _FakeClient.captured['load']
     assert loader_options == {'compute_type': 'float16'}
 
 
-def test_facade_puts_all_three_on_the_wire(monkeypatch):
+def test_facade_puts_all_four_on_the_wire(monkeypatch):
     model = _proxy_whisper(monkeypatch)
-    model.transcribe(b'\x00\x01' * 2000, beam_size=10, vad_filter=False, vad_parameters={'threshold': 0.1})
+    model.transcribe(
+        b'\x00\x01' * 2000, beam_size=10, vad_filter=False, vad_parameters={'threshold': 0.1}, word_timestamps=True
+    )
 
     _, args = _FakeClient.captured['infer']
     assert args['beam_size'] == 10
     assert args['vad_filter'] is False
     assert args['vad_parameters'] == {'threshold': 0.1}
+    assert args['word_timestamps'] is True
 
 
 def _local_whisper(monkeypatch, recorder):
@@ -378,15 +415,18 @@ def _recording_inference(calls):
     return _inference
 
 
-def test_local_mode_forwards_all_three(monkeypatch):
+def test_local_mode_forwards_all_four(monkeypatch):
     """The half no acceptance criterion covers: local mode ignored these too."""
     calls = []
     model = _local_whisper(monkeypatch, _recording_inference(calls))
-    model.transcribe(b'\x00\x01' * 2000, beam_size=4, vad_filter=False, vad_parameters={'threshold': 0.2})
+    model.transcribe(
+        b'\x00\x01' * 2000, beam_size=4, vad_filter=False, vad_parameters={'threshold': 0.2}, word_timestamps=True
+    )
 
     assert calls[0]['beam_size'] == 4
     assert calls[0]['vad_filter'] is False
     assert calls[0]['vad_parameters'] == {'threshold': 0.2}
+    assert calls[0]['word_timestamps'] is True
 
 
 def test_local_and_remote_hand_the_loader_the_same_vad_parameters(monkeypatch):

--- a/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
+++ b/packages/ai/tests/ai/common/models/audio/test_whisper_identity.py
@@ -1,4 +1,10 @@
-"""Unit tests for Whisper model identity and per-request language (no torch/faster-whisper)."""
+"""Unit tests for Whisper model identity and per-request decode parameters.
+
+Covers `language` (#1751) plus `beam_size` / `vad_filter` / `vad_parameters` (#1809).
+No torch, no faster-whisper, no model download.
+"""
+
+import pytest
 
 from ai.common.models.audio.whisper import WhisperLoader, Whisper
 import ai.common.models.audio.whisper as whispermod
@@ -99,43 +105,54 @@ def test_per_call_language_overrides_the_instance_default(monkeypatch):
 
 
 class _FakeWhisperModel:
-    """Records the decode kwargs faster-whisper would have received."""
+    """Records the decode kwargs faster-whisper would have received, one entry per call."""
 
     def __init__(self):
-        self.captured = {}
+        self.calls = []
+
+    @property
+    def captured(self):
+        """Kwargs of the most recent call, for the single-audio tests."""
+        return self.calls[-1] if self.calls else {}
 
     def transcribe(self, audio, **kw):
-        self.captured.update(kw)
+        self.calls.append(dict(kw))
         return iter(()), type('Info', (), {'language': kw.get('language')})()
 
 
-def _run_inference(bundle_language=None, preprocessed_language=None, language=None):
+def _run_inference(bundle_language=None, preprocessed_language=None, audios=None, **decode_kwargs):
+    """Run inference() against a fake model and return it.
+
+    Returns the model, not its kwargs, so batch tests can reach `.calls`.
+    """
     model = _FakeWhisperModel()
     bundle = {'model': model}
     if bundle_language is not None:
         bundle['language'] = bundle_language
 
-    preprocessed = {'audios': [[0.0] * 2000], 'batch_size': 1}
+    if audios is None:
+        audios = [[0.0] * 2000]
+    preprocessed = {'audios': audios, 'batch_size': len(audios)}
     if preprocessed_language is not None:
         preprocessed['language'] = preprocessed_language
 
-    WhisperLoader.inference(bundle, preprocessed, language=language)
-    return model.captured
+    WhisperLoader.inference(bundle, preprocessed, **decode_kwargs)
+    return model
 
 
 def test_inference_falls_back_to_bundle_language():
     """Back-compat: with nothing on preprocessed, the loaded bundle value is used."""
-    assert _run_inference(bundle_language='ja')['language'] == 'ja'
+    assert _run_inference(bundle_language='ja').captured['language'] == 'ja'
 
 
 def test_inference_falls_back_to_preprocessed_language():
     """preprocess() carries the loaded language forward; it beats the bundle value."""
-    assert _run_inference(bundle_language='ja', preprocessed_language='ko')['language'] == 'ko'
+    assert _run_inference(bundle_language='ja', preprocessed_language='ko').captured['language'] == 'ko'
 
 
 def test_inference_prefers_the_per_request_language():
     """An explicit per-request language wins over both fallbacks."""
-    captured = _run_inference(bundle_language='ja', preprocessed_language='ko', language='fr')
+    captured = _run_inference(bundle_language='ja', preprocessed_language='ko', language='fr').captured
     assert captured['language'] == 'fr'
 
 
@@ -157,3 +174,233 @@ def test_postprocess_still_falls_back_to_loaded_language():
     results = WhisperLoader.postprocess(bundle, raw_output, 1, ['$text', 'language'])
 
     assert results[0]['language'] == 'de'
+
+
+# -----------------------------------------------------------------------------
+# beam_size (#1809)
+# -----------------------------------------------------------------------------
+
+
+def test_beam_size_defaults_to_five():
+    assert _run_inference().captured['beam_size'] == 5
+
+
+def test_beam_size_is_forwarded():
+    """1 is the value #1809's acceptance criterion names; 10 is the other end."""
+    assert _run_inference(beam_size=1).captured['beam_size'] == 1
+    assert _run_inference(beam_size=10).captured['beam_size'] == 10
+
+
+# -----------------------------------------------------------------------------
+# vad_filter (#1809)
+# -----------------------------------------------------------------------------
+
+
+def test_vad_filter_defaults_to_true():
+    """Deliberate divergence: WhisperModel.transcribe defaults it to False upstream."""
+    assert _run_inference().captured['vad_filter'] is True
+
+
+def test_vad_filter_is_forwarded_both_ways():
+    assert _run_inference(vad_filter=False).captured['vad_filter'] is False
+    assert _run_inference(vad_filter=True).captured['vad_filter'] is True
+
+
+def test_vad_parameters_are_still_sent_when_the_filter_is_off():
+    """faster-whisper ignores them, but skipping the merge would be a silent change."""
+    assert _run_inference(vad_filter=False).captured['vad_parameters'] == WhisperLoader._VAD_DEFAULTS
+
+
+# -----------------------------------------------------------------------------
+# vad_parameters (#1809)
+# -----------------------------------------------------------------------------
+
+
+def test_vad_parameters_unset_uses_the_defaults():
+    assert _run_inference().captured['vad_parameters'] == WhisperLoader._VAD_DEFAULTS
+    assert _run_inference(vad_parameters=None).captured['vad_parameters'] == WhisperLoader._VAD_DEFAULTS
+
+
+def test_vad_parameters_empty_dict_agrees_with_none():
+    """`{}` is a distinct input a JSON caller can send; it must not mean something else."""
+    assert _run_inference(vad_parameters={}).captured['vad_parameters'] == WhisperLoader._VAD_DEFAULTS
+
+
+@pytest.mark.parametrize(
+    'key,value',
+    [('threshold', 0.3), ('min_silence_duration_ms', 250), ('speech_pad_ms', 100)],
+)
+def test_vad_parameters_override_is_per_key(key, value):
+    """Overriding one key must leave every other default intact."""
+    merged = _run_inference(vad_parameters={key: value}).captured['vad_parameters']
+
+    assert merged[key] == value
+    for other, default in WhisperLoader._VAD_DEFAULTS.items():
+        if other != key:
+            assert merged[other] == default
+
+
+def test_vad_parameters_can_replace_every_default():
+    override = {'threshold': 0.9, 'min_silence_duration_ms': 10, 'speech_pad_ms': 0}
+
+    assert _run_inference(vad_parameters=override).captured['vad_parameters'] == override
+
+
+def test_vad_parameters_adds_keys_we_do_not_default():
+    """The audio_transcribe node relies on this — max_speech_duration_s is not ours."""
+    merged = _run_inference(vad_parameters={'max_speech_duration_s': 2}).captured['vad_parameters']
+
+    assert merged['max_speech_duration_s'] == 2
+    assert merged['threshold'] == WhisperLoader._VAD_DEFAULTS['threshold']
+
+
+def test_vad_parameters_drops_a_nested_none():
+    merged = _run_inference(vad_parameters={'threshold': None}).captured['vad_parameters']
+
+    assert merged['threshold'] == WhisperLoader._VAD_DEFAULTS['threshold']
+
+
+def test_vad_parameters_keeps_a_nested_zero():
+    """Filter on `is None`, not truthiness — 0 is meaningful for both of these."""
+    merged = _run_inference(vad_parameters={'threshold': 0, 'speech_pad_ms': 0}).captured['vad_parameters']
+
+    assert merged['threshold'] == 0
+    assert merged['speech_pad_ms'] == 0
+
+
+def test_vad_defaults_are_never_mutated():
+    original = dict(WhisperLoader._VAD_DEFAULTS)
+
+    first = _run_inference(vad_parameters={'max_speech_duration_s': 2}).captured['vad_parameters']
+    second = _run_inference(vad_parameters={'threshold': 0.1}).captured['vad_parameters']
+
+    assert first['max_speech_duration_s'] == 2
+    assert 'max_speech_duration_s' not in second  # no leak between calls
+    assert WhisperLoader._VAD_DEFAULTS == original
+
+
+# -----------------------------------------------------------------------------
+# Cross-cutting (#1809)
+# -----------------------------------------------------------------------------
+
+
+def test_all_decode_parameters_travel_together():
+    """Resolution differs per parameter — `language` has fallbacks, the others do not."""
+    captured = _run_inference(language='fr', beam_size=3, vad_filter=False, vad_parameters={'threshold': 0.2}).captured
+
+    assert captured['language'] == 'fr'
+    assert captured['beam_size'] == 3
+    assert captured['vad_filter'] is False
+    assert captured['vad_parameters']['threshold'] == 0.2
+
+
+def test_every_item_in_a_batch_gets_the_same_decode_kwargs():
+    model = _run_inference(audios=[[0.0] * 2000, [0.0] * 3000], beam_size=7)
+
+    assert len(model.calls) == 2
+    assert model.calls[0] == model.calls[1]
+    assert model.calls[0]['beam_size'] == 7
+
+
+def test_a_too_short_clip_is_skipped_without_losing_the_parameters():
+    """Under the 1600-sample floor the loop `continue`s; the long clip still decodes."""
+    model = _run_inference(audios=[[0.0] * 100, [0.0] * 2000], beam_size=9)
+
+    assert len(model.calls) == 1
+    assert model.calls[0]['beam_size'] == 9
+
+
+class _RaisingWhisperModel:
+    """Stands in for faster-whisper rejecting an unknown VadOptions key."""
+
+    def transcribe(self, audio, **kw):
+        raise TypeError("__init__() got an unexpected keyword argument 'nonsense'")
+
+
+def test_a_bad_vad_key_degrades_one_item_instead_of_killing_the_batch():
+    """New in #1809: the dict now reaches the decoder, so a typo can fail."""
+    bundle = {'model': _RaisingWhisperModel()}
+    preprocessed = {'audios': [[0.0] * 2000, [0.0] * 2000], 'batch_size': 2}
+
+    results = WhisperLoader.inference(bundle, preprocessed, vad_parameters={'nonsense': 1})
+
+    assert len(results) == 2
+    for item in results:
+        assert item['error']
+        assert item['segments'] == []
+        assert item['text'] == ''
+
+
+# -----------------------------------------------------------------------------
+# Identity and facade (#1809)
+# -----------------------------------------------------------------------------
+
+
+def test_decode_parameters_never_reach_loader_options(monkeypatch):
+    """#1809 acceptance: the names never reach generate_model_id(), which hashes
+    whatever it is handed — it does not ignore them.
+    """
+    model = _proxy_whisper(monkeypatch)
+    model.transcribe(b'\x00\x01' * 2000, beam_size=10, vad_filter=False, vad_parameters={'threshold': 0.1})
+
+    _, _, loader_options = _FakeClient.captured['load']
+    assert loader_options == {'compute_type': 'float16'}
+
+
+def test_facade_puts_all_three_on_the_wire(monkeypatch):
+    model = _proxy_whisper(monkeypatch)
+    model.transcribe(b'\x00\x01' * 2000, beam_size=10, vad_filter=False, vad_parameters={'threshold': 0.1})
+
+    _, args = _FakeClient.captured['infer']
+    assert args['beam_size'] == 10
+    assert args['vad_filter'] is False
+    assert args['vad_parameters'] == {'threshold': 0.1}
+
+
+def _local_whisper(monkeypatch, recorder):
+    """A local-mode Whisper with no faster-whisper and no model download.
+
+    Without the address patch it silently takes the proxy path and asserts nothing.
+    """
+    monkeypatch.setattr(whispermod, 'get_model_server_address', lambda: None)
+    monkeypatch.setattr(WhisperLoader, 'load', staticmethod(lambda *a, **k: ({'model': _FakeWhisperModel()}, {}, -1)))
+    monkeypatch.setattr(WhisperLoader, 'inference', staticmethod(recorder))
+    return Whisper('tiny', output_fields=['$text'])
+
+
+def _recording_inference(calls):
+    """inference() stand-in returning a real result list — postprocess() runs on it."""
+
+    def _inference(model, preprocessed, metadata=None, stream=None, **kw):
+        calls.append(kw)
+        return [{'segments': [], 'text': '', 'language': 'en'}]
+
+    return _inference
+
+
+def test_local_mode_forwards_all_three(monkeypatch):
+    """The half no acceptance criterion covers: local mode ignored these too."""
+    calls = []
+    model = _local_whisper(monkeypatch, _recording_inference(calls))
+    model.transcribe(b'\x00\x01' * 2000, beam_size=4, vad_filter=False, vad_parameters={'threshold': 0.2})
+
+    assert calls[0]['beam_size'] == 4
+    assert calls[0]['vad_filter'] is False
+    assert calls[0]['vad_parameters'] == {'threshold': 0.2}
+
+
+def test_local_and_remote_hand_the_loader_the_same_vad_parameters(monkeypatch):
+    """Parity for the facade's vad_parameters=None default.
+
+    Remote's None-drop happens in saas extract_infer_kwargs — not assertable here.
+    """
+    calls = []
+    local = _local_whisper(monkeypatch, _recording_inference(calls))
+    local.transcribe(b'\x00\x01' * 2000)
+
+    remote = _proxy_whisper(monkeypatch)
+    remote.transcribe(b'\x00\x01' * 2000)
+    _, args = _FakeClient.captured['infer']
+
+    assert calls[0]['vad_parameters'] is None
+    assert args['vad_parameters'] is None


### PR DESCRIPTION
Closes #1809.

`Whisper.transcribe()` accepted `beam_size`, `vad_filter` and `vad_parameters` and put all three on the wire, but `WhisperLoader.inference()` declared only `language` and hardcoded the rest — so the model server's signature narrowing dropped them, and `_transcribe_local()` never forwarded them either. Both modes ignored them, for different reasons.

Fixing that surfaced five more instances of the same defect in this node: a parameter declared in one place and not read in the other. All six are fixed here, because each one alone leaves a knob that silently does nothing.

| where | what was wrong |
| --- | --- |
| `WhisperLoader.inference()` | `beam_size` / `vad_filter` / `vad_parameters` not declared |
| node `services.json` | `silence_threshold`, `min_seconds`, `max_seconds`, `vad_level` declared, read by nothing |
| `preconfig.profiles` | set `mode`, the node reads `model` |
| `inference()` | `word_timestamps` never passed, so the `words` block was dead code |
| `IInstance` | built `Transcribe()` without the kwarg it accepts |
| `WhisperLoader.load()` | genuine loader options changed identity but never reached `WhisperModel()` |

Reasoning, measurements and the full findings are on #1809.

## For the reviewer

**Every profile was loading `base`.** `preconfig.profiles` set `mode` while `IGlobal` reads `config.get('model', 'base')`, with no translation anywhere. Picking `large-v3` gave you `base` — including `nodes:test-full`, which advertises five model sizes and ran `base` five times. This is the one change with user-visible behaviour: anyone on a non-`default` profile now gets the model they asked for, with the matching speed and memory cost.

**Four config fields are removed, not deprecated.** Nothing validates node config keys — the base `validateConfig` is a bare `pass`, the contract test checks only `title`/`protocol`/`node_type`, `getNodeConfig` does not filter, and saas does not either — so configs still carrying them keep working. Removing declared fields is established practice here (#1490, #1584, #1445). There is deliberately no automatic translation to the replacements: `silence_threshold: 0.25` becoming `min_silence_duration_ms: 250` would move transcripts for anyone who had set it.

**The node's `vad_max_speech_duration_s` default moves 20 → 0.** It never reached the decoder, so "no limit" is what actually runs today; keeping `20` would make a plumbing fix change shipped transcripts as a side effect. `0` is the sentinel because faster-whisper's real default is `inf`, which JSON cannot express.

**`max_chunk_duration` is deliberately not exposed.** The first draft added it beside `chunk_duration`. @dsapandora caught that it can never fire: its `elif` runs only when the lower threshold did not, and any buffer long enough to reach it has already been flushed — `_flush_audio()` zeroes the counter besides. A second threshold means something only with a "cut here, it is quiet" test between the two, and this class has no silence detection; pause handling belongs to Whisper's VAD, as the class docstring has said since the initial commit. The field is gone and the dead branch with it. Whether seam-aware cutting is worth having at all is #1907, which leads with measurement rather than a fix.

**A new failure mode.** `vad_parameters={'nonsense': 1}` used to be discarded silently. It now reaches `VadOptions(**vad_parameters)` and raises, degrading that one item to a result carrying `error` rather than killing the batch. That is the correct trade — silently ignoring a caller's tuning is the bug being fixed — but it is a behaviour change.

**Transcript expectations drop `"Mr"`.** With profiles actually selecting their model, `small` and `tiny` write "Mr. Gorbachev" where `base`, `medium` and `large-v3` write "Mr Gorbachev". All five transcribe the line correctly; the mismatch was one period. Both `test` and `fulltest` now assert `"Gorbachev, tear down this wall."`, with a comment saying why.

**The generated README block is stale on purpose.** `nodes:docs-generate` only runs on `main`/`stage`/`develop`, so the four removed fields and the two new ones appear in the `ROCKETRIDE:GENERATED:PARAMS` block after this merges. Hand-editing inside the markers is forbidden.

## Identity: the #1750 convention

`WhisperLoader` never defined `_SERVER_PARAMS`, so keeping decode params out of model identity held only because the facade stopped sending them. An old client that still puts them in `loader_options` hashed to a different `model_id` and duplicated the weights through a rolling upgrade — the skew hole #1750 closed for GLiNER.

Separately, `load()` swallowed `**kwargs`, so `revision` changed the model id without reaching `WhisperModel()` — the default branch loaded under a different identity. Same bug `408ee1e8` fixed for GLiNER's `from_pretrained()`.

Both halves now follow that convention: `_SERVER_PARAMS` excludes the decode params from the hash, `load()` names them so they are absorbed rather than forwarded (forwarding would raise), and everything else in `**kwargs` reaches `WhisperModel()`.

## Verification

- 74 unit tests across `test_whisper_identity.py` and the new `nodes/test/audio_transcribe/test_decode_params.py`
- `nodes:test-full -k audio_transcribe` — 27 passed, all six profiles on their own models for the first time
- Baseline `nodes:test` captured before any edit; the `default` transcript is byte-identical after
- `docs:build`, ruff and gitleaks clean

Two guards were mutation-verified: reverting `vad_max_speech_duration_s` to `20` fails `test_empty_config_reproduces_todays_call`, and replacing the merge's `is None` filter with a truthiness check fails `test_zero_is_kept_on_every_other_vad_key`.

`IInstance` cannot be imported by the node test harness (relative imports), so its `Transcribe(...)` call is checked statically via AST. `transcribe.py` is loaded inside a synthetic package, so the flush itself is exercised for real.

## Skew

The saas forwarding channel has existed since saas #466 and already sweeps these names into `infer_kwargs`; it only ever dropped them because `inference()` did not declare them. New server + current saas works immediately. A saas PR follows with the submodule bump, the integration test, and a `pnpm-lock.yaml` refresh — the rebase range adds dependencies the saas lockfile does not know.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable Whisper decoding options, including beam size, VAD filtering, language, and word-level timestamps.
  * Added configurable audio chunking with unlimited-duration support.
  * Improved consistency of transcription settings across local and remote processing.

* **Bug Fixes**
  * Improved handling and defaults for transcription and VAD settings.
  * Updated transcription profiles to use model selection consistently.

* **Documentation**
  * Documented chunking, decoding, VAD options, defaults, and legacy configuration compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
