### PR TITLE
chore(security): raise adm-zip floor past CVE-fix version 0.6.0

### DIFF
--- a/apps/vscode/package.json
+++ b/apps/vscode/package.json
@@ -636,7 +636,7 @@
 	},
 	"dependencies": {
 		"@octokit/rest": "^22.0.1",
-		"adm-zip": "^0.5.17",
+		"adm-zip": "^0.6.0",
 		"chart.js": "^4.4.0",
 		"dockerode": "^4.0.12",
 		"proper-lockfile": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@types/node": "^20.19.41",
 		"@types/react": "~18.3.31",
 		"@types/react-dom": "~18.3.7",
-		"adm-zip": "^0.5.17",
+		"adm-zip": "^0.6.0",
 		"concurrently": "^8.2.2",
 		"dotenv": "^16.4.5",
 		"eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   shell: workspace:*
   '@remix-run/router': '>=1.23.3 <2'
+  adm-zip: '>=0.6.0 <1'
   body-parser: '>=1.20.6 <2'
   brace-expansion: '>=5.0.7 <6'
   minimatch@3>brace-expansion: '>=1.1.12 <2'
@@ -55,8 +56,8 @@ importers:
         specifier: ~18.3.7
         version: 18.3.7(@types/react@18.3.31)
       adm-zip:
-        specifier: ^0.5.17
-        version: 0.5.17
+        specifier: '>=0.6.0 <1'
+        version: 0.6.0
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
@@ -976,8 +977,8 @@ importers:
         specifier: ^22.0.1
         version: 22.0.1
       adm-zip:
-        specifier: ^0.5.17
-        version: 0.5.17
+        specifier: '>=0.6.0 <1'
+        version: 0.6.0
       chart.js:
         specifier: ^4.4.0
         version: 4.5.1
@@ -5196,13 +5197,9 @@ packages:
     resolution: {integrity: sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==}
     engines: {node: '>=0.8'}
 
-  adm-zip@0.5.10:
-    resolution: {integrity: sha512-x0HvcHqVJNTPk/Bw8JbLWlWoo6Wwnsug0fnYYro1HBrjxZ3G7/AZk7Ahv8JwDe1uIcz8eBqvu86FuF1POiG7vQ==}
-    engines: {node: '>=6.0'}
-
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -15697,7 +15694,7 @@ snapshots:
       '@module-federation/managers': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/sdk': 2.5.1(node-fetch@2.7.0(encoding@0.1.13))
       '@module-federation/third-party-dts-extractor': 2.5.1
-      adm-zip: 0.5.10
+      adm-zip: 0.6.0
       ansi-colors: 4.1.3
       isomorphic-ws: 5.0.0(ws@8.21.0)
       node-schedule: 2.1.1
@@ -17758,9 +17755,7 @@ snapshots:
 
   adler-32@1.3.1: {}
 
-  adm-zip@0.5.10: {}
-
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,6 +54,7 @@ packages:
 overrides:
   shell: 'workspace:*'
   '@remix-run/router': '>=1.23.3 <2'
+  adm-zip: '>=0.6.0 <1'
   body-parser: '>=1.20.6 <2'
   brace-expansion: '>=5.0.7 <6'
   # minimatch 3.x (eslint's config-array, glob@7) does a CJS default-import of


### PR DESCRIPTION
## Summary

Closes GHSA-xcpc-8h2w-3j85 (CVSS 7.5): a crafted ZIP file can trigger 4GB memory allocation on adm-zip <0.6.0.

## Changes

- `package.json`: bump `adm-zip` devDep from `^0.5.17` to `^0.6.0`
- `apps/vscode/package.json`: bump `adm-zip` devDep from `^0.5.17` to `^0.6.0`
- `pnpm-workspace.yaml`: add `adm-zip: '>=0.6.0 <1'` override so the transitive pull (via `@module-federation/managers` at 0.5.10) is also raised, not just the direct deps

## Verification

Regenerated `pnpm-lock.yaml` resolves every adm-zip node to 0.6.0. Overrides count 20 → 21; `lockfileVersion` still 9.0.

## API compatibility note

adm-zip 0.5 → 0.6 is a semver-treated-as-major bump per 0.x conventions. Usage sites in `apps/vscode/src/engine/shared/engine-installer.ts` and `apps/vscode/src/engine/service/service-windows.ts` use the stable API surface (`new AdmZip(path)`, `extractAllTo`, `getEntries`, `extractEntryTo`) that exists in both 0.5.x and 0.6.x. The 0.6.x line adds the memory-allocation guard that is the point of this bump. **CI vscode extension tests are the real check for behavioural regressions.**

## Alerts closed (3 total)

- #228 (`pnpm-lock.yaml`)
- #229 (`apps/vscode/package.json`)
- #230 (root `package.json`)

## Test plan

- [ ] CI green, especially `apps/vscode` build and tests
- [ ] Manual smoke test on vscode extension: engine install (which exercises `extractArchive`) still works on a Linux + Windows build
- [ ] After merge, Dependabot re-scan closes all 3 alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the ZIP archive support library to version 0.6.0.
  * Standardized the supported ZIP library version across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->