### PR TITLE
fix(nodes): per-thread Google transport and GET-only retries for transport faults

### DIFF
--- a/nodes/src/nodes/tool_google_workspace/google_client.py
+++ b/nodes/src/nodes/tool_google_workspace/google_client.py
@@ -39,8 +39,10 @@ This file owns everything that guards credentials and requests:
 - scope diagnostics (:func:`token_scope_report`) shared by ``validateConfig``,
   ``check_connection``, and ``build_service`` so the three checks cannot drift;
 - request execution with exponential backoff on 429/5xx and on rate-limit
-  403s (parsed from the structured error body), while permission 403s and
-  other errors fail fast with an agent-readable message.
+  403s (parsed from the structured error body), plus the same backoff for
+  status-less transport faults on GET requests only, all on a per-thread
+  transport (httplib2 is not thread safe under parallel agent tool calls);
+  permission 403s and other errors fail fast with an agent-readable message.
 
 Per-service subpackages keep only their tool functions and response cleaners,
 and bind these functions via ``functools.partial`` (see e.g. ``sheets/client.py``).
@@ -52,6 +54,7 @@ import base64
 import binascii
 import json
 import os
+import threading
 import time as _time
 from dataclasses import dataclass, field
 from typing import Any
@@ -399,21 +402,66 @@ def build_service(svc: GoogleService, auth_type: str, cfg: dict, scopes: list[st
     return build(svc.api, svc.version, credentials=creds, cache_discovery=False)
 
 
+_thread_transport = threading.local()
+
+
+def _request_http(request: Any):
+    """Per-thread transport for a request built on a shared service handle.
+
+    googleapiclient services carry one httplib2 transport and every request
+    built from a service inherits it. httplib2 is not thread safe: concurrent
+    ``execute()`` calls on the same handle can interleave on one TLS
+    connection, which surfaces as ``[SSL] record layer failure`` when an agent
+    executor runs a wave of tool calls in parallel threads. Rebuild the
+    authorized transport once per thread, keyed by the credential object, so
+    parallel calls never share a connection. Returns None (keep the request's
+    own transport) when there is nothing to rebuild from.
+    """
+    shared = getattr(request, 'http', None)
+    creds = getattr(shared, 'credentials', None)
+    if creds is None:
+        return None
+    try:
+        import google_auth_httplib2
+        import httplib2
+    except ImportError:
+        return None
+    cache = getattr(_thread_transport, 'by_creds', None)
+    if cache is None:
+        cache = {}
+        _thread_transport.by_creds = cache
+    http = cache.get(id(creds))
+    if http is None:
+        http = google_auth_httplib2.AuthorizedHttp(creds, http=httplib2.Http())
+        cache[id(creds)] = http
+    return http
+
+
 def execute(svc: GoogleService, request: Any, *, binary: bool = False) -> Any:
     """Run an API request with exponential backoff on 429/5xx and rate-limit 403s.
+
+    Status-less failures (connection reset, TLS fault, timeout) are retried
+    with the same backoff for GET requests only. A mutation whose response was
+    lost may still have landed on Google's side, so it fails fast and leaves
+    the re-check to the caller rather than risking a duplicated side effect.
+    Requests run on a per-thread transport (see ``_request_http``).
 
     ``binary=True`` returns the raw response (bytes from get_media/export_media);
     otherwise the JSON dict (or {} when the API returns no body). With 4 attempts
     the sleeps are 1s, 2s, 4s — worst case ~7s before the final raise.
     """
     base_delay = 1.0
+    http = _request_http(request)
     for attempt in range(4):
         try:
-            result = request.execute()
+            result = request.execute(http=http) if http is not None else request.execute()
             return result if binary else (result or {})
         except Exception as exc:  # googleapiclient.errors.HttpError and transport errors
             status = getattr(getattr(exc, 'resp', None), 'status', None)
             if status and (int(status) in _RETRY_STATUSES or _is_rate_limit_403(exc)) and attempt < 3:
+                _time.sleep(base_delay * (2**attempt))
+                continue
+            if status is None and attempt < 3 and getattr(request, 'method', None) == 'GET':
                 _time.sleep(base_delay * (2**attempt))
                 continue
             detail = getattr(exc, 'reason', None) or str(exc)

--- a/nodes/src/nodes/tool_google_workspace/google_client.py
+++ b/nodes/src/nodes/tool_google_workspace/google_client.py
@@ -40,9 +40,10 @@ This file owns everything that guards credentials and requests:
   ``check_connection``, and ``build_service`` so the three checks cannot drift;
 - request execution with exponential backoff on 429/5xx and on rate-limit
   403s (parsed from the structured error body), plus the same backoff for
-  status-less transport faults on GET requests only, all on a per-thread
-  transport (httplib2 is not thread safe under parallel agent tool calls);
-  permission 403s and other errors fail fast with an agent-readable message.
+  status-less transport faults on reads only, all on a per-thread transport
+  (httplib2 is not thread safe under parallel agent tool calls); permission
+  403s, non-transport errors, and lost mutations fail fast with an
+  agent-readable message.
 
 Per-service subpackages keep only their tool functions and response cleaners,
 and bind these functions via ``functools.partial`` (see e.g. ``sheets/client.py``).
@@ -56,7 +57,10 @@ import json
 import os
 import threading
 import time as _time
+from collections import OrderedDict
 from dataclasses import dataclass, field
+from functools import lru_cache
+from http.client import HTTPException as _HTTPException
 from typing import Any
 from urllib.parse import urlparse
 
@@ -404,6 +408,26 @@ def build_service(svc: GoogleService, auth_type: str, cfg: dict, scopes: list[st
 
 _thread_transport = threading.local()
 
+# Worker threads are pooled and outlive the credentials they serve, so the
+# per-thread cache is bounded rather than open ended: an unbounded map would pin
+# an AuthorizedHttp — and the sockets it holds — for every credential the thread
+# had ever seen. Weak keys would not bound it either, because the cached
+# AuthorizedHttp keeps a strong reference to its own credentials, so a weakly
+# held key can never be collected while its entry is stored.
+_TRANSPORT_CACHE_MAX = 8
+
+
+def _close_transport(http: Any) -> None:
+    """Release the sockets an evicted transport still holds, best effort."""
+    inner = getattr(http, 'http', None)
+    close = getattr(inner, 'close', None)
+    if close is None:
+        return
+    try:
+        close()
+    except Exception:  # noqa: BLE001 - eviction must never fail a live request
+        pass
+
 
 def _request_http(request: Any):
     """Per-thread transport for a request built on a shared service handle.
@@ -413,9 +437,14 @@ def _request_http(request: Any):
     ``execute()`` calls on the same handle can interleave on one TLS
     connection, which surfaces as ``[SSL] record layer failure`` when an agent
     executor runs a wave of tool calls in parallel threads. Rebuild the
-    authorized transport once per thread, keyed by the credential object, so
-    parallel calls never share a connection. Returns None (keep the request's
-    own transport) when there is nothing to rebuild from.
+    authorized transport once per thread so parallel calls never share a
+    connection. Returns None (keep the request's own transport) when there is
+    nothing to rebuild from.
+
+    Entries are keyed by ``id(creds)``, which is safe precisely because the
+    cached transport keeps that credential object alive: no stored key can be
+    recycled onto a different credential. Past ``_TRANSPORT_CACHE_MAX`` the
+    least recently used entry is dropped and its connections closed.
     """
     shared = getattr(request, 'http', None)
     creds = getattr(shared, 'credentials', None)
@@ -428,23 +457,82 @@ def _request_http(request: Any):
         return None
     cache = getattr(_thread_transport, 'by_creds', None)
     if cache is None:
-        cache = {}
+        cache = OrderedDict()
         _thread_transport.by_creds = cache
-    http = cache.get(id(creds))
-    if http is None:
-        http = google_auth_httplib2.AuthorizedHttp(creds, http=httplib2.Http())
-        cache[id(creds)] = http
+    key = id(creds)
+    http = cache.get(key)
+    if http is not None:
+        cache.move_to_end(key)
+        return http
+    http = google_auth_httplib2.AuthorizedHttp(creds, http=httplib2.Http())
+    cache[key] = http
+    while len(cache) > _TRANSPORT_CACHE_MAX:
+        _evicted_key, evicted = cache.popitem(last=False)
+        _close_transport(evicted)
     return http
+
+
+@lru_cache(maxsize=1)
+def _transport_error_types() -> tuple[type[BaseException], ...]:
+    """Exception types meaning the request never produced a usable response.
+
+    ``OSError`` covers connection resets, timeouts and ``ssl.SSLError``;
+    ``HTTPException`` covers truncated or blank replies. httplib2 and
+    google-auth wrap some faults in types that derive from neither, so include
+    those when the optional dependencies are importable.
+
+    Resolved on first failure rather than at import, so a module imported before
+    its optional dependencies are in place still picks them up; caching keeps it
+    to one resolution per process. Tests reset it with ``cache_clear()``.
+    """
+    types: list[type[BaseException]] = [OSError, _HTTPException]
+    try:
+        import httplib2
+
+        types.append(httplib2.HttpLib2Error)
+    except ImportError:
+        pass
+    try:
+        from google.auth.exceptions import TransportError
+
+        types.append(TransportError)
+    except ImportError:
+        pass
+    return tuple(types)
+
+
+def _is_read_request(request: Any, original_method: str | None) -> bool:
+    """Whether a lost response can be replayed without repeating a side effect.
+
+    ``HttpRequest.execute()`` rewrites ``method`` from GET to POST in place when
+    the URI passes googleapiclient's 2048-character limit, moving the query
+    string into the body under an ``x-http-method-override: GET`` header.
+    Reading ``request.method`` after a failed attempt would therefore misread
+    long reads — Sheets ``values.batchGet`` over many ranges, long Drive/Gmail
+    ``q`` searches — as mutations and deny them their retry. Classifying from
+    the method captured before the first attempt is what avoids that; the
+    override header is a fallback for a request that arrives already executed,
+    whose ``method`` has therefore already been rewritten.
+    """
+    if original_method == 'GET':
+        return True
+    headers = getattr(request, 'headers', None) or {}
+    items = getattr(headers, 'items', None)
+    if items is None:
+        return False
+    return any(str(name).lower() == 'x-http-method-override' and value == 'GET' for name, value in items())
 
 
 def execute(svc: GoogleService, request: Any, *, binary: bool = False) -> Any:
     """Run an API request with exponential backoff on 429/5xx and rate-limit 403s.
 
-    Status-less failures (connection reset, TLS fault, timeout) are retried
-    with the same backoff for GET requests only. A mutation whose response was
-    lost may still have landed on Google's side, so it fails fast and leaves
-    the re-check to the caller rather than risking a duplicated side effect.
-    Requests run on a per-thread transport (see ``_request_http``).
+    Transport faults carrying no HTTP status (connection reset, TLS fault,
+    timeout) are retried with the same backoff for reads only. A mutation whose
+    response was lost may still have landed on Google's side, so it fails fast
+    and leaves the re-check to the caller rather than risking a duplicated side
+    effect. Errors that are not transport faults — a programming error raised
+    anywhere under the call — fail on the first attempt rather than sleeping
+    through four. Requests run on a per-thread transport (see ``_request_http``).
 
     ``binary=True`` returns the raw response (bytes from get_media/export_media);
     otherwise the JSON dict (or {} when the API returns no body). With 4 attempts
@@ -452,6 +540,8 @@ def execute(svc: GoogleService, request: Any, *, binary: bool = False) -> Any:
     """
     base_delay = 1.0
     http = _request_http(request)
+    # Captured up front: the first execute() may rewrite method in place.
+    is_read = _is_read_request(request, getattr(request, 'method', None))
     for attempt in range(4):
         try:
             result = request.execute(http=http) if http is not None else request.execute()
@@ -461,7 +551,7 @@ def execute(svc: GoogleService, request: Any, *, binary: bool = False) -> Any:
             if status and (int(status) in _RETRY_STATUSES or _is_rate_limit_403(exc)) and attempt < 3:
                 _time.sleep(base_delay * (2**attempt))
                 continue
-            if status is None and attempt < 3 and getattr(request, 'method', None) == 'GET':
+            if status is None and attempt < 3 and is_read and isinstance(exc, _transport_error_types()):
                 _time.sleep(base_delay * (2**attempt))
                 continue
             detail = getattr(exc, 'reason', None) or str(exc)

--- a/nodes/src/nodes/tool_google_workspace/google_client.py
+++ b/nodes/src/nodes/tool_google_workspace/google_client.py
@@ -416,6 +416,13 @@ _thread_transport = threading.local()
 # held key can never be collected while its entry is stored.
 _TRANSPORT_CACHE_MAX = 8
 
+# googleapiclient's build_http() gives the service transport a timeout (its own
+# DEFAULT_HTTP_TIMEOUT_SEC, or the global socket timeout when one is set). A bare
+# httplib2.Http() defaults to timeout=None, so rebuilding the transport without
+# carrying that over would let a hung connection block its worker thread forever
+# — and a read that never returns never raises, so the retry below never fires.
+_DEFAULT_HTTP_TIMEOUT_SEC = 60
+
 
 def _close_transport(http: Any) -> None:
     """Release the sockets an evicted transport still holds, best effort."""
@@ -441,6 +448,9 @@ def _request_http(request: Any):
     connection. Returns None (keep the request's own transport) when there is
     nothing to rebuild from.
 
+    The rebuilt transport inherits the service transport's timeout, so it cannot
+    silently fall back to httplib2's indefinite default.
+
     Entries are keyed by ``id(creds)``, which is safe precisely because the
     cached transport keeps that credential object alive: no stored key can be
     recycled onto a different credential. Past ``_TRANSPORT_CACHE_MAX`` the
@@ -450,6 +460,7 @@ def _request_http(request: Any):
     creds = getattr(shared, 'credentials', None)
     if creds is None:
         return None
+    timeout = getattr(getattr(shared, 'http', None), 'timeout', None) or _DEFAULT_HTTP_TIMEOUT_SEC
     try:
         import google_auth_httplib2
         import httplib2
@@ -464,7 +475,7 @@ def _request_http(request: Any):
     if http is not None:
         cache.move_to_end(key)
         return http
-    http = google_auth_httplib2.AuthorizedHttp(creds, http=httplib2.Http())
+    http = google_auth_httplib2.AuthorizedHttp(creds, http=httplib2.Http(timeout=timeout))
     cache[key] = http
     while len(cache) > _TRANSPORT_CACHE_MAX:
         _evicted_key, evicted = cache.popitem(last=False)

--- a/nodes/test/tool_google_workspace/test_google_client.py
+++ b/nodes/test/tool_google_workspace/test_google_client.py
@@ -294,3 +294,89 @@ def test_broker_refresh_invalid_expiry_raises_and_keeps_credentials_unchanged(se
         creds.refresh(None)
     # the half-update is the bug: neither token nor expiry may have changed
     assert creds.token == 'stale'
+
+
+def _scripted_request(method, outcomes):
+    """Request double whose execute() pops scripted outcomes in order."""
+    calls = {'count': 0, 'http_seen': []}
+
+    def execute(http=None):
+        calls['http_seen'].append(http)
+        index = min(calls['count'], len(outcomes) - 1)
+        calls['count'] += 1
+        outcome = outcomes[index]
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    request = types.SimpleNamespace(method=method, http=None, execute=execute)
+    return request, calls
+
+
+def test_execute_retries_transport_faults_for_get(monkeypatch, service):
+    monkeypatch.setattr(google_client._time, 'sleep', lambda seconds: None)
+    fault = OSError('[SSL] record layer failure (_ssl.c:2580)')
+    request, calls = _scripted_request('GET', [fault, fault, {'ok': True}])
+
+    assert google_client.execute(service, request) == {'ok': True}
+    assert calls['count'] == 3
+
+
+def test_execute_gives_up_on_get_after_four_transport_attempts(monkeypatch, service):
+    monkeypatch.setattr(google_client._time, 'sleep', lambda seconds: None)
+    fault = OSError('connection reset by peer')
+    request, calls = _scripted_request('GET', [fault])
+
+    with pytest.raises(ValueError, match='request failed'):
+        google_client.execute(service, request)
+    assert calls['count'] == 4
+
+
+def test_execute_does_not_retry_transport_faults_for_mutations(monkeypatch, service):
+    monkeypatch.setattr(google_client._time, 'sleep', lambda seconds: None)
+    request, calls = _scripted_request('POST', [OSError('connection reset by peer')])
+
+    with pytest.raises(ValueError, match='request failed'):
+        google_client.execute(service, request)
+    assert calls['count'] == 1
+
+
+def test_execute_uses_a_distinct_transport_per_thread(monkeypatch, service):
+    import threading
+
+    class FakeAuthorizedHttp:
+        def __init__(self, credentials, http=None):
+            self.credentials = credentials
+            self.http = http
+
+    fake_google_auth = types.SimpleNamespace(AuthorizedHttp=FakeAuthorizedHttp)
+    fake_httplib2 = types.SimpleNamespace(Http=lambda: object())
+    monkeypatch.setitem(sys.modules, 'google_auth_httplib2', fake_google_auth)
+    monkeypatch.setitem(sys.modules, 'httplib2', fake_httplib2)
+    monkeypatch.setattr(google_client, '_thread_transport', threading.local())
+
+    credentials = object()
+    per_thread = {}
+
+    def run(name):
+        seen = []
+        for _ in range(2):
+            request = types.SimpleNamespace(
+                method='GET',
+                http=types.SimpleNamespace(credentials=credentials),
+                execute=lambda http=None: seen.append(http) or {},
+            )
+            google_client.execute(service, request)
+        per_thread[name] = seen
+
+    threads = [threading.Thread(target=run, args=(i,)) for i in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    first, second = per_thread[0], per_thread[1]
+    assert first[0] is first[1], 'a thread must reuse its own transport'
+    assert second[0] is second[1], 'a thread must reuse its own transport'
+    assert first[0] is not second[0], 'threads must not share a transport'
+    assert isinstance(first[0], FakeAuthorizedHttp)

--- a/nodes/test/tool_google_workspace/test_google_client.py
+++ b/nodes/test/tool_google_workspace/test_google_client.py
@@ -350,7 +350,7 @@ def test_execute_uses_a_distinct_transport_per_thread(monkeypatch, service):
             self.http = http
 
     fake_google_auth = types.SimpleNamespace(AuthorizedHttp=FakeAuthorizedHttp)
-    fake_httplib2 = types.SimpleNamespace(Http=lambda: object())
+    fake_httplib2 = types.SimpleNamespace(Http=lambda timeout=None: object())
     monkeypatch.setitem(sys.modules, 'google_auth_httplib2', fake_google_auth)
     monkeypatch.setitem(sys.modules, 'httplib2', fake_httplib2)
     monkeypatch.setattr(google_client, '_thread_transport', threading.local())
@@ -423,6 +423,9 @@ def test_request_http_evicts_and_closes_beyond_the_cache_bound(monkeypatch):
     closed = []
 
     class FakeHttp:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+
         def close(self):
             closed.append(self)
 
@@ -475,3 +478,32 @@ def test_transport_error_types_picks_up_optional_dependencies_lazily(monkeypatch
         assert calls['count'] == 2, 'an httplib2 transport fault earns a retry'
     finally:
         google_client._transport_error_types.cache_clear()
+
+
+def test_request_http_preserves_the_service_transport_timeout(monkeypatch):
+    """A rebuilt transport must not fall back to httplib2's indefinite default."""
+    import threading
+
+    class FakeHttp:
+        def __init__(self, timeout=None):
+            self.timeout = timeout
+
+    class FakeAuthorizedHttp:
+        def __init__(self, credentials, http=None):
+            self.credentials = credentials
+            self.http = http
+
+    monkeypatch.setitem(sys.modules, 'google_auth_httplib2', types.SimpleNamespace(AuthorizedHttp=FakeAuthorizedHttp))
+    monkeypatch.setitem(sys.modules, 'httplib2', types.SimpleNamespace(Http=FakeHttp))
+    monkeypatch.setattr(google_client, '_thread_transport', threading.local())
+
+    def rebuilt(inner_timeout):
+        shared = types.SimpleNamespace(credentials=object(), http=FakeHttp(timeout=inner_timeout))
+        return google_client._request_http(types.SimpleNamespace(http=shared))
+
+    # googleapiclient's build_http() sets 60s by default; a global socket timeout
+    # overrides it. Either way the rebuilt transport must carry it over.
+    assert rebuilt(60).http.timeout == 60
+    assert rebuilt(12.5).http.timeout == 12.5
+    # No inner transport to read from: fall back rather than block forever.
+    assert rebuilt(None).http.timeout == google_client._DEFAULT_HTTP_TIMEOUT_SEC

--- a/nodes/test/tool_google_workspace/test_google_client.py
+++ b/nodes/test/tool_google_workspace/test_google_client.py
@@ -380,3 +380,98 @@ def test_execute_uses_a_distinct_transport_per_thread(monkeypatch, service):
     assert second[0] is second[1], 'a thread must reuse its own transport'
     assert first[0] is not second[0], 'threads must not share a transport'
     assert isinstance(first[0], FakeAuthorizedHttp)
+
+
+def test_execute_retries_a_long_get_rewritten_to_post(monkeypatch, service):
+    """A GET past MAX_URI_LENGTH is rewritten to POST in place, yet stays a read."""
+    monkeypatch.setattr(google_client._time, 'sleep', lambda seconds: None)
+    fault = OSError('[SSL] record layer failure (_ssl.c:2580)')
+    request, calls = _scripted_request('GET', [fault, fault, {'ok': True}])
+    scripted = request.execute
+
+    def execute(http=None):
+        request.method = 'POST'  # the in-place rewrite, before the network call
+        return scripted(http=http)
+
+    request.execute = execute
+
+    assert google_client.execute(service, request) == {'ok': True}
+    assert calls['count'] == 3
+
+
+def test_execute_treats_a_method_override_header_as_a_read(monkeypatch, service):
+    monkeypatch.setattr(google_client._time, 'sleep', lambda seconds: None)
+    request, calls = _scripted_request('POST', [OSError('connection reset by peer'), {'ok': True}])
+    request.headers = {'X-HTTP-Method-Override': 'GET'}
+
+    assert google_client.execute(service, request) == {'ok': True}
+    assert calls['count'] == 2
+
+
+def test_execute_does_not_retry_status_less_programming_errors(monkeypatch, service):
+    monkeypatch.setattr(google_client._time, 'sleep', lambda seconds: None)
+    request, calls = _scripted_request('GET', [ValueError('bad field name')])
+
+    with pytest.raises(ValueError, match='request failed'):
+        google_client.execute(service, request)
+    assert calls['count'] == 1, 'only transport faults earn a retry'
+
+
+def test_request_http_evicts_and_closes_beyond_the_cache_bound(monkeypatch):
+    import threading
+
+    closed = []
+
+    class FakeHttp:
+        def close(self):
+            closed.append(self)
+
+    class FakeAuthorizedHttp:
+        def __init__(self, credentials, http=None):
+            self.credentials = credentials
+            self.http = http
+
+    monkeypatch.setitem(sys.modules, 'google_auth_httplib2', types.SimpleNamespace(AuthorizedHttp=FakeAuthorizedHttp))
+    monkeypatch.setitem(sys.modules, 'httplib2', types.SimpleNamespace(Http=FakeHttp))
+    monkeypatch.setattr(google_client, '_thread_transport', threading.local())
+
+    def transport_for(creds):
+        return google_client._request_http(types.SimpleNamespace(http=types.SimpleNamespace(credentials=creds)))
+
+    bound = google_client._TRANSPORT_CACHE_MAX
+    credentials = [object() for _ in range(bound)]  # held, so ids stay distinct
+    for creds in credentials:
+        transport_for(creds)
+    assert len(google_client._thread_transport.by_creds) == bound
+    assert closed == []
+
+    # Touch the oldest so recency, not insertion order, decides what goes: a
+    # plain FIFO cache would evict credentials[0] here and pass a weaker test.
+    reused = transport_for(credentials[0])
+    overflow = object()
+    transport_for(overflow)
+
+    cache = google_client._thread_transport.by_creds
+    assert len(cache) == bound, 'the per-thread cache must stay bounded'
+    assert len(closed) == 1, 'the evicted transport must have its sockets closed'
+    assert id(credentials[1]) not in cache, 'the least recently used entry goes first'
+    assert cache[id(credentials[0])] is reused, 'a re-touched entry must survive'
+    assert id(overflow) in cache
+
+
+def test_transport_error_types_picks_up_optional_dependencies_lazily(monkeypatch, service):
+    """Resolved on first failure, so a late-imported httplib2 still counts."""
+    monkeypatch.setattr(google_client._time, 'sleep', lambda seconds: None)
+
+    class FakeHttpLib2Error(Exception):
+        """Neither an OSError nor an HTTPException, exactly like the real one."""
+
+    monkeypatch.setitem(sys.modules, 'httplib2', types.SimpleNamespace(HttpLib2Error=FakeHttpLib2Error))
+    google_client._transport_error_types.cache_clear()
+    try:
+        assert FakeHttpLib2Error in google_client._transport_error_types()
+        request, calls = _scripted_request('GET', [FakeHttpLib2Error('connection lost'), {'ok': True}])
+        assert google_client.execute(service, request) == {'ok': True}
+        assert calls['count'] == 2, 'an httplib2 transport fault earns a retry'
+    finally:
+        google_client._transport_error_types.cache_clear()


### PR DESCRIPTION
## Summary

- `execute()` now runs each request on a per-thread `AuthorizedHttp` keyed by the credential object, so parallel agent tool calls never share one httplib2 transport (httplib2 is not thread safe; sharing it surfaces as `[SSL] record layer failure` on the first parallel wave of a fresh task)
- status-less transport failures (connection reset, TLS fault, timeout) now retry with the existing backoff for GET requests only; mutations still fail fast, since a lost response does not mean a lost write and blind POST retry can duplicate the side effect
- 4 new unit tests: GET transport retry, GET exhaustion, no retry for mutations, distinct transport per thread

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally (`pytest nodes/test/tool_google_workspace/`: 349 passed, 20 skipped)
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #2034


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for Google Workspace read requests by retrying temporary transport failures, including long-running reads.
  - Ensured update and mutation requests fail promptly when transport errors occur.
  - Improved concurrent request handling by isolating network connections per thread.
  - Standardized error reporting for unsuccessful requests and avoided retries for programming errors.
  - Limited cached network connections and closed evicted connections to support stable long-running operation.

- **Tests**
  - Added coverage for retries, failures, successful responses, long-running reads, connection isolation, timeout preservation, and cache behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->