### PR TITLE
fix(local_text_output): strip only leading exclude prefix

### DIFF
--- a/nodes/src/nodes/local_text_output/IInstance.py
+++ b/nodes/src/nodes/local_text_output/IInstance.py
@@ -24,6 +24,7 @@
 import os
 from rocketlib import IInstanceBase, Entry, warning, extended_length_path, shorten_path_components
 from .IGlobal import IGlobal
+from .path_prefix import strip_exclude_prefix
 
 
 class IInstance(IInstanceBase):
@@ -86,16 +87,12 @@ class IInstance(IInstanceBase):
                 abs_path = self.current_object.path
                 exclude = self.IGlobal.exclude
 
-                # Determine if the absolute path should be used or if we need to exclude a path
-                relative_path = ''
-                if exclude == 'N/A':
-                    relative_path = abs_path
-                else:
-                    if abs_path.startswith(exclude):
-                        relative_path = abs_path.replace(exclude, '')
-                    else:
-                        warning(f'The path {abs_path} does not start with {exclude}')
-                        return
+                # Remove one complete leading path prefix. Raw string replacement
+                # would also remove matching text from later path components.
+                relative_path = strip_exclude_prefix(abs_path, exclude)
+                if relative_path is None:
+                    warning(f'The path {abs_path} does not start with {exclude}')
+                    return
 
                 # Remove the file extension and add .txt
                 # e.g. Hackathon/folder1/gradient_terms_of_use.txt

--- a/nodes/src/nodes/local_text_output/path_prefix.py
+++ b/nodes/src/nodes/local_text_output/path_prefix.py
@@ -1,0 +1,43 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Pure path-prefix handling for the local text output node."""
+
+_PATH_SEPARATORS = '/\\'
+
+
+def strip_exclude_prefix(path: str, exclude: str) -> str | None:
+    """Remove one complete leading exclude prefix, or return None when it does not match."""
+    if exclude in ('N/A', ''):
+        return path
+
+    if not path.startswith(exclude):
+        return None
+
+    if len(path) == len(exclude):
+        return ''
+
+    if exclude[-1] in _PATH_SEPARATORS or path[len(exclude)] in _PATH_SEPARATORS:
+        return path[len(exclude) :]
+
+    return None

--- a/nodes/src/nodes/local_text_output/path_prefix.py
+++ b/nodes/src/nodes/local_text_output/path_prefix.py
@@ -26,9 +26,9 @@
 _PATH_SEPARATORS = '/\\'
 
 
-def strip_exclude_prefix(path: str, exclude: str) -> str | None:
+def strip_exclude_prefix(path: str, exclude: str | None) -> str | None:
     """Remove one complete leading exclude prefix, or return None when it does not match."""
-    if exclude in ('N/A', ''):
+    if exclude in (None, 'N/A', ''):
         return path
 
     if not path.startswith(exclude):

--- a/nodes/test/local_text_output/test_instance.py
+++ b/nodes/test/local_text_output/test_instance.py
@@ -94,6 +94,16 @@ def test_close_writes_normal_file(tmp_path):
     assert _read(expected) == 'hello world'
 
 
+def test_close_with_unset_exclude_preserves_source_path(tmp_path):
+    """An omitted exclude value behaves like no exclusion instead of skipping output."""
+    inst = _make_instance(str(tmp_path))
+    inst.IGlobal.exclude = None
+    _drive(inst, '/data/folder/report.md', 'content')
+
+    expected = os.path.join(str(tmp_path), 'data', 'folder', 'report.txt')
+    assert _read(expected) == 'content'
+
+
 def test_close_removes_only_leading_exclude_prefix(tmp_path):
     """A repeated path segment after the accepted prefix remains in the destination."""
     inst = _make_instance(str(tmp_path))

--- a/nodes/test/local_text_output/test_instance.py
+++ b/nodes/test/local_text_output/test_instance.py
@@ -94,6 +94,27 @@ def test_close_writes_normal_file(tmp_path):
     assert _read(expected) == 'hello world'
 
 
+def test_close_removes_only_leading_exclude_prefix(tmp_path):
+    """A repeated path segment after the accepted prefix remains in the destination."""
+    inst = _make_instance(str(tmp_path))
+    inst.IGlobal.exclude = '/data'
+    _drive(inst, '/data/archive/data/report.md', 'content')
+
+    expected = os.path.join(str(tmp_path), 'archive', 'data', 'report.txt')
+    incorrectly_replaced = os.path.join(str(tmp_path), 'archive', 'report.txt')
+    assert _read(expected) == 'content'
+    assert not os.path.exists(incorrectly_replaced)
+
+
+def test_close_rejects_partial_exclude_component(tmp_path):
+    """An exclude value must end at a path boundary, not inside a component."""
+    inst = _make_instance(str(tmp_path))
+    inst.IGlobal.exclude = '/data/job'
+    _drive(inst, '/data/jobs/report.md', 'content')
+
+    assert not any(tmp_path.iterdir())
+
+
 def test_close_writes_path_exceeding_windows_max_path(tmp_path):
     r"""A derived path well past 260 chars must still be written (\\?\ prefix)."""
     deep = '/'.join('dir_%02d_padded_segment' % i for i in range(25))

--- a/nodes/test/local_text_output/test_path_prefix.py
+++ b/nodes/test/local_text_output/test_path_prefix.py
@@ -19,6 +19,10 @@ def test_no_exclude_preserves_complete_source_path():
     assert path_prefix.strip_exclude_prefix('/data/folder/report.md', 'N/A') == '/data/folder/report.md'
 
 
+def test_unset_exclude_preserves_complete_source_path():
+    assert path_prefix.strip_exclude_prefix('/data/folder/report.md', None) == '/data/folder/report.md'
+
+
 def test_empty_exclude_preserves_existing_behavior():
     assert path_prefix.strip_exclude_prefix('/data/folder/report.md', '') == '/data/folder/report.md'
 

--- a/nodes/test/local_text_output/test_path_prefix.py
+++ b/nodes/test/local_text_output/test_path_prefix.py
@@ -1,0 +1,59 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Unit tests for local_text_output exclude-prefix handling."""
+
+import importlib.util
+from pathlib import Path
+
+
+_MODULE_FILE = Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'local_text_output' / 'path_prefix.py'
+_spec = importlib.util.spec_from_file_location('local_text_output_path_prefix_under_test', _MODULE_FILE)
+path_prefix = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(path_prefix)
+
+
+def test_no_exclude_preserves_complete_source_path():
+    assert path_prefix.strip_exclude_prefix('/data/folder/report.md', 'N/A') == '/data/folder/report.md'
+
+
+def test_empty_exclude_preserves_existing_behavior():
+    assert path_prefix.strip_exclude_prefix('/data/folder/report.md', '') == '/data/folder/report.md'
+
+
+def test_prefix_without_trailing_separator_is_removed_at_boundary():
+    assert path_prefix.strip_exclude_prefix('/data/job/report.md', '/data/job') == '/report.md'
+
+
+def test_prefix_with_trailing_separator_is_removed_once():
+    assert path_prefix.strip_exclude_prefix('/data/job/report.md', '/data/job/') == 'report.md'
+
+
+def test_later_matching_segment_is_preserved():
+    assert path_prefix.strip_exclude_prefix('/data/archive/data/report.md', '/data') == '/archive/data/report.md'
+
+
+def test_partial_path_component_is_rejected():
+    assert path_prefix.strip_exclude_prefix('/data/jobs/report.md', '/data/job') is None
+
+
+def test_unrelated_prefix_is_rejected():
+    assert path_prefix.strip_exclude_prefix('/data/job/report.md', '/other') is None
+
+
+def test_exact_path_match_produces_empty_relative_path():
+    assert path_prefix.strip_exclude_prefix('/data/job', '/data/job') == ''
+
+
+def test_windows_separator_is_a_path_boundary():
+    assert path_prefix.strip_exclude_prefix(r'C:\data\job\report.md', r'C:\data\job') == r'\report.md'
+
+
+def test_windows_partial_path_component_is_rejected():
+    assert path_prefix.strip_exclude_prefix(r'C:\data\jobs\report.md', r'C:\data\job') is None
+
+
+def test_mixed_separator_is_accepted_as_a_path_boundary():
+    assert path_prefix.strip_exclude_prefix(r'C:\data\job/report.md', r'C:\data\job') == '/report.md'


### PR DESCRIPTION
## Summary

- remove exactly one complete leading `exclude` path prefix instead of replacing every matching substring
- reject partial path-component matches while preserving later repeated path segments
- add deterministic pure unit tests and end-to-end filesystem regression tests

## Type

Fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Additional verification:

- `./builder nodes:test` — 3,537 passed, 230 expected skips, 0 failures
- focused path and node tests — 50 passed, 4 Windows-only skips
- all node contract tests — 346 passed
- Ruff lint and format checks pass
- Python compilation and `git diff --check` pass
- Fable 5 review: approved with no blocking findings

`./builder test` was not run because this change is isolated to a Python node; the full node test target, including the built server and dynamic node test, passed.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (not applicable; the documented contract is unchanged)
- [x] Breaking changes documented (not applicable; this restores documented behavior)

## Linked Issue

Fixes #2077