### PR TITLE
fix(ai): declare pyjwt so the published engine image starts

### DIFF
--- a/packages/ai/src/ai/requirements.txt
+++ b/packages/ai/src/ai/requirements.txt
@@ -12,3 +12,9 @@ tenacity
 nvidia-ml-py
 croniter
 filetype
+
+# JWT for /task/fetch capability tokens (ai/modules/task/fetch.py) and the
+# local file-store URL signer (ai/account/file_store.py). Declared here, not
+# per-module: task/__init__.py imports .fetch before its own depends() runs,
+# so the package must already be present when `import ai` finishes.
+pyjwt


### PR DESCRIPTION
## Summary

- Declare `pyjwt` in `packages/ai/src/ai/requirements.txt`. `ai/modules/task/fetch.py:38` and `ai/account/file_store.py` both `import jwt`, but no `packages/ai` requirements file declared it, so the engine died during `server.use('task')` with `ModuleNotFoundError: No module named 'jwt'` and every published OSS image from 3.3.0-hackathon onward failed to start.
- Declared in the shared `ai/requirements.txt` rather than per-module on purpose: `task/__init__.py` imports `.fetch` (line 7) before its own `depends()` call (line 11), so a `task/requirements.txt` entry would be installed too late. The shared file is installed by `depends()` when `ai/__init__.py` is imported, which always precedes `ai.modules.task` and covers both consumers. `packages/ai/tests/requirements.txt` already includes the shared file, so `tests/ai/account/test_store_auth.py` (which imports `jwt` and `ai.modules.task.fetch`) resolves in a clean environment too.
- Unpinned to match the surrounding entries (resolves to 2.13.0, same as the hosted environment). No `[crypto]` extra: both call sites use HS256.

Complements #1847 — once that smoke step lands, it would fail on exactly this until the dependency is declared.

## Type

fix

## Testing

- [ ] Tests added or updated — none: a requirements line has no natural unit test; the published-image start is what #1847 asserts in CI.
- [x] Tested locally — clean venv: `pip install -r packages/ai/src/ai/requirements.txt` resolves; `import jwt` gives 2.13.0; HS256 encode/decode with `options={'require': ['exp']}` works. Also scanned every third-party import under `packages/ai/src/ai` against the requirement files: `jwt` was the only undeclared module on the startup path.
- [ ] `./builder test` passes — not run (requires a full engine build); change is a single requirements entry.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable) — n/a
- [ ] Breaking changes documented (if applicable) — none

## Linked Issue

Fixes #1828

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Declare the missing `pyjwt` runtime dependency so the published engine image starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->