### PR TITLE
chore(security): sweep workspace overrides past current CVE fix versions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,15 +6,17 @@ settings:
 
 overrides:
   shell: workspace:*
-  '@remix-run/router': '>=1.23.2 <2'
+  '@remix-run/router': '>=1.23.3 <2'
+  body-parser: '>=1.20.6 <2'
   brace-expansion: '>=5.0.7 <6'
   minimatch@3>brace-expansion: '>=1.1.12 <2'
   diff@7: '>=8.0.3 <9'
-  dompurify: '>=3.4.9 <3.5.0'
+  dompurify: '>=3.4.13 <3.5.0'
   fast-uri: '>=3.1.5 <4'
   glob: '>=11.1.0'
+  immutable: '>=5.1.8 <6'
   joi: '>=18.2.1 <19'
-  js-yaml: '>=4.2.0 <5'
+  js-yaml: '>=4.3.1 <5'
   lodash: '>=4.18.1 <5'
   prismjs: '>=1.30.0 <2'
   react-router: '>=6.30.4 <7'
@@ -22,9 +24,10 @@ overrides:
   react-router-config>react-router: 5.3.4
   react-router-dom@5>react-router: 5.3.4
   serialize-javascript: '>=7.0.5 <8'
+  shell-quote: '>=1.9.0 <2'
   undici: '>=7.29.0 <8'
   uuid: '>=11.1.1 <12'
-  webpack-dev-server: '>=5.2.5 <6'
+  webpack-dev-server: '>=5.2.6 <6'
   ws: '>=8.21.0 <9'
 
 patchedDependencies:
@@ -380,7 +383,7 @@ importers:
         specifier: ^0.3.3
         version: 0.3.7
       dompurify:
-        specifier: '>=3.4.9 <3.5.0'
+        specifier: '>=3.4.13 <3.5.0'
         version: 3.4.13
       monaco-editor:
         specifier: ^0.55.1
@@ -757,8 +760,8 @@ importers:
         specifier: ~0.8.5
         version: 0.8.5
       dompurify:
-        specifier: '>=3.4.9 <3.5.0'
-        version: 3.4.11
+        specifier: '>=3.4.13 <3.5.0'
+        version: 3.4.13
       elkjs:
         specifier: ~0.9.3
         version: 0.9.3
@@ -4101,8 +4104,8 @@ packages:
   '@protobufjs/utf8@1.1.2':
     resolution: {integrity: sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==}
 
-  '@remix-run/router@1.23.2':
-    resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
   '@rjsf/core@5.20.1':
@@ -5493,8 +5496,8 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
-  body-parser@1.20.5:
-    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   bonjour-service@1.4.0:
@@ -6493,9 +6496,6 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
-
   dompurify@3.4.13:
     resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
@@ -7475,8 +7475,8 @@ packages:
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
 
-  immutable@5.1.5:
-    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
+  immutable@5.1.9:
+    resolution: {integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==}
 
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
@@ -8101,8 +8101,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.2.0:
-    resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -10696,7 +10696,7 @@ packages:
       clsx: ~2.1.1
       d3: ~7.9.0
       dagre: ~0.8.5
-      dompurify: '>=3.4.9 <3.5.0'
+      dompurify: '>=3.4.13 <3.5.0'
       elkjs: ~0.9.3
       fuzzysort: ~3.1.0
       html-react-parser: ~5.2.3
@@ -10740,8 +10740,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.4:
-    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+  shell-quote@1.10.0:
+    resolution: {integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==}
     engines: {node: '>= 0.4'}
 
   side-channel-list@1.0.0:
@@ -11687,8 +11687,8 @@ packages:
       webpack:
         optional: true
 
-  webpack-dev-server@5.2.5:
-    resolution: {integrity: sha512-4wZtCquSuv9CKX8oybo+mqxtxZqWz47uM1Ch94lxowBztOhWCbhqvRbfC/mODOwxgV2brY+JGZpHq58/SuVFYg==}
+  webpack-dev-server@5.2.6:
+    resolution: {integrity: sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==}
     engines: {node: '>= 18.12.0'}
     hasBin: true
     peerDependencies:
@@ -13632,7 +13632,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.5(debug@4.4.3)(tslib@2.8.1)(webpack@5.104.1(postcss@8.5.26))
+      webpack-dev-server: 5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack@5.104.1(postcss@8.5.26))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@minify-html/node'
@@ -13701,7 +13701,7 @@ snapshots:
       update-notifier: 6.0.2
       webpack: 5.104.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.5(debug@4.4.3)(tslib@2.8.1)(webpack@5.104.1(postcss@8.5.26))
+      webpack-dev-server: 5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack@5.104.1(postcss@8.5.26))
       webpack-merge: 6.0.1
     transitivePeerDependencies:
       - '@docusaurus/faster'
@@ -13990,7 +13990,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -14036,7 +14036,7 @@ snapshots:
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.5
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -14680,7 +14680,7 @@ snapshots:
       '@docusaurus/utils-common': 3.10.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       joi: 18.2.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -14708,7 +14708,7 @@ snapshots:
       '@docusaurus/utils-common': 3.8.1(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(html-minifier-terser@7.2.0)(postcss@8.5.26)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       joi: 18.2.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -14742,7 +14742,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3(patch_hash=b4537d301adf6274380ff5c1d230529130779eb42a463d26483d7b1c5b9849ce)
       jiti: 1.21.7
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -14783,7 +14783,7 @@ snapshots:
       globby: 11.1.0
       gray-matter: 4.0.3(patch_hash=b4537d301adf6274380ff5c1d230529130779eb42a463d26483d7b1c5b9849ce)
       jiti: 1.21.7
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
@@ -15069,7 +15069,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -15172,7 +15172,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.6': {}
@@ -16460,7 +16460,7 @@ snapshots:
 
   '@protobufjs/utf8@1.1.2': {}
 
-  '@remix-run/router@1.23.2': {}
+  '@remix-run/router@1.23.3': {}
 
   '@rjsf/core@5.20.1(@rjsf/utils@5.20.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -16925,7 +16925,7 @@ snapshots:
       '@textlint/resolver': 15.8.0
       '@textlint/types': 15.8.0
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       pluralize: 2.0.0
       string-width: 4.2.3
@@ -18124,7 +18124,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@1.20.5:
+  body-parser@1.20.6:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
@@ -18551,7 +18551,7 @@ snapshots:
       date-fns: 2.30.0
       lodash: 4.18.1
       rxjs: 7.8.2
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       spawn-command: 0.0.2
       supports-color: 8.1.1
       tree-kill: 1.2.2
@@ -18629,7 +18629,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.6.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -18638,7 +18638,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -19206,10 +19206,6 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
-    optionalDependencies:
-      '@types/trusted-types': 2.0.7
-
   dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
@@ -19704,7 +19700,7 @@ snapshots:
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.5
+      body-parser: 1.20.6
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
@@ -20115,7 +20111,7 @@ snapshots:
 
   gray-matter@4.0.3(patch_hash=b4537d301adf6274380ff5c1d230529130779eb42a463d26483d7b1c5b9849ce):
     dependencies:
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -20496,7 +20492,7 @@ snapshots:
 
   immer@9.0.21: {}
 
-  immutable@5.1.5: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -21392,7 +21388,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.2.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -21543,7 +21539,7 @@ snapshots:
   launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
 
   lefthook-darwin-arm64@2.1.8:
     optional: true
@@ -22383,7 +22379,7 @@ snapshots:
       glob: 13.0.6
       he: 1.2.0
       is-path-inside: 3.0.3
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       log-symbols: 4.1.0
       minimatch: 9.0.9
       ms: 2.1.3
@@ -22515,7 +22511,7 @@ snapshots:
       minimatch: 3.1.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.4
+      shell-quote: 1.10.0
       string.prototype.padend: 3.1.6
 
   npm-run-path@4.0.1:
@@ -23493,7 +23489,7 @@ snapshots:
   rc-config-loader@4.1.4:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      js-yaml: 4.2.0
+      js-yaml: 4.3.1
       json5: 2.2.3
       require-from-string: 2.0.2
     transitivePeerDependencies:
@@ -23690,7 +23686,7 @@ snapshots:
 
   react-router-dom@6.26.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
+      '@remix-run/router': 1.23.3
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.30.4(react@18.3.1)
@@ -23710,12 +23706,12 @@ snapshots:
 
   react-router@6.30.4(react@16.14.0):
     dependencies:
-      '@remix-run/router': 1.23.2
+      '@remix-run/router': 1.23.3
       react: 16.14.0
 
   react-router@6.30.4(react@18.3.1):
     dependencies:
-      '@remix-run/router': 1.23.2
+      '@remix-run/router': 1.23.3
       react: 18.3.1
 
   react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
@@ -24221,7 +24217,7 @@ snapshots:
     dependencies:
       '@bufbuild/protobuf': 2.11.0
       colorjs.io: 0.5.2
-      immutable: 5.1.5
+      immutable: 5.1.9
       rxjs: 7.8.2
       supports-color: 8.1.1
       sync-child-process: 1.0.2
@@ -24249,7 +24245,7 @@ snapshots:
   sass@1.100.0:
     dependencies:
       chokidar: 5.0.0
-      immutable: 5.1.5
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       '@parcel/watcher': 2.5.6
@@ -24530,7 +24526,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.4: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.0:
     dependencies:
@@ -25579,7 +25575,7 @@ snapshots:
     transitivePeerDependencies:
       - tslib
 
-  webpack-dev-server@5.2.5(debug@4.4.3)(tslib@2.8.1)(webpack@5.104.1(postcss@8.5.26)):
+  webpack-dev-server@5.2.6(debug@4.4.3)(tslib@2.8.1)(webpack@5.104.1(postcss@8.5.26)):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -53,7 +53,8 @@ packages:
 # downgrades for Docusaurus-era parents.
 overrides:
   shell: 'workspace:*'
-  '@remix-run/router': '>=1.23.2 <2'
+  '@remix-run/router': '>=1.23.3 <2'
+  body-parser: '>=1.20.6 <2'
   brace-expansion: '>=5.0.7 <6'
   # minimatch 3.x (eslint's config-array, glob@7) does a CJS default-import of
   # brace-expansion; v5's commonjs build exports named {expand} only, so the
@@ -62,11 +63,12 @@ overrides:
   # ReDoS fix the floor exists for.
   'minimatch@3>brace-expansion': '>=1.1.12 <2'
   'diff@7': '>=8.0.3 <9'
-  dompurify: '>=3.4.9 <3.5.0'
+  dompurify: '>=3.4.13 <3.5.0'
   fast-uri: '>=3.1.5 <4'
   glob: '>=11.1.0'
+  immutable: '>=5.1.8 <6'
   joi: '>=18.2.1 <19'
-  js-yaml: '>=4.2.0 <5'
+  js-yaml: '>=4.3.1 <5'
   lodash: '>=4.18.1 <5'
   prismjs: '>=1.30.0 <2'
   react-router: '>=6.30.4 <7'
@@ -74,9 +76,10 @@ overrides:
   'react-router-config>react-router': '5.3.4'
   'react-router-dom@5>react-router': '5.3.4'
   serialize-javascript: '>=7.0.5 <8'
+  shell-quote: '>=1.9.0 <2'
   undici: '>=7.29.0 <8'
   uuid: '>=11.1.1 <12'
-  webpack-dev-server: '>=5.2.5 <6'
+  webpack-dev-server: '>=5.2.6 <6'
   ws: '>=8.21.0 <9'
 
 # Patch gray-matter's frontmatter handling for the docs site (see patches/).


### PR DESCRIPTION
## Summary

Third in the same-pattern series after #1948 (undici) and #1949 (fast-uri, brace-expansion). Bumps existing floors that had fallen behind newer advisories, adds three new pins for CVEs on packages not yet in the overrides block.

### Bumps

| Package | Old floor | New floor |
|---|---|---|
| `@remix-run/router` | `>=1.23.2` | `>=1.23.3` |
| `dompurify` | `>=3.4.9` | `>=3.4.13` |
| `js-yaml` | `>=4.2.0` | `>=4.3.1` |
| `webpack-dev-server` | `>=5.2.5` | `>=5.2.6` |

### Adds

| Package | Floor |
|---|---|
| `body-parser` | `>=1.20.6 <2` |
| `immutable` | `>=5.1.8 <6` |
| `shell-quote` | `>=1.9.0 <2` |

## Verification

Regenerated `pnpm-lock.yaml` with `pnpm install --lockfile-only`. All 7 packages resolve above the floor:

- `@remix-run/router` 1.23.3
- `body-parser` 1.20.6
- `dompurify` 3.4.13
- `immutable` 5.1.9
- `js-yaml` 4.3.1
- `shell-quote` 1.10.0
- `webpack-dev-server` 5.2.6

`lockfileVersion` still 9.0. No unrelated regens.

## Alerts closed (11 total, all `pnpm-lock.yaml`)

- `@remix-run/router`: #308
- `dompurify`: #246, #311
- `js-yaml`: #232, #310
- `webpack-dev-server`: #238, #239
- `body-parser`: #241
- `immutable`: #242, #243
- `shell-quote`: #233

(commit message says 10; miscount of the alerts list — the correct total is 11.)

## Test plan

- [ ] CI green
- [ ] After merge, Dependabot re-scan closes all 11 alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal project configuration to maintain compatibility and improve the reliability of development and build workflows.
  * No changes were made to the product’s user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->