### PR TITLE
fix(agent_rocketride): make list summaries answerable and repeats visible

### DIFF
--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -158,7 +158,10 @@ def _sample_rows(value: list, pad: str, depth: int) -> List[str]:
     rows: List[str] = []
     spent = 0
     for i, row in enumerate(value):
-        text = f'{pad}{_INDENT}row[{i}]:\n{_describe_dict(row, depth + 1)}'
+        # The branch above is chosen from the first item alone, so a later row can be
+        # a scalar. Widening the window past two rows made that reachable.
+        body = _describe_dict(row, depth + 1) if isinstance(row, dict) else _describe(row, depth + 1)
+        text = f'{pad}{_INDENT}row[{i}]:\n{body}'
         if i >= _SUMMARY_MIN_ROWS and spent + len(text) > _SUMMARY_ROW_BUDGET:
             break
         rows.append(text)
@@ -416,9 +419,11 @@ def _store_and_preview(
     if fingerprint is None:
         return entry
 
-    prior_key = seen.get(fingerprint)
-    if prior_key is None:
-        seen[fingerprint] = key
+    # A wave runs its calls on a thread pool, so two identical results can both read
+    # an empty slot and neither would be flagged. setdefault is atomic and gives the
+    # first writer the slot, so exactly one entry stays unflagged.
+    prior_key = seen.setdefault(fingerprint, key)
+    if prior_key == key:
         return entry
 
     entry['deduplicated'] = True

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -63,6 +63,12 @@ _PEEK_MAX_ARRAY_ITEMS = 50
 # covering most single-record API responses in one read.
 _PEEK_DEFAULT_LENGTH = 8000
 
+# Nesting depth past which a summary stops descending. A summary is read by a model,
+# so beyond a handful of levels it stops informing, and the cap doubles as the guard
+# against a self-referential or pathologically deep result, which otherwise recurses
+# until RecursionError and costs the tool its result.
+_SUMMARY_MAX_DEPTH = 6
+
 # Rows of a list-of-dicts always sampled in a structural summary, whatever they cost.
 _SUMMARY_MIN_ROWS = 2
 
@@ -107,6 +113,9 @@ def _describe(value: Any, depth: int = 0) -> str:
     - Lists of primitives show a short sample (first 3 items).
     - Depth is tracked so nested structures are indented readably.
     """
+    if depth > _SUMMARY_MAX_DEPTH:
+        return '...'
+
     pad = _INDENT * depth
     if value is None:
         return 'null'

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -26,11 +26,12 @@ The path component is a JMESPath expression and may itself contain colons
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextvars import copy_context
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import jmespath
 
@@ -356,11 +357,32 @@ def _auto_key(wave_name: str, idx: int) -> str:
     return f'{wave_name}.r{idx}'
 
 
+def _result_fingerprint(result: Any) -> Optional[str]:
+    """Fingerprint a tool result so an identical one can be recognised later.
+
+    Args:
+        result: The value a tool returned.
+
+    Returns:
+        A hex digest, or None if *result* cannot be encoded. default=str mirrors
+        planner._json_default, since results can carry Decimal and datetime from
+        database tools.
+    """
+    try:
+        encoded = json.dumps(result, sort_keys=True, ensure_ascii=False, default=str)
+    except (ValueError, RecursionError):
+        # A cyclic result is stored and summarised by the time this runs. Dedup only
+        # advises the planner, so dropping the signal costs less than the result.
+        return None
+    return hashlib.sha256(encoded.encode('utf-8')).hexdigest()
+
+
 def _store_and_preview(
     tool: str,
     key: str,
     result: Any,
     context: AgentContext,
+    agent_base: AgentBase = None,
 ) -> Dict[str, Any]:
     """Store *result* in memory under *key* and return a compact summary dict.
 
@@ -373,6 +395,10 @@ def _store_and_preview(
     The full result is stored as a native Python object in memory so that
     memory.peek can later extract specific fields via JMESPath without
     re-parsing a JSON string.
+
+    A result identical to one already stored this run also carries `deduplicated`
+    and a `note` naming the earlier key. It signals, it never blocks: repeating a
+    call is often legitimate, so the call still ran and the result is still stored.
     """
     try:
         context.memory.put(key, result)
@@ -380,8 +406,28 @@ def _store_and_preview(
         error(f'rocketride wave memory.put key={key!r} failed: {exc}')
         raise
 
-    summary = _describe(result)
-    return {'tool': tool, 'key': key, 'summary': summary}
+    entry = {'tool': tool, 'key': key, 'summary': _describe(result)}
+
+    seen = getattr(agent_base, 'seen_results', None)
+    if seen is None:
+        return entry
+
+    fingerprint = _result_fingerprint(result)
+    if fingerprint is None:
+        return entry
+
+    prior_key = seen.get(fingerprint)
+    if prior_key is None:
+        seen[fingerprint] = key
+        return entry
+
+    entry['deduplicated'] = True
+    entry['note'] = (
+        f'This result is identical to {prior_key}, which is already in memory, so this call '
+        f'produced no new information. Read {prior_key} with memory.peek, or change approach: '
+        f'repeating a call that returns the same data will not advance the task.'
+    )
+    return entry
 
 
 # ---------------------------------------------------------------------------
@@ -499,7 +545,7 @@ def _execute_wave_calls(
             # Store the result in memory and return a structural summary.
             # The summary is what gets injected into the next planning prompt;
             # the full result stays in memory for later memory.peek access.
-            return _store_and_preview(tool, key, result, context)
+            return _store_and_preview(tool, key, result, context, agent_base)
 
         except Exception as exc:
             err_msg = f'{type(exc).__name__}: {exc}'

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -62,6 +62,14 @@ _PEEK_MAX_ARRAY_ITEMS = 50
 # covering most single-record API responses in one read.
 _PEEK_DEFAULT_LENGTH = 8000
 
+# Rows of a list-of-dicts always sampled in a structural summary, whatever they cost.
+_SUMMARY_MIN_ROWS = 2
+
+# Character budget for the rows sampled beyond _SUMMARY_MIN_ROWS. Narrow rows such
+# as {id, name, mimeType} fit in full, which is what a find-by-name task needs to
+# converge; wide or deeply nested rows exhaust it immediately and still stop at two.
+_SUMMARY_ROW_BUDGET = 4000
+
 # Compiled regex for {{memory.ref:key:format:path}} template tags.
 #
 # Capture groups:
@@ -91,8 +99,10 @@ def _describe(value: Any, depth: int = 0) -> str:
     Design decisions:
     - Strings longer than 80 chars are truncated with a char count so the LLM
       knows it is a large value and should use chunked reading if needed.
-    - Lists of dicts show field names and the first two rows so the LLM can
-      see both the schema and representative data.
+    - Lists of dicts show field names, then as many rows as fit a character
+      budget, so narrow rows are listed in full and a lookup can be answered
+      from the summary. The header reports how many rows were shown when some
+      are omitted, so the LLM knows the sample is partial.
     - Lists of primitives show a short sample (first 3 items).
     - Depth is tracked so nested structures are indented readably.
     """
@@ -118,17 +128,41 @@ def _describe(value: Any, depth: int = 0) -> str:
             # Collect field names from up to 5 rows to handle sparse rows
             # where early rows may be missing fields that appear later.
             keys = list(dict.fromkeys(k for row in value[:5] if isinstance(row, dict) for k in row))
-            lines = [f'{n} items, fields: {keys}']
-            # Show first 2 rows as sample data so the LLM can see real values
-            for i, row in enumerate(value[:2]):
-                lines.append(f'{pad}{_INDENT}row[{i}]:\n{_describe_dict(row, depth + 1)}')
-            return '\n'.join(lines)
+            rows = _sample_rows(value, pad, depth)
+            header = f'{n} items, fields: {keys}'
+            if len(rows) < n:
+                # Say the sample is partial, so a lookup peeks the key instead of
+                # re-running the search that produced it.
+                header += f' (showing {len(rows)} of {n})'
+            return '\n'.join([header] + rows)
         # Non-dict list — show a short JSON sample
         sample = json.dumps(value[:3], ensure_ascii=False)
         return f'{n} items, sample: {sample}'
     if isinstance(value, dict):
         return _describe_dict(value, depth)
     return str(value)
+
+
+def _sample_rows(value: list, pad: str, depth: int) -> List[str]:
+    """Render as many rows of *value* as the summary budget allows.
+
+    Args:
+        value: The list of dicts being summarised.
+        pad: Indentation prefix for the current depth.
+        depth: Current nesting depth.
+
+    Returns:
+        The rendered rows, always at least _SUMMARY_MIN_ROWS where available.
+    """
+    rows: List[str] = []
+    spent = 0
+    for i, row in enumerate(value):
+        text = f'{pad}{_INDENT}row[{i}]:\n{_describe_dict(row, depth + 1)}'
+        if i >= _SUMMARY_MIN_ROWS and spent + len(text) > _SUMMARY_ROW_BUDGET:
+            break
+        rows.append(text)
+        spent += len(text)
+    return rows
 
 
 def _describe_dict(d: dict, depth: int) -> str:

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -165,8 +165,8 @@ def _sample_rows(value: list, depth: int) -> List[str]:
     rows: List[str] = []
     spent = 0
     for i, row in enumerate(value):
-        # The branch above is chosen from the first item alone, so a later row can be
-        # a scalar. Widening the window past two rows made that reachable.
+        # _describe picks this branch from the first item alone, so a later row can
+        # be a scalar. Widening the window past two rows made that reachable.
         body = _describe_dict(row, depth + 1) if isinstance(row, dict) else _describe(row, depth + 1)
         text = f'{pad}{_INDENT}row[{i}]:\n{body}'
         if i >= _SUMMARY_MIN_ROWS and spent + len(text) > _SUMMARY_ROW_BUDGET:

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -63,10 +63,9 @@ _PEEK_MAX_ARRAY_ITEMS = 50
 # covering most single-record API responses in one read.
 _PEEK_DEFAULT_LENGTH = 8000
 
-# Nesting depth past which a summary stops descending. A summary is read by a model,
-# so beyond a handful of levels it stops informing, and the cap doubles as the guard
-# against a self-referential or pathologically deep result, which otherwise recurses
-# until RecursionError and costs the tool its result.
+# Nesting depth past which a summary stops descending: past a few levels it stops
+# informing the model, and the cap is also what keeps a cyclic result from recursing
+# until RecursionError and costing the tool its result.
 _SUMMARY_MAX_DEPTH = 6
 
 # Rows of a list-of-dicts always sampled in a structural summary, whatever they cost.
@@ -116,7 +115,6 @@ def _describe(value: Any, depth: int = 0) -> str:
     if depth > _SUMMARY_MAX_DEPTH:
         return '...'
 
-    pad = _INDENT * depth
     if value is None:
         return 'null'
     if isinstance(value, bool):
@@ -138,7 +136,7 @@ def _describe(value: Any, depth: int = 0) -> str:
             # Collect field names from up to 5 rows to handle sparse rows
             # where early rows may be missing fields that appear later.
             keys = list(dict.fromkeys(k for row in value[:5] if isinstance(row, dict) for k in row))
-            rows = _sample_rows(value, pad, depth)
+            rows = _sample_rows(value, depth)
             header = f'{n} items, fields: {keys}'
             if len(rows) < n:
                 # Say the sample is partial, so a lookup peeks the key instead of
@@ -153,17 +151,17 @@ def _describe(value: Any, depth: int = 0) -> str:
     return str(value)
 
 
-def _sample_rows(value: list, pad: str, depth: int) -> List[str]:
+def _sample_rows(value: list, depth: int) -> List[str]:
     """Render as many rows of *value* as the summary budget allows.
 
     Args:
         value: The list of dicts being summarised.
-        pad: Indentation prefix for the current depth.
         depth: Current nesting depth.
 
     Returns:
         The rendered rows, always at least _SUMMARY_MIN_ROWS where available.
     """
+    pad = _INDENT * depth
     rows: List[str] = []
     spent = 0
     for i, row in enumerate(value):
@@ -394,7 +392,7 @@ def _store_and_preview(
     key: str,
     result: Any,
     context: AgentContext,
-    agent_base: AgentBase = None,
+    agent_base: AgentBase,
 ) -> Dict[str, Any]:
     """Store *result* in memory under *key* and return a compact summary dict.
 

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -50,7 +50,7 @@ _MAX_WORKERS = 8
 # API from blocking the entire wave indefinitely.
 _TOOL_TIMEOUT_S = 120
 
-# Indentation used by _describe() when rendering nested structures.
+# Indentation used when rendering nested structures.
 _INDENT = '  '
 
 # Maximum array items returned by a memory.peek tool call with a JMESPath path.
@@ -71,10 +71,24 @@ _SUMMARY_MAX_DEPTH = 6
 # Rows of a list-of-dicts always sampled in a structural summary, whatever they cost.
 _SUMMARY_MIN_ROWS = 2
 
-# Character budget for the rows sampled beyond _SUMMARY_MIN_ROWS. Narrow rows such
-# as {id, name, mimeType} fit in full, which is what a find-by-name task needs to
-# converge; wide or deeply nested rows exhaust it immediately and still stop at two.
-_SUMMARY_ROW_BUDGET = 4000
+# Character budget for a whole summary. A dict splits its share between the fields
+# that hold containers, so a result with many lists cannot cost more than a result
+# with one. Narrow rows such as {id, name, mimeType} still fit in full, which is what
+# a find-by-name task needs to converge.
+_SUMMARY_BUDGET = 4000
+
+# Smallest share a field can be given. Without it a result with many fields would
+# hand each one too little to render a single row.
+_SUMMARY_MIN_SHARE = 300
+
+# Ceiling applied to the finished summary. The budget is divided rather than
+# multiplied on the way down, so this only catches the overshoot from always
+# rendering _SUMMARY_MIN_ROWS.
+_SUMMARY_HARD_CAP = 6000
+
+# Appended when the cap trims a summary, so the planner peeks instead of assuming
+# it saw everything.
+_SUMMARY_TRUNCATED = '\n... (truncated, peek the key for the rest)'
 
 # Compiled regex for {{memory.ref:key:format:path}} template tags.
 #
@@ -94,7 +108,7 @@ _REF_PATTERN = re.compile(r'\{\{memory\.ref:([^}:]+)(?::([^}:]+))?(?::([^}]+))?\
 # ---------------------------------------------------------------------------
 
 
-def _describe(value: Any, depth: int = 0) -> str:
+def _describe(value: Any) -> str:
     """Return a compact structural summary of *value* for LLM context.
 
     The summary is shown in the "Previous tool results" section of the prompt
@@ -102,13 +116,27 @@ def _describe(value: Any, depth: int = 0) -> str:
     It shows field names, array lengths, and sample values — enough for the
     LLM to formulate a correct JMESPath path for memory.peek.
 
+    Every planning wave resends every prior summary, so size here is paid
+    repeatedly. The result is bounded by _SUMMARY_HARD_CAP.
+    """
+    summary = _render(value, 0, _SUMMARY_BUDGET)
+    if len(summary) > _SUMMARY_HARD_CAP:
+        # The notice counts against the cap, so the returned string never exceeds it.
+        keep = _SUMMARY_HARD_CAP - len(_SUMMARY_TRUNCATED)
+        return f'{summary[:keep]}{_SUMMARY_TRUNCATED}'
+    return summary
+
+
+def _render(value: Any, depth: int, budget: int) -> str:
+    """Render *value* within *budget* characters.
+
     Design decisions:
     - Strings longer than 80 chars are truncated with a char count so the LLM
       knows it is a large value and should use chunked reading if needed.
-    - Lists of dicts show field names, then as many rows as fit a character
-      budget, so narrow rows are listed in full and a lookup can be answered
-      from the summary. The header reports how many rows were shown when some
-      are omitted, so the LLM knows the sample is partial.
+    - Lists of dicts show field names, then as many rows as fit the budget,
+      so narrow rows are listed in full and a lookup can be answered from the
+      summary. The header reports how many rows were shown when some are
+      omitted, so the LLM knows the sample is partial.
     - Lists of primitives show a short sample (first 3 items).
     - Depth is tracked so nested structures are indented readably.
     """
@@ -136,7 +164,7 @@ def _describe(value: Any, depth: int = 0) -> str:
             # Collect field names from up to 5 rows to handle sparse rows
             # where early rows may be missing fields that appear later.
             keys = list(dict.fromkeys(k for row in value[:5] if isinstance(row, dict) for k in row))
-            rows = _sample_rows(value, depth)
+            rows = _sample_rows(value, depth, budget)
             header = f'{n} items, fields: {keys}'
             if len(rows) < n:
                 # Say the sample is partial, so a lookup peeks the key instead of
@@ -147,41 +175,50 @@ def _describe(value: Any, depth: int = 0) -> str:
         sample = json.dumps(value[:3], ensure_ascii=False)
         return f'{n} items, sample: {sample}'
     if isinstance(value, dict):
-        return _describe_dict(value, depth)
+        return _describe_dict(value, depth, budget)
     return str(value)
 
 
-def _sample_rows(value: list, depth: int) -> List[str]:
-    """Render as many rows of *value* as the summary budget allows.
+def _sample_rows(value: list, depth: int, budget: int) -> List[str]:
+    """Render as many rows of *value* as *budget* allows.
 
     Args:
         value: The list of dicts being summarised.
         depth: Current nesting depth.
+        budget: Characters this list may spend.
 
     Returns:
         The rendered rows, always at least _SUMMARY_MIN_ROWS where available.
+        The first _SUMMARY_MIN_ROWS count against the budget too, so wide rows
+        exhaust it and the sample stops at two.
     """
     pad = _INDENT * depth
     rows: List[str] = []
     spent = 0
     for i, row in enumerate(value):
-        # _describe picks this branch from the first item alone, so a later row can
+        # _render picks this branch from the first item alone, so a later row can
         # be a scalar. Widening the window past two rows made that reachable.
-        body = _describe_dict(row, depth + 1) if isinstance(row, dict) else _describe(row, depth + 1)
+        body = _render(row, depth + 1, budget)
         text = f'{pad}{_INDENT}row[{i}]:\n{body}'
-        if i >= _SUMMARY_MIN_ROWS and spent + len(text) > _SUMMARY_ROW_BUDGET:
+        if i >= _SUMMARY_MIN_ROWS and spent + len(text) > budget:
             break
         rows.append(text)
         spent += len(text)
     return rows
 
 
-def _describe_dict(d: dict, depth: int) -> str:
-    """Render a dict as indented key: value lines using _describe for values."""
+def _describe_dict(d: dict, depth: int, budget: int) -> str:
+    """Render a dict as indented key: value lines using _render for values.
+
+    The budget is split between the fields holding containers rather than handed
+    to each in turn, so what a lookup can answer does not depend on key order.
+    """
     pad = _INDENT * depth
+    containers = sum(1 for v in d.values() if isinstance(v, (list, dict)) and v)
+    share = max(_SUMMARY_MIN_SHARE, budget // containers) if containers else budget
     lines = []
     for k, v in d.items():
-        desc = _describe(v, depth + 1)
+        desc = _render(v, depth + 1, share)
         if '\n' in desc:
             # Multi-line value — put it on its own line below the key
             lines.append(f'{pad}{k}:\n{desc}')

--- a/nodes/src/nodes/agent_rocketride/executor.py
+++ b/nodes/src/nodes/agent_rocketride/executor.py
@@ -380,9 +380,11 @@ def _result_fingerprint(result: Any) -> Optional[str]:
     """
     try:
         encoded = json.dumps(result, sort_keys=True, ensure_ascii=False, default=str)
-    except (ValueError, RecursionError):
-        # A cyclic result is stored and summarised by the time this runs. Dedup only
-        # advises the planner, so dropping the signal costs less than the result.
+    except (TypeError, ValueError, RecursionError):
+        # sort_keys raises TypeError on keys that cannot be ordered or encoded, and
+        # default= is consulted for values only, never keys. The result is stored and
+        # summarised by the time this runs. Dedup only advises the planner, so dropping
+        # the signal costs less than the result.
         return None
     return hashlib.sha256(encoded.encode('utf-8')).hexdigest()
 

--- a/nodes/src/nodes/agent_rocketride/planner.py
+++ b/nodes/src/nodes/agent_rocketride/planner.py
@@ -249,6 +249,9 @@ def _build_wave_question(
 
         Do NOT use memory.peek to inspect or validate bulk data before answering.
         If the structural summary tells you what you need, that is enough.
+        When a summary says it is showing fewer rows than the item count, what you
+        are looking for may be in the rows it did not show: peek that key rather
+        than repeating the call that produced it.
 
         - {{memory.ref:key:format}} (answer template)
         Use in the final answer to embed stored data. The system fetches, formats, and

--- a/nodes/src/nodes/agent_rocketride/rocketride_agent.py
+++ b/nodes/src/nodes/agent_rocketride/rocketride_agent.py
@@ -106,6 +106,10 @@ class RocketRideDriver(AgentBase):
         # can inject all prior results into the prompt as context.
         waves: List[Dict[str, Any]] = []
 
+        # Fingerprint of each stored result mapped to the key holding it, so a later
+        # identical result can name it. Rebuilt per run, never shared across runs.
+        self.seen_results: Dict[str, str] = {}
+
         # trace is returned to the caller and recorded for observability.
         # waves is shared by reference — appending to it here also updates trace.
         trace: Dict[str, Any] = {'waves': waves, 'run_id': run_id}
@@ -163,6 +167,9 @@ class RocketRideDriver(AgentBase):
                     w['results'] = [r for r in w.get('results', []) if r.get('key') not in remove_keys]
                 # Drop wave entries that are now completely empty (all results pruned)
                 waves[:] = [w for w in waves if w.get('results')]
+                # Forget fingerprints for cleared keys, or a later note would point at
+                # a key that no longer resolves.
+                self.seen_results = {f: k for f, k in self.seen_results.items() if k not in remove_keys}
 
             # Surface the LLM's thought to the UI — one-sentence description of
             # what the agent is doing this turn.  Shown in the "thinking" panel.

--- a/nodes/test/agent_rocketride/test_result_summary.py
+++ b/nodes/test/agent_rocketride/test_result_summary.py
@@ -1,0 +1,191 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Sample-window tests for agent_rocketride structural summaries (#2032).
+
+Tool results are injected into the planning prompt as a structural summary. For a
+list of dicts that summary showed a fixed two rows, so a find-by-name task over a
+larger result could never see its target: the planner re-ran the search, saw two
+of N again, and looped to max_waves. One observed run made 26 drive.file_search
+calls and burned roughly 400k tokens without converging.
+
+The window is now driven by a character budget, so narrow rows are listed in full
+while wide rows still stop at two, and the header reports a partial sample so the
+planner knows to peek rather than search again.
+
+executor.py is loaded from source with rocketlib and ai.common.* stubbed, so no
+engine, model or key is involved.
+"""
+
+import importlib.util
+import os
+import sys
+import types
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_NODE_DIR = os.path.join(_HERE, '..', '..', 'src', 'nodes', 'agent_rocketride')
+_PKG = 'agent_rocketride'
+
+
+def _load_executor():
+    """
+    Load the node's executor module with its engine dependencies stubbed.
+
+    Returns:
+        The executor module. sys.modules is left as it was found.
+    """
+    stubs = {
+        'rocketlib': types.ModuleType('rocketlib'),
+        'ai': types.ModuleType('ai'),
+        'ai.common': types.ModuleType('ai.common'),
+        'ai.common.agent': types.ModuleType('ai.common.agent'),
+        'ai.common.schema': types.ModuleType('ai.common.schema'),
+    }
+    stubs['rocketlib'].debug = lambda *a, **kw: None
+    stubs['rocketlib'].error = lambda *a, **kw: None
+    stubs['ai.common.agent'].AgentBase = type('AgentBase', (), {})
+    stubs['ai.common.agent'].AgentContext = type('AgentContext', (), {})
+    stubs['ai.common.schema'].Question = type('Question', (), {})
+
+    saved = {name: sys.modules.get(name) for name in stubs}
+    saved_pkg = {k: v for k, v in sys.modules.items() if k == _PKG or k.startswith(_PKG + '.')}
+    sys.modules.update(stubs)
+
+    try:
+        pkg_spec = importlib.util.spec_from_file_location(
+            _PKG, os.path.join(_NODE_DIR, '__init__.py'), submodule_search_locations=[_NODE_DIR]
+        )
+        # Registered but not executed: the relative imports only need the package to exist.
+        sys.modules[_PKG] = importlib.util.module_from_spec(pkg_spec)
+
+        for sub in ('formatters', 'executor'):
+            spec = importlib.util.spec_from_file_location(f'{_PKG}.{sub}', os.path.join(_NODE_DIR, f'{sub}.py'))
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules[f'{_PKG}.{sub}'] = mod
+            spec.loader.exec_module(mod)
+
+        return sys.modules[f'{_PKG}.executor']
+    finally:
+        for name in stubs:
+            if saved[name] is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = saved[name]
+        for mod_name in [k for k in sys.modules if k == _PKG or k.startswith(_PKG + '.')]:
+            sys.modules.pop(mod_name, None)
+        sys.modules.update(saved_pkg)
+
+
+def _drive_files(count, target_index=None, target_name='Email Template.docx'):
+    """
+    Build a Drive-style file listing, optionally naming one row as the lookup target.
+
+    Args:
+        count: How many files to generate.
+        target_index: Index to give target_name, or None for none.
+        target_name: The name a find-by-name task is looking for.
+
+    Returns:
+        A list of {id, name, mimeType} dicts.
+    """
+    rows = []
+    for i in range(count):
+        name = target_name if i == target_index else f'Document {i}.docx'
+        rows.append(
+            {
+                'id': f'1AbCdEfGhIjKlMnOpQrStUvWxYz{i:04d}',
+                'name': name,
+                'mimeType': 'application/vnd.google-apps.document',
+            }
+        )
+    return rows
+
+
+def test_narrow_rows_are_listed_in_full():
+    """
+    A default-sized Drive page is fully visible, which is what lets a lookup converge.
+
+    file_search defaults to pageSize 25. Showing two of those was the #2032 loop.
+    """
+    executor = _load_executor()
+    files = _drive_files(25, target_index=17)
+
+    summary = executor._describe(files)
+
+    assert '25 items' in summary
+    assert 'Email Template.docx' in summary, (
+        'the target sits at row 17 of 25 and is absent from the summary, so the planner '
+        'cannot answer the lookup and will search again'
+    )
+    assert 'showing' not in summary, 'nothing was omitted, so the header should not claim a partial sample'
+
+
+def test_wide_rows_still_stop_at_two():
+    """
+    Context economy is preserved: two wide rows exhaust the budget between them.
+
+    Width here means field count, not value length. Long strings are already
+    truncated to 80 characters by _describe, so they cost little on their own.
+    """
+    executor = _load_executor()
+    wide = [{f'field_{k}': f'value for field {k}' for k in range(80)} for _ in range(10)]
+
+    summary = executor._describe(wide)
+
+    assert summary.count('row[') == 2
+    assert '(showing 2 of 10)' in summary
+
+
+def test_partial_sample_is_labelled():
+    """When rows are omitted the header says so, so the planner knows to peek."""
+    executor = _load_executor()
+    rows = [{'body': 'y' * 500, 'index': i} for i in range(40)]
+
+    summary = executor._describe(rows)
+
+    shown = summary.count('row[')
+    assert shown < 40
+    assert f'(showing {shown} of 40)' in summary
+
+
+def test_small_result_is_unchanged():
+    """A two-row result renders exactly as before, with no partial-sample header."""
+    executor = _load_executor()
+    rows = [{'a': 1}, {'a': 2}]
+
+    summary = executor._describe(rows)
+
+    assert summary.count('row[') == 2
+    assert 'showing' not in summary
+
+
+def test_row_budget_bounds_the_summary():
+    """A large narrow result stays bounded rather than inlining every row."""
+    executor = _load_executor()
+    files = _drive_files(5000)
+
+    summary = executor._describe(files)
+
+    assert len(summary) < executor._SUMMARY_ROW_BUDGET * 2
+    assert summary.count('row[') < 5000
+    assert '5000 items' in summary
+
+
+def test_field_names_and_item_count_survive():
+    """The schema header the LLM uses to build a JMESPath is still emitted."""
+    executor = _load_executor()
+
+    summary = executor._describe(_drive_files(3))
+
+    assert summary.startswith("3 items, fields: ['id', 'name', 'mimeType']")
+
+
+def test_empty_and_non_dict_lists_are_untouched():
+    """Only the list-of-dicts branch changed."""
+    executor = _load_executor()
+
+    assert executor._describe([]) == '[] (0 items)'
+    assert executor._describe([1, 2, 3, 4]) == '4 items, sample: [1, 2, 3]'

--- a/nodes/test/agent_rocketride/test_result_summary.py
+++ b/nodes/test/agent_rocketride/test_result_summary.py
@@ -31,8 +31,7 @@ _PKG = 'agent_rocketride'
 
 
 def _load_executor():
-    """
-    Load the node's executor module with its engine dependencies stubbed.
+    """Load the node's executor module with its engine dependencies stubbed.
 
     Returns:
         The executor module. sys.modules is left as it was found.
@@ -80,8 +79,7 @@ def _load_executor():
 
 
 def _drive_files(count, target_index=None, target_name='Email Template.docx'):
-    """
-    Build a Drive-style file listing, optionally naming one row as the lookup target.
+    """Build a Drive-style file listing, optionally naming one row as the lookup target.
 
     Args:
         count: How many files to generate.
@@ -105,8 +103,7 @@ def _drive_files(count, target_index=None, target_name='Email Template.docx'):
 
 
 def test_narrow_rows_are_listed_in_full():
-    """
-    A default-sized Drive page is fully visible, which is what lets a lookup converge.
+    """A default-sized Drive page is fully visible, which is what lets a lookup converge.
 
     file_search defaults to pageSize 25. Showing two of those was the #2032 loop.
     """
@@ -124,8 +121,7 @@ def test_narrow_rows_are_listed_in_full():
 
 
 def test_wide_rows_still_stop_at_two():
-    """
-    Context economy is preserved: two wide rows exhaust the budget between them.
+    """Context economy is preserved: two wide rows exhaust the budget between them.
 
     Width here means field count, not value length. Long strings are already
     truncated to 80 characters by _describe, so they cost little on their own.
@@ -192,8 +188,7 @@ def test_empty_and_non_dict_lists_are_untouched():
 
 
 def test_a_scalar_after_the_first_row_does_not_crash():
-    """
-    The list-of-dicts branch is chosen from the first item alone.
+    """The list-of-dicts branch is chosen from the first item alone.
 
     A scalar later in the list used to be out of reach because only two rows were
     ever rendered. Widening the window made it reachable, so it has to be handled.
@@ -207,8 +202,7 @@ def test_a_scalar_after_the_first_row_does_not_crash():
 
 
 def test_a_self_referential_result_is_summarised_rather_than_lost():
-    """
-    A cycle used to recurse until RecursionError, which cost the tool its result.
+    """A cycle used to recurse until RecursionError, which cost the tool its result.
 
     The executor catches it, so the run survived, but the planner saw a recursion
     error instead of the data the tool actually returned.
@@ -245,3 +239,58 @@ def test_ordinary_nesting_is_untouched_by_the_cap():
 
     assert '...' not in summary
     assert '"y"' in summary
+
+
+class _RecordingMemory:
+    """Memory channel that records what was stored, mirroring the {ok} contract."""
+
+    def __init__(self):
+        self.store = {}
+
+    def put(self, key, value):
+        self.store[key] = value
+        return {'ok': True}
+
+
+class _FakeContext:
+    def __init__(self):
+        self.memory = _RecordingMemory()
+
+
+class _FakeAgent:
+    def __init__(self):
+        self.seen_results = {}
+
+
+def test_a_cyclic_result_is_not_reported_as_an_error():
+    """A cycle survived the summary but was still lost when it reached the fingerprint.
+
+    memory.put has already succeeded by then, so raising here would tell the planner
+    the tool failed while its result sat in memory, unreachable.
+    """
+    executor = _load_executor()
+    result = {'rows': [{'a': 1}]}
+    result['self'] = result
+    context, agent = _FakeContext(), _FakeAgent()
+
+    entry = executor._store_and_preview('drive.list', 'wave-0.r0', result, context, agent)
+
+    assert 'error' not in entry
+    assert entry['key'] == 'wave-0.r0'
+    assert 'rows' in entry['summary']
+    assert context.memory.store['wave-0.r0'] is result
+    assert agent.seen_results == {}, 'an unfingerprintable result must not claim a slot'
+
+
+def test_fingerprinting_still_flags_a_repeat_of_an_encodable_result():
+    """Skipping the cycle must not disable detection for everything after it."""
+    executor = _load_executor()
+    context, agent = _FakeContext(), _FakeAgent()
+    result = {'rows': [{'a': 1}]}
+
+    first = executor._store_and_preview('drive.list', 'wave-0.r0', result, context, agent)
+    second = executor._store_and_preview('drive.list', 'wave-1.r0', result, context, agent)
+
+    assert 'deduplicated' not in first
+    assert second['deduplicated'] is True
+    assert 'wave-0.r0' in second['note']

--- a/nodes/test/agent_rocketride/test_result_summary.py
+++ b/nodes/test/agent_rocketride/test_result_summary.py
@@ -204,3 +204,44 @@ def test_a_scalar_after_the_first_row_does_not_crash():
 
     assert '4 items' in summary
     assert '42' in summary, 'the scalar row should still be described, not dropped'
+
+
+def test_a_self_referential_result_is_summarised_rather_than_lost():
+    """
+    A cycle used to recurse until RecursionError, which cost the tool its result.
+
+    The executor catches it, so the run survived, but the planner saw a recursion
+    error instead of the data the tool actually returned.
+    """
+    executor = _load_executor()
+    result = {'rows': [{'a': 1}]}
+    result['self'] = result
+
+    summary = executor._describe(result)
+
+    assert 'rows' in summary
+    assert '...' in summary, 'the cycle should terminate in a marker, not an exception'
+
+
+def test_a_pathologically_deep_result_terminates():
+    """The same cap covers depth that is legitimate but far past useful."""
+    executor = _load_executor()
+    deep = cursor = {}
+    for _ in range(2000):
+        cursor['n'] = {}
+        cursor = cursor['n']
+
+    summary = executor._describe(deep)
+
+    assert summary.count('n:') <= executor._SUMMARY_MAX_DEPTH + 1
+    assert summary.endswith('...')
+
+
+def test_ordinary_nesting_is_untouched_by_the_cap():
+    """The cap must not truncate the shapes real results actually have."""
+    executor = _load_executor()
+
+    summary = executor._describe([{'id': 'x', 'meta': {'name': 'y', 'tags': ['a']}}])
+
+    assert '...' not in summary
+    assert '"y"' in summary

--- a/nodes/test/agent_rocketride/test_result_summary.py
+++ b/nodes/test/agent_rocketride/test_result_summary.py
@@ -189,3 +189,18 @@ def test_empty_and_non_dict_lists_are_untouched():
 
     assert executor._describe([]) == '[] (0 items)'
     assert executor._describe([1, 2, 3, 4]) == '4 items, sample: [1, 2, 3]'
+
+
+def test_a_scalar_after_the_first_row_does_not_crash():
+    """
+    The list-of-dicts branch is chosen from the first item alone.
+
+    A scalar later in the list used to be out of reach because only two rows were
+    ever rendered. Widening the window made it reachable, so it has to be handled.
+    """
+    executor = _load_executor()
+
+    summary = executor._describe([{'a': 1}, {'a': 2}, 42, {'a': 4}])
+
+    assert '4 items' in summary
+    assert '42' in summary, 'the scalar row should still be described, not dropped'

--- a/nodes/test/agent_rocketride/test_result_summary.py
+++ b/nodes/test/agent_rocketride/test_result_summary.py
@@ -294,3 +294,34 @@ def test_fingerprinting_still_flags_a_repeat_of_an_encodable_result():
     assert 'deduplicated' not in first
     assert second['deduplicated'] is True
     assert 'wave-0.r0' in second['note']
+
+
+def test_a_result_with_unorderable_keys_is_not_reported_as_an_error():
+    """sort_keys raises TypeError on keys it cannot order, which default= never covers.
+
+    A dict keyed by both an int and a string comes back from any tool that returns row
+    indexes beside named metadata. As with a cycle, memory.put has already succeeded,
+    so raising here would report a working tool as failed.
+    """
+    executor = _load_executor()
+    result = {1: 'first', 'name': 'mixed'}
+    context, agent = _FakeContext(), _FakeAgent()
+
+    entry = executor._store_and_preview('db.query', 'wave-0.r0', result, context, agent)
+
+    assert 'error' not in entry
+    assert context.memory.store['wave-0.r0'] is result
+    assert agent.seen_results == {}, 'an unfingerprintable result must not claim a slot'
+
+
+def test_a_result_with_an_unencodable_key_is_not_reported_as_an_error():
+    """The other TypeError from sort_keys: a key json cannot encode at all."""
+    executor = _load_executor()
+    result = {(1, 2): 'tuple key'}
+    context, agent = _FakeContext(), _FakeAgent()
+
+    entry = executor._store_and_preview('db.query', 'wave-0.r0', result, context, agent)
+
+    assert 'error' not in entry
+    assert context.memory.store['wave-0.r0'] is result
+    assert agent.seen_results == {}

--- a/nodes/test/agent_rocketride/test_result_summary.py
+++ b/nodes/test/agent_rocketride/test_result_summary.py
@@ -165,7 +165,7 @@ def test_row_budget_bounds_the_summary():
 
     summary = executor._describe(files)
 
-    assert len(summary) < executor._SUMMARY_ROW_BUDGET * 2
+    assert len(summary) <= executor._SUMMARY_HARD_CAP
     assert summary.count('row[') < 5000
     assert '5000 items' in summary
 
@@ -325,3 +325,33 @@ def test_a_result_with_an_unencodable_key_is_not_reported_as_an_error():
     assert 'error' not in entry
     assert context.memory.store['wave-0.r0'] is result
     assert agent.seen_results == {}
+
+
+def test_many_list_fields_cannot_exceed_the_summary_cap():
+    """Each list used to get its own budget, so a result with twenty of them paid twenty times.
+
+    The summary is resent in every planning prompt, so this is charged once per wave.
+    """
+    executor = _load_executor()
+    wide = {f'field_{i}': _drive_files(200) for i in range(20)}
+
+    summary = executor._describe(wide)
+
+    assert len(summary) <= executor._SUMMARY_HARD_CAP, (
+        f'summary is {len(summary)} chars; a per-list budget lets a wide result grow without bound'
+    )
+
+
+def test_summary_does_not_depend_on_key_order():
+    """A noisy field must not spend the budget a later field needs to be answerable."""
+    executor = _load_executor()
+    noise = [{'ts': f'10:{i:02d}', 'msg': 'x' * 60} for i in range(300)]
+    files = _drive_files(25, target_index=17)
+
+    noise_first = executor._describe({'log': noise, 'files': files})
+    files_first = executor._describe({'files': files, 'log': noise})
+
+    assert ('Email Template.docx' in noise_first) == ('Email Template.docx' in files_first), (
+        'the same result answers the lookup or not depending on key order'
+    )
+    assert len(noise_first) == len(files_first)

--- a/packages/ai/tests/ai/common/agent/test_repeated_result_detection.py
+++ b/packages/ai/tests/ai/common/agent/test_repeated_result_detection.py
@@ -190,3 +190,34 @@ def test_removed_key_lets_an_identical_result_store_again():
         'the earlier key was removed, so its fingerprint must be forgotten rather than '
         'pointing the planner at a key that no longer resolves'
     )
+
+
+def test_two_identical_calls_in_one_wave_flag_exactly_one():
+    """
+    A wave dispatches its calls on a thread pool, so the check and the write race.
+
+    Both could read an empty slot and neither would be flagged. Exactly one entry
+    should stay unflagged as the original.
+    """
+    plans = [
+        {
+            'tool_calls': [
+                {'tool': 'drive.file_search', 'args': {'query': 'a'}},
+                {'tool': 'drive.file_search', 'args': {'query': 'b'}},
+            ],
+            'scratch': '',
+        },
+        {'done': True, 'answer': 'x', 'scratch': ''},
+    ]
+    tools = _RepeatingTools()
+    ii = _FakeIInstance(tools)
+    d = _driver(plans)
+    payload = d.run_agent(ii, _question(), emit_answers_lane=False)
+
+    entries = _results(payload['stack'][0]['payload'])
+    assert len(entries) == 2
+    flagged = [e for e in entries if e.get('deduplicated')]
+    assert len(flagged) == 1, (
+        f'{len(flagged)} of 2 identical in-wave results were flagged; the fingerprint check and write must not race'
+    )
+    assert len(tools.invocations) == 2, 'both calls still run'

--- a/packages/ai/tests/ai/common/agent/test_repeated_result_detection.py
+++ b/packages/ai/tests/ai/common/agent/test_repeated_result_detection.py
@@ -221,3 +221,62 @@ def test_two_identical_calls_in_one_wave_flag_exactly_one():
         f'{len(flagged)} of 2 identical in-wave results were flagged; the fingerprint check and write must not race'
     )
     assert len(tools.invocations) == 2, 'both calls still run'
+
+
+class _FailingThenRepeatingTools(_RepeatingTools):
+    """Fails the first call, then returns the same rows for every later call."""
+
+    def invoke(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        self.invocations.append((tool_name, args))
+        if len(self.invocations) == 1:
+            raise RuntimeError('upstream unavailable')
+        return {'files': self.rows}
+
+
+def test_a_failed_call_does_not_poison_the_fingerprint_index():
+    """
+    An error never reaches the store path, so a retry is not mistaken for a repeat.
+
+    A failure followed by a successful call is progress, and flagging that first
+    success as a duplicate would tell the planner the opposite.
+    """
+    plans = [_search('a'), _search('b'), _search('c'), {'done': True, 'answer': 'x', 'scratch': ''}]
+    ii = _FakeIInstance(_FailingThenRepeatingTools())
+    d = _driver(plans)
+    payload = d.run_agent(ii, _question(), emit_answers_lane=False)
+
+    entries = _results(payload['stack'][0]['payload'])
+    errored = [e for e in entries if e.get('error')]
+    assert len(errored) == 1, 'the first call should have failed'
+    first_success = next(e for e in entries if not e.get('error'))
+    assert 'deduplicated' not in first_success, 'the first successful result is new information'
+
+
+def test_identical_results_from_different_tools_are_still_flagged():
+    """
+    The fingerprint is of the result, not the call, so a match across tools counts.
+
+    Two tools returning the same data means the second added nothing, which is the
+    signal regardless of which tool produced it.
+    """
+    tools = _RepeatingTools()
+    tools.list.append(
+        {
+            'name': 'drive.file_list',
+            'description': 'List files.',
+            'inputSchema': {'type': 'object', 'properties': {}},
+        }
+    )
+    plans = [
+        _search('a'),
+        {'tool_calls': [{'tool': 'drive.file_list', 'args': {}}], 'scratch': ''},
+        {'done': True, 'answer': 'x', 'scratch': ''},
+    ]
+    ii = _FakeIInstance(tools)
+    d = _driver(plans)
+    payload = d.run_agent(ii, _question(), emit_answers_lane=False)
+
+    entries = _results(payload['stack'][0]['payload'])
+    assert len(entries) == 2
+    assert entries[1].get('deduplicated') is True
+    assert entries[0]['key'] in entries[1]['note']

--- a/packages/ai/tests/ai/common/agent/test_repeated_result_detection.py
+++ b/packages/ai/tests/ai/common/agent/test_repeated_result_detection.py
@@ -1,0 +1,192 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""
+Repeated-result detection through the real agent_rocketride wave loop (#2032).
+
+The observed failure rephrased its query every wave while the result stayed
+identical, so argument-based deduplication would have missed it entirely. The
+fingerprint is taken of the result instead.
+
+It signals, it never blocks: the call still runs and the result is still stored,
+with a `deduplicated` flag and a note naming the earlier key.
+
+The planner is scripted, call_tool is real, and invocations are recorded.
+"""
+
+from typing import Any, Dict, List
+
+from ai.common.schema import Question
+from nodes.agent_rocketride.rocketride_agent import RocketRideDriver
+
+
+class _RepeatingTools:
+    """Host Tools channel whose search returns the same rows whatever it is asked."""
+
+    def __init__(self) -> None:
+        self.list: List[Dict[str, Any]] = [
+            {
+                'name': 'drive.file_search',
+                'description': 'Search files.',
+                'inputSchema': {'type': 'object', 'properties': {'query': {'type': 'string'}}},
+            }
+        ]
+        self.invocations: List[tuple] = []
+        self.rows = [{'id': f'f{i}', 'name': f'Document {i}.docx'} for i in range(25)]
+
+    def invoke(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        self.invocations.append((tool_name, args))
+        return {'files': self.rows}
+
+
+class _CountingTools(_RepeatingTools):
+    """Returns a different result on every call, so nothing should be flagged."""
+
+    def invoke(self, tool_name: str, args: Dict[str, Any]) -> Any:
+        self.invocations.append((tool_name, args))
+        return {'files': self.rows[: len(self.invocations)]}
+
+
+class _DictMemory:
+    """Dict-backed Memory channel mirroring the {ok, value} contract."""
+
+    def __init__(self) -> None:
+        self.store: Dict[str, Any] = {}
+
+    def put(self, key: str, value: Any) -> Dict[str, Any]:
+        self.store[key] = value
+        return {'ok': True}
+
+    def get(self, key: str) -> Dict[str, Any]:
+        if key in self.store:
+            return {'ok': True, 'value': self.store[key]}
+        return {'ok': False}
+
+    def clear(self, key: str = None) -> Dict[str, Any]:
+        if key is None:
+            self.store.clear()
+        else:
+            self.store.pop(key, None)
+        return {'ok': True}
+
+    def list(self) -> Dict[str, Any]:
+        return {'ok': True, 'keys': list(self.store)}
+
+
+class _FakeHost:
+    def __init__(self, tools) -> None:
+        self.llm = object()
+        self.tools = tools
+        self.memory = _DictMemory()
+
+
+class _FakeInner:
+    def __init__(self) -> None:
+        self.pipeId = 1
+        self.written: List[Any] = []
+
+    def writeAnswers(self, answer: Any) -> None:
+        self.written.append(answer)
+
+    def sendSSE(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+
+class _FakeIInstance:
+    def __init__(self, tools) -> None:
+        self._agent_host = _FakeHost(tools)
+        self.instance = _FakeInner()
+
+
+def _driver(plans: List[Dict[str, Any]]) -> RocketRideDriver:
+    """
+    A RocketRideDriver with __init__ bypassed and the planner scripted.
+
+    Args:
+        plans: One planner response per wave, returned in order.
+
+    Returns:
+        The driver, with call_tool left real so dispatches are recorded.
+    """
+    d = RocketRideDriver.__new__(RocketRideDriver)
+    d._instructions = []
+    d._agent_description = ''
+    d._require_tool_call = False
+    d._max_waves = 10
+    plan_iter = iter(plans)
+    d.call_llm_json = lambda context, prompt, **kw: next(plan_iter)
+    return d
+
+
+def _question() -> Question:
+    q = Question()
+    q.addQuestion('Find the email template in my Drive.')
+    return q
+
+
+def _search(query: str) -> Dict[str, Any]:
+    """One wave that searches with the given query."""
+    return {'tool_calls': [{'tool': 'drive.file_search', 'args': {'query': query}}], 'scratch': ''}
+
+
+def _results(trace: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Flatten every result entry across the trace's waves."""
+    return [r for w in trace.get('waves', []) for r in w.get('results', [])]
+
+
+def test_repeated_result_is_flagged_but_never_blocked():
+    """The second identical result is flagged, and the tool still ran."""
+    plans = [_search('email template'), _search('template document'), {'done': True, 'answer': 'x', 'scratch': ''}]
+    tools = _RepeatingTools()
+    ii = _FakeIInstance(tools)
+    d = _driver(plans)
+    payload = d.run_agent(ii, _question(), emit_answers_lane=False)
+
+    entries = _results(payload['stack'][0]['payload'])
+    assert len(entries) == 2, f'expected one result per wave, got {len(entries)}'
+
+    assert 'deduplicated' not in entries[0], 'the first result is new and must not be flagged'
+    assert entries[1].get('deduplicated') is True, (
+        'the second search returned identical rows from a different query, which is the '
+        'no-progress signal the planner was missing'
+    )
+    assert entries[0]['key'] in entries[1]['note'], 'the note must name the key already holding the data'
+
+    assert len(tools.invocations) == 2, 'the repeated call must still execute; this signals, it does not block'
+    assert tools.invocations[0][1] != tools.invocations[1][1], 'the queries differed, so only the result matched'
+
+
+def test_distinct_results_are_not_flagged():
+    """A tool making genuine progress is never marked as repeating."""
+    plans = [_search('a'), _search('b'), {'done': True, 'answer': 'x', 'scratch': ''}]
+    ii = _FakeIInstance(_CountingTools())
+    d = _driver(plans)
+    payload = d.run_agent(ii, _question(), emit_answers_lane=False)
+
+    entries = _results(payload['stack'][0]['payload'])
+    assert all('deduplicated' not in e for e in entries), 'distinct results must not be flagged'
+
+
+def test_removed_key_lets_an_identical_result_store_again():
+    """A cleared key drops its fingerprint, so no note can point at a dead key."""
+    plans = [
+        _search('email template'),
+        {
+            'tool_calls': [{'tool': 'drive.file_search', 'args': {'query': 'again'}}],
+            'remove': ['wave-0.r0'],
+            'scratch': '',
+        },
+        {'done': True, 'answer': 'x', 'scratch': ''},
+    ]
+    ii = _FakeIInstance(_RepeatingTools())
+    d = _driver(plans)
+    payload = d.run_agent(ii, _question(), emit_answers_lane=False)
+
+    entries = _results(payload['stack'][0]['payload'])
+    assert entries, 'the surviving wave should still carry its result'
+    assert all('deduplicated' not in e for e in entries), (
+        'the earlier key was removed, so its fingerprint must be forgotten rather than '
+        'pointing the planner at a key that no longer resolves'
+    )


### PR DESCRIPTION
## Summary

- A tool result is shown to the planner as a structural summary, and for a list of dicts that summary sampled a fixed two rows whatever a row cost. A find-by-name task over a normal result could never see its target.
- Sizes the sample by a character budget instead, says when rows are withheld, stops forbidding `memory.peek` in that case, and flags a tool result identical to one already stored.

## Type

fix

## Root cause

Counting rows is the wrong unit. Two rows of a wide database record are large; twenty-five rows of `{id, name, mimeType}` are small. Observed on Cloud: an agent called `drive.file_search` 26 times across 26 waves, rephrasing the query each round, while every search returned the same 25 files and the model saw 2 of them. Roughly 400,000 tokens, no answer. Its own narration names the cause: "since I don't see an obvious email template in the first two items of the previous search".

The escape hatch was closed by the prompt itself, which said "Do NOT use memory.peek to inspect or validate bulk data before answering. If the structural summary tells you what you need, that is enough." For a lookup, the summary is precisely what cannot tell you what you need.

## What changed

1. **`_sample_rows` renders rows against a character budget** with a floor of two, so narrow rows list in full and wide ones still stop at two. Characters rather than tokens, matching the existing `_PEEK_DEFAULT_LENGTH` convention in the same file.
2. **The header reports `(showing N of M)`** when rows are withheld.
3. **The memory instructions carve out the partial case**: peek that key rather than repeating the call that produced it. The general prohibition stands.
4. **A result identical to one already stored is flagged** with `deduplicated` and a note naming the earlier key.

5. **The budget bounds the whole summary, not one list.** `_sample_rows` reset its
counter per call and `_describe_dict` calls it once per list-valued field, so each
list got a fresh allowance. A dict now splits its budget between the fields holding
containers, and a ceiling is applied to the finished summary.
6. **A result whose keys defeat `json.dumps` is kept.** `sort_keys` raises `TypeError`
on keys that cannot be ordered or encoded, which `default=` does not cover.

`memory.peek` needs no exemption from (4): it returns before the store path and its results are never stored, so there is no key to name. A failed call returns from the error branch and never reaches the store path either, so a retry after a failure is not mistaken for a repeat.

A cyclic or pathologically deep result reaches the planner as an error rather than as data. On develop the summary recurses until `RecursionError`, and both that and the fingerprint added by (4) run after `memory.put` has already succeeded, so the result sits in memory while the planner is told the call failed. Summaries now stop descending past a depth cap, and fingerprinting returns `None` for a result it cannot encode so deduplication is skipped rather than raising. The signal is advisory; the result is not.

Fingerprinting the summary instead, which is cycle-safe by construction, is unsound. The summary is lossy, so two 200-row pages differing only in the row being searched for hash the same, and the page holding the answer would be flagged as a repeat.

## Why four changes

Showing more rows fixes this result. It does not fix the next agent that stalls. Two of the three standard mitigations for this failure class were already here and only needed wiring: `memory.peek` is the pagination primitive, and `max_waves` is the iteration guard, which is why the run stopped at 26 rather than never. What was missing was the signal that data had been withheld, plus permission to act on it.

## Why result identity, not argument identity

The observed loop rephrased its query every wave, so the arguments differed each time while the result stayed identical. Argument-based deduplication, the obvious first idea, would not have caught this at all.

It signals, it never blocks. The call still runs and the result is still stored under its own key. Repeating a call is often legitimate, so refusing one would break polling, retries, and re-reading data that changed.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes (ran `builder ai:test` and `builder nodes:test` in full; not the C++ engine or SDK suites, which this does not touch)

`test_result_summary.py` covers the summary with no engine, model or key. `test_repeated_result_detection.py` drives the real wave loop with the planner scripted and `call_tool` left real, so a flagged repeat is observed end to end and the tool is confirmed to have still run.

Reverting `executor.py` to develop fails 9 of the 13 summary cases and 3 of the 6 repeat-detection cases. The rest guard against a wrong implementation rather than a missing one, so they pass either way by design.

The effect on the model is not deterministic, so it was measured rather than asserted, across a range of models from several vendors. Holding the planner prompt fixed and varying only the summary and its matching instruction, the pre-fix summary re-issued the search or answered from the rows it could see, and the post-fix summary answered with the filename. The prompt instruction alone, without the wider sample, only worked on some models, which is why both are here.

For a 25-file page the summary goes from 298 to 3252 characters, roughly 738 extra tokens once.

Full suites: `builder ai:test` 2698 passed, `builder nodes:test` 4236 passed, 0 failed.

### Summary size

The per-list budget let a wide result grow without bound, and the summary is resent in
every planning prompt and accumulates across waves, so the cost is paid repeatedly.
Same inputs, measured:

| result | develop | before the split | now |
| --- | --- | --- | --- |
| 20 list fields, 200 rows each | 3,829 | 81,849 | 6,000 |
| lists nested inside rows | 3,349 | 47,369 | 6,000 |
| one 40-row list | 217 | 2,169 | 2,169 |

Across 150 randomly shaped results the summary never exceeds the ceiling, where the
per-list version reached 137,023 characters.

Splitting the budget rather than sharing one counter is what keeps the result
order-independent. With a single counter the first field rendered spends what a later
field needs, so the same data answers the lookup or not depending on key order:
a `{log, files}` result showed 2 of 40 file rows, and `{files, log}` showed 40. Both
show 38 now, and the header says the sample is partial.

Reverting each guard on its own fails exactly one new test: the exception list 2, the
budget split 1, the ceiling 1.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable)

## Linked Issue

Fixes #2032


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection and optional annotation of repeated tool results without blocking execution.
  * Improved structural result summaries with safe depth limits, size budgets, partial samples, and cycle handling.
  * Added guidance to inspect memory when summaries omit relevant rows.

* **Bug Fixes**
  * Cleared result tracking when stored results are removed.
  * Prevented failed tool calls from affecting repeated-result detection.

* **Tests**
  * Added coverage for result sampling, recursion safety, truncation, and repeated-result scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



