### PR TITLE
fix(embedding_transformer): deliver each flushed batch exactly once

### DIFF
--- a/nodes/src/nodes/embedding_transformer/IInstance.py
+++ b/nodes/src/nodes/embedding_transformer/IInstance.py
@@ -51,6 +51,10 @@ class IInstance(IInstanceBase):
     def _flushDocuments(self):
         """
         Flush the documents to the instance.
+
+        Callers suppress the engine's default forward, not this helper: close()
+        flushes through here too, and preventing the default there would skip
+        Parent::close().
         """
         # If we have no documents, stop here
         if len(self.documents) == 0:
@@ -75,12 +79,14 @@ class IInstance(IInstanceBase):
         # Add this set of documents to the list
         self.documents.extend(documents)
 
-        # If we have less than the max documents, stop here
-        if len(self.documents) < self.maxDocuments:
-            return self.preventDefault()
+        # Flush once we have a full batch, otherwise keep buffering
+        if len(self.documents) >= self.maxDocuments:
+            self._flushDocuments()
 
-        # Flush the documents
-        self._flushDocuments()
+        # These documents are either still buffered or already went downstream with
+        # the flush above, so suppress the engine's default forward of them either
+        # way. preventDefault() raises, so it must stay last.
+        return self.preventDefault()
 
     def writeQuestions(self, question: Question):
         """

--- a/nodes/test/embedding_transformer/test_forward_once.py
+++ b/nodes/test/embedding_transformer/test_forward_once.py
@@ -1,0 +1,283 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Delivery-count regression tests for embedding_transformer's document batching (#2051).
+
+The engine forwards a lane handler's incoming argument after the handler returns,
+unless it raised Ec.PreventDefault (__checkCallParent, engLib/python/call.hpp). The
+flush path forwarded the buffer explicitly and returned normally, so every full
+batch reached downstream twice.
+
+_simulate_engine_dispatch stands in for that rule, so these assert delivery counts
+rather than "the node forwarded once", which was true throughout the bug.
+
+rocketlib and ai.common.* are stubbed and the node is loaded from source, so no
+engine, server or model is involved.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_NODE_DIR = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'embedding_transformer')
+_PKG = 'embedding_transformer'
+
+
+class FakeDoc:
+    """Stand-in for ai.common.schema.Doc, carrying the fields the node touches."""
+
+    def __init__(self, page_content):
+        self.page_content = page_content
+        self.embedding = None
+        self.embedding_model = None
+
+
+class FakeQuestion:
+    """Stand-in for ai.common.schema.Question, passed through untouched."""
+
+
+class FakeEmbeddingBase:
+    """Stand-in for ai.common.embedding.EmbeddingBase, needed only by IGlobal's annotation."""
+
+
+class _PreventDefaultRaised(Exception):
+    """Stand-in for the real preventDefault(), which raises rather than setting a flag."""
+
+
+def _simulate_engine_dispatch(write_override, default_forward):
+    """Mimic checkCallParent(): the engine forwards after a handler returns, unless it raised PreventDefault."""
+    try:
+        write_override()
+    except _PreventDefaultRaised:
+        return
+    default_forward()
+
+
+def _load_iinstance():
+    """
+    Stub rocketlib and ai.common.*, then load the node's IGlobal and IInstance from source.
+
+    Returns:
+        The IInstance class. sys.modules is left as it was found.
+    """
+    saved = {}
+
+    class FakeIInstanceBase:
+        IGlobal = None
+        instance = None
+
+        def __init__(self):
+            pass
+
+        def preventDefault(self):
+            pass
+
+    class FakeIGlobalBase:
+        glb = None
+        IEndpoint = None
+
+    class FakeEntry:
+        pass
+
+    stubs = {
+        'rocketlib': types.ModuleType('rocketlib'),
+        'ai': types.ModuleType('ai'),
+        'ai.common': types.ModuleType('ai.common'),
+        'ai.common.schema': types.ModuleType('ai.common.schema'),
+        'ai.common.config': types.ModuleType('ai.common.config'),
+        'ai.common.embedding': types.ModuleType('ai.common.embedding'),
+    }
+    stubs['rocketlib'].IInstanceBase = FakeIInstanceBase
+    stubs['rocketlib'].IGlobalBase = FakeIGlobalBase
+    stubs['rocketlib'].Entry = FakeEntry
+    stubs['ai.common.schema'].Doc = FakeDoc
+    stubs['ai.common.schema'].Question = FakeQuestion
+    stubs['ai.common.embedding'].EmbeddingBase = FakeEmbeddingBase
+    stubs['ai.common.config'].Config = type('FakeConfig', (), {'getNodeConfig': staticmethod(lambda lt, cc: {})})
+
+    for name, stub in stubs.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = stub
+
+    # Snapshot pre-existing node modules so cleanup restores rather than clobbers them.
+    saved_pkg = {k: v for k, v in sys.modules.items() if k == _PKG or k.startswith(_PKG + '.')}
+
+    try:
+        pkg_spec = importlib.util.spec_from_file_location(
+            _PKG, os.path.join(_NODE_DIR, '__init__.py'), submodule_search_locations=[_NODE_DIR]
+        )
+        # Registered but not executed: the relative imports only need the package to exist.
+        sys.modules[_PKG] = importlib.util.module_from_spec(pkg_spec)
+
+        for sub in ('IGlobal', 'IInstance'):
+            spec = importlib.util.spec_from_file_location(f'{_PKG}.{sub}', os.path.join(_NODE_DIR, f'{sub}.py'))
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[f'{_PKG}.{sub}'] = mod
+            spec.loader.exec_module(mod)
+
+        return sys.modules[f'{_PKG}.IInstance'].IInstance
+    finally:
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+        for mod_name in [k for k in sys.modules if k == _PKG or k.startswith(_PKG + '.')]:
+            sys.modules.pop(mod_name, None)
+        sys.modules.update(saved_pkg)
+
+
+def _make_instance():
+    """
+    Build an IInstance wired to fakes.
+
+    Returns:
+        (inst, delivered, encoded): docs that reached the next node, and one entry
+        per batch sent to the embedding.
+    """
+    inst = _load_iinstance()()
+
+    delivered = []
+    encoded = []
+
+    inst.IGlobal = types.SimpleNamespace(
+        embedding=types.SimpleNamespace(
+            encodeChunks=lambda docs: encoded.append(list(docs)),
+            encodeQuestion=lambda question: encoded.append(question),
+        )
+    )
+    inst.instance = types.SimpleNamespace(writeDocuments=lambda docs: delivered.extend(docs))
+    inst.preventDefault = lambda: (_ for _ in ()).throw(_PreventDefaultRaised())
+
+    # The engine calls open() per object; without it self.documents is the class-level list.
+    inst.open(None)
+
+    return inst, delivered, encoded
+
+
+def _docs(count, start=0):
+    """Build count fake chunks, labelled from start so ordering is checkable."""
+    return [FakeDoc(f'chunk-{start + i}') for i in range(count)]
+
+
+def _write(inst, delivered, batch):
+    """Dispatch writeDocuments(batch) the way the engine would."""
+    _simulate_engine_dispatch(lambda: inst.writeDocuments(batch), lambda: delivered.extend(batch))
+
+
+def test_partial_batch_is_buffered_and_delivers_nothing():
+    inst, delivered, encoded = _make_instance()
+    batch = _docs(10)
+
+    _write(inst, delivered, batch)
+
+    assert delivered == []
+    assert encoded == []
+    assert inst.documents == batch
+
+
+def test_full_batch_is_delivered_exactly_once():
+    """A full batch in one call, the common path and the #2051 path."""
+    inst, delivered, encoded = _make_instance()
+    batch = _docs(inst.maxDocuments)
+
+    _write(inst, delivered, batch)
+
+    assert delivered == batch, (
+        f'delivered {len(delivered)} documents for a batch of {len(batch)}. The flush forwards the '
+        f'buffer explicitly, so writeDocuments must raise preventDefault() or the engine forwards '
+        f'the incoming batch on top of it'
+    )
+    assert encoded == [batch]
+    assert inst.documents == []
+
+
+def test_oversized_batch_is_delivered_exactly_once():
+    inst, delivered, encoded = _make_instance()
+    batch = _docs(inst.maxDocuments * 2 + 1)
+
+    _write(inst, delivered, batch)
+
+    assert delivered == batch
+    assert encoded == [batch]
+    assert inst.documents == []
+
+
+def test_documents_accumulate_across_calls_and_flush_once():
+    """Three quarter-batches buffer silently, the fourth flushes all of them."""
+    inst, delivered, encoded = _make_instance()
+    quarter = inst.maxDocuments // 4
+    batches = [_docs(quarter, start=i * quarter) for i in range(4)]
+
+    for batch in batches[:-1]:
+        _write(inst, delivered, batch)
+        assert delivered == []
+
+    _write(inst, delivered, batches[-1])
+
+    expected = [doc for batch in batches for doc in batch]
+    assert delivered == expected
+    assert encoded == [expected]
+
+
+def test_second_full_batch_does_not_redeliver_the_first():
+    inst, delivered, encoded = _make_instance()
+    first = _docs(inst.maxDocuments)
+    second = _docs(inst.maxDocuments, start=inst.maxDocuments)
+
+    _write(inst, delivered, first)
+    _write(inst, delivered, second)
+
+    assert delivered == first + second
+    assert encoded == [first, second]
+
+
+def test_close_flushes_stragglers_exactly_once_and_still_closes():
+    """
+    Below the threshold nothing flushes until close().
+
+    close() must not raise PreventDefault: the parent call it would suppress is
+    Parent::close(), and every downstream node would be left open.
+    """
+    inst, delivered, encoded = _make_instance()
+    batch = _docs(3)
+    _write(inst, delivered, batch)
+    assert delivered == []
+
+    closed = []
+    _simulate_engine_dispatch(inst.close, lambda: closed.append('parent-close'))
+
+    assert delivered == batch
+    assert encoded == [batch]
+    assert closed == ['parent-close'], 'close() suppressed Parent::close(); downstream never closes'
+
+
+def test_close_with_empty_buffer_delivers_nothing_and_still_closes():
+    inst, delivered, encoded = _make_instance()
+
+    closed = []
+    _simulate_engine_dispatch(inst.close, lambda: closed.append('parent-close'))
+
+    assert (delivered, encoded, closed) == ([], [], ['parent-close'])
+
+
+def test_write_questions_relies_on_the_engine_default_forward():
+    """
+    The questions lane mutates in place and forwards nothing of its own.
+
+    Pinned so the documents-lane fix is not copied onto this lane, which would
+    drop every question instead of delivering it once.
+    """
+    inst, _, encoded = _make_instance()
+    question = FakeQuestion()
+
+    forwarded = []
+    _simulate_engine_dispatch(lambda: inst.writeQuestions(question), lambda: forwarded.append(question))
+
+    assert encoded == [question]
+    assert forwarded == [question]

--- a/nodes/test/embedding_transformer/test_lane_batch_forward_once.py
+++ b/nodes/test/embedding_transformer/test_lane_batch_forward_once.py
@@ -1,0 +1,166 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+End-to-end guard for embedding_transformer's batched document forwarding (#2051).
+
+The engine's default forward lives in compiled C++, so a unit test can only re-state
+it. This measures it: one payload through two pipelines, counting deliveries at a
+response sink that appends one entry per document.
+
+    webhook -> response_documents                           (baseline)
+    webhook -> embedding_transformer -> response_documents  (node under test)
+
+64 documents in one write flushes inside writeDocuments, the path that doubled. 63
+leaves the buffer short so nothing flushes until close(), which must not
+preventDefault or Parent::close() is suppressed and the chunks never arrive.
+"""
+
+import json
+import uuid
+from typing import Any, Dict
+
+import pytest
+
+# The node downloads miniLM, which is why conftest keeps it in skip_nodes (RR-1120).
+# That set filters only the generated tests, so this file carries its own marker:
+#
+#     builder nodes:test --pytest="-m skip_node -k lane_batch_forward_once"
+pytestmark = pytest.mark.skip_node
+
+# IInstance.maxDocuments, the buffer size that triggers a flush.
+MAX_DOCUMENTS = 64
+
+EMBEDDING = {'id': 'embed_1', 'provider': 'embedding_transformer', 'config': {'profile': 'miniLM'}}
+
+
+def _documents_payload(count: int) -> bytes:
+    """
+    Build count chunks as a single lane/documents write.
+
+    A JSON array arrives as one writeDocuments call, which is how a preprocessor
+    emits an object's chunks and what makes the flush threshold reachable in one hop.
+
+    Args:
+        count: How many chunks to put in the write.
+
+    Returns:
+        The UTF-8 JSON payload.
+    """
+    return json.dumps([{'page_content': f'RocketRide chunk number {i}.'} for i in range(count)]).encode('utf-8')
+
+
+def _chain(middle: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """
+    Build a straight webhook -> [middle] -> response_documents pipeline.
+
+    Args:
+        middle: The component under test, or None for the baseline pipeline.
+
+    Returns:
+        A pipeline dict for `client.use()`, with a fresh `project_id` so repeated
+        runs never collide with a still-registered pipeline.
+    """
+    components = [{'id': 'webhook_1', 'provider': 'webhook', 'config': {}, 'input': []}]
+
+    prev = 'webhook_1'
+    if middle is not None:
+        components.append({**middle, 'input': [{'lane': 'documents', 'from': prev}]})
+        prev = middle['id']
+
+    components.append(
+        {
+            'id': 'response_1',
+            'provider': 'response_documents',
+            'config': {},
+            'input': [{'lane': 'documents', 'from': prev}],
+        }
+    )
+    return {'project_id': str(uuid.uuid4()), 'source': 'webhook_1', 'components': components}
+
+
+async def _deliveries(client, pipeline: Dict[str, Any], payload: bytes) -> int:
+    """
+    Run one payload through a pipeline and count the documents that reached the sink.
+
+    Args:
+        client: Connected RocketRide client (fixture).
+        pipeline: The pipeline to register and run.
+        payload: The bytes to write into the pipe.
+
+    Returns:
+        The number of entries the response sink captured on the documents lane.
+    """
+    result = await client.use(pipeline=pipeline)
+    token = result['token']
+
+    try:
+        pipe = await client.pipe(token, objinfo={'name': 'batch_forward_once'}, mime_type='lane/documents')
+        await pipe.open()
+        await pipe.write(payload)
+        response = await pipe.close()
+    finally:
+        # Two pipelines run back to back; leaving them registered piles up live tasks
+        # and later pipe.open() calls get refused. Same teardown as framework/runner.py.
+        try:
+            await client.terminate(token)
+        except Exception:
+            pass
+
+    return len(response.get('documents') or [])
+
+
+async def _assert_forwarded_once(client, count: int, reason: str):
+    """
+    Assert the node delivers the same number of documents as the bare source.
+
+    The baseline is asserted first so a wrong count cannot be blamed on the source.
+
+    Args:
+        client: Connected RocketRide client (fixture).
+        count: How many chunks to send in a single write.
+        reason: What a disagreeing node-side count means.
+    """
+    payload = _documents_payload(count)
+
+    baseline = await _deliveries(client, _chain(), payload)
+    assert baseline == count, (
+        f'the source itself delivered {baseline} documents, expected {count} - the run is not a valid baseline'
+    )
+
+    forwarded = await _deliveries(client, _chain(EMBEDDING), payload)
+    assert forwarded == baseline, (
+        f'embedding_transformer delivered {forwarded} documents where the source delivered {baseline}. {reason}'
+    )
+
+
+async def test_full_batch_delivered_once(client):
+    """
+    A full batch must reach the sink once, not twice.
+
+    Args:
+        client: Connected RocketRide client (fixture).
+    """
+    await _assert_forwarded_once(
+        client,
+        MAX_DOCUMENTS,
+        'A full batch is flushed with an explicit self.instance.writeDocuments(), so writeDocuments '
+        'must call preventDefault() to stop the engine forwarding the incoming batch on top of it',
+    )
+
+
+async def test_partial_batch_delivered_once_on_close(client):
+    """
+    One document below the threshold, so nothing flushes until close().
+
+    Args:
+        client: Connected RocketRide client (fixture).
+    """
+    await _assert_forwarded_once(
+        client,
+        MAX_DOCUMENTS - 1,
+        'Below maxDocuments the buffer is flushed from close(), which must forward without '
+        'preventDefault() so Parent::close() still runs',
+    )


### PR DESCRIPTION
## Summary

- `writeDocuments()` flushed its buffer with an explicit `self.instance.writeDocuments()` and then returned normally, so the engine's own default forward delivered the same batch again. Any object producing a full 64-chunk batch came back doubled.
- Adds the missing `preventDefault()`, in the lane handler rather than in `_flushDocuments()`.
- Adds an end-to-end test that measures delivery counts against a real pipeline, plus an engine-free unit test.

## Type

fix

## Root cause

After a lane handler returns, the engine calls `Parent::writeDocuments(documents)` and forwards the original argument downstream. `__checkCallParent` (`engLib/python/call.hpp:195-217`) inspects only the error code, so the one thing that suppresses it is `preventDefault()`, which raises `Ec.PreventDefault`.

The buffering branch already did that. The flush branch did not:

```python
if len(self.documents) < self.maxDocuments:
    return self.preventDefault()   # correct, nothing forwarded yet
self._flushDocuments()             # forwards explicitly, then returns None
```

So downstream received the buffer from the explicit forward, plus the incoming batch from the engine. `preprocessor_langchain` emits an object's chunks in a single `writeDocuments` call, so flush size equals argument size and it is exactly 2x on the normal text path.

Same class as #1849 (`guardrails`, fixed in #1861) and #1638 (`memory_persistent`).

## Why the handler and not `_flushDocuments()`

`close()` flushes through the same helper, and raising PreventDefault there would suppress `Parent::close()`, leaving every downstream node open. The helper forwards, the handler suppresses, and `_flushDocuments()`'s docstring now records that.

No docs change: no lane, field or `services.json` entry moves, and `README.md:11` already described the intended batching behaviour.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes (ran `builder nodes:test` in full, plus the gated lane test; did not run the C++ engine or SDK suites, which this change does not touch)

Measured against a locally built engine, not just reasoned about. `test_lane_batch_forward_once.py` runs one payload through `webhook -> response_documents` and then `webhook -> embedding_transformer -> response_documents`, counting entries at the sink, which appends one per document.

| Run | 64 documents (flush path) | 63 documents (close path) |
| --- | --- | --- |
| With fix | pass | pass |
| Fix reverted | **fail: delivered 128 where source delivered 64** | pass |

The 63 case passing in both runs is what places the defect on the flush path alone.

`test_forward_once.py` covers the same contract with no engine, driving `IInstance` through a stand-in for the dispatch rule. It asserts delivery counts rather than "the node forwarded once", which was true throughout the bug, and also pins that `close()` must not raise PreventDefault and that `writeQuestions` still relies on the default forward. Reverting the fix fails 4 of its 8 cases.

Regression check on the full suite:

```
builder nodes:test    ->  3532 passed, 230 skipped, 0 failed
ruff check / format   ->  clean
```

`test_lane_batch_forward_once.py` carries the `skip_node` marker because the node downloads miniLM from the HF hub, which is why `conftest.py` already keeps it out of the default run (RR-1120). Run it with:

```
builder nodes:test --pytest="-m skip_node -k lane_batch_forward_once"
```

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

Separately, `documents: List[Doc] = []` (line 39) is a mutable class attribute, saved only by `open()` rebinding it per instance. Different defect, left alone here; happy to file an issue.

## Linked Issue

Fixes #2051


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed document batching so full, partial, oversized, and accumulated batches are forwarded exactly once.
  - Ensured buffered documents are delivered when the embedding transformer closes.
  - Preserved expected forwarding behavior for questions and empty buffers.

- **Tests**
  - Added regression coverage for batching, forwarding, and close-time delivery.
  - Added end-to-end coverage for full and partial lane batches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->