### PR TITLE
Fix/laser sdk version

### DIFF
--- a/nodes/src/nodes/constraints.lock
+++ b/nodes/src/nodes/constraints.lock
@@ -730,7 +730,7 @@ language-tags==1.3.1
     # via csvw
 lark==1.3.1
     # via cel-python
-laser-sdk==0.0.1rc21
+laser-sdk==0.1.1
     # via -r nodes/src/nodes/tool_laserdata_memory/requirements.txt
 leb128==1.0.9
     # via asynch

--- a/nodes/src/nodes/tool_laserdata_memory/README.md
+++ b/nodes/src/nodes/tool_laserdata_memory/README.md
@@ -36,8 +36,9 @@ destructive clear/reset tool.
 
 ## SDK contract provenance
 
-Built against **`laser-sdk==0.0.1rc21`** (PyPI, pinned in `requirements.txt`). rc20+ speaks only
-Apache Iggy's VSR cluster protocol (the upcoming clustering wire format), so the server must be a
+Pinned to **`laser-sdk==0.1.1`** (PyPI, in `requirements.txt`); the contract below was verified
+against `0.0.1rc21` and has not been re-checked on 0.1.1. rc20+ speaks only Apache Iggy's VSR
+cluster protocol (the upcoming clustering wire format), so the server must be a
 VSR-enabled build: LaserData Cloud deployments **created on/after 2026-07-31** serve it (older
 deployments must be recreated — confirmed with the LaserData team), as does
 [laserdata/laser-stack](https://github.com/laserdata/laser-stack) locally. The full

--- a/nodes/src/nodes/tool_laserdata_memory/requirements.txt
+++ b/nodes/src/nodes/tool_laserdata_memory/requirements.txt
@@ -2,4 +2,7 @@
 # deployments created on/after 2026-07-31 serve VSR (verified live: full
 # memory round-trip on rc21); older deployments must be recreated, and a
 # local server must be a VSR-enabled build (e.g. laserdata/laser-stack).
-laser-sdk==0.0.1rc21
+# Pin moved rc21 -> 0.1.1 so it resolves alongside sibling LaserData nodes
+# in the shared constraint compile (#2030). The VSR notes above were
+# verified on rc21 and have not been re-checked on 0.1.1.
+laser-sdk==0.1.1


### PR DESCRIPTION
## Summary

- Bump `laser-sdk` pin in `tool_laserdata_memory` from `0.0.1rc21` to `0.1.1` so it resolves alongside sibling LaserData nodes in the shared constraint compile
- Update README provenance section to reflect the new pin

## Type

fix

## Testing

- [ ] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #2030

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the Laser SDK dependency to version `0.1.1`.
  - Clarified SDK contract documentation, including the version used for prior verification and the need for re-checking against the updated version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->