### PR TITLE
fix: skip stop parameter for reasoning models to prevent 400 errors

### DIFF
--- a/packages/ai/src/ai/common/chat.py
+++ b/packages/ai/src/ai/common/chat.py
@@ -23,18 +23,24 @@ from ai.common.llm_native_stream import STOP_SEQUENCES_VAR, dispatch_native_chat
 from ai.common.llm_adapter import LangChainAdapter, NativeOpenAIResponsesAdapter, drive_adapter
 
 
-def _stop_kwargs() -> dict:
+def _stop_kwargs(is_reasoning: bool = False) -> dict:
     """Return ``{'stop': [...]}`` only when stop sequences are active for this call.
 
-    Passing ``stop=`` unconditionally (even ``stop=None``) breaks model backends and
-    test mocks whose ``invoke``/``stream`` signature does not accept a ``stop`` kwarg, so
+    Passing `stop=` unconditionally (even `stop=None`) breaks model backends and
+    test mocks whose `invoke`/`stream` signature does not accept a `stop` kwarg, so
     the argument is omitted entirely for the common no-stop path.
 
-    INVARIANT: this is read within the synchronous ``ask()`` call, while
-    ``LLMBase._question`` still holds the contextvar (before its ``finally`` reset).
-    Do not defer consumption (e.g. by returning a lazy generator to the caller) —
-    the value would then read ``None`` after the reset and silently send no stop.
+    Reasoning models (gpt-5.x / o-series) reject the `stop` parameter outright with a
+    400 `unsupported_parameter` error, so `is_reasoning` gates it off regardless of
+    whether stop sequences are active -- callers pass `self._is_reasoning`.
+
+    INVARIANT: this is read within the synchronous `ask()` call, while
+    `LLMBase._question` still holds the contextvar (before its `finally` reset).
+    Do not defer consumption (e.g. by returning a lazy generator to the caller) --
+    the value would then read `None` after the reset and silently send no stop.
     """
+    if is_reasoning:
+        return {}
     stop = STOP_SEQUENCES_VAR.get()
     return {'stop': stop} if stop else {}
 
@@ -186,7 +192,7 @@ class ChatBase:
         """
         # Non-streaming: invoke through the adapter — same shared normalization as streaming,
         # but a genuinely different mechanism, so the streaming fallback can still recover.
-        text, _items = LangChainAdapter(self._llm, stream_kwargs=_stop_kwargs()).collect(prompt)
+        text, _items = LangChainAdapter(self._llm, stream_kwargs=_stop_kwargs(self._is_reasoning)).collect(prompt)
         return text
 
     def getTokens(self, value: str) -> int:
@@ -412,7 +418,7 @@ class ChatBase:
             # Only retry non-streaming if nothing reached the UI; otherwise the full
             # fallback would arrive on top of the partial we already streamed.
             if emitted is None or not emitted['any']:
-                adapter = LangChainAdapter(self._llm, stream_kwargs=_stop_kwargs())
+                adapter = LangChainAdapter(self._llm, stream_kwargs=_stop_kwargs(self._is_reasoning))
                 content_text, _items = adapter.collect(prompt)
                 # Reasoning reaches its own lane; it must never land in the visible text.
                 if adapter.reasoning and on_reasoning_chunk is not None:
@@ -508,7 +514,7 @@ class ChatBase:
             try:
                 # Stream the LangChain path through the normalized adapter; drive_adapter
                 # fans text/thinking to the callbacks and returns the joined answer.
-                adapter = LangChainAdapter(_llm, stream_kwargs=_stop_kwargs())
+                adapter = LangChainAdapter(_llm, stream_kwargs=_stop_kwargs(self._is_reasoning))
                 answer, _items = drive_adapter(adapter, prompt, on_chunk_w, on_reasoning_chunk_w)
                 if answer:
                     result = answer

--- a/packages/ai/tests/ai/common/test_chat_string_wiring.py
+++ b/packages/ai/tests/ai/common/test_chat_string_wiring.py
@@ -76,6 +76,23 @@ def test_stop_sequences_reach_the_model():
     assert llm.kwargs == {'stop': ['\nObservation:']}
 
 
+def test_stop_sequences_omitted_for_reasoning_model():
+    # gpt-5.x / o-series models reject the 'stop' parameter outright (400
+    # unsupported_parameter), so it must never be sent when _is_reasoning is True,
+    # even if the caller (e.g. a CrewAI/ReAct agent) set stop sequences.
+    from ai.common.llm_native_stream import STOP_SEQUENCES_VAR
+
+    llm = _FakeLLM([_Piece('plain answer here')])
+    chat = _Chat(llm)
+    chat._is_reasoning = True
+    token = STOP_SEQUENCES_VAR.set(['\nObservation:'])
+    try:
+        chat.chat_string('hi', on_chunk=lambda t: None)
+    finally:
+        STOP_SEQUENCES_VAR.reset(token)
+    assert llm.kwargs == {}
+
+
 def test_chat_nonstreaming_invokes_via_adapter():
     # _chat drains via collect() → invoke() (a different mechanism than stream(), so the
     # streaming fallback can recover); content is normalized (thinking dropped) and stop passes.


### PR DESCRIPTION
## Summary

<!-- Describe your changes in 1-3 bullet points -->

- `_stop_kwargs()` in `chat.py` now takes an `is_reasoning` flag and omits `stop` entirely when the model is a reasoning model (gpt-5.x / o-series), which reject the parameter outright with a 400 `unsupported_parameter` error
- All three call sites now pass `self._is_reasoning`, an existing capability flag already stamped from `services.json`
- Added a regression test confirming `stop` is omitted when `_is_reasoning=True`, alongside the existing test confirming it's still sent for normal models

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [x] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #1538

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with reasoning models by omitting unsupported stop-sequence parameters.
  - Ensured consistent behavior across standard, fallback, and streaming chat requests.

- **Tests**
  - Added regression coverage for configured stop sequences when reasoning mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->