### PR TITLE
fix(audio-transcribe): preserve profile configuration

### DIFF
--- a/nodes/src/nodes/audio_transcribe/IGlobal.py
+++ b/nodes/src/nodes/audio_transcribe/IGlobal.py
@@ -132,7 +132,7 @@ class IGlobal(IGlobalBase):
         # Was 20, but it never reached the decoder — 0 is what actually runs today.
         self._whisper_max_speech_duration_s = float(config.get('vad_max_speech_duration_s', 0))
 
-        debug(f'    Audio transcribe: model={self.model_name}, language={language}')
+        debug(f'    Audio transcribe: model={self.model_name}, language={language}, compute_type={compute_type}')
 
     def endGlobal(self):
         """Clean up global state."""

--- a/nodes/src/nodes/audio_transcribe/README.md
+++ b/nodes/src/nodes/audio_transcribe/README.md
@@ -8,7 +8,7 @@ Receives an audio or video stream, extracts the audio track as 16 kHz mono PCM, 
 
 Uses `ai.common.models.Whisper`: transcription routes to the model server when the engine is started with `--modelserver`, otherwise it runs locally via `faster-whisper`. No API key is required either way. Decoding and VAD are configurable per request — see `beam_size` and the `vad_*` fields below; the defaults reproduce the behaviour this node had before they were exposed. Transcription calls are serialized through a global lock so a single loaded model is shared safely across instances.
 
-Models are downloaded from HuggingFace on first use. GPU is used automatically when available (`compute_type` defaults to `float16`).
+Models are downloaded from HuggingFace on first use. GPU is used automatically when available; `compute_type` picks the precision of the loaded weights and defaults to `float16`, which CTranslate2 downgrades to `int8` on CPU.
 
 ---
 
@@ -27,7 +27,10 @@ When a `documents` listener is attached, the node also emits one document per me
 
 | Field | Type | Description |
 |---|---|---|
-| `model` | string | Default "base". The Whisper model to use for transcription |
+| `profile` | string | Default "default". The model preset this node runs. Every other field below is stored per profile |
+| `model` | string | Defaults to the selected profile's model. Overrides it when set |
+| `language` | string | Default "en". ISO 639-1 code of the spoken language |
+| `compute_type` | string | Default "float16". CTranslate2 weight precision: `float16`, `int8`, `int8_float16` or `float32`. `float16` needs a GPU and falls back to `int8` on CPU |
 | `chunk_duration` | number | Default 60. Seconds of audio to buffer before sending a chunk to Whisper |
 | `beam_size` | number | Default 5. Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate |
 | `vad_filter` | boolean | Default true. Use Whisper's built-in Silero VAD to drop non-speech before transcribing |
@@ -35,7 +38,6 @@ When a `documents` listener is attached, the node also emits one document per me
 | `vad_min_silence_duration_ms` | number | Default 500. Silence this long ends a speech chunk |
 | `vad_speech_pad_ms` | number | Default 400. Padding added to each side of a detected speech chunk |
 | `vad_max_speech_duration_s` | number | Default 0. Split speech chunks longer than this. 0 means no limit |
-| `profile` | string | Default "default".  |
 
 The five `vad_*` fields map onto faster-whisper's `VadOptions`. They are merged over the
 node's defaults rather than replacing them, so setting one leaves the others alone. Note
@@ -76,7 +78,21 @@ that would change transcripts for anyone who had set them.
 
 The node ships one profile per model size (`tiny`, `base`, `small`, `medium`, `large-v3`) plus `default`, which is an alias for `base`. Only the model and `language: en` differ; everything else comes from the field defaults.
 
-Before #1809 the profiles set `mode`, but the node reads `model` — so every profile silently loaded `base`, whichever one you picked. Selecting a profile now actually selects that model.
+Pick one with the **Model Profile** selector. Each profile owns a full copy of the fields above, stored under its own key, so editing `beam_size` on `medium` leaves `tiny`'s settings untouched:
+
+```json
+{
+  "profile": "medium",
+  "medium": { "beam_size": 1, "language": "de" }
+}
+```
+
+A config with no `profile` key keeps working: it resolves against `default`, whether its values sit at the top level or inside a `"default": { … }` object.
+
+Two bugs are worth knowing about because their shape explains the current design:
+
+- Before #1809 the profiles set `mode`, but the node reads `model` — so every profile silently loaded `base`, whichever one you picked.
+- Before #2067 the selector was hidden and listed only `default`, so five of the six profiles were unreachable from the UI. The `model` field is declared once **per profile**, each defaulted to that profile's own model. A single shared field defaulted to `base` would be written into the selected profile's object on the first save and win the merge — silently downgrading `medium` to `base` with nothing logged.
 
 ---
 
@@ -93,11 +109,17 @@ Defaults to English (`en`). Change the `language` config value to transcribe oth
 
 | Field | Type | Description | Default |
 |---|---|---|---|
+| `transcribe.base.model` | `string` | **Model**<br/>The Whisper model to use for transcription. Defaults to the model this profile selects | `"base"` |
 | `transcribe.beam_size` | `number` | **Beam Size**<br/>Beam size for decoding. 1 is greedy (fastest); higher is slower and usually more accurate | `5` |
 | `transcribe.chunk_duration` | `number` | **Chunk Duration (s)**<br/>Seconds of audio to buffer before sending a chunk to Whisper | `60` |
+| `transcribe.compute_type` | `string` | **Compute Type**<br/>CTranslate2 weight precision. float16 needs a GPU and falls back to int8 on CPU; float32 is the most precise and the slowest | `"float16"` |
+| `transcribe.default.model` | `string` | **Model**<br/>The Whisper model to use for transcription. Defaults to the model this profile selects | `"base"` |
 | `transcribe.language` | `string` | **Language**<br/>ISO 639-1 code of the spoken language (e.g. en, ru, de). Must match the audio; a mismatch produces garbled half-translated text | `"en"` |
-| `transcribe.model` | `string` | **Model**<br/>The Whisper model to use for transcription | `"base"` |
-| `transcribe.profile` | `string` |  | `"default"` |
+| `transcribe.large-v3.model` | `string` | **Model**<br/>The Whisper model to use for transcription. Defaults to the model this profile selects | `"large-v3"` |
+| `transcribe.medium.model` | `string` | **Model**<br/>The Whisper model to use for transcription. Defaults to the model this profile selects | `"medium"` |
+| `transcribe.profile` | `string` | **Model Profile**<br/>Whisper model preset. Each profile keeps its own copy of the settings below, so switching profiles does not disturb another profile's overrides | `"default"` |
+| `transcribe.small.model` | `string` | **Model**<br/>The Whisper model to use for transcription. Defaults to the model this profile selects | `"small"` |
+| `transcribe.tiny.model` | `string` | **Model**<br/>The Whisper model to use for transcription. Defaults to the model this profile selects | `"tiny"` |
 | `transcribe.vad_filter` | `boolean` | **VAD Filter**<br/>Use Whisper's built-in Silero VAD to drop non-speech before transcribing | `true` |
 | `transcribe.vad_max_speech_duration_s` | `number` | **VAD Maximum Speech (s)**<br/>Split speech chunks longer than this. 0 means no limit | `0` |
 | `transcribe.vad_min_silence_duration_ms` | `number` | **VAD Minimum Silence (ms)**<br/>Silence this long ends a speech chunk | `500` |

--- a/nodes/src/nodes/audio_transcribe/services.json
+++ b/nodes/src/nodes/audio_transcribe/services.json
@@ -78,28 +78,37 @@
 		// Defines profiles used with the "profile": key
 		// "model", not "mode": IGlobal reads config.get('model'), so every profile
 		// silently loaded base regardless of its name (#1809).
+		// "title" is what the profile selector displays — transcribe.profile
+		// enumerates this section with "*>preconfig.profiles.*.title", so a profile
+		// without one lists as a blank entry (#2067).
 		"profiles": {
 			"default": {
+				"title": "Default (Base)",
 				"model": "base",
 				"language": "en"
 			},
 			"tiny": {
+				"title": "Tiny",
 				"model": "tiny",
 				"language": "en"
 			},
 			"base": {
+				"title": "Base",
 				"model": "base",
 				"language": "en"
 			},
 			"small": {
+				"title": "Small",
 				"model": "small",
 				"language": "en"
 			},
 			"medium": {
+				"title": "Medium",
 				"model": "medium",
 				"language": "en"
 			},
 			"large-v3": {
+				"title": "Large v3",
 				"model": "large-v3",
 				"language": "en"
 			}
@@ -155,10 +164,25 @@
 	//		in the shape
 	//
 	"fields": {
-		"transcribe.model": {
+		// One model field per profile, not one shared field (#2067).
+		//
+		// A profile's editable overrides live in connConfig[<profile>], and
+		// Config.getNodeConfig merges that object OVER preconfig.profiles[<profile>] —
+		// the user object wins. The UI materialises every declared default into that
+		// object, so a single shared "transcribe.model" carrying default "base" would
+		// write model=base into connConfig["medium"] and quietly downgrade the medium
+		// profile to base on the first save. Giving each profile its own copy, defaulted
+		// to the model that profile declares, makes materialising the default a no-op
+		// while an explicit change stays a real override.
+		//
+		// The schema property name is the last dotted segment, so every one of these
+		// resolves to the "model" key IGlobal reads. Same shape as
+		// preprocessor_langchain's langchain.splitter.<profile>.splitter fields, which
+		// the node reads back as "splitter".
+		"transcribe.default.model": {
 			"type": "string",
 			"title": "Model",
-			"description": "The Whisper model to use for transcription",
+			"description": "The Whisper model to use for transcription. Defaults to the model this profile selects",
 			"enum": [
 				["tiny", "Tiny - Faster, least acccurate"],
 				["base", "Base - Fast, low accuracy"],
@@ -168,6 +192,71 @@
 			],
 			"default": "base"
 		},
+		"transcribe.tiny.model": {
+			"type": "string",
+			"title": "Model",
+			"description": "The Whisper model to use for transcription. Defaults to the model this profile selects",
+			"enum": [
+				["tiny", "Tiny - Faster, least acccurate"],
+				["base", "Base - Fast, low accuracy"],
+				["small", "Small - Medium, medium accuracy"],
+				["medium", "Medium - Slower, high accuracy"],
+				["large-v3", "Large v3 - Slowest, Highest accuracy"]
+			],
+			"default": "tiny"
+		},
+		"transcribe.base.model": {
+			"type": "string",
+			"title": "Model",
+			"description": "The Whisper model to use for transcription. Defaults to the model this profile selects",
+			"enum": [
+				["tiny", "Tiny - Faster, least acccurate"],
+				["base", "Base - Fast, low accuracy"],
+				["small", "Small - Medium, medium accuracy"],
+				["medium", "Medium - Slower, high accuracy"],
+				["large-v3", "Large v3 - Slowest, Highest accuracy"]
+			],
+			"default": "base"
+		},
+		"transcribe.small.model": {
+			"type": "string",
+			"title": "Model",
+			"description": "The Whisper model to use for transcription. Defaults to the model this profile selects",
+			"enum": [
+				["tiny", "Tiny - Faster, least acccurate"],
+				["base", "Base - Fast, low accuracy"],
+				["small", "Small - Medium, medium accuracy"],
+				["medium", "Medium - Slower, high accuracy"],
+				["large-v3", "Large v3 - Slowest, Highest accuracy"]
+			],
+			"default": "small"
+		},
+		"transcribe.medium.model": {
+			"type": "string",
+			"title": "Model",
+			"description": "The Whisper model to use for transcription. Defaults to the model this profile selects",
+			"enum": [
+				["tiny", "Tiny - Faster, least acccurate"],
+				["base", "Base - Fast, low accuracy"],
+				["small", "Small - Medium, medium accuracy"],
+				["medium", "Medium - Slower, high accuracy"],
+				["large-v3", "Large v3 - Slowest, Highest accuracy"]
+			],
+			"default": "medium"
+		},
+		"transcribe.large-v3.model": {
+			"type": "string",
+			"title": "Model",
+			"description": "The Whisper model to use for transcription. Defaults to the model this profile selects",
+			"enum": [
+				["tiny", "Tiny - Faster, least acccurate"],
+				["base", "Base - Fast, low accuracy"],
+				["small", "Small - Medium, medium accuracy"],
+				["medium", "Medium - Slower, high accuracy"],
+				["large-v3", "Large v3 - Slowest, Highest accuracy"]
+			],
+			"default": "large-v3"
+		},
 		// Read by IGlobal since the initial commit, but never declared here, so the
 		// UI could not set it and every profile silently pinned English.
 		"transcribe.language": {
@@ -175,6 +264,21 @@
 			"title": "Language",
 			"description": "ISO 639-1 code of the spoken language (e.g. en, ru, de). Must match the audio; a mismatch produces garbled half-translated text",
 			"default": "en"
+		},
+		// Read by IGlobal since the initial commit and honoured by ai.common.models.Whisper
+		// (it is part of the model identity, local and on the model server), but never
+		// declared here, so the UI could not reach it (#2067).
+		"transcribe.compute_type": {
+			"type": "string",
+			"title": "Compute Type",
+			"description": "CTranslate2 weight precision. float16 needs a GPU and falls back to int8 on CPU; float32 is the most precise and the slowest",
+			"enum": [
+				["float16", "Float16 - GPU default, int8 on CPU"],
+				["int8", "Int8 - Fastest, smallest"],
+				["int8_float16", "Int8/Float16 - Mixed precision, GPU"],
+				["float32", "Float32 - Most precise, slowest"]
+			],
+			"default": "float16"
 		},
 		// Buffering, passed to Transcribe(). Defaults are its own constants, which ran
 		// unconditionally before — min_seconds/max_seconds never reached it (#1809).
@@ -222,19 +326,68 @@
 			"description": "Split speech chunks longer than this. 0 means no limit",
 			"default": 0
 		},
+		// One object group per profile. The group name is the key its values are stored
+		// under in the node config (connConfig[<profile>]), which is exactly where
+		// Config.getNodeConfig looks for a selected profile's overrides. Every profile
+		// carries the full editable set, so switching profiles never hides a knob.
 		"transcribe.default": {
 			"object": "default",
-			"properties": ["transcribe.model", "transcribe.language", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+			"properties": ["transcribe.default.model", "transcribe.language", "transcribe.compute_type", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
 		},
+		"transcribe.tiny": {
+			"object": "tiny",
+			"properties": ["transcribe.tiny.model", "transcribe.language", "transcribe.compute_type", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+		},
+		"transcribe.base": {
+			"object": "base",
+			"properties": ["transcribe.base.model", "transcribe.language", "transcribe.compute_type", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+		},
+		"transcribe.small": {
+			"object": "small",
+			"properties": ["transcribe.small.model", "transcribe.language", "transcribe.compute_type", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+		},
+		"transcribe.medium": {
+			"object": "medium",
+			"properties": ["transcribe.medium.model", "transcribe.language", "transcribe.compute_type", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+		},
+		"transcribe.large-v3": {
+			"object": "large-v3",
+			"properties": ["transcribe.large-v3.model", "transcribe.language", "transcribe.compute_type", "transcribe.chunk_duration", "transcribe.beam_size", "transcribe.vad_filter", "transcribe.vad_threshold", "transcribe.vad_min_silence_duration_ms", "transcribe.vad_speech_pad_ms", "transcribe.vad_max_speech_duration_s"]
+		},
+		// Visible since #2067: it was hidden and enumerated only "default", so five of
+		// the six declared profiles could not be picked from the UI at all. The enum is
+		// generated from preconfig.profiles so a new profile cannot be left out of the
+		// list; the conditional still needs its own entry to attach that profile's group.
 		"transcribe.profile": {
-			"hidden": true,
 			"type": "string",
+			"title": "Model Profile",
+			"description": "Whisper model preset. Each profile keeps its own copy of the settings below, so switching profiles does not disturb another profile's overrides",
 			"default": "default",
-			"enum": [["default", "Default"]],
+			"enum": ["*>preconfig.profiles.*.title"],
 			"conditional": [
 				{
 					"value": "default",
 					"properties": ["transcribe.default"]
+				},
+				{
+					"value": "tiny",
+					"properties": ["transcribe.tiny"]
+				},
+				{
+					"value": "base",
+					"properties": ["transcribe.base"]
+				},
+				{
+					"value": "small",
+					"properties": ["transcribe.small"]
+				},
+				{
+					"value": "medium",
+					"properties": ["transcribe.medium"]
+				},
+				{
+					"value": "large-v3",
+					"properties": ["transcribe.large-v3"]
 				}
 			]
 		}

--- a/nodes/test/audio_transcribe/test_config_resolution.py
+++ b/nodes/test/audio_transcribe/test_config_resolution.py
@@ -1,0 +1,340 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Resolver tests for audio_transcribe's profile configuration (#2067).
+
+test_decode_params.py stubs Config.getNodeConfig out, so it proves what IGlobal does
+with a config dict but says nothing about how that dict is produced. This file runs the
+*real* resolver — packages/ai/src/ai/common/config.py, loaded from source behind a
+stubbed rocketlib — against the *real* services.json.
+
+That combination is what the bug lives in. A profile's editable overrides are stored in
+connConfig[<profile>] and merged OVER preconfig.profiles[<profile>], so any default the
+config form materialises into that object beats the profile's own value. With one shared
+model field defaulted to "base", picking "medium" and pressing Save wrote model=base and
+the node quietly transcribed with base — no error, no log, and the integration runs (which
+only exercise the default profile) stay green.
+
+No server, no engine, no FFmpeg, no model download, no GPU, no network.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import os
+import sys
+import types
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_NODE_DIR = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'audio_transcribe')
+_SERVICES_JSON = os.path.join(_NODE_DIR, 'services.json')
+_DISCOVERY_PY = os.path.join(_HERE, '..', 'framework', 'discovery.py')
+_CONFIG_PY = os.path.join(_HERE, '..', '..', '..', 'packages', 'ai', 'src', 'ai', 'common', 'config.py')
+
+_LOGICAL_TYPE = 'audio_transcribe://'
+
+# Every key IGlobal.beginGlobal() reads out of the resolved config. Anything a profile
+# adds that is not in here (e.g. the display "title") is inert at runtime.
+_KEYS_IGLOBAL_READS = (
+    'model',
+    'language',
+    'compute_type',
+    'chunk_duration',
+    'beam_size',
+    'vad_filter',
+    'vad_threshold',
+    'vad_min_silence_duration_ms',
+    'vad_speech_pad_ms',
+    'vad_max_speech_duration_s',
+)
+
+
+def _parse_services_json():
+    """Parse via the repo's JSONC reader — services.json has comments and trailing commas."""
+    spec = importlib.util.spec_from_file_location('_audio_transcribe_discovery', _DISCOVERY_PY)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod._parse_service_json(_SERVICES_JSON)
+
+
+_SERVICE = _parse_services_json()
+_PROFILES = _SERVICE['preconfig']['profiles']
+_PROFILE_NAMES = sorted(_PROFILES)
+
+
+def _load_get_node_config(service):
+    """Load the real Config.getNodeConfig behind a rocketlib stub serving `service`."""
+    saved = {}
+
+    class FakeIJson:
+        """Stands in for rocketlib.IJson. Plain dicts never match it, which is the point:
+        the resolver's IJson branches must not be the thing under test here.
+        """
+
+        @staticmethod
+        def toDict(value):
+            return dict(value)
+
+    rocketlib = types.ModuleType('rocketlib')
+    rocketlib.getServiceDefinition = lambda logicalType: service
+    rocketlib.IJson = FakeIJson
+    rocketlib.warning = lambda *a, **kw: None
+
+    stubs = {'rocketlib': rocketlib}
+
+    # config.py imports json5 at module scope for getConfig(), which this file never
+    # calls. Stub it only when it is genuinely absent so the real parser is used when
+    # the engine's interpreter has it.
+    if importlib.util.find_spec('json5') is None:
+        json5 = types.ModuleType('json5')
+        json5.loads = json.loads
+        stubs['json5'] = json5
+
+    for name, stub in stubs.items():
+        saved[name] = sys.modules.get(name)
+        sys.modules[name] = stub
+
+    mod_name = '_audio_transcribe_ai_config_under_test'
+    try:
+        spec = importlib.util.spec_from_file_location(mod_name, _CONFIG_PY)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        spec.loader.exec_module(mod)
+        return mod.Config.getNodeConfig
+    finally:
+        sys.modules.pop(mod_name, None)
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+
+
+def _resolve(conn_config):
+    """Resolve a node config exactly as IGlobal.beginGlobal() would."""
+    get_node_config = _load_get_node_config(copy.deepcopy(_SERVICE))
+    return get_node_config(_LOGICAL_TYPE, copy.deepcopy(conn_config))
+
+
+def _group_id(profile):
+    """The field id of `profile`'s object group, read off the selector's conditional.
+
+    Going through the conditional rather than guessing the id is deliberate: a profile
+    whose group is never attached to the selector is unreachable from the UI, and this
+    lookup fails loudly instead of silently testing a group nobody can open.
+    """
+    conditionals = _SERVICE['fields']['transcribe.profile']['conditional']
+    matches = [c for c in conditionals if c['value'] == profile]
+
+    assert len(matches) == 1, f'profile {profile} has {len(matches)} conditional entries'
+    assert len(matches[0]['properties']) == 1, f'profile {profile} attaches more than one group'
+
+    return matches[0]['properties'][0]
+
+
+def _materialised_defaults(profile):
+    """What the config form writes into connConfig[profile] on an untouched save.
+
+    RJSF fills every declared default into the form data, so this is the payload the
+    resolver actually sees the first time someone opens the node and presses Save.
+    """
+    fields = _SERVICE['fields']
+    group = fields[_group_id(profile)]
+
+    written = {}
+    for prop in group['properties']:
+        field = fields[prop]
+        if 'default' in field:
+            written[prop.rsplit('.', 1)[-1]] = field['default']
+
+    return written
+
+
+# -----------------------------------------------------------------------------
+# Compatibility: what already-saved configs must keep resolving to
+# -----------------------------------------------------------------------------
+
+
+def test_unconfigured_node_still_resolves_to_base_english():
+    config = _resolve({})
+
+    assert config['model'] == 'base'
+    assert config['language'] == 'en'
+
+
+def test_selecting_the_default_profile_matches_an_unconfigured_node():
+    assert _resolve({'profile': 'default'})['model'] == _resolve({})['model']
+
+
+def test_hand_authored_default_profile_overrides_survive():
+    """The shape the UI has always written: profile + a same-named object of overrides."""
+    config = _resolve({'profile': 'default', 'default': {'model': 'large-v3', 'beam_size': 1}})
+
+    assert config['model'] == 'large-v3'
+    assert config['beam_size'] == 1
+    assert config['language'] == 'en'  # untouched, still from the profile
+
+
+def test_legacy_flat_config_without_a_profile_key_still_resolves():
+    """Configs written before the node had a profile selector put keys at the top level."""
+    config = _resolve({'model': 'small', 'language': 'de'})
+
+    assert config['model'] == 'small'
+    assert config['language'] == 'de'
+
+
+def test_legacy_nested_object_without_a_profile_key_still_resolves():
+    """The other historical shape: the default profile's object, but no "profile" key."""
+    assert _resolve({'default': {'model': 'small'}})['model'] == 'small'
+
+
+# -----------------------------------------------------------------------------
+# The bug: a selected profile must actually select its model
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize('profile', _PROFILE_NAMES)
+def test_selecting_a_profile_selects_its_model(profile):
+    assert _resolve({'profile': profile})['model'] == _PROFILES[profile]['model']
+
+
+@pytest.mark.parametrize('profile', _PROFILE_NAMES)
+def test_an_untouched_save_cannot_downgrade_the_selected_model(profile):
+    """The regression this file exists for.
+
+    One shared model field defaulted to "base" makes this resolve to base for tiny,
+    small, medium and large-v3 — the node silently runs a different model than the one
+    on screen. Per-profile model fields make the materialised default a no-op.
+    """
+    written = _materialised_defaults(profile)
+    config = _resolve({'profile': profile, profile: written})
+
+    assert config['model'] == _PROFILES[profile]['model']
+
+
+@pytest.mark.parametrize('profile', _PROFILE_NAMES)
+def test_an_untouched_save_preserves_everything_the_profile_declares(profile):
+    """The model key is the one that bit, but the same merge decides every profile-supplied key.
+
+    Keys the profile does not declare (beam_size, the vad_* family, ...) are absent
+    before the save and carry their declared default after it; that those defaults equal
+    IGlobal's own fallbacks is checked in test_decode_params.py.
+    """
+    written = _materialised_defaults(profile)
+    saved = _resolve({'profile': profile, profile: written})
+
+    for key in _KEYS_IGLOBAL_READS:
+        if key in _PROFILES[profile]:
+            assert saved[key] == _PROFILES[profile][key], f'{key} moved on an untouched save of {profile}'
+
+
+@pytest.mark.parametrize('profile', _PROFILE_NAMES)
+def test_overrides_survive_alongside_the_profile_model(profile):
+    """Editing a knob must not cost you the profile, and picking a profile must not cost
+    you the knob. Both halves of #2067 in one assertion.
+    """
+    written = _materialised_defaults(profile)
+    written.update({'beam_size': 1, 'language': 'de', 'vad_filter': False, 'compute_type': 'int8'})
+
+    config = _resolve({'profile': profile, profile: written})
+
+    assert config['model'] == _PROFILES[profile]['model']
+    assert config['beam_size'] == 1
+    assert config['language'] == 'de'
+    assert config['vad_filter'] is False
+    assert config['compute_type'] == 'int8'
+
+
+def test_an_explicit_model_override_still_wins_over_the_profile():
+    """The model field stays editable — a deliberate change is not the bug."""
+    assert _resolve({'profile': 'medium', 'medium': {'model': 'tiny'}})['model'] == 'tiny'
+
+
+def test_one_profiles_overrides_do_not_leak_into_another():
+    """Each profile owns its own object, so switching profiles keeps both sets intact."""
+    conn = {
+        'profile': 'medium',
+        'medium': {'beam_size': 1},
+        'tiny': {'beam_size': 9, 'model': 'large-v3'},
+    }
+
+    config = _resolve(conn)
+
+    assert config['model'] == 'medium'
+    assert config['beam_size'] == 1
+
+
+def test_the_profile_display_title_never_reaches_a_key_iglobal_reads():
+    """Profiles gained a "title" so the selector can label them; it must stay inert."""
+    config = _resolve({'profile': 'large-v3'})
+
+    assert config['title'] == 'Large v3'
+    assert 'title' not in _KEYS_IGLOBAL_READS
+    assert config['model'] == 'large-v3'
+
+
+# -----------------------------------------------------------------------------
+# The schema side: every declared profile has to be reachable from the UI
+# -----------------------------------------------------------------------------
+
+
+def test_the_profile_selector_is_visible():
+    """It was `"hidden": true`, so the node offered no way to pick a profile at all."""
+    assert not _SERVICE['fields']['transcribe.profile'].get('hidden')
+
+
+def test_the_selector_enumerates_every_declared_profile():
+    """The enum is generated from preconfig so a new profile cannot be left off the list."""
+    assert _SERVICE['fields']['transcribe.profile']['enum'] == ['*>preconfig.profiles.*.title']
+
+
+def test_every_profile_declares_a_title():
+    """The generated enum reads preconfig.profiles.<name>.title; a missing one lists blank."""
+    for name, values in _PROFILES.items():
+        assert values.get('title'), f'profile {name} has no title to display'
+
+
+def test_the_selector_attaches_a_group_for_every_profile():
+    conditionals = _SERVICE['fields']['transcribe.profile']['conditional']
+
+    assert sorted(c['value'] for c in conditionals) == _PROFILE_NAMES
+
+
+@pytest.mark.parametrize('profile', _PROFILE_NAMES)
+def test_each_group_stores_under_its_own_profile_key(profile):
+    """The group's "object" name is the connConfig key the resolver reads overrides from,
+    so a mismatch here sends the edits somewhere nothing looks.
+    """
+    assert _SERVICE['fields'][_group_id(profile)]['object'] == profile
+
+
+@pytest.mark.parametrize('profile', _PROFILE_NAMES)
+def test_each_group_exposes_the_same_editable_fields(profile):
+    """Field ids differ per profile; the config keys they resolve to must not."""
+    fields = _SERVICE['fields'][_group_id(profile)]['properties']
+    names = [prop.rsplit('.', 1)[-1] for prop in fields]
+
+    assert sorted(names) == sorted(_KEYS_IGLOBAL_READS)
+
+
+@pytest.mark.parametrize('profile', _PROFILE_NAMES)
+def test_each_groups_model_default_matches_its_profile(profile):
+    """Stated on the schema itself, so the invariant is visible without running a merge."""
+    fields = _SERVICE['fields']
+    model_field = next(p for p in fields[_group_id(profile)]['properties'] if p.endswith('.model'))
+
+    assert fields[model_field]['default'] == _PROFILES[profile]['model']
+
+
+def test_compute_type_is_declared_with_the_runtime_fallback_as_its_default():
+    """IGlobal has read compute_type since the initial commit; float16 is its fallback."""
+    field = _SERVICE['fields']['transcribe.compute_type']
+
+    assert field['default'] == 'float16'
+    assert [choice[0] for choice in field['enum']] == ['float16', 'int8', 'int8_float16', 'float32']

--- a/nodes/test/audio_transcribe/test_decode_params.py
+++ b/nodes/test/audio_transcribe/test_decode_params.py
@@ -53,6 +53,7 @@ class _FakeWhisper:
     def __init__(self, model_name, output_fields=None, language=None, compute_type=None, **kwargs):
         self.model_name = model_name
         self.language = language
+        self.compute_type = compute_type
         self.calls = []
 
     def transcribe(self, audio, **kw):
@@ -66,7 +67,7 @@ class _FakeWhisper:
 def _load_iglobal():
     """Load IGlobal.py from source behind stubs. Returns (IGlobal, config_holder)."""
     saved = {}
-    config_holder = {'raw': {}}
+    config_holder = {'raw': {}, 'debug': []}
 
     class FakeIGlobalBase:
         glb = None
@@ -79,7 +80,7 @@ def _load_iglobal():
         'ai.common.models': types.ModuleType('ai.common.models'),
     }
     stubs['rocketlib'].IGlobalBase = FakeIGlobalBase
-    stubs['rocketlib'].debug = lambda *a, **kw: None
+    stubs['rocketlib'].debug = lambda message='', *a, **kw: config_holder['debug'].append(str(message))
     stubs['ai.common.config'].Config = type(
         'FakeConfig', (), {'getNodeConfig': staticmethod(lambda lt, cc: config_holder['raw'])}
     )
@@ -125,6 +126,17 @@ def _parse_services_json():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod._parse_service_json(_SERVICES_JSON)
+
+
+def _profile_groups(service):
+    """The per-profile object groups, keyed by profile name (#2067).
+
+    Each declared profile gets its own group, so a check that used to read
+    transcribe.default alone now has five more places to be wrong.
+    """
+    return {
+        field['object']: field for field in service['fields'].values() if isinstance(field, dict) and 'object' in field
+    }
 
 
 # -----------------------------------------------------------------------------
@@ -206,11 +218,57 @@ def test_language_defaults_to_english():
 
 
 def test_language_is_declared_in_services_json():
-    fields = _parse_services_json()['fields']
+    service = _parse_services_json()
+    fields = service['fields']
 
     assert 'transcribe.language' in fields
-    assert 'transcribe.language' in fields['transcribe.default']['properties']
     assert fields['transcribe.language']['default'] == 'en'
+
+    for profile, group in _profile_groups(service).items():
+        assert 'transcribe.language' in group['properties'], f'language missing from profile {profile}'
+
+
+def test_compute_type_reaches_the_whisper_constructor():
+    """Read by IGlobal since the initial commit, undeclared until #2067."""
+    assert _built_whisper({'compute_type': 'int8'}).compute_type == 'int8'
+
+
+def test_compute_type_defaults_to_float16():
+    assert _built_whisper({}).compute_type == 'float16'
+
+
+def test_compute_type_is_declared_in_services_json():
+    service = _parse_services_json()
+    fields = service['fields']
+
+    assert fields['transcribe.compute_type']['default'] == 'float16'
+
+    for profile, group in _profile_groups(service).items():
+        assert 'transcribe.compute_type' in group['properties'], f'compute_type missing from profile {profile}'
+
+
+def _debug_lines(raw_config):
+    """Build an IGlobal from a node config and return everything it logged."""
+    IGlobal, holder = _load_iglobal()
+    holder['raw'] = raw_config
+
+    ig = IGlobal.__new__(IGlobal)
+    ig.glb = types.SimpleNamespace(logicalType='audio_transcribe://', connConfig={})
+    ig.beginGlobal()
+    return holder['debug']
+
+
+def test_the_startup_log_names_what_was_actually_loaded():
+    """The only runtime signal of which model is running.
+
+    Both #1809 and #2067 are bugs where the node loaded a different model than the one on
+    screen and said nothing, so the line has to name every value that identifies the model.
+    """
+    logged = ' '.join(_debug_lines({'model': 'medium', 'language': 'de', 'compute_type': 'int8'}))
+
+    assert 'model=medium' in logged
+    assert 'language=de' in logged
+    assert 'compute_type=int8' in logged
 
 
 # -----------------------------------------------------------------------------
@@ -262,11 +320,12 @@ def test_services_json_declares_every_field_iglobal_reads():
     """
     service = _parse_services_json()
     fields = service['fields']
-    properties = fields['transcribe.default']['properties']
+    groups = _profile_groups(service)
 
     for name in _NEW_FIELDS:
         assert f'transcribe.{name}' in fields, f'{name} missing from services.json fields'
-        assert f'transcribe.{name}' in properties, f'{name} missing from transcribe.default'
+        for profile, group in groups.items():
+            assert f'transcribe.{name}' in group['properties'], f'{name} missing from profile {profile}'
 
 
 def test_services_json_defaults_match_the_python_fallbacks():
@@ -430,12 +489,13 @@ def test_dead_fields_are_gone():
     """Nothing reads these, so declaring them offers knobs that silently do nothing."""
     service = _parse_services_json()
     fields = service['fields']
-    properties = fields['transcribe.default']['properties']
+    groups = _profile_groups(service)
 
     for name in _DEAD_FIELDS:
         key = f'transcribe.{name}'
         assert key not in fields, f'{name} is declared again but nothing reads it'
-        assert key not in properties, f'{name} is back in transcribe.default'
+        for profile, group in groups.items():
+            assert key not in group['properties'], f'{name} is back in profile {profile}'
 
     for profile, values in service['preconfig']['profiles'].items():
         leftovers = sorted(set(values) & set(_DEAD_FIELDS))


### PR DESCRIPTION
## Summary

- expose every declared `audio_transcribe` model profile with a matching per-profile configuration object
- preserve the selected model when the form materializes defaults, and expose the runtime-supported `compute_type`
- add hardware-free regression coverage through the real `Config.getNodeConfig()` resolver and update the co-located README/generated schema

## Type

Fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Executed locally:

- `uv run --python 3.13 --with pytest --with pytest-asyncio --with numpy --with json5 pytest nodes/test/audio_transcribe -q` — 84 passed
- `uv run --python 3.13 --with pytest --with pytest-asyncio --with numpy --with json5 pytest nodes/test/test_contracts.py -q` — 346 passed
- Ruff check — passed
- Ruff format check — passed
- node documentation generator for `audio_transcribe` — idempotent, 0 updates
- `git diff --check` — passed
- pre-commit hooks: gitleaks, Ruff check, and Ruff format — passed

`./builder docs:build` completed reference generation, gathering, indexing, and both Docusaurus compilations, then failed the repository-wide broken-link gate on the pre-existing `llm_qwen` link to `../../../../tools/sync_models/README.md`. This PR does not modify `llm_qwen` or that target.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (not applicable)
- [x] Breaking changes documented (no breaking changes; existing default and legacy config shapes are covered by regression tests)

## Linked Issue

Fixes #2067