### PR TITLE
fix(ai): verify a task port can be bound before handing it out

### DIFF
--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -66,12 +66,15 @@ Central orchestration server managing:
 """
 
 import time
+import errno
+import socket
+import sys
 import asyncio
 import uuid
 from typing import List
 from fastapi import WebSocket
 from dataclasses import dataclass
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Set
 from ai.constants import (
     CONST_CLEANUP_DELAY_TIME,
     CONST_CLEANUP_SLEEP_TIME,
@@ -228,6 +231,12 @@ class TaskServer(DAPBase):
 
         # Global port allocation tracking
         self._allocated_ports: List[int] = []
+
+        # Ports the operating system refuses to bind — Windows exclusion ranges,
+        # POSIX privileged ports. Re-probing them cannot change the answer while
+        # this process lives, so the verdict is kept. Ports merely held by
+        # another socket are deliberately not remembered: that owner can exit.
+        self._reserved_ports: Set[int] = set()
 
         # Shared store instance (lazy-loaded via property)
 
@@ -764,24 +773,179 @@ class TaskServer(DAPBase):
         # Extract and return the task instance
         return control.task
 
-    def assign_port(self) -> int:
+    @staticmethod
+    def _probe_port(port: int) -> Optional[int]:
         """
-        Allocate available port from managed pool.
+        Test whether a TCP port can be bound right now.
+
+        Binds a throwaway socket to IPv4 loopback and closes it again — the
+        address both consumers of an assigned port use: the data WebServer is
+        started on '127.0.0.1', and pydevd's listener opens an AF_INET socket
+        on the '--debug_host' it is handed.
+
+        No socket options are set, deliberately. On Windows SO_REUSEADDR makes
+        a busy port report EACCES instead of EADDRINUSE, and EACCES is the
+        verdict assign_port caches for the life of the process — so the option
+        would have the allocator permanently blacklist ports that are merely
+        busy. Anyone adding socket options here has to revisit that cache.
+        bind() alone proves ownership, so the socket never listens and cannot
+        accept a stray connection.
+
+        Args:
+            port (int): TCP port number to test.
 
         Returns:
-            Available port number (base_port to base_port+9999 range)
+            Optional[int]: None when the port binds, otherwise the errno of the
+                failure: EACCES when the operating system forbids the port,
+                EADDRINUSE when another socket holds it. Never None for a
+                failure — an OSError carrying no errno falls back to
+                EADDRINUSE, so a port that failed to bind can never read as
+                free.
+        """
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except OSError as e:
+            return e.errno or errno.EADDRINUSE
+
+        try:
+            sock.bind(('127.0.0.1', port))
+        except OSError as e:
+            return e.errno or errno.EADDRINUSE
+        finally:
+            sock.close()
+
+        return None
+
+    @staticmethod
+    def _no_ports_message(
+        base_port: int,
+        first_port: int,
+        last_port: int,
+        tallies: Dict[str, int],
+        unexpected_errno: Optional[int],
+    ) -> str:
+        """
+        Build the error message for an exhausted port window.
+
+        Names whichever cause accounts for most of the window, so nobody is
+        sent hunting a foreign process when the ports are held by this server
+        or when probing itself was failing. Only the two causes that point
+        outward — other processes, operating-system reservations — carry a
+        platform command.
+
+        Args:
+            base_port (int): The configured base port, before clamping.
+            first_port (int): First port the scan considered.
+            last_port (int): Last port the scan considered.
+            tallies (Dict[str, int]): Counts keyed 'allocated', 'occupied',
+                'reserved' and 'unexpected'.
+            unexpected_errno (Optional[int]): Last errno that was neither
+                EACCES nor EADDRINUSE, if one occurred.
+
+        Returns:
+            str: A message beginning 'No available ports'.
+        """
+        if first_port > last_port:
+            return f'No available ports: configured base_port {base_port} leaves no ports at or below 65535.'
+
+        kind = max(tallies, key=lambda name: tallies[name])
+
+        if kind == 'allocated':
+            cause = 'the whole range is already allocated by this server'
+            hint = (
+                'This server holds that many task ports; look for tasks that never released one, or widen its window.'
+            )
+        elif kind == 'unexpected':
+            name = errno.errorcode.get(unexpected_errno, str(unexpected_errno))
+            cause = f'every probe failed with errno {unexpected_errno} ({name})'
+            hint = (
+                'That is this process running out of resources rather than a port conflict; check its open descriptors.'
+            )
+        elif kind == 'reserved':
+            cause = 'most of the range is reserved by the operating system'
+            if sys.platform == 'win32':
+                hint = (
+                    'List the exclusions with `netsh int ipv4 show excludedportrange protocol=tcp` '
+                    '(and the ipv6 equivalent) and move base_port outside them.'
+                )
+            else:
+                hint = 'Ports below 1024 need elevated privileges; move base_port higher.'
+        else:
+            cause = 'most of the range is in use by other processes'
+            if sys.platform == 'win32':
+                hint = 'List current listeners with `netstat -ano`.'
+            elif sys.platform == 'darwin':
+                hint = 'List current listeners with `lsof -nP -iTCP -sTCP:LISTEN`.'
+            else:
+                hint = 'List current listeners with `ss -ltn`.'
+
+        return (
+            f'No available ports in the range {first_port}-{last_port}: {cause} '
+            f'({tallies["allocated"]} allocated by this server, {tallies["occupied"]} in use by other processes, '
+            f'{tallies["reserved"]} reserved by the operating system, '
+            f'{tallies["unexpected"]} unexpected probe failures). {hint}'
+        )
+
+    def assign_port(self) -> int:
+        """
+        Allocate an available port from the managed pool.
+
+        Returns the first port in the configured window that is neither already
+        handed out nor rejected by a bind probe, so the child process that
+        receives the number on its command line can actually listen on it.
+        Ports the operating system forbids are remembered and skipped without
+        probing again; ports held by another socket are re-probed on every call.
+
+        Returns:
+            int: An available port number inside the configured window.
 
         Raises:
-            RuntimeError: If no ports available
+            RuntimeError: If no port in the window can be bound. The message
+                names whichever cause accounts for most of the window.
         """
         base_port = self._config.get('base_port', 20000)
-        # Search for available port
-        for port in range(base_port, base_port + 10000):
-            if port not in self._allocated_ports:
+
+        # Port 0 means "any ephemeral port" to bind(), so it always probes free
+        # and would leave the child choosing its own port while the parent dials
+        # zero. The upper bound keeps the scan inside the valid range: bind()
+        # raises OverflowError, not OSError, above 65535.
+        first_port = max(base_port, 1)
+        last_port = min(base_port + 9999, 65535)
+
+        tallies = {'allocated': 0, 'occupied': 0, 'reserved': 0, 'unexpected': 0}
+        unexpected_errno = None
+
+        for port in range(first_port, last_port + 1):
+            if port in self._allocated_ports:
+                tallies['allocated'] += 1
+                continue
+
+            if port in self._reserved_ports:
+                tallies['reserved'] += 1
+                continue
+
+            failure = self._probe_port(port)
+
+            if failure is None:
                 self._allocated_ports.append(port)
+                skipped = tallies['occupied'] + tallies['reserved'] + tallies['unexpected']
+                if skipped:
+                    self.debug_message(
+                        f'Assigned port {port}, having skipped {tallies["occupied"]} in use, '
+                        f'{tallies["reserved"]} reserved and {tallies["unexpected"]} unexpected'
+                    )
                 return port
 
-        raise RuntimeError(f'No available ports in the range {base_port}-{base_port + 9999}')
+            if failure == errno.EACCES:
+                self._reserved_ports.add(port)
+                tallies['reserved'] += 1
+            elif failure == errno.EADDRINUSE:
+                tallies['occupied'] += 1
+            else:
+                tallies['unexpected'] += 1
+                unexpected_errno = failure
+
+        raise RuntimeError(self._no_ports_message(base_port, first_port, last_port, tallies, unexpected_errno))
 
     def release_port(self, port: int) -> None:
         """

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -777,11 +777,16 @@ class TaskServer(DAPBase):
         """
         Allocate an available port from the managed pool.
 
-        Returns the first port in the configured window that is neither already
-        handed out nor rejected by a bind probe, so the child process that
-        receives the number on its command line can actually listen on it.
-        Ports the operating system forbids are remembered and skipped without
-        probing again; ports held by another socket are re-probed on every call.
+        Returns the first port in the window that is neither already handed out
+        nor rejected by a bind probe, so the child that receives the number on
+        its command line can actually listen on it. OS-forbidden ports are
+        cached; ports merely held by another socket are re-probed every call.
+
+        Two consequences of probing without SO_REUSEADDR: on POSIX a port still
+        in TIME_WAIT reads as in-use even though the child could bind it, so a
+        just-released port is not handed straight back; and the sweep runs
+        synchronously on the event loop, one socket()/bind()/close() per
+        candidate. Both are acceptable at this window size.
 
         Returns:
             int: An available port number inside the configured window.
@@ -792,52 +797,86 @@ class TaskServer(DAPBase):
         """
         base_port = self._config.get('base_port', 20000)
 
-        # Port 0 means "any ephemeral port" to bind(), so it always probes free
-        # and would leave the child choosing its own port while the parent dials
-        # zero. The upper bound keeps the scan inside the valid range: bind()
-        # raises OverflowError, not OSError, above 65535.
+        # Port 0 means "any ephemeral port" to bind(), so it always probes free.
+        # Above 65535 bind() raises OverflowError, not OSError.
         first_port = max(base_port, 1)
         last_port = min(base_port + 9999, 65535)
 
-        tallies = {'allocated': 0, 'occupied': 0, 'reserved': 0, 'unexpected': 0}
-        unexpected_errno = None
+        # Windows exclusion ranges come and go with Hyper-V, WSL and Docker, so
+        # a cached verdict can outlive the reservation. Without a retry the
+        # usable window could only ever shrink. One retry, never more.
+        for attempt in range(2):
+            num_allocated = num_occupied = num_reserved = num_unexpected = 0
+            unexpected_errno = None
 
-        # Membership snapshot. `_allocated_ports` stays a list — release_port and
-        # the pool assertions read it as one — but a linear scan per candidate
-        # makes a full window quadratic, and this method blocks the event loop.
-        # Nothing awaits inside the loop, so the snapshot cannot go stale.
-        already_allocated = set(self._allocated_ports)
+            # Skipped on a cached verdict rather than a live probe: only these
+            # can be stale, so only these justify a retry.
+            trusted_cache = 0
 
-        for port in range(first_port, last_port + 1):
-            if port in already_allocated:
-                tallies['allocated'] += 1
-                continue
+            # Snapshot: the list stays authoritative for release_port, but a
+            # linear scan per candidate would make a full window quadratic.
+            already_allocated = set(self._allocated_ports)
 
-            if port in self._reserved_ports:
-                tallies['reserved'] += 1
-                continue
+            for port in range(first_port, last_port + 1):
+                if port in already_allocated:
+                    num_allocated += 1
+                    continue
 
-            failure = self._probe_port(port)
+                if port in self._reserved_ports:
+                    num_reserved += 1
+                    trusted_cache += 1
+                    continue
 
-            if failure is None:
-                self._allocated_ports.append(port)
-                skipped = tallies['occupied'] + tallies['reserved'] + tallies['unexpected']
-                if skipped:
+                failure = self._probe_port(port)
+
+                if failure is None:
+                    self._allocated_ports.append(port)
+                    if num_occupied or num_reserved or num_unexpected:
+                        self.debug_message(
+                            f'Assigned port {port}, having skipped {num_occupied} in use, '
+                            f'{num_reserved} reserved and {num_unexpected} unexpected'
+                        )
+                    return port
+
+                if failure == errno.EACCES:
+                    self._reserved_ports.add(port)
+                    num_reserved += 1
+                elif failure == errno.EADDRINUSE:
+                    num_occupied += 1
+                else:
+                    num_unexpected += 1
+                    unexpected_errno = failure
+
+            # A window exhausted by live probes has nothing stale to forget.
+            if attempt or not trusted_cache:
+                break
+
+            self.debug_message(
+                f'No port free in {first_port}-{last_port}; dropping {len(self._reserved_ports)} '
+                f'cached OS reservations and probing again'
+            )
+            self._reserved_ports.clear()
+
+        # Every failure was ours, not the pool's — an fd ceiling, say. Nothing
+        # was learned about these ports, and the child has its own fd table, so
+        # degrade to the old behaviour rather than refuse to launch.
+        if num_unexpected and not num_occupied and not num_reserved:
+            name = errno.errorcode.get(unexpected_errno, str(unexpected_errno))
+            for port in range(first_port, last_port + 1):
+                if port not in already_allocated:
+                    self._allocated_ports.append(port)
                     self.debug_message(
-                        f'Assigned port {port}, having skipped {tallies["occupied"]} in use, '
-                        f'{tallies["reserved"]} reserved and {tallies["unexpected"]} unexpected'
+                        f'Could not probe any port in {first_port}-{last_port} (errno '
+                        f'{unexpected_errno} / {name}); assigning {port} unverified'
                     )
-                return port
+                    return port
 
-            if failure == errno.EACCES:
-                self._reserved_ports.add(port)
-                tallies['reserved'] += 1
-            elif failure == errno.EADDRINUSE:
-                tallies['occupied'] += 1
-            else:
-                tallies['unexpected'] += 1
-                unexpected_errno = failure
-
+        tallies = {
+            'allocated': num_allocated,
+            'occupied': num_occupied,
+            'reserved': num_reserved,
+            'unexpected': num_unexpected,
+        }
         raise RuntimeError(self._no_ports_message(base_port, first_port, last_port, tallies, unexpected_errno))
 
     def release_port(self, port: int) -> None:
@@ -1714,41 +1753,29 @@ class TaskServer(DAPBase):
         """
         Test whether a TCP port can be bound right now.
 
-        Binds a throwaway socket to IPv4 loopback and closes it again — the
-        address both consumers of an assigned port use: the data WebServer is
-        started on '127.0.0.1', and pydevd's listener opens an AF_INET socket
-        on the '--debug_host' it is handed.
+        IPv4 loopback is what both consumers bind: the data WebServer on
+        '127.0.0.1', and pydevd's AF_INET listener on the given '--debug_host'.
 
-        No socket options are set, deliberately. On Windows SO_REUSEADDR makes
-        a busy port report EACCES instead of EADDRINUSE, and EACCES is the
-        verdict assign_port caches for the life of the process — so the option
-        would have the allocator permanently blacklist ports that are merely
-        busy. Anyone adding socket options here has to revisit that cache.
-        bind() alone proves ownership, so the socket never listens and cannot
-        accept a stray connection.
+        No socket options, deliberately: on Windows SO_REUSEADDR turns a busy
+        port's EADDRINUSE into EACCES, which assign_port caches for the life of
+        the process — the allocator would blacklist ports that are merely busy.
+        Adding options here means revisiting that cache.
 
         Args:
             port (int): TCP port number to test.
 
         Returns:
-            Optional[int]: None when the port binds, otherwise the errno of the
-                failure: EACCES when the operating system forbids the port,
-                EADDRINUSE when another socket holds it. Never None for a
-                failure — an OSError carrying no errno falls back to
-                EADDRINUSE, so a port that failed to bind can never read as
-                free.
+            Optional[int]: None when the port binds, otherwise the failure's
+                errno — EACCES when the OS forbids the port, EADDRINUSE when
+                another socket holds it. Never None for a failure.
         """
         try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.bind(('127.0.0.1', port))
         except OSError as e:
+            # None is the success sentinel and an OSError may carry no errno,
+            # so fail closed.
             return e.errno or errno.EADDRINUSE
-
-        try:
-            sock.bind(('127.0.0.1', port))
-        except OSError as e:
-            return e.errno or errno.EADDRINUSE
-        finally:
-            sock.close()
 
         return None
 
@@ -1763,11 +1790,9 @@ class TaskServer(DAPBase):
         """
         Build the error message for an exhausted port window.
 
-        Names whichever cause accounts for most of the window, so nobody is
-        sent hunting a foreign process when the ports are held by this server
-        or when probing itself was failing. Only the two causes that point
-        outward — other processes, operating-system reservations — carry a
-        platform command.
+        Names whichever cause accounts for most of the window, so nobody hunts
+        a foreign process for ports this server holds. Only the two outward
+        causes carry a platform command.
 
         Args:
             base_port (int): The configured base port, before clamping.
@@ -1784,7 +1809,10 @@ class TaskServer(DAPBase):
         if first_port > last_port:
             return f'No available ports: configured base_port {base_port} leaves no ports at or below 65535.'
 
-        kind = max(tallies, key=lambda name: tallies[name])
+        # On a tie, dict order would silently always pick the same cause.
+        highest = max(tallies.values())
+        leaders = [name for name, count in tallies.items() if count == highest]
+        kind = leaders[0]
 
         if kind == 'allocated':
             cause = 'most of the range is already allocated by this server'
@@ -1815,9 +1843,28 @@ class TaskServer(DAPBase):
             else:
                 hint = 'List current listeners with `ss -ltn`.'
 
+        # The hint can only speak for one cause, so name the other.
+        if len(leaders) > 1:
+            labels = {
+                'allocated': 'ports this server holds',
+                'occupied': 'ports other processes hold',
+                'reserved': 'ports the operating system reserves',
+                'unexpected': 'probes that failed unexpectedly',
+            }
+            also = ', '.join(labels[name] for name in leaders[1:])
+            cause += f' — tied with {also}, so this hint covers only one of them'
+
+        # Otherwise "widen its window" is advice that cannot be followed upward.
+        clamped = ''
+        if last_port < base_port + 9999:
+            clamped = (
+                f' The window is {last_port - first_port + 1} ports, not 10000: base_port {base_port} '
+                f'would run past 65535, so it was clamped.'
+            )
+
         return (
             f'No available ports in the range {first_port}-{last_port}: {cause} '
             f'({tallies["allocated"]} allocated by this server, {tallies["occupied"]} in use by other processes, '
             f'{tallies["reserved"]} reserved by the operating system, '
-            f'{tallies["unexpected"]} unexpected probe failures). {hint}'
+            f'{tallies["unexpected"]} unexpected probe failures). {hint}{clamped}'
         )

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -773,119 +773,6 @@ class TaskServer(DAPBase):
         # Extract and return the task instance
         return control.task
 
-    @staticmethod
-    def _probe_port(port: int) -> Optional[int]:
-        """
-        Test whether a TCP port can be bound right now.
-
-        Binds a throwaway socket to IPv4 loopback and closes it again — the
-        address both consumers of an assigned port use: the data WebServer is
-        started on '127.0.0.1', and pydevd's listener opens an AF_INET socket
-        on the '--debug_host' it is handed.
-
-        No socket options are set, deliberately. On Windows SO_REUSEADDR makes
-        a busy port report EACCES instead of EADDRINUSE, and EACCES is the
-        verdict assign_port caches for the life of the process — so the option
-        would have the allocator permanently blacklist ports that are merely
-        busy. Anyone adding socket options here has to revisit that cache.
-        bind() alone proves ownership, so the socket never listens and cannot
-        accept a stray connection.
-
-        Args:
-            port (int): TCP port number to test.
-
-        Returns:
-            Optional[int]: None when the port binds, otherwise the errno of the
-                failure: EACCES when the operating system forbids the port,
-                EADDRINUSE when another socket holds it. Never None for a
-                failure — an OSError carrying no errno falls back to
-                EADDRINUSE, so a port that failed to bind can never read as
-                free.
-        """
-        try:
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        except OSError as e:
-            return e.errno or errno.EADDRINUSE
-
-        try:
-            sock.bind(('127.0.0.1', port))
-        except OSError as e:
-            return e.errno or errno.EADDRINUSE
-        finally:
-            sock.close()
-
-        return None
-
-    @staticmethod
-    def _no_ports_message(
-        base_port: int,
-        first_port: int,
-        last_port: int,
-        tallies: Dict[str, int],
-        unexpected_errno: Optional[int],
-    ) -> str:
-        """
-        Build the error message for an exhausted port window.
-
-        Names whichever cause accounts for most of the window, so nobody is
-        sent hunting a foreign process when the ports are held by this server
-        or when probing itself was failing. Only the two causes that point
-        outward — other processes, operating-system reservations — carry a
-        platform command.
-
-        Args:
-            base_port (int): The configured base port, before clamping.
-            first_port (int): First port the scan considered.
-            last_port (int): Last port the scan considered.
-            tallies (Dict[str, int]): Counts keyed 'allocated', 'occupied',
-                'reserved' and 'unexpected'.
-            unexpected_errno (Optional[int]): Last errno that was neither
-                EACCES nor EADDRINUSE, if one occurred.
-
-        Returns:
-            str: A message beginning 'No available ports'.
-        """
-        if first_port > last_port:
-            return f'No available ports: configured base_port {base_port} leaves no ports at or below 65535.'
-
-        kind = max(tallies, key=lambda name: tallies[name])
-
-        if kind == 'allocated':
-            cause = 'the whole range is already allocated by this server'
-            hint = (
-                'This server holds that many task ports; look for tasks that never released one, or widen its window.'
-            )
-        elif kind == 'unexpected':
-            name = errno.errorcode.get(unexpected_errno, str(unexpected_errno))
-            cause = f'every probe failed with errno {unexpected_errno} ({name})'
-            hint = (
-                'That is this process running out of resources rather than a port conflict; check its open descriptors.'
-            )
-        elif kind == 'reserved':
-            cause = 'most of the range is reserved by the operating system'
-            if sys.platform == 'win32':
-                hint = (
-                    'List the exclusions with `netsh int ipv4 show excludedportrange protocol=tcp` '
-                    '(and the ipv6 equivalent) and move base_port outside them.'
-                )
-            else:
-                hint = 'Ports below 1024 need elevated privileges; move base_port higher.'
-        else:
-            cause = 'most of the range is in use by other processes'
-            if sys.platform == 'win32':
-                hint = 'List current listeners with `netstat -ano`.'
-            elif sys.platform == 'darwin':
-                hint = 'List current listeners with `lsof -nP -iTCP -sTCP:LISTEN`.'
-            else:
-                hint = 'List current listeners with `ss -ltn`.'
-
-        return (
-            f'No available ports in the range {first_port}-{last_port}: {cause} '
-            f'({tallies["allocated"]} allocated by this server, {tallies["occupied"]} in use by other processes, '
-            f'{tallies["reserved"]} reserved by the operating system, '
-            f'{tallies["unexpected"]} unexpected probe failures). {hint}'
-        )
-
     def assign_port(self) -> int:
         """
         Allocate an available port from the managed pool.
@@ -915,8 +802,14 @@ class TaskServer(DAPBase):
         tallies = {'allocated': 0, 'occupied': 0, 'reserved': 0, 'unexpected': 0}
         unexpected_errno = None
 
+        # Membership snapshot. `_allocated_ports` stays a list — release_port and
+        # the pool assertions read it as one — but a linear scan per candidate
+        # makes a full window quadratic, and this method blocks the event loop.
+        # Nothing awaits inside the loop, so the snapshot cannot go stale.
+        already_allocated = set(self._allocated_ports)
+
         for port in range(first_port, last_port + 1):
-            if port in self._allocated_ports:
+            if port in already_allocated:
                 tallies['allocated'] += 1
                 continue
 
@@ -1815,3 +1708,116 @@ class TaskServer(DAPBase):
         finally:
             # Ensure cleanup occurs regardless of how connection ends
             await self._dapbase_on_disconnected(conn)
+
+    @staticmethod
+    def _probe_port(port: int) -> Optional[int]:
+        """
+        Test whether a TCP port can be bound right now.
+
+        Binds a throwaway socket to IPv4 loopback and closes it again — the
+        address both consumers of an assigned port use: the data WebServer is
+        started on '127.0.0.1', and pydevd's listener opens an AF_INET socket
+        on the '--debug_host' it is handed.
+
+        No socket options are set, deliberately. On Windows SO_REUSEADDR makes
+        a busy port report EACCES instead of EADDRINUSE, and EACCES is the
+        verdict assign_port caches for the life of the process — so the option
+        would have the allocator permanently blacklist ports that are merely
+        busy. Anyone adding socket options here has to revisit that cache.
+        bind() alone proves ownership, so the socket never listens and cannot
+        accept a stray connection.
+
+        Args:
+            port (int): TCP port number to test.
+
+        Returns:
+            Optional[int]: None when the port binds, otherwise the errno of the
+                failure: EACCES when the operating system forbids the port,
+                EADDRINUSE when another socket holds it. Never None for a
+                failure — an OSError carrying no errno falls back to
+                EADDRINUSE, so a port that failed to bind can never read as
+                free.
+        """
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        except OSError as e:
+            return e.errno or errno.EADDRINUSE
+
+        try:
+            sock.bind(('127.0.0.1', port))
+        except OSError as e:
+            return e.errno or errno.EADDRINUSE
+        finally:
+            sock.close()
+
+        return None
+
+    @staticmethod
+    def _no_ports_message(
+        base_port: int,
+        first_port: int,
+        last_port: int,
+        tallies: Dict[str, int],
+        unexpected_errno: Optional[int],
+    ) -> str:
+        """
+        Build the error message for an exhausted port window.
+
+        Names whichever cause accounts for most of the window, so nobody is
+        sent hunting a foreign process when the ports are held by this server
+        or when probing itself was failing. Only the two causes that point
+        outward — other processes, operating-system reservations — carry a
+        platform command.
+
+        Args:
+            base_port (int): The configured base port, before clamping.
+            first_port (int): First port the scan considered.
+            last_port (int): Last port the scan considered.
+            tallies (Dict[str, int]): Counts keyed 'allocated', 'occupied',
+                'reserved' and 'unexpected'.
+            unexpected_errno (Optional[int]): Last errno that was neither
+                EACCES nor EADDRINUSE, if one occurred.
+
+        Returns:
+            str: A message beginning 'No available ports'.
+        """
+        if first_port > last_port:
+            return f'No available ports: configured base_port {base_port} leaves no ports at or below 65535.'
+
+        kind = max(tallies, key=lambda name: tallies[name])
+
+        if kind == 'allocated':
+            cause = 'most of the range is already allocated by this server'
+            hint = (
+                'This server holds that many task ports; look for tasks that never released one, or widen its window.'
+            )
+        elif kind == 'unexpected':
+            name = errno.errorcode.get(unexpected_errno, str(unexpected_errno))
+            cause = f'most probes failed unexpectedly, last with errno {unexpected_errno} ({name})'
+            hint = (
+                'That is this process running out of resources rather than a port conflict; check its open descriptors.'
+            )
+        elif kind == 'reserved':
+            cause = 'most of the range is reserved by the operating system'
+            if sys.platform == 'win32':
+                hint = (
+                    'List the exclusions with `netsh int ipv4 show excludedportrange protocol=tcp` '
+                    '(and the ipv6 equivalent) and move base_port outside them.'
+                )
+            else:
+                hint = 'Ports below 1024 need elevated privileges; move base_port higher.'
+        else:
+            cause = 'most of the range is in use by other processes'
+            if sys.platform == 'win32':
+                hint = 'List current listeners with `netstat -ano`.'
+            elif sys.platform == 'darwin':
+                hint = 'List current listeners with `lsof -nP -iTCP -sTCP:LISTEN`.'
+            else:
+                hint = 'List current listeners with `ss -ltn`.'
+
+        return (
+            f'No available ports in the range {first_port}-{last_port}: {cause} '
+            f'({tallies["allocated"]} allocated by this server, {tallies["occupied"]} in use by other processes, '
+            f'{tallies["reserved"]} reserved by the operating system, '
+            f'{tallies["unexpected"]} unexpected probe failures). {hint}'
+        )

--- a/packages/ai/src/ai/node.py
+++ b/packages/ai/src/ai/node.py
@@ -150,9 +150,23 @@ def _setup_shared_web_server() -> Tuple[Optional[Any], Optional[Any]]:
     timeout = _SHARED_SERVER_STARTUP_TIMEOUT_SECONDS
     deadline = time.monotonic() + timeout
 
-    # Block until the lifespan startup callback fires, bounded so a misbehaving
-    # uvicorn can't deadlock the subprocess.
-    signalled = startup_ready.wait(timeout=max(0.0, deadline - time.monotonic()))
+    # Wait for the lifespan startup callback in slices, so a serve() that dies
+    # before ever firing it is noticed now instead of at the deadline. uvicorn
+    # runs that hook before it binds, so a bind failure normally sets the event
+    # first and is caught by the poll below; this covers the earlier failures,
+    # such as the lifespan handler itself raising.
+    while not startup_ready.is_set():
+        if future.done():
+            future.result()
+            break
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+
+        startup_ready.wait(timeout=min(_SHARED_SERVER_POLL_INTERVAL_SECONDS, remaining))
+
+    signalled = startup_ready.is_set()
 
     # Then wait for a listener to actually exist. uvicorn sets Server.started
     # only after create_server() returns, which is the first moment the port is

--- a/packages/ai/src/ai/node.py
+++ b/packages/ai/src/ai/node.py
@@ -3,6 +3,7 @@ import sys
 import os
 import asyncio
 import threading
+import time
 from typing import Optional, Tuple, Any
 
 # Remove auto-added script directory to avoid import conflicts with the ai package
@@ -15,11 +16,16 @@ os.environ['PYDEVD_DISABLE_FILE_VALIDATION'] = '1'
 # Import directly from C++
 from engLib import debug
 
-# How long to wait for the shared WebServer's startup callback to fire
-# before giving up and proceeding to processArguments. The callback fires
-# when uvicorn enters its serve loop; the wait is the handshake that
-# guarantees the listener is up before EaaS gets a chance to connect.
+# Total budget for the shared WebServer to come up: the startup callback plus
+# the wait for a bound listener share this one deadline, so a slow start cannot
+# spend it twice. The callback marks uvicorn entering its serve loop, which
+# happens before the socket is bound — proof of a listener comes from
+# Server.started, which is polled separately.
 _SHARED_SERVER_STARTUP_TIMEOUT_SECONDS = 10.0
+
+# Gap between readiness polls. This runs on the subprocess's main thread while
+# uvicorn starts on another, so a spin would compete with the startup it waits on.
+_SHARED_SERVER_POLL_INTERVAL_SECONDS = 0.02
 
 # Bound for waiting on ``serve()`` after ``server.stop()`` — guards
 # against a stuck uvicorn hanging subprocess shutdown forever.
@@ -122,9 +128,9 @@ def _setup_shared_web_server() -> Tuple[Optional[Any], Optional[Any]]:
 
     from ai.web import WebServer
 
-    # Event the on_startup callback sets when the server is ready to
-    # accept connections. Main thread waits on this to guarantee EaaS
-    # never connects before the listener is bound.
+    # Event the on_startup callback sets. It marks uvicorn entering its serve
+    # loop, which happens before the socket is bound, so it is a liveness hint
+    # rather than proof of a listener. The poll below carries that guarantee.
     startup_ready = threading.Event()
 
     async def _on_startup() -> None:
@@ -140,22 +146,39 @@ def _setup_shared_web_server() -> Tuple[Optional[Any], Optional[Any]]:
 
     future = asyncio.run_coroutine_threadsafe(server.serve(), server_loop)
 
-    # Block until the server's lifespan startup callback fires, with a
-    # safety-net timeout so a misbehaving uvicorn can't deadlock the
-    # subprocess. The timeout is generous in production (10s) and is
-    # dialled down by tests.
-    signalled = startup_ready.wait(timeout=_SHARED_SERVER_STARTUP_TIMEOUT_SECONDS)
+    # Read the constant here, at call time: tests override it on the module.
+    timeout = _SHARED_SERVER_STARTUP_TIMEOUT_SECONDS
+    deadline = time.monotonic() + timeout
 
-    # Fail fast if `serve()` exited before signalling startup (e.g. bind
-    # error, permission denied, port already in use).
-    if future.done():
-        future.result()  # re-raises the exception from serve()
+    # Block until the lifespan startup callback fires, bounded so a misbehaving
+    # uvicorn can't deadlock the subprocess.
+    signalled = startup_ready.wait(timeout=max(0.0, deadline - time.monotonic()))
+
+    # Then wait for a listener to actually exist. uvicorn sets Server.started
+    # only after create_server() returns, which is the first moment the port is
+    # ours. `future.done()` is checked first on every pass, so a child that has
+    # already died wins over a stale readiness flag.
+    while True:
+        if future.done():
+            # Re-raises a bind error, permission denied or port-already-in-use
+            # out of serve(). A future that finished cleanly just ends the wait.
+            future.result()
+            break
+
+        if getattr(getattr(server, 'server', None), 'started', False):
+            break
+
+        if time.monotonic() >= deadline:
+            debug(
+                f'shared WebServer never began listening on {data_host}:{data_port} '
+                f'within {timeout}s; proceeding anyway'
+            )
+            break
+
+        time.sleep(_SHARED_SERVER_POLL_INTERVAL_SECONDS)
 
     if not signalled:
-        debug(
-            f'shared WebServer startup did not signal within '
-            f'{_SHARED_SERVER_STARTUP_TIMEOUT_SECONDS}s; proceeding anyway'
-        )
+        debug(f'shared WebServer startup did not signal within {timeout}s; proceeding anyway')
 
     return server, future
 
@@ -272,9 +295,11 @@ def run():
                 debugpy.wait_for_client()
 
         except Exception as e:
-            import logging
-
-            logging.getLogger(__name__).warning('Failed to initialize debugpy: %s', e)
+            # Non-fatal: debugging is optional and must not take the task down.
+            # Named, though — a debug port inside an OS exclusion range fails
+            # here, and that is indistinguishable from "debugging is off" unless
+            # the host and port are said out loud.
+            debug(f'failed to initialize debugpy on {parsed_args.debug_host}:{parsed_args.debug_port}: {e}')
 
     # Start the global event loop for async operations
     _start_event_loop()

--- a/packages/ai/src/ai/node.py
+++ b/packages/ai/src/ai/node.py
@@ -14,7 +14,7 @@ if sys.path and (sys.path[0].endswith('ai') or sys.path[0].endswith('ai\\') or s
 os.environ['PYDEVD_DISABLE_FILE_VALIDATION'] = '1'
 
 # Import directly from C++
-from engLib import debug
+from engLib import debug, warning
 
 # Total budget for the shared WebServer to come up: the startup callback plus
 # the wait for a bound listener share this one deadline, so a slow start cannot
@@ -128,9 +128,8 @@ def _setup_shared_web_server() -> Tuple[Optional[Any], Optional[Any]]:
 
     from ai.web import WebServer
 
-    # Event the on_startup callback sets. It marks uvicorn entering its serve
-    # loop, which happens before the socket is bound, so it is a liveness hint
-    # rather than proof of a listener. The poll below carries that guarantee.
+    # Set when uvicorn enters its serve loop — which happens before the socket
+    # is bound, so this is a liveness hint, not proof of a listener.
     startup_ready = threading.Event()
 
     async def _on_startup() -> None:
@@ -146,15 +145,12 @@ def _setup_shared_web_server() -> Tuple[Optional[Any], Optional[Any]]:
 
     future = asyncio.run_coroutine_threadsafe(server.serve(), server_loop)
 
-    # Read the constant here, at call time: tests override it on the module.
+    # Read at call time: tests override the constant on the module.
     timeout = _SHARED_SERVER_STARTUP_TIMEOUT_SECONDS
     deadline = time.monotonic() + timeout
 
-    # Wait for the lifespan startup callback in slices, so a serve() that dies
-    # before ever firing it is noticed now instead of at the deadline. uvicorn
-    # runs that hook before it binds, so a bind failure normally sets the event
-    # first and is caught by the poll below; this covers the earlier failures,
-    # such as the lifespan handler itself raising.
+    # In slices, so a serve() that dies before ever firing the callback is
+    # noticed now rather than at the deadline.
     while not startup_ready.is_set():
         if future.done():
             future.result()
@@ -168,28 +164,32 @@ def _setup_shared_web_server() -> Tuple[Optional[Any], Optional[Any]]:
 
     signalled = startup_ready.is_set()
 
-    # Then wait for a listener to actually exist. uvicorn sets Server.started
-    # only after create_server() returns, which is the first moment the port is
-    # ours. `future.done()` is checked first on every pass, so a child that has
-    # already died wins over a stale readiness flag.
+    # Now wait for a listener to exist: uvicorn sets Server.started only after
+    # create_server() returns. future.done() goes first on every pass so a child
+    # that already died beats a stale readiness flag.
     while True:
         if future.done():
-            # Re-raises a bind error, permission denied or port-already-in-use
-            # out of serve(). A future that finished cleanly just ends the wait.
+            # Re-raises a bind error, permission denied or port-already-in-use.
             future.result()
+
+            # It returned instead: serve() ended on its own, so /task/data would
+            # stay unreachable for the rest of this subprocess.
+            if not getattr(getattr(server, 'server', None), 'started', False):
+                warning(f'shared WebServer stopped before it began listening on {data_host}:{data_port}')
             break
 
         if getattr(getattr(server, 'server', None), 'started', False):
             break
 
-        if time.monotonic() >= deadline:
-            debug(
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            warning(
                 f'shared WebServer never began listening on {data_host}:{data_port} '
                 f'within {timeout}s; proceeding anyway'
             )
             break
 
-        time.sleep(_SHARED_SERVER_POLL_INTERVAL_SECONDS)
+        time.sleep(min(_SHARED_SERVER_POLL_INTERVAL_SECONDS, remaining))
 
     if not signalled:
         debug(f'shared WebServer startup did not signal within {timeout}s; proceeding anyway')
@@ -309,11 +309,11 @@ def run():
                 debugpy.wait_for_client()
 
         except Exception as e:
-            # Non-fatal: debugging is optional and must not take the task down.
-            # Named, though — a debug port inside an OS exclusion range fails
-            # here, and that is indistinguishable from "debugging is off" unless
-            # the host and port are said out loud.
-            debug(f'failed to initialize debugpy on {parsed_args.debug_host}:{parsed_args.debug_port}: {e}')
+            # Non-fatal: debugging is optional. Named, though — a debug port in
+            # an OS exclusion range fails here and otherwise looks like
+            # "debugging is off". `warning`, not `debug`: engLib's debug() is
+            # gated on the DebugOut level, which is off by default.
+            warning(f'failed to initialize debugpy on {parsed_args.debug_host}:{parsed_args.debug_port}: {e}')
 
     # Start the global event loop for async operations
     _start_event_loop()

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -306,10 +306,86 @@ def test_assign_port_exhausted_blames_other_processes(monkeypatch):
 
 
 def test_assign_port_exhausted_reports_unexpected_errno(monkeypatch):
-    """A probe failing for our own reasons is reported as itself, not as 'in use'."""
-    _patch_probe(monkeypatch, lambda port: errno.EMFILE)
+    """A probe failing for our own reasons is reported as itself, not as 'in use'.
+
+    One port reports a genuine conflict, so the our-fault fallback below does
+    not apply and the window really is refused.
+    """
+    _patch_probe(monkeypatch, lambda port: errno.EADDRINUSE if port == 20000 else errno.EMFILE)
     ts = _make_server()
     with pytest.raises(RuntimeError, match=f'most probes failed unexpectedly, last with errno {errno.EMFILE}'):
+        ts.assign_port()
+
+
+def test_assign_port_falls_back_when_every_probe_fails_for_our_own_reasons(monkeypatch):
+    """An fd ceiling must not become a refusal to launch.
+
+    When every probe fails for a reason of ours rather than the pool's, nothing
+    was learned about the ports. The child is a separate process with its own
+    descriptor table and would very likely bind, so degrade to what the old
+    allocator did instead of failing the task.
+    """
+    _patch_probe(monkeypatch, lambda port: errno.EMFILE)
+    ts = _make_server()
+    assert ts.assign_port() == 20000
+    assert ts._allocated_ports == [20000]
+
+
+def test_assign_port_drops_stale_reservations_before_giving_up(monkeypatch):
+    """A window that looks fully reserved is re-probed once with a clean cache.
+
+    Windows exclusion ranges come and go as Hyper-V, WSL and Docker start and
+    stop, so a cached EACCES can outlive the reservation. Without this the
+    usable window could only shrink, and a long-lived engine would end up
+    refusing every task while `netsh` reported no exclusions at all.
+    """
+    _patch_probe(monkeypatch, lambda port: None)
+    ts = _make_server()
+    # Cached earlier, when the range really was excluded. The OS has since let
+    # it go, but nothing re-probes a cached port, so the pool looks empty.
+    ts._reserved_ports = set(range(20000, 30000))
+
+    assert ts.assign_port() == 20000
+    assert ts._reserved_ports == set(), 'the stale cache must not survive the retry'
+
+
+def test_assign_port_does_not_resweep_when_the_cache_was_not_consulted(monkeypatch):
+    """A window exhausted by live probes has nothing stale to forget.
+
+    Re-probing it would spend a second full sweep of syscalls on the event loop
+    for nothing, so the retry is gated on cached verdicts actually being used.
+    """
+    probed = []
+
+    def _probe(port):
+        probed.append(port)
+        return errno.EADDRINUSE
+
+    _patch_probe(monkeypatch, _probe)
+    ts = _make_server()
+
+    with pytest.raises(RuntimeError, match='in use by other processes'):
+        ts.assign_port()
+
+    assert len(probed) == 10000, f'expected one sweep of the window, got {len(probed)} probes'
+
+
+def test_assign_port_exhausted_says_the_window_was_clamped(monkeypatch):
+    """A base high enough to run past 65535 gets a short window; say so.
+
+    Otherwise the message advises widening a window that cannot widen upward.
+    """
+    _patch_probe(monkeypatch, lambda port: errno.EADDRINUSE)
+    ts = _make_server(config={'base_port': 60000})
+    with pytest.raises(RuntimeError, match='was clamped'):
+        ts.assign_port()
+
+
+def test_assign_port_exhausted_names_a_tied_cause(monkeypatch):
+    """On a tie the message must not silently pick one of two very different paths."""
+    _patch_probe(monkeypatch, lambda port: errno.EACCES if port < 25000 else errno.EADDRINUSE)
+    ts = _make_server()
+    with pytest.raises(RuntimeError, match='tied with'):
         ts.assign_port()
 
 
@@ -370,11 +446,16 @@ def test_probe_port_never_reports_a_failed_bind_as_free(monkeypatch):
     """An OSError carrying no errno must not read as 'port is free'."""
 
     class _NoErrnoSocket:
+        # _probe_port opens the socket with `with`, so the stub is a context
+        # manager rather than something with a close().
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
         def bind(self, address):
             raise OSError()
-
-        def close(self):
-            pass
 
     monkeypatch.setattr(task_server_module.socket, 'socket', lambda *a, **kw: _NoErrnoSocket())
     assert TaskServer._probe_port(20000) == errno.EADDRINUSE

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -309,7 +309,7 @@ def test_assign_port_exhausted_reports_unexpected_errno(monkeypatch):
     """A probe failing for our own reasons is reported as itself, not as 'in use'."""
     _patch_probe(monkeypatch, lambda port: errno.EMFILE)
     ts = _make_server()
-    with pytest.raises(RuntimeError, match=f'every probe failed with errno {errno.EMFILE}'):
+    with pytest.raises(RuntimeError, match=f'most probes failed unexpectedly, last with errno {errno.EMFILE}'):
         ts.assign_port()
 
 

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -20,12 +20,15 @@ Focus areas:
 
 from __future__ import annotations
 
+import errno
+import socket
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ai.modules.task import task_server as task_server_module
 from ai.modules.task.task_server import TaskServer
 
 
@@ -50,6 +53,7 @@ def _make_server(*, config=None, web_server=None):
     ts._connection_id = 0
     ts._unauthed_by_ip = {}
     ts._allocated_ports = []
+    ts._reserved_ports = set()
     ts._store_instance = None
     ts._config = config if config is not None else {}
     ts._server = web_server or MagicMock()
@@ -137,20 +141,71 @@ def test_next_connection_id_starts_at_one_and_monotonic():
 # ---------------------------------------------------------------------------
 
 
-def test_assign_port_uses_default_base_port():
+def _patch_probe(monkeypatch, probe):
+    """
+    Install a stand-in for the port probe.
+
+    _probe_port is a staticmethod, so a bare function assigned to the class
+    would be bound and receive self; the wrapping lives here rather than in
+    every test.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): fixture performing the swap.
+        probe (Callable[[int], Optional[int]]): verdict for a given port.
+
+    Returns:
+        None
+    """
+    monkeypatch.setattr(TaskServer, '_probe_port', staticmethod(probe))
+
+
+@pytest.fixture
+def all_ports_bindable(monkeypatch):
+    """
+    Report every port as bindable.
+
+    Keeps the pool-bookkeeping tests independent of whatever the host machine
+    happens to have bound or reserved — on a developer box the default 20000 is
+    routinely held by another engine.
+
+    Args:
+        monkeypatch (pytest.MonkeyPatch): fixture used to swap the probe.
+
+    Returns:
+        None
+    """
+    _patch_probe(monkeypatch, lambda port: None)
+
+
+def _probe_returning(**by_port):
+    """
+    Build a probe stub with a per-port verdict.
+
+    Args:
+        **by_port: mapping of ``p<port>`` to the errno that port should report;
+            any port not named is reported bindable.
+
+    Returns:
+        Callable[[int], Optional[int]]: stand-in for ``_probe_port``.
+    """
+    table = {int(k[1:]): v for k, v in by_port.items()}
+    return lambda port: table.get(port)
+
+
+def test_assign_port_uses_default_base_port(all_ports_bindable):
     """Without a configured base_port, allocation starts at 20000."""
     ts = _make_server()
     assert ts.assign_port() == 20000
     assert ts._allocated_ports == [20000]
 
 
-def test_assign_port_respects_configured_base_port():
+def test_assign_port_respects_configured_base_port(all_ports_bindable):
     """`_config['base_port']` overrides the default starting port."""
     ts = _make_server(config={'base_port': 30000})
     assert ts.assign_port() == 30000
 
 
-def test_assign_port_returns_next_free_in_range():
+def test_assign_port_returns_next_free_in_range(all_ports_bindable):
     """Allocations skip already-taken ports and return the next free one."""
     ts = _make_server()
     ts._allocated_ports = [20000, 20001, 20002]
@@ -173,12 +228,156 @@ def test_release_port_unknown_is_noop():
     assert ts._allocated_ports == [20000]
 
 
-def test_assign_port_exhausts_after_10000():
+def test_assign_port_exhausts_after_10000(all_ports_bindable):
     """When every port in the 10000-wide window is taken, allocation raises."""
     ts = _make_server()
     ts._allocated_ports = list(range(20000, 30000))
     with pytest.raises(RuntimeError, match='No available ports'):
         ts.assign_port()
+
+
+def test_assign_port_skips_unbindable_port(monkeypatch):
+    """A port the probe rejects is passed over for the next one."""
+    _patch_probe(monkeypatch, _probe_returning(p20000=errno.EADDRINUSE))
+    ts = _make_server()
+    assert ts.assign_port() == 20001
+    assert ts._allocated_ports == [20001]
+
+
+def test_assign_port_reprobes_ports_in_use(monkeypatch):
+    """An occupied port is probed again next time, because its owner can exit."""
+    probed = []
+
+    def _probe(port):
+        probed.append(port)
+        return errno.EADDRINUSE if port == 20000 else None
+
+    _patch_probe(monkeypatch, _probe)
+    ts = _make_server()
+    ts.assign_port()
+    ts.assign_port()
+    assert probed.count(20000) == 2
+    assert ts._reserved_ports == set()
+
+
+def test_assign_port_does_not_hand_back_a_released_but_still_held_port(monkeypatch):
+    """A released port whose old owner still holds the socket is skipped.
+
+    Teardown returns ports to the pool without waiting for the child to exit,
+    so the next allocation would otherwise be handed a port that is still bound.
+    """
+    _patch_probe(monkeypatch, _probe_returning(p20000=errno.EADDRINUSE))
+    ts = _make_server()
+    ts._allocated_ports = [20000]
+    ts.release_port(20000)
+    assert ts.assign_port() == 20001
+
+
+def test_assign_port_caches_system_reserved_ports(monkeypatch):
+    """An EACCES port is remembered and never probed a second time."""
+    probed = []
+
+    def _probe(port):
+        probed.append(port)
+        return errno.EACCES if port == 20000 else None
+
+    _patch_probe(monkeypatch, _probe)
+    ts = _make_server()
+    assert ts.assign_port() == 20001
+    assert ts.assign_port() == 20002
+    assert probed.count(20000) == 1
+    assert ts._reserved_ports == {20000}
+
+
+def test_assign_port_exhausted_blames_system_reservations(monkeypatch):
+    """When every candidate is forbidden, the message names the OS reservation."""
+    _patch_probe(monkeypatch, lambda port: errno.EACCES)
+    ts = _make_server(config={'base_port': 30000})
+    with pytest.raises(RuntimeError, match='reserved by the operating system'):
+        ts.assign_port()
+
+
+def test_assign_port_exhausted_blames_other_processes(monkeypatch):
+    """When every candidate is occupied, the message names other processes."""
+    _patch_probe(monkeypatch, lambda port: errno.EADDRINUSE)
+    ts = _make_server()
+    with pytest.raises(RuntimeError, match='in use by other processes'):
+        ts.assign_port()
+
+
+def test_assign_port_exhausted_reports_unexpected_errno(monkeypatch):
+    """A probe failing for our own reasons is reported as itself, not as 'in use'."""
+    _patch_probe(monkeypatch, lambda port: errno.EMFILE)
+    ts = _make_server()
+    with pytest.raises(RuntimeError, match=f'every probe failed with errno {errno.EMFILE}'):
+        ts.assign_port()
+
+
+def test_assign_port_exhausted_by_self_does_not_blame_other_processes(all_ports_bindable):
+    """The self-allocated message must not send the reader hunting other processes."""
+    ts = _make_server()
+    ts._allocated_ports = list(range(20000, 30000))
+    with pytest.raises(RuntimeError) as excinfo:
+        ts.assign_port()
+    message = str(excinfo.value)
+    assert 'already allocated by this server' in message
+    assert 'ss -ltn' not in message
+    assert 'netsh' not in message
+    assert 'lsof' not in message
+
+
+def test_assign_port_rejects_window_past_the_last_valid_port(monkeypatch):
+    """A base_port above 65535 leaves an empty window and never reaches a probe."""
+    probed = []
+    _patch_probe(monkeypatch, lambda port: probed.append(port))
+    ts = _make_server(config={'base_port': 70000})
+    with pytest.raises(RuntimeError, match='leaves no ports at or below 65535'):
+        ts.assign_port()
+    assert probed == []
+
+
+def test_assign_port_never_returns_port_zero(all_ports_bindable):
+    """base_port 0 must not yield port 0, which means 'any port' to bind()."""
+    ts = _make_server(config={'base_port': 0})
+    assert ts.assign_port() == 1
+
+
+def test_assign_port_returns_a_bindable_port():
+    """The unpatched allocator returns a port the caller can really bind."""
+    ts = _make_server()
+    port = ts.assign_port()
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        sock.bind(('127.0.0.1', port))
+    finally:
+        sock.close()
+
+
+def test_probe_port_detects_a_held_port():
+    """_probe_port reports EADDRINUSE while a socket holds the port, None after."""
+    holder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        holder.bind(('127.0.0.1', 0))
+        port = holder.getsockname()[1]
+        assert TaskServer._probe_port(port) == errno.EADDRINUSE
+    finally:
+        holder.close()
+
+    assert TaskServer._probe_port(port) is None
+
+
+def test_probe_port_never_reports_a_failed_bind_as_free(monkeypatch):
+    """An OSError carrying no errno must not read as 'port is free'."""
+
+    class _NoErrnoSocket:
+        def bind(self, address):
+            raise OSError()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(task_server_module.socket, 'socket', lambda *a, **kw: _NoErrnoSocket())
+    assert TaskServer._probe_port(20000) == errno.EADDRINUSE
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai/tests/ai/test_node.py
+++ b/packages/ai/tests/ai/test_node.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 import asyncio
 import sys
 import threading
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -257,8 +258,13 @@ def test_setup_blocks_until_on_startup_fires(monkeypatch):
         # Note: do NOT fire on_startup here — the test controls timing.
         return MagicMock()
 
+    # A real serve() future is pending while the server runs, and the wait polls
+    # it: a bare MagicMock would report done() truthy and end the wait at once.
+    pending_future = MagicMock(name='future')
+    pending_future.done.return_value = False
+
     monkeypatch.setattr('ai.web.WebServer', fake_web_server)
-    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: MagicMock())
+    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: pending_future)
 
     # Use a sub-thread so we can observe whether _setup is still blocked.
     def call_setup():
@@ -333,6 +339,38 @@ def test_setup_reraises_when_serve_future_already_failed(monkeypatch):
 
     with pytest.raises(RuntimeError, match='bind failed'):
         node._setup_shared_web_server()
+
+
+def test_setup_reraises_without_waiting_out_the_timeout(monkeypatch):
+    """A ``serve()`` that dies before the callback fires is reported at once.
+
+    uvicorn runs the lifespan hook before it binds, so a bind failure normally
+    signals startup first and is caught right after the wait. When the failure
+    comes earlier — the lifespan handler itself raising — nothing will ever set
+    the event, and waiting out the full budget before looking at the future
+    would delay the diagnosis by exactly that long.
+    """
+    monkeypatch.setattr(sys, 'argv', ['node.py', '--data_port=12345'])
+    # Generous on purpose: the point of the test is that it is not spent.
+    monkeypatch.setattr(node, '_SHARED_SERVER_STARTUP_TIMEOUT_SECONDS', 30.0)
+
+    future = MagicMock(name='future')
+    future.done.return_value = True
+    future.result.side_effect = RuntimeError('lifespan startup failed')
+
+    def fake_web_server(config=None, on_startup=None, **kwargs):
+        # Never fire on_startup: the failure precedes it.
+        return MagicMock(name='WebServer-instance')
+
+    monkeypatch.setattr('ai.web.WebServer', fake_web_server)
+    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: future)
+
+    started_at = time.monotonic()
+    with pytest.raises(RuntimeError, match='lifespan startup failed'):
+        node._setup_shared_web_server()
+    elapsed = time.monotonic() - started_at
+
+    assert elapsed < 5.0, f'should not have waited out the 30s budget; took {elapsed:.1f}s'
 
 
 def test_setup_reports_when_the_listener_never_comes_up(monkeypatch):

--- a/packages/ai/tests/ai/test_node.py
+++ b/packages/ai/tests/ai/test_node.py
@@ -298,11 +298,18 @@ def test_setup_returns_even_when_startup_callback_never_fires(monkeypatch):
         # Never fire on_startup.
         return MagicMock()
 
+    # A live serve() future is pending. A bare MagicMock reports done() truthy,
+    # which would end both waits on their first pass and leave the 0.05s budget
+    # unspent — the timeout path this test exists for would never be reached.
+    pending_future = MagicMock(name='future')
+    pending_future.done.return_value = False
+
     monkeypatch.setattr('ai.web.WebServer', fake_web_server)
-    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: MagicMock())
+    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: pending_future)
 
     debug_messages = []
     monkeypatch.setattr(node, 'debug', lambda msg, *a, **kw: debug_messages.append(str(msg)))
+    monkeypatch.setattr(node, 'warning', lambda msg, *a, **kw: None)
 
     server, future = node._setup_shared_web_server()
 
@@ -344,11 +351,8 @@ def test_setup_reraises_when_serve_future_already_failed(monkeypatch):
 def test_setup_reraises_without_waiting_out_the_timeout(monkeypatch):
     """A ``serve()`` that dies before the callback fires is reported at once.
 
-    uvicorn runs the lifespan hook before it binds, so a bind failure normally
-    signals startup first and is caught right after the wait. When the failure
-    comes earlier — the lifespan handler itself raising — nothing will ever set
-    the event, and waiting out the full budget before looking at the future
-    would delay the diagnosis by exactly that long.
+    Nothing will ever set the event, so waiting out the full budget before
+    looking at the future would delay the diagnosis by exactly that long.
     """
     monkeypatch.setattr(sys, 'argv', ['node.py', '--data_port=12345'])
     # Generous on purpose: the point of the test is that it is not spent.
@@ -373,15 +377,48 @@ def test_setup_reraises_without_waiting_out_the_timeout(monkeypatch):
     assert elapsed < 5.0, f'should not have waited out the 30s budget; took {elapsed:.1f}s'
 
 
+def test_setup_reports_a_server_that_stopped_before_listening(monkeypatch):
+    """``serve()`` ending cleanly during startup must not return in silence.
+
+    It raises nothing, so the fail-fast branch has nothing to re-raise — but the
+    listener never came up either, and the caller is about to publish a
+    ``shared_web_server`` whose ``/task/data`` stays unreachable for the rest of
+    the subprocess's life. That is the one path that can hand back a dead server.
+    """
+    monkeypatch.setattr(sys, 'argv', ['node.py', '--data_host=127.0.0.1', '--data_port=12345'])
+
+    server_instance = MagicMock(name='WebServer-instance')
+    server_instance.server.started = False
+
+    # Completed, and completed cleanly: result() returns rather than raising.
+    future = MagicMock(name='future')
+    future.done.return_value = True
+    future.result.return_value = None
+
+    def fake_web_server(config=None, on_startup=None, **kwargs):
+        _fire_startup_callback_now(on_startup)
+        return server_instance
+
+    monkeypatch.setattr('ai.web.WebServer', fake_web_server)
+    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: future)
+
+    warnings = []
+    monkeypatch.setattr(node, 'warning', lambda msg, *a, **kw: warnings.append(str(msg)))
+    monkeypatch.setattr(node, 'debug', lambda msg, *a, **kw: None)
+
+    node._setup_shared_web_server()
+
+    assert any('stopped before it began listening on 127.0.0.1:12345' in m for m in warnings), (
+        f'a cleanly-stopped server must be named, not returned silently; got {warnings!r}'
+    )
+
+
 def test_setup_reports_when_the_listener_never_comes_up(monkeypatch):
     """Startup signalled but no socket bound is its own diagnosis.
 
-    uvicorn fires the lifespan hook before it binds, so the callback firing
-    proves nothing about the port. Reaching the deadline with `serve()` still
-    running and `Server.started` still false means the listener never appeared —
-    a different fault from "the callback never fired", and the one a reserved or
-    occupied port produces. It must name the endpoint and must not claim the
-    callback failed.
+    A different fault from "the callback never fired", and the one a reserved or
+    occupied port produces, so it must name the endpoint and stay quiet about
+    the callback.
     """
     monkeypatch.setattr(sys, 'argv', ['node.py', '--data_host=127.0.0.1', '--data_port=12345'])
     monkeypatch.setattr(node, '_SHARED_SERVER_STARTUP_TIMEOUT_SECONDS', 0.05)
@@ -400,18 +437,23 @@ def test_setup_reports_when_the_listener_never_comes_up(monkeypatch):
     monkeypatch.setattr('ai.web.WebServer', fake_web_server)
     monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: future)
 
-    messages = []
-    monkeypatch.setattr(node, 'debug', lambda msg, *a, **kw: messages.append(str(msg)))
+    warnings = []
+    debugs = []
+    monkeypatch.setattr(node, 'warning', lambda msg, *a, **kw: warnings.append(str(msg)))
+    monkeypatch.setattr(node, 'debug', lambda msg, *a, **kw: debugs.append(str(msg)))
 
     server, returned_future = node._setup_shared_web_server()
 
     assert server is not None
     assert returned_future is not None
-    assert any('never began listening on 127.0.0.1:12345' in m for m in messages), (
-        f'expected the listener case to be named; got {messages!r}'
+    # A warning, not a debug: engLib's debug() is gated on the DebugOut level,
+    # which is off by default, so a failure routed through it would be invisible
+    # exactly when it matters.
+    assert any('never began listening on 127.0.0.1:12345' in m for m in warnings), (
+        f'expected the listener case named as a warning; got {warnings!r}'
     )
-    assert not any('did not signal' in m for m in messages), (
-        f'callback did fire, so the not-signalled line must stay quiet; got {messages!r}'
+    assert not any('did not signal' in m for m in debugs), (
+        f'callback did fire, so the not-signalled line must stay quiet; got {debugs!r}'
     )
 
 
@@ -434,6 +476,7 @@ def test_setup_is_quiet_when_the_listener_comes_up(monkeypatch):
 
     messages = []
     monkeypatch.setattr(node, 'debug', lambda msg, *a, **kw: messages.append(str(msg)))
+    monkeypatch.setattr(node, 'warning', lambda msg, *a, **kw: messages.append(str(msg)))
 
     node._setup_shared_web_server()
 

--- a/packages/ai/tests/ai/test_node.py
+++ b/packages/ai/tests/ai/test_node.py
@@ -64,6 +64,20 @@ def _fire_startup_callback_async(on_startup) -> None:
     threading.Thread(target=fire, daemon=True).start()
 
 
+def _fire_startup_callback_now(on_startup) -> None:
+    """Invoke an ``on_startup`` async callback and return once it has run.
+
+    Unlike :pyfunc:`_fire_startup_callback_async`, the event is set before this
+    returns. Tests that need ``signalled`` to be true use this so they cannot
+    race the wait's own timeout on a loaded machine.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(on_startup())
+    finally:
+        loop.close()
+
+
 # ---------------------------------------------------------------------------
 # _setup_shared_web_server — argv parsing and gating
 # ---------------------------------------------------------------------------
@@ -319,6 +333,73 @@ def test_setup_reraises_when_serve_future_already_failed(monkeypatch):
 
     with pytest.raises(RuntimeError, match='bind failed'):
         node._setup_shared_web_server()
+
+
+def test_setup_reports_when_the_listener_never_comes_up(monkeypatch):
+    """Startup signalled but no socket bound is its own diagnosis.
+
+    uvicorn fires the lifespan hook before it binds, so the callback firing
+    proves nothing about the port. Reaching the deadline with `serve()` still
+    running and `Server.started` still false means the listener never appeared —
+    a different fault from "the callback never fired", and the one a reserved or
+    occupied port produces. It must name the endpoint and must not claim the
+    callback failed.
+    """
+    monkeypatch.setattr(sys, 'argv', ['node.py', '--data_host=127.0.0.1', '--data_port=12345'])
+    monkeypatch.setattr(node, '_SHARED_SERVER_STARTUP_TIMEOUT_SECONDS', 0.05)
+
+    # A bare MagicMock reports done() truthy and started truthy, which would
+    # leave the poll at the future branch and never reach the deadline.
+    server_instance = MagicMock(name='WebServer-instance')
+    server_instance.server.started = False
+    future = MagicMock(name='future')
+    future.done.return_value = False
+
+    def fake_web_server(config=None, on_startup=None, **kwargs):
+        _fire_startup_callback_now(on_startup)
+        return server_instance
+
+    monkeypatch.setattr('ai.web.WebServer', fake_web_server)
+    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: future)
+
+    messages = []
+    monkeypatch.setattr(node, 'debug', lambda msg, *a, **kw: messages.append(str(msg)))
+
+    server, returned_future = node._setup_shared_web_server()
+
+    assert server is not None
+    assert returned_future is not None
+    assert any('never began listening on 127.0.0.1:12345' in m for m in messages), (
+        f'expected the listener case to be named; got {messages!r}'
+    )
+    assert not any('did not signal' in m for m in messages), (
+        f'callback did fire, so the not-signalled line must stay quiet; got {messages!r}'
+    )
+
+
+def test_setup_is_quiet_when_the_listener_comes_up(monkeypatch):
+    """A healthy startup logs nothing — the control for the test above."""
+    monkeypatch.setattr(sys, 'argv', ['node.py', '--data_host=127.0.0.1', '--data_port=12345'])
+    monkeypatch.setattr(node, '_SHARED_SERVER_STARTUP_TIMEOUT_SECONDS', 0.5)
+
+    server_instance = MagicMock(name='WebServer-instance')
+    server_instance.server.started = True
+    future = MagicMock(name='future')
+    future.done.return_value = False
+
+    def fake_web_server(config=None, on_startup=None, **kwargs):
+        _fire_startup_callback_now(on_startup)
+        return server_instance
+
+    monkeypatch.setattr('ai.web.WebServer', fake_web_server)
+    monkeypatch.setattr('asyncio.run_coroutine_threadsafe', lambda coro, loop: future)
+
+    messages = []
+    monkeypatch.setattr(node, 'debug', lambda msg, *a, **kw: messages.append(str(msg)))
+
+    node._setup_shared_web_server()
+
+    assert messages == [], f'a healthy startup should be silent; got {messages!r}'
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `TaskServer.assign_port` now probes each candidate with a real `bind` and skips ports the OS forbids or another process holds, instead of handing out the first number it had not issued yet.
- Bind failures in the subprocess are no longer silent: the data channel waits for uvicorn's bound listener rather than its lifespan hook (which fires *before* the socket exists), and a failed `debugpy.listen` is reported with host and port instead of disappearing into the stdlib logger.
- Exhausting a port window now names which of four causes dominates, and only points at other processes when they are actually to blame.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

Regression floor was taken on an unmodified tree first: `✖ Builder failed`, jest `27 failed, 8 skipped, 182 passed, 217 total`, every other lane green. After the change: `✔ Builder complete!`, jest `8 skipped, 209 passed, 217 total` — the same 217 total, so exactly the 27 recovered and nothing previously green turned red. `packages/ai` went 1885 → 1900 passed, which is the 15 tests added here.

New coverage: an unbindable port is skipped; an occupied port is re-probed next time while a forbidden one is cached; a released-but-still-held port is not handed straight back; each exhaustion message names the right cause; `base_port=0` never yields port 0; a failed probe can never read as free.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

No public contract changed: `assign_port` still returns an `int`, `--base_port` behaves as documented, and no `.md` in the repo mentions the flag, so no co-located doc update is due.

## Linked Issue

Fixes #1888

Related: #1879 — the base-port windows of client-python and client-mcp still overlap after this change; the probe makes that collision survivable rather than removing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port selection by detecting ports already in use or reserved by the operating system.
  * Added clearer diagnostics when no usable ports are available.
  * Improved web server startup coordination, error propagation, and timeout handling.
  * Added more informative debugging output when debugger initialization fails.

* **Tests**
  * Expanded coverage for port availability, boundary conditions, exhaustion scenarios, and server startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->