### PR TITLE
fix(store): retry the transport failures boto actually raises

### DIFF
--- a/packages/ai/src/ai/account/store_providers/s3/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3/s3.py
@@ -255,7 +255,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError, _RaceConditionError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS + (_RaceConditionError,)),
         reraise=True,
     )
     async def write_file_atomic(self, filename: str, data: str, expected_version: Optional[str] = None) -> str:
@@ -313,7 +313,7 @@ class S3Store(IStore):
             new_etag = response.get('ETag', '').strip('"')
             return new_etag
 
-        except (ConnectionError, TimeoutError, self._RaceConditionError):
+        except TRANSIENT_ERRORS + (self._RaceConditionError,):
             # Let tenacity handle retries
             raise
         except Exception as e:

--- a/packages/ai/src/ai/account/store_providers/s3/s3.py
+++ b/packages/ai/src/ai/account/store_providers/s3/s3.py
@@ -7,6 +7,49 @@ from typing import Optional
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 from ...store import IStore, StorageError, VersionMismatchError, STORE_MAX_RETRY_ATTEMPTS
 
+# botocore raises its OWN exception types for transport failures, and none of
+# them inherit from the builtin `ConnectionError` or `TimeoutError`:
+#
+#     EndpointConnectionError  builtin ConnectionError = False
+#     ConnectTimeoutError      builtin ConnectionError = False
+#     ReadTimeoutError         builtin ConnectionError = False
+#
+# So a retry tuple of `(ConnectionError, TimeoutError)` matches nothing boto
+# actually raises. Every real S3 transport failure fell through to the bare
+# `except Exception`, got wrapped in StorageError, and Tenacity never saw it —
+# the retry logic in this module had never once retried the failure it exists
+# for.
+#
+# Two base classes cover the family: botocore's own `ConnectionError` (parent of
+# EndpointConnectionError, ConnectTimeoutError, ProxyConnectionError, SSLError)
+# and `HTTPClientError` (parent of ReadTimeoutError, ConnectionClosedError,
+# ResponseStreamingError). `IncompleteReadError` sits under neither and is added
+# by name — a truncated body is exactly the transient case worth another try.
+#
+# `EndpointResolutionError` is deliberately NOT retried. It is nearly always a
+# misconfigured region or endpoint, and retrying a config error only delays the
+# message that would have explained it.
+#
+# The import is GUARDED because boto3 is optional here: store_providers/__init__
+# imports S3Store unconditionally, so this module is loaded on filesystem-store
+# deployments that have never installed boto3. `_get_client()` handles that with
+# a readable error at call time; a hard import here would replace it with an
+# ImportError at import time, on installs that never touch S3.
+try:
+    from botocore.exceptions import (
+        ConnectionError as _BotoConnectionError,
+        HTTPClientError as _BotoHTTPClientError,
+        IncompleteReadError as _BotoIncompleteReadError,
+    )
+
+    _BOTO_TRANSIENT: tuple = (_BotoConnectionError, _BotoHTTPClientError, _BotoIncompleteReadError)
+except ImportError:  # pragma: no cover - boto3 not installed; S3 is unusable anyway
+    _BOTO_TRANSIENT = ()
+
+# One tuple, used by every retry decorator and every pass-through `except` in
+# this file, so the two can never disagree about what counts as transient.
+TRANSIENT_ERRORS: tuple = (ConnectionError, TimeoutError) + _BOTO_TRANSIENT
+
 
 class S3Store(IStore):
     """
@@ -65,7 +108,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def write_file(self, filename: str, data: str) -> None:
@@ -80,7 +123,7 @@ class S3Store(IStore):
 
             await asyncio.to_thread(client.put_object, Bucket=self._bucket, Key=key, Body=data.encode('utf-8'))
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             # Let these bubble up for retry
             raise
         except Exception as e:
@@ -89,7 +132,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def read_file(self, filename: str) -> str:
@@ -109,7 +152,7 @@ class S3Store(IStore):
             data = await asyncio.to_thread(_read)
             return data.decode('utf-8')
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             # Let these bubble up for retry
             raise
         except Exception as e:
@@ -121,7 +164,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def write_bytes(self, filename: str, data: bytes) -> None:
@@ -138,7 +181,7 @@ class S3Store(IStore):
 
             await asyncio.to_thread(client.put_object, Bucket=self._bucket, Key=key, Body=data)
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             # Let these bubble up for retry
             raise
         except Exception as e:
@@ -147,7 +190,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def read_bytes(self, filename: str) -> bytes:
@@ -169,7 +212,7 @@ class S3Store(IStore):
 
             return await asyncio.to_thread(_read)
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             # Let these bubble up for retry
             raise
         except Exception as e:
@@ -180,7 +223,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def read_file_with_metadata(self, filename: str) -> tuple:
@@ -201,7 +244,7 @@ class S3Store(IStore):
             data, etag = await asyncio.to_thread(_read)
             return (data.decode('utf-8'), etag)
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             raise
         except Exception as e:
             # Check for NoSuchKey exception (can be ClientError with 'NoSuchKey' in message or class name)
@@ -286,7 +329,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def delete_file(self, filename: str, expected_version: Optional[str] = None) -> None:
@@ -325,7 +368,7 @@ class S3Store(IStore):
             # Delete the file
             await asyncio.to_thread(client.delete_object, Bucket=self._bucket, Key=key)
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             raise
         except StorageError:
             raise
@@ -335,7 +378,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def move_file(self, src: str, dst: str) -> None:
@@ -367,7 +410,7 @@ class S3Store(IStore):
                     raise StorageError(f'File not found: {src}')
                 raise
             await asyncio.to_thread(client.delete_object, Bucket=self._bucket, Key=src_key)
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             raise
         except StorageError:
             raise
@@ -377,7 +420,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def list_files(self, prefix: str = '') -> list:
@@ -409,7 +452,7 @@ class S3Store(IStore):
 
             return await asyncio.to_thread(_list)
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             raise
         except Exception as e:
             raise StorageError(f'Failed to list files with prefix {prefix} from S3: {e}') from e
@@ -417,7 +460,7 @@ class S3Store(IStore):
     @retry(
         stop=stop_after_attempt(STORE_MAX_RETRY_ATTEMPTS),
         wait=wait_exponential(multiplier=1, min=1),
-        retry=retry_if_exception_type((ConnectionError, TimeoutError)),
+        retry=retry_if_exception_type(TRANSIENT_ERRORS),
         reraise=True,
     )
     async def list_entries(
@@ -491,7 +534,7 @@ class S3Store(IStore):
 
             return await asyncio.to_thread(_list_entries)
 
-        except (ConnectionError, TimeoutError):
+        except TRANSIENT_ERRORS:
             raise
         except Exception as e:
             raise StorageError(f'Failed to list entries with prefix {prefix} from S3: {e}') from e


### PR DESCRIPTION
Closes #2115. Found by CodeRabbit on #2114; the analysis held.

## The defect

Every retry decorator in `store_providers/s3/s3.py` matched only Python builtins:

```python
retry=retry_if_exception_type((ConnectionError, TimeoutError))
```

botocore's transport exceptions inherit from neither:

```
EndpointConnectionError    builtin ConnectionError=False  TimeoutError=False
ConnectTimeoutError        builtin ConnectionError=False  TimeoutError=False
ReadTimeoutError           builtin ConnectionError=False  TimeoutError=False
```

A real S3 transport failure therefore fell through to the bare `except Exception`, was wrapped in `StorageError`, and Tenacity never saw it. **The retry logic in this file has never retried the failure it exists for.** It retried only builtin errors, which boto does not raise here.

9 decorators and 9 `except` clauses, all matching the wrong thing.

## The fix

One tuple, used at all 18 sites, so the decorator and the pass-through `except` cannot drift apart:

```python
TRANSIENT_ERRORS = (ConnectionError, TimeoutError) + _BOTO_TRANSIENT
```

Two botocore base classes cover the family — its own `ConnectionError` (parent of `EndpointConnectionError`, `ConnectTimeoutError`, `ProxyConnectionError`, `SSLError`) and `HTTPClientError` (parent of `ReadTimeoutError`, `ConnectionClosedError`, `ResponseStreamingError`). `IncompleteReadError` sits under neither and is named explicitly; a truncated body is exactly the transient case worth another attempt.

Verified against the live class hierarchy rather than the docs:

```
EndpointConnectionError   caught: True
ConnectTimeoutError       caught: True
ReadTimeoutError          caught: True
ConnectionClosedError     caught: True
IncompleteReadError       caught: True
ResponseStreamingError    caught: True
EndpointResolutionError   caught: False   <- deliberate
```

`EndpointResolutionError` is excluded on purpose. It is nearly always a misconfigured region or endpoint, and retrying a config error only delays the message that would have explained it.

## The guarded import is load-bearing, not defensive habit

`store_providers/__init__.py` imports `S3Store` **unconditionally**, so this module is loaded on filesystem-store deployments that never installed boto3. That is why `_get_client()` imports boto3 lazily and raises a readable `boto3 library not installed` at call time.

A top-level `from botocore.exceptions import …` would replace that with an `ImportError` at import time, breaking installs that never touch S3. So the import is wrapped and the tuple degrades.

Verified in a subprocess with `botocore` blocked in `sys.modules`:

```
module imported: True
tuple: ['ConnectionError', 'TimeoutError']  len=2
```

My first attempt at that test used the deprecated `find_module` hook, which Python 3.12 ignores — it reported a pass while botocore was still fully importable. Redone with a real block; the result above is from the version that actually fails when it should.

## Not in scope

`azure` has the same shape with its own exception types. Left alone rather than widened, same as with #2114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015nTVr6jfSFYm1GppxbjghP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved S3 storage reliability by retrying additional transient connection, timeout, and incomplete-read failures.
  - Applied consistent retry handling across reading, writing, deleting, moving, and listing files.
  - Preserved clear handling for endpoint-resolution failures, which are not retried.
  - Continued support for environments where the optional S3 client library is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->