### PR TITLE
docs(nodes): clear the last three nodes the migration PRs did not cover

### DIFF
--- a/nodes/src/nodes/ocr/README.md
+++ b/nodes/src/nodes/ocr/README.md
@@ -57,11 +57,12 @@ On the `documents` lane, every incoming document must be of type `Image` (the no
 
 ## Profiles
 
-Profiles are preconfigured combinations of engine, script family, and table engine. Selecting a profile sets all three at once. The default profile is `latin`.
+Profiles are preconfigured combinations of engine, script family, and table engine. Selecting a profile sets all three at once. Default: **Latin (English)**
+(`latin`).
 
 | Profile key            | Title                         | Engine  | Script family         | Table engine |
 | ---------------------- | ----------------------------- | ------- | --------------------- | ------------ |
-| `latin`                | Latin (English)               | EasyOCR | `latin`               | DocTR        |
+| `latin` **(default)**  | Latin (English)               | EasyOCR | `latin`               | DocTR        |
 | `latin-extended`       | Latin Extended (European)     | EasyOCR | `latin-extended`      | DocTR        |
 | `cyrillic`             | Cyrillic (Russian, etc.)      | EasyOCR | `cyrillic`            | DocTR        |
 | `arabic`               | Arabic/Persian/Urdu           | EasyOCR | `arabic`              | DocTR        |

--- a/nodes/src/nodes/tool_laserdata_memory/README.md
+++ b/nodes/src/nodes/tool_laserdata_memory/README.md
@@ -42,9 +42,11 @@ destructive clear/reset tool.
 
 ## Profiles
 
+Default: **Your own Apache Iggy server** (`local`).
+
 | Profile | Deployment | Context |
 |---|---|---|
-| `local` *(default)* | Your own Apache Iggy server | Uses the local connection-string field |
+| `local` **(default)** | Your own Apache Iggy server | Uses the local connection-string field |
 | `cloud` | LaserData Cloud | Uses the cloud connection-string field |
 
 ### SDK contract provenance

--- a/nodes/src/nodes/tool_mcp_client/README.md
+++ b/nodes/src/nodes/tool_mcp_client/README.md
@@ -33,12 +33,17 @@ The implementation is pure Python standard library (`subprocess`, `urllib`, JSON
 
 ## Profiles
 
+The directory registers two services and each keeps its own default: MCP Client
+defaults to **RocketRide MCP server (stdio)** (`RocketRide`), and the Butterbase
+MCP Client preset to **Butterbase MCP server** (`butterbase`). Both are marked
+below; which one applies depends on the service you added to the pipeline.
+
 | Profile | Transport | Notes |
 |---|---|---|
-| RocketRide MCP server (stdio) *(default)* | `stdio` | Launches `python -m rocketride_mcp` |
+| RocketRide MCP server (stdio) **(default)** | `stdio` | Launches `python -m rocketride_mcp` |
 | Generic MCP server (Streamable HTTP) | `streamable-http` | Enter endpoint URL |
 | Generic MCP server (legacy HTTP+SSE) | `sse` | Enter SSE endpoint URL |
-| Butterbase MCP server | `streamable-http` | Branded Butterbase preset |
+| Butterbase MCP server **(default)** | `streamable-http` | Branded Butterbase preset |
 
 ## Configuration
 

--- a/scripts/validate-node-readme.py
+++ b/scripts/validate-node-readme.py
@@ -42,6 +42,10 @@ GEN_START = '<!-- ROCKETRIDE:GENERATED:PARAMS START -->'
 GEN_END = '<!-- ROCKETRIDE:GENERATED:PARAMS END -->'
 PROFILE_HEADERS = {
     'profile': 'profile',
+    # A table that gives the key and the title their own columns (ocr) heads the
+    # first one 'Profile key'. Without the alias every row resolves to an empty
+    # cell and a well-formed table reports every profile missing.
+    'profile key': 'profile',
     'model': 'model',
     'model id': 'model',
     'context': 'modelTotalTokens',

--- a/tests/test_validate_node_readme.py
+++ b/tests/test_validate_node_readme.py
@@ -537,3 +537,30 @@ def test_profile_title_mismatch_still_fails_when_words_differ(tmp_path):
     )
     checks = [check for check, _ in failures(node)]
     assert 'Profiles default title appears in intro' in checks
+
+
+KEY_AND_TITLE_PROFILES = {
+    'latin': {'title': 'Latin (English)'},
+    'cyrillic': {'title': 'Cyrillic (Russian, etc.)'},
+}
+
+KEY_AND_TITLE_SECTION = """## Profiles
+
+Default: **Latin (English)** (`latin`).
+
+| Profile key | Title | Engine |
+| ----------- | ----- | ------ |
+| `latin` **(default)** | Latin (English) | EasyOCR |
+| `cyrillic` | Cyrillic (Russian, etc.) | EasyOCR |"""
+
+
+def test_profile_key_column_heading_resolves_rows(tmp_path):
+    """A table giving key and title separate columns heads the first 'Profile key'."""
+    node = write_node(
+        tmp_path,
+        class_type=('ocr',),
+        profiles=KEY_AND_TITLE_PROFILES,
+        default='latin',
+        profile_section=KEY_AND_TITLE_SECTION,
+    )
+    assert failures(node) == []


### PR DESCRIPTION
Takes `fix/docs` to **124 of 124 nodes passing** the README schema.

These three predate the six family migrations, so no PR owned them and nothing
re-validated them once #2022 tightened the Profiles contract. CI only checks a
node when a PR touches it, so they would have stayed broken until someone next
edited them — and then failed an unrelated PR.

## `ocr` — a validator gap, not a documentation problem

Its table is the best-formed profile table in the corpus: twelve profiles with
the key and the title in separate columns, plus engine, script family, and
table engine. It failed because the first column is headed `Profile key`, which
`PROFILE_HEADERS` did not alias, so every row resolved to an empty cell and the
validator reported all twelve profiles missing and twelve unknown rows.

The alias is added, with a test. Separating key from title is a shape worth
supporting rather than a mistake to correct. `ocr` additionally needed its
default marked and its title in the intro.

## `tool_mcp_client` — a real content gap

It registers MCP Client (`mcp_client://`, default `RocketRide`) and the
Butterbase preset (`tool_butterbase://`, default `butterbase`). Only the
RocketRide row was marked, so the Butterbase preset's default was undocumented.
Both are now marked and named in the intro, following the multi-service shape
the schema describes.

## `tool_laserdata_memory`

Needed the intro sentence naming its declared default.

## Verification

- 124 of 124 nodes pass `scripts/validate-node-readme.py`
- 24 validator tests pass
- ruff check/format and gitleaks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified default OCR, Laser Data Memory, RocketRide STDIO, and Butterbase MCP profiles.
  * Standardized profile-default formatting in node documentation.

* **Bug Fixes**
  * Improved profile table validation for documentation using a separate “Profile key” column.

* **Tests**
  * Added coverage verifying profile keys, titles, rows, and defaults are correctly recognized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->