### PR TITLE
chore(security): pin actions/checkout in lock-node-deps.yml (Scorecard #671)

### DIFF
--- a/.github/workflows/lock-node-deps.yml
+++ b/.github/workflows/lock-node-deps.yml
@@ -78,7 +78,7 @@ jobs:
           permission-issues: write
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           token: ${{ steps.app-token.outputs.token || github.token }}
           # actions/checkout writes `token` into .git/config by default. The


### PR DESCRIPTION
## Summary

Pins `actions/checkout` in `.github/workflows/lock-node-deps.yml:81` from the floating `@v4` tag to the SHA the rest of this repo already uses (`34e114876b0b11c390a56381ad16ebd13914f8d5`, v4.x), with a version comment. **Closes Scorecard PinnedDependenciesID alert #671.**

## Context: the other 20 Scorecard alerts (not this PR)

The full CodeQL Scorecard sweep opened 21 alerts on this repo. This PR is the one code change that was safe to apply as a drop-in. The other 20 are being dismissed as `won't fix` on the alerts themselves, with per-alert rationale:

### 16 × TokenPermissionsID (high sev, job-level write scopes)

All hit legitimate job-level write escalations in release / prerelease / experimental-release / release-backmerge / storage-cleanup / sync-models workflows, where the write scope is the minimum the job needs (publishing packages, pushing tags, creating releases, opening back-merge PRs, deleting old artifacts, committing model manifests). Workflow-level defaults are already `contents: read`; the in-file comments already reference closing prior Scorecard alerts (`#513`, `#516`, `#566`, `#567`, `#605`) via the same workflow-level-read + job-level-escalation pattern.

Removing these write scopes would break the workflows.

### 4 × PinnedDependenciesID (medium sev, npm/pip commands)

- `n8n-nodes-ci.yml:56` and `n8n-nodes-release.yml:64`: npm binary is version-pinned to `11.19.0`, and the subsequent `npm ci --no-audit --no-fund` reads `packages/n8n-nodes/package-lock.json` where every dep is hash-pinned. Scorecard's rule can't see through the bootstrap.
- `os-matrix.yml:103-104`: `build + wheel` intentionally unversioned. The comment immediately above the command explains why (on Ubuntu 24.04+ `wheel` is distro-managed and pinning a specific version breaks the pip bootstrap; a plain install skips the already-satisfied wheel).

## Test plan

- [ ] CI green
- [ ] After merge, Scorecard re-scan closes alert #671
- [ ] The 20 dismissed alerts stay closed with the rationale on record

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency-locking workflow to use a pinned checkout action version for improved consistency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->