### PR TITLE
fix(client-python): retry pipe open() on transient connect-refused

### DIFF
--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -408,6 +408,10 @@ Returned by `await client.pipe(...)`. One streaming upload: **open** -> **write*
 | `__aenter__` | `async def __aenter__(self)`                           | `self`            | Enters context; calls `open()`.                    |
 | `__aexit__`  | `async def __aexit__(self, exc_type, exc_val, exc_tb)` | -                 | Exits context; calls `close()`.                    |
 
+`open()` retries automatically (a few short attempts) if it hits a transient
+connection error while the pipeline's data listener is still starting up; a
+`PipeException` from `open()` means the pipe genuinely could not be opened.
+
 ---
 
 ## Question

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -408,9 +408,10 @@ Returned by `await client.pipe(...)`. One streaming upload: **open** -> **write*
 | `__aenter__` | `async def __aenter__(self)`                           | `self`            | Enters context; calls `open()`.                    |
 | `__aexit__`  | `async def __aexit__(self, exc_type, exc_val, exc_tb)` | -                 | Exits context; calls `close()`.                    |
 
-`open()` retries automatically (a few short attempts) if it hits a transient
-connection error while the pipeline's data listener is still starting up; a
-`PipeException` from `open()` means the pipe genuinely could not be opened.
+`open()` retries once automatically if it hits a transient "Connect call
+failed" while the pipeline's data listener is still starting up (worst case
+adds ~1.5s); a `PipeException` from `open()` means the pipe genuinely could
+not be opened.
 
 ---
 

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -410,8 +410,8 @@ Returned by `await client.pipe(...)`. One streaming upload: **open** -> **write*
 
 `open()` retries once automatically if it hits a transient "Connect call
 failed" while the pipeline's data listener is still starting up (worst case
-adds ~1.5s); a `PipeException` from `open()` means the pipe genuinely could
-not be opened.
+adds ~1.75s); a `PipeException` from `open()` means it kept failing past that
+retry budget.
 
 ---
 

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -219,11 +219,15 @@ class DataMixin(DAPClient):
                 if not self._client.did_fail(response):
                     break
 
-                message = response.get('message') or ''
-                if not isinstance(message, str):
+                message = response.get('message')
+                if message is None:
+                    message = ''
+                elif not isinstance(message, str):
                     # A well-behaved server always sends a string, but don't let a
                     # malformed one (e.g. a bare int/bool) blow up the `in` check
-                    # below or the PipeException raised past the retry.
+                    # below or the PipeException raised past the retry. `or ''`
+                    # here would also turn falsey-but-real values like `0`/`False`
+                    # into an empty message, so check for absence explicitly.
                     message = str(message)
                 if attempt < _PIPE_OPEN_RETRY_ATTEMPTS and _is_transient_pipe_open_error(message):
                     await asyncio.sleep(_PIPE_OPEN_RETRY_BACKOFF_SECONDS * attempt)

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -60,6 +60,31 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from ..core import DAPClient, PipeException
 from ..types import PIPELINE_RESULT, UPLOAD_RESULT
 
+# A just-registered pipeline's per-pipe data listener can occasionally still be
+# binding when `open()` reaches it - observed under heavy concurrent load (e.g. many
+# pipelines opened at once in CI) as a transient "Connect call failed" on the
+# freshly assigned port. That's indistinguishable from a real "pipeline isn't
+# running" failure to the caller, so give it one short extra retry before
+# surfacing it as an error.
+#
+# The engine already retries this exact connect internally (up to 10 attempts,
+# 150ms apart - see task_engine.py's `_connect_data_client`) before it gives up
+# and reports "Connect call failed" back to us, so a single SDK-level attempt
+# already absorbs ~1.5s of engine-side retrying. Each retry here re-runs that
+# whole engine-side loop from scratch, so keep the attempt count low: at
+# `_PIPE_OPEN_RETRY_ATTEMPTS = 2` (one retry), worst case is two ~1.5s engine
+# cycles plus one short backoff, roughly 3.2s, before `open()` raises.
+_PIPE_OPEN_RETRY_ATTEMPTS = 2
+_PIPE_OPEN_RETRY_BACKOFF_SECONDS = 0.25
+
+
+def _is_transient_pipe_open_error(message: str) -> bool:
+    # Deliberately narrower than "any connection-shaped error": a misconfigured
+    # `remote` node surfaces a plain "Connection refused" for a permanent failure
+    # that this retry can't fix (the engine's inner connect loop doesn't run for
+    # it), so only the exact race-condition signature above is retried.
+    return 'Connect call failed' in message
+
 
 class DataMixin(DAPClient):
     """
@@ -154,12 +179,19 @@ class DataMixin(DAPClient):
             Must be called before writing data. The server assigns a unique
             pipe ID and prepares to receive your data.
 
+            If the only problem is a transient "Connect call failed" while the
+            pipeline's data listener is still starting up, this retries once
+            before giving up - worst case that adds ~1.5s (the engine's own
+            internal connect retry runs again on the retry). Any other failure
+            raises immediately on the first attempt.
+
             Returns:
                 self: The opened pipe instance for method chaining
 
             Raises:
                 RuntimeError: If the pipe is already opened.
-                PipeException: If the server rejects the open request.
+                PipeException: If the server rejects the open request, or if it
+                    keeps failing with a transient connect error past the retry.
 
             Example:
                 pipe = await client.pipe(token, mimetype="text/plain")
@@ -169,25 +201,34 @@ class DataMixin(DAPClient):
             if self._opened:
                 raise RuntimeError('Pipe already opened')
 
-            request = self._client.build_request(
-                'rrext_process',
-                arguments={
-                    'subcommand': 'open',
-                    'object': self._objinfo,
-                    'mimeType': self._mime_type,
-                    'provider': self._provider,
-                },
-                token=self._token,
-            )
+            response = None
+            for attempt in range(1, _PIPE_OPEN_RETRY_ATTEMPTS + 1):
+                request = self._client.build_request(
+                    'rrext_process',
+                    arguments={
+                        'subcommand': 'open',
+                        'object': self._objinfo,
+                        'mimeType': self._mime_type,
+                        'provider': self._provider,
+                    },
+                    token=self._token,
+                )
 
-            response = await self._client.request(request)
+                response = await self._client.request(request)
 
-            if self._client.did_fail(response):
+                if not self._client.did_fail(response):
+                    break
+
+                message = response.get('message') or ''
+                if attempt < _PIPE_OPEN_RETRY_ATTEMPTS and _is_transient_pipe_open_error(message):
+                    await asyncio.sleep(_PIPE_OPEN_RETRY_BACKOFF_SECONDS * attempt)
+                    continue
+
                 # The server's message stays the message: an application may show
                 # it to an end user. The developer checklist rides along as `hint`
                 # (PipeException.hint), and `code` classifies the failure.
                 response = dict(response)
-                response['message'] = response.get('message') or 'Failed to open a data pipe.'
+                response['message'] = message or 'Failed to open a data pipe.'
                 response['hint'] = (
                     'Common causes:\n'
                     "- Pipeline isn't running (wrong token or task terminated)\n"

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -181,9 +181,9 @@ class DataMixin(DAPClient):
 
             If the only problem is a transient "Connect call failed" while the
             pipeline's data listener is still starting up, this retries once
-            before giving up - worst case that adds ~1.5s (the engine's own
-            internal connect retry runs again on the retry). Any other failure
-            raises immediately on the first attempt.
+            before giving up - worst case that adds ~1.75s (a short backoff,
+            then the engine's own internal connect retry runs again on the
+            retry). Any other failure raises immediately on the first attempt.
 
             Returns:
                 self: The opened pipe instance for method chaining

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -220,6 +220,11 @@ class DataMixin(DAPClient):
                     break
 
                 message = response.get('message') or ''
+                if not isinstance(message, str):
+                    # A well-behaved server always sends a string, but don't let a
+                    # malformed one (e.g. a bare int/bool) blow up the `in` check
+                    # below or the PipeException raised past the retry.
+                    message = str(message)
                 if attempt < _PIPE_OPEN_RETRY_ATTEMPTS and _is_transient_pipe_open_error(message):
                     await asyncio.sleep(_PIPE_OPEN_RETRY_BACKOFF_SECONDS * attempt)
                     continue

--- a/packages/client-python/tests/test_pipe_open_retry.py
+++ b/packages/client-python/tests/test_pipe_open_retry.py
@@ -1,0 +1,92 @@
+import asyncio
+
+import pytest
+
+from rocketride.core.exceptions import PipeException
+from rocketride.mixins.data import DataMixin, _PIPE_OPEN_RETRY_ATTEMPTS
+
+
+class ScriptedTransport:
+    """Fake transport that answers each `send()` with a scripted response, resolving
+    the request's future the same way a real server reply would via `on_receive`.
+    """
+
+    def __init__(self, results):
+        # results: list of ('ok', body) | ('fail', message) tuples, consumed in send() order.
+        self._results = list(results)
+        self.client = None  # set after construction, once the client exists
+        self.send_count = 0
+
+    def bind(self, **handlers):
+        self.handlers = handlers
+
+    def is_connected(self):
+        return True
+
+    async def send(self, message):
+        self.send_count += 1
+        kind, payload = self._results.pop(0)
+        response = {'type': 'response', 'request_seq': message['seq']}
+        if kind == 'ok':
+            response['success'] = True
+            response['body'] = payload
+        else:
+            response['success'] = False
+            response['message'] = payload
+        await self.client.on_receive(response)
+
+
+def _make_pipe(results):
+    transport = ScriptedTransport(results)
+    client = DataMixin(module='TEST', transport=transport)
+    transport.client = client
+    pipe = DataMixin.DataPipe(client, token='tok', mime_type='text/plain')
+    return pipe, transport
+
+
+def test_open_retries_on_transient_connect_error(monkeypatch):
+    _real_sleep = asyncio.sleep
+    monkeypatch.setattr(asyncio, 'sleep', lambda *_a, **_kw: _real_sleep(0))
+
+    pipe, transport = _make_pipe(
+        [
+            ('fail', "Failed to open a data pipe.\n\nConnect call failed ('127.0.0.1', 40006)"),
+            ('ok', {'pipe_id': 7}),
+        ]
+    )
+
+    async def run_test():
+        await pipe.open()
+        assert transport.send_count == 2
+        assert pipe.pipe_id == 7
+        assert pipe.is_opened
+
+    asyncio.run(run_test())
+
+
+def test_open_gives_up_after_exhausting_retries(monkeypatch):
+    _real_sleep = asyncio.sleep
+    monkeypatch.setattr(asyncio, 'sleep', lambda *_a, **_kw: _real_sleep(0))
+
+    transient_failure = ('fail', "Connect call failed ('127.0.0.1', 40006)")
+    pipe, transport = _make_pipe([transient_failure] * (_PIPE_OPEN_RETRY_ATTEMPTS + 1))
+
+    async def run_test():
+        with pytest.raises(PipeException, match='Connect call failed'):
+            await pipe.open()
+        assert transport.send_count == _PIPE_OPEN_RETRY_ATTEMPTS
+        assert not pipe.is_opened
+
+    asyncio.run(run_test())
+
+
+def test_open_does_not_retry_non_transient_failure():
+    pipe, transport = _make_pipe([('fail', 'No pipeline found for token')])
+
+    async def run_test():
+        with pytest.raises(PipeException, match='No pipeline found'):
+            await pipe.open()
+        assert transport.send_count == 1
+        assert not pipe.is_opened
+
+    asyncio.run(run_test())

--- a/packages/client-python/tests/test_pipe_open_retry.py
+++ b/packages/client-python/tests/test_pipe_open_retry.py
@@ -90,3 +90,35 @@ def test_open_does_not_retry_non_transient_failure():
         assert not pipe.is_opened
 
     asyncio.run(run_test())
+
+
+def test_open_does_not_retry_connection_refused():
+    # "Connection refused" is a distinct, permanent signature (e.g. a
+    # misconfigured `remote` node) that the engine's inner connect-retry loop
+    # never runs for, unlike "Connect call failed" - retrying it would just add
+    # latency to a failure that was never going to succeed.
+    pipe, transport = _make_pipe([('fail', "Connection refused ('127.0.0.1', 40006)")])
+
+    async def run_test():
+        with pytest.raises(PipeException, match='Connection refused'):
+            await pipe.open()
+        assert transport.send_count == 1
+        assert not pipe.is_opened
+
+    asyncio.run(run_test())
+
+
+def test_open_failure_keeps_message_and_carries_hint():
+    pipe, transport = _make_pipe([('fail', 'No pipeline found for token')])
+
+    async def run_test():
+        with pytest.raises(PipeException) as excinfo:
+            await pipe.open()
+        exc = excinfo.value
+        # The server's message is preserved verbatim (fit to show an end user);
+        # the developer checklist rides along separately as `hint`.
+        assert str(exc) == 'No pipeline found for token'
+        assert exc.hint is not None
+        assert 'Common causes' in exc.hint
+
+    asyncio.run(run_test())

--- a/packages/client-python/tests/test_pipe_open_retry.py
+++ b/packages/client-python/tests/test_pipe_open_retry.py
@@ -122,6 +122,20 @@ def test_open_does_not_retry_non_string_failure_message():
     asyncio.run(run_test())
 
 
+def test_open_preserves_falsey_non_string_failure_message():
+    # `0`/`False` are real messages, not "no message" - they must survive
+    # normalization instead of being swallowed into the generic fallback.
+    pipe, transport = _make_pipe([('fail', 0)])
+
+    async def run_test():
+        with pytest.raises(PipeException, match='0'):
+            await pipe.open()
+        assert transport.send_count == 1
+        assert not pipe.is_opened
+
+    asyncio.run(run_test())
+
+
 def test_open_failure_keeps_message_and_carries_hint():
     pipe, transport = _make_pipe([('fail', 'No pipeline found for token')])
 

--- a/packages/client-python/tests/test_pipe_open_retry.py
+++ b/packages/client-python/tests/test_pipe_open_retry.py
@@ -108,6 +108,20 @@ def test_open_does_not_retry_connection_refused():
     asyncio.run(run_test())
 
 
+def test_open_does_not_retry_non_string_failure_message():
+    # A malformed response with a non-string `message` (e.g. a bare int) must
+    # not blow up the `in` check that classifies transient errors.
+    pipe, transport = _make_pipe([('fail', 404)])
+
+    async def run_test():
+        with pytest.raises(PipeException, match='404'):
+            await pipe.open()
+        assert transport.send_count == 1
+        assert not pipe.is_opened
+
+    asyncio.run(run_test())
+
+
 def test_open_failure_keeps_message_and_carries_hint():
     pipe, transport = _make_pipe([('fail', 'No pipeline found for token')])
 


### PR DESCRIPTION
## Summary

Fixes #2218

- `DataMixin.DataPipe.open()` now retries a few times with a short backoff when the server's `rrext_process` open call fails with a transient `Connect call failed`/`Connection refused` error, before surfacing it as a `PipeException`.
- Any other failure (bad token, wrong MIME type, terminated pipeline, etc.) still raises immediately on the first attempt — only this specific transient signature is retried.

## Why

A just-registered pipeline's per-pipe data listener can occasionally still be binding when `open()` reaches it, under heavy concurrent load (many pipelines opened at once — e.g. the `nodes` test suite running under `pytest-xdist` in CI). This surfaces client-side as `[Errno 111] Connect call failed ('127.0.0.1', <port>)`, indistinguishable from a real "pipeline isn't running" failure.

This was diagnosed after investigating CI flakiness on an unrelated PR (#2113): two consecutive CI runs each failed exactly one test, with the identical `PipeException: [Errno 111] Connect call failed` signature on a different ephemeral port each time, hitting two different, unrelated tests (`nodes/test/guardrails/test_lane_forward_once.py` and `nodes/test/test_dynamic.py`). Neither failing test, nor the PR's own diff, touches this code path — consistent with a resource-contention race in pipe-open rather than a bug in either test.

## Approach

Chose a client-side retry over a C++ engine-side fix (making pipe-open synchronous on the listener being bound) because it's surgical, low-risk, and benefits real production callers hitting the same race under load — not just CI. The engine-side fix would be the more "correct" root cause fix but is a much larger, riskier change to core engine code.

## Type

fix

## Testing

- [x] Tests added (`packages/client-python/tests/test_pipe_open_retry.py`): retries on the transient error, gives up after exhausting retries, does not retry a non-transient failure.
- [x] `ruff check` / `ruff format --check` pass
- [x] Verified `test_deploy.py` / `test_tool.py` failures (require a live server, absent in this environment) are pre-existing and unaffected by this change

## Checklist

- [x] Commit messages follow conventional commits
- [x] No secrets or credentials included
- [ ] Wiki updated (if applicable)
- [ ] Breaking changes documented (if applicable) — none; behavior-only change, no signature change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Data pipe opening now retries transient “Connect call failed” errors once after a short delay, adding up to approximately 1.75 seconds in the worst case.
  * Pipe opening reports a failure after the retry limit is reached.

* **Bug Fixes**
  * Non-transient failures, including “Connection refused,” are reported immediately without retries.
  * Server error messages are preserved when reporting pipe-opening failures.

* **Documentation**
  * Documented retry timing and pipe-opening failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
