### PR TITLE
fix(store_pinecone): read list_indexes() entries that are IndexModel objects

### DIFF
--- a/nodes/src/nodes/store_pinecone/IGlobal.py
+++ b/nodes/src/nodes/store_pinecone/IGlobal.py
@@ -61,7 +61,11 @@ def _index_field(index: Any, name: str, default: Any = None) -> Any:
                     return method()
                 except Exception:
                     continue
-        return {key: getattr(value, key) for key in dir(value) if not key.startswith('_')}
+        return {
+            key: getattr(value, key)
+            for key in dir(value)
+            if not key.startswith('_') and not callable(getattr(value, key, None))
+        }
     return value
 
 

--- a/nodes/src/nodes/store_pinecone/IGlobal.py
+++ b/nodes/src/nodes/store_pinecone/IGlobal.py
@@ -35,6 +35,36 @@ from rocketlib import warning
 HTTP_BODY_MARKER = 'http response body:'
 
 
+def _index_field(index: Any, name: str, default: Any = None) -> Any:
+    """Read a field from an entry returned by ``list_indexes()``.
+
+    The shape of those entries is not stable across the pinecone client. Older
+    releases yielded plain dicts; from v7 the description objects (``IndexModel``)
+    are returned instead, and they expose attributes but no ``.get()``. Calling
+    ``.get()`` on one raises ``'IndexModel' object has no attribute 'get'``.
+
+    requirements.txt pins no version, so which shape arrives depends on when the
+    dependency was resolved.
+    """
+    if isinstance(index, dict):
+        return index.get(name, default)
+    value = getattr(index, name, None)
+    if value is None:
+        return default
+    # Nested descriptions (``spec``) are themselves model objects; hand back a
+    # mapping so callers can treat both shapes alike.
+    if not isinstance(value, (str, int, float, bool, dict, list)):
+        for converter in ('to_dict', 'model_dump', 'dict'):
+            method = getattr(value, converter, None)
+            if callable(method):
+                try:
+                    return method()
+                except Exception:
+                    continue
+        return {key: getattr(value, key) for key in dir(value) if not key.startswith('_')}
+    return value
+
+
 class IGlobal(StoreGlobalBase):
     serverName: str = 'pinecone'
 
@@ -104,9 +134,11 @@ class IGlobal(StoreGlobalBase):
             index_list = client.list_indexes()
 
             # Check if collection exists and validate mode compatibility
-            existing_collection = next((index for index in index_list if index.get('name') == collection), None)
+            existing_collection = next(
+                (index for index in index_list if _index_field(index, 'name') == collection), None
+            )
             if existing_collection:
-                is_serverless = 'serverless' in existing_collection.get('spec', {})
+                is_serverless = 'serverless' in (_index_field(existing_collection, 'spec', {}) or {})
                 if mode == 'serverless-dense' and not is_serverless:
                     warning(
                         f"Collection '{collection}' exists and is pod-based but you selected serverless mode. Please select 'Pinecone Pod-Based Index' to use this collection"

--- a/nodes/src/nodes/store_pinecone/IGlobal.py
+++ b/nodes/src/nodes/store_pinecone/IGlobal.py
@@ -65,6 +65,22 @@ def _index_field(index: Any, name: str, default: Any = None) -> Any:
     return value
 
 
+def _is_serverless(index: Any) -> bool:
+    """Return True when an index description denotes a serverless index.
+
+    The value has to be read, not just the key. ``IndexSpec.to_dict()`` emits
+    every variant it knows about, unset ones included, so a pod-based index
+    describes itself as ``{'serverless': None, 'pod': {...}, 'byoc': None}``.
+    Testing for key membership therefore reports every pod-based index as
+    serverless and produces the opposite compatibility warning to the one the
+    user needs.
+    """
+    spec = _index_field(index, 'spec', {}) or {}
+    if isinstance(spec, dict):
+        return bool(spec.get('serverless'))
+    return bool(getattr(spec, 'serverless', None))
+
+
 class IGlobal(StoreGlobalBase):
     serverName: str = 'pinecone'
 
@@ -138,7 +154,7 @@ class IGlobal(StoreGlobalBase):
                 (index for index in index_list if _index_field(index, 'name') == collection), None
             )
             if existing_collection:
-                is_serverless = 'serverless' in (_index_field(existing_collection, 'spec', {}) or {})
+                is_serverless = _is_serverless(existing_collection)
                 if mode == 'serverless-dense' and not is_serverless:
                     warning(
                         f"Collection '{collection}' exists and is pod-based but you selected serverless mode. Please select 'Pinecone Pod-Based Index' to use this collection"

--- a/nodes/test/store_pinecone/test_index_description.py
+++ b/nodes/test/store_pinecone/test_index_description.py
@@ -1,0 +1,135 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression tests for reading `list_indexes()` entries.
+
+Two shapes have to work. Older pinecone clients yielded plain dicts; from v7
+they yield IndexModel description objects, which expose attributes and no
+`.get()`. Calling `.get()` on one raises
+`'IndexModel' object has no attribute 'get'`, and requirements.txt pins no
+version, so which shape arrives depends on when the dependency was resolved.
+
+The serverless check is covered separately because `IndexSpec.to_dict()` emits
+every variant it knows about, unset ones included: a pod-based index describes
+itself as `{'serverless': None, 'pod': {...}}`. Testing key membership rather
+than the value reports pod-based indexes as serverless and emits the opposite
+compatibility warning to the one the user needs.
+
+IGlobal is imported directly with its two engine imports stubbed. The driver
+module is deliberately untouched -- it pulls in `depends` and the pinecone SDK
+at import time, and none of that is needed to exercise these helpers.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+import pytest
+
+_IGLOBAL_PATH = Path(__file__).resolve().parents[3] / 'nodes' / 'src' / 'nodes' / 'store_pinecone' / 'IGlobal.py'
+
+
+@contextmanager
+def _stubbed_engine_imports() -> Iterator[types.ModuleType]:
+    """Import IGlobal.py with `ai.common.store` and `rocketlib` stubbed out."""
+    saved = {name: sys.modules.get(name) for name in ('ai', 'ai.common', 'ai.common.store', 'rocketlib')}
+
+    ai = types.ModuleType('ai')
+    common = types.ModuleType('ai.common')
+    store = types.ModuleType('ai.common.store')
+    store.StoreGlobalBase = type('StoreGlobalBase', (), {})
+    rocketlib = types.ModuleType('rocketlib')
+    rocketlib.warning = lambda *args, **kwargs: None
+
+    sys.modules.update({'ai': ai, 'ai.common': common, 'ai.common.store': store, 'rocketlib': rocketlib})
+    try:
+        spec = importlib.util.spec_from_file_location('store_pinecone_iglobal', _IGLOBAL_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        yield module
+    finally:
+        for name, original in saved.items():
+            if original is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = original
+        sys.modules.pop('store_pinecone_iglobal', None)
+
+
+@pytest.fixture(name='iglobal')
+def _iglobal() -> Iterator[types.ModuleType]:
+    with _stubbed_engine_imports() as module:
+        yield module
+
+
+class _Spec:
+    """Stand-in for IndexSpec: unset variants are present and None."""
+
+    def __init__(self, serverless=None, pod=None):
+        self.serverless = serverless
+        self.pod = pod
+
+    def to_dict(self):
+        return {'serverless': self.serverless, 'pod': self.pod, 'byoc': None}
+
+
+class _IndexModel:
+    """Stand-in for a v7+ description object: attributes, and no `.get()`."""
+
+    def __init__(self, name, spec):
+        self.name = name
+        self.spec = spec
+
+
+_SERVERLESS_SPEC = {'cloud': 'aws', 'region': 'us-east-1'}
+_POD_SPEC = {'environment': 'us-east1-gcp', 'pod_type': 'p1.x1'}
+
+
+def test_index_model_has_no_get_method():
+    """Guards the premise: the old `.get()` call is what fails on v7+ entries."""
+    with pytest.raises(AttributeError):
+        _IndexModel('idx', _Spec()).get('name')
+
+
+def test_reads_name_from_a_dict_entry(iglobal):
+    entry = {'name': 'my-index', 'spec': {'serverless': _SERVERLESS_SPEC}}
+    assert iglobal._index_field(entry, 'name') == 'my-index'
+
+
+def test_reads_name_from_a_model_entry(iglobal):
+    entry = _IndexModel('my-index', _Spec(serverless=_SERVERLESS_SPEC))
+    assert iglobal._index_field(entry, 'name') == 'my-index'
+
+
+def test_missing_field_returns_the_default(iglobal):
+    assert iglobal._index_field(_IndexModel('my-index', _Spec()), 'absent', 'fallback') == 'fallback'
+    assert iglobal._index_field({'name': 'my-index'}, 'absent', 'fallback') == 'fallback'
+
+
+def test_nested_spec_object_is_converted_to_a_mapping(iglobal):
+    entry = _IndexModel('my-index', _Spec(serverless=_SERVERLESS_SPEC))
+    assert iglobal._index_field(entry, 'spec') == {'serverless': _SERVERLESS_SPEC, 'pod': None, 'byoc': None}
+
+
+@pytest.mark.parametrize(
+    ('entry_factory', 'expected'),
+    [
+        # A pod-based spec still carries a 'serverless' key, set to None.
+        (lambda: _IndexModel('idx', _Spec(pod=_POD_SPEC)), False),
+        (lambda: _IndexModel('idx', _Spec(serverless=_SERVERLESS_SPEC)), True),
+        (lambda: {'name': 'idx', 'spec': {'serverless': None, 'pod': _POD_SPEC}}, False),
+        (lambda: {'name': 'idx', 'spec': {'serverless': _SERVERLESS_SPEC}}, True),
+        # An entry with no spec at all must not be reported as serverless.
+        (lambda: {'name': 'idx'}, False),
+    ],
+    ids=['model-pod', 'model-serverless', 'dict-pod', 'dict-serverless', 'no-spec'],
+)
+def test_serverless_detection_reads_the_value_not_the_key(iglobal, entry_factory, expected):
+    assert iglobal._is_serverless(entry_factory()) is expected


### PR DESCRIPTION
## Summary

- `list_indexes()` returns `IndexModel` objects from pinecone-client v7+, not the dicts older releases yielded. The probe calls `.get()` on each entry, which raises `'IndexModel' object has no attribute 'get'`.
- Adds an accessor that reads either shape instead of pinning a client version. `requirements.txt` pins none today, so which shape arrives depends on when the dependency was resolved.
- Also fixes the serverless check to read the value rather than the key, per review. `IndexSpec.to_dict()` emits unset variants as `None`, so a pod-based index carries `{'serverless': None, ...}` and the membership test reported it as serverless.

The crash only appears once an index exists. `next()` stops evaluating on an empty account, so the first run looks healthy and every run after it fails.

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`nodes/test/store_pinecone/test_index_description.py`: 10 tests covering pod and serverless indexes as both dicts and description objects. They fail against the old checks and pass against the new ones, and run under plain pytest with no engine build. `ruff check` and `ruff format --check` clean.

Found running an ingest against pinecone 9.1.0 on engine `server-v3.3.1`. Cloud emits the same warning at `/opt/rocketride/nodes/pinecone/IGlobal.py:226`.

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable): none

## Linked Issue

Fixes #1984


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pinecone index compatibility across legacy dictionary formats and newer model-based responses.
  * Corrected serverless mode detection based on the index specification.
  * Enhanced handling of nested index details and missing specification values.

* **Tests**
  * Added regression coverage for legacy and current Pinecone index descriptions, including pod, serverless, and incomplete configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->