### PR TITLE
fix(store): give the S3 provider real binary I/O

### DIFF
--- a/packages/ai/src/ai/account/store_providers/s3/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3/s3.py
@@ -124,6 +124,65 @@ class S3Store(IStore):
         retry=retry_if_exception_type((ConnectionError, TimeoutError)),
         reraise=True,
     )
+    async def write_bytes(self, filename: str, data: bytes) -> None:
+        """
+        Write binary data to S3 with retry logic.
+
+        Overrides the base implementation, which routes bytes through
+        ``str`` via latin-1 and would re-encode them as UTF-8 on the way
+        out -- doubling every byte above 0x7F in the stored object.
+        """
+        try:
+            client = self._get_client()
+            key = self._get_key(filename)
+
+            await asyncio.to_thread(client.put_object, Bucket=self._bucket, Key=key, Body=data)
+
+        except (ConnectionError, TimeoutError):
+            # Let these bubble up for retry
+            raise
+        except Exception as e:
+            raise StorageError(f'Failed to write file {filename} to S3: {e}') from e
+
+    @retry(
+        stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=1),
+        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        reraise=True,
+    )
+    async def read_bytes(self, filename: str) -> bytes:
+        """
+        Read binary data from S3 with retry logic.
+
+        Overrides the base implementation, which calls :meth:`read_file`
+        and therefore UTF-8 decodes the object body. Any object that is
+        not valid UTF-8 -- a zip, an image, a font -- raises
+        ``UnicodeDecodeError`` there before the caller sees a byte.
+        """
+        try:
+            client = self._get_client()
+            key = self._get_key(filename)
+
+            def _read():
+                response = client.get_object(Bucket=self._bucket, Key=key)
+                return response['Body'].read()
+
+            return await asyncio.to_thread(_read)
+
+        except (ConnectionError, TimeoutError):
+            # Let these bubble up for retry
+            raise
+        except Exception as e:
+            if self._is_no_such_key_error(e):
+                raise StorageError(f'File not found: {filename}')
+            raise StorageError(f'Failed to read file {filename} from S3: {e}') from e
+
+    @retry(
+        stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
+        wait=wait_exponential(multiplier=1, min=1),
+        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        reraise=True,
+    )
     async def read_file_with_metadata(self, filename: str) -> tuple:
         """
         Read data from S3 with ETag metadata.


### PR DESCRIPTION
## What breaks

App deploy fails on staging for every user, at the `materialize` phase:

```
[app_build] rocketride_sb.staging-doctor v1: infra failure (attempts exhausted):
retained transport zip unreadable: Failed to read file
.../bundle/rocketride_sb.staging-doctor-v000001.zip from S3:
'utf-8' codec can't decode byte 0xe9 in position 10: invalid continuation byte
```

Two different orgs in the staging logs, 8+ builds, so it is not user-specific. It blocks the hackathon app-builder challenge.

## Why

`app_build.py` does the right thing — it calls `raw.read_bytes(...)`. The bug is under it.

`Store.read_bytes` (`store.py:226`) has no S3 implementation and falls back to:

```python
content = await self.read_file(filename)   # str
return content.encode('latin-1')
```

and `S3Store.read_file` ends with `data.decode('utf-8')`. So a binary read never reaches the latin-1 step — it dies inside `read_file`. `0xe9` at offset 10 is inside the zip local-file-header.

Only `filesystem` overrides binary I/O. `s3`, `azure` and `memory` all inherit the text round-trip:

| provider | `read_bytes` | `write_bytes` |
|---|---|---|
| filesystem | yes | yes |
| **s3** | **no** | **no** |
| azure | no | no |
| memory | no | no |

That is the whole "works locally, fails in cloud" split: local runs use the filesystem store.

## Verification

Not inferred from the source — read off the deployed pod and the real bucket.

The stored object is a **valid archive**, so the upload path was never at fault:

```
$ aws s3api get-object --bucket rocketride-saas-staging-storage --key .../v000001.zip
ContentLength 7557
00000000: 504b 0304    PK..
Zip archive data, compression method=deflate     11 entries
```

Both code paths against those exact bytes:

```
OLD  read_bytes -> read_file -> data.decode('utf-8')
     UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe9 in position 10
NEW  read_bytes -> raw bytes
     zip opened, 11 entries, first: apps/staging-doctor-ui/.gitignore
```

The old path reproduces the reported byte and offset exactly.

## On `write_bytes`

Overridden alongside, because the pair has to agree. It changes what gets stored, so I checked the existing objects rather than assuming: the stored `remoteEntry.js` is **pure ASCII** (0 bytes above 0x7F), where latin-1 and UTF-8 are the same mapping. No existing object changes meaning.

Callers today are `copy_file`, `file_store` move/copy, and the `remoteEntry.js` write — binary copies through S3 are broken by the same fallback.

## Not in scope

`azure` and `memory` have the identical gap. Azure is not deployed and memory is test-only, so I left them rather than widen an incident fix. Worth a follow-up.

**This cannot reach staging through the normal path** — the staging deploy pipeline has not had a successful run in 40 attempts (rocketride-ai/rocketride-saas#587). That needs solving separately or this fix sits in `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nTVr6jfSFYm1GppxbjghP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of binary files stored in S3.
  - Binary data is now preserved exactly when uploaded or downloaded.
  - Fixed errors when reading files containing non-text or non-UTF-8 content.
  - Missing files continue to return a clear “File not found” error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->