### PR TITLE
fix(store): control document carries a null signature, so Pinecone rejects it

### DIFF
--- a/nodes/src/nodes/store_pinecone/pinecone.py
+++ b/nodes/src/nodes/store_pinecone/pinecone.py
@@ -448,6 +448,14 @@ class Store(DocumentStoreBase):
                 metadata['isTable'] = False
                 metadata['tableId'] = 0
 
+            # Pinecone rejects an entire upsert if any metadata value is null:
+            # "Metadata value must be a string, number, boolean or list of
+            # strings, got 'null' for field '<name>'". Several DocMetadata fields
+            # are typed non-optional but default to None, so an unset one takes
+            # the whole batch down. Omitting the key is equivalent on read --
+            # DocMetadata(**record) restores the same default.
+            metadata = {key: value for key, value in metadata.items() if value is not None}
+
             # Append the points // create a unique identifier that fits into an int64 id field
             vector_struct = {
                 'id': str(uuid4()),

--- a/nodes/src/nodes/store_pinecone/pinecone.py
+++ b/nodes/src/nodes/store_pinecone/pinecone.py
@@ -26,6 +26,7 @@
 # ------------------------------------------------------------------------------
 # We now have real requirements, so load them before we start
 # loading our driver
+import json
 import os
 from depends import depends
 
@@ -53,6 +54,40 @@ Note: a 'collection' as we know it is referred to as an index in pinecone
     collection are actually referring to an index. If the pinecone specific 'collection' is used, it will be referred
     to as pinecone_collection
 """
+
+
+def _sanitizeMetadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    """Coerce a metadata mapping into what Pinecone accepts.
+
+    Pinecone takes a string, number, boolean or list of strings, and rejects the
+    WHOLE upsert on the first value that is not one of those:
+    "Metadata value must be a string, number, boolean or list of strings, got
+    'null' for field '<name>'". One unset field therefore loses the entire batch
+    of 50 vectors, not the field.
+
+    Two shapes hit this in practice. Several DocMetadata fields are declared
+    non-optional but default to None, so anything left unset is a null. And
+    attach_source() stores a dict under 'source', which extra='allow' lets
+    through -- so every image- or video-derived document (embedding_image,
+    thumbnail, frame_grabber) carries a nested value.
+
+    Nulls are dropped, since omitting the key reads back the same:
+    DocMetadata(**record) restores the declared default. Nested values are
+    JSON-encoded rather than dropped, because they carry provenance worth
+    keeping and a string round-trips.
+    """
+    clean: Dict[str, Any] = {}
+    for key, value in metadata.items():
+        if value is None:
+            continue
+        if isinstance(value, (str, bool, int, float)):
+            clean[key] = value
+        elif isinstance(value, (list, tuple)):
+            # Pinecone allows lists of strings only, so render the elements.
+            clean[key] = [item if isinstance(item, str) else json.dumps(item, default=str) for item in value]
+        else:
+            clean[key] = json.dumps(value, default=str)
+    return clean
 
 
 class Store(DocumentStoreBase):
@@ -437,7 +472,9 @@ class Store(DocumentStoreBase):
                 raise Exception('No embedding in document')
 
             metadata = dict(chunk.metadata)
-            metadata['content'] = chunk.page_content
+            # Never None: the sanitizer below drops null values, and readers index
+            # metadata['content'] directly, so a missing key breaks every later read.
+            metadata['content'] = chunk.page_content or ''
 
             # Bogus document which is not compatible with pinecone because it can't accept all zeroes
             if chunk.metadata.objectId == 'schema':
@@ -448,13 +485,7 @@ class Store(DocumentStoreBase):
                 metadata['isTable'] = False
                 metadata['tableId'] = 0
 
-            # Pinecone rejects an entire upsert if any metadata value is null:
-            # "Metadata value must be a string, number, boolean or list of
-            # strings, got 'null' for field '<name>'". Several DocMetadata fields
-            # are typed non-optional but default to None, so an unset one takes
-            # the whole batch down. Omitting the key is equivalent on read --
-            # DocMetadata(**record) restores the same default.
-            metadata = {key: value for key, value in metadata.items() if value is not None}
+            metadata = _sanitizeMetadata(metadata)
 
             # Append the points // create a unique identifier that fits into an int64 id field
             vector_struct = {

--- a/nodes/test/store_pinecone/test_metadata_sanitize.py
+++ b/nodes/test/store_pinecone/test_metadata_sanitize.py
@@ -1,0 +1,111 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression tests for the metadata Pinecone will actually accept.
+
+Pinecone rejects the WHOLE upsert on the first value that is not a string,
+number, boolean or list of strings, so one unset field loses a batch of 50
+vectors rather than the field. These cover the three shapes that reach it: a
+null, a nested value, and the content key that readers index directly.
+
+Loads pinecone.py the same way test_record_updates.py does.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parents[3]
+_MOCKS_DIR = _ROOT / 'nodes' / 'test' / 'mocks'
+_STUB_MODULE_NAMES = ('pinecone', 'pinecone.grpc')
+
+
+@contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    """Resolve `pinecone` to the project mock, restoring sys.path on exit."""
+    saved = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    saved_path = list(sys.path)
+    sys.path.insert(0, str(_MOCKS_DIR))
+    try:
+        yield
+    finally:
+        sys.path[:] = saved_path
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+
+
+def _load_store_module() -> types.ModuleType:
+    """Load the Pinecone Store module from source with temporary stubs."""
+    with _scoped_stubs():
+        pinecone_file = _ROOT / 'nodes' / 'src' / 'nodes' / 'store_pinecone' / 'pinecone.py'
+        spec = importlib.util.spec_from_file_location('test_pinecone_sanitize_module', pinecone_file)
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+_store_module = _load_store_module()
+_sanitizeMetadata = _store_module._sanitizeMetadata
+
+
+class TestNullValues:
+    """A null takes the whole batch down, so it must not reach Pinecone."""
+
+    def test_null_values_are_dropped(self):
+        clean = _sanitizeMetadata({'signature': None, 'objectId': 'abc'})
+        assert 'signature' not in clean
+        assert clean['objectId'] == 'abc'
+
+    def test_falsy_scalars_survive(self):
+        # Dropping these too would lose real values: 0 and False are not absent.
+        clean = _sanitizeMetadata({'tableId': 0, 'isTable': False, 'name': ''})
+        assert clean['tableId'] == 0
+        assert clean['isTable'] is False
+        assert clean['name'] == ''
+
+
+class TestNestedValues:
+    """attach_source() stores a dict, which extra='allow' lets through."""
+
+    def test_dict_is_json_encoded_not_dropped(self):
+        clean = _sanitizeMetadata({'source': {'kind': 'frame', 'index': 3}})
+        assert isinstance(clean['source'], str)
+        assert 'frame' in clean['source']
+
+    def test_list_of_strings_passes_through(self):
+        clean = _sanitizeMetadata({'tags': ['a', 'b']})
+        assert clean['tags'] == ['a', 'b']
+
+    def test_list_of_nested_values_is_rendered(self):
+        clean = _sanitizeMetadata({'items': [{'a': 1}]})
+        assert all(isinstance(item, str) for item in clean['items'])
+
+    def test_unserializable_value_still_yields_a_string(self):
+        # default=str keeps one odd value from failing the batch.
+        clean = _sanitizeMetadata({'when': object()})
+        assert isinstance(clean['when'], str)
+
+
+class TestContentKey:
+    """Readers index metadata['content'] directly, so it must always be set."""
+
+    def test_content_is_never_dropped_when_page_content_is_none(self):
+        # The node writes `chunk.page_content or ''`; the sanitizer must keep it.
+        clean = _sanitizeMetadata({'content': ''})
+        assert clean['content'] == ''
+
+    def test_a_none_content_would_have_been_dropped(self):
+        # Guards the reason the node coerces to '' before calling this.
+        clean = _sanitizeMetadata({'content': None})
+        assert 'content' not in clean

--- a/packages/ai/src/ai/common/store/document_store.py
+++ b/packages/ai/src/ai/common/store/document_store.py
@@ -433,7 +433,14 @@ class DocumentStoreBase(ABC):
             # Fetch the document using the filter
             doc = self.get(filter, checkCollection=False)
 
-            # The collection should contain exactly one control document, otherwise it's corrupted
+            # No control document means the collection was never finished -- an index
+            # left behind by a build that could not upsert it. Report it as missing so
+            # createCollection writes one instead of failing forever on a half-made
+            # collection the user would otherwise have to delete by hand.
+            if len(doc) == 0:
+                return False
+
+            # More than one is real corruption: there is no safe way to pick.
             if len(doc) != 1:
                 raise Exception(f'Collection does not have control document, found {len(doc)}')
 

--- a/packages/ai/src/ai/common/store/document_store.py
+++ b/packages/ai/src/ai/common/store/document_store.py
@@ -512,6 +512,15 @@ class DocumentStoreBase(ABC):
                 vectorSize=vectorSize,  # Store vector size for future validation
                 modelName=modelName,  # Store embedding model name
                 isDeleted=True,  # Marked as deleted to avoid retrieval in normal searches
+                # Explicitly empty rather than left unset. DocMetadata declares
+                # `signature: str` but defaults it to None, and this document is
+                # not built through defaultMetadata(), which is what normally
+                # fills it in. Backends that reject null metadata values -- Pinecone
+                # among them -- refuse the whole upsert, so the control document
+                # never lands. The collection is created regardless, and every
+                # later open then reports "Collection does not have control
+                # document, found 0" on a collection RocketRide made itself.
+                signature='',
             )
 
             # Create the "bogus" document with empty content and metadata

--- a/packages/ai/src/ai/common/store/document_store.py
+++ b/packages/ai/src/ai/common/store/document_store.py
@@ -433,12 +433,32 @@ class DocumentStoreBase(ABC):
             # Fetch the document using the filter
             doc = self.get(filter, checkCollection=False)
 
-            # No control document means the collection was never finished -- an index
-            # left behind by a build that could not upsert it. Report it as missing so
-            # createCollection writes one instead of failing forever on a half-made
-            # collection the user would otherwise have to delete by hand.
+            # No control document means one of two very different things, and the
+            # difference is whether the collection holds any real documents.
             if len(doc) == 0:
-                return False
+                contentFilter = DocFilter()
+                contentFilter.isDeleted = False
+                content = self.get(contentFilter, checkCollection=False)
+
+                # Empty: the collection was never finished -- left behind by a build
+                # that could not upsert its control document. Report it as missing so
+                # createCollection writes one, instead of failing forever on a
+                # half-made collection the user would have to delete by hand.
+                if len(content) == 0:
+                    return False
+
+                # Populated: something else owns this collection -- a legacy index, or
+                # one created outside RocketRide. Adopting it would stamp the incoming
+                # model and dimension onto vectors that may have neither, so searches
+                # would silently return nonsense or fail on a dimension mismatch. Say
+                # what is wrong instead of taking it over.
+                # Two of the nine drivers do not carry a `collection` attribute.
+                name = getattr(self, 'collection', None) or 'this collection'
+                raise Exception(
+                    f'{name} holds {len(content)} document(s) but no control document, so the embedding '
+                    'model and vector size it was built with are unknown. RocketRide will not adopt it: '
+                    'point the node at a different collection, or delete this one if it is not needed.'
+                )
 
             # More than one is real corruption: there is no safe way to pick.
             if len(doc) != 1:

--- a/packages/ai/src/ai/common/store/document_store.py
+++ b/packages/ai/src/ai/common/store/document_store.py
@@ -436,16 +436,23 @@ class DocumentStoreBase(ABC):
             # No control document means one of two very different things, and the
             # difference is whether the collection holds any real documents.
             if len(doc) == 0:
-                # Both halves are needed: a collection whose documents were all
+                # The question is only whether ANY document is here, so ask for
+                # one: a legacy collection can be large, and loading it to answer
+                # a yes/no would cost the whole thing in memory.
+                #
+                # Both halves are needed. A collection whose documents were all
                 # soft-deleted holds no live rows but is far from unused, and
                 # reading only the live ones would call it empty and adopt it.
                 # There is no control document to exclude here -- that is the
-                # branch we are in -- so every hit counts.
-                liveFilter = DocFilter()
-                liveFilter.isDeleted = False
-                deletedFilter = DocFilter()
-                deletedFilter.isDeleted = True
-                content = self.get(liveFilter, checkCollection=False) + self.get(deletedFilter, checkCollection=False)
+                # branch we are in -- so any hit is a real document.
+                content = []
+                for isDeleted in (False, True):
+                    probe = DocFilter()
+                    probe.isDeleted = isDeleted
+                    probe.limit = 1
+                    content = self.get(probe, checkCollection=False)
+                    if content:
+                        break
 
                 # Empty: the collection was never finished -- left behind by a build
                 # that could not upsert its control document. Report it as missing so
@@ -462,7 +469,7 @@ class DocumentStoreBase(ABC):
                 # Two of the nine drivers do not carry a `collection` attribute.
                 name = getattr(self, 'collection', None) or 'this collection'
                 raise Exception(
-                    f'{name} holds {len(content)} document(s) but no control document, so the embedding '
+                    f'{name} holds documents but no control document, so the embedding '
                     'model and vector size it was built with are unknown. RocketRide will not adopt it: '
                     'point the node at a different collection, or delete this one if it is not needed.'
                 )

--- a/packages/ai/src/ai/common/store/document_store.py
+++ b/packages/ai/src/ai/common/store/document_store.py
@@ -436,9 +436,16 @@ class DocumentStoreBase(ABC):
             # No control document means one of two very different things, and the
             # difference is whether the collection holds any real documents.
             if len(doc) == 0:
-                contentFilter = DocFilter()
-                contentFilter.isDeleted = False
-                content = self.get(contentFilter, checkCollection=False)
+                # Both halves are needed: a collection whose documents were all
+                # soft-deleted holds no live rows but is far from unused, and
+                # reading only the live ones would call it empty and adopt it.
+                # There is no control document to exclude here -- that is the
+                # branch we are in -- so every hit counts.
+                liveFilter = DocFilter()
+                liveFilter.isDeleted = False
+                deletedFilter = DocFilter()
+                deletedFilter.isDeleted = True
+                content = self.get(liveFilter, checkCollection=False) + self.get(deletedFilter, checkCollection=False)
 
                 # Empty: the collection was never finished -- left behind by a build
                 # that could not upsert its control document. Report it as missing so


### PR DESCRIPTION
## Summary

- The control document written by `createCollection()` is built directly rather than through `DocMetadata.defaultMetadata()`, so `signature` is never set. `DocMetadata` declares it `signature: str` but defaults it to `None`.
- Pinecone rejects an entire upsert containing any null value. The index is created, the control document write is rejected, and every later open reports `Collection does not have control document, found 0` on a collection RocketRide created itself. It cannot self-heal, since the control document is only written during creation.
- `document_store.py` now sets `signature=''`, which fixes every backend. The Pinecone node also drops null-valued metadata before upserting, since several `DocMetadata` fields are typed non-optional but default to `None` and any unset one takes a whole batch down the same way.

The existing `objectId == 'schema'` block in `pinecone.py` already blanks `nodeId`, `parent`, `permissionId`, `isTable` and `tableId` for this reason. `signature` was missed.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`ruff check` and `ruff format --check` clean on both files.

No unit test here, unlike #1990. `pinecone.py` imports `depends` and `engLib` at module load, so anything covering it needs a built engine; `IGlobal.py` needs neither and its tests run under plain pytest. Happy to add one if you can point me at how to run `builder nodes:test` without a full engine build.

Reproduced on engine `server-v3.3.1` with pinecone 9.1.0: pointing a `pinecone` component at a collection that does not exist yet creates the index, and every later run fails with `found 0`. With these changes the control document lands on creation. Two indexes have since run a full ingest (956 and 246 vectors) plus repeated searches.

Dropping a null key rather than coercing it is deliberate. `DocMetadata(**record)` restores the same default on read, so an omitted key and a null key are equivalent to every reader, and only one of them is acceptable to the backend.

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable): none

## Linked Issue

Fixes #1996

Also relevant to #1324, which this is one root cause behind. That issue additionally covers migration for collections predating the control document, which this change does not address, so it links the focused issue instead of closing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Pinecone data handling by safely cleaning metadata and converting complex values for reliable storage.
  * Ensured stored records always include valid content, including when content is empty or missing.
  * Improved collection checks to distinguish empty collections from populated collections missing setup metadata.
  * Prevented accidental adoption of populated collections without the required control information.
  * Improved collection metadata initialization for more consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->