### PR TITLE
fix: surface consecutive scheduler skips when a run never completes (#1838)

### DIFF
--- a/packages/ai/src/ai/modules/task/task_scheduler.py
+++ b/packages/ai/src/ai/modules/task/task_scheduler.py
@@ -69,6 +69,12 @@ _SCHEDULER_ACTOR = {'userId': 'system:scheduler', 'display': 'Scheduler', 'email
 # returned a real token" — a tick due in that window must still skip.
 _DISPATCHING = '__dispatching__'
 
+# Consecutive-skip counts at which a wedged schedule (the overlap guard
+# never clears because the previous run never completes, e.g. a
+# non-terminating source) gets a visibility warning. Edit this tuple to
+# change the cadence.
+_SKIP_WARN_THRESHOLDS = (3, 10, 100)
+
 # (team_id, project_id, source_id) — the schedule identity.
 RunKey = Tuple[str, str, str]
 
@@ -96,6 +102,8 @@ class TaskScheduler:
         self._entries: Dict[RunKey, ScheduledRun] = {}
         # key -> token of the most-recently dispatched run (overlap guard)
         self._active_tokens: Dict[RunKey, str] = {}
+        # key -> consecutive skip count (overlap guard visibility, issue #1838)
+        self._skip_counts: Dict[RunKey, int] = {}
         self._scheduling: asyncio.Task | None = None
         self._inflight_starts: set[asyncio.Task] = set()
 
@@ -129,8 +137,11 @@ class TaskScheduler:
             # Disabled/errored/removed deployments also lose their overlap guards.
             for key in [k for k in self._active_tokens if k[0] == team_id and k[1] == project_id]:
                 self._active_tokens.pop(key, None)
+            for key in [k for k in self._skip_counts if k[0] == team_id and k[1] == project_id]:
+                self._skip_counts.pop(key, None)
             return
 
+        scheduled_keys = set()
         for source_id, sched in (deployment.get('schedules') or {}).items():
             cron = (sched or {}).get('cron')
             if not cron or sched.get('paused', False):
@@ -143,6 +154,15 @@ class TaskScheduler:
             entry = ScheduledRun(next_run=next_run, key=(team_id, project_id, source_id), org_id=org_id, cron=cron)
             self._entries[entry.key] = entry
             heapq.heappush(self._schedule, entry)
+            scheduled_keys.add(entry.key)
+
+        # A source that was removed, paused, or has a bad cron no longer has
+        # a live entry - drop its skip count too, or a later resume would
+        # continue a stale streak and could fire a false warning.
+        for key in [
+            k for k in self._skip_counts if k[0] == team_id and k[1] == project_id and k not in scheduled_keys
+        ]:
+            self._skip_counts.pop(key, None)
 
     def is_run_active(self, team_id: str, project_id: str, source_id: str) -> bool:
         """True while a dispatched run of the source is starting or running.
@@ -291,7 +311,11 @@ class TaskScheduler:
                     # is still active — schedules never overlap themselves.
                     if self._is_previous_run_active(entry.key):
                         debug(f'[SCHEDULER] {entry.key}: previous run still active, skipping')
+                        self._note_skip(entry.key)
                         continue
+
+                    # A tick is about to dispatch: only consecutive skips matter.
+                    self._skip_counts.pop(entry.key, None)
 
                     # Mark the key in-flight BEFORE the dispatch task exists,
                     # so a tick due during startup sees the guard closed.
@@ -332,6 +356,22 @@ class TaskScheduler:
             return True
         ctrl = self._server._task_control.get(token)
         return bool(ctrl and not ctrl.task.is_task_complete())
+
+    def _note_skip(self, key: RunKey) -> None:
+        """Count a consecutive overlap-guard skip and warn at thresholds.
+
+        A source that never terminates leaves the guard closed forever, so
+        the schedule stops firing while still reporting itself active. This
+        only makes that visible in the logs — it never changes the guard's
+        decision or the deployment's state.
+        """
+        count = self._skip_counts.get(key, 0) + 1
+        self._skip_counts[key] = count
+        if count in _SKIP_WARN_THRESHOLDS:
+            warning(
+                f'[SCHEDULER] {key}: {count} consecutive skips - the previous run has not '
+                'completed, so this schedule is not firing'
+            )
 
     async def _start_run(self, entry: ScheduledRun) -> None:
         """Fire one (team, project, source) occurrence via trusted dispatch."""

--- a/packages/ai/src/ai/modules/task/task_scheduler.py
+++ b/packages/ai/src/ai/modules/task/task_scheduler.py
@@ -159,9 +159,7 @@ class TaskScheduler:
         # A source that was removed, paused, or has a bad cron no longer has
         # a live entry - drop its skip count too, or a later resume would
         # continue a stale streak and could fire a false warning.
-        for key in [
-            k for k in self._skip_counts if k[0] == team_id and k[1] == project_id and k not in scheduled_keys
-        ]:
+        for key in [k for k in self._skip_counts if k[0] == team_id and k[1] == project_id and k not in scheduled_keys]:
             self._skip_counts.pop(key, None)
 
     def is_run_active(self, team_id: str, project_id: str, source_id: str) -> bool:

--- a/packages/ai/tests/ai/modules/task/test_task_scheduler.py
+++ b/packages/ai/tests/ai/modules/task/test_task_scheduler.py
@@ -33,6 +33,8 @@ of the backend (covered by test_deployment_backend) or dispatch (covered by
 cmd/task tests).
 """
 
+import asyncio
+import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -296,3 +298,202 @@ class TestOverlapGuard:
         scheduler._server._task_control['tk_manual'] = running
         scheduler.register_manual_run('team-1', 'proj-1', 'src-1', 'tk_manual')
         assert scheduler.is_run_active('team-1', 'proj-1', 'src-1')
+
+
+# ============================================================================
+# Skip visibility (issue #1838) — a non-terminating source closes the
+# overlap guard forever, so the schedule stops firing while still reporting
+# itself active. These pin the added consecutive-skip counter and its
+# threshold warnings; the guard's own skip/dispatch decision is untouched
+# and stays covered by TestOverlapGuard/TestStartRun above.
+# ============================================================================
+
+
+class TestSkipVisibility:
+    KEY = ('team-1', 'proj-1', 'src-1')
+
+    def test_sync_drops_skip_counts_when_disabled(self, scheduler):
+        """Disabling/removing a deployment drops its skip counts, not just its schedule entries."""
+        scheduler.sync('org-1', _dep())
+        scheduler._skip_counts[self.KEY] = 5
+
+        scheduler.sync('org-1', _dep(state='disabled', schedules={}))
+
+        assert self.KEY not in scheduler._skip_counts
+
+    @pytest.mark.parametrize(
+        'remaining_schedules',
+        [
+            pytest.param({'src-2': {'cron': '* * * * *', 'paused': False}}, id='removed'),
+            pytest.param(
+                {
+                    'src-1': {'cron': '* * * * *', 'paused': True},
+                    'src-2': {'cron': '* * * * *', 'paused': False},
+                },
+                id='paused',
+            ),
+        ],
+    )
+    def test_sync_prunes_only_the_affected_sources_skip_count(self, scheduler, remaining_schedules):
+        """Removing or pausing one source prunes only its own skip count - a sibling source stays untouched."""
+        scheduler.sync(
+            'org-1',
+            _dep(
+                schedules={
+                    'src-1': {'cron': '* * * * *', 'paused': False},
+                    'src-2': {'cron': '* * * * *', 'paused': False},
+                }
+            ),
+        )
+        key1 = ('team-1', 'proj-1', 'src-1')
+        key2 = ('team-1', 'proj-1', 'src-2')
+        scheduler._skip_counts[key1] = 5
+        scheduler._skip_counts[key2] = 7
+
+        scheduler.sync('org-1', _dep(schedules=remaining_schedules))
+
+        assert key1 not in scheduler._skip_counts
+        assert scheduler._skip_counts[key2] == 7  # the blanket-wipe failure mode this guards against
+
+    @pytest.mark.parametrize('threshold', sched_mod._SKIP_WARN_THRESHOLDS)
+    def test_warns_at_threshold_not_before(self, scheduler, monkeypatch, threshold):
+        """A warning fires exactly at each configured threshold, never before it."""
+        warn = MagicMock()
+        monkeypatch.setattr(sched_mod, 'warning', warn)
+
+        # Seed one skip short of the threshold directly, rather than looping
+        # _note_skip from zero - a loop would cross any SMALLER threshold on
+        # the way (e.g. 3, on the way to 10), firing a warning that has
+        # nothing to do with the one under test here.
+        scheduler._skip_counts[self.KEY] = threshold - 2
+
+        scheduler._note_skip(self.KEY)  # count == threshold - 1
+        warn.assert_not_called()
+
+        scheduler._note_skip(self.KEY)  # count == threshold
+        warn.assert_called_once()
+        message = warn.call_args.args[0]
+        assert 'src-1' in message
+        assert str(threshold) in message
+
+    def test_no_repeat_warning_between_thresholds(self, scheduler, monkeypatch):
+        """No warning repeats on every skip between two thresholds."""
+        warn = MagicMock()
+        monkeypatch.setattr(sched_mod, 'warning', warn)
+
+        for _ in range(9):  # consecutive skips 1-9; next threshold is 10
+            scheduler._note_skip(self.KEY)
+        assert warn.call_count == 1  # only the 3rd skip warned
+
+    def test_dispatch_resets_the_counter(self, scheduler, monkeypatch):
+        """Resetting the counter (as a dispatch does) breaks a skip streak."""
+        warn = MagicMock()
+        monkeypatch.setattr(sched_mod, 'warning', warn)
+
+        scheduler._note_skip(self.KEY)
+        scheduler._note_skip(self.KEY)
+        # Mirrors the tick loop's reset line exactly: a tick that dispatches
+        # clears the counter before the next skip streak can accumulate.
+        scheduler._skip_counts.pop(self.KEY, None)
+
+        scheduler._note_skip(self.KEY)
+        scheduler._note_skip(self.KEY)
+        warn.assert_not_called()  # only 2 consecutive skips since the reset
+
+    @staticmethod
+    async def _run_one_tick(scheduler, monkeypatch):
+        """
+        Drive _run() itself through exactly one batch of due entries, with
+        no real waiting: _run()'s tick-processing is fully synchronous up to
+        its trailing `await asyncio.sleep(delay)`, so patching that one call
+        to raise immediately stops the loop right after the batch - no
+        restructuring of _run(), no real elapsed time, nothing timing-
+        dependent to flake.
+        """
+
+        async def _stop(_delay):
+            raise asyncio.CancelledError
+
+        monkeypatch.setattr(sched_mod.asyncio, 'sleep', _stop)
+        with pytest.raises(asyncio.CancelledError):
+            await scheduler._run()
+
+    @pytest.mark.asyncio
+    async def test_run_loop_increments_skip_count_on_skip(self, scheduler, account_stub, dispatch, monkeypatch):
+        """
+        Exercises the _note_skip call added inside _run() itself, not a
+        reimplementation of it.
+        """
+        entry = _entry(scheduler)
+        entry.next_run = time.time() - 1  # due now, no real wait
+
+        running = MagicMock()
+        running.task.is_task_complete.return_value = False
+        scheduler._active_tokens[entry.key] = 'tk_running'
+        scheduler._server._task_control['tk_running'] = running
+
+        await self._run_one_tick(scheduler, monkeypatch)
+
+        assert scheduler._skip_counts[entry.key] == 1
+        # The count alone doesn't prove a skip caused it. dispatch not being
+        # awaited plus _active_tokens left untouched (the dispatch branch's
+        # own distinguishing side effect, `_active_tokens[key] = _DISPATCHING`)
+        # together rule out the dispatch branch having run at all.
+        dispatch.assert_not_awaited()
+        assert scheduler._active_tokens[entry.key] == 'tk_running'
+
+    @pytest.mark.asyncio
+    async def test_run_loop_clears_skip_count_on_dispatch(self, scheduler, account_stub, dispatch, monkeypatch):
+        """
+        Exercises the reset pop added inside _run() itself, not a
+        reimplementation of it.
+        """
+        entry = _entry(scheduler)
+        entry.next_run = time.time() - 1  # due now, no real wait
+        scheduler._skip_counts[entry.key] = 5  # a prior skip streak
+
+        await self._run_one_tick(scheduler, monkeypatch)
+
+        assert entry.key not in scheduler._skip_counts
+        # Let the dispatch task this tick created finish before the test ends.
+        await asyncio.gather(*scheduler._inflight_starts, return_exceptions=True)
+        # The count being gone isn't enough on its own - a change that cleared
+        # counters without dispatching would pass that alone. Pin that a
+        # dispatch is what happened, not merely that the count is absent.
+        dispatch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skip_and_dispatch_decisions_are_unchanged(self, scheduler, account_stub, dispatch):
+        """
+        The fix must be purely additive: the same ticks skip and the same
+        ticks dispatch, with or without it. This drives the pre-existing
+        tick-loop decision (_is_previous_run_active -> skip, else
+        _start_run -> dispatch) over a short sequence and pins the exact
+        outcome. It references no symbol this change added, so it must
+        pass against unmodified source too — that is what proves additive.
+        """
+        entry = _entry(scheduler)
+        decisions = []
+
+        async def _tick():
+            if scheduler._is_previous_run_active(entry.key):
+                decisions.append('skip')
+            else:
+                await scheduler._start_run(entry)
+                decisions.append('dispatch')
+
+        await _tick()  # nothing active yet -> dispatch
+
+        running = MagicMock()
+        running.task.is_task_complete.return_value = False
+        scheduler._server._task_control['tk_dispatched'] = running
+
+        await _tick()  # previous run still going -> skip
+        await _tick()  # still going -> skip
+
+        running.task.is_task_complete.return_value = True
+
+        await _tick()  # previous run finished -> guard reopens -> dispatch
+
+        assert decisions == ['dispatch', 'skip', 'skip', 'dispatch']
+        assert dispatch.await_count == 2


### PR DESCRIPTION
Addresses #1838.

## Summary

- A scheduled deployment on a non-terminating source runs once, then skips every
  subsequent tick forever while still reporting `active`. The overlap guard
  (`_is_previous_run_active`) is correct and returns `True` on each tick because
  `is_task_complete()` is never true — but nothing surfaces it. The only trace is a
  `debug()` line that is off at normal log levels.
- Adds a consecutive-skip counter per key and warns at 3, 10, and 100 skips. The
  counter resets whenever a tick dispatches.
- Purely additive: this does not change *when* the guard defers, only whether a
  wedge is visible.

## Type

fix

## Approach

The issue offers three directions. This implements (1), surface it. (2) bounding the
deferral and (3) distinguishing terminating from non-terminating sources both require
either picking a timeout value or inferring source behaviour, and the right answers
depend on how long a legitimate long run may take — maintainer calls, not mine. (1) is
the only one that needs no such decision.

A **consecutive-skip count**, not an elapsed-time bound: a count needs no units and no
assumption about legitimate long-run duration. Reset happens inline in the tick loop
immediately after the guard check passes, before the dispatch task is created — "a tick
actually dispatched" is the moment it clears the guard and proceeds, independent of
whether `_start_run` later succeeds.

**Thresholds, not every tick.** A wedge that logs on every tick is its own kind of
invisible. `_SKIP_WARN_THRESHOLDS = (3, 10, 100)` is a module-level constant so the
cadence is one line to change. The warning is deliberately silent past 100 — the
thresholds exist to mark that a wedge happened and roughly how long it has run, not to
monitor it continuously; a wedged schedule that has already logged three times at
increasing magnitudes has been reported.

**Logs, does not mutate deployment state.** Marking the deployment would change what
`active` means, which is a public contract touching whatever renders and reports
status — beyond an additive change.

Uses the `warning` helper already imported alongside `debug` at `:53`; no new logging
dependency.

Counter state is cleaned up on both paths through `sync()`. The disabled/errored/removed
branch drops counts for the whole `(team_id, project_id)` scope, mirroring where
`_active_tokens` is already cleaned. The enabled branch collects the scheduled keys while
rebuilding entries and then prunes any `_skip_counts` key under that scope which is no
longer scheduled — so a source paused or removed from an otherwise-enabled deployment
clears its counter and can't later resume onto a stale streak. The `_active_tokens`
cleanup itself is untouched.

The line numbers and code in the issue matched `develop` exactly — no drift.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Nine tests in a new `TestSkipVisibility` class in
`packages/ai/tests/ai/modules/task/test_task_scheduler.py`.

Warning behaviour:

1. The warning fires at each configured threshold and not on the skip before it —
   parametrized over `_SKIP_WARN_THRESHOLDS` itself rather than a second hardcoded
   tuple, so a wrong value at 10 or 100 fails the suite. Each case seeds the counter at
   `threshold - 2`; counting up from zero would re-cross the lower thresholds and the
   10 and 100 cases would pick up the warning from 3.
2. No repeat between thresholds — nothing new at skips 4 through 9.
3. A dispatch resets the counter: skip twice, dispatch, skip twice, no warning.

Behaviour through the loop:

4. Skip/dispatch decisions are unchanged — a 4-tick sequence asserting the exact
   outcome `['dispatch', 'skip', 'skip', 'dispatch']`.
5. A skipped tick through `_run()` increments the counter — and leaves
   `_active_tokens` untouched, which rules out the dispatch branch having run at all.
6. A dispatching tick through `_run()` clears an existing count — asserting the
   dispatch was awaited, not merely that the count is gone, so a future change that
   cleared counters without dispatching would still fail here.

Cleanup:

7. Disabling or removing a deployment drops its skip counts, not just its schedule
   entries.
8. and 9. Removing a single source from a still-enabled deployment, and pausing one —
   parametrized, since `sync()` skips both through the same `continue` but they leave
   the schedules dict in different shapes. Both assert a sibling source's count under
   the same `(team_id, project_id)` survives, which is what distinguishes the targeted
   prune from a blanket wipe.

Tests 5 and 6 cover the two lines this PR adds inside the loop; 7 through 9 cover the
two cleanup paths. All three cleanup tests were verified against source with both
cleanup blocks stripped out — each fails with the counts still present.

Test 4 drives only pre-existing surface (`_is_previous_run_active`, `_start_run`,
`_active_tokens`/`_task_control`) and references nothing this PR adds, so it passes
against unmodified source *and* against the change — that parity is what makes it
evidence the change is additive, and it's kept alongside the loop-driven tests rather
than replaced by them.

One caveat if you want to check that yourself: the threshold test parametrizes over
`_SKIP_WARN_THRESHOLDS` at collection time, so reverting `task_scheduler.py` while
keeping this test file breaks import of the module as a whole — the other new tests
never get as far as failing individually. Test 4 does still pass against pre-#1838
scheduler source; I verified it by temporarily making that one parametrize lookup
collection-safe, then reverting the adjustment. It just can't be selected in isolation
against a reverted tree without that change.

Tests 5 and 6 need the loop to run deterministically. `_run()`'s tick processing is
synchronous up to its trailing `await asyncio.sleep(delay)`, so an entry is forced due
by setting `next_run` directly and that one sleep is patched to raise `CancelledError` —
exactly one tick batch runs and the loop exits. No real elapsed time, no timing
assumptions, and no restructuring of production code to make it testable. I ran them
repeatedly to check for flakiness before relying on them.

With the change: 27 passed — nine test functions, eleven cases, since two of them are
parametrized, plus the 16 pre-existing scheduler tests, which pass unchanged.

`./builder test` is unchecked because the JS dependency install fails on my machine
(no `node-pty` prebuild for Node 26), so I ran the tests through the installed engine
binary instead. Worth flagging separately: that engine snapshot's bundled `rocketride`
package is missing `_log_codec`, which `task_server.py` pulls in transitively via
`run_log.py`, so I had to put `packages/client-python/src` ahead of it on `sys.path`
to import the test module at all. That's a staleness artifact of my local binary, not
something in this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added visibility into repeated task runs skipped because a previous run is still in progress.
  - Warnings now appear after 3, 10, and 100 consecutive skipped runs, with duplicate warnings suppressed between thresholds.
  - Skip tracking resets after a task is successfully dispatched.
  - Tracking is cleared when deployments or schedules are disabled, removed, paused, or become invalid.
  - Existing dispatch and overlap-protection behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->