### PR TITLE
fix(server): copy the path in ap::Location::fileName; add unit coverage

### DIFF
--- a/packages/server/engine-core/apLib/Location.h
+++ b/packages/server/engine-core/apLib/Location.h
@@ -53,9 +53,11 @@ struct Location {
     int line() const noexcept;
     static std::string sanitizeFunctionName(std::string_view name) noexcept;
 
-    // We use string_view's here so that *no* allocations occur
-    // this requires that all strings passed here must be constant
-    // literals
+    // We use string_view's here so that *no* allocations occur. That puts one
+    // requirement on the caller: the characters must outlive every Error this
+    // location is copied into. A string literal always does; anything else has
+    // to be interned or otherwise live for the process. The views need not be
+    // NUL-terminated - fileName() copies the path before parsing it.
     std::string_view m_path;
     int m_line = 0;
     std::string_view m_function;

--- a/packages/server/engine-core/apLib/Location.hpp
+++ b/packages/server/engine-core/apLib/Location.hpp
@@ -85,12 +85,22 @@ inline std::string Location::function() const noexcept {
 }
 
 // Filename accessor (strips just the file name off the path)
+//
+// The path is copied into a std::string before it is parsed. m_path is a view, and a
+// view carries no NUL at its end, so handing path(m_path.data()) a view that is a
+// substring of a larger buffer reads on past the characters that belong to it.
+// Constructing or rendering a std::filesystem::path can also throw - on Windows the
+// narrow/wide conversion does, for bytes the active code page cannot represent - and
+// this accessor is noexcept, so a throw here is terminate rather than a bad file name.
+// Returning the path unsplit is a far better answer than aborting the process.
 inline std::string Location::fileName() const noexcept {
     if (m_path.empty()) return {};
-    if (m_fullPath)
-        return std::filesystem::path(m_path.data()).string();
-    else
-        return std::filesystem::path(m_path.data()).filename().string();
+    try {
+        const std::filesystem::path path{std::string(m_path)};
+        return m_fullPath ? path.string() : path.filename().string();
+    } catch (...) {
+        return std::string(m_path);
+    }
 }
 
 }  // namespace ap

--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -23,11 +23,15 @@
 
 #include "test.h"
 
-// Everything here feeds Location string literals, which is what the class asks for: it
-// holds string_views so that constructing one costs no allocation, and that is only sound
-// while the characters outlive every Error the location is copied into. A view over a
-// caller-local string has no place in these tests because it has no place in the product -
-// what it produces is undefined, not a result worth pinning.
+// Most cases here feed Location string literals, which is the ordinary way the class is
+// used: it holds string_views so that constructing one costs no allocation, and that is
+// only sound while the characters outlive every Error the location is copied into. A view
+// over a caller-local string has no place in these tests because it has no place in the
+// product - what it produces is undefined, not a result worth pinning.
+//
+// What is pinned below is the other half of that contract: a view is valid without being
+// NUL-terminated, so fileName() must stop at the end of the view rather than read on to
+// the next NUL in whatever buffer the view points into.
 //
 // Separators are platform-specific and the cases below are split accordingly: '/' divides
 // a path everywhere, '\' only on Windows.
@@ -61,6 +65,25 @@ TEST_CASE("Location::fileName") {
 
     SECTION("full path mode keeps the directory") {
         ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "fileName", true};
+        REQUIRE(loc.fileName() == "/usr/src/apLib/Location.hpp");
+    }
+
+    // The two cases below hold a view that is a prefix of a longer buffer, so the
+    // character one past its end is 'a', not a NUL. Reading the path as a C string would
+    // pick up the trailing words - and, in the general case, run off the allocation.
+    SECTION("a view without a NUL after it stops at its own end") {
+        const std::string buffer{"/usr/src/apLib/Location.hpp and more text"};
+        const std::string_view path =
+            std::string_view{buffer}.substr(0, buffer.find(' '));
+        ap::Location loc{path, 91, "fileName"};
+        REQUIRE(loc.fileName() == "Location.hpp");
+    }
+
+    SECTION("a view without a NUL after it stops at its own end in full path mode") {
+        const std::string buffer{"/usr/src/apLib/Location.hpp and more text"};
+        const std::string_view path =
+            std::string_view{buffer}.substr(0, buffer.find(' '));
+        ap::Location loc{path, 91, "fileName", true};
         REQUIRE(loc.fileName() == "/usr/src/apLib/Location.hpp");
     }
 

--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -1,0 +1,151 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+#include "test.h"
+
+// Everything here feeds Location string literals, which is what the class asks for: it
+// holds string_views so that constructing one costs no allocation, and that is only sound
+// while the characters outlive every Error the location is copied into. A view over a
+// caller-local string has no place in these tests because it has no place in the product -
+// what it produces is undefined, not a result worth pinning.
+//
+// Separators are platform-specific and the cases below are split accordingly: '/' divides
+// a path everywhere, '\' only on Windows.
+
+TEST_CASE("Location::fileName") {
+    SECTION("an unset location has no file name") {
+        ap::Location loc{};
+        REQUIRE(!loc);
+        REQUIRE(loc.fileName().empty());
+    }
+
+    SECTION("the directory is stripped") {
+        ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "fileName"};
+        REQUIRE(loc.fileName() == "Location.hpp");
+    }
+
+    SECTION("a bare name is its own file name") {
+        ap::Location loc{"Location.hpp", 1, "f"};
+        REQUIRE(loc.fileName() == "Location.hpp");
+    }
+
+    SECTION("a trailing separator leaves no file name") {
+        ap::Location loc{"/usr/src/apLib/", 1, "f"};
+        REQUIRE(loc.fileName().empty());
+    }
+
+    SECTION("a lone separator leaves no file name") {
+        ap::Location loc{"/", 1, "f"};
+        REQUIRE(loc.fileName().empty());
+    }
+
+    SECTION("full path mode keeps the directory") {
+        ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "fileName", true};
+        REQUIRE(loc.fileName() == "/usr/src/apLib/Location.hpp");
+    }
+
+#if ROCKETRIDE_PLAT_WIN
+    SECTION("a backslash divides a path on Windows") {
+        ap::Location loc{"E:\\dev\\apLib\\Location.hpp", 91, "fileName"};
+        REQUIRE(loc.fileName() == "Location.hpp");
+    }
+
+    SECTION("mixed separators split on the last one") {
+        ap::Location loc{"E:\\dev/apLib\\Location.hpp", 1, "f"};
+        REQUIRE(loc.fileName() == "Location.hpp");
+    }
+
+    // A drive with no separator after it: "C:Location.hpp" names a file relative to the
+    // current directory *of drive C*, so the drive is part of the path and not of the name.
+    SECTION("a drive-relative path keeps only the name") {
+        ap::Location loc{"C:Location.hpp", 1, "f"};
+        REQUIRE(loc.fileName() == "Location.hpp");
+    }
+#endif
+}
+
+TEST_CASE("Location accessors") {
+    SECTION("line and function are returned as given") {
+        ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "fileName"};
+        REQUIRE(loc.line() == 91);
+        REQUIRE(loc.function() == "fileName");
+    }
+
+    SECTION("an unset location is false, a set one is true") {
+        REQUIRE(!ap::Location{});
+        REQUIRE(ap::Location{"a.cpp", 1, "f"});
+    }
+
+    SECTION("locations compare on all three fields") {
+        const ap::Location loc{"a.cpp", 1, "f"};
+        REQUIRE(loc == ap::Location{"a.cpp", 1, "f"});
+        REQUIRE(loc != ap::Location{"a.cpp", 2, "f"});
+        REQUIRE(loc != ap::Location{"b.cpp", 1, "f"});
+        REQUIRE(loc != ap::Location{"a.cpp", 1, "g"});
+    }
+
+    // Ordering exists so a location can key a container: same file sorts by line.
+    SECTION("ordering groups by path then line") {
+        REQUIRE(ap::Location{"a.cpp", 1, "f"} < ap::Location{"a.cpp", 2, "f"});
+        REQUIRE(ap::Location{"a.cpp", 9, "f"} < ap::Location{"b.cpp", 1, "f"});
+        REQUIRE(!(ap::Location{"a.cpp", 2, "f"} < ap::Location{"a.cpp", 1, "f"}));
+    }
+}
+
+TEST_CASE("Location::operator||") {
+    const ap::Location caller{"caller.cpp", 10, "caller"};
+    const ap::Location callee{"callee.cpp", 20, "callee"};
+
+    SECTION("a set right-hand side wins") {
+        REQUIRE((caller || callee) == callee);
+    }
+
+    SECTION("an unset right-hand side leaves the left in place") {
+        REQUIRE((caller || ap::Location{}) == caller);
+    }
+
+    SECTION("two unset locations stay unset") {
+        REQUIRE(!(ap::Location{} || ap::Location{}));
+    }
+}
+
+TEST_CASE("Location::sanitizeFunctionName") {
+    SECTION("an ordinary name is left alone") {
+        REQUIRE(ap::Location::sanitizeFunctionName("fileName") == "fileName");
+    }
+
+    // Lambda type names are long, unstable and useless in a log line, so everything from
+    // the '<' onwards collapses to a marker.
+    SECTION("a lambda collapses to a marker") {
+        REQUIRE(ap::Location::sanitizeFunctionName("pybind11_init::<lambda_96>::operator()") ==
+                "pybind11_init::[lambda]");
+    }
+
+    SECTION("an unclosed angle bracket is not a lambda") {
+        REQUIRE(ap::Location::sanitizeFunctionName("operator<") == "operator<");
+    }
+
+    SECTION("an empty name stays empty") {
+        REQUIRE(ap::Location::sanitizeFunctionName("").empty());
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `packages/server/engine-core/test/Location.cpp`, covering `fileName()` path splitting, `sanitizeFunctionName()`, the accessors, comparison/ordering and `operator||`.
- `ap::Location` backs every `Error` in the engine and reaches users through engine logs, the event monitor and `completionError`, but had no tests.
- Fixes what writing those tests exposed, raised in review: `fileName()` passed `m_path.data()` to `std::filesystem::path`, but `m_path` is a `string_view` and a view carries no NUL at its end. A location built over a substring of a larger buffer read on into the rest of that buffer, and in the general case off the end of the allocation. The path is now copied into a `std::string` before it is parsed, and two sections pin that — one per branch of the accessor.
- Constructing or rendering a `std::filesystem::path` can also throw (on Windows the narrow/wide conversion does, for bytes the active code page cannot represent) while the accessor is `noexcept`, so a throw there was `terminate` rather than a bad file name — the same SIGABRT shape as #1913. It now returns the path unsplit instead of aborting.
- The class comment is corrected with it: the characters must outlive every `Error` the location is copied into, but they need not be NUL-terminated, and they are no longer required to be string literals — #1915 hands `Location` interned strings.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`aptest` builds and the new cases pass. Two notes for anyone building this locally: `aptest`
must be run from `dist/server`, since it resolves its datasets relative to `execDir()`; and
`test/CMakeLists.txt` globs sources without `CONFIGURE_DEPENDS`, so an incremental build needs
CMake re-run before it sees a newly added file. Neither affects CI, which configures from
clean.

Windows-specific cases are behind `#if ROCKETRIDE_PLAT_WIN`, matching the existing convention
in `test/error/Error.cpp` and `test/file/Selections.cpp`.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none; `fileName()` returns the same string for every input the engine passes today

## Linked Issue

Closes #1914


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved source-location file-name handling for bounded and non-null-terminated paths.
  * Added graceful fallback behavior when path processing fails, preventing unexpected errors.
  * Improved handling across platform-specific path formats and function-name variations.

* **Documentation**
  * Clarified source-location lifetime, allocation, and path-handling requirements.

* **Tests**
  * Added comprehensive coverage for paths, accessors, comparisons, fallback behavior, and formatting edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
