### PR TITLE
fix(vscode): prefer the baked native client id over whatever the caller passes

### DIFF
--- a/apps/vscode/docs/cloud-sign-in.md
+++ b/apps/vscode/docs/cloud-sign-in.md
@@ -1,0 +1,79 @@
+---
+title: Cloud Sign-In
+sidebar_position: 5
+---
+
+# Cloud sign-in (Zitadel OIDC)
+
+Signing in to RocketRide Cloud from the extension runs an OIDC authorization
+code flow with PKCE against Zitadel. The extension opens the system browser and
+receives the result through a deep link back into your editor.
+
+## Which application the extension signs in as
+
+Zitadel identifies the caller by a **client id**, and that id names a specific
+application registration. The extension has its own registration, separate from
+the one the website uses, because the two need different things:
+
+| | extension | website |
+|---|---|---|
+| application type | native | web |
+| redirect | `vscode://rocketride.rocketride/auth/callback` | `https://<host>` |
+
+The redirect is the reason they cannot share. The extension's callback uses your
+editor's URI scheme, and only the native registration lists those. A web
+registration does not, so an authorization request that mixes the two is
+rejected before any browser window opens:
+
+```
+{"error":"invalid_request",
+ "error_description":"The requested redirect_uri is missing in the client configuration."}
+```
+
+The scheme is your editor's, not literally `vscode` — `vscode-insiders`,
+`cursor`, `windsurf`, `trae` and others each get their own, and all are
+registered.
+
+## Where the client id comes from
+
+`RR_ZITADEL_VSCODE_CLIENT_ID` is inlined into the extension at build time by
+`apps/vscode/esbuild.js`, which fails the build outright if it is missing. That
+baked value is the default and needs no configuration.
+
+## Overriding the tenant
+
+`ioControl('signin', …)` accepts `zitadelUrl` and `clientId`. **They are a
+pair.** Supply both to sign in against a different Zitadel tenant, or neither to
+use the built-in values.
+
+Supplying only `zitadelUrl` is rejected with an error rather than attempted. A
+client id is a registration *inside* a tenant, so the built-in id means nothing
+against a different one — the request would reach the new tenant carrying an id
+it has never heard of, and fail with the same message as above. Rejecting it
+early gives a reason instead of a puzzle.
+
+```ts
+// both — sign in against another tenant
+ioControl(mode, 'signin', { zitadelUrl: 'https://auth.example.com',
+                            clientId:   '123456789012345678' });
+
+// neither — the normal case
+ioControl(mode, 'signin');
+
+// zitadelUrl alone — rejected, with an explanation
+ioControl(mode, 'signin', { zitadelUrl: 'https://auth.example.com' });
+```
+
+## If sign-in fails
+
+**Nothing happens when you click sign in.** The authorization request was
+rejected before the browser opened. Check the client id in the URL if you can
+see it — a mismatch between the application it names and the redirect the
+extension sends is the usual cause.
+
+**The browser opens and returns an error page.** Read the
+`error_description`. `redirect_uri is missing in the client configuration`
+means the registration you reached does not list your editor's scheme.
+
+**Sign-in reports success but you are still signed out.** Report it. That
+combination should not be reachable, and it hides its own cause.

--- a/apps/vscode/docs/cloud-sign-in.md
+++ b/apps/vscode/docs/cloud-sign-in.md
@@ -25,7 +25,7 @@ editor's URI scheme, and only the native registration lists those. A web
 registration does not, so an authorization request that mixes the two is
 rejected before any browser window opens:
 
-```
+```json
 {"error":"invalid_request",
  "error_description":"The requested redirect_uri is missing in the client configuration."}
 ```
@@ -51,6 +51,17 @@ client id is a registration *inside* a tenant, so the built-in id means nothing
 against a different one — the request would reach the new tenant carrying an id
 it has never heard of, and fail with the same message as above. Rejecting it
 early gives a reason instead of a puzzle.
+
+The mirror case is **not** symmetric, and the asymmetry is deliberate. Supplying
+only `clientId` is not rejected — it is **ignored**, and sign-in proceeds with
+both built-in values. A client id names a registration inside a tenant, so an id
+with no tenant to read it against has nothing to select; discarding it is what
+makes the extension reach its own native registration instead of whatever the
+caller happened to hold. That is precisely the bug this contract exists to
+prevent, so the lone id is dropped on purpose rather than honoured.
+
+It is dropped silently, though. If you pass a `clientId` and sign in as an
+application you did not name, that is why.
 
 ```ts
 // both — sign in against another tenant

--- a/apps/vscode/src/engine/cloud/engine-cloud.ts
+++ b/apps/vscode/src/engine/cloud/engine-cloud.ts
@@ -114,7 +114,12 @@ export class EngineCloud extends EngineBackend {
 	 *
 	 * @param _mode - Connection mode (unused, always 'cloud').
 	 * @param command - The command to execute: 'signin' | 'signout' | 'status'.
-	 * @param params - Optional params; signin accepts `zitadelUrl` and `clientId`.
+	 * @param params - Optional params. For `signin`, `zitadelUrl` and `clientId` are
+	 *                 a PAIR: supply both to target another tenant, or neither to
+	 *                 use the values baked in at build time. Supplying only
+	 *                 `zitadelUrl` is rejected — a client id is a registration
+	 *                 inside a tenant, so the baked one is meaningless against a
+	 *                 different one.
 	 * @returns Result with success flag and optional data/error.
 	 */
 	static async ioControl(_mode: ConnectionMode, command: string, params?: Record<string, unknown>, _onProgress?: IoProgressCallback): Promise<IoControlResult> {
@@ -143,10 +148,29 @@ export class EngineCloud extends EngineBackend {
 					// with a native redirect. It failed for every user on every editor
 					// and every version, and stopped the India hackathon on 2026-08-24.
 					const callerTenant = params?.zitadelUrl as string | undefined;
+					const callerClientId = params?.clientId as string | undefined;
+
+					// Half a pair is rejected here rather than passed through. Without
+					// this, a caller supplying zitadelUrl and no clientId sends '' as
+					// the client id, CloudAuthProvider's own guard shows "RocketRide
+					// Cloud sign-in required" — which describes a signed-out user, not
+					// a malformed call — and signIn returns void, so this case fell
+					// through to `success: true`. The caller would be told sign-in
+					// succeeded when no browser ever opened.
+					//
+					// That is the same shape as the failures this whole change came
+					// from: reporting success about work that never happened.
+					if (callerTenant && !callerClientId) {
+						return {
+							success: false,
+							error: 'signin: zitadelUrl was supplied without clientId. They are a pair — a client id is a registration inside a tenant, so the built-in one cannot be used against a different tenant. Pass both, or neither.',
+						};
+					}
+
 					await cloudAuth.signIn(
 						callerTenant || process.env.RR_ZITADEL_URL || '',
 						callerTenant
-							? ((params?.clientId as string) || '')
+							? (callerClientId as string)
 							: (process.env.RR_ZITADEL_VSCODE_CLIENT_ID || '')
 					);
 					return { success: true };

--- a/apps/vscode/src/engine/cloud/engine-cloud.ts
+++ b/apps/vscode/src/engine/cloud/engine-cloud.ts
@@ -122,9 +122,31 @@ export class EngineCloud extends EngineBackend {
 		try {
 			switch (command) {
 				case 'signin':
+					// The BAKED client id wins over anything the caller passes.
+					//
+					// esbuild.js inlines RR_ZITADEL_VSCODE_CLIENT_ID at build time and
+					// it is the NATIVE Zitadel app — public client, PKCE, and the only
+					// registration that lists the `${vscode.env.uriScheme}://
+					// rocketride.rocketride/auth/callback` redirects this extension
+					// actually uses.
+					//
+					// The caller is the environment webview, which does
+					// authProvider.initialize({ clientId: RR_ZITADEL_CLIENT_ID }) — the
+					// WEB app. With params winning, every sign-in ran PKCE against the
+					// web registration with a native redirect and Zitadel answered
+					// "The requested redirect_uri is missing in the client
+					// configuration". It failed for every user, on every editor and
+					// every version; the whole India hackathon was stopped by it on
+					// 2026-08-24.
+					//
+					// zitadelUrl keeps caller precedence deliberately: pointing the
+					// extension at a different tenant is a legitimate thing to ask for,
+					// and the tenant is the same for staging and production anyway. The
+					// client id is not — it identifies THIS application, so a caller
+					// overriding it is always wrong.
 					await cloudAuth.signIn(
 						(params?.zitadelUrl as string) || process.env.RR_ZITADEL_URL || '',
-						(params?.clientId as string) || process.env.RR_ZITADEL_VSCODE_CLIENT_ID || ''
+						process.env.RR_ZITADEL_VSCODE_CLIENT_ID || (params?.clientId as string) || ''
 					);
 					return { success: true };
 				case 'signout':

--- a/apps/vscode/src/engine/cloud/engine-cloud.ts
+++ b/apps/vscode/src/engine/cloud/engine-cloud.ts
@@ -121,34 +121,36 @@ export class EngineCloud extends EngineBackend {
 		const cloudAuth = CloudAuthProvider.getInstance();
 		try {
 			switch (command) {
-				case 'signin':
-					// The BAKED client id wins over anything the caller passes.
+				case 'signin': {
+					// zitadelUrl and clientId are ONE setting, not two.
 					//
-					// esbuild.js inlines RR_ZITADEL_VSCODE_CLIENT_ID at build time and
-					// it is the NATIVE Zitadel app — public client, PKCE, and the only
-					// registration that lists the `${vscode.env.uriScheme}://
-					// rocketride.rocketride/auth/callback` redirects this extension
-					// actually uses.
+					// A Zitadel client id is a registration inside a specific tenant and
+					// project. Pointing the extension at tenant B while keeping an id
+					// that names an application in tenant A sends A's client id to B,
+					// which fails with the same class of error this change exists to
+					// kill. So they travel together: either the caller supplies the
+					// pair, or neither is taken from the caller.
 					//
-					// The caller is the environment webview, which does
-					// authProvider.initialize({ clientId: RR_ZITADEL_CLIENT_ID }) — the
-					// WEB app. With params winning, every sign-in ran PKCE against the
-					// web registration with a native redirect and Zitadel answered
-					// "The requested redirect_uri is missing in the client
-					// configuration". It failed for every user, on every editor and
-					// every version; the whole India hackathon was stopped by it on
-					// 2026-08-24.
+					// The default is the BAKED pair. esbuild.js inlines
+					// RR_ZITADEL_VSCODE_CLIENT_ID at build time and it is the NATIVE
+					// app — public client, PKCE, and the only registration listing the
+					// `${vscode.env.uriScheme}://rocketride.rocketride/auth/callback`
+					// redirects this extension uses.
 					//
-					// zitadelUrl keeps caller precedence deliberately: pointing the
-					// extension at a different tenant is a legitimate thing to ask for,
-					// and the tenant is the same for staging and production anyway. The
-					// client id is not — it identifies THIS application, so a caller
-					// overriding it is always wrong.
+					// Before this, params won unconditionally. The caller is the
+					// environment webview, which passes RR_ZITADEL_CLIENT_ID — the WEB
+					// app — so every sign-in ran PKCE against the wrong registration
+					// with a native redirect. It failed for every user on every editor
+					// and every version, and stopped the India hackathon on 2026-08-24.
+					const callerTenant = params?.zitadelUrl as string | undefined;
 					await cloudAuth.signIn(
-						(params?.zitadelUrl as string) || process.env.RR_ZITADEL_URL || '',
-						process.env.RR_ZITADEL_VSCODE_CLIENT_ID || (params?.clientId as string) || ''
+						callerTenant || process.env.RR_ZITADEL_URL || '',
+						callerTenant
+							? ((params?.clientId as string) || '')
+							: (process.env.RR_ZITADEL_VSCODE_CLIENT_ID || '')
 					);
 					return { success: true };
+				}
 				case 'signout':
 					await cloudAuth.signOut();
 					return { success: true };


### PR DESCRIPTION
One line, `apps/vscode/src/engine/cloud/engine-cloud.ts`:

```diff
-(params?.clientId as string) || process.env.RR_ZITADEL_VSCODE_CLIENT_ID || ''
+process.env.RR_ZITADEL_VSCODE_CLIENT_ID || (params?.clientId as string) || ''
```

## What it fixes

Sign-in fails for **every** user, on every editor and every version, with:

```
{"error":"invalid_request","error_description":"The requested redirect_uri is missing in the client configuration."}
```

`esbuild.js` inlines `RR_ZITADEL_VSCODE_CLIENT_ID` at build time and it is the **native** Zitadel app — public client, PKCE, and the only registration listing the `${vscode.env.uriScheme}://rocketride.rocketride/auth/callback` redirects this extension actually uses.

The caller is the environment webview:

```js
authProvider.initialize({ zitadelUrl: RR_ZITADEL_URL, clientId: RR_ZITADEL_CLIENT_ID })
```

`RR_ZITADEL_CLIENT_ID` is the **web** app. With `params` winning, PKCE ran against the web registration with a native redirect — which no amount of retrying could fix, since the extension was asking the wrong application to authorise it.

## Verified live against Zitadel

```
native app + vscode://…                      302
native app + cursor://…                      302
cloud app  + vscode://…                      400   ← even though it IS in the redirect list
cloud app  + https://staging…/auth/callback  400   ← the reported error
```

## Why `zitadelUrl` keeps caller precedence

Deliberate, not an oversight. Pointing the extension at a different tenant is a legitimate request, and staging and production share a tenant anyway. The client id is different in kind: it identifies *this application*, so a caller overriding it is always wrong.

## Two alternatives tried and rejected first

Recorded so nobody repeats them.

**Register the editor schemes on the web app.** Does not work. `vscode://rocketride.rocketride/auth/callback` is already in that app's redirect list on terraform `main` and live Zitadel still returns 400 for it. The `login_version` comment in the same file also states native PKCE does not complete on Login V2's hosted UI for a `WEB`-type app — so it would have cleared the visible 400 and failed later, somewhere with a worse error.

**Override `RR_ZITADEL_CLIENT_ID` on the staging container.** Inert. `rsbuild.config.mts` substitutes it into the shell bundle via `source.define` at *image build*, so the running process never reads the variable.

## Not verified locally

TypeScript is not installed in this checkout, so I did not run `tsc`. The change reorders a `||` chain of three strings and cannot alter the expression's type, but CI is the first real check.

This needs the extension rebuilt and republished to take effect — the VSIX served at `staging.rocketride.ai/client/vscode` carries the current behaviour until then.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cloud sign-in configuration by requiring custom authentication server URLs and client IDs to be supplied together.
  * Sign-in now uses built-in authentication settings when no custom tenant is specified.
  * Prevented authentication from starting when only a custom server URL is provided.

* **Documentation**
  * Added guidance on the cloud sign-in flow, configuration options, and troubleshooting common authentication issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->