### PR TITLE
fix(client-python): CLI event subscription before the task exists

### DIFF
--- a/packages/client-python/src/rocketride/cli/commands/start.py
+++ b/packages/client-python/src/rocketride/cli/commands/start.py
@@ -142,14 +142,10 @@ class StartCommand(BaseCommand):
         """
         Handle successful server connection establishment.
 
-        Set up event subscriptions and prepare for pipeline execution
-        once the connection to the RocketRide server is established.
-
         Args:
             connection_info: Optional connection details for logging
         """
-        # Subscribe to summary events for status updates
-        await self.client.set_events(token=self.args.token, event_types=['summary', 'output'])
+        # No event subscription here: the task does not exist until execute() runs
 
     async def execute(self, client: 'RocketRideClient') -> int:
         """
@@ -217,6 +213,10 @@ class StartCommand(BaseCommand):
 
             # Extract task token from response
             token = response.get('token', None)
+
+            # The task exists now, so its events can be subscribed to
+            if token:
+                await self.client.set_events(token=token, event_types=['summary', 'output'])
 
             # Success phase - display results
             execution_lines = [

--- a/packages/client-python/src/rocketride/cli/commands/upload.py
+++ b/packages/client-python/src/rocketride/cli/commands/upload.py
@@ -144,8 +144,11 @@ class UploadCommand(BaseCommand):
         Args:
             connection_info: Optional connection details for logging
         """
-        # Subscribe to summary events for status updates
-        await self.client.set_events(token=self.args.token, event_types=['summary', 'output'])
+        # Subscribe to summary events for status updates. With --pipeline_path
+        # there is no token yet, and the upload progress display is driven by
+        # send_files' own events rather than by this subscription.
+        if self.args.token:
+            await self.client.set_events(token=self.args.token, event_types=['summary', 'output'])
 
     async def execute(self, client: 'RocketRideClient') -> int:
         """


### PR DESCRIPTION
## Problem

`rocketride start <pipeline>` and `rocketride upload <files> --pipeline_path <pipe>` fail on every platform without `--token`:

```
Execution error occured
    You must specifiy either token or project_id/source
```

Both subscribe in `on_connected`, which runs before the task is created:

```python
await self.client.set_events(token=self.args.token, event_types=[...])
```

Without `--token` that sends `None`, and the server rejects it (`cmd_monitor.py:492`). Subscribing to a token whose task isn't running fails too — `Your pipeline is not running` — so there is no token value that works at that point in `start`.

## Fix

- `start.py`: drop the `on_connected` subscription and subscribe after `use()` returns a token. The subscription is load-bearing here — without it the `Webhook ready - system is ready to accept requests` status line is lost.
- `upload.py`: guard `on_connected` so it only subscribes when `--token` supplied an existing task. Nothing is added for the `--pipeline_path` path: `on_event` handles only `apaevt_status_upload`, which `send_files` emits client-side, so a `summary`/`output` subscription feeds nothing. Verified by removing it — uploads, progress, throughput and per-file results are identical.

`status`/`stop` share the line but validate the token and return before connecting, so their `on_connected` is unreachable with `None` — left unchanged.

## Testing

Against a live engine: `start` starts, issues a token, and still shows its startup status; `upload testdata/documents --pipeline_path` completes 16/16; `stop` unaffected. `ruff check` / `ruff format --check` pass.

## Known difference from develop

`start` no longer re-subscribes on reconnect. `set_events` is deprecated and does not register in `_monitor_keys`, which is the only state `_resubscribe_all_monitors()` replays — previously subscribing inside `on_connected` got that replay for free. `start` exits immediately after starting the pipeline and the CLI sets no `persist`, so there is no reconnect window in practice. Migrating these call sites to `add_monitor` would close it properly, but that is a wider change than this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
