### PR TITLE
fix: prefer IPv4 socket in WebServer.get_port() (#994)

### DIFF
--- a/packages/ai/src/ai/web/server.py
+++ b/packages/ai/src/ai/web/server.py
@@ -51,6 +51,7 @@ Usage::
 import os
 import secrets
 import signal
+import socket
 import sys
 import threading
 import urllib.parse
@@ -784,6 +785,14 @@ class WebServer:
         # Delegate to the shared inner authentication method
         return await self._authenticate_credential_inner(authorization)
 
+    def _set_port(self, port: int) -> int:
+        """Cache the resolved port and publish RR_BASE_URL if it is not already set."""
+        self._port = port
+        # Deferred from _create_server when port was 0
+        if not os.environ.get('RR_BASE_URL'):
+            os.environ['RR_BASE_URL'] = f'{self._base_url_scheme}://{self._base_url_host}:{port}'
+        return self._port
+
     def get_port(self) -> int:
         """
         Get the port number on which the server is running.
@@ -791,6 +800,9 @@ class WebServer:
         Resolved lazily from the bound socket on first use: with port=0 the OS
         assigns the real port at bind time, which uvicorn does *after* the
         lifespan startup hook, so self._port is still 0 until a request arrives.
+        On a dual-stack host, uvicorn binds one socket per address family and
+        the OS may assign each a different port; the IPv4 socket is preferred,
+        falling back to IPv6 only when no IPv4 socket is bound.
 
         Returns:
             int: The port number actually bound by uvicorn.
@@ -800,6 +812,7 @@ class WebServer:
             5565
         """
         if not self._port and self.server is not None:
+            fallback_port: int | None = None
             for srv in getattr(self.server, 'servers', None) or []:
                 for sock in getattr(srv, 'sockets', None) or []:
                     try:
@@ -807,12 +820,18 @@ class WebServer:
                     except OSError:
                         continue  # closed/bad socket; try the next one
                     bound_port = bound[1] if isinstance(bound, tuple) and len(bound) >= 2 else None
-                    if bound_port:
-                        self._port = bound_port
-                        # Deferred from _create_server when port was 0
-                        if not os.environ.get('RR_BASE_URL'):
-                            os.environ['RR_BASE_URL'] = f'{self._base_url_scheme}://{self._base_url_host}:{bound_port}'
-                        return self._port
+                    if not bound_port:
+                        continue
+                    # On dual-stack hosts with port=0, uvicorn binds once per address family
+                    # and the kernel assigns a different ephemeral port to each. Prefer IPv4
+                    # so in-process clients resolving 'localhost' reach a listening port on
+                    # the first attempt regardless of getaddrinfo ordering. See #994.
+                    if getattr(sock, 'family', None) == socket.AF_INET:
+                        return self._set_port(bound_port)
+                    if fallback_port is None:
+                        fallback_port = bound_port
+            if fallback_port is not None:
+                return self._set_port(fallback_port)
         return self._port
 
     def registerStatusCallback(self, callback: Callable[[Dict[str, any]], None]) -> None:

--- a/packages/ai/tests/ai/web/test_server.py
+++ b/packages/ai/tests/ai/web/test_server.py
@@ -306,6 +306,7 @@ class TestGetPort:
     """Verify get_port() prefers a bound IPv4 socket over IPv6. See #994."""
 
     def test_dual_stack_prefers_ipv4(self, monkeypatch):
+        """On a dual-stack host, get_port() returns the IPv4 port even when IPv6 is listed first."""
         monkeypatch.delenv('RR_BASE_URL', raising=False)
         ipv4 = _bind_ipv4()
         ipv6 = _bind_ipv6()
@@ -325,6 +326,7 @@ class TestGetPort:
             ipv6.close()
 
     def test_ipv6_only_falls_back(self, monkeypatch):
+        """With no IPv4 socket bound, get_port() falls back to the IPv6 port."""
         monkeypatch.delenv('RR_BASE_URL', raising=False)
         ipv6 = _bind_ipv6()
         try:

--- a/packages/ai/tests/ai/web/test_server.py
+++ b/packages/ai/tests/ai/web/test_server.py
@@ -2,6 +2,7 @@
 
 import os
 import signal
+import socket
 import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -254,3 +255,104 @@ class TestEnsureSigningKey:
         monkeypatch.setenv('RR_STORE_URL', 'filesystem:///tmp/store')
         _ensure_signing_key()
         assert len(os.environ.get('RR_SIGNING_KEY', '')) == 64
+
+
+# ============================================================================
+# WebServer.get_port() tests — see #994
+# ============================================================================
+
+
+def _bind_ipv4() -> socket.socket:
+    """Bind a real IPv4 socket to an OS-assigned ephemeral port."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(('127.0.0.1', 0))
+    return sock
+
+
+def _bind_ipv6() -> socket.socket:
+    """Bind a real IPv6 socket to an OS-assigned ephemeral port, or skip.
+
+    ``socket.has_ipv6`` only reports build-time support, not whether this
+    host can actually bind the IPv6 loopback (many CI runners can't) — so
+    the bind itself, not just the flag, decides whether to skip.
+    """
+    if not socket.has_ipv6:
+        pytest.skip('platform built without IPv6 support')
+    sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        sock.bind(('::1', 0))
+    except OSError as exc:
+        sock.close()
+        pytest.skip(f'cannot bind IPv6 loopback: {exc}')
+    return sock
+
+
+def _make_port_server() -> WebServer:
+    """Build a minimal WebServer-like object suitable for get_port() tests."""
+    server = object.__new__(WebServer)
+    server._port = 0
+    server.server = None
+    server._base_url_scheme = 'http'
+    server._base_url_host = 'localhost'
+    return server
+
+
+def _stub_uvicorn_server(*sockets: socket.socket) -> SimpleNamespace:
+    """Minimal stand-in for uvicorn's server object: server.servers[*].sockets."""
+    return SimpleNamespace(servers=[SimpleNamespace(sockets=list(sockets))])
+
+
+class TestGetPort:
+    """Verify get_port() prefers a bound IPv4 socket over IPv6. See #994."""
+
+    def test_dual_stack_prefers_ipv4(self, monkeypatch):
+        monkeypatch.delenv('RR_BASE_URL', raising=False)
+        ipv4 = _bind_ipv4()
+        ipv6 = _bind_ipv6()
+        try:
+            ipv4_port = ipv4.getsockname()[1]
+            ipv6_port = ipv6.getsockname()[1]
+            if ipv4_port == ipv6_port:
+                pytest.skip('kernel assigned the same port to both families; preference is unobservable')
+
+            server = _make_port_server()
+            # IPv6 listed first — the test proves nothing if IPv4 wins by position alone.
+            server.server = _stub_uvicorn_server(ipv6, ipv4)
+
+            assert server.get_port() == ipv4_port
+        finally:
+            ipv4.close()
+            ipv6.close()
+
+    def test_ipv6_only_falls_back(self, monkeypatch):
+        monkeypatch.delenv('RR_BASE_URL', raising=False)
+        ipv6 = _bind_ipv6()
+        try:
+            ipv6_port = ipv6.getsockname()[1]
+
+            server = _make_port_server()
+            server.server = _stub_uvicorn_server(ipv6)
+
+            assert server.get_port() == ipv6_port
+        finally:
+            ipv6.close()
+
+    def test_rr_base_url_behaviour(self, monkeypatch):
+        """RR_BASE_URL is published from the resolved port only when unset."""
+        ipv4 = _bind_ipv4()
+        try:
+            ipv4_port = ipv4.getsockname()[1]
+
+            monkeypatch.delenv('RR_BASE_URL', raising=False)
+            server = _make_port_server()
+            server.server = _stub_uvicorn_server(ipv4)
+            server.get_port()
+            assert os.environ['RR_BASE_URL'] == f'http://localhost:{ipv4_port}'
+
+            monkeypatch.setenv('RR_BASE_URL', 'sentinel-value')
+            other_server = _make_port_server()
+            other_server.server = _stub_uvicorn_server(ipv4)
+            other_server.get_port()
+            assert os.environ['RR_BASE_URL'] == 'sentinel-value'
+        finally:
+            ipv4.close()


### PR DESCRIPTION
Fixes #994



\## What



`WebServer.get\_port()` returned the port of whichever bound socket uvicorn

enumerated first. On a dual-stack host with the default `host=localhost` and

`port=0`, uvicorn binds once per address family and the kernel assigns a

different ephemeral port to each, so the in-process `http://localhost:<port>`

URL could point at a port only listening on the other family.



This implements \*\*option 1\*\* from the issue: prefer the IPv4 socket, falling

back to IPv6 only when no IPv4 socket is bound. It is a policy change local to

`get\_port()` with no caller changes. Happy to switch to option 3

(`get\_local\_uri()`) instead if you'd rather resolve host and port together —

that's a larger change touching the `task\_http/\*` callers, so I went with the

smallest fix that resolves the reported behaviour.



The `RR\_BASE\_URL` side effect is extracted into a `\_set\_port()` helper so it

isn't duplicated across the two return paths. Semantics are unchanged: it is

still set only when previously unset.



`import socket` is added for `socket.AF\_INET`. If you'd rather not add the

import, `len(bound) == 2` distinguishes the families too, since `getsockname()`

returns a 2-tuple for IPv4 and a 4-tuple for IPv6 — but the explicit family

check reads clearer.



\## Tests



`get\_port()` had no tests; these are the first. Three cases, using real bound

sockets rather than mocks: IPv4 preferred when both families are bound (IPv6

listed first, so position alone can't produce a pass), IPv6-only falls back, and

`RR\_BASE\_URL` is published from the resolved port without overwriting an

existing value.



IPv6 binds are guarded so they skip rather than error where the loopback isn't

bindable, since `socket.has\_ipv6` reports build-time support only.



\## Verification



Full `packages/ai/tests` suite, before and after, with the change stashed for the

baseline: identical except `1557 passed` → `1560 passed`. The pre-existing

failures in both runs are unrelated to this change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic port detection for web servers running in mixed IPv4 and IPv6 environments.
  * IPv4 connections are now preferred when available, with IPv6 used as a fallback.
  * Invalid or closed connections are handled more reliably during port resolution.
  * The base server URL is now published only when it has not already been configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->