### PR TITLE
docs(chat): expand README with usage steps and troubleshooting

### DIFF
--- a/nodes/src/nodes/webhook/chat/README.md
+++ b/nodes/src/nodes/webhook/chat/README.md
@@ -3,14 +3,13 @@ title: Chat
 date: 2026-04-09
 sidebar_position: 1
 ---
-
 <head>
   <title>Chat - RocketRide Documentation</title>
 </head>
 
 ## What it does
 
-Source node that serves a web-based chat interface. Users open the chat URL in a browser, type questions, and each submission flows through the pipeline as a `questions` lane. Results are returned in the chat window.
+Source node that serves a web-based chat interface. Users open the chat URL in a browser, type questions, and each submission flows through the pipeline as a questions lane. Results are returned in the chat window.
 
 After the pipeline starts, the Project Log displays the chat URL and public authorization key.
 
@@ -18,8 +17,27 @@ After the pipeline starts, the Project Log displays the chat URL and public auth
 
 | Lane in | Lane out    | Description                                               |
 | ------- | ----------- | --------------------------------------------------------- |
-| -       | `questions` | Each message submitted via the chat UI becomes a question |
+| -       | questions   | Each message submitted via the chat UI becomes a question |
 
 ## Configuration
 
 None. The chat URL and authorization key are generated automatically when the pipeline starts.
+
+## Usage
+
+1. Add a Chat source node to your pipeline.
+2. Connect its questions output to a downstream node (e.g. an LLM or embedding node).
+3. Press the play button on the Chat node to start it.
+4. Click Chat now to open the chat interface, or use the URL shown in the Project Log.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| ------- | ----- | --- |
+| Request URL is missing an http or https protocol | The Chat node started before the pipeline server was fully ready, or the node has no downstream connection. | Ensure at least one node is connected to the Chat questions output, then restart the pipeline. |
+| Chat opens but responses are empty | The downstream LLM node is missing an API key or is misconfigured. | Open the LLM node settings and verify the API key and model selection. |
+| Chat window does not open | Browser popup blocker prevented the window. | Copy the chat URL from the Project Log and open it manually. |
+
+## Combining with other sources
+
+A pipeline can have both a Chat and a Webhook source. Use Webhook for document ingestion and Chat for interactive Q&A. Both feed into the same downstream nodes and the pipeline routes data by lane type automatically.


### PR DESCRIPTION
## What

The Chat source node README was 25 lines with no usage guidance or troubleshooting.

## Why

While building a RAG pipeline, I hit the "Request URL is missing http" error on the Chat node. Nothing in the docs explained what caused it or how to fix it. Took trial and error to figure out it needed a downstream connection before starting.

## Changes

- Added step-by-step usage instructions
- Added troubleshooting table covering three common issues:
  - Missing URL protocol error
  - Empty responses from chat
  - Popup blocker preventing chat window
- Added note on combining Chat with Webhook sources in RAG pipelines

All three issues came from my own experience building a Medical RAG app on RocketRide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added usage instructions for setting up and launching the Chat node.
  * Added troubleshooting guidance for common connection, response, and popup-blocking issues.
  * Documented how to combine Chat and Webhook sources in the same pipeline.
  * Clarified the presentation of the `questions` lane identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->