### PR TITLE
ci(docs): scope the node schema check to the PR's diff, and make it blocking

### DIFF
--- a/.github/workflows/docs-schemas.yml
+++ b/.github/workflows/docs-schemas.yml
@@ -66,10 +66,16 @@ jobs:
 
           # Node dirs whose README or service metadata changed. Deleted nodes
           # drop out via the -d test.
+          # `|| true` on both filters is load-bearing under `set -euo pipefail`:
+          # grep exits 1 when nothing matches, and the `-d` test exits 1 when
+          # the last candidate is a deleted node. Either would kill the step
+          # before the empty check below could report the intended skip, which
+          # on a blocking job means an unrelated PR fails for no reason.
           CHANGED="$(git diff --name-only "$BASE"...HEAD \
-            | grep -E '^nodes/src/nodes/[^/]+/(README\.md|services[^/]*\.json)$' \
+            | { grep -E '^nodes/src/nodes/[^/]+/(README\.md|services[^/]*\.json)$' || true; } \
             | cut -d/ -f1-4 \
-            | sort -u | while read -r d; do [ -d "$d" ] && echo "$d"; done)"
+            | sort -u \
+            | { while read -r d; do [ -d "$d" ] && echo "$d"; done || true; })"
 
           if [ -z "$CHANGED" ]; then
             echo 'No node README or services*.json touched — nothing to validate.'
@@ -101,11 +107,14 @@ jobs:
       - name: Node README schema — whole corpus
         run: |
           python3 scripts/validate-node-readme.py --all nodes/src/nodes | tee /tmp/sweep.txt || true
+          # `grep -c` already prints 0 when it matches nothing; it just exits 1
+          # as well. `|| true` swallows the status — `|| echo 0` would print a
+          # second zero and render as "0 0".
           {
             echo '### Node README schema — corpus'
             echo
-            echo "- passing: $(grep -c '^ok' /tmp/sweep.txt || echo 0)"
-            echo "- failing: $(grep -cE '^x ' /tmp/sweep.txt || echo 0)"
+            echo "- passing: $(grep -c '^ok' /tmp/sweep.txt || true)"
+            echo "- failing: $(grep -cE '^x ' /tmp/sweep.txt || true)"
           } >> "$GITHUB_STEP_SUMMARY"
 
   # -------------------------------------------------------------------------

--- a/.github/workflows/docs-schemas.yml
+++ b/.github/workflows/docs-schemas.yml
@@ -30,13 +30,67 @@ permissions:
 
 jobs:
   # -------------------------------------------------------------------------
-  #  Schema validators. ADVISORY while the node corpus is migrated: the node
-  #  README checker fails most of the corpus today, so a hard gate would make
-  #  every PR into this branch red. Drop continue-on-error once the migration
-  #  lands and the validator reports a clean sweep.
+  #  Schema validators — scoped to what the PR actually touches, and BLOCKING.
+  #
+  #  Deliberately not `--all`. 109 of 124 nodes fail the schema today, so a
+  #  corpus-wide gate would be red on every PR from the day it was added. A
+  #  check that has always failed is a check nobody reads, and the day it fails
+  #  for a new reason looks identical to every day before it. Scoping to the
+  #  diff inverts that: green by default, so red means this PR broke something.
+  #
+  #  Being scoped is also what lets it be a hard gate immediately rather than
+  #  waiting on a 109-node cleanup to finish first. The backlog drains on its
+  #  own — touching a node obliges you to bring its README along — and it can
+  #  never grow, because a new or edited node is validated the moment it lands.
+  #
+  #  services*.json counts as a trigger, not just README.md: the metadata is
+  #  what decides which sections are required or forbidden, so a metadata-only
+  #  change can invalidate a README that nobody edited.
+  #
+  #  The corpus-wide number still has a home — see the `corpus` job below.
   # -------------------------------------------------------------------------
   schemas:
-    name: Schema validators (advisory)
+    name: Schema validators
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0 # need the base commit to diff against
+      - name: Validate the node READMEs this PR touches
+        run: |
+          set -euo pipefail
+          BASE='${{ github.event.pull_request.base.sha }}'
+          if [ -z "$BASE" ]; then BASE="$(git rev-parse HEAD^)"; fi
+
+          # Node dirs whose README or service metadata changed. Deleted nodes
+          # drop out via the -d test.
+          CHANGED="$(git diff --name-only "$BASE"...HEAD \
+            | grep -E '^nodes/src/nodes/[^/]+/(README\.md|services[^/]*\.json)$' \
+            | cut -d/ -f1-4 \
+            | sort -u | while read -r d; do [ -d "$d" ] && echo "$d"; done)"
+
+          if [ -z "$CHANGED" ]; then
+            echo 'No node README or services*.json touched — nothing to validate.'
+            exit 0
+          fi
+          echo "Validating $(echo "$CHANGED" | wc -l | tr -d ' ') node(s):"
+          echo "$CHANGED" | sed 's/^/  /'
+          # shellcheck disable=SC2086
+          python3 scripts/validate-node-readme.py $CHANGED
+      - name: Validate client doc parity
+        if: always()
+        run: python3 scripts/validate-client-docs.py
+
+  # -------------------------------------------------------------------------
+  #  Corpus-wide sweep. A count, not a gate — `--all` is information when it is
+  #  a trend line and noise when it is a merge blocker, so it lives here where
+  #  a large number is expected and readable. Retire this job once the count
+  #  reaches zero; the scoped gate above keeps it there.
+  # -------------------------------------------------------------------------
+  corpus:
+    name: Corpus sweep (informational)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     continue-on-error: true
@@ -44,11 +98,15 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
-      - name: Validate node READMEs
-        run: python3 scripts/validate-node-readme.py --all nodes/src/nodes
-      - name: Validate client doc parity
-        if: always()
-        run: python3 scripts/validate-client-docs.py
+      - name: Node README schema — whole corpus
+        run: |
+          python3 scripts/validate-node-readme.py --all nodes/src/nodes | tee /tmp/sweep.txt || true
+          {
+            echo '### Node README schema — corpus'
+            echo
+            echo "- passing: $(grep -c '^ok' /tmp/sweep.txt || echo 0)"
+            echo "- failing: $(grep -cE '^x ' /tmp/sweep.txt || echo 0)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # -------------------------------------------------------------------------
   #  Stage and compile the docs site. Catches what only a full build can:


### PR DESCRIPTION
Split out of #1970 so the bash gets reviewed as bash, separately from 600 lines of prose. Adopts the suggestion from the `fix/docs` review.

## The problem

The node README checker ran `--all` across the corpus. 109 of 124 nodes fail the schema today, so the job was red on every PR from the day it was added — which is why it was marked advisory and kept off the merge path.

That defused the immediate damage but left a worse one: a check that has always failed is a check nobody reads, and the day it fails for a *new* reason looks identical to the two hundred days before it. The genuinely interesting failures were going to be buried under structural noise like `unknown heading '## Modes' — move under ## Notes`.

## The change

Validate only the nodes whose files the PR actually touched.

- **Green by default**, so red means this PR broke something
- **Blocking immediately** — no waiting on a 109-node cleanup before the check protects anything
- **The backlog drains on its own.** Touching a node obliges you to bring its README along, and it can never grow, because a new or edited node is validated the moment it lands.

`services*.json` counts as a trigger alongside `README.md`. The metadata decides which sections are required or forbidden, so a metadata-only change can invalidate a README nobody edited. That also closes a gap where the docs path filter watched only READMEs.

`--all` keeps a home in a new informational job that writes pass/fail counts to the run summary — a large number is a trend line there rather than a merge blocker. Retire that job when the count reaches zero; the scoped gate keeps it there.

## Cross-check

Checked against the existing `docs:check` gate so two checks cannot disagree about what a good README is. `docs:check` verifies exported client package READMEs match their `docs/` sources — export drift, not document structure. No overlap.

## Two bugs CodeRabbit caught in the first version

Both reproduced before fixing.

Under `set -euo pipefail`, `grep` exits 1 when nothing matches, so a PR touching no node files died on the command substitution before reaching the check meant to report a clean skip. On a blocking job that would have blocked unrelated PRs outright. The `-d` test in the trailing loop had the same shape for a deleted node.

`grep -c` already prints `0` when it matches nothing and exits 1 as well, so `|| echo 0` emitted a second zero and the summary rendered `0 0`.

## Scope

Touches `.github/workflows/docs-schemas.yml` only — a file that triggers exclusively on `fix/docs`, with no `workflow_dispatch` or `schedule`. `ci.yml`, the shared pipeline, remains a **zero-line diff against develop**, and nothing on develop references these validators.

## Verification

Run under bash rather than the zsh it was written in, since zsh does not word-split unquoted variables and hid a real difference:

- real diff → resolves 8 nodes, all pass, exit 0
- diff with no node files → reaches the skip path, exit 0
- an unmigrated node in the set → exit 1, PR goes red
- counts render as a single `0`

Both jobs ran green on #1970 before the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Schema validation now runs only for changed, existing node directories.
  * Validation failures now block pull requests when relevant schema files change.
  * Checks safely handle deleted nodes, empty changes, and pull requests without relevant updates.
  * Added an informational full-node validation sweep with pass/fail counts in the workflow summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->