### PR TITLE
feat(shared-ui): add variable picker affordance to config fields

### DIFF
--- a/apps/shared/src/components/canvas/components/rjsf-widgets/base-input-template/BaseInputTemplate.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/base-input-template/BaseInputTemplate.tsx
@@ -23,6 +23,8 @@
 
 import { ChangeEvent, FocusEvent, useState, useEffect, useCallback, useRef, KeyboardEvent } from 'react';
 import TextField, { TextFieldProps } from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
 import { ariaDescribedByIds, BaseInputTemplateProps, examplesId, getInputProps, labelValue, FormContextType, RJSFSchema, StrictRJSFSchema } from '@rjsf/utils';
 
 import { useEnvVarAutocomplete } from '../hooks/useEnvVarAutocomplete';
@@ -104,6 +106,15 @@ export default function BaseInputTemplate<
 		},
 		[autocomplete, controlledValue, onChange, options.emptyValue]
 	);
+
+	const showVarPicker = envKeys.length > 0 && !(disabled || readonly);
+	const handleOpenPicker = useCallback(() => {
+		const el = inputRef.current;
+		if (!el) return;
+		el.focus();
+		const cursor = el.selectionStart ?? String(controlledValue ?? '').length;
+		autocomplete.openAll(el, cursor);
+	}, [autocomplete, controlledValue]);
 
 	const handleKeyDown = useCallback(
 		(e: KeyboardEvent<HTMLInputElement>) => {
@@ -206,6 +217,26 @@ export default function BaseInputTemplate<
 				inputRef={inputRef}
 				InputLabelProps={DisplayInputLabelProps}
 				{...(textFieldProps as TextFieldProps)}
+				InputProps={{
+					...(textFieldProps as TextFieldProps).InputProps,
+					endAdornment: showVarPicker ? (
+						<InputAdornment position="end">
+							{(textFieldProps as TextFieldProps).InputProps?.endAdornment}
+							<IconButton
+								size="small"
+								aria-label="Insert variable"
+								title="Insert variable"
+								onClick={handleOpenPicker}
+								edge="end"
+								sx={{ fontSize: '0.75rem', fontFamily: 'monospace', px: 0.75 }}
+							>
+								{'${}'}
+							</IconButton>
+						</InputAdornment>
+					) : (
+						(textFieldProps as TextFieldProps).InputProps?.endAdornment
+					),
+				}}
 				{...(compactDescriptions
 					? {
 							slotProps: {

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.test.ts
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.test.ts
@@ -21,3 +21,11 @@ test('insertEnvVarRef replaces an incomplete ${ trigger span', () => {
 test('insertEnvVarRef preserves text after the cursor', () => {
 	assert.equal(insertEnvVarRef('abCD', 'ROCKETRIDE_X', 2, 2), 'ab${ROCKETRIDE_X}CD');
 });
+
+test('explicit picker insert range stays stable when end equals open caret', () => {
+	// openAll stores the same index for start and end; moving the live caret must not
+	// matter when callers pass that frozen end (regression for CodeRabbit #2018).
+	const value = 'hello world';
+	const openAt = 6;
+	assert.equal(insertEnvVarRef(value, 'ROCKETRIDE_NAME', openAt, openAt), 'hello ${ROCKETRIDE_NAME}world');
+});

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.test.ts
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.test.ts
@@ -1,0 +1,23 @@
+/**
+ * MIT License
+ * Copyright (c) 2026 Aparavi Software AG
+ * See LICENSE file for details.
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { insertEnvVarRef } from './useEnvVarAutocomplete';
+
+test('insertEnvVarRef inserts at the caret when openAll leaves triggerStart === cursorPos', () => {
+	assert.equal(insertEnvVarRef('hello world', 'ROCKETRIDE_NAME', 6, 6), 'hello ${ROCKETRIDE_NAME}world');
+});
+
+test('insertEnvVarRef replaces an incomplete ${ trigger span', () => {
+	const value = 'pre ${ROCKETRID';
+	assert.equal(insertEnvVarRef(value, 'ROCKETRIDE_API_KEY', 4, value.length), 'pre ${ROCKETRIDE_API_KEY}');
+});
+
+test('insertEnvVarRef preserves text after the cursor', () => {
+	assert.equal(insertEnvVarRef('abCD', 'ROCKETRIDE_X', 2, 2), 'ab${ROCKETRIDE_X}CD');
+});

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.ts
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.ts
@@ -72,9 +72,20 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 
 	// Track the position of the `${` trigger in the input value
 	const triggerStartRef = useRef<number>(0);
+	/**
+	 * When set, selection uses this end cursor instead of the live caret.
+	 * Keeps explicit-picker inserts stable if the user moves the caret while
+	 * the suggestions popover is open.
+	 */
+	const explicitInsertEndRef = useRef<number | null>(null);
+
+	const clearExplicitInsert = useCallback(() => {
+		explicitInsertEndRef.current = null;
+	}, []);
 
 	const handleInputChange = useCallback(
 		(value: string, cursorPos: number, anchorElement: HTMLElement | null) => {
+			clearExplicitInsert();
 			if (!anchorElement || !envKeys.length) {
 				setIsOpen(false);
 				return;
@@ -100,16 +111,18 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 
 			setIsOpen(false);
 		},
-		[envKeys],
+		[clearExplicitInsert, envKeys],
 	);
 
 	const handleSelect = useCallback(
 		(key: string, currentValue: string, inputEl: HTMLInputElement | HTMLTextAreaElement | null): string => {
 			const triggerStart = triggerStartRef.current;
-			const cursorPos = inputEl?.selectionStart ?? currentValue.length;
+			const cursorPos =
+				explicitInsertEndRef.current ?? inputEl?.selectionStart ?? currentValue.length;
 
 			const newValue = insertEnvVarRef(currentValue, key, triggerStart, cursorPos);
 
+			explicitInsertEndRef.current = null;
 			setIsOpen(false);
 
 			// Restore cursor position after the inserted reference
@@ -132,6 +145,7 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 			}
 			// Insert at the caret — no `${` prefix required for the picker path.
 			triggerStartRef.current = cursorPos;
+			explicitInsertEndRef.current = cursorPos;
 			setSuggestions([...envKeys]);
 			setAnchorEl(anchorElement);
 			setHighlightedIndex(0);
@@ -141,6 +155,7 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 	);
 
 	const handleDismiss = useCallback(() => {
+		explicitInsertEndRef.current = null;
 		setIsOpen(false);
 	}, []);
 

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.ts
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/hooks/useEnvVarAutocomplete.ts
@@ -27,7 +27,13 @@ export interface UseEnvVarAutocompleteResult {
 	highlightedIndex: number;
 	/** Move highlight up/down. */
 	moveHighlight: (direction: 'up' | 'down') => void;
+	/**
+	 * Open the suggestions list with every saved variable at ``cursorPos``.
+	 * Used by the explicit picker button so users need not type ``${``.
+	 */
+	openAll: (anchorElement: HTMLElement | null, cursorPos: number) => void;
 }
+
 
 // =============================================================================
 // Constants
@@ -35,6 +41,17 @@ export interface UseEnvVarAutocompleteResult {
 
 /** Matches `${` followed by an optional partial ROCKETRIDE_* key name at the end of a string. */
 const TRIGGER_REGEX = /\$\{(ROCKETRIDE_\w*)?$/;
+
+/**
+ * Insert `${key}` replacing the span from ``triggerStart`` to ``cursorPos``.
+ * Used by both the `${` autocomplete path and the explicit picker (`openAll`),
+ * where ``triggerStart === cursorPos`` so the reference is inserted at the caret.
+ */
+export function insertEnvVarRef(currentValue: string, key: string, triggerStart: number, cursorPos: number): string {
+	const before = currentValue.substring(0, triggerStart);
+	const after = currentValue.substring(cursorPos);
+	return `${before}\${${key}}${after}`;
+}
 
 // =============================================================================
 // Hook
@@ -91,10 +108,7 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 			const triggerStart = triggerStartRef.current;
 			const cursorPos = inputEl?.selectionStart ?? currentValue.length;
 
-			// Replace from the `${` trigger to the cursor with the full variable reference
-			const before = currentValue.substring(0, triggerStart);
-			const after = currentValue.substring(cursorPos);
-			const newValue = `${before}\${${key}}${after}`;
+			const newValue = insertEnvVarRef(currentValue, key, triggerStart, cursorPos);
 
 			setIsOpen(false);
 
@@ -108,6 +122,22 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 			return newValue;
 		},
 		[],
+	);
+
+	const openAll = useCallback(
+		(anchorElement: HTMLElement | null, cursorPos: number) => {
+			if (!anchorElement || !envKeys.length) {
+				setIsOpen(false);
+				return;
+			}
+			// Insert at the caret — no `${` prefix required for the picker path.
+			triggerStartRef.current = cursorPos;
+			setSuggestions([...envKeys]);
+			setAnchorEl(anchorElement);
+			setHighlightedIndex(0);
+			setIsOpen(true);
+		},
+		[envKeys],
 	);
 
 	const handleDismiss = useCallback(() => {
@@ -124,5 +154,15 @@ export function useEnvVarAutocomplete(envKeys: string[]): UseEnvVarAutocompleteR
 		[suggestions.length],
 	);
 
-	return { isOpen, suggestions, anchorEl, handleInputChange, handleSelect, handleDismiss, highlightedIndex, moveHighlight };
+	return {
+		isOpen,
+		suggestions,
+		anchorEl,
+		handleInputChange,
+		handleSelect,
+		handleDismiss,
+		highlightedIndex,
+		moveHighlight,
+		openAll,
+	};
 }

--- a/apps/shared/src/components/canvas/components/rjsf-widgets/textarea-widget/TextareaWidget.tsx
+++ b/apps/shared/src/components/canvas/components/rjsf-widgets/textarea-widget/TextareaWidget.tsx
@@ -6,6 +6,8 @@
 
 import { ChangeEvent, FocusEvent, useState, useEffect, useCallback, useRef, KeyboardEvent, FC } from 'react';
 import TextField from '@mui/material/TextField';
+import InputAdornment from '@mui/material/InputAdornment';
+import IconButton from '@mui/material/IconButton';
 import { WidgetProps } from '@rjsf/utils';
 
 import { useEnvVarAutocomplete } from '../hooks/useEnvVarAutocomplete';
@@ -40,6 +42,15 @@ const TextareaWidget: FC<WidgetProps> = ({ id, value, label, required, autofocus
 		},
 		[autocomplete, controlledValue, onChange, options.emptyValue],
 	);
+
+	const showVarPicker = envKeys.length > 0 && !(disabled || readonly);
+	const handleOpenPicker = useCallback(() => {
+		const el = inputRef.current;
+		if (!el) return;
+		el.focus();
+		const cursor = el.selectionStart ?? String(controlledValue ?? '').length;
+		autocomplete.openAll(el, cursor);
+	}, [autocomplete, controlledValue]);
 
 	const handleKeyDown = useCallback(
 		// MUI TextField forwards onKeyDown from its root <div>, so the event is
@@ -94,6 +105,26 @@ const TextareaWidget: FC<WidgetProps> = ({ id, value, label, required, autofocus
 				variant="outlined"
 				InputLabelProps={{ shrink: true }}
 				helperText={typeof options?.description === 'string' ? options.description : schema?.description}
+				InputProps={
+					showVarPicker
+						? {
+								endAdornment: (
+									<InputAdornment position="end">
+										<IconButton
+											size="small"
+											aria-label="Insert variable"
+											title="Insert variable"
+											onClick={handleOpenPicker}
+											edge="end"
+											sx={{ fontSize: '0.75rem', fontFamily: 'monospace', px: 0.75 }}
+										>
+											{'${}'}
+										</IconButton>
+									</InputAdornment>
+								),
+							}
+						: undefined
+				}
 			/>
 			{envKeys.length > 0 && (
 				<EnvVarSuggestions open={autocomplete.isOpen} anchorEl={autocomplete.anchorEl} suggestions={autocomplete.suggestions} highlightedIndex={autocomplete.highlightedIndex} onSelect={onEnvVarSelect} onDismiss={autocomplete.handleDismiss} />


### PR DESCRIPTION
## Summary
- Add a visible `${}` insert-variable button on `BaseInputTemplate` and `TextareaWidget` when `envKeys` exist and the field is editable
- Extend `useEnvVarAutocomplete` with `openAll` so the picker inserts `${ROCKETRIDE_*}` at the caret without typing `${`
- Add unit tests for insert-at-caret behavior

Fixes #1275

## Test plan
- [ ] Open a node config field with saved Variables; confirm `${}` adornment appears
- [ ] Click `${}`; pick a variable; confirm `${ROCKETRIDE_NAME}` inserts at the caret
- [ ] Confirm adornment is hidden when the field is disabled/readonly or `envKeys` is empty
- [ ] Confirm typing `${` still opens the existing autocomplete

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an environment-variable picker button to editable input and textarea fields.
  * Open suggestions at the current cursor position to quickly insert environment-variable references.
  * Support displaying all available environment variables from the picker.
  * Preserve existing field adornments while displaying the new picker action.

* **Bug Fixes**
  * Improved insertion when replacing incomplete variable references, preserving trailing text and the intended cursor position.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->