### PR TITLE
chore(security): raise brace-expansion and fast-uri floors past CVE fix versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,11 @@ settings:
 overrides:
   shell: workspace:*
   '@remix-run/router': '>=1.23.2 <2'
-  brace-expansion: '>=5.0.5 <6'
+  brace-expansion: '>=5.0.7 <6'
   minimatch@3>brace-expansion: '>=1.1.12 <2'
   diff@7: '>=8.0.3 <9'
   dompurify: '>=3.4.9 <3.5.0'
+  fast-uri: '>=3.1.5 <4'
   glob: '>=11.1.0'
   joi: '>=18.2.1 <19'
   js-yaml: '>=4.2.0 <5'
@@ -5519,9 +5520,9 @@ packages:
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -6868,8 +6869,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -17791,7 +17792,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -18185,7 +18186,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -19757,7 +19758,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.20.1:
     dependencies:
@@ -22349,7 +22350,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -22357,7 +22358,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,7 +54,7 @@ packages:
 overrides:
   shell: 'workspace:*'
   '@remix-run/router': '>=1.23.2 <2'
-  brace-expansion: '>=5.0.5 <6'
+  brace-expansion: '>=5.0.7 <6'
   # minimatch 3.x (eslint's config-array, glob@7) does a CJS default-import of
   # brace-expansion; v5's commonjs build exports named {expand} only, so the
   # global floor crashes every minimatch@3 consumer ("expand is not a
@@ -63,6 +63,7 @@ overrides:
   'minimatch@3>brace-expansion': '>=1.1.12 <2'
   'diff@7': '>=8.0.3 <9'
   dompurify: '>=3.4.9 <3.5.0'
+  fast-uri: '>=3.1.5 <4'
   glob: '>=11.1.0'
   joi: '>=18.2.1 <19'
   js-yaml: '>=4.2.0 <5'


### PR DESCRIPTION
## Summary

Same pattern as the recently-merged undici floor bump (#1948). Two changes in `pnpm-workspace.yaml`:

- **`brace-expansion`**: floor bumped from `>=5.0.5` to `>=5.0.7`. The v5 line was vulnerable up to 5.0.6 (CVE patched at 5.0.7). The existing scoped `minimatch@3>brace-expansion` pin at `>=1.1.12 <2` is unaffected: the advisory range starts at 3.0.0.
- **`fast-uri`**: added at `>=3.1.5 <4`. Three open advisories all patched at or before 3.1.5; the natural resolution was landing at 3.1.2.

## Verification

Regenerated `pnpm-lock.yaml` with `pnpm install --lockfile-only`:

- `fast-uri` resolves to 3.1.5 (was 3.1.2)
- `brace-expansion` (v5 branch) resolves to 5.0.9 (was 5.0.6) in the two places it appears
- `brace-expansion` v1 branch under `minimatch@3` unchanged at 1.1.18 (already above the 1.x fix at 1.1.12)
- `lockfileVersion` still 9.0
- Overrides count went from 19 to 20 (only `fast-uri` added, no regen dropping other CVE pins)

## Alerts closed

- 3 `fast-uri` high-severity alerts on `pnpm-lock.yaml` (#244, #249, #307)
- 1 `brace-expansion` high-severity alert on `pnpm-lock.yaml` (#231)

## Test plan

- [ ] CI green (in particular `n8n-nodes CI` shouldn't regress; this only touches root workspace)
- [ ] After merge, verify Dependabot re-scan closes the 4 alerts above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version constraints for improved compatibility and security.
  * Added a minimum supported version for URI handling dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->