### PR TITLE
fix(prompt): suppress the default forward so the LLM receives one question

### DIFF
--- a/nodes/src/nodes/prompt/IInstance.py
+++ b/nodes/src/nodes/prompt/IInstance.py
@@ -47,6 +47,14 @@ class IInstance(IInstanceBase):
         for q in question.questions:
             self.question.addQuestion(q.text)
 
+        # Collecting alone is not enough: without this the framework also
+        # forwards the untouched incoming question, so the LLM downstream
+        # receives two -- the original, carrying none of the configured
+        # instructions, and the merged one emitted from closing(). Both are
+        # answered, and the first reply ignores every instruction the node
+        # exists to apply. Same defect and same fix as the guardrails node.
+        self.preventDefault()
+
     def writeDocuments(self, documents):
         """
         Collect documents for merging.


### PR DESCRIPTION
## Summary

- The `prompt` node collects its inputs and emits one merged, instructed question from `closing()`, but never calls `preventDefault()`. The framework also forwards the untouched incoming question, so a downstream `llm_openai` receives two and answers both.
- Only the merged question carries the configured `instructions`, so the user sees two replies and the first ignores every instruction the node exists to apply.
- One line, matching the fix already applied to the `guardrails` node in #1849 and #1884.

The node's own README already documents the behaviour this implements: "the fully assembled question is not emitted until the node is closing ... the enriched question is emitted on the `questions` lane". A single emission, at close, carrying the instructions. The pass-through is not documented anywhere, so this brings the code in line with its contract rather than changing it.

`examples/rag-pipeline.pipe` wires `prompt_1` from `qdrant_2` on both the `documents` and `questions` lanes and feeds `llm_openai_1`, which is the exact shape that duplicates.

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

`ruff check` and `ruff format --check` clean.

Observed on `chat -> embedding_openai -> pinecone -> prompt -> llm_openai -> response_answers` running on RocketRide Cloud. One question, two replies: the first ignored the instruction "refer to each excerpt as 'Excerpt N', give exactly one answer", the second followed it. Removing the `prompt` node yields exactly one reply.

`writeDocuments`, `writeText` and `writeTable` keep collecting without suppression on purpose: their lanes declare no outputs in `services.json`, so there is nothing to forward.

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [x] Breaking changes documented (if applicable): anything relying on the duplicate was relying on undocumented behaviour

## Linked Issue

Fixes #1985
