### PR TITLE
fix: duplicate node from overflow menu

### DIFF
--- a/apps/shared/src/components/canvas/components/node/node-component/header/NodeHeader.tsx
+++ b/apps/shared/src/components/canvas/components/node/node-component/header/NodeHeader.tsx
@@ -152,7 +152,7 @@ export default function NodeHeader({ id, hideEdit = false, nodeType, icon, title
 		{
 			...duplicate,
 			handleClick: () => {
-				copy();
+				copy([id]);
 				paste();
 			},
 			disabled: !!actionsPanelType || isLocked,

--- a/apps/shared/src/components/canvas/hooks/useCopyPaste.test.ts
+++ b/apps/shared/src/components/canvas/hooks/useCopyPaste.test.ts
@@ -1,0 +1,43 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG Inc.
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { Node } from '@xyflow/react';
+
+import { getNodesToCopy } from './useCopyPaste';
+import type { INodeData } from '../types';
+
+type FlowNode = Node<INodeData>;
+
+function node(id: string, selected: boolean): FlowNode {
+	return {
+		id,
+		selected,
+		position: { x: 0, y: 0 },
+		data: { provider: id } as INodeData,
+	};
+}
+
+test('contextual copy targets the overflow-menu node when nothing is selected', () => {
+	const menuNode = node('response_image_1', false);
+	const copied = getNodesToCopy([menuNode, node('parse_1', false)], [menuNode.id]);
+
+	assert.deepEqual(copied.map((candidate) => candidate.id), ['response_image_1']);
+});
+
+test('contextual copy targets the overflow-menu node instead of another selected node', () => {
+	const selectedParse = node('parse_1', true);
+	const menuNode = node('response_text_1', false);
+	const copied = getNodesToCopy([selectedParse, menuNode], [menuNode.id]);
+
+	assert.deepEqual(copied.map((candidate) => candidate.id), ['response_text_1']);
+});
+
+test('copy without an explicit target keeps selection-based behaviour for keyboard copy', () => {
+	const copied = getNodesToCopy([node('parse_1', false), node('response_text_1', true)]);
+
+	assert.deepEqual(copied.map((candidate) => candidate.id), ['response_text_1']);
+});

--- a/apps/shared/src/components/canvas/hooks/useCopyPaste.tsx
+++ b/apps/shared/src/components/canvas/hooks/useCopyPaste.tsx
@@ -29,7 +29,7 @@
  * edges; paste duplicates them with fresh IDs and offset positions.
  */
 
-import { useCallback, useMemo } from 'react';
+import { useCallback } from 'react';
 import { Node, Edge } from '@xyflow/react';
 
 import { useFlow } from './useFlowContext';
@@ -58,24 +58,41 @@ const clipboardRef: { current: { nodes: FlowNode[]; edges: Edge[] } | null } = {
 // =============================================================================
 
 /**
+ * Returns the nodes that should be copied for a copy action.
+ *
+ * A contextual action (such as a node's overflow menu) supplies its node IDs
+ * explicitly so it does not depend on canvas selection. Keyboard copy omits
+ * the argument and retains the normal selection-based behaviour.
+ */
+export function getNodesToCopy(nodes: FlowNode[], nodeIds?: readonly string[]): FlowNode[] {
+	if (nodeIds) {
+		const ids = new Set(nodeIds);
+		return nodes.filter((node) => ids.has(node.id));
+	}
+
+	return nodes.filter((node) => node.selected);
+}
+
+/**
  * Hook that provides a copy handler for the flow canvas.
  *
- * Captures the currently selected nodes and their internal edges into
- * the module-level clipboard.
+ * Captures explicitly targeted nodes, or the current selection when no target
+ * is supplied, and their internal edges into the module-level clipboard.
  *
- * @returns A memoized callback that copies the current selection.
+ * @returns A memoized callback that copies the requested nodes.
  */
 export function useCopy() {
 	const { nodes, edges } = useFlow();
-	const selectedNodes = useMemo(() => nodes.filter((n) => n.selected), [nodes]);
 
-	const copy = useCallback(() => {
-		if (selectedNodes.length === 0) {
+	const copy = useCallback((nodeIds?: readonly string[]) => {
+		const nodesToCopy = getNodesToCopy(nodes, nodeIds);
+
+		if (nodesToCopy.length === 0) {
 			clipboardRef.current = null;
 			return;
 		}
 
-		const selection = [...selectedNodes];
+		const selection = [...nodesToCopy];
 
 		// Build lookup set for fast edge-membership checks
 		const ids = new Set(selection.map((n: FlowNode) => n.id));
@@ -88,7 +105,7 @@ export function useCopy() {
 			nodes: JSON.parse(JSON.stringify(selection)),
 			edges: JSON.parse(JSON.stringify(internalEdges)),
 		};
-	}, [selectedNodes, edges]);
+	}, [nodes, edges]);
 
 	return copy;
 }


### PR DESCRIPTION
## Summary

- Fix node overflow-menu **Duplicate** so it copies the node whose menu was opened.
- Preserve selection-based behavior for normal keyboard copy.
- Add regression coverage for no-selection, wrong-selection, and keyboard-copy cases.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Focused copy/paste regression tests passed (3/3). The full suite is currently blocked locally by the project dependency/build-script setup, before the tests run.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1946

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the duplicate action so it copies the intended node before pasting.
  - Improved contextual copy behavior when duplicating a specific node.
  - Preserved keyboard copy behavior for currently selected nodes.
  - Ensured copied nodes continue to be deep-copied and clipboard contents are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->