### PR TITLE
fix(nodes): constraints.lock pinned a withdrawn onnxruntime — 1.20.1 no longer exists

### DIFF
--- a/nodes/src/nodes/constraints.lock
+++ b/nodes/src/nodes/constraints.lock
@@ -870,14 +870,14 @@ oauthlib==3.3.1
     # via requests-oauthlib
 obstore==0.8.2
     # via daytona
-onnxruntime==1.20.1
+onnxruntime==1.22.0
     # via
     #   -r nodes/src/nodes/anonymize/requirements.txt
     #   -r nodes/src/nodes/audio_transcribe/requirements.txt
     #   chromadb
     #   faster-whisper
     #   gliner
-onnxruntime-gpu==1.20.1 ; sys_platform != 'darwin'
+onnxruntime-gpu==1.22.0 ; sys_platform != 'darwin'
     # via
     #   -r nodes/src/nodes/anonymize/requirements.txt
     #   -r nodes/src/nodes/audio_transcribe/requirements.txt


### PR DESCRIPTION
Two lines. The lock disagreed with the requirements sitting beside it, and the version it named has been **removed from PyPI**.

```
constraints.lock                            onnxruntime==1.20.1
                                            onnxruntime-gpu==1.20.1
requirements_whisper.txt / _gliner.txt      onnxruntime-gpu==1.22.0
nodes/anonymize/requirements.txt            onnxruntime-gpu==1.22.0
```

`onnxruntime-gpu` 1.20.1 has **zero files** on the registry. 1.20.0 and 1.20.2 are still published, so it was withdrawn rather than never released.

Anything resolving from the lock instead of the requirements asks for something it cannot download, and fails at resolve time. **No alert is attached to that**, because nothing watches for a pin that stopped existing — which is what makes it worse than a vulnerable version.

## How I found it

From the other end entirely: a Job running the deployed cloud image died with

```
Failed to compile constraints: × No solution found when resolving dependencies:
╰─▶ Because there is no version of onnxruntime-gpu{sys_platform != 'darwin'}==1.20.1 ...
```

That image predates the 1.22.0 bump. The source had already been fixed; the lock hadn't caught up.

## Surgical, and checked rather than assumed

A regeneration would be the tidier move, but it churns 1686 lines I can't validate. So I bumped the two lines and verified the closure doesn't change:

- `onnxruntime` 1.20.1 and 1.22.0 declare **identical** dependency sets — coloredlogs, flatbuffers, numpy, packaging, protobuf, sympy.
- `onnxruntime-gpu` 1.22.0 additionally requires five nvidia packages, and **all five are already in this lock**, at versions inside its ranges:

```
nvidia-cuda-nvrtc-cu12==12.8.93     satisfies ~=12.0
nvidia-cuda-runtime-cu12==12.8.90   satisfies ~=12.0
nvidia-cudnn-cu12==9.10.2.21        satisfies ~=9.0
nvidia-cufft-cu12==11.3.3.83        satisfies ~=11.0
nvidia-curand-cu12==10.3.9.90       satisfies ~=10.0
```

So this brings the lock in line with the requirements it exists to constrain, and changes nothing else. If you'd rather have a full regeneration, say so and I'll leave it to whoever can run the solve with the whole node set available.

## Worth a rule, not just a fix

A lock that disagrees with its own requirements is the inverse of the override problem from the recent sweeps: there an override outranked the parents, here the lock outranks a source that has already moved. Both fail quietly, and both are invisible to a diff of what changed in git.