### PR TITLE
fix(chroma): default to local profile and correct local port to 8000

### DIFF
--- a/nodes/src/nodes/store_chroma/services.json
+++ b/nodes/src/nodes/store_chroma/services.json
@@ -175,7 +175,7 @@
 		},
 		"vector.local.port": {
 			"type": ["number", "string"],
-			"default": "8330",
+			"default": "8000",
 			"description": "Port number. Enter a plain integer such as 8000, or an env-var placeholder like ${ROCKETRIDE_CHROMA_PORT}. Placeholders resolve to a string at run time, so this field accepts both a number and a string; the node coerces the value to an integer before connecting, so either form works."
 		},
 		//
@@ -203,7 +203,7 @@
 			"title": "Type of chroma host",
 			"description": "Connect to...",
 			"type": "string",
-			"default": "cloud",
+			"default": "local",
 			"enum": ["*>preconfig.profiles.*.title"],
 			"conditional": [
 				{


### PR DESCRIPTION
## What

The Chroma vector store node defaults to `cloud` profile with port `8330`. Both are wrong for the most common case — a developer running Chroma locally for the first time.

## Problem

I ran into this while building a RAG pipeline during onboarding. After selecting Chroma in the RAG Chat template, the pipeline immediately failed with "could not connect to a Chroma server" because:

1. The default profile is `cloud`, which requires ChromaDB Cloud credentials most users don't have yet
2. The default local port is `8330`, but ChromaDB's actual default is `8000`

Both issues are silent — no error message tells you what to change.

## Fix

- Default profile: `cloud` → `local`
- Default local port: `8330` → `8000`
- Updated README schema table to match

## Testing

Verified locally: after this change, a fresh RAG Chat pipeline with Chroma connects to a local `chroma run` instance on first try without any config changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default local Chroma connection port to `8000`.
  * Changed the default Chroma profile from cloud to local.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->