### PR TITLE
fix: route Claude 5 models to adaptive thinking format

### DIFF
--- a/nodes/test/llm_anthropic/test_extended_thinking_init.py
+++ b/nodes/test/llm_anthropic/test_extended_thinking_init.py
@@ -98,3 +98,19 @@ def test_string_false_from_the_form_stays_off(monkeypatch, falsy):
 
     assert chat._thinking_mode_kwargs == {}
     assert chat._native_stream_provider == ''
+
+
+@pytest.mark.parametrize('model', ['claude-sonnet-5', 'claude-opus-5'])
+def test_claude_5_models_use_adaptive_thinking(monkeypatch, model):
+    config = {
+        'model': model,
+        'apikey': 'sk-ant-test',
+        'modelTotalTokens': 200000,
+        'modelOutputTokens': 8192,
+        'capabilities': {'reasoning': True},
+        'extendedThinking': True,
+    }
+    monkeypatch.setattr(Config, 'getNodeConfig', staticmethod(lambda *a, **k: dict(config)))
+    chat = _load_node_module().Chat('anthropic', {}, {})
+
+    assert chat._thinking_mode_kwargs.get('thinking', {}).get('type') == 'adaptive'

--- a/packages/ai/src/ai/common/llm_native_stream.py
+++ b/packages/ai/src/ai/common/llm_native_stream.py
@@ -56,19 +56,28 @@ def gate_model_name(model: str) -> str:
     return m
 
 
+_ADAPTIVE_MODEL_PREFIXES = (
+    'claude-opus-4-7',
+    'claude-opus-4-8',
+    'claude-opus-5',
+    'claude-sonnet-5',
+    'claude-fable-5',
+    'claude-mythos-5',
+)
+
+
 def build_anthropic_thinking_kwargs(model_gate: str, model_output_tokens: int) -> Dict[str, Any]:
-    """Return ``ChatAnthropic`` thinking kwargs by model name, or ``{}`` if unsupported."""
     if model_gate.startswith('claude-3') and 'haiku' in model_gate:
-        return {}  # Only legacy Claude 3/3.5 Haiku lack extended thinking; 4.5+ supports it.
+        return {}
     out: Dict[str, Any] = {}
-    if model_gate.startswith('claude-opus-4-7') or model_gate.startswith('claude-opus-4-8'):
+    if model_gate.startswith(_ADAPTIVE_MODEL_PREFIXES):
         out['thinking'] = {'type': 'adaptive', 'display': 'summarized'}
     else:
         budget = max(2048, model_output_tokens // 2)
         if budget >= model_output_tokens:
             budget = model_output_tokens - 1024
         if budget < 1024:
-            return {}  # output window too small for a valid thinking budget
+            return {}
         out['betas'] = ['interleaved-thinking-2025-05-14']
         out['thinking'] = {'type': 'enabled', 'budget_tokens': budget}
     return out


### PR DESCRIPTION
Fixes #1911

Problem

build_anthropic_thinking_kwargs() in packages/ai/src/ai/common/llm_native_stream.py only routed claude-opus-4-7 and claude-opus-4-8 to the modern "adaptive" thinking format ({"type": "adaptive", "display": "summarized"}). Every other model — including all Claude 5 models (Sonnet 5, Opus 5, etc.) — fell through to the legacy branch and got {"type": "enabled", "budget_tokens": N} plus the interleaved-thinking-2025-05-14 beta header instead.

Claude 5 models no longer accept the legacy enabled/budget_tokens format at all, so any node with extendedThinking turned on and a Claude 5 model configured fails immediately with an HTTP 400 from Anthropic's API.

Fix

Added a _ADAPTIVE_MODEL_PREFIXES tuple covering the existing Opus 4.7/4.8 prefixes plus the Claude 5 family (claude-opus-5, claude-sonnet-5, claude-fable-5, claude-mythos-5), and route any model matching those prefixes to the adaptive format. Non-matching models keep using the legacy format unchanged, so this doesn't touch behavior for any currently-working model.

Tests

Added test_claude_5_models_use_adaptive_thinking (parametrized over claude-sonnet-5 and claude-opus-5) to nodes/test/llm_anthropic/test_extended_thinking_init.py, asserting _thinking_mode_kwargs['thinking']['type'] == 'adaptive' for both. This locks in the correct routing so a future refactor of this gate can't silently regress it back to sending the legacy format to Claude 5 models.

Testing done
./builder nodes:test passes locally, including the two new test cases.
Verified the existing Opus 4.7/4.8 and legacy-model test cases still pass unchanged.