### PR TITLE
ci(actions): verify SHA version comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,20 @@ env:
 #  Build
 # ---------------------------------------------------------------------------
 jobs:
+  action-pins:
+    name: Verify action pins
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Test pin verifier
+        run: node --test scripts/verify-action-pins.test.mjs
+
+      - name: Compare pins with version tags
+        run: node scripts/verify-action-pins.mjs
+
   init:
     name: Initialize
     uses: ./.github/workflows/_init.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Test pin verifier
         run: node --test scripts/verify-action-pins.test.mjs

--- a/.github/workflows/lock-node-deps.yml
+++ b/.github/workflows/lock-node-deps.yml
@@ -90,7 +90,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv (pinned for reproducible compiles)
-        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.1
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5.4.2
         with:
           version: "0.5.29"
 

--- a/.github/workflows/release-backmerge.yml
+++ b/.github/workflows/release-backmerge.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-stall-check.yml
+++ b/.github/workflows/release-stall-check.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout (full history — we compare branches)
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -80,7 +80,7 @@ jobs:
 
       - name: Open or refresh the tracking issue
         if: steps.gap.outputs.stalled == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const behind  = '${{ steps.gap.outputs.behind }}';
@@ -122,7 +122,7 @@ jobs:
 
       - name: Close the tracking issue once main catches up
         if: steps.gap.outputs.stalled == 'false'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const marker = '<!-- release-stall-check -->';

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
 		"pipeline"
 	],
 	"scripts": {
-		"prepare": "lefthook install --force"
+		"prepare": "lefthook install --force",
+		"check:action-pins": "node scripts/verify-action-pins.mjs",
+		"test:action-pins": "node --test scripts/verify-action-pins.test.mjs"
 	},
 	"packageManager": "pnpm@10.33.0",
 	"engines": {

--- a/scripts/verify-action-pins.mjs
+++ b/scripts/verify-action-pins.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+/** Verify that pinned GitHub Action SHAs agree with their version comments. */
+
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const USES_RE = /^\s*(?:-\s*)?uses:\s*([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[^@\s#]+)?)@([0-9a-f]{40})(?:\s+#\s*(\S+))?\s*$/;
+const VERSION_RE = /^v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?$/;
+
+/** Parse remotely hosted, SHA-pinned actions from one workflow. */
+export function parseWorkflow(source, filename) {
+	return source.split(/\r?\n/).flatMap((line, index) => {
+		const match = line.match(USES_RE);
+		if (!match) return [];
+		const action = match[1];
+		return [
+			{
+				filename,
+				line: index + 1,
+				action,
+				repository: action.split('/').slice(0, 2).join('/'),
+				sha: match[2],
+				version: match[3] ?? null,
+			},
+		];
+	});
+}
+
+/** Compare parsed pins with a resolver that maps repository + tag to eligible commit SHAs. */
+export async function verifyPins(pins, resolveTag) {
+	const errors = [];
+	await Promise.all(
+		pins.map(async (pin) => {
+			if (!pin.version) {
+				errors.push({ ...pin, message: `${pin.action}@${pin.sha} is missing a version comment (for example, # v4).` });
+				return;
+			}
+			if (!VERSION_RE.test(pin.version)) {
+				errors.push({ ...pin, message: `Version comment "${pin.version}" is not a supported Git tag.` });
+				return;
+			}
+			try {
+				const expected = await resolveTag(pin.repository, pin.version);
+				const candidates = Array.isArray(expected) ? expected : [expected];
+				if (!candidates.some((sha) => sha.toLowerCase() === pin.sha.toLowerCase())) {
+					errors.push({
+						...pin,
+						message: `${pin.repository}@${pin.version} does not include pinned commit ${pin.sha}.`,
+					});
+				}
+			} catch (error) {
+				errors.push({ ...pin, message: `Could not resolve ${pin.repository}@${pin.version}: ${error.message}` });
+			}
+		})
+	);
+	return errors.sort((a, b) => a.filename.localeCompare(b.filename) || a.line - b.line);
+}
+
+/** Resolve exact tags, or every release within a major-only comment such as v4. */
+export async function resolveGitHubTag(repository, version) {
+	const remote = `https://github.com/${repository}.git`;
+	const majorOnly = /^v\d+$/.test(version);
+	const patterns = majorOnly ? [`refs/tags/${version}*`] : [`refs/tags/${version}`, `refs/tags/${version}^{}`];
+	const { stdout } = await execFileAsync('git', ['ls-remote', '--tags', remote, ...patterns], { encoding: 'utf8', timeout: 30_000, windowsHide: true });
+	const refs = new Map(
+		stdout
+			.trim()
+			.split(/\r?\n/)
+			.filter(Boolean)
+			.map((line) => {
+				const [sha, ref] = line.split(/\s+/);
+				return [ref, sha];
+			})
+	);
+	const tags = new Map();
+	for (const [ref, sha] of refs) {
+		const base = ref.replace(/\^\{\}$/, '');
+		const tagName = base.slice('refs/tags/'.length);
+		if (majorOnly && tagName !== version && !tagName.startsWith(`${version}.`)) continue;
+		if (ref.endsWith('^{}') || !tags.has(base)) tags.set(base, sha);
+	}
+	if (!tags.size) throw new Error('tag does not exist');
+	return [...new Set(tags.values())];
+}
+
+async function workflowFiles(root) {
+	const workflowDir = path.join(root, '.github', 'workflows');
+	const entries = await fs.readdir(workflowDir, { withFileTypes: true });
+	return entries.filter((entry) => entry.isFile() && /\.ya?ml$/i.test(entry.name)).map((entry) => path.join(workflowDir, entry.name));
+}
+
+async function main() {
+	const root = process.cwd();
+	const pins = [];
+	for (const filename of await workflowFiles(root)) {
+		const relative = path.relative(root, filename).replaceAll('\\', '/');
+		pins.push(...parseWorkflow(await fs.readFile(filename, 'utf8'), relative));
+	}
+
+	const cache = new Map();
+	const cachedResolver = (repository, version) => {
+		const key = `${repository}@${version}`;
+		if (!cache.has(key)) cache.set(key, resolveGitHubTag(repository, version));
+		return cache.get(key);
+	};
+	const errors = await verifyPins(pins, cachedResolver);
+
+	if (errors.length) {
+		for (const error of errors) {
+			console.error(`::error file=${error.filename},line=${error.line}::${error.message}`);
+		}
+		console.error(`\n${errors.length} invalid action pin(s) found across ${pins.length} pinned uses.`);
+		process.exitCode = 1;
+		return;
+	}
+	console.log(`Verified ${pins.length} action pins against ${cache.size} upstream tags.`);
+}
+
+if (process.argv[1] && pathToFileURL(path.resolve(process.argv[1])).href === import.meta.url) {
+	await main();
+}

--- a/scripts/verify-action-pins.mjs
+++ b/scripts/verify-action-pins.mjs
@@ -14,7 +14,7 @@ import { pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 const execFileAsync = promisify(execFile);
-const USES_RE = /^\s*(?:-\s*)?uses:\s*([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[^@\s#]+)?)@([0-9a-f]{40})(?:\s+#\s*(\S+))?\s*$/;
+const USES_RE = /^\s*(?:-\s*)?uses:\s*(["']?)([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+(?:\/[^@\s#]+)?)@([0-9a-f]{40})\1(?:\s+#\s*(\S+))?\s*$/;
 const VERSION_RE = /^v\d+(?:\.\d+){0,2}(?:[-+][0-9A-Za-z.-]+)?$/;
 
 /** Parse remotely hosted, SHA-pinned actions from one workflow. */
@@ -22,15 +22,15 @@ export function parseWorkflow(source, filename) {
 	return source.split(/\r?\n/).flatMap((line, index) => {
 		const match = line.match(USES_RE);
 		if (!match) return [];
-		const action = match[1];
+		const action = match[2];
 		return [
 			{
 				filename,
 				line: index + 1,
 				action,
 				repository: action.split('/').slice(0, 2).join('/'),
-				sha: match[2],
-				version: match[3] ?? null,
+				sha: match[3],
+				version: match[4] ?? null,
 			},
 		];
 	});
@@ -93,12 +93,14 @@ export async function resolveGitHubTag(repository, version) {
 	return [...new Set(tags.values())];
 }
 
+/** Return every YAML workflow in the repository's workflow directory. */
 async function workflowFiles(root) {
 	const workflowDir = path.join(root, '.github', 'workflows');
 	const entries = await fs.readdir(workflowDir, { withFileTypes: true });
 	return entries.filter((entry) => entry.isFile() && /\.ya?ml$/i.test(entry.name)).map((entry) => path.join(workflowDir, entry.name));
 }
 
+/** Run the repository-wide verifier and emit GitHub annotation commands. */
 async function main() {
 	const root = process.cwd();
 	const pins = [];

--- a/scripts/verify-action-pins.test.mjs
+++ b/scripts/verify-action-pins.test.mjs
@@ -1,0 +1,53 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+// =============================================================================
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { parseWorkflow, verifyPins } from './verify-action-pins.mjs';
+
+const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+
+describe('action pin verification', () => {
+	it('accepts a pin whose version resolves to its SHA', async () => {
+		const pins = parseWorkflow(`- uses: actions/checkout@${SHA} # v4`, 'ci.yml');
+		assert.deepEqual(await verifyPins(pins, async () => SHA), []);
+	});
+
+	it('reports a drifted version comment', async () => {
+		const pins = parseWorkflow(`uses: astral-sh/setup-uv@${SHA} # v5.4.1`, 'lock.yml');
+		const errors = await verifyPins(pins, async () => OTHER_SHA);
+		assert.equal(errors.length, 1);
+		assert.match(errors[0].message, /does not include pinned commit a{40}/);
+	});
+
+	it('accepts a pinned patch commit within a major version line', async () => {
+		const pins = parseWorkflow(`uses: actions/checkout@${SHA} # v4`, 'ci.yml');
+		assert.deepEqual(await verifyPins(pins, async () => [OTHER_SHA, SHA]), []);
+	});
+
+	it('requires comments on SHA-pinned remote actions', async () => {
+		const pins = parseWorkflow(`uses: actions/github-script@${SHA}`, 'release.yml');
+		const errors = await verifyPins(pins, async () => SHA);
+		assert.match(errors[0].message, /missing a version comment/);
+	});
+
+	it('resolves an action subpath through its two-segment repository', () => {
+		const [pin] = parseWorkflow(`uses: github/gh-aw/actions/setup@${SHA} # v1`, 'agentic.yml');
+		assert.equal(pin.repository, 'github/gh-aw');
+	});
+
+	it('ignores local, Docker, and unpinned action references', () => {
+		const pins = parseWorkflow(
+			`
+uses: ./local-action
+uses: docker://alpine:3
+uses: actions/checkout@v4
+`,
+			'ci.yml'
+		);
+		assert.deepEqual(pins, []);
+	});
+});

--- a/scripts/verify-action-pins.test.mjs
+++ b/scripts/verify-action-pins.test.mjs
@@ -28,6 +28,18 @@ describe('action pin verification', () => {
 		assert.deepEqual(await verifyPins(pins, async () => [OTHER_SHA, SHA]), []);
 	});
 
+	it('validates single- and double-quoted uses values', async () => {
+		const pins = parseWorkflow(`uses: "actions/checkout@${SHA}" # v4\n- uses: 'actions/setup-node@${OTHER_SHA}' # v4`, 'quoted.yml');
+		assert.deepEqual(
+			pins.map(({ action, sha, version }) => ({ action, sha, version })),
+			[
+				{ action: 'actions/checkout', sha: SHA, version: 'v4' },
+				{ action: 'actions/setup-node', sha: OTHER_SHA, version: 'v4' },
+			]
+		);
+		assert.deepEqual(await verifyPins(pins, async (_repository, _version) => [SHA, OTHER_SHA]), []);
+	});
+
 	it('requires comments on SHA-pinned remote actions', async () => {
 		const pins = parseWorkflow(`uses: actions/github-script@${SHA}`, 'release.yml');
 		const errors = await verifyPins(pins, async () => SHA);


### PR DESCRIPTION
## What changed

- Add a dependency-free Node verifier that parses every SHA-pinned marketplace action in `.github/workflows`.
- Resolve lightweight and annotated Git tags with `git ls-remote` and compare them to the pinned commit.
- Preserve the repository's major-line convention (`# v4` accepts any `v4.x.y` release) while enforcing exact comments such as `# v5.4.2`.
- Emit GitHub workflow annotations on the precise file and line.
- Add six unit tests plus a five-minute CI job.
- Correct the stale `setup-uv` comment (`v5.4.1` → `v5.4.2`) and add missing version comments to four existing pins.

## Why

Pinned SHAs protect execution, but a stale version comment misleads reviewers and maintainers. The repository already carried a concrete example: the `setup-uv` commit was for `v5.4.2` while its comment still said `v5.4.1`. Nothing prevented the two from drifting again.

The checker deliberately distinguishes exact release comments from moving major-line comments so routine Dependabot pins do not become false positives.

Fixes #1878

## Validation

- `npm run test:action-pins` — 6 passed
- `npm run check:action-pins` — verified 79 pins against 27 upstream tag sets
- Parsed every workflow with PyYAML
- `git diff --check`
- Repository pre-commit: gitleaks passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated verification for pinned GitHub Actions, including version alignment and comment validation.
  * Added commands and CI coverage to run action-pin checks and tests.
* **Bug Fixes**
  * Improved consistency and reliability of workflow action version annotations.
* **Tests**
  * Added coverage for valid pins, version drift, patch updates, required comments, subpath repositories, and excluded references.
* **Chores**
  * Updated an action reference to a newer patch release and clarified version annotations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->