### PR TITLE
fix(image_cleanup): align PNG return contract

### DIFF
--- a/nodes/src/nodes/image_cleanup/IGlobal.py
+++ b/nodes/src/nodes/image_cleanup/IGlobal.py
@@ -28,7 +28,7 @@ from ai.common.config import Config
 
 
 class IGlobal(IGlobalBase):
-    process: Callable[[str, bytes], bytes]
+    process: Callable[[str, bytes], tuple[str, bytes]]
 
     def beginGlobal(self) -> None:
         # Get the confif info

--- a/nodes/src/nodes/image_cleanup/morphology.py
+++ b/nodes/src/nodes/image_cleanup/morphology.py
@@ -27,15 +27,15 @@ import numpy as np
 
 def morph_image(png_bytes: bytes) -> bytes:
     """
-    Perform morphological closing to remove small holes and noise in the binary JPEG image (in bytes).
+    Perform morphological closing to remove small holes and noise in the binary PNG image.
 
     Args:
-        png_bytes (bytes): The input binary png image as bytes.
+        png_bytes (bytes): The input binary PNG image as bytes.
 
     Returns:
-        bytes: The cleaned image encoded as png bytes.
+        bytes: The cleaned image encoded as PNG bytes.
     """
-    # Decode the JPEG bytes into a grayscale image
+    # Decode the PNG bytes into a grayscale image
     image = cv2.imdecode(np.frombuffer(png_bytes, np.uint8), cv2.IMREAD_GRAYSCALE)
 
     # Create a small 2x2 square kernel for morphological operation
@@ -46,7 +46,7 @@ def morph_image(png_bytes: bytes) -> bytes:
     # It helps close small holes (e.g., in text characters like 'o') and remove noise.
     cleaned = cv2.morphologyEx(image, cv2.MORPH_CLOSE, kernel)
 
-    # Encode the cleaned image back to png
+    # Encode the cleaned image back to PNG
     success, output_bytes = cv2.imencode('.png', cleaned)
     if not success:
         raise ValueError('Failed to encode morph image to PNG.')

--- a/nodes/src/nodes/image_cleanup/process.py
+++ b/nodes/src/nodes/image_cleanup/process.py
@@ -27,23 +27,23 @@ from .morphology import morph_image
 from .png import ensure_png
 
 
-def process_image(mimeType: str, input_bytes: bytes) -> bytes:
+def process_image(mimeType: str, input_bytes: bytes) -> tuple[str, bytes]:
     """
-    Accept raw bytes of a an image, preprocesses for OCR using three stages.
+    Accept raw image bytes and preprocess them for OCR using three stages.
 
     1. Grayscale conversion and binarization
     2. Deskewing to correct text alignment
     3. Morphological cleanup to enhance OCR clarity
 
     Returns:
-        bytes: Preprocessed JPEG image in bytes, ready for OCR.
+        tuple[str, bytes]: The PNG MIME type and preprocessed PNG bytes, ready for OCR.
     """
     image = input_bytes
 
-    # Step 1: Convert to png if needed
+    # Step 1: Convert to PNG if needed
     mimeType, image = ensure_png(mimeType, input_bytes)
 
-    # Step 2: Convert image to binary grayscale png
+    # Step 2: Convert image to binary grayscale PNG
     image = binary_image(image)
 
     # Step 3: Deskew the binary image to align text

--- a/nodes/test/image_cleanup/test_process.py
+++ b/nodes/test/image_cleanup/test_process.py
@@ -1,0 +1,172 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Deterministic tests for image_cleanup's PNG processing contract."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Callable
+
+import pytest
+
+
+NODE_DIR = Path(__file__).parents[2] / 'src' / 'nodes' / 'image_cleanup'
+
+
+def _load_module(monkeypatch, module_name, filename, dependencies=None):
+    """Load one image_cleanup module with only its direct dependencies stubbed."""
+    package = module_name.rsplit('.', 1)[0]
+    package_module = ModuleType(package)
+    package_module.__path__ = [str(NODE_DIR)]
+    monkeypatch.setitem(sys.modules, package, package_module)
+
+    for dependency, attributes in (dependencies or {}).items():
+        dependency_module = ModuleType(f'{package}.{dependency}')
+        for name, value in attributes.items():
+            setattr(dependency_module, name, value)
+        monkeypatch.setitem(sys.modules, dependency_module.__name__, dependency_module)
+
+    spec = importlib.util.spec_from_file_location(module_name, NODE_DIR / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_process_image_returns_png_contract_and_runs_each_stage_once(monkeypatch):
+    """Each stage receives the previous result and the public return is ``(MIME, bytes)``."""
+    calls = []
+
+    def ensure_png(mime_type, image_bytes):
+        calls.append(('ensure_png', mime_type, image_bytes))
+        return 'image/png', b'normalized'
+
+    def stage(name, output):
+        def run(image_bytes):
+            calls.append((name, image_bytes))
+            return output
+
+        return run
+
+    module = _load_module(
+        monkeypatch,
+        '_image_cleanup_process_test.process',
+        'process.py',
+        {
+            'png': {'ensure_png': ensure_png},
+            'binary': {'binary_image': stage('binary_image', b'binary')},
+            'deskew': {'deskew_image': stage('deskew_image', b'deskewed')},
+            'morphology': {'morph_image': stage('morph_image', b'cleaned')},
+        },
+    )
+
+    assert module.process_image('image/jpeg', b'original') == ('image/png', b'cleaned')
+    assert calls == [
+        ('ensure_png', 'image/jpeg', b'original'),
+        ('binary_image', b'normalized'),
+        ('deskew_image', b'binary'),
+        ('morph_image', b'deskewed'),
+    ]
+
+
+def test_process_image_return_annotation_matches_runtime_tuple(monkeypatch):
+    """Static callers see the same two-value contract that the function returns."""
+
+    def identity(value):
+        return value
+
+    module = _load_module(
+        monkeypatch,
+        '_image_cleanup_annotation_test.process',
+        'process.py',
+        {
+            'png': {'ensure_png': lambda mime, data: ('image/png', data)},
+            'binary': {'binary_image': identity},
+            'deskew': {'deskew_image': identity},
+            'morphology': {'morph_image': identity},
+        },
+    )
+
+    assert module.process_image.__annotations__['return'] == tuple[str, bytes]
+
+
+def test_global_process_annotation_matches_runtime_tuple(monkeypatch):
+    """The callable exposed to instances carries the same two-value contract."""
+    rocketlib = ModuleType('rocketlib')
+    rocketlib.IGlobalBase = type('IGlobalBase', (), {})
+    config_module = ModuleType('ai.common.config')
+    config_module.Config = type('Config', (), {})
+
+    monkeypatch.setitem(sys.modules, 'rocketlib', rocketlib)
+    monkeypatch.setitem(sys.modules, 'ai', ModuleType('ai'))
+    monkeypatch.setitem(sys.modules, 'ai.common', ModuleType('ai.common'))
+    monkeypatch.setitem(sys.modules, 'ai.common.config', config_module)
+
+    module = _load_module(monkeypatch, '_image_cleanup_global_test.IGlobal', 'IGlobal.py')
+
+    assert module.IGlobal.__annotations__['process'] == Callable[[str, bytes], tuple[str, bytes]]
+
+
+class _FakePILImage:
+    """Minimal Pillow image used to test conversion without an optional dependency."""
+
+    def __init__(self):
+        self.converted_to = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback):
+        return False
+
+    def convert(self, mode):
+        self.converted_to = mode
+        return self
+
+    def save(self, output, format):  # noqa: A002 - mirrors Pillow's public keyword
+        assert format == 'PNG'
+        output.write(b'converted-png')
+
+
+def _load_png_module(monkeypatch, open_image):
+    pil_module = ModuleType('PIL')
+    pil_module.Image = type('_ImageAPI', (), {'open': staticmethod(open_image)})
+    monkeypatch.setitem(sys.modules, 'PIL', pil_module)
+    return _load_module(monkeypatch, '_image_cleanup_png_test.png', 'png.py')
+
+
+def test_ensure_png_passes_png_bytes_through_without_opening_image(monkeypatch):
+    """PNG input keeps byte identity and does not invoke Pillow."""
+    module = _load_png_module(monkeypatch, lambda _stream: pytest.fail('PNG pass-through opened Pillow'))
+    source = b'already-png'
+
+    assert module.ensure_png('IMAGE/PNG', source) == ('image/png', source)
+
+
+def test_ensure_png_converts_non_png_input_to_rgba_png(monkeypatch):
+    """Non-PNG input is opened, normalized to RGBA, and returned with the PNG MIME type."""
+    image = _FakePILImage()
+    seen = []
+
+    def open_image(stream):
+        seen.append(stream.read())
+        return image
+
+    module = _load_png_module(monkeypatch, open_image)
+
+    assert module.ensure_png('image/jpeg', b'jpeg-source') == ('image/png', b'converted-png')
+    assert seen == [b'jpeg-source']
+    assert image.converted_to == 'RGBA'
+
+
+def test_ensure_png_reports_conversion_failures(monkeypatch):
+    """A decoder failure remains a clear node-level ``ValueError``."""
+    module = _load_png_module(monkeypatch, lambda _stream: (_ for _ in ()).throw(OSError('bad image')))
+
+    with pytest.raises(ValueError, match='Failed to convert image to PNG: bad image'):
+        module.ensure_png('image/jpeg', b'not-an-image')


### PR DESCRIPTION
## Summary

- Align `process_image` and `IGlobal.process` annotations with the existing `(mime_type, image_bytes)` runtime return value.
- Correct stale JPEG wording in the PNG-only cleanup path.
- Add six deterministic unit tests for stage ordering, both public annotations, PNG pass-through, non-PNG conversion, and conversion errors.

## Type

Fix / code-quality correction. Runtime behavior and the public node output remain unchanged.

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes — not run from this isolated unbuilt worktree; focused tests and CI cover this change

Local verification:

- `pytest nodes/test/image_cleanup/test_process.py -q` — 6 passed on Python 3.11
- Same suite via `uv` on Python 3.10 — 6 passed
- `ruff check` on all four changed files — passed
- `ruff format --check` on all four changed files — passed
- `python3 -m compileall -q nodes/src/nodes/image_cleanup nodes/test/image_cleanup` — passed
- Real Pillow/OpenCV smoke test: generated JPEG processed to a valid same-size PNG — passed
- Fable 5 cross-review — approved after aligning the `IGlobal.process` callable annotation

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (not applicable)
- [x] Breaking changes documented (not applicable; no behavior or public-contract change)

## Linked Issue

Fixes #2073