### PR TITLE
fix: guard deploy API on RocketRide Cloud

### DIFF
--- a/packages/client-python/src/rocketride/core/__init__.py
+++ b/packages/client-python/src/rocketride/core/__init__.py
@@ -43,6 +43,7 @@ Components:
     PipeException: Raised for data pipe operation errors
     ExecutionException: Raised for pipeline execution errors
     ValidationException: Raised for input validation failures
+    NotSupportedException: Raised when an operation is unavailable on the connected engine
 
 Usage:
     # These are typically used internally, but can be imported for advanced use cases
@@ -71,6 +72,7 @@ from .exceptions import (
     PipeException,
     ExecutionException,
     ValidationException,
+    NotSupportedException,
 )
 
 __all__ = [
@@ -88,6 +90,7 @@ __all__ = [
     'PipeException',
     'ExecutionException',
     'ValidationException',
+    'NotSupportedException',
     'DAPBase',
     'DAPClient',
     'DAPException',

--- a/packages/client-python/src/rocketride/core/exceptions.py
+++ b/packages/client-python/src/rocketride/core/exceptions.py
@@ -271,3 +271,39 @@ class ValidationException(RocketRideException):
     """
 
     pass
+
+
+class NotSupportedException(RocketRideException, RuntimeError):
+    """
+    Exception raised when an operation is not available on the connected engine.
+
+    Raised when the SDK exposes an API surface that the connected engine does
+    not implement, so the call is rejected client-side instead of failing with
+    an opaque server error.
+
+    Note:
+        Also inherits from :class:`RuntimeError` so that callers catching
+        ``RuntimeError`` continue to work.
+
+    Common scenarios:
+    - Deployment operations attempted against RocketRide Cloud
+    - An engine edition that does not serve the requested command
+
+    Example:
+        try:
+            await client.deploy.publish(pipeline)
+        except NotSupportedException as e:
+            print(f"Operation not available here: {e}")
+    """
+
+    def __init__(self, message: str):
+        """
+        Initialize with a plain message.
+
+        This exception is raised client-side, before any request is sent, so
+        there is no server response to wrap.
+
+        Args:
+            message: Human-readable description of what is unavailable.
+        """
+        super().__init__({'message': message})

--- a/packages/client-python/src/rocketride/deploy.py
+++ b/packages/client-python/src/rocketride/deploy.py
@@ -47,7 +47,9 @@ Usage:
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
+from .core import CONST_DEFAULT_WEB_CLOUD
 from .types.deploy import (
     Deployment,
     DeployHistoryResult,
@@ -60,7 +62,6 @@ from .types.pipeline import PipelineConfig
 
 if TYPE_CHECKING:
     from .client import RocketRideClient
-
 
 def _list_args(
     kwargs: dict,
@@ -105,6 +106,17 @@ class DeployApi:
         """
         self._client = client
 
+    def _ensure_supported(self) -> None:
+        uri = self._client.get_connection_info().get('uri', '')
+
+        cloud_host = urlparse(CONST_DEFAULT_WEB_CLOUD).hostname
+        current_host = urlparse(uri).hostname
+
+        if current_host == cloud_host:
+            raise RuntimeError(
+                'Deploy operations are not supported on RocketRide Cloud.'
+            )    
+
     # =========================================================================
     # PUBLISH — immutable artifact into the org registry
     # =========================================================================
@@ -137,6 +149,8 @@ class DeployApi:
             ``{'artifact': ...}`` plus ``'deployment'`` when ``deploy_to``
             was given.
         """
+        self._ensure_supported()
+
         kwargs: dict = {'subcommand': 'publish', 'pipeline': pipeline}
         if comment is not None:
             kwargs['comment'] = comment
@@ -164,6 +178,8 @@ class DeployApi:
         Returns:
             The updated deployment record, registry-joined.
         """
+        self._ensure_supported()
+
         return await self._client.call(
             'rrext_deploy', subcommand='deploy', projectId=project_id, version=version, teamId=team_id
         )
@@ -197,6 +213,7 @@ class DeployApi:
         Returns:
             ``{'rows', 'total', 'page', 'pageSize'}``.
         """
+        self._ensure_supported()
         kwargs: dict = {'subcommand': 'list'}
         if team_id is not None:
             kwargs['teamId'] = team_id
@@ -213,6 +230,7 @@ class DeployApi:
         Returns:
             The deployment record (version, state, schedules, actors).
         """
+        self._ensure_supported()
         return await self._client.call('rrext_deploy', subcommand='get', projectId=project_id, teamId=team_id)
 
     async def versions(
@@ -240,6 +258,7 @@ class DeployApi:
         Returns:
             ``{'rows', 'total', 'page', 'pageSize'}``.
         """
+        self._ensure_supported()
         kwargs: dict = {'subcommand': 'versions', 'projectId': project_id}
         return await self._client.call('rrext_deploy', **_list_args(kwargs, page, page_size, search, filters, sort))
 
@@ -260,6 +279,7 @@ class DeployApi:
         Returns:
             ``{'token', 'version'}`` of the started run.
         """
+        self._ensure_supported()
         return await self._client.call(
             'rrext_deploy', subcommand='run', projectId=project_id, sourceId=source_id, teamId=team_id
         )
@@ -279,6 +299,7 @@ class DeployApi:
         Returns:
             The pipeline definition exactly as published.
         """
+        self._ensure_supported()
         return await self._client.call('rrext_deploy', subcommand='artifact', projectId=project_id, version=version)
 
     async def history(
@@ -314,6 +335,7 @@ class DeployApi:
         Returns:
             ``{'rows', 'total', 'page', 'pageSize'}``.
         """
+        self._ensure_supported()
         kwargs: dict = {'subcommand': 'history', 'projectId': project_id}
         if team_id is not None:
             kwargs['teamId'] = team_id
@@ -336,6 +358,7 @@ class DeployApi:
         Returns:
             The updated deployment record.
         """
+        self._ensure_supported()
         return await self._client.call('rrext_deploy', subcommand='disable', projectId=project_id, teamId=team_id)
 
     async def enable(self, project_id: str, team_id: str) -> Deployment:
@@ -349,6 +372,7 @@ class DeployApi:
         Returns:
             The updated deployment record.
         """
+        self._ensure_supported()
         return await self._client.call('rrext_deploy', subcommand='enable', projectId=project_id, teamId=team_id)
 
     async def remove(self, project_id: str, team_id: str) -> Deployment:
@@ -366,6 +390,7 @@ class DeployApi:
         Returns:
             The final deployment record (state ``removed``).
         """
+        self._ensure_supported()
         return await self._client.call('rrext_deploy', subcommand='remove', projectId=project_id, teamId=team_id)
 
     # =========================================================================
@@ -400,6 +425,7 @@ class DeployApi:
         Returns:
             The updated deployment record.
         """
+        self._ensure_supported()
         kwargs: dict = {
             'subcommand': 'schedule_set',
             'projectId': project_id,
@@ -439,6 +465,7 @@ class DeployApi:
         Returns:
             The updated deployment record.
         """
+        self._ensure_supported()
         kwargs: dict = {
             'subcommand': 'source_config',
             'projectId': project_id,
@@ -463,6 +490,7 @@ class DeployApi:
         Returns:
             The updated deployment record.
         """
+        self._ensure_supported()
         return await self._client.call(
             'rrext_deploy', subcommand='schedule_pause', projectId=project_id, sourceId=source_id, teamId=team_id
         )
@@ -479,6 +507,7 @@ class DeployApi:
         Returns:
             The updated deployment record.
         """
+        self._ensure_supported()
         return await self._client.call(
             'rrext_deploy', subcommand='schedule_resume', projectId=project_id, sourceId=source_id, teamId=team_id
         )
@@ -498,6 +527,7 @@ class DeployApi:
         Returns:
             ``{'valid', 'next'}`` plus ``'error'`` when invalid.
         """
+        self._ensure_supported()
         kwargs: dict = {'subcommand': 'preview', 'schedule': schedule}
         if count is not None:
             kwargs['count'] = count

--- a/packages/client-python/src/rocketride/deploy.py
+++ b/packages/client-python/src/rocketride/deploy.py
@@ -109,8 +109,8 @@ class DeployApi:
     def _ensure_supported(self) -> None:
         uri = self._client.get_connection_info().get('uri', '')
 
-        cloud_host = urlparse(CONST_DEFAULT_WEB_CLOUD).hostname
-        current_host = urlparse(uri).hostname
+        cloud_host = (urlparse(CONST_DEFAULT_WEB_CLOUD).hostname or '').rstrip('.')
+        current_host = (urlparse(uri).hostname or '').rstrip('.')
 
         if current_host == cloud_host:
             raise RuntimeError(

--- a/packages/client-python/src/rocketride/deploy.py
+++ b/packages/client-python/src/rocketride/deploy.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
-from .core import CONST_DEFAULT_WEB_CLOUD
+from .core import CONST_DEFAULT_WEB_CLOUD, NotSupportedException
 from .types.deploy import (
     Deployment,
     DeployHistoryResult,
@@ -62,6 +62,7 @@ from .types.pipeline import PipelineConfig
 
 if TYPE_CHECKING:
     from .client import RocketRideClient
+
 
 def _list_args(
     kwargs: dict,
@@ -113,9 +114,7 @@ class DeployApi:
         current_host = (urlparse(uri).hostname or '').rstrip('.')
 
         if current_host == cloud_host:
-            raise RuntimeError(
-                'Deploy operations are not supported on RocketRide Cloud.'
-            )    
+            raise NotSupportedException('Deploy operations are not supported on RocketRide Cloud.')
 
     # =========================================================================
     # PUBLISH — immutable artifact into the org registry

--- a/packages/client-python/tests/test_deploy_unit.py
+++ b/packages/client-python/tests/test_deploy_unit.py
@@ -99,3 +99,13 @@ async def test_publish_allowed_on_self_hosted():
             },
         )
     ]
+
+@pytest.mark.asyncio
+async def test_trailing_dns_dot_cloud_uri_is_rejected():
+    fake = FakeClient('wss://api.rocketride.ai./task/service')
+    api = DeployApi(fake)
+
+    with pytest.raises(RuntimeError, match='not supported'):
+        await api.publish({'project_id': 'p1', 'name': 'test'})
+
+    assert fake.calls == []

--- a/packages/client-python/tests/test_deploy_unit.py
+++ b/packages/client-python/tests/test_deploy_unit.py
@@ -1,0 +1,101 @@
+import pytest
+
+from rocketride.deploy import DeployApi
+
+
+class FakeClient:
+    def __init__(self, uri: str):
+        self.uri = uri
+        self.calls = []
+
+    def get_connection_info(self):
+        return {
+            'connected': True,
+            'transport': 'WebSocket',
+            'uri': self.uri,
+        }
+
+    async def call(self, command: str, **kwargs):
+        self.calls.append((command, kwargs))
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_publish_rejected_on_rocketride_cloud():
+    fake = FakeClient('wss://api.rocketride.ai/task/service')
+    api = DeployApi(fake)
+
+    with pytest.raises(RuntimeError, match='not supported'):
+        await api.publish({'project_id': 'test', 'name': 'test'})
+
+    assert fake.calls == []
+
+@pytest.mark.asyncio
+async def test_deploy_rejected_on_rocketride_cloud():
+    fake = FakeClient('wss://api.rocketride.ai/task/service')
+    api = DeployApi(fake)
+
+    with pytest.raises(RuntimeError, match='not supported'):
+        await api.deploy('project-1', 1, 'team-1')
+
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+async def test_list_rejected_on_rocketride_cloud():
+    fake = FakeClient('wss://api.rocketride.ai/task/service')
+    api = DeployApi(fake)
+
+    with pytest.raises(RuntimeError, match='not supported'):
+        await api.list()
+
+    assert fake.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ('method', 'args', 'kwargs'),
+    [
+        ('publish', ({'project_id': 'p1', 'name': 'test'},), {}),
+        ('deploy', ('p1', 1, 'team1'), {}),
+        ('list', (), {}),
+        ('get', ('p1', 'team1'), {}),
+        ('versions', ('p1',), {}),
+        ('run', ('p1', 'source1', 'team1'), {}),
+        ('artifact', ('p1', 1), {}),
+        ('history', ('p1',), {}),
+        ('disable', ('p1', 'team1'), {}),
+        ('enable', ('p1', 'team1'), {}),
+        ('remove', ('p1', 'team1'), {}),
+        ('set_schedule', ('p1', 'source1', '* * * * *', 'team1'), {}),
+        ('set_source_config', ('p1', 'source1', 'team1'), {}),
+        ('pause_schedule', ('p1', 'source1', 'team1'), {}),
+        ('resume_schedule', ('p1', 'source1', 'team1'), {}),
+        ('preview', ('* * * * *',), {}),
+    ],
+)
+async def test_all_deploy_operations_rejected_on_cloud(method, args, kwargs):
+    fake = FakeClient('wss://api.rocketride.ai/task/service')
+    api = DeployApi(fake)
+
+    with pytest.raises(RuntimeError, match='not supported'):
+        await getattr(api, method)(*args, **kwargs)
+
+    assert fake.calls == []
+
+@pytest.mark.asyncio
+async def test_publish_allowed_on_self_hosted():
+    fake = FakeClient('ws://localhost:5565/task/service')
+    api = DeployApi(fake)
+
+    await api.publish({'project_id': 'p1', 'name': 'test'})
+
+    assert fake.calls == [
+        (
+            'rrext_deploy',
+            {
+                'subcommand': 'publish',
+                'pipeline': {'project_id': 'p1', 'name': 'test'},
+            },
+        )
+    ]

--- a/packages/client-python/tests/test_deploy_unit.py
+++ b/packages/client-python/tests/test_deploy_unit.py
@@ -1,6 +1,7 @@
 import pytest
 
 from rocketride.deploy import DeployApi
+from rocketride.core import NotSupportedException
 
 
 class FakeClient:
@@ -25,10 +26,11 @@ async def test_publish_rejected_on_rocketride_cloud():
     fake = FakeClient('wss://api.rocketride.ai/task/service')
     api = DeployApi(fake)
 
-    with pytest.raises(RuntimeError, match='not supported'):
+    with pytest.raises(NotSupportedException, match='not supported'):
         await api.publish({'project_id': 'test', 'name': 'test'})
 
     assert fake.calls == []
+
 
 @pytest.mark.asyncio
 async def test_deploy_rejected_on_rocketride_cloud():
@@ -83,6 +85,7 @@ async def test_all_deploy_operations_rejected_on_cloud(method, args, kwargs):
 
     assert fake.calls == []
 
+
 @pytest.mark.asyncio
 async def test_publish_allowed_on_self_hosted():
     fake = FakeClient('ws://localhost:5565/task/service')
@@ -99,6 +102,7 @@ async def test_publish_allowed_on_self_hosted():
             },
         )
     ]
+
 
 @pytest.mark.asyncio
 async def test_trailing_dns_dot_cloud_uri_is_rejected():


### PR DESCRIPTION
## Summary
- Raises a clear error before Python SDK deploy operations are sent to RocketRide Cloud, where the deploy API is unsupported.
- Adds `NotSupportedException` to `core/exceptions.py` and raises it before unsupported `rrext_deploy` commands are sent. It inherits from `RuntimeError`, so existing callers are unaffected.
- Adds unit coverage for all DeployApi operations and verifies self-hosted deployments are still allowed.

## Type

Fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Added unit coverage in `packages/client-python/tests/test_deploy_unit.py`.

Result:

`21 passed`

The existing deploy integration tests were also attempted, but require a local RocketRide server listening on `localhost:5565`, which was not available in my environment.

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #1987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment availability checks based on the connected environment.
  * Deployment operations now clearly indicate when they are unavailable in RocketRide Cloud.
  * Supported self-hosted environments continue to allow publishing.
  * Added a public exception for unsupported operations.

* **Bug Fixes**
  * Prevented unsupported deployment requests from being sent.
  * Improved handling of cloud hostnames, including trailing-dot variants.
  * Added validation for self-hosted publishing commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->