### PR TITLE
fix(canvas): keep unloaded node configs invalid

### DIFF
--- a/apps/shared/src/components/canvas/context/FlowGraphContext.tsx
+++ b/apps/shared/src/components/canvas/context/FlowGraphContext.tsx
@@ -676,8 +676,9 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 	 * checking whether its service schema requires configuration.
 	 *
 	 * A node requires config when its Pipe schema has properties
-	 * (excluding the hideForm flag). Nodes without schemas or with
-	 * hideForm set are considered valid by default.
+	 * (excluding the hideForm flag). A summary-only catalog entry stays
+	 * invalid until its full schema arrives; fully resolved nodes without
+	 * configurable fields are valid by default.
 	 *
 	 * Matches the logic from the old factory code in factories.ts.
 	 */
@@ -687,6 +688,10 @@ export function FlowGraphProvider({ children }: IFlowGraphProviderProps): ReactE
 			const service = servicesJson?.[data.provider];
 			if (!service) return true;
 			const pipe = service.Pipe as { schema?: { properties?: Record<string, unknown> } } | undefined;
+			// The catalog initially contains summaries only. Until the full
+			// definition arrives, assume a node needs configuration rather than
+			// briefly marking it valid and allowing it to run without required fields.
+			if (!pipe) return false;
 			return hasConfigurableSchema(pipe) ? false : true;
 		},
 		[servicesJson]


### PR DESCRIPTION
## Summary

- Fixed a timing issue where a newly added node could briefly look fully configured before RocketRide had loaded its full config schema.
- This was especially confusing with the OpenAI node: it could show a valid/white cog and be runnable even though no API key had been set, then fail later with an OpenAI “Missing credentials” error.
- Nodes now stay invalid while their full schema is loading. Once it loads, the existing form validation checks the required fields normally.

## Type

Fix

## Testing

- [ ] Tests added or updated
- [x] Target file passes ESLint
- [x] `git diff --check` passes
- [ ] `./builder test` passes

## Checklist

- [x] Commit message follows conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (not needed)
- [ ] Breaking changes documented (none)

## Linked Issue

Fixes #2031

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node configuration validation when service details are unavailable.
  * Nodes based only on catalog summaries now remain unconfigured until their full configuration schema is loaded.
  * Resolved services without configurable fields continue to be treated as valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->