### PR TITLE
fix(ai): raise clear error when reasoning model is cut off mid-think-block

### DIFF
--- a/packages/ai/src/ai/common/util.py
+++ b/packages/ai/src/ai/common/util.py
@@ -46,6 +46,16 @@ def parseJson(value: str) -> Any:
         # so fence detection below is not confused by content inside the think block.
         value = re.sub(r'<think>.*?</think>', '', value, flags=re.DOTALL).strip()
 
+        # An UNCLOSED block means the model ran out of output budget while still
+        # reasoning, so it never reached the JSON at all. The regex above cannot
+        # match it, and the generic "unable to parse" that follows sends you
+        # looking at the schema instead of at modelOutputTokens. Say which it is.
+        if value.startswith('<think>') and '</think>' not in value:
+            raise ValueError(
+                'model was cut off inside a <think> block and never emitted JSON; '
+                'raise modelOutputTokens, or disable reasoning for this call'
+            )
+
         # If the LLM wrapped the response in a ```json fence, strip the opening marker.
         # We only check the beginning of the string so we don't accidentally strip ``` sequences
         # that appear inside JSON string values (e.g. a chartjs fenced code block in an "answer" field).

--- a/packages/ai/tests/ai/common/test_util.py
+++ b/packages/ai/tests/ai/common/test_util.py
@@ -104,6 +104,19 @@ def test_parse_json_strips_think_then_fence():
     assert util.parseJson(raw) == {'x': 'y'}
 
 
+def test_parse_json_raises_on_unterminated_think_block():
+    """A <think> block with no closing tag means the model ran out of
+    output budget before emitting any JSON; this must raise a clear
+    error naming modelOutputTokens rather than a generic JSON error.
+    """
+    raw = (
+        '<think>The user wants a JSON summary. Let me work through the '
+        'fields one at a time. First the title, which should be'
+    )
+    with pytest.raises(ValueError, match='cut off inside a <think> block'):
+        util.parseJson(raw)
+
+
 def test_parse_json_keeps_inner_backticks_in_string_value():
     """Triple-backticks inside a JSON string value must NOT be treated as fences."""
     raw = '{"answer": "see ```python\\nprint(1)\\n``` here"}'


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- `parseJson` now raises a clear `ValueError` when a reasoning model is cut off mid-`<think>` block, instead of a generic `JSONDecodeError` that misleadingly points at the schema/prompt
- Added a regression test covering the unterminated `<think>` block case

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #1822


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when AI reasoning output is cut off before valid JSON is produced.
  * Added guidance to increase the model output token limit or disable reasoning when this occurs.

* **Tests**
  * Added coverage to ensure unterminated reasoning blocks produce a clear, actionable error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->