### PR TITLE
fix(shell): prevent reconnect stall in CONNECTING

### DIFF
--- a/packages/shell/src/components/layout/ConnectionErrorBanner.tsx
+++ b/packages/shell/src/components/layout/ConnectionErrorBanner.tsx
@@ -25,9 +25,10 @@
 // =============================================================================
 //
 // Renders a fixed top banner whenever ConnectionStatus carries a latched
-// failure (status.lastFailure). Network failures offer a Retry that re-runs
-// bootstrap via reload; auth failures offer Sign in via the shell's
-// edition-aware login dispatcher (shell:loginRequest).
+// failure (status.lastFailure). Network failures offer a Retry that prefers
+// ConnectionManager.reconnect() when a token is stored (reload as fallback);
+// auth failures offer Sign in via the shell's edition-aware login dispatcher
+// (shell:loginRequest).
 // =============================================================================
 
 import React, { CSSProperties, useEffect, useState } from 'react';
@@ -119,11 +120,12 @@ export const ConnectionErrorBanner: React.FC<ConnectionErrorBannerProps> = ({ me
 	const action = isNetworkFailure ? 'Retry' : isOAuthCallbackFailure ? 'Try again' : 'Sign in';
 	const onAction = isNetworkFailure
 		? onRetry ?? (() => {
-			// A reload re-runs bootstrap, which recovers every shape: a stored
-			// token logs back in, tokenless renders the landing, and a still-
-			// unreachable server re-latches this banner. In-place recovery via
-			// ConnectionManager.reconnect() is preferred when available; reload
-			// remains a safe fallback for a full shell reset.
+			// Prefer in-place recovery when a stored token exists; reload only
+			// when there is nothing to reconnect with or reconnect itself fails.
+			const manager = ConnectionManager.getInstance();
+			if (manager.loadToken()) {
+				return manager.reconnect().catch(() => window.location.reload());
+			}
 			window.location.reload();
 		})
 		: onSignIn ?? (() => {

--- a/packages/shell/src/components/layout/ConnectionErrorBanner.tsx
+++ b/packages/shell/src/components/layout/ConnectionErrorBanner.tsx
@@ -122,9 +122,8 @@ export const ConnectionErrorBanner: React.FC<ConnectionErrorBannerProps> = ({ me
 			// A reload re-runs bootstrap, which recovers every shape: a stored
 			// token logs back in, tokenless renders the landing, and a still-
 			// unreachable server re-latches this banner. In-place recovery via
-			// ConnectionManager.reconnect() stalls in CONNECTING even against a
-			// healthy server (pre-existing; tracked separately) — don't use it
-			// as the default action.
+			// ConnectionManager.reconnect() is preferred when available; reload
+			// remains a safe fallback for a full shell reset.
 			window.location.reload();
 		})
 		: onSignIn ?? (() => {

--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -809,6 +809,67 @@ test('reconnect clears a stale connect operation and logs in again with the stor
 	);
 });
 
+test('reconnect flushes a stale onDisconnected microtask before connecting again', async () => {
+	const { manager, emitted } = createTestManager();
+	manager.serverUri = 'https://shell.example.test';
+	let loginCalls = 0;
+	let disconnectCalls = 0;
+	manager.loadToken = () => 'stored-token';
+	manager.clearToken = () => {};
+	manager.clearSessionAppId = () => {};
+	manager.refreshServices = async () => {};
+	manager.client = testClient({
+		login: async () => {
+			loginCalls++;
+			return authenticatedResult;
+		},
+		disconnect: async () => { disconnectCalls++; },
+		getAccountInfo: () => authenticatedResult,
+	});
+	manager.manager = {
+		disconnect: async () => {
+			disconnectCalls++;
+			// Mimic a late SDK onDisconnected: queued after disconnect returns.
+			// reconnect()'s microtask flush must drain this while lifecycleOwner
+			// is still unset; otherwise it can flip a fresh connect back to
+			// CONNECTING (#1628).
+			queueMicrotask(() => {
+				if (!manager.lifecycleOwner) return;
+				if (manager.connectionStatus.state !== ConnectionState.AUTH_FAILED) {
+					manager.updateConnectionStatus({ state: ConnectionState.CONNECTING, errorKind: undefined });
+				}
+				manager.emit('shell:disconnected', { reason: 'stale transport close', hasError: false });
+			});
+		},
+	};
+
+	const hung: TestOperation = {
+		key: 'hung',
+		generation: 1,
+		credential: 'stored-token',
+		promise: new Promise(() => {}),
+		connectedPublished: true,
+	};
+	manager.connectionOperation = hung;
+	manager.lifecycleOwner = hung;
+	manager.connectionGeneration = 1;
+	manager.connectionStatus.state = ConnectionState.CONNECTING;
+	manager._attachPromise = Promise.resolve();
+
+	await manager.reconnect();
+	await Promise.resolve();
+
+	assert.equal(disconnectCalls, 1);
+	assert.equal(loginCalls, 1);
+	assert.equal(manager.connectionStatus.state, ConnectionState.CONNECTED);
+	assert.equal(
+		emitted.filter(({ event, payload }) =>
+			event === 'shell:disconnected' && (payload as { reason?: string }).reason === 'stale transport close',
+		).length,
+		0,
+	);
+});
+
 test('disconnect does not publish an intentional disconnected event after a newer generation takes ownership', async () => {
 	const { manager, emitted } = createTestManager();
 	let disconnectCalls = 0;

--- a/packages/shell/src/connection/connection.test.ts
+++ b/packages/shell/src/connection/connection.test.ts
@@ -54,7 +54,7 @@ type TestOperation = {
 type ConnectionManagerTestAdapter = {
 	client: TestClient | RocketRideClient | null;
 	manager: { disconnect(client: RocketRideClient): Promise<void> } | null;
-	_attachPromise: Promise<void>;
+	_attachPromise: Promise<void> | undefined;
 	serverUri: string;
 	pendingEvents: Map<string, unknown>;
 	lifecycleOwner?: TestOperation;
@@ -85,6 +85,7 @@ type ConnectionManagerTestAdapter = {
 	connect(credential?: unknown): Promise<ConnectResult | null>;
 	bootstrap(): Promise<{ result: ConnectResult; appId: string } | null>;
 	disconnect(): Promise<void>;
+	reconnect(): Promise<void>;
 	logout(): Promise<void>;
 };
 
@@ -741,6 +742,71 @@ test('disconnect and logout invalidate an in-flight operation before client clea
 			[{ event: 'shell:disconnected', payload: { reason: 'Disconnected by request', hasError: false } }],
 		);
 	}
+});
+
+test('disconnect detaches the shared client even when no RemoteManager is bound', async () => {
+	const { manager, emitted } = createTestManager();
+	let disconnectCalls = 0;
+	manager.client = testClient({
+		disconnect: async () => { disconnectCalls++; },
+	});
+	manager.manager = null;
+
+	await manager.disconnect();
+
+	assert.equal(disconnectCalls, 1);
+	assert.equal(manager.connectionStatus.state, ConnectionState.DISCONNECTED);
+	assert.deepEqual(
+		emitted.filter(({ event }) => event === 'shell:disconnected'),
+		[{ event: 'shell:disconnected', payload: { reason: 'Disconnected by request', hasError: false } }],
+	);
+});
+
+test('reconnect clears a stale connect operation and logs in again with the stored token', async () => {
+	const { manager, emitted } = createTestManager();
+	manager.serverUri = 'https://shell.example.test';
+	let loginCalls = 0;
+	let disconnectCalls = 0;
+	manager.loadToken = () => 'stored-token';
+	manager.clearToken = () => {};
+	manager.clearSessionAppId = () => {};
+	manager.refreshServices = async () => {};
+	manager.client = testClient({
+		login: async () => {
+			loginCalls++;
+			return authenticatedResult;
+		},
+		disconnect: async () => { disconnectCalls++; },
+		getAccountInfo: () => authenticatedResult,
+	});
+	manager.manager = {
+		disconnect: async () => { disconnectCalls++; },
+	};
+
+	const hungKey = `${RocketRideClient.normalizeUri(manager.serverUri)}\u0000stored-token`;
+	const hung: TestOperation = {
+		key: hungKey,
+		generation: 1,
+		credential: 'stored-token',
+		promise: new Promise(() => {}),
+		connectedPublished: false,
+	};
+	manager.connectionOperation = hung;
+	manager.lifecycleOwner = hung;
+	manager.connectionGeneration = 1;
+	manager.connectionStatus.state = ConnectionState.CONNECTING;
+	manager._attachPromise = Promise.resolve();
+
+	await manager.reconnect();
+
+	assert.equal(disconnectCalls, 1);
+	assert.equal(loginCalls, 1);
+	assert.equal(manager.connectionStatus.state, ConnectionState.CONNECTED);
+	assert.equal(manager._attachPromise, undefined);
+	assert.equal(
+		emitted.some(({ event }) => event === 'shell:login'),
+		true,
+	);
 });
 
 test('disconnect does not publish an intentional disconnected event after a newer generation takes ownership', async () => {

--- a/packages/shell/src/connection/connection.ts
+++ b/packages/shell/src/connection/connection.ts
@@ -396,7 +396,14 @@ export class ConnectionManager implements IConnectionManager {
 			// Fired when the WebSocket closes for any reason
 			onDisconnected: async (reason, hasError) => {
 				if (!this.hasCurrentLifecycleOwner()) return;
-				this.lifecycleOwner!.connectedPublished = false;
+				const owner = this.lifecycleOwner!;
+				// Ignore disconnects that arrive before this owner published
+				// CONNECTED (in-flight login / reconnect) — and ignore stale
+				// callbacks from a prior transport after reconnect already
+				// restored an authenticated attachment (#1628).
+				if (!owner.connectedPublished) return;
+				if (this.client?.isAttached() && this.client.isAuthenticated()) return;
+				owner.connectedPublished = false;
 				this.clearServicesCache();
 				// Don't overwrite AUTH_FAILED state
 				if (this.connectionStatus.state !== ConnectionState.AUTH_FAILED) {
@@ -1018,6 +1025,15 @@ export class ConnectionManager implements IConnectionManager {
 		if (manager && client) {
 			await manager.disconnect(client);
 			if (this.manager === manager) this.manager = null;
+		} else if (client) {
+			// No RemoteManager (anonymous attach or a path that never bound one).
+			// Still detach the shared persist client so reconnect()/connect()
+			// cannot stall on a half-closed transport (#1628).
+			try {
+				await client.disconnect();
+			} catch (error) {
+				console.error('[ConnectionManager] Client disconnect during tear-down failed:', error);
+			}
 		}
 		if (this.connectionGeneration !== generation) return;
 
@@ -1031,11 +1047,17 @@ export class ConnectionManager implements IConnectionManager {
 	}
 
 	/**
-	 * Disconnect and reconnect.
+	 * Disconnect and reconnect with the stored token.
+	 *
+	 * Flushes microtasks after disconnect so async onDisconnected handlers from
+	 * the torn-down transport run while ``lifecycleOwner`` is still unset and
+	 * no-op, instead of flipping a fresh connect back to CONNECTING (#1628).
 	 */
 	public async reconnect(): Promise<void> {
 		const token = this.loadToken();
 		await this.disconnect();
+		await Promise.resolve();
+		this._attachPromise = undefined;
 		if (token) {
 			await this.connect(token);
 		}


### PR DESCRIPTION
## Summary
- Ignore stale `onDisconnected` callbacks while a reconnect is already in flight so the connection manager does not stall in `CONNECTING`.
- Always detach the shared client on disconnect, even when no `RemoteManager` is bound.
- Flush microtasks in `reconnect()` before `connect()`, and cover the behavior with connection manager unit tests (plus small `ConnectionErrorBanner` alignment).

Fixes #1628

## Test plan
- [x] `node --import tsx --test src/connection/connection.test.ts` in `packages/shell` (26/26 pass)
- [ ] Manual reconnect after transport drop while already reconnecting
- [ ] Confirm disconnect still cleans up when RemoteManager is absent

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery from connection interruptions by reconnecting with the stored session when possible.
  * Falls back to reloading the page when reconnection is unavailable or unsuccessful.
  * Prevented stale or premature network callbacks from incorrectly changing connection status.
  * Ensured clients are properly detached when connection management is unavailable.
  * Improved cleanup and handling of failed connection teardown operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->