### PR TITLE
fix(nodes): clamp agent_rocketride max_waves to its schema bounds

### DIFF
--- a/nodes/src/nodes/agent_rocketride/rocketride_agent.py
+++ b/nodes/src/nodes/agent_rocketride/rocketride_agent.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from rocketlib import debug, error
+from rocketlib import debug, error, warning
 
 from ai.common.agent import AgentBase, AgentContext
 from ai.common.agent.types import AgentRunResult
@@ -47,6 +47,31 @@ from .executor import execute_wave, resolve_answer_refs
 # Prevents runaway loops if the LLM fails to converge on done=true.
 # Can be overridden via the ``max_waves`` node configuration field.
 _DEFAULT_MAX_WAVES = 10
+
+# Bounds declared for ``max_waves`` in services.json. Schema minimum/maximum
+# are not enforced at config validation, so an out-of-range value (e.g. 60)
+# used to be accepted and run as-is; clamp here so the schema's stated
+# contract holds at runtime.
+_MAX_WAVES_BOUNDS = (1, 50)
+
+
+def _resolve_max_waves(value: Any) -> int:
+    """Return ``max_waves`` as an int clamped to the services.json bounds.
+
+    Non-numeric values fall back to the default rather than failing later
+    inside the wave loop.
+    """
+    lo, hi = _MAX_WAVES_BOUNDS
+    try:
+        waves = int(value)
+    except (TypeError, ValueError):
+        warning(f'agent_rocketride: max_waves={value!r} is not an integer; using {_DEFAULT_MAX_WAVES}')
+        return _DEFAULT_MAX_WAVES
+    if waves < lo or waves > hi:
+        clamped = max(lo, min(hi, waves))
+        warning(f'agent_rocketride: max_waves={waves} is outside the schema bounds [{lo}, {hi}]; using {clamped}')
+        return clamped
+    return waves
 
 
 class RocketRideDriver(AgentBase):
@@ -71,7 +96,7 @@ class RocketRideDriver(AgentBase):
         """Initialize the Wave driver and load host services."""
         super().__init__(iGlobal)
         config = Config.getNodeConfig(iGlobal.glb.logicalType, iGlobal.glb.connConfig)
-        self._max_waves = config.get('max_waves', _DEFAULT_MAX_WAVES)
+        self._max_waves = _resolve_max_waves(config.get('max_waves', _DEFAULT_MAX_WAVES))
 
     # ------------------------------------------------------------------
     # Main driver

--- a/nodes/test/agent_rocketride/test_config_bounds.py
+++ b/nodes/test/agent_rocketride/test_config_bounds.py
@@ -1,0 +1,78 @@
+# =============================================================================
+# RocketRide Engine
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit tests for agent_rocketride config bounds (max_waves clamping)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_NODES_SRC = Path(__file__).resolve().parents[2] / 'src'
+if str(_NODES_SRC) not in sys.path:
+    sys.path.insert(0, str(_NODES_SRC))
+
+# Self-sufficient bootstrap: importing the module pulls engine runtime modules
+# (depends/rocketlib/ai.common) plus jmespath via the executor; stub them if
+# absent so this file never depends on a sibling test having run first, then
+# drop what we added.
+_added = []
+for _name in (
+    'depends',
+    'rocketlib',
+    'jmespath',
+    'ai',
+    'ai.common',
+    'ai.common.agent',
+    'ai.common.agent.types',
+    'ai.common.config',
+    'ai.common.schema',
+    'ai.common.utils',
+):
+    if _name not in sys.modules:
+        _stub = MagicMock()
+        if _name == 'depends':
+            _stub.depends = lambda *a, **k: None
+        if _name == 'ai.common.agent':
+            _stub.AgentBase = object
+        sys.modules[_name] = _stub
+        _added.append(_name)
+
+_fresh_nodes = 'nodes' not in sys.modules
+from nodes.agent_rocketride import rocketride_agent
+
+for _name in _added:
+    sys.modules.pop(_name, None)
+if _fresh_nodes:
+    for _name in [k for k in list(sys.modules) if k == 'nodes' or k.startswith('nodes.')]:
+        sys.modules.pop(_name, None)
+
+
+def test_in_range_value_passes_through():
+    assert rocketride_agent._resolve_max_waves(25) == 25
+    assert rocketride_agent._resolve_max_waves(1) == 1
+    assert rocketride_agent._resolve_max_waves(50) == 50
+
+
+def test_value_above_schema_maximum_is_clamped():
+    assert rocketride_agent._resolve_max_waves(60) == 50
+
+
+def test_value_below_schema_minimum_is_clamped():
+    assert rocketride_agent._resolve_max_waves(0) == 1
+    assert rocketride_agent._resolve_max_waves(-5) == 1
+
+
+def test_non_numeric_value_falls_back_to_default():
+    assert rocketride_agent._resolve_max_waves('lots') == rocketride_agent._DEFAULT_MAX_WAVES
+    assert rocketride_agent._resolve_max_waves(None) == rocketride_agent._DEFAULT_MAX_WAVES
+
+
+def test_numeric_string_is_accepted_and_clamped():
+    assert rocketride_agent._resolve_max_waves('30') == 30
+    assert rocketride_agent._resolve_max_waves('99') == 50


### PR DESCRIPTION
## Summary

- clamp `max_waves` to the `[1, 50]` bounds declared in `services.json`, with a warning when a value is clamped; previously an out-of-range value (observed: 60) was accepted and used as-is
- non-numeric values fall back to the default (10) instead of failing later inside the wave loop
- 5 new unit tests in `nodes/test/agent_rocketride/` (new test package, bootstrap mirrors the existing google_client/agent_crewai pattern)

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally (`pytest nodes/test/agent_rocketride/`: 5 passed; `tool_google_workspace` neighbors unaffected: 349 passed. The 4 pre-existing `agent_crewai` failures in a bare venv are `ModuleNotFoundError: ai` and occur without this change)
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #2033


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of maximum wave configuration values.
  * Invalid values now default safely, while values outside supported limits are automatically adjusted.
  * Numeric values provided as text are now accepted.

* **Tests**
  * Added coverage for valid values, invalid inputs, numeric strings, and lower and upper boundary enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->