### PR TITLE
docs(vscode): document workspace folder and Return Answers requirements

### DIFF
--- a/docs/README-vscode.md
+++ b/docs/README-vscode.md
@@ -16,8 +16,22 @@
 
 1. Install the **RocketRide** extension from the VS Code Marketplace
 2. Click the **RocketRide** icon in the Activity Bar
-3. Create a `.pipe` file - it opens automatically in the visual canvas builder
+3. Open a folder in VS Code, then create a `.pipe` file - it opens automatically in the visual canvas builder
 4. Wire up nodes by connecting input and output lanes, then hit **Play** to run
+
+### Your first pipeline
+
+Every pipeline starts with a source node and ends with a return node. The return
+node is what sends results back to the caller - without it the pipeline runs, but
+nothing comes back.
+
+A minimal chat pipeline is three nodes:
+
+    Chat (source)  ->  Ollama (LLM)  ->  Return Answers
+
+Wire `Chat.Questions` to the LLM's `Questions` input, then the LLM's `Answers`
+output to `Return Answers`. If the return node is missing, the pipeline starts
+without an error but the chat replies *"I don't see any answers in there..."*
 
 <img src="https://raw.githubusercontent.com/rocketride-org/rocketride-server/develop/docs/images/canvas.png" alt="RocketRide visual canvas builder" width="800">
 


### PR DESCRIPTION
Documents two Quick Start prerequisites that aren't currently mentioned:

- A workspace folder must be open before "New pipeline" does anything — clicking it with no folder open silently does nothing except a toast in the corner
- Chat pipelines need a terminal `Return Answers` node — wiring Chat → LLM the obvious way produces no answer *and* no error, and the Errors tab stays empty

## Type

docs

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Docs-only change, no code paths touched. Verified the rendered Markdown in
GitHub's preview. The described pipeline (Chat → Ollama → Return Answers) is
the one I built locally to get a working response.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Closes #1945

## Notes

I hit both of these as a first-time user this week. I only worked out the
`Return Answers` requirement by opening the RAG Chat template and
reverse-engineering the wiring.

Every flow diagram in `examples/README.md` already ends in `-> response`, so
the pattern is consistent — it just isn't stated in the Quick Start.

The root `README.md` has a similar "Building Your First Pipe" section with the
same gap. Happy to update that in a follow-up if useful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Your first pipeline” section to the VS Code quick-start guide.
  * Explained required source and return nodes, including a minimal chat pipeline example.
  * Clarified pipeline wiring and behavior when the return node is omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->