### PR TITLE
fix(server): intern Python caller location names so ap::Location views stay valid

### DIFF
--- a/packages/server/engine-lib/engLib/store/python/bindings.cpp
+++ b/packages/server/engine-lib/engLib/store/python/bindings.cpp
@@ -519,8 +519,15 @@ PYBIND11_EMBEDDED_MODULE(engLib, engLib) {
         // file/function names are bounded by its Python sources, so the pool stays small;
         // it is never pruned, which is what makes the views permanently safe. unordered_set
         // is node-based, so inserting never moves an element another view already points at.
-        static std::mutex internLock;
-        static std::unordered_set<std::string> internPool;
+        //
+        // The pool and its lock are leaked on purpose rather than left as ordinary
+        // function-local statics. Those are destroyed in reverse order of construction, and
+        // engine::config::monitor() (config/global.hpp) is constructed first - so the pool
+        // would be gone while the monitor still holds Errors viewing into it, putting the
+        // same dangling read back at shutdown. Leaking is what makes "life of the process"
+        // exact; the memory is reclaimed by the OS when the process ends.
+        static auto &internLock = *new std::mutex();
+        static auto &internPool = *new std::unordered_set<std::string>();
         const auto intern = [](std::string value) -> std::string_view {
             const std::lock_guard<std::mutex> guard(internLock);
             return *internPool.insert(std::move(value)).first;

--- a/packages/server/engine-lib/engLib/store/python/bindings.cpp
+++ b/packages/server/engine-lib/engLib/store/python/bindings.cpp
@@ -48,7 +48,12 @@
 //=============================================================================
 
 #include <engLib/eng.h>
+#include <mutex>
 #include <optional>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <unordered_set>
 
 //-----------------------------------------------------------------------------
 // These are generic definition helps that help in writing declarations.
@@ -505,7 +510,22 @@ PYBIND11_EMBEDDED_MODULE(engLib, engLib) {
     ///     .py file, not bindings.cpp
     ///------------------------------------------------------------
     auto getPythonCallerLocation =
-        []() -> std::optional<std::tuple<std::string, int, std::string>> {
+        []() -> std::optional<std::tuple<std::string_view, int, std::string_view>> {
+        // The names are interned for the life of the process, and the views handed out
+        // below point into that pool. ap::Location holds string_views and Error keeps a
+        // Location by value, so a location built over a caller-local std::string outlives
+        // its own storage the moment that scope ends - every later read of it, such as the
+        // completionError property, then lands in freed memory. A pipeline's distinct
+        // file/function names are bounded by its Python sources, so the pool stays small;
+        // it is never pruned, which is what makes the views permanently safe. unordered_set
+        // is node-based, so inserting never moves an element another view already points at.
+        static std::mutex internLock;
+        static std::unordered_set<std::string> internPool;
+        const auto intern = [](std::string value) -> std::string_view {
+            const std::lock_guard<std::mutex> guard(internLock);
+            return *internPool.insert(std::move(value)).first;
+        };
+
         try {
             py::object frame = py::module_::import("sys").attr("_getframe")(0);
             py::str pathStr(frame.attr("f_code").attr("co_filename"));
@@ -515,7 +535,8 @@ PYBIND11_EMBEDDED_MODULE(engLib, engLib) {
             int line = py::cast<int>(frame.attr("f_lineno"));
             std::string func =
                 funcStr.attr("encode")("utf-8").cast<std::string>();
-            return std::make_tuple(std::move(path), line, std::move(func));
+            return std::make_tuple(intern(std::move(path)), line,
+                                   intern(std::move(func)));
         } catch (...) {
             return std::nullopt;
         }


### PR DESCRIPTION
## Summary

- The engine aborts mid-run when a Python node reports an error or warning: `getPythonCallerLocation()` handed `ap::Location` views into `std::string`s that died at the end of the enclosing block, while the `Error` holding those views was moved into the monitor and outlived them.
- Intern the file and function names in a process-lifetime pool and return `string_view`, so the views stay valid for as long as any `Error` can hold them.
- No behavioural change when the monitor is off; that path never built a `Location` from Python strings.

**Why the dump points at `Location.hpp:91`, not at this change.** `fileName()` does
`std::filesystem::path(m_path.data())`, and `m_path` is the dangling view. Reading it walks
freed memory until it hits a NUL, and MSVC's `path` throws on what it finds there. Because
`fileName()` is `noexcept`, that throw goes straight to `terminate` — hence SIGABRT rather
than a reported error. Both frames are in the stack on the issue (16 and 17); frame 17 is
where the bad view was constructed.

The pool is an `unordered_set`, which is node-based, so an insert never moves a string
another view already points at. It is never pruned — that is what keeps the views valid for
the life of the process — and a pipeline's distinct file/function names are bounded by its
Python sources, so it stays small.

**The pool and its lock are leaked on purpose.** Both are allocated with `new` and never
deleted, rather than left as ordinary function-local statics. Statics are destroyed in
reverse order of construction, and `engine::config::monitor()` (`config/global.hpp:51`) is a
function-local static constructed at engine start — so it is destroyed last, and the pool
would already be gone while the monitor still held `Error`s viewing into it. That is the
same dangling read this PR fixes, moved to shutdown. The lock is leaked for the same reason:
locking a destroyed mutex from another thread during shutdown is the same shape of defect.
A leak detector will report this block, which is expected; the comment above it says why the
`delete` is not there.

**On the pool never being pruned** (raised by CodeRabbit as unbounded growth): the interned
values are `co_filename` and `co_name` of the frame that called `engLib.error()`, and neither
is new on each run. Python is imported from directories placed on `sys.path` once at start-up
(`engLib/python/init.cpp:177`), so a later pipeline interns the same strings it already has;
and dynamically generated code compiles under a constant file name, `'<agent_script>'`
(`packages/ai/src/ai/common/sandbox.py:199`). The bound is the sources on disk, not the number
of runs. Details in the thread below.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

No test is added: the defect is undefined behaviour, so there is no assertion that reliably
distinguishes fixed from broken — a reader of freed memory may return the right bytes.
Verified instead by rebuilding the engine and re-running the pipeline that reproduced the
abort, which now completes and reports the location correctly. The full suite is left to CI.

The follow-up commit that leaks the pool was not re-run against a fresh engine build — it
changes only where the two objects live, and the shutdown path it protects is not reachable
from a pipeline run. The pattern itself was compiled standalone to confirm that the leaked
statics need no lambda capture and that repeated calls return the same storage.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none; the helper is a file-local lambda

## Linked Issue

Fixes #1913


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of error messages that include caller locations.
  * Prevented invalid or inconsistent location details during concurrent operations.
  * Preserved existing fallback behavior when caller-location information is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
