### PR TITLE
fix(nodes,ai): refresh the MCP tool catalog instead of caching it once

### DIFF
--- a/nodes/src/nodes/tool_mcp_client/IGlobal.py
+++ b/nodes/src/nodes/tool_mcp_client/IGlobal.py
@@ -59,6 +59,16 @@ from .mcp_streamable_http_client import McpStreamableHttpClient
 REFRESH_MIN_INTERVAL_S = 1.0
 
 
+def _monotonic() -> float:
+    """Clock used for the refresh rate limit.
+
+    Indirection on purpose: tests drive this instead of patching
+    ``time.monotonic`` on the stdlib module, which is process-wide and would
+    reach anything else relying on it.
+    """
+    return time.monotonic()
+
+
 class ToolUnavailableError(Exception):
     """A tool the agent asked for is not on the MCP server, even after a
     catalog refresh. Distinct from a transport failure so callers can tell
@@ -252,7 +262,7 @@ class IGlobal(IGlobalBase):
             by_namespaced[f'{self.serverName}.{t.name}'] = t
         self._tools_by_original = by_original
         self._tools_by_namespaced = by_namespaced
-        self._catalog_fetched_at = time.monotonic()
+        self._catalog_fetched_at = _monotonic()
 
     def refresh_tools(self, *, reason: str, min_age_s: float = 0.0) -> bool:
         """Re-read tools/list from the server and swap the cache.
@@ -270,7 +280,7 @@ class IGlobal(IGlobalBase):
         lock = self.__dict__.setdefault('_refresh_lock', threading.Lock())
         with lock:
             fetched_at = getattr(self, '_catalog_fetched_at', None)
-            if fetched_at is not None and min_age_s > 0 and (time.monotonic() - fetched_at) < min_age_s:
+            if fetched_at is not None and min_age_s > 0 and (_monotonic() - fetched_at) < min_age_s:
                 return False
             try:
                 tools = client.list_tools()
@@ -299,10 +309,12 @@ class IGlobal(IGlobalBase):
         if server_name != self.serverName:
             return None
         tool = (getattr(self, '_tools_by_original', None) or {}).get(tool_name)
-        if tool is None and self.refresh_tools(
-            reason=f'lookup miss for {tool_name!r}', min_age_s=REFRESH_MIN_INTERVAL_S
-        ):
-            tool = (self._tools_by_original or {}).get(tool_name)
+        if tool is None:
+            self.refresh_tools(reason=f'lookup miss for {tool_name!r}', min_age_s=REFRESH_MIN_INTERVAL_S)
+            # Re-read whatever the attempt returned: False also means "another
+            # thread refreshed inside the rate-limit window", and that refresh
+            # may be the one carrying this tool.
+            tool = (getattr(self, '_tools_by_original', None) or {}).get(tool_name)
         return tool
 
     def call_tool(self, *, server_name: str, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:

--- a/nodes/src/nodes/tool_mcp_client/IGlobal.py
+++ b/nodes/src/nodes/tool_mcp_client/IGlobal.py
@@ -30,11 +30,16 @@ Step 3: STDIO transport (no external MCP SDK dependency).
 - Spawns MCP server process
 - Performs MCP initialize handshake
 - Discovers tools at startup via tools/list and caches them
+- Re-reads the catalog on every discovery query and on every lookup miss
+  (rate-limited), so tools added or renamed on a running server become
+  callable without restarting the engine (issue #1402)
 """
 
 from __future__ import annotations
 
 import shlex
+import threading
+import time
 from typing import Any, Dict, List, Optional
 
 from ai.common.config import Config
@@ -44,6 +49,21 @@ from rocketlib import IGlobalBase, OPEN_MODE, warning
 from .mcp_stdio_client import McpStdioClient, McpToolDef
 from .mcp_sse_client import McpSseClient
 from .mcp_streamable_http_client import McpStreamableHttpClient
+
+
+# The catalog is re-read from the server on every discovery query (a new
+# agent instance building its tool list, or the agent host re-querying this
+# node after a miss) and on every lookup miss — but at most this often, so a
+# burst of queries or repeated misses for one unknown tool (schema lookup,
+# then invoke) costs the server a single tools/list.
+REFRESH_MIN_INTERVAL_S = 1.0
+
+
+class ToolUnavailableError(Exception):
+    """A tool the agent asked for is not on the MCP server, even after a
+    catalog refresh. Distinct from a transport failure so callers can tell
+    "this tool does not exist" from "the server did not answer".
+    """
 
 
 class IGlobal(IGlobalBase):
@@ -219,26 +239,84 @@ class IGlobal(IGlobalBase):
     # Tool cache + accessors for IInstance hooks
     # ------------------------------------------------------------------
     def _cache_tools(self, tools: List[McpToolDef]) -> None:
-        self._tools_by_original: Dict[str, McpToolDef] = {}
-        self._tools_by_namespaced: Dict[str, McpToolDef] = {}
+        """Replace the cached catalog atomically.
+
+        Both maps are built locally and swapped in with plain attribute
+        assignment, so a reader iterating the previous maps never observes a
+        half-filled catalog.
+        """
+        by_original: Dict[str, McpToolDef] = {}
+        by_namespaced: Dict[str, McpToolDef] = {}
         for t in tools:
-            self._tools_by_original[t.name] = t
-            self._tools_by_namespaced[f'{self.serverName}.{t.name}'] = t
+            by_original[t.name] = t
+            by_namespaced[f'{self.serverName}.{t.name}'] = t
+        self._tools_by_original = by_original
+        self._tools_by_namespaced = by_namespaced
+        self._catalog_fetched_at = time.monotonic()
+
+    def refresh_tools(self, *, reason: str, min_age_s: float = 0.0) -> bool:
+        """Re-read tools/list from the server and swap the cache.
+
+        Returns True when the catalog was refreshed, False when there is no
+        connected client, the catalog is younger than ``min_age_s``, or the
+        server did not answer (the previous catalog is kept in that case).
+        Serialized so concurrent misses trigger one tools/list, not a
+        stampede. Emits a warning naming the tools that appeared or
+        disappeared, so a changed catalog is visible in the run.
+        """
+        client = getattr(self, '_client', None)
+        if client is None:
+            return False
+        lock = self.__dict__.setdefault('_refresh_lock', threading.Lock())
+        with lock:
+            fetched_at = getattr(self, '_catalog_fetched_at', None)
+            if fetched_at is not None and min_age_s > 0 and (time.monotonic() - fetched_at) < min_age_s:
+                return False
+            try:
+                tools = client.list_tools()
+            except Exception as e:
+                warning(f"mcp_client '{self.serverName}': tool catalog refresh ({reason}) failed: {e}")
+                return False
+            before = set((getattr(self, '_tools_by_original', None) or {}).keys())
+            self._cache_tools(tools)
+            after = set(self._tools_by_original.keys())
+            added, removed = sorted(after - before), sorted(before - after)
+            if added or removed:
+                warning(
+                    f"mcp_client '{self.serverName}': tool catalog changed on refresh ({reason}); "
+                    f'added={added} removed={removed}'
+                )
+            return True
 
     def list_namespaced_tools(self) -> List[Dict[str, Any]]:
+        self.refresh_tools(reason='catalog query', min_age_s=REFRESH_MIN_INTERVAL_S)
         out: List[Dict[str, Any]] = []
-        for namespaced, tool in (self._tools_by_namespaced or {}).items():
+        for namespaced, tool in (getattr(self, '_tools_by_namespaced', None) or {}).items():
             out.append({'name': namespaced, 'description': tool.description, 'inputSchema': tool.inputSchema})
         return out
 
     def get_tool(self, *, server_name: str, tool_name: str) -> Optional[McpToolDef]:
         if server_name != self.serverName:
             return None
-        return (self._tools_by_original or {}).get(tool_name)
+        tool = (getattr(self, '_tools_by_original', None) or {}).get(tool_name)
+        if tool is None and self.refresh_tools(
+            reason=f'lookup miss for {tool_name!r}', min_age_s=REFRESH_MIN_INTERVAL_S
+        ):
+            tool = (self._tools_by_original or {}).get(tool_name)
+        return tool
 
     def call_tool(self, *, server_name: str, tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
         if server_name != self.serverName:
             raise Exception(f'Unknown MCP serverName {server_name!r} (this node configured as {self.serverName!r})')
-        if self._client is None:
+        if getattr(self, '_client', None) is None:
             raise Exception('MCP client is not connected')
+        # A tool the catalog does not know is refreshed once, then refused
+        # loudly rather than handed to the server (whose "not found" a weak
+        # planner narrates around).
+        if self.get_tool(server_name=server_name, tool_name=tool_name) is None:
+            known = sorted((getattr(self, '_tools_by_original', None) or {}).keys())
+            raise ToolUnavailableError(
+                f"Tool {tool_name!r} is not available on MCP server '{self.serverName}' "
+                f'(catalog refreshed; known tools: {known})'
+            )
         return self._client.call_tool(name=tool_name, arguments=arguments or {})

--- a/nodes/src/nodes/tool_mcp_client/README.md
+++ b/nodes/src/nodes/tool_mcp_client/README.md
@@ -8,7 +8,7 @@ Connects to an MCP server over one of three transports (STDIO (local subprocess)
 
 This node has no pipeline lanes: it is a control-plane tool node, connected to agents via the `tools` invoke channel.
 
-Tools are namespaced as `serverName.toolName` (e.g. `mcp.search_docs`), where `serverName` is set in configuration. Tools are discovered **once at pipeline startup** and cached; a server that adds tools later requires a pipeline restart to pick them up.
+Tools are namespaced as `serverName.toolName` (e.g. `mcp.search_docs`), where `serverName` is set in configuration. Tools are discovered at pipeline startup and cached, and the cache is re-read from the server whenever an agent discovers its tools or asks for a tool the cache does not know (at most once per second), so a server that adds or renames tools while the pipeline runs is picked up without a restart. A changed catalog is reported as a pipeline warning naming the added and removed tools. A tool that is still unknown after that refresh is refused with an explicit `ToolUnavailableError` and is never sent to the server, so an agent sees a clear failure rather than a plausible-looking answer.
 
 The implementation is pure Python standard library (`subprocess`, `urllib`, JSON-RPC 2.0), no MCP SDK dependency and no extra packages to install. Each request has a 20-second timeout.
 

--- a/nodes/src/nodes/tool_mcp_client/mcp_stdio_client.py
+++ b/nodes/src/nodes/tool_mcp_client/mcp_stdio_client.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 import json
 import os
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
@@ -85,6 +86,10 @@ class McpStdioClient:
 
         self._proc: subprocess.Popen[str] | None = None
         self._next_id = 1
+        # One request in flight at a time: responses are matched by id but read
+        # line-by-line by whichever thread is receiving, and a foreign id is
+        # dropped — so two concurrent requests would starve each other.
+        self._request_lock = threading.Lock()
 
     def start(self) -> None:
         if self._proc is not None:
@@ -212,13 +217,14 @@ class McpStdioClient:
         self._send(msg)
 
     def _request(self, method: str, params: Any) -> Any:  # noqa: ANN401
-        req_id = self._next_id
-        self._next_id += 1
-        msg: Dict[str, Any] = {'jsonrpc': '2.0', 'id': req_id, 'method': method}
-        if params is not None:
-            msg['params'] = params
-        self._send(msg)
-        return self._recv_response(req_id=req_id)
+        with self._request_lock:
+            req_id = self._next_id
+            self._next_id += 1
+            msg: Dict[str, Any] = {'jsonrpc': '2.0', 'id': req_id, 'method': method}
+            if params is not None:
+                msg['params'] = params
+            self._send(msg)
+            return self._recv_response(req_id=req_id)
 
     def _send(self, msg: Dict[str, Any]) -> None:
         proc = self._proc

--- a/nodes/test/tool_mcp_client/stub_mcp_server.py
+++ b/nodes/test/tool_mcp_client/stub_mcp_server.py
@@ -20,9 +20,16 @@ two degenerate shapes we care about, plus a normal tool as a control:
 ``tools/call`` echoes back the exact ``arguments`` object the server received
 under ``received_arguments`` so tests can assert that the synthesized no-op
 placeholder (``rr_no_args``) is stripped before the call reaches the server.
+
+If ``STUB_MCP_TOOLS_FILE`` names a readable JSON file holding a list of tool
+definitions, that list is re-read on every ``tools/list`` and ``tools/call``,
+so a test can add or rename tools while the server keeps running (the
+catalog-staleness scenario of issue #1402). Otherwise the static ``TOOLS`` list
+above is served.
 """
 
 import json
+import os
 import sys
 
 TOOLS = [
@@ -46,6 +53,20 @@ TOOLS = [
         },
     },
 ]
+
+
+def _current_tools():
+    """Return the live tool list: the JSON file if configured, else ``TOOLS``."""
+    path = os.environ.get('STUB_MCP_TOOLS_FILE')
+    if path:
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                tools = json.load(f)
+            if isinstance(tools, list):
+                return tools
+        except (OSError, ValueError):
+            pass
+    return TOOLS
 
 
 def _write(msg):
@@ -77,12 +98,12 @@ def _handle(msg):
         }
 
     if method == 'tools/list':
-        return {'jsonrpc': '2.0', 'id': msg_id, 'result': {'tools': TOOLS}}
+        return {'jsonrpc': '2.0', 'id': msg_id, 'result': {'tools': _current_tools()}}
 
     if method == 'tools/call':
         name = params.get('name')
         arguments = params.get('arguments', {})
-        known = {t['name'] for t in TOOLS}
+        known = {t['name'] for t in _current_tools()}
         if name not in known:
             return {
                 'jsonrpc': '2.0',

--- a/nodes/test/tool_mcp_client/test_catalog_refresh.py
+++ b/nodes/test/tool_mcp_client/test_catalog_refresh.py
@@ -128,9 +128,14 @@ def _iglobal(client, *initial):
 
 @pytest.fixture
 def clock(monkeypatch):
-    """Controllable ``time.monotonic`` for the IGlobal module."""
+    """Controllable refresh clock for the IGlobal module.
+
+    Patches the module's own ``_monotonic`` shim, not ``time.monotonic`` on the
+    stdlib module — the latter is process-wide and would reach every other
+    consumer for the duration of the test.
+    """
     now = [1000.0]
-    monkeypatch.setattr(iglobal_module.time, 'monotonic', lambda: now[0])
+    monkeypatch.setattr(iglobal_module, '_monotonic', lambda: now[0])
     return now
 
 
@@ -212,6 +217,21 @@ class TestLookupMiss:
         clock[0] += REFRESH_MIN_INTERVAL_S
         assert g.get_tool(server_name='srv', tool_name='ghost') is None
         assert client.list_calls == 2
+
+    def test_miss_re_reads_the_cache_even_when_its_own_refresh_is_skipped(self):
+        # Another caller refreshed the catalog inside the rate-limit window, so
+        # our own attempt is skipped and returns False — but the tool it
+        # fetched is in the cache, and the miss path must still find it.
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+
+        def _refresh_by_someone_else(**_kwargs):
+            g._cache_tools([_tool('a'), _tool('late')])
+            return False
+
+        g.refresh_tools = _refresh_by_someone_else
+
+        assert g.get_tool(server_name='srv', tool_name='late').name == 'late'
 
     def test_other_server_name_is_not_this_node(self):
         client = _ScriptedClient([_tool('a')])

--- a/nodes/test/tool_mcp_client/test_catalog_refresh.py
+++ b/nodes/test/tool_mcp_client/test_catalog_refresh.py
@@ -1,0 +1,385 @@
+"""Catalog-staleness tests for tool_mcp_client (issue #1402).
+
+Before this change the MCP tool catalog was fetched once in ``beginGlobal()``
+and never re-read, so a tool added or renamed on a running server was invisible
+until the engine restarted — and a lookup miss surfaced as the server's own
+"not found", which a weak planner narrates around.
+
+These tests pin the new contract:
+
+- a lookup miss refreshes the catalog once (rate-limited) and retries;
+- a tool that is still unknown after the refresh raises ``ToolUnavailableError``
+  and is never sent to the server;
+- discovery queries re-read the server, rate-limited by ``REFRESH_MIN_INTERVAL_S``;
+- a failed refresh keeps the previous catalog and warns; a changed catalog
+  warns with the added/removed names;
+- the cache swap is atomic for concurrent readers.
+
+The first part is server-free (a scripted client); the last part drives the
+real stdio transport against ``stub_mcp_server.py`` with a tool added while
+the server keeps running.
+"""
+
+import json
+import os
+import sys
+import threading
+import types
+from pathlib import Path
+
+import pytest
+
+_NODE_SRC = os.path.join(os.path.dirname(__file__), '..', '..', 'src', 'nodes', 'tool_mcp_client')
+sys.path.insert(0, _NODE_SRC)
+
+
+def _ensure_iglobal_import_stubs():
+    """Provide the minimal engine imports required by the real IGlobal module."""
+    rocketlib = sys.modules.get('rocketlib') or types.ModuleType('rocketlib')
+    if not hasattr(rocketlib, 'IGlobalBase'):
+        rocketlib.IGlobalBase = type('IGlobalBase', (), {})
+    if not hasattr(rocketlib, 'IInstanceBase'):
+        rocketlib.IInstanceBase = type('IInstanceBase', (), {})
+    if not hasattr(rocketlib, 'OPEN_MODE'):
+        rocketlib.OPEN_MODE = type('OPEN_MODE', (), {'CONFIG': 'config'})
+    if not hasattr(rocketlib, 'warning'):
+        rocketlib.warning = lambda *_args, **_kwargs: None
+    sys.modules['rocketlib'] = rocketlib
+
+    for name in ('ai', 'ai.common', 'ai.common.config'):
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+    if not hasattr(sys.modules['ai.common.config'], 'Config'):
+
+        class _Config:
+            @staticmethod
+            def getNodeConfig(*_args, **_kwargs):
+                return {}
+
+        sys.modules['ai.common.config'].Config = _Config
+
+    if 'tool_mcp_client' not in sys.modules:
+        package = types.ModuleType('tool_mcp_client')
+        package.__path__ = [str(Path(_NODE_SRC).resolve())]
+        sys.modules['tool_mcp_client'] = package
+
+
+# Stub engine-only deps just long enough to import the node, then restore
+# sys.modules so the stubs never leak to sibling tests (see _sys_modules_guard).
+_CORE_STUBS = ('rocketlib', 'ai', 'ai.common', 'ai.common.config')
+_saved_core = {_name: sys.modules.get(_name) for _name in _CORE_STUBS}
+_ensure_iglobal_import_stubs()
+try:
+    from tool_mcp_client import IGlobal as iglobal_module  # noqa: E402
+    from tool_mcp_client.IGlobal import (  # noqa: E402
+        REFRESH_MIN_INTERVAL_S,
+        IGlobal,
+        ToolUnavailableError,
+    )
+    from tool_mcp_client.IInstance import IInstance  # noqa: E402
+    from tool_mcp_client.mcp_stdio_client import McpStdioClient, McpToolDef  # noqa: E402
+finally:
+    for _name, _mod in _saved_core.items():
+        if _mod is None:
+            sys.modules.pop(_name, None)
+        else:
+            sys.modules[_name] = _mod
+
+STUB_SERVER = os.path.join(os.path.dirname(__file__), 'stub_mcp_server.py')
+
+
+def _tool(name):
+    return McpToolDef(name=name, description=f'{name} description', inputSchema={'type': 'object', 'properties': {}})
+
+
+class _ScriptedClient:
+    """A connected MCP client whose successive ``list_tools()`` answers are scripted."""
+
+    def __init__(self, *catalogs):
+        self._catalogs = [list(c) for c in catalogs]
+        self.list_calls = 0
+        self.calls = []
+
+    def list_tools(self):
+        self.list_calls += 1
+        if self.list_calls <= len(self._catalogs):
+            return self._catalogs[self.list_calls - 1]
+        return self._catalogs[-1]
+
+    def call_tool(self, *, name, arguments):
+        self.calls.append((name, arguments))
+        return {'content': [{'type': 'text', 'text': f'called {name}'}]}
+
+
+class _FailingClient(_ScriptedClient):
+    def list_tools(self):
+        self.list_calls += 1
+        raise RuntimeError('server went away')
+
+
+def _iglobal(client, *initial):
+    """An IGlobal as ``beginGlobal`` leaves it: connected client + cached catalog."""
+    g = IGlobal.__new__(IGlobal)
+    g.serverName = 'srv'
+    g._client = client
+    g._cache_tools(list(initial))
+    return g
+
+
+@pytest.fixture
+def clock(monkeypatch):
+    """Controllable ``time.monotonic`` for the IGlobal module."""
+    now = [1000.0]
+    monkeypatch.setattr(iglobal_module.time, 'monotonic', lambda: now[0])
+    return now
+
+
+@pytest.fixture
+def warnings(monkeypatch):
+    seen = []
+    monkeypatch.setattr(iglobal_module, 'warning', lambda msg: seen.append(str(msg)))
+    return seen
+
+
+# ---------------------------------------------------------------------------
+# Lookup miss -> refresh once -> retry
+# ---------------------------------------------------------------------------
+
+
+class TestLookupMiss:
+    def test_get_tool_miss_refreshes_and_finds_a_tool_added_after_start(self, clock):
+        client = _ScriptedClient([_tool('a'), _tool('late')])
+        g = _iglobal(client, _tool('a'))
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        assert g.get_tool(server_name='srv', tool_name='late').name == 'late'
+        assert client.list_calls == 1
+        assert {d['name'] for d in g.list_namespaced_tools()} == {'srv.a', 'srv.late'}
+
+    def test_call_tool_calls_a_tool_added_after_start(self, clock):
+        client = _ScriptedClient([_tool('a'), _tool('late')])
+        g = _iglobal(client, _tool('a'))
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        result = g.call_tool(server_name='srv', tool_name='late', arguments={'x': 1})
+
+        assert result['content'][0]['text'] == 'called late'
+        assert client.calls == [('late', {'x': 1})]
+
+    def test_unknown_tool_after_refresh_raises_and_never_reaches_the_server(self, clock):
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        with pytest.raises(ToolUnavailableError) as exc:
+            g.call_tool(server_name='srv', tool_name='ghost', arguments={})
+
+        assert "'ghost'" in str(exc.value) and "'srv'" in str(exc.value) and "'a'" in str(exc.value)
+        assert client.calls == []
+        assert client.list_calls == 1
+
+    def test_instance_invoke_of_unknown_tool_is_refused_loudly(self, clock):
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+        instance = IInstance.__new__(IInstance)
+        instance.IGlobal = g
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        with pytest.raises(ToolUnavailableError):
+            instance._tool_invoke_dynamic(tool_name='srv.ghost', input_obj={'q': 1})
+
+        assert client.calls == []
+
+    def test_known_tool_does_not_refresh(self):
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+
+        g.call_tool(server_name='srv', tool_name='a', arguments={})
+
+        assert client.list_calls == 0
+        assert client.calls == [('a', {})]
+
+    def test_repeated_misses_within_the_interval_refresh_once(self, clock):
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        assert g.get_tool(server_name='srv', tool_name='ghost') is None
+        clock[0] += REFRESH_MIN_INTERVAL_S / 2
+        assert g.get_tool(server_name='srv', tool_name='ghost') is None
+        assert client.list_calls == 1
+
+        clock[0] += REFRESH_MIN_INTERVAL_S
+        assert g.get_tool(server_name='srv', tool_name='ghost') is None
+        assert client.list_calls == 2
+
+    def test_other_server_name_is_not_this_node(self):
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+
+        assert g.get_tool(server_name='other', tool_name='a') is None
+        assert client.list_calls == 0
+
+    def test_no_client_means_no_refresh_and_no_crash(self):
+        g = IGlobal.__new__(IGlobal)
+        g.serverName = 'srv'
+
+        assert g.get_tool(server_name='srv', tool_name='a') is None
+        assert g.list_namespaced_tools() == []
+
+
+# ---------------------------------------------------------------------------
+# Catalog query -> refresh after TTL only
+# ---------------------------------------------------------------------------
+
+
+class TestCatalogQuery:
+    def test_query_within_the_interval_serves_the_cache(self, clock):
+        client = _ScriptedClient([_tool('a'), _tool('late')])
+        g = _iglobal(client, _tool('a'))
+        clock[0] += REFRESH_MIN_INTERVAL_S / 2
+
+        assert {d['name'] for d in g.list_namespaced_tools()} == {'srv.a'}
+        assert client.list_calls == 0
+
+    def test_query_after_the_interval_re_reads_the_server(self, clock):
+        client = _ScriptedClient([_tool('a'), _tool('late')])
+        g = _iglobal(client, _tool('a'))
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        assert {d['name'] for d in g.list_namespaced_tools()} == {'srv.a', 'srv.late'}
+        assert client.list_calls == 1
+        # The refresh restarts the interval: an immediate second query is served from cache.
+        assert {d['name'] for d in g.list_namespaced_tools()} == {'srv.a', 'srv.late'}
+        assert client.list_calls == 1
+
+    def test_query_descriptor_shape_is_unchanged(self):
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+
+        [descriptor] = g.list_namespaced_tools()
+
+        assert descriptor == {
+            'name': 'srv.a',
+            'description': 'a description',
+            'inputSchema': {'type': 'object', 'properties': {}},
+        }
+
+
+# ---------------------------------------------------------------------------
+# Refresh outcomes: failure keeps the cache; change is reported
+# ---------------------------------------------------------------------------
+
+
+class TestRefreshOutcomes:
+    def test_failed_refresh_keeps_previous_catalog_and_warns(self, clock, warnings):
+        client = _FailingClient()
+        g = _iglobal(client, _tool('a'))
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        assert g.refresh_tools(reason='test') is False
+        assert {d['name'] for d in g.list_namespaced_tools()} == {'srv.a'}
+        assert g.call_tool(server_name='srv', tool_name='a', arguments={})['content'][0]['text'] == 'called a'
+        assert any('refresh (test) failed' in w and 'server went away' in w for w in warnings)
+
+    def test_changed_catalog_warns_with_added_and_removed_names(self, warnings):
+        client = _ScriptedClient([_tool('a'), _tool('c')])
+        g = _iglobal(client, _tool('a'), _tool('b'))
+
+        assert g.refresh_tools(reason='test') is True
+
+        [msg] = warnings
+        assert "added=['c']" in msg and "removed=['b']" in msg
+
+    def test_unchanged_catalog_does_not_warn(self, warnings):
+        client = _ScriptedClient([_tool('a')])
+        g = _iglobal(client, _tool('a'))
+
+        assert g.refresh_tools(reason='test') is True
+        assert warnings == []
+
+    def test_cache_swap_is_atomic_for_a_concurrent_reader(self):
+        client = _ScriptedClient([_tool('a'), _tool('b')])
+        g = _iglobal(client, _tool('a'))
+        old_by_name = g._tools_by_original
+        old_by_namespaced = g._tools_by_namespaced
+
+        g.refresh_tools(reason='test')
+
+        # A reader still holding the previous maps sees them unchanged; the
+        # new catalog is a fresh object, not an in-place mutation.
+        assert set(old_by_name) == {'a'} and set(old_by_namespaced) == {'srv.a'}
+        assert set(g._tools_by_original) == {'a', 'b'}
+        assert g._tools_by_original is not old_by_name
+
+
+# ---------------------------------------------------------------------------
+# End-to-end against the stub stdio MCP server, tools changing under it
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def live_tools_file(tmp_path, monkeypatch):
+    path = tmp_path / 'tools.json'
+    path.write_text(json.dumps([{'name': 'echo_tool', 'description': 'echo', 'inputSchema': {'type': 'object'}}]))
+    monkeypatch.setenv('STUB_MCP_TOOLS_FILE', str(path))
+    return path
+
+
+@pytest.fixture
+def stub_client(live_tools_file):
+    c = McpStdioClient(command=sys.executable, args=[STUB_SERVER], timeout_s=10.0)
+    c.start()
+    try:
+        yield c
+    finally:
+        c.stop()
+
+
+class TestAgainstStubServer:
+    def test_tool_added_after_start_becomes_callable_and_ghost_is_refused(self, stub_client, live_tools_file, clock):
+        g = IGlobal.__new__(IGlobal)
+        g.serverName = 'stub'
+        g._client = stub_client
+        g._cache_tools(stub_client.list_tools())
+        assert {t['name'] for t in g.list_namespaced_tools()} == {'stub.echo_tool'}
+
+        # The server grows a tool while the engine keeps running.
+        live_tools_file.write_text(
+            json.dumps(
+                [
+                    {'name': 'echo_tool', 'description': 'echo', 'inputSchema': {'type': 'object'}},
+                    {'name': 'late_tool', 'description': 'added later', 'inputSchema': {'type': 'object'}},
+                ]
+            )
+        )
+        clock[0] += REFRESH_MIN_INTERVAL_S
+
+        result = g.call_tool(server_name='stub', tool_name='late_tool', arguments={'k': 'v'})
+        assert result['content'][0]['text'] == 'called late_tool'
+        assert result['received_arguments'] == {'k': 'v'}
+
+        clock[0] += REFRESH_MIN_INTERVAL_S
+        with pytest.raises(ToolUnavailableError):
+            g.call_tool(server_name='stub', tool_name='ghost_tool', arguments={})
+
+    def test_stdio_requests_from_several_threads_do_not_starve_each_other(self, stub_client):
+        errors = []
+
+        def worker():
+            try:
+                for _ in range(5):
+                    names = {t.name for t in stub_client.list_tools()}
+                    assert 'echo_tool' in names
+                    stub_client.call_tool(name='echo_tool', arguments={'msg': 'hi'})
+            except Exception as e:  # pragma: no cover - failure path
+                errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors
+        assert not any(t.is_alive() for t in threads)

--- a/packages/ai/src/ai/common/agent/_internal/host.py
+++ b/packages/ai/src/ai/common/agent/_internal/host.py
@@ -20,6 +20,16 @@ from rocketlib import ToolDescriptor
 from rocketlib.types import IInvokeOp, IInvokeTool, IInvokeMemory
 
 
+class ToolNotFoundError(ValueError):
+    """The agent asked for a tool that is not in the catalog, even after the
+    owning tool node was re-queried.
+
+    A ``ValueError`` subclass so existing ``except ValueError`` handling still
+    applies, but distinguishable so drivers and guards can treat "this tool does
+    not exist" differently from a tool that exists and failed (issue #1402).
+    """
+
+
 class AgentHostServices:
     class LLM:
         """LLM host interface backed by IInvokeLLM operations."""
@@ -62,7 +72,11 @@ class AgentHostServices:
 
             Discovers all tools on every connected tool node once at
             construction.  Drivers read the prepared catalog as
-            ``self.list`` (a flat ``List[ToolDescriptor]``).
+            ``self.list`` (a flat ``List[ToolDescriptor]``).  A lookup for a
+            tool the catalog does not know re-queries the owning node once
+            (the node may have grown the tool since discovery — see
+            ``_lookup``), so a stale catalog does not silently become a
+            "not found" the model narrates around.
             """
             self._invoker = invoker
             self._tool_list: Dict[str, Any] = {}
@@ -70,38 +84,72 @@ class AgentHostServices:
 
             # For every tool node
             for tool_node in self._tool_nodes:
-                # Get this nodes tool list
-                param = IInvokeTool.Query()
-                try:
-                    self._invoker.instance.invoke(param, component_id=tool_node)
-                except Exception:
-                    # We expect this to throw because no node will
-                    # return success — but param.tools should be populated with the tool descriptors from this node
-                    pass
-
-                # Add the tools, namespaced by node id so that two nodes
-                # exposing the same tool name (e.g. two postgres instances)
-                # never collide.
-                for tool in param.tools:
-                    # Get the actual tool name id
-                    tool_id = tool.get('name')
-
-                    # Create a unique identifier for it
-                    namespaced = f'{tool_node}.{tool_id}'
-
-                    # Build a descriptor for the tool, namespaced by node id
-                    descriptor = {**tool, 'name': namespaced}
-
-                    # And save it to the tool list
-                    self._tool_list[namespaced] = {
-                        'node_id': tool_node,
-                        'tool_id': tool_id,
-                        'tool': descriptor,
-                    }
+                self._tool_list.update(self._discover(tool_node))
 
             # Prepared flat descriptor list, ready for direct reference
             # via `context.tools.list` from any driver.
             self.list: List[ToolDescriptor] = [entry['tool'] for entry in self._tool_list.values()]
+
+        def _discover(self, tool_node: str) -> Dict[str, Any]:
+            """Query one tool node and return its catalog entries, namespaced by node id."""
+            # Get this nodes tool list
+            param = IInvokeTool.Query()
+            try:
+                self._invoker.instance.invoke(param, component_id=tool_node)
+            except Exception:
+                # We expect this to throw because no node will
+                # return success — but param.tools should be populated with the tool descriptors from this node
+                pass
+
+            # Add the tools, namespaced by node id so that two nodes
+            # exposing the same tool name (e.g. two postgres instances)
+            # never collide.
+            entries: Dict[str, Any] = {}
+            for tool in param.tools:
+                # Get the actual tool name id
+                tool_id = tool.get('name')
+
+                # Create a unique identifier for it
+                namespaced = f'{tool_node}.{tool_id}'
+
+                # Build a descriptor for the tool, namespaced by node id
+                descriptor = {**tool, 'name': namespaced}
+
+                # And save it to the tool list
+                entries[namespaced] = {
+                    'node_id': tool_node,
+                    'tool_id': tool_id,
+                    'tool': descriptor,
+                }
+            return entries
+
+        def _refresh_node(self, tool_node: str) -> None:
+            """Re-discover one node and swap its entries into the catalog atomically."""
+            fresh = self._discover(tool_node)
+            merged = {name: entry for name, entry in self._tool_list.items() if entry['node_id'] != tool_node}
+            merged.update(fresh)
+            # Plain attribute assignment so a concurrent reader iterating the
+            # previous dict/list never sees a half-updated catalog.
+            self._tool_list = merged
+            self.list = [entry['tool'] for entry in merged.values()]
+
+        def _lookup(self, tool_name: str) -> Dict[str, Any]:
+            """Resolve a namespaced tool name to its catalog entry.
+
+            On a miss, the owning node (the ``<node_id>.`` prefix) is
+            re-queried once; if the tool is still unknown, raise
+            ``ToolNotFoundError`` rather than a bare ``ValueError``.
+            """
+            entry = self._tool_list.get(tool_name)
+            if entry is not None:
+                return entry
+            node_id = tool_name.split('.', 1)[0] if tool_name else ''
+            if node_id in self._tool_nodes:
+                self._refresh_node(node_id)
+                entry = self._tool_list.get(tool_name)
+                if entry is not None:
+                    return entry
+            raise ToolNotFoundError(f'Tool {tool_name} not found in tool catalog (owning node re-queried)')
 
         def get(self, tool_name: str) -> Any:
             """
@@ -110,12 +158,8 @@ class AgentHostServices:
             Returns:
                 A specification of the given tool
             """
-            # Make sure this is a valid tool
-            if tool_name not in self._tool_list:
-                raise ValueError(f'Tool {tool_name} not found in tool catalog')
-
-            # Return the specific tool
-            return self._tool_list[tool_name]['tool']
+            # Make sure this is a valid tool (re-queries the owning node on a miss)
+            return self._lookup(tool_name)['tool']
 
         def query(self) -> Any:
             """
@@ -145,13 +189,11 @@ class AgentHostServices:
                 tool_name: Tool name as published by discovery.
                 input: Tool input payload.
             """
-            # Make sure this is a valid tool
-            if tool_name not in self._tool_list:
-                raise ValueError(f'Tool {tool_name} not found in tool catalog')
+            # Make sure this is a valid tool (re-queries the owning node on a miss)
+            entry = self._lookup(tool_name)
 
             # Build the invoke using the original (un-prefixed) name so the
             # provider's _owns_tool() match works.
-            entry = self._tool_list[tool_name]
             param = IInvokeTool.Validate(tool_name=entry['tool_id'], input=input)
 
             # Call the tool to validate - throws on error
@@ -170,13 +212,11 @@ class AgentHostServices:
             Returns:
                 The tool output (extracted from ``param.output``).
             """
-            # Make sure this is a valid tool
-            if tool_name not in self._tool_list:
-                raise ValueError(f'Tool {tool_name} not found in tool catalog')
+            # Make sure this is a valid tool (re-queries the owning node on a miss)
+            entry = self._lookup(tool_name)
 
             # Build the invoke using the original (un-prefixed) name so the
             # provider's _owns_tool() match works.
-            entry = self._tool_list[tool_name]
             param = IInvokeTool.Invoke(tool_name=entry['tool_id'], input=args)
 
             # Invoke it

--- a/packages/ai/src/ai/common/agent/_internal/host.py
+++ b/packages/ai/src/ai/common/agent/_internal/host.py
@@ -143,8 +143,14 @@ class AgentHostServices:
             entry = self._tool_list.get(tool_name)
             if entry is not None:
                 return entry
-            node_id = tool_name.split('.', 1)[0] if tool_name else ''
-            if node_id in self._tool_nodes:
+            # Node ids may themselves contain dots, so the owning node is the
+            # longest known id the name is prefixed by — not the first segment.
+            node_id = max(
+                (node for node in self._tool_nodes if tool_name.startswith(f'{node}.')),
+                key=len,
+                default=None,
+            )
+            if node_id is not None:
                 self._refresh_node(node_id)
                 entry = self._tool_list.get(tool_name)
                 if entry is not None:

--- a/packages/ai/tests/ai/common/agent/test_tools_catalog_refresh.py
+++ b/packages/ai/tests/ai/common/agent/test_tools_catalog_refresh.py
@@ -1,0 +1,213 @@
+"""Agent-host tool catalog: re-query the owning node on a miss (issue #1402).
+
+``AgentHostServices.Tools`` discovers every connected tool node once, at
+construction, and is cached on the IInstance for its whole life. Before this
+change a tool the model asked for that was not in that snapshot raised a bare
+``ValueError('Tool X not found in tool catalog')`` — even when the owning node
+(for example ``tool_mcp_client`` after its server grew a tool) could serve it —
+and a weak planner narrates around that error instead of failing.
+
+Now a miss re-queries the owning node once (the ``<node_id>.`` prefix of the
+namespaced name), swaps that node's entries into the catalog atomically, and
+only then raises ``ToolNotFoundError`` (a ``ValueError`` subclass, so existing
+handlers still match) if the tool is still unknown.
+
+``host.py`` is loaded from its file so the tests also run without a built
+engine (the same approach as ``nodes/test/tool_mcp_client/test_mcp_agent_catalog.py``);
+inside the engine the real ``rocketlib`` is used untouched.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+_HOST_PY = Path(__file__).resolve().parents[4] / 'src' / 'ai' / 'common' / 'agent' / '_internal' / 'host.py'
+
+
+def _ensure_rocketlib_stubs() -> None:
+    """Provide the two rocketlib imports host.py needs when the engine is absent."""
+    try:
+        import rocketlib.types  # noqa: F401
+
+        return
+    except Exception:
+        pass
+
+    class IInvokeOp:
+        pass
+
+    class IInvokeTool(IInvokeOp):
+        class Query(IInvokeOp):
+            def __init__(self) -> None:
+                self.tools: List[Any] = []
+
+        class Invoke(IInvokeOp):
+            def __init__(self, *, tool_name: str, input: Any) -> None:
+                self.tool_name = tool_name
+                self.input = input
+                self.output = None
+
+        class Validate(IInvokeOp):
+            def __init__(self, *, tool_name: str, input: Any) -> None:
+                self.tool_name = tool_name
+                self.input = input
+
+    class IInvokeMemory(IInvokeTool):
+        pass
+
+    rocketlib = sys.modules.get('rocketlib') or types.ModuleType('rocketlib')
+    if not hasattr(rocketlib, 'ToolDescriptor'):
+        rocketlib.ToolDescriptor = dict
+    rl_types = types.ModuleType('rocketlib.types')
+    rl_types.IInvokeOp = IInvokeOp
+    rl_types.IInvokeTool = IInvokeTool
+    rl_types.IInvokeMemory = IInvokeMemory
+    rocketlib.types = rl_types
+    sys.modules['rocketlib'] = rocketlib
+    sys.modules['rocketlib.types'] = rl_types
+
+
+_ensure_rocketlib_stubs()
+
+_spec = importlib.util.spec_from_file_location('_rr_agent_host_under_test', _HOST_PY)
+host = importlib.util.module_from_spec(_spec)
+sys.modules[_spec.name] = host
+_spec.loader.exec_module(host)
+
+Tools = host.AgentHostServices.Tools
+ToolNotFoundError = host.ToolNotFoundError
+IInvokeTool = host.IInvokeTool
+
+
+class _FakeInstance:
+    """Engine instance seam: one tool node whose catalog can change under the host."""
+
+    def __init__(self, tools_by_node: Dict[str, List[Dict[str, Any]]]) -> None:
+        self.tools_by_node = tools_by_node
+        self.queries: List[str] = []
+        self.invocations: List[tuple] = []
+        self.validations: List[tuple] = []
+
+    def getControllerNodeIds(self, kind: str) -> List[str]:
+        return list(self.tools_by_node) if kind == 'tool' else []
+
+    def invoke(self, param, component_id: str):
+        if isinstance(param, IInvokeTool.Query):
+            self.queries.append(component_id)
+            param.tools.extend(dict(t) for t in self.tools_by_node.get(component_id, []))
+            # Real tool nodes append their descriptors and raise PreventDefault;
+            # the host swallows this and reads param.tools.
+            raise RuntimeError('no node returned success')
+        if isinstance(param, IInvokeTool.Invoke):
+            self.invocations.append((component_id, param.tool_name, param.input))
+            param.output = {'called': param.tool_name}
+            return None
+        if isinstance(param, IInvokeTool.Validate):
+            self.validations.append((component_id, param.tool_name, param.input))
+            return None
+        raise AssertionError(f'unexpected op {param!r}')
+
+
+class _FakeInvoker:
+    def __init__(self, instance: _FakeInstance) -> None:
+        self.instance = instance
+
+
+def _descriptor(name: str) -> Dict[str, Any]:
+    return {'name': name, 'description': f'{name} description', 'inputSchema': {'type': 'object', 'properties': {}}}
+
+
+@pytest.fixture
+def instance() -> _FakeInstance:
+    return _FakeInstance({'n1': [_descriptor('srv.a')]})
+
+
+@pytest.fixture
+def tools(instance) -> Tools:
+    return Tools(_FakeInvoker(instance))
+
+
+class TestDiscovery:
+    def test_construction_discovers_each_node_once_and_namespaces_by_node(self, instance, tools):
+        assert instance.queries == ['n1']
+        assert [d['name'] for d in tools.list] == ['n1.srv.a']
+        assert tools.query() == tools.list
+
+    def test_known_tool_invokes_without_re_query(self, instance, tools):
+        assert tools.invoke('n1.srv.a', {'q': 1}) == {'called': 'srv.a'}
+        assert instance.invocations == [('n1', 'srv.a', {'q': 1})]
+        assert instance.queries == ['n1']
+
+
+class TestMiss:
+    def test_tool_added_on_the_node_after_discovery_is_found_and_invoked(self, instance, tools):
+        instance.tools_by_node['n1'].append(_descriptor('srv.late'))
+
+        assert tools.invoke('n1.srv.late', {'x': 2}) == {'called': 'srv.late'}
+
+        assert instance.queries == ['n1', 'n1']
+        assert instance.invocations == [('n1', 'srv.late', {'x': 2})]
+        assert {d['name'] for d in tools.list} == {'n1.srv.a', 'n1.srv.late'}
+
+    def test_get_and_validate_also_recover_after_a_miss(self, instance, tools):
+        instance.tools_by_node['n1'].append(_descriptor('srv.late'))
+
+        assert tools.get('n1.srv.late')['name'] == 'n1.srv.late'
+        tools.validate('n1.srv.late', {'x': 1})
+
+        assert instance.validations == [('n1', 'srv.late', {'x': 1})]
+        # One re-query served both: get() refreshed, validate() hit the cache.
+        assert instance.queries == ['n1', 'n1']
+
+    def test_still_unknown_after_re_query_raises_tool_not_found(self, instance, tools):
+        with pytest.raises(ToolNotFoundError) as exc:
+            tools.invoke('n1.srv.ghost', {})
+
+        assert isinstance(exc.value, ValueError)
+        assert 'n1.srv.ghost' in str(exc.value)
+        assert instance.queries == ['n1', 'n1']
+        assert instance.invocations == []
+
+    def test_unknown_node_prefix_does_not_query_anything(self, instance, tools):
+        with pytest.raises(ToolNotFoundError):
+            tools.invoke('nope.srv.a', {})
+
+        assert instance.queries == ['n1']
+
+    def test_a_miss_refresh_replaces_the_whole_node_entry_set(self, instance, tools):
+        # The node swapped srv.a for srv.b: the miss on srv.b re-queries n1 and
+        # the stale srv.a entry goes away with it. (A known name is still
+        # served from the cache until then; the node itself is the authority at
+        # call time — tool_mcp_client refuses a vanished tool loudly.)
+        instance.tools_by_node['n1'] = [_descriptor('srv.b')]
+
+        assert tools.invoke('n1.srv.b', {}) == {'called': 'srv.b'}
+
+        assert [d['name'] for d in tools.list] == ['n1.srv.b']
+        assert 'n1.srv.a' not in tools._tool_list
+
+    def test_refresh_swaps_the_catalog_instead_of_mutating_it(self, instance, tools):
+        old_catalog = tools._tool_list
+        old_list = tools.list
+        instance.tools_by_node['n1'].append(_descriptor('srv.late'))
+
+        tools.get('n1.srv.late')
+
+        assert set(old_catalog) == {'n1.srv.a'} and [d['name'] for d in old_list] == ['n1.srv.a']
+        assert tools._tool_list is not old_catalog and tools.list is not old_list
+
+    def test_refresh_only_touches_the_owning_node(self):
+        instance = _FakeInstance({'n1': [_descriptor('srv.a')], 'n2': [_descriptor('other.z')]})
+        tools = Tools(_FakeInvoker(instance))
+        instance.tools_by_node['n2'].append(_descriptor('other.late'))
+
+        tools.invoke('n2.other.late', {})
+
+        assert instance.queries == ['n1', 'n2', 'n2']
+        assert {d['name'] for d in tools.list} == {'n1.srv.a', 'n2.other.z', 'n2.other.late'}

--- a/packages/ai/tests/ai/common/agent/test_tools_catalog_refresh.py
+++ b/packages/ai/tests/ai/common/agent/test_tools_catalog_refresh.py
@@ -202,6 +202,18 @@ class TestMiss:
         assert set(old_catalog) == {'n1.srv.a'} and [d['name'] for d in old_list] == ['n1.srv.a']
         assert tools._tool_list is not old_catalog and tools.list is not old_list
 
+    def test_dotted_node_id_resolves_to_the_longest_matching_node(self):
+        # 'n1.x.late' is prefixed by both known node ids 'n1' and 'n1.x'.
+        # Splitting on the first dot would re-query 'n1' and still miss.
+        instance = _FakeInstance({'n1': [_descriptor('a')], 'n1.x': [_descriptor('b')]})
+        tools = Tools(_FakeInvoker(instance))
+        instance.tools_by_node['n1.x'].append(_descriptor('late'))
+
+        assert tools.invoke('n1.x.late', {}) == {'called': 'late'}
+
+        assert instance.queries == ['n1', 'n1.x', 'n1.x']
+        assert {d['name'] for d in tools.list} == {'n1.a', 'n1.x.b', 'n1.x.late'}
+
     def test_refresh_only_touches_the_owning_node(self):
         instance = _FakeInstance({'n1': [_descriptor('srv.a')], 'n2': [_descriptor('other.z')]})
         tools = Tools(_FakeInvoker(instance))


### PR DESCRIPTION
## Summary

- `tool_mcp_client` fetched `tools/list` once in `beginGlobal()` and never again, and the agent host built its tool list once per instance, so a tool added or renamed on a running MCP server was invisible until the engine restarted — and the miss surfaced as the server's own "not found", which a weak planner narrates around (#1402).
- Node side (`nodes/src/nodes/tool_mcp_client/IGlobal.py`): the catalog is re-read from the server on every discovery query and on every lookup miss. `REFRESH_MIN_INTERVAL_S = 1.0` is a rate limit, not a TTL — a miss refreshes immediately unless the catalog is younger than a second, so there is no fixed staleness window; a burst of queries or repeated misses for one unknown tool costs one `tools/list`. Refreshes are serialized (no stampede), the cache is swapped atomically (the RocketRide executor calls tools from a thread pool), a changed catalog emits a warning naming added/removed tools, a failed refresh keeps the previous catalog and warns, and a tool still unknown after refresh is refused with `ToolUnavailableError` and never sent to the server.
- `mcp_stdio_client.py`: JSON-RPC requests are now serialized with a lock. The stdio transport reads responses line-by-line and drops foreign ids, so two concurrent requests (parallel tool calls, or a refresh during a call) starved each other — a pre-existing hazard this change would have exposed more often.
- Host side (`packages/ai/src/ai/common/agent/_internal/host.py`, `AgentHostServices.Tools`): a miss re-queries the owning tool node once (the `<node_id>.` prefix of the namespaced name), swaps that node's entries atomically, and only then raises `ToolNotFoundError`. It subclasses `ValueError` on purpose so every existing `except ValueError` keeps matching; it is distinguishable so drivers and guards can tell "does not exist" from "exists and failed".
- `tool_mcp_client/README.md`: the "discovered once at pipeline startup, restart required" statement is replaced with the new contract (co-located docs rule).

Deliberately out of scope: the LLM-side fabrication guard. `require_tool_call` still counts a not-found as an attempted call (`AgentBase.call_tool` records before invoke) — I can follow up if you'd like a catalog miss not to count. LangChain/CrewAI drivers bind their tool set per run, so for them a new tool appears on the next run; the RocketRide driver benefits within a run.

## Type

fix

## Testing

- [x] Tests added or updated — 18 in `nodes/test/tool_mcp_client/test_catalog_refresh.py`: scripted-client cases (miss → refresh → retry, refusal without a server call, rate limit, discovery refresh, failed refresh keeps cache + warns, change warning, atomic swap) plus end-to-end against `stub_mcp_server.py`, which now serves a mutable tool list via `STUB_MCP_TOOLS_FILE` (a tool added while the server runs becomes callable, a ghost is refused, four threads share the stdio client without starving). 10 in `packages/ai/tests/ai/common/agent/test_tools_catalog_refresh.py`: host re-query on miss, `ToolNotFoundError`, unknown node prefix, whole-node entry replacement, atomic swap, owning-node-only refresh; it loads `host.py` from file so it also runs without a built engine (same approach as `test_mcp_agent_catalog.py`).
- [x] Tested locally (plain venv, Python 3.14): `pytest nodes/test/tool_mcp_client/test_catalog_refresh.py` → 18 passed; `pytest nodes/test/tool_mcp_client` → 47 passed, 2 skipped (exit 1 comes from the pre-existing sys.modules-leak report against the sibling `test_zero_arg_tools.py`, untouched here; the new file alone exits 0); `pytest packages/ai/tests/ai/common/agent/test_tools_catalog_refresh.py --noconftest` → 10 passed (`--noconftest` only because that conftest imports engine-only modules; under `ai:test` it runs normally); `ruff check` / `ruff format --check` clean on all touched paths.
- [ ] `./builder test` passes — not run locally (needs the engine build); the new tests run under `nodes:test` / `ai:test`.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (if applicable) — node README updated
- [ ] Breaking changes documented (if applicable) — none; the new error types subclass existing ones or are new

## Linked Issue

Fixes #1402

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tool catalogs now refresh automatically during discovery and when unknown tools are requested.
  - Newly added tools can be used without restarting the pipeline.
  - Unknown tools are rejected locally with a clear error instead of being sent to the server.
  - Catalog additions and removals are reported with warnings.

- **Bug Fixes**
  - Improved reliability for concurrent tool requests and catalog updates.
  - Prevented stale or inconsistent tool listings during refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->