### PR TITLE
fix: reject conflicting media lane in audio_player (#1966)

### DIFF
--- a/nodes/src/nodes/audio_player/IInstance.py
+++ b/nodes/src/nodes/audio_player/IInstance.py
@@ -21,8 +21,12 @@
 # SOFTWARE.
 # =============================================================================
 
-from rocketlib import IInstanceBase
+from rocketlib import AVI_ACTION, IInstanceBase
 from .IGlobal import IGlobal
+
+
+class LaneConflictError(RuntimeError):
+    """Raised when a second media lane BEGINs while the other is still active."""
 
 
 class IInstance(IInstanceBase):
@@ -32,14 +36,39 @@ class IInstance(IInstanceBase):
         from .player import Player
 
         self._audio = Player(lock=self.IGlobal.lock)
+        self._active_lane = None
 
     def endInstance(self):
         self._audio = None
+        self._active_lane = None
+
+    def _guard_lane(self, lane: str, action: int):
+        # Single choke point for the lane-conflict policy (issue #1966): one
+        # Player can only play one lane at a time, and a second concurrent
+        # BEGIN would deadlock its non-reentrant lock instead of erroring.
+        # Change the policy or LaneConflictError here only. Precondition check
+        # only - state is committed in _commit_lane, only after writeAVI
+        # actually succeeds, so a raised BEGIN/END never wedges the state.
+        if action == AVI_ACTION.BEGIN and self._active_lane not in (None, lane):
+            raise LaneConflictError(
+                f'audio_player: cannot start the {lane} lane, the {self._active_lane} lane '
+                f'is already playing on this object; only one lane can play at a time'
+            )
+
+    def _commit_lane(self, lane: str, action: int):
+        if action == AVI_ACTION.BEGIN:
+            self._active_lane = lane
+        elif action == AVI_ACTION.END and self._active_lane == lane:
+            self._active_lane = None
 
     def writeAudio(self, action: int, mimeType: str, buffer: bytes):
         # Use the standard AVI write method for audio
+        self._guard_lane('audio', action)
         self._audio.writeAVI(action, mimeType, buffer)
+        self._commit_lane('audio', action)
 
     def writeVideo(self, action: int, mimeType: str, buffer: bytes):
         # Use the standard AVI write method for video
+        self._guard_lane('video', action)
         self._audio.writeAVI(action, mimeType, buffer)
+        self._commit_lane('video', action)

--- a/nodes/src/nodes/audio_player/IInstance.py
+++ b/nodes/src/nodes/audio_player/IInstance.py
@@ -49,10 +49,13 @@ class IInstance(IInstanceBase):
         # Change the policy or LaneConflictError here only. Precondition check
         # only - state is committed in _commit_lane, only after writeAVI
         # actually succeeds, so a raised BEGIN/END never wedges the state.
-        if action == AVI_ACTION.BEGIN and self._active_lane not in (None, lane):
+        # A repeated BEGIN on the SAME lane re-enters the Player's lock exactly
+        # like a different lane would, so any active lane blocks every BEGIN,
+        # not just a mismatched one.
+        if action == AVI_ACTION.BEGIN and self._active_lane is not None:
             raise LaneConflictError(
-                f'audio_player: cannot start the {lane} lane, the {self._active_lane} lane '
-                f'is already playing on this object; only one lane can play at a time'
+                f'audio_player: cannot start the {lane} lane, this object already has an '
+                f'active {self._active_lane} lane; only one lane can play at a time'
             )
 
     def _commit_lane(self, lane: str, action: int):

--- a/nodes/test/audio_player/test_lane_conflict.py
+++ b/nodes/test/audio_player/test_lane_conflict.py
@@ -172,3 +172,55 @@ def test_failed_begin_does_not_wedge_the_other_lane():
         inst.writeVideo(AVI_ACTION.BEGIN, 'video/mp4', b'')
     assert not isinstance(excinfo.value, LaneConflictError), 'video was wrongly rejected as a lane conflict'
     assert 'simulated start failure' in str(excinfo.value)
+
+
+def _drive_repeated_begin(inst, lane, results, errors):
+    from rocketlib import AVI_ACTION
+
+    write = inst.writeAudio if lane == 'audio' else inst.writeVideo
+    mime = 'audio/wav' if lane == 'audio' else 'video/mp4'
+
+    try:
+        write(AVI_ACTION.BEGIN, mime, b'')
+        write(AVI_ACTION.BEGIN, mime, b'')
+        results.append('completed')
+    except Exception as e:  # noqa: BLE001 - capturing whatever the guard raises
+        errors.append(e)
+
+
+def _assert_repeated_begin_is_rejected_not_deadlocked(lane):
+    """
+    A second BEGIN on the SAME lane re-enters the Player's non-reentrant lock
+    exactly like a different lane would (CodeRabbit catch on #1966: the guard
+    only compared lanes, so audio-then-audio slipped through to writeAVI while
+    the Player still held the lock). Same bounded-thread technique as the
+    cross-lane test: a regression must show up as a failing assertion, never
+    as a hung suite.
+    """
+    inst = _fresh_instance()
+    from audio_player.IInstance import LaneConflictError
+
+    results = []
+    errors = []
+
+    t = threading.Thread(target=_drive_repeated_begin, args=(inst, lane, results, errors), daemon=True)
+    t.start()
+    t.join(timeout=5)
+
+    assert not t.is_alive(), (
+        f'repeated {lane} BEGIN did not return within 5s - same-lane lock re-entry, not a slow test'
+    )
+    assert not results, f'expected the repeated BEGIN to be rejected, but it completed: {results}'
+    assert len(errors) == 1, f'expected exactly one LaneConflictError, got: {errors}'
+    assert isinstance(errors[0], LaneConflictError), f'wrong error type: {errors[0]!r}'
+
+    # Same teardown reasoning as test_second_lane_begin_is_rejected_not_deadlocked above.
+    inst._audio._playback_finished = True
+
+
+def test_repeated_audio_begin_is_rejected_not_deadlocked():
+    _assert_repeated_begin_is_rejected_not_deadlocked('audio')
+
+
+def test_repeated_video_begin_is_rejected_not_deadlocked():
+    _assert_repeated_begin_is_rejected_not_deadlocked('video')

--- a/nodes/test/audio_player/test_lane_conflict.py
+++ b/nodes/test/audio_player/test_lane_conflict.py
@@ -1,0 +1,174 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+"""Regression test for issue #1966: audio_player deadlocked when a single
+object carried both an audio and a video stream, because both lanes drove the
+same Player through one non-reentrant lock.
+"""
+
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from pathlib import Path
+
+_NODE_DIR = Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 'audio_player'
+_AI_SRC = Path(__file__).resolve().parent.parent.parent.parent / 'packages' / 'ai' / 'src'
+
+
+def _install_stubs():
+    """Fake only the hardware/binary deps audio_player needs at import time
+    (real PortAudio hardware isn't available here); the real IGlobal,
+    IInstance, Player, and AVIReader lock/lane logic run unmodified.
+    """
+    if 'sounddevice' not in sys.modules:
+        sd = types.ModuleType('sounddevice')
+
+        class _FakeOutputStream:
+            def __init__(self, **kwargs):
+                pass
+
+            def start(self):
+                pass
+
+            def stop(self):
+                pass
+
+            def close(self):
+                pass
+
+        class _CallbackStop(Exception):
+            pass
+
+        sd.OutputStream = _FakeOutputStream
+        sd.CallbackStop = _CallbackStop
+        sys.modules['sounddevice'] = sd
+
+    ai_src = str(_AI_SRC)
+    if ai_src not in sys.path:
+        sys.path.insert(0, ai_src)
+
+    if 'audio_player' not in sys.modules:
+        pkg = types.ModuleType('audio_player')
+        pkg.__path__ = [str(_NODE_DIR)]
+        sys.modules['audio_player'] = pkg
+
+
+def _fresh_instance():
+    """A real audio_player IInstance wired to a real threading.Lock, built the
+    way IGlobal.beginGlobal wires it (IGlobal.py:34) without running
+    beginGlobal itself (which would try to install requirements.txt).
+    """
+    _install_stubs()
+    from audio_player.IGlobal import IGlobal
+    from audio_player.IInstance import IInstance
+
+    inst = IInstance()
+    g = IGlobal()
+    g.lock = threading.Lock()
+    inst.IGlobal = g
+    inst.beginInstance()
+    return inst
+
+
+def _drive_conflicting_begins(inst, results, errors):
+    from rocketlib import AVI_ACTION
+
+    try:
+        inst.writeAudio(AVI_ACTION.BEGIN, 'audio/wav', b'')
+        inst.writeVideo(AVI_ACTION.BEGIN, 'video/mp4', b'')
+        results.append('completed')
+    except Exception as e:  # noqa: BLE001 - capturing whatever the guard raises
+        errors.append(e)
+
+
+def test_second_lane_begin_is_rejected_not_deadlocked():
+    """
+    Pre-fix, this sequence hangs: writeVideo(BEGIN) re-enters the Player's
+    non-reentrant lock from the thread that already holds it (reader.py
+    _lock/writeAVI). Run on a background thread with a bounded join so a
+    regression shows up as a failing assertion, never as a hung suite.
+    """
+    inst = _fresh_instance()
+    from audio_player.IInstance import LaneConflictError
+
+    results = []
+    errors = []
+
+    t = threading.Thread(target=_drive_conflicting_begins, args=(inst, results, errors), daemon=True)
+    t.start()
+    t.join(timeout=5)
+
+    assert not t.is_alive(), (
+        'writeVideo(BEGIN) did not return within 5s while the audio lane was active - '
+        'this is the issue #1966 deadlock (non-reentrant Player lock re-entered from the '
+        'same thread), not a slow test'
+    )
+    assert not results, f'expected the conflicting BEGIN to be rejected, but it completed: {results}'
+    assert len(errors) == 1, f'expected exactly one LaneConflictError, got: {errors}'
+    assert isinstance(errors[0], LaneConflictError), f'wrong error type: {errors[0]!r}'
+    assert 'audio' in str(errors[0]) and 'video' in str(errors[0])
+
+    # The audio lane's Player was BEGIN'd but never WRITE/END'd (by design: this
+    # test only proves the conflicting BEGIN is rejected, not a full stream).
+    # Player.stop() waits for _playback_finished, which only a WRITE-triggered
+    # ffmpeg thread ever sets - calling it here would hang on something
+    # unrelated to issue #1966, in player.py, which this fix must not touch.
+    # Mark it finished so the Player's own __del__/stop() can't hang later.
+    inst._audio._playback_finished = True
+
+
+def test_own_lane_end_then_begin_is_not_rejected():
+    """
+    Ending the active lane frees the node for a fresh stream on either lane -
+    the guard tracks 'currently active', not 'ever used'.
+
+    This drives the guard/commit pair directly rather than through
+    writeAudio/writeVideo: a real END with no prior WRITE hangs in
+    Player.stop() (see the note in the test above), which is unrelated to the
+    guard being tested here and out of scope for this fix.
+    """
+    from rocketlib import AVI_ACTION
+
+    inst = _fresh_instance()
+
+    inst._guard_lane('audio', AVI_ACTION.BEGIN)
+    inst._commit_lane('audio', AVI_ACTION.BEGIN)
+    inst._guard_lane('audio', AVI_ACTION.END)
+    inst._commit_lane('audio', AVI_ACTION.END)
+    inst._guard_lane('video', AVI_ACTION.BEGIN)  # must not raise
+    inst._commit_lane('video', AVI_ACTION.BEGIN)
+    assert inst._active_lane == 'video'
+
+
+def test_failed_begin_does_not_wedge_the_other_lane():
+    """
+    If writeAVI(BEGIN) itself raises (e.g. Player.start()'s bare
+    'already started' RuntimeError), the lane must not be left marked active
+    with no END coming - otherwise every later BEGIN on either lane is
+    permanently rejected.
+    """
+    import pytest
+    from rocketlib import AVI_ACTION
+    from audio_player.IInstance import LaneConflictError
+
+    inst = _fresh_instance()
+
+    def _boom(action, mimeType, buffer):
+        raise RuntimeError('simulated start failure')
+
+    inst._audio.writeAVI = _boom
+
+    with pytest.raises(RuntimeError, match='simulated start failure'):
+        inst.writeAudio(AVI_ACTION.BEGIN, 'audio/wav', b'')
+    assert inst._active_lane is None, 'a failed BEGIN must not leave the lane marked active'
+
+    # Video's BEGIN must reach the real call (and fail for the same stubbed
+    # reason) instead of being rejected as a stale conflict left by the
+    # failed audio BEGIN.
+    with pytest.raises(RuntimeError) as excinfo:
+        inst.writeVideo(AVI_ACTION.BEGIN, 'video/mp4', b'')
+    assert not isinstance(excinfo.value, LaneConflictError), 'video was wrongly rejected as a lane conflict'
+    assert 'simulated start failure' in str(excinfo.value)


### PR DESCRIPTION
Fixes #1966

## Summary

- `audio_player` routed both lane handlers into a single `Player`, so an object carrying both audio and video took `IGlobal.lock` twice from the same thread — a non-reentrant `threading.Lock`, so the task hung silently with no error and no log line.
- Rejects the conflicting lane with an explicit `LaneConflictError` instead, preserving the one-stream-at-a-time invariant the lock exists to hold.
- Adds the first tests for this node.

## Type

fix

## Approach

Of the two shapes sketched in the issue, this is the second. Per-lane `Player`s would resolve the hang but break the serialised-playback invariant — each `Player` acquires and releases the mutex independently, so a dual-lane object would produce two overlapping `OutputStream`s. Rejecting the second lane keeps the limitation visible rather than accidental.

Two details I chose defaults for, noted on the issue and happy to change:

- **Order-dependent** rather than fixed priority — an object may legitimately carry either lane alone, so hardcoding one to yield would reject valid single-lane input.
- **Raises**, surfacing as a task error. Verified this is consistent: the C++ side (`call.hpp:120-126`) stringifies any non-`APERR` exception into a generic task error without branching on type, so `LaneConflictError` and the existing bare `RuntimeError` from `start()` surface identically.

Lane state is committed only after `writeAVI` returns successfully. If it raises on BEGIN, the lane is not marked active, so a failed start can't wedge the instance against all later lanes.

`player.py`, `reader.py`, and `IGlobal.py` are untouched. In particular `IGlobal.lock` stays a plain `Lock` rather than being promoted to `RLock`.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Three tests, run against the real `rocketlib` / `AVIReader` lock logic with only the audio hardware stubbed. Each was run against unmodified source first to confirm it fails, then against the fix. The underlying deadlock was also reproduced directly outside pytest — the thread outlived a 5s join.

`./builder test` is unchecked because the JS dependency install fails on my machine (no `node-pty` prebuild for Node 26), so I ran the tests through the installed engine binary instead.

## Note for the reviewer

While building the regression test I hit a separate hang: a clean BEGIN/END with no intervening WRITE blocks in `Player.stop()` (`player.py:159-161`) waiting on `_playback_finished`, which only flips via a WRITE-triggered data thread. This is independent of the lock bug and out of scope here, but it's why the tests don't drive the plain BEGIN/END path directly. Happy to file it separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented conflicting audio and video playback actions from running simultaneously.
  * Rejected repeated playback starts on an already active audio or video lane.
  * Ensured failed playback attempts do not leave the system in a blocked state.
  * Allowed a new media lane to begin after the active lane ends.
  * Improved cleanup by resetting active playback state during initialization and teardown.
  * Added clearer handling for playback lane conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->