### PR TITLE
fix(vscode): read nssm.exe from zip buffer instead of extractEntryTo

### DIFF
--- a/apps/vscode/src/engine/service/service-windows.ts
+++ b/apps/vscode/src/engine/service/service-windows.ts
@@ -451,10 +451,21 @@ export class WindowsServiceManager extends ServiceManager {
 		if (!nssmData) {
 			throw new Error('Could not read nssm.exe from downloaded archive');
 		}
-		fs.mkdirSync(NSSM_DIR, { recursive: true });
-		fs.writeFileSync(NSSM_PATH, nssmData);
 
-		try { fs.unlinkSync(zipPath); } catch { /* ignore */ }
+		fs.mkdirSync(NSSM_DIR, { recursive: true });
+
+		let tempDir: string | undefined;
+		try {
+			tempDir = fs.mkdtempSync(path.join(NSSM_DIR, '.nssm-'));
+			const tempPath = path.join(tempDir, 'nssm.exe');
+			fs.writeFileSync(tempPath, nssmData);
+			fs.renameSync(tempPath, NSSM_PATH);
+		} finally {
+			if (tempDir) {
+				try { fs.rmSync(tempDir, { recursive: true, force: true }); } catch { /* ignore */ }
+			}
+			try { fs.unlinkSync(zipPath); } catch { /* ignore */ }
+		}
 
 		if (!fs.existsSync(NSSM_PATH)) {
 			throw new Error(`NSSM extraction failed, expected at ${NSSM_PATH}`);

--- a/apps/vscode/src/engine/service/service-windows.ts
+++ b/apps/vscode/src/engine/service/service-windows.ts
@@ -447,11 +447,17 @@ export class WindowsServiceManager extends ServiceManager {
 			throw new Error('Could not find nssm.exe in downloaded archive');
 		}
 
-		zip.extractEntryTo(nssmEntry, NSSM_DIR, false, true);
+		const nssmData = zip.readFile(nssmEntry);
+		if (!nssmData) {
+			throw new Error('Could not read nssm.exe from downloaded archive');
+		}
+		fs.mkdirSync(NSSM_DIR, { recursive: true });
+		fs.writeFileSync(NSSM_PATH, nssmData);
+
 		try { fs.unlinkSync(zipPath); } catch { /* ignore */ }
 
 		if (!fs.existsSync(NSSM_PATH)) {
-			throw new Error(`NSSM extraction failed — expected at ${NSSM_PATH}`);
+			throw new Error(`NSSM extraction failed, expected at ${NSSM_PATH}`);
 		}
 
 		this.logger.output(`${icons.success} NSSM downloaded to ${NSSM_PATH}`);

--- a/apps/vscode/src/engine/service/service-windows.ts
+++ b/apps/vscode/src/engine/service/service-windows.ts
@@ -427,35 +427,32 @@ export class WindowsServiceManager extends ServiceManager {
 			}
 		}
 
-		// Verify ZIP integrity before extraction
-		const zipBuffer = fs.readFileSync(zipPath);
-		const zipHash = crypto.createHash('sha256').update(zipBuffer).digest('hex');
-		if (zipHash !== NSSM_SHA256) {
-			try { fs.unlinkSync(zipPath); } catch { /* ignore */ }
-			throw new Error('NSSM integrity check failed — expected ' + NSSM_SHA256 + ', got ' + zipHash);
-		}
-
-		const AdmZip = require('adm-zip');
-		const zip = new AdmZip(zipPath);
-		const entries = zip.getEntries();
-
-		const nssmEntry = entries.find((e: { entryName: string }) =>
-			e.entryName.includes('win64/nssm.exe') || e.entryName.includes('win64\\nssm.exe')
-		);
-
-		if (!nssmEntry) {
-			throw new Error('Could not find nssm.exe in downloaded archive');
-		}
-
-		const nssmData = zip.readFile(nssmEntry);
-		if (!nssmData) {
-			throw new Error('Could not read nssm.exe from downloaded archive');
-		}
-
-		fs.mkdirSync(NSSM_DIR, { recursive: true });
-
 		let tempDir: string | undefined;
 		try {
+			// Verify ZIP integrity before extraction
+			const zipBuffer = fs.readFileSync(zipPath);
+			const zipHash = crypto.createHash('sha256').update(zipBuffer).digest('hex');
+			if (zipHash !== NSSM_SHA256) {
+				throw new Error('NSSM integrity check failed, expected ' + NSSM_SHA256 + ', got ' + zipHash);
+			}
+
+			const AdmZip = require('adm-zip');
+			const zip = new AdmZip(zipPath);
+			const entries = zip.getEntries();
+
+			const nssmEntry = entries.find((e: { entryName: string }) =>
+				e.entryName.includes('win64/nssm.exe') || e.entryName.includes('win64\\nssm.exe')
+			);
+
+			if (!nssmEntry) {
+				throw new Error('Could not find nssm.exe in downloaded archive');
+			}
+
+			const nssmData = zip.readFile(nssmEntry);
+			if (!nssmData) {
+				throw new Error('Could not read nssm.exe from downloaded archive');
+			}
+
 			tempDir = fs.mkdtempSync(path.join(NSSM_DIR, '.nssm-'));
 			const tempPath = path.join(tempDir, 'nssm.exe');
 			fs.writeFileSync(tempPath, nssmData);


### PR DESCRIPTION
## Summary

Makes the Windows service installer compatible with adm-zip 0.6.0 so the pending Dependabot bump (#1622) can be merged safely.

adm-zip 0.6.0 changed the semantics of \`extractEntryTo(entry, target, maintainEntryPath = false)\` for entries with a subdirectory prefix. Previously, \`nssm.exe\` inside \`win64/\` flattened to \`NSSM_DIR/nssm.exe\`. Under 0.6.0, the entry path is preserved and the file lands at \`NSSM_DIR/win64/nssm.exe\`. The immediate \`fs.existsSync(NSSM_PATH)\` guard would then fail and the installer would throw with 'NSSM extraction failed'.

Rather than adapt to the new semantics (which requires updating \`NSSM_PATH\` and any consumers), this replaces the extract call with a direct \`readFile(entry) + writeFileSync(NSSM_PATH, buffer)\`. Behavior is deterministic across adm-zip versions and immune to any further changes in the extract API.

Also drops one em-dash from the failure message (per project style).

## Related
- Unblocks Dependabot #1622 (adm-zip 0.5.17 -> 0.6.0). After this lands, that PR should be safe to merge; it will close 3 alerts on this repo plus 1 mirrored alert on rocketride-saas.

## Test plan
- [ ] Manually verify NSSM install on a Windows machine (VS Code extension service install path)
- [ ] Confirm CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved NSSM extraction reliability by safely writing archive contents through a temporary location before atomically replacing the destination.
  * Added clearer errors when the required archive entry cannot be read.
  * Improved cleanup of temporary files and archives after extraction attempts, including failed extractions.
  * Updated extraction failure messaging to provide more actionable feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->