### PR TITLE
fix(config): preserve top-level profile settings

### DIFF
--- a/packages/ai/src/ai/common/config.py
+++ b/packages/ai/src/ai/common/config.py
@@ -192,18 +192,26 @@ class Config:
             # Get the default from the profile
             defaultConfig = profileConfig
 
-            # Get the user specified profile
-            userConfig = connConfig.get(profile, {})
+            # Resolve explicit configuration in the same order as the default
+            # profile branch: profile defaults < top-level keys < profile keys.
+            # A number of pipeline files keep credentials and other overrides
+            # at the top level even when they select a profile.
+            profileUserConfig = connConfig.get(profile, {})
+            if isinstance(profileUserConfig, IJson):
+                profileUserConfig = IJson.toDict(profileUserConfig)
+            if not isinstance(profileUserConfig, dict):
+                profileUserConfig = {}
 
-            # If it is none, then set to empty
-            if not userConfig:
-                userConfig = {}
+            userConfig = {key: value for key, value in connConfig.items() if key not in ('profile', profile)}
+            for key, value in profileUserConfig.items():
+                if value is not None:
+                    userConfig[key] = value
 
             # Merge defaultConfig into userConfig
             config = merge(userConfig, defaultConfig)
 
         # Output the computed configuration
-        return config
+        return IJson.toDict(config)
 
     @staticmethod
     def getProviderConfig(providerConfig: Dict[str, any]):

--- a/packages/ai/tests/ai/common/test_config_shapes.py
+++ b/packages/ai/tests/ai/common/test_config_shapes.py
@@ -26,7 +26,14 @@ _SERVICE = {
     'preconfig': {
         'default': 'default',
         'profiles': {
-            'default': {'instructions': [], 'agent_description': '', 'role': 'Assistant', 'require_tool_call': False},
+            'default': {
+                'instructions': [],
+                'agent_description': '',
+                'role': 'Assistant',
+                'require_tool_call': False,
+                'entityTypes': [],
+            },
+            'exa': {'apikey': '', 'region': 'us-east-1'},
         },
     }
 }
@@ -38,12 +45,31 @@ def _load_config():
 
     rl = types.ModuleType('rocketlib')
 
-    class _IJson:
+    class FakeIJson:
+        def __init__(self, value):
+            self.value = value
+
+        def get(self, key, default=None):
+            if isinstance(self.value, dict):
+                return self.value.get(key, default)
+            return default
+
+        def items(self):
+            if isinstance(self.value, dict):
+                return self.value.items()
+            return ()
+
         @staticmethod
         def toDict(x):
-            return dict(x) if isinstance(x, dict) else x
+            if isinstance(x, FakeIJson):
+                return FakeIJson.toDict(x.value)
+            if isinstance(x, dict):
+                return {key: FakeIJson.toDict(value) for key, value in x.items()}
+            if isinstance(x, list):
+                return [FakeIJson.toDict(value) for value in x]
+            return x
 
-    rl.IJson = _IJson
+    rl.IJson = FakeIJson
     rl.warning = lambda *a, **k: None
     rl.getServiceDefinition = lambda logical_type: _SERVICE
     sys.modules['rocketlib'] = rl
@@ -53,7 +79,7 @@ def _load_config():
         spec = importlib.util.spec_from_file_location('rr_real_config', _CONFIG_PATH)
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        return mod.Config
+        return mod.Config, FakeIJson
     finally:
         for k, v in saved.items():
             if v is None:
@@ -62,7 +88,7 @@ def _load_config():
                 sys.modules[k] = v
 
 
-Config = _load_config()
+Config, ConfigIJson = _load_config()
 
 
 class TestFlatShape:
@@ -107,6 +133,36 @@ class TestExplicitProfileBranchUnaffected:
     def test_explicit_profile_reads_nested(self):
         cfg = Config.getNodeConfig('agent_x', {'profile': 'default', 'default': {'instructions': ['x']}})
         assert cfg['instructions'] == ['x']
+
+
+class TestExplicitProfilePrecedence:
+    def test_top_level_keys_apply_with_an_explicit_profile(self):
+        cfg = Config.getNodeConfig('agent_x', {'profile': 'exa', 'apikey': 'top-level-key'})
+
+        assert cfg['apikey'] == 'top-level-key'
+        assert cfg['region'] == 'us-east-1'
+
+    def test_profile_specific_keys_override_top_level_keys(self):
+        cfg = Config.getNodeConfig(
+            'agent_x',
+            {'profile': 'exa', 'apikey': 'top-level-key', 'exa': {'apikey': 'profile-key'}},
+        )
+
+        assert cfg['apikey'] == 'profile-key'
+
+
+class TestNativeConfigTypes:
+    def test_configured_arrays_and_objects_are_native_python_values(self):
+        cfg = Config.getNodeConfig(
+            'agent_x',
+            {
+                'entityTypes': ConfigIJson(['PERSON', ConfigIJson({'nested': ['LOCATION']})]),
+            },
+        )
+
+        assert cfg['entityTypes'] == ['PERSON', {'nested': ['LOCATION']}]
+        assert isinstance(cfg['entityTypes'], list)
+        assert isinstance(cfg['entityTypes'][1], dict)
 
 
 class TestRequireToolCallResolution:


### PR DESCRIPTION
## Summary

- Fix explicit profile configuration so top-level node settings are preserved.
- Apply profile-specific settings last, so they correctly override top-level values.
- Normalize returned config values to regular Python dicts and lists.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1839

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved explicit profile configuration handling so profile-specific settings correctly take precedence over general settings.
  - Preserved configured values that are intentionally set, while ignoring invalid nested profile data safely.
  - Converted configuration values into standard native types for more consistent behavior across supported settings.

- **Tests**
  - Added coverage for profile precedence, nested configuration values, and native type conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->