### PR TITLE
fix(depends): opt-in PyTorch CPU index to avoid CUDA on CPU-only hosts

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -238,7 +238,7 @@ class FileLock:
                     msvcrt.locking(self._file.fileno(), msvcrt.LK_NBLCK, 1)
                 else:
                     fcntl.flock(self._file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                # Lock acquired — initialize sidecar state and enable writes
+                # Lock acquired - initialize sidecar state and enable writes
                 _progress_path = self._sidecar_path
                 _sidecar_start_time = time.time()
                 _last_sidecar_message = None
@@ -250,7 +250,7 @@ class FileLock:
                 # Read what the lock holder is doing and include it in our status
                 detail = _read_progress(self._sidecar_path)
                 if detail:
-                    monitorStatus(f'Waiting — {detail}')
+                    monitorStatus(f'Waiting - {detail}')
                 else:
                     monitorStatus('Waiting for another installation to complete...')
                 time.sleep(self.poll_interval)
@@ -324,11 +324,30 @@ def _get_constraints_path() -> str:
 def _constraints_args(constraints_path: str, exe_dir: str) -> list[str]:
     """Return uv ``-c`` args if the constraints file exists and is non-empty, else ``[]``.
 
-    Relative to exe_dir (the subprocess cwd) — uv splits the value on whitespace.
+    Relative to exe_dir (the subprocess cwd); uv splits the value on whitespace.
     """
     if os.path.exists(constraints_path) and os.path.getsize(constraints_path) > 0:
         return ['-c', os.path.relpath(constraints_path, exe_dir)]
     return []
+
+
+def _torch_cpu_index_args() -> list[str]:
+    """Return uv args to resolve torch from the PyTorch CPU wheel index, or ``[]``.
+
+    Opt-in via the ``ROCKETRIDE_TORCH_CPU`` environment variable (set to ``1``,
+    ``true`` or ``yes``). Default off, so GPU hosts and existing installs are
+    unaffected. When enabled, the PyTorch CPU wheel index is added as an extra
+    index so ``torch`` (and the transitive ``nvidia-*`` / ``triton`` CUDA stack
+    that PyPI's default GPU wheel pulls in) resolves to ``+cpu`` builds instead.
+
+    See issue #1697: on a CPU-only node the default resolve installs ~6.6 GB of
+    CUDA libraries that can never run there, and it can also prevent the engine
+    from booting on hosts without a matching GPU wheel. Because the CPU index is
+    additive and left off by default, self-hosted GPU users are not affected.
+    """
+    if os.environ.get('ROCKETRIDE_TORCH_CPU', '').strip().lower() not in ('1', 'true', 'yes'):
+        return []
+    return ['--extra-index-url', 'https://download.pytorch.org/whl/cpu']
 
 
 def _run(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
@@ -483,8 +502,8 @@ def _ensure_setuptools():
     """Ensure setuptools is installed in the parent env.
 
     Required because we compile/install with --no-build-isolation, which means uv
-    builds source-only wheels (e.g. docopt 0.6.2, transitively pulled by kokoro →
-    misaki → num2words) against the parent env. Several legacy sdists declare
+    builds source-only wheels (e.g. docopt 0.6.2, transitively pulled by kokoro to
+    misaki to num2words) against the parent env. Several legacy sdists declare
     setup.py-style builds without listing setuptools in build-system.requires,
     so uv can't auto-bootstrap them. Mirroring _ensure_wheel so the parent env
     has the standard PEP 517 backend available at compile/install time.
@@ -624,7 +643,7 @@ def bootstrap():
     _ensure_site_packages()  # Must be first!
     _ensure_pip()
     _ensure_wheel()  # Needed for building packages with --no-build-isolation
-    _ensure_setuptools()  # Same reason — required by sdists with legacy setup.py builds
+    _ensure_setuptools()  # Same reason - required by sdists with legacy setup.py builds
     _ensure_uv()
 
 
@@ -706,6 +725,8 @@ def _compile_constraints(constraints_path: str):
         '--no-build-isolation',  # Don't create temp venvs (engine.exe can't create venvs)
         '--emit-index-url',  # Preserve --extra-index-url etc. so install/dry-run can find packages (e.g. torch+cu128)
     ]
+    # Optionally resolve torch from the PyTorch CPU index (opt-in, default off). See #1697.
+    args.extend(_torch_cpu_index_args())
     debug(f'Compile: {args}')
     result = subprocess.run(
         args,
@@ -822,6 +843,9 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
 
     args.extend(_constraints_args(constraints_path, exe_dir))
 
+    # Optionally resolve torch from the PyTorch CPU index (opt-in, default off). See #1697.
+    args.extend(_torch_cpu_index_args())
+
     debug(f'Dry-run: {args}')
     result = subprocess.run(
         args,
@@ -840,7 +864,7 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
         error(f'Dependency resolution failed for {requirements_path}: {output}')
         raise RuntimeError(f'Dependency resolution failed: {output[:200]}')
 
-    # Parse packages from output — lines starting with "+ "
+    # Parse packages from output - lines starting with "+ "
     packages = []
     for line in (result.stderr + result.stdout).splitlines():
         line = line.strip()
@@ -873,7 +897,7 @@ def _install_requirements(requirements_path: str, constraints_path: str):
         debug(f'  Empty requirements file, skipping: {requirements_path}')
         return
 
-    # Start heartbeat early — the dry-run can block on uv's internal lock
+    # Start heartbeat early - the dry-run can block on uv's internal lock
     # for minutes, and we need monitorStatus events to keep the task startup
     # timeout alive during that time.
     _start_heartbeat()
@@ -918,10 +942,13 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
         '--no-build-isolation',  # Don't create temp venvs (engine.exe can't create venvs)
     ]
 
-    # Relative to cwd (exe_dir) — see the --excludes note in _install_dry_run (#1256).
+    # Relative to cwd (exe_dir) - see the --excludes note in _install_dry_run (#1256).
     uv_args.extend(['--excludes', os.path.relpath(_write_excludes_file(), exe_dir)])
 
     uv_args.extend(_constraints_args(constraints_path, exe_dir))
+
+    # Optionally resolve torch from the PyTorch CPU index (opt-in, default off). See #1697.
+    uv_args.extend(_torch_cpu_index_args())
 
     # Run uv and stream output (heartbeat is already running from the caller)
     debug(f'Install: {uv_args}')

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -350,6 +350,65 @@ def _torch_cpu_index_args() -> list[str]:
     return ['--extra-index-url', 'https://download.pytorch.org/whl/cpu']
 
 
+def _torch_cpu_enabled() -> bool:
+    """True when the opt-in ``ROCKETRIDE_TORCH_CPU`` flag is set."""
+    return os.environ.get('ROCKETRIDE_TORCH_CPU', '').strip().lower() in ('1', 'true', 'yes')
+
+
+def _torch_cpu_overrides_file() -> Optional[str]:
+    """Write a uv overrides file that forces torch/torchvision to their ``+cpu`` builds.
+
+    Only used when ``ROCKETRIDE_TORCH_CPU`` is enabled. Adding the CPU index alone is
+    not enough: the declared requirements pin exact CUDA locals (e.g. ``torch==X+cu128``
+    for non-Darwin), so uv would still resolve the GPU wheel. An overrides file forces
+    the version regardless of the declared pin (see uv docs on overrides).
+
+    The ``+cpu`` versions are derived from the existing CUDA pins found in the
+    requirement files, so this tracks version bumps automatically rather than
+    hardcoding a version. Returns the overrides path, or ``None`` if disabled or no
+    CUDA-pinned torch requirement is found.
+    """
+    if not _torch_cpu_enabled():
+        return None
+
+    import re
+
+    pattern = re.compile(r'^\s*(torch|torchvision)\s*==\s*([0-9][0-9.]*)\+cu\w+', re.IGNORECASE)
+    overrides: list[str] = []
+    seen: set[str] = set()
+    for req_path in _find_requirement_files():
+        try:
+            with open(req_path, 'r', encoding='utf-8') as f:
+                for line in f:
+                    match = pattern.match(line)
+                    if match:
+                        name = match.group(1).lower()
+                        if name not in seen:
+                            seen.add(name)
+                            overrides.append(f'{name}=={match.group(2)}+cpu')
+        except OSError:
+            continue
+
+    if not overrides:
+        return None
+
+    overrides_path = os.path.join(engine_cache_dir(), 'torch-cpu-overrides.txt')
+    with open(overrides_path, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(overrides) + '\n')
+    return overrides_path
+
+
+def _torch_cpu_override_args(exe_dir: str) -> list[str]:
+    """Return uv ``--override`` args forcing torch/torchvision to ``+cpu`` builds, or ``[]``.
+
+    Relative to exe_dir (the subprocess cwd), consistent with the other file args.
+    """
+    overrides_path = _torch_cpu_overrides_file()
+    if not overrides_path:
+        return []
+    return ['--override', os.path.relpath(overrides_path, exe_dir)]
+
+
 def _run(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
     """
     Run a subprocess command, keeping stdin open until process exits.
@@ -669,8 +728,14 @@ def _find_requirement_files() -> list[str]:
 
 
 def _compute_hash(file_paths: list[str]) -> str:
-    """Compute a fast hash from file metadata (mtime + size)."""
+    """Compute a fast hash from file metadata (mtime + size), plus the torch CPU mode.
+
+    The ``ROCKETRIDE_TORCH_CPU`` value is included so that toggling it invalidates
+    the cache and rebuilds the constraints file, instead of reusing constraints that
+    were compiled for the other mode. See #1697.
+    """
     hasher = hashlib.md5()
+    hasher.update(f'torch_cpu:{os.environ.get("ROCKETRIDE_TORCH_CPU", "")}\n'.encode())
     for path in sorted(file_paths):
         stat = os.stat(path)
         entry = f'{path}:{stat.st_size}:{stat.st_mtime_ns}\n'
@@ -727,6 +792,7 @@ def _compile_constraints(constraints_path: str):
     ]
     # Optionally resolve torch from the PyTorch CPU index (opt-in, default off). See #1697.
     args.extend(_torch_cpu_index_args())
+    args.extend(_torch_cpu_override_args(exe_dir))
     debug(f'Compile: {args}')
     result = subprocess.run(
         args,
@@ -845,6 +911,7 @@ def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]
 
     # Optionally resolve torch from the PyTorch CPU index (opt-in, default off). See #1697.
     args.extend(_torch_cpu_index_args())
+    args.extend(_torch_cpu_override_args(exe_dir))
 
     debug(f'Dry-run: {args}')
     result = subprocess.run(
@@ -949,6 +1016,7 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
 
     # Optionally resolve torch from the PyTorch CPU index (opt-in, default off). See #1697.
     uv_args.extend(_torch_cpu_index_args())
+    uv_args.extend(_torch_cpu_override_args(exe_dir))
 
     # Run uv and stream output (heartbeat is already running from the caller)
     debug(f'Install: {uv_args}')


### PR DESCRIPTION
Adds ROCKETRIDE_TORCH_CPU env flag (default off). When set, resolves torch from the PyTorch CPU wheel index so the transitive nvidia-* / triton CUDA  stack is not installed on CPU-only hosts. GPU users are unaffected.

Refs #1697

## Summary

<!-- Describe your changes in 1-3 bullet points -->

-

## Type

<!-- What kind of change is this? (feature, fix, refactor, docs, chore, etc.) -->

## Testing

- [ ] Tests added or updated
- [ ] Tested locally
- [ ] `./builder test` passes

## Checklist

- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [ ] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

<!-- REQUIRED: Every PR must be linked to an issue. Use one of: -->
<!-- Fixes #123 / Closes #123 / Resolves #123 -->

Fixes #


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in support for resolving and installing PyTorch CPU-only packages.
  * Enable this mode with `ROCKETRIDE_TORCH_CPU=1`, `true`, or `yes`.
  * CPU package settings are applied consistently during dependency checks, previews, and installation.
  * Existing behavior remains unchanged unless the option is enabled.

* **Style**
  * Improved consistency in comments and status messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->