### PR TITLE
fix(nodes): make the File Store sink's streamed media path work

### DIFF
--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
     # ``rocketlib`` (which predate ``Entry``) importable at runtime.
     from rocketlib import Entry
 
+from ai.common.avi.descriptor import descriptor_from_payload
 from ai.common.utils import optional_str, require_dict, require_str
 
 from .IGlobal import IGlobal
@@ -66,11 +67,6 @@ from .IGlobal import IGlobal
 # more than MAX_READ_LIMIT in one shot must use a streaming approach.
 DEFAULT_READ_LIMIT = 256 * 1024  # 256 KB
 MAX_READ_LIMIT = 4 * 1024 * 1024  # 4 MB
-
-# Connection id used for the sink's streaming-media write handles. The FileStore
-# caps handles per connection id; a single constant is fine because sink handles
-# are opened and closed within one object's media stream (only a few open at once).
-_SINK_CONNECTION_ID = 0
 
 # Upper bound on the `_1`, `_2`, … collision suffixes the sink will try before
 # giving up. Bounds the probe loop so a store that keeps reporting a path as
@@ -542,13 +538,40 @@ class IInstance(IInstanceBase):
             # Best-effort close, then best-effort delete — separately, so a
             # failed close never strands the partial file in the store.
             try:
-                _run_on_stream_loop(self.IGlobal.file_store.close_write(st['handle'], _SINK_CONNECTION_ID))
+                _run_on_stream_loop(self.IGlobal.file_store.close_write(st['handle']))
             except Exception:
                 pass
             try:
                 _run_on_stream_loop(self.IGlobal.file_store.delete(st['path']))
             except Exception:
                 pass
+
+    def _stream_filename(self, descriptor, mime: str) -> str:
+        """Filename for one media stream, preferring the name the stream carries.
+
+        A producer that fans one object out into several streams (frame_grabber's
+        frames, a cropper's crops) names each one in the BEGIN descriptor. Using it
+        is what keeps those distinguishable: derived from ``currentObject`` alone
+        they would all collide on the source object's name.
+
+        The name is untrusted — it comes from whatever node is upstream and is used
+        to build a store path — so it is reduced to a bare filename here. Both
+        separators are checked explicitly: ``os.path.basename`` on a POSIX host
+        leaves ``..\\..\\x`` untouched, and the store's own ``..`` rejection is a
+        second wall, not the only one.
+        """
+        name = getattr(getattr(descriptor, 'metadata', None), 'name', None) if descriptor else None
+        if name:
+            name = os.path.basename(str(name).replace('\\', '/'))
+        if not name or '/' in name or '\\' in name:
+            name = None
+        ext = self._media_ext(mime)
+        if not name:
+            return f'{self._sink_base_name()}{ext}'
+        # A stream can legitimately arrive named without an extension, and splitext cannot tell:
+        # it reads `1.crop0` as extension `.crop0`. The mime is authoritative for media, so
+        # append it unless it is already there.
+        return name if name.lower().endswith(ext.lower()) else f'{name}{ext}'
 
     def _sink_media(self, kind: str, aviAction, mimeType: str, data: bytes) -> None:
         """Stream media chunks straight to the store with bounded memory.
@@ -565,7 +588,14 @@ class IInstance(IInstanceBase):
 
         if aviAction == AVI_ACTION.BEGIN:
             self._media_abort(kind)
-            streams[kind] = {'handle': None, 'path': None, 'mime': mimeType}
+            # BEGIN carries the stream descriptor, which is the only place the stream's
+            # own name appears; keep it for _stream_filename.
+            streams[kind] = {
+                'handle': None,
+                'path': None,
+                'mime': mimeType,
+                'descriptor': descriptor_from_payload(data),
+            }
         elif aviAction == AVI_ACTION.WRITE:
             st = streams.get(kind)
             if st is None or not data:
@@ -574,16 +604,16 @@ class IInstance(IInstanceBase):
                 self._check_ready()
                 if not self.IGlobal.allow_write:
                     raise ValueError('write access is not enabled for this filesystem tool')
-                path = self._sink_target_path(f'{self._sink_base_name()}{self._media_ext(st["mime"])}')
-                st['handle'] = _run_on_stream_loop(self.IGlobal.file_store.open_write(path, _SINK_CONNECTION_ID))
+                path = self._sink_target_path(self._stream_filename(st.get('descriptor'), st['mime']))
+                st['handle'] = _run_on_stream_loop(self.IGlobal.file_store.open_write(path))
                 st['path'] = path
-            _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data), _SINK_CONNECTION_ID))
+            _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))
         elif aviAction == AVI_ACTION.END:
             st = streams.pop(kind, None)
             if st is None or st['handle'] is None:
                 return
             try:
-                _run_on_stream_loop(self.IGlobal.file_store.close_write(st['handle'], _SINK_CONNECTION_ID))
+                _run_on_stream_loop(self.IGlobal.file_store.close_write(st['handle']))
             except Exception:
                 # A failed commit leaves an incomplete file: remove it before
                 # propagating, so downstream never sees a truncated object.

--- a/nodes/test/tool_filesystem/test_sink_lanes.py
+++ b/nodes/test/tool_filesystem/test_sink_lanes.py
@@ -265,17 +265,17 @@ def test_media_stream_ops_share_one_live_event_loop():
     fs = _fs()
     seen = []
 
-    async def _open_write(path, connection_id):
+    async def _open_write(path):
         seen.append(('open', asyncio.get_running_loop()))
         fs.streams['h1'] = {'path': path, 'chunks': []}
         return 'h1'
 
-    async def _write_chunk(handle, data, connection_id=0):
+    async def _write_chunk(handle, data):
         seen.append(('chunk', asyncio.get_running_loop()))
         fs.streams[handle]['chunks'].append(bytes(data))
         return len(data)
 
-    async def _close_write(handle, connection_id=0):
+    async def _close_write(handle):
         seen.append(('close', asyncio.get_running_loop()))
         return None
 

--- a/nodes/test/tool_filesystem/test_sink_naming.py
+++ b/nodes/test/tool_filesystem/test_sink_naming.py
@@ -278,17 +278,17 @@ def _fs(exists_paths=()):
     fs.streams = {}
     counter = {'n': 0}
 
-    async def _open_write(path, connection_id):
+    async def _open_write(path):
         counter['n'] += 1
         handle = f'h{counter["n"]}'
         fs.streams[handle] = {'path': path, 'chunks': []}
         return handle
 
-    async def _write_chunk(handle, data, connection_id=0):
+    async def _write_chunk(handle, data):
         fs.streams[handle]['chunks'].append(bytes(data))
         return len(data)
 
-    async def _close_write(handle, connection_id=0):
+    async def _close_write(handle):
         return None
 
     fs.open_write = AsyncMock(side_effect=_open_write)
@@ -487,3 +487,62 @@ class TestSinkWrite:
         with pytest.raises(ValueError, match='does not match any allowed path pattern'):
             inst._sink_write(b'd', 'secret.pdf')
         fs.write.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Per-stream naming from the BEGIN descriptor
+# ---------------------------------------------------------------------------
+
+
+class _Descriptor:
+    """Stand-in for a parsed stream descriptor carrying only a name."""
+
+    def __init__(self, name):
+        self.metadata = types.SimpleNamespace(name=name)
+
+
+class TestStreamFilename:
+    """A stream's own name wins over the source object's, so fan-out stays distinguishable."""
+
+    def test_descriptor_name_is_preferred(self):
+        inst = _sink_instance(_fs(), name='1.jpg')
+        assert inst._stream_filename(_Descriptor('1.crop0.jpg'), 'image/jpeg') == '1.crop0.jpg'
+
+    def test_falls_back_to_the_object_name(self):
+        """No descriptor, or no name on it, keeps the previous behaviour."""
+        inst = _sink_instance(_fs(), name='report.pdf')
+        assert inst._stream_filename(None, 'image/jpeg') == 'report.jpg'
+        assert inst._stream_filename(_Descriptor(None), 'image/jpeg') == 'report.jpg'
+
+    def test_extension_appended_when_the_name_has_none(self):
+        """
+        A producer names a stream without necessarily giving it an extension.
+
+        os.path.splitext cannot answer this: it splits at the last dot, so `1.crop0` looks
+        like stem `1` with extension `.crop0` and the file would be stored with nothing
+        identifying its type. The stream's mime decides instead.
+        """
+        inst = _sink_instance(_fs(), name='1.jpg')
+        assert inst._stream_filename(_Descriptor('1.crop0'), 'image/jpeg') == '1.crop0.jpg'
+
+    def test_extension_is_not_doubled(self):
+        """A name that already ends in the stream's extension is left alone."""
+        inst = _sink_instance(_fs(), name='1.jpg')
+        assert inst._stream_filename(_Descriptor('1.crop0.jpg'), 'image/jpeg') == '1.crop0.jpg'
+        assert inst._stream_filename(_Descriptor('1.crop0.JPG'), 'image/jpeg') == '1.crop0.JPG'
+
+    def test_path_separators_are_stripped(self):
+        """
+        The name is untrusted: it comes from whatever node is upstream.
+
+        Backslashes are checked explicitly because os.path.basename on a POSIX host leaves
+        a Windows-style traversal completely untouched. The stored name also picks up the
+        stream's real extension, so a payload cannot masquerade as another type.
+        """
+        inst = _sink_instance(_fs(), name='report.pdf')
+        assert inst._stream_filename(_Descriptor('../../secrets/key.pem'), 'image/jpeg') == 'key.pem.jpg'
+        assert inst._stream_filename(_Descriptor(r'..\..\secrets\key.pem'), 'image/jpeg') == 'key.pem.jpg'
+
+    def test_name_that_reduces_to_nothing_falls_back(self):
+        inst = _sink_instance(_fs(), name='report.pdf')
+        assert inst._stream_filename(_Descriptor('../'), 'image/jpeg') == 'report.jpg'


### PR DESCRIPTION
## Summary

- The sink called `FileStore.open_write`/`write_chunk`/`close_write` with a connection id they do not take as a parameter — the store reads it from its bound context — so every streamed write raised before a byte reached the store.
- Media filenames came from the source object rather than from the stream, so a producer that fans one object out into several streams had them all resolve to one path.
- The unit-test mocks declared those store methods with the same extra parameter, so the two were wrong in agreement and the suite could not catch it.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`builder nodes:test --pytest-pattern=tool_filesystem` on this branch alone: **106 passed,
1 skipped** (the skip is `test_model_server_ocr.py`, `img2table not installed`, unrelated).
Run in isolation rather than only on top of the follow-up branch, so the state CI will
actually see is the state that was verified.

Six tests cover the naming rule: the stream's own name wins, a missing descriptor falls
back to the object name as before, an extension is appended when the name lacks one and
not doubled when it has one, and a name carrying path separators is reduced to a bare
filename — checked for both separators, since `os.path.basename` on a POSIX host leaves a
Windows-style traversal untouched.

The full suite is left to CI.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — media files now keep the name their producer gave them instead of the source object's

## Linked Issue

Fixes #1927


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Streamed files now use names provided by the stream metadata when available.
  - File extensions are added automatically based on the content type, with sensible fallback names when needed.
  - Unsafe path characters are removed from incoming names to keep saved files secure and well-formed.

- **Bug Fixes**
  - Improved handling of duplicate filenames and interrupted streams, preventing incomplete files from being retained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->