### PR TITLE
fix(tool_http_request): block SSRF destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - media stream descriptors + end-to-end source provenance (#1525)
 
 ### Fixed
+- **nodes**: harden HTTP Request SSRF guardrails for URL credentials and hostname-safe whitelist boundaries; regexes now match canonical URL starts and fail closed on unsupported or ambiguous authority syntax, so unrestricted authority and search-style patterns may require migration (#2060)
 - **agent**: optional require_tool_call runtime fabrication guard (#1490)
 - **ai**: install test deps via depends() so engine constraints apply (#1466) (#1471)
 - **ai**: migrate GPU import guard to find_spec/exec_module (Python 3.12+) (#1460)

--- a/nodes/src/nodes/requirements.txt
+++ b/nodes/src/nodes/requirements.txt
@@ -13,13 +13,8 @@ cryptography>=46.0.7,<47
 # Pinned to cover GHSA-65pc-fj4g-8rjx (crafted input to idna.encode() can
 # bypass the CVE-2024-3651 fix), patched in 3.10.
 idna>=3.10
-# HTTPAdapter.get_connection_with_tls_context is required by tool_http_request
-# to pin validated DNS addresses and prevent DNS rebinding. 2.32.4 also fixes
-# CVE-2024-47081 for other Requests consumers sharing this environment.
-requests>=2.32.4,<3
-# The pinned-address adapter depends on urllib3 2.7 connection hooks. Keep the
-# minor line bounded so an internal transport change cannot silently bypass it.
-urllib3>=2.7,<2.8
+requests
+urllib3
 numpy
 httpx
 fastapi

--- a/nodes/src/nodes/requirements.txt
+++ b/nodes/src/nodes/requirements.txt
@@ -13,7 +13,9 @@ cryptography>=46.0.7,<47
 # Pinned to cover GHSA-65pc-fj4g-8rjx (crafted input to idna.encode() can
 # bypass the CVE-2024-3651 fix), patched in 3.10.
 idna>=3.10
-requests
+# HTTPAdapter.get_connection_with_tls_context is required by tool_http_request
+# to pin validated DNS addresses and prevent DNS rebinding.
+requests>=2.32.3
 urllib3
 numpy
 httpx

--- a/nodes/src/nodes/requirements.txt
+++ b/nodes/src/nodes/requirements.txt
@@ -14,8 +14,9 @@ cryptography>=46.0.7,<47
 # bypass the CVE-2024-3651 fix), patched in 3.10.
 idna>=3.10
 # HTTPAdapter.get_connection_with_tls_context is required by tool_http_request
-# to pin validated DNS addresses and prevent DNS rebinding.
-requests>=2.32.3,<3
+# to pin validated DNS addresses and prevent DNS rebinding. 2.32.4 also fixes
+# CVE-2024-47081 for other Requests consumers sharing this environment.
+requests>=2.32.4,<3
 # The pinned-address adapter depends on urllib3 2.7 connection hooks. Keep the
 # minor line bounded so an internal transport change cannot silently bypass it.
 urllib3>=2.7,<2.8

--- a/nodes/src/nodes/requirements.txt
+++ b/nodes/src/nodes/requirements.txt
@@ -15,8 +15,10 @@ cryptography>=46.0.7,<47
 idna>=3.10
 # HTTPAdapter.get_connection_with_tls_context is required by tool_http_request
 # to pin validated DNS addresses and prevent DNS rebinding.
-requests>=2.32.3
-urllib3
+requests>=2.32.3,<3
+# The pinned-address adapter depends on urllib3 2.7 connection hooks. Keep the
+# minor line bounded so an internal transport change cannot silently bypass it.
+urllib3>=2.7,<2.8
 numpy
 httpx
 fastapi

--- a/nodes/src/nodes/tool_http_request/IGlobal.py
+++ b/nodes/src/nodes/tool_http_request/IGlobal.py
@@ -73,7 +73,9 @@ class IGlobal(IGlobalBase):
             if cfg.get(flag, method in ('GET', 'POST', 'PUT', 'PATCH', 'DELETE')):
                 enabled.add(method)
 
-        raw_whitelist = cfg.get('urlWhitelist') or []
+        raw_whitelist = cfg.get('urlWhitelist')
+        if raw_whitelist is None or raw_whitelist == '':
+            raw_whitelist = []
         if not isinstance(raw_whitelist, list):
             import json
 
@@ -84,15 +86,19 @@ class IGlobal(IGlobalBase):
             except (json.JSONDecodeError, TypeError, ValueError) as e:
                 raise ValueError(f'urlWhitelist is malformed and cannot be parsed: {e}') from e
         patterns: list[re.Pattern] = []
-        for row in raw_whitelist:
+        for index, row in enumerate(raw_whitelist):
             if not hasattr(row, 'get'):
-                continue
-            pat_str = str(row.get('whitelistPattern') or '').strip()
-            if pat_str:
-                try:
-                    patterns.append(re.compile(pat_str))
-                except re.error as e:
-                    warning(f'Invalid URL whitelist regex {pat_str!r}: {e}')
+                raise ValueError(f'urlWhitelist entry {index + 1} must be an object')
+            raw_pattern = row.get('whitelistPattern')
+            if not isinstance(raw_pattern, str):
+                raise ValueError(f'urlWhitelist entry {index + 1} whitelistPattern must be a string')
+            pat_str = raw_pattern.strip()
+            if not pat_str:
+                raise ValueError(f'urlWhitelist entry {index + 1} must contain a non-empty whitelistPattern')
+            try:
+                patterns.append(re.compile(pat_str))
+            except re.error as e:
+                raise ValueError(f'Invalid URL whitelist regex {pat_str!r}: {e}') from e
 
         return enabled, patterns
 
@@ -134,7 +140,7 @@ class IGlobal(IGlobalBase):
 
             _, patterns = self._build_guardrails(cfg)
             if not patterns:
-                warning('URL whitelist is empty — all URLs will be allowed')
+                warning('URL whitelist is empty — all public URLs will be allowed')
         except Exception as e:
             warning(str(e))
 

--- a/nodes/src/nodes/tool_http_request/IGlobal.py
+++ b/nodes/src/nodes/tool_http_request/IGlobal.py
@@ -63,6 +63,11 @@ class IGlobal(IGlobalBase):
 
         cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
         self.enabled_methods, self.url_patterns = self._build_guardrails(cfg)
+        if self.url_patterns:
+            warning(
+                'URL whitelist patterns now require a supported, explicit authority boundary; '
+                'review existing patterns before making requests'
+            )
         self.rate_limiter = self._build_rate_limiter(cfg)
 
     @staticmethod
@@ -94,7 +99,7 @@ class IGlobal(IGlobalBase):
                 raise ValueError(f'urlWhitelist entry {index + 1} whitelistPattern must be a string')
             pat_str = raw_pattern.strip()
             if not pat_str:
-                raise ValueError(f'urlWhitelist entry {index + 1} must contain a non-empty whitelistPattern')
+                continue
             try:
                 patterns.append(re.compile(pat_str))
             except re.error as e:

--- a/nodes/src/nodes/tool_http_request/IInstance.py
+++ b/nodes/src/nodes/tool_http_request/IInstance.py
@@ -35,7 +35,7 @@ import json
 
 from rocketlib import IInstanceBase, tool_function
 
-from .http_client import execute_request
+from .http_client import _canonicalize_url, _resolve_path_params, execute_request
 from .IGlobal import IGlobal
 
 
@@ -84,7 +84,7 @@ class IInstance(IInstanceBase):
                 },
                 'path_params': {
                     'type': 'object',
-                    'description': 'Path parameter replacements (e.g. {"id": "123"} replaces :id in the URL)',
+                    'description': 'Path-only parameter replacements (e.g. {"id": "123"} replaces :id in the URL path)',
                     'additionalProperties': {'type': 'string'},
                 },
                 'auth': {
@@ -151,8 +151,9 @@ class IInstance(IInstanceBase):
         # Expand convenience shortcuts into canonical form
         _normalize_shortcuts(args)
 
-        # Validate guardrails from config
-        self._validate_guardrails(args)
+        # Resolve path-only placeholders first so the whitelist sees the exact
+        # URL that will be sent.
+        resolved_url = self._validate_guardrails(args)
 
         # Enforce rate limits before executing the request
         rate_limiter = self.IGlobal.rate_limiter
@@ -161,10 +162,10 @@ class IInstance(IInstanceBase):
 
         try:
             return execute_request(
-                url=args.get('url', ''),
+                url=resolved_url,
                 method=args.get('method', 'GET'),
                 query_params=args.get('query_params'),
-                path_params=args.get('path_params'),
+                path_params=None,
                 headers=args.get('headers'),
                 auth=args.get('auth'),
                 body=args.get('body'),
@@ -194,8 +195,9 @@ class IInstance(IInstanceBase):
         url = args.get('url')
         if not url or not isinstance(url, str):
             raise ValueError('url is required and must be a non-empty string')
-        if self.IGlobal.url_patterns and not any(p.search(url) for p in self.IGlobal.url_patterns):
-            raise ValueError(f'URL "{url}" does not match any allowed URL pattern.')
+        resolved_url = _canonicalize_url(_resolve_path_params(url, args.get('path_params')))
+        if self.IGlobal.url_patterns and not any(p.match(resolved_url) for p in self.IGlobal.url_patterns):
+            raise ValueError(f'URL "{resolved_url}" does not match any allowed URL pattern.')
 
         auth = args.get('auth')
         if auth is not None:
@@ -234,6 +236,8 @@ class IInstance(IInstanceBase):
                     raise ValueError(
                         f'body.raw.content_type must be one of {sorted(valid_raw_content_types)}; got {ct!r}'
                     )
+
+        return resolved_url
 
 
 def _normalize_shortcuts(args):

--- a/nodes/src/nodes/tool_http_request/IInstance.py
+++ b/nodes/src/nodes/tool_http_request/IInstance.py
@@ -24,9 +24,9 @@
 """
 HTTP Request tool node instance.
 
-Exposes a single ``http_request`` tool that can call any HTTP API endpoint.
-Security guardrails (allowed methods + URL whitelist) are enforced before
-every request.
+Exposes a single ``http_request`` tool that can call public HTTP API endpoints.
+Security guardrails (allowed methods, URL whitelist, and public-network-only
+destinations) are enforced before every request.
 """
 
 from __future__ import annotations
@@ -139,6 +139,7 @@ class IInstance(IInstanceBase):
             'For JSON bodies, pass "body_json" as a JSON object (e.g. {"name": "foo"}) — it is serialized automatically. '
             'For bearer auth, pass "bearer_token" as a string. '
             'For basic auth, pass "basic_auth": {"username": "...", "password": "..."}. '
+            'Non-public network destinations are blocked, and redirects are returned without being followed. '
             'Optional: "headers", "query_params", "path_params", "timeout" (seconds, default 30, max 300).'
         ),
     )

--- a/nodes/src/nodes/tool_http_request/IInstance.py
+++ b/nodes/src/nodes/tool_http_request/IInstance.py
@@ -32,11 +32,306 @@ destinations) are enforced before every request.
 from __future__ import annotations
 
 import json
+import re
+from urllib.parse import urlsplit
 
 from rocketlib import IInstanceBase, tool_function
 
-from .http_client import _canonicalize_url, _resolve_path_params, execute_request
+from .http_client import _build_final_url, execute_request
 from .IGlobal import IGlobal
+
+
+def _match(pattern, url):
+    """Apply a configured regex without interpreting or rewriting its syntax."""
+    try:
+        return pattern.match(url)
+    except (TypeError, ValueError):
+        return None
+
+
+def _take_literal_scheme(source):
+    """Return an exact HTTP(S) scheme and the first authority-source index."""
+    position = 2 if source.startswith(r'\A') else 1 if source.startswith('^') else 0
+    for scheme in ('https', 'http'):
+        prefix = f'{scheme}://'
+        if source.startswith(prefix, position):
+            return scheme, position + len(prefix)
+    return None
+
+
+def _take_exact_host(source, position):
+    """Parse one literal/escaped DNS, IPv4, or bracketed-IPv6 host."""
+    bracketed = source.startswith(r'\[', position)
+    if bracketed:
+        position += 2
+
+    literal = []
+    while position < len(source):
+        if bracketed and source.startswith(r'\]', position):
+            if not literal:
+                return None
+            return f'[{"".join(literal)}]', position + 2
+
+        character = source[position]
+        if character == '\\':
+            if position + 1 < len(source) and source[position + 1] in '.-_':
+                literal.append(source[position + 1])
+                position += 2
+                continue
+            break
+
+        allowed = character.isascii() and (character.isalnum() or character in '-_%')
+        if bracketed:
+            allowed = allowed or character == ':'
+        if not allowed:
+            break
+        literal.append(character)
+        position += 1
+
+    if bracketed or not literal:
+        return None
+    return ''.join(literal), position
+
+
+def _take_positive_numeric_quantifier(source, position):
+    """Return a quantifier endpoint and its inclusive length bounds."""
+    if position < len(source) and source[position] == '+':
+        return position + 1, 1, None
+    if position >= len(source) or source[position] != '{':
+        return position, 1, 1
+
+    end = source.find('}', position + 1)
+    if end < 0:
+        return None
+    fields = source[position + 1 : end].split(',')
+    if len(fields) > 2 or not fields[0].isdigit():
+        return None
+    if len(fields) == 2 and fields[1] and not fields[1].isdigit():
+        return None
+    try:
+        minimum = int(fields[0])
+        maximum = int(fields[1]) if len(fields) == 2 and fields[1] else None
+    except (ValueError, OverflowError):
+        return None
+    if minimum < 1 or maximum is not None and maximum < minimum:
+        return None
+    if len(fields) == 1:
+        maximum = minimum
+    return end + 1, minimum, maximum
+
+
+def _take_numeric_port(source, position):
+    """Parse an exact port or a nonempty decimal-digit language."""
+    digit_start = position
+    while position < len(source) and source[position].isdigit():
+        position += 1
+    if position > digit_start:
+        return position, source[digit_start:position], None, None
+    if not source.startswith('[0-9]', position):
+        return None
+    quantifier = _take_positive_numeric_quantifier(source, position + len('[0-9]'))
+    if quantifier is None:
+        return None
+    end, minimum, maximum = quantifier
+    return end, None, minimum, maximum
+
+
+def _take_port_policy(source, position):
+    """Parse no port, a required numeric port, or an optional numeric port."""
+    if source.startswith('(?::', position):
+        port_policy = _take_numeric_port(source, position + len('(?::'))
+        if port_policy is not None and source.startswith(')?', port_policy[0]):
+            return port_policy[0] + 2, True, port_policy[1:]
+        return None
+    if position < len(source) and source[position] == ':':
+        port_policy = _take_numeric_port(source, position + 1)
+        if port_policy is None:
+            return None
+        return port_policy[0], False, port_policy[1:]
+    return position, False, None
+
+
+def _explicit_port_text(netloc):
+    """Return the canonical authority's explicit port without normalizing it."""
+    if netloc.startswith('['):
+        close = netloc.find(']')
+        suffix = netloc[close + 1 :]
+        return suffix[1:] if suffix.startswith(':') else None
+    separator = netloc.rfind(':')
+    return netloc[separator + 1 :] if separator >= 0 else None
+
+
+def _port_policy_matches(port_policy, optional, actual_port):
+    """Return whether an explicit port satisfies a recognized source policy."""
+    if port_policy is None:
+        return actual_port is None
+    if actual_port is None:
+        return optional
+    literal, minimum, maximum = port_policy
+    if literal is not None:
+        return actual_port == literal
+    return actual_port.isdigit() and len(actual_port) >= minimum and (maximum is None or len(actual_port) <= maximum)
+
+
+def _take_authority_boundary(source, position):
+    """Return the boundary endpoint, semantics, and accepted URL delimiter."""
+    if position < len(source) and source[position] == '/':
+        return position + 1, False, frozenset({'/'})
+    if source.startswith(r'\?', position):
+        return position + 2, False, frozenset({'?'})
+    boundaries = {
+        '(?=/|$)': frozenset({'/', ''}),
+        '(?:/|$)': frozenset({'/', ''}),
+        r'(?=\?|$)': frozenset({'?', ''}),
+        r'(?:\?|$)': frozenset({'?', ''}),
+        '(?=/|\\?|$)': frozenset({'/', '?', ''}),
+        '(?:/|\\?|$)': frozenset({'/', '?', ''}),
+    }
+    for boundary, delimiters in boundaries.items():
+        if source.startswith(boundary, position):
+            return position + len(boundary), True, delimiters
+    if source[position:] in ('$', r'\Z', r'\z'):
+        return len(source), source[position:] == '$', frozenset({''})
+    return None
+
+
+def _inline_flag_group(source, position, verbose):
+    """Return an inline-flag group endpoint, scope kind, and verbose mode."""
+    if not source.startswith('(?', position):
+        return None
+    flag_end = position + 2
+    while flag_end < len(source) and source[flag_end] in 'aiLmsux-':
+        flag_end += 1
+    flag_text = source[position + 2 : flag_end]
+    if not flag_text or flag_end >= len(source) or source[flag_end] not in ':)':
+        return None
+
+    enabled, separator, disabled = flag_text.partition('-')
+    if 'x' in enabled:
+        verbose = True
+    if separator and 'x' in disabled:
+        verbose = False
+    return flag_end + 1, source[flag_end] == ':', verbose
+
+
+def _tail_has_no_outer_alternation(source, position, flags):
+    """Allow arbitrary post-boundary regex syntax, but not an outer branch."""
+    depth = 0
+    index = position
+    verbose_modes = [bool(flags & re.VERBOSE)]
+    while index < len(source):
+        if source[index] == '\\':
+            index += 2
+            continue
+        if source.startswith('(?#', index):
+            comment_end = source.find(')', index + 3)
+            if comment_end < 0:
+                return False
+            index = comment_end + 1
+            continue
+        if verbose_modes[-1] and source[index] == '#':
+            newline = source.find('\n', index + 1)
+            index = len(source) if newline < 0 else newline + 1
+            continue
+        if source[index] == '[':
+            index += 1
+            if index < len(source) and source[index] == '^':
+                index += 1
+            if index < len(source) and source[index] == ']':
+                index += 1
+            while index < len(source) and source[index] != ']':
+                index += 2 if source[index] == '\\' else 1
+            if index >= len(source):
+                return False
+            index += 1
+            continue
+        if source[index] == '(':
+            inline_flags = _inline_flag_group(source, index, verbose_modes[-1])
+            if inline_flags is not None:
+                index, scoped, verbose = inline_flags
+                if scoped:
+                    depth += 1
+                    verbose_modes.append(verbose)
+                else:
+                    verbose_modes[-1] = verbose
+                continue
+            depth += 1
+            verbose_modes.append(verbose_modes[-1])
+        elif source[index] == ')':
+            if depth == 0:
+                return False
+            depth -= 1
+            verbose_modes.pop()
+        elif source[index] == '|' and depth == 0:
+            return False
+        index += 1
+    return depth == 0
+
+
+def _recognizes_authority_policy(pattern, canonical_url):
+    """Recognize the documented fail-closed authority-policy source grammar.
+
+    The grammar is an optional start anchor, a literal HTTP(S) scheme, either
+    an exact host with an optional numeric-port policy or a whole-authority
+    ``[^/]`` policy, and a proven authority boundary. Regex syntax is otherwise
+    unrestricted only after that boundary.
+    """
+    source = pattern.pattern
+    scheme_result = _take_literal_scheme(source)
+    if scheme_result is None:
+        return False
+    source_scheme, position = scheme_result
+
+    parsed = urlsplit(canonical_url)
+    if parsed.scheme.lower() != source_scheme or not parsed.hostname or parsed.username is not None:
+        return False
+
+    if source.startswith('[^/]', position):
+        quantifier_start = position + len('[^/]')
+        quantifier = _take_positive_numeric_quantifier(source, quantifier_start)
+        if quantifier is None or quantifier[0] == quantifier_start:
+            return False
+        position, minimum, maximum = quantifier
+        authority_length = len(parsed.netloc)
+        if authority_length < minimum or maximum is not None and authority_length > maximum:
+            return False
+    else:
+        host_result = _take_exact_host(source, position)
+        if host_result is None:
+            return False
+        source_host, position = host_result
+        actual_host = f'[{parsed.hostname}]' if parsed.netloc.startswith('[') else parsed.hostname
+        if source_host.lower() != actual_host.lower():
+            return False
+        port_result = _take_port_policy(source, position)
+        if port_result is None:
+            return False
+        position, optional_port, port_policy = port_result
+        if not _port_policy_matches(port_policy, optional_port, _explicit_port_text(parsed.netloc)):
+            return False
+
+    boundary = _take_authority_boundary(source, position)
+    if boundary is None:
+        return False
+    boundary_end, uses_dollar, delimiters = boundary
+    if uses_dollar and pattern.flags & re.MULTILINE:
+        return False
+    authority_end = len(parsed.scheme) + len('://') + len(parsed.netloc)
+    actual_delimiter = canonical_url[authority_end : authority_end + 1]
+    if actual_delimiter not in delimiters:
+        return False
+    return _tail_has_no_outer_alternation(source, boundary_end, pattern.flags)
+
+
+def _pattern_matches_canonical_url(pattern, canonical_url):
+    """Match the canonical URL, then prove the regex authority policy."""
+    if not isinstance(pattern.pattern, str):
+        return False
+
+    match = _match(pattern, canonical_url)
+    if match is None:
+        return False
+    return _recognizes_authority_policy(pattern, canonical_url)
 
 
 class IInstance(IInstanceBase):
@@ -151,9 +446,9 @@ class IInstance(IInstanceBase):
         # Expand convenience shortcuts into canonical form
         _normalize_shortcuts(args)
 
-        # Resolve path-only placeholders first so the whitelist sees the exact
-        # URL that will be sent.
-        resolved_url = self._validate_guardrails(args)
+        # Resolve every URL-affecting option before whitelist matching. The
+        # execution helper uses the same final-URL construction path.
+        self._validate_guardrails(args)
 
         # Enforce rate limits before executing the request
         rate_limiter = self.IGlobal.rate_limiter
@@ -162,10 +457,10 @@ class IInstance(IInstanceBase):
 
         try:
             return execute_request(
-                url=resolved_url,
+                url=args.get('url'),
                 method=args.get('method', 'GET'),
                 query_params=args.get('query_params'),
-                path_params=None,
+                path_params=args.get('path_params'),
                 headers=args.get('headers'),
                 auth=args.get('auth'),
                 body=args.get('body'),
@@ -195,9 +490,16 @@ class IInstance(IInstanceBase):
         url = args.get('url')
         if not url or not isinstance(url, str):
             raise ValueError('url is required and must be a non-empty string')
-        resolved_url = _canonicalize_url(_resolve_path_params(url, args.get('path_params')))
-        if self.IGlobal.url_patterns and not any(p.match(resolved_url) for p in self.IGlobal.url_patterns):
-            raise ValueError(f'URL "{resolved_url}" does not match any allowed URL pattern.')
+        resolved_url = _build_final_url(
+            url,
+            path_params=args.get('path_params'),
+            query_params=args.get('query_params'),
+            auth=args.get('auth'),
+        )
+        if self.IGlobal.url_patterns and not any(
+            _pattern_matches_canonical_url(pattern, resolved_url) for pattern in self.IGlobal.url_patterns
+        ):
+            raise ValueError('URL does not match any allowed URL pattern.')
 
         auth = args.get('auth')
         if auth is not None:

--- a/nodes/src/nodes/tool_http_request/README.md
+++ b/nodes/src/nodes/tool_http_request/README.md
@@ -60,7 +60,8 @@ proxies or implicit `.netrc` credentials. `REQUESTS_CA_BUNDLE` and `CURL_CA_BUND
 remain supported for custom HTTPS certificate authorities. A caller-supplied `Host`
 header is rejected because it could route an allowlisted URL to a different virtual host.
 The network classifier requires Python `3.10.14+`, `3.11.9+`, `3.12.4+`, or `3.13+`
-and the transport is bounded to the audited urllib3 `2.7.x` line.
+and the transport requires the Requests and urllib3 connection hooks used for
+validated-address pinning.
 
 Keep an outbound firewall or equivalent egress policy around the engine as a second
 boundary. RFC 6052 permits operator-chosen NAT64 prefixes that cannot be identified from

--- a/nodes/src/nodes/tool_http_request/README.md
+++ b/nodes/src/nodes/tool_http_request/README.md
@@ -50,9 +50,10 @@ Four security guardrails are enforced before every request:
 The node ships one profile, **Default**, which sets `serverName` to `http`.
 
 Whitelist patterns are checked against the final URL after path parameters are resolved.
-Invalid, empty, or malformed whitelist entries fail configuration validation instead of
-silently removing the intended restriction. Regex matching starts at the beginning of
-the URL; add `$` when the entire URL must match.
+An empty `urlWhitelist` (`[]`) allows all public URLs and emits a warning. Empty entries
+such as `[{"whitelistPattern": ""}]`, and invalid or malformed patterns, fail configuration
+validation instead of silently removing the intended restriction. Regex matching starts
+at the beginning of the URL; add `$` when the entire URL must match.
 
 The node connects directly to the validated destination and does not use environment
 proxies or implicit `.netrc` credentials. `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE`

--- a/nodes/src/nodes/tool_http_request/README.md
+++ b/nodes/src/nodes/tool_http_request/README.md
@@ -20,7 +20,8 @@ Four security guardrails are enforced before every request:
   which allows all public URLs** (config validation emits a warning when the whitelist is empty).
 - **Network boundary**: loopback, private, link-local, shared, reserved, unspecified,
   and multicast destination addresses are blocked. Redirects are returned to the agent
-  as 3xx responses and are not followed automatically.
+  as 3xx responses and are not followed automatically. There is no private-network
+  override: localhost and internal API endpoints are intentionally unsupported.
 - **Rate limiting**: token-bucket limits per second and per minute, plus a concurrency
   cap. On by default (10/s, 100/min, 5 concurrent).
 
@@ -48,14 +49,22 @@ Four security guardrails are enforced before every request:
 
 The node ships one profile, **Default**, which sets `serverName` to `http`.
 
-Invalid whitelist regexes are skipped with a warning rather than failing the pipeline,
-so a typo in a pattern silently widens (or, if it was the only pattern, removes) the
-URL restriction; non-public network destinations remain blocked. Check the logs after
-editing the whitelist.
+Whitelist patterns are checked against the final URL after path parameters are resolved.
+Invalid, empty, or malformed whitelist entries fail configuration validation instead of
+silently removing the intended restriction. Regex matching starts at the beginning of
+the URL; add `$` when the entire URL must match.
+
+The node connects directly to the validated destination and does not use environment
+proxies or implicit `.netrc` credentials. `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE`
+remain supported for custom HTTPS certificate authorities. A caller-supplied `Host`
+header is rejected because it could route an allowlisted URL to a different virtual host.
+The network classifier requires Python `3.10.14+`, `3.11.9+`, `3.12.4+`, or `3.13+`
+and the transport is bounded to the audited urllib3 `2.7.x` line.
 
 Keep an outbound firewall or equivalent egress policy around the engine as a second
-boundary. It limits impact if application-level guardrails are bypassed or their behavior
-changes in a future release.
+boundary. RFC 6052 permits operator-chosen NAT64 prefixes that cannot be identified from
+an IPv6 address alone; the egress boundary must also block translated access to private
+networks.
 
 ---
 
@@ -90,8 +99,8 @@ is only applied when the corresponding advanced field is not also set.
 | Parameter      | Description                                                              |
 |----------------|---------------------------------------------------------------------------|
 | `query_params` | Key-value pairs appended to the URL as the query string                  |
-| `headers`      | Custom request headers                                                   |
-| `path_params`  | Replacements for `:name` placeholders in the URL (e.g. `{"id": "123"}` replaces `:id`) |
+| `headers`      | Custom request headers. `Host` cannot be overridden.                     |
+| `path_params`  | Replacements for `:name` placeholders in the URL path only (e.g. `{"id": "123"}` replaces `:id`) |
 | `timeout`      | Request timeout in seconds. Default `30`, capped at `300`.               |
 | `auth`         | Advanced auth config (see Authentication below). Prefer the shortcuts.   |
 | `body`         | Advanced body config (see Request bodies below). Prefer `body_json`.     |
@@ -112,7 +121,7 @@ is only applied when the corresponding advanced field is not also set.
 
 `json` is populated automatically when the response `Content-Type` contains `json` (or
 `javascript`) and the body parses; otherwise it is `null` and the raw text is in `body`.
-`elapsed_ms` is wall-clock request time in milliseconds.
+`elapsed_ms` is wall-clock request time, including DNS validation, in milliseconds.
 
 ---
 

--- a/nodes/src/nodes/tool_http_request/README.md
+++ b/nodes/src/nodes/tool_http_request/README.md
@@ -1,6 +1,6 @@
 # tool_http_request
 
-A RocketRide tool node that lets an AI agent make HTTP requests to any API endpoint, like curl for agents.
+A RocketRide tool node that lets an AI agent make HTTP requests to public API endpoints, like curl for agents.
 
 ## What it does
 
@@ -12,12 +12,15 @@ structured response containing status, headers, body text, parsed JSON, and timi
 Uses the **requests** library to execute calls. The node has no lanes; it is attached to
 an agent purely as a tool.
 
-Three security guardrails are enforced before every request, all configured on the node:
+Four security guardrails are enforced before every request:
 
 - **Allowed methods**: per-method toggles. `GET`, `POST`, `PUT`, `PATCH`, `DELETE` are
   enabled by default; `HEAD` and `OPTIONS` are disabled by default.
 - **URL whitelist**: regex patterns the request URL must match. **Empty by default,
-  which allows all URLs** (config validation emits a warning when the whitelist is empty).
+  which allows all public URLs** (config validation emits a warning when the whitelist is empty).
+- **Network boundary**: loopback, private, link-local, shared, reserved, unspecified,
+  and multicast destination addresses are blocked. Redirects are returned to the agent
+  as 3xx responses and are not followed automatically.
 - **Rate limiting**: token-bucket limits per second and per minute, plus a concurrency
   cap. On by default (10/s, 100/min, 5 concurrent).
 
@@ -37,7 +40,7 @@ Three security guardrails are enforced before every request, all configured on t
 | `allowHEAD` | boolean | Default false.  |
 | `allowOPTIONS` | boolean | Default false.  |
 | `whitelistPattern` | string | Default empty.  |
-| `urlWhitelist` | array | Regex patterns for allowed URLs. A request URL must match at least one pattern. If empty, all URLs are allowed. |
+| `urlWhitelist` | array | Regex patterns for allowed public URLs. A request URL must match at least one pattern. If empty, all public URLs are allowed; non-public network destinations remain blocked. |
 | `rateLimitPerSecond` | number | Default 10. Maximum number of HTTP requests allowed per second. Uses a token-bucket algorithm for smooth enforcement. |
 | `rateLimitPerMinute` | number | Default 100. Maximum number of HTTP requests allowed per minute. Provides a broader throttle beyond the per-second limit. |
 | `maxConcurrentRequests` | number | Default 5. Maximum number of HTTP requests that can be in-flight simultaneously. |
@@ -47,7 +50,12 @@ The node ships one profile, **Default**, which sets `serverName` to `http`.
 
 Invalid whitelist regexes are skipped with a warning rather than failing the pipeline,
 so a typo in a pattern silently widens (or, if it was the only pattern, removes) the
-restriction, check the logs after editing the whitelist.
+URL restriction; non-public network destinations remain blocked. Check the logs after
+editing the whitelist.
+
+Keep an outbound firewall or equivalent egress policy around the engine as a second
+boundary. Application-level DNS checks cannot prevent every DNS-rebinding or proxy-resolver
+race, where a hostname resolves differently between validation and connection.
 
 ---
 
@@ -174,7 +182,7 @@ non-zero value is clamped to a minimum of `1`.
 | `http_request.rateLimitPerMinute` | `number` | **Max requests per minute**<br/>Maximum number of HTTP requests allowed per minute. Provides a broader throttle beyond the per-second limit. | `100` |
 | `http_request.rateLimitPerSecond` | `number` | **Max requests per second**<br/>Maximum number of HTTP requests allowed per second. Uses a token-bucket algorithm for smooth enforcement. | `10` |
 | `http_request.serverName` | `string` | **Server name**<br/>Namespace prefix for the tool: <serverName>.http_request | `"http"` |
-| `http_request.urlWhitelist` | `array` | **URL Whitelist**<br/>Regex patterns for allowed URLs. A request URL must match at least one pattern. If empty, all URLs are allowed. |  |
+| `http_request.urlWhitelist` | `array` | **URL Whitelist**<br/>Regex patterns for allowed public URLs. A request URL must match at least one pattern. If empty, all public URLs are allowed; non-public network destinations remain blocked. |  |
 | `http_request.whitelistPattern` | `string` | **URL Pattern (regex)** | `""` |
 
 ## Source

--- a/nodes/src/nodes/tool_http_request/README.md
+++ b/nodes/src/nodes/tool_http_request/README.md
@@ -54,8 +54,8 @@ URL restriction; non-public network destinations remain blocked. Check the logs 
 editing the whitelist.
 
 Keep an outbound firewall or equivalent egress policy around the engine as a second
-boundary. Application-level DNS checks cannot prevent every DNS-rebinding or proxy-resolver
-race, where a hostname resolves differently between validation and connection.
+boundary. It limits impact if application-level guardrails are bypassed or their behavior
+changes in a future release.
 
 ---
 

--- a/nodes/src/nodes/tool_http_request/README.md
+++ b/nodes/src/nodes/tool_http_request/README.md
@@ -49,19 +49,63 @@ Four security guardrails are enforced before every request:
 
 The node ships one profile, **Default**, which sets `serverName` to `http`.
 
-Whitelist patterns are checked against the final URL after path parameters are resolved.
-An empty `urlWhitelist` (`[]`) allows all public URLs and emits a warning. Empty entries
-such as `[{"whitelistPattern": ""}]`, and invalid or malformed patterns, fail configuration
-validation instead of silently removing the intended restriction. Regex matching starts
-at the beginning of the URL; add `$` when the entire URL must match.
+Whitelist regexes are applied with Python `pattern.match()` to the final canonical URL after
+path parameters, regular query parameters, and query-based API-key auth are applied. The
+configured regex is never rewritten, so normal Python regex syntax retains its usual meaning.
+A nonmatch is denied.
+
+After a successful match, a fail-closed source recognizer proves the regex's authority policy.
+It accepts an optional `^` or `\A`, a literal `http://` or `https://`, then one of:
+
+- an exact DNS, IPv4, or escaped-bracket IPv6 host written with literal characters and escaped
+  dots, optionally followed by an exact numeric port, a decimal port language such as
+  `:[0-9]+` or `:[0-9]{3,4}`, or the optional form `(?::[0-9]+)?`; or
+- the whole-authority form `[^/]` with a nonempty `+` or brace bound, such as `[^/]+` or
+  `[^/]{1,20}`.
+
+The authority policy must be followed immediately by a proven boundary: a consuming `/` or
+`\?`, the narrow boundary forms `(?=/|$)` or `(?:/|$)` (and their query variants), or a terminal
+`$`, `\Z`, or `\z` on Python versions that support it. Arbitrary Python regex syntax may follow
+a proven consuming path or query delimiter; top-level alternatives remain unsupported because
+they can hide a different authority policy. A `$` authority boundary is unsupported with
+`re.MULTILINE` because it would no longer prove the end of the authority; that flag remains
+available to regex syntax after a consuming delimiter.
+
+Any other authority syntax fails closed at request time even if Python's regex engine matches
+the URL. This includes wildcard, character-class, lookaround, possessive, subdomain-language,
+or alternation syntax before the boundary. For example, use
+`^https://api\.example\.com(?::[0-9]+)?(?:/|$)` for an exact host with an optional numeric port,
+or `^https://[^/]+(?:/|$)` for a deliberately broad authority. A scheme-only prefix such as
+`^https://` is denied. Use an empty whitelist for the documented allow-all-public mode.
+
+The configuration author is trusted; request URLs are attacker-controlled. The restricted
+grammar prevents an accidental hostname or port prefix from being interpreted across URL
+authority fields. It is not intended to defend against an administrator who deliberately
+configures a broad policy.
+
+An empty `urlWhitelist` (`[]`), or a list containing only blank or whitespace-only UI
+placeholder rows, means no whitelist patterns and therefore allows all public destinations;
+non-public destinations remain blocked. Blank rows mixed with valid patterns are ignored.
+Invalid non-empty regexes, non-string values, and malformed entries fail configuration
+validation.
+
+### Compatibility and whitelist migration
+
+Whitelist matching previously used search-anywhere semantics and accepted unrestricted regex
+syntax in the authority. It now starts at the beginning of the canonical URL and accepts only
+the authority grammar above; configuring a whitelist emits a startup migration warning.
+Patterns written for a raw, noncanonical URL or with unsupported authority constructs now fail
+closed. Migrate them to the canonical form, preferably anchor them with `^` or `\A`, and express
+host/port intent with one of the supported exact or whole-authority forms.
 
 The node connects directly to the validated destination and does not use environment
 proxies or implicit `.netrc` credentials. `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE`
 remain supported for custom HTTPS certificate authorities. A caller-supplied `Host`
 header is rejected because it could route an allowlisted URL to a different virtual host.
-The network classifier requires Python `3.10.14+`, `3.11.9+`, `3.12.4+`, or `3.13+`
-and the transport requires the Requests and urllib3 connection hooks used for
-validated-address pinning.
+URLs containing userinfo or credentials are rejected, including an empty userinfo delimiter
+before `@`. The network classifier requires Python `3.10.15+`, `3.11.10+`, `3.12.4+`, or
+`3.13+`. The transport verifies the required `requests` and `urllib3` connection capabilities
+at startup; behavior tests cover the supported dependency combinations.
 
 Keep an outbound firewall or equivalent egress policy around the engine as a second
 boundary. RFC 6052 permits operator-chosen NAT64 prefixes that cannot be identified from
@@ -193,8 +237,8 @@ non-zero value is clamped to a minimum of `1`.
 | `http_request.rateLimitPerMinute` | `number` | **Max requests per minute**<br/>Maximum number of HTTP requests allowed per minute. Provides a broader throttle beyond the per-second limit. | `100` |
 | `http_request.rateLimitPerSecond` | `number` | **Max requests per second**<br/>Maximum number of HTTP requests allowed per second. Uses a token-bucket algorithm for smooth enforcement. | `10` |
 | `http_request.serverName` | `string` | **Server name**<br/>Namespace prefix for the tool: <serverName>.http_request | `"http"` |
-| `http_request.urlWhitelist` | `array` | **URL Whitelist**<br/>Regex patterns for allowed public URLs. A request URL must match at least one pattern. If empty, all public URLs are allowed; non-public network destinations remain blocked. |  |
-| `http_request.whitelistPattern` | `string` | **URL Pattern (regex)** | `""` |
+| `http_request.urlWhitelist` | `array` | **URL Whitelist**<br/>Python regex patterns applied with match() to the final canonical URL after path substitution, regular query parameters, and query-based API-key auth. A request-time source recognizer accepts only exact literal/escaped hosts with supported numeric-port forms, or a deliberate [^/] whole-authority form, followed by an explicit authority boundary. Unsupported or ambiguous authority syntax fails closed even when the regex matches. [] or only blank placeholder rows allows all public destinations; non-public destinations remain blocked. Blank rows mixed with valid patterns are ignored; invalid non-empty regexes, non-string values, and malformed entries fail closed. |  |
+| `http_request.whitelistPattern` | `string` | **URL Pattern (regex)**<br/>Applied with Python regex match() to the final canonical URL after path substitution, regular query parameters, and query-based API-key auth. After matching, a fail-closed source grammar requires a literal HTTP(S) scheme; an exact literal/escaped DNS, IPv4, or bracketed-IPv6 host with an optional exact or [0-9]-based port policy, or a whole-authority [^/] policy; and an explicit path, query, or end boundary. Unsupported or ambiguous authority regex syntax is denied at request time. Example: ^https://api\.example\.com(?::[0-9]+)?(?:/\|$). Scheme-only prefixes are denied; use an empty whitelist to allow all public destinations. Blank placeholder rows are ignored. | `""` |
 
 ## Source
 

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -40,7 +40,6 @@ from typing import Any, Dict, Optional
 from urllib.parse import quote, unquote, urlsplit
 
 import requests
-import urllib3
 from requests.auth import HTTPBasicAuth
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ProxyError
@@ -76,19 +75,6 @@ if not (
     and hasattr(HTTPSConnection, '_new_conn')
 ):
     raise RuntimeError('tool_http_request requires the supported urllib3 pinned-connection hooks')
-
-
-def _has_supported_urllib3_runtime(version: str) -> bool:
-    """Return whether urllib3 is on the audited minor line."""
-    try:
-        major, minor = (int(part) for part in version.split('.')[:2])
-    except (TypeError, ValueError):
-        return False
-    return (major, minor) == (2, 7)
-
-
-if not _has_supported_urllib3_runtime(urllib3.__version__):
-    raise RuntimeError('tool_http_request requires urllib3>=2.7,<2.8 for safe DNS address pinning')
 
 
 def _has_safe_ipaddress_runtime(version_info) -> bool:

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -52,6 +52,12 @@ MAX_TIMEOUT_SECONDS = 300
 
 ResolvedAddress = tuple[int, int, int, tuple]
 
+if not all(
+    hasattr(HTTPAdapter, method)
+    for method in ('get_connection_with_tls_context', 'build_connection_pool_key_attributes')
+):
+    raise RuntimeError('tool_http_request requires requests>=2.32.3 for safe DNS address pinning')
+
 
 class _PinnedConnectionMixin:
     """Open a socket only to addresses that passed SSRF validation."""

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -31,14 +31,16 @@ params) and returns a structured response dict.  Uses the ``requests`` library.
 from __future__ import annotations
 
 import ipaddress
+import os
 import re
 import socket
 import sys
 import time
 from typing import Any, Dict, Optional
-from urllib.parse import quote, urlsplit
+from urllib.parse import quote, unquote, urlsplit
 
 import requests
+import urllib3
 from requests.auth import HTTPBasicAuth
 from requests.adapters import HTTPAdapter
 from requests.exceptions import ProxyError
@@ -46,17 +48,63 @@ from requests.utils import select_proxy
 from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
+from urllib3.poolmanager import SSL_KEYWORDS
 
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_TIMEOUT_SECONDS = 300
 
 ResolvedAddress = tuple[int, int, int, tuple]
 
+_NAT64_WELL_KNOWN_NETWORK = ipaddress.IPv6Network('64:ff9b::/96')
+_NAT64_LOCAL_USE_NETWORK = ipaddress.IPv6Network('64:ff9b:1::/48')
+_MINIMUM_SAFE_IPADDRESS_PATCH = {
+    (3, 10): 14,
+    (3, 11): 9,
+    (3, 12): 4,
+}
+
 if not all(
     hasattr(HTTPAdapter, method)
     for method in ('get_connection_with_tls_context', 'build_connection_pool_key_attributes')
 ):
     raise RuntimeError('tool_http_request requires requests>=2.32.3 for safe DNS address pinning')
+
+if not (
+    HTTPConnectionPool.ConnectionCls is HTTPConnection
+    and HTTPSConnectionPool.ConnectionCls is HTTPSConnection
+    and hasattr(HTTPConnection, '_new_conn')
+    and hasattr(HTTPSConnection, '_new_conn')
+):
+    raise RuntimeError('tool_http_request requires the supported urllib3 pinned-connection hooks')
+
+
+def _has_supported_urllib3_runtime(version: str) -> bool:
+    """Return whether urllib3 is on the audited minor line."""
+    try:
+        major, minor = (int(part) for part in version.split('.')[:2])
+    except (TypeError, ValueError):
+        return False
+    return (major, minor) == (2, 7)
+
+
+if not _has_supported_urllib3_runtime(urllib3.__version__):
+    raise RuntimeError('tool_http_request requires urllib3>=2.7,<2.8 for safe DNS address pinning')
+
+
+def _has_safe_ipaddress_runtime(version_info) -> bool:
+    """Return whether CPython contains the patched special-address tables."""
+    major, minor, patch = version_info[:3]
+    if major != 3 or minor < 10:
+        return False
+    minimum_patch = _MINIMUM_SAFE_IPADDRESS_PATCH.get((major, minor))
+    return minimum_patch is None or patch >= minimum_patch
+
+
+if not _has_safe_ipaddress_runtime(sys.version_info):
+    raise RuntimeError(
+        'tool_http_request requires a Python security patch level with corrected IP address classification: '
+        'Python >=3.10.14, >=3.11.9, >=3.12.4, or >=3.13'
+    )
 
 
 class _PinnedConnectionMixin:
@@ -128,6 +176,12 @@ class _PinnedAddressAdapter(HTTPAdapter):
 
         host_params, pool_kwargs = self.build_connection_pool_key_attributes(request, verify, cert)
         scheme = host_params.pop('scheme')
+        if scheme != 'https':
+            # Requests includes TLS-only pool options even for HTTP. urllib3's
+            # PoolManager normally strips them, but this adapter constructs the
+            # pinned pool directly and must mirror that behavior.
+            for keyword in SSL_KEYWORDS:
+                pool_kwargs.pop(keyword, None)
         pool_class = _PinnedHTTPSConnectionPool if scheme == 'https' else _PinnedHTTPConnectionPool
         pool = pool_class(
             **host_params,
@@ -161,7 +215,8 @@ def execute_request(
 
     Raises ``requests.RequestException`` on transport-level failures.
     """
-    resolved_url = _resolve_path_params(url, path_params)
+    start = time.monotonic()
+    resolved_url = _canonicalize_url(_resolve_path_params(url, path_params))
     validated_addresses = _validate_public_url(resolved_url)
 
     req_headers = dict(headers or {})
@@ -170,6 +225,9 @@ def execute_request(
 
     _apply_auth(auth, req_headers, extra_params, req_auth_out := [None])
     req_auth = req_auth_out[0]
+
+    if any(name.lower() == 'host' for name in req_headers):
+        raise ValueError('The Host header is derived from the validated URL and cannot be overridden')
 
     merged_params = dict(query_params or {})
     merged_params.update(extra_params)
@@ -192,7 +250,6 @@ def execute_request(
     else:
         req_kwargs['timeout'] = DEFAULT_TIMEOUT_SECONDS
 
-    start = time.monotonic()
     resp = _request_with_validated_addresses(req_kwargs, validated_addresses)
     elapsed_ms = round((time.monotonic() - start) * 1000)
 
@@ -209,6 +266,9 @@ def _request_with_validated_addresses(req_kwargs: Dict[str, Any], addresses: tup
     scheme = urlsplit(req_kwargs['url']).scheme.lower()
     with requests.Session() as session:
         session.trust_env = False
+        # Preserve the established Requests custom-CA behavior without
+        # re-enabling environment proxies or implicit .netrc credentials.
+        session.verify = os.environ.get('REQUESTS_CA_BUNDLE') or os.environ.get('CURL_CA_BUNDLE') or True
         session.mount(f'{scheme}://', _PinnedAddressAdapter(addresses))
         return session.request(**req_kwargs)
 
@@ -220,6 +280,9 @@ def _validate_public_url(url: str) -> tuple[ResolvedAddress, ...]:
         raise ValueError('URL scheme must be http or https')
     if not parsed.hostname:
         raise ValueError('URL must include a hostname')
+
+    if _url_has_dot_segments(url):
+        raise ValueError('URL path must not contain dot segments')
 
     try:
         parsed_port = parsed.port
@@ -264,7 +327,7 @@ def _is_public_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -
         return False
     if isinstance(address, ipaddress.IPv4Address):
         return True
-    if address.is_site_local or address in ipaddress.IPv6Network('::/96'):
+    if address.is_site_local or address in ipaddress.IPv6Network('::/96') or address in _NAT64_LOCAL_USE_NETWORK:
         return False
 
     embedded = []
@@ -274,22 +337,57 @@ def _is_public_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -
         embedded.append(address.sixtofour)
     if address.teredo is not None:
         embedded.extend(address.teredo)
+    if address in _NAT64_WELL_KNOWN_NETWORK:
+        embedded.append(ipaddress.IPv4Address(address.packed[-4:]))
     return all(item.is_global and not item.is_multicast for item in embedded)
 
 
+def _url_has_dot_segments(url: str) -> bool:
+    """Detect traversal segments; fail closed on excessive encoding layers."""
+    path = urlsplit(url).path
+    for _decode_attempt in range(5):
+        normalized_separators = path.replace('\\', '/')
+        if any(segment in {'.', '..'} for segment in normalized_separators.split('/')):
+            return True
+        decoded = unquote(path)
+        if decoded == path:
+            return False
+        path = decoded
+    return True
+
+
+def _canonicalize_url(url: str) -> str:
+    """Return the stable URL form Requests will put on the wire."""
+    # Fragments are client-side only and HTTPAdapter removes them from the
+    # request target, so they must not influence whitelist matching.
+    prepared_url = urlsplit(url)._replace(fragment='').geturl()
+    for _attempt in range(3):
+        if _url_has_dot_segments(prepared_url):
+            raise ValueError('URL path must not contain dot segments')
+        normalized_url = requests.Request('GET', prepared_url).prepare().url
+        if normalized_url == prepared_url:
+            return normalized_url
+        prepared_url = normalized_url
+    raise ValueError('URL normalization did not stabilize')
+
+
 def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str:
-    """Replace ``:name`` placeholders in the URL with values from *path_params*."""
+    """Replace ``:name`` placeholders in the URL path with literal segments."""
     if not path_params:
         return url
-    resolved = url
+    parsed = urlsplit(url)
+    resolved_path = parsed.path
     for key, value in path_params.items():
+        if str(value) in {'.', '..'}:
+            raise ValueError('Path parameter values cannot be dot segments')
         # Encode (safe='') so the value stays one path segment and cannot slip
-        # past the URL allowlist, which is checked against the unresolved
-        # template. The function replacement keeps it literal (no re.sub
-        # backslash/group-ref interpretation, e.g. '\1' -> re.error).
+        # past the final URL allowlist. The function replacement keeps it
+        # literal (no re.sub backslash/group-ref interpretation, e.g. '\1' ->
+        # re.error). Only the parsed path is eligible for substitution, so a
+        # parameter cannot replace the URL's scheme, hostname, port, or query.
         replacement = quote(str(value), safe='')
-        resolved = re.sub(rf':{re.escape(key)}\b', lambda _m, r=replacement: r, resolved)
-    return resolved
+        resolved_path = re.sub(rf':{re.escape(key)}\b', lambda _m, r=replacement: r, resolved_path)
+    return parsed._replace(path=resolved_path).geturl()
 
 
 def _apply_auth(

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -30,10 +30,12 @@ params) and returns a structured response dict.  Uses the ``requests`` library.
 
 from __future__ import annotations
 
+import ipaddress
 import re
+import socket
 import time
 from typing import Any, Dict, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import requests
 from requests.auth import HTTPBasicAuth
@@ -58,6 +60,7 @@ def execute_request(
     Raises ``requests.RequestException`` on transport-level failures.
     """
     resolved_url = _resolve_path_params(url, path_params)
+    _validate_public_url(resolved_url)
 
     req_headers = dict(headers or {})
     req_auth = None
@@ -75,6 +78,9 @@ def execute_request(
         'headers': req_headers,
         'params': merged_params or None,
         'auth': req_auth,
+        # Redirect targets have not passed the URL whitelist or network-address
+        # checks. Return 3xx responses to the caller instead of following them.
+        'allow_redirects': False,
     }
 
     _apply_body(body, req_headers, req_kwargs)
@@ -94,6 +100,67 @@ def execute_request(
 # ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
+
+
+def _validate_public_url(url: str) -> None:
+    """Reject malformed URLs and destinations outside the public Internet."""
+    parsed = urlsplit(url)
+    if parsed.scheme.lower() not in {'http', 'https'}:
+        raise ValueError('URL scheme must be http or https')
+    if not parsed.hostname:
+        raise ValueError('URL must include a hostname')
+
+    try:
+        parsed_port = parsed.port
+    except ValueError:
+        raise ValueError('URL port is invalid') from None
+    port = parsed_port if parsed_port is not None else (443 if parsed.scheme.lower() == 'https' else 80)
+    if port == 0:
+        raise ValueError('URL port is invalid')
+
+    try:
+        resolved = socket.getaddrinfo(
+            parsed.hostname,
+            port,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+            proto=socket.IPPROTO_TCP,
+        )
+    except socket.gaierror:
+        raise requests.ConnectionError(f'URL hostname {parsed.hostname!r} could not be resolved') from None
+
+    if not resolved:
+        raise requests.ConnectionError(f'URL hostname {parsed.hostname!r} could not be resolved')
+
+    for _family, _socktype, _proto, _canonname, sockaddr in resolved:
+        raw_address = sockaddr[0].split('%', 1)[0]
+        try:
+            address = ipaddress.ip_address(raw_address)
+        except ValueError:
+            raise requests.ConnectionError(
+                f'URL hostname {parsed.hostname!r} resolved to an invalid network address'
+            ) from None
+        if not _is_public_address(address):
+            raise ValueError(f'URL hostname {parsed.hostname!r} resolves to a non-public network address')
+
+
+def _is_public_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    """Return whether an address is safe for an Internet-only HTTP client."""
+    if not address.is_global or address.is_multicast:
+        return False
+    if isinstance(address, ipaddress.IPv4Address):
+        return True
+    if address.is_site_local or address in ipaddress.IPv6Network('::/96'):
+        return False
+
+    embedded = []
+    if address.ipv4_mapped is not None:
+        embedded.append(address.ipv4_mapped)
+    if address.sixtofour is not None:
+        embedded.append(address.sixtofour)
+    if address.teredo is not None:
+        embedded.extend(address.teredo)
+    return all(item.is_global and not item.is_multicast for item in embedded)
 
 
 def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str:

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -33,15 +33,111 @@ from __future__ import annotations
 import ipaddress
 import re
 import socket
+import sys
 import time
 from typing import Any, Dict, Optional
 from urllib.parse import quote, urlsplit
 
 import requests
 from requests.auth import HTTPBasicAuth
+from requests.adapters import HTTPAdapter
+from requests.exceptions import ProxyError
+from requests.utils import select_proxy
+from urllib3.connection import HTTPConnection, HTTPSConnection
+from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.exceptions import ConnectTimeoutError, NewConnectionError
 
 DEFAULT_TIMEOUT_SECONDS = 30
 MAX_TIMEOUT_SECONDS = 300
+
+ResolvedAddress = tuple[int, int, int, tuple]
+
+
+class _PinnedConnectionMixin:
+    """Open a socket only to addresses that passed SSRF validation."""
+
+    validated_addresses: tuple[ResolvedAddress, ...]
+
+    def __init__(self, *args, validated_addresses: tuple[ResolvedAddress, ...], **kwargs):
+        self.validated_addresses = validated_addresses
+        super().__init__(*args, **kwargs)
+
+    def _new_conn(self):
+        last_error = None
+        last_error_was_timeout = False
+        for family, socktype, proto, sockaddr in self.validated_addresses:
+            sock = None
+            try:
+                sock = socket.socket(family, socktype, proto)
+                for option in self.socket_options or ():
+                    sock.setsockopt(*option)
+                if self.timeout is not None:
+                    sock.settimeout(self.timeout)
+                if self.source_address:
+                    sock.bind(self.source_address)
+                sock.connect(sockaddr)
+                sys.audit('http.client.connect', self, self.host, self.port)
+                return sock
+            except OSError as error:
+                last_error = error
+                last_error_was_timeout = isinstance(error, socket.timeout)
+                if sock is not None:
+                    sock.close()
+
+        if last_error_was_timeout:
+            raise ConnectTimeoutError(
+                self,
+                f'Connection to {self.host} timed out. (connect timeout={self.timeout})',
+            ) from last_error
+        raise NewConnectionError(self, f'Failed to connect to a validated address: {last_error}') from last_error
+
+
+class _PinnedHTTPConnection(_PinnedConnectionMixin, HTTPConnection):
+    pass
+
+
+class _PinnedHTTPSConnection(_PinnedConnectionMixin, HTTPSConnection):
+    pass
+
+
+class _PinnedHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = _PinnedHTTPConnection
+
+
+class _PinnedHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = _PinnedHTTPSConnection
+
+
+class _PinnedAddressAdapter(HTTPAdapter):
+    """Use the original hostname for HTTP/TLS while connecting to validated IPs."""
+
+    def __init__(self, validated_addresses: tuple[ResolvedAddress, ...]):
+        self.validated_addresses = validated_addresses
+        self._pinned_pools = []
+        super().__init__()
+
+    def get_connection_with_tls_context(self, request, verify, proxies=None, cert=None):
+        if select_proxy(request.url, proxies):
+            raise ProxyError('Proxies are not supported by the public-network HTTP tool')
+
+        host_params, pool_kwargs = self.build_connection_pool_key_attributes(request, verify, cert)
+        scheme = host_params.pop('scheme')
+        pool_class = _PinnedHTTPSConnectionPool if scheme == 'https' else _PinnedHTTPConnectionPool
+        pool = pool_class(
+            **host_params,
+            **pool_kwargs,
+            maxsize=1,
+            block=True,
+            validated_addresses=self.validated_addresses,
+        )
+        self._pinned_pools.append(pool)
+        return pool
+
+    def close(self):
+        for pool in self._pinned_pools:
+            pool.close()
+        self._pinned_pools.clear()
+        super().close()
 
 
 def execute_request(
@@ -60,7 +156,7 @@ def execute_request(
     Raises ``requests.RequestException`` on transport-level failures.
     """
     resolved_url = _resolve_path_params(url, path_params)
-    _validate_public_url(resolved_url)
+    validated_addresses = _validate_public_url(resolved_url)
 
     req_headers = dict(headers or {})
     req_auth = None
@@ -91,7 +187,7 @@ def execute_request(
         req_kwargs['timeout'] = DEFAULT_TIMEOUT_SECONDS
 
     start = time.monotonic()
-    resp = requests.request(**req_kwargs)
+    resp = _request_with_validated_addresses(req_kwargs, validated_addresses)
     elapsed_ms = round((time.monotonic() - start) * 1000)
 
     return _build_response(resp, elapsed_ms)
@@ -102,7 +198,16 @@ def execute_request(
 # ---------------------------------------------------------------------------
 
 
-def _validate_public_url(url: str) -> None:
+def _request_with_validated_addresses(req_kwargs: Dict[str, Any], addresses: tuple[ResolvedAddress, ...]):
+    """Execute one request using only the DNS addresses already validated."""
+    scheme = urlsplit(req_kwargs['url']).scheme.lower()
+    with requests.Session() as session:
+        session.trust_env = False
+        session.mount(f'{scheme}://', _PinnedAddressAdapter(addresses))
+        return session.request(**req_kwargs)
+
+
+def _validate_public_url(url: str) -> tuple[ResolvedAddress, ...]:
     """Reject malformed URLs and destinations outside the public Internet."""
     parsed = urlsplit(url)
     if parsed.scheme.lower() not in {'http', 'https'}:
@@ -132,7 +237,8 @@ def _validate_public_url(url: str) -> None:
     if not resolved:
         raise requests.ConnectionError(f'URL hostname {parsed.hostname!r} could not be resolved')
 
-    for _family, _socktype, _proto, _canonname, sockaddr in resolved:
+    validated = []
+    for family, socktype, proto, _canonname, sockaddr in resolved:
         raw_address = sockaddr[0].split('%', 1)[0]
         try:
             address = ipaddress.ip_address(raw_address)
@@ -142,6 +248,8 @@ def _validate_public_url(url: str) -> None:
             ) from None
         if not _is_public_address(address):
             raise ValueError(f'URL hostname {parsed.hostname!r} resolves to a non-public network address')
+        validated.append((family, socktype, proto, sockaddr))
+    return tuple(validated)
 
 
 def _is_public_address(address: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:

--- a/nodes/src/nodes/tool_http_request/http_client.py
+++ b/nodes/src/nodes/tool_http_request/http_client.py
@@ -57,8 +57,8 @@ ResolvedAddress = tuple[int, int, int, tuple]
 _NAT64_WELL_KNOWN_NETWORK = ipaddress.IPv6Network('64:ff9b::/96')
 _NAT64_LOCAL_USE_NETWORK = ipaddress.IPv6Network('64:ff9b:1::/48')
 _MINIMUM_SAFE_IPADDRESS_PATCH = {
-    (3, 10): 14,
-    (3, 11): 9,
+    (3, 10): 15,
+    (3, 11): 10,
     (3, 12): 4,
 }
 
@@ -89,7 +89,7 @@ def _has_safe_ipaddress_runtime(version_info) -> bool:
 if not _has_safe_ipaddress_runtime(sys.version_info):
     raise RuntimeError(
         'tool_http_request requires a Python security patch level with corrected IP address classification: '
-        'Python >=3.10.14, >=3.11.9, >=3.12.4, or >=3.13'
+        'Python >=3.10.15, >=3.11.10, >=3.12.4, or >=3.13'
     )
 
 
@@ -202,27 +202,23 @@ def execute_request(
     Raises ``requests.RequestException`` on transport-level failures.
     """
     start = time.monotonic()
-    resolved_url = _canonicalize_url(_resolve_path_params(url, path_params))
+    resolved_url = _build_final_url(url, path_params=path_params, query_params=query_params, auth=auth)
     validated_addresses = _validate_public_url(resolved_url)
 
     req_headers = dict(headers or {})
     req_auth = None
-    extra_params: Dict[str, str] = {}
 
-    _apply_auth(auth, req_headers, extra_params, req_auth_out := [None])
+    _apply_auth(auth, req_headers, req_auth_out := [None])
     req_auth = req_auth_out[0]
 
     if any(name.lower() == 'host' for name in req_headers):
         raise ValueError('The Host header is derived from the validated URL and cannot be overridden')
 
-    merged_params = dict(query_params or {})
-    merged_params.update(extra_params)
-
     req_kwargs: Dict[str, Any] = {
         'method': method.upper(),
         'url': resolved_url,
         'headers': req_headers,
-        'params': merged_params or None,
+        'params': None,
         'auth': req_auth,
         # Redirect targets have not passed the URL whitelist or network-address
         # checks. Return 3xx responses to the caller instead of following them.
@@ -236,7 +232,13 @@ def execute_request(
     else:
         req_kwargs['timeout'] = DEFAULT_TIMEOUT_SECONDS
 
-    resp = _request_with_validated_addresses(req_kwargs, validated_addresses)
+    transport_error = None
+    try:
+        resp = _request_with_validated_addresses(req_kwargs, validated_addresses)
+    except requests.RequestException as error:
+        transport_error = _sanitize_transport_error(error)
+    if transport_error is not None:
+        raise transport_error
     elapsed_ms = round((time.monotonic() - start) * 1000)
 
     return _build_response(resp, elapsed_ms)
@@ -259,9 +261,18 @@ def _request_with_validated_addresses(req_kwargs: Dict[str, Any], addresses: tup
         return session.request(**req_kwargs)
 
 
+def _sanitize_transport_error(error: requests.RequestException) -> requests.RequestException:
+    """Return a same-type transport error without request URL state."""
+    try:
+        return type(error)('HTTP request failed')
+    except TypeError:
+        return requests.RequestException('HTTP request failed')
+
+
 def _validate_public_url(url: str) -> tuple[ResolvedAddress, ...]:
     """Reject malformed URLs and destinations outside the public Internet."""
     parsed = urlsplit(url)
+    _reject_url_userinfo(parsed)
     if parsed.scheme.lower() not in {'http', 'https'}:
         raise ValueError('URL scheme must be http or https')
     if not parsed.hostname:
@@ -346,7 +357,9 @@ def _canonicalize_url(url: str) -> str:
     """Return the stable URL form Requests will put on the wire."""
     # Fragments are client-side only and HTTPAdapter removes them from the
     # request target, so they must not influence whitelist matching.
-    prepared_url = urlsplit(url)._replace(fragment='').geturl()
+    parsed = urlsplit(url)
+    _reject_url_userinfo(parsed)
+    prepared_url = parsed._replace(fragment='').geturl()
     for _attempt in range(3):
         if _url_has_dot_segments(prepared_url):
             raise ValueError('URL path must not contain dot segments')
@@ -355,6 +368,12 @@ def _canonicalize_url(url: str) -> str:
             return normalized_url
         prepared_url = normalized_url
     raise ValueError('URL normalization did not stabilize')
+
+
+def _reject_url_userinfo(parsed) -> None:
+    """Reject URL credentials so they cannot alter the validated destination."""
+    if parsed.username is not None:
+        raise ValueError('URL must not include userinfo')
 
 
 def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str:
@@ -376,13 +395,45 @@ def _resolve_path_params(url: str, path_params: Optional[Dict[str, str]]) -> str
     return parsed._replace(path=resolved_path).geturl()
 
 
+def _build_final_url(
+    url: str,
+    *,
+    path_params: Optional[Dict[str, str]] = None,
+    query_params: Optional[Dict[str, str]] = None,
+    auth: Optional[Dict[str, Any]] = None,
+) -> str:
+    """Return the canonical URL after every URL-affecting request option."""
+    resolved_url = _canonicalize_url(_resolve_path_params(url, path_params))
+    merged_params = dict(query_params or {})
+    merged_params.update(_api_key_query_params(auth))
+    if not merged_params:
+        return resolved_url
+    prepared_url = requests.Request('GET', resolved_url, params=merged_params).prepare().url
+    return _canonicalize_url(prepared_url)
+
+
+def _api_key_query_params(auth: Optional[Dict[str, Any]]) -> Dict[str, str]:
+    """Extract query-based API-key auth for final URL construction."""
+    if not isinstance(auth, dict):
+        return {}
+    auth_type = auth.get('type') or 'none'
+    if not isinstance(auth_type, str) or auth_type.strip().lower() != 'api_key':
+        return {}
+    api_key = auth.get('api_key') or {}
+    if not isinstance(api_key, dict):
+        return {}
+    add_to = api_key.get('add_to') or 'header'
+    if not isinstance(add_to, str) or add_to.strip().lower() != 'query_param':
+        return {}
+    return {api_key.get('key', ''): api_key.get('value', '')}
+
+
 def _apply_auth(
     auth: Optional[Dict[str, Any]],
     headers: Dict[str, str],
-    extra_params: Dict[str, str],
     req_auth_out: list,
 ) -> None:
-    """Mutate *headers* / *extra_params* / *req_auth_out* based on auth config."""
+    """Mutate *headers* / *req_auth_out* based on auth config."""
     if not auth:
         return
     auth_type = (auth.get('type') or 'none').strip().lower()
@@ -406,9 +457,7 @@ def _apply_auth(
         key = api_key.get('key', '')
         value = api_key.get('value', '')
         add_to = (api_key.get('add_to') or 'header').strip().lower()
-        if add_to == 'query_param':
-            extra_params[key] = value
-        else:
+        if add_to != 'query_param':
             headers[key] = value
 
 

--- a/nodes/src/nodes/tool_http_request/services.json
+++ b/nodes/src/nodes/tool_http_request/services.json
@@ -9,7 +9,7 @@
 	"prefix": "http",
 	"icon": "http.svg",
 	"documentation": "https://docs.rocketride.org",
-	"description": ["Makes HTTP requests to public API endpoints, like curl for agents.", "The agent provides the full request (method, URL, headers, body, auth).", "The node blocks non-public network destinations and automatic redirects, then enforces URL patterns and enabled HTTP methods."],
+	"description": ["Makes HTTP requests to public API endpoints, like curl for agents.", "The agent provides the full request (method, URL, headers, body, auth).", "The node blocks non-public network destinations, returns 3xx responses without following them automatically, and enforces URL patterns and enabled HTTP methods."],
 	"tile": ["Tool: ${parameters.http_request.serverName}.http_request"],
 	"lanes": {},
 	"preconfig": {

--- a/nodes/src/nodes/tool_http_request/services.json
+++ b/nodes/src/nodes/tool_http_request/services.json
@@ -9,7 +9,7 @@
 	"prefix": "http",
 	"icon": "http.svg",
 	"documentation": "https://docs.rocketride.org",
-	"description": ["Makes HTTP requests to any API endpoint, like curl for agents.", "The agent provides the full request (method, URL, headers, body, auth).", "The node enforces security guardrails: only whitelisted URLs and enabled HTTP methods are permitted."],
+	"description": ["Makes HTTP requests to public API endpoints, like curl for agents.", "The agent provides the full request (method, URL, headers, body, auth).", "The node blocks non-public network destinations and automatic redirects, then enforces URL patterns and enabled HTTP methods."],
 	"tile": ["Tool: ${parameters.http_request.serverName}.http_request"],
 	"lanes": {},
 	"preconfig": {
@@ -101,7 +101,7 @@
 		},
 		"http_request.urlWhitelist": {
 			"title": "URL Whitelist",
-			"description": "Regex patterns for allowed URLs. A request URL must match at least one pattern. If empty, all URLs are allowed.",
+			"description": "Regex patterns for allowed public URLs. A request URL must match at least one pattern. If empty, all public URLs are allowed; non-public network destinations remain blocked.",
 			"type": "array",
 			"optional": true,
 			"minItems": 0,

--- a/nodes/src/nodes/tool_http_request/services.json
+++ b/nodes/src/nodes/tool_http_request/services.json
@@ -97,11 +97,12 @@
 		"http_request.whitelistPattern": {
 			"type": "string",
 			"title": "URL Pattern (regex)",
+			"description": "Applied with Python regex match() to the final canonical URL after path substitution, regular query parameters, and query-based API-key auth. After matching, a fail-closed source grammar requires a literal HTTP(S) scheme; an exact literal/escaped DNS, IPv4, or bracketed-IPv6 host with an optional exact or [0-9]-based port policy, or a whole-authority [^/] policy; and an explicit path, query, or end boundary. Unsupported or ambiguous authority regex syntax is denied at request time. Example: ^https://api\\.example\\.com(?::[0-9]+)?(?:/|$). Scheme-only prefixes are denied; use an empty whitelist to allow all public destinations. Blank placeholder rows are ignored.",
 			"default": ""
 		},
 		"http_request.urlWhitelist": {
 			"title": "URL Whitelist",
-			"description": "Regex patterns for allowed public URLs. A request URL must match at least one pattern. If empty, all public URLs are allowed; non-public network destinations remain blocked.",
+			"description": "Python regex patterns applied with match() to the final canonical URL after path substitution, regular query parameters, and query-based API-key auth. A request-time source recognizer accepts only exact literal/escaped hosts with supported numeric-port forms, or a deliberate [^/] whole-authority form, followed by an explicit authority boundary. Unsupported or ambiguous authority syntax fails closed even when the regex matches. [] or only blank placeholder rows allows all public destinations; non-public destinations remain blocked. Blank rows mixed with valid patterns are ignored; invalid non-empty regexes, non-string values, and malformed entries fail closed.",
 			"type": "array",
 			"optional": true,
 			"minItems": 0,

--- a/nodes/test/tool_http_request/test_guardrail_validation.py
+++ b/nodes/test/tool_http_request/test_guardrail_validation.py
@@ -1,0 +1,186 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression tests for HTTP-tool configuration and URL guardrails."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import types
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip('requests')
+
+NODE_DIR = Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 'tool_http_request'
+
+
+def _load_node_modules(monkeypatch: pytest.MonkeyPatch):
+    """Load the node files with small engine-runtime stubs."""
+    package_name = f'_tool_http_request_guardrail_test_{id(monkeypatch)}'
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(NODE_DIR)]
+    monkeypatch.setitem(sys.modules, package_name, package)
+
+    rocketlib = types.ModuleType('rocketlib')
+    rocketlib.IGlobalBase = object
+    rocketlib.IInstanceBase = object
+    rocketlib.OPEN_MODE = types.SimpleNamespace(CONFIG='config')
+    rocketlib.warning = Mock()
+    rocketlib.tool_function = lambda **_kwargs: lambda function: function
+    monkeypatch.setitem(sys.modules, 'rocketlib', rocketlib)
+
+    config_module = types.ModuleType('ai.common.config')
+    config_module.Config = Mock()
+    utils_module = types.ModuleType('ai.common.utils')
+    utils_module.config_int = Mock()
+    ai_module = types.ModuleType('ai')
+    common_module = types.ModuleType('ai.common')
+    monkeypatch.setitem(sys.modules, 'ai', ai_module)
+    monkeypatch.setitem(sys.modules, 'ai.common', common_module)
+    monkeypatch.setitem(sys.modules, 'ai.common.config', config_module)
+    monkeypatch.setitem(sys.modules, 'ai.common.utils', utils_module)
+
+    def load(name: str):
+        qualified_name = f'{package_name}.{name}'
+        spec = importlib.util.spec_from_file_location(qualified_name, NODE_DIR / f'{name}.py')
+        module = importlib.util.module_from_spec(spec)
+        monkeypatch.setitem(sys.modules, qualified_name, module)
+        spec.loader.exec_module(module)
+        return module
+
+    http_client = load('http_client')
+    iglobal = load('IGlobal')
+    iinstance = load('IInstance')
+    return http_client, iglobal, iinstance
+
+
+@pytest.mark.parametrize(
+    'whitelist,error',
+    [
+        ([{'whitelistPattern': '['}], 'Invalid URL whitelist regex'),
+        ([{'whitelistPattern': ''}], 'non-empty whitelistPattern'),
+        ([{'whitelistPattern': ['^https://service.example/$']}], 'must be a string'),
+        ([{'whitelistPattern': True}], 'must be a string'),
+        ([{'whitelistPattern': 123}], 'must be a string'),
+        (['https://service.example'], 'must be an object'),
+        ({}, 'malformed and cannot be parsed'),
+        (False, 'malformed and cannot be parsed'),
+        (0, 'malformed and cannot be parsed'),
+    ],
+)
+def test_invalid_url_whitelist_fails_closed(monkeypatch, whitelist, error):
+    """A malformed intended restriction cannot silently become allow-all."""
+    _http_client, iglobal, _iinstance = _load_node_modules(monkeypatch)
+
+    with pytest.raises(ValueError, match=error):
+        iglobal.IGlobal._build_guardrails({'urlWhitelist': whitelist})
+
+
+def test_empty_url_whitelist_still_allows_all_public_urls(monkeypatch):
+    """An intentionally empty whitelist keeps the documented public-only default."""
+    _http_client, iglobal, _iinstance = _load_node_modules(monkeypatch)
+
+    _enabled, patterns = iglobal.IGlobal._build_guardrails({'urlWhitelist': []})
+
+    assert patterns == []
+
+
+def test_whitelist_checks_path_resolved_url(monkeypatch):
+    """The allowlist sees the exact path that will be sent on the wire."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(r'^https://service\.example/users/42$')],
+    )
+
+    resolved_url = instance._validate_guardrails(
+        {
+            'url': 'https://service.example/users/:id',
+            'method': 'GET',
+            'path_params': {'id': '42'},
+        }
+    )
+
+    assert resolved_url == 'https://service.example/users/42'
+
+
+def test_whitelist_rejects_path_after_resolution(monkeypatch):
+    """A template cannot be approved before its final path is known."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(r'^https://service\.example/users/allowed$')],
+    )
+
+    with pytest.raises(ValueError, match='does not match'):
+        instance._validate_guardrails(
+            {
+                'url': 'https://service.example/users/:id',
+                'method': 'GET',
+                'path_params': {'id': 'denied'},
+            }
+        )
+
+
+@pytest.mark.parametrize('encoded_segment', ['%2e%2e', '%252e%252e', '%2e%2e%5cadmin'])
+def test_whitelist_rejects_encoded_dot_segments(monkeypatch, encoded_segment):
+    """Requests cannot decode traversal syntax after the whitelist approves it."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(r'^https://service\.example/public/')],
+    )
+
+    with pytest.raises(ValueError, match='dot segments'):
+        instance._validate_guardrails(
+            {
+                'url': f'https://service.example/public/{encoded_segment}/admin',
+                'method': 'GET',
+            }
+        )
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'https://attacker.example/?next=https://service.example/public/data',
+        'https://attacker.example/#https://service.example/public/data',
+    ],
+)
+def test_whitelist_pattern_cannot_match_inside_query_or_fragment(monkeypatch, url):
+    """Only the request URL prefix—not embedded URL-shaped data—can satisfy a pattern."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(r'https://service\.example/public/')],
+    )
+
+    with pytest.raises(ValueError, match='does not match'):
+        instance._validate_guardrails({'url': url, 'method': 'GET'})
+
+
+def test_whitelist_checks_url_without_fragment(monkeypatch):
+    """A fragment that is never sent cannot change allowlist matching."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(r'https://service\.example/public/data$')],
+    )
+
+    resolved_url = instance._validate_guardrails(
+        {'url': 'https://service.example/public/data#client-only', 'method': 'GET'}
+    )
+
+    assert resolved_url == 'https://service.example/public/data'

--- a/nodes/test/tool_http_request/test_guardrail_validation.py
+++ b/nodes/test/tool_http_request/test_guardrail_validation.py
@@ -65,7 +65,7 @@ def _load_node_modules(monkeypatch: pytest.MonkeyPatch):
     'whitelist,error',
     [
         ([{'whitelistPattern': '['}], 'Invalid URL whitelist regex'),
-        ([{'whitelistPattern': ''}], 'non-empty whitelistPattern'),
+        ([{}], 'must be a string'),
         ([{'whitelistPattern': ['^https://service.example/$']}], 'must be a string'),
         ([{'whitelistPattern': True}], 'must be a string'),
         ([{'whitelistPattern': 123}], 'must be a string'),
@@ -90,6 +90,87 @@ def test_empty_url_whitelist_still_allows_all_public_urls(monkeypatch):
     _enabled, patterns = iglobal.IGlobal._build_guardrails({'urlWhitelist': []})
 
     assert patterns == []
+
+
+@pytest.mark.parametrize(
+    'whitelist',
+    [
+        [{'whitelistPattern': ''}],
+        [{'whitelistPattern': ' \t '}],
+    ],
+)
+def test_placeholder_only_url_whitelist_is_treated_as_empty(monkeypatch, whitelist):
+    """Empty UI placeholder rows preserve the documented public-only default."""
+    _http_client, iglobal, _iinstance = _load_node_modules(monkeypatch)
+
+    _enabled, patterns = iglobal.IGlobal._build_guardrails({'urlWhitelist': whitelist})
+
+    assert patterns == []
+
+
+def test_blank_url_whitelist_rows_are_ignored_alongside_valid_patterns(monkeypatch):
+    """Placeholder rows never broaden a whitelist containing real patterns."""
+    _http_client, iglobal, _iinstance = _load_node_modules(monkeypatch)
+
+    _enabled, patterns = iglobal.IGlobal._build_guardrails(
+        {
+            'urlWhitelist': [
+                {'whitelistPattern': ''},
+                {'whitelistPattern': '^https://service\\.example/public/'},
+                {'whitelistPattern': '  '},
+            ]
+        }
+    )
+
+    assert [pattern.pattern for pattern in patterns] == [r'^https://service\.example/public/']
+
+
+def test_config_preserves_arbitrary_valid_python_regex_syntax(monkeypatch):
+    """Config compilation does not reject or rewrite valid Python regex syntax."""
+    _http_client, iglobal, _iinstance = _load_node_modules(monkeypatch)
+    sources = [
+        r'^https://service\.example(?=/|$)',
+        r'^https://service\.example/(?# (?= is comment text)[a-z]+$',
+        r'^https://service\.example/[](?=a-z]$',
+        r'^https://service\.example/x{,100}$',
+        r'^https://service\.example/x{,}$',
+        r'^https://service\.example/x{1,}$',
+        r'^https://service\.example/x{1,100}$',
+        r'^https://service\.example/x{1}$',
+    ]
+    if sys.version_info >= (3, 11):
+        sources.append(r'^https://service\.example/.++$')
+
+    _enabled, patterns = iglobal.IGlobal._build_guardrails(
+        {'urlWhitelist': [{'whitelistPattern': source} for source in sources]}
+    )
+
+    assert [pattern.pattern for pattern in patterns] == sources
+
+
+@pytest.mark.parametrize(
+    'pattern',
+    [
+        'https://service\\.example/',
+        '^https://service\\.example/',
+    ],
+)
+def test_begin_global_warns_about_whitelist_migration(monkeypatch, pattern):
+    """Every configured whitelist gets a canonical-matching migration warning."""
+    _http_client, iglobal, _iinstance = _load_node_modules(monkeypatch)
+    cfg = {'urlWhitelist': [{'whitelistPattern': pattern}]}
+    iglobal.Config.getNodeConfig.return_value = cfg
+    iglobal.config_int.side_effect = [1, 60, 10]
+    instance = object.__new__(iglobal.IGlobal)
+    instance.IEndpoint = types.SimpleNamespace(endpoint=types.SimpleNamespace(openMode='run'))
+    instance.glb = types.SimpleNamespace(logicalType='tool_http_request', connConfig={})
+
+    instance.beginGlobal()
+
+    iglobal.warning.assert_called_once_with(
+        'URL whitelist patterns now require a supported, explicit authority boundary; '
+        'review existing patterns before making requests'
+    )
 
 
 def test_whitelist_checks_path_resolved_url(monkeypatch):
@@ -129,6 +210,309 @@ def test_whitelist_rejects_path_after_resolution(monkeypatch):
                 'path_params': {'id': 'denied'},
             }
         )
+
+
+@pytest.mark.parametrize(
+    ('request_options', 'expected_url'),
+    [
+        (
+            {'query_params': {'extra': '2'}},
+            'https://api.example.com/path?fixed=1&extra=2',
+        ),
+        (
+            {
+                'auth': {
+                    'type': 'api_key',
+                    'api_key': {'key': 'api_key', 'value': 'secret', 'add_to': 'query_param'},
+                }
+            },
+            'https://api.example.com/path?fixed=1&api_key=secret',
+        ),
+    ],
+)
+def test_whitelist_rejects_final_query_mutations(monkeypatch, request_options, expected_url):
+    """Exact URL patterns reject query data added after path substitution."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(r'^https://api\.example\.com/path\?fixed=1$')],
+    )
+
+    with pytest.raises(ValueError, match='does not match') as exc_info:
+        instance._validate_guardrails(
+            {
+                'url': 'https://api.example.com/path?fixed=1',
+                'method': 'GET',
+                **request_options,
+            }
+        )
+
+    assert expected_url not in str(exc_info.value)
+    assert 'secret' not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    ('request_options', 'expected_url'),
+    [
+        (
+            {'query_params': {'extra': '2'}},
+            'https://api.example.com/path?fixed=1&extra=2',
+        ),
+        (
+            {
+                'auth': {
+                    'type': 'api_key',
+                    'api_key': {'key': 'api_key', 'value': 'secret', 'add_to': 'query_param'},
+                }
+            },
+            'https://api.example.com/path?fixed=1&api_key=secret',
+        ),
+    ],
+)
+def test_whitelist_checks_final_query_url(monkeypatch, request_options, expected_url):
+    """Exact URL patterns see the canonical query string sent to transport."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(rf'^{re.escape(expected_url)}$')],
+    )
+
+    assert (
+        instance._validate_guardrails(
+            {
+                'url': 'https://api.example.com/path?fixed=1',
+                'method': 'GET',
+                **request_options,
+            }
+        )
+        == expected_url
+    )
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'url'),
+    [
+        (r'^https://', 'https://api.example.com/x'),
+        (r'^https://api\.example\.com', 'https://api.example.com.evil.net/x'),
+        (r'^https://api\.example\.com:4', 'https://api.example.com:443/x'),
+    ],
+)
+def test_whitelist_rejects_matches_ending_inside_authority(monkeypatch, pattern, url):
+    """Whitelist matches must consume some authority without stopping inside a field."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(pattern)],
+    )
+
+    with pytest.raises(ValueError, match='does not match'):
+        instance._validate_guardrails({'url': url, 'method': 'GET'})
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'url'),
+    [
+        (r'^https://api\.example\.com.*', 'https://api.example.com.evil.net/data'),
+        (r'^https://api\.example\.com.*$', 'https://api.example.com.evil.net/data'),
+        (r'^https://api\.example\.com:4.*', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com.*/private$', 'https://api.example.com.evil.net/private'),
+        (r'^https://api\.example\.com.+/private$', 'https://api.example.com.evil.net/x/private'),
+        (r'^https://api\.example\.com[^?]*\?key=x$', 'https://api.example.com.evil.net/private?key=x'),
+        (r'^https://api\.example\.com.{,100}$', 'https://api.example.com.evil.net/private'),
+        (r'^https://api\.example\.com.{,}$', 'https://api.example.com.evil.net/private'),
+        (r'^https://api\.example\.com(?::443)?.*/private$', 'https://api.example.com:4434/private'),
+        (r'^https://api\.example\.com\w*/private$', 'https://api.example.comevil/private'),
+        (r'^https://api\.example\.com[^./]{,4}/private$', 'https://api.example.comevil/private'),
+        (r'^https://api\.example\.com[a-z]{,4}/', 'https://api.example.comevil/private'),
+        (r'^https://192\.0\.2\.1[0-9]{1}/private$', 'https://192.0.2.10/private'),
+        (r'^https://\[2001:db8::1[0-9a-f]{1}\]/private$', 'https://[2001:db8::1a]/private'),
+        (r'^https://api\.example\.com:443[1-9]*/private$', 'https://api.example.com:4431/private'),
+        (r'^https://api\.example\.com:443[0-9]{1}/private$', 'https://api.example.com:4431/private'),
+        (r'^https://api\.example\.com:443[0-9]{,1}/private$', 'https://api.example.com:4431/private'),
+        pytest.param(
+            r'^https://api\.example\.com:443[1-9]*+/private$',
+            'https://api.example.com:4431/private',
+            marks=pytest.mark.skipif(sys.version_info < (3, 11), reason='possessive quantifiers require Python 3.11'),
+        ),
+        (
+            r'^(?:https://api\.example\.com.*/private$|https://[^/]+(?:/|$))',
+            'https://api.example.com.evil.net/private',
+        ),
+        (
+            r'^(?:https://api\.example\.com:443.*/private$|https://api\.example\.com:[0-9]+(?:/|$))',
+            'https://api.example.com:4434/private',
+        ),
+        (
+            r'^https://api\.example\.com:443/private$|^https://api\.example\.com:443[1-9]*/private$',
+            'https://api.example.com:4431/private',
+        ),
+        (r'^https://api\.example\.com', 'https://api.example.com/private'),
+        (r'^https://api\.example\.com:443', 'https://api.example.com:443/private'),
+        (r'^(?=https://api\.example\.com).*', 'https://api.example.com.evil.net/private'),
+        (r'^https://api\.example\.com(?=:443).*', 'https://api.example.com:4434/private'),
+    ],
+)
+def test_whitelist_rejects_consuming_authority_prefixes(monkeypatch, pattern, url):
+    """Full matches cannot hide hostname or port prefixes behind later syntax."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(pattern)],
+    )
+
+    with pytest.raises(ValueError, match='does not match'):
+        instance._validate_guardrails({'url': url, 'method': 'GET'})
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'url'),
+    [
+        (r'^https://api\.example\.com.*/private$', 'https://api.example.com.evil.net/private'),
+        (r'^https://192\.0\.2\.1.*/private$', 'https://192.0.2.10/private'),
+        (r'^https://\[2001:db8::1.*/private$', 'https://[2001:db8::10]/private'),
+    ],
+)
+def test_canonical_match_rejects_extended_hostnames_for_each_address_family(monkeypatch, pattern, url):
+    """DNS, IPv4, and bracketed IPv6 prefixes are detected semantically."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+
+    assert not iinstance._pattern_matches_canonical_url(re.compile(pattern), url)
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'url'),
+    [
+        (r'^https://api\.example\.com.*/private$', 'https://api.example.com.evil.net/private'),
+        (r'^https://api\.example\.com.+/private$', 'https://api.example.com.evil.net/x/private'),
+        (r'^https://api\.example\.com[^?]*\?key=x$', 'https://api.example.com.evil.net/x?key=x'),
+        (r'^https://api\.example\.com.{,100}$', 'https://api.example.com.evil.net/private'),
+        (r'^https://api\.example\.com.{,}$', 'https://api.example.com.evil.net/private'),
+    ],
+)
+def test_canonical_match_rejects_forced_suffix_regex_constructs(monkeypatch, pattern, url):
+    """Path/query suffixes and legal brace forms cannot conceal a hostname prefix."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+
+    assert not iinstance._pattern_matches_canonical_url(re.compile(pattern), url)
+
+
+def test_canonical_match_rejects_python_314_terminal_z(monkeypatch):
+    """Python 3.14's terminal z anchor cannot force an unsafe match past the host."""
+    try:
+        pattern = re.compile(r'^https://api\.example\.com.*\z')
+    except re.error:
+        pytest.skip(r'Python does not support \z')
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+
+    assert not iinstance._pattern_matches_canonical_url(pattern, 'https://api.example.com.evil.net/private')
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'url'),
+    [
+        (r'^https://api\.example\.com[a-z]*(?:/|$)', 'https://api.example.com/private'),
+        (r'^https://(?=api\.example\.com)api\.example\.com/', 'https://api.example.com/private'),
+        (r'^https://(?:api\.example\.com|[^/]+)(?:/|$)', 'https://api.example.com/private'),
+        (r'^https?://api\.example\.com/', 'https://api.example.com/private'),
+        (r'^https://api.example.com/', 'https://api.example.com/private'),
+        (r'^https://(?:[a-z0-9-]+\.)*example\.com(?:/|$)', 'https://sub.api.example.com/data'),
+        (r'.+/private$', 'https://any.public.example/private'),
+        (
+            '^https://api\\.example\\.com/never(?x:# (\n)|^https://api\\.example\\.com/private(?x:# )\n)',
+            'https://api.example.com/private',
+        ),
+    ],
+)
+def test_canonical_match_rejects_unsupported_authority_syntax(monkeypatch, pattern, url):
+    """Ambiguous authority syntax fails closed even when the regex matches the URL."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+
+    assert re.compile(pattern).match(url)
+    assert not iinstance._pattern_matches_canonical_url(re.compile(pattern), url)
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'url'),
+    [
+        (r'^https://[^/]+(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://[^/]{1,20}(?:/|$)', 'https://api.example.com/data'),
+        (r'^https://[^/]+(?:/|$)', 'https://192.0.2.10/data'),
+        (r'^https://[^/]+(?:/|$)', 'https://[2001:db8::10]:443/data'),
+        (r'^https://api\.example\.com(?:/|$)', 'https://api.example.com/data'),
+        (r'^https://api\.example\.com:443(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com(?::443)?(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com(?::443)?(?:/|$)', 'https://api.example.com/data'),
+        (r'^https://\[2001:db8::1\]:443/', 'https://[2001:db8::1]:443/data'),
+        (r'^https://api\.example\.com/files/escaped\.json$', 'https://api.example.com/files/escaped.json'),
+        (r'^https://api\.example\.com/files/.+?$', 'https://api.example.com/files/a/b'),
+        (r'^https://api\.example\.com/files/[a-z]{1,10}$', 'https://api.example.com/files/abc'),
+        (r'^https://api\.example\.com/[]a]$', 'https://api.example.com/]'),
+        (r'^https://api\.example\.com/x{,}$', 'https://api.example.com/xxx'),
+        pytest.param(
+            r'^https://api\.example\.com/files/.++$',
+            'https://api.example.com/files/abc',
+            marks=pytest.mark.skipif(sys.version_info < (3, 11), reason='possessive quantifiers require Python 3.11'),
+        ),
+        (r'^https://api\.example\.com(?=/|$)', 'https://api.example.com/data'),
+        (r'^https://api\.example\.com:[0-9]+(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com:[0-9]{3,4}(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com(?::[0-9]{3,4})?(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com(?::[0-9]{3,4})?(?:/|$)', 'https://api.example.com/data'),
+        (r'^https://192\.0\.2\.10(?:/|$)', 'https://192.0.2.10/data'),
+        (r'^https://\[2001:db8::10\](?:/|$)', 'https://[2001:db8::10]/data'),
+        (r'^https://api\.example\.com\?key=[a-z]+$', 'https://api.example.com?key=value'),
+        (r'^https://api\.example\.com$', 'https://api.example.com'),
+        (r'^https://api\.example\.com\Z', 'https://api.example.com'),
+    ],
+)
+def test_canonical_match_preserves_safe_full_url_patterns(monkeypatch, pattern, url):
+    """Authority-safe URL, path, escaped, lazy, and bounded patterns still work."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+
+    assert iinstance._pattern_matches_canonical_url(re.compile(pattern), url)
+
+
+def test_canonical_match_rejects_multiline_authority_boundary(monkeypatch):
+    """MULTILINE must not turn a line end into an authority boundary."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    pattern = re.compile(r'^https://api\.example\.com$', re.MULTILINE)
+
+    assert pattern.match('https://api.example.com\n.evil')
+    assert not iinstance._pattern_matches_canonical_url(pattern, 'https://api.example.com\n.evil')
+
+
+def test_canonical_match_allows_multiline_after_consuming_path_boundary(monkeypatch):
+    """Post-boundary regex flags do not weaken a consumed authority delimiter."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    pattern = re.compile(r'^https://api\.example\.com/data$', re.MULTILINE)
+
+    assert iinstance._pattern_matches_canonical_url(pattern, 'https://api.example.com/data')
+
+
+@pytest.mark.parametrize(
+    ('pattern', 'url'),
+    [
+        (r'^https://[^/]+(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com/public/', 'https://api.example.com/public/data'),
+        (r'^https://api\.example\.com(?::[0-9]+)?(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://api\.example\.com:443(?:/|$)', 'https://api.example.com:443/data'),
+        (r'^https://\[2001:db8::1\]:443(?:/|$)', 'https://[2001:db8::1]:443/data'),
+    ],
+)
+def test_whitelist_allows_matches_ending_at_authority_boundaries(monkeypatch, pattern, url):
+    """Host-agnostic, path, port, and IPv6 boundary patterns remain valid."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(
+        enabled_methods={'GET'},
+        url_patterns=[re.compile(pattern)],
+    )
+
+    assert instance._validate_guardrails({'url': url, 'method': 'GET'}) == url
 
 
 @pytest.mark.parametrize('encoded_segment', ['%2e%2e', '%252e%252e', '%2e%2e%5cadmin'])
@@ -184,3 +568,21 @@ def test_whitelist_checks_url_without_fragment(monkeypatch):
     )
 
     assert resolved_url == 'https://service.example/public/data'
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'https://username@service.example/data',
+        'https://username:password@service.example/data',
+        'https://@service.example/data',
+    ],
+)
+def test_guardrails_reject_userinfo_urls(monkeypatch, url):
+    """Instance validation rejects URL credentials before whitelist matching."""
+    _http_client, _iglobal, iinstance = _load_node_modules(monkeypatch)
+    instance = object.__new__(iinstance.IInstance)
+    instance.IGlobal = types.SimpleNamespace(enabled_methods={'GET'}, url_patterns=[])
+
+    with pytest.raises(ValueError, match='userinfo'):
+        instance._validate_guardrails({'url': url, 'method': 'GET'})

--- a/nodes/test/tool_http_request/test_resolve_path_params.py
+++ b/nodes/test/tool_http_request/test_resolve_path_params.py
@@ -8,8 +8,8 @@
 Path-param values are percent-encoded and inserted via a re.sub callback. This
 keeps each value as a single, literal path segment: a value used as a plain
 re.sub replacement string would be interpreted as a template (``\\1`` ->
-``re.error``, ``\\t`` -> a tab character), and an unencoded value could contain
-``/`` or ``..`` and alter the URL structure past the allowlist.
+``re.error``, ``\\t`` -> a tab character). Final URL validation separately
+rejects raw or encoded dot-segment traversal before the allowlist and network.
 """
 
 from __future__ import annotations
@@ -53,6 +53,22 @@ def test_reserved_chars_are_encoded_to_stay_one_segment():
     out = _resolve_path_params('https://api/public/:id', {'id': '../admin?x=1'})
     assert out == 'https://api/public/..%2Fadmin%3Fx%3D1'
     assert '/admin' not in out
+
+
+@pytest.mark.parametrize('value', ['.', '..'])
+def test_dot_segment_value_is_rejected(value):
+    """A path parameter cannot traverse outside an allowlisted path prefix."""
+    with pytest.raises(ValueError, match='dot segments'):
+        _resolve_path_params('https://api/public/:id/profile', {'id': value})
+
+
+def test_placeholders_outside_path_are_not_replaced():
+    """Path parameters cannot rewrite the authority, query, or fragment."""
+    out = _resolve_path_params(
+        'https://:host/public/:id?query=:id#fragment-:id',
+        {'host': 'attacker.example', 'id': '42'},
+    )
+    assert out == 'https://:host/public/42?query=:id#fragment-:id'
 
 
 def test_plain_value_substitution():

--- a/nodes/test/tool_http_request/test_ssrf_protection.py
+++ b/nodes/test/tool_http_request/test_ssrf_protection.py
@@ -47,21 +47,6 @@ def test_requests_exposes_secure_adapter_hook():
 
 
 @pytest.mark.parametrize(
-    'version,expected',
-    [
-        ('2.6.9', False),
-        ('2.7.0', True),
-        ('2.7.4', True),
-        ('2.8.0', False),
-        ('invalid', False),
-    ],
-)
-def test_urllib3_runtime_is_bounded_to_audited_minor(version, expected):
-    """Unknown urllib3 transport internals fail closed instead of bypassing the pin."""
-    assert http_client._has_supported_urllib3_runtime(version) is expected
-
-
-@pytest.mark.parametrize(
     'version_info,expected',
     [
         ((3, 10, 13), False),

--- a/nodes/test/tool_http_request/test_ssrf_protection.py
+++ b/nodes/test/tool_http_request/test_ssrf_protection.py
@@ -1,0 +1,241 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Regression tests for HTTP-tool SSRF protections."""
+
+from __future__ import annotations
+
+import socket
+import sys
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip('requests')
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / 'src' / 'nodes' / 'tool_http_request'))
+
+import http_client  # noqa: E402
+
+
+def _dns_result(address: str) -> tuple:
+    """Build one getaddrinfo result for an IPv4 or IPv6 address."""
+    if ':' in address:
+        return (socket.AF_INET6, socket.SOCK_STREAM, socket.IPPROTO_TCP, '', (address, 443, 0, 0))
+    return (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, '', (address, 443))
+
+
+def _mock_dns(monkeypatch: pytest.MonkeyPatch, *addresses: str) -> Mock:
+    resolver = Mock(return_value=[_dns_result(address) for address in addresses])
+    monkeypatch.setattr(http_client.socket, 'getaddrinfo', resolver)
+    return resolver
+
+
+@pytest.mark.parametrize(
+    'address',
+    [
+        '127.0.0.1',
+        '10.0.0.1',
+        '172.16.0.1',
+        '192.168.0.1',
+        '169.254.169.254',
+        '100.64.0.1',
+        '0.0.0.0',
+        '224.0.0.1',
+        '240.0.0.1',
+        '::1',
+        'fc00::1',
+        'fe80::1',
+        'fec0::1',
+        '::',
+        '::7f00:1',
+        '::ffff:127.0.0.1',
+        '2002:7f00:1::',
+        'ff02::1',
+    ],
+)
+def test_validate_public_url_rejects_non_public_addresses(monkeypatch, address):
+    """Loopback, private, link-local, shared, unspecified, and multicast addresses are blocked."""
+    _mock_dns(monkeypatch, address)
+
+    with pytest.raises(ValueError, match='non-public network address'):
+        http_client._validate_public_url('https://service.example/data')
+
+
+def test_validate_public_url_rejects_mixed_public_and_private_dns(monkeypatch):
+    """One unsafe DNS answer blocks the host even when another answer is public."""
+    _mock_dns(monkeypatch, '93.184.216.34', '10.0.0.8')
+
+    with pytest.raises(ValueError, match='non-public network address'):
+        http_client._validate_public_url('https://service.example/data')
+
+
+@pytest.mark.parametrize(
+    'url',
+    [
+        'http://2130706433/',
+        'http://0x7f000001/',
+        'http://public.example@127.0.0.1/',
+        'http://[::ffff:127.0.0.1]/',
+    ],
+)
+def test_validate_public_url_rejects_disguised_loopback_hosts(monkeypatch, url):
+    """Numeric and user-info URL forms cannot hide a loopback destination."""
+    _mock_dns(monkeypatch, '127.0.0.1')
+
+    with pytest.raises(ValueError, match='non-public network address'):
+        http_client._validate_public_url(url)
+
+
+@pytest.mark.parametrize('address', ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'])
+def test_validate_public_url_allows_public_addresses(monkeypatch, address):
+    """Ordinary public IPv4 and IPv6 destinations remain usable."""
+    resolver = _mock_dns(monkeypatch, address)
+
+    http_client._validate_public_url('https://service.example:8443/data')
+
+    resolver.assert_called_once_with(
+        'service.example',
+        8443,
+        family=socket.AF_UNSPEC,
+        type=socket.SOCK_STREAM,
+        proto=socket.IPPROTO_TCP,
+    )
+
+
+@pytest.mark.parametrize(
+    'url,error',
+    [
+        ('file:///etc/passwd', 'scheme'),
+        ('ftp://service.example/data', 'scheme'),
+        ('https:///missing-host', 'hostname'),
+        ('https://service.example:invalid/data', 'port'),
+        ('https://service.example:0/data', 'port'),
+    ],
+)
+def test_validate_public_url_rejects_malformed_or_unsupported_urls(url, error):
+    """Only complete HTTP(S) URLs reach DNS or the network."""
+    with pytest.raises(ValueError, match=error):
+        http_client._validate_public_url(url)
+
+
+def test_validate_public_url_rejects_dns_failure(monkeypatch):
+    """An unresolved host fails closed instead of reaching requests for a second lookup."""
+    resolver = Mock(side_effect=socket.gaierror('not found'))
+    monkeypatch.setattr(http_client.socket, 'getaddrinfo', resolver)
+
+    with pytest.raises(http_client.requests.ConnectionError, match='could not be resolved'):
+        http_client._validate_public_url('https://missing.example/data')
+
+
+def test_validate_public_url_rejects_empty_dns_answer(monkeypatch):
+    """A resolver response without usable addresses fails closed."""
+    monkeypatch.setattr(http_client.socket, 'getaddrinfo', Mock(return_value=[]))
+
+    with pytest.raises(http_client.requests.ConnectionError, match='could not be resolved'):
+        http_client._validate_public_url('https://missing.example/data')
+
+
+def test_validate_public_url_rejects_invalid_resolver_address(monkeypatch):
+    """Unexpected resolver output cannot bypass address classification."""
+    result = (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, '', ('not-an-address', 443))
+    monkeypatch.setattr(http_client.socket, 'getaddrinfo', Mock(return_value=[result]))
+
+    with pytest.raises(http_client.requests.ConnectionError, match='invalid network address'):
+        http_client._validate_public_url('https://service.example/data')
+
+
+def test_execute_request_blocks_private_destination_before_network(monkeypatch):
+    """A direct request to an unsafe destination never reaches requests."""
+    _mock_dns(monkeypatch, '169.254.169.254')
+    request = Mock()
+    monkeypatch.setattr(http_client.requests, 'request', request)
+
+    with pytest.raises(ValueError, match='non-public network address'):
+        http_client.execute_request(url='http://169.254.169.254/latest/meta-data/', method='GET')
+
+    request.assert_not_called()
+
+
+@pytest.mark.parametrize('status_code', [301, 302, 303, 307, 308])
+def test_execute_request_disables_automatic_redirects(monkeypatch, status_code):
+    """A 3xx response is returned to the caller and cannot jump past URL validation."""
+    _mock_dns(monkeypatch, '93.184.216.34')
+    response = Mock(
+        status_code=status_code,
+        reason='Found',
+        headers={'Location': 'http://127.0.0.1/admin', 'Content-Type': 'text/plain'},
+        text='',
+    )
+    request = Mock(return_value=response)
+    monkeypatch.setattr(http_client.requests, 'request', request)
+
+    result = http_client.execute_request(url='https://service.example/redirect', method='GET')
+
+    assert result['status_code'] == status_code
+    assert request.call_args.kwargs['allow_redirects'] is False
+
+
+def test_execute_request_validates_path_resolved_url(monkeypatch):
+    """URL safety validation runs after path parameters are inserted."""
+    _mock_dns(monkeypatch, '93.184.216.34')
+    response = Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok')
+    request = Mock(return_value=response)
+    monkeypatch.setattr(http_client.requests, 'request', request)
+
+    http_client.execute_request(
+        url='https://service.example/users/:id',
+        method='GET',
+        path_params={'id': '../admin'},
+    )
+
+    assert request.call_args.kwargs['url'] == 'https://service.example/users/..%2Fadmin'
+    assert request.call_args.kwargs['allow_redirects'] is False
+
+
+def test_execute_request_query_value_cannot_change_destination(monkeypatch):
+    """An internal URL inside a query value is data, not the request destination."""
+    resolver = _mock_dns(monkeypatch, '93.184.216.34')
+    response = Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok')
+    request = Mock(return_value=response)
+    monkeypatch.setattr(http_client.requests, 'request', request)
+
+    http_client.execute_request(
+        url='https://service.example/fetch',
+        method='GET',
+        query_params={'target': 'http://127.0.0.1/admin'},
+    )
+
+    assert resolver.call_args.args[0] == 'service.example'
+    assert request.call_args.kwargs['params'] == {'target': 'http://127.0.0.1/admin'}
+
+
+def test_execute_request_preserves_existing_request_options(monkeypatch):
+    """The SSRF guard changes redirect behavior without dropping normal request options."""
+    _mock_dns(monkeypatch, '93.184.216.34')
+    response = Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok')
+    request = Mock(return_value=response)
+    monkeypatch.setattr(http_client.requests, 'request', request)
+
+    http_client.execute_request(
+        url='https://service.example/data',
+        method='POST',
+        headers={'X-Test': 'value'},
+        auth={'type': 'bearer', 'bearer': {'token': 'secret'}},
+        body={'type': 'raw', 'raw': {'content': '{}', 'content_type': 'application/json'}},
+        timeout=12,
+    )
+
+    kwargs = request.call_args.kwargs
+    assert kwargs['method'] == 'POST'
+    assert kwargs['headers'] == {
+        'X-Test': 'value',
+        'Authorization': 'Bearer secret',
+        'Content-Type': 'application/json',
+    }
+    assert kwargs['data'] == '{}'
+    assert kwargs['timeout'] == 12
+    assert kwargs['allow_redirects'] is False

--- a/nodes/test/tool_http_request/test_ssrf_protection.py
+++ b/nodes/test/tool_http_request/test_ssrf_protection.py
@@ -34,6 +34,12 @@ def _mock_dns(monkeypatch: pytest.MonkeyPatch, *addresses: str) -> Mock:
     return resolver
 
 
+def test_requests_exposes_secure_adapter_hook():
+    """The installed Requests API must support the pinned connection adapter."""
+    assert hasattr(http_client.HTTPAdapter, 'get_connection_with_tls_context')
+    assert hasattr(http_client.HTTPAdapter, 'build_connection_pool_key_attributes')
+
+
 @pytest.mark.parametrize(
     'address',
     [

--- a/nodes/test/tool_http_request/test_ssrf_protection.py
+++ b/nodes/test/tool_http_request/test_ssrf_protection.py
@@ -148,11 +148,105 @@ def test_validate_public_url_rejects_invalid_resolver_address(monkeypatch):
         http_client._validate_public_url('https://service.example/data')
 
 
+def test_pinned_connection_reuses_validated_dns_address(monkeypatch):
+    """A later private DNS answer cannot replace the public address that was validated."""
+    resolver = Mock(
+        side_effect=[
+            [_dns_result('93.184.216.34')],
+            [_dns_result('127.0.0.1')],
+        ]
+    )
+    monkeypatch.setattr(http_client.socket, 'getaddrinfo', resolver)
+    validated = http_client._validate_public_url('https://service.example/data')
+
+    class FakeSocket:
+        def __init__(self):
+            self.connected_to = None
+
+        def setsockopt(self, *_args):
+            pass
+
+        def settimeout(self, _timeout):
+            pass
+
+        def bind(self, _source_address):
+            pass
+
+        def connect(self, sockaddr):
+            self.connected_to = sockaddr
+
+        def close(self):
+            pass
+
+    fake_socket = FakeSocket()
+    monkeypatch.setattr(http_client.socket, 'socket', Mock(return_value=fake_socket))
+    connection = http_client._PinnedHTTPSConnection(
+        'service.example',
+        443,
+        timeout=1,
+        validated_addresses=validated,
+    )
+
+    assert connection._new_conn() is fake_socket
+    assert resolver.call_count == 1
+    assert fake_socket.connected_to == ('93.184.216.34', 443)
+    assert connection.host == 'service.example'
+
+
+def test_pinned_adapter_keeps_original_https_hostname():
+    """The pinned pool retains the original host for Host, SNI, and certificate verification."""
+    addresses = ((socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, ('93.184.216.34', 443)),)
+    adapter = http_client._PinnedAddressAdapter(addresses)
+    request = http_client.requests.Request('GET', 'https://service.example/data').prepare()
+
+    pool = adapter.get_connection_with_tls_context(request, verify=True, proxies={})
+
+    assert isinstance(pool, http_client._PinnedHTTPSConnectionPool)
+    assert pool.host == 'service.example'
+    assert pool.conn_kw['validated_addresses'] == addresses
+    adapter.close()
+
+
+def test_pinned_adapter_rejects_explicit_proxy():
+    """A proxy cannot take over destination resolution after validation."""
+    addresses = ((socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, ('93.184.216.34', 443)),)
+    adapter = http_client._PinnedAddressAdapter(addresses)
+    request = http_client.requests.Request('GET', 'https://service.example/data').prepare()
+
+    with pytest.raises(http_client.ProxyError, match='Proxies are not supported'):
+        adapter.get_connection_with_tls_context(
+            request,
+            verify=True,
+            proxies={'https': 'http://proxy.example:8080'},
+        )
+
+    adapter.close()
+
+
+def test_pinned_transport_ignores_environment_proxies(monkeypatch):
+    """Environment proxy settings cannot move DNS and connection control outside the node."""
+    session = Mock()
+    session.trust_env = True
+    session.__enter__ = Mock(return_value=session)
+    session.__exit__ = Mock(return_value=False)
+    session.request = Mock(return_value=Mock())
+    monkeypatch.setattr(http_client.requests, 'Session', Mock(return_value=session))
+    addresses = ((socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, ('93.184.216.34', 443)),)
+
+    http_client._request_with_validated_addresses(
+        {'url': 'https://service.example/data', 'method': 'GET'},
+        addresses,
+    )
+
+    assert session.trust_env is False
+    session.mount.assert_called_once()
+
+
 def test_execute_request_blocks_private_destination_before_network(monkeypatch):
     """A direct request to an unsafe destination never reaches requests."""
     _mock_dns(monkeypatch, '169.254.169.254')
     request = Mock()
-    monkeypatch.setattr(http_client.requests, 'request', request)
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
 
     with pytest.raises(ValueError, match='non-public network address'):
         http_client.execute_request(url='http://169.254.169.254/latest/meta-data/', method='GET')
@@ -171,12 +265,12 @@ def test_execute_request_disables_automatic_redirects(monkeypatch, status_code):
         text='',
     )
     request = Mock(return_value=response)
-    monkeypatch.setattr(http_client.requests, 'request', request)
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
 
     result = http_client.execute_request(url='https://service.example/redirect', method='GET')
 
     assert result['status_code'] == status_code
-    assert request.call_args.kwargs['allow_redirects'] is False
+    assert request.call_args.args[0]['allow_redirects'] is False
 
 
 def test_execute_request_validates_path_resolved_url(monkeypatch):
@@ -184,7 +278,7 @@ def test_execute_request_validates_path_resolved_url(monkeypatch):
     _mock_dns(monkeypatch, '93.184.216.34')
     response = Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok')
     request = Mock(return_value=response)
-    monkeypatch.setattr(http_client.requests, 'request', request)
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
 
     http_client.execute_request(
         url='https://service.example/users/:id',
@@ -192,8 +286,8 @@ def test_execute_request_validates_path_resolved_url(monkeypatch):
         path_params={'id': '../admin'},
     )
 
-    assert request.call_args.kwargs['url'] == 'https://service.example/users/..%2Fadmin'
-    assert request.call_args.kwargs['allow_redirects'] is False
+    assert request.call_args.args[0]['url'] == 'https://service.example/users/..%2Fadmin'
+    assert request.call_args.args[0]['allow_redirects'] is False
 
 
 def test_execute_request_query_value_cannot_change_destination(monkeypatch):
@@ -201,7 +295,7 @@ def test_execute_request_query_value_cannot_change_destination(monkeypatch):
     resolver = _mock_dns(monkeypatch, '93.184.216.34')
     response = Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok')
     request = Mock(return_value=response)
-    monkeypatch.setattr(http_client.requests, 'request', request)
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
 
     http_client.execute_request(
         url='https://service.example/fetch',
@@ -210,7 +304,7 @@ def test_execute_request_query_value_cannot_change_destination(monkeypatch):
     )
 
     assert resolver.call_args.args[0] == 'service.example'
-    assert request.call_args.kwargs['params'] == {'target': 'http://127.0.0.1/admin'}
+    assert request.call_args.args[0]['params'] == {'target': 'http://127.0.0.1/admin'}
 
 
 def test_execute_request_preserves_existing_request_options(monkeypatch):
@@ -218,7 +312,7 @@ def test_execute_request_preserves_existing_request_options(monkeypatch):
     _mock_dns(monkeypatch, '93.184.216.34')
     response = Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok')
     request = Mock(return_value=response)
-    monkeypatch.setattr(http_client.requests, 'request', request)
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
 
     http_client.execute_request(
         url='https://service.example/data',
@@ -229,7 +323,7 @@ def test_execute_request_preserves_existing_request_options(monkeypatch):
         timeout=12,
     )
 
-    kwargs = request.call_args.kwargs
+    kwargs = request.call_args.args[0]
     assert kwargs['method'] == 'POST'
     assert kwargs['headers'] == {
         'X-Test': 'value',

--- a/nodes/test/tool_http_request/test_ssrf_protection.py
+++ b/nodes/test/tool_http_request/test_ssrf_protection.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 import socket
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from unittest.mock import Mock
 
@@ -38,6 +40,42 @@ def test_requests_exposes_secure_adapter_hook():
     """The installed Requests API must support the pinned connection adapter."""
     assert hasattr(http_client.HTTPAdapter, 'get_connection_with_tls_context')
     assert hasattr(http_client.HTTPAdapter, 'build_connection_pool_key_attributes')
+    assert http_client.HTTPConnectionPool.ConnectionCls is http_client.HTTPConnection
+    assert http_client.HTTPSConnectionPool.ConnectionCls is http_client.HTTPSConnection
+    assert hasattr(http_client.HTTPConnection, '_new_conn')
+    assert hasattr(http_client.HTTPSConnection, '_new_conn')
+
+
+@pytest.mark.parametrize(
+    'version,expected',
+    [
+        ('2.6.9', False),
+        ('2.7.0', True),
+        ('2.7.4', True),
+        ('2.8.0', False),
+        ('invalid', False),
+    ],
+)
+def test_urllib3_runtime_is_bounded_to_audited_minor(version, expected):
+    """Unknown urllib3 transport internals fail closed instead of bypassing the pin."""
+    assert http_client._has_supported_urllib3_runtime(version) is expected
+
+
+@pytest.mark.parametrize(
+    'version_info,expected',
+    [
+        ((3, 10, 13), False),
+        ((3, 10, 14), True),
+        ((3, 11, 8), False),
+        ((3, 11, 9), True),
+        ((3, 12, 3), False),
+        ((3, 12, 4), True),
+        ((3, 13, 0), True),
+    ],
+)
+def test_ipaddress_runtime_security_patch_floor(version_info, expected):
+    """Known-vulnerable Python patch levels fail closed before URL validation."""
+    assert http_client._has_safe_ipaddress_runtime(version_info) is expected
 
 
 @pytest.mark.parametrize(
@@ -60,6 +98,10 @@ def test_requests_exposes_secure_adapter_hook():
         '::7f00:1',
         '::ffff:127.0.0.1',
         '2002:7f00:1::',
+        '64:ff9b::7f00:1',
+        '64:ff9b::a9fe:a9fe',
+        '64:ff9b:1::7f00:1',
+        '64:ff9b:1::808:808',
         'ff02::1',
     ],
 )
@@ -96,7 +138,14 @@ def test_validate_public_url_rejects_disguised_loopback_hosts(monkeypatch, url):
         http_client._validate_public_url(url)
 
 
-@pytest.mark.parametrize('address', ['93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946'])
+@pytest.mark.parametrize(
+    'address',
+    [
+        '93.184.216.34',
+        '2606:2800:220:1:248:1893:25c8:1946',
+        '64:ff9b::808:808',
+    ],
+)
 def test_validate_public_url_allows_public_addresses(monkeypatch, address):
     """Ordinary public IPv4 and IPv6 destinations remain usable."""
     resolver = _mock_dns(monkeypatch, address)
@@ -120,6 +169,11 @@ def test_validate_public_url_allows_public_addresses(monkeypatch, address):
         ('https:///missing-host', 'hostname'),
         ('https://service.example:invalid/data', 'port'),
         ('https://service.example:0/data', 'port'),
+        ('https://service.example/public/../admin', 'dot segments'),
+        ('https://service.example/public/%2e%2e/admin', 'dot segments'),
+        ('https://service.example/public/%252e%252e/admin', 'dot segments'),
+        ('https://service.example/public/%2e%2e%5cadmin', 'dot segments'),
+        ('https://service.example/public/%25252525252541/admin', 'dot segments'),
     ],
 )
 def test_validate_public_url_rejects_malformed_or_unsupported_urls(url, error):
@@ -213,6 +267,58 @@ def test_pinned_adapter_keeps_original_https_hostname():
     adapter.close()
 
 
+def test_pinned_adapter_builds_plain_http_connection_without_tls_options():
+    """TLS-only kwargs never reach urllib3's plain HTTP connection class."""
+    addresses = ((socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, ('93.184.216.34', 80)),)
+    adapter = http_client._PinnedAddressAdapter(addresses)
+    request = http_client.requests.Request('GET', 'http://service.example/data').prepare()
+
+    pool = adapter.get_connection_with_tls_context(request, verify=True, proxies={})
+    connection = pool._new_conn()
+
+    assert isinstance(pool, http_client._PinnedHTTPConnectionPool)
+    assert isinstance(connection, http_client._PinnedHTTPConnection)
+    assert not set(http_client.SSL_KEYWORDS).intersection(pool.conn_kw)
+    adapter.close()
+
+
+def test_execute_plain_http_request_through_pinned_transport(monkeypatch):
+    """A real HTTP exchange uses the pinned address and keeps the URL hostname."""
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            self.server.received_host = self.headers['Host']
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'pinned transport works')
+
+        def log_message(self, _format, *_args):
+            pass
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    port = server.server_address[1]
+    addresses = ((socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, ('127.0.0.1', port)),)
+    monkeypatch.setattr(http_client, '_validate_public_url', Mock(return_value=addresses))
+
+    try:
+        result = http_client.execute_request(
+            url=f'http://service.example:{port}/data',
+            method='GET',
+            timeout=2,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert result['status_code'] == 200
+    assert result['body'] == 'pinned transport works'
+    assert server.received_host == f'service.example:{port}'
+
+
 def test_pinned_adapter_rejects_explicit_proxy():
     """A proxy cannot take over destination resolution after validation."""
     addresses = ((socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, ('93.184.216.34', 443)),)
@@ -248,6 +354,46 @@ def test_pinned_transport_ignores_environment_proxies(monkeypatch):
     session.mount.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    'environment,expected',
+    [
+        ({}, True),
+        ({'REQUESTS_CA_BUNDLE': '/custom/requests-ca.pem'}, '/custom/requests-ca.pem'),
+        ({'CURL_CA_BUNDLE': '/custom/curl-ca.pem'}, '/custom/curl-ca.pem'),
+        (
+            {
+                'REQUESTS_CA_BUNDLE': '/custom/requests-ca.pem',
+                'CURL_CA_BUNDLE': '/custom/curl-ca.pem',
+            },
+            '/custom/requests-ca.pem',
+        ),
+    ],
+)
+def test_pinned_transport_preserves_custom_ca_bundle(monkeypatch, environment, expected):
+    """Custom CA files remain usable without re-enabling proxies or netrc."""
+    monkeypatch.delenv('REQUESTS_CA_BUNDLE', raising=False)
+    monkeypatch.delenv('CURL_CA_BUNDLE', raising=False)
+    for name, value in environment.items():
+        monkeypatch.setenv(name, value)
+
+    session = Mock()
+    session.trust_env = True
+    session.verify = True
+    session.__enter__ = Mock(return_value=session)
+    session.__exit__ = Mock(return_value=False)
+    session.request = Mock(return_value=Mock())
+    monkeypatch.setattr(http_client.requests, 'Session', Mock(return_value=session))
+    addresses = ((socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, ('93.184.216.34', 443)),)
+
+    http_client._request_with_validated_addresses(
+        {'url': 'https://service.example/data', 'method': 'GET'},
+        addresses,
+    )
+
+    assert session.trust_env is False
+    assert session.verify == expected
+
+
 def test_execute_request_blocks_private_destination_before_network(monkeypatch):
     """A direct request to an unsafe destination never reaches requests."""
     _mock_dns(monkeypatch, '169.254.169.254')
@@ -256,6 +402,31 @@ def test_execute_request_blocks_private_destination_before_network(monkeypatch):
 
     with pytest.raises(ValueError, match='non-public network address'):
         http_client.execute_request(url='http://169.254.169.254/latest/meta-data/', method='GET')
+
+    request.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    'headers,auth',
+    [
+        ({'Host': 'internal.example'}, None),
+        ({'hOsT': 'internal.example'}, None),
+        (None, {'type': 'api_key', 'api_key': {'key': 'Host', 'value': 'internal.example'}}),
+    ],
+)
+def test_execute_request_rejects_host_header_override(monkeypatch, headers, auth):
+    """Callers cannot route an allowlisted URL to a different virtual host."""
+    _mock_dns(monkeypatch, '93.184.216.34')
+    request = Mock()
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
+
+    with pytest.raises(ValueError, match='Host header'):
+        http_client.execute_request(
+            url='https://service.example/data',
+            method='GET',
+            headers=headers,
+            auth=auth,
+        )
 
     request.assert_not_called()
 
@@ -289,11 +460,26 @@ def test_execute_request_validates_path_resolved_url(monkeypatch):
     http_client.execute_request(
         url='https://service.example/users/:id',
         method='GET',
-        path_params={'id': '../admin'},
+        path_params={'id': 'team/admin'},
     )
 
-    assert request.call_args.args[0]['url'] == 'https://service.example/users/..%2Fadmin'
+    assert request.call_args.args[0]['url'] == 'https://service.example/users/team%2Fadmin'
     assert request.call_args.args[0]['allow_redirects'] is False
+
+
+def test_execute_request_rejects_encoded_path_param_traversal(monkeypatch):
+    """Encoded separators cannot hide a dot segment until Requests prepares the URL."""
+    request = Mock()
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
+
+    with pytest.raises(ValueError, match='dot segments'):
+        http_client.execute_request(
+            url='https://service.example/users/:id/profile',
+            method='GET',
+            path_params={'id': '../admin'},
+        )
+
+    request.assert_not_called()
 
 
 def test_execute_request_query_value_cannot_change_destination(monkeypatch):

--- a/nodes/test/tool_http_request/test_ssrf_protection.py
+++ b/nodes/test/tool_http_request/test_ssrf_protection.py
@@ -49,10 +49,10 @@ def test_requests_exposes_secure_adapter_hook():
 @pytest.mark.parametrize(
     'version_info,expected',
     [
-        ((3, 10, 13), False),
-        ((3, 10, 14), True),
-        ((3, 11, 8), False),
-        ((3, 11, 9), True),
+        ((3, 10, 14), False),
+        ((3, 10, 15), True),
+        ((3, 11, 9), False),
+        ((3, 11, 10), True),
         ((3, 12, 3), False),
         ((3, 12, 4), True),
         ((3, 13, 0), True),
@@ -107,19 +107,19 @@ def test_validate_public_url_rejects_mixed_public_and_private_dns(monkeypatch):
 
 
 @pytest.mark.parametrize(
-    'url',
+    'url,error',
     [
-        'http://2130706433/',
-        'http://0x7f000001/',
-        'http://public.example@127.0.0.1/',
-        'http://[::ffff:127.0.0.1]/',
+        ('http://2130706433/', 'non-public network address'),
+        ('http://0x7f000001/', 'non-public network address'),
+        ('http://public.example@127.0.0.1/', 'userinfo'),
+        ('http://[::ffff:127.0.0.1]/', 'non-public network address'),
     ],
 )
-def test_validate_public_url_rejects_disguised_loopback_hosts(monkeypatch, url):
+def test_validate_public_url_rejects_disguised_loopback_hosts(monkeypatch, url, error):
     """Numeric and user-info URL forms cannot hide a loopback destination."""
     _mock_dns(monkeypatch, '127.0.0.1')
 
-    with pytest.raises(ValueError, match='non-public network address'):
+    with pytest.raises(ValueError, match=error):
         http_client._validate_public_url(url)
 
 
@@ -392,6 +392,27 @@ def test_execute_request_blocks_private_destination_before_network(monkeypatch):
 
 
 @pytest.mark.parametrize(
+    'url',
+    [
+        'https://username@service.example/data',
+        'https://username:password@service.example/data',
+        'https://@service.example/data',
+    ],
+)
+def test_execute_request_rejects_userinfo_before_dns_or_transport(monkeypatch, url):
+    """Credentials in a URL cannot alter the validated request destination."""
+    resolver = _mock_dns(monkeypatch, '93.184.216.34')
+    request = Mock(return_value=Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok'))
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
+
+    with pytest.raises(ValueError, match='userinfo'):
+        http_client.execute_request(url=url, method='GET')
+
+    resolver.assert_not_called()
+    request.assert_not_called()
+
+
+@pytest.mark.parametrize(
     'headers,auth',
     [
         ({'Host': 'internal.example'}, None),
@@ -481,7 +502,78 @@ def test_execute_request_query_value_cannot_change_destination(monkeypatch):
     )
 
     assert resolver.call_args.args[0] == 'service.example'
-    assert request.call_args.args[0]['params'] == {'target': 'http://127.0.0.1/admin'}
+    assert request.call_args.args[0]['url'] == 'https://service.example/fetch?target=http%3A%2F%2F127.0.0.1%2Fadmin'
+    assert request.call_args.args[0]['params'] is None
+
+
+@pytest.mark.parametrize(
+    ('query_params', 'auth', 'expected_url'),
+    [
+        (
+            {'extra': '2'},
+            None,
+            'https://service.example/path?fixed=1&extra=2',
+        ),
+        (
+            None,
+            {
+                'type': 'api_key',
+                'api_key': {'key': 'api_key', 'value': 'secret', 'add_to': 'query_param'},
+            },
+            'https://service.example/path?fixed=1&api_key=secret',
+        ),
+    ],
+)
+def test_execute_request_passes_final_query_url_to_transport(monkeypatch, query_params, auth, expected_url):
+    """The transport receives the one canonical URL that guardrails check."""
+    _mock_dns(monkeypatch, '93.184.216.34')
+    response = Mock(status_code=200, reason='OK', headers={'Content-Type': 'text/plain'}, text='ok')
+    request = Mock(return_value=response)
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
+
+    http_client.execute_request(
+        url='https://service.example/path?fixed=1',
+        method='GET',
+        query_params=query_params,
+        auth=auth,
+    )
+
+    assert request.call_args.args[0]['url'] == expected_url
+    assert request.call_args.args[0]['params'] is None
+
+
+def test_execute_request_redacts_query_api_key_from_transport_error(monkeypatch):
+    """Transport failures cannot retain query API-key URL state."""
+    _mock_dns(monkeypatch, '93.184.216.34')
+    secret = 'supersecret'
+    final_url = f'https://service.example/path?api_key={secret}'
+    prepared_request = http_client.requests.Request('GET', final_url).prepare()
+    response = http_client.requests.Response()
+    response.request = prepared_request
+    transport_error = http_client.requests.ConnectionError(
+        f'Max retries exceeded with url: /path?api_key={secret}',
+        request=prepared_request,
+        response=response,
+    )
+    request = Mock(side_effect=transport_error)
+    monkeypatch.setattr(http_client, '_request_with_validated_addresses', request)
+
+    with pytest.raises(http_client.requests.ConnectionError) as exc_info:
+        http_client.execute_request(
+            url='https://service.example/path',
+            method='GET',
+            auth={
+                'type': 'api_key',
+                'api_key': {'key': 'api_key', 'value': secret, 'add_to': 'query_param'},
+            },
+        )
+
+    error = exc_info.value
+    assert secret not in str(error)
+    assert getattr(error, 'request', None) is None
+    assert getattr(error, 'response', None) is None
+    assert error.__cause__ is None
+    assert error.__context__ is None
 
 
 def test_execute_request_preserves_existing_request_options(monkeypatch):


### PR DESCRIPTION
## Summary

- reject HTTP destinations that resolve to loopback, private, link-local, shared, reserved, unspecified, multicast, or otherwise non-public addresses, and pin the connection to the exact validated DNS results
- return 3xx responses without following them automatically, so redirect targets cannot bypass URL and network validation
- strip TLS-only pool arguments from plain-HTTP connections, preserving working `http://` transport through the pinned adapter
- block IPv4-embedded IPv6 bypasses, including standard and local-use NAT64, 6to4, Teredo, and IPv4-compatible forms
- require Python patch releases with corrected `ipaddress` classification: 3.10.15+, 3.11.10+, 3.12.4+, or 3.13+
- reject URL userinfo and validate whitelist regexes with a fail-closed authority grammar before applying them to the canonical URL
- ignore blank whitelist rows from the UI while rejecting malformed non-empty patterns
- keep shared `requests` and `urllib3` requirements unbounded, using the universal lock plus runtime capability checks for the transport hooks this implementation needs
- preserve custom CA bundles while keeping proxies and implicit `.netrc` credentials disabled
- document whitelist migration, the public-network boundary, and deployment-level outbound filtering as defense in depth

## Why

The HTTP tool previously applied its URL regex only to the original URL. A permitted public URL could redirect to an internal service, and the node did not independently reject direct private or metadata-service destinations. That made server-side request forgery possible when the tool had an empty or broad URL whitelist.

An empty URL whitelist still means all **public** URLs are allowed. Operators can narrow that set with URL patterns.

## Compatibility notes

- There is intentionally no private-network override. Existing pipelines that call localhost, internal services, or self-hosted private APIs through this node will be rejected.
- Environment proxies and implicit `.netrc` credentials are ignored. `REQUESTS_CA_BUNDLE` and `CURL_CA_BUNDLE` remain supported.
- Whitelist patterns now match the canonical URL from its beginning and must express a supported authority boundary. Search-style, ambiguous-authority, or unrestricted-authority patterns may require migration; the node emits a startup warning.
- Outbound firewall or equivalent egress controls remain a required defense-in-depth boundary, including for operator-selected NAT64 prefixes that cannot be inferred from an IPv6 address alone.

Follow-up to the security finding on #1974.

## Validation

- repository-native focused suite: `209 passed, 2 skipped` (`./builder nodes:test --pytest-pattern=tool_http_request --pytest-parallel=off`)
- exact Python patch matrix:
  - Python 3.10.15: `205 passed, 3 skipped`
  - Python 3.11.10: `207 passed, 1 skipped`
  - Python 3.12.4: `207 passed, 1 skipped`
  - Python 3.13.13: `207 passed, 1 skipped`
  - Python 3.14.5: `208 passed`
- Requests/urllib3 compatibility matrix on Python 3.11.10: `207 passed, 1 skipped` for each of `2.32.3/2.2.3`, `2.32.3/2.5.0`, `2.32.4/2.6.0`, and locked `2.34.2/2.7.0`
- node contracts: `346 passed` (`./builder nodes:test-contracts`)
- docs helpers: `35 passed` (`./builder docs:test`)
- Ruff check/format, JSON parsing, `git diff --check`, and pre-commit gitleaks passed
- docs production bundles compile; the final site link check is blocked by the pre-existing, untouched broken link in `nodes/src/nodes/llm_qwen/README.md`
- a fresh independent adversarial review passed all 22 authority-parser attack/compatibility cases and found no remaining blocker
