### PR TITLE
fix(client-python): get_task_status now validates into TASK_STATUS

### DIFF
--- a/packages/client-python/src/rocketride/mixins/execution.py
+++ b/packages/client-python/src/rocketride/mixins/execution.py
@@ -60,7 +60,7 @@ import os
 from typing import Dict, Any, List, Optional
 from ..core import DAPClient
 from ..types.pipeline import PipelineConfig
-from ..types.task import TASK_STATUS
+from ..types.task import TASK_STATUS, TASK_STATE
 
 try:
     import json5
@@ -383,14 +383,14 @@ class ExecutionMixin(DAPClient):
             token: Task token of the pipeline to check (from use())
 
         Returns:
-            Dict containing status information:
-            - state: Current execution state ('starting', 'running', 'completed', 'failed', etc.)
-            - progress: Progress information if available (items processed, percentage, etc.)
-            - error: Error message if pipeline failed
-            - started_at: When execution started (timestamp)
-            - completed_at: When execution finished (timestamp, if completed)
-            - performance: Processing speed and resource usage metrics
-            - Additional pipeline-specific status data
+            A TASK_STATUS model with status information, including:
+            - state: Current lifecycle state, a TASK_STATE enum value
+              (NONE, STARTING, INITIALIZING, RUNNING, STOPPING, COMPLETED, CANCELLED)
+            - completed: True once the task has finished execution
+            - errors / warnings: Recent error and warning message history
+            - startTime / endTime: Execution timestamps (Unix time)
+            - metrics / tokens: Performance and resource usage data
+            - Additional pipeline-specific status fields (see TASK_STATUS)
 
         Raises:
             RuntimeError: If status retrieval fails
@@ -407,37 +407,29 @@ class ExecutionMixin(DAPClient):
             # Monitor until completion
             while True:
                 status = await client.get_task_status(token)
-                state = status.get('state')
 
-                if state == 'running':
-                    progress = status.get('progress', {})
-                    print(f"Processing: {progress.get('percentage', 0):.1f}%")
-                elif state == 'completed':
+                if status.state == TASK_STATE.RUNNING.value:
+                    print(f"Processing: {status.completedCount}/{status.totalCount}")
+                elif status.completed and status.state == TASK_STATE.COMPLETED.value:
                     print("Pipeline completed successfully!")
                     break
-                elif state == 'failed':
-                    error = status.get('error', 'Unknown error')
-                    print(f"Pipeline failed: {error}")
+                elif status.exitCode != 0:
+                    print(f"Pipeline failed: {status.exitMessage or status.errors}")
                     break
 
                 await asyncio.sleep(1)  # Check every second
 
-        Status States:
-            - 'starting': Pipeline is initializing
-            - 'running': Pipeline is actively processing data
-            - 'waiting': Pipeline is waiting for more data
-            - 'completed': Pipeline finished successfully
-            - 'failed': Pipeline encountered an error
-            - 'terminated': Pipeline was stopped by user
-
         Tips:
             - Poll status regularly for long-running operations
-            - Check 'progress' field for completion percentage
-            - Use 'error' field for detailed error information
-            - Performance metrics help optimize pipeline configurations
+            - Compare 'state' against TASK_STATE enum members, not strings
+            - Check 'completedCount'/'totalCount' for progress
+            - Use 'errors'/'exitMessage' for failure details
+            - 'metrics'/'tokens' help optimize pipeline configurations
         """
-        # Send status request
-        return await self.call('rrext_get_task_status', token=token)
+        # Send status request and validate the raw response into TASK_STATUS
+        # so the annotation, docstring, and runtime behavior all agree.
+        raw = await self.call('rrext_get_task_status', token=token)
+        return TASK_STATUS.model_validate(raw)
 
     async def get_task_token(self, project_id: str, source: str, *, team_id: str = '') -> str | None:
         """

--- a/packages/client-python/tests/RocketRideClient_test.py
+++ b/packages/client-python/tests/RocketRideClient_test.py
@@ -277,8 +277,7 @@ class TestPipelineOperations:
 
             status = await client.get_task_status(result['token'])
 
-            assert 'state' in status
-            assert status['state'] in [state.value for state in TASK_STATE]
+            assert status.state in [state.value for state in TASK_STATE]
 
             await client.terminate(result['token'])
         finally:
@@ -1544,8 +1543,7 @@ class TestEndToEndWorkflow:
             assert 'text' in process_result
             assert test_data in process_result['text'][0]
 
-            assert 'state' in status
-            assert status['state'] in [state.value for state in TASK_STATE]
+            assert status.state in [state.value for state in TASK_STATE]
             assert result['token'] is not None
         finally:
             if token:
@@ -1603,8 +1601,8 @@ Line 3: random data {random.random()}"""
             assert 'text' in processing_result
             assert 'End-to-end file processing test' in processing_result['text'][0]
 
-            assert 'state' in final_status
-            assert 'completed' in final_status
+            assert final_status.state is not None
+            assert final_status.completed is not None
         finally:
             if token:
                 await ensure_clean_pipeline(client, token)
@@ -1829,7 +1827,7 @@ Line 3: random data {random.random()}"""
 
             # Check status after valid operation
             status_after_valid = await client.get_task_status(token)
-            assert len(status_after_valid['errors']) == 0
+            assert len(status_after_valid.errors) == 0
 
             # Try to send data after termination (should fail)
             await client.terminate(token)
@@ -1887,7 +1885,7 @@ Line 3: random data {random.random()}"""
 
             # Get final status to verify task completed
             final_status = await client.get_task_status(token)
-            assert 'state' in final_status
+            assert final_status.state is not None
 
             await client.terminate(token)
             token = None


### PR DESCRIPTION
Fixes #1988. The method's annotation, docstring, and body disagreed about the return type: the docstring said Dict and used `.get()`, the annotation said `TASK_STATUS`, and the body just returned the raw dict from `self.call()` unvalidated into either.

- Validate the raw response into `TASK_STATUS.model_validate()` so the annotation is true at runtime
- Correct the docstring: `state` is an int from the `TASK_STATE` enum, not one of the string literals it previously listed
- Update the 5 call sites in `RocketRideClient_test.py` that used dict-style access (`status['state']`, `'state' in status`) on the result, since those would now raise `TypeError` against a validated model

 Summary
- `get_task_status()` now validates its response into `TASK_STATUS` instead of returning a raw dict
- Docstring corrected to match the real model (enum-based `state`, actual field names)
- Test assertions updated to use attribute access

 Notes for reviewers
I grepped the repo for other `get_task_status` call sites. Found one live REST endpoint (`packages/ai/src/ai/modules/task_http/task_status.py`) that passes the result straight into `response()` — confirmed this is safe since `model_dump()` recursively serializes nested pydantic models even under an `Any`-typed field, so the JSON output is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Task status results are now returned as structured, typed objects.
  - Status information includes typed state values, progress details, and failure information.

- **Improvements**
  - Updated task-status documentation and examples to reflect the structured response format.
  - Improved consistency when accessing task status across processing, uploads, error recovery, and large-data workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->