### PR TITLE
fix(ai,nodes): stream-absolute audio timestamps; declare transcribe language

### DIFF
--- a/nodes/src/nodes/audio_transcribe/README.md
+++ b/nodes/src/nodes/audio_transcribe/README.md
@@ -94,13 +94,11 @@ Defaults to English (`en`). Change the `language` config value to transcribe oth
 | Field | Type | Description | Default |
 |---|---|---|---|
 | `transcribe.beam_size` | `number` | **Beam Size**<br/>Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate | `5` |
-| `transcribe.max_seconds` | `number` | **Maximum Seconds**<br/>The maximum seconds of audio to buffer to process | `300` |
-| `transcribe.min_seconds` | `number` | **Minimum Seconds**<br/>The minimum seconds of audio to process in a batch and looking for silence | `240` |
+| `transcribe.chunk_duration` | `number` | **Chunk Duration (s)**<br/>Seconds of audio to buffer before sending a chunk to Whisper | `60` |
+| `transcribe.language` | `string` | **Language**<br/>ISO 639-1 code of the spoken language (e.g. en, ru, de). Must match the audio; a mismatch produces garbled half-translated text | `"en"` |
 | `transcribe.model` | `string` | **Model**<br/>The Whisper model to use for transcription | `"base"` |
 | `transcribe.profile` | `string` |  | `"default"` |
-| `transcribe.silence_threshold` | `number` | **Silence Threshold**<br/>The silence threshold to detect silence in speech (in seconds) | `0.25` |
 | `transcribe.vad_filter` | `boolean` | **VAD Filter**<br/>Use Whisper's built-in Silero VAD to drop non-speech before transcribing | `true` |
-| `transcribe.vad_level` | `number` | **VAD Level**<br/>The VAD level to use for silence detection (0-3) | `1` |
 | `transcribe.vad_max_speech_duration_s` | `number` | **VAD Maximum Speech (s)**<br/>Split speech chunks longer than this. 0 means no limit | `0` |
 | `transcribe.vad_min_silence_duration_ms` | `number` | **VAD Minimum Silence (ms)**<br/>Silence this long ends a speech chunk | `500` |
 | `transcribe.vad_speech_pad_ms` | `number` | **VAD Speech Padding (ms)**<br/>Padding added to each side of a detected speech chunk | `400` |

--- a/nodes/src/nodes/audio_transcribe/services.json
+++ b/nodes/src/nodes/audio_transcribe/services.json
@@ -168,6 +168,14 @@
 			],
 			"default": "base"
 		},
+		// Read by IGlobal since the initial commit, but never declared here, so the
+		// UI could not set it and every profile silently pinned English.
+		"transcribe.language": {
+			"type": "string",
+			"title": "Language",
+			"description": "ISO 639-1 code of the spoken language (e.g. en, ru, de). Must match the audio; a mismatch produces garbled half-translated text",
+			"default": "en"
+		},
 		// Buffering, passed to Transcribe(). Defaults are its own constants, which ran
 		// unconditionally before — min_seconds/max_seconds never reached it (#1809).
 		"transcribe.chunk_duration": {
@@ -216,7 +224,7 @@
 		},
 		"transcribe.default": {
 			"object": "default",
-			"properties": ["transcribe.model", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+			"properties": ["transcribe.model", "transcribe.language", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
 		},
 		"transcribe.profile": {
 			"hidden": true,

--- a/nodes/test/audio_transcribe/test_decode_params.py
+++ b/nodes/test/audio_transcribe/test_decode_params.py
@@ -51,6 +51,8 @@ class _FakeWhisper:
     """Stands in for ai.common.models.Whisper, recording the decode kwargs."""
 
     def __init__(self, model_name, output_fields=None, language=None, compute_type=None, **kwargs):
+        self.model_name = model_name
+        self.language = language
         self.calls = []
 
     def transcribe(self, audio, **kw):
@@ -179,6 +181,36 @@ def test_several_keys_at_once():
     assert kw['vad_parameters']['threshold'] == 0.7
     assert kw['vad_parameters']['max_speech_duration_s'] == 15
     assert kw['vad_parameters']['min_silence_duration_ms'] == 500  # untouched default
+
+
+def _built_whisper(raw_config):
+    """Build an IGlobal from a node config and return the _FakeWhisper it constructed."""
+    IGlobal, holder = _load_iglobal()
+    holder['raw'] = raw_config
+
+    ig = IGlobal.__new__(IGlobal)
+    ig.glb = types.SimpleNamespace(logicalType='audio_transcribe://', connConfig={})
+    ig.beginGlobal()
+    return ig._whisper
+
+
+def test_language_reaches_the_whisper_constructor():
+    """IGlobal has read `language` since the initial commit, but services.json never
+    declared it, so the UI could not reach it and every profile pinned en.
+    """
+    assert _built_whisper({'language': 'ru'}).language == 'ru'
+
+
+def test_language_defaults_to_english():
+    assert _built_whisper({}).language == 'en'
+
+
+def test_language_is_declared_in_services_json():
+    fields = _parse_services_json()['fields']
+
+    assert 'transcribe.language' in fields
+    assert 'transcribe.language' in fields['transcribe.default']['properties']
+    assert fields['transcribe.language']['default'] == 'en'
 
 
 # -----------------------------------------------------------------------------

--- a/nodes/test/audio_transcribe/test_stream_timestamps.py
+++ b/nodes/test/audio_transcribe/test_stream_timestamps.py
@@ -1,0 +1,136 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Buffer timestamps audio_transcribe hands downstream must be stream-absolute.
+
+Every Whisper buffer after the first used to be stamped 0: AudioReader's
+getTimestamp() divided a counter nothing incremented, so documents-lane
+consumers saw each 60s chunk restart at 0-60s. The reader-side fix lives in
+packages/ai (see tests/ai/common/avi/test_audio_timestamp.py); this file
+guards the node's half of the contract: Transcribe must capture the stream
+position when a buffer STARTS and offset every segment it emits by it.
+
+Same stub harness as test_decode_params.py: transcribe.py is loaded from
+source behind stubs, the fake AudioReader reproduces the fixed getTimestamp()
+semantics (position of the chunk being delivered), no server, no model.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_NODE_DIR = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'audio_transcribe')
+
+SAMPLE_RATE = 16000
+ONE_SECOND = b'\x00\x01' * SAMPLE_RATE  # int16 mono
+
+
+def _load_transcribe():
+    """Load transcribe.py behind stubs (mirrors test_decode_params._load_transcribe)."""
+    saved = {}
+    pkg_name = '_audio_transcribe_ts_pkg'
+
+    class FakeAudioReader:
+        """Emulates the fixed AudioReader: getTimestamp() returns the stream
+        position of the chunk currently being delivered to onData().
+        """
+
+        def __init__(self, **kwargs):
+            self._bytes_fed = 0
+
+        def start(self):
+            self._bytes_fed = 0
+
+        def getTimestamp(self):
+            return self._bytes_fed / 2 / SAMPLE_RATE
+
+        def feed(self, chunk: bytes):
+            self.onData(chunk)
+            self._bytes_fed += len(chunk)
+
+    pkg = types.ModuleType(pkg_name)
+    pkg.__path__ = [_NODE_DIR]
+    iglobal_stub = types.ModuleType(f'{pkg_name}.IGlobal')
+    iglobal_stub.IGlobal = object
+
+    stubs = {
+        pkg_name: pkg,
+        f'{pkg_name}.IGlobal': iglobal_stub,
+        'ai': types.ModuleType('ai'),
+        'ai.common': types.ModuleType('ai.common'),
+        'ai.common.avi': types.ModuleType('ai.common.avi'),
+        'ai.common.avi.audio': types.ModuleType('ai.common.avi.audio'),
+        'rocketlib': types.ModuleType('rocketlib'),
+    }
+    stubs['ai.common.avi.audio'].AudioReader = FakeAudioReader
+    stubs['rocketlib'].debug = lambda *a, **kw: None
+
+    for name, stub in stubs.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = stub
+
+    mod_name = f'{pkg_name}.transcribe'
+    try:
+        spec = importlib.util.spec_from_file_location(mod_name, os.path.join(_NODE_DIR, 'transcribe.py'))
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod.Transcribe
+    finally:
+        sys.modules.pop(mod_name, None)
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+
+def _make_node(chunk_duration=2):
+    """Transcribe whose fake decoder emits one segment 0.5s into each buffer."""
+    Transcribe = _load_transcribe()
+    emitted = []
+
+    node = Transcribe(
+        segment_callback=emitted.extend,
+        transcribe=lambda audio: [types.SimpleNamespace(text='Hello.', start=0.5, end=1.0)],
+        chunk_duration=chunk_duration,
+    )
+    node.start()
+    return node, emitted
+
+
+def test_each_buffer_is_stamped_with_its_stream_position():
+    node, emitted = _make_node(chunk_duration=2)
+
+    for _ in range(4):  # two full 2s buffers
+        node.feed(ONE_SECOND)
+
+    assert [ts for ts, _ in emitted] == [0.5, 2.5]
+
+
+def test_final_flush_keeps_the_absolute_position():
+    node, emitted = _make_node(chunk_duration=2)
+
+    for _ in range(5):
+        node.feed(ONE_SECOND)
+    node.onData(None)  # end of stream flushes the 1s remainder
+
+    assert [ts for ts, _ in emitted] == [0.5, 2.5, 4.5]
+
+
+def test_timestamp_is_captured_at_buffer_start_not_flush():
+    """The base must come from the buffer's FIRST chunk; reading it at flush
+    time would stamp the buffer with its end position.
+    """
+    node, emitted = _make_node(chunk_duration=3)
+
+    for _ in range(3):
+        node.feed(ONE_SECOND)
+
+    assert emitted[0][0] == 0.5  # not 2.5 or 3.5

--- a/packages/ai/src/ai/common/avi/audio.py
+++ b/packages/ai/src/ai/common/avi/audio.py
@@ -79,8 +79,10 @@ class AudioReader(AVIReader):
         onData() callback — so from inside onData() this is the position where
         the current chunk starts.
         """
-        # Sample size depends on format
-        sample_size = 2 if self._format == 'pcm' else 4  # 4 bytes for f32le, 2 for 16-bit WAV
-        samples = self._bytes_read / sample_size
+        # Both output modes emit pcm_s16le, so 2 bytes per sample either way.
+        # In wav mode the count also includes the container header — a fixed
+        # sub-millisecond offset, deliberately not parsed out; the pcm mode
+        # used in production is exact.
+        samples = self._bytes_read / 2
         frames = samples / self._channels
         return frames / self._sample_rate

--- a/packages/ai/src/ai/common/avi/audio.py
+++ b/packages/ai/src/ai/common/avi/audio.py
@@ -29,7 +29,6 @@ class AudioReader(AVIReader):
         self._sample_rate = kwargs.get('sample_rate', 44100)
         self._channels = kwargs.get('channels', 2)
         self._format = kwargs.get('format', 'wav').lower()  # Ensure lowercase format
-        self._samples = 0
 
         # Base ffmpeg arguments
         args = [
@@ -74,13 +73,14 @@ class AudioReader(AVIReader):
         super().__init__(args, name, **kwargs)
 
     def getTimestamp(self) -> float:
+        """Stream position, in seconds, of the decoded audio delivered so far.
+
+        Backed by AVIReader's decoded-output byte count, incremented after each
+        onData() callback — so from inside onData() this is the position where
+        the current chunk starts.
+        """
         # Sample size depends on format
         sample_size = 2 if self._format == 'pcm' else 4  # 4 bytes for f32le, 2 for 16-bit WAV
-        samples = self._samples / sample_size
+        samples = self._bytes_read / sample_size
         frames = samples / self._channels
         return frames / self._sample_rate
-
-    def start(self):
-        self._done = False
-        self._samples = 0
-        super().start()

--- a/packages/ai/src/ai/common/avi/reader.py
+++ b/packages/ai/src/ai/common/avi/reader.py
@@ -40,6 +40,9 @@ class AVIReader(ABC):
         self._write_chunk_size = 16 * 1024  # adjust for optimal performance
         self._read_chunk_size = 16 * 1024  # adjust for optimal performance
 
+        # Decoded bytes delivered to onData() so far; also reset per stream in start()
+        self._bytes_read = 0
+
     def __del__(self):
         """
         Cleanup resources when the object is deleted.
@@ -93,6 +96,10 @@ class AVIReader(ABC):
                 # fail with the same root cause.
                 if self._error is None:
                     self._error = e
+
+            # Count AFTER the callback: while onData() runs, the counter (and so
+            # getTimestamp()) still reads the stream position of this chunk's start
+            self._bytes_read += len(data)
 
         # Signal callback we are done
         self.onData(None)
@@ -304,6 +311,9 @@ class AVIReader(ABC):
         # Done is set when ffmpeg terminates
         self._done = False
         self._exit_code = 0
+
+        # New stream - restart the decoded-output byte count
+        self._bytes_read = 0
 
         # Capture errors from the background _data_process thread so they
         # can be re-raised on the pipe thread when stop() is called

--- a/packages/ai/tests/ai/common/avi/test_audio_timestamp.py
+++ b/packages/ai/tests/ai/common/avi/test_audio_timestamp.py
@@ -78,12 +78,16 @@ def test_timestamp_resets_per_stream():
     assert reader.getTimestamp() == 0.0
 
 
-def test_wav_format_uses_its_own_sample_size():
+def test_wav_format_also_uses_16bit_samples():
+    """Both output modes emit pcm_s16le — the old wav branch divided by 4,
+    a sample size the ffmpeg args never produce.
+    """
+
     class _WavProbe(AudioReader):
         def onData(self, data):
             pass
 
     reader = _WavProbe(name='wav', format='wav', sample_rate=8000, channels=2)
-    reader._bytes_read = 8000 * 2 * 4  # one second of stereo at 4 bytes/sample
+    reader._bytes_read = 8000 * 2 * 2  # one second of stereo pcm_s16le
 
     assert reader.getTimestamp() == 1.0

--- a/packages/ai/tests/ai/common/avi/test_audio_timestamp.py
+++ b/packages/ai/tests/ai/common/avi/test_audio_timestamp.py
@@ -1,0 +1,89 @@
+"""AudioReader.getTimestamp() must track the decoded stream position.
+
+The counter behind it lives in AVIReader._data_process, which nothing
+incremented before: getTimestamp() divided a byte count that was only ever
+reset, so every caller saw 0.0 and audio_transcribe stamped each 60s buffer
+with time 0-60 instead of its stream position.
+
+No ffmpeg here: _data_process is driven directly with a fake stdout, which is
+exactly how decoded bytes reach onData() in production.
+"""
+
+import io
+
+from ai.common.avi.audio import AudioReader
+
+SAMPLE_RATE = 16000
+BYTES_PER_SECOND = SAMPLE_RATE * 2  # int16 mono
+
+
+class _Probe(AudioReader):
+    """Records getTimestamp() as seen from inside each onData() callback."""
+
+    def __init__(self):
+        super().__init__(name='probe', format='pcm', sample_rate=SAMPLE_RATE, channels=1)
+        self.stamps = []
+
+    def onData(self, data):
+        if data is not None:
+            self.stamps.append(self.getTimestamp())
+
+
+class _ChunkedStdout(io.RawIOBase):
+    """Feeds fixed-size chunks regardless of the size _data_process asks for."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def read(self, _size=-1):
+        return self._chunks.pop(0) if self._chunks else b''
+
+
+def _drive(reader, chunks):
+    reader.start()
+    reader.stdout = _ChunkedStdout(chunks)
+    reader._data_process()
+
+
+def test_timestamp_advances_with_decoded_bytes():
+    reader = _Probe()
+    one_second = b'\x00\x01' * SAMPLE_RATE
+
+    _drive(reader, [one_second, one_second, one_second])
+
+    assert reader.stamps == [0.0, 1.0, 2.0]
+    assert reader.getTimestamp() == 3.0
+
+
+def test_timestamp_inside_ondata_is_the_chunk_start():
+    """The transcribe node reads the buffer start time from inside onData();
+    counting before the callback would shift every buffer by one chunk.
+    """
+    reader = _Probe()
+
+    _drive(reader, [b'\x00\x01' * (SAMPLE_RATE // 2)])  # 0.5 s
+
+    assert reader.stamps == [0.0]
+    assert reader.getTimestamp() == 0.5
+
+
+def test_timestamp_resets_per_stream():
+    reader = _Probe()
+    _drive(reader, [b'\x00\x01' * SAMPLE_RATE])
+    assert reader.getTimestamp() == 1.0
+
+    reader._started = False  # writeAVI(END) side effects are not under test here
+    reader.start()
+
+    assert reader.getTimestamp() == 0.0
+
+
+def test_wav_format_uses_its_own_sample_size():
+    class _WavProbe(AudioReader):
+        def onData(self, data):
+            pass
+
+    reader = _WavProbe(name='wav', format='wav', sample_rate=8000, channels=2)
+    reader._bytes_read = 8000 * 2 * 4  # one second of stereo at 4 bytes/sample
+
+    assert reader.getTimestamp() == 1.0


### PR DESCRIPTION
Fixes #1999.

- `AVIReader._data_process` counts decoded bytes after each `onData()`; `AudioReader.getTimestamp()` is backed by it (was: divided a never-incremented counter → always 0.0, every `audio_transcribe` buffer stamped 0–60s). Reset per stream in `start()`; dead `_samples` and the redundant `AudioReader.start()` override removed.
- `services.json` declares `transcribe.language` (default `en`); regenerated README also catches the params table up with #1875's field removals.
- Tests: reader counting/start-of-chunk/reset semantics (`packages/ai/tests/ai/common/avi/test_audio_timestamp.py`), node buffer stamping (`nodes/test/audio_transcribe/test_stream_timestamps.py`), language wiring + declaration (`test_decode_params.py`).

Verified end-to-end: 85.4-min file through the chunked pipeline now yields monotonic sentence timestamps 0.2–5120.8s across 86 distinct 60s windows (before: everything in 0–60s).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable transcription language support using ISO 639-1 codes, defaulting to English.
* **Bug Fixes**
  * Improved audio transcription timestamps to accurately reflect each audio buffer’s position, including partial buffers and restarted streams.
  * Ensured timestamp accuracy across supported audio formats.
* **Documentation**
  * Updated transcription settings documentation to reflect current options and remove obsolete audio detection controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->