### PR TITLE
fix(client-python): import NotRequired from typing_extensions for 3.10 support

### DIFF
--- a/packages/client-python/pyproject.toml
+++ b/packages/client-python/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "websockets>=11.0.0",
     "aiofiles>=23.0.0",
     "pydantic>=2.0.0",
+    "typing_extensions>=4.0.0",
 ]
 requires-python = ">=3.10"
 license = "MIT"

--- a/packages/client-python/src/rocketride/types/billing.py
+++ b/packages/client-python/src/rocketride/types/billing.py
@@ -36,7 +36,9 @@ Types Defined:
     PromoRedemption: Result of redeeming a credit-grant code.
 """
 
-from typing import Literal, NotRequired, TypedDict
+from typing import Literal, TypedDict
+
+from typing_extensions import NotRequired
 
 
 # =============================================================================

--- a/packages/client-python/src/rocketride/types/client.py
+++ b/packages/client-python/src/rocketride/types/client.py
@@ -55,7 +55,9 @@ Usage:
         print(f"Event: {event['event']}")
 """
 
-from typing import Any, Callable, Awaitable, NotRequired, TypedDict, Literal, Optional, Union
+from typing import Any, Callable, Awaitable, TypedDict, Literal, Optional, Union
+
+from typing_extensions import NotRequired
 
 
 class TraceInfo(TypedDict):


### PR DESCRIPTION
## Description

Fixes #1820. `packages/client-python/pyproject.toml` declares `requires-python = ">=3.10"` and ships the `Programming Language :: Python :: 3.10` trove classifier, but `types/billing.py` and `types/client.py` both import `NotRequired` directly from `typing`, which only gained it in Python 3.11 (PEP 655). On 3.10, `import rocketride` fails outright.

**One correction to the issue as filed:** it identifies `billing.py` as the sole offender ("Scope is exactly one file... billing.py holds all 17 NotRequired uses"). `types/client.py` has the same unconditional `from typing import ..., NotRequired, ...` (line 58, used at line 227 for `developerId`). Since `types/__init__.py` imports `client` before `billing`, the reported traceback actually surfaces in `client.py` first — fixing `billing.py` alone would not have resolved the reported error. Both files are fixed here.

## Fix

- `from typing import ..., NotRequired, ...` → split into a `typing` import (unaffected names) plus `from typing_extensions import NotRequired`, in both files.
- Added `typing_extensions>=4.0.0` to `dependencies` in `pyproject.toml` — it was previously only present transitively via `pydantic`, not something this package declared or controlled (matches the issue's own note on this).

## Testing performed

Reproduced and verified against real interpreters, not just by reading the code:

```bash
# Before the fix
python3.10 -c "import sys; sys.path.insert(0,'packages/client-python/src'); import rocketride"
# ImportError: cannot import name 'NotRequired' from 'typing'

# After the fix
python3.10 -c "import sys; sys.path.insert(0,'packages/client-python/src'); import rocketride"
# OK

python3.11 -c "import sys; sys.path.insert(0,'packages/client-python/src'); import rocketride"
# OK (before and after — no regression on newer interpreters)
```

Also ran the full `client-python` test suite before and after this change:

```
48 failed, 52 passed, 6 skipped, 21 errors
```

Identical counts on both a clean `develop` checkout and this branch — the failures are pre-existing integration tests that require a live RocketRide engine connection, unrelated to this change.

## Breaking changes

None. Adds one new direct dependency (`typing_extensions`) that was already present transitively via `pydantic`, so no new resolution constraint in practice.

Fixes #1820

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python package compatibility across supported Python versions.
  * Resolved typing-related import issues affecting billing and client type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->