### PR TITLE
fix(shell): Documents.openDocument re-reads a clean document instead of trusting its cache forever

### DIFF
--- a/packages/shell/src/components/docs/Documents.test.ts
+++ b/packages/shell/src/components/docs/Documents.test.ts
@@ -1,0 +1,165 @@
+// =============================================================================
+// MIT License
+// Copyright (c) 2026 Aparavi Software AG
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// =============================================================================
+
+// The shell tsconfig deliberately keeps the browser surface node-free
+// ("types": []); this co-located node:test suite opts back in explicitly.
+/// <reference types="node" />
+
+/**
+ * Regression tests for the Cloud Pipeline Builder stale-content bug
+ * (rocketride-org/rocketride-server#2036): `check_connection` -- no, this is
+ * `Documents.openDocument` trusting an already-present, clean cache entry
+ * forever, even when it no longer matches the backing store. Proven on
+ * cloud.rocketride.ai: store v1, open it, overwrite the stored file to v2 via
+ * the fs API directly, then close+reopen or hard-reload the browser -- the
+ * editor kept showing v1. Publishing the same bytes under a NEW filename
+ * showed v2 immediately, which is what pointed at a name-keyed cache rather
+ * than a propagation delay.
+ *
+ * The one case worth protecting is a document with genuine unsaved local
+ * edits (`dirty: true`) -- that content must never be silently replaced by
+ * whatever the store currently holds.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { Documents, type IVirtualFileSystem, type DocumentsState, type WorkspaceBinding } from './Documents';
+
+/** In-memory VFS backed by a mutable Map, so tests can simulate an external
+ * write to the store between two `openDocument` calls. */
+function makeFakeVfs(initial: Record<string, unknown> = {}): { vfs: IVirtualFileSystem; store: Map<string, unknown>; failNextRead: Set<string> } {
+	const store = new Map<string, unknown>(Object.entries(initial));
+	const failNextRead = new Set<string>();
+	const vfs: IVirtualFileSystem = {
+		list: async () => [],
+		read: async (path: string) => {
+			if (failNextRead.has(path)) {
+				failNextRead.delete(path);
+				throw new Error('simulated read failure');
+			}
+			return store.has(path) ? store.get(path) : null;
+		},
+		write: async (path: string, content: unknown) => {
+			store.set(path, content);
+		},
+		rename: async () => undefined,
+		delete: async () => undefined,
+		mkdir: async () => undefined,
+	};
+	return { vfs, store, failNextRead };
+}
+
+/** A DocumentsState as it would come back from persisted workspace appState:
+ * a document entry with no active editor referencing it (`editorCount: 0`)
+ * and marked clean -- exactly what a hard browser reload restores. */
+function makePersistedState(uri: string, content: unknown): DocumentsState {
+	return {
+		documents: { [uri]: { uri, content, dirty: false, version: 1, editorCount: 0, isNew: false } },
+		editors: {},
+		groups: { 'group-1': { id: 'group-1', editorIds: [], activeEditorIndex: -1 } },
+		rootNode: { type: 'leaf', id: 'group-1', groupId: 'group-1' },
+		activeGroupId: 'group-1',
+	};
+}
+
+function makeWorkspace(state: DocumentsState): WorkspaceBinding {
+	return {
+		appState: { documents: state },
+		updateAppState: () => {},
+	};
+}
+
+test('opening a document for the first time reads from the VFS', async () => {
+	const { vfs } = makeFakeVfs({ 'a.pipe': 'v1' });
+	const docs = new Documents(vfs);
+	await docs.openDocument('a.pipe');
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v1');
+});
+
+test('closing the last editor of a clean document evicts it, so a later reopen sees an external change', async () => {
+	const { vfs, store } = makeFakeVfs({ 'a.pipe': 'v1' });
+	const docs = new Documents(vfs);
+	await docs.openDocument('a.pipe');
+	const [editorId] = Object.keys(docs.getState().editors);
+	docs.closeEditor(editorId!);
+	assert.equal(docs.getDocument('a.pipe'), undefined, 'a clean, unreferenced document should be evicted on close');
+
+	store.set('a.pipe', 'v2');
+	await docs.openDocument('a.pipe');
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v2');
+});
+
+test('#2036: a clean document restored from a persisted session is re-read, not trusted forever', async () => {
+	// Simulates surviving a hard browser reload: the constructor restores
+	// documents.['a.pipe'] from persisted appState with the OLD content and
+	// editorCount: 0 (no live editor references it yet in this fresh session).
+	const { vfs } = makeFakeVfs({ 'a.pipe': 'v2' }); // the store was updated externally since persistence
+	const docs = new Documents(vfs, makeWorkspace(makePersistedState('a.pipe', 'v1')));
+
+	// Sanity: the persisted (stale) content is there before any open happens.
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v1');
+
+	await docs.openDocument('a.pipe');
+
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v2', 'open must re-read a clean document rather than trust the persisted cache');
+});
+
+test('a document with unsaved edits is never silently replaced by the store', async () => {
+	const { vfs, store } = makeFakeVfs({ 'a.pipe': 'v1' });
+	const docs = new Documents(vfs);
+	await docs.openDocument('a.pipe');
+	docs.updateContent('a.pipe', 'my unsaved edit');
+	assert.equal(docs.getDocument('a.pipe')?.dirty, true);
+
+	// An external write happens while the user has unsaved local changes.
+	store.set('a.pipe', 'v2 from someone else');
+
+	// Open the same document in a second pane (bypasses the "already open in
+	// this group" short-circuit, exercising the same-uri-different-group path).
+	const secondGroup = docs.splitGroup('group-1', 'horizontal');
+	await docs.openDocument('a.pipe', secondGroup);
+
+	assert.equal(docs.getDocument('a.pipe')?.content, 'my unsaved edit', 'dirty content must not be clobbered by a fresh read');
+});
+
+test('a failed re-read falls back to the previously cached content instead of clearing it', async () => {
+	const { vfs, store, failNextRead } = makeFakeVfs({ 'a.pipe': 'v1' });
+	const docs = new Documents(vfs);
+	await docs.openDocument('a.pipe');
+	const [editorId] = Object.keys(docs.getState().editors);
+
+	// Re-open the same document from a persisted-like state with editorCount 0
+	// (simulating a fresh session) so the read path is exercised again, but
+	// this time the read throws (e.g. a transient network blip).
+	docs.closeEditor(editorId!); // fresh close, doc would normally be evicted...
+	// ...so seed it back as if freshly restored, to isolate the failure path
+	// from the eviction behavior already covered above.
+	const docs2 = new Documents(vfs, makeWorkspace(makePersistedState('a.pipe', 'v1')));
+	failNextRead.add('a.pipe');
+	store.set('a.pipe', 'v2'); // irrelevant: the read will throw before reaching this
+
+	await docs2.openDocument('a.pipe');
+
+	assert.equal(docs2.getDocument('a.pipe')?.content, 'v1', 'a failed read must not wipe out the last known-good content');
+	assert.equal(docs2.getDocument('a.pipe')?.isNew, false, 'a document recovered from cache after a failed read is not "new"');
+});

--- a/packages/shell/src/components/docs/Documents.test.ts
+++ b/packages/shell/src/components/docs/Documents.test.ts
@@ -194,6 +194,22 @@ test('a failed re-read falls back to the previously cached content instead of cl
 	assert.equal(docs2.getDocument('a.pipe')?.isNew, false, 'a document recovered from cache after a failed read is not "new"');
 });
 
+test('a cached null content is preserved when a re-read fails, not replaced with empty string', async () => {
+	// A document's content can legitimately be `null` -- e.g. saved that way
+	// via updateContent(uri, null) then saveDocument(), which preserves
+	// content verbatim while only flipping `dirty`. `doc?.content ?? ''`
+	// would treat that valid null the same as "no cached document at all"
+	// and clobber it with '' before the read even runs -- permanently, once
+	// the read then fails and there's nothing to overwrite it with.
+	const { vfs, failNextRead } = makeFakeVfs({ 'a.pipe': null });
+	failNextRead.add('a.pipe');
+	const docs = new Documents(vfs, makeWorkspace(makePersistedState('a.pipe', null)));
+
+	await docs.openDocument('a.pipe');
+
+	assert.equal(docs.getDocument('a.pipe')?.content, null, 'a legitimately null cached content must survive a failed re-read, not become an empty string');
+});
+
 test('a static document reopened in another group stays static and is never read from the VFS', async () => {
 	// static documents (e.g. a monitor/webview panel) are explicitly not
 	// backed by the VFS -- there's nothing on the store for a freshness

--- a/packages/shell/src/components/docs/Documents.test.ts
+++ b/packages/shell/src/components/docs/Documents.test.ts
@@ -204,3 +204,21 @@ test('an untitled document reopened in another group keeps isNew true and is nev
 	assert.equal(docs.getDocument(uri)?.content, 'draft content');
 	assert.equal(reads.includes(uri), false, 'an untitled document must never be read from the VFS');
 });
+
+test('two concurrent opens of the same uri into the same group do not create duplicate tabs', async () => {
+	// The "already open in this group" check at the top of openDocument runs
+	// on a snapshot taken before the VFS read below it. If that read actually
+	// suspends (a real await, which a Promise-returning read always causes at
+	// least once), a second openDocument(uri, group) call for the identical
+	// document can run entirely in between and commit its own editor first --
+	// racing both calls here reproduces exactly that interleaving.
+	const { vfs } = makeFakeVfs({ 'a.pipe': 'v1' });
+	const docs = new Documents(vfs);
+
+	await Promise.all([docs.openDocument('a.pipe', 'group-1'), docs.openDocument('a.pipe', 'group-1')]);
+
+	const group = docs.getState().groups['group-1']!;
+	const editorsForUri = group.editorIds.filter((eid) => docs.getState().editors[eid]?.documentUri === 'a.pipe');
+	assert.equal(editorsForUri.length, 1, 'racing two opens of the same document into the same group must not open two tabs');
+	assert.equal(docs.getDocument('a.pipe')?.editorCount, 1, 'editorCount must reflect the single tab actually created, not one per racing call');
+});

--- a/packages/shell/src/components/docs/Documents.test.ts
+++ b/packages/shell/src/components/docs/Documents.test.ts
@@ -49,20 +49,30 @@ import { Documents, type IVirtualFileSystem, type DocumentsState, type Workspace
  * write to the store between two `openDocument` calls. `reads` records every
  * path `read()` was called with, so tests can assert a path was NEVER read
  * (e.g. a static or untitled document, which has nothing on the store to
- * read in the first place). */
+ * read in the first place). `pauseNextRead`/`resumeRead` let a test suspend
+ * a read mid-flight to deterministically interleave another call into the
+ * gap, without relying on timer-based guessing. */
 function makeFakeVfs(initial: Record<string, unknown> = {}): {
 	vfs: IVirtualFileSystem;
 	store: Map<string, unknown>;
 	failNextRead: Set<string>;
 	reads: string[];
+	pauseNextRead: (path: string) => void;
+	resumeRead: (path: string) => void;
 } {
 	const store = new Map<string, unknown>(Object.entries(initial));
 	const failNextRead = new Set<string>();
 	const reads: string[] = [];
+	const pauseOnRead = new Set<string>();
+	const pausedResolvers = new Map<string, () => void>();
 	const vfs: IVirtualFileSystem = {
 		list: async () => [],
 		read: async (path: string) => {
 			reads.push(path);
+			if (pauseOnRead.has(path)) {
+				pauseOnRead.delete(path);
+				await new Promise<void>((resolve) => pausedResolvers.set(path, resolve));
+			}
 			if (failNextRead.has(path)) {
 				failNextRead.delete(path);
 				throw new Error('simulated read failure');
@@ -76,7 +86,17 @@ function makeFakeVfs(initial: Record<string, unknown> = {}): {
 		delete: async () => undefined,
 		mkdir: async () => undefined,
 	};
-	return { vfs, store, failNextRead, reads };
+	return {
+		vfs,
+		store,
+		failNextRead,
+		reads,
+		pauseNextRead: (path: string) => pauseOnRead.add(path),
+		resumeRead: (path: string) => {
+			pausedResolvers.get(path)?.();
+			pausedResolvers.delete(path);
+		},
+	};
 }
 
 /** A DocumentsState as it would come back from persisted workspace appState:
@@ -221,4 +241,27 @@ test('two concurrent opens of the same uri into the same group do not create dup
 	const editorsForUri = group.editorIds.filter((eid) => docs.getState().editors[eid]?.documentUri === 'a.pipe');
 	assert.equal(editorsForUri.length, 1, 'racing two opens of the same document into the same group must not open two tabs');
 	assert.equal(docs.getDocument('a.pipe')?.editorCount, 1, 'editorCount must reflect the single tab actually created, not one per racing call');
+});
+
+test('discarding a document while its re-read is in flight does not resurrect it', async () => {
+	// discardDocument() force-removes a document specifically because its
+	// backing file was deleted from disk. If that races in while a clean
+	// document is being re-read for a second pane, the read's result (which
+	// may have started before the deletion, or is now reading a vanished
+	// file) must not silently bring the document back.
+	const { vfs, pauseNextRead, resumeRead } = makeFakeVfs({ 'a.pipe': 'v1' });
+	const docs = new Documents(vfs);
+	await docs.openDocument('a.pipe'); // cached, clean, one editor in group-1
+
+	const secondGroup = docs.splitGroup('group-1', 'horizontal');
+	pauseNextRead('a.pipe');
+	const reopen = docs.openDocument('a.pipe', secondGroup); // suspends inside vfs.read()
+
+	docs.discardDocument('a.pipe'); // simulates: the backing file was deleted from disk
+	resumeRead('a.pipe');
+	await reopen;
+
+	assert.equal(docs.getDocument('a.pipe'), undefined, 'a document discarded mid-read must not be resurrected');
+	const remainingEditors = Object.values(docs.getState().editors).filter((e) => e.documentUri === 'a.pipe');
+	assert.equal(remainingEditors.length, 0, 'no editor should be created for a document discarded mid-open');
 });

--- a/packages/shell/src/components/docs/Documents.test.ts
+++ b/packages/shell/src/components/docs/Documents.test.ts
@@ -46,13 +46,23 @@ import test from 'node:test';
 import { Documents, type IVirtualFileSystem, type DocumentsState, type WorkspaceBinding } from './Documents';
 
 /** In-memory VFS backed by a mutable Map, so tests can simulate an external
- * write to the store between two `openDocument` calls. */
-function makeFakeVfs(initial: Record<string, unknown> = {}): { vfs: IVirtualFileSystem; store: Map<string, unknown>; failNextRead: Set<string> } {
+ * write to the store between two `openDocument` calls. `reads` records every
+ * path `read()` was called with, so tests can assert a path was NEVER read
+ * (e.g. a static or untitled document, which has nothing on the store to
+ * read in the first place). */
+function makeFakeVfs(initial: Record<string, unknown> = {}): {
+	vfs: IVirtualFileSystem;
+	store: Map<string, unknown>;
+	failNextRead: Set<string>;
+	reads: string[];
+} {
 	const store = new Map<string, unknown>(Object.entries(initial));
 	const failNextRead = new Set<string>();
+	const reads: string[] = [];
 	const vfs: IVirtualFileSystem = {
 		list: async () => [],
 		read: async (path: string) => {
+			reads.push(path);
 			if (failNextRead.has(path)) {
 				failNextRead.delete(path);
 				throw new Error('simulated read failure');
@@ -66,7 +76,7 @@ function makeFakeVfs(initial: Record<string, unknown> = {}): { vfs: IVirtualFile
 		delete: async () => undefined,
 		mkdir: async () => undefined,
 	};
-	return { vfs, store, failNextRead };
+	return { vfs, store, failNextRead, reads };
 }
 
 /** A DocumentsState as it would come back from persisted workspace appState:
@@ -162,4 +172,35 @@ test('a failed re-read falls back to the previously cached content instead of cl
 
 	assert.equal(docs2.getDocument('a.pipe')?.content, 'v1', 'a failed read must not wipe out the last known-good content');
 	assert.equal(docs2.getDocument('a.pipe')?.isNew, false, 'a document recovered from cache after a failed read is not "new"');
+});
+
+test('a static document reopened in another group stays static and is never read from the VFS', async () => {
+	// static documents (e.g. a monitor/webview panel) are explicitly not
+	// backed by the VFS -- there's nothing on the store for a freshness
+	// check to mean anything, and openDocument must not try one.
+	const { vfs, reads } = makeFakeVfs();
+	const docs = new Documents(vfs);
+	docs.openStaticDocument('monitor', 'Monitor', 'live status');
+
+	const secondGroup = docs.splitGroup('group-1', 'horizontal');
+	await docs.openDocument('monitor', secondGroup);
+
+	assert.equal(docs.getDocument('monitor')?.static, true, 'reopening in another group must not drop the static flag');
+	assert.equal(docs.getDocument('monitor')?.content, 'live status');
+	assert.equal(reads.includes('monitor'), false, 'a static document must never be read from the VFS');
+});
+
+test('an untitled document reopened in another group keeps isNew true and is never read from the VFS', async () => {
+	// isNew (untitled) documents have never been saved -- there's no store
+	// counterpart to re-read, and doing so would falsely mark them saved.
+	const { vfs, reads } = makeFakeVfs();
+	const docs = new Documents(vfs);
+	const uri = docs.createDocument(undefined, 'draft content');
+
+	const secondGroup = docs.splitGroup('group-1', 'horizontal');
+	await docs.openDocument(uri, secondGroup);
+
+	assert.equal(docs.getDocument(uri)?.isNew, true, 'reopening in another group must not clear isNew');
+	assert.equal(docs.getDocument(uri)?.content, 'draft content');
+	assert.equal(reads.includes(uri), false, 'an untitled document must never be read from the VFS');
 });

--- a/packages/shell/src/components/docs/Documents.test.ts
+++ b/packages/shell/src/components/docs/Documents.test.ts
@@ -27,14 +27,14 @@
 
 /**
  * Regression tests for the Cloud Pipeline Builder stale-content bug
- * (rocketride-org/rocketride-server#2036): `check_connection` -- no, this is
- * `Documents.openDocument` trusting an already-present, clean cache entry
- * forever, even when it no longer matches the backing store. Proven on
- * cloud.rocketride.ai: store v1, open it, overwrite the stored file to v2 via
- * the fs API directly, then close+reopen or hard-reload the browser -- the
- * editor kept showing v1. Publishing the same bytes under a NEW filename
- * showed v2 immediately, which is what pointed at a name-keyed cache rather
- * than a propagation delay.
+ * (rocketride-org/rocketride-server#2036): `Documents.openDocument` (and, for
+ * the hard-reload half of the repro, the constructor's post-restore refresh)
+ * trusting an already-present, clean cache entry forever, even when it no
+ * longer matches the backing store. Proven on cloud.rocketride.ai: store v1,
+ * open it, overwrite the stored file to v2 via the fs API directly, then
+ * close+reopen or hard-reload the browser -- the editor kept showing v1.
+ * Publishing the same bytes under a NEW filename showed v2 immediately, which
+ * is what pointed at a name-keyed cache rather than a propagation delay.
  *
  * The one case worth protecting is a document with genuine unsaved local
  * edits (`dirty: true`) -- that content must never be silently replaced by
@@ -99,14 +99,31 @@ function makeFakeVfs(initial: Record<string, unknown> = {}): {
 	};
 }
 
-/** A DocumentsState as it would come back from persisted workspace appState:
- * a document entry with no active editor referencing it (`editorCount: 0`)
- * and marked clean -- exactly what a hard browser reload restores. */
+/** A DocumentsState as it would come back from persisted workspace appState
+ * with no tab open for the document (`editorCount: 0`, no editor entry) and
+ * marked clean -- e.g. every tab was closed before the session was saved. */
 function makePersistedState(uri: string, content: unknown): DocumentsState {
 	return {
 		documents: { [uri]: { uri, content, dirty: false, version: 1, editorCount: 0, isNew: false } },
 		editors: {},
 		groups: { 'group-1': { id: 'group-1', editorIds: [], activeEditorIndex: -1 } },
+		rootNode: { type: 'leaf', id: 'group-1', groupId: 'group-1' },
+		activeGroupId: 'group-1',
+	};
+}
+
+/** Same as makePersistedState, but with a tab actually open for the document
+ * (`editorCount: 1`, one editor referencing it) -- what a hard browser
+ * reload restores when the document had a live editor at the time of the
+ * reload. Unlike makePersistedState's editorCount: 0, this is the case
+ * #2085's review pointed out openDocument's re-read never covers, since
+ * GroupEditorPane renders state.documents[uri] directly without going
+ * through openDocument on restore. */
+function makePersistedStateWithOpenEditor(uri: string, content: unknown): DocumentsState {
+	return {
+		documents: { [uri]: { uri, content, dirty: false, version: 1, editorCount: 1, isNew: false } },
+		editors: { 'editor-1': { id: 'editor-1', documentUri: uri, scrollTop: 0, scrollLeft: 0, cursorLine: 1, cursorColumn: 1, label: uri } },
+		groups: { 'group-1': { id: 'group-1', editorIds: ['editor-1'], activeEditorIndex: 0 } },
 		rootNode: { type: 'leaf', id: 'group-1', groupId: 'group-1' },
 		activeGroupId: 'group-1',
 	};
@@ -140,9 +157,14 @@ test('closing the last editor of a clean document evicts it, so a later reopen s
 });
 
 test('#2036: a clean document restored from a persisted session is re-read, not trusted forever', async () => {
-	// Simulates surviving a hard browser reload: the constructor restores
-	// documents.['a.pipe'] from persisted appState with the OLD content and
-	// editorCount: 0 (no live editor references it yet in this fresh session).
+	// Simulates the "close all tabs, reopen from the sidebar" half of the
+	// repro: the constructor restores documents.['a.pipe'] from persisted
+	// appState with the OLD content and editorCount: 0 (every tab for it was
+	// closed before the session was saved, so nothing re-opens it on restore
+	// -- that requires an explicit openDocument call, exercised below). The
+	// other half -- a hard reload with a tab still open for it -- is covered
+	// by the next test, since editorCount: 0 here means the constructor's own
+	// post-restore refresh has nothing to do for this uri.
 	const { vfs } = makeFakeVfs({ 'a.pipe': 'v2' }); // the store was updated externally since persistence
 	const docs = new Documents(vfs, makeWorkspace(makePersistedState('a.pipe', 'v1')));
 
@@ -152,6 +174,26 @@ test('#2036: a clean document restored from a persisted session is re-read, not 
 	await docs.openDocument('a.pipe');
 
 	assert.equal(docs.getDocument('a.pipe')?.content, 'v2', 'open must re-read a clean document rather than trust the persisted cache');
+});
+
+test('#2036: a hard reload with a tab still open re-reads the document without an explicit openDocument call', async () => {
+	// The other half of the reported repro, and the one #2085's review found
+	// still unfixed: a hard browser reload restores documents/editors/groups
+	// verbatim (a tab is already open for a.pipe, editorCount: 1) and
+	// GroupEditorPane renders state.documents[uri] directly -- openDocument
+	// is never called on this path, so its re-read fix alone can't reach it.
+	const { vfs } = makeFakeVfs({ 'a.pipe': 'v2' }); // the store was updated externally since persistence
+	const docs = new Documents(vfs, makeWorkspace(makePersistedStateWithOpenEditor('a.pipe', 'v1')));
+
+	// Sanity: the persisted (stale) content is there synchronously, before the
+	// constructor's fire-and-forget post-restore refresh has resolved.
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v1');
+
+	// Flush pending microtasks (the refresh's vfs.read() and the _update() in
+	// its continuation) without depending on Documents exposing that promise.
+	await new Promise((resolve) => setTimeout(resolve, 0));
+
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v2', 'a hard reload with a live editor must re-read a clean document, not trust the persisted cache indefinitely');
 });
 
 test('a document with unsaved edits is never silently replaced by the store', async () => {
@@ -173,25 +215,18 @@ test('a document with unsaved edits is never silently replaced by the store', as
 });
 
 test('a failed re-read falls back to the previously cached content instead of clearing it', async () => {
+	// Persisted-like state with editorCount 0 (a fresh session, nothing else
+	// referencing the cached copy yet) so opening it exercises the re-read
+	// path, but this time the read throws (e.g. a transient network blip).
 	const { vfs, store, failNextRead } = makeFakeVfs({ 'a.pipe': 'v1' });
-	const docs = new Documents(vfs);
-	await docs.openDocument('a.pipe');
-	const [editorId] = Object.keys(docs.getState().editors);
-
-	// Re-open the same document from a persisted-like state with editorCount 0
-	// (simulating a fresh session) so the read path is exercised again, but
-	// this time the read throws (e.g. a transient network blip).
-	docs.closeEditor(editorId!); // fresh close, doc would normally be evicted...
-	// ...so seed it back as if freshly restored, to isolate the failure path
-	// from the eviction behavior already covered above.
-	const docs2 = new Documents(vfs, makeWorkspace(makePersistedState('a.pipe', 'v1')));
+	const docs = new Documents(vfs, makeWorkspace(makePersistedState('a.pipe', 'v1')));
 	failNextRead.add('a.pipe');
 	store.set('a.pipe', 'v2'); // irrelevant: the read will throw before reaching this
 
-	await docs2.openDocument('a.pipe');
+	await docs.openDocument('a.pipe');
 
-	assert.equal(docs2.getDocument('a.pipe')?.content, 'v1', 'a failed read must not wipe out the last known-good content');
-	assert.equal(docs2.getDocument('a.pipe')?.isNew, false, 'a document recovered from cache after a failed read is not "new"');
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v1', 'a failed read must not wipe out the last known-good content');
+	assert.equal(docs.getDocument('a.pipe')?.isNew, false, 'a document recovered from cache after a failed read is not "new"');
 });
 
 test('a cached null content is preserved when a re-read fails, not replaced with empty string', async () => {
@@ -280,4 +315,33 @@ test('discarding a document while its re-read is in flight does not resurrect it
 	assert.equal(docs.getDocument('a.pipe'), undefined, 'a document discarded mid-read must not be resurrected');
 	const remainingEditors = Object.values(docs.getState().editors).filter((e) => e.documentUri === 'a.pipe');
 	assert.equal(remainingEditors.length, 0, 'no editor should be created for a document discarded mid-open');
+});
+
+test('an eviction via closeEditor mid-read does not silently cancel the open, unlike a genuine discard', async () => {
+	// #2085 review: distinct from the discard test above. That one is a real
+	// discardDocument() (backing file deleted from disk) and must NOT
+	// resurrect the document. This is closeEditor() evicting the SAME clean,
+	// now-unreferenced document because its only other tab just closed --
+	// the document and its backing file are still perfectly valid, so this
+	// second open must still succeed instead of silently doing nothing.
+	const { vfs, pauseNextRead, resumeRead } = makeFakeVfs({ 'a.pipe': 'v1' });
+	const docs = new Documents(vfs);
+	await docs.openDocument('a.pipe'); // group-1, editorCount: 1, clean
+	const [firstEditorId] = Object.keys(docs.getState().editors);
+
+	const secondGroup = docs.splitGroup('group-1', 'horizontal');
+	pauseNextRead('a.pipe');
+	const reopen = docs.openDocument('a.pipe', secondGroup); // suspends inside vfs.read()
+
+	docs.closeEditor(firstEditorId!); // last editor for a.pipe in group-1 closes -> evicted (clean, editorCount hits 0)
+	assert.equal(docs.getDocument('a.pipe'), undefined, 'sanity: the document is evicted here, not discarded');
+
+	resumeRead('a.pipe');
+	await reopen;
+
+	assert.equal(docs.getDocument('a.pipe')?.content, 'v1', 'the second open must still succeed after an unrelated eviction, not silently do nothing');
+	const group = docs.getState().groups[secondGroup]!;
+	const editorsForUri = group.editorIds.filter((eid) => docs.getState().editors[eid]?.documentUri === 'a.pipe');
+	assert.equal(editorsForUri.length, 1, 'a tab must actually be created for the second open');
+	assert.equal(docs.getDocument('a.pipe')?.editorCount, 1, 'editorCount must reflect only the surviving second-pane editor');
 });

--- a/packages/shell/src/components/docs/Documents.tsx
+++ b/packages/shell/src/components/docs/Documents.tsx
@@ -639,14 +639,24 @@ export class Documents {
 				};
 			}
 
-			// Prefer this call's (possibly freshly re-read) result, UNLESS
-			// something else changed this document while the read was in
-			// flight -- e.g. a concurrent open of the same uri finishing
+			// If this document existed when the read started but is gone now,
+			// something deliberately removed it while the read was in flight --
+			// discardDocument() is the one caller that does this, specifically
+			// because the backing file was deleted from disk. Recreating it
+			// from finalDoc (a read that may have started before the deletion,
+			// or already be racing a since-vanished file) would silently
+			// resurrect a document the system just determined doesn't exist;
+			// respect the removal and abort instead of opening anything.
+			const current = prev.documents[uri];
+			if (initialDoc && !current) return prev;
+
+			// Otherwise, prefer this call's (possibly freshly re-read) result,
+			// UNLESS something else changed this document while the read was
+			// in flight -- e.g. a concurrent open of the same uri finishing
 			// first (in a DIFFERENT group), or the user editing it via another
 			// path. That live state must win over a read that's now stale by
 			// comparison; a referential match against the pre-read snapshot
 			// means nothing raced, so the fresh read is safe to apply.
-			const current = prev.documents[uri];
 			const base = current === initialDoc ? finalDoc : (current ?? finalDoc);
 			const updatedDoc = { ...base, editorCount: (current?.editorCount ?? 0) + 1 };
 			const newEditorIds = [...group.editorIds, editorId];

--- a/packages/shell/src/components/docs/Documents.tsx
+++ b/packages/shell/src/components/docs/Documents.tsx
@@ -618,18 +618,37 @@ export class Documents {
 
 		const finalDoc = doc;
 		this._update((prev) => {
+			const group = prev.groups[targetGroup];
+			if (!group) return prev;
+
+			// The "already open in this group" check at the top of this method
+			// ran on a snapshot taken before the read above -- if that read
+			// actually suspended (an await), a second openDocument(uri,
+			// targetGroup) call (e.g. a rapid double-click) could have run
+			// entirely in between and already committed its own new editor for
+			// this exact uri+group. Re-checking here, against the LATEST state,
+			// catches that: activate the editor it already added instead of
+			// piling on a duplicate tab for the same document in the same pane.
+			const racedEditorId = group.editorIds.find((eid) => prev.editors[eid]?.documentUri === uri);
+			if (racedEditorId) {
+				const idx = group.editorIds.indexOf(racedEditorId);
+				return {
+					...prev,
+					groups: { ...prev.groups, [targetGroup]: { ...group, activeEditorIndex: idx } },
+					activeGroupId: targetGroup,
+				};
+			}
+
 			// Prefer this call's (possibly freshly re-read) result, UNLESS
 			// something else changed this document while the read was in
 			// flight -- e.g. a concurrent open of the same uri finishing
-			// first, or the user editing it via another path. That live
-			// state must win over a read that's now stale by comparison; a
-			// referential match against the pre-read snapshot means nothing
-			// raced, so the fresh read is safe to apply.
+			// first (in a DIFFERENT group), or the user editing it via another
+			// path. That live state must win over a read that's now stale by
+			// comparison; a referential match against the pre-read snapshot
+			// means nothing raced, so the fresh read is safe to apply.
 			const current = prev.documents[uri];
 			const base = current === initialDoc ? finalDoc : (current ?? finalDoc);
 			const updatedDoc = { ...base, editorCount: (current?.editorCount ?? 0) + 1 };
-			const group = prev.groups[targetGroup];
-			if (!group) return prev;
 			const newEditorIds = [...group.editorIds, editorId];
 			return {
 				...prev,

--- a/packages/shell/src/components/docs/Documents.tsx
+++ b/packages/shell/src/components/docs/Documents.tsx
@@ -576,9 +576,19 @@ export class Documents {
 		// externally (another client, a direct store write) since it was last
 		// read -- so it's never trusted indefinitely; only a DIRTY document
 		// (genuine unsaved edits) is worth keeping as-is rather than re-read.
+		//
+		// static and isNew documents are exempt from that re-read even though
+		// both are also always clean: static documents are explicitly not
+		// backed by the VFS (saveDocument itself skips them), and an isNew
+		// (untitled) document has no counterpart on the store to validate
+		// freshness against. Re-reading either would call vfs.read() on a URI
+		// that was never a real file, and reconstructing the Document below
+		// would drop `static`/`isNew` since neither field is carried over --
+		// silently turning a static panel into a VFS-backed one, or an
+		// unsaved scratch buffer into what looks like a saved file.
 		const initialDoc = s.documents[uri];
 		let doc = initialDoc;
-		if (!doc || !doc.dirty) {
+		if (!doc || (!doc.dirty && !doc.static && !doc.isNew)) {
 			let content: unknown = doc?.content ?? '';
 			let loadedOk = !!doc; // a prior cached copy is a valid fallback if the read below fails
 			if (this._vfs) {

--- a/packages/shell/src/components/docs/Documents.tsx
+++ b/packages/shell/src/components/docs/Documents.tsx
@@ -570,11 +570,17 @@ export class Documents {
 			return;
 		}
 
-		// Load content if document not yet open
-		let doc = s.documents[uri];
-		if (!doc) {
-			let content: unknown = '';
-			let loadedOk = false;
+		// Load content when the document isn't open yet, or IS open but clean
+		// (nothing local to protect). A clean cached entry can be stale relative
+		// to the backing store -- restored from a persisted session, or written
+		// externally (another client, a direct store write) since it was last
+		// read -- so it's never trusted indefinitely; only a DIRTY document
+		// (genuine unsaved edits) is worth keeping as-is rather than re-read.
+		const initialDoc = s.documents[uri];
+		let doc = initialDoc;
+		if (!doc || !doc.dirty) {
+			let content: unknown = doc?.content ?? '';
+			let loadedOk = !!doc; // a prior cached copy is a valid fallback if the read below fails
 			if (this._vfs) {
 				try {
 					const raw = await this._vfs.read(uri);
@@ -583,10 +589,10 @@ export class Documents {
 						loadedOk = true;
 					}
 				} catch {
-					/* read failed */
+					/* read failed -- fall back to whatever we already had, if anything */
 				}
 			}
-			doc = { uri, content, dirty: false, version: 1, editorCount: 0, isNew: !loadedOk };
+			doc = { uri, content, dirty: false, version: (doc?.version ?? 0) + 1, editorCount: 0, isNew: !loadedOk };
 		}
 
 		const editorId = this._nextEditorId();
@@ -602,7 +608,16 @@ export class Documents {
 
 		const finalDoc = doc;
 		this._update((prev) => {
-			const updatedDoc = { ...(prev.documents[uri] ?? finalDoc), editorCount: (prev.documents[uri]?.editorCount ?? 0) + 1 };
+			// Prefer this call's (possibly freshly re-read) result, UNLESS
+			// something else changed this document while the read was in
+			// flight -- e.g. a concurrent open of the same uri finishing
+			// first, or the user editing it via another path. That live
+			// state must win over a read that's now stale by comparison; a
+			// referential match against the pre-read snapshot means nothing
+			// raced, so the fresh read is safe to apply.
+			const current = prev.documents[uri];
+			const base = current === initialDoc ? finalDoc : (current ?? finalDoc);
+			const updatedDoc = { ...base, editorCount: (current?.editorCount ?? 0) + 1 };
 			const group = prev.groups[targetGroup];
 			if (!group) return prev;
 			const newEditorIds = [...group.editorIds, editorId];

--- a/packages/shell/src/components/docs/Documents.tsx
+++ b/packages/shell/src/components/docs/Documents.tsx
@@ -589,7 +589,12 @@ export class Documents {
 		const initialDoc = s.documents[uri];
 		let doc = initialDoc;
 		if (!doc || (!doc.dirty && !doc.static && !doc.isNew)) {
-			let content: unknown = doc?.content ?? '';
+			// `doc?.content ?? ''` would be wrong here: a saved document can
+			// legitimately carry `null` (or any other falsy-but-not-missing
+			// value) as its content -- saveDocument() preserves content
+			// verbatim while only flipping `dirty`. Only fall back to '' when
+			// there's no cached document at all to read content from.
+			let content: unknown = doc ? doc.content : '';
 			let loadedOk = !!doc; // a prior cached copy is a valid fallback if the read below fails
 			if (this._vfs) {
 				try {

--- a/packages/shell/src/components/docs/Documents.tsx
+++ b/packages/shell/src/components/docs/Documents.tsx
@@ -58,7 +58,15 @@ export interface Document {
 	content: unknown;
 	/** True if the document has unsaved changes. */
 	dirty: boolean;
-	/** Monotonically increasing version counter, bumped on every content change. */
+	/**
+	 * Monotonically increasing version counter. Bumped on every edit, and also
+	 * on every re-read from the VFS (openDocument, or the constructor's
+	 * post-restore refresh) even when the re-read happens to return
+	 * byte-identical content -- there are no consumers outside this file today
+	 * that would be affected by that imprecision, but treat it as "the cache
+	 * was last confirmed/updated at this version," not strictly "content
+	 * changed at this version."
+	 */
 	version: number;
 	/** Number of editors currently viewing this document. */
 	editorCount: number;
@@ -405,6 +413,15 @@ export class Documents {
 	private _editorCounter = 0;
 	private _groupCounter = 1;
 	private _splitCounter = 0;
+	/**
+	 * Per-URI counter bumped by `discardDocument` (never by `closeEditor`'s
+	 * ordinary eviction of a clean, unreferenced document). `openDocument`
+	 * snapshots this at the start of its read and compares it at the end to
+	 * tell the two apart: both leave the document missing from `prev.documents`
+	 * when the read resolves, but only a real discard should stop the read's
+	 * result from being applied.
+	 */
+	private _discardEpoch = new Map<string, number>();
 
 	/**
 	 * Creates a new Documents instance.
@@ -439,6 +456,46 @@ export class Documents {
 		} else {
 			this._state = makeDefaultState();
 		}
+
+		// #2036's actual repro is a hard browser reload, and that never runs
+		// through openDocument: the restore above puts documents/editors/groups
+		// back verbatim, and the editor pane renders state.documents[uri]
+		// directly. Without this, a document with a live editor at restore time
+		// (editorCount > 0) would show its persisted -- possibly stale -- content
+		// forever, exactly like the bug this PR otherwise fixes. Apply the same
+		// trust rule as openDocument (dirty is protected, clean is not) once at
+		// startup instead. A document with no live editor is left alone; it
+		// gets the normal lazy re-read the next time it's actually opened.
+		void this._refreshRestoredDocuments();
+	}
+
+	/**
+	 * Re-reads every clean, VFS-backed, currently-open document once, right
+	 * after a persisted session is restored. See the constructor's call site.
+	 */
+	private async _refreshRestoredDocuments(): Promise<void> {
+		if (!this._vfs) return;
+		const candidates = Object.entries(this._state.documents).filter(([, doc]) => doc.editorCount > 0 && !doc.dirty && !doc.static && !doc.isNew);
+		await Promise.all(
+			candidates.map(async ([uri, initialDoc]) => {
+				let content: unknown;
+				try {
+					const raw = await this._vfs!.read(uri);
+					if (raw === null || raw === undefined) return; // nothing to refresh with -- leave the restored content in place
+					content = raw;
+				} catch {
+					return; // read failed -- leave the restored (stale but present) content in place, same fallback openDocument uses
+				}
+				this._update((prev) => {
+					// Same race guard as openDocument: only apply this read if
+					// nothing else changed the document while it was in flight
+					// (e.g. the user edited or closed it before this resolved).
+					const current = prev.documents[uri];
+					if (current !== initialDoc) return prev;
+					return { ...prev, documents: { ...prev.documents, [uri]: { ...current, content, version: current.version + 1 } } };
+				});
+			})
+		);
 	}
 
 	// --- Internal helpers ----------------------------------------------------
@@ -587,6 +644,9 @@ export class Documents {
 		// silently turning a static panel into a VFS-backed one, or an
 		// unsaved scratch buffer into what looks like a saved file.
 		const initialDoc = s.documents[uri];
+		// Snapshot for the discard-vs-eviction check below, taken alongside
+		// initialDoc so both reflect the same instant.
+		const discardEpochAtStart = this._discardEpoch.get(uri) ?? 0;
 		let doc = initialDoc;
 		if (!doc || (!doc.dirty && !doc.static && !doc.isNew)) {
 			// `doc?.content ?? ''` would be wrong here: a saved document can
@@ -645,15 +705,25 @@ export class Documents {
 			}
 
 			// If this document existed when the read started but is gone now,
-			// something deliberately removed it while the read was in flight --
-			// discardDocument() is the one caller that does this, specifically
-			// because the backing file was deleted from disk. Recreating it
-			// from finalDoc (a read that may have started before the deletion,
-			// or already be racing a since-vanished file) would silently
-			// resurrect a document the system just determined doesn't exist;
-			// respect the removal and abort instead of opening anything.
+			// something removed it while the read was in flight. That has two
+			// causes with opposite correct outcomes, both of which leave the
+			// same missing entry here:
+			//   - discardDocument(): the backing file was deleted from disk.
+			//     Recreating it from finalDoc (a read that may have started
+			//     before the deletion, or already be racing a since-vanished
+			//     file) would silently resurrect a document the system just
+			//     determined doesn't exist -- respect the removal and abort.
+			//   - closeEditor() evicting a now-unreferenced clean document
+			//     (e.g. the user closed this uri's only other tab, in a
+			//     different group, while this open's read was in flight): the
+			//     document and its backing file are both still perfectly
+			//     valid, there's just no cached copy left to compare against.
+			//     Aborting here would silently do nothing -- no tab, no error --
+			//     for a call that should succeed. Fall through and recreate
+			//     from finalDoc instead, same as the "never cached" case.
+			// _discardEpoch (bumped only by discardDocument) tells them apart.
 			const current = prev.documents[uri];
-			if (initialDoc && !current) return prev;
+			if (initialDoc && !current && (this._discardEpoch.get(uri) ?? 0) !== discardEpochAtStart) return prev;
 
 			// Otherwise, prefer this call's (possibly freshly re-read) result,
 			// UNLESS something else changed this document while the read was
@@ -847,6 +917,11 @@ export class Documents {
 		this._update((prev) => {
 			const doc = prev.documents[uri];
 			if (!doc) return prev;
+
+			// Distinguishes this removal from closeEditor's ordinary eviction of
+			// a clean, unreferenced document for any in-flight openDocument read
+			// on this uri -- see `_discardEpoch`'s doc comment.
+			this._discardEpoch.set(uri, (this._discardEpoch.get(uri) ?? 0) + 1);
 
 			// Find and remove all editors for this document
 			const editorIdsToRemove = Object.entries(prev.editors)


### PR DESCRIPTION
## Summary

`Documents` (the shared editor-tab model behind the Cloud Pipeline Builder, `rocket-ui`, and every other app built on `packages/shell`) keeps a document's content in memory keyed by URI. Once a document was cached, `openDocument` only re-read from the VFS when the cache entry was *missing* — a clean (non-dirty) entry was trusted indefinitely, regardless of whether the backing store had since changed underneath it.

Reported on cloud.rocketride.ai (#2036): store a pipeline with a "v1" marker, open it, overwrite the stored file to "v2" via the fs API directly (confirmed with a read that the store genuinely holds v2), then hard-reload the browser / close all tabs / reopen from the sidebar — the editor kept showing v1. Publishing the identical v2 bytes under a new filename showed v2 immediately, which is what pointed at a name-keyed cache rather than a propagation delay.

- `openDocument` now re-reads whenever the cached document is missing **or clean**; only a **dirty** document (genuine unsaved local edits) is trusted as-is — that's the one case actually worth protecting from being silently overwritten.
- A failed re-read falls back to the previously cached content rather than wiping it, so a transient read error can't turn an already-working tab blank.
- Along the way, this exposed a second, more subtle bug in the same method: the closing `_update()` call preferred `prev.documents[uri]` over the freshly-read content whenever an entry already existed in live state. That's correct for the race it was actually guarding (a concurrent `openDocument` for the same URI finishing first) — but wrong here, since the *stale* entry is exactly what already exists in live state. Fixed by comparing `prev.documents[uri]` against a snapshot taken before the read (referential equality): unchanged means the fresh read is safe to apply; changed means something else raced ahead and its result should win, preserving the original race-safety intent.
- Also found (@joshuadarron's review): the same re-read exposed a second, independently-reachable bug -- racing two `openDocument` calls for the same URI into the same group (e.g. a rapid double-click on a sidebar entry) could commit two editors for one document in one pane, because the "already open in this group" check only ran on the pre-read snapshot. Re-checking against the latest state right before committing now catches this and activates the existing tab instead of piling on a duplicate.
- And a third: `discardDocument()`'s "don't resurrect a deleted file" guard used "the document went missing while the read was in flight" as its signal for "this was discarded" -- but `closeEditor()` produces the exact same signal by evicting a now-unreferenced clean document (e.g. the same URI's last other tab closing in a different group, mid-read). That made a real, second `openDocument` silently no-op -- no tab, no error. A dedicated per-URI counter, bumped only by `discardDocument`, now tells a genuine discard apart from an ordinary eviction.
- Finally, the reported hard-reload half of the repro was still open after the above: a hard reload restores `documents`/`editors`/`groups` verbatim and the editor pane renders the restored content directly, never calling `openDocument`. The constructor now kicks off the same re-read, once, for every restored document that still has a live editor referencing it.

## Test plan

- [x] `Documents.test.ts` (none existed for this file) — 12 cases, run via `node --import tsx --test` (the same discovery `shell:test-run` uses, so this gates CI for free): first-time open reads from the VFS; closing the last editor of a clean document evicts it so a later external change is picked up; a clean document restored from a persisted session (no live editor) is re-read on open, not trusted forever; **the hard-reload half of #2036 — a clean document restored WITH a live editor is re-read by the constructor itself, without any `openDocument` call**; a document with unsaved edits is never clobbered by a concurrent external write; a failed re-read falls back to the last-known-good content, including a legitimately-`null` cached value; static/untitled documents are never re-read from the VFS; two concurrent opens of the same uri into the same group don't create duplicate tabs; discarding a document mid-read does not resurrect it; **an eviction via `closeEditor` mid-read is not mistaken for a discard and does not silently swallow the open**.
- [x] Verified the #2036 regression tests (both the close/reopen and the hard-reload cases) fail against the unmodified code and pass with the fix.
- [x] Also verified my *first* attempt at the fix (the dirty-check alone, without the snapshot-comparison fix for the `_update` merge) still failed that same test — caught before it shipped, not after.
- [x] `npx tsc --noEmit` in `packages/shell` — clean.
- [x] `npx prettier --check` clean on both touched files.

<!-- Generated with the assistance of Claude Code -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Documents now refresh from the virtual file system when reopened, reflecting external changes.
  - Unsaved edits and cached content remain protected when refreshes fail.
  - Concurrent updates no longer overwrite newer content with stale results.
  - Reopened documents maintain correct version tracking.
  - Static and untitled documents are preserved when reopened.
  - Concurrent opens no longer create duplicate tabs.
  - Discarded documents are not restored unexpectedly during refreshes.

- **Tests**
  - Added regression coverage for document caching, refreshes, failures, concurrent opens, and unsaved changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
