### PR TITLE
feat(pipedrive): in-panel help for every config input (RR-1904)

### DIFF
--- a/apps/shared/src/components/canvas/components/rjsf-widgets/field-label-with-info/FieldLabelWithInfo.test.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/field-label-with-info/FieldLabelWithInfo.test.tsx
@@ -47,6 +47,17 @@ test('opted-in inputs render one focusable info trigger outside the hidden notch
 	assert.doesNotMatch(fieldset, /role="button"/);
 });
 
+// Descriptions now go through sanitizeAndParseHtmlToReact so a service that
+// writes <b> gets bold text rather than literal tags. Only the plain-text path
+// is asserted here: the markup path calls DOMPurify, which needs a DOM this
+// runner does not provide. Rendered markup is checked by hand in the panel.
+test('a description without markup reaches the tooltip untouched', () => {
+	const label = FieldLabelWithInfo({ label: 'Read-only mode', description: 'Prevents write operations.', fieldTitle: 'Read-only mode' }) as ReactElement<Record<string, unknown>>;
+	const tooltip = Children.toArray(label.props.children)[1] as ReactElement<Record<string, unknown>>;
+
+	assert.equal(tooltip.props.title, 'Prevents write operations.');
+});
+
 test('info trigger blocks Enter and Space from activating a parent label', () => {
 	const label = FieldLabelWithInfo({ label: 'Read-only mode', description: 'Prevents write operations.', fieldTitle: 'Read-only mode' }) as ReactElement<Record<string, unknown>>;
 	const tooltip = Children.toArray(label.props.children)[1] as ReactElement<Record<string, unknown>>;

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/field-label-with-info/FieldLabelWithInfo.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/field-label-with-info/FieldLabelWithInfo.tsx
@@ -26,6 +26,8 @@ import Box from '@mui/material/Box';
 import InfoIcon from '@mui/icons-material/Info';
 import Tooltip from '@mui/material/Tooltip';
 
+import { sanitizeAndParseHtmlToReact } from '../../../util/helpers';
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -66,6 +68,11 @@ export default function FieldLabelWithInfo({ label, description, fieldTitle, id 
 
 	const accessibleName = fieldTitle ? `More information about ${fieldTitle}` : 'More information';
 
+	// Service descriptions may carry simple markup. Tooltip renders a string
+	// verbatim, so parse it the way DescriptionField does rather than showing the
+	// user a literal <b>.
+	const richDescription = typeof description === 'string' ? sanitizeAndParseHtmlToReact(description) : description;
+
 	// Keep the icon pointer-interactive even when nested inside a MUI InputLabel or
 	// FormControlLabel: activating the icon must not toggle a checkbox or steal focus.
 	// Suppressing mouse and keyboard activation cancels the label's default behavior
@@ -79,7 +86,7 @@ export default function FieldLabelWithInfo({ label, description, fieldTitle, id 
 	return (
 		<Box component="span" id={id} sx={{ display: 'inline-flex', alignItems: 'center' }}>
 			{label}
-			<Tooltip title={description} placement="right" describeChild>
+			<Tooltip title={richDescription} placement="right" describeChild>
 				<span role="button" tabIndex={0} aria-label={accessibleName} onMouseDown={suppressLabelActivation} onClick={suppressLabelActivation} onKeyDown={suppressLabelActivation} style={{ display: 'inline-flex', alignItems: 'center', cursor: 'default', pointerEvents: 'auto' }}>
 					<InfoIcon sx={{ ml: 0.5, color: 'text.secondary', fontSize: 16 }} />
 				</span>

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.test.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.test.tsx
@@ -1,0 +1,73 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import React, { Children, type ReactElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import OptionInfoIcon from './OptionInfoIcon';
+
+const DESCRIPTION = 'Deals and everything hanging off them.';
+const DESCRIPTION_ID = 'root_toolGroups__option_0__description';
+
+const renderIcon = () => renderToStaticMarkup(<OptionInfoIcon description={DESCRIPTION} descriptionId={DESCRIPTION_ID} />);
+
+test('option help renders an icon that assistive technology ignores', () => {
+	const markup = renderIcon();
+
+	assert.match(markup, /<svg[^>]*aria-hidden="true"/);
+	assert.doesNotMatch(markup, /role="button"/);
+});
+
+test('option help stays out of the tab order so menu arrow keys keep working', () => {
+	// A focusable descendant makes MenuList resolve the next option from the
+	// focused element rather than the option row, which kills arrow navigation.
+	assert.doesNotMatch(renderIcon(), /tabindex="0"/);
+});
+
+test('option help mirrors its text into the node the option describes itself with', () => {
+	const markup = renderIcon();
+
+	assert.match(markup, new RegExp(`id="${DESCRIPTION_ID}"`));
+	assert.match(markup, new RegExp(DESCRIPTION));
+});
+
+test('reading option help does not toggle the option it sits on', () => {
+	const icon = OptionInfoIcon({ description: DESCRIPTION, descriptionId: DESCRIPTION_ID }) as ReactElement<Record<string, unknown>>;
+	const tooltip = Children.toArray(icon.props.children)[0] as ReactElement<Record<string, unknown>>;
+	const trigger = tooltip.props.children as ReactElement<Record<string, unknown>>;
+
+	for (const handlerName of ['onMouseDown', 'onClick']) {
+		let defaultPrevented = false;
+		let propagationStopped = false;
+
+		(trigger.props[handlerName] as (event: Record<string, unknown>) => void)({
+			preventDefault: () => (defaultPrevented = true),
+			stopPropagation: () => (propagationStopped = true),
+		});
+
+		assert.equal(defaultPrevented, true, `${handlerName} did not prevent the default`);
+		assert.equal(propagationStopped, true, `${handlerName} reached the MenuItem`);
+	}
+});

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.test.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.test.tsx
@@ -53,6 +53,23 @@ test('option help mirrors its text into the node the option describes itself wit
 	assert.match(markup, new RegExp(DESCRIPTION));
 });
 
+test('the hidden node carries what the tooltip carries, not the raw source text', () => {
+	// The hidden node is the ONLY copy assistive technology reads — the tooltip
+	// is pointer-only and aria-hidden. Rendered as raw text, a description
+	// carrying `<code>` or `<br>` was announced with its tag names spoken: the
+	// markup a sighted user never sees, read aloud to the one user who cannot
+	// see the tooltip it was written for.
+	//
+	// Asserted as ONE value feeding both renderings rather than by rendering
+	// markup: `sanitizeAndParseHtmlToReact` sanitizes with dompurify, which
+	// needs a real DOM, and this suite runs in plain node with none.
+	const icon = OptionInfoIcon({ description: DESCRIPTION, descriptionId: DESCRIPTION_ID }) as ReactElement<Record<string, unknown>>;
+	const [tooltip, hidden] = Children.toArray(icon.props.children) as ReactElement<Record<string, unknown>>[];
+
+	assert.equal(hidden.props.id, DESCRIPTION_ID);
+	assert.strictEqual(hidden.props.children, tooltip.props.title);
+});
+
 test('reading option help does not toggle the option it sits on', () => {
 	const icon = OptionInfoIcon({ description: DESCRIPTION, descriptionId: DESCRIPTION_ID }) as ReactElement<Record<string, unknown>>;
 	const tooltip = Children.toArray(icon.props.children)[0] as ReactElement<Record<string, unknown>>;

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.tsx
@@ -1,0 +1,92 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+import { SyntheticEvent } from 'react';
+import Box from '@mui/material/Box';
+import InfoIcon from '@mui/icons-material/Info';
+import Tooltip from '@mui/material/Tooltip';
+
+import { sanitizeAndParseHtmlToReact } from '../../../util/helpers';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type OptionInfoIconProps = {
+	/** Help text for this option; may contain simple HTML, which is sanitized. */
+	description: string;
+	/** Id of the hidden text node the option's `aria-describedby` points at. */
+	descriptionId: string;
+};
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * Per-option help affordance for a select dropdown: a hover tooltip plus the
+ * hidden text node that carries the same content to assistive technology.
+ *
+ * Deliberately not `FieldLabelWithInfo`. That component's trigger is tabbable,
+ * which is correct beside a field label but wrong inside a `MenuItem`: MUI's
+ * `Menu` closes on Tab so the trigger is unreachable anyway, and a focusable
+ * descendant makes `MenuList` resolve the next option from the focused span
+ * rather than the option row, which silently kills arrow-key navigation. The
+ * icon is therefore pointer-only and hidden from the accessibility tree, and
+ * the description reaches screen readers through the option's
+ * `aria-describedby` instead.
+ *
+ * Populate it from `ui:enumDescriptions`, a parallel array index-aligned with
+ * `ui:enumNames` that the engine builds from an option's optional third tuple
+ * element in `services.json` (`[value, label, description]`).
+ *
+ * @param description - Help text for the option the icon sits on.
+ * @param descriptionId - Id the owning option references via `aria-describedby`.
+ * @return The icon and its visually hidden description node.
+ * @example
+ * <OptionInfoIcon description="Deals and their products." descriptionId="root_toolGroups__option_0__description" />
+ */
+export default function OptionInfoIcon({ description, descriptionId }: OptionInfoIconProps) {
+	// A MenuItem commits its selection on click, so let neither the pointer press
+	// nor the click reach it - reading the help must not toggle the option.
+	const suppressOptionActivation = (event: SyntheticEvent) => {
+		event.preventDefault();
+		event.stopPropagation();
+	};
+
+	return (
+		<Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', ml: 'auto', pl: 1 }}>
+			<Tooltip title={sanitizeAndParseHtmlToReact(description)} placement="right">
+				<Box component="span" onMouseDown={suppressOptionActivation} onClick={suppressOptionActivation} sx={{ display: 'inline-flex', alignItems: 'center', cursor: 'default' }}>
+					<InfoIcon aria-hidden="true" sx={{ color: 'text.secondary', fontSize: 16 }} />
+				</Box>
+			</Tooltip>
+			{/* The tooltip is pointer-only, so the same text is mirrored here for the
+			    option's aria-describedby. Clipped rather than display:none, which
+			    would take it out of the accessibility tree along with the pixels. */}
+			<Box component="span" id={descriptionId} sx={{ position: 'absolute', width: 1, height: 1, p: 0, m: -1, overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0 }}>
+				{description}
+			</Box>
+		</Box>
+	);
+}

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/option-info-icon/OptionInfoIcon.tsx
@@ -74,9 +74,16 @@ export default function OptionInfoIcon({ description, descriptionId }: OptionInf
 		event.stopPropagation();
 	};
 
+	// Parsed ONCE, and used for both renderings. The hidden node is the only
+	// copy a screen reader ever reads, so leaving it as raw text meant a
+	// description carrying `<code>` or `<br>` was announced with its tag names
+	// spoken aloud — the markup a sighted user never sees, read out to the one
+	// user who cannot see the tooltip it was written for.
+	const richDescription = sanitizeAndParseHtmlToReact(description);
+
 	return (
 		<Box component="span" sx={{ display: 'inline-flex', alignItems: 'center', ml: 'auto', pl: 1 }}>
-			<Tooltip title={sanitizeAndParseHtmlToReact(description)} placement="right">
+			<Tooltip title={richDescription} placement="right">
 				<Box component="span" onMouseDown={suppressOptionActivation} onClick={suppressOptionActivation} sx={{ display: 'inline-flex', alignItems: 'center', cursor: 'default' }}>
 					<InfoIcon aria-hidden="true" sx={{ color: 'text.secondary', fontSize: 16 }} />
 				</Box>
@@ -85,7 +92,7 @@ export default function OptionInfoIcon({ description, descriptionId }: OptionInf
 			    option's aria-describedby. Clipped rather than display:none, which
 			    would take it out of the accessibility tree along with the pixels. */}
 			<Box component="span" id={descriptionId} sx={{ position: 'absolute', width: 1, height: 1, p: 0, m: -1, overflow: 'hidden', clip: 'rect(0 0 0 0)', whiteSpace: 'nowrap', border: 0 }}>
-				{description}
+				{richDescription}
 			</Box>
 		</Box>
 	);

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/select-widget/SelectWidget.test.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/select-widget/SelectWidget.test.tsx
@@ -1,0 +1,124 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+// A closed MUI Select renders its Menu through a Modal that returns null, and
+// react-dom/server cannot render a portal, so the option markup never reaches
+// renderToStaticMarkup. These tests call the widget as a plain function and
+// inspect the element tree instead.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { Children, type ReactElement } from 'react';
+
+import SelectWidget from './SelectWidget';
+
+type ElementWithProps = ReactElement<Record<string, unknown>>;
+
+const SelectForTest = SelectWidget as unknown as (props: Record<string, unknown>) => ElementWithProps;
+
+const ENUM_OPTIONS = [
+	{ value: 'deals', label: 'Deals (27)' },
+	{ value: 'persons', label: 'Persons (18)' },
+	{ value: 'notes', label: 'Notes (11)' },
+];
+
+// The middle option deliberately has no help text: the icon must be driven by
+// the presence of a description, not by the field carrying any at all.
+const ENUM_DESCRIPTIONS = ['Deals and their products.', '', 'Notes and their comments.'];
+
+const renderWidget = (overrides: Record<string, unknown> = {}) =>
+	SelectForTest({
+		schema: { type: 'array', description: 'Which groups this node publishes.' },
+		id: 'root_toolGroups',
+		name: 'toolGroups',
+		label: 'Tool groups',
+		hideLabel: false,
+		required: false,
+		disabled: false,
+		readonly: false,
+		hideError: false,
+		autofocus: false,
+		multiple: true,
+		value: ['deals', 'notes'],
+		options: { enumOptions: ENUM_OPTIONS, enumDescriptions: ENUM_DESCRIPTIONS },
+		onChange: () => undefined,
+		onBlur: () => undefined,
+		onFocus: () => undefined,
+		rawErrors: [],
+		errorSchema: {},
+		uiSchema: {},
+		registry: {},
+		formContext: {},
+		...overrides,
+	});
+
+const menuItemsOf = (widget: ElementWithProps) => Children.toArray(widget.props.children) as ElementWithProps[];
+
+const renderValueOf = (widget: ElementWithProps) => (widget.props.SelectProps as { renderValue: (selected: unknown) => string }).renderValue;
+
+test('the collapsed multi-select shows plain labels rather than the options themselves', () => {
+	// Without an explicit renderValue MUI composes the closed display out of each
+	// selected MenuItem's children, which would stamp an info icon into the field.
+	assert.equal(renderValueOf(renderWidget())(['0', '2']), 'Deals (27), Notes (11)');
+});
+
+test('an unset select displays nothing rather than the first option', () => {
+	const renderValue = renderValueOf(renderWidget({ multiple: false, value: undefined }));
+
+	assert.equal(renderValue(''), '');
+	assert.equal(renderValue([]), '');
+});
+
+test('the overflow title covers every selection, not just the first', () => {
+	const slotProps = renderWidget().props.slotProps as { input: { title?: string } };
+
+	assert.equal(slotProps.input.title, 'Deals (27), Notes (11)');
+});
+
+test('options carry their help text through aria-describedby', () => {
+	const [deals, persons, notes] = menuItemsOf(renderWidget());
+
+	assert.equal(deals.props['aria-describedby'], 'root_toolGroups__option_0__description');
+	assert.equal(notes.props['aria-describedby'], 'root_toolGroups__option_2__description');
+	assert.equal(persons.props['aria-describedby'], undefined);
+});
+
+test('an option names itself after its label so the hidden help cannot leak into it', () => {
+	assert.equal(menuItemsOf(renderWidget())[0].props['aria-label'], 'Deals (27)');
+});
+
+test('only options that were given help text render an icon', () => {
+	const [deals, persons] = menuItemsOf(renderWidget());
+
+	assert.equal(Children.toArray(deals.props.children).length, 2);
+	assert.equal(Children.toArray(persons.props.children).length, 1);
+});
+
+test('a field with no option help renders exactly as it did before', () => {
+	const widget = renderWidget({ options: { enumOptions: ENUM_OPTIONS } });
+
+	for (const option of menuItemsOf(widget)) {
+		assert.equal(option.props['aria-describedby'], undefined);
+		assert.equal(Children.toArray(option.props.children).length, 1);
+	}
+});

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/select-widget/SelectWidget.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/select-widget/SelectWidget.tsx
@@ -27,6 +27,7 @@ import TextField, { TextFieldProps } from '@mui/material/TextField';
 import { ariaDescribedByIds, enumOptionsIndexForValue, enumOptionsValueForIndex, labelValue, FormContextType, RJSFSchema, StrictRJSFSchema, WidgetProps } from '@rjsf/utils';
 
 import FieldLabelWithInfo from '../field-label-with-info/FieldLabelWithInfo';
+import OptionInfoIcon from '../option-info-icon/OptionInfoIcon';
 
 // =============================================================================
 // Component
@@ -102,8 +103,25 @@ export default function SelectWidget<
 	const selectedIndexes = enumOptionsIndexForValue<S>(value, enumOptions, multiple);
 	const { InputLabelProps, SelectProps, autocomplete, ...textFieldRemainingProps } = textFieldProps;
 
+	// Per-option help text, index-aligned with enumOptions. The engine emits it as
+	// `ui:enumDescriptions` when a service gives an enum option a third tuple element.
+	const rawEnumDescriptions = (options as { enumDescriptions?: unknown }).enumDescriptions;
+	const enumDescriptions = Array.isArray(rawEnumDescriptions) ? rawEnumDescriptions : undefined;
+
+	// Join the selected options' plain labels. MUI otherwise composes the collapsed
+	// display out of each selected MenuItem's own children, which would stamp an
+	// info icon into the closed field once per selection.
+	const renderSelectedLabels = (selected: unknown): string =>
+		(Array.isArray(selected) ? selected : [selected])
+			// An unset single-select is '', and Number('') is 0 - without this the
+			// empty field would display the first option.
+			.filter((index) => index !== '' && index !== null && typeof index !== 'undefined')
+			.map((index) => enumOptions?.[Number(index)]?.label)
+			.filter((optionLabel): optionLabel is string => typeof optionLabel === 'string')
+			.join(', ');
+
 	// Resolve the label of the selected option to use as a tooltip on the input (for overflow cases)
-	const selectedOptionLabel = !isEmpty && Array.isArray(enumOptions) && typeof selectedIndexes !== 'undefined' ? enumOptions[Number(selectedIndexes)]?.label : undefined;
+	const selectedOptionLabel = isEmpty ? undefined : renderSelectedLabels(selectedIndexes) || undefined;
 
 	return (
 		<TextField
@@ -155,15 +173,23 @@ export default function SelectWidget<
 			SelectProps={{
 				...SelectProps,
 				multiple,
+				renderValue: SelectProps?.renderValue ?? renderSelectedLabels,
 			}}
 			aria-describedby={ariaDescribedByIds<T>(id)}
 		>
 			{Array.isArray(enumOptions) &&
 				enumOptions.map(({ value, label }, i: number) => {
-					const disabled: boolean = Array.isArray(enumDisabled) && enumDisabled.indexOf(value) !== -1;
+					const optionDisabled: boolean = Array.isArray(enumDisabled) && enumDisabled.indexOf(value) !== -1;
+					const rawDescription = enumDescriptions?.[i];
+					const optionDescription = typeof rawDescription === 'string' && rawDescription.trim() ? rawDescription : undefined;
+					const descriptionId = optionDescription ? `${id}__option_${i}__description` : undefined;
 					return (
-						<MenuItem key={i} value={String(i)} disabled={disabled}>
-							{label}
+						// aria-label pins the accessible name to the label so the hidden description
+						// node inside the option cannot leak into it; the help text is announced
+						// through aria-describedby instead.
+						<MenuItem key={i} value={String(i)} disabled={optionDisabled} aria-label={typeof label === 'string' ? label : undefined} aria-describedby={descriptionId}>
+							<span>{label}</span>
+							{optionDescription && descriptionId && <OptionInfoIcon description={optionDescription} descriptionId={descriptionId} />}
 						</MenuItem>
 					);
 				})}

--- a/nodes/src/nodes/tool_pipedrive/README.md
+++ b/nodes/src/nodes/tool_pipedrive/README.md
@@ -28,16 +28,16 @@ mutating tool.
 | Field | Type | Description |
 |---|---|---|
 | `apiToken` | string | Default empty. Pipedrive API token (Settings -> Personal preferences -> API), or an OAuth access token. Stored encrypted. |
-| `companyDomain` | string | Default empty. The "acme" in `https://acme.pipedrive.com`. When set, requests go to `https://{domain}.pipedrive.com/api/v1`; otherwise `https://api.pipedrive.com/api/v1`. |
+| `companyDomain` | string | Default empty. Just the subdomain — the "acme" in `https://acme.pipedrive.com`, not the whole URL. When set, requests go to `https://{domain}.pipedrive.com/api/v1`; otherwise `https://api.pipedrive.com/api/v1`. A token belongs to one company, so a domain from another account fails as a 401 or 404 rather than as an obvious configuration error. |
 | `readOnly` | boolean | Default false. When enabled, every create, update and delete tool is blocked and `request` only accepts GET. |
-| `toolGroups` | array | Default `["deals", "persons", "organizations", "activities", "pipelines", "stages", "notes", "search"]`. Which groups of tools to publish, shown as a multi-select dropdown with per-group tool counts. Select **All groups** for everything. |
+| `toolGroups` | array | Default `["deals", "persons", "organizations", "activities", "pipelines", "stages", "notes", "search"]`. Which groups of tools to publish, shown as a multi-select dropdown with per-group tool counts and a hover tooltip describing what each group covers. Select **All groups** for everything. |
 | `allowRawRequest` | boolean | Default true. Publishes the generic `request` tool. |
 
 ### Tool groups
 
 Full v1 coverage is 255 tools. That is more than an LLM can choose between reliably,
 and more than some providers accept in one request, so the node only publishes the
-groups listed in **Tool groups**. The default eight groups publish 108 tools — the
+groups listed in **Tool groups**. The default eight groups publish 106 tools — the
 everyday CRM surface. Add group names to reach further, or use `all`.
 
 Available groups, with the number of tools each publishes:
@@ -51,7 +51,9 @@ Available groups, with the number of tools each publishes:
 
 The config panel renders these as a multi-select dropdown. RJSF picks that widget for
 an array carrying `uniqueItems: true` and an `items.enum`; **All groups** is the last
-option.
+option. Each option carries a third element in that `items.enum` tuple, which the
+engine forwards as `ui:enumDescriptions` and the panel shows as a hover tooltip
+describing what the group covers.
 
 A tool in a group that is not published is invisible to the agent and refused if
 invoked anyway.

--- a/nodes/src/nodes/tool_pipedrive/services.json
+++ b/nodes/src/nodes/tool_pipedrive/services.json
@@ -39,7 +39,7 @@
 		"pipedrive.companyDomain": {
 			"type": "string",
 			"title": "Company Domain",
-			"description": "Your Pipedrive company domain, i.e. the \"acme\" in https://acme.pipedrive.com. When set, requests go to https://{domain}.pipedrive.com/api/v1; otherwise https://api.pipedrive.com/api/v1 is used.",
+			"description": "Just the subdomain: the <b>acme</b> in <code>https://acme.pipedrive.com</code>, not the whole URL. Requests then go to <code>https://acme.pipedrive.com/api/v1</code>. <br><br>Leave it blank to use the shared <code>https://api.pipedrive.com/api/v1</code> host. An API token belongs to one company, so a domain from a different account fails as a 401 or 404 on every tool rather than as an obvious configuration error.",
 			"default": "",
 			"optional": true
 		},
@@ -56,37 +56,37 @@
 		"pipedrive.toolGroups": {
 			"type": "array",
 			"title": "Tool groups",
-			"description": "Which groups of Pipedrive tools this node publishes to the agent. The full API is 255 tools, which is more than an LLM can choose between reliably, so only the selected groups are exposed. Pick one or more from the list; tool counts are shown per group, and selections totalling more than 120 log a warning but still run. Selecting <b>All groups</b> publishes everything and skips that warning.",
+			"description": "Which groups of Pipedrive tools this node publishes to the agent. A group is one resource area of the CRM; every tool belongs to exactly one, and a group you do not select is invisible to the agent. <br><br>The full v1 surface is 255 tools, which is well past the point where an LLM picks the right one reliably, and every published tool spends context on every turn. So pick the smallest set that covers the job rather than everything that might one day be useful. Each option shows its tool count; hover an option to see what it covers. <br><br>Selections totalling more than 120 tools log a warning and still run. <b>All groups</b> publishes everything and skips that warning.",
 			"uniqueItems": true,
 			"items": {
 				"type": "string",
 				"enum": [
-					["deals", "Deals (27)"],
-					["persons", "Persons (18)"],
-					["organizations", "Organizations (18)"],
-					["activities", "Activities (13)"],
-					["pipelines", "Pipelines (8)"],
-					["stages", "Stages (7)"],
-					["notes", "Notes (11)"],
-					["search", "Search (4)"],
-					["call_logs", "Call logs (5)"],
-					["fields", "Custom fields (6)"],
-					["files", "Files (8)"],
-					["filters", "Filters (7)"],
-					["goals", "Goals (5)"],
-					["leads", "Leads (12)"],
-					["mailbox", "Mailbox (6)"],
-					["misc", "Misc: currencies, channels, meetings (8)"],
-					["org_relationships", "Organization relationships (5)"],
-					["permission_sets", "Permission sets (3)"],
-					["products", "Products (16)"],
-					["projects", "Projects (22)"],
-					["roles", "Roles (13)"],
-					["subscriptions", "Subscriptions (9)"],
-					["teams", "Teams (8)"],
-					["users", "Users (12)"],
-					["webhooks", "Webhooks (3)"],
-					["all", "All groups (255) - skips the size warning"]
+					["deals", "Deals (27)", "Deal records and everything hanging off them: products, participants, followers, files and the change log. Includes <code>deal_list</code>, <code>deal_create</code>, <code>deal_search</code> and the <code>deal_summary</code> and <code>deal_timeline</code> roll-ups."],
+					["persons", "Persons (18)", "Contacts: create, update, merge and search people, plus the deals, activities and files attached to them. Includes <code>person_list</code>, <code>person_search</code> and <code>person_merge</code>."],
+					["organizations", "Organizations (18)", "Companies: create, update, merge and search organizations, plus their people, deals, activities and files. Includes <code>organization_list</code>, <code>organization_search</code> and <code>organization_persons_list</code>."],
+					["activities", "Activities (13)", "Calls, meetings and tasks, together with the account's custom activity types and fields. Includes <code>activity_list</code>, <code>activity_create</code> and <code>activity_mark_done</code>."],
+					["pipelines", "Pipelines (8)", "Pipelines and their reporting. Start here to discover the account's pipeline and stage layout. Includes <code>pipeline_list</code>, <code>pipeline_deals_list</code> and <code>pipeline_conversion_stats</code>."],
+					["stages", "Stages (7)", "The stages inside a pipeline and the deals sitting in each one. Includes <code>stage_list</code>, <code>stage_deals_list</code> and <code>stage_create</code>."],
+					["notes", "Notes (11)", "Notes attached to deals, people, organizations, leads or projects, and the comment threads on them. Includes <code>note_list</code>, <code>note_create</code> and <code>note_comment_create</code>."],
+					["search", "Search (4)", "Cross-record search for when you do not know which record type holds the answer, plus incremental sync. Includes <code>item_search</code>, <code>lookup</code>, <code>item_search_by_field</code> and <code>recents_list</code>."],
+					["call_logs", "Call logs (5)", "Phone call logs and their audio recordings. Includes <code>call_log_list</code>, <code>call_log_create</code> and <code>call_log_recording_add</code>."],
+					["fields", "Custom fields (6)", "Custom field definitions on deals, people, organizations and products. Read this to resolve the 40-character keys custom fields are written with. Includes <code>field_list</code>, <code>field_get</code> and <code>field_create</code>."],
+					["files", "Files (8)", "Files attached to records, including linked Google Drive documents. Includes <code>file_list</code>, <code>file_create</code>, <code>file_download</code> and <code>file_link_remote</code>."],
+					["filters", "Filters (7)", "Saved filters, so an agent can reuse a view the user already built in the Pipedrive UI. Includes <code>filter_list</code>, <code>filter_helpers_get</code> and <code>filter_create</code>."],
+					["goals", "Goals (5)", "Sales goals and how far along they are. Includes <code>goal_find</code>, <code>goal_results_get</code> and <code>goal_create</code>."],
+					["leads", "Leads (12)", "The Leads Inbox: leads, their labels and their sources. Includes <code>lead_list</code>, <code>lead_create</code>, <code>lead_search</code> and <code>lead_label_list</code>."],
+					["mailbox", "Mailbox (6)", "Mail threads and messages synced into Pipedrive, and linking a thread to a deal or lead. Includes <code>mail_thread_list</code>, <code>mail_thread_messages_list</code> and <code>mail_message_get</code>."],
+					["misc", "Misc: currencies, channels, meetings (8)", "Account-level odds and ends: currencies, messaging channels, video-meeting links and billing add-ons. Includes <code>currency_list</code>, <code>channel_create</code> and <code>meeting_link_create</code>."],
+					["org_relationships", "Organization relationships (5)", "Parent and child links between organizations. Includes <code>org_relationship_list</code>, <code>org_relationship_create</code> and <code>org_relationship_update</code>."],
+					["permission_sets", "Permission sets (3)", "Read-only view of the account's permission sets and who is assigned to them. Includes <code>permission_set_list</code> and <code>permission_set_assignments_list</code>."],
+					["products", "Products (16)", "The product catalogue, its variations and prices, and the deals each product is attached to. Includes <code>product_list</code>, <code>product_search</code> and <code>product_variation_list</code>."],
+					["projects", "Projects (22)", "Projects and the boards, phases, tasks and plans they are made of. Includes <code>project_list</code>, <code>project_create</code>, <code>project_task_list</code> and <code>project_phase_list</code>."],
+					["roles", "Roles (13)", "Role administration: create roles, assign users, and control which pipelines and records each role can see. Includes <code>role_list</code>, <code>role_assignment_add</code> and <code>role_pipelines_set</code>."],
+					["subscriptions", "Subscriptions (9)", "Recurring and installment revenue subscriptions attached to deals, and their payment schedules. Includes <code>subscription_find_by_deal</code>, <code>subscription_recurring_create</code> and <code>subscription_payments_list</code>."],
+					["teams", "Teams (8)", "Teams and their membership. Includes <code>team_list</code>, <code>team_user_add</code> and <code>team_list_for_user</code>."],
+					["users", "Users (12)", "User accounts, their permissions, settings and connected third-party accounts. Use it to resolve a name to the user_id that owner filters need. Includes <code>user_list</code>, <code>user_me</code> and <code>user_find</code>."],
+					["webhooks", "Webhooks (3)", "Webhook subscriptions registered by this API token. Includes <code>webhook_list</code>, <code>webhook_create</code> and <code>webhook_delete</code>."],
+					["all", "All groups (255) - skips the size warning", "Publishes every group, all 255 tools including the raw request escape hatch, and skips the 120-tool warning. Meant for scripted callers: an LLM-driven agent picks badly from a list this long."]
 				]
 			},
 			"default": ["deals", "persons", "organizations", "activities", "pipelines", "stages", "notes", "search"]
@@ -106,7 +106,12 @@
 		{
 			"section": "Pipe",
 			"title": "Pipedrive",
-			"properties": ["type", "pipedrive.apiToken", "pipedrive.companyDomain", "pipedrive.readOnly", "pipedrive.toolGroups", "pipedrive.allowRawRequest"]
+			"properties": ["type", "pipedrive.apiToken", "pipedrive.companyDomain", "pipedrive.readOnly", "pipedrive.toolGroups", "pipedrive.allowRawRequest"],
+			"ui": {
+				"ui:options": {
+					"compactDescriptions": true
+				}
+			}
 		}
 	]
 }

--- a/nodes/test/tool_pipedrive/test_pipedrive.py
+++ b/nodes/test/tool_pipedrive/test_pipedrive.py
@@ -991,6 +991,13 @@ class TestToolGroupsField:
     def test_default_selection_matches_the_code_default(self):
         assert set(self.field['default']) == DEFAULT_GROUPS
 
+    def test_readme_states_the_real_default_tool_count(self):
+        """The README quotes the default selection's size; regrouping a tool must not leave it stale."""
+        readme = (Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'tool_pipedrive' / 'README.md').read_text(
+            encoding='utf-8'
+        )
+        assert f'default eight groups publish {published_tool_count(DEFAULT_GROUPS)} tools' in readme
+
     def test_all_option_advertises_the_full_surface(self):
         labels = {option[0]: option[1] for option in self.field['items']['enum']}
         total = sum(tool_counts_by_group().values()) + 1  # + the request escape hatch

--- a/nodes/test/tool_pipedrive/test_pipedrive.py
+++ b/nodes/test/tool_pipedrive/test_pipedrive.py
@@ -10,6 +10,7 @@ env-gated live suite.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import traceback
 import types
@@ -914,6 +915,16 @@ _MANIFEST = json.loads(
 )
 
 
+def _tool_names_by_group() -> dict[str, set[str]]:
+    """Map each group to the tool names it publishes, read off the decorators."""
+    names: dict[str, set[str]] = {}
+    for attr_name in dir(IInstance):
+        group = getattr(getattr(IInstance, attr_name, None), '__pipedrive_group__', None)
+        if group:
+            names.setdefault(group, set()).add(attr_name)
+    return names
+
+
 class TestToolGroupsField:
     """The manifest drives the config panel; it must not drift from the code.
 
@@ -950,6 +961,32 @@ class TestToolGroupsField:
         labels = {option[0]: option[1] for option in self.field['items']['enum']}
         for group, count in tool_counts_by_group().items():
             assert f'({count})' in labels[group], f'{group} label is stale: {labels[group]}'
+
+    def test_every_option_carries_help_text(self):
+        """The third tuple element is the tooltip the config panel shows on that option."""
+        for option in self.field['items']['enum']:
+            assert len(option) == 3, f'{option[0]} has no description'
+            assert option[2].strip(), f'{option[0]} description is empty'
+            assert option[2].strip() != option[1].strip(), f'{option[0]} description just repeats its label'
+
+    def test_help_text_only_names_tools_that_exist(self):
+        """Descriptions cite representative tools; a rename must not leave the tooltip lying."""
+        by_group = _tool_names_by_group()
+        for value, _label, description in self.field['items']['enum']:
+            # The sentinel spans every group and also advertises the ungrouped
+            # request escape hatch, so it has no single group to check against.
+            if value == 'all':
+                continue
+            for cited in re.findall(r'<code>([a-z0-9_]+)</code>', description):
+                assert cited in by_group[value], f'{value} description cites {cited}, which is not in that group'
+
+    def test_help_text_cites_at_least_two_tools_per_group(self):
+        """A description that names nothing concrete does not tell an operator what the group covers."""
+        for value, _label, description in self.field['items']['enum']:
+            if value == 'all':
+                continue
+            cited = re.findall(r'<code>([a-z0-9_]+)</code>', description)
+            assert len(cited) >= 2, f'{value} description cites {len(cited)} tools'
 
     def test_default_selection_matches_the_code_default(self):
         assert set(self.field['default']) == DEFAULT_GROUPS

--- a/packages/server/engine-lib/engLib/store/services/services.cpp
+++ b/packages/server/engine-lib/engLib/store/services/services.cpp
@@ -786,14 +786,42 @@ ErrorOr<IServices::ServiceSchema> IServices::getField(
             // Determines if enum names are specified
             const auto hasEnumNames = fieldInfo.isMember("enumNames");
 
-            // Declare our enum values and names arrays
+            // Declare our enum values, names and descriptions arrays
             json::Value enumValues(json::arrayValue);
             json::Value enumNames(json::arrayValue);
+            json::Value enumDescriptions(json::arrayValue);
+
+            // Whether any option actually carries help text
+            bool hasEnumDescriptions = false;
 
             // Grab our input arrays
             const auto &inputValues = fieldInfo["enum"];
             const auto &inputNames =
                 hasEnumNames ? fieldInfo["enumNames"] : json::nullValue;
+
+            // An option with no help text still needs a slot, so the three
+            // arrays stay index aligned
+            const json::Value noDescription;
+
+            // Every option must land in all three arrays at the same index -
+            // the config panel looks a name and a description up by the
+            // option's position, so appending through here is what keeps them
+            // from drifting apart
+            const auto appendOption = [&](const json::Value &value,
+                                          const json::Value &name,
+                                          const json::Value &description) {
+                enumValues.append(value);
+                enumNames.append(name);
+
+                // Only a non-empty string counts as help text
+                if (description.isString() && !description.asString().empty()) {
+                    enumDescriptions.append(description);
+                    hasEnumDescriptions = true;
+                    return;
+                }
+
+                enumDescriptions.append("");
+            };
 
             // For each item
             for (json::Value::ArrayIndex index = 0; index < inputValues.size();
@@ -801,14 +829,14 @@ ErrorOr<IServices::ServiceSchema> IServices::getField(
                 // Get our item
                 const auto &item = inputValues.get(index, json::nullValue);
 
-                // If it is one or two strings, use the first as the value
-                // and the second (if specified) as the name
+                // If it is one, two or three strings, use the first as the
+                // value, the second (if specified) as the name, and the third
+                // (if specified) as the per-option help text the config panel
+                // shows on that option
                 if (item.isArray()) {
-                    enumValues.append(item[0]);
-                    if (item.size() > 1)
-                        enumNames.append(item[1]);
-                    else
-                        enumNames.append(item[0]);
+                    appendOption(item[0],
+                                 item.size() > 1 ? item[1] : item[0],
+                                 item.size() > 2 ? item[2] : noDescription);
                     continue;
                 }
 
@@ -817,14 +845,11 @@ ErrorOr<IServices::ServiceSchema> IServices::getField(
 
                 // If it is a normal item, just append it and continue
                 if (!itemText.startsWith("*>")) {
-                    // Append the value
-                    enumValues.append(itemText);
-
                     // If we have names, add it, otherwise, just use the value
-                    if (hasEnumNames)
-                        enumNames.append(inputNames.get(index, itemText));
-                    else
-                        enumNames.append(itemText);
+                    appendOption(itemText,
+                                 hasEnumNames ? inputNames.get(index, itemText)
+                                              : json::Value(itemText),
+                                 noDescription);
                     continue;
                 }
 
@@ -847,11 +872,10 @@ ErrorOr<IServices::ServiceSchema> IServices::getField(
 
                 // Now, enumerate them
                 for (auto &itemValue : obj.getMemberNames()) {
-                    enumValues.append(itemValue);
-                    if (hasTitle)
-                        enumNames.append(obj[itemValue][title]);
-                    else
-                        enumNames.append(itemValue);
+                    appendOption(itemValue,
+                                 hasTitle ? obj[itemValue][title]
+                                          : json::Value(itemValue),
+                                 noDescription);
                 }
             }
 
@@ -884,6 +908,11 @@ ErrorOr<IServices::ServiceSchema> IServices::getField(
 
             // Add the enum names
             info.ui["ui:enumNames"] = enumNames;
+
+            // Only emit the descriptions when a service actually authored some,
+            // so every other service's ui schema stays byte identical
+            if (hasEnumDescriptions)
+                info.ui["ui:enumDescriptions"] = enumDescriptions;
 
             // Remove it from the field info - it is obsolete here
             fieldInfo.removeMember("enumNames");
@@ -945,6 +974,17 @@ ErrorOr<IServices::ServiceSchema> IServices::getField(
             // Get the field info (or subfields, etc)
             auto subfield = getField(context, "items", items);
             if (!subfield) return subfield.ccode();
+
+            // react-jsonschema-form resolves a scalar array's option list
+            // against the *array's* ui schema, not the items' one, and
+            // traverseUI only walks children - an item parked in arrayItem
+            // never contributes any ui. Without this the option labels were
+            // dropped on the floor and the dropdown fell back to rendering the
+            // raw enum values. Lift the option metadata onto the array itself;
+            // anything the array declares for itself still wins.
+            for (const auto *key : {"ui:enumNames", "ui:enumDescriptions"})
+                if (subfield->ui.isMember(key) && !info.ui.isMember(key))
+                    info.ui[key] = subfield->ui[key];
 
             // Get the single field
             info.arrayItem.push_back(_mv(subfield));

--- a/packages/server/engine-lib/test/store/tests/services.cpp
+++ b/packages/server/engine-lib/test/store/tests/services.cpp
@@ -41,4 +41,26 @@ TEST_CASE("store::Services") {
         REQUIRE(schema.isMember("services"));
         REQUIRE(schema["services"].isObject());
     }
+
+    // react-jsonschema-form reads a scalar array's option labels off the array's
+    // own ui schema, so the metadata processField builds for the items subfield
+    // has to be lifted onto the array. Without that the config panel renders the
+    // raw enum values instead of the labels the service authored.
+    SECTION("scalar array enums keep their option metadata") {
+        // tool_pipedrive is the only service with a scalar array enum, so it is
+        // what this exercises; if it ever goes away, move the check rather than
+        // letting it pass on an absent service.
+        const auto &services = schema["services"];
+        REQUIRE(services.isMember("tool_pipedrive"));
+
+        const auto &ui = services["tool_pipedrive"]["Pipe"]["ui"]["toolGroups"];
+
+        REQUIRE(ui.isMember("ui:enumNames"));
+        REQUIRE(ui["ui:enumNames"][0].asString() == "Deals (27)");
+
+        // The optional third element of an enum tuple rides along the same path
+        REQUIRE(ui.isMember("ui:enumDescriptions"));
+        REQUIRE(ui["ui:enumDescriptions"].size() == ui["ui:enumNames"].size());
+        REQUIRE(!ui["ui:enumDescriptions"][0].asString().empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Adds an info icon to every Pipedrive config field and a hover tooltip to each **Tool groups** option describing what that group publishes, plus clearer copy for the tool-groups rationale and the company domain.
- Fixes the pre-existing engine bug this depends on: a scalar array's `[value, label]` enum pairs never reached react-jsonschema-form, so the Tool groups dropdown rendered raw ids (`deals`, `org_relationships`) instead of `Deals (27)`. `processField` put the labels on the items subfield, but `traverseUI` only walks `children` and the items node lives in `arrayItem`. Nothing in the requested UX was visible without this.
- Fixes a second pre-existing bug found on the way: `SelectWidget` resolved its overflow title with `enumOptions[Number(selectedIndexes)]`, and `Number()` of a multi-element array is `NaN` — so the input's title silently disappeared as soon as a second option was selected, i.e. in Pipedrive's default state.

An enum option may now carry an optional third element, `[value, label, description]`, which the engine forwards as a parallel `ui:enumDescriptions` array. Single-select enums get the same capability for free. Options without a description render exactly as before.

`tool_gohighlevel` (#1695, merged after this branch was cut) is the second consumer of the label half. Its review added pipedrive-style `[value, label]` pairs with per-group counts and `default` markers, and its author noted the labels did not appear to survive to the UI — for pipedrive either, both nodes serving `ui.toolGroups` as `{}`. That is this bug. Those labels start rendering once this lands; no change is needed on their side.

**Design note:** the per-option icon is deliberately `aria-hidden` and non-focusable rather than a reuse of `FieldLabelWithInfo`. A tabbable trigger inside a `MenuItem` is unreachable (MUI's `Menu` closes on Tab) and makes `MenuList` resolve the next option from the focused span rather than the option row, which under the Select's `disableListWrap` silently kills arrow-key navigation. The description reaches assistive tech through `aria-describedby` on the option instead. `SelectWidget` also had to gain an explicit `renderValue`, because MUI otherwise composes the collapsed display from each selected `MenuItem`'s children — which would have stamped an info icon into the closed field once per selection.

`test_no_widget_override` is unchanged and still passes: the help text lives in `items.enum` and the `compactDescriptions` flag on `shape[0]`, so the field still carries no `ui` block.

## Type

feature

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Run per suite:

- `engtest` — 515 assertions in 25 cases pass, including a new section asserting `services.tool_pipedrive.Pipe.ui.toolGroups` carries `ui:enumNames[0] == "Deals (27)"` and a length-matched, non-empty `ui:enumDescriptions`.
- `./builder shared:test` — 89/89 pass. New `SelectWidget.test.tsx` and `OptionInfoIcon.test.tsx`, plus a case added to `FieldLabelWithInfo.test.tsx`.
- `python -m pytest nodes/test/tool_pipedrive/test_pipedrive.py` — 154/154 pass, ruff clean. Three new tests hold the copy to the code: every option must carry a description, every tool cited in `<code>` must exist in that group, and each group must cite at least two.

Not covered by automation, and checked by hand in the config panel instead:

- The open dropdown. A closed MUI `Menu` is a `Modal` that returns `null`, and `react-dom/server` throws on portals, so no option markup reaches `renderToStaticMarkup`. Tooltip placement, click suppression, arrow keys and typeahead are manual checks.
- The HTML path in `FieldLabelWithInfo`. It calls DOMPurify, which needs a DOM the `node:test` runner does not provide, so the new test covers the plain-text path only.

Full `./builder test` was not run locally.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

No breaking changes: `ui:enumDescriptions` is only emitted when a service authors it, so every other service's compiled ui schema is byte-identical.

The `processArray` hoist only touches array fields whose items carry an `enum`. There are exactly two in the repo — `tool_pipedrive.toolGroups` and, since #1695 merged, `tool_gohighlevel.toolGroups` — and for both the hoist can only add the two keys that were previously dropped on the floor. Nothing else changes shape.

> The commit message on `dd6a9281` says pipedrive is the only such field. That was true when the branch was cut and stopped being true when #1695 merged; left as written rather than rewriting a pushed history.

Note the commits are independently reviewable but not independently deployable — the manifest and widget changes only take effect once the engine binary is rebuilt.

## Related Issues

Closes #1904


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added informational icons and accessible descriptions to select options when additional help is available.
  * Rich-text descriptions now render correctly in field and option tooltips.
  * Improved multi-select value display and empty-selection behavior.
  * Pipedrive configuration now provides clearer domain guidance and detailed tool-group descriptions.

* **Documentation**
  * Updated Pipedrive documentation with accurate tool counts, validation details, and authentication guidance.

* **Accessibility**
  * Improved labels, keyboard behavior, and screen-reader descriptions for select options and informational controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->