### PR TITLE
fix(tool_slack): reject message_post text over Slack limit

### DIFF
--- a/nodes/src/nodes/tool_slack/slack_client.py
+++ b/nodes/src/nodes/tool_slack/slack_client.py
@@ -50,6 +50,10 @@ from slack_sdk.webhook import WebhookClient
 # Hard caps enforced regardless of what the caller requests.
 MAX_CHANNELS = 1000
 MAX_HISTORY_MESSAGES = 200
+# Slack chat.postMessage / incoming-webhook `text` hard maximum (characters).
+# Refuse above this so a single call stays one atomic message and the returned
+# `ts` identifies what the caller sent (see #1831).
+MAX_MESSAGE_TEXT_CHARS = 40_000
 
 # Per-request page size for cursor pagination (Slack recommends <= 200).
 _PAGE_SIZE = 200
@@ -309,12 +313,17 @@ class SlackClient:
             that channel/thread arguments were ignored.
 
         Raises:
-            ValueError: On missing/empty ``text`` or missing ``channel`` in
-                token mode.
+            ValueError: On missing/empty ``text``, ``text`` longer than
+                ``MAX_MESSAGE_TEXT_CHARS``, or missing ``channel`` in token mode.
             SlackError: Typed error on API failure.
         """
         if not isinstance(text, str) or not text.strip():
             raise ValueError('text must not be empty')
+        if len(text) > MAX_MESSAGE_TEXT_CHARS:
+            raise ValueError(
+                f'text exceeds Slack limit of {MAX_MESSAGE_TEXT_CHARS} characters '
+                f'({len(text)} given); shorten the message so it posts atomically'
+            )
 
         if self._webhook is not None:
             return self._post_via_webhook(text)

--- a/nodes/test/tool_slack/test_slack.py
+++ b/nodes/test/tool_slack/test_slack.py
@@ -295,6 +295,28 @@ class TestMessagePost:
             client.message_post(channel='C-1', text='   ')
         web.chat_postMessage.assert_not_called()
 
+    def test_text_over_limit_raises_token_mode(self):
+        client, web = _make_token_client()
+        too_long = 'x' * (slack_client.MAX_MESSAGE_TEXT_CHARS + 1)
+        with pytest.raises(ValueError, match='exceeds Slack limit'):
+            client.message_post(channel='C-1', text=too_long)
+        web.chat_postMessage.assert_not_called()
+
+    def test_text_at_limit_posts_token_mode(self):
+        client, web = _make_token_client()
+        web.chat_postMessage.return_value = {'ok': True, 'channel': 'C-1', 'ts': '1.2', 'message': {}}
+        text = 'y' * slack_client.MAX_MESSAGE_TEXT_CHARS
+        result = client.message_post(channel='C-1', text=text)
+        web.chat_postMessage.assert_called_once()
+        assert result['ok'] is True
+
+    def test_text_over_limit_raises_webhook_mode(self):
+        client, hook = _make_webhook_client()
+        too_long = 'z' * (slack_client.MAX_MESSAGE_TEXT_CHARS + 1)
+        with pytest.raises(ValueError, match='exceeds Slack limit'):
+            client.message_post(text=too_long)
+        hook.send.assert_not_called()
+
     def test_missing_channel_in_token_mode_raises(self):
         client, web = _make_token_client()
         with pytest.raises(ValueError, match='channel is required'):


### PR DESCRIPTION
## Summary
- Refuse `message_post` text longer than Slack's hard limit (`MAX_MESSAGE_TEXT_CHARS` = 40000) in both token and webhook modes (policy: refuse oversize text so the post stays atomic and the returned `ts` stays trustworthy).
- Fixes #1831

## Test plan
- [ ] `python -m pytest nodes/test/tool_slack/test_slack.py::TestMessagePost -q`
- [ ] Confirm over-limit text raises `ValueError` and does not call Slack APIs (token + webhook)
- [ ] Confirm text at the limit still posts successfully in token mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Slack messages exceeding 40,000 characters are now rejected before sending.
  * Messages at or below the limit continue to post successfully.
  * Oversized messages are handled consistently for token and webhook connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->