### PR TITLE
fix(thumbnail): assign unique chunk IDs

### DIFF
--- a/nodes/src/nodes/thumbnail/IInstance.py
+++ b/nodes/src/nodes/thumbnail/IInstance.py
@@ -123,6 +123,7 @@ class IInstance(IInstanceBase):
 
                 # Emit the document(s) for further processing in the pipeline
                 self.instance.writeDocuments([doc])
+                self.chunkId += 1
 
                 # Reset image data after processing is complete
                 self.image_data = b''

--- a/nodes/test/thumbnail/test_chunk_ids.py
+++ b/nodes/test/thumbnail/test_chunk_ids.py
@@ -1,0 +1,77 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression coverage for sequential thumbnail document identities."""
+
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+from rocketlib import AVI_ACTION
+
+NODES_SRC = Path(__file__).parent.parent.parent / 'src' / 'nodes'
+while str(NODES_SRC) in sys.path:
+    sys.path.remove(str(NODES_SRC))
+sys.path.insert(0, str(NODES_SRC))
+
+thumbnail_module = importlib.import_module('thumbnail.IInstance')
+IInstance = thumbnail_module.IInstance
+
+
+class _Capture:
+    """Minimal engine binding that records emitted thumbnail documents."""
+
+    def __init__(self):
+        self.documents = []
+        self.currentObject = SimpleNamespace(
+            objectId='album-1',
+            path='/inbox/album.pdf',
+            permissionId=0,
+            componentId='thumbnail-test',
+        )
+
+    def hasListener(self, lane):  # noqa: N802 (engine method name)
+        return lane == 'documents'
+
+    def writeDocuments(self, documents):  # noqa: N802 (engine method name)
+        self.documents.extend(documents)
+
+
+class _Endpoint:
+    endpoint = SimpleNamespace(jobConfig={'nodeId': 'thumbnail-node'})
+
+
+def _drive_image(inst, payload):
+    """Send one complete image stream and swallow the engine preventDefault signal."""
+    for action, buffer in (
+        (AVI_ACTION.BEGIN, b''),
+        (AVI_ACTION.WRITE, payload),
+        (AVI_ACTION.END, b''),
+    ):
+        try:
+            inst.writeImage(action, 'image/png', buffer)
+        except Exception:
+            pass
+
+
+def test_sequential_images_receive_distinct_chunk_ids(monkeypatch):
+    """Every thumbnail from one object must have a stable, unique document key."""
+    image = SimpleNamespace(width=640, height=480)
+    thumbnail = SimpleNamespace(width=128, height=96)
+    monkeypatch.setattr(thumbnail_module.ImageProcessor, 'load_image_from_bytes', lambda _: image)
+    monkeypatch.setattr(thumbnail_module.ImageProcessor, 'get_thumbnail', lambda _: thumbnail)
+    monkeypatch.setattr(thumbnail_module.ImageProcessor, 'get_base64', lambda _: 'dGh1bWJuYWls')
+
+    inst = IInstance()
+    inst.instance = _Capture()
+    inst.IEndpoint = _Endpoint()
+    inst.open(inst.instance.currentObject)
+
+    _drive_image(inst, b'first-image')
+    _drive_image(inst, b'second-image')
+    _drive_image(inst, b'third-image')
+
+    assert [doc.metadata.chunkId for doc in inst.instance.documents] == [0, 1, 2]

--- a/nodes/test/thumbnail/test_chunk_ids.py
+++ b/nodes/test/thumbnail/test_chunk_ids.py
@@ -45,16 +45,13 @@ class _Endpoint:
 
 
 def _drive_image(inst, payload):
-    """Send one complete image stream and swallow the engine preventDefault signal."""
+    """Send one complete image stream through the real node handler."""
     for action, buffer in (
         (AVI_ACTION.BEGIN, b''),
         (AVI_ACTION.WRITE, payload),
         (AVI_ACTION.END, b''),
     ):
-        try:
-            inst.writeImage(action, 'image/png', buffer)
-        except Exception:
-            pass
+        inst.writeImage(action, 'image/png', buffer)
 
 
 def test_sequential_images_receive_distinct_chunk_ids(monkeypatch):
@@ -66,6 +63,7 @@ def test_sequential_images_receive_distinct_chunk_ids(monkeypatch):
     monkeypatch.setattr(thumbnail_module.ImageProcessor, 'get_base64', lambda _: 'dGh1bWJuYWls')
 
     inst = IInstance()
+    monkeypatch.setattr(inst, 'preventDefault', lambda: None)
     inst.instance = _Capture()
     inst.IEndpoint = _Endpoint()
     inst.open(inst.instance.currentObject)


### PR DESCRIPTION
## What changed

- Increment the thumbnail node's per-object `chunkId` after each emitted document.
- Add an engine-backed regression test that sends three sequential image streams and verifies IDs `0, 1, 2`.

## Why

The thumbnail node initialized `chunkId` once but never advanced it. Multi-frame and multi-image objects therefore emitted every document with `chunkId=0`, causing downstream vector/document stores keyed by object and chunk to overwrite earlier thumbnails.

This preserves the existing reset-on-`open()` behavior while making each thumbnail within one object addressable.

Fixes #1964

## Validation

- `builder.cmd nodes:test --pytest-pattern="sequential_images_receive_distinct_chunk_ids" --pytest-parallel=off` — 1 passed (3,526 collected)
- `ruff check nodes/src/nodes/thumbnail/IInstance.py nodes/test/thumbnail/test_chunk_ids.py`
- Repository pre-commit: gitleaks, Ruff check, and Ruff format all passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed thumbnail processing so each emitted image receives a unique, sequential chunk ID.
  * Improved reliability when processing multiple complete image streams in sequence, ensuring IDs continue correctly across thumbnails.

* **Tests**
  * Added coverage verifying sequential chunk IDs across multiple thumbnails and complete image streams.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->