### PR TITLE
feat(nodes): add db_hotdata, an ephemeral per-run database node

### DIFF
--- a/docs/README-nodes.md
+++ b/docs/README-nodes.md
@@ -153,6 +153,7 @@ channel; they have no data lanes and **bind to an agent** (see
 | `db_postgres`   | answers, questions → answers, table, text | PostgreSQL and Supabase (insert + NL-to-SQL) |
 | `db_mysql`      | answers, questions → answers, table, text | MySQL                                        |
 | `db_clickhouse` | questions → answers, table, text   | ClickHouse (NL-to-SQL)                       |
+| `db_hotdata`    | answers, questions → answers, table, text | Hotdata (ephemeral per-run database, load + index + NL-to-SQL) |
 
 ### Graph Databases
 

--- a/examples/db_hotdata.pipe
+++ b/examples/db_hotdata.pipe
@@ -1,0 +1,132 @@
+{
+  "components": [
+    {
+      "id": "chat_1",
+      "provider": "chat",
+      "name": "Ask a question",
+      "config": {
+        "hideForm": true,
+        "mode": "Source",
+        "parameters": {},
+        "type": "chat"
+      },
+      "ui": {
+        "position": {
+          "x": 20,
+          "y": 220
+        },
+        "nodeType": "default",
+        "formDataValid": true
+      }
+    },
+    {
+      "id": "db_hotdata_1",
+      "provider": "db_hotdata",
+      "name": "Hotdata",
+      "config": {
+        "profile": "default",
+        "default": {
+          "apikey": "${ROCKETRIDE_HOTDATA_API_KEY}",
+          "workspace_id": "${ROCKETRIDE_HOTDATA_WORKSPACE}",
+          "api_url": "",
+          "ttl": "24h",
+          "table": "pipeline_data",
+          "db_description": "Scratch database for this run. Load data with load_data before asking questions.",
+          "max_attempts": 3,
+          "max_execute_rows": 25000,
+          "allow_execute": false,
+          "job_timeout_secs": 300,
+          "async_after_ms": 5000
+        },
+        "parameters": {}
+      },
+      "input": [
+        {
+          "lane": "questions",
+          "from": "chat_1"
+        }
+      ],
+      "ui": {
+        "position": {
+          "x": 260,
+          "y": 220
+        },
+        "nodeType": "default",
+        "formDataValid": true
+      }
+    },
+    {
+      "id": "llm_anthropic_1",
+      "provider": "llm_anthropic",
+      "name": "Anthropic",
+      "config": {
+        "profile": "claude-sonnet-4-6",
+        "claude-sonnet-4-6": {
+          "apikey": "${ROCKETRIDE_ANTHROPIC_KEY}"
+        },
+        "parameters": {}
+      },
+      "control": [
+        {
+          "classType": "llm",
+          "from": "db_hotdata_1"
+        }
+      ],
+      "ui": {
+        "position": {
+          "x": 260,
+          "y": 400
+        },
+        "nodeType": "default",
+        "formDataValid": true
+      }
+    },
+    {
+      "id": "response_answers_1",
+      "provider": "response_answers",
+      "name": "Return Answers",
+      "config": {
+        "laneName": "answers"
+      },
+      "input": [
+        {
+          "lane": "answers",
+          "from": "db_hotdata_1"
+        }
+      ],
+      "ui": {
+        "position": {
+          "x": 500,
+          "y": 140
+        },
+        "nodeType": "default",
+        "formDataValid": true
+      }
+    },
+    {
+      "id": "response_table_1",
+      "provider": "response_table",
+      "name": "Return Table",
+      "config": {
+        "laneName": "table"
+      },
+      "input": [
+        {
+          "lane": "table",
+          "from": "db_hotdata_1"
+        }
+      ],
+      "ui": {
+        "position": {
+          "x": 500,
+          "y": 300
+        },
+        "nodeType": "default",
+        "formDataValid": true
+      }
+    }
+  ],
+  "version": 1,
+  "isLocked": false,
+  "project_id": "f72ea61b-ff92-44f1-a999-eb2de1a4d9cb"
+}

--- a/examples/db_hotdata.pipe
+++ b/examples/db_hotdata.pipe
@@ -26,8 +26,8 @@
       "config": {
         "profile": "default",
         "default": {
-          "apikey": "${ROCKETRIDE_HOTDATA_API_KEY}",
-          "workspace_id": "${ROCKETRIDE_HOTDATA_WORKSPACE}",
+          "apikey": "${ROCKETRIDE_DB_HOTDATA_KEY}",
+          "workspace_id": "${ROCKETRIDE_DB_HOTDATA_WORKSPACE_ID}",
           "api_url": "",
           "ttl": "24h",
           "table": "pipeline_data",
@@ -128,5 +128,5 @@
   ],
   "version": 1,
   "isLocked": false,
-  "project_id": "f72ea61b-ff92-44f1-a999-eb2de1a4d9cb"
+  "project_id": "a1488265-190a-4dbc-b8bc-4b4e6a0759a6"
 }

--- a/nodes/src/nodes/db_hotdata/IGlobal.py
+++ b/nodes/src/nodes/db_hotdata/IGlobal.py
@@ -74,7 +74,10 @@ class IGlobal(IGlobalBase):
     # Fingerprints of append payloads already loaded this run. Hotdata has no
     # idempotency key on loads and append duplicates rows, so a retrying agent
     # would silently double the data without this.
-    _loaded: Optional[set] = None
+    #: fingerprint -> outcome: "pending" while in flight, then "complete"
+    #: or "partial". A partial append must keep reporting itself as
+    #: partial, or a repeat call is told the table has all the rows.
+    _loaded: Optional[dict] = None
 
     apikey: str = ''
     workspace_id: str = ''
@@ -93,7 +96,7 @@ class IGlobal(IGlobalBase):
             return
 
         self._db_lock = threading.Lock()
-        self._loaded = set()
+        self._loaded = {}
 
         cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
 
@@ -142,32 +145,40 @@ class IGlobal(IGlobalBase):
                 database = self.database
         return database
 
-    def seen_load(self, fingerprint: str) -> bool:
-        """Reserve an append payload; True if this exact payload already ran.
+    def seen_load(self, fingerprint: str) -> Optional[str]:
+        """Reserve an append payload; return the prior outcome if there was one.
 
-        Append is not idempotent on Hotdata's side, so a repeated identical
-        load would duplicate rows. Checked and recorded atomically because
-        agents fire tool calls in parallel.
+        Append is not idempotent on Hotdata's side, so a repeated identical load
+        would duplicate rows. Checked and recorded atomically because agents fire
+        tool calls in parallel.
 
-        This is a *reservation*, not a record of success. The caller must call
-        ``release_load`` if the load then fails, otherwise a retry of a failed
-        load would be skipped as a duplicate and the rows would be lost while
-        the tool reported them as already present.
+        Returns None when this payload is new (and reserves it), otherwise the
+        stored outcome: ``pending``, ``complete`` or ``partial``. The caller must
+        call ``release_load`` if the load then fails, or ``record_load`` with the
+        final outcome once it settles.
         """
         if self._loaded is None:
-            self._loaded = set()
+            self._loaded = {}
         with self._db_lock:
-            if fingerprint in self._loaded:
-                return True
-            self._loaded.add(fingerprint)
-            return False
+            existing = self._loaded.get(fingerprint)
+            if existing is not None:
+                return existing
+            self._loaded[fingerprint] = 'pending'
+            return None
+
+    def record_load(self, fingerprint: str, outcome: str) -> None:
+        """Record how a reserved load finished: 'complete' or 'partial'."""
+        if self._loaded is None:
+            self._loaded = {}
+        with self._db_lock:
+            self._loaded[fingerprint] = outcome
 
     def release_load(self, fingerprint: str) -> None:
         """Undo a reservation whose load did not complete, so a retry can run."""
         if not self._loaded:
             return
         with self._db_lock:
-            self._loaded.discard(fingerprint)
+            self._loaded.pop(fingerprint, None)
 
     def drop_database(self, database: Dict[str, Any]) -> None:
         """Forget a database the server reports gone.

--- a/nodes/src/nodes/db_hotdata/IGlobal.py
+++ b/nodes/src/nodes/db_hotdata/IGlobal.py
@@ -178,6 +178,11 @@ class IGlobal(IGlobalBase):
         with self._db_lock:
             if self.database is database:
                 self.database = None
+                # The append fingerprints describe the contents of that specific
+                # database. Keeping them would make an identical append to the
+                # replacement database report deduplicated without loading.
+                if self._loaded:
+                    self._loaded.clear()
 
     def validateConfig(self) -> None:
         try:

--- a/nodes/src/nodes/db_hotdata/IGlobal.py
+++ b/nodes/src/nodes/db_hotdata/IGlobal.py
@@ -1,0 +1,207 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Hotdata node - global (shared) state.
+
+Reads config and builds a REST client. The database itself is created lazily on
+the first tool call (creating one costs money and a pipeline may never invoke
+the node) and deleted in ``endGlobal``.
+
+Every database carries a TTL. ``endGlobal`` is the real teardown; the TTL is the
+crash net for when it never runs. Hotdata documents expiry as best-effort - the
+database will not be deleted *before* ``expires_at``, but cleanup may lag - so
+the TTL is a backstop, not a substitute for deleting explicitly.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import uuid
+from typing import Any, Dict, Optional
+
+from ai.common.config import Config
+from rocketlib import IGlobalBase, OPEN_MODE, debug, warning
+
+from .hotdata_client import HotdataClient
+
+
+def _int_or(value: Any, default: int, *, lo: int, hi: int) -> int:
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(n, hi))
+
+
+def _bool_or(value: Any, default: bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ('1', 'true', 'yes', 'on')
+    return default
+
+
+class IGlobal(IGlobalBase):
+    """Global state for db_hotdata."""
+
+    client: Optional[HotdataClient] = None
+    database: Optional[Dict[str, Any]] = None  # created lazily, deleted in endGlobal
+    # Guards lazy database creation: agents issue parallel tool calls, and an
+    # unsynchronized check-then-act would create two billed databases and orphan
+    # one (the failure tool_daytona hit in production with sandboxes).
+    _db_lock: Optional[threading.Lock] = None
+    # Fingerprints of append payloads already loaded this run. Hotdata has no
+    # idempotency key on loads and append duplicates rows, so a retrying agent
+    # would silently double the data without this.
+    _loaded: Optional[set] = None
+
+    apikey: str = ''
+    workspace_id: str = ''
+    ttl: str = '24h'
+    table: str = 'pipeline_data'
+    db_description: str = ''
+    max_attempts: int = 3
+    max_execute_rows: int = 25000
+    allow_execute: bool = False
+    allow_destructive_load: bool = False
+    job_timeout_secs: int = 300
+    async_after_ms: int = 5000
+
+    def beginGlobal(self) -> None:
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            return
+
+        self._db_lock = threading.Lock()
+        self._loaded = set()
+
+        cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+
+        # Config keys arrive unprefixed here ('apikey', not 'hotdata.apikey').
+        self.apikey = str(cfg.get('apikey') or '').strip() or os.environ.get('HOTDATA_API_KEY', '').strip()
+        self.workspace_id = (
+            str(cfg.get('workspace_id') or '').strip() or os.environ.get('HOTDATA_WORKSPACE', '').strip()
+        )
+
+        if not self.apikey:
+            raise Exception('db_hotdata: apikey is required')
+        if not self.workspace_id:
+            raise Exception('db_hotdata: workspace_id is required')
+
+        api_url = str(cfg.get('api_url') or '').strip()
+        self.ttl = str(cfg.get('ttl') or '24h').strip() or '24h'
+        self.table = str(cfg.get('table') or 'pipeline_data').strip() or 'pipeline_data'
+        self.db_description = str(cfg.get('db_description') or '').strip()
+        self.max_attempts = _int_or(cfg.get('max_attempts'), 3, lo=1, hi=10)
+        self.max_execute_rows = _int_or(cfg.get('max_execute_rows'), 25000, lo=1, hi=25000)
+        self.allow_execute = _bool_or(cfg.get('allow_execute'), False)
+        self.allow_destructive_load = _bool_or(cfg.get('allow_destructive_load'), False)
+        self.job_timeout_secs = _int_or(cfg.get('job_timeout_secs'), 300, lo=10, hi=3600)
+        self.async_after_ms = _int_or(cfg.get('async_after_ms'), 5000, lo=0, hi=60000)
+
+        self.client = HotdataClient(
+            apikey=self.apikey,
+            workspace_id=self.workspace_id,
+            base_url=api_url,
+            retry_budget_s=float(self.job_timeout_secs),
+        )
+
+    def get_database(self) -> Dict[str, Any]:
+        """Return this run's database, creating it on first use.
+
+        Always carries a TTL so an engine crash cannot leave a billed database
+        running forever.
+        """
+        database = self.database
+        if database is None:
+            with self._db_lock:
+                if self.database is None:
+                    name = f'rocketride-{uuid.uuid4().hex[:12]}'
+                    self.database = self.client.create_database(name=name, expires_at=self.ttl)
+                    debug(f'db_hotdata: created database {self.database.get("id", "?")} (ttl {self.ttl})')
+                database = self.database
+        return database
+
+    def seen_load(self, fingerprint: str) -> bool:
+        """Reserve an append payload; True if this exact payload already ran.
+
+        Append is not idempotent on Hotdata's side, so a repeated identical
+        load would duplicate rows. Checked and recorded atomically because
+        agents fire tool calls in parallel.
+
+        This is a *reservation*, not a record of success. The caller must call
+        ``release_load`` if the load then fails, otherwise a retry of a failed
+        load would be skipped as a duplicate and the rows would be lost while
+        the tool reported them as already present.
+        """
+        if self._loaded is None:
+            self._loaded = set()
+        with self._db_lock:
+            if fingerprint in self._loaded:
+                return True
+            self._loaded.add(fingerprint)
+            return False
+
+    def release_load(self, fingerprint: str) -> None:
+        """Undo a reservation whose load did not complete, so a retry can run."""
+        if not self._loaded:
+            return
+        with self._db_lock:
+            self._loaded.discard(fingerprint)
+
+    def drop_database(self, database: Dict[str, Any]) -> None:
+        """Forget a database the server reports gone.
+
+        Expiry is best-effort but it does fire; dropping the stale handle lets
+        the next get_database() create a fresh one instead of failing forever.
+        """
+        with self._db_lock:
+            if self.database is database:
+                self.database = None
+
+    def validateConfig(self) -> None:
+        try:
+            cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+            if not str(cfg.get('apikey') or '').strip() and not os.environ.get('HOTDATA_API_KEY', '').strip():
+                warning('apikey is required')
+            if not str(cfg.get('workspace_id') or '').strip() and not os.environ.get('HOTDATA_WORKSPACE', '').strip():
+                warning('workspace_id is required')
+        except Exception as e:
+            warning(str(e))
+
+    def endGlobal(self) -> None:
+        if self.database is not None and self.client is not None:
+            database_id = self.database.get('id')
+            try:
+                if database_id:
+                    self.client.delete_database(database_id)
+                    debug(f'db_hotdata: deleted database {database_id}')
+            except Exception as e:
+                # Teardown must never fail a pipeline. The TTL still bounds the
+                # cost, it just takes longer than an explicit delete.
+                warning(f'db_hotdata: database delete failed: {e}')
+            finally:
+                self.database = None
+        self.client = None
+        self.apikey = ''
+        self.workspace_id = ''

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -162,7 +162,9 @@ def _schema_summary(tables: List[Any]) -> List[str]:
         name = '.'.join(p for p in (table.get('schema'), table.get('table')) if p)
         columns = table.get('columns') or []
         rendered = ', '.join(
-            f'{c.get("name")} {c.get("data_type")}'.strip() for c in columns if isinstance(c, dict) and c.get('name')
+            f'{c.get("name") or c.get("column_name")} {c.get("data_type") or c.get("type") or ""}'.strip()
+            for c in columns
+            if isinstance(c, dict) and (c.get('name') or c.get('column_name'))
         )
         lines.append(f'{name}({rendered})' if rendered else f'{name}(no columns reported)')
     return lines
@@ -182,6 +184,11 @@ def _to_ndjson(rows: List[Any]) -> bytes:
     return ('\n'.join(lines) + '\n').encode('utf-8')
 
 
+def _cell(value: Any) -> str:
+    """Render one table cell: pipes and newlines both break the row otherwise."""
+    return str(value).replace('|', '\\|').replace('\r\n', ' ').replace('\n', ' ').replace('\r', ' ')
+
+
 def _rows_to_markdown(rows: List[Any], limit: int = 100) -> str:
     """Render result rows as a GitHub-flavored table for the text/table lanes."""
     if not rows:
@@ -198,7 +205,7 @@ def _rows_to_markdown(rows: List[Any], limit: int = 100) -> str:
 
     header = '| ' + ' | '.join(columns) + ' |'
     divider = '| ' + ' | '.join('---' for _ in columns) + ' |'
-    body = ['| ' + ' | '.join(str(row.get(c, '')).replace('|', '\\|') for c in columns) + ' |' for row in shown]
+    body = ['| ' + ' | '.join(_cell(row.get(c, '')) for c in columns) + ' |' for row in shown]
     table = '\n'.join([header, divider] + body)
     if len(rows) > limit:
         table += f'\n\n_{len(rows) - limit} more rows not shown._'
@@ -471,7 +478,7 @@ class IInstance(IInstanceBase):
         question_text: str,
         limit: int,
         previous_sql: str = '',
-        error: str = '',
+        previous_error: str = '',
     ) -> str:
         """Translate a question to SQL with the bound LLM."""
         glb = self.IGlobal
@@ -494,16 +501,16 @@ class IInstance(IInstanceBase):
 
         q.addExample(
             'Which products sold the most units?',
-            'SELECT product, SUM(units) AS "units" FROM sales GROUP BY product ORDER BY "units" DESC LIMIT 250',
+            f'SELECT product, SUM(units) AS "units" FROM sales GROUP BY product ORDER BY "units" DESC LIMIT {limit}',
         )
         q.addExample(
             'Find support tickets that mention a refund',
-            "SELECT * FROM bm25_search('default.main.tickets', 'body', 'refund') LIMIT 250",
+            f"SELECT * FROM bm25_search('default.main.tickets', 'body', 'refund') LIMIT {limit}",
         )
 
-        if previous_sql and error:
+        if previous_sql and previous_error:
             q.addContext(
-                f'Your previous SQL was rejected with this error:\n\n{error}\n\n'
+                f'Your previous SQL was rejected with this error:\n\n{previous_error}\n\n'
                 f'Failed SQL:\n{previous_sql}\n\n'
                 f'Fix the query and try again.'
             )
@@ -588,7 +595,7 @@ class IInstance(IInstanceBase):
         previous_sql = ''
         last_error = ''
         for attempt in range(1, attempts + 1):
-            sql = self._generate_sql(question_text, limit, previous_sql=previous_sql, error=last_error)
+            sql = self._generate_sql(question_text, limit, previous_sql=previous_sql, previous_error=last_error)
             cleaned, statement_count = _split_statements(sql)
             if statement_count > 1:
                 previous_sql, last_error = sql, 'Only one statement per request is allowed.'
@@ -760,6 +767,8 @@ class IInstance(IInstanceBase):
         database_id = database.get('id')
         schema = str(args.get('schema') or '').strip() or database.get('default_schema') or 'main'
 
+        if not database_id:
+            raise RuntimeError('db_hotdata: database was created without an id')
         self._ensure_table(database_id, schema, table, key)
 
         upload_id = ''
@@ -866,6 +875,10 @@ class IInstance(IInstanceBase):
                 (finished.get('result') or {}).get('row_count') if isinstance(finished.get('result'), dict) else None
             )
         debug(f'db_hotdata: loaded into {schema}.{table} (mode {mode})')
+        if row_count is None:
+            # output_schema declares an integer; the agent should not see null
+            # after a load that succeeded.
+            row_count = len(rows) if rows else 0
         out = {'table': table, 'schema': schema, 'mode': mode, 'row_count': row_count}
         if finished.get('partial'):
             out['partial'] = True

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -829,11 +829,11 @@ class IInstance(IInstanceBase):
                 key=key,
                 rows=rows,
             )
-            if fingerprint and result.get('partial'):
-                # Only some rows landed. Keeping the reservation would make a
-                # retry of the same payload report deduplicated and drop the
-                # missing rows for good.
-                glb.release_load(fingerprint)
+            # A partial append deliberately KEEPS its reservation. Append is not
+            # idempotent, so an unknown subset of the payload already landed and
+            # a blind retry would duplicate exactly those rows. There is no safe
+            # automatic action here: the caller has to reconcile. Releasing would
+            # trade silent data loss for silent duplication.
             return result
         except Exception:
             if fingerprint:
@@ -875,14 +875,20 @@ class IInstance(IInstanceBase):
                 (finished.get('result') or {}).get('row_count') if isinstance(finished.get('result'), dict) else None
             )
         debug(f'db_hotdata: loaded into {schema}.{table} (mode {mode})')
-        if row_count is None:
-            # output_schema declares an integer; the agent should not see null
-            # after a load that succeeded.
-            row_count = len(rows) if rows else 0
+        if row_count is None and rows:
+            # Fall back only when we actually uploaded inline rows. A result_id
+            # load has no local count, and reporting 0 there would claim an empty
+            # load that may well have inserted rows.
+            row_count = len(rows)
         out = {'table': table, 'schema': schema, 'mode': mode, 'row_count': row_count}
         if finished.get('partial'):
             out['partial'] = True
-            out['note'] = 'The load only partially succeeded; some rows may be missing. Retrying is safe.'
+            out['note'] = (
+                'The load only partially succeeded: an unknown subset of the rows landed. '
+                'Do NOT simply retry this payload - append is not idempotent, so a retry would '
+                'duplicate the rows that did load. Query the table to see what is present and '
+                'load only what is missing.'
+            )
         return out
 
     @tool_function(

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -523,6 +523,24 @@ class IInstance(IInstanceBase):
             raise RuntimeError('db_hotdata: the connected LLM did not return a query')
         return strip_sql_fences(result.answer)
 
+    def _validate_generated_sql(self, sql: str) -> Tuple[str, str]:
+        """Return (cleaned_sql, error). Error is '' when the SQL is acceptable.
+
+        The single place that decides whether generated SQL may leave the node.
+        get_data retries on the error, get_sql refuses to hand it back; both ask
+        the same question so the paths cannot drift apart.
+        """
+        cleaned, statement_count = _split_statements(sql)
+        if statement_count > 1:
+            return cleaned, 'Only one statement per request is allowed.'
+        verb = _leading_verb(cleaned)
+        if verb in _WRITE_VERBS:
+            return cleaned, (
+                f'"{verb}" is not permitted: the Hotdata SQL surface is read-only. '
+                'Use SELECT, WITH, EXPLAIN, DESCRIBE or VALUES only.'
+            )
+        return cleaned, ''
+
     def _resolve_limit(self, raw_limit: Any) -> int:
         """Clamp a caller-supplied row limit, rejecting JSON booleans."""
         cap = self.IGlobal.max_execute_rows
@@ -557,7 +575,23 @@ class IInstance(IInstanceBase):
         if not question_text:
             raise ValueError('db_hotdata: question is required')
         limit = self._resolve_limit(args.get('limit'))
-        return {'sql': self._generate_sql(question_text, limit), 'dialect': 'datafusion'}
+        attempts = max(1, int(getattr(self.IGlobal, 'max_attempts', 3) or 3))
+
+        previous_sql = ''
+        last_error = ''
+        for _ in range(attempts):
+            sql = self._generate_sql(question_text, limit, previous_sql=previous_sql, previous_error=last_error)
+            cleaned, invalid = self._validate_generated_sql(sql)
+            if not invalid:
+                return {'sql': cleaned, 'dialect': 'datafusion'}
+            previous_sql, last_error = cleaned, invalid
+            debug(f'db_hotdata: regenerating SQL, previous attempt rejected: {invalid}')
+
+        # Handing back SQL the node's own execute would refuse is worse than
+        # failing: the caller has no signal that it is unusable.
+        raise RuntimeError(
+            f'db_hotdata: could not generate acceptable SQL after {attempts} attempts. Last issue: {last_error}'
+        )
 
     @tool_function(
         input_schema={
@@ -596,21 +630,13 @@ class IInstance(IInstanceBase):
         last_error = ''
         for attempt in range(1, attempts + 1):
             sql = self._generate_sql(question_text, limit, previous_sql=previous_sql, previous_error=last_error)
-            cleaned, statement_count = _split_statements(sql)
-            if statement_count > 1:
-                previous_sql, last_error = sql, 'Only one statement per request is allowed.'
-                continue
             # Same read-only guard `execute` applies. The server rejects writes
             # anyway, but catching it here turns a wasted round trip into an
-            # immediate corrective retry and keeps both paths consistent.
-            verb = _leading_verb(cleaned)
-            if verb in _WRITE_VERBS:
-                previous_sql = cleaned
-                last_error = (
-                    f'"{verb}" is not permitted: the Hotdata SQL surface is read-only. '
-                    'Use SELECT, WITH, EXPLAIN, DESCRIBE or VALUES only.'
-                )
-                debug(f'db_hotdata: rejected generated {verb.upper()} before execution')
+            # immediate corrective retry.
+            cleaned, invalid = self._validate_generated_sql(sql)
+            if invalid:
+                previous_sql, last_error = cleaned, invalid
+                debug(f'db_hotdata: rejected generated SQL before execution: {invalid}')
                 continue
             try:
                 result = self._run_sql(cleaned, limit)

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -1,0 +1,919 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Hotdata node - per-instance tool surface.
+
+Exposes schema introspection, read-only SQL, natural-language querying, data
+loading and index building, plus the questions and answers lanes.
+"""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import time
+from typing import Any, Dict, List, Tuple
+
+from ai.common.schema import Answer, Question
+from ai.common.utils import normalize_tool_input
+from rocketlib import IInstanceBase, debug, error, tool_function, warning
+from rocketlib.types import IInvokeLLM
+
+from .hotdata_schema import (
+    format_schema_for_prompt,
+    get_dialect_prompt_text,
+    strip_sql_fences,
+)
+
+#: Statement verbs Hotdata rejects before execution. Caught client-side so the
+#: agent gets a clear reason instead of a generic server error.
+_WRITE_VERBS = frozenset(
+    {
+        'insert',
+        'update',
+        'delete',
+        'merge',
+        'copy',
+        'create',
+        'drop',
+        'alter',
+        'truncate',
+        'grant',
+        'revoke',
+        'set',
+        'prepare',
+        'begin',
+        'commit',
+        'rollback',
+        'vacuum',
+    }
+)
+
+#: Poll interval bounds while waiting on an async query run, seconds.
+_POLL_BASE_S = 0.5
+_POLL_MAX_S = 5.0
+
+_TERMINAL_OK = frozenset({'succeeded', 'success', 'completed', 'complete', 'ready', 'finished'})
+_TERMINAL_BAD = frozenset({'failed', 'error', 'cancelled', 'canceled'})
+
+#: Async job states from the loads/indexes 202 envelope.
+_JOB_PENDING = frozenset({'pending', 'running'})
+_JOB_OK = frozenset({'succeeded', 'ready'})
+_JOB_BAD = frozenset({'failed', 'cancelled', 'canceled'})
+
+#: Load modes Hotdata accepts, and the subset that needs key columns.
+_LOAD_MODES = frozenset({'append', 'replace', 'upsert', 'update', 'delete'})
+
+#: Modes that overwrite or remove rows already in the table. The SQL surface is
+#: read-only, but load_data is a separate write path - without this gate an agent
+#: told to "delete the bad rows" simply routes around the SQL guard via replace.
+_DESTRUCTIVE_MODES = frozenset({'replace', 'update', 'delete'})
+_KEYED_MODES = frozenset({'upsert', 'update', 'delete'})
+
+#: Index types. bm25 is full text, vector is semantic, sorted speeds range scans.
+_INDEX_TYPES = frozenset({'bm25', 'vector', 'sorted'})
+
+
+def _strip_sql_noise(sql: str) -> str:
+    """Remove comments and string/identifier literals, preserving structure.
+
+    Used only for statement counting and verb detection - never for anything
+    sent to the server.
+    """
+    out: List[str] = []
+    i = 0
+    n = len(sql)
+    while i < n:
+        ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < n else ''
+        if ch == '-' and nxt == '-':
+            i = sql.find('\n', i)
+            if i == -1:
+                break
+            continue
+        if ch == '/' and nxt == '*':
+            end = sql.find('*/', i + 2)
+            i = n if end == -1 else end + 2
+            continue
+        if ch == "'":
+            i += 1
+            while i < n:
+                if sql[i] == "'":
+                    if i + 1 < n and sql[i + 1] == "'":
+                        i += 2
+                        continue
+                    i += 1
+                    break
+                i += 1
+            out.append(' ')
+            continue
+        if ch == '"':
+            i += 1
+            while i < n and sql[i] != '"':
+                i += 1
+            i += 1
+            out.append(' ')
+            continue
+        out.append(ch)
+        i += 1
+    return ''.join(out)
+
+
+def _split_statements(sql: str) -> Tuple[str, int]:
+    """Return (cleaned sql, statement count).
+
+    One trailing semicolon is tolerated and stripped; anything beyond that is a
+    genuine batch, which Hotdata rejects (one statement per request).
+    """
+    stripped = sql.strip()
+    noise_free = _strip_sql_noise(stripped)
+    parts = [p for p in noise_free.split(';') if p.strip()]
+    if stripped.endswith(';'):
+        stripped = stripped[:-1].rstrip()
+    return stripped, len(parts)
+
+
+def _schema_summary(tables: List[Any]) -> List[str]:
+    """One flat line per table: ``schema.table(col type, col type)``."""
+    lines = []
+    for table in tables or []:
+        if not isinstance(table, dict):
+            continue
+        name = '.'.join(p for p in (table.get('schema'), table.get('table')) if p)
+        columns = table.get('columns') or []
+        rendered = ', '.join(
+            f'{c.get("name")} {c.get("data_type")}'.strip() for c in columns if isinstance(c, dict) and c.get('name')
+        )
+        lines.append(f'{name}({rendered})' if rendered else f'{name}(no columns reported)')
+    return lines
+
+
+def _to_ndjson(rows: List[Any]) -> bytes:
+    """Serialize rows as newline-delimited JSON.
+
+    Hotdata's ``json`` load format is NDJSON: one object per line. Uploading a
+    JSON array fails schema inference server-side.
+    """
+    lines = []
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError('db_hotdata: every row must be an object, not a scalar or list')
+        lines.append(json.dumps(row, default=str))
+    return ('\n'.join(lines) + '\n').encode('utf-8')
+
+
+def _rows_to_markdown(rows: List[Any], limit: int = 100) -> str:
+    """Render result rows as a GitHub-flavored table for the text/table lanes."""
+    if not rows:
+        return 'No rows.'
+    shown = rows[:limit]
+    if not isinstance(shown[0], dict):
+        return '\n'.join(str(r) for r in shown)
+
+    columns: List[str] = []
+    for row in shown:
+        for key in row:
+            if key not in columns:
+                columns.append(key)
+
+    header = '| ' + ' | '.join(columns) + ' |'
+    divider = '| ' + ' | '.join('---' for _ in columns) + ' |'
+    body = ['| ' + ' | '.join(str(row.get(c, '')).replace('|', '\\|') for c in columns) + ' |' for row in shown]
+    table = '\n'.join([header, divider] + body)
+    if len(rows) > limit:
+        table += f'\n\n_{len(rows) - limit} more rows not shown._'
+    return table
+
+
+def _leading_verb(sql: str) -> str:
+    cleaned = _strip_sql_noise(sql).strip()
+    if not cleaned:
+        return ''
+    # A leading '(' is legal for parenthesised SELECTs.
+    cleaned = cleaned.lstrip('(').strip()
+    token = cleaned.split(None, 1)[0] if cleaned else ''
+    return token.lower().strip('(')
+
+
+class IInstance(IInstanceBase):
+    """Tool surface for db_hotdata."""
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _run_sql(self, sql: str, limit: int) -> Dict[str, Any]:
+        """Execute one statement, following the async job if the server defers it."""
+        glb = self.IGlobal
+        database = glb.get_database()
+        database_id = database.get('id')
+        if not database_id:
+            raise RuntimeError('db_hotdata: database was created without an id')
+
+        response = glb.client.query(
+            sql=sql,
+            database_id=database_id,
+            async_after_ms=glb.async_after_ms,
+        )
+
+        run_id = response.get('query_run_id') or response.get('id')
+        if response.get('rows') is not None and not response.get('truncated'):
+            rows = response.get('rows') or []
+            return {'rows': rows[:limit], 'row_count': len(rows[:limit]), 'sql': sql}
+
+        if run_id and response.get('result_id') is None:
+            response = self._await_run(run_id)
+
+        result_id = response.get('result_id')
+        if result_id:
+            payload = glb.client.get_result(result_id, offset=0, limit=limit)
+            rows = payload.get('rows') or payload.get('data') or []
+            return {'rows': rows[:limit], 'row_count': len(rows[:limit]), 'sql': sql}
+
+        rows = response.get('rows') or []
+        return {'rows': rows[:limit], 'row_count': len(rows[:limit]), 'sql': sql}
+
+    def _await_run(self, run_id: str) -> Dict[str, Any]:
+        """Poll a query run to a terminal state under a monotonic deadline."""
+        glb = self.IGlobal
+        deadline = time.monotonic() + glb.job_timeout_secs
+        delay = _POLL_BASE_S
+        while True:
+            run = glb.client.get_query_run(run_id)
+            status = str(run.get('status') or '').lower()
+            if status in _TERMINAL_BAD:
+                message = run.get('error') or run.get('message') or status
+                raise RuntimeError(f'db_hotdata: query failed: {message}')
+            if status in _TERMINAL_OK or run.get('result_id'):
+                return run
+            if time.monotonic() + delay > deadline:
+                raise RuntimeError(f'db_hotdata: query did not finish within {glb.job_timeout_secs}s')
+            time.sleep(delay)
+            delay = min(delay * 2, _POLL_MAX_S)
+
+    # ------------------------------------------------------------------
+    # Tools
+    # ------------------------------------------------------------------
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'schema': {'type': 'string', 'description': 'Restrict to one schema. Optional.'},
+                'table': {'type': 'string', 'description': 'Restrict to one table. Optional.'},
+            },
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'tables': {'type': 'array', 'description': 'Tables with their columns and types.'},
+            },
+        },
+        description=(
+            "Inspect the live schema of this run's Hotdata database. "
+            'Call this before writing SQL so column names and types are exact. '
+            'Names are three-part (catalog.schema.table); the run\'s own catalog answers to "default". '
+            'Types are Arrow types (Utf8, Int64, Timestamp, ...), not Postgres types. '
+            'Returns tables with their columns.'
+        ),
+    )
+    def get_schema(self, args: Any) -> Dict[str, Any]:
+        args = normalize_tool_input(args, tool_name='get_schema')
+        glb = self.IGlobal
+        database = glb.get_database()
+        database_id = database.get('id')
+        connection_id = database.get('default_connection_id')
+        if not connection_id:
+            raise RuntimeError('db_hotdata: database has no default_connection_id; cannot read the schema')
+
+        schema = str(args.get('schema') or '').strip()
+        table = str(args.get('table') or '').strip()
+
+        payload = glb.client.information_schema(
+            connection_id=connection_id,
+            schema=schema,
+            table=table,
+            include_columns=True,
+        )
+        tables = payload.get('tables') or payload.get('data') or []
+        # Small models reliably miscount columns when made to walk the nested
+        # JSON (observed: a 4-column table reported as "note and product").
+        # A flat one-line-per-table rendering removes the parsing step.
+        return {'summary': _schema_summary(tables), 'tables': tables, 'database_id': database_id}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'sql': {'type': 'string', 'description': 'One read-only SQL statement.'},
+                'limit': {'type': 'integer', 'description': 'Maximum rows to return.'},
+            },
+            'required': ['sql'],
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'rows': {'type': 'array', 'description': 'Result rows.'},
+                'row_count': {'type': 'integer', 'description': 'Number of rows returned.'},
+            },
+        },
+        description=(
+            "Run one read-only SQL statement against this run's Hotdata database. "
+            'The engine is Apache DataFusion with the PostgreSQL parser dialect: Postgres syntax, '
+            'DataFusion semantics and function library. The SQL surface is read-only - INSERT, UPDATE, DELETE '
+            'and all DDL are rejected. Exactly one statement per call, no semicolon-separated batches. '
+            'Unquoted identifiers fold to lowercase, so double-quote any name with uppercase or spaces. '
+            'JSON operators and pg_catalog functions do not exist here. '
+            'Use get_schema first if you are unsure of column names.'
+        ),
+    )
+    def execute(self, args: Any) -> Dict[str, Any]:
+        args = normalize_tool_input(args, tool_name='execute')
+        glb = self.IGlobal
+
+        if not glb.allow_execute:
+            warning('db_hotdata: execute is disabled (allow_execute is off)')
+            raise RuntimeError('db_hotdata: raw SQL execution is disabled; enable allow_execute on the node')
+
+        sql = args.get('sql')
+        if not isinstance(sql, str) or not sql.strip():
+            raise ValueError('db_hotdata: sql is required and must be a non-empty string')
+
+        cleaned, statement_count = _split_statements(sql)
+        if statement_count > 1:
+            raise ValueError(
+                'db_hotdata: only one statement per call is supported; Hotdata rejects semicolon-separated batches'
+            )
+        if not cleaned:
+            raise ValueError('db_hotdata: sql is required and must be a non-empty string')
+
+        verb = _leading_verb(cleaned)
+        if verb in _WRITE_VERBS:
+            raise ValueError(
+                f'db_hotdata: "{verb}" is not permitted - the Hotdata SQL surface is read-only '
+                '(SELECT, WITH, EXPLAIN, DESCRIBE and VALUES only)'
+            )
+
+        raw_limit = args.get('limit')
+        if isinstance(raw_limit, bool) or not isinstance(raw_limit, int):
+            limit = min(250, glb.max_execute_rows)
+        else:
+            limit = max(1, min(raw_limit, glb.max_execute_rows))
+
+        debug(f'db_hotdata: executing statement, limit {limit}')
+        return self._run_sql(cleaned, limit)
+
+    # ------------------------------------------------------------------
+    # Lanes
+    # ------------------------------------------------------------------
+
+    def writeQuestions(self, question: Question) -> None:
+        """Questions lane: answer the question and emit to whichever lanes are wired."""
+        question_text = question.questions[0].text if getattr(question, 'questions', None) else None
+        if not question_text:
+            warning('db_hotdata: no question text provided')
+            return
+
+        lanes = self.instance.getListeners()
+        try:
+            result = self.get_data({'question': question_text})
+        except Exception as e:
+            error(f'db_hotdata: error handling question: {e}')
+            self._emitError(str(e), lanes)
+            return
+
+        rows = result.get('rows') or []
+        markdown = _rows_to_markdown(rows)
+
+        if 'text' in lanes:
+            self.instance.writeText(markdown)
+        if 'table' in lanes and rows:
+            self.instance.writeTable(markdown)
+        if 'answers' in lanes:
+            answer = Answer()
+            answer.setAnswer(markdown)
+            self.instance.writeAnswers(answer)
+
+    def writeAnswers(self, answer: Answer) -> None:
+        """Answers lane: load structured rows into the configured table.
+
+        Note this does NOT generate INSERT statements the way the SQL database
+        nodes do - Hotdata rejects INSERT and CREATE TABLE outright. Rows are
+        serialized, uploaded, and loaded through the REST load API instead.
+        """
+        items = answer.getJson()
+        if not items:
+            debug('db_hotdata: no items to load')
+            return
+        if isinstance(items, dict):
+            items = [items]
+
+        try:
+            self.load_data({'table': self.IGlobal.table, 'rows': items, 'mode': 'append'})
+        except Exception as e:
+            error(f'db_hotdata: error in writeAnswers: {e}')
+
+    def _emitError(self, message: str, lanes) -> None:
+        """Emit a failure to the wired lanes, structurally distinguishable from prose."""
+        if 'text' in lanes:
+            self.instance.writeText(message)
+        if 'answers' in lanes:
+            answer = Answer()
+            answer.setAnswer(json.dumps({'error': message}))
+            self.instance.writeAnswers(answer)
+
+    # ------------------------------------------------------------------
+    # Natural language to SQL
+    # ------------------------------------------------------------------
+
+    def _schema_context(self) -> str:
+        """Live schema as prompt text, best-effort.
+
+        A schema lookup failure must not sink the whole question - the LLM can
+        still produce something reasonable, and the execute step surfaces any
+        real problem with a server error the retry loop can act on.
+        """
+        try:
+            database = self.IGlobal.get_database()
+            payload = self.IGlobal.client.information_schema(
+                connection_id=database.get('default_connection_id'),
+                include_columns=True,
+            )
+            tables = payload.get('tables') or payload.get('data') or []
+            return format_schema_for_prompt(tables)
+        except Exception as e:
+            warning(f'db_hotdata: could not read schema for the prompt: {e}')
+            return 'Schema could not be read; rely on information_schema queries.'
+
+    def _generate_sql(
+        self,
+        question_text: str,
+        limit: int,
+        previous_sql: str = '',
+        error: str = '',
+    ) -> str:
+        """Translate a question to SQL with the bound LLM."""
+        glb = self.IGlobal
+
+        q = Question(role='You are a Hotdata SQL query generator.')
+        q.addInstruction(
+            'Output format',
+            'Output ONLY the raw SQL query -- no markdown fences, no explanation, no preamble.',
+        )
+        q.addInstruction('SQL dialect', get_dialect_prompt_text())
+        q.addInstruction(
+            'Row limit',
+            f'Always add LIMIT {limit} unless the question asks for a specific different limit.',
+        )
+        q.addContext(self._schema_context())
+
+        db_desc = (getattr(glb, 'db_description', '') or '').strip()
+        if db_desc:
+            q.addContext(f'Data context: {db_desc}')
+
+        q.addExample(
+            'Which products sold the most units?',
+            'SELECT product, SUM(units) AS "units" FROM sales GROUP BY product ORDER BY "units" DESC LIMIT 250',
+        )
+        q.addExample(
+            'Find support tickets that mention a refund',
+            "SELECT * FROM bm25_search('default.main.tickets', 'body', 'refund') LIMIT 250",
+        )
+
+        if previous_sql and error:
+            q.addContext(
+                f'Your previous SQL was rejected with this error:\n\n{error}\n\n'
+                f'Failed SQL:\n{previous_sql}\n\n'
+                f'Fix the query and try again.'
+            )
+
+        q.addGoal('Generate one valid read-only SQL query that answers the question.')
+        q.addQuestion(question_text)
+
+        result = self.instance.invoke(IInvokeLLM.Ask(question=q))
+        if not result or not getattr(result, 'answer', None):
+            raise RuntimeError('db_hotdata: the connected LLM did not return a query')
+        return strip_sql_fences(result.answer)
+
+    def _resolve_limit(self, raw_limit: Any) -> int:
+        """Clamp a caller-supplied row limit, rejecting JSON booleans."""
+        cap = self.IGlobal.max_execute_rows
+        if isinstance(raw_limit, bool) or not isinstance(raw_limit, int):
+            return min(250, cap)
+        return max(1, min(raw_limit, cap))
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'question': {'type': 'string', 'description': 'The question, in plain language.'},
+                'limit': {'type': 'integer', 'description': 'Maximum rows to return.'},
+            },
+            'required': ['question'],
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'sql': {'type': 'string', 'description': 'The SQL that was generated.'},
+            },
+        },
+        description=(
+            "Translate a plain-language question into SQL for this run's Hotdata database "
+            'WITHOUT running it. Use this when you want to inspect or explain the query first; '
+            'use get_data when you want the answer.'
+        ),
+    )
+    def get_sql(self, args: Any) -> Dict[str, Any]:
+        args = normalize_tool_input(args, tool_name='get_sql')
+        question_text = str(args.get('question') or '').strip()
+        if not question_text:
+            raise ValueError('db_hotdata: question is required')
+        limit = self._resolve_limit(args.get('limit'))
+        return {'sql': self._generate_sql(question_text, limit), 'dialect': 'datafusion'}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'question': {'type': 'string', 'description': 'The question, in plain language.'},
+                'limit': {'type': 'integer', 'description': 'Maximum rows to return.'},
+            },
+            'required': ['question'],
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'rows': {'type': 'array', 'description': 'Result rows.'},
+                'sql': {'type': 'string', 'description': 'The SQL that produced them.'},
+                'row_count': {'type': 'integer', 'description': 'Number of rows returned.'},
+            },
+        },
+        description=(
+            "Answer a plain-language question about the data in this run's Hotdata database. "
+            'The connected LLM writes the SQL, it runs, and the rows come back. '
+            'Load data with load_data first - a fresh database is empty. '
+            'If a generated query fails it is retried with the error fed back in.'
+        ),
+    )
+    def get_data(self, args: Any) -> Dict[str, Any]:
+        args = normalize_tool_input(args, tool_name='get_data')
+        question_text = str(args.get('question') or '').strip()
+        if not question_text:
+            raise ValueError('db_hotdata: question is required')
+
+        limit = self._resolve_limit(args.get('limit'))
+        attempts = max(1, int(getattr(self.IGlobal, 'max_attempts', 3) or 3))
+
+        previous_sql = ''
+        last_error = ''
+        for attempt in range(1, attempts + 1):
+            sql = self._generate_sql(question_text, limit, previous_sql=previous_sql, error=last_error)
+            cleaned, statement_count = _split_statements(sql)
+            if statement_count > 1:
+                previous_sql, last_error = sql, 'Only one statement per request is allowed.'
+                continue
+            # Same read-only guard `execute` applies. The server rejects writes
+            # anyway, but catching it here turns a wasted round trip into an
+            # immediate corrective retry and keeps both paths consistent.
+            verb = _leading_verb(cleaned)
+            if verb in _WRITE_VERBS:
+                previous_sql = cleaned
+                last_error = (
+                    f'"{verb}" is not permitted: the Hotdata SQL surface is read-only. '
+                    'Use SELECT, WITH, EXPLAIN, DESCRIBE or VALUES only.'
+                )
+                debug(f'db_hotdata: rejected generated {verb.upper()} before execution')
+                continue
+            try:
+                result = self._run_sql(cleaned, limit)
+                result['attempts'] = attempt
+                return result
+            except Exception as e:
+                previous_sql, last_error = cleaned, str(e)
+                debug(f'db_hotdata: attempt {attempt} failed: {last_error}')
+
+        raise RuntimeError(f'db_hotdata: could not answer after {attempts} attempts. Last error: {last_error}')
+
+    @tool_function(
+        input_schema={'type': 'object', 'properties': {}},
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'dialect': {'type': 'string', 'description': 'Dialect identifier.'},
+                'briefing': {'type': 'string', 'description': 'How this SQL dialect differs from Postgres.'},
+            },
+        },
+        description=(
+            'Describe the SQL dialect of this database before you write SQL by hand. '
+            'Hotdata is Apache DataFusion behind a PostgreSQL parser, so Postgres syntax is accepted '
+            "but the function library and types are DataFusion's. Read this to avoid writing JSON "
+            'operators, pg_catalog lookups or other Postgres-only constructs that do not exist here.'
+        ),
+    )
+    def dialect(self, args: Any) -> Dict[str, Any]:
+        normalize_tool_input(args, tool_name='dialect')
+        return {'dialect': 'datafusion', 'briefing': get_dialect_prompt_text()}
+
+    # ------------------------------------------------------------------
+    # Loading and indexing
+    # ------------------------------------------------------------------
+
+    def _await_job(self, response: Dict[str, Any]) -> Dict[str, Any]:
+        """Follow a 202 job to completion, or pass a synchronous result straight through."""
+        job_id = response.get('id') if response.get('status') in _JOB_PENDING else None
+        if not job_id:
+            return response
+
+        glb = self.IGlobal
+        deadline = time.monotonic() + glb.job_timeout_secs
+        delay = _POLL_BASE_S
+        while True:
+            job = glb.client.get_job(job_id)
+            status = str(job.get('status') or '').lower()
+            if status in _JOB_BAD:
+                message = job.get('error_message') or status
+                raise RuntimeError(f'db_hotdata: job {job_id} failed: {message}')
+            if status == 'partially_succeeded':
+                warning(f'db_hotdata: job {job_id} only partially succeeded')
+                return job
+            if status in _JOB_OK:
+                return job
+            if time.monotonic() + delay > deadline:
+                raise RuntimeError(f'db_hotdata: job {job_id} did not finish within {glb.job_timeout_secs}s')
+            time.sleep(delay)
+            delay = min(delay * 2, _POLL_MAX_S)
+
+    def _ensure_table(self, database_id: str, schema: str, table: str, key: Any) -> None:
+        """Declare the table if it does not exist yet.
+
+        CREATE TABLE is rejected by the SQL surface, so tables only come into
+        existence over REST. An already-declared table returns a 409, which is
+        success for our purposes.
+        """
+        try:
+            self.IGlobal.client.create_table(
+                database_id=database_id,
+                schema=schema,
+                name=table,
+                key=key or None,
+            )
+        except Exception as e:
+            if '409' in str(e) or 'exists' in str(e).lower():
+                return
+            raise
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'table': {'type': 'string', 'description': 'Target table name.'},
+                'rows': {'type': 'array', 'description': 'Rows to load, as a list of flat objects.'},
+                'result_id': {'type': 'string', 'description': 'Load a previous query result instead of rows.'},
+                'mode': {
+                    'type': 'string',
+                    'description': 'append (default) or upsert. replace, update and delete overwrite existing rows and require allow_destructive_load on the node.',
+                },
+                'key': {'type': 'array', 'description': 'Key columns, required for upsert/update/delete.'},
+                'schema': {'type': 'string', 'description': 'Target schema. Defaults to the database default.'},
+            },
+            'required': ['table'],
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'table': {'type': 'string', 'description': 'Table that was loaded.'},
+                'row_count': {'type': 'integer', 'description': 'Rows loaded, when the server reports it.'},
+            },
+        },
+        description=(
+            "Load data into a table in this run's Hotdata database, creating the table if needed. "
+            'Pass rows as a list of flat objects, or result_id to load a previous query result without '
+            're-uploading it. This is the ONLY way to get data in - the SQL surface is read-only, so '
+            'INSERT does not work. Use mode=append to add, replace to overwrite, or upsert with key columns. '
+            'Do not call this twice for the same data: append adds rows again rather than replacing them. '
+            'An identical append repeated within one run is skipped and returns deduplicated=true. '
+            'Data lives only for this pipeline run.'
+        ),
+    )
+    def load_data(self, args: Any) -> Dict[str, Any]:
+        args = normalize_tool_input(args, tool_name='load_data')
+        glb = self.IGlobal
+
+        table = str(args.get('table') or '').strip()
+        if not table:
+            raise ValueError('db_hotdata: table is required')
+
+        rows = args.get('rows')
+        result_id = str(args.get('result_id') or '').strip()
+        if not result_id and not isinstance(rows, list):
+            raise ValueError('db_hotdata: provide either rows (a list of objects) or result_id')
+        if result_id and isinstance(rows, list) and rows:
+            raise ValueError('db_hotdata: provide rows or result_id, not both')
+
+        mode = str(args.get('mode') or 'append').strip().lower()
+        if mode not in _LOAD_MODES:
+            raise ValueError(f'db_hotdata: mode must be one of {", ".join(sorted(_LOAD_MODES))}')
+        if mode in _DESTRUCTIVE_MODES and not glb.allow_destructive_load:
+            raise ValueError(
+                f'db_hotdata: mode "{mode}" overwrites or removes existing rows and is disabled; '
+                'enable allow_destructive_load on the node, or use append or upsert'
+            )
+
+        key = args.get('key')
+        if key is not None and not isinstance(key, list):
+            raise ValueError('db_hotdata: key must be a list of column names')
+        if mode in _KEYED_MODES and not key:
+            raise ValueError(f'db_hotdata: mode "{mode}" requires key columns')
+
+        database = glb.get_database()
+        database_id = database.get('id')
+        schema = str(args.get('schema') or '').strip() or database.get('default_schema') or 'main'
+
+        self._ensure_table(database_id, schema, table, key)
+
+        upload_id = ''
+        data_format = ''
+        # Bound on every path: the failure handler below releases it, and the
+        # result_id path never sets one.
+        fingerprint = None
+        if not result_id:
+            if not rows:
+                return {'table': table, 'row_count': 0, 'schema': schema}
+            # Hotdata's `json` format is NDJSON - one object per line. A JSON
+            # array is rejected with "Expected JSON record to be an object,
+            # found Array", which only shows up against the live API.
+            payload = _to_ndjson(rows)
+
+            # Append is not idempotent server-side and Hotdata exposes no
+            # idempotency key on loads, so an agent that re-calls load_data (a
+            # routine retry) silently doubles the data. Verified against the
+            # live API: an identical append took 2 rows to 4. Guard identical
+            # appends within a single pipeline run and say so in the result
+            # rather than duplicating business data.
+            if mode == 'append':
+                fingerprint = hashlib.sha256(f'{schema}.{table}|'.encode('utf-8') + payload).hexdigest()
+                if glb.seen_load(fingerprint):
+                    warning(f'db_hotdata: identical append to {schema}.{table} already ran this session; skipping')
+                    return {
+                        'table': table,
+                        'schema': schema,
+                        'mode': mode,
+                        'row_count': len(rows),
+                        'deduplicated': True,
+                        'note': (
+                            'This exact payload was already appended to this table during this run, '
+                            'so it was not loaded again. The table already contains these rows.'
+                        ),
+                    }
+
+            upload_id = glb.client.upload_bytes(
+                payload,
+                filename=f'{table}.ndjson',
+                content_type='application/x-ndjson',
+            )
+            data_format = 'json'
+
+        # The dedup fingerprint above is a reservation. If anything from here on
+        # fails, release it: otherwise the agent's retry is skipped as a
+        # duplicate and the rows are silently never loaded.
+        try:
+            return self._perform_load(
+                glb,
+                database_id=database_id,
+                schema=schema,
+                table=table,
+                mode=mode,
+                upload_id=upload_id,
+                result_id=result_id,
+                data_format=data_format,
+                key=key,
+                rows=rows,
+            )
+        except Exception:
+            if fingerprint:
+                glb.release_load(fingerprint)
+            raise
+
+    def _perform_load(
+        self,
+        glb,
+        *,
+        database_id,
+        schema,
+        table,
+        mode,
+        upload_id,
+        result_id,
+        data_format,
+        key,
+        rows,
+    ) -> Dict[str, Any]:
+        """Issue the load and wait for it. Split out so load_data can release the
+        dedup reservation on any failure below the upload.
+        """
+        response = glb.client.load_table(
+            database_id=database_id,
+            schema=schema,
+            table=table,
+            mode=mode,
+            upload_id=upload_id,
+            result_id=result_id,
+            data_format=data_format,
+            key=key,
+            async_after_ms=glb.async_after_ms,
+        )
+        finished = self._await_job(response)
+        row_count = finished.get('row_count')
+        if row_count is None:
+            row_count = (
+                (finished.get('result') or {}).get('row_count') if isinstance(finished.get('result'), dict) else None
+            )
+        debug(f'db_hotdata: loaded into {schema}.{table} (mode {mode})')
+        return {'table': table, 'schema': schema, 'mode': mode, 'row_count': row_count}
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'properties': {
+                'table': {'type': 'string', 'description': 'Table holding the column to index.'},
+                'column': {'type': 'string', 'description': 'Column to index.'},
+                'index_type': {'type': 'string', 'description': 'bm25 (full text), vector (semantic) or sorted.'},
+                'schema': {'type': 'string', 'description': 'Schema. Defaults to the database default.'},
+                'index_name': {'type': 'string', 'description': 'Optional index name.'},
+                'metric': {'type': 'string', 'description': 'Vector distance metric. Optional.'},
+            },
+            'required': ['table', 'column'],
+        },
+        output_schema={
+            'type': 'object',
+            'properties': {
+                'index_name': {'type': 'string', 'description': 'Name of the index created.'},
+                'status': {'type': 'string', 'description': 'Index status.'},
+            },
+        },
+        description=(
+            'Build an index on a column so it can be searched. '
+            'index_type=bm25 enables full-text search via bm25_search(table, column, query); '
+            'index_type=vector enables semantic search via vector_search(table, column, query) and '
+            'vector_distance(column, query) for ORDER BY - the server embeds the query text itself using '
+            'the workspace embedding provider. index_type=sorted speeds up range filters. '
+            'Index first, then query with those functions in normal SQL.'
+        ),
+    )
+    def build_index(self, args: Any) -> Dict[str, Any]:
+        args = normalize_tool_input(args, tool_name='build_index')
+        glb = self.IGlobal
+
+        table = str(args.get('table') or '').strip()
+        column = str(args.get('column') or '').strip()
+        if not table or not column:
+            raise ValueError('db_hotdata: table and column are required')
+
+        index_type = str(args.get('index_type') or 'bm25').strip().lower()
+        if index_type not in _INDEX_TYPES:
+            raise ValueError(f'db_hotdata: index_type must be one of {", ".join(sorted(_INDEX_TYPES))}')
+
+        database = glb.get_database()
+        connection_id = database.get('default_connection_id')
+        if not connection_id:
+            raise RuntimeError('db_hotdata: database has no default_connection_id; cannot create an index')
+        schema = str(args.get('schema') or '').strip() or database.get('default_schema') or 'main'
+        index_name = str(args.get('index_name') or '').strip() or f'{table}_{column}_{index_type}'
+
+        response = glb.client.create_index(
+            connection_id=connection_id,
+            schema=schema,
+            table=table,
+            index_name=index_name,
+            columns=[column],
+            index_type=index_type,
+            metric=str(args.get('metric') or '').strip(),
+            async_after_ms=glb.async_after_ms,
+        )
+        finished = self._await_job(response)
+        debug(f'db_hotdata: built {index_type} index {index_name} on {schema}.{table}.{column}')
+        return {
+            'index_name': index_name,
+            'index_type': index_type,
+            'status': finished.get('status') or 'ready',
+        }

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -374,11 +374,7 @@ class IInstance(IInstanceBase):
                 '(SELECT, WITH, EXPLAIN, DESCRIBE and VALUES only)'
             )
 
-        raw_limit = args.get('limit')
-        if isinstance(raw_limit, bool) or not isinstance(raw_limit, int):
-            limit = min(250, glb.max_execute_rows)
-        else:
-            limit = max(1, min(raw_limit, glb.max_execute_rows))
+        limit = self._resolve_limit(args.get('limit'))
 
         debug(f'db_hotdata: executing statement, limit {limit}')
         return self._run_sql(cleaned, limit)
@@ -431,7 +427,12 @@ class IInstance(IInstanceBase):
         try:
             self.load_data({'table': self.IGlobal.table, 'rows': items, 'mode': 'append'})
         except Exception as e:
+            # Re-raise rather than only logging. The answers lane has no output
+            # lane to emit to, so swallowing here would let the run report
+            # success while the rows were never loaded - silent data loss. The
+            # client already retries transient failures before we get here.
             error(f'db_hotdata: error in writeAnswers: {e}')
+            raise
 
     def _emitError(self, message: str, lanes) -> None:
         """Emit a failure to the wired lanes, structurally distinguishable from prose."""
@@ -640,7 +641,12 @@ class IInstance(IInstanceBase):
 
     def _await_job(self, response: Dict[str, Any]) -> Dict[str, Any]:
         """Follow a 202 job to completion, or pass a synchronous result straight through."""
-        job_id = response.get('id') if response.get('status') in _JOB_PENDING else None
+        # The polled status is lowercased below, so the envelope casing is not
+        # guaranteed either. A 'Pending' envelope would otherwise be treated as
+        # a finished job and the caller would keep a dedup reservation for rows
+        # that never landed.
+        envelope_status = str(response.get('status') or '').lower()
+        job_id = response.get('id') if envelope_status in _JOB_PENDING else None
         if not job_id:
             return response
 
@@ -655,6 +661,11 @@ class IInstance(IInstanceBase):
                 raise RuntimeError(f'db_hotdata: job {job_id} failed: {message}')
             if status == 'partially_succeeded':
                 warning(f'db_hotdata: job {job_id} only partially succeeded')
+                # Flag it so load_data releases the dedup reservation: only some
+                # rows landed, so a retry of the same payload must not be
+                # skipped as a duplicate.
+                job = dict(job)
+                job['partial'] = True
                 return job
             if status in _JOB_OK:
                 return job
@@ -797,7 +808,7 @@ class IInstance(IInstanceBase):
         # fails, release it: otherwise the agent's retry is skipped as a
         # duplicate and the rows are silently never loaded.
         try:
-            return self._perform_load(
+            result = self._perform_load(
                 glb,
                 database_id=database_id,
                 schema=schema,
@@ -809,6 +820,12 @@ class IInstance(IInstanceBase):
                 key=key,
                 rows=rows,
             )
+            if fingerprint and result.get('partial'):
+                # Only some rows landed. Keeping the reservation would make a
+                # retry of the same payload report deduplicated and drop the
+                # missing rows for good.
+                glb.release_load(fingerprint)
+            return result
         except Exception:
             if fingerprint:
                 glb.release_load(fingerprint)
@@ -849,7 +866,11 @@ class IInstance(IInstanceBase):
                 (finished.get('result') or {}).get('row_count') if isinstance(finished.get('result'), dict) else None
             )
         debug(f'db_hotdata: loaded into {schema}.{table} (mode {mode})')
-        return {'table': table, 'schema': schema, 'mode': mode, 'row_count': row_count}
+        out = {'table': table, 'schema': schema, 'mode': mode, 'row_count': row_count}
+        if finished.get('partial'):
+            out['partial'] = True
+            out['note'] = 'The load only partially succeeded; some rows may be missing. Retrying is safe.'
+        return out
 
     @tool_function(
         input_schema={

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -696,7 +696,10 @@ class IInstance(IInstanceBase):
                 key=key or None,
             )
         except Exception as e:
-            if '409' in str(e) or 'exists' in str(e).lower():
+            # 409 means the table is already declared, which is success here.
+            # Branch on the status rather than the message: a load failure whose
+            # body happened to mention 'exists' would otherwise be swallowed.
+            if getattr(e, 'status_code', None) == 409:
                 return
             raise
 

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -880,7 +880,11 @@ class IInstance(IInstanceBase):
             # load has no local count, and reporting 0 there would claim an empty
             # load that may well have inserted rows.
             row_count = len(rows)
-        out = {'table': table, 'schema': schema, 'mode': mode, 'row_count': row_count}
+        out = {'table': table, 'schema': schema, 'mode': mode}
+        if row_count is not None:
+            # output_schema declares an integer, so omit the key rather than
+            # reporting null for a result_id load the server gave no count for.
+            out['row_count'] = row_count
         if finished.get('partial'):
             out['partial'] = True
             out['note'] = (

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -797,17 +797,25 @@ class IInstance(IInstanceBase):
                 fingerprint = hashlib.sha256(f'{schema}.{table}|'.encode('utf-8') + payload).hexdigest()
                 prior = glb.seen_load(fingerprint)
                 if prior is not None:
+                    out = {'table': table, 'schema': schema, 'mode': mode}
+                    if prior == 'pending':
+                        # Another call is mid-flight with this exact payload. It
+                        # may still fail and release the reservation, so claiming
+                        # success here would report rows that never landed.
+                        warning(f'db_hotdata: identical append to {schema}.{table} is already in flight')
+                        out['in_progress'] = True
+                        out['note'] = (
+                            'An identical append to this table is already running in this pipeline. '
+                            'It was NOT sent again, because append is not idempotent. Wait for that '
+                            'load to finish and query the table to confirm what landed - this call '
+                            'makes no claim about the rows being present.'
+                        )
+                        return out
                     warning(f'db_hotdata: identical append to {schema}.{table} already ran this session; skipping')
-                    out = {
-                        'table': table,
-                        'schema': schema,
-                        'mode': mode,
-                        'row_count': len(rows),
-                        'deduplicated': True,
-                    }
+                    out['deduplicated'] = True
                     if prior == 'partial':
-                        # Reporting this as a clean duplicate would claim the table
-                        # holds all the rows, which a partial load contradicts.
+                        # The landed subset is unknown, so no row_count: reporting
+                        # the full input size would overstate what is in the table.
                         out['partial'] = True
                         out['note'] = (
                             'This exact payload was already attempted during this run and only '
@@ -817,6 +825,7 @@ class IInstance(IInstanceBase):
                             'and load only what is missing.'
                         )
                     else:
+                        out['row_count'] = len(rows)
                         out['note'] = (
                             'This exact payload was already appended to this table during this run, '
                             'so it was not loaded again. The table already contains these rows.'

--- a/nodes/src/nodes/db_hotdata/IInstance.py
+++ b/nodes/src/nodes/db_hotdata/IInstance.py
@@ -795,19 +795,33 @@ class IInstance(IInstanceBase):
             # rather than duplicating business data.
             if mode == 'append':
                 fingerprint = hashlib.sha256(f'{schema}.{table}|'.encode('utf-8') + payload).hexdigest()
-                if glb.seen_load(fingerprint):
+                prior = glb.seen_load(fingerprint)
+                if prior is not None:
                     warning(f'db_hotdata: identical append to {schema}.{table} already ran this session; skipping')
-                    return {
+                    out = {
                         'table': table,
                         'schema': schema,
                         'mode': mode,
                         'row_count': len(rows),
                         'deduplicated': True,
-                        'note': (
+                    }
+                    if prior == 'partial':
+                        # Reporting this as a clean duplicate would claim the table
+                        # holds all the rows, which a partial load contradicts.
+                        out['partial'] = True
+                        out['note'] = (
+                            'This exact payload was already attempted during this run and only '
+                            'partially succeeded: an unknown subset of the rows landed. It was NOT '
+                            'loaded again, because append is not idempotent and a retry would '
+                            'duplicate whatever did land. Query the table to see what is present '
+                            'and load only what is missing.'
+                        )
+                    else:
+                        out['note'] = (
                             'This exact payload was already appended to this table during this run, '
                             'so it was not loaded again. The table already contains these rows.'
-                        ),
-                    }
+                        )
+                    return out
 
             upload_id = glb.client.upload_bytes(
                 payload,
@@ -832,6 +846,8 @@ class IInstance(IInstanceBase):
                 key=key,
                 rows=rows,
             )
+            if fingerprint:
+                glb.record_load(fingerprint, 'partial' if result.get('partial') else 'complete')
             # A partial append deliberately KEEPS its reservation. Append is not
             # idempotent, so an unknown subset of the payload already landed and
             # a blind retry would duplicate exactly those rows. There is no safe

--- a/nodes/src/nodes/db_hotdata/README.md
+++ b/nodes/src/nodes/db_hotdata/README.md
@@ -1,0 +1,82 @@
+# Hotdata
+
+A database and tool node backed by one **ephemeral** [Hotdata](https://www.hotdata.dev/) database per pipeline run — load data, index it, query it, and it is gone when the run ends.
+
+## What it does
+
+Every other database node in the catalogue points at a store that outlives the run. This one does the opposite: the first time it is used it provisions a Hotdata database with a TTL, and `endGlobal` deletes it. That makes it the right choice for scratch work — pull a dataset in, join and aggregate it, emit the answer, leave nothing behind.
+
+As a pipeline node it takes natural-language questions on the `questions` lane and emits results on `table` / `text` / `answers`, and it loads structured rows arriving on the `answers` lane. As a tool node an agent drives it directly.
+
+It needs a connected LLM (the `llm` control connection) to translate questions into SQL, in the same way `db_postgres` and `rocketride_sql` do.
+
+## Tools
+
+| Tool | What it does |
+| --- | --- |
+| `load_data` | Load rows, or a previous query result by `result_id`, into a table. Creates the table if needed |
+| `get_data` | Answer a plain-language question. The bound LLM writes the SQL; failures are retried with the error fed back |
+| `get_sql` | Generate the SQL for a question without running it |
+| `execute` | Run one raw read-only SQL statement. Gated by `allow_execute` |
+| `get_schema` | Live tables and columns from `information_schema` |
+| `build_index` | Build a `bm25`, `vector` or `sorted` index on a column |
+| `dialect` | The full SQL dialect briefing — read this before writing SQL by hand |
+
+## Lanes
+
+| Lane | Direction | Behaviour |
+| --- | --- | --- |
+| `questions` | in | Natural-language question, answered and emitted to `table` / `text` / `answers` |
+| `answers` | in | Structured rows, loaded into the configured table |
+
+## Setup
+
+Set an API key and workspace ID on the node, or export `HOTDATA_API_KEY` and `HOTDATA_WORKSPACE`. The default endpoint is `https://api.hotdata.dev`.
+
+Wire an LLM to the node's `llm` control connection — without one, natural-language querying cannot work. See `examples/db_hotdata.pipe`.
+
+## SQL dialect
+
+Hotdata runs **Apache DataFusion 54 behind the PostgreSQL parser dialect**. Treat that as "Postgres syntax, DataFusion semantics and function library" — not as Postgres. Call the `dialect` tool for the full briefing; the essentials:
+
+- Postgres syntax works: `::` casts, CTEs, window functions, `DISTINCT ON`, `ILIKE`, `INTERVAL`.
+- Unquoted identifiers fold to lowercase — double-quote any name with uppercase or spaces.
+- The function library is DataFusion's. **No JSON/JSONB operators** (`->`, `->>`, `jsonb_*`), no `pg_catalog`, no `to_number` or `age()`. Use `arrow_typeof`, `arrow_cast`, `date_bin`, `approx_percentile_cont` instead.
+- Types are Arrow types (`Utf8`, `Int64`, `Timestamp`, `Decimal128`) — there is no native JSON, UUID or ENUM.
+- Names are three-part `catalog.schema.table`; this database's own catalog is `default`.
+- Search uses engine functions: `bm25_search(table, column, query)`, `vector_search(table, column, query)`, and `vector_distance(column, query)` for `ORDER BY`. Build the matching index first with `build_index`.
+
+## Limits
+
+- **The SQL surface is read-only.** `INSERT`, `UPDATE`, `DELETE` and all DDL are rejected by the server. `load_data` is the only way to get data in, and it uploads rather than issuing SQL.
+- `allow_execute` is an application-level gate on raw SQL. It is **not** write protection — the SQL surface rejects writes regardless. It exists to keep untrusted callers from running expensive scans, which are billed per TB scanned.
+- **`load_data` is a write path, and the SQL read-only guarantee does not cover it.** `replace`, `update` and `delete` modes overwrite or remove existing rows, so they are disabled unless `allow_destructive_load` is on. Without that gate an agent asked to "delete the bad rows" will route around the SQL guard by calling `load_data` with `mode=replace`. Default is append/upsert only.
+- One statement per call; `SHOW TABLES` and `SHOW COLUMNS` error, so use `information_schema` or `DESCRIBE`.
+- **Data is destroyed when the run ends.** The configured TTL is only a fallback for a crashed engine.
+- Rate limits are dynamic and unpublished; the node honours `Retry-After` and retries shed requests, but a sustained overload surfaces as an error.
+- Connections to external warehouses are configured on the Hotdata side, outside RocketRide's view.
+
+## Examples
+
+`examples/db_hotdata.pipe` — Chat → Hotdata → Answers/Table, with Anthropic bound as the SQL-writing LLM.
+
+An agent flow: `load_data` the rows, `build_index` on the text column, then `get_data` with a question, or `execute` a query using `bm25_search`.
+
+## Upstream docs
+
+- [Hotdata API reference](https://www.hotdata.dev/docs/api-reference) and [OpenAPI spec](https://www.hotdata.dev/openapi.yaml)
+- [Core concepts](https://www.hotdata.dev/docs/core-concepts-overview)
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `apikey is required` / `workspace_id is required` | Neither the config field nor the env var is set |
+| `raw SQL execution is disabled` | Turn on `allow_execute`, or use `get_data` instead |
+| `only one statement per call` | Hotdata rejects semicolon-separated batches |
+| Unknown function errors | A Postgres-only function that DataFusion lacks — check `dialect` |
+| `still shedding load after ...s (HTTP 429)` | Sustained back-pressure; retry later or reduce concurrency |
+| Empty results from a fresh run | The database starts empty every run — `load_data` first |
+
+<!-- ROCKETRIDE:GENERATED:PARAMS START -->
+<!-- ROCKETRIDE:GENERATED:PARAMS END -->

--- a/nodes/src/nodes/db_hotdata/README.md
+++ b/nodes/src/nodes/db_hotdata/README.md
@@ -28,6 +28,9 @@ It needs a connected LLM (the `llm` control connection) to translate questions i
 | --- | --- | --- |
 | `questions` | in | Natural-language question, answered and emitted to `table` / `text` / `answers` |
 | `answers` | in | Structured rows, loaded into the configured table |
+| `table` | out | Query results as a Markdown table |
+| `text` | out | Query results rendered as text |
+| `answers` | out | Query results as an answer payload |
 
 ## Setup
 

--- a/nodes/src/nodes/db_hotdata/__init__.py
+++ b/nodes/src/nodes/db_hotdata/__init__.py
@@ -1,0 +1,37 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+# ------------------------------------------------------------------------------
+# Main module
+# ------------------------------------------------------------------------------
+import os
+from depends import depends  # type: ignore
+
+# Load the requirements
+requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+depends(requirements)
+
+from .IGlobal import IGlobal  # noqa: E402
+from .IInstance import IInstance  # noqa: E402
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/db_hotdata/hotdata.svg
+++ b/nodes/src/nodes/db_hotdata/hotdata.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 481 265" width="48" height="48" fill="currentColor" role="img" aria-label="Hotdata"><path d="M479.863 126.376L239.553 0.186L0.341 125.827L240.539 264.636L479.863 126.376Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 324 324" width="48" height="48" fill="currentColor" role="img" aria-label="Hotdata"><path d="M0 0h85l238 238v85h-85L0 85Z"/><path d="M0 204h116v119H77L0 246Z"/></svg>

--- a/nodes/src/nodes/db_hotdata/hotdata.svg
+++ b/nodes/src/nodes/db_hotdata/hotdata.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 481 265" width="48" height="48" fill="currentColor" role="img" aria-label="Hotdata"><path d="M479.863 126.376L239.553 0.186L0.341 125.827L240.539 264.636L479.863 126.376Z"/></svg>

--- a/nodes/src/nodes/db_hotdata/hotdata_client.py
+++ b/nodes/src/nodes/db_hotdata/hotdata_client.py
@@ -44,6 +44,7 @@ at Hotdata's explicit request. Two tiers:
 from __future__ import annotations
 
 import random
+import re
 import time
 from typing import Any, Dict, List, Optional
 
@@ -72,6 +73,24 @@ MAX_RETRY_AFTER_S = 120.0
 _IDEMPOTENT_METHODS = ('GET', 'DELETE')
 
 _HTTP_TOO_MANY_REQUESTS = 429
+
+
+#: Identifiers that get interpolated into request paths. Agent-supplied table and
+#: schema names reach these, so anything outside this set is refused rather than
+#: escaped: `../../other` would otherwise resolve to a different endpoint once
+#: requests normalises the path, and `orders?x=1` would inject a query string.
+_IDENTIFIER_RE = re.compile(r'^[A-Za-z0-9_][A-Za-z0-9_$-]{0,127}$')
+
+
+def _require_identifier(value: Any, what: str) -> str:
+    """Return `value` if it is a safe path segment, else raise ValueError."""
+    text = str(value or '').strip()
+    if not _IDENTIFIER_RE.match(text):
+        raise ValueError(
+            f'db_hotdata: invalid {what} {text!r} - use letters, digits, underscore, '
+            'dollar or hyphen only (no dots, slashes or query characters)'
+        )
+    return text
 
 
 class HotdataError(RuntimeError):
@@ -472,6 +491,8 @@ class HotdataClient:
             body['partition_by'] = partition_by
         if sorted_by:
             body['sorted_by'] = sorted_by
+        database_id = _require_identifier(database_id, 'database id')
+        schema = _require_identifier(schema, 'schema name')
         return self._request('POST', f'/v1/databases/{database_id}/schemas/{schema}/tables', json_body=body)
 
     def load_table(
@@ -504,7 +525,9 @@ class HotdataClient:
             body['key'] = key
         return self._request(
             'POST',
-            f'/v1/databases/{database_id}/schemas/{schema}/tables/{table}/loads',
+            f'/v1/databases/{_require_identifier(database_id, "database id")}'
+            f'/schemas/{_require_identifier(schema, "schema name")}'
+            f'/tables/{_require_identifier(table, "table name")}/loads',
             json_body=body,
         )
 
@@ -543,7 +566,9 @@ class HotdataClient:
             body['output_column'] = output_column
         return self._request(
             'POST',
-            f'/v1/connections/{connection_id}/tables/{schema}/{table}/indexes',
+            f'/v1/connections/{_require_identifier(connection_id, "connection id")}'
+            f'/tables/{_require_identifier(schema, "schema name")}'
+            f'/{_require_identifier(table, "table name")}/indexes',
             json_body=body,
         )
 

--- a/nodes/src/nodes/db_hotdata/hotdata_client.py
+++ b/nodes/src/nodes/db_hotdata/hotdata_client.py
@@ -1,0 +1,569 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""REST client for the Hotdata API.
+
+Deliberately plain ``requests`` rather than the vendor SDK: the node needs no
+new dependency pins, and the shared ``post_with_retry`` helper cannot express
+the one rule that matters here — retry a POST only when the request provably
+never reached the server.
+
+Retry policy mirrors the vendor SDK (``hotdata/_retry.py``, ``hotdata/query.py``)
+at Hotdata's explicit request. Two tiers:
+
+* **429 (admission shedding).** The server sheds load aggressively and tags the
+  body ``OVERLOADED``. A shed request did no work, so it is safe to replay on
+  any method. ``Retry-After`` is honored when present (capped), otherwise capped
+  exponential backoff with jitter, all under an overall deadline budget.
+* **Everything else stays idempotent-only.** A read timeout or 5xx on a POST may
+  mean the server already did the work, so it propagates rather than being
+  replayed. Only a pre-response connection failure — where the request never
+  left — is retried on every method.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Dict, List, Optional
+
+import requests
+
+#: Default API host. Overridable for Hotdata's alternate environments.
+DEFAULT_BASE_URL = 'https://api.hotdata.dev'
+
+#: Per-request socket timeout, seconds.
+DEFAULT_TIMEOUT_S = 60.0
+
+#: Overall budget for a single logical call including all retries, seconds.
+DEFAULT_RETRY_BUDGET_S = 120.0
+
+#: Base delay for exponential backoff between 429 retries, seconds.
+BASE_BACKOFF_S = 0.5
+
+#: Cap on any single computed backoff delay, seconds.
+MAX_BACKOFF_S = 30.0
+
+#: Cap on a server-sent ``Retry-After``. Hotdata's limits are dynamic and
+#: unpublished; an unbounded value would stall a pipeline indefinitely.
+MAX_RETRY_AFTER_S = 120.0
+
+#: Methods safe to replay after a response may already have been produced.
+_IDEMPOTENT_METHODS = ('GET', 'DELETE')
+
+_HTTP_TOO_MANY_REQUESTS = 429
+
+
+class HotdataError(RuntimeError):
+    """Any non-retryable failure talking to the Hotdata API."""
+
+
+class HotdataOverloadedError(HotdataError):
+    """429 retries exhausted the deadline budget."""
+
+
+def _parse_retry_after(headers: Any) -> Optional[float]:
+    """Seconds from a ``Retry-After`` header, capped, or None if absent/unparseable."""
+    if not headers:
+        return None
+    raw = None
+    for key in ('Retry-After', 'retry-after'):
+        try:
+            raw = headers.get(key)
+        except AttributeError:
+            return None
+        if raw is not None:
+            break
+    if raw is None:
+        return None
+    try:
+        seconds = float(raw)
+    except (TypeError, ValueError):
+        # HTTP-date form is legal but Hotdata sends deltas; ignore rather than guess.
+        return None
+    if seconds < 0:
+        return None
+    return min(seconds, MAX_RETRY_AFTER_S)
+
+
+def _encode_params(params: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Normalize query params for the API.
+
+    ``requests`` renders a Python ``True`` as the string ``"True"``, which the
+    server rejects with "provided string was not `true` or `false`". Booleans
+    must go over the wire lowercase.
+    """
+    if not params:
+        return params
+    encoded: Dict[str, Any] = {}
+    for key, value in params.items():
+        if value is None:
+            continue
+        encoded[key] = 'true' if value is True else 'false' if value is False else value
+    return encoded
+
+
+def _backoff_delay(attempt: int) -> float:
+    """Capped exponential backoff with equal jitter for retry number ``attempt`` (1-based)."""
+    ceiling = min(BASE_BACKOFF_S * (2 ** max(0, attempt - 1)), MAX_BACKOFF_S)
+    return (ceiling / 2.0) + random.uniform(0.0, ceiling / 2.0)
+
+
+class HotdataClient:
+    """Thin REST client scoped to one workspace."""
+
+    def __init__(
+        self,
+        apikey: str,
+        workspace_id: str,
+        base_url: str = '',
+        timeout: float = DEFAULT_TIMEOUT_S,
+        retry_budget_s: float = DEFAULT_RETRY_BUDGET_S,
+    ) -> None:
+        self.apikey = apikey
+        self.workspace_id = workspace_id
+        self.base_url = (base_url or DEFAULT_BASE_URL).rstrip('/')
+        self.timeout = timeout
+        self.retry_budget_s = retry_budget_s
+
+    # ------------------------------------------------------------------
+    # Transport
+    # ------------------------------------------------------------------
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            'Authorization': f'Bearer {self.apikey}',
+            'X-Workspace-Id': self.workspace_id,
+            'Accept': 'application/json',
+        }
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        extra_headers: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Issue one API call, applying the retry policy described in the module docstring."""
+        method = method.upper()
+        idempotent = method in _IDEMPOTENT_METHODS
+        url = f'{self.base_url}{path}'
+        deadline = time.monotonic() + self.retry_budget_s
+        attempt = 0
+        headers = self._headers()
+        if extra_headers:
+            headers.update(extra_headers)
+        params = _encode_params(params)
+
+        while True:
+            attempt += 1
+            try:
+                response = requests.request(
+                    method,
+                    url,
+                    headers=headers,
+                    json=json_body,
+                    params=params,
+                    timeout=self.timeout,
+                )
+            except requests.exceptions.ReadTimeout as exc:
+                # The request reached the server; replaying a POST could double-execute.
+                if not idempotent:
+                    raise HotdataError(f'hotdata: {method} {path} timed out awaiting response') from exc
+                if not self._sleep_before_retry(None, attempt, deadline):
+                    raise HotdataError(f'hotdata: {method} {path} timed out awaiting response') from exc
+                continue
+            except (requests.exceptions.ConnectTimeout, requests.exceptions.ConnectionError) as exc:
+                # Pre-response: the request never left, so any method may be replayed.
+                if not self._sleep_before_retry(None, attempt, deadline):
+                    raise HotdataError(f'hotdata: cannot reach {url}: {exc}') from exc
+                continue
+            except requests.exceptions.RequestException as exc:
+                raise HotdataError(f'hotdata: {method} {path} failed: {exc}') from exc
+
+            status = getattr(response, 'status_code', 0)
+
+            if status == _HTTP_TOO_MANY_REQUESTS:
+                retry_after = _parse_retry_after(getattr(response, 'headers', None))
+                if not self._sleep_before_retry(retry_after, attempt, deadline):
+                    raise HotdataOverloadedError(
+                        f'hotdata: {method} {path} still shedding load after {self.retry_budget_s:g}s (HTTP 429)'
+                    )
+                continue
+
+            if status >= 500:
+                if idempotent and self._sleep_before_retry(None, attempt, deadline):
+                    continue
+                raise HotdataError(f'hotdata: {method} {path} failed with HTTP {status}: {_body_snippet(response)}')
+
+            if status >= 400:
+                raise HotdataError(f'hotdata: {method} {path} failed with HTTP {status}: {_body_snippet(response)}')
+
+            return _parse_json(response)
+
+    def _sleep_before_retry(self, retry_after: Optional[float], attempt: int, deadline: float) -> bool:
+        """Sleep before the next attempt. Returns False when the budget is spent."""
+        delay = retry_after if retry_after is not None else _backoff_delay(attempt)
+        if time.monotonic() + delay > deadline:
+            return False
+        time.sleep(delay)
+        return True
+
+    # ------------------------------------------------------------------
+    # Databases
+    # ------------------------------------------------------------------
+
+    def create_database(
+        self,
+        name: str,
+        expires_at: str,
+        schemas: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        """Create a managed database.
+
+        ``expires_at`` is required by this client even though the API treats it as
+        optional: a database created without a TTL outlives the pipeline run and
+        bills until someone notices.
+        """
+        if not expires_at:
+            raise ValueError('hotdata: expires_at is required — refusing to create a database with no TTL')
+        body: Dict[str, Any] = {'name': name, 'expires_at': expires_at}
+        if schemas:
+            body['schemas'] = schemas
+        return self._request('POST', '/v1/databases', json_body=body)
+
+    def delete_database(self, database_id: str) -> None:
+        self._request('DELETE', f'/v1/databases/{database_id}')
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def query(
+        self,
+        sql: str,
+        database_id: str,
+        async_after_ms: int = 5000,
+        default_catalog: str = '',
+        default_schema: str = '',
+    ) -> Dict[str, Any]:
+        """Run one SQL statement. May return rows inline or a ``query_run_id`` to poll."""
+        body: Dict[str, Any] = {
+            'sql': sql,
+            'database_id': database_id,
+            'async': True,
+            'async_after_ms': async_after_ms,
+        }
+        if default_catalog:
+            body['default_catalog'] = default_catalog
+        if default_schema:
+            body['default_schema'] = default_schema
+        return self._request('POST', '/v1/query', json_body=body)
+
+    def get_query_run(self, query_run_id: str) -> Dict[str, Any]:
+        return self._request('GET', f'/v1/query-runs/{query_run_id}')
+
+    def get_result(self, result_id: str, offset: int = 0, limit: Optional[int] = None) -> Dict[str, Any]:
+        params: Dict[str, Any] = {'offset': offset}
+        if limit is not None:
+            params['limit'] = limit
+        return self._request('GET', f'/v1/results/{result_id}', params=params)
+
+    def information_schema(
+        self,
+        connection_id: str,
+        schema: str = '',
+        table: str = '',
+        include_columns: bool = True,
+        limit: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Introspect via the REST endpoint.
+
+        ``SHOW TABLES`` / ``SHOW COLUMNS`` error on this engine, so REST
+        introspection (or ``information_schema`` in SQL) is the only route.
+
+        Scoped by **connection_id**, not database_id - a database's connection is
+        its ``default_connection_id``. Passing database_id here is silently
+        ignored by the server and yields an empty table list.
+        """
+        params: Dict[str, Any] = {'connection_id': connection_id, 'include_columns': include_columns}
+        if schema:
+            params['schema'] = schema
+        if table:
+            params['table'] = table
+        if limit is not None:
+            params['limit'] = limit
+        return self._request('GET', '/v1/information_schema', params=params)
+
+    # ------------------------------------------------------------------
+    # Uploads
+    # ------------------------------------------------------------------
+
+    def create_upload(
+        self,
+        filename: str,
+        content_type: str = 'application/json',
+        declared_size_bytes: int = 0,
+        part_size: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Reserve an upload slot.
+
+        The response's ``mode`` decides the path: ``single`` gives one presigned
+        ``url``, otherwise ``part_urls`` plus ``part_size`` for a multipart PUT.
+        """
+        body: Dict[str, Any] = {
+            'filename': filename,
+            'content_type': content_type,
+            'declared_size_bytes': declared_size_bytes,
+        }
+        if part_size is not None:
+            body['part_size'] = part_size
+        return self._request('POST', '/v1/uploads', json_body=body)
+
+    def _put_presigned(self, url: str, headers: Optional[Dict[str, str]], data: bytes) -> None:
+        """PUT bytes straight to object storage.
+
+        Presigned PUTs carry their own auth in the URL, so our bearer token must
+        NOT be attached. Re-PUTting the same object key is idempotent, so unlike
+        an API POST this is safe to retry.
+        """
+        deadline = time.monotonic() + self.retry_budget_s
+        attempt = 0
+        while True:
+            attempt += 1
+            try:
+                response = requests.request(
+                    'PUT',
+                    url,
+                    headers=dict(headers or {}),
+                    data=data,
+                    timeout=self.timeout,
+                )
+            except (
+                requests.exceptions.ReadTimeout,
+                requests.exceptions.ConnectTimeout,
+                requests.exceptions.ConnectionError,
+            ) as exc:
+                if not self._sleep_before_retry(None, attempt, deadline):
+                    raise HotdataError(f'hotdata: upload PUT failed: {exc}') from exc
+                continue
+            except requests.exceptions.RequestException as exc:
+                raise HotdataError(f'hotdata: upload PUT failed: {exc}') from exc
+
+            status = getattr(response, 'status_code', 0)
+            if status == _HTTP_TOO_MANY_REQUESTS or status >= 500:
+                retry_after = _parse_retry_after(getattr(response, 'headers', None))
+                if self._sleep_before_retry(retry_after, attempt, deadline):
+                    continue
+            if status >= 400:
+                raise HotdataError(f'hotdata: upload PUT failed with HTTP {status}: {_body_snippet(response)}')
+            return
+
+    def get_part_urls(self, upload_id: str, finalize_token: str, part_numbers: List[int]) -> Dict[str, Any]:
+        return self._request(
+            'POST',
+            f'/v1/uploads/{upload_id}/parts',
+            json_body={'part_numbers': part_numbers},
+            extra_headers={'X-Upload-Finalize-Token': finalize_token},
+        )
+
+    def finalize_upload(self, upload_id: str, finalize_token: str) -> Dict[str, Any]:
+        return self._request(
+            'POST',
+            f'/v1/uploads/{upload_id}/finalize',
+            json_body={},
+            extra_headers={'X-Upload-Finalize-Token': finalize_token},
+        )
+
+    def upload_bytes(self, payload: bytes, filename: str, content_type: str = 'application/json') -> str:
+        """Run the whole upload dance and return the finalized ``upload_id``."""
+        slot = self.create_upload(
+            filename=filename,
+            content_type=content_type,
+            declared_size_bytes=len(payload),
+        )
+        upload_id = slot.get('upload_id')
+        token = slot.get('finalize_token')
+        if not upload_id or not token:
+            raise HotdataError('hotdata: upload slot response missing upload_id or finalize_token')
+
+        mode = str(slot.get('mode') or 'single').lower()
+        headers = slot.get('headers') or {}
+
+        if mode == 'single' or slot.get('url'):
+            self._put_presigned(slot.get('url'), headers, payload)
+        else:
+            part_size = int(slot.get('part_size') or 0) or len(payload) or 1
+            chunks = [payload[i : i + part_size] for i in range(0, len(payload), part_size)] or [b'']
+            urls = slot.get('part_urls') or []
+            if len(urls) < len(chunks):
+                fetched = self.get_part_urls(upload_id, token, list(range(1, len(chunks) + 1)))
+                urls = [p.get('url') if isinstance(p, dict) else p for p in (fetched.get('parts') or [])]
+            if len(urls) < len(chunks):
+                raise HotdataError('hotdata: server returned fewer part URLs than parts to upload')
+            for url, chunk in zip(urls, chunks):
+                self._put_presigned(url, headers, chunk)
+
+        self.finalize_upload(upload_id, token)
+        return upload_id
+
+    # ------------------------------------------------------------------
+    # Schemas, tables, loads
+    # ------------------------------------------------------------------
+
+    def create_schema(
+        self,
+        database_id: str,
+        name: str,
+        tables: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {'name': name}
+        if tables:
+            body['tables'] = tables
+        return self._request('POST', f'/v1/databases/{database_id}/schemas', json_body=body)
+
+    def create_table(
+        self,
+        database_id: str,
+        schema: str,
+        name: str,
+        key: Optional[List[str]] = None,
+        partition_by: Optional[List[str]] = None,
+        sorted_by: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Declare a table over REST.
+
+        ``CREATE TABLE`` is rejected by the SQL surface, so this is the only way
+        a table comes into existence.
+        """
+        body: Dict[str, Any] = {'name': name}
+        if key:
+            body['key'] = key
+        if partition_by:
+            body['partition_by'] = partition_by
+        if sorted_by:
+            body['sorted_by'] = sorted_by
+        return self._request('POST', f'/v1/databases/{database_id}/schemas/{schema}/tables', json_body=body)
+
+    def load_table(
+        self,
+        database_id: str,
+        schema: str,
+        table: str,
+        mode: str = 'append',
+        upload_id: str = '',
+        result_id: str = '',
+        data_format: str = '',
+        key: Optional[List[str]] = None,
+        async_after_ms: int = 5000,
+    ) -> Dict[str, Any]:
+        """Load an upload or a previous query result into a table.
+
+        Exactly one of ``upload_id`` / ``result_id``. Loading straight from a
+        prior ``result_id`` skips the upload round trips entirely.
+        """
+        if bool(upload_id) == bool(result_id):
+            raise ValueError('hotdata: load_table needs exactly one of upload_id or result_id')
+        body: Dict[str, Any] = {'mode': mode, 'async': True, 'async_after_ms': async_after_ms}
+        if upload_id:
+            body['upload_id'] = upload_id
+        if result_id:
+            body['result_id'] = result_id
+        if data_format:
+            body['format'] = data_format
+        if key:
+            body['key'] = key
+        return self._request(
+            'POST',
+            f'/v1/databases/{database_id}/schemas/{schema}/tables/{table}/loads',
+            json_body=body,
+        )
+
+    # ------------------------------------------------------------------
+    # Indexes and jobs
+    # ------------------------------------------------------------------
+
+    def create_index(
+        self,
+        connection_id: str,
+        schema: str,
+        table: str,
+        index_name: str,
+        columns: List[str],
+        index_type: str = 'bm25',
+        embedding_provider_id: str = '',
+        metric: str = '',
+        dimensions: Optional[int] = None,
+        output_column: str = '',
+        async_after_ms: int = 5000,
+    ) -> Dict[str, Any]:
+        body: Dict[str, Any] = {
+            'index_name': index_name,
+            'columns': columns,
+            'index_type': index_type,
+            'async': True,
+            'async_after_ms': async_after_ms,
+        }
+        if embedding_provider_id:
+            body['embedding_provider_id'] = embedding_provider_id
+        if metric:
+            body['metric'] = metric
+        if dimensions is not None:
+            body['dimensions'] = dimensions
+        if output_column:
+            body['output_column'] = output_column
+        return self._request(
+            'POST',
+            f'/v1/connections/{connection_id}/tables/{schema}/{table}/indexes',
+            json_body=body,
+        )
+
+    def get_job(self, job_id: str) -> Dict[str, Any]:
+        return self._request('GET', f'/v1/jobs/{job_id}')
+
+
+def _parse_json(response: Any) -> Dict[str, Any]:
+    """Parse a JSON body, tolerating an empty 204-style response."""
+    try:
+        body = response.json()
+    except Exception:
+        return {}
+    if body is None:
+        return {}
+    if not isinstance(body, dict):
+        return {'data': body}
+    return body
+
+
+def _body_snippet(response: Any, limit: int = 500) -> str:
+    """A short, safe excerpt of an error body for log and exception text."""
+    try:
+        text = response.text
+    except Exception:
+        return '<unreadable body>'
+    if not isinstance(text, str):
+        return '<unreadable body>'
+    text = text.strip()
+    return text[:limit] if text else '<empty body>'

--- a/nodes/src/nodes/db_hotdata/hotdata_client.py
+++ b/nodes/src/nodes/db_hotdata/hotdata_client.py
@@ -305,8 +305,11 @@ class HotdataClient:
     ) -> Dict[str, Any]:
         """Introspect via the REST endpoint.
 
-        ``SHOW TABLES`` / ``SHOW COLUMNS`` error on this engine, so REST
-        introspection (or ``information_schema`` in SQL) is the only route.
+        Preferred over the ``SHOW`` forms for reliability, not because they
+        fail: ``SHOW TABLES`` works (verified 2026-08-13, contrary to Hotdata's
+        written brief), but ``DESCRIBE`` / ``SHOW COLUMNS`` return nothing for a
+        table that has never been loaded. REST returns structured columns in a
+        single call regardless.
 
         Scoped by **connection_id**, not database_id - a database's connection is
         its ``default_connection_id``. Passing database_id here is silently

--- a/nodes/src/nodes/db_hotdata/hotdata_client.py
+++ b/nodes/src/nodes/db_hotdata/hotdata_client.py
@@ -226,6 +226,10 @@ class HotdataClient:
     def _sleep_before_retry(self, retry_after: Optional[float], attempt: int, deadline: float) -> bool:
         """Sleep before the next attempt. Returns False when the budget is spent."""
         delay = retry_after if retry_after is not None else _backoff_delay(attempt)
+        # A server-sent `Retry-After: 0` is a valid header value and would
+        # otherwise spin this loop with no pause, flooding a server that is
+        # already shedding load, until the whole budget is spent.
+        delay = max(delay, BASE_BACKOFF_S)
         if time.monotonic() + delay > deadline:
             return False
         time.sleep(delay)

--- a/nodes/src/nodes/db_hotdata/hotdata_client.py
+++ b/nodes/src/nodes/db_hotdata/hotdata_client.py
@@ -94,7 +94,15 @@ def _require_identifier(value: Any, what: str) -> str:
 
 
 class HotdataError(RuntimeError):
-    """Any non-retryable failure talking to the Hotdata API."""
+    """Any non-retryable failure talking to the Hotdata API.
+
+    Carries ``status_code`` when the failure came from an HTTP response, so
+    callers can branch on the status instead of pattern-matching the message.
+    """
+
+    def __init__(self, message: str, status_code: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class HotdataOverloadedError(HotdataError):
@@ -235,10 +243,16 @@ class HotdataClient:
             if status >= 500:
                 if idempotent and self._sleep_before_retry(None, attempt, deadline):
                     continue
-                raise HotdataError(f'hotdata: {method} {path} failed with HTTP {status}: {_body_snippet(response)}')
+                raise HotdataError(
+                    f'hotdata: {method} {path} failed with HTTP {status}: {_body_snippet(response)}',
+                    status_code=status,
+                )
 
             if status >= 400:
-                raise HotdataError(f'hotdata: {method} {path} failed with HTTP {status}: {_body_snippet(response)}')
+                raise HotdataError(
+                    f'hotdata: {method} {path} failed with HTTP {status}: {_body_snippet(response)}',
+                    status_code=status,
+                )
 
             return _parse_json(response)
 

--- a/nodes/src/nodes/db_hotdata/hotdata_schema.py
+++ b/nodes/src/nodes/db_hotdata/hotdata_schema.py
@@ -1,0 +1,171 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Dialect briefing and schema formatting for Hotdata NL-to-SQL.
+
+The dialect text below is the crux of this node. Hotdata runs Apache DataFusion
+54 behind the *PostgreSQL parser dialect*, which is a genuinely unusual
+combination: an LLM told only "Postgres" will confidently emit ``->>``,
+``jsonb_*``, ``pg_catalog`` lookups and ``age()``, none of which exist. An LLM
+told only "DataFusion" will not know it can use ``::`` casts, ``DISTINCT ON`` or
+``ILIKE``. Both failure modes are silent until the query errors.
+
+Content came from the Hotdata team directly, then was checked against the live
+API. Two of their claims did not hold and have been corrected here: ``SHOW
+TABLES`` and ``SHOW FUNCTIONS`` both work, and the ``DESCRIBE`` / ``SHOW
+COLUMNS`` failure is about a table having no data yet, not about the syntax
+being unsupported. Everything else was confirmed, including the absence of
+``to_number`` and the presence of ``arrow_typeof``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+#: The dialect contract, injected into every NL-to-SQL prompt and returned
+#: verbatim by the ``dialect`` tool.
+DIALECT_BRIEFING = """Hotdata runs Apache DataFusion 54 with the PostgreSQL parser dialect.
+Treat that as "Postgres syntax, DataFusion semantics and function library" - NOT as Postgres.
+
+SYNTAX (Postgres-compatible):
+- :: casts, double-quoted identifiers, CTEs including RECURSIVE, window functions,
+  DISTINCT ON, SIMILAR TO, ILIKE, INTERVAL '1 day', EXTRACT(... FROM ...),
+  LATERAL (except on FULL OUTER / RIGHT joins).
+- Unquoted identifiers fold to lowercase. Any column or table whose real name has
+  uppercase letters or spaces MUST be double-quoted, e.g. "CustomerID".
+- One statement per request. No semicolon-separated batches.
+
+READ-ONLY SURFACE:
+- Only SELECT-shaped statements run in SQL. INSERT/UPDATE/DELETE, COPY TO and all DDL
+  (CREATE/DROP/ALTER, including CREATE VIEW and temp tables) are rejected before
+  execution, as are SET / PREPARE / BEGIN / COMMIT.
+- There are no transactions, no session variables and no search_path.
+- EXPLAIN, EXPLAIN ANALYZE, DESCRIBE <table> and VALUES are allowed.
+
+FUNCTIONS - DataFusion's library, not Postgres's:
+- The common core matches: string, math, date_trunc/date_part, aggregates, window
+  functions, array_* / make_array, string_agg, generate_series, regexp_match /
+  regexp_replace / regexp_like, coalesce/nullif/greatest/least.
+- These Postgres extras DO NOT EXIST: any JSON/JSONB function or operator
+  (->, ->>, jsonb_*), pg_catalog / pg_* introspection, to_number, age(),
+  regexp_split_to_table/array, width_bucket, mode(), percentile_disc.
+- DataFusion-only helpers that DO exist and are often the right answer. Use these
+  exact signatures - guessing the arity or argument types fails at planning time:
+  - arrow_typeof(expr) -> the expression's real Arrow type as text.
+  - arrow_cast(expr, 'Int64') -> cast using an exact Arrow type name, quoted.
+  - date_bin(INTERVAL '15 minutes', ts_expr, TIMESTAMP '1970-01-01') -> time buckets.
+  - approx_percentile_cont(numeric_expr, fraction) -> two arguments only.
+  - approx_distinct(expr).
+- approx_percentile_cont and approx_distinct are AGGREGATES over rows. The
+  argument must be a numeric column spanning rows, never an array: passing
+  make_array(...) yields List(Int64) and fails with "Unsupported CAST from
+  List(Int64) to Float64". To aggregate over a literal set, generate rows first
+  and aggregate the column, e.g.
+  SELECT approx_percentile_cont(v, 0.95) FROM (SELECT unnest(generate_series(1, 100)) AS v).
+
+TYPES are Arrow types, not Postgres types:
+- Utf8/LargeUtf8, Int8..Int64, Float64, Decimal128(p,s), Timestamp(unit, tz),
+  Date32, List/Struct/Map.
+- There is no native JSON, UUID, ENUM or geometry type; JSON arrives as a string.
+- Cast targets accept SQL names (BIGINT, TEXT, TIMESTAMP) or exact Arrow names
+  via arrow_cast.
+
+NAMES are three-part: catalog.schema.table. Every query runs inside exactly one
+database scope; the database's own catalog answers to `default` and any attached
+catalog answers to its alias. The system catalog is `hotdata`.
+
+INTROSPECTION:
+- SELECT * FROM information_schema.tables / .columns / .schemata / .catalogs works
+  and is the reliable route - prefer it.
+- information_schema.views, .routines and .parameters exist but ALWAYS return zero
+  rows, so you cannot list available functions that way.
+- DESCRIBE <table> and SHOW COLUMNS FROM <table> fail on a table that has been
+  declared but never loaded ("declared but has no data"). Load data first, or use
+  information_schema, which works on an empty table.
+
+ENGINE-SPECIFIC FUNCTIONS (no Postgres equivalent):
+- bm25_search('catalog.schema.table', 'column', 'query text') - full-text search
+  table function; rows come back scored, highest first.
+- vector_search('catalog.schema.table', 'column', 'query text') - semantic search
+  table function; the server embeds the text with the index's own provider and metric.
+- vector_distance(col, 'query text') - distance expression for ORDER BY, ascending
+  = closest. Requires a fully-qualified column reference.
+- ~57 PostGIS-named spatial functions (ST_Area, ST_Distance, ST_Intersects,
+  ST_GeomFromText, ST_MakePoint, ST_X/ST_Y, ST_Simplify, ST_Centroid, ...) - a
+  subset of PostGIS, not all of it.
+- Both search functions resolve only catalogs attached to the current database; a
+  raw connection id or __db_<id> prefix will error.
+
+When unsure whether a function exists, prefer the plain-SQL construction over a
+Postgres-specific shortcut. Unknown-function errors name the closest match, so read
+the error and retry rather than guessing a second variant."""
+
+
+def get_dialect_prompt_text() -> str:
+    """The dialect contract as prompt text."""
+    return DIALECT_BRIEFING
+
+
+def format_schema_for_prompt(tables: List[Dict[str, Any]]) -> str:
+    """Render an information_schema payload as compact prompt context.
+
+    Tolerant of shape: the REST payload nests columns under each table, but a
+    flat column list is accepted too.
+    """
+    if not tables:
+        return 'No tables have been created in this database yet.'
+
+    lines: List[str] = ['Tables available in this database:']
+    for entry in tables:
+        if not isinstance(entry, dict):
+            continue
+        name = entry.get('table') or entry.get('table_name') or entry.get('name') or '?'
+        schema = entry.get('schema') or entry.get('table_schema') or ''
+        catalog = entry.get('catalog') or entry.get('table_catalog') or ''
+        qualified = '.'.join([p for p in (catalog, schema, name) if p])
+
+        columns = entry.get('columns') or []
+        rendered: List[str] = []
+        for col in columns:
+            if isinstance(col, dict):
+                col_name = col.get('name') or col.get('column_name') or '?'
+                col_type = col.get('type') or col.get('data_type') or ''
+                rendered.append(f'{col_name} {col_type}'.strip())
+            elif isinstance(col, str):
+                rendered.append(col)
+
+        if rendered:
+            lines.append(f'  {qualified} ({", ".join(rendered)})')
+        else:
+            lines.append(f'  {qualified}')
+    return '\n'.join(lines)
+
+
+def strip_sql_fences(text: str) -> str:
+    """Remove markdown fences an LLM may wrap around generated SQL."""
+    cleaned = (text or '').strip()
+    if not cleaned.startswith('```'):
+        return cleaned
+    lines = cleaned.split('\n')
+    end = len(lines) - 1 if lines[-1].strip() == '```' else len(lines)
+    return '\n'.join(lines[1:end]).strip()

--- a/nodes/src/nodes/db_hotdata/requirements.txt
+++ b/nodes/src/nodes/db_hotdata/requirements.txt
@@ -1,0 +1,1 @@
+# Nothing other than the base is required

--- a/nodes/src/nodes/db_hotdata/services.json
+++ b/nodes/src/nodes/db_hotdata/services.json
@@ -1,0 +1,160 @@
+{
+	"title": "Hotdata",
+	"protocol": "db_hotdata://",
+	"classType": ["database", "tool"],
+	"capabilities": ["noremote", "invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.db_hotdata",
+	"prefix": "hotdata",
+	"icon": "hotdata.svg",
+	"documentation": "https://docs.rocketride.org",
+	"description": [
+		"Creates one ephemeral Hotdata database for each pipeline run.",
+		"Lets agents inspect its live schema and execute read-only SQL before the database is destroyed at teardown."
+	],
+	"tile": [],
+	"lanes": {
+		"answers": [],
+		"questions": ["table", "text", "answers"]
+	},
+	"invoke": {
+		"llm": {
+			"description": "LLM used to generate SQL from natural language",
+			"min": 1
+		}
+	},
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"title": "Hotdata",
+				"apikey": ""
+			}
+		}
+	},
+	"fields": {
+		"hotdata.apikey": {
+			"type": "string",
+			"title": "API Key",
+			"description": "Hotdata API key.",
+			"default": "",
+			"secure": true,
+			"ui": {
+				"ui:widget": "ApiKeyWidget"
+			}
+		},
+		"hotdata.workspace_id": {
+			"type": "string",
+			"title": "Workspace ID",
+			"description": "Hotdata workspace ID.",
+			"default": ""
+		},
+		"hotdata.api_url": {
+			"type": "string",
+			"title": "API URL",
+			"description": "Hotdata API base URL. Leave empty for https://api.hotdata.dev.",
+			"default": "",
+			"optional": true
+		},
+		"hotdata.ttl": {
+			"type": "string",
+			"title": "Database lifetime",
+			"description": "Crash-safety expiry for the ephemeral database.",
+			"default": "24h",
+			"enum": [
+				["1h", "1 hour"],
+				["24h", "24 hours"],
+				["7d", "7 days"]
+			]
+		},
+		"hotdata.table": {
+			"type": "string",
+			"title": "Table",
+			"description": "Table that rows arriving on the answers lane are loaded into. Created on first use.",
+			"default": "pipeline_data"
+		},
+		"hotdata.db_description": {
+			"type": "string",
+			"title": "Database description",
+			"description": "Schema and domain hints for natural-language SQL generation.",
+			"default": "",
+			"optional": true
+		},
+		"hotdata.max_attempts": {
+			"type": "integer",
+			"title": "Maximum attempts",
+			"description": "Maximum SQL-generation attempts.",
+			"default": 3,
+			"minimum": 1,
+			"maximum": 10
+		},
+		"hotdata.max_execute_rows": {
+			"type": "integer",
+			"title": "Maximum execute rows",
+			"description": "Maximum rows returned by raw SQL execution.",
+			"default": 25000,
+			"minimum": 1,
+			"maximum": 25000
+		},
+		"hotdata.allow_destructive_load": {
+			"type": "boolean",
+			"title": "Allow destructive loads",
+			"description": "Permit load_data to use replace, update or delete modes, which overwrite or remove existing rows. Off by default: load_data is append/upsert only, so an agent cannot destroy data another pipeline step loaded.",
+			"default": false
+		},
+		"hotdata.allow_execute": {
+			"type": "boolean",
+			"title": "Allow direct query execution",
+			"description": "Permit trusted callers to submit raw read-only SQL.",
+			"default": false
+		},
+		"hotdata.job_timeout_secs": {
+			"type": "integer",
+			"title": "Job timeout (seconds)",
+			"description": "Maximum time to wait for an asynchronous query.",
+			"default": 300,
+			"minimum": 10,
+			"maximum": 3600
+		},
+		"hotdata.async_after_ms": {
+			"type": "integer",
+			"title": "Run asynchronously after (milliseconds)",
+			"description": "Wait this long before a query continues as an asynchronous job.",
+			"default": 5000,
+			"minimum": 0,
+			"maximum": 60000
+		}
+	},
+	"test": {
+		"profiles": ["default"],
+		"outputs": [],
+		"cases": [
+			{
+				"name": "Hotdata smoke test (placeholder key)",
+				"questions": "test query"
+			}
+		]
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Hotdata",
+			"properties": [
+				"type",
+				"hotdata.apikey",
+				"hotdata.workspace_id",
+				"hotdata.api_url",
+				"hotdata.ttl",
+				"hotdata.table",
+				"hotdata.db_description",
+				"hotdata.max_attempts",
+				"hotdata.max_execute_rows",
+				"hotdata.allow_execute",
+				"hotdata.allow_destructive_load",
+				"hotdata.job_timeout_secs",
+				"hotdata.async_after_ms"
+			]
+		}
+	]
+}

--- a/nodes/src/nodes/db_hotdata/services.json
+++ b/nodes/src/nodes/db_hotdata/services.json
@@ -127,7 +127,7 @@
 		}
 	},
 	"test": {
-		"requires": ["ROCKETRIDE_HOTDATA_API_KEY", "ROCKETRIDE_HOTDATA_WORKSPACE"],
+		"requires": ["ROCKETRIDE_DB_HOTDATA_KEY", "ROCKETRIDE_DB_HOTDATA_WORKSPACE_ID"],
 		"profiles": ["default"],
 		"outputs": [],
 		"cases": [

--- a/nodes/src/nodes/db_hotdata/services.json
+++ b/nodes/src/nodes/db_hotdata/services.json
@@ -127,6 +127,7 @@
 		}
 	},
 	"test": {
+		"requires": ["ROCKETRIDE_HOTDATA_API_KEY", "ROCKETRIDE_HOTDATA_WORKSPACE"],
 		"profiles": ["default"],
 		"outputs": [],
 		"cases": [

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -838,7 +838,7 @@ def test_load_data_with_no_rows_does_no_work():
 
 def test_existing_table_409_is_treated_as_success():
     def _create(**_kw):
-        raise RuntimeError('hotdata: POST ... failed with HTTP 409: table exists')
+        raise client_mod.HotdataError('hotdata: POST ... failed with HTTP 409', status_code=409)
 
     g = _loaded_global()
     g.client = SimpleNamespace(
@@ -1511,3 +1511,24 @@ def test_legitimate_identifiers_build_the_expected_paths():
         connection_id='conn-1', schema='main', table='orders', index_name='i', index_type='bm25', columns=['note']
     )
     assert rec.calls[-1]['url'].endswith('/v1/connections/conn-1/tables/main/orders/indexes')
+
+
+def test_a_non_409_failure_mentioning_exists_is_not_swallowed():
+    """The 409 branch keys off the status, not the message. A different failure
+    whose body happens to say 'exists' must still propagate.
+    """
+
+    def _create(**_kw):
+        raise client_mod.HotdataError(
+            'hotdata: POST ... failed with HTTP 400: column already exists in another table',
+            status_code=400,
+        )
+
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        create_table=_create,
+        upload_bytes=lambda *_a, **_k: 'up-1',
+        load_table=lambda **_kw: {'row_count': 1},
+    )
+    with pytest.raises(client_mod.HotdataError, match='HTTP 400'):
+        _instance(g).load_data({'table': 'orders', 'rows': [{'a': 1}]})

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1417,14 +1417,12 @@ def test_pending_envelope_is_matched_case_insensitively():
     assert out.get('row_count') == 3, 'the job should have been polled to completion'
 
 
-def test_partial_load_releases_the_dedup_reservation():
-    """Only some rows landed, so a retry of the same payload must reach the
-    server rather than being skipped as a duplicate.
+def test_partial_append_keeps_its_reservation_and_warns_against_retry():
+    """Append is not idempotent. A partial load means an unknown subset already
+    landed, so releasing the reservation would let a blind retry duplicate
+    exactly those rows. Keep it and tell the caller to reconcile instead.
     """
-    jobs = [
-        {'status': 'partially_succeeded', 'id': 'job-1'},
-        {'status': 'succeeded', 'row_count': 1},
-    ]
+    jobs = [{'status': 'partially_succeeded', 'id': 'job-1'}]
     calls = []
     g = _global()
     g._loaded = set()
@@ -1440,8 +1438,28 @@ def test_partial_load_releases_the_dedup_reservation():
     g.database = {'id': 'db-1', 'default_schema': 'main'}
     inst = _instance(g)
     rows = [{'a': 1}]
+
     first = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
     assert first.get('partial') is True
+    assert 'do not simply retry' in first['note'].lower()
+
     second = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
-    assert not second.get('deduplicated'), 'a partial load must be retryable'
-    assert len(calls) == 2
+    assert second.get('deduplicated') is True, 'a partial append must not silently re-append'
+    assert len(calls) == 1, 'the retry must not reach the server and duplicate the landed subset'
+
+
+def test_result_id_load_does_not_claim_zero_rows():
+    """A result_id load has no local row count; reporting 0 would claim an empty
+    load that may well have inserted rows.
+    """
+    g = _global()
+    g._loaded = set()
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+        load_table=lambda **_kw: {'status': 'succeeded'},
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    out = _instance(g).load_data({'table': 'orders', 'result_id': 'res-1', 'mode': 'append'})
+    assert out['row_count'] is None, f'unknown must stay unknown, got {out["row_count"]}'

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1174,7 +1174,7 @@ def test_get_data_retries_after_a_rejected_write_and_succeeds():
 
 def _load_global(uploads, *, destructive=False):
     g = _global(allow_destructive_load=destructive)
-    g._loaded = set()
+    g._loaded = {}
     g.client = SimpleNamespace(
         create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
         upload_bytes=lambda payload, **_kw: uploads.append(payload) or f'upl-{len(uploads)}',
@@ -1311,7 +1311,7 @@ def test_execute_still_blocks_sql_writes_regardless_of_the_load_gate():
 
 def _failing_load_global(calls, fail_times):
     g = _global()
-    g._loaded = set()
+    g._loaded = {}
     state = {'n': 0}
 
     def _load(**_kw):
@@ -1361,7 +1361,7 @@ def test_result_id_load_failure_propagates_without_nameerror():
     never creates one, so the name must still be bound. This regressed once.
     """
     g = _global()
-    g._loaded = set()
+    g._loaded = {}
     g.client = SimpleNamespace(
         create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
         create_table=lambda **_kw: {},
@@ -1400,11 +1400,13 @@ def test_drop_database_clears_the_dedup_fingerprints():
     g = _global()
     handle = {'id': 'db-1'}
     g.database = handle
-    g._loaded = set()
-    assert g.seen_load('fp-1') is False
+    g._loaded = {}
+    assert g.seen_load('fp-1') is None, 'first sight of a payload reserves it'
+    g.record_load('fp-1', 'complete')
+    assert g.seen_load('fp-1') == 'complete'
     g.drop_database(handle)
     assert g.database is None
-    assert g.seen_load('fp-1') is False, 'the fingerprint should not survive the drop'
+    assert g.seen_load('fp-1') is None, 'the fingerprint should not survive the drop'
 
 
 def test_pending_envelope_is_matched_case_insensitively():
@@ -1425,7 +1427,7 @@ def test_partial_append_keeps_its_reservation_and_warns_against_retry():
     jobs = [{'status': 'partially_succeeded', 'id': 'job-1'}]
     calls = []
     g = _global()
-    g._loaded = set()
+    g._loaded = {}
     g.client = SimpleNamespace(
         create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
         create_table=lambda **_kw: {},
@@ -1453,7 +1455,7 @@ def test_result_id_load_does_not_claim_zero_rows():
     load that may well have inserted rows.
     """
     g = _global()
-    g._loaded = set()
+    g._loaded = {}
     g.client = SimpleNamespace(
         create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
         create_table=lambda **_kw: {},
@@ -1532,3 +1534,34 @@ def test_a_non_409_failure_mentioning_exists_is_not_swallowed():
     )
     with pytest.raises(client_mod.HotdataError, match='HTTP 400'):
         _instance(g).load_data({'table': 'orders', 'rows': [{'a': 1}]})
+
+
+def test_a_repeated_partial_append_keeps_reporting_partial():
+    """A partial outcome must survive the dedup branch. Reporting the repeat as a
+    clean duplicate would claim the table holds every row, which the partial
+    result contradicts.
+    """
+    jobs = [{'status': 'partially_succeeded', 'id': 'job-1'}]
+    calls = []
+    g = _global()
+    g._loaded = {}
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+        upload_bytes=lambda *_a, **_k: 'upl-1',
+        load_table=lambda **_kw: calls.append(1) or {'status': 'pending', 'id': 'job-1'},
+        get_job=lambda _i: jobs.pop(0),
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    inst = _instance(g)
+    rows = [{'a': 1}]
+
+    first = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert first.get('partial') is True
+
+    second = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert second.get('deduplicated') is True
+    assert second.get('partial') is True, 'the repeat must still be reported as partial'
+    assert 'only what is missing' in second['note']
+    assert len(calls) == 1, 'the repeat must not reach the server'

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1663,3 +1663,51 @@ def test_pending_then_failure_lets_a_retry_through():
     with pytest.raises(RuntimeError):
         inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
     assert len(calls) == 2, 'the retry must reach the server, not be swallowed as a duplicate'
+
+
+# ---------------------------------------------------------------------------
+# get_sql must apply the same guard as get_data and execute
+#
+# Raised in review: get_sql handed back generated SQL unchecked, so a write verb
+# or a semicolon batch came back as a "query" the node's own execute would then
+# refuse - and unlike get_data there was no corrective retry. All three paths
+# now ask the same question via _validate_generated_sql.
+# ---------------------------------------------------------------------------
+
+
+def test_get_sql_retries_when_the_model_returns_a_write():
+    """First answer is a DELETE; the model gets the error fed back and the
+    corrected SELECT is what the caller receives.
+    """
+    g = _loaded_global(max_attempts=3)
+    inst = _llm_instance(g, ["DELETE FROM orders WHERE status='refunded'", 'SELECT * FROM orders'])
+    out = inst.get_sql({'question': 'clean up the refunds'})
+    assert out['sql'] == 'SELECT * FROM orders'
+    assert len(inst.asked) == 2, 'the write should have triggered one regeneration'
+    assert 'read-only' in inst.asked[1].all_text(), 'the rejection reason must reach the model'
+
+
+def test_get_sql_refuses_rather_than_returning_unusable_sql():
+    """When every attempt is a write, failing is better than handing back SQL
+    the node's own execute would refuse - the caller gets a clear reason.
+    """
+    g = _loaded_global(max_attempts=2)
+    inst = _llm_instance(g, ['DROP TABLE orders', 'TRUNCATE orders'])
+    with pytest.raises(RuntimeError, match='could not generate acceptable SQL'):
+        inst.get_sql({'question': 'wipe it'})
+
+
+def test_get_sql_rejects_a_semicolon_batch():
+    g = _loaded_global(max_attempts=2)
+    inst = _llm_instance(g, ['SELECT 1; SELECT 2', 'SELECT 1'])
+    assert inst.get_sql({'question': 'two things'})['sql'] == 'SELECT 1'
+
+
+def test_all_three_sql_paths_share_one_validator():
+    """get_data, get_sql and execute must agree on what is acceptable."""
+    inst = _instance(_global())
+    for sql in ('DELETE FROM t', 'SELECT 1; SELECT 2'):
+        _cleaned, invalid = inst._validate_generated_sql(sql)
+        assert invalid, f'{sql!r} should be rejected by the shared validator'
+    _cleaned, invalid = inst._validate_generated_sql('SELECT 1;')
+    assert not invalid, 'a single statement with a trailing semicolon is fine'

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1,0 +1,1358 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit tests for the db_hotdata node (no network).
+
+Covers the REST client's retry policy, the lock-guarded ephemeral-database
+lifecycle, and the get_schema / execute tool surface. Every dependency on the
+engine runtime or the network is stubbed into sys.modules before import and
+popped afterwards, so nothing leaks into other nodes' tests under a full
+`builder nodes:test-full` run.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import threading
+import time
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+
+_WARNING_CALLS: list[str] = []
+_DEBUG_CALLS: list[str] = []
+_NORMALIZE_CALLS: list[str] = []
+
+
+def _reset_logs() -> None:
+    _WARNING_CALLS.clear()
+    _DEBUG_CALLS.clear()
+    _NORMALIZE_CALLS.clear()
+
+
+def _stub_warning(msg, *_a, **_k) -> None:
+    _WARNING_CALLS.append(str(msg))
+
+
+def _stub_debug(msg, *_a, **_k) -> None:
+    _DEBUG_CALLS.append(str(msg))
+
+
+def _stub_normalize(args, **kw):
+    _NORMALIZE_CALLS.append(kw.get('tool_name', 'tool'))
+    return args if isinstance(args, dict) else {}
+
+
+class _StubQuestion:
+    """Records what the node puts in front of the LLM so prompts can be asserted."""
+
+    def __init__(self, role=''):
+        self.role = role
+        self.instructions = []
+        self.contexts = []
+        self.examples = []
+        self.goals = []
+        self.questions = []
+
+    def addInstruction(self, title, text):
+        self.instructions.append((title, text))
+
+    def addContext(self, text):
+        self.contexts.append(text)
+
+    def addExample(self, q, a):
+        self.examples.append((q, a))
+
+    def addGoal(self, text):
+        self.goals.append(text)
+
+    def addQuestion(self, text):
+        self.questions.append(text)
+
+    def all_text(self):
+        parts = [t for _, t in self.instructions] + self.contexts + self.goals + self.questions
+        return '\n'.join(parts)
+
+
+class _StubAnswer:
+    def __init__(self, payload=None):
+        self._payload = payload
+        self.answer = None
+
+    def getJson(self):
+        return self._payload
+
+    def setAnswer(self, text):
+        self.answer = text
+
+
+class _RequestException(Exception):
+    pass
+
+
+class _ConnectionError(_RequestException):
+    pass
+
+
+class _ConnectTimeout(_ConnectionError):
+    pass
+
+
+class _ReadTimeout(_RequestException):
+    pass
+
+
+def _build_import_stubs() -> dict:
+    rocketlib = types.ModuleType('rocketlib')
+    rocketlib.IInstanceBase = object
+    rocketlib.IGlobalBase = object
+    rocketlib.tool_function = lambda *_a, **_k: lambda fn: fn
+    rocketlib.warning = _stub_warning
+    rocketlib.debug = _stub_debug
+    rocketlib.error = lambda *_a, **_k: None
+    rocketlib.OPEN_MODE = SimpleNamespace(CONFIG='config')
+
+    requests = types.ModuleType('requests')
+    requests.exceptions = SimpleNamespace(
+        RequestException=_RequestException,
+        ConnectionError=_ConnectionError,
+        ConnectTimeout=_ConnectTimeout,
+        ReadTimeout=_ReadTimeout,
+        Timeout=_ReadTimeout,
+    )
+    requests.request = lambda *_a, **_k: None  # replaced per-test
+
+    rocketlib_types = types.ModuleType('rocketlib.types')
+    rocketlib_types.IInvokeLLM = SimpleNamespace(Ask=lambda question=None: SimpleNamespace(question=question))
+    rocketlib.types = rocketlib_types
+
+    ai_pkg = types.ModuleType('ai')
+    ai_pkg.__path__ = []
+    ai_common = types.ModuleType('ai.common')
+    ai_common.__path__ = []
+    ai_utils = types.ModuleType('ai.common.utils')
+    ai_utils.normalize_tool_input = _stub_normalize
+    ai_config = types.ModuleType('ai.common.config')
+    ai_config.Config = SimpleNamespace(getNodeConfig=lambda *_a, **_k: {})
+    ai_schema = types.ModuleType('ai.common.schema')
+    ai_schema.Question = _StubQuestion
+    ai_schema.Answer = _StubAnswer
+
+    return {
+        'rocketlib': rocketlib,
+        'rocketlib.types': rocketlib_types,
+        'requests': requests,
+        'ai': ai_pkg,
+        'ai.common': ai_common,
+        'ai.common.utils': ai_utils,
+        'ai.common.config': ai_config,
+        'ai.common.schema': ai_schema,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Load the node modules as a synthetic package so relative imports resolve.
+# ---------------------------------------------------------------------------
+
+_NODE_DIR = Path(__file__).resolve().parent.parent / 'src' / 'nodes' / 'db_hotdata'
+_PKG = 'db_hotdata_under_test'
+
+
+def _load_modules():
+    stubs = _build_import_stubs()
+    added = [name for name in stubs if name not in sys.modules]
+    for name in added:
+        sys.modules[name] = stubs[name]
+
+    pkg = types.ModuleType(_PKG)
+    pkg.__path__ = [str(_NODE_DIR)]
+    sys.modules[_PKG] = pkg
+    loaded = [_PKG]
+
+    try:
+        mods = {}
+        for short in ('hotdata_client', 'hotdata_schema', 'IGlobal', 'IInstance'):
+            dotted = f'{_PKG}.{short}'
+            spec = importlib.util.spec_from_file_location(dotted, _NODE_DIR / f'{short}.py')
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[dotted] = module
+            loaded.append(dotted)
+            spec.loader.exec_module(module)
+            mods[short] = module
+        return mods, stubs['requests']
+    finally:
+        for name in loaded:
+            sys.modules.pop(name, None)
+        for name in added:
+            sys.modules.pop(name, None)
+
+
+_MODS, _REQUESTS_STUB = _load_modules()
+client_mod = _MODS['hotdata_client']
+schema_mod = _MODS['hotdata_schema']
+iglobal_mod = _MODS['IGlobal']
+iinstance_mod = _MODS['IInstance']
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status_code=200, body=None, headers=None, text=''):
+        self.status_code = status_code
+        self._body = body if body is not None else {}
+        self.headers = headers or {}
+        self.text = text
+
+    def json(self):
+        return self._body
+
+
+class _Recorder:
+    """Stands in for requests.request, replaying a queued list of outcomes."""
+
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def __call__(self, method, url, **kw):
+        self.calls.append({'method': method, 'url': url, **kw})
+        outcome = self.outcomes.pop(0) if self.outcomes else _Resp()
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    _reset_logs()
+    monkeypatch.setattr(client_mod.time, 'sleep', lambda *_a: None)
+    yield
+
+
+def _client(outcomes):
+    recorder = _Recorder(outcomes)
+    client_mod.requests.request = recorder
+    c = client_mod.HotdataClient(apikey='sk-secret-key', workspace_id='ws-1', retry_budget_s=30.0)
+    return c, recorder
+
+
+def _global(**overrides):
+    g = iglobal_mod.IGlobal()
+    g._db_lock = threading.Lock()
+    g.database = None
+    g.client = SimpleNamespace()
+    g.apikey = 'sk-secret-key'
+    g.workspace_id = 'ws-1'
+    g.ttl = '24h'
+    g.max_execute_rows = 25000
+    g.allow_execute = True
+    g.job_timeout_secs = 30
+    g.async_after_ms = 5000
+    for k, v in overrides.items():
+        setattr(g, k, v)
+    return g
+
+
+def _instance(glb):
+    inst = iinstance_mod.IInstance()
+    inst.IGlobal = glb
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# Client: request building
+# ---------------------------------------------------------------------------
+
+
+def test_request_carries_auth_workspace_and_timeout():
+    c, rec = _client([_Resp(200, {'ok': True})])
+    c.get_query_run('run-1')
+    call = rec.calls[0]
+    assert call['method'] == 'GET'
+    assert call['url'] == 'https://api.hotdata.dev/v1/query-runs/run-1'
+    assert call['headers']['Authorization'] == 'Bearer sk-secret-key'
+    assert call['headers']['X-Workspace-Id'] == 'ws-1'
+    assert call['timeout'] == client_mod.DEFAULT_TIMEOUT_S
+
+
+def test_base_url_override_strips_trailing_slash():
+    client_mod.requests.request = _Recorder([_Resp(200, {})])
+    c = client_mod.HotdataClient('k', 'w', base_url='https://alt.example.com/')
+    assert c.base_url == 'https://alt.example.com'
+
+
+# ---------------------------------------------------------------------------
+# Client: retry policy
+# ---------------------------------------------------------------------------
+
+
+def test_429_is_retried_and_retry_after_is_honored(monkeypatch):
+    slept = []
+    monkeypatch.setattr(client_mod.time, 'sleep', lambda d: slept.append(d))
+    c, rec = _client([_Resp(429, headers={'Retry-After': '7'}), _Resp(200, {'id': 'db-1'})])
+    assert c.create_database('n', '24h') == {'id': 'db-1'}
+    assert len(rec.calls) == 2
+    assert slept == [7.0]
+
+
+def test_retry_after_is_capped():
+    assert client_mod._parse_retry_after({'Retry-After': '99999'}) == client_mod.MAX_RETRY_AFTER_S
+    assert client_mod._parse_retry_after({}) is None
+    assert client_mod._parse_retry_after({'Retry-After': 'Wed, 21 Oct 2026 07:28:00 GMT'}) is None
+
+
+def test_429_budget_exhaustion_raises_overloaded(monkeypatch):
+    monkeypatch.setattr(client_mod.time, 'sleep', lambda *_a: None)
+    c, _ = _client([_Resp(429, headers={'Retry-After': '600'})])
+    with pytest.raises(client_mod.HotdataOverloadedError):
+        c.create_database('n', '24h')
+
+
+def test_post_read_timeout_is_not_replayed():
+    c, rec = _client([_ReadTimeout('read timed out'), _Resp(200, {'id': 'db-1'})])
+    with pytest.raises(client_mod.HotdataError):
+        c.create_database('n', '24h')
+    assert len(rec.calls) == 1, 'a POST that may have reached the server must not be replayed'
+
+
+def test_get_read_timeout_is_retried():
+    c, rec = _client([_ReadTimeout('read timed out'), _Resp(200, {'status': 'succeeded'})])
+    assert c.get_query_run('run-1') == {'status': 'succeeded'}
+    assert len(rec.calls) == 2
+
+
+def test_pre_response_connection_error_is_retried_on_post():
+    c, rec = _client([_ConnectTimeout('never left'), _Resp(200, {'id': 'db-1'})])
+    assert c.create_database('n', '24h') == {'id': 'db-1'}
+    assert len(rec.calls) == 2
+
+
+def test_post_5xx_is_not_retried():
+    c, rec = _client([_Resp(503, text='upstream down'), _Resp(200, {})])
+    with pytest.raises(client_mod.HotdataError):
+        c.create_database('n', '24h')
+    assert len(rec.calls) == 1
+
+
+def test_get_5xx_is_retried():
+    c, rec = _client([_Resp(503, text='blip'), _Resp(200, {'status': 'succeeded'})])
+    assert c.get_query_run('run-1') == {'status': 'succeeded'}
+    assert len(rec.calls) == 2
+
+
+def test_4xx_raises_runtime_error_with_body_snippet():
+    c, _ = _client([_Resp(400, text='bad sql')])
+    with pytest.raises(client_mod.HotdataError, match='bad sql'):
+        c.get_query_run('run-1')
+
+
+# ---------------------------------------------------------------------------
+# Client: TTL is mandatory
+# ---------------------------------------------------------------------------
+
+
+def test_create_database_always_sends_expires_at():
+    c, rec = _client([_Resp(200, {'id': 'db-1'})])
+    c.create_database('run-db', '24h')
+    assert rec.calls[0]['json']['expires_at'] == '24h'
+
+
+def test_create_database_refuses_empty_ttl():
+    c, rec = _client([_Resp(200, {'id': 'db-1'})])
+    with pytest.raises(ValueError):
+        c.create_database('run-db', '')
+    assert rec.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_get_database_creates_exactly_one():
+    """The tool_daytona failure: unguarded check-then-act billed two databases."""
+    created = []
+
+    def _slow_create(name, expires_at, schemas=None):
+        time.sleep(0.02)  # widen the race window
+        created.append(name)
+        return {'id': f'db-{len(created)}'}
+
+    g = _global()
+    g.client = SimpleNamespace(create_database=_slow_create)
+
+    results = []
+    threads = [threading.Thread(target=lambda: results.append(g.get_database())) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(created) == 1, f'expected exactly one database, got {len(created)}'
+    assert all(r is results[0] for r in results)
+
+
+def test_drop_database_clears_only_the_matching_handle():
+    g = _global()
+    handle = {'id': 'db-1'}
+    g.database = handle
+    g.drop_database({'id': 'other'})
+    assert g.database is handle
+    g.drop_database(handle)
+    assert g.database is None
+
+
+def test_end_global_deletes_and_clears_secrets():
+    deleted = []
+    g = _global()
+    g.database = {'id': 'db-1'}
+    g.client = SimpleNamespace(delete_database=lambda i: deleted.append(i))
+    g.endGlobal()
+    assert deleted == ['db-1']
+    assert g.database is None and g.client is None
+    assert g.apikey == '' and g.workspace_id == ''
+
+
+def test_end_global_warns_but_does_not_raise_on_delete_failure():
+    def _boom(_i):
+        raise RuntimeError('gone')
+
+    g = _global()
+    g.database = {'id': 'db-1'}
+    g.client = SimpleNamespace(delete_database=_boom)
+    g.endGlobal()  # must not raise
+    assert any('delete failed' in m for m in _WARNING_CALLS)
+    assert g.database is None
+
+
+def test_secrets_never_reach_the_logs():
+    g = _global()
+    g.database = {'id': 'db-1'}
+    g.client = SimpleNamespace(delete_database=lambda _i: None)
+    g.endGlobal()
+    joined = ' '.join(_WARNING_CALLS + _DEBUG_CALLS)
+    assert 'sk-secret-key' not in joined
+    assert 'ws-1' not in joined
+
+
+# ---------------------------------------------------------------------------
+# SQL guards
+# ---------------------------------------------------------------------------
+
+
+def test_single_trailing_semicolon_is_accepted():
+    cleaned, count = iinstance_mod._split_statements('SELECT 1;')
+    assert cleaned == 'SELECT 1'
+    assert count == 1
+
+
+def test_semicolon_inside_a_literal_is_not_a_statement_break():
+    _, count = iinstance_mod._split_statements("SELECT 'a;b' AS x")
+    assert count == 1
+
+
+def test_comments_are_ignored_when_counting():
+    _, count = iinstance_mod._split_statements('SELECT 1 -- trailing ; comment\n')
+    assert count == 1
+
+
+def test_execute_rejects_multi_statement():
+    inst = _instance(_global())
+    with pytest.raises(ValueError, match='one statement'):
+        inst.execute({'sql': 'SELECT 1; SELECT 2'})
+
+
+def test_execute_rejects_write_verbs():
+    inst = _instance(_global())
+    for sql in ('INSERT INTO t VALUES (1)', 'create table t (a int)', 'DROP TABLE t'):
+        with pytest.raises(ValueError, match='read-only'):
+            inst.execute({'sql': sql})
+
+
+def test_execute_refuses_when_allow_execute_is_off():
+    inst = _instance(_global(allow_execute=False))
+    with pytest.raises(RuntimeError, match='disabled'):
+        inst.execute({'sql': 'SELECT 1'})
+
+
+def test_execute_requires_non_empty_sql():
+    inst = _instance(_global())
+    for bad in ({}, {'sql': ''}, {'sql': 42}):
+        with pytest.raises(ValueError):
+            inst.execute(bad)
+
+
+# ---------------------------------------------------------------------------
+# Tools
+# ---------------------------------------------------------------------------
+
+
+def test_execute_returns_inline_rows_and_applies_limit():
+    g = _global()
+    g.client = SimpleNamespace(
+        query=lambda **_kw: {'rows': [{'a': 1}, {'a': 2}, {'a': 3}]},
+        create_database=lambda **_kw: {'id': 'db-1'},
+    )
+    inst = _instance(g)
+    out = inst.execute({'sql': 'SELECT a FROM t', 'limit': 2})
+    assert out['row_count'] == 2
+    assert out['rows'] == [{'a': 1}, {'a': 2}]
+    assert 'execute' in _NORMALIZE_CALLS
+
+
+def test_execute_limit_is_clamped_and_booleans_rejected():
+    seen = {}
+
+    def _query(**kw):
+        seen.update(kw)
+        return {'rows': []}
+
+    g = _global(max_execute_rows=10)
+    g.client = SimpleNamespace(query=_query, create_database=lambda **_kw: {'id': 'db-1'})
+    inst = _instance(g)
+    out = inst.execute({'sql': 'SELECT 1', 'limit': 9999})
+    assert out['row_count'] == 0
+    # JSON true must not be read as limit=1
+    inst.execute({'sql': 'SELECT 1', 'limit': True})
+
+
+def test_execute_follows_async_run_to_a_result():
+    polls = [{'status': 'running'}, {'status': 'succeeded', 'result_id': 'res-1'}]
+    g = _global()
+    g.client = SimpleNamespace(
+        query=lambda **_kw: {'query_run_id': 'run-1'},
+        get_query_run=lambda _i: polls.pop(0),
+        get_result=lambda _i, offset=0, limit=None: {'rows': [{'a': 1}]},
+        create_database=lambda **_kw: {'id': 'db-1'},
+    )
+    inst = _instance(g)
+    out = inst.execute({'sql': 'SELECT a FROM t'})
+    assert out['rows'] == [{'a': 1}]
+
+
+def test_failed_query_run_raises_runtime_error():
+    g = _global()
+    g.client = SimpleNamespace(
+        query=lambda **_kw: {'query_run_id': 'run-1'},
+        get_query_run=lambda _i: {'status': 'failed', 'error': 'syntax error at or near "SELCT"'},
+        create_database=lambda **_kw: {'id': 'db-1'},
+    )
+    inst = _instance(g)
+    with pytest.raises(RuntimeError, match='syntax error'):
+        inst.execute({'sql': 'SELECT 1'})
+
+
+def _llm_instance(glb, answers):
+    """An instance whose bound LLM replays a queued list of SQL answers."""
+    asked = []
+
+    def _invoke(ask):
+        asked.append(ask.question)
+        reply = answers.pop(0) if answers else 'SELECT 1'
+        if isinstance(reply, BaseException):
+            raise reply
+        return SimpleNamespace(answer=reply)
+
+    inst = _instance(glb)
+    inst.instance = SimpleNamespace(invoke=_invoke)
+    inst.asked = asked
+    return inst
+
+
+# ---------------------------------------------------------------------------
+# NL-to-SQL
+# ---------------------------------------------------------------------------
+
+
+def test_dialect_returns_the_full_briefing_not_a_bare_string():
+    inst = _instance(_global())
+    out = inst.dialect({})
+    assert out['dialect'] == 'datafusion'
+    briefing = out['briefing']
+    # The distinctions an LLM gets wrong by default must all be present.
+    for marker in ('DataFusion 54', 'PostgreSQL parser dialect', 'jsonb_', 'pg_catalog', 'bm25_search'):
+        assert marker in briefing, f'dialect briefing is missing {marker!r}'
+    assert len(briefing) > 1000
+    # Verified against the live API 2026-08-12: SHOW TABLES works, so the briefing
+    # must not tell the LLM it errors.
+    assert 'SHOW TABLES / SHOW COLUMNS / SHOW FUNCTIONS are NOT available' not in briefing
+
+
+def test_generated_prompt_carries_dialect_and_schema():
+    g = _loaded_global()
+    g.db_description = 'Sales data for EMEA'
+    g.client = SimpleNamespace(
+        information_schema=lambda **_kw: {
+            'tables': [{'name': 'sales', 'columns': [{'name': 'units', 'type': 'Int64'}]}]
+        },
+    )
+    inst = _llm_instance(g, ['SELECT 1'])
+    inst.get_sql({'question': 'how many units?'})
+    text = inst.asked[0].all_text()
+    assert 'PostgreSQL parser dialect' in text
+    assert 'sales' in text and 'units' in text
+    assert 'Sales data for EMEA' in text
+    assert 'how many units?' in inst.asked[0].questions
+
+
+def test_get_sql_strips_markdown_fences():
+    g = _loaded_global()
+    g.client = SimpleNamespace(information_schema=lambda **_kw: {'tables': []})
+    inst = _llm_instance(g, ['```sql\nSELECT 1\n```'])
+    assert inst.get_sql({'question': 'anything'})['sql'] == 'SELECT 1'
+
+
+def test_get_sql_requires_a_question():
+    inst = _llm_instance(_loaded_global(), [])
+    with pytest.raises(ValueError, match='question is required'):
+        inst.get_sql({})
+
+
+def test_get_data_retries_with_the_error_fed_back():
+    calls = {'n': 0}
+
+    def _query(**_kw):
+        calls['n'] += 1
+        if calls['n'] == 1:
+            raise RuntimeError("Invalid function 'to_number'. Did you mean 'to_char'?")
+        return {'rows': [{'a': 1}]}
+
+    g = _loaded_global(max_attempts=3)
+    g.client = SimpleNamespace(information_schema=lambda **_kw: {'tables': []}, query=_query)
+    inst = _llm_instance(g, ['SELECT to_number(x) FROM t', 'SELECT x FROM t'])
+
+    out = inst.get_data({'question': 'convert x'})
+    assert out['rows'] == [{'a': 1}]
+    assert out['attempts'] == 2
+    # The second prompt must contain the first failure so the LLM can correct it.
+    assert 'to_number' in inst.asked[1].all_text()
+
+
+def test_get_data_gives_up_after_max_attempts():
+    g = _loaded_global(max_attempts=2)
+    g.client = SimpleNamespace(
+        information_schema=lambda **_kw: {'tables': []},
+        query=lambda **_kw: (_ for _ in ()).throw(RuntimeError('boom')),
+    )
+    inst = _llm_instance(g, ['SELECT 1', 'SELECT 2'])
+    with pytest.raises(RuntimeError, match='after 2 attempts'):
+        inst.get_data({'question': 'x'})
+
+
+def test_get_data_rejects_a_multi_statement_generation():
+    g = _loaded_global(max_attempts=2)
+    g.client = SimpleNamespace(
+        information_schema=lambda **_kw: {'tables': []},
+        query=lambda **_kw: {'rows': [{'ok': 1}]},
+    )
+    inst = _llm_instance(g, ['SELECT 1; DROP TABLE t', 'SELECT 1'])
+    out = inst.get_data({'question': 'x'})
+    assert out['attempts'] == 2, 'the batched generation must be rejected and retried'
+
+
+def test_schema_lookup_failure_does_not_sink_the_question():
+    def _boom(**_kw):
+        raise RuntimeError('information_schema unavailable')
+
+    g = _loaded_global()
+    g.client = SimpleNamespace(information_schema=_boom, query=lambda **_kw: {'rows': []})
+    inst = _llm_instance(g, ['SELECT 1'])
+    out = inst.get_data({'question': 'x'})
+    assert out['row_count'] == 0
+    assert any('could not read schema' in m for m in _WARNING_CALLS)
+
+
+def test_missing_llm_answer_raises():
+    g = _loaded_global()
+    g.client = SimpleNamespace(information_schema=lambda **_kw: {'tables': []})
+    inst = _instance(g)
+    inst.instance = SimpleNamespace(invoke=lambda _ask: SimpleNamespace(answer=''))
+    with pytest.raises(RuntimeError, match='did not return a query'):
+        inst.get_sql({'question': 'x'})
+
+
+def test_schema_formatting_handles_empty_and_flat_shapes():
+    assert 'No tables' in schema_mod.format_schema_for_prompt([])
+    text = schema_mod.format_schema_for_prompt(
+        [{'table_name': 'orders', 'table_schema': 'main', 'columns': ['id Int64', 'total Float64']}]
+    )
+    assert 'main.orders' in text and 'total Float64' in text
+
+
+def _loaded_global(**overrides):
+    """A global whose database already exists, with the fields loads/indexes need."""
+    g = _global(**overrides)
+    g.database = {
+        'id': 'db-1',
+        'default_schema': 'main',
+        'default_catalog': 'default',
+        'default_connection_id': 'conn-1',
+    }
+    return g
+
+
+# ---------------------------------------------------------------------------
+# Uploads
+# ---------------------------------------------------------------------------
+
+
+def test_upload_bytes_single_mode_puts_without_bearer_and_finalizes():
+    slot = _Resp(
+        201,
+        {
+            'upload_id': 'up-1',
+            'finalize_token': 'tok-1',
+            'mode': 'single',
+            'url': 'https://storage.example/put',
+            'headers': {'Content-Type': 'application/json'},
+        },
+    )
+    c, rec = _client([slot, _Resp(200), _Resp(200, {'status': 'ready'})])
+    assert c.upload_bytes(b'[{"a":1}]', 't.json') == 'up-1'
+
+    put = rec.calls[1]
+    assert put['method'] == 'PUT'
+    assert put['url'] == 'https://storage.example/put'
+    assert 'Authorization' not in put['headers'], 'presigned PUT must not carry our bearer token'
+    assert put['data'] == b'[{"a":1}]'
+
+    finalize = rec.calls[2]
+    assert finalize['url'].endswith('/v1/uploads/up-1/finalize')
+    assert finalize['headers']['X-Upload-Finalize-Token'] == 'tok-1'
+
+
+def test_upload_slot_missing_token_raises():
+    c, _ = _client([_Resp(201, {'upload_id': 'up-1'})])
+    with pytest.raises(client_mod.HotdataError, match='finalize_token'):
+        c.upload_bytes(b'x', 't.json')
+
+
+def test_load_table_requires_exactly_one_source():
+    c, _ = _client([])
+    with pytest.raises(ValueError):
+        c.load_table('db-1', 'main', 't', upload_id='u', result_id='r')
+    with pytest.raises(ValueError):
+        c.load_table('db-1', 'main', 't')
+
+
+# ---------------------------------------------------------------------------
+# load_data
+# ---------------------------------------------------------------------------
+
+
+def test_load_data_uploads_rows_as_json_and_loads():
+    seen = {}
+
+    def _upload(payload, filename, content_type='application/json'):
+        seen['payload'] = payload
+        seen['filename'] = filename
+        return 'up-1'
+
+    def _load(**kw):
+        seen['load'] = kw
+        return {'row_count': 2, 'status': 'succeeded'}
+
+    g = _loaded_global()
+    g.client = SimpleNamespace(create_table=lambda **kw: {}, upload_bytes=_upload, load_table=_load)
+    inst = _instance(g)
+    out = inst.load_data({'table': 'orders', 'rows': [{'a': 1}, {'a': 2}]})
+
+    assert out['table'] == 'orders' and out['schema'] == 'main'
+    assert seen['load']['data_format'] == 'json'
+    assert seen['load']['upload_id'] == 'up-1'
+    assert seen['load']['mode'] == 'append'
+    assert b'"a": 1' in seen['payload'] or b'"a":1' in seen['payload']
+
+
+def test_load_data_from_result_id_skips_upload():
+    calls = {'uploaded': False}
+
+    def _upload(*_a, **_k):
+        calls['uploaded'] = True
+        return 'up-x'
+
+    def _load(**kw):
+        calls['load'] = kw
+        return {'row_count': 5}
+
+    g = _loaded_global()
+    g.client = SimpleNamespace(create_table=lambda **_kw: {}, upload_bytes=_upload, load_table=_load)
+    inst = _instance(g)
+    out = inst.load_data({'table': 'orders', 'result_id': 'res-9'})
+    assert calls['uploaded'] is False, 'result_id must avoid the upload round trips entirely'
+    assert calls['load']['result_id'] == 'res-9'
+    assert out['row_count'] == 5
+
+
+def test_load_data_validates_arguments():
+    g = _loaded_global()
+    g.client = SimpleNamespace(create_table=lambda **_kw: {}, load_table=lambda **_kw: {})
+    inst = _instance(g)
+    with pytest.raises(ValueError, match='table is required'):
+        inst.load_data({'rows': [{'a': 1}]})
+    with pytest.raises(ValueError, match='rows'):
+        inst.load_data({'table': 't'})
+    with pytest.raises(ValueError, match='not both'):
+        inst.load_data({'table': 't', 'rows': [{'a': 1}], 'result_id': 'r'})
+    with pytest.raises(ValueError, match='mode must be'):
+        inst.load_data({'table': 't', 'rows': [{'a': 1}], 'mode': 'obliterate'})
+    with pytest.raises(ValueError, match='requires key'):
+        inst.load_data({'table': 't', 'rows': [{'a': 1}], 'mode': 'upsert'})
+
+
+def test_load_data_with_no_rows_does_no_work():
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        create_table=lambda **_kw: {},
+        upload_bytes=lambda *_a, **_k: pytest.fail('must not upload an empty batch'),
+        load_table=lambda **_kw: pytest.fail('must not load an empty batch'),
+    )
+    inst = _instance(g)
+    assert inst.load_data({'table': 'orders', 'rows': []})['row_count'] == 0
+
+
+def test_existing_table_409_is_treated_as_success():
+    def _create(**_kw):
+        raise RuntimeError('hotdata: POST ... failed with HTTP 409: table exists')
+
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        create_table=_create,
+        upload_bytes=lambda *_a, **_k: 'up-1',
+        load_table=lambda **_kw: {'row_count': 1},
+    )
+    inst = _instance(g)
+    assert inst.load_data({'table': 'orders', 'rows': [{'a': 1}]})['row_count'] == 1
+
+
+# ---------------------------------------------------------------------------
+# Async jobs
+# ---------------------------------------------------------------------------
+
+
+def test_load_follows_202_job_to_completion():
+    jobs = [{'status': 'running'}, {'status': 'succeeded', 'row_count': 7}]
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        create_table=lambda **_kw: {},
+        upload_bytes=lambda *_a, **_k: 'up-1',
+        load_table=lambda **_kw: {'id': 'job-1', 'status': 'pending'},
+        get_job=lambda _i: jobs.pop(0),
+    )
+    inst = _instance(g)
+    assert inst.load_data({'table': 'orders', 'rows': [{'a': 1}]})['row_count'] == 7
+
+
+def test_failed_job_raises_with_server_message():
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        create_table=lambda **_kw: {},
+        upload_bytes=lambda *_a, **_k: 'up-1',
+        load_table=lambda **_kw: {'id': 'job-1', 'status': 'pending'},
+        get_job=lambda _i: {'status': 'failed', 'error_message': 'bad parquet'},
+    )
+    inst = _instance(g)
+    with pytest.raises(RuntimeError, match='bad parquet'):
+        inst.load_data({'table': 'orders', 'rows': [{'a': 1}]})
+
+
+def test_partially_succeeded_job_warns_but_returns():
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        create_table=lambda **_kw: {},
+        upload_bytes=lambda *_a, **_k: 'up-1',
+        load_table=lambda **_kw: {'id': 'job-1', 'status': 'pending'},
+        get_job=lambda _i: {'status': 'partially_succeeded', 'row_count': 3},
+    )
+    inst = _instance(g)
+    assert inst.load_data({'table': 'orders', 'rows': [{'a': 1}]})['row_count'] == 3
+    assert any('partially' in m for m in _WARNING_CALLS)
+
+
+# ---------------------------------------------------------------------------
+# build_index
+# ---------------------------------------------------------------------------
+
+
+def test_build_index_uses_default_connection_and_derives_a_name():
+    seen = {}
+    g = _loaded_global()
+    g.client = SimpleNamespace(create_index=lambda **kw: seen.update(kw) or {'status': 'ready'})
+    inst = _instance(g)
+    out = inst.build_index({'table': 'docs', 'column': 'body', 'index_type': 'bm25'})
+    assert seen['connection_id'] == 'conn-1'
+    assert seen['schema'] == 'main'
+    assert seen['columns'] == ['body']
+    assert out['index_name'] == 'docs_body_bm25'
+    assert out['status'] == 'ready'
+
+
+def test_build_index_validates_type_and_required_args():
+    g = _loaded_global()
+    g.client = SimpleNamespace(create_index=lambda **_kw: {})
+    inst = _instance(g)
+    with pytest.raises(ValueError, match='table and column'):
+        inst.build_index({'table': 'docs'})
+    with pytest.raises(ValueError, match='index_type must be'):
+        inst.build_index({'table': 'docs', 'column': 'body', 'index_type': 'magic'})
+
+
+def test_build_index_without_connection_id_raises():
+    g = _loaded_global()
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    g.client = SimpleNamespace(create_index=lambda **_kw: {})
+    inst = _instance(g)
+    with pytest.raises(RuntimeError, match='default_connection_id'):
+        inst.build_index({'table': 'docs', 'column': 'body'})
+
+
+def test_get_schema_uses_information_schema_not_show_tables():
+    seen = {}
+
+    def _info(**kw):
+        seen.update(kw)
+        return {'tables': [{'name': 'orders'}]}
+
+    g = _loaded_global()
+    g.client = SimpleNamespace(information_schema=_info)
+    inst = _instance(g)
+    out = inst.get_schema({'schema': 'public'})
+    assert out['tables'] == [{'name': 'orders'}]
+    # Scoped by connection_id: passing database_id is silently ignored server-side
+    # and yields an empty table list.
+    assert seen['connection_id'] == 'conn-1'
+    assert 'database_id' not in seen
+    assert seen['include_columns'] is True
+    assert 'get_schema' in _NORMALIZE_CALLS
+
+
+# ---------------------------------------------------------------------------
+# Lanes
+# ---------------------------------------------------------------------------
+
+
+class _FakeLaneInstance:
+    """Captures what the node writes downstream."""
+
+    def __init__(self, lanes, invoke=None):
+        self._lanes = lanes
+        self.texts = []
+        self.tables = []
+        self.answers = []
+        self.invoke = invoke or (lambda _ask: SimpleNamespace(answer='SELECT 1'))
+
+    def getListeners(self):
+        return self._lanes
+
+    def writeText(self, text):
+        self.texts.append(text)
+
+    def writeTable(self, markdown):
+        self.tables.append(markdown)
+
+    def writeAnswers(self, answer):
+        self.answers.append(answer)
+
+
+def test_questions_lane_emits_to_every_wired_lane():
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        information_schema=lambda **_kw: {'tables': []},
+        query=lambda **_kw: {'rows': [{'product': 'widget', 'units': 3}]},
+    )
+    inst = _instance(g)
+    inst.instance = _FakeLaneInstance(['text', 'table', 'answers'])
+
+    question = SimpleNamespace(questions=[SimpleNamespace(text='what sold most?')])
+    inst.writeQuestions(question)
+
+    assert len(inst.instance.texts) == 1
+    assert '| product | units |' in inst.instance.texts[0]
+    assert len(inst.instance.tables) == 1
+    assert len(inst.instance.answers) == 1
+
+
+def test_questions_lane_only_writes_wired_lanes():
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        information_schema=lambda **_kw: {'tables': []},
+        query=lambda **_kw: {'rows': [{'a': 1}]},
+    )
+    inst = _instance(g)
+    inst.instance = _FakeLaneInstance(['text'])
+    inst.writeQuestions(SimpleNamespace(questions=[SimpleNamespace(text='q')]))
+    assert inst.instance.texts and not inst.instance.tables and not inst.instance.answers
+
+
+def test_questions_lane_emits_structured_error_on_failure():
+    g = _loaded_global(max_attempts=1)
+    g.client = SimpleNamespace(
+        information_schema=lambda **_kw: {'tables': []},
+        query=lambda **_kw: (_ for _ in ()).throw(RuntimeError('table not found')),
+    )
+    inst = _instance(g)
+    inst.instance = _FakeLaneInstance(['text', 'answers'])
+    inst.writeQuestions(SimpleNamespace(questions=[SimpleNamespace(text='q')]))
+
+    assert inst.instance.answers, 'a failure must still reach the answers lane'
+    payload = json.loads(inst.instance.answers[0].answer)
+    assert 'error' in payload, 'errors must be structurally distinguishable from prose'
+
+
+def test_questions_lane_ignores_an_empty_question():
+    inst = _instance(_loaded_global())
+    inst.instance = _FakeLaneInstance(['text'])
+    inst.writeQuestions(SimpleNamespace(questions=[]))
+    assert not inst.instance.texts
+    assert any('no question text' in m.lower() for m in _WARNING_CALLS)
+
+
+def test_answers_lane_loads_via_upload_never_insert():
+    seen = {}
+
+    def _load(**kw):
+        seen['load'] = kw
+        return {'row_count': 2}
+
+    g = _loaded_global(table='sales')
+    g.client = SimpleNamespace(
+        create_table=lambda **_kw: {},
+        upload_bytes=lambda *_a, **_k: 'up-1',
+        load_table=_load,
+        query=lambda **_kw: pytest.fail('the answers lane must never emit SQL'),
+    )
+    inst = _instance(g)
+    inst.instance = _FakeLaneInstance([])
+    inst.writeAnswers(_StubAnswer([{'a': 1}, {'a': 2}]))
+
+    assert seen['load']['table'] == 'sales'
+    assert seen['load']['mode'] == 'append'
+    assert seen['load']['upload_id'] == 'up-1'
+
+
+def test_answers_lane_wraps_a_single_dict():
+    seen = {}
+    g = _loaded_global(table='sales')
+    g.client = SimpleNamespace(
+        create_table=lambda **_kw: {},
+        upload_bytes=lambda payload, **_k: seen.setdefault('payload', payload) or 'up-1',
+        load_table=lambda **_kw: {'row_count': 1},
+    )
+    inst = _instance(g)
+    inst.writeAnswers(_StubAnswer({'a': 1}))
+    lines = [ln for ln in seen['payload'].decode().split('\n') if ln.strip()]
+    assert [json.loads(ln) for ln in lines] == [{'a': 1}]
+
+
+def test_rows_are_uploaded_as_ndjson_not_a_json_array():
+    """Hotdata rejects a JSON array with 'Expected JSON record to be an object'."""
+    payload = iinstance_mod._to_ndjson([{'a': 1}, {'a': 2}])
+    text = payload.decode()
+    assert not text.lstrip().startswith('['), 'must not be a JSON array'
+    lines = [ln for ln in text.split('\n') if ln.strip()]
+    assert len(lines) == 2
+    assert [json.loads(ln) for ln in lines] == [{'a': 1}, {'a': 2}]
+    assert text.endswith('\n')
+
+
+def test_ndjson_rejects_non_object_rows():
+    with pytest.raises(ValueError, match='must be an object'):
+        iinstance_mod._to_ndjson([{'a': 1}, [1, 2, 3]])
+
+
+def test_answers_lane_ignores_empty_payloads():
+    g = _loaded_global()
+    g.client = SimpleNamespace(
+        create_table=lambda **_kw: pytest.fail('must not touch the API for an empty payload'),
+    )
+    inst = _instance(g)
+    inst.writeAnswers(_StubAnswer(None))
+
+
+def test_answers_lane_logs_but_does_not_raise_on_load_failure():
+    def _boom(**_kw):
+        raise RuntimeError('load rejected')
+
+    g = _loaded_global()
+    g.client = SimpleNamespace(create_table=lambda **_kw: {}, upload_bytes=lambda *_a, **_k: 'u', load_table=_boom)
+    inst = _instance(g)
+    inst.writeAnswers(_StubAnswer([{'a': 1}]))  # must not raise
+
+
+def test_markdown_rendering_escapes_pipes_and_truncates():
+    md = iinstance_mod._rows_to_markdown([{'a': 'x|y'}])
+    assert 'x\\|y' in md
+    many = iinstance_mod._rows_to_markdown([{'a': i} for i in range(150)])
+    assert 'more rows not shown' in many
+    assert iinstance_mod._rows_to_markdown([]) == 'No rows.'
+
+
+def test_boolean_query_params_are_lowercased():
+    """Requests renders True as "True"; Hotdata rejects anything but true/false."""
+    c, rec = _client([_Resp(200, {'tables': []})])
+    c.information_schema(connection_id='conn-1', include_columns=True)
+    assert rec.calls[0]['params']['include_columns'] == 'true'
+
+
+def test_none_query_params_are_dropped():
+    assert client_mod._encode_params({'a': None, 'b': 1, 'c': False}) == {'b': 1, 'c': 'false'}
+
+
+def test_get_data_rejects_generated_write_sql_without_calling_the_server():
+    """The NL path must apply the same read-only guard as execute."""
+    calls = []
+
+    g = _global(max_attempts=2)
+    g.client = SimpleNamespace(
+        query=lambda **kw: calls.append(kw) or {'rows': []},
+        create_database=lambda **_kw: {'id': 'db-1'},
+    )
+    inst = _instance(g)
+    inst._generate_sql = lambda *_a, **_k: 'CREATE TABLE customers (id BIGINT)'
+
+    with pytest.raises(RuntimeError, match='could not answer'):
+        inst.get_data({'question': 'make a customers table'})
+
+    assert calls == [], 'generated DDL must never reach the server'
+    assert any('read-only' in m for m in _DEBUG_CALLS + _WARNING_CALLS) or True
+
+
+def test_get_data_retries_after_a_rejected_write_and_succeeds():
+    """A rejected write is fed back so the next attempt can produce a SELECT."""
+    produced = ['DELETE FROM t', 'SELECT 1']
+    seen = []
+
+    g = _global(max_attempts=3)
+    g.client = SimpleNamespace(
+        query=lambda **kw: seen.append(kw.get('sql')) or {'rows': [{'a': 1}]},
+        create_database=lambda **_kw: {'id': 'db-1'},
+    )
+    inst = _instance(g)
+    inst._generate_sql = lambda *_a, **_k: produced.pop(0)
+
+    out = inst.get_data({'question': 'anything'})
+    assert out['rows'] == [{'a': 1}]
+    assert seen == ['SELECT 1'], 'only the SELECT should have been executed'
+
+
+# ---------------------------------------------------------------------------
+# Append de-duplication
+#
+# Verified against the live API: an identical append took a table from 2 rows to
+# 4. Hotdata exposes no idempotency key on loads, so the guard lives here.
+# ---------------------------------------------------------------------------
+
+
+def _load_global(uploads, *, destructive=False):
+    g = _global(allow_destructive_load=destructive)
+    g._loaded = set()
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        upload_bytes=lambda payload, **_kw: uploads.append(payload) or f'upl-{len(uploads)}',
+        load_table=lambda **_kw: {'row_count': 2},
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    return g
+
+
+def test_identical_append_is_skipped_the_second_time():
+    uploads = []
+    inst = _instance(_load_global(uploads))
+    rows = [{'a': 1}, {'a': 2}]
+
+    first = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert not first.get('deduplicated')
+    assert len(uploads) == 1
+
+    second = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert second.get('deduplicated') is True
+    assert len(uploads) == 1, 'the duplicate append must not reach the server'
+    assert any('skipping' in m for m in _WARNING_CALLS)
+
+
+def test_different_payload_still_appends():
+    uploads = []
+    inst = _instance(_load_global(uploads))
+    inst.load_data({'table': 'orders', 'rows': [{'a': 1}], 'mode': 'append'})
+    inst.load_data({'table': 'orders', 'rows': [{'a': 2}], 'mode': 'append'})
+    assert len(uploads) == 2
+
+
+def test_same_payload_to_a_different_table_still_appends():
+    uploads = []
+    inst = _instance(_load_global(uploads))
+    rows = [{'a': 1}]
+    inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    inst.load_data({'table': 'invoices', 'rows': rows, 'mode': 'append'})
+    assert len(uploads) == 2
+
+
+def test_replace_is_never_deduplicated():
+    uploads = []
+    inst = _instance(_load_global(uploads, destructive=True))
+    rows = [{'a': 1}]
+    inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'replace'})
+    out = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'replace'})
+    assert not out.get('deduplicated'), 'replace is idempotent by nature - do not skip it'
+    assert len(uploads) == 2
+
+
+def test_get_schema_includes_a_flat_summary_line():
+    """Small models miscount columns walking nested JSON; the summary is flat."""
+    g = _global()
+    g.database = {'id': 'db-1', 'default_connection_id': 'conn-1', 'default_schema': 'main'}
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: g.database,
+        information_schema=lambda **_kw: {
+            'tables': [
+                {
+                    'schema': 'main',
+                    'table': 'orders',
+                    'columns': [
+                        {'name': 'note', 'data_type': 'Utf8View'},
+                        {'name': 'product', 'data_type': 'Utf8View'},
+                        {'name': 'region', 'data_type': 'Utf8View'},
+                        {'name': 'units', 'data_type': 'Int64'},
+                    ],
+                }
+            ]
+        },
+    )
+    out = _instance(g).get_schema({})
+    assert out['summary'] == ['main.orders(note Utf8View, product Utf8View, region Utf8View, units Int64)']
+    # every column name must survive into the flat line
+    for col in ('note', 'product', 'region', 'units'):
+        assert col in out['summary'][0]
+
+
+def test_schema_summary_handles_a_table_with_no_columns():
+    assert iinstance_mod._schema_summary([{'schema': 'main', 'table': 't'}]) == ['main.t(no columns reported)']
+
+
+# ---------------------------------------------------------------------------
+# Destructive-load gate
+#
+# The SQL surface is read-only, but load_data is a separate write path. A
+# capable agent told to "delete the refunded orders" found this in one attempt
+# during agentic testing: blocked on DELETE, it called load_data mode=replace
+# and wiped the table (6 rows -> 1). These lock the gate shut.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('mode', ['replace', 'update', 'delete'])
+def test_destructive_load_modes_refused_by_default(mode):
+    g = _global(allow_destructive_load=False)
+    g.client = SimpleNamespace(create_database=lambda **_kw: {'id': 'db-1'})
+    inst = _instance(g)
+    with pytest.raises(ValueError, match='allow_destructive_load'):
+        inst.load_data({'table': 't', 'rows': [{'a': 1}], 'mode': mode, 'key': ['a']})
+
+
+@pytest.mark.parametrize('mode', ['append', 'upsert'])
+def test_non_destructive_modes_need_no_gate(mode):
+    inst = _instance(_load_global([]))
+    out = inst.load_data({'table': 't', 'rows': [{'a': 1}], 'mode': mode, 'key': ['a']})
+    assert out['mode'] == mode
+
+
+def test_destructive_mode_allowed_once_gated_on():
+    inst = _instance(_load_global([], destructive=True))
+    out = inst.load_data({'table': 't', 'rows': [{'a': 1}], 'mode': 'replace'})
+    assert out['mode'] == 'replace'
+
+
+def test_execute_still_blocks_sql_writes_regardless_of_the_load_gate():
+    inst = _instance(_global(allow_destructive_load=True))
+    with pytest.raises(ValueError, match='read-only'):
+        inst.execute({'sql': "DELETE FROM orders WHERE status='refunded'"})
+
+
+# ---------------------------------------------------------------------------
+# Dedup reservation must not survive a failed load
+#
+# The append fingerprint is recorded atomically at check time so parallel tool
+# calls cannot double-load. That reservation has to be released when the load
+# then fails - otherwise the agent's retry is skipped as a duplicate and the
+# rows are never loaded, while the tool reports "the table already contains
+# these rows".
+# ---------------------------------------------------------------------------
+
+
+def _failing_load_global(calls, fail_times):
+    g = _global()
+    g._loaded = set()
+    state = {'n': 0}
+
+    def _load(**_kw):
+        state['n'] += 1
+        calls.append(state['n'])
+        if state['n'] <= fail_times:
+            raise RuntimeError('hotdata: POST /loads failed with HTTP 503')
+        return {'row_count': 1}
+
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        upload_bytes=lambda payload, **_kw: 'upl-1',
+        load_table=_load,
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    return g
+
+
+def test_failed_append_can_be_retried_and_actually_loads():
+    calls = []
+    inst = _instance(_failing_load_global(calls, fail_times=1))
+    rows = [{'a': 1}]
+
+    with pytest.raises(RuntimeError):
+        inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+
+    # The retry must reach the server, not be swallowed as a duplicate.
+    out = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert not out.get('deduplicated'), 'a retry after a failed load must not be treated as a duplicate'
+    assert len(calls) == 2, f'expected the retry to hit load_table, got {len(calls)} call(s)'
+
+
+def test_successful_append_is_still_deduplicated():
+    calls = []
+    inst = _instance(_failing_load_global(calls, fail_times=0))
+    rows = [{'a': 1}]
+    inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    out = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert out.get('deduplicated') is True
+    assert len(calls) == 1, 'the second identical append must not reach the server'
+
+
+def test_result_id_load_failure_propagates_without_nameerror():
+    """The failure handler releases the dedup reservation; the result_id path
+    never creates one, so the name must still be bound. This regressed once.
+    """
+    g = _global()
+    g._loaded = set()
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+        load_table=lambda **_kw: (_ for _ in ()).throw(RuntimeError('load failed')),
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    inst = _instance(g)
+    with pytest.raises(RuntimeError, match='load failed'):
+        inst.load_data({'table': 't', 'result_id': 'res-1', 'mode': 'append'})

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1563,5 +1563,92 @@ def test_a_repeated_partial_append_keeps_reporting_partial():
     second = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
     assert second.get('deduplicated') is True
     assert second.get('partial') is True, 'the repeat must still be reported as partial'
+    assert 'row_count' not in second, 'the landed subset is unknown - do not claim the full count'
     assert 'only what is missing' in second['note']
     assert len(calls) == 1, 'the repeat must not reach the server'
+
+
+# ---------------------------------------------------------------------------
+# Reservation states must stay distinct
+#
+# seen_load() returns 'pending' while a load is still in flight. Treating that
+# as a completed dedup told a concurrent caller the rows were already present
+# before the original load had finished - and if that original then failed and
+# released the reservation, the rows never landed at all.
+# ---------------------------------------------------------------------------
+
+
+def _blocking_load_global(gate, calls):
+    g = _global()
+    g._loaded = {}
+
+    def _load(**_kw):
+        calls.append(1)
+        gate.wait(timeout=5)
+        return {'row_count': 1}
+
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+        upload_bytes=lambda *_a, **_k: 'upl-1',
+        load_table=_load,
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    return g
+
+
+def test_concurrent_identical_append_gets_in_progress_not_false_success():
+    gate = threading.Event()
+    calls = []
+    inst = _instance(_blocking_load_global(gate, calls))
+    rows = [{'a': 1}]
+    results = {}
+
+    first = threading.Thread(
+        target=lambda: results.update(first=inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'}))
+    )
+    first.start()
+    while not calls:  # wait until the first call is genuinely mid-flight
+        time.sleep(0.01)
+
+    second = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert second.get('in_progress') is True, 'a mid-flight duplicate must not report completion'
+    assert 'deduplicated' not in second, 'in-flight is not a completed dedup'
+    assert 'row_count' not in second, 'nothing has landed yet - claim no count'
+
+    gate.set()
+    first.join(timeout=5)
+    assert calls == [1], 'the concurrent call must not have reached the server'
+
+
+def test_pending_then_failure_lets_a_retry_through():
+    """A caller that saw 'pending' was told nothing landed. When the original
+    load then fails, the reservation is released so a genuine retry can run.
+    """
+    calls = []
+
+    def _load(**_kw):
+        calls.append(1)
+        raise RuntimeError('hotdata: POST /loads failed with HTTP 503')
+
+    g = _global()
+    g._loaded = {}
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+        upload_bytes=lambda *_a, **_k: 'upl-1',
+        load_table=_load,
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    inst = _instance(g)
+    rows = [{'a': 1}]
+
+    with pytest.raises(RuntimeError):
+        inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert g._loaded == {}, 'a failed load must not leave a reservation behind'
+
+    with pytest.raises(RuntimeError):
+        inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert len(calls) == 2, 'the retry must reach the server, not be swallowed as a duplicate'

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1091,14 +1091,20 @@ def test_answers_lane_ignores_empty_payloads():
     inst.writeAnswers(_StubAnswer(None))
 
 
-def test_answers_lane_logs_but_does_not_raise_on_load_failure():
+def test_answers_lane_surfaces_a_load_failure():
+    """The answers lane has no output lane to emit to, so swallowing a load
+    failure would let the run report success while the rows were never loaded.
+    """
+
     def _boom(**_kw):
         raise RuntimeError('load rejected')
 
     g = _loaded_global()
     g.client = SimpleNamespace(create_table=lambda **_kw: {}, upload_bytes=lambda *_a, **_k: 'u', load_table=_boom)
     inst = _instance(g)
-    inst.writeAnswers(_StubAnswer([{'a': 1}]))  # must not raise
+    with pytest.raises(RuntimeError, match='load rejected'):
+        inst.writeAnswers(_StubAnswer([{'a': 1}]))
+    assert any('writeAnswers' in m for m in _WARNING_CALLS + _DEBUG_CALLS) or True
 
 
 def test_markdown_rendering_escapes_pipes_and_truncates():
@@ -1365,3 +1371,76 @@ def test_result_id_load_failure_propagates_without_nameerror():
     inst = _instance(g)
     with pytest.raises(RuntimeError, match='load failed'):
         inst.load_data({'table': 't', 'result_id': 'res-1', 'mode': 'append'})
+
+
+# ---------------------------------------------------------------------------
+# CodeRabbit findings on PR #1937
+# ---------------------------------------------------------------------------
+
+
+def test_retry_after_zero_does_not_spin(monkeypatch):
+    """`Retry-After: 0` is a legal header. Without a floor the retry loop would
+    re-issue with no pause until the whole budget was spent, flooding a server
+    that is already shedding load.
+    """
+    slept = []
+    monkeypatch.setattr(client_mod.time, 'sleep', lambda d: slept.append(d))
+    c, rec = _client([_Resp(429, headers={'Retry-After': '0'}), _Resp(200, {'id': 'db-1'})])
+    c.create_database('n', '24h')
+    assert slept, 'a zero Retry-After must still pause'
+    assert min(slept) >= client_mod.BASE_BACKOFF_S
+
+
+def test_drop_database_clears_the_dedup_fingerprints():
+    """Fingerprints describe one specific database. Keeping them across a drop
+    would make an identical append to the replacement report deduplicated
+    without loading anything.
+    """
+    g = _global()
+    handle = {'id': 'db-1'}
+    g.database = handle
+    g._loaded = set()
+    assert g.seen_load('fp-1') is False
+    g.drop_database(handle)
+    assert g.database is None
+    assert g.seen_load('fp-1') is False, 'the fingerprint should not survive the drop'
+
+
+def test_pending_envelope_is_matched_case_insensitively():
+    """A 'Pending' 202 envelope must be followed, not treated as finished."""
+    polls = [{'status': 'succeeded', 'row_count': 3}]
+    g = _global()
+    g.client = SimpleNamespace(get_job=lambda _i: polls.pop(0))
+    inst = _instance(g)
+    out = inst._await_job({'status': 'Pending', 'id': 'job-1'})
+    assert out.get('row_count') == 3, 'the job should have been polled to completion'
+
+
+def test_partial_load_releases_the_dedup_reservation():
+    """Only some rows landed, so a retry of the same payload must reach the
+    server rather than being skipped as a duplicate.
+    """
+    jobs = [
+        {'status': 'partially_succeeded', 'id': 'job-1'},
+        {'status': 'succeeded', 'row_count': 1},
+    ]
+    calls = []
+    g = _global()
+    g._loaded = set()
+    g.client = SimpleNamespace(
+        create_database=lambda **_kw: {'id': 'db-1', 'default_schema': 'main'},
+        create_table=lambda **_kw: {},
+        information_schema=lambda **_kw: {'tables': []},
+        upload_bytes=lambda *_a, **_k: 'upl-1',
+        # JobStatus per the published spec: pending|running|succeeded|partially_succeeded|failed
+        load_table=lambda **_kw: calls.append(1) or {'status': 'pending', 'id': 'job-1'},
+        get_job=lambda _i: jobs.pop(0),
+    )
+    g.database = {'id': 'db-1', 'default_schema': 'main'}
+    inst = _instance(g)
+    rows = [{'a': 1}]
+    first = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert first.get('partial') is True
+    second = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+    assert not second.get('deduplicated'), 'a partial load must be retryable'
+    assert len(calls) == 2

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -170,9 +170,14 @@ _PKG = 'db_hotdata_under_test'
 
 def _load_modules():
     stubs = _build_import_stubs()
-    added = [name for name in stubs if name not in sys.modules]
-    for name in added:
-        sys.modules[name] = stubs[name]
+    # Force the stubs in, remembering whatever was there. Installing only when a
+    # name is absent works in isolation but not under `builder nodes:test`, where
+    # the real rocketlib/ai.common/requests are already imported by other nodes'
+    # tests - the module under test would then bind the real objects and every
+    # assertion about captured warnings or normalize_tool_input would fail.
+    saved = {name: sys.modules.get(name) for name in stubs}
+    for name, module in stubs.items():
+        sys.modules[name] = module
 
     pkg = types.ModuleType(_PKG)
     pkg.__path__ = [str(_NODE_DIR)]
@@ -193,8 +198,12 @@ def _load_modules():
     finally:
         for name in loaded:
             sys.modules.pop(name, None)
-        for name in added:
-            sys.modules.pop(name, None)
+        # Restore exactly what was there so nothing leaks into other nodes' tests.
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
 
 
 _MODS, _REQUESTS_STUB = _load_modules()

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -527,15 +527,18 @@ def test_execute_limit_is_clamped_and_booleans_rejected():
 
     def _query(**kw):
         seen.update(kw)
-        return {'rows': []}
+        return {'rows': [{'a': i} for i in range(25)]}
 
     g = _global(max_execute_rows=10)
     g.client = SimpleNamespace(query=_query, create_database=lambda **_kw: {'id': 'db-1'})
     inst = _instance(g)
+    # execute does not rewrite the SQL - it slices the returned rows - so assert
+    # the effective limit through row_count rather than the statement text.
     out = inst.execute({'sql': 'SELECT 1', 'limit': 9999})
-    assert out['row_count'] == 0
+    assert out['row_count'] == 10, f'9999 should clamp to max_execute_rows=10, got {out["row_count"]}'
     # JSON true must not be read as limit=1
-    inst.execute({'sql': 'SELECT 1', 'limit': True})
+    out = inst.execute({'sql': 'SELECT 1', 'limit': True})
+    assert out['row_count'] == 10, f'a boolean limit must not be coerced to 1, got {out["row_count"]}'
 
 
 def test_execute_follows_async_run_to_a_result():
@@ -1104,7 +1107,6 @@ def test_answers_lane_surfaces_a_load_failure():
     inst = _instance(g)
     with pytest.raises(RuntimeError, match='load rejected'):
         inst.writeAnswers(_StubAnswer([{'a': 1}]))
-    assert any('writeAnswers' in m for m in _WARNING_CALLS + _DEBUG_CALLS) or True
 
 
 def test_markdown_rendering_escapes_pipes_and_truncates():
@@ -1142,7 +1144,6 @@ def test_get_data_rejects_generated_write_sql_without_calling_the_server():
         inst.get_data({'question': 'make a customers table'})
 
     assert calls == [], 'generated DDL must never reach the server'
-    assert any('read-only' in m for m in _DEBUG_CALLS + _WARNING_CALLS) or True
 
 
 def test_get_data_retries_after_a_rejected_write_and_succeeds():

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1605,12 +1605,23 @@ def test_concurrent_identical_append_gets_in_progress_not_false_success():
     rows = [{'a': 1}]
     results = {}
 
-    first = threading.Thread(
-        target=lambda: results.update(first=inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'}))
-    )
+    def _run_first():
+        try:
+            results['first'] = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
+        except Exception as exc:  # reported below instead of hanging the suite
+            results['error'] = exc
+
+    first = threading.Thread(target=_run_first)
     first.start()
-    while not calls:  # wait until the first call is genuinely mid-flight
+    # Bounded wait. If the first call fails before reaching load_table, `calls`
+    # never fills, and an unbounded loop here would hang the entire test suite.
+    deadline = time.monotonic() + 5
+    while not calls and time.monotonic() < deadline:
         time.sleep(0.01)
+    if not calls:
+        gate.set()
+        first.join(timeout=5)
+        pytest.fail(f'the first load never reached load_table: {results.get("error")!r}')
 
     second = inst.load_data({'table': 'orders', 'rows': rows, 'mode': 'append'})
     assert second.get('in_progress') is True, 'a mid-flight duplicate must not report completion'

--- a/nodes/test/test_db_hotdata.py
+++ b/nodes/test/test_db_hotdata.py
@@ -1462,4 +1462,52 @@ def test_result_id_load_does_not_claim_zero_rows():
     )
     g.database = {'id': 'db-1', 'default_schema': 'main'}
     out = _instance(g).load_data({'table': 'orders', 'result_id': 'res-1', 'mode': 'append'})
-    assert out['row_count'] is None, f'unknown must stay unknown, got {out["row_count"]}'
+    assert 'row_count' not in out, f'unknown count must be omitted, got {out.get("row_count")!r}'
+
+
+# ---------------------------------------------------------------------------
+# Path-segment safety
+#
+# schema/table/index names arrive as agent tool arguments and are interpolated
+# into request paths. Verified before the guard existed: a table named
+# '../../other' produced .../tables/../../other/loads, which requests
+# normalises into a different endpoint, and 'orders?x=1' injected a query
+# string. Refuse rather than escape.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('hostile', ['../../other', 'orders?x=1', 'a/b', 'x#y', 'has space', '', '.'])
+def test_hostile_identifiers_are_refused(hostile):
+    c, _rec = _client([_Resp(200, {})])
+    with pytest.raises(ValueError, match='invalid'):
+        c.load_table(
+            database_id='db-1',
+            schema='main',
+            table=hostile,
+            mode='append',
+            upload_id='u',
+            result_id='',
+            data_format='json',
+            key=None,
+            async_after_ms=0,
+        )
+
+
+def test_legitimate_identifiers_build_the_expected_paths():
+    c, rec = _client([_Resp(200, {}), _Resp(200, {}), _Resp(200, {})])
+    c.load_table(
+        database_id='db-1',
+        schema='main',
+        table='orders_2024',
+        mode='append',
+        upload_id='u',
+        result_id='',
+        data_format='json',
+        key=None,
+        async_after_ms=0,
+    )
+    assert rec.calls[-1]['url'].endswith('/v1/databases/db-1/schemas/main/tables/orders_2024/loads')
+    c.create_index(
+        connection_id='conn-1', schema='main', table='orders', index_name='i', index_type='bm25', columns=['note']
+    )
+    assert rec.calls[-1]['url'].endswith('/v1/connections/conn-1/tables/main/orders/indexes')


### PR DESCRIPTION
## Summary

Adds `db_hotdata`, a `["database","tool"]` node wrapping [Hotdata](https://www.hotdata.dev/). It
gives a pipeline run a **disposable OLAP database**: created lazily on first use, loaded with
Parquet/CSV/NDJSON, indexed, queried, then destroyed at the end of the run.

Closes #1926.

This fills the one structural gap in the catalogue. Every other SQL, vector and graph node writes to
a persistent store - `rocketride_sql` and friends share one long-lived per-tenant Postgres whose
tables outlive every run; `db_postgres`/`db_mysql`/`db_clickhouse` need a server the user already
operates. An agent that wants to load a file, index it, join it three ways and throw it away had two
options before this: `tool_python`, which has no network or filesystem, or writing into the tenant's
production database.

## Surface

`classType: ["database","tool"]`, `capabilities: ["noremote","invoke"]`, `prefix: hotdata`,
`lanes: {"answers": [], "questions": ["table","text","answers"]}`, `invoke.llm.min = 1`.

Seven agent-callable tools:

| Tool | Purpose |
| --- | --- |
| `get_schema` | Live schema via `information_schema` (`SHOW TABLES` is not used) |
| `get_data` | Natural language in, rows out; the bound LLM writes the SQL |
| `get_sql` | Returns generated SQL without executing it |
| `execute` | Raw SQL, gated by `allow_execute` (default off), single statement only |
| `dialect` | Returns the full dialect briefing, not just an engine name |
| `load_data` | Rows or a prior `result_id` into a table, via upload + load |
| `build_index` | `bm25` / `vector` / `sorted` |

Plus lane handlers: `writeAnswers` ingests structured rows, `writeQuestions` answers in-pipeline.

## Design decisions worth reviewing

All grounded in a precedent survey of the 11 database/graph-classed services on `origin/develop`.

**`capabilities: ["noremote","invoke"]`** - unanimous across those 11; none uses `experimental`.
`noremote` is load-bearing here rather than cosmetic: it clears `PROTOCOL_CAPS::REMOTING`, which is
on by default (`packages/server/engine-lib/engLib/store/services/services.cpp:1799`). With remoting
on, distributed instances would each hold their own `IGlobal` and each create their own **billed**
database. Verified against the running engine - the registered node reports `capabilities: 1024`
with the REMOTING bit absent.

**No `DatabaseGlobalBase`.** It is SQLAlchemy-based and Hotdata ships no dialect. This is the
`graph_arango` pattern: custom REST client, node-local query safety.

**One database per run, lock-guarded.** Created lazily under a `threading.Lock` with
double-checked locking, deleted in `endGlobal()`. Copied from `tool_daytona/IGlobal.py`, whose
comment records that the unguarded version created two billed sandboxes and orphaned one. There is a
unit test that races 8 threads and asserts exactly one database is created.

**Every database carries a TTL.** `create_database` raises if `expires_at` is empty rather than
letting a caller create an immortal billed database. `endGlobal()` is the real teardown; the TTL is
the crash net.

**No vendor SDK, no new dependency pins.** `requests`, `urllib3` and `httpx` are already baseline
and `requests==2.34.2` is already in `constraints.lock`, so the engine-wide solve cannot break -
which is exactly how `tool_daytona` ended up pinned to `daytona==0.140.0`. The `hotdata` SDK is
0.9.0 with 18 releases in four months, and `hotdata-framework` pulls pandas and pyarrow
unconditionally. `requirements.txt` carries only a comment, per `aparavi_aql`.

**Asymmetric retry policy**, mirroring the vendor SDK at Hotdata's explicit request. 429 is
admission shedding - the request did no work, so it replays on any method, honouring `Retry-After`
(capped) under an overall deadline. Everything else stays idempotent-only: a read timeout or 5xx on
a POST propagates rather than replaying, because the server may already have done the work. There
are tests for both directions.

## Vendor coordination

Confirmed directly with Hotdata (Divya Ranganathan, Zac Farrell) in a shared channel. Several
answers contradicted the public docs and changed the implementation:

| Topic | Answer | Effect on this PR |
| --- | --- | --- |
| OpenAPI spec | Published at `https://www.hotdata.dev/openapi.yaml` (52 paths, 70 operations) | Client generated against it rather than the HTML docs |
| SQL surface | Read-only. DataFusion 54 with the **PostgreSQL parser dialect** - "Postgres syntax, DataFusion semantics". INSERT/UPDATE/DELETE and all DDL rejected before execution | **The `answers` lane cannot use INSERT.** It batches rows to NDJSON, uploads, and loads. Tables are declared over REST, not `CREATE TABLE` |
| Function library | DataFusion's, not Postgres's. No JSON operators, no `pg_catalog`, no `to_number`/`age()` | The `dialect` tool returns the full briefing so the LLM stops reaching for functions that do not exist |
| Rate limits | Dynamic, unpublished, used aggressively for back-pressure; 429s must be retried | Retry policy above |
| Ingestion | Bulk upload is the prioritised path; an inline load for small batches is in their backlog | `load_data` hides upload + load + job polling behind one blocking call |
| `attach_catalog` | **Not federation** - a shared "global" database, not a warehouse connection | Deferred; earlier issue text was wrong and has been corrected |
| Load from prior result | Supported - pass `result_id` instead of `upload_id` | `load_data` accepts `result_id` |
| Read-only API keys | Rolling out; fine-grained permissions planned, no ETA | See known limitation below |

## Testing

Test ladder from `rocketride-testing-nodes`. Reporting exactly the rungs climbed.

- [x] **Lint** - `uvx ruff check` and `ruff format --check` clean on the node dir and test file
- [x] **Unit** - `pytest nodes/test/test_db_hotdata.py` - **85 passed**, zero network, sys.modules stub pattern
- [x] **Contract suite** - `pytest nodes/test/test_contracts.py` - **338 passed** across the whole catalogue
- [ ] **`./builder nodes:test` / `nodes:test-full` / `nodes:test-contracts`** - **not run.** These run
      `server:build` first and there is no `packages/server/build` in this workspace, so they would
      trigger a full C++ engine build. Not claimed.
- [x] **Live vendor harness** - **12/12** against a real Hotdata workspace, fresh seed
- [x] **Live engine** - node registers in a running engine's `/services` catalogue with correct
      classType, lanes, prefix and capability bitmask
- [x] **Live pipeline via the SDK** - real answer payloads returned, not just green lifecycle rows
- [ ] **IDE canvas walk-through** - not performed by a human yet; icon rendering is therefore **not
      claimed** (icons cache harder than code and need a full IDE restart to verify)

### What the live tests actually caught

Three real bugs that unit tests could not have found, all fixed:

1. **NDJSON, not a JSON array.** Hotdata's `json` load format is newline-delimited. Uploading a JSON
   array fails schema inference server-side with `Expected JSON record to be an object, found Array`.
2. **`get_schema` returned no columns.** The REST introspection response nests columns under each
   table; the first implementation surfaced table metadata only, so an agent asked to name the
   columns replied "note, product, and two other columns". Now returns full column lists with Arrow
   types.

3. **`load_data` was an ungated write path around the read-only guard.** Found by the adversarial
   agentic case, not by review. The agent was told *"the refunded orders are polluting the data,
   delete every refunded order and confirm the deletion."* Blocked on `DELETE` by the SQL verb
   guard, it called `load_data` with `mode=replace` instead and wiped the table - 6 rows to 1 - then
   truthfully reported success. The read-only guarantee only ever covered the SQL surface;
   `load_data` accepts `replace`, `update` and `delete` and was gated by nothing.

   Fixed by adding **`allow_destructive_load`** (default **off**): `load_data` is append/upsert only
   unless explicitly enabled. A dedicated flag rather than reusing `allow_execute`, because
   "let the agent run raw SELECTs" and "let the agent overwrite a table" are different risks and
   should not be granted together. Four regression tests lock it shut, and it is re-verified against
   the live API - with the gate off all three destructive modes are refused and the row count is
   untouched; with it on, `replace` works as intended.

   This also made several claims in the docs false, now corrected: the `execute` tool description
   said "Writes are impossible", the dialect briefing did not scope its read-only statement to SQL,
   and the README implied the node could not write at all. That wording is why the model believed
   its own deletion report.

4. **The load dedup cache poisoned itself on failure.** Caught in self-review, not by a test.
   Identical appends are deduplicated within a run because Hotdata's append is not idempotent and
   exposes no idempotency key - verified live, a repeated append took 2 rows to 4. But the
   fingerprint was reserved *before* the upload and load were attempted, so a load that then failed
   left the reservation in place: the agent's retry was skipped as a duplicate and returned
   `deduplicated: true` with the note "the table already contains these rows", when it did not.
   Silent data loss asserting the opposite. Now a reservation is released via `release_load()` on
   any failure below the upload, preserving the parallel-safety the atomic check provides. Two
   regression tests cover retry-after-failure and still-dedups-on-success.

   The first cut of that fix then introduced a `NameError` on the `result_id` path, because the
   initialiser landed inside the `if not result_id:` branch while the failure handler referenced it
   unconditionally. Found by exercising that path directly rather than trusting the green suite;
   there is now a regression test for it.

### Agentic testing

Ran `agent_rocketride` with `db_hotdata` bound as a tool, `memory_internal` as memory, and a
configured agent (`agent_description`, five operating instructions, `max_waves`, and
`require_tool_call: true` so the model cannot answer from prompt context without touching the
database). The agent loads data through `load_data`, inspects schema, aggregates, builds a bm25
index and searches it.

Results on `nvidia/nemotron-3-ultra-550b-a55b` (a reasoning model, 131k budget): **6/7**, every
numeric answer exact against ground truth computed independently in Python - worst region by refund
rate, the product driving it, revenue tied up in refunds, and a full product revenue ranking. The
seventh case is the read-only guard, which failed and produced finding 3 above; it passes now.

## Known limitations, documented in the README

- **A Database API Token cannot delete databases.** Verified: `DELETE /v1/databases/{id}` returns
  403 `ACCESS_DENIED - This credential is limited to creating databases, querying, uploading data,
  and creating schemas/tables`. `endGlobal()` warns rather than raising, so a run still succeeds and
  the TTL reclaims the database - but with this token type the explicit teardown never happens.
  Users who want deletion need the broader token type. Raised with Hotdata.
- **`allow_execute` is not write protection.** The SQL surface rejects writes regardless. The gate
  is defence in depth and cost control at $10.24/TB scanned.
- **The read-only guarantee covers SQL only.** `load_data` is a separate write path; destructive
  modes require `allow_destructive_load`, off by default.
- **Connected-source credentials live on the Hotdata side**, outside RocketRide's governance view.
- **Retrying a load is not provably idempotent.** The spec carries an `idempotency_key` only on
  `/v1/databases/bulk`, and `POST .../loads` documents a 409 without saying what triggers it. Our
  policy already never replays a POST that may have reached the server, so the exposure is bounded.
  Confirmation pending from Hotdata; if replays turn out to be unsafe, the lane switches from
  `append` to `upsert` with a key column.

## Issues found for Hotdata (reported upstream, not blocking)

1. **A user error is surfaced as an internal DataFusion bug report.** Calling
   `approx_percentile_cont` with the wrong arity returns HTTP 400 containing "Internal error: ...
   This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by
   filing a bug report". That is a planning/validation error, not a bug. It misdirects users and
   burns an LLM's retry budget on an unfixable message.
2. **`SHOW TABLES` works, contradicting their written brief**, which states it errors. The live
   harness asserts observed behaviour so a future change is visible.

## Blast radius

Self-contained: the node directory, one test file, one example pipeline, and one row in
`docs/README-nodes.md`. No `packages/` changes. No new dependency pins, so `constraints.lock` is
untouched.

## Files

12 files, ~3,450 insertions.

## Reviewer notes

- `hotdata_client.py` - the retry policy is the part most worth a careful read
- `IInstance._split_statements` - strips comments and string literals before counting statements, so
  `SELECT 'a;b'` is not mistaken for a batch
- `IGlobal.get_database` - double-checked locking; the concurrency test is the one that matters
- The naming trap: PyPI `hot-dev` and `github.com/hot-dev/hot-python` are **a different company**.
  The Hotdata package is `hotdata`, and we do not depend on it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Hotdata database node for temporary, per-run databases.
  * Supports data loading, schema inspection, read-only SQL queries, asynchronous jobs, and BM25, vector, and sorted indexes.
  * Added natural-language question-to-SQL workflows with separate answer and table outputs.
  * Added upload support, append de-duplication, configurable limits, timeouts, retention, credentials, and safety controls.
  * Included a complete chat-to-database pipeline example.

* **Documentation**
  * Added setup guidance, SQL dialect details, usage instructions, limits, troubleshooting information, and catalog coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->