### PR TITLE
fix(store_weaviate): align preconfig default with the profile field default

### DIFF
--- a/nodes/src/nodes/store_weaviate/README.md
+++ b/nodes/src/nodes/store_weaviate/README.md
@@ -56,7 +56,7 @@ Each ingested chunk is stored with these properties alongside its vector: `conte
 | Weaviate cloud server      | `cloud` | _(your Weaviate Cloud endpoint)_ | `443`  |
 | Your own Weaviate server   | `local` | `localhost`                      | `8080` |
 
-The preconfig default profile is `cloud`. The cloud profile exposes host, API key, score, and collection; the local profile exposes host, port, gRPC port, score, and collection.
+The default profile is `local`, both for a config that names no profile and for a node dropped in the editor. The cloud profile exposes host, API key, score, and collection; the local profile exposes host, port, gRPC port, score, and collection.
 
 ---
 

--- a/nodes/src/nodes/store_weaviate/services.json
+++ b/nodes/src/nodes/store_weaviate/services.json
@@ -132,7 +132,10 @@
 	"preconfig": {
 		// Define the values that will be merged into any profile configuration
 		// specified, unless the profile is 'absolute'
-		"default": "cloud",
+		// Must match the "weaviate.profile" field default below: this one is the
+		// fallback for a config that carries no "profile" key, that one is what
+		// the editor writes into a fresh node. They describe the same choice.
+		"default": "local",
 		// Defines profiles used with the "profile": key
 		"profiles": {
 			"local": {

--- a/nodes/test/store_weaviate/test_services_profile_default.py
+++ b/nodes/test/store_weaviate/test_services_profile_default.py
@@ -1,0 +1,91 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""services.json invariants for the Weaviate store node.
+
+The node declares its connection profile twice: `preconfig.default` is the
+fallback when a config carries no `profile` key, and `weaviate.profile.default`
+is what the editor writes into a fresh node. Both describe the same choice, so
+they must agree — otherwise which one a user lands on depends on how the config
+reached the node (see #1777).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+_NODE_DIR = Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'store_weaviate'
+_SERVICES_PATH = _NODE_DIR / 'services.json'
+
+
+def _strip_jsonc(raw: str) -> str:
+    """Drop // and /* */ comments, leaving comment-like text inside strings alone.
+
+    services.json is JSONC, and `//` also occurs inside real values (the
+    `documentation` URL), so this tracks string state rather than pattern-matching.
+    """
+    out: list[str] = []
+    i, n = 0, len(raw)
+    in_string = False
+    while i < n:
+        ch = raw[i]
+        if in_string:
+            out.append(ch)
+            if ch == '\\' and i + 1 < n:
+                out.append(raw[i + 1])
+                i += 2
+                continue
+            if ch == '"':
+                in_string = False
+            i += 1
+        elif ch == '"':
+            in_string = True
+            out.append(ch)
+            i += 1
+        elif raw.startswith('//', i):
+            i = raw.find('\n', i)
+            if i == -1:
+                break
+        elif raw.startswith('/*', i):
+            end = raw.find('*/', i + 2)
+            i = n if end == -1 else end + 2
+        else:
+            out.append(ch)
+            i += 1
+    return ''.join(out)
+
+
+def _services() -> dict:
+    return json.loads(_strip_jsonc(_SERVICES_PATH.read_text(encoding='utf-8')))
+
+
+def test_preconfig_default_matches_profile_field_default():
+    svc = _services()
+    preconfig_default = svc['preconfig']['default']
+    field_default = svc['fields']['weaviate.profile']['default']
+    assert preconfig_default == field_default, (
+        f'preconfig.default is {preconfig_default!r} but weaviate.profile.default is '
+        f'{field_default!r}; the connection profile a user gets would depend on whether '
+        f'it arrived via preconfig or fell through to the field default'
+    )
+
+
+def test_default_profile_exists_and_can_connect_unconfigured():
+    """The default profile must ship a usable host, not an empty one to fill in."""
+    svc = _services()
+    profiles = svc['preconfig']['profiles']
+    default = svc['preconfig']['default']
+    assert default in profiles, f'default profile {default!r} is not defined'
+    assert profiles[default].get('host'), (
+        f'default profile {default!r} ships an empty host, so an unconfigured node cannot connect'
+    )
+
+
+def test_every_profile_choice_is_reachable_from_the_field():
+    """Each preconfig profile needs a conditional branch, or its fields never render."""
+    svc = _services()
+    branches = {c['value'] for c in svc['fields']['weaviate.profile']['conditional']}
+    assert branches == set(svc['preconfig']['profiles'])

--- a/nodes/test/store_weaviate/test_services_profile_default.py
+++ b/nodes/test/store_weaviate/test_services_profile_default.py
@@ -79,7 +79,10 @@ def test_default_profile_exists_and_can_connect_unconfigured():
     profiles = svc['preconfig']['profiles']
     default = svc['preconfig']['default']
     assert default in profiles, f'default profile {default!r} is not defined'
-    assert profiles[default].get('host'), (
+    # weaviate.py strips the host before use, so a whitespace-only value is as
+    # unusable as an empty one — check what the runtime would actually see.
+    host = profiles[default].get('host')
+    assert isinstance(host, str) and host.strip(), (
         f'default profile {default!r} ships an empty host, so an unconfigured node cannot connect'
     )
 


### PR DESCRIPTION
## Summary

- `store_weaviate/services.json` declared the node's connection profile twice, to different values: `preconfig.default` was `"cloud"` while `weaviate.profile.default` was `"local"`. Set both to `local`.
- Added `services.json` invariant tests so the two cannot drift apart again.
- Updated the hand-written README prose that documented the old value. The generated params block is unaffected — `nodes:docs-generate` reads field defaults only (`gen-node-tables.mjs:123`), and the field default is unchanged.

## Why `local`

The issue deliberately left the direction open, since it is a behaviour decision rather than something the schema settles on its own. The evidence points one way:

- The `cloud` profile ships `host: ""` and `apikey: ""`. Falling back to it hands an unconfigured node a config that **cannot** connect. The `local` profile ships `localhost:8080`, which works against a stock Weaviate.
- `local` is already what the editor writes into a fresh node and what the generated README params table documents. Aligning `preconfig.default` to it makes the two paths agree on the behaviour users already observe, rather than changing that behaviour.
- The node's own `test.profiles` is `["local"]`.

For context on why the two entry points differ at all: `preconfig.default` is the fallback used when a config carries no `profile` key (`packages/ai/src/ai/common/config.py:142`), whereas `weaviate.profile.default` is the schema default the editor pre-fills. A hand-written `.pipe` therefore resolved to `cloud` while an editor-created one resolved to `local`.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`nodes/test/store_weaviate/test_services_profile_default.py` — 3 tests, all passing. I reverted the schema change and confirmed 2 of the 3 fail on the pre-fix file, so they are not vacuous:

```
AssertionError: preconfig.default is 'cloud' but weaviate.profile.default is 'local'; ...
AssertionError: default profile 'cloud' ships an empty host, so an unconfigured node cannot connect
```

The tests parse `services.json` directly and import nothing from the node, so they run without a built engine. `ruff check` and `ruff format --check` are clean on the new file.

I did not run the full `./builder test` — it needs the built engine, which I do not have set up locally. The sibling `test_record_updates.py` fails in my environment on a missing `depends` module, pre-existing and unrelated to this change.

One pre-existing note: `prettier --check` already flagged `store_weaviate/README.md` before this change (table alignment). I left it rather than mix an unrelated reformat into this diff.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable) — none. This aligns the schema with the default users already get from the editor; it does not change what an existing `.pipe` with an explicit `profile` key does.

## Note for reviewers

While checking whether this pattern was isolated, I scanned all 39 profile-bearing nodes. Three others have the same contradiction and are **not** touched here, since each is its own behaviour decision:

| Node | `preconfig.default` | field default |
| --- | --- | --- |
| `store_chroma` | `local` | `cloud` |
| `store_pinecone` | `serverless-dense` | `pod-based` |
| `anonymize` | `glinerSmall` | `glinerMergedLarge` |

The invariant test added here is written per-node, but would generalise to a cross-node test once those three are settled. Filed separately as a follow-up.

## Linked Issue

Fixes #1777


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Weaviate configurations and newly added nodes now default to the local profile instead of the cloud profile.
  - Existing profile-specific settings remain unchanged.

- **Bug Fixes**
  - Improved consistency between editor defaults and service preconfigurations.
  - Added validation to ensure the default profile has valid connection details.
  - Confirmed that all configured profiles are properly supported and reachable through their available settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->