### PR TITLE
fix(llm-perplexity): align default profile

### DIFF
--- a/nodes/src/nodes/llm_perplexity/README.md
+++ b/nodes/src/nodes/llm_perplexity/README.md
@@ -84,7 +84,7 @@ To obtain an API key, visit [https://www.perplexity.ai/settings/api](https://www
 |---|---|---|---|
 | `model` | `string` | **Model**<br/>Perplexity AI model |  |
 | `modelTotalTokens` | `number` | **Tokens**<br/>Total Tokens |  |
-| `perplexity.profile` | `string` | **Model**<br/>Perplexity AI model | `"sonar-pro"` |
+| `perplexity.profile` | `string` | **Model**<br/>Perplexity AI model | `"sonar"` |
 
 ## Dependencies
 

--- a/nodes/src/nodes/llm_perplexity/services.json
+++ b/nodes/src/nodes/llm_perplexity/services.json
@@ -126,7 +126,7 @@
 			"title": "Model",
 			"description": "Perplexity AI model",
 			"type": "string",
-			"default": "sonar-pro",
+			"default": "sonar",
 			"enum": [
 				"*>preconfig.profiles.*.title"
 			],

--- a/nodes/test/llm_perplexity/test_perplexity_config.py
+++ b/nodes/test/llm_perplexity/test_perplexity_config.py
@@ -14,6 +14,7 @@ _SERVICES_PATH = Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'llm_pe
 
 
 def _load_services() -> dict:
+    """Load and parse the Perplexity service configuration."""
     services = _parse_service_json(str(_SERVICES_PATH))
     assert services is not None
     return services

--- a/nodes/test/llm_perplexity/test_perplexity_config.py
+++ b/nodes/test/llm_perplexity/test_perplexity_config.py
@@ -5,44 +5,18 @@
 
 """Configuration contract tests for the Perplexity node."""
 
-import json
-import re
 from pathlib import Path
+
+from test.framework.discovery import _parse_service_json
 
 
 _SERVICES_PATH = Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'llm_perplexity' / 'services.json'
 
 
 def _load_services() -> dict:
-    content = _SERVICES_PATH.read_text(encoding='utf-8')
-    output = []
-    in_string = False
-    escaped = False
-    index = 0
-
-    while index < len(content):
-        char = content[index]
-        if in_string:
-            output.append(char)
-            if escaped:
-                escaped = False
-            elif char == '\\':
-                escaped = True
-            elif char == '"':
-                in_string = False
-            index += 1
-            continue
-        if char == '"':
-            in_string = True
-        elif char == '/' and index + 1 < len(content) and content[index + 1] == '/':
-            while index < len(content) and content[index] != '\n':
-                index += 1
-            continue
-        output.append(char)
-        index += 1
-
-    content = re.sub(r',(\s*[}\]])', r'\1', ''.join(output))
-    return json.loads(content)
+    services = _parse_service_json(str(_SERVICES_PATH))
+    assert services is not None
+    return services
 
 
 def test_profile_selector_default_matches_preconfig_default():

--- a/nodes/test/llm_perplexity/test_perplexity_config.py
+++ b/nodes/test/llm_perplexity/test_perplexity_config.py
@@ -1,0 +1,66 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+# =============================================================================
+
+"""Configuration contract tests for the Perplexity node."""
+
+import json
+import re
+from pathlib import Path
+
+
+_SERVICES_PATH = Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'llm_perplexity' / 'services.json'
+
+
+def _load_services() -> dict:
+    content = _SERVICES_PATH.read_text(encoding='utf-8')
+    output = []
+    in_string = False
+    escaped = False
+    index = 0
+
+    while index < len(content):
+        char = content[index]
+        if in_string:
+            output.append(char)
+            if escaped:
+                escaped = False
+            elif char == '\\':
+                escaped = True
+            elif char == '"':
+                in_string = False
+            index += 1
+            continue
+        if char == '"':
+            in_string = True
+        elif char == '/' and index + 1 < len(content) and content[index + 1] == '/':
+            while index < len(content) and content[index] != '\n':
+                index += 1
+            continue
+        output.append(char)
+        index += 1
+
+    content = re.sub(r',(\s*[}\]])', r'\1', ''.join(output))
+    return json.loads(content)
+
+
+def test_profile_selector_default_matches_preconfig_default():
+    services = _load_services()
+
+    assert services['fields']['perplexity.profile']['default'] == services['preconfig']['default']
+
+
+def test_default_profile_is_declared_and_selectable():
+    services = _load_services()
+    default = services['preconfig']['default']
+    selector_values = {option['value'] for option in services['fields']['perplexity.profile']['conditional']}
+
+    assert default in services['preconfig']['profiles']
+    assert default in selector_values
+
+
+def test_node_test_configuration_exercises_the_default_profile():
+    services = _load_services()
+
+    assert services['test']['profiles'] == [services['preconfig']['default']]


### PR DESCRIPTION
## Summary

- Align the Perplexity profile selector default with the declared `preconfig.default` profile (`sonar`).
- Regenerate the machine-owned README schema so the published default matches node metadata.
- Add deterministic contract tests for default alignment, selectability, and built-in test coverage.

## Type

Fix

## Testing

- [x] Tests added or updated
- [x] Tested locally
- [ ] `./builder test` passes

Validated with:

- `./builder nodes:test-contracts` — 346 passed
- `./builder nodes:test --pytest-pattern=llm_perplexity --pytest-parallel=off` — 12 passed, 1 unrelated skip
- `dist/server/engine -m pytest nodes/test/llm_perplexity -q --rootdir nodes` — 9 passed
- `./builder docs:test` — 35 passed
- `ruff check` and `ruff format --check` — passed
- `nodes:docs-generate` rerun — zero additional changes

`./builder docs:build` reaches Docusaurus compilation but is currently blocked by a pre-existing broken link in `llm_qwen` to `tools/sync_models/README.md`; this PR does not touch that node or link.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [x] Wiki updated (not applicable)
- [x] Breaking changes documented (not applicable; no breaking change)

## Linked Issue

Fixes #2079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The Perplexity node now uses the **sonar** profile by default when no profile is selected.

* **Bug Fixes**
  * Synchronized the profile selector and preconfigured default for consistent model selection.

* **Tests**
  * Added validation confirming the default profile is available, selectable, and covered by node tests. This helps ensure the intended default remains reliable across configurations and future updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->