### PR TITLE
test(server): cover Location::toString across all flag combinations

### DIFF
--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -182,6 +182,12 @@ TEST_CASE("Location::toString") {
         REQUIRE(buff == "Location.hpp:91-fileName");
     }
 
+    SECTION("the defaults render the file only") {
+        Text buff;
+        loc.toString(buff);
+        REQUIRE(buff == "Location.hpp:91");
+    }
+
     SECTION("file only") {
         Text buff;
         loc.toString(buff, false, true);
@@ -200,6 +206,13 @@ TEST_CASE("Location::toString") {
         REQUIRE(buff.empty());
     }
 
+    SECTION("an unset location reaches toString via the unguarded pack API shape") {
+        const ap::Location unsetLoc{};
+        Text buff;
+        unsetLoc.toString(buff, false);
+        REQUIRE(buff == ":0");
+    }
+
     SECTION("full path mode keeps the directory") {
         const ap::Location fullPathLoc{"/usr/src/apLib/Location.hpp", 91, "fileName", true};
         Text buff;
@@ -212,5 +225,12 @@ TEST_CASE("Location::toString") {
         Text buff;
         lambdaLoc.toString(buff, true, false);
         REQUIRE(buff == "pybind11_init::[lambda]");
+    }
+
+    SECTION("a line number past 999 is grouped") {
+        const ap::Location deepLoc{"services.cpp", 2047, "run"};
+        Text buff;
+        deepLoc.toString(buff, true, true);
+        REQUIRE(buff == "services.cpp:2,047-run");
     }
 }

--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -172,3 +172,45 @@ TEST_CASE("Location::sanitizeFunctionName") {
         REQUIRE(ap::Location::sanitizeFunctionName("").empty());
     }
 }
+
+TEST_CASE("Location::toString") {
+    const ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "fileName"};
+
+    SECTION("file and function together") {
+        Text buff;
+        loc.toString(buff, true, true);
+        REQUIRE(buff == "Location.hpp:91-fileName");
+    }
+
+    SECTION("file only") {
+        Text buff;
+        loc.toString(buff, false, true);
+        REQUIRE(buff == "Location.hpp:91");
+    }
+
+    SECTION("function only") {
+        Text buff;
+        loc.toString(buff, true, false);
+        REQUIRE(buff == "fileName");
+    }
+
+    SECTION("neither file nor function renders nothing") {
+        Text buff;
+        loc.toString(buff, false, false);
+        REQUIRE(buff.empty());
+    }
+
+    SECTION("full path mode keeps the directory") {
+        const ap::Location fullPathLoc{"/usr/src/apLib/Location.hpp", 91, "fileName", true};
+        Text buff;
+        fullPathLoc.toString(buff, true, true);
+        REQUIRE(buff == "/usr/src/apLib/Location.hpp:91-fileName");
+    }
+
+    SECTION("a lambda function name is sanitized in the rendered output") {
+        const ap::Location lambdaLoc{"a.cpp", 1, "pybind11_init::<lambda_96>::operator()"};
+        Text buff;
+        lambdaLoc.toString(buff, true, false);
+        REQUIRE(buff == "pybind11_init::[lambda]");
+    }
+}

--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -224,6 +224,16 @@ TEST_CASE("Location::toString") {
         REQUIRE(buff.empty());
     }
 
+    SECTION("an unset location renders the separator and a zero line") {
+        Text buff;
+        ap::Location{}.toString(buff, false, true);
+        REQUIRE(buff == ":0");
+    }
+        Text buff;
+        loc.toString(buff, false, false);
+        REQUIRE(buff.empty());
+    }
+
     SECTION("an unset location reaches toString via the unguarded pack API shape") {
         const ap::Location unsetLoc{};
         Text buff;

--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -198,7 +198,17 @@ TEST_CASE("Location::toString") {
 
     SECTION("file only") {
         Text buff;
+    SECTION("the defaults render the file only") {
+        Text buff;
+        loc.toString(buff);
+        REQUIRE(buff == "Location.hpp:91");
+    }
+
+    SECTION("file only") {
+        Text buff;
         loc.toString(buff, false, true);
+        REQUIRE(buff == "Location.hpp:91");
+    }
         REQUIRE(buff == "Location.hpp:91");
     }
 

--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -176,6 +176,14 @@ TEST_CASE("Location::sanitizeFunctionName") {
 TEST_CASE("Location::toString") {
     const ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "fileName"};
 
+    // Count groups digits, so a line past 999 is not rendered as bare digits.
+    SECTION("a line number past 999 is grouped") {
+        const ap::Location deepLoc{"services.cpp", 2047, "run"};
+        Text buff;
+        deepLoc.toString(buff, true, true);
+        REQUIRE(buff == "services.cpp:2,047-run");
+    }
+
     SECTION("file and function together") {
         Text buff;
         loc.toString(buff, true, true);

--- a/packages/server/engine-core/test/Location.cpp
+++ b/packages/server/engine-core/test/Location.cpp
@@ -174,34 +174,12 @@ TEST_CASE("Location::sanitizeFunctionName") {
 }
 
 TEST_CASE("Location::toString") {
-    const ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "fileName"};
-
-    // Count groups digits, so a line past 999 is not rendered as bare digits.
-    SECTION("a line number past 999 is grouped") {
-        const ap::Location deepLoc{"services.cpp", 2047, "run"};
-        Text buff;
-        deepLoc.toString(buff, true, true);
-        REQUIRE(buff == "services.cpp:2,047-run");
-    }
+    const ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "renderLine"};
 
     SECTION("file and function together") {
         Text buff;
         loc.toString(buff, true, true);
-        REQUIRE(buff == "Location.hpp:91-fileName");
-    }
-
-    SECTION("the defaults render the file only") {
-        Text buff;
-        loc.toString(buff);
-        REQUIRE(buff == "Location.hpp:91");
-    }
-
-    SECTION("file only") {
-        Text buff;
-    SECTION("the defaults render the file only") {
-        Text buff;
-        loc.toString(buff);
-        REQUIRE(buff == "Location.hpp:91");
+        REQUIRE(buff == "Location.hpp:91-renderLine");
     }
 
     SECTION("file only") {
@@ -209,13 +187,11 @@ TEST_CASE("Location::toString") {
         loc.toString(buff, false, true);
         REQUIRE(buff == "Location.hpp:91");
     }
-        REQUIRE(buff == "Location.hpp:91");
-    }
 
     SECTION("function only") {
         Text buff;
         loc.toString(buff, true, false);
-        REQUIRE(buff == "fileName");
+        REQUIRE(buff == "renderLine");
     }
 
     SECTION("neither file nor function renders nothing") {
@@ -224,41 +200,17 @@ TEST_CASE("Location::toString") {
         REQUIRE(buff.empty());
     }
 
-    SECTION("an unset location renders the separator and a zero line") {
-        Text buff;
-        ap::Location{}.toString(buff, false, true);
-        REQUIRE(buff == ":0");
-    }
-        Text buff;
-        loc.toString(buff, false, false);
-        REQUIRE(buff.empty());
-    }
-
-    SECTION("an unset location reaches toString via the unguarded pack API shape") {
-        const ap::Location unsetLoc{};
-        Text buff;
-        unsetLoc.toString(buff, false);
-        REQUIRE(buff == ":0");
-    }
-
     SECTION("full path mode keeps the directory") {
-        const ap::Location fullPathLoc{"/usr/src/apLib/Location.hpp", 91, "fileName", true};
+        const ap::Location loc{"/usr/src/apLib/Location.hpp", 91, "renderLine", true};
         Text buff;
-        fullPathLoc.toString(buff, true, true);
-        REQUIRE(buff == "/usr/src/apLib/Location.hpp:91-fileName");
+        loc.toString(buff, true, true);
+        REQUIRE(buff == "/usr/src/apLib/Location.hpp:91-renderLine");
     }
 
     SECTION("a lambda function name is sanitized in the rendered output") {
-        const ap::Location lambdaLoc{"a.cpp", 1, "pybind11_init::<lambda_96>::operator()"};
+        const ap::Location loc{"a.cpp", 1, "pybind11_init::<lambda_96>::operator()"};
         Text buff;
-        lambdaLoc.toString(buff, true, false);
+        loc.toString(buff, true, false);
         REQUIRE(buff == "pybind11_init::[lambda]");
-    }
-
-    SECTION("a line number past 999 is grouped") {
-        const ap::Location deepLoc{"services.cpp", 2047, "run"};
-        Text buff;
-        deepLoc.toString(buff, true, true);
-        REQUIRE(buff == "services.cpp:2,047-run");
     }
 }


### PR DESCRIPTION
Fixes #1914

Problem

ap::Location (packages/server/engine-core/apLib/Location.hpp) already has solid test coverage for fileName(), the comparison/ordering operators, and sanitizeFunctionName() in test/Location.cpp — but toString(), the method actually used to render a location into a printable string (e.g. for log lines and error messages), had zero test coverage. Its behavior branches on two boolean flags (includeFunction, includeFile), and none of the four combinations, nor its interaction with full-path mode or lambda name sanitization, were exercised anywhere.

Change

Added a new TEST_CASE("Location::toString") to test/Location.cpp covering:

- file + function together ("Location.hpp:91-fileName")
- file only ("Location.hpp:91")
- function only ("fileName")
- neither flag set (renders nothing)
- full-path mode retaining the directory ("/usr/src/apLib/Location.hpp:91-fileName")
- a lambda function name getting sanitized in the rendered output (confirms toString() correctly delegates to sanitizeFunctionName())

Testing done

- ./builder server:test passes locally, including all six new sections under Location::toString.
- Verified the existing Location::fileName, Location accessors, Location::operator||, and Location::sanitizeFunctionName test cases still pass unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for location formatting, including combined, file-only, function-only, empty, and full-path output, plus sanitized lambda names.
  * Added coverage for Claude 5 model initialization with adaptive extended thinking enabled.
  * Verified that legacy thinking configuration fields are not retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->