### PR TITLE
fix(dictionary): reject non-array LLM responses

### DIFF
--- a/nodes/src/nodes/dictionary/IInstance.py
+++ b/nodes/src/nodes/dictionary/IInstance.py
@@ -142,6 +142,11 @@ to be delinquent on their repayment schedule by 60 days or more.
     def writeAnswers(self, answer: Answer):
         # Iterate over the extracted JSON objects
         definitions = answer.getJson()
+        if not isinstance(definitions, list):
+            raise ValueError(
+                f'Dictionary expected the LLM response to be a JSON array of definitions, '
+                f'got {type(definitions).__name__}.'
+            )
 
         # Create a list of documents
         documents: List[Doc] = []

--- a/nodes/src/nodes/dictionary/README.md
+++ b/nodes/src/nodes/dictionary/README.md
@@ -8,6 +8,8 @@ Reads text and uses a connected LLM to extract a dictionary of domain-specific t
 
 Both plain text and table content are handled the same way: each incoming chunk is sent to the LLM with a structured prompt (`expectJson: true`), the LLM returns a single JSON array of definitions, and the node writes one output document per definition. Output documents are stamped with an incrementing `chunkId` (reset for each input object) and marked as non-table content (`isTable: false`, `tableId: 0`).
 
+If the LLM response is valid JSON but is not an array, the node raises a descriptive `ValueError` before emitting any documents. Invalid JSON continues to surface the response parsing error.
+
 The node has no Python package requirements of its own: it relies entirely on the separately installed AI module.
 
 ---

--- a/nodes/test/dictionary/__init__.py
+++ b/nodes/test/dictionary/__init__.py
@@ -1,0 +1,1 @@
+# Dictionary node unit tests.

--- a/nodes/test/dictionary/test_response_shape.py
+++ b/nodes/test/dictionary/test_response_shape.py
@@ -1,0 +1,171 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Deterministic response-shape tests for the dictionary node."""
+
+import importlib
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+_NODE_ROOT = Path(__file__).resolve().parents[2] / 'src' / 'nodes'
+_STUB_MODULES = ('rocketlib', 'rocketlib.types', 'ai', 'ai.common', 'ai.common.schema')
+_MISSING = object()
+
+
+class _StubDoc:
+    def __init__(self, page_content, metadata):
+        self.page_content = page_content
+        self.metadata = metadata
+
+
+class _StubDocMetadata:
+    def __init__(self, owner, **values):
+        self.owner = owner
+        self.values = values
+
+
+class _Answer:
+    def __init__(self, value):
+        self.value = value
+
+    def getJson(self):
+        return self.value
+
+
+class _InvalidJsonAnswer:
+    def getJson(self):
+        raise ValueError('Answer is not in JSON format.')
+
+
+def _stub_module(monkeypatch, name):
+    module = sys.modules.get(name)
+    if module is None:
+        module = types.ModuleType(name)
+        monkeypatch.setitem(sys.modules, name, module)
+
+        parent_name, _, child_name = name.rpartition('.')
+        if parent_name:
+            parent = _stub_module(monkeypatch, parent_name)
+            monkeypatch.setattr(parent, child_name, module, raising=False)
+
+    return module
+
+
+def _ensure_attrs(monkeypatch, module, **attrs):
+    for name, value in attrs.items():
+        if not hasattr(module, name):
+            monkeypatch.setattr(module, name, value, raising=False)
+
+
+@pytest.fixture
+def dictionary_module(monkeypatch, request):
+    """Import the node with local engine/schema stubs and restore module state."""
+    original_path = list(sys.path)
+    original_stubs = {name: sys.modules.get(name, _MISSING) for name in _STUB_MODULES}
+    original_node_modules = {
+        name: module for name, module in sys.modules.items() if name == 'dictionary' or name.startswith('dictionary.')
+    }
+
+    def restore_import_state():
+        for name in tuple(sys.modules):
+            if (name == 'dictionary' or name.startswith('dictionary.')) and name not in original_node_modules:
+                del sys.modules[name]
+        sys.modules.update(original_node_modules)
+
+        assert sys.path == original_path
+        for name, original_module in original_stubs.items():
+            if original_module is _MISSING:
+                assert name not in sys.modules
+            else:
+                assert sys.modules[name] is original_module
+
+    request.addfinalizer(restore_import_state)
+
+    with monkeypatch.context() as patch:
+        _ensure_attrs(
+            patch,
+            _stub_module(patch, 'rocketlib'),
+            IInstanceBase=object,
+            IGlobalBase=object,
+            Entry=object,
+            OPEN_MODE=types.SimpleNamespace(CONFIG='config'),
+        )
+        _ensure_attrs(patch, _stub_module(patch, 'rocketlib.types'), IInvokeLLM=MagicMock())
+        _stub_module(patch, 'ai')
+        _stub_module(patch, 'ai.common')
+        _ensure_attrs(
+            patch,
+            _stub_module(patch, 'ai.common.schema'),
+            Answer=object,
+            Doc=_StubDoc,
+            DocMetadata=_StubDocMetadata,
+            Question=MagicMock(),
+            QuestionType=types.SimpleNamespace(QUESTION='question'),
+        )
+
+        patch.syspath_prepend(str(_NODE_ROOT))
+        yield importlib.import_module('dictionary.IInstance')
+
+
+def _make_instance(dictionary_module):
+    instance_type = dictionary_module.IInstance
+    instance = instance_type.__new__(instance_type)
+    instance.instance = MagicMock()
+    instance.chunkId = 0
+    return instance
+
+
+def test_array_emits_one_document_per_definition_with_incrementing_metadata(dictionary_module):
+    instance = _make_instance(dictionary_module)
+    definitions = [
+        {'term': 'Red loan', 'description': 'A delinquent loan below the credit-score threshold.'},
+        {'term': 'CPMD', 'description': 'Credit Portfolio Marketing Division.'},
+    ]
+
+    instance.writeAnswers(_Answer(definitions))
+
+    instance.instance.writeDocuments.assert_called_once()
+    documents = instance.instance.writeDocuments.call_args.args[0]
+    assert [json.loads(document.page_content) for document in documents] == definitions
+    assert [document.metadata.values['chunkId'] for document in documents] == [0, 1]
+    assert all(document.metadata.values['isTable'] is False for document in documents)
+    assert all(document.metadata.values['tableId'] == 0 for document in documents)
+    assert instance.chunkId == 2
+
+
+def test_empty_array_is_valid_and_emits_an_empty_document_batch(dictionary_module):
+    instance = _make_instance(dictionary_module)
+
+    instance.writeAnswers(_Answer([]))
+
+    instance.instance.writeDocuments.assert_called_once_with([])
+    assert instance.chunkId == 0
+
+
+@pytest.mark.parametrize('value', [{'term': 'CPMD'}, 'definition', 42, None])
+def test_non_array_json_is_rejected_before_any_documents_are_emitted(dictionary_module, value):
+    instance = _make_instance(dictionary_module)
+
+    with pytest.raises(ValueError, match='expected the LLM response to be a JSON array of definitions'):
+        instance.writeAnswers(_Answer(value))
+
+    instance.instance.writeDocuments.assert_not_called()
+    assert instance.chunkId == 0
+
+
+def test_invalid_json_error_propagates_without_emitting_documents(dictionary_module):
+    instance = _make_instance(dictionary_module)
+
+    with pytest.raises(ValueError, match='Answer is not in JSON format'):
+        instance.writeAnswers(_InvalidJsonAnswer())
+
+    instance.instance.writeDocuments.assert_not_called()
+    assert instance.chunkId == 0

--- a/nodes/test/dictionary/test_response_shape.py
+++ b/nodes/test/dictionary/test_response_shape.py
@@ -45,24 +45,40 @@ class _InvalidJsonAnswer:
         raise ValueError('Answer is not in JSON format.')
 
 
-def _stub_module(monkeypatch, name):
-    module = sys.modules.get(name)
-    if module is None:
-        module = types.ModuleType(name)
+def _install_stubs(monkeypatch):
+    """Force deterministic stubs, regardless of modules left by earlier tests."""
+    rocketlib = types.ModuleType('rocketlib')
+    rocketlib.__path__ = []
+    rocketlib.IInstanceBase = object
+    rocketlib.IGlobalBase = object
+    rocketlib.Entry = object
+    rocketlib.OPEN_MODE = types.SimpleNamespace(CONFIG='config')
+
+    rocketlib_types = types.ModuleType('rocketlib.types')
+    rocketlib_types.IInvokeLLM = MagicMock()
+    rocketlib.types = rocketlib_types
+
+    ai = types.ModuleType('ai')
+    ai.__path__ = []
+    ai_common = types.ModuleType('ai.common')
+    ai_common.__path__ = []
+    ai_schema = types.ModuleType('ai.common.schema')
+    ai_schema.Answer = object
+    ai_schema.Doc = _StubDoc
+    ai_schema.DocMetadata = _StubDocMetadata
+    ai_schema.Question = MagicMock()
+    ai_schema.QuestionType = types.SimpleNamespace(QUESTION='question')
+    ai.common = ai_common
+    ai_common.schema = ai_schema
+
+    for name, module in {
+        'rocketlib': rocketlib,
+        'rocketlib.types': rocketlib_types,
+        'ai': ai,
+        'ai.common': ai_common,
+        'ai.common.schema': ai_schema,
+    }.items():
         monkeypatch.setitem(sys.modules, name, module)
-
-        parent_name, _, child_name = name.rpartition('.')
-        if parent_name:
-            parent = _stub_module(monkeypatch, parent_name)
-            monkeypatch.setattr(parent, child_name, module, raising=False)
-
-    return module
-
-
-def _ensure_attrs(monkeypatch, module, **attrs):
-    for name, value in attrs.items():
-        if not hasattr(module, name):
-            monkeypatch.setattr(module, name, value, raising=False)
 
 
 @pytest.fixture
@@ -90,26 +106,9 @@ def dictionary_module(monkeypatch, request):
     request.addfinalizer(restore_import_state)
 
     with monkeypatch.context() as patch:
-        _ensure_attrs(
-            patch,
-            _stub_module(patch, 'rocketlib'),
-            IInstanceBase=object,
-            IGlobalBase=object,
-            Entry=object,
-            OPEN_MODE=types.SimpleNamespace(CONFIG='config'),
-        )
-        _ensure_attrs(patch, _stub_module(patch, 'rocketlib.types'), IInvokeLLM=MagicMock())
-        _stub_module(patch, 'ai')
-        _stub_module(patch, 'ai.common')
-        _ensure_attrs(
-            patch,
-            _stub_module(patch, 'ai.common.schema'),
-            Answer=object,
-            Doc=_StubDoc,
-            DocMetadata=_StubDocMetadata,
-            Question=MagicMock(),
-            QuestionType=types.SimpleNamespace(QUESTION='question'),
-        )
+        _install_stubs(patch)
+        for name in original_node_modules:
+            patch.delitem(sys.modules, name)
 
         patch.syspath_prepend(str(_NODE_ROOT))
         yield importlib.import_module('dictionary.IInstance')


### PR DESCRIPTION
## Summary

- reject parsed dictionary responses that are not JSON arrays before creating or emitting documents
- preserve valid-array document metadata and chunk numbering
- add deterministic response-shape regression tests and document the controlled failure behavior

## Type

fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Local verification:

- `pytest nodes/test/dictionary/test_response_shape.py nodes/test/test_contracts.py -q` — 353 passed
- `ruff check nodes/src/nodes/dictionary/IInstance.py nodes/test/dictionary/test_response_shape.py`
- `ruff format --check nodes/src/nodes/dictionary/IInstance.py nodes/test/dictionary/test_response_shape.py`
- `python3 -m compileall -q nodes/src/nodes/dictionary nodes/test/dictionary`
- `git diff --check`
- Fable 5 review — approved with no actionable findings

The complete local `nodes/test` collection requires the repository build environment and optional packages (`rocketlib`, `ai`, `pydantic`, `numpy`, and provider dependencies) that are not installed in this bare worktree; CI remains the authoritative full-environment run.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (not applicable)
- [x] Breaking changes documented (not applicable)

## Linked Issue

Fixes #2074

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to ensure dictionary responses are JSON arrays before generating output.
  * Added clear errors for valid but incorrectly shaped responses.
  * Prevented output writes when response validation fails.
  * Preserved parsing errors for invalid JSON responses.

* **Documentation**
  * Documented response-shape validation and error behavior.

* **Tests**
  * Added coverage for valid arrays, empty arrays, invalid response shapes, and malformed JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->