### PR TITLE
fix(client-typescript): CLI process import for signal handlers

### DIFF
--- a/packages/client-typescript/src/cli/rocketride.ts
+++ b/packages/client-typescript/src/cli/rocketride.ts
@@ -70,7 +70,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import * as glob from 'glob';
-import * as process from 'process';
+import process from 'node:process';
 import { Command } from 'commander';
 import { RocketRideClient } from '../client/client';
 import { DAPMessage, PipelineConfig, UPLOAD_RESULT } from '../client/types';


### PR DESCRIPTION
The TypeScript CLI died in its constructor on every platform, before parsing any argument: `TypeError: process.on is not a function`.

`import * as process` compiles to `__importStar`, which copies only own properties. `process` is an EventEmitter, so `on`/`once` live on the prototype and were dropped. A default import keeps the object reference.

```diff
-import * as process from 'process';
+import process from 'node:process';
```

`tsc --noEmit` clean; `rocketride --help` renders on Windows and macOS 26.6.1 arm64. Signal handling itself (SIGINT/SIGTERM cleanup) is untested — only that registering the handlers no longer throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
