### PR TITLE
feat(nodes): let the File Store sink choose what to do when a file exists

### DIFF
--- a/nodes/src/nodes/tool_filesystem/IGlobal.py
+++ b/nodes/src/nodes/tool_filesystem/IGlobal.py
@@ -48,20 +48,21 @@ from ai.common.config import Config
 from rocketlib import IGlobalBase, OPEN_MODE, warning
 
 
+class OnConflict(IntEnum):
+    """What to do when the sink's target path is already taken.
+
+    Member names are the services.store.json enum values uppercased, which is what lets
+    :meth:`IGlobal._sink_config` resolve one to the other by name. Resolved once at config
+    time, so each write compares ints.
+    """
+
+    UNIQUE = 0
+    OVERWRITE = 1
+    SKIP = 2
+
+
 class IGlobal(IGlobalBase):
     """Global state for tool_filesystem."""
-
-    class OnConflict(IntEnum):
-        """What to do when the sink's target path is already taken.
-
-        Member names are the services.store.json enum values uppercased, which is what lets
-        :meth:`_sink_config` resolve one to the other by name. Resolved once at config time,
-        so each write compares ints.
-        """
-
-        UNIQUE = 0
-        OVERWRITE = 1
-        SKIP = 2
 
     client_id: str | None = None
     file_store: object | None = None  # ai.account.file_store.FileStore
@@ -168,9 +169,9 @@ class IGlobal(IGlobalBase):
             raw_expires = 3600
         url_expires_in = min(raw_expires, 3600) if raw_expires > 0 else 3600
         try:
-            on_conflict = IGlobal.OnConflict[str(cfg.get('onConflict', '')).strip().upper()]
+            on_conflict = OnConflict[str(cfg.get('onConflict', '')).strip().upper()]
         except KeyError:
-            on_conflict = IGlobal.OnConflict.UNIQUE
+            on_conflict = OnConflict.UNIQUE
         return target_dir, emit_url, url_expires_in, on_conflict
 
     def validateConfig(self) -> None:
@@ -187,4 +188,4 @@ class IGlobal(IGlobalBase):
         self.target_dir = 'output/'
         self.emit_url = False
         self.url_expires_in = 3600
-        self.on_conflict = IGlobal.OnConflict.UNIQUE
+        self.on_conflict = OnConflict.UNIQUE

--- a/nodes/src/nodes/tool_filesystem/IGlobal.py
+++ b/nodes/src/nodes/tool_filesystem/IGlobal.py
@@ -42,6 +42,7 @@ Surfaces ``read_file``, ``write_file``, ``delete_file``, ``list_directory``,
 from __future__ import annotations
 
 import re
+from enum import IntEnum
 
 from ai.common.config import Config
 from rocketlib import IGlobalBase, OPEN_MODE, warning
@@ -49,6 +50,18 @@ from rocketlib import IGlobalBase, OPEN_MODE, warning
 
 class IGlobal(IGlobalBase):
     """Global state for tool_filesystem."""
+
+    class OnConflict(IntEnum):
+        """What to do when the sink's target path is already taken.
+
+        Member names are the services.store.json enum values uppercased, which is what lets
+        :meth:`_sink_config` resolve one to the other by name. Resolved once at config time,
+        so each write compares ints.
+        """
+
+        UNIQUE = 0
+        OVERWRITE = 1
+        SKIP = 2
 
     client_id: str | None = None
     file_store: object | None = None  # ai.account.file_store.FileStore
@@ -62,6 +75,7 @@ class IGlobal(IGlobalBase):
     target_dir: str = 'output/'
     emit_url: bool = False
     url_expires_in: int = 3600
+    on_conflict: OnConflict = OnConflict.UNIQUE
 
     def beginGlobal(self) -> None:
         if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
@@ -76,7 +90,12 @@ class IGlobal(IGlobalBase):
         self.allow_stat = bool(cfg.get('allowStat', True))
         self.allow_delete = bool(cfg.get('allowDelete', False))
         self.path_patterns = self._build_path_patterns(cfg)
-        self.target_dir, self.emit_url, self.url_expires_in = self._sink_config(cfg)
+        (
+            self.target_dir,
+            self.emit_url,
+            self.url_expires_in,
+            self.on_conflict,
+        ) = self._sink_config(cfg)
 
         try:
             # Engine identity: this node runs INSIDE the engine subprocess
@@ -132,11 +151,14 @@ class IGlobal(IGlobalBase):
         return patterns
 
     @staticmethod
-    def _sink_config(cfg: dict) -> tuple[str, bool, int]:
-        """Parse the sink lane config into ``(target_dir, emit_url, url_expires_in)``.
+    def _sink_config(cfg: dict) -> tuple[str, bool, int, OnConflict]:
+        """Parse the sink lane config into ``(target_dir, emit_url, url_expires_in, on_conflict)``.
 
         ``url_expires_in`` is clamped to the FileStore range of 1..3600 seconds;
         non-positive or missing values fall back to the 3600-second default.
+        ``on_conflict`` falls back to :attr:`OnConflict.UNIQUE` on anything that does not name
+        a member, so a mistyped config degrades to the non-destructive outcome rather than
+        failing the pipeline.
         """
         target_dir = str(cfg.get('targetDir', 'output/'))
         emit_url = bool(cfg.get('emitUrl', False))
@@ -145,7 +167,11 @@ class IGlobal(IGlobalBase):
         except (TypeError, ValueError):
             raw_expires = 3600
         url_expires_in = min(raw_expires, 3600) if raw_expires > 0 else 3600
-        return target_dir, emit_url, url_expires_in
+        try:
+            on_conflict = IGlobal.OnConflict[str(cfg.get('onConflict', '')).strip().upper()]
+        except KeyError:
+            on_conflict = IGlobal.OnConflict.UNIQUE
+        return target_dir, emit_url, url_expires_in, on_conflict
 
     def validateConfig(self) -> None:
         try:
@@ -161,3 +187,4 @@ class IGlobal(IGlobalBase):
         self.target_dir = 'output/'
         self.emit_url = False
         self.url_expires_in = 3600
+        self.on_conflict = IGlobal.OnConflict.UNIQUE

--- a/nodes/src/nodes/tool_filesystem/IGlobal.py
+++ b/nodes/src/nodes/tool_filesystem/IGlobal.py
@@ -51,9 +51,8 @@ from rocketlib import IGlobalBase, OPEN_MODE, warning
 class OnConflict(IntEnum):
     """What to do when the sink's target path is already taken.
 
-    Member names are the services.store.json enum values uppercased, which is what lets
-    :meth:`IGlobal._sink_config` resolve one to the other by name. Resolved once at config
-    time, so each write compares ints.
+    Member names are the services.store.json enum values uppercased, so
+    :meth:`IGlobal._sink_config` resolves one to the other by name.
     """
 
     UNIQUE = 0
@@ -157,9 +156,8 @@ class IGlobal(IGlobalBase):
 
         ``url_expires_in`` is clamped to the FileStore range of 1..3600 seconds;
         non-positive or missing values fall back to the 3600-second default.
-        ``on_conflict`` falls back to :attr:`OnConflict.UNIQUE` on anything that does not name
-        a member, so a mistyped config degrades to the non-destructive outcome rather than
-        failing the pipeline.
+        ``on_conflict`` falls back to :attr:`OnConflict.UNIQUE` on anything that does not
+        name a member, so a mistyped config degrades to the non-destructive outcome.
         """
         target_dir = str(cfg.get('targetDir', 'output/'))
         emit_url = bool(cfg.get('emitUrl', False))

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -388,28 +388,20 @@ class IInstance(IInstanceBase):
         return ''
 
     def _sink_target_path(self, filename: str, *, index: int | None = None) -> str | None:
-        """Resolve the store path to write to under targetDir, per the conflict policy.
+        """Resolve the store path to write to under targetDir, per ``onConflict``.
 
-        Each candidate is whitelist-checked *before* it is probed, so a path the
-        whitelist would reject never reveals whether files exist in the store.
+        ``overwrite`` returns the path unprobed, ``skip`` yields ``None`` if a file is
+        already there, ``unique`` suffixes ``_1``, ``_2``, … up to
+        ``MAX_COLLISION_SUFFIX``. Each candidate is whitelist-checked *before* it is
+        probed, so a rejected path never reveals whether files exist in the store.
+
+        Args:
+            filename: Name the object carries.
+            index:    Ordinal used to disambiguate several files from one object.
 
         Returns:
-            The path to write, or ``None`` when ``onConflict`` is ``skip`` and the
-            path is already taken — callers must treat that as "leave it alone",
-            not as an error. The reason is logged here, so the message lives in one
-            place rather than at each caller.
-
-        The three policies:
-
-        * ``overwrite`` — write straight over whatever is there. No ``stat()`` at
-          all, which also saves a store round-trip per stream.
-        * ``skip`` — leave an existing *file* alone. A directory at the candidate
-          name is not a file to preserve, so it does not trigger a skip; the write
-          proceeds and the store rejects it if it cannot hold both.
-        * ``unique`` (default) — keep the object's own name (``output/report.pdf``)
-          and fall back to ``_1``, ``_2``, … when it is taken. Bounded by
-          ``MAX_COLLISION_SUFFIX`` and raises past it, rather than probing forever
-          if the store keeps reporting the path as existing.
+            The path to write, or ``None`` when ``skip`` left an existing file alone —
+            not an error, and logged here rather than at each caller.
         """
         target_dir = (self.IGlobal.target_dir or '').strip()
         if target_dir and not target_dir.endswith('/'):
@@ -422,14 +414,11 @@ class IInstance(IInstanceBase):
         self._check_path(candidate)
 
         if self.IGlobal.on_conflict == OnConflict.OVERWRITE:
-            # No probe: replacing is the point, so a stat only costs a round-trip. How the
-            # replacement happens is decided later — a one-shot write is last-write-wins, a
-            # stream goes through _write_path_for.
+            # No probe: replacing is the point, so a stat only costs a round-trip.
             return candidate
 
         if self.IGlobal.on_conflict == OnConflict.SKIP:
-            # 'both' means a file and a same-named directory co-exist, which an object
-            # store allows; there is still a file to leave alone.
+            # 'both' is an object store holding a key and a same-named prefix: still a file.
             if _run_async(self.IGlobal.file_store.stat(candidate)).get('type') in ('file', 'both'):
                 warning(f'tool_filesystem: {filename!r} already exists and onConflict is skip; not written')
                 return None
@@ -480,8 +469,7 @@ class IInstance(IInstanceBase):
         no Doc/chunkId semantics — so downstream JSON consumers get the refs
         without vector-store metadata riding along.
         """
-        # A skipped write yields None rather than a ref; those are dropped here so a
-        # reference is only ever emitted for a file this node actually created.
+        # A skipped write yields None; dropping those keeps refs to files actually written.
         refs = [ref for ref in refs if ref]
         if not refs:
             return
@@ -598,11 +586,9 @@ class IInstance(IInstanceBase):
     def _write_path_for(self, path: str) -> str:
         """Where the stream's bytes actually go.
 
-        Only ``overwrite`` stages. Opening the destination is already destructive — the
-        filesystem backend truncates at ``open_write`` — so the stream writes to a sibling
-        and renames on success, leaving the operator's file intact until there is a complete
-        one to replace it with. ``unique`` and ``skip`` probed their path free and write to
-        it directly.
+        Only ``overwrite`` stages: ``open_write`` truncates the destination, so the bytes
+        go to a sibling and rename in on success, keeping the existing file until a
+        complete one can replace it. ``unique`` and ``skip`` probed their path free.
 
         Args:
             path: The final destination.
@@ -615,9 +601,8 @@ class IInstance(IInstanceBase):
         try:
             return self._staging_path(path)
         except ValueError:
-            # A whitelist that admits the destination but not a sibling of it. Failing here
-            # would break a pipeline that worked before this staging existed, so fall back
-            # to writing in place — with the exposure this method exists to avoid.
+            # Writing in place is worse than staging, better than failing a pipeline
+            # that worked before staging existed.
             warning(
                 f'tool_filesystem: the path whitelist rejects a staging file beside {path!r}; '
                 'writing in place, so an interrupted stream will leave it incomplete'
@@ -627,9 +612,8 @@ class IInstance(IInstanceBase):
     def _discard_partial(self, st: dict) -> None:
         """Remove what a half-written stream produced.
 
-        Always safe to delete: under ``unique`` and ``skip`` the path was probed free before
-        the handle opened, and under ``overwrite`` the bytes went to a staging sibling. Either
-        way the file removed here is one this stream created.
+        Always safe: ``unique`` and ``skip`` probed the path free before opening it, and
+        ``overwrite`` wrote to a staging sibling — so this file is one the stream created.
 
         Args:
             st: The stream state being discarded.
@@ -640,9 +624,7 @@ class IInstance(IInstanceBase):
         try:
             _run_on_stream_loop(self.IGlobal.file_store.delete(write_path))
         except Exception as e:
-            # The cleanup itself failed — the store may still hold the handle the failed
-            # close left open. Say so: the leftover is inert, but silence is how it ends up
-            # discovered by hand in the target directory months later.
+            # The leftover is inert, but silence means nobody ever learns it is there.
             warning(f'tool_filesystem: could not remove {write_path!r} after a failed write: {e}')
 
     def _stream_filename(self, descriptor, mime: str) -> str:
@@ -706,8 +688,7 @@ class IInstance(IInstanceBase):
                 name = self._stream_filename(st.get('descriptor'), st['mime'])
                 path = self._sink_target_path(name)
                 if path is None:
-                    # Drop the stream, so the remaining chunks and the END that follows
-                    # find nothing and become no-ops.
+                    # Dropped, so the remaining chunks and the END find nothing.
                     streams.pop(kind, None)
                     return
                 write_path = self._write_path_for(path)
@@ -717,8 +698,8 @@ class IInstance(IInstanceBase):
             try:
                 _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))
             except Exception:
-                # Nothing later in this object revisits this stream, so undiscarded it would
-                # hold the store's write lock until the next object's open().
+                # Nothing revisits this stream, so its handle would hold the store's
+                # write lock until the next object's open().
                 self._media_abort(kind)
                 raise
         elif aviAction == AVI_ACTION.END:
@@ -728,8 +709,7 @@ class IInstance(IInstanceBase):
             try:
                 _run_on_stream_loop(self.IGlobal.file_store.close_write(st['handle']))
                 if st['write_path'] != st['path']:
-                    # Staged under overwrite: the destination is replaced only now, with a
-                    # complete file, so everything up to this point left it untouched.
+                    # Staged: the destination is replaced only now, and only by a whole file.
                     _run_on_stream_loop(self.IGlobal.file_store.rename(st['write_path'], st['path'], overwrite=True))
             except Exception:
                 # A failed commit leaves an incomplete file: remove it before

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -713,7 +713,14 @@ class IInstance(IInstanceBase):
                 st['handle'] = _run_on_stream_loop(self.IGlobal.file_store.open_write(write_path))
                 st['path'] = path
                 st['write_path'] = write_path
-            _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))
+            try:
+                _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))
+            except Exception:
+                # Nothing later in this object reaches this stream, so without discarding it
+                # here the handle stays open — holding the store's write lock — and the
+                # partial file sits in the store until the next object's open() sweeps it.
+                self._media_abort(kind)
+                raise
         elif aviAction == AVI_ACTION.END:
             st = streams.pop(kind, None)
             if st is None or st['handle'] is None:

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -422,8 +422,9 @@ class IInstance(IInstanceBase):
         self._check_path(candidate)
 
         if self.IGlobal.on_conflict == OnConflict.OVERWRITE:
-            # FilesystemStore.open_write opens 'wb' and FileStore.write is
-            # last-write-wins, so replacing needs no explicit truncate here.
+            # No probe: replacing is the point, so a stat only costs a round-trip. How the
+            # replacement happens is decided later — a one-shot write is last-write-wins, a
+            # stream goes through _write_path_for.
             return candidate
 
         if self.IGlobal.on_conflict == OnConflict.SKIP:
@@ -597,14 +598,11 @@ class IInstance(IInstanceBase):
     def _write_path_for(self, path: str) -> str:
         """Where the stream's bytes actually go.
 
-        Only ``overwrite`` needs staging. Under ``unique`` and ``skip`` the destination was
-        probed free, so there is nothing at risk and the stream writes straight to it.
-
-        Under ``overwrite`` the destination holds the operator's file, and opening it is
-        already destructive — the filesystem backend truncates at ``open_write``, and the
-        object stores commit over it at ``close_write``. Writing to a sibling and renaming
-        on success keeps the original intact until there is a complete file to replace it
-        with, and makes the failure cleanup unambiguous: the staging file is always ours.
+        Only ``overwrite`` stages. Opening the destination is already destructive — the
+        filesystem backend truncates at ``open_write`` — so the stream writes to a sibling
+        and renames on success, leaving the operator's file intact until there is a complete
+        one to replace it with. ``unique`` and ``skip`` probed their path free and write to
+        it directly.
 
         Args:
             path: The final destination.
@@ -641,8 +639,11 @@ class IInstance(IInstanceBase):
             return
         try:
             _run_on_stream_loop(self.IGlobal.file_store.delete(write_path))
-        except Exception:
-            pass
+        except Exception as e:
+            # The cleanup itself failed — the store may still hold the handle the failed
+            # close left open. Say so: the leftover is inert, but silence is how it ends up
+            # discovered by hand in the target directory months later.
+            warning(f'tool_filesystem: could not remove {write_path!r} after a failed write: {e}')
 
     def _stream_filename(self, descriptor, mime: str) -> str:
         """Filename for one media stream, preferring the name the stream carries.
@@ -716,9 +717,8 @@ class IInstance(IInstanceBase):
             try:
                 _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))
             except Exception:
-                # Nothing later in this object reaches this stream, so without discarding it
-                # here the handle stays open — holding the store's write lock — and the
-                # partial file sits in the store until the next object's open() sweeps it.
+                # Nothing later in this object revisits this stream, so undiscarded it would
+                # hold the store's write lock until the next object's open().
                 self._media_abort(kind)
                 raise
         elif aviAction == AVI_ACTION.END:

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -59,7 +59,7 @@ if TYPE_CHECKING:
 from ai.common.avi.descriptor import descriptor_from_payload
 from ai.common.utils import optional_str, require_dict, require_str
 
-from .IGlobal import IGlobal
+from .IGlobal import IGlobal, OnConflict
 
 # Cap on bytes returned by a single read_file call. The underlying FileStore
 # defaults to 100 MB, which can blow the agent's context window or OOM the
@@ -396,13 +396,16 @@ class IInstance(IInstanceBase):
         Returns:
             The path to write, or ``None`` when ``onConflict`` is ``skip`` and the
             path is already taken — callers must treat that as "leave it alone",
-            not as an error.
+            not as an error. The reason is logged here, so the message lives in one
+            place rather than at each caller.
 
         The three policies:
 
         * ``overwrite`` — write straight over whatever is there. No ``stat()`` at
           all, which also saves a store round-trip per stream.
-        * ``skip`` — leave an existing file alone.
+        * ``skip`` — leave an existing *file* alone. A directory at the candidate
+          name is not a file to preserve, so it does not trigger a skip; the write
+          proceeds and the store rejects it if it cannot hold both.
         * ``unique`` (default) — keep the object's own name (``output/report.pdf``)
           and fall back to ``_1``, ``_2``, … when it is taken. Bounded by
           ``MAX_COLLISION_SUFFIX`` and raises past it, rather than probing forever
@@ -418,13 +421,16 @@ class IInstance(IInstanceBase):
         candidate = f'{target_dir}{stem}{ext}'
         self._check_path(candidate)
 
-        if self.IGlobal.on_conflict == self.IGlobal.OnConflict.OVERWRITE:
+        if self.IGlobal.on_conflict == OnConflict.OVERWRITE:
             # FilesystemStore.open_write opens 'wb' and FileStore.write is
             # last-write-wins, so replacing needs no explicit truncate here.
             return candidate
 
-        if self.IGlobal.on_conflict == self.IGlobal.OnConflict.SKIP:
-            if _run_async(self.IGlobal.file_store.stat(candidate)).get('exists'):
+        if self.IGlobal.on_conflict == OnConflict.SKIP:
+            # 'both' means a file and a same-named directory co-exist, which an object
+            # store allows; there is still a file to leave alone.
+            if _run_async(self.IGlobal.file_store.stat(candidate)).get('type') in ('file', 'both'):
+                warning(f'tool_filesystem: {filename!r} already exists and onConflict is skip; not written')
                 return None
             return candidate
 
@@ -461,7 +467,6 @@ class IInstance(IInstanceBase):
             raise ValueError('write access is not enabled for this filesystem tool')
         path = self._sink_target_path(filename, index=index)
         if path is None:
-            warning(f'tool_filesystem: {filename!r} already exists and onConflict is skip; not written')
             return None
         _run_async(self.IGlobal.file_store.write(path, data))
         return self._sink_ref(path)
@@ -571,10 +576,28 @@ class IInstance(IInstanceBase):
                 _run_on_stream_loop(self.IGlobal.file_store.close_write(st['handle']))
             except Exception:
                 pass
-            try:
-                _run_on_stream_loop(self.IGlobal.file_store.delete(st['path']))
-            except Exception:
-                pass
+            self._discard_partial(st)
+
+    def _discard_partial(self, st: dict) -> None:
+        """Remove a half-written stream's file, but only one this stream created.
+
+        Under ``unique`` and ``skip`` the path was probed free before the handle opened,
+        so whatever is there now is this stream's own partial output and deleting it is
+        the cleanup it was written for.
+
+        Under ``overwrite`` the path is the user's existing file. Deleting it would turn
+        an interrupted stream into the loss of a file the node never created — worse than
+        the truncation ``overwrite`` already implies, and not what the README warns about.
+
+        Args:
+            st: The stream state being discarded.
+        """
+        if not st.get('created'):
+            return
+        try:
+            _run_on_stream_loop(self.IGlobal.file_store.delete(st['path']))
+        except Exception:
+            pass
 
     def _stream_filename(self, descriptor, mime: str) -> str:
         """Filename for one media stream, preferring the name the stream carries.
@@ -640,8 +663,10 @@ class IInstance(IInstanceBase):
                     # Drop the stream, so the remaining chunks and the END that follows
                     # find nothing and become no-ops.
                     streams.pop(kind, None)
-                    warning(f'tool_filesystem: {name!r} already exists and onConflict is skip; not written')
                     return
+                # Under overwrite the path was not probed, so the file may be the user's
+                # rather than ours; _discard_partial must not remove it.
+                st['created'] = self.IGlobal.on_conflict != OnConflict.OVERWRITE
                 st['handle'] = _run_on_stream_loop(self.IGlobal.file_store.open_write(path))
                 st['path'] = path
             _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))
@@ -654,10 +679,7 @@ class IInstance(IInstanceBase):
             except Exception:
                 # A failed commit leaves an incomplete file: remove it before
                 # propagating, so downstream never sees a truncated object.
-                try:
-                    _run_on_stream_loop(self.IGlobal.file_store.delete(st['path']))
-                except Exception:
-                    pass
+                self._discard_partial(st)
                 raise
             self._sink_emit([self._sink_ref(st['path'], st['mime'])])
 

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -578,24 +578,69 @@ class IInstance(IInstanceBase):
                 pass
             self._discard_partial(st)
 
+    def _staging_path(self, path: str) -> str:
+        """A sibling path to stream into before it replaces ``path``.
+
+        Args:
+            path: The final destination.
+
+        Returns:
+            The staging path.
+
+        Raises:
+            ValueError: If the whitelist admits the destination but not the sibling.
+        """
+        staged = f'{path}.part-{self.instance.currentObject.objectId}'
+        self._check_path(staged)
+        return staged
+
+    def _write_path_for(self, path: str) -> str:
+        """Where the stream's bytes actually go.
+
+        Only ``overwrite`` needs staging. Under ``unique`` and ``skip`` the destination was
+        probed free, so there is nothing at risk and the stream writes straight to it.
+
+        Under ``overwrite`` the destination holds the operator's file, and opening it is
+        already destructive — the filesystem backend truncates at ``open_write``, and the
+        object stores commit over it at ``close_write``. Writing to a sibling and renaming
+        on success keeps the original intact until there is a complete file to replace it
+        with, and makes the failure cleanup unambiguous: the staging file is always ours.
+
+        Args:
+            path: The final destination.
+
+        Returns:
+            The path to open for writing — the destination itself, or a staging sibling.
+        """
+        if self.IGlobal.on_conflict != OnConflict.OVERWRITE:
+            return path
+        try:
+            return self._staging_path(path)
+        except ValueError:
+            # A whitelist that admits the destination but not a sibling of it. Failing here
+            # would break a pipeline that worked before this staging existed, so fall back
+            # to writing in place — with the exposure this method exists to avoid.
+            warning(
+                f'tool_filesystem: the path whitelist rejects a staging file beside {path!r}; '
+                'writing in place, so an interrupted stream will leave it incomplete'
+            )
+            return path
+
     def _discard_partial(self, st: dict) -> None:
-        """Remove a half-written stream's file, but only one this stream created.
+        """Remove what a half-written stream produced.
 
-        Under ``unique`` and ``skip`` the path was probed free before the handle opened,
-        so whatever is there now is this stream's own partial output and deleting it is
-        the cleanup it was written for.
-
-        Under ``overwrite`` the path is the user's existing file. Deleting it would turn
-        an interrupted stream into the loss of a file the node never created — worse than
-        the truncation ``overwrite`` already implies, and not what the README warns about.
+        Always safe to delete: under ``unique`` and ``skip`` the path was probed free before
+        the handle opened, and under ``overwrite`` the bytes went to a staging sibling. Either
+        way the file removed here is one this stream created.
 
         Args:
             st: The stream state being discarded.
         """
-        if not st.get('created'):
+        write_path = st.get('write_path')
+        if not write_path:
             return
         try:
-            _run_on_stream_loop(self.IGlobal.file_store.delete(st['path']))
+            _run_on_stream_loop(self.IGlobal.file_store.delete(write_path))
         except Exception:
             pass
 
@@ -664,11 +709,10 @@ class IInstance(IInstanceBase):
                     # find nothing and become no-ops.
                     streams.pop(kind, None)
                     return
-                # Under overwrite the path was not probed, so the file may be the user's
-                # rather than ours; _discard_partial must not remove it.
-                st['created'] = self.IGlobal.on_conflict != OnConflict.OVERWRITE
-                st['handle'] = _run_on_stream_loop(self.IGlobal.file_store.open_write(path))
+                write_path = self._write_path_for(path)
+                st['handle'] = _run_on_stream_loop(self.IGlobal.file_store.open_write(write_path))
                 st['path'] = path
+                st['write_path'] = write_path
             _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))
         elif aviAction == AVI_ACTION.END:
             st = streams.pop(kind, None)
@@ -676,6 +720,10 @@ class IInstance(IInstanceBase):
                 return
             try:
                 _run_on_stream_loop(self.IGlobal.file_store.close_write(st['handle']))
+                if st['write_path'] != st['path']:
+                    # Staged under overwrite: the destination is replaced only now, with a
+                    # complete file, so everything up to this point left it untouched.
+                    _run_on_stream_loop(self.IGlobal.file_store.rename(st['write_path'], st['path'], overwrite=True))
             except Exception:
                 # A failed commit leaves an incomplete file: remove it before
                 # propagating, so downstream never sees a truncated object.

--- a/nodes/src/nodes/tool_filesystem/IInstance.py
+++ b/nodes/src/nodes/tool_filesystem/IInstance.py
@@ -387,16 +387,26 @@ class IInstance(IInstanceBase):
             return os.path.splitext(os.path.basename(name))[1]
         return ''
 
-    def _sink_target_path(self, filename: str, *, index: int | None = None) -> str:
-        """Resolve a free store path under targetDir, suffixing on collision.
-
-        Keeps the object's own name (``output/report.pdf``) and only falls back
-        to ``_1``, ``_2``, … when that name is already taken. The search is
-        bounded by ``MAX_COLLISION_SUFFIX`` and raises past it, rather than
-        probing forever if the store keeps reporting the path as existing.
+    def _sink_target_path(self, filename: str, *, index: int | None = None) -> str | None:
+        """Resolve the store path to write to under targetDir, per the conflict policy.
 
         Each candidate is whitelist-checked *before* it is probed, so a path the
         whitelist would reject never reveals whether files exist in the store.
+
+        Returns:
+            The path to write, or ``None`` when ``onConflict`` is ``skip`` and the
+            path is already taken — callers must treat that as "leave it alone",
+            not as an error.
+
+        The three policies:
+
+        * ``overwrite`` — write straight over whatever is there. No ``stat()`` at
+          all, which also saves a store round-trip per stream.
+        * ``skip`` — leave an existing file alone.
+        * ``unique`` (default) — keep the object's own name (``output/report.pdf``)
+          and fall back to ``_1``, ``_2``, … when it is taken. Bounded by
+          ``MAX_COLLISION_SUFFIX`` and raises past it, rather than probing forever
+          if the store keeps reporting the path as existing.
         """
         target_dir = (self.IGlobal.target_dir or '').strip()
         if target_dir and not target_dir.endswith('/'):
@@ -407,6 +417,17 @@ class IInstance(IInstanceBase):
 
         candidate = f'{target_dir}{stem}{ext}'
         self._check_path(candidate)
+
+        if self.IGlobal.on_conflict == self.IGlobal.OnConflict.OVERWRITE:
+            # FilesystemStore.open_write opens 'wb' and FileStore.write is
+            # last-write-wins, so replacing needs no explicit truncate here.
+            return candidate
+
+        if self.IGlobal.on_conflict == self.IGlobal.OnConflict.SKIP:
+            if _run_async(self.IGlobal.file_store.stat(candidate)).get('exists'):
+                return None
+            return candidate
+
         n = 0
         while _run_async(self.IGlobal.file_store.stat(candidate)).get('exists'):
             n += 1
@@ -426,16 +447,22 @@ class IInstance(IInstanceBase):
             url = _run_async(self.IGlobal.file_store.get_url(path, expires_in=self.IGlobal.url_expires_in))
         return {'storePath': path, 'url': url, 'name': os.path.basename(path), 'mime': mime}
 
-    def _sink_write(self, data: bytes, filename: str, *, index: int | None = None) -> dict:
+    def _sink_write(self, data: bytes, filename: str, *, index: int | None = None) -> dict | None:
         """Persist ``data`` in one shot (documents/text/table) and return a ref.
 
         Enforces ``allow_write``; ``_sink_target_path`` applies the whitelist to
         every candidate before probing, so a rejected path never touches the store.
+
+        Returns:
+            The reference, or ``None`` when the conflict policy skipped the write.
         """
         self._check_ready()
         if not self.IGlobal.allow_write:
             raise ValueError('write access is not enabled for this filesystem tool')
         path = self._sink_target_path(filename, index=index)
+        if path is None:
+            warning(f'tool_filesystem: {filename!r} already exists and onConflict is skip; not written')
+            return None
         _run_async(self.IGlobal.file_store.write(path, data))
         return self._sink_ref(path)
 
@@ -447,6 +474,9 @@ class IInstance(IInstanceBase):
         no Doc/chunkId semantics — so downstream JSON consumers get the refs
         without vector-store metadata riding along.
         """
+        # A skipped write yields None rather than a ref; those are dropped here so a
+        # reference is only ever emitted for a file this node actually created.
+        refs = [ref for ref in refs if ref]
         if not refs:
             return
         if 'json' not in self.instance.getListeners():
@@ -604,7 +634,14 @@ class IInstance(IInstanceBase):
                 self._check_ready()
                 if not self.IGlobal.allow_write:
                     raise ValueError('write access is not enabled for this filesystem tool')
-                path = self._sink_target_path(self._stream_filename(st.get('descriptor'), st['mime']))
+                name = self._stream_filename(st.get('descriptor'), st['mime'])
+                path = self._sink_target_path(name)
+                if path is None:
+                    # Drop the stream, so the remaining chunks and the END that follows
+                    # find nothing and become no-ops.
+                    streams.pop(kind, None)
+                    warning(f'tool_filesystem: {name!r} already exists and onConflict is skip; not written')
+                    return
                 st['handle'] = _run_on_stream_loop(self.IGlobal.file_store.open_write(path))
                 st['path'] = path
             _run_on_stream_loop(self.IGlobal.file_store.write_chunk(st['handle'], bytes(data)))

--- a/nodes/src/nodes/tool_filesystem/README.md
+++ b/nodes/src/nodes/tool_filesystem/README.md
@@ -148,6 +148,12 @@ emits a JSON reference for each file it writes.
   two inputs at `a/1.jpg` and `b/1.jpg` both resolve to the same target in a flat
   `targetDir` and the second silently replaces the first. `unique` stays the default for
   exactly that reason.
+  A streamed write that is cut off part-way leaves the target in whatever state it reached.
+  Under `unique` and `skip` the sink removes it — the path was free, so the partial file is
+  its own. Under `overwrite` it does not, because the file at that path is yours: an
+  interrupted stream leaves it truncated rather than deleted.
+  `skip` compares against an existing **file**. A directory sharing the name is not a file
+  to preserve and does not by itself cause a skip.
   Every candidate is whitelist-checked *before* it is probed, so a path the whitelist
   would reject never reveals whether files exist in the store.
 - **How the extension is chosen:** each lane owns its own rule, keyed to what the lane

--- a/nodes/src/nodes/tool_filesystem/README.md
+++ b/nodes/src/nodes/tool_filesystem/README.md
@@ -148,10 +148,10 @@ emits a JSON reference for each file it writes.
   two inputs at `a/1.jpg` and `b/1.jpg` both resolve to the same target in a flat
   `targetDir` and the second silently replaces the first. `unique` stays the default for
   exactly that reason.
-  A streamed write that is cut off part-way leaves the target in whatever state it reached.
-  Under `unique` and `skip` the sink removes it — the path was free, so the partial file is
-  its own. Under `overwrite` it does not, because the file at that path is yours: an
-  interrupted stream leaves it truncated rather than deleted.
+  A streamed write that is cut off part-way never leaves a partial file behind. Under
+  `unique` and `skip` the sink deletes what it wrote. Under `overwrite` the stream goes to
+  a `.part-<objectId>` sibling and only replaces the target once it is complete, so an
+  interrupted run leaves the existing file exactly as it was.
   `skip` compares against an existing **file**. A directory sharing the name is not a file
   to preserve and does not by itself cause a skip.
   Every candidate is whitelist-checked *before* it is probed, so a path the whitelist

--- a/nodes/src/nodes/tool_filesystem/README.md
+++ b/nodes/src/nodes/tool_filesystem/README.md
@@ -126,6 +126,7 @@ emits a JSON reference for each file it writes.
 | Field | Type | Description |
 |---|---|---|
 | `targetDir` | string | Default `output/`. Base directory (relative to the account file store root) that lane-written files are placed under. |
+| `onConflict` | string | Default `unique`. What to do when the target path is already taken: `unique` writes under `_1`, `_2`, …; `overwrite` replaces the existing file (destructive — see the warning below); `skip` leaves it alone. |
 | `emitUrl` | boolean | Default false. Also include a time-limited signed download URL in the emitted JSON reference. |
 | `urlExpiresIn` | integer | Default 3600 (max 3600). TTL in seconds for the signed URL when `emitUrl` is on. |
 | `whitelistPattern` | string | Default empty. |
@@ -135,10 +136,18 @@ emits a JSON reference for each file it writes.
 
 - **Where it writes:** `targetDir` (default `output/`) + the object's original name stem,
   with the lane's extension rule applied — e.g. `output/report.txt` (nameless inputs fall
-  back to the object id). If that name is already taken the sink appends `_1`, `_2`, …,
-  and gives up with an error after `MAX_COLLISION_SUFFIX` (100) attempts rather than
-  probing indefinitely. When one object emits several documents they also carry an index
+  back to the object id). When one object emits several documents they also carry an index
   (`report_0.txt`, `report_1.txt`, …).
+- **When the file already exists**, `onConflict` decides between three behaviours. With
+  `unique` (the default) the sink appends `_1`, `_2`, …, giving up with an error after
+  `MAX_COLLISION_SUFFIX` (100) attempts rather than probing indefinitely. With `skip` it
+  leaves the existing file alone, logs a warning, and emits no reference for it. With
+  `overwrite` it replaces the file — and skips the existence probe entirely, which also
+  saves a store round-trip per stream.
+  **`overwrite` can lose data.** Filenames derive from the source object's *basename*, so
+  two inputs at `a/1.jpg` and `b/1.jpg` both resolve to the same target in a flat
+  `targetDir` and the second silently replaces the first. `unique` stays the default for
+  exactly that reason.
   Every candidate is whitelist-checked *before* it is probed, so a path the whitelist
   would reject never reveals whether files exist in the store.
 - **How the extension is chosen:** each lane owns its own rule, keyed to what the lane

--- a/nodes/src/nodes/tool_filesystem/services.store.json
+++ b/nodes/src/nodes/tool_filesystem/services.store.json
@@ -33,6 +33,17 @@
 			"description": "Base directory (relative to the account file store root) that lane-written files are placed under.",
 			"default": "output/"
 		},
+		"filesystem.onConflict": {
+			"type": "string",
+			"title": "When the file already exists",
+			"description": "All three are one decision, so they are one setting. 'Replace' is destructive in a way that is easy to miss: names come from the source object's BASENAME, so two inputs from different folders that share a filename resolve to the same target and the second silently replaces the first. Leave it on 'Write under a new name' unless you are deliberately re-running into the same directory.",
+			"default": "unique",
+			"enum": [
+				["unique", "Write under a new name (file_1, file_2, ...)"],
+				["overwrite", "Replace the existing file"],
+				["skip", "Leave the existing file alone"]
+			]
+		},
 		"filesystem.emitUrl": {
 			"type": "boolean",
 			"title": "Emit download URL",
@@ -72,7 +83,7 @@
 		{
 			"section": "Pipe",
 			"title": "File Store",
-			"properties": ["type", "filesystem.targetDir", "filesystem.emitUrl", "filesystem.urlExpiresIn", "filesystem.pathWhitelist"]
+			"properties": ["type", "filesystem.targetDir", "filesystem.onConflict", "filesystem.emitUrl", "filesystem.urlExpiresIn", "filesystem.pathWhitelist"]
 		}
 	]
 }

--- a/nodes/src/nodes/tool_filesystem/services.store.json
+++ b/nodes/src/nodes/tool_filesystem/services.store.json
@@ -36,7 +36,7 @@
 		"filesystem.onConflict": {
 			"type": "string",
 			"title": "When the file already exists",
-			"description": "All three are one decision, so they are one setting. 'Replace' is destructive in a way that is easy to miss: names come from the source object's BASENAME, so two inputs from different folders that share a filename resolve to the same target and the second silently replaces the first. Leave it on 'Write under a new name' unless you are deliberately re-running into the same directory.",
+			"description": "What the sink does when the target path is already taken. 'Replace' is destructive in a way that is easy to miss: names come from the source object's BASENAME, so two inputs from different folders that share a filename resolve to the same target and the second silently replaces the first. Leave it on 'Write under a new name' unless you are deliberately re-running into the same directory.",
 			"default": "unique",
 			"enum": [
 				["unique", "Write under a new name (file_1, file_2, ...)"],

--- a/nodes/test/tool_filesystem/test_read_size_cap.py
+++ b/nodes/test/tool_filesystem/test_read_size_cap.py
@@ -109,8 +109,7 @@ def _install_tool_filesystem_pkg_stub() -> None:
         path_patterns: list | None = None
 
     iglobal_mod.IGlobal = _IGlobalStub
-    # ``IInstance`` imports OnConflict from this module, so the stub has to export it too.
-    # Loaded from the production source rather than restated: the sink resolves the config
+    # Read from the production source rather than restated: the sink resolves the config
     # value by member name, so a copy that drifted would be a silent divergence.
     iglobal_mod.OnConflict = _load_production_on_conflict()
     sys.modules['tool_filesystem.IGlobal'] = iglobal_mod

--- a/nodes/test/tool_filesystem/test_read_size_cap.py
+++ b/nodes/test/tool_filesystem/test_read_size_cap.py
@@ -109,7 +109,32 @@ def _install_tool_filesystem_pkg_stub() -> None:
         path_patterns: list | None = None
 
     iglobal_mod.IGlobal = _IGlobalStub
+    # ``IInstance`` imports OnConflict from this module, so the stub has to export it too.
+    # Loaded from the production source rather than restated: the sink resolves the config
+    # value by member name, so a copy that drifted would be a silent divergence.
+    iglobal_mod.OnConflict = _load_production_on_conflict()
     sys.modules['tool_filesystem.IGlobal'] = iglobal_mod
+
+
+def _load_production_on_conflict():
+    """The real ``OnConflict`` enum, read straight out of ``IGlobal.py``.
+
+    Executing that module needs ``ai``/``rocketlib``, which this suite deliberately avoids
+    importing; the enum itself is stdlib-only, so it is compiled on its own instead.
+    """
+    import ast
+    from enum import IntEnum
+
+    tree = ast.parse((_NODE_DIR / 'IGlobal.py').read_text(encoding='utf-8'))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == 'OnConflict':
+            members = {
+                stmt.targets[0].id: ast.literal_eval(stmt.value)
+                for stmt in node.body
+                if isinstance(stmt, ast.Assign) and isinstance(stmt.targets[0], ast.Name)
+            }
+            return IntEnum('OnConflict', members)
+    raise AssertionError('OnConflict not found in IGlobal.py')
 
 
 # Stub rocketlib only while importing the node, then restore so it never leaks.

--- a/nodes/test/tool_filesystem/test_sink_lanes.py
+++ b/nodes/test/tool_filesystem/test_sink_lanes.py
@@ -454,3 +454,32 @@ def test_chunk_write_failure_discards_the_stream():
     (deleted,), _ = fs.delete.await_args
     assert deleted == 'output/o7.png'
     assert not inst._media_streams.get('image'), 'the stream must not stay pending'
+
+
+def test_failed_cleanup_is_reported_not_swallowed():
+    """When the cleanup delete fails, the leftover must at least be named.
+
+    Observed against a real store: a close that fails without releasing the OS handle
+    leaves the staging file undeletable. Nothing downstream breaks, but a silent pass here
+    means the debris is only ever found by looking in the directory.
+    """
+    import tool_filesystem.IInstance as mod
+
+    fs = _fs()
+    fs.close_write.side_effect = RuntimeError('close failed')
+    fs.delete.side_effect = RuntimeError('still open')
+    inst = _sink_instance(fs, has_name=False, object_id='o8', on_conflict='overwrite')
+    from rocketlib import AVI_ACTION
+
+    said = []
+    original = mod.warning
+    mod.warning = lambda msg: said.append(msg)
+    try:
+        inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+        inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'bytes')
+        with pytest.raises(RuntimeError, match='close failed'):
+            inst.writeImage(AVI_ACTION.END, 'image/png', b'')
+    finally:
+        mod.warning = original
+
+    assert any('o8.png.part-o8' in m for m in said), f'the leftover path must be named: {said}'

--- a/nodes/test/tool_filesystem/test_sink_lanes.py
+++ b/nodes/test/tool_filesystem/test_sink_lanes.py
@@ -433,3 +433,24 @@ def test_whitelist_rejecting_the_sibling_falls_back_to_writing_in_place():
     (opened,), _ = fs.open_write.await_args
     assert opened == 'output/o6.png'
     fs.rename.assert_not_awaited()
+
+
+def test_chunk_write_failure_discards_the_stream():
+    """A failed chunk must not leave the handle open and the file behind.
+
+    Nothing later in the object's lifecycle revisits a stream that raised here, so the
+    store would hold the write lock and the partial file until the next object began.
+    """
+    fs = _fs()
+    fs.write_chunk.side_effect = RuntimeError('chunk failed')
+    inst = _sink_instance(fs, has_name=False, object_id='o7')
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    with pytest.raises(RuntimeError, match='chunk failed'):
+        inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'bytes')
+
+    fs.close_write.assert_awaited()
+    (deleted,), _ = fs.delete.await_args
+    assert deleted == 'output/o7.png'
+    assert not inst._media_streams.get('image'), 'the stream must not stay pending'

--- a/nodes/test/tool_filesystem/test_sink_lanes.py
+++ b/nodes/test/tool_filesystem/test_sink_lanes.py
@@ -332,9 +332,8 @@ def test_end_close_failure_deletes_partial_and_raises():
 # ---------------------------------------------------------------------------
 # overwrite stages the stream and swaps it in only when it is complete
 #
-# Opening the destination is itself destructive — the filesystem backend truncates at
-# open_write, the object stores commit over it at close_write — so a stream that fails
-# part-way would leave the operator's file neither old nor new.
+# open_write is itself destructive, so writing straight to the destination would leave a
+# failed stream's file neither old nor new.
 # ---------------------------------------------------------------------------
 
 
@@ -436,13 +435,12 @@ def test_whitelist_rejecting_the_sibling_falls_back_to_writing_in_place():
 
 
 def test_chunk_write_failure_discards_the_stream():
-    """A failed chunk must not leave the handle open and the file behind.
-
-    Nothing later in the object's lifecycle revisits a stream that raised here, so the
-    store would hold the write lock and the partial file until the next object began.
-    """
+    """A failed chunk must not leave the handle open and the file behind."""
     fs = _fs()
     fs.write_chunk.side_effect = RuntimeError('chunk failed')
+    order = []
+    for name in ('close_write', 'delete'):
+        getattr(fs, name).side_effect = (lambda n: lambda *a, **k: order.append((n, a)))(name)
     inst = _sink_instance(fs, has_name=False, object_id='o7')
     from rocketlib import AVI_ACTION
 
@@ -450,19 +448,17 @@ def test_chunk_write_failure_discards_the_stream():
     with pytest.raises(RuntimeError, match='chunk failed'):
         inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'bytes')
 
-    fs.close_write.assert_awaited()
+    # Order matters, not just occurrence: FileStore.delete refuses a path whose write handle
+    # is still open, so a cleanup that deleted before closing would fail against a real store
+    # while passing against mocks that accept either.
+    assert [c[0] for c in order] == ['close_write', 'delete'], order
     (deleted,), _ = fs.delete.await_args
     assert deleted == 'output/o7.png'
     assert not inst._media_streams.get('image'), 'the stream must not stay pending'
 
 
 def test_failed_cleanup_is_reported_not_swallowed():
-    """When the cleanup delete fails, the leftover must at least be named.
-
-    Observed against a real store: a close that fails without releasing the OS handle
-    leaves the staging file undeletable. Nothing downstream breaks, but a silent pass here
-    means the debris is only ever found by looking in the directory.
-    """
+    """An undeletable leftover must at least be named, or it is only found by hand."""
     import tool_filesystem.IInstance as mod
 
     fs = _fs()
@@ -482,4 +478,6 @@ def test_failed_cleanup_is_reported_not_swallowed():
     finally:
         mod.warning = original
 
+    (attempted,), _ = fs.delete.await_args
+    assert attempted == 'output/o8.png.part-o8', 'the staging path is what cleanup must try to remove'
     assert any('o8.png.part-o8' in m for m in said), f'the leftover path must be named: {said}'

--- a/nodes/test/tool_filesystem/test_sink_lanes.py
+++ b/nodes/test/tool_filesystem/test_sink_lanes.py
@@ -330,48 +330,34 @@ def test_end_close_failure_deletes_partial_and_raises():
 
 
 # ---------------------------------------------------------------------------
-# Cleanup must not remove a file this node did not create
+# overwrite stages the stream and swaps it in only when it is complete
+#
+# Opening the destination is itself destructive — the filesystem backend truncates at
+# open_write, the object stores commit over it at close_write — so a stream that fails
+# part-way would leave the operator's file neither old nor new.
 # ---------------------------------------------------------------------------
 
 
-def test_abort_does_not_delete_under_overwrite():
-    """The user's own file is at that path — an interrupted stream must not remove it.
-
-    Under unique/skip the path was probed free, so whatever sits there is this stream's
-    partial output and deleting it is the intended cleanup. Under overwrite it is the file
-    the operator asked to replace, and losing it entirely to a transient failure is worse
-    than the truncation overwrite already implies.
-    """
+def test_overwrite_streams_to_a_sibling_and_renames_on_success():
     fs = _fs()
     inst = _sink_instance(fs, has_name=False, object_id='o1', on_conflict='overwrite')
     from rocketlib import AVI_ACTION
 
     inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
-    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'partial')
-    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')  # abort the first stream
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'bytes')
+    inst.writeImage(AVI_ACTION.END, 'image/png', b'')
 
-    fs.close_write.assert_awaited()  # handle still released
-    fs.delete.assert_not_awaited()  # but the existing file is left alone
-
-
-def test_abort_still_deletes_under_unique():
-    """Unchanged where the path was probed free: the partial is ours to remove."""
-    fs = _fs()
-    inst = _sink_instance(fs, has_name=False, object_id='o2')
-    from rocketlib import AVI_ACTION
-
-    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
-    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'partial')
-    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
-
-    fs.delete.assert_awaited()
+    (opened,), _ = fs.open_write.await_args
+    assert opened == 'output/o1.png.part-o1', 'the destination must not be opened directly'
+    (src, dst), kwargs = fs.rename.await_args
+    assert (src, dst) == ('output/o1.png.part-o1', 'output/o1.png') and kwargs == {'overwrite': True}
 
 
-def test_failed_commit_does_not_delete_under_overwrite():
-    """Same rule on the END path, where close_write raising triggers the cleanup."""
+def test_overwrite_leaves_the_destination_alone_when_the_stream_fails():
+    """The whole point: a failed replacement must not damage what was already there."""
     fs = _fs()
     fs.close_write.side_effect = RuntimeError('commit failed')
-    inst = _sink_instance(fs, has_name=False, object_id='o3', on_conflict='overwrite')
+    inst = _sink_instance(fs, has_name=False, object_id='o2', on_conflict='overwrite')
     from rocketlib import AVI_ACTION
 
     inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
@@ -379,4 +365,71 @@ def test_failed_commit_does_not_delete_under_overwrite():
     with pytest.raises(RuntimeError, match='commit failed'):
         inst.writeImage(AVI_ACTION.END, 'image/png', b'')
 
-    fs.delete.assert_not_awaited()
+    fs.rename.assert_not_awaited()  # nothing was swapped in
+    (deleted,), _ = fs.delete.await_args
+    assert deleted == 'output/o2.png.part-o2', 'only the staging file may be removed'
+
+
+def test_overwrite_abort_removes_only_the_staging_file():
+    fs = _fs()
+    inst = _sink_instance(fs, has_name=False, object_id='o3', on_conflict='overwrite')
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'partial')
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')  # abort the first stream
+
+    (deleted,), _ = fs.delete.await_args
+    assert deleted == 'output/o3.png.part-o3'
+    fs.rename.assert_not_awaited()
+
+
+def test_unique_writes_straight_to_the_destination():
+    """No staging where the path was probed free — there is nothing to protect."""
+    fs = _fs()
+    inst = _sink_instance(fs, has_name=False, object_id='o4')
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'bytes')
+    inst.writeImage(AVI_ACTION.END, 'image/png', b'')
+
+    (opened,), _ = fs.open_write.await_args
+    assert opened == 'output/o4.png'
+    fs.rename.assert_not_awaited()
+
+
+def test_unique_abort_still_deletes_its_own_partial():
+    fs = _fs()
+    inst = _sink_instance(fs, has_name=False, object_id='o5')
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'partial')
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+
+    (deleted,), _ = fs.delete.await_args
+    assert deleted == 'output/o5.png'
+
+
+def test_whitelist_rejecting_the_sibling_falls_back_to_writing_in_place():
+    """A tight whitelist must not fail a pipeline that worked before staging existed."""
+    import re
+
+    fs = _fs()
+    inst = _sink_instance(
+        fs,
+        has_name=False,
+        object_id='o6',
+        on_conflict='overwrite',
+        path_patterns=[re.compile(r'^output/o6\.png$')],
+    )
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'bytes')
+    inst.writeImage(AVI_ACTION.END, 'image/png', b'')
+
+    (opened,), _ = fs.open_write.await_args
+    assert opened == 'output/o6.png'
+    fs.rename.assert_not_awaited()

--- a/nodes/test/tool_filesystem/test_sink_lanes.py
+++ b/nodes/test/tool_filesystem/test_sink_lanes.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
 from test_sink_naming import _fs, _sink_instance
 
 
@@ -326,3 +327,56 @@ def test_end_close_failure_deletes_partial_and_raises():
         inst.writeImage(AVI_ACTION.END, 'image/png', b'')
     fs.delete.assert_awaited_once_with('output/s3.png')
     inst.instance.writeJson.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Cleanup must not remove a file this node did not create
+# ---------------------------------------------------------------------------
+
+
+def test_abort_does_not_delete_under_overwrite():
+    """The user's own file is at that path — an interrupted stream must not remove it.
+
+    Under unique/skip the path was probed free, so whatever sits there is this stream's
+    partial output and deleting it is the intended cleanup. Under overwrite it is the file
+    the operator asked to replace, and losing it entirely to a transient failure is worse
+    than the truncation overwrite already implies.
+    """
+    fs = _fs()
+    inst = _sink_instance(fs, has_name=False, object_id='o1', on_conflict='overwrite')
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'partial')
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')  # abort the first stream
+
+    fs.close_write.assert_awaited()  # handle still released
+    fs.delete.assert_not_awaited()  # but the existing file is left alone
+
+
+def test_abort_still_deletes_under_unique():
+    """Unchanged where the path was probed free: the partial is ours to remove."""
+    fs = _fs()
+    inst = _sink_instance(fs, has_name=False, object_id='o2')
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'partial')
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+
+    fs.delete.assert_awaited()
+
+
+def test_failed_commit_does_not_delete_under_overwrite():
+    """Same rule on the END path, where close_write raising triggers the cleanup."""
+    fs = _fs()
+    fs.close_write.side_effect = RuntimeError('commit failed')
+    inst = _sink_instance(fs, has_name=False, object_id='o3', on_conflict='overwrite')
+    from rocketlib import AVI_ACTION
+
+    inst.writeImage(AVI_ACTION.BEGIN, 'image/png', b'')
+    inst.writeImage(AVI_ACTION.WRITE, 'image/png', b'bytes')
+    with pytest.raises(RuntimeError, match='commit failed'):
+        inst.writeImage(AVI_ACTION.END, 'image/png', b'')
+
+    fs.delete.assert_not_awaited()

--- a/nodes/test/tool_filesystem/test_sink_naming.py
+++ b/nodes/test/tool_filesystem/test_sink_naming.py
@@ -31,7 +31,12 @@ class TestServicesContract:
         assert d['lanes'] == {}
         assert d['protocol'] == 'tool_filesystem://'
         # Sink config must be gone from the tool surface.
-        for key in ('filesystem.targetDir', 'filesystem.emitUrl', 'filesystem.urlExpiresIn'):
+        for key in (
+            'filesystem.targetDir',
+            'filesystem.onConflict',
+            'filesystem.emitUrl',
+            'filesystem.urlExpiresIn',
+        ):
             assert key not in d['fields']
             assert key not in d['shape'][0]['properties']
 

--- a/nodes/test/tool_filesystem/test_sink_naming.py
+++ b/nodes/test/tool_filesystem/test_sink_naming.py
@@ -301,10 +301,8 @@ def _install_iinstance_stubs():
         ig.IGlobal = _IGlobalStub
         sys.modules['tool_filesystem.IGlobal'] = ig
 
-    # IInstance imports OnConflict from this module, so whichever stub is installed has to
-    # expose it. Taken from the real IGlobal rather than restated, and set every time rather
-    # than only when absent — test_read_size_cap installs its own stub over the same key, and
-    # a conditional patch would make the result depend on which module ran first.
+    # Set unconditionally: test_read_size_cap installs its own stub over the same key, so a
+    # conditional patch would depend on which module ran first.
     stub_module = sys.modules['tool_filesystem.IGlobal']
     stub_module.OnConflict = _load_real_iglobal_module().OnConflict
     stub_module.IGlobal.on_conflict = stub_module.OnConflict.UNIQUE
@@ -651,12 +649,7 @@ class TestConflictPolicy:
         inst.instance.writeJson.assert_not_called()
 
     def test_skip_compares_against_a_file_not_a_directory(self):
-        """A directory sharing the name is not a file to preserve.
-
-        `stat` reports type as well as existence; skipping on bare existence would drop
-        the output for a name that holds no file at all, which is not what the setting
-        says it does.
-        """
+        """A directory sharing the name is not a file to preserve, so it does not skip."""
         fs = _fs()
 
         async def _dir_stat(path):
@@ -667,11 +660,7 @@ class TestConflictPolicy:
         assert inst._sink_target_path('report.pdf') == 'output/report.pdf'
 
     def test_skip_treats_a_file_shadowed_by_a_directory_as_present(self):
-        """`both` means an object store holds a key and a same-named prefix.
-
-        There is a file there to leave alone, so it skips — the directory alongside it
-        does not make it any less of a file.
-        """
+        """`both` still has a file to leave alone, so it skips."""
         fs = _fs()
 
         async def _both_stat(path):

--- a/nodes/test/tool_filesystem/test_sink_naming.py
+++ b/nodes/test/tool_filesystem/test_sink_naming.py
@@ -65,6 +65,10 @@ class TestServicesContract:
         assert f['filesystem.urlExpiresIn']['default'] == 3600
         assert f['filesystem.urlExpiresIn']['minimum'] == 1
         assert f['filesystem.urlExpiresIn']['maximum'] == 3600
+        assert f['filesystem.onConflict']['type'] == 'string'
+        assert f['filesystem.onConflict']['default'] == 'unique', 'the safe outcome must be the default'
+        assert [c[0] for c in f['filesystem.onConflict']['enum']] == ['unique', 'overwrite', 'skip']
+        assert 'filesystem.onConflict' in d['shape'][0]['properties']
         # No agent-tool toggles on the store surface.
         assert not any(k.startswith('filesystem.allow') for k in f)
 
@@ -205,15 +209,38 @@ def _load_real_iglobal():
 class TestSinkConfig:
     def test_defaults_when_missing(self):
         IG = _load_real_iglobal()
-        assert IG._sink_config({}) == ('output/', False, 3600)
+        assert IG._sink_config({}) == ('output/', False, 3600, IG.OnConflict.UNIQUE)
 
     def test_explicit_values(self):
         IG = _load_real_iglobal()
-        assert IG._sink_config({'targetDir': 'out2/', 'emitUrl': True, 'urlExpiresIn': 120}) == (
+        assert IG._sink_config({'targetDir': 'out2/', 'emitUrl': True, 'urlExpiresIn': 120, 'onConflict': 'skip'}) == (
             'out2/',
             True,
             120,
+            IG.OnConflict.SKIP,
         )
+
+    def test_conflict_policy_defaults_to_the_non_destructive_choice(self):
+        """A mistyped or missing policy degrades to `unique`, never to overwriting."""
+        IG = _load_real_iglobal()
+        assert IG._sink_config({})[3] is IG.OnConflict.UNIQUE
+        assert IG._sink_config({'onConflict': 'nonsense'})[3] is IG.OnConflict.UNIQUE
+        assert IG._sink_config({'onConflict': None})[3] is IG.OnConflict.UNIQUE
+        assert IG._sink_config({'onConflict': '  skip  '})[3] is IG.OnConflict.SKIP
+        assert IG._sink_config({'onConflict': 'OVERWRITE'})[3] is IG.OnConflict.OVERWRITE
+
+    def test_overwriting_is_never_reached_by_accident(self):
+        """The destructive outcome has to be named exactly; nothing else degrades into it."""
+        IG = _load_real_iglobal()
+        for junk in ({}, {'onConflict': ''}, {'onConflict': 'true'}, {'onConflict': True}):
+            assert IG._sink_config(junk)[3] is IG.OnConflict.UNIQUE
+
+    def test_members_cover_exactly_the_services_json_enum(self):
+        """Member names are what resolves the dropdown value, so a new choice needs a member."""
+        IG = _load_real_iglobal()
+        fields = _load_services('services.store.json')['fields']
+        choices = [c[0] for c in fields['filesystem.onConflict']['enum']]
+        assert sorted(m.name.lower() for m in IG.OnConflict) == sorted(choices)
 
     def test_url_expires_clamped_to_ceiling(self):
         IG = _load_real_iglobal()
@@ -257,6 +284,16 @@ def _install_iinstance_stubs():
 
         ig.IGlobal = _IGlobalStub
         sys.modules['tool_filesystem.IGlobal'] = ig
+
+    # test_read_size_cap installs its own IGlobal stub over this key, so patch whichever one
+    # is current rather than only the one built above. Every other attribute the sink reads is
+    # set per-instance by _sink_instance; OnConflict is the one it reads off the class, and it
+    # comes from the real IGlobal so a stub cannot drift from the members IInstance compares
+    # against.
+    stub = sys.modules['tool_filesystem.IGlobal'].IGlobal
+    if not hasattr(stub, 'OnConflict'):
+        stub.OnConflict = _load_real_iglobal().OnConflict
+        stub.on_conflict = stub.OnConflict.UNIQUE
 
 
 def _fs(exists_paths=()):
@@ -309,6 +346,7 @@ def _sink_instance(
     allow_write=True,
     path_patterns=None,
     listeners=('json',),
+    on_conflict='unique',
 ):
     """Build an IInstance wired to a stub IGlobal + mocked engine ``instance``."""
     _install_iinstance_stubs()
@@ -323,6 +361,7 @@ def _sink_instance(
     g.target_dir = target_dir
     g.emit_url = emit_url
     g.url_expires_in = url_expires_in
+    g.on_conflict = IGlobal.OnConflict[on_conflict.upper()]
     inst.IGlobal = g
     inst.instance = MagicMock()
     inst.instance.getListeners.return_value = list(listeners)
@@ -546,3 +585,49 @@ class TestStreamFilename:
     def test_name_that_reduces_to_nothing_falls_back(self):
         inst = _sink_instance(_fs(), name='report.pdf')
         assert inst._stream_filename(_Descriptor('../'), 'image/jpeg') == 'report.jpg'
+
+
+class TestConflictPolicy:
+    def test_unique_suffixes_rather_than_replacing(self):
+        """The default: never destructive, never silent."""
+        fs = _fs(exists_paths={'output/report.pdf'})
+        inst = _sink_instance(fs, object_id='obj-123')
+        assert inst._sink_target_path('report.pdf') == 'output/report_1.pdf'
+
+    def test_overwrite_returns_the_plain_path(self):
+        """Overwriting replaces in place rather than finding a free name."""
+        fs = _fs(exists_paths={'output/report.pdf'})
+        inst = _sink_instance(fs, object_id='obj-123', on_conflict='overwrite')
+        assert inst._sink_target_path('report.pdf') == 'output/report.pdf'
+
+    def test_overwrite_does_not_probe_the_store(self):
+        """
+        No stat() at all when overwriting.
+
+        Worth asserting rather than assuming: the probe is a network round-trip per stream
+        on S3 or Azure, and skipping it is half the point of the setting.
+        """
+        fs = _fs(exists_paths={'output/report.pdf'})
+        inst = _sink_instance(fs, object_id='obj-123', on_conflict='overwrite')
+        inst._sink_target_path('report.pdf')
+        fs.stat.assert_not_awaited()
+
+    def test_skip_returns_none_when_taken(self):
+        """`None` means "leave it alone" — it is a decision, not a failure."""
+        fs = _fs(exists_paths={'output/report.pdf'})
+        inst = _sink_instance(fs, object_id='obj-123', on_conflict='skip')
+        assert inst._sink_target_path('report.pdf') is None
+
+    def test_skip_writes_normally_when_free(self):
+        fs = _fs()
+        inst = _sink_instance(fs, object_id='obj-123', on_conflict='skip')
+        assert inst._sink_target_path('report.pdf') == 'output/report.pdf'
+
+    def test_skipped_write_touches_nothing_and_emits_no_ref(self):
+        """A skipped one-shot write must not create a file or claim it did."""
+        fs = _fs(exists_paths={'output/report.md'})
+        inst = _sink_instance(fs, name='report.pdf', on_conflict='skip')
+        assert inst._sink_write(b'data', 'report.md') is None
+        fs.write.assert_not_awaited()
+        inst._sink_emit([None])
+        inst.instance.writeJson.assert_not_called()

--- a/nodes/test/tool_filesystem/test_sink_naming.py
+++ b/nodes/test/tool_filesystem/test_sink_naming.py
@@ -197,63 +197,74 @@ def _install_stubs():
         sys.modules['ai.common.schema'] = m
 
 
-def _load_real_iglobal():
-    """Load the real ``IGlobal`` under a unique module name (deps stubbed)."""
+def _load_real_iglobal_module():
+    """Load the real ``IGlobal`` module under a unique name (deps stubbed)."""
     _install_stubs()
     spec = importlib.util.spec_from_file_location('tfs_iglobal_real', str(_NODE_DIR / 'IGlobal.py'))
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
-    return mod.IGlobal
+    return mod
+
+
+def _load_real_iglobal():
+    """The real ``IGlobal`` class."""
+    return _load_real_iglobal_module().IGlobal
 
 
 class TestSinkConfig:
     def test_defaults_when_missing(self):
-        IG = _load_real_iglobal()
-        assert IG._sink_config({}) == ('output/', False, 3600, IG.OnConflict.UNIQUE)
+        mod = _load_real_iglobal_module()
+        assert mod.IGlobal._sink_config({}) == ('output/', False, 3600, mod.OnConflict.UNIQUE)
 
     def test_explicit_values(self):
-        IG = _load_real_iglobal()
+        mod = _load_real_iglobal_module()
+        IG = mod.IGlobal
         assert IG._sink_config({'targetDir': 'out2/', 'emitUrl': True, 'urlExpiresIn': 120, 'onConflict': 'skip'}) == (
             'out2/',
             True,
             120,
-            IG.OnConflict.SKIP,
+            mod.OnConflict.SKIP,
         )
 
     def test_conflict_policy_defaults_to_the_non_destructive_choice(self):
         """A mistyped or missing policy degrades to `unique`, never to overwriting."""
-        IG = _load_real_iglobal()
-        assert IG._sink_config({})[3] is IG.OnConflict.UNIQUE
-        assert IG._sink_config({'onConflict': 'nonsense'})[3] is IG.OnConflict.UNIQUE
-        assert IG._sink_config({'onConflict': None})[3] is IG.OnConflict.UNIQUE
-        assert IG._sink_config({'onConflict': '  skip  '})[3] is IG.OnConflict.SKIP
-        assert IG._sink_config({'onConflict': 'OVERWRITE'})[3] is IG.OnConflict.OVERWRITE
+        mod = _load_real_iglobal_module()
+        IG = mod.IGlobal
+        assert IG._sink_config({})[3] is mod.OnConflict.UNIQUE
+        assert IG._sink_config({'onConflict': 'nonsense'})[3] is mod.OnConflict.UNIQUE
+        assert IG._sink_config({'onConflict': None})[3] is mod.OnConflict.UNIQUE
+        assert IG._sink_config({'onConflict': '  skip  '})[3] is mod.OnConflict.SKIP
+        assert IG._sink_config({'onConflict': 'OVERWRITE'})[3] is mod.OnConflict.OVERWRITE
 
     def test_overwriting_is_never_reached_by_accident(self):
         """The destructive outcome has to be named exactly; nothing else degrades into it."""
-        IG = _load_real_iglobal()
+        mod = _load_real_iglobal_module()
+        IG = mod.IGlobal
         for junk in ({}, {'onConflict': ''}, {'onConflict': 'true'}, {'onConflict': True}):
-            assert IG._sink_config(junk)[3] is IG.OnConflict.UNIQUE
+            assert IG._sink_config(junk)[3] is mod.OnConflict.UNIQUE
 
     def test_members_cover_exactly_the_services_json_enum(self):
         """Member names are what resolves the dropdown value, so a new choice needs a member."""
-        IG = _load_real_iglobal()
+        mod = _load_real_iglobal_module()
         fields = _load_services('services.store.json')['fields']
         choices = [c[0] for c in fields['filesystem.onConflict']['enum']]
-        assert sorted(m.name.lower() for m in IG.OnConflict) == sorted(choices)
+        assert sorted(m.name.lower() for m in mod.OnConflict) == sorted(choices)
 
     def test_url_expires_clamped_to_ceiling(self):
-        IG = _load_real_iglobal()
+        mod = _load_real_iglobal_module()
+        IG = mod.IGlobal
         assert IG._sink_config({'urlExpiresIn': 999999})[2] == 3600
 
     def test_url_expires_non_positive_falls_back_to_default(self):
-        IG = _load_real_iglobal()
+        mod = _load_real_iglobal_module()
+        IG = mod.IGlobal
         assert IG._sink_config({'urlExpiresIn': -5})[2] == 3600
         assert IG._sink_config({'urlExpiresIn': 0})[2] == 3600
 
     def test_url_expires_non_numeric_falls_back_to_default(self):
         # A bad config value must not raise out of beginGlobal.
-        IG = _load_real_iglobal()
+        mod = _load_real_iglobal_module()
+        IG = mod.IGlobal
         assert IG._sink_config({'urlExpiresIn': 'not-a-number'})[2] == 3600
 
 
@@ -285,15 +296,13 @@ def _install_iinstance_stubs():
         ig.IGlobal = _IGlobalStub
         sys.modules['tool_filesystem.IGlobal'] = ig
 
-    # test_read_size_cap installs its own IGlobal stub over this key, so patch whichever one
-    # is current rather than only the one built above. Every other attribute the sink reads is
-    # set per-instance by _sink_instance; OnConflict is the one it reads off the class, and it
-    # comes from the real IGlobal so a stub cannot drift from the members IInstance compares
-    # against.
-    stub = sys.modules['tool_filesystem.IGlobal'].IGlobal
-    if not hasattr(stub, 'OnConflict'):
-        stub.OnConflict = _load_real_iglobal().OnConflict
-        stub.on_conflict = stub.OnConflict.UNIQUE
+    # IInstance imports OnConflict from this module, so whichever stub is installed has to
+    # expose it. Taken from the real IGlobal rather than restated, and set every time rather
+    # than only when absent — test_read_size_cap installs its own stub over the same key, and
+    # a conditional patch would make the result depend on which module ran first.
+    stub_module = sys.modules['tool_filesystem.IGlobal']
+    stub_module.OnConflict = _load_real_iglobal_module().OnConflict
+    stub_module.IGlobal.on_conflict = stub_module.OnConflict.UNIQUE
 
 
 def _fs(exists_paths=()):
@@ -308,7 +317,11 @@ def _fs(exists_paths=()):
     fs.delete = AsyncMock(return_value=None)
 
     async def _stat(path):
-        return {'exists': path in exists_paths}
+        # Shaped like the real FileStore.stat, which reports `type` alongside `exists` —
+        # the conflict policy distinguishes a file from a directory sharing the name.
+        if path in exists_paths:
+            return {'exists': True, 'type': 'file', 'size': 1, 'modified': 0}
+        return {'exists': False}
 
     fs.stat = AsyncMock(side_effect=_stat)
 
@@ -350,7 +363,7 @@ def _sink_instance(
 ):
     """Build an IInstance wired to a stub IGlobal + mocked engine ``instance``."""
     _install_iinstance_stubs()
-    from tool_filesystem.IGlobal import IGlobal
+    from tool_filesystem.IGlobal import IGlobal, OnConflict
     from tool_filesystem.IInstance import IInstance
 
     inst = IInstance()
@@ -361,7 +374,7 @@ def _sink_instance(
     g.target_dir = target_dir
     g.emit_url = emit_url
     g.url_expires_in = url_expires_in
-    g.on_conflict = IGlobal.OnConflict[on_conflict.upper()]
+    g.on_conflict = OnConflict[on_conflict.upper()]
     inst.IGlobal = g
     inst.instance = MagicMock()
     inst.instance.getListeners.return_value = list(listeners)
@@ -631,3 +644,34 @@ class TestConflictPolicy:
         fs.write.assert_not_awaited()
         inst._sink_emit([None])
         inst.instance.writeJson.assert_not_called()
+
+    def test_skip_compares_against_a_file_not_a_directory(self):
+        """A directory sharing the name is not a file to preserve.
+
+        `stat` reports type as well as existence; skipping on bare existence would drop
+        the output for a name that holds no file at all, which is not what the setting
+        says it does.
+        """
+        fs = _fs()
+
+        async def _dir_stat(path):
+            return {'exists': True, 'type': 'dir'}
+
+        fs.stat.side_effect = _dir_stat
+        inst = _sink_instance(fs, object_id='obj-123', on_conflict='skip')
+        assert inst._sink_target_path('report.pdf') == 'output/report.pdf'
+
+    def test_skip_treats_a_file_shadowed_by_a_directory_as_present(self):
+        """`both` means an object store holds a key and a same-named prefix.
+
+        There is a file there to leave alone, so it skips — the directory alongside it
+        does not make it any less of a file.
+        """
+        fs = _fs()
+
+        async def _both_stat(path):
+            return {'exists': True, 'type': 'both', 'size': 1, 'modified': 0}
+
+        fs.stat.side_effect = _both_stat
+        inst = _sink_instance(fs, object_id='obj-123', on_conflict='skip')
+        assert inst._sink_target_path('report.pdf') is None

--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -993,12 +993,16 @@ class FileStore:
         if not old_rest or not new_rest:
             raise StorageError('rename cannot target a scope root')
 
-        # Directory means children under old_path/. Listing a prefix also returns the file
-        # sitting at that path, so it is excluded — counting it sends every plain file down
-        # the directory branch. Same test stat() uses.
+        # Listing a prefix also returns the file at that path; counting it would send every
+        # plain file down the directory branch. Same test stat() uses.
         dir_prefix = old_full.rstrip('/') + '/'
         listed = await self._store.list_files(dir_prefix)
         all_files = [f for f in listed if f != old_full and f.startswith(dir_prefix)]
+
+        # stat()'s 'both': neither branch covers it, and the directory one would move the
+        # children and leave the file, reporting success.
+        if all_files and old_full in listed:
+            raise StorageError(f'Cannot rename {old_path!r}: it is both a file and a directory')
 
         if all_files:
             # Directory rename: refuse if any source file is open, then check
@@ -1034,9 +1038,7 @@ class FileStore:
                     pass
                 if dest_exists:
                     raise StorageError(f'Destination already exists: {new_path}')
-            # Native move — os.replace, or a server-side copy on an object store. Leaves the
-            # destination alone until the new content is in place, and never reads the file
-            # through this process, which a read-then-write would.
+            # Native move — the destination is untouched until the new content is in place.
             await self._store.move_file(old_full, new_full)
 
     async def stat(self, path: str) -> dict:

--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -993,9 +993,9 @@ class FileStore:
         if not old_rest or not new_rest:
             raise StorageError('rename cannot target a scope root')
 
-        # Check for directory (has children under old_path/). Listing a prefix returns the
-        # file sitting at that path too, so it has to be excluded — counting it would send
-        # every plain file down the directory branch. Same test as stat() uses for is_dir.
+        # Directory means children under old_path/. Listing a prefix also returns the file
+        # sitting at that path, so it is excluded — counting it sends every plain file down
+        # the directory branch. Same test stat() uses.
         dir_prefix = old_full.rstrip('/') + '/'
         listed = await self._store.list_files(dir_prefix)
         all_files = [f for f in listed if f != old_full and f.startswith(dir_prefix)]
@@ -1034,10 +1034,9 @@ class FileStore:
                     pass
                 if dest_exists:
                     raise StorageError(f'Destination already exists: {new_path}')
-            # Native move: on a filesystem this is os.replace, on an object store a
-            # server-side copy. Both leave the destination untouched until the new content
-            # is in place, and neither reads the file through this process — which a
-            # read-then-write would, spiking memory by the file's whole size.
+            # Native move — os.replace, or a server-side copy on an object store. Leaves the
+            # destination alone until the new content is in place, and never reads the file
+            # through this process, which a read-then-write would.
             await self._store.move_file(old_full, new_full)
 
     async def stat(self, path: str) -> dict:

--- a/packages/ai/src/ai/account/file_store.py
+++ b/packages/ai/src/ai/account/file_store.py
@@ -993,9 +993,12 @@ class FileStore:
         if not old_rest or not new_rest:
             raise StorageError('rename cannot target a scope root')
 
-        # Check for directory (has children under old_path/)
+        # Check for directory (has children under old_path/). Listing a prefix returns the
+        # file sitting at that path too, so it has to be excluded — counting it would send
+        # every plain file down the directory branch. Same test as stat() uses for is_dir.
         dir_prefix = old_full.rstrip('/') + '/'
-        all_files = await self._store.list_files(dir_prefix)
+        listed = await self._store.list_files(dir_prefix)
+        all_files = [f for f in listed if f != old_full and f.startswith(dir_prefix)]
 
         if all_files:
             # Directory rename: refuse if any source file is open, then check
@@ -1031,9 +1034,11 @@ class FileStore:
                     pass
                 if dest_exists:
                     raise StorageError(f'Destination already exists: {new_path}')
-            data = await self._store.read_bytes(old_full)
-            await self._store.write_bytes(new_full, data)
-            await self._store.delete_file(old_full)
+            # Native move: on a filesystem this is os.replace, on an object store a
+            # server-side copy. Both leave the destination untouched until the new content
+            # is in place, and neither reads the file through this process — which a
+            # read-then-write would, spiking memory by the file's whole size.
+            await self._store.move_file(old_full, new_full)
 
     async def stat(self, path: str) -> dict:
         """

--- a/packages/ai/src/ai/account/store.py
+++ b/packages/ai/src/ai/account/store.py
@@ -242,6 +242,30 @@ class IStore(ABC):
         content = await self.read_file(filename)
         return content.encode('latin-1')
 
+    async def move_file(self, src: str, dst: str) -> None:
+        """
+        Move a file onto ``dst``, replacing it if it exists.
+
+        Backends override this with their native primitive — ``os.replace`` on a filesystem,
+        a server-side copy on an object store — which is what makes publishing a file written
+        elsewhere safe: the destination is replaced only once the new content is in place,
+        and the bytes never pass through this process.
+
+        The default below has neither property. It reads the whole file into memory and
+        writes over the destination, so a failure part-way leaves the destination damaged.
+        It exists so a backend that cannot move natively still works.
+
+        Args:
+            src: Relative path to move from
+            dst: Relative path to move onto
+
+        Raises:
+            StorageError: If the source is missing or the move fails
+        """
+        data = await self.read_bytes(src)
+        await self.write_bytes(dst, data)
+        await self.delete_file(src)
+
     # =========================================================================
     # Handle-Based I/O — open / read / write / close
     # =========================================================================

--- a/packages/ai/src/ai/account/store.py
+++ b/packages/ai/src/ai/account/store.py
@@ -246,14 +246,9 @@ class IStore(ABC):
         """
         Move a file onto ``dst``, replacing it if it exists.
 
-        Backends override this with their native primitive — ``os.replace`` on a filesystem,
-        a server-side copy on an object store — which is what makes publishing a file written
-        elsewhere safe: the destination is replaced only once the new content is in place,
-        and the bytes never pass through this process.
-
-        The default below has neither property. It reads the whole file into memory and
-        writes over the destination, so a failure part-way leaves the destination damaged.
-        It exists so a backend that cannot move natively still works.
+        Backends override this with a native primitive that leaves the destination alone
+        until the new content is in place and never routes the bytes through this process.
+        This fallback has neither property — it exists for backends without one.
 
         Args:
             src: Relative path to move from

--- a/packages/ai/src/ai/account/store_providers/azure/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure/azure.py
@@ -276,6 +276,50 @@ class AzureBlobStore(IStore):
         retry=retry_if_exception_type((ConnectionError, TimeoutError)),
         reraise=True,
     )
+    async def move_file(self, src: str, dst: str) -> None:
+        """Move a blob onto ``dst``, replacing it if it exists.
+
+        The copy is server-side — the bytes never travel through this process — and the
+        destination is only replaced once it completes, so a failure leaves the old blob as
+        it was. Within one account a same-account copy completes synchronously; the status is
+        checked rather than assumed, so a pending copy surfaces instead of a silent truncation.
+
+        Args:
+            src: Source path, relative to the container prefix.
+            dst: Destination path, relative to the container prefix.
+
+        Raises:
+            StorageError: If the source is missing or the move fails.
+        """
+        try:
+            client = self._get_client()
+            src_client = client.get_blob_client(container=self._container, blob=self._get_blob_name(src))
+            dst_client = client.get_blob_client(container=self._container, blob=self._get_blob_name(dst))
+
+            try:
+                await asyncio.to_thread(src_client.get_blob_properties)
+            except Exception as e:
+                raise StorageError(f'File not found: {src}') from e
+
+            result = await asyncio.to_thread(dst_client.start_copy_from_url, src_client.url)
+            if str(result.get('copy_status', '')).lower() != 'success':
+                raise StorageError(f'Copy of {src} to {dst} did not complete: {result.get("copy_status")}')
+
+            await asyncio.to_thread(src_client.delete_blob)
+
+        except (ConnectionError, TimeoutError):
+            raise
+        except StorageError:
+            raise
+        except Exception as e:
+            raise StorageError(f'Failed to move {src} to {dst} in Azure: {e}') from e
+
+    @retry(
+        stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=1),
+        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        reraise=True,
+    )
     async def list_files(self, prefix: str = '') -> list:
         """
         List all blobs in Azure container with given prefix.

--- a/packages/ai/src/ai/account/store_providers/azure/azure.py
+++ b/packages/ai/src/ai/account/store_providers/azure/azure.py
@@ -279,10 +279,8 @@ class AzureBlobStore(IStore):
     async def move_file(self, src: str, dst: str) -> None:
         """Move a blob onto ``dst``, replacing it if it exists.
 
-        The copy is server-side — the bytes never travel through this process — and the
-        destination is only replaced once it completes, so a failure leaves the old blob as
-        it was. Within one account a same-account copy completes synchronously; the status is
-        checked rather than assumed, so a pending copy surfaces instead of a silent truncation.
+        The copy is server-side and the destination is replaced only once it completes, so a
+        failure leaves the old blob as it was. The status is checked rather than assumed.
 
         Args:
             src: Source path, relative to the container prefix.
@@ -301,7 +299,9 @@ class AzureBlobStore(IStore):
             except Exception as e:
                 raise StorageError(f'File not found: {src}') from e
 
-            result = await asyncio.to_thread(dst_client.start_copy_from_url, src_client.url)
+            # Without requires_sync the copy can return 'pending' having already started
+            # overwriting the destination, which this process cannot undo.
+            result = await asyncio.to_thread(dst_client.start_copy_from_url, src_client.url, requires_sync=True)
             if str(result.get('copy_status', '')).lower() != 'success':
                 raise StorageError(f'Copy of {src} to {dst} did not complete: {result.get("copy_status")}')
 

--- a/packages/ai/src/ai/account/store_providers/filesystem/filesystem.py
+++ b/packages/ai/src/ai/account/store_providers/filesystem/filesystem.py
@@ -278,6 +278,32 @@ class FilesystemStore(IStore):
         except Exception as e:
             raise StorageError(f'Failed to write file {filename}: {e}') from e
 
+    async def move_file(self, src: str, dst: str) -> None:
+        """Move a file onto ``dst``, replacing it if it exists.
+
+        ``os.replace`` is atomic within a filesystem: readers see either the old file or the
+        new one, never a partial write, and the destination is never truncated first. That is
+        what makes it safe to use for publishing a file written elsewhere.
+
+        Args:
+            src: Source path, relative to the store root.
+            dst: Destination path, relative to the store root.
+
+        Raises:
+            StorageError: If the source is missing or the move fails.
+        """
+        try:
+            src_path = self._get_full_path(src)
+            dst_path = self._get_full_path(dst)
+            if not src_path.exists():
+                raise StorageError(f'File not found: {src}')
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            await asyncio.to_thread(os.replace, str(src_path), str(dst_path))
+        except StorageError:
+            raise
+        except Exception as e:
+            raise StorageError(f'Failed to move {src} to {dst}: {e}') from e
+
     async def read_bytes(self, filename: str) -> bytes:
         """Read binary data from file."""
         try:

--- a/packages/ai/src/ai/account/store_providers/filesystem/filesystem.py
+++ b/packages/ai/src/ai/account/store_providers/filesystem/filesystem.py
@@ -281,9 +281,8 @@ class FilesystemStore(IStore):
     async def move_file(self, src: str, dst: str) -> None:
         """Move a file onto ``dst``, replacing it if it exists.
 
-        ``os.replace`` is atomic within a filesystem: readers see either the old file or the
-        new one, never a partial write, and the destination is never truncated first. That is
-        what makes it safe to use for publishing a file written elsewhere.
+        ``os.replace`` is atomic within a filesystem: readers see the old file or the new
+        one, never a partial write, and the destination is never truncated first.
 
         Args:
             src: Source path, relative to the store root.

--- a/packages/ai/src/ai/account/store_providers/s3/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3/s3.py
@@ -282,9 +282,8 @@ class S3Store(IStore):
     async def move_file(self, src: str, dst: str) -> None:
         """Move an object onto ``dst``, replacing it if it exists.
 
-        ``CopyObject`` runs inside S3 — the bytes never travel through this process — and the
-        destination key is only replaced once the copy has succeeded, so a failure leaves the
-        old object as it was.
+        ``CopyObject`` runs inside S3 and the destination key is replaced only once the copy
+        has succeeded, so a failure leaves the old object as it was.
 
         Args:
             src: Source path, relative to the store prefix.

--- a/packages/ai/src/ai/account/store_providers/s3/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3/s3.py
@@ -279,6 +279,49 @@ class S3Store(IStore):
         retry=retry_if_exception_type((ConnectionError, TimeoutError)),
         reraise=True,
     )
+    async def move_file(self, src: str, dst: str) -> None:
+        """Move an object onto ``dst``, replacing it if it exists.
+
+        ``CopyObject`` runs inside S3 — the bytes never travel through this process — and the
+        destination key is only replaced once the copy has succeeded, so a failure leaves the
+        old object as it was.
+
+        Args:
+            src: Source path, relative to the store prefix.
+            dst: Destination path, relative to the store prefix.
+
+        Raises:
+            StorageError: If the source is missing or the move fails.
+        """
+        try:
+            client = self._get_client()
+            src_key = self._get_key(src)
+            dst_key = self._get_key(dst)
+            try:
+                await asyncio.to_thread(
+                    client.copy_object,
+                    Bucket=self._bucket,
+                    Key=dst_key,
+                    CopySource={'Bucket': self._bucket, 'Key': src_key},
+                )
+            except Exception as e:
+                if self._is_no_such_key_error(e):
+                    raise StorageError(f'File not found: {src}')
+                raise
+            await asyncio.to_thread(client.delete_object, Bucket=self._bucket, Key=src_key)
+        except (ConnectionError, TimeoutError):
+            raise
+        except StorageError:
+            raise
+        except Exception as e:
+            raise StorageError(f'Failed to move {src} to {dst} in S3: {e}') from e
+
+    @retry(
+        stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=1),
+        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        reraise=True,
+    )
     async def list_files(self, prefix: str = '') -> list:
         """
         List all files in S3 with given prefix.


### PR DESCRIPTION
> Stacked on #1929 — this PR targets `fix/filestore-media-stream`, so the diff shows only
> the feature. GitHub retargets it to `develop` once that one merges.

## Summary

- Adds `When the file already exists` to the File Store sink: `unique` (unchanged default), `overwrite`, `skip`.
- One setting rather than a boolean plus a fallback — the fallback is meaningless whenever the boolean is set, which is why that shape needs a `conditional` to hide it.
- Resolved once at config time into an `IntEnum` nested in `IGlobal`, so the write path compares ints rather than strings.

## Type

feature

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`builder nodes:test --pytest-pattern=tool_filesystem` on this branch: **115 passed, 1
skipped** — nine more than the branch below it, which is exactly what this adds.

Member names are the services.store.json enum values, which is what lets one resolve to
the other by name with no lookup table. A test asserts those two lists stay equal, so a
choice added to the dropdown without a matching member fails rather than silently falling
back.

The fallback itself is covered from both directions: a mistyped, absent, `None` or boolean
value degrades to `unique`, and nothing but the exact word reaches `overwrite`. `skip`
returns None from `_sink_target_path`, which is a decision and not an error — the tests
assert no write is attempted and no reference is emitted.

The full suite is left to CI.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none; the default is the previous behaviour

## Linked Issue

Closes #1928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable file conflict handling with `unique`, `overwrite`, and `skip` options.
  - Unique naming now uses bounded suffixing for collisions.
  - Skip mode preserves existing files, while overwrite mode replaces them safely.
  - File renames now use efficient move operations across supported storage backends.

- **Bug Fixes**
  - Improved cleanup of interrupted or failed streamed writes without deleting pre-existing files.

- **Documentation**
  - Documented conflict policies, collision behavior, and overwrite risks.

- **Tests**
  - Added coverage for conflict settings, collisions, skipped writes, and stream cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->