### PR TITLE
fix #1919 : Hand-crafted (non-canvas; Cursor Agent ) pipeline does not show up on canvas.

### DIFF
--- a/apps/vscode/src/extension.ts
+++ b/apps/vscode/src/extension.ts
@@ -554,7 +554,11 @@ function registerUtilityCommands(context: vscode.ExtensionContext): void {
 				uri = vscode.Uri.file(filePath);
 			} else {
 				const folders = vscode.workspace.workspaceFolders;
-				uri = folders?.length ? vscode.Uri.joinPath(folders[0].uri, filePath) : vscode.Uri.file(filePath);
+				if (folders?.length) {
+					uri = vscode.Uri.file(path.resolve(folders[0].uri.fsPath, filePath));
+				} else {
+					uri = vscode.Uri.file(filePath);
+				}
 			}
 			try {
 				const doc = await vscode.workspace.openTextDocument(uri);

--- a/apps/vscode/src/providers/SidebarProvider.ts
+++ b/apps/vscode/src/providers/SidebarProvider.ts
@@ -717,7 +717,10 @@ export class SidebarProvider implements vscode.WebviewViewProvider {
 	private resolveFileUri(filePath: string): vscode.Uri {
 		if (path.isAbsolute(filePath)) return vscode.Uri.file(filePath);
 		const folders = vscode.workspace.workspaceFolders;
-		if (folders?.length) return vscode.Uri.joinPath(folders[0].uri, filePath);
+		if (folders?.length) {
+			const absolutePath = path.resolve(folders[0].uri.fsPath, filePath);
+			return vscode.Uri.file(absolutePath);
+		}
 		return vscode.Uri.file(filePath);
 	}
 


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- On Windows operating systems (in vscode or cursor), the workspace root URI  (folders[0].uri) contains a percent-encoded drive letter colon (e.g., file:///c%3A/sac/... where %3A stands for :).

- Since the URI file:///c%3A/... does not match the normalized URI structure file:///c:/... stored in VS Code's internal document registry, it throws: Error: Unable to retrieve document.....)

- This PR modifies resolveFileUri to resolve relative file paths relative to folders[0].uri.fsPath using path.resolve, then wrapping it in vscode.Uri.file. This ensures Windows drive colons are normalized and not encoded as %3A.

- and modifies the rocketride.sidebar.files.openFileAtLine command handler to similarly resolve relative paths into normalized absolute file URIs rather than using vscode.Uri.joinPath.




## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->
Fixes #1919

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved opening files from the sidebar when paths are relative.
  * Relative file paths now resolve correctly from the first workspace folder.
  * Absolute paths and projects without an open workspace continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->