### PR TITLE
fix(client-mcp): make the SSE server actually work, and let /health say so

### DIFF
--- a/packages/client-mcp/docs/index.md
+++ b/packages/client-mcp/docs/index.md
@@ -325,7 +325,15 @@ pip install rocketride-mcp[sse]
 rocketride-mcp-sse --host 0.0.0.0 --port 8080
 ```
 
-SSE mode supports optional Bearer token authentication via the `MCP_API_KEY` environment variable. The `/health` endpoint is always accessible for monitoring.
+SSE mode supports optional Bearer token authentication via the `MCP_API_KEY` environment variable. The `/health` endpoint is always accessible for monitoring — it bypasses the Bearer check so a probe does not need the API key.
+
+`/health` answers `200` only when it can open and close a connection to the engine. Otherwise it answers `503`, so a container `HEALTHCHECK` that only looks at the status code is meaningful:
+
+| Status | Body                                                 | Meaning                                                               |
+| ------ | ---------------------------------------------------- | --------------------------------------------------------------------- |
+| `200`  | `{"status": "ok", ...}`                              | The engine round-tripped; tool calls should work.                     |
+| `503`  | `{"status": "degraded", "engine": "unreachable"}`    | This server is fine; the engine at `ROCKETRIDE_URI` is not answering. |
+| `503`  | `{"status": "error", "error": "configuration", ...}` | This server cannot build a client at all — check the env vars.        |
 
 ## Configuration
 

--- a/packages/client-mcp/src/rocketride_mcp/sse_server.py
+++ b/packages/client-mcp/src/rocketride_mcp/sse_server.py
@@ -21,6 +21,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import hmac
 import logging
 import os
 
@@ -55,17 +56,25 @@ class AuthMiddleware(BaseHTTPMiddleware):
             return await call_next(request)
         if _API_KEY:
             auth = request.headers.get('authorization', '')
-            if auth != f'Bearer {_API_KEY}':
+            # compare_digest, not '!=': a plain comparison short-circuits on
+            # the first differing byte and leaks the token a byte at a time.
+            if not hmac.compare_digest(auth, f'Bearer {_API_KEY}'):
                 return JSONResponse({'error': 'unauthorized'}, status_code=401)
         return await call_next(request)
 
 
 def _get_client() -> RocketRideClient:
-    """Create a RocketRideClient from environment/settings."""
+    """Create a RocketRideClient from environment/settings.
+
+    The credential lives on ``Settings.apikey`` — the same field the stdio
+    server reads. This used to say ``settings.auth``, a field that has never
+    existed on the dataclass, so every tool call and every health probe died
+    with AttributeError before reaching the engine.
+    """
     settings = load_settings()
     return RocketRideClient(
         uri=settings.uri,
-        auth=settings.auth or '',
+        auth=settings.apikey or '',
     )
 
 
@@ -154,15 +163,37 @@ def create_app() -> Starlette:
         return Response()
 
     async def health(_request: Request) -> JSONResponse:
-        """Return server health status and engine reachability."""
+        """Report whether this server can actually serve a tool call.
+
+        Answers 503 — not 200 — when it cannot. The Docker HEALTHCHECK is a
+        bare ``urlopen``, so a 200 with ``status: degraded`` in the body left
+        the container marked healthy while every tool call failed; that is how
+        the ``settings.auth`` crash shipped unnoticed.
+
+        A configuration fault (missing env vars, a wiring bug in this module)
+        is reported separately from an engine that is simply not answering:
+        collapsing both into ``engine: unreachable`` sent operators looking at
+        the wrong process.
+        """
         status: dict = {'status': 'ok', 'server': 'rocketride-mcp'}
         try:
             client = _get_client()
+        except Exception as exc:
+            logger.exception('health: cannot build engine client')
+            status['status'] = 'error'
+            status['error'] = 'configuration'
+            status['detail'] = str(exc)
+            return JSONResponse(status, status_code=503)
+
+        try:
             await client.connect()
             await client.disconnect()
-        except Exception:
+        except Exception as exc:
+            logger.warning('health: engine unreachable: %s', exc)
             status['status'] = 'degraded'
             status['engine'] = 'unreachable'
+            return JSONResponse(status, status_code=503)
+
         return JSONResponse(status)
 
     middleware = [Middleware(AuthMiddleware)] if _API_KEY else []

--- a/packages/client-mcp/src/rocketride_mcp/sse_server.py
+++ b/packages/client-mcp/src/rocketride_mcp/sse_server.py
@@ -178,11 +178,15 @@ def create_app() -> Starlette:
         status: dict = {'status': 'ok', 'server': 'rocketride-mcp'}
         try:
             client = _get_client()
-        except Exception as exc:
+        except Exception:
+            # The exception text can carry ROCKETRIDE_URI or the credential,
+            # and /health is deliberately unauthenticated (it bypasses the
+            # Bearer check above) — so the detail goes to the log, which is
+            # already trusted, and the body stays a fixed string.
             logger.exception('health: cannot build engine client')
             status['status'] = 'error'
             status['error'] = 'configuration'
-            status['detail'] = str(exc)
+            status['detail'] = 'engine client could not be constructed; see server logs'
             return JSONResponse(status, status_code=503)
 
         try:

--- a/packages/client-mcp/src/rocketride_mcp/sse_server.py
+++ b/packages/client-mcp/src/rocketride_mcp/sse_server.py
@@ -21,6 +21,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import asyncio
+import contextlib
 import hmac
 import logging
 import os
@@ -46,6 +48,12 @@ logger = logging.getLogger(__name__)
 
 _API_KEY = os.environ.get('MCP_API_KEY', '')
 
+# Whole-probe budget for /health. RocketRideClient.connect() bounds only the
+# WebSocket handshake — the authentication request that follows has no default
+# timeout — so an engine that accepts the socket and then goes quiet would
+# leave the probe pending forever.
+_HEALTH_PROBE_TIMEOUT = 10.0
+
 
 class AuthMiddleware(BaseHTTPMiddleware):
     """Require Bearer token for all non-health endpoints."""
@@ -61,6 +69,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
             if not hmac.compare_digest(auth, f'Bearer {_API_KEY}'):
                 return JSONResponse({'error': 'unauthorized'}, status_code=401)
         return await call_next(request)
+
+
+async def _probe_engine(client: RocketRideClient) -> None:
+    """Open and close one engine connection, always attempting the close.
+
+    The disconnect lives in ``finally`` so a probe that fails partway — or is
+    cancelled by the surrounding :func:`asyncio.wait_for` — does not strand a
+    half-open connection. A close that fails on its own is suppressed: the
+    engine has already answered by then, which is what the probe asked.
+    """
+    try:
+        await client.connect()
+    finally:
+        with contextlib.suppress(Exception):
+            await client.disconnect()
 
 
 def _get_client() -> RocketRideClient:
@@ -190,8 +213,7 @@ def create_app() -> Starlette:
             return JSONResponse(status, status_code=503)
 
         try:
-            await client.connect()
-            await client.disconnect()
+            await asyncio.wait_for(_probe_engine(client), timeout=_HEALTH_PROBE_TIMEOUT)
         except Exception as exc:
             logger.warning('health: engine unreachable: %s', exc)
             status['status'] = 'degraded'

--- a/packages/client-mcp/src/rocketride_mcp/sse_server.py
+++ b/packages/client-mcp/src/rocketride_mcp/sse_server.py
@@ -54,6 +54,10 @@ _API_KEY = os.environ.get('MCP_API_KEY', '')
 # leave the probe pending forever.
 _HEALTH_PROBE_TIMEOUT = 10.0
 
+# Separate budget for closing the probe connection, so a disconnect that
+# blocks cannot extend the endpoint past the probe budget above.
+_HEALTH_CLEANUP_TIMEOUT = 5.0
+
 
 class AuthMiddleware(BaseHTTPMiddleware):
     """Require Bearer token for all non-health endpoints."""
@@ -71,19 +75,21 @@ class AuthMiddleware(BaseHTTPMiddleware):
         return await call_next(request)
 
 
-async def _probe_engine(client: RocketRideClient) -> None:
-    """Open and close one engine connection, always attempting the close.
+async def _close_quietly(client: RocketRideClient) -> None:
+    """Close a probe connection under its own deadline, swallowing failures.
 
-    The disconnect lives in ``finally`` so a probe that fails partway — or is
-    cancelled by the surrounding :func:`asyncio.wait_for` — does not strand a
-    half-open connection. A close that fails on its own is suppressed: the
-    engine has already answered by then, which is what the probe asked.
+    Deliberately called from the request handler rather than from inside the
+    probe coroutine. Cleanup attached to a cancelled await runs *during*
+    cancellation, and ``asyncio.wait_for`` waits for that cancellation to
+    finish — so a disconnect that blocks would push /health past the very
+    budget the timeout exists to enforce. Run here, the close is an ordinary
+    await in an uncancelled coroutine with a bound of its own.
+
+    A close that fails on its own is suppressed rather than downgrading the
+    verdict: the engine already answered, which is what the probe asked.
     """
-    try:
-        await client.connect()
-    finally:
-        with contextlib.suppress(Exception):
-            await client.disconnect()
+    with contextlib.suppress(Exception):
+        await asyncio.wait_for(client.disconnect(), timeout=_HEALTH_CLEANUP_TIMEOUT)
 
 
 def _get_client() -> RocketRideClient:
@@ -213,12 +219,16 @@ def create_app() -> Starlette:
             return JSONResponse(status, status_code=503)
 
         try:
-            await asyncio.wait_for(_probe_engine(client), timeout=_HEALTH_PROBE_TIMEOUT)
+            await asyncio.wait_for(client.connect(), timeout=_HEALTH_PROBE_TIMEOUT)
         except Exception as exc:
             logger.warning('health: engine unreachable: %s', exc)
             status['status'] = 'degraded'
             status['engine'] = 'unreachable'
             return JSONResponse(status, status_code=503)
+        finally:
+            # Runs on both paths, including the timeout — the connection is
+            # closed whether or not the engine answered.
+            await _close_quietly(client)
 
         return JSONResponse(status)
 

--- a/packages/client-mcp/tests/test_sse_server.py
+++ b/packages/client-mcp/tests/test_sse_server.py
@@ -10,6 +10,7 @@
 # container's HEALTHCHECK reported it healthy.
 
 import asyncio
+import time
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -237,3 +238,34 @@ def test_health_survives_a_disconnect_that_raises(env_rocketride: None) -> None:
 
     assert response.status_code == 200
     assert response.json()['status'] == 'ok'
+
+
+def test_health_stays_bounded_when_cleanup_also_blocks(monkeypatch, env_rocketride: None) -> None:
+    """A blocking disconnect cannot extend the endpoint past its budget.
+
+    ``asyncio.wait_for`` waits for the cancellation of the coroutine it
+    cancels, so cleanup attached to the cancelled await would have been
+    awaited *inside* that window with no bound of its own — the endpoint
+    could hang despite the probe budget. The close is bounded separately.
+    """
+    monkeypatch.setattr(sse, '_HEALTH_PROBE_TIMEOUT', 0.05)
+    monkeypatch.setattr(sse, '_HEALTH_CLEANUP_TIMEOUT', 0.05)
+
+    async def _never_answers() -> None:
+        await asyncio.sleep(30)
+
+    client = MagicMock()
+    client.connect = AsyncMock(side_effect=_never_answers)
+    client.disconnect = AsyncMock(side_effect=_never_answers)
+
+    started = time.monotonic()
+    with patch.object(sse, '_get_client', return_value=client):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+    elapsed = time.monotonic() - started
+
+    assert response.status_code == 503
+    assert response.json()['engine'] == 'unreachable'
+    # Both budgets are 50ms; a generous ceiling still fails if either await
+    # is unbounded (the blocked calls sleep for 30s).
+    assert elapsed < 10, f'/health outran its budget: {elapsed:.1f}s'

--- a/packages/client-mcp/tests/test_sse_server.py
+++ b/packages/client-mcp/tests/test_sse_server.py
@@ -1,0 +1,166 @@
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# Tests for rocketride_mcp.sse_server — the HTTP/SSE transport shipped as
+# docker/Dockerfile.mcp and the `rocketride-mcp-sse` console script.
+#
+# This module previously had no tests at all, which is how `settings.auth` (a
+# field that has never existed on the Settings dataclass) shipped and stayed
+# broken: every tool call and every health probe died with AttributeError
+# before reaching the engine, and /health answered 200 regardless, so the
+# container's HEALTHCHECK reported it healthy.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytest.importorskip('starlette', reason='SSE transport is an optional extra: pip install rocketride-mcp[sse]')
+
+from starlette.testclient import TestClient  # noqa: E402
+
+import rocketride_mcp.sse_server as sse  # noqa: E402
+
+
+# -----------------------------------------------------------------------------
+# Client construction
+# -----------------------------------------------------------------------------
+
+
+def test_get_client_uses_the_apikey_field(env_rocketride: None) -> None:
+    """The credential is read from Settings.apikey, the field that exists.
+
+    Regression test for the `settings.auth` AttributeError. Asserting on the
+    kwargs passed to RocketRideClient — rather than just "it did not raise" —
+    is what keeps the credential from silently going missing again.
+    """
+    with patch.object(sse, 'RocketRideClient') as ctor:
+        sse._get_client()
+
+    ctor.assert_called_once_with(uri='wss://test.example.com', auth='test-api-key')
+
+
+def test_get_client_propagates_missing_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing ROCKETRIDE_URI / auth surfaces as ValueError, not AttributeError."""
+    monkeypatch.delenv('ROCKETRIDE_AUTH', raising=False)
+    monkeypatch.delenv('ROCKETRIDE_APIKEY', raising=False)
+    monkeypatch.delenv('ROCKETRIDE_URI', raising=False)
+
+    with pytest.raises(ValueError):
+        sse._get_client()
+
+
+# -----------------------------------------------------------------------------
+# /health
+# -----------------------------------------------------------------------------
+
+
+def _connectable_client() -> MagicMock:
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock()
+    return client
+
+
+def test_health_returns_200_when_the_engine_round_trips(env_rocketride: None) -> None:
+    """A healthy server answers 200 with status ok."""
+    with patch.object(sse, '_get_client', return_value=_connectable_client()):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body['status'] == 'ok'
+    assert body['server'] == 'rocketride-mcp'
+
+
+def test_health_returns_503_when_the_engine_is_unreachable(env_rocketride: None) -> None:
+    """An unreachable engine fails the probe instead of passing it.
+
+    The Docker HEALTHCHECK is a bare urlopen, so a 200 carrying
+    ``status: degraded`` marked the container healthy while nothing worked.
+    """
+    client = MagicMock()
+    client.connect = AsyncMock(side_effect=OSError('connection refused'))
+    client.disconnect = AsyncMock()
+
+    with patch.object(sse, '_get_client', return_value=client):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body['status'] == 'degraded'
+    assert body['engine'] == 'unreachable'
+
+
+def test_health_reports_a_configuration_fault_distinctly(env_rocketride: None) -> None:
+    """A wiring/config error is not reported as an unreachable engine.
+
+    Collapsing both into ``engine: unreachable`` is what sent operators
+    looking at the engine when the fault was in this process.
+    """
+    with patch.object(sse, '_get_client', side_effect=ValueError('Missing required environment variable')):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body['status'] == 'error'
+    assert body['error'] == 'configuration'
+    assert 'engine' not in body
+
+
+# -----------------------------------------------------------------------------
+# Bearer auth middleware
+# -----------------------------------------------------------------------------
+
+
+def test_health_is_reachable_without_a_token(monkeypatch: pytest.MonkeyPatch, env_rocketride: None) -> None:
+    """/health bypasses auth so monitoring does not need the API key."""
+    monkeypatch.setattr(sse, '_API_KEY', 's3cret')
+
+    with patch.object(sse, '_get_client', return_value=_connectable_client()):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    'header',
+    [
+        None,
+        'Bearer wrong',
+        's3cret',  # right token, missing the scheme
+        'bearer s3cret',  # scheme is case-sensitive here
+    ],
+)
+def test_non_health_routes_reject_bad_credentials(
+    header: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+    env_rocketride: None,
+) -> None:
+    """Anything but the exact ``Bearer <MCP_API_KEY>`` value is a 401."""
+    monkeypatch.setattr(sse, '_API_KEY', 's3cret')
+
+    headers = {'authorization': header} if header is not None else {}
+    with TestClient(sse.create_app()) as http:
+        response = http.get('/sse', headers=headers)
+
+    assert response.status_code == 401
+    assert response.json() == {'error': 'unauthorized'}
+
+
+def test_auth_middleware_is_absent_when_no_api_key_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+    env_rocketride: None,
+) -> None:
+    """With MCP_API_KEY unset the server is open — documented, and asserted.
+
+    Recorded as a test so the "unauthenticated by default" posture is a
+    deliberate, visible choice rather than an accident of configuration.
+    """
+    monkeypatch.setattr(sse, '_API_KEY', '')
+
+    app = sse.create_app()
+
+    assert not [m for m in app.user_middleware if m.cls is sse.AuthMiddleware]

--- a/packages/client-mcp/tests/test_sse_server.py
+++ b/packages/client-mcp/tests/test_sse_server.py
@@ -9,6 +9,8 @@
 # before reaching the engine, and /health answered 200 regardless, so the
 # container's HEALTHCHECK reported it healthy.
 
+import asyncio
+
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -177,3 +179,61 @@ def test_auth_middleware_is_absent_when_no_api_key_is_set(
     app = sse.create_app()
 
     assert not [m for m in app.user_middleware if m.cls is sse.AuthMiddleware]
+
+
+def test_health_bounds_a_probe_that_never_answers(monkeypatch, env_rocketride: None) -> None:
+    """An engine that accepts the socket then goes quiet cannot hang /health.
+
+    ``RocketRideClient.connect()`` bounds only the WebSocket handshake; the
+    authentication request that follows has no default timeout. Without a
+    whole-probe budget the endpoint stays pending indefinitely.
+    """
+    monkeypatch.setattr(sse, '_HEALTH_PROBE_TIMEOUT', 0.05)
+
+    async def _never_answers() -> None:
+        await asyncio.sleep(30)
+
+    client = MagicMock()
+    client.connect = AsyncMock(side_effect=_never_answers)
+    client.disconnect = AsyncMock()
+
+    with patch.object(sse, '_get_client', return_value=client):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+
+    assert response.status_code == 503
+    assert response.json()['engine'] == 'unreachable'
+    # The cancelled probe still ran its cleanup rather than stranding the socket.
+    client.disconnect.assert_awaited()
+
+
+def test_health_disconnects_even_when_the_probe_fails(env_rocketride: None) -> None:
+    """A failed connect still attempts the close, so nothing is left half-open."""
+    client = MagicMock()
+    client.connect = AsyncMock(side_effect=OSError('connection refused'))
+    client.disconnect = AsyncMock()
+
+    with patch.object(sse, '_get_client', return_value=client):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+
+    assert response.status_code == 503
+    client.disconnect.assert_awaited_once()
+
+
+def test_health_survives_a_disconnect_that_raises(env_rocketride: None) -> None:
+    """A close that fails on its own does not turn a healthy engine into 503.
+
+    The engine answered — that is what the probe asked. A noisy teardown is
+    logged by the client, not escalated into a health verdict.
+    """
+    client = MagicMock()
+    client.connect = AsyncMock()
+    client.disconnect = AsyncMock(side_effect=RuntimeError('already closed'))
+
+    with patch.object(sse, '_get_client', return_value=client):
+        with TestClient(sse.create_app()) as http:
+            response = http.get('/health')
+
+    assert response.status_code == 200
+    assert response.json()['status'] == 'ok'

--- a/packages/client-mcp/tests/test_sse_server.py
+++ b/packages/client-mcp/tests/test_sse_server.py
@@ -61,8 +61,15 @@ def _connectable_client() -> MagicMock:
 
 
 def test_health_returns_200_when_the_engine_round_trips(env_rocketride: None) -> None:
-    """A healthy server answers 200 with status ok."""
-    with patch.object(sse, '_get_client', return_value=_connectable_client()):
+    """A healthy server answers 200 with status ok, and closes the probe.
+
+    The lifecycle assertions matter as much as the payload: without them a
+    change that dropped ``disconnect()`` would still pass here while leaking
+    one engine connection per health probe — and probes run every 30s under
+    the Docker HEALTHCHECK.
+    """
+    client = _connectable_client()
+    with patch.object(sse, '_get_client', return_value=client):
         with TestClient(sse.create_app()) as http:
             response = http.get('/health')
 
@@ -70,6 +77,8 @@ def test_health_returns_200_when_the_engine_round_trips(env_rocketride: None) ->
     body = response.json()
     assert body['status'] == 'ok'
     assert body['server'] == 'rocketride-mcp'
+    client.connect.assert_awaited_once()
+    client.disconnect.assert_awaited_once()
 
 
 def test_health_returns_503_when_the_engine_is_unreachable(env_rocketride: None) -> None:
@@ -107,6 +116,10 @@ def test_health_reports_a_configuration_fault_distinctly(env_rocketride: None) -
     assert body['status'] == 'error'
     assert body['error'] == 'configuration'
     assert 'engine' not in body
+    # /health is unauthenticated, so the raw exception text — which can carry
+    # the URI or the credential — must not reach the body.
+    assert 'Missing required environment variable' not in body['detail']
+    assert 'see server logs' in body['detail']
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **`_get_client()` read `settings.auth`, a field that has never existed.** `Settings` is a dataclass with exactly `apikey` and `uri`; the stdio server at `server.py:98` reads `settings.apikey`, the SSE copy did not. `list_pipelines`, `run_pipeline` and the health probe all call `_get_client()` first, so the whole transport raised `AttributeError` before reaching the engine, on every deployment, regardless of configuration.
- **`/health` answered 200 while reporting the server broken**, so `Dockerfile.mcp`'s bare-`urlopen` HEALTHCHECK marked the container healthy. It now answers `503` unless the engine actually round-trips, and separates a configuration fault from an unreachable engine instead of collapsing both into `engine: unreachable`.
- **`mcp>=1.2.0` was unbounded and 2.0 removed `mcp.server.fastmcp`** (now `mcp/server/mcpserver/`), which this module imports at line 35. `Dockerfile.mcp` runs `pip install "./client-mcp[sse]"` with no lock file, so an image built today has an entrypoint that dies on import. Pinned `<2`; porting the SSE server to the 2.x server API is separate work that should not ride on a back-portable fix.
- `AuthMiddleware` now compares the bearer token with `hmac.compare_digest` rather than `!=`, while the file is under test for the first time.

Verified against the real package before the fix:

```
Settings fields: ['apikey', 'uri']
_get_client()  -> AttributeError: 'Settings' object has no attribute 'auth'
GET /health    -> 200 {'status': 'degraded', 'server': 'rocketride-mcp', 'engine': 'unreachable'}
mcp 2.0.0      -> ModuleNotFoundError: No module named 'mcp.server.fastmcp'
mcp 1.20.0     -> imports fine
```

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`sse_server.py` was the only module in `client-mcp` with no test coverage, which is how all three defects shipped. New `packages/client-mcp/tests/test_sse_server.py` (11 tests) covers client construction — asserting the credential actually reaches `RocketRideClient`, not merely that nothing raised — both health outcomes plus the configuration-fault case, and the `MCP_API_KEY` middleware (allow, four rejection shapes, `/health` bypass, and the no-key-set posture). It `importorskip`s starlette so runs without the `[sse]` extra are unaffected.

- Full `client-mcp` suite: **85 passed, 1 skipped**.
- Against `develop`, three of the new tests fail — `test_get_client_uses_the_apikey_field` with the `AttributeError` itself, plus both `/health` status-code tests. They are regression tests, not restatements.
- `ruff check` and `ruff format --check` clean on both Python files.

`./builder test` was not run — it drives the full engine build, which this environment cannot produce.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

`/health` returning `503` instead of `200` when the engine is down is a deliberate behaviour change and the point of the fix — a health check that cannot fail is not one. Anything scraping the body for `status` is unaffected; anything checking only the status code starts working. Documented in the same change per the co-located documentation rule: the "SSE Mode" section of `packages/client-mcp/docs/index.md` gains the status/body/meaning table.

Note: `prettier --check` on `packages/client-mcp/docs/index.md` was already failing on `develop` (the frontmatter quote style and a JSON sample). I left that alone rather than bury this fix under unrelated reformatting — my added section is prettier-clean on its own.

## Linked Issue

Closes #1923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an unauthenticated `/health` endpoint for monitoring SSE service availability.
  - Health checks return `200` after a successful engine connection round trip.
  - Health checks return `503` with distinct responses for unreachable engines and configuration errors.
  - Added Bearer token authentication for protected routes when an API key is configured.

- **Bug Fixes**
  - Improved API-key handling and authentication security.
  - Ensured health probes time out and clean up reliably.

- **Documentation**
  - Documented health endpoint authentication behavior and response statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->