### PR TITLE
feat(tool_github): add pr_review_context one-shot PR review preset

### DIFF
--- a/nodes/src/nodes/tool_github/IInstance.py
+++ b/nodes/src/nodes/tool_github/IInstance.py
@@ -127,6 +127,47 @@ _SEARCH_STOPWORDS = frozenset(
 # quotes does not split them: -label:"good first issue" | repo:acme/app | "exact phrase" | word
 _QUERY_TOKEN_RE = re.compile(r'-?\w+:"[^"]*"|-?\w+:\S+|"[^"]*"|\S+')
 
+# Ticket refs in PR/issue text: bare ``#123`` and keyword forms (Fixes/Closes/Refs #123).
+_TICKET_ID_RE = re.compile(
+    r'(?:(?:fix(?:es)?|close[sd]?|resolve[sd]?|ref(?:erence)?s?)\s+)?#(\d+)\b',
+    re.IGNORECASE,
+)
+
+# Unified diffs can be huge; keep agent context bounded.
+_MAX_DIFF_CHARS = 100_000
+
+
+def _extract_ticket_ids(*texts: str | None) -> list[int]:
+    """Return unique ticket numbers referenced in the given texts, in first-seen order."""
+    seen: set[int] = set()
+    ids: list[int] = []
+    for text in texts:
+        if not text:
+            continue
+        for m in _TICKET_ID_RE.finditer(text):
+            n = int(m.group(1))
+            if n not in seen:
+                seen.add(n)
+                ids.append(n)
+    return ids
+
+
+def _basename(path: str) -> str:
+    return path.rsplit('/', 1)[-1]
+
+
+def _match_reasons(text: str, ticket_ids: list[int], basenames: set[str]) -> list[str]:
+    """Cheap overlap reasons: ticket mentions and changed-file basenames in title/body."""
+    reasons: list[str] = []
+    lower = text.lower()
+    for tid in ticket_ids:
+        if re.search(rf'(?<!\d)#{tid}(?!\d)', text):
+            reasons.append(f'ticket:#{tid}')
+    for name in sorted(basenames):
+        if name and name.lower() in lower:
+            reasons.append(f'file:{name}')
+    return reasons
+
 
 def _relax_query(q: str, *, max_terms: int = 5) -> str | None:
     """Build an OR-relaxed variant of a free-text-heavy query.
@@ -604,6 +645,133 @@ class IInstance(IInstanceBase):
             body['draft'] = bool(args['draft'])
         data = call(self._token(), 'POST', f'/repos/{repo}/pulls', body=body)
         return clean_pr(data)
+
+    @tool_function(
+        input_schema={
+            'type': 'object',
+            'required': ['pr_number'],
+            'properties': {
+                'repo': {'type': 'string', 'description': _REPO_DESC},
+                'pr_number': {'type': 'integer', 'description': 'Pull request number to assemble review context for'},
+            },
+        },
+        description=(
+            'One-shot PR review context: PR metadata, changed files, unified diff, and related '
+            'open PRs/issues matched by ticket IDs (#N / Fixes|Closes|Refs #N) or overlapping '
+            'changed-file basenames. Diffs larger than 100_000 characters are truncated.'
+        ),
+    )
+    def pr_review_context(self, args):
+        args = normalize_tool_input(args, tool_name='tool_github')
+        repo = self._repo(args)
+        num = require_int(args, 'pr_number', tool_name='pr_review_context')
+        token = self._token()
+
+        pr_raw = call(token, 'GET', f'/repos/{repo}/pulls/{num}')
+        pr = clean_pr(pr_raw)
+
+        files_raw = call(
+            token,
+            'GET',
+            f'/repos/{repo}/pulls/{num}/files',
+            params={'per_page': 100},
+        )
+        files = [
+            {
+                'filename': f.get('filename'),
+                'status': f.get('status'),
+                'additions': f.get('additions'),
+                'deletions': f.get('deletions'),
+                'changes': f.get('changes'),
+            }
+            for f in (files_raw or [])
+        ]
+
+        diff = call(
+            token,
+            'GET',
+            f'/repos/{repo}/pulls/{num}',
+            accept='application/vnd.github.v3.diff',
+            raw=True,
+        )
+        if not isinstance(diff, str):
+            diff = '' if diff is None else str(diff)
+        diff_truncated = False
+        if len(diff) > _MAX_DIFF_CHARS:
+            diff = (
+                diff[:_MAX_DIFF_CHARS]
+                + f'\n\n...[diff truncated at {_MAX_DIFF_CHARS} characters]...'
+            )
+            diff_truncated = True
+
+        ticket_ids = _extract_ticket_ids(pr.get('title'), pr.get('body'))
+        basenames = {_basename(f['filename']) for f in files if f.get('filename')}
+
+        open_prs = call(
+            token,
+            'GET',
+            f'/repos/{repo}/pulls',
+            params={'state': 'open', 'per_page': 100},
+        )
+        related_prs: list[dict] = []
+        for other in open_prs or []:
+            other_num = other.get('number')
+            if other_num == num:
+                continue
+            haystack = f'{other.get("title") or ""}\n{other.get("body") or ""}'
+            reasons = _match_reasons(haystack, ticket_ids, basenames)
+            if reasons:
+                related_prs.append(
+                    {
+                        'number': other_num,
+                        'title': other.get('title'),
+                        'html_url': other.get('html_url'),
+                        'state': other.get('state'),
+                        'reasons': reasons,
+                    }
+                )
+
+        open_issues = call(
+            token,
+            'GET',
+            f'/repos/{repo}/issues',
+            params={'state': 'open', 'per_page': 100},
+        )
+        related_issues: list[dict] = []
+        for issue in open_issues or []:
+            # Issues endpoint includes PRs; skip those (and the current PR number).
+            if issue.get('pull_request') is not None:
+                continue
+            issue_num = issue.get('number')
+            if issue_num == num:
+                continue
+            haystack = f'{issue.get("title") or ""}\n{issue.get("body") or ""}'
+            reasons = _match_reasons(haystack, ticket_ids, basenames)
+            # Also treat an open issue whose number is a referenced ticket as related.
+            if issue_num in ticket_ids and f'ticket:#{issue_num}' not in reasons:
+                reasons = [f'ticket:#{issue_num}', *reasons]
+            if reasons:
+                related_issues.append(
+                    {
+                        'number': issue_num,
+                        'title': issue.get('title'),
+                        'html_url': issue.get('html_url'),
+                        'state': issue.get('state'),
+                        'reasons': reasons,
+                    }
+                )
+
+        return {
+            'pr': pr,
+            'files': files,
+            'diff': diff,
+            'diff_truncated': diff_truncated,
+            'ticket_ids': ticket_ids,
+            'related': {
+                'prs': related_prs,
+                'issues': related_issues,
+            },
+        }
 
     # =======================================================================
     # REVIEWS

--- a/nodes/src/nodes/tool_github/README.md
+++ b/nodes/src/nodes/tool_github/README.md
@@ -64,6 +64,7 @@ List tools accept `per_page` (1–100, default 30) and `page` (default 1) for pa
 | `pr_get` | Get a single pull request by number. |
 | `pr_list` | List pull requests in a repository. |
 | `pr_create` | Create a new pull request. |
+| `pr_review_context` | One-shot PR review context: metadata, changed files, unified diff, and related open PRs/issues. |
 | `review_create` | Submit a review on a pull request (approve, request changes, or comment). |
 | `review_list` | List all reviews on a pull request. |
 | `review_get` | Get a single review on a pull request. |
@@ -110,11 +111,12 @@ GitHub's issues endpoint includes pull requests; `issue_list` filters them out, 
 
 ### Pull requests
 
-| Tool        | Description                                                  |
-|-------------|--------------------------------------------------------------|
-| `pr_get`    | Get a single pull request by number                          |
-| `pr_list`   | List pull requests (filter by state, base branch)            |
-| `pr_create` | Create a pull request (title, head, base, body, draft flag)  |
+| Tool                 | Description                                                  |
+|----------------------|--------------------------------------------------------------|
+| `pr_get`             | Get a single pull request by number                          |
+| `pr_list`            | List pull requests (filter by state, base branch)            |
+| `pr_create`          | Create a pull request (title, head, base, body, draft flag)  |
+| `pr_review_context`  | One-shot review seed: PR metadata (`clean_pr`), changed files, unified diff (truncated at 100k chars), and related open PRs/issues matched by ticket IDs (`#N`, Fixes/Closes/Refs `#N`) or overlapping changed-file basenames |
 
 ### Reviews
 
@@ -182,9 +184,9 @@ Blocked tools: `file_create`, `file_edit`, `file_delete`, `issue_create`,
 `workflow_dispatch`, `workflow_enable`, `workflow_disable`, `user_invite`.
 
 Always allowed: `file_get`, `file_list`, `issue_get`, `issue_list`, `pr_get`, `pr_list`,
-`review_list`, `review_get`, `repo_get`, `release_list`, `release_get`, `workflow_list`,
-`workflow_get`, `workflow_get_usage`, `org_list_repos`, `user_get_repos`, `search_code`,
-`search_issues`, `commit_list`, `commit_get`.
+`pr_review_context`, `review_list`, `review_get`, `repo_get`, `release_list`, `release_get`,
+`workflow_list`, `workflow_get`, `workflow_get_usage`, `org_list_repos`, `user_get_repos`,
+`search_code`, `search_issues`, `commit_list`, `commit_get`.
 
 Note the default is `false`, a freshly added node can write. Turn read-only mode on
 explicitly for inspect-only agents.

--- a/nodes/src/nodes/tool_github/github_client.py
+++ b/nodes/src/nodes/tool_github/github_client.py
@@ -97,15 +97,21 @@ def call(
     *,
     params: dict | None = None,
     body: dict | None = None,
+    accept: str | None = None,
+    raw: bool = False,
 ) -> Any:
-    """Make an authenticated GitHub API call and return parsed JSON.
+    """Make an authenticated GitHub API call and return parsed JSON (or raw text).
 
     Raises ``ValueError`` with a human-readable message on HTTP errors.
-    Returns an empty dict for 204 No Content responses.
+    Returns an empty dict for 204 No Content responses (or ``''`` when ``raw``).
+
+    Args:
+        accept: Optional ``Accept`` header override (e.g. ``application/vnd.github.v3.diff``).
+        raw: When True, return response body as text instead of parsing JSON.
     """
     headers = {
         'Authorization': f'Bearer {token}',
-        'Accept': 'application/vnd.github+json',
+        'Accept': accept or 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
     }
 
@@ -125,7 +131,7 @@ def call(
             raise ValueError(f'GitHub request failed: {exc}') from exc
 
         if resp.status_code == 204:
-            return {}
+            return '' if raw else {}
 
         if not resp.ok:
             is_rate_limit = resp.status_code == 429 or (
@@ -141,6 +147,8 @@ def call(
 
             _raise_github_error(resp)
 
+        if raw:
+            return resp.text
         return resp.json()
 
     def github_rate_limit_wait(retry_state: RetryCallState) -> float:

--- a/nodes/test/tool_github/test_pr_review_context.py
+++ b/nodes/test/tool_github/test_pr_review_context.py
@@ -1,0 +1,280 @@
+import sys
+import types
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch, Mock
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src' / 'nodes'))
+
+_STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.config', 'ai.common.utils')
+
+
+def _install_stubs() -> None:
+    mod_rl = types.ModuleType('rocketlib')
+
+    def mock_tool_function(*args, **kwargs):
+        return lambda f: f
+
+    mod_rl.tool_function = mock_tool_function
+
+    class IInstanceBase:
+        pass
+
+    class IGlobalBase:
+        pass
+
+    mod_rl.IInstanceBase = IInstanceBase
+    mod_rl.IGlobalBase = IGlobalBase
+    mod_rl.OPEN_MODE = Mock()
+    mod_rl.warning = Mock()
+    sys.modules['rocketlib'] = mod_rl
+
+    sys.modules['ai'] = types.ModuleType('ai')
+    sys.modules['ai.common'] = types.ModuleType('ai.common')
+
+    mod_ai_common_config = types.ModuleType('ai.common.config')
+
+    class Config:
+        pass
+
+    mod_ai_common_config.Config = Config
+    sys.modules['ai.common.config'] = mod_ai_common_config
+
+    mod_ai_common_utils = types.ModuleType('ai.common.utils')
+    mod_ai_common_utils.normalize_tool_input = lambda x, **kwargs: x
+    mod_ai_common_utils.require_str = lambda x, k, **kwargs: x.get(k)
+    mod_ai_common_utils.require_int = lambda x, k, **kwargs: x.get(k)
+    sys.modules['ai.common.utils'] = mod_ai_common_utils
+
+
+@contextmanager
+def _scoped_stubs() -> Iterator[None]:
+    original_modules = {module_name: sys.modules.get(module_name) for module_name in _STUB_MODULE_NAMES}
+    _install_stubs()
+    try:
+        yield
+    finally:
+        for module_name, module in original_modules.items():
+            if module is None:
+                sys.modules.pop(module_name, None)
+            else:
+                sys.modules[module_name] = module
+
+
+with _scoped_stubs():
+    from tool_github.github_client import call
+    from tool_github.IInstance import (
+        IInstance,
+        _MAX_DIFF_CHARS,
+        _extract_ticket_ids,
+        _match_reasons,
+    )
+
+
+def test_extract_ticket_ids_bare_and_keywords():
+    ids = _extract_ticket_ids(
+        'feat: wire PR context (#1852)',
+        'Fixes #1000\nCloses #1852\nRefs #999\nAlso see #42.',
+    )
+    assert ids == [1852, 1000, 999, 42]
+
+
+def test_match_reasons_tickets_and_basenames():
+    reasons = _match_reasons(
+        'Related to #1852 and touches github_client.py',
+        ticket_ids=[1852, 42],
+        basenames={'github_client.py', 'missing.py'},
+    )
+    assert 'ticket:#1852' in reasons
+    assert 'ticket:#42' not in reasons
+    assert 'file:github_client.py' in reasons
+    assert 'file:missing.py' not in reasons
+
+
+@patch('tool_github.github_client.requests.request')
+def test_call_accept_and_raw_text(mock_request):
+    resp = Mock(spec=requests.Response)
+    resp.ok = True
+    resp.status_code = 200
+    resp.text = 'diff --git a/foo b/foo\n'
+    resp.json.side_effect = AssertionError('json() should not be called when raw=True')
+
+    mock_request.return_value = resp
+
+    result = call(
+        'token',
+        'GET',
+        '/repos/acme/app/pulls/1',
+        accept='application/vnd.github.v3.diff',
+        raw=True,
+    )
+
+    assert result == 'diff --git a/foo b/foo\n'
+    headers = mock_request.call_args.kwargs['headers']
+    assert headers['Accept'] == 'application/vnd.github.v3.diff'
+
+
+def test_pr_review_context_assembles_diff_files_and_related():
+    inst = Mock()
+    inst._token.return_value = 'token'
+    inst._repo.return_value = 'acme/app'
+
+    pr_payload = {
+        'number': 10,
+        'title': 'Add review context (Fixes #1852)',
+        'body': 'Closes #1852 and touches tool_github.',
+        'state': 'open',
+        'merged': False,
+        'draft': False,
+        'head': {'ref': 'feat/x', 'sha': 'abc'},
+        'base': {'ref': 'develop', 'sha': 'def'},
+        'user': {'login': 'alice'},
+        'created_at': '2026-01-01T00:00:00Z',
+        'updated_at': '2026-01-02T00:00:00Z',
+        'merged_at': None,
+        'html_url': 'https://github.com/acme/app/pull/10',
+        'commits': 1,
+        'additions': 5,
+        'deletions': 1,
+        'changed_files': 1,
+    }
+    files_payload = [
+        {
+            'filename': 'nodes/src/nodes/tool_github/IInstance.py',
+            'status': 'modified',
+            'additions': 5,
+            'deletions': 1,
+            'changes': 6,
+        }
+    ]
+    open_prs = [
+        pr_payload,
+        {
+            'number': 11,
+            'title': 'Also mentions IInstance.py',
+            'body': 'overlap on basename',
+            'state': 'open',
+            'html_url': 'https://github.com/acme/app/pull/11',
+            'head': {},
+            'base': {},
+            'user': {},
+        },
+        {
+            'number': 12,
+            'title': 'Unrelated PR',
+            'body': 'no overlap',
+            'state': 'open',
+            'html_url': 'https://github.com/acme/app/pull/12',
+            'head': {},
+            'base': {},
+            'user': {},
+        },
+    ]
+    open_issues = [
+        {
+            'number': 1852,
+            'title': 'PR review context preset',
+            'body': 'feature request',
+            'state': 'open',
+            'html_url': 'https://github.com/acme/app/issues/1852',
+        },
+        {
+            'number': 99,
+            'title': 'Mentions IInstance.py in passing',
+            'body': '',
+            'state': 'open',
+            'html_url': 'https://github.com/acme/app/issues/99',
+        },
+        {
+            'number': 10,
+            'title': 'This is actually a PR in issues list',
+            'body': '',
+            'state': 'open',
+            'html_url': 'https://github.com/acme/app/pull/10',
+            'pull_request': {'url': 'https://api.github.com/repos/acme/app/pulls/10'},
+        },
+    ]
+    diff_text = 'diff --git a/IInstance.py b/IInstance.py\n+new line\n'
+
+    def _side_effect(token, method, path, *, params=None, body=None, accept=None, raw=False):
+        if path.endswith('/pulls/10') and raw:
+            return diff_text
+        if path.endswith('/pulls/10/files'):
+            return files_payload
+        if path.endswith('/pulls/10'):
+            return pr_payload
+        if path.endswith('/pulls'):
+            return open_prs
+        if path.endswith('/issues'):
+            return open_issues
+        raise AssertionError(f'unexpected call: {method} {path} raw={raw} accept={accept}')
+
+    with patch('tool_github.IInstance.call', side_effect=_side_effect) as mocked:
+        result = IInstance.pr_review_context(inst, {'pr_number': 10})
+
+    assert result['pr']['number'] == 10
+    assert result['pr']['title'].startswith('Add review context')
+    assert result['files'] == [
+        {
+            'filename': 'nodes/src/nodes/tool_github/IInstance.py',
+            'status': 'modified',
+            'additions': 5,
+            'deletions': 1,
+            'changes': 6,
+        }
+    ]
+    assert result['diff'] == diff_text
+    assert result['diff_truncated'] is False
+    assert result['ticket_ids'] == [1852]
+
+    related_pr_nums = {p['number'] for p in result['related']['prs']}
+    assert related_pr_nums == {11}
+    assert 'file:IInstance.py' in result['related']['prs'][0]['reasons']
+
+    related_issue_nums = {i['number'] for i in result['related']['issues']}
+    assert related_issue_nums == {1852, 99}
+    assert any(i['number'] == 1852 and 'ticket:#1852' in i['reasons'] for i in result['related']['issues'])
+
+    # Diff request must use Accept override + raw text.
+    assert any(
+        c.kwargs.get('raw') is True and c.kwargs.get('accept') == 'application/vnd.github.v3.diff'
+        for c in mocked.call_args_list
+    )
+
+
+def test_pr_review_context_truncates_large_diff():
+    inst = Mock()
+    inst._token.return_value = 'token'
+    inst._repo.return_value = 'acme/app'
+
+    huge = 'x' * (_MAX_DIFF_CHARS + 50)
+
+    def _side_effect(token, method, path, *, params=None, body=None, accept=None, raw=False):
+        if path.endswith('/pulls/1') and raw:
+            return huge
+        if path.endswith('/pulls/1/files'):
+            return []
+        if path.endswith('/pulls/1'):
+            return {
+                'number': 1,
+                'title': 'big',
+                'body': '',
+                'state': 'open',
+                'head': {},
+                'base': {},
+                'user': {},
+            }
+        if path.endswith('/pulls') or path.endswith('/issues'):
+            return []
+        raise AssertionError(path)
+
+    with patch('tool_github.IInstance.call', side_effect=_side_effect):
+        result = IInstance.pr_review_context(inst, {'pr_number': 1})
+
+    assert result['diff_truncated'] is True
+    assert len(result['diff']) < len(huge)
+    assert f'truncated at {_MAX_DIFF_CHARS}' in result['diff']
+    assert result['diff'].startswith('x' * 100)


### PR DESCRIPTION
## Summary
- Add `pr_review_context(pr_number)` on `tool_github` that returns PR metadata, changed files, unified diff, and related open PRs/issues in one call
- Match related items by ticket IDs (`#N`, Fixes/Closes/Refs) and overlapping changed-file basenames
- Truncate diffs over 100k characters; extend `github_client.call` with `accept=` / `raw=`

Fixes #1852

## Test plan
- [ ] `pytest nodes/test/tool_github/test_pr_review_context.py -v --noconftest`
- [ ] Against a real repo: call `pr_review_context` and confirm diff + files + related issues populate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a GitHub pull request review context tool.
  - View pull request metadata, changed files, and a bounded unified diff in one result.
  - Discover related open pull requests and issues using ticket references and changed-file names.
  - Excludes the current pull request and pull requests from issue-related results.
  - Available in read-only mode.

- **Documentation**
  - Added the new tool to the GitHub integration’s available tools and usage documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->