### PR TITLE
fix(docs): stop the node validator eating underscores in identifiers

### DIFF
--- a/scripts/validate-node-readme.py
+++ b/scripts/validate-node-readme.py
@@ -130,6 +130,21 @@ def canon(h: str) -> str:
     return 'About' if h.startswith('About') else h.strip()
 
 
+def _clean_cell(c: str) -> str:
+    """Strip markdown decoration from a table cell without eating identifiers.
+
+    Underscores cannot be removed wholesale: they are markdown emphasis, but
+    they are also legal in the names this function exists to compare. Lane
+    `_source`, profile `gemini-2_5-flash` and connection `streamable_http` all
+    lose characters under a blanket strip and then fail to match the metadata
+    that declared them. Emphasis is therefore only removed when a pair of
+    underscores wraps the whole cell.
+    """
+    c = c.replace('`', '').replace('*', '')
+    c = re.sub(r'\s*_?\(default\)_?\s*', '', c).strip()
+    return re.sub(r'^_(.+?)_$', r'\1', c).strip()
+
+
 def table_col(text: str, section: str, col: int = 0):
     """First-column cell values of tables in a section (markup-stripped).
 
@@ -148,7 +163,7 @@ def table_col(text: str, section: str, col: int = 0):
         nxt = lines[i + 1] if i + 1 < len(lines) else ''
         if re.match(r'^\|[\s\-:|]+\|$', nxt):
             continue  # header row
-        cells = [re.sub(r'\s*\(default\)\s*', '', re.sub(r'[*_`]', '', c)).strip() for c in row.group(1).split('|')]
+        cells = [_clean_cell(c) for c in row.group(1).split('|')]
         if cells and not set(cells[0]) <= {'-', ' ', ':'}:
             vals.append(cells[col] if col < len(cells) else '')
     return [v for v in vals if v]


### PR DESCRIPTION
One-function fix, kept separate from the batch PRs so it can be reviewed as code.

## The bug

`table_col` stripped ``[*_`]`` from every table cell to remove markdown decoration before comparing names against `services*.json`.

Underscores are markdown emphasis — but they are also legal characters in the identifiers that function exists to compare. So the strip silently corrupted them. A README documenting lane `` `_source` `` had it reduced to `source`, which then failed to match the lane that declared it.

## How it surfaced

`tool_pipe` failed with:

```
FAIL: Lanes rows match declared lanes — missing lane-in: ['_source']
```

Its README lists `_source` correctly. The README was right; the validator was wrong.

## Why it matters beyond one node

Thirteen nodes carry an underscore in a lane, connection, or profile name. The LLM family is worst affected, and it is the largest batch still ahead:

| node | names |
|---|---|
| `llm_gemini` | `gemini-3_1-pro-preview`, `gemini-3_1-flash-image-preview` |
| `llm_ollama` | `llama3_3`, `llama3_1-8b`, `llama3_1-70b` |
| `llm_bedrock` | `ai21_jamba-1_5-large`, `amazon_titan-text-express` |
| `llm_vision_ollama` | `llama3_2-vision-11b`, `qwen2_5vl-3b` |
| `anomaly_detector` | `z_score`, `rolling_avg` |
| `core`, `telegram`, `tool_pipe` | `_source` |

Left unfixed this would have produced a wave of false failures right as the check became blocking.

Profiles partly masked it: their comparison falls back to fuzzy containment across two columns, so a corrupted name often still matched something. Lanes and connections compare strictly, so they failed outright — which is why this showed up on a lane first.

## The fix

Emphasis is only stripped when a pair of underscores wraps the entire cell, which is the only case where an underscore is decoration rather than part of a name. Backticks and asterisks are still removed unconditionally.

## Verification

| input | expected | result |
|---|---|---|
| `` `_source` `` | `_source` | pass |
| ``*`z_score`*`` | `z_score` | pass |
| `` `gemini-2_5-flash` `` | `gemini-2_5-flash` | pass |
| `` `streamable_http` `` | `streamable_http` | pass |
| `Claude Sonnet 4.6 _(default)_` | `Claude Sonnet 4.6` | pass |
| `**Weaviate cloud** *(default)*` | `Weaviate cloud` | pass |
| `_emphasised_` | `emphasised` | pass |

Both `*(default)*` and `_(default)_` markers are already in use in migrated READMEs; both still parse. Corpus pass count unchanged, and `tool_pipe` goes from FAIL to PASS with no edit to its README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown table formatting validation.
  * Preserved underscores in identifiers and names, including `_source`, `gemini-2_5-flash`, and `streamable_http`.
  * Continued normalizing unnecessary cell formatting without altering valid identifier text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->