### PR TITLE
refactor(shared): promote JsonTree to a first-class peer component

### DIFF
--- a/apps/shared/src/components/json-tree/JsonTree.tsx
+++ b/apps/shared/src/components/json-tree/JsonTree.tsx
@@ -5,8 +5,10 @@
  * A general-purpose, --rr-*-themed JSON tree used wherever the product shows a
  * raw JSON payload (trace detail, event bodies, tool I/O). A peer component, not
  * owned by any one feature. All styling is inline CSSProperties on --rr-* tokens
- * (no external CSS); leaf strings and child counts are capped so a large or
- * base64 payload can never dump megabytes / thousands of nodes into the DOM.
+ * (no external CSS). DOM size is bounded per node, not globally: leaf strings
+ * are capped at 200 chars and each node renders at most MAX_CHILDREN child
+ * rows, while collapsed subtrees render nothing — so DOM growth is driven by
+ * explicit user expansion, not by payload size; there is no recursion-depth cap.
  */
 import React, { useState, CSSProperties } from 'react';
 import { commonStyles } from 'shell';

--- a/apps/shared/src/components/json-tree/JsonTree.tsx
+++ b/apps/shared/src/components/json-tree/JsonTree.tsx
@@ -1,10 +1,12 @@
 /**
- * @file JsonTree — recursive JSON viewer for the Trace detail panel
+ * @file JsonTree — the platform's shared recursive JSON viewer.
  * @license MIT
  *
- * Ported from apps/vscode TraceSection/JsonTree.tsx.
- * All styles are inline CSSProperties objects; no external CSS files.
- * Colour tokens use the --rr-* namespace.
+ * A general-purpose, --rr-*-themed JSON tree used wherever the product shows a
+ * raw JSON payload (trace detail, event bodies, tool I/O). A peer component, not
+ * owned by any one feature. All styling is inline CSSProperties on --rr-* tokens
+ * (no external CSS); leaf strings and child counts are capped so a large or
+ * base64 payload can never dump megabytes / thousands of nodes into the DOM.
  */
 import React, { useState, CSSProperties } from 'react';
 import { commonStyles } from 'shell';
@@ -13,9 +15,10 @@ import { commonStyles } from 'shell';
 // TYPES
 // =============================================================================
 
-interface JsonTreeProps {
+export interface IJsonTreeProps {
+	/** The value to render — any JSON-serialisable data (object, array, or scalar). */
 	data: unknown;
-	/** Auto-expand to this depth (default 1) */
+	/** Auto-expand to this depth (default 1). */
 	defaultExpanded?: number;
 }
 
@@ -205,9 +208,8 @@ const JsonNode: React.FC<JsonNodeProps> = ({ label, value, depth, defaultExpandD
 		display = String(value);
 	} else if (typeof value === 'string') {
 		valStyle = styles.valStr;
-		// Cap leaf strings: an un-recognised media entry (base64 payload) must never
-		// dump megabytes into one DOM node and freeze the webview. Matches the events-ui
-		// JsonTree, which already truncates at 200 chars.
+		// Cap leaf strings at 200 chars: a large or base64 payload must never dump
+		// megabytes into one DOM node and freeze the panel.
 		display = JSON.stringify(value.length > 200 ? value.slice(0, 200) + '…' : value);
 	} else {
 		display = String(value);
@@ -227,7 +229,7 @@ const JsonNode: React.FC<JsonNodeProps> = ({ label, value, depth, defaultExpandD
 // MAIN COMPONENT
 // =============================================================================
 
-export const JsonTree: React.FC<JsonTreeProps> = ({ data, defaultExpanded = 1 }) => {
+export const JsonTree: React.FC<IJsonTreeProps> = ({ data, defaultExpanded = 1 }) => {
 	if (data === undefined || data === null) {
 		return <div style={styles.empty}>No data</div>;
 	}

--- a/apps/shared/src/components/json-tree/index.ts
+++ b/apps/shared/src/components/json-tree/index.ts
@@ -1,0 +1,2 @@
+export { JsonTree } from './JsonTree';
+export type { IJsonTreeProps } from './JsonTree';

--- a/apps/shared/src/components/trace/TraceDetail.tsx
+++ b/apps/shared/src/components/trace/TraceDetail.tsx
@@ -11,7 +11,7 @@
  * DetailPanel today, the Analyze page tomorrow).
  */
 import React, { useState, useMemo, useCallback, useEffect, CSSProperties } from 'react';
-import { JsonTree } from './JsonTree';
+import { JsonTree } from '../json-tree';
 import { renderTraceInput, renderTraceOutput, summaryTraceInput, renderTraceData } from './renderers';
 import { traceDataEqual } from './renderers/utils';
 import { renderFinalSections, resultFieldCount } from './renderers/render_final';

--- a/apps/shared/src/components/trace/index.tsx
+++ b/apps/shared/src/components/trace/index.tsx
@@ -1,4 +1,3 @@
 export { default as Trace } from './Trace';
 export { TraceDetail } from './TraceDetail';
 export type { ITraceDetailProps, ITraceFetchResult } from './TraceDetail';
-export { JsonTree } from './JsonTree';

--- a/apps/shared/src/components/trace/renderers/format_answer.tsx
+++ b/apps/shared/src/components/trace/renderers/format_answer.tsx
@@ -4,7 +4,7 @@
 
 import { ReactElement } from 'react';
 import { RS } from './styles';
-import { JsonTree } from '../JsonTree';
+import { JsonTree } from '../../json-tree';
 
 export interface AnswerFields {
 	answer?: string | Record<string, unknown> | unknown[];

--- a/apps/shared/src/components/trace/renderers/media_renderers.test.tsx
+++ b/apps/shared/src/components/trace/renderers/media_renderers.test.tsx
@@ -18,7 +18,7 @@ import { LANE_RENDERERS } from './render_final';
 import { isAudio } from './render_audio';
 import { isVideo } from './render_video';
 import { isImage } from './render_image';
-import { JsonTree } from '../JsonTree';
+import { JsonTree } from '../../json-tree';
 
 type Lane = 'image' | 'audio' | 'video';
 const LANES: Lane[] = ['image', 'audio', 'video'];

--- a/apps/shared/src/components/trace/renderers/render_final.tsx
+++ b/apps/shared/src/components/trace/renderers/render_final.tsx
@@ -11,7 +11,7 @@ import { renderText, isText } from './render_text';
 import { renderAudio, isAudio } from './render_audio';
 import { renderVideo, isVideo } from './render_video';
 import { renderTable, isTable } from './render_table';
-import { JsonTree } from '../JsonTree';
+import { JsonTree } from '../../json-tree';
 
 // =============================================================================
 // STYLES

--- a/apps/shared/src/components/trace/renderers/render_tool.tsx
+++ b/apps/shared/src/components/trace/renderers/render_tool.tsx
@@ -14,7 +14,7 @@
 
 import { ReactElement } from 'react';
 import { RS } from './styles';
-import { JsonTree } from '../JsonTree';
+import { JsonTree } from '../../json-tree';
 
 // =============================================================================
 // TYPES


### PR DESCRIPTION
## What
Promotes the shared JSON viewer out of `components/trace/` into its own first-class peer at `components/json-tree/`, so consumers no longer reach into the tracer for a general-purpose viewer.

## Changes
- `git mv` `components/trace/JsonTree.tsx` → `components/json-tree/JsonTree.tsx` (history preserved)
- Add `components/json-tree/index.ts` barrel; export `IJsonTreeProps`
- Repoint trace's internal consumers (`TraceDetail` + 4 renderers) to `../json-tree`
- Drop the `JsonTree` re-export from the trace barrel (no external consumer used it)

## Why
The JSON viewer is general-purpose (event bodies, tool I/O, trace payloads) — `trace/` shouldn't own it. **This is the base for further shared-set UI refactor work; subsequent UI PRs stack on this branch.**

## Verification
- `builder shared:test` → 77/77 pass, incl. the `JsonTree` 5 MB-cap test through the new path.
- No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved the shared JSON viewer’s organization and availability across trace details and rendered results.
  - Standardized access to the viewer for more consistent behavior throughout the application.
  - Clarified handling of large payloads and string content, helping keep JSON data displays readable and responsive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->