### PR TITLE
docs(agents): land the pipeline-builder skill set in docs/agents/skills/

### DIFF
--- a/docs/agents/skills/MCP_TOOL_CONTRACT.md
+++ b/docs/agents/skills/MCP_TOOL_CONTRACT.md
@@ -1,0 +1,79 @@
+# MCP Tool Contract (frozen)
+
+The tool-name/result-shape contract between these skills and the RocketRide HTTP MCP server.
+Frozen against `rocketride-server` `origin/develop @ eb67ddea` (module
+`packages/ai/src/ai/modules/mcp/`, 27 tools). The skills reference **only** names and shapes in
+this file; anything not listed here does not exist — never invent a tool.
+
+## Result envelope (every tool)
+
+Every result is a JSON object with `ok`. `ok: false` carries `error` and usually a `hint`;
+the MCP `is_error` flag mirrors it, and `structured_content` mirrors the text JSON.
+**Check `ok` — a successful tool *call* is not a successful *result*.**
+
+## Introspection
+
+| Tool | Input | Result (key fields) |
+|---|---|---|
+| `list_components` | — | `{ok, components: [{name, category, summary, wiring?}], note?}`. **No `lanes`/`invoke`** — wire from the bundled L1 index. Components whose integration isn't configured are **hidden**, with `note` pointing at `list_integrations`. |
+| `describe_component` | `{name}` | Full service definition (the L2 schema). |
+| `validate_pipeline` | `{pipeline}` (inline object) | `{ok, errors, warnings}` — the compiler. Zero errors before any run. |
+| `describe_pipeline` | `{pipeline}` | Static per-node summary (preflight aid, not a gate). |
+
+## Execution
+
+| Tool | Input | Result / semantics |
+|---|---|---|
+| `run_pipeline` | `{pipeline, inputs?, ttl?, use_existing?, source?, threads?}` | `{ok, task_token, projectId, source, result?}`. Inline pipeline **only** (no filepath). With `inputs` it is a **one-shot**: the string is sent, `result` comes back inline, and the token is finished — don't poll it. **Keep `projectId` + `source`**: they key the log tools. |
+| `run_dropper_pipe` | like `run_pipeline`, minus `inputs` | `{ok, task_token, upload_url, dropper_url, projectId, source}`. Out-of-band file ingress: multipart-POST files to `upload_url`, or hand the user `dropper_url` (browser drag-drop). URLs carry only the public `pk_` key — never the control token. |
+| `send_data` | `{task_token, input}` | Sends to a running task; result inline. `input` is a **string** — serialize JSON; there is no chat operation (chat pipelines → SDK fallback). |
+| `send_files` | `{task_token, files: [path]}` | Store-resolvable paths only — not a host-file upload; for host files use `run_dropper_pipe`. |
+| `terminate` | `{task_token}` | Stops the task. |
+
+## Visibility
+
+| Tool | Input | Result |
+|---|---|---|
+| `monitor` | `{task_token, timeout? ≤300, interval?}` | Bounded poll, returns a snapshot: `{ok, state, state_label, completed, terminal, status, counts: {completedCount, failedCount, totalCount}, errors, warnings, polls, poll_timed_out?}`. `terminal: true` means done; `poll_timed_out: true` means the *poll* hung, not the task. |
+| `list_running_pipelines` | — | `{ok, tasks, count}`. |
+
+## Run logs (DVR — the debugging evidence)
+
+All keyed by `(projectId, source[, teamId])` **returned by `run_pipeline`/`run_dropper_pipe`** —
+never by task token. Omit `teamId` for your own dev runs. Works for past and live runs.
+Retention: 7 days (dev) / 30 days (deploy). Runs started with `pipelineTraceLevel: "none"` have
+chapters/console but **empty traces**.
+
+| Tool | Purpose |
+|---|---|
+| `log_chapters` | Run/chapter listing — find the run. |
+| `log_read` | Paged events (≤200 events / 1 MiB per page, cursor to continue). |
+| `log_traces` | Per-object trace summaries (1–100, default 20). |
+| `log_trace` | One object's full node/lane trace — the per-node enter/leave evidence. |
+
+## Capability
+
+| Tool | Purpose |
+|---|---|
+| `store_read` / `store_list` / `store_stat` | Object store access (read is inline and uncapped — prefer `stat` + URL for big objects). |
+| `store_get_url` | Signed URL — artifact-by-reference for large results. |
+| `save_template` / `load_template` | Gate D "save to cloud". |
+| `deploy_add` / `deploy_list` / `deploy_status` / `deploy_remove` / `deploy_update` | Gate D "publish" + deployment lifecycle. |
+
+## Integrations / credentials
+
+| Tool | Purpose |
+|---|---|
+| `list_integrations` | Bare: per-integration readiness rows. With `{name}`: field detail + `setup_block` instructions to relay to the user. Secret **values never transit MCP** — there is no `set_env`; credentials are configured out-of-band (env/account), and pipelines still reference `${ROCKETRIDE_*}`. |
+
+## Gaps the skills must compensate for (server-verified, current)
+
+1. **`run_pipeline` does not validate first** — the skills' mandatory `validate_pipeline` +
+   re-validate loop is the only guard. Never run without a clean result in hand.
+2. **No cost preflight** — Gate C.5 stays a skills-side estimate and hard stop.
+3. **Strings-only input, no chat tool** — serialize JSON; drive chat pipelines via the SDK.
+4. **`list_components` has no lanes** — select from it if live, but **wire** from the bundled
+   L1 index / `describe_component`.
+5. **No `get_run_result` and none planned** — results are inline; evidence is `log_*`.
+6. A known node missing from `list_components` usually means its integration isn't configured —
+   check `list_integrations` before concluding it doesn't exist (the bundled index still lists it).

--- a/docs/agents/skills/MCP_TOOL_CONTRACT.md
+++ b/docs/agents/skills/MCP_TOOL_CONTRACT.md
@@ -7,7 +7,7 @@ this file; anything not listed here does not exist — never invent a tool.
 
 ## Result envelope (every tool)
 
-Every result is a JSON object with `ok`. `ok: false` carries `error` and usually a `hint`;
+Every result is a JSON object with `ok`. `ok: false` carries `error_type`, `message`, and usually a `hint`;
 the MCP `is_error` flag mirrors it, and `structured_content` mirrors the text JSON.
 **Check `ok` — a successful tool *call* is not a successful *result*.**
 
@@ -24,8 +24,8 @@ the MCP `is_error` flag mirrors it, and `structured_content` mirrors the text JS
 
 | Tool | Input | Result / semantics |
 |---|---|---|
-| `run_pipeline` | `{pipeline, inputs?, ttl?, use_existing?, source?, threads?}` | `{ok, task_token, projectId, source, result?}`. Inline pipeline **only** (no filepath). With `inputs` it is a **one-shot**: the string is sent, `result` comes back inline, and the token is finished — don't poll it. **Keep `projectId` + `source`**: they key the log tools. |
-| `run_dropper_pipe` | like `run_pipeline`, minus `inputs` | `{ok, task_token, upload_url, dropper_url, projectId, source}`. Out-of-band file ingress: multipart-POST files to `upload_url`, or hand the user `dropper_url` (browser drag-drop). URLs carry only the public `pk_` key — never the control token. |
+| `run_pipeline` | `{pipeline, inputs?, ttl?, use_existing?, source?, threads?, pipelineTraceLevel?}` | `{ok, task_token, projectId, source, result?}`. Inline pipeline **only** (no filepath). With `inputs` it is a **one-shot**: the string is sent, `result` comes back inline, and the token is finished — don't poll it. **Keep `projectId` + `source`**: they key the log tools. `pipelineTraceLevel?`: `none\|metadata\|summary\|full`, server default `summary`. |
+| `run_dropper_pipe` | like `run_pipeline` (incl. `pipelineTraceLevel?`), minus `inputs` | `{ok, task_token, upload_url, dropper_url, projectId, source}`. Out-of-band file ingress: multipart-POST files to `upload_url`, or hand the user `dropper_url` (browser drag-drop). URLs carry only the public `pk_` key — never the control token. |
 | `send_data` | `{task_token, input}` | Sends to a running task; result inline. `input` is a **string** — serialize JSON; there is no chat operation (chat pipelines → SDK fallback). |
 | `send_files` | `{task_token, files: [path]}` | Store-resolvable paths only — not a host-file upload; for host files use `run_dropper_pipe`. |
 | `terminate` | `{task_token}` | Stops the task. |
@@ -64,7 +64,7 @@ chapters/console but **empty traces**.
 
 | Tool | Purpose |
 |---|---|
-| `list_integrations` | Bare: per-integration readiness rows. With `{name}`: field detail + `setup_block` instructions to relay to the user. Secret **values never transit MCP** — there is no `set_env`; credentials are configured out-of-band (env/account), and pipelines still reference `${ROCKETRIDE_*}`. |
+| `list_integrations` | Bare: per-integration readiness rows. With `{name}`: field detail + `setup` instructions to relay to the user. Secret **values never transit MCP** — there is no `set_env`; credentials are configured out-of-band (env/account), and pipelines still reference `${ROCKETRIDE_*}`. |
 
 ## Gaps the skills must compensate for (server-verified, current)
 

--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -1,14 +1,40 @@
 # Skills
 
-Reserved for RocketRide agent skills — hand-curated direction sets that tell an
-assistant how to drive a specific connector or workflow. Empty for now; skills
-land here as they are written.
+RocketRide agent skills — hand-curated direction sets that tell an assistant how
+to drive a specific connector or workflow.
 
 Skills are authored by hand, not derived from other documentation. A skill is a
 set of directions for an agent, so it is written for that reader and reviewed as
 such, the same way the sibling `ROCKETRIDE_*.md` files are.
 
+## The pipeline-builder skill set
+
+Five skills that take a plain-language request to a valid, running RocketRide
+pipeline — designed so even a weak/cheap model performs reliably, because
+verification comes from tools (the engine validates, the run result is the
+proof) and from hard process gates, not model intelligence.
+
+| Skill | Owns |
+|---|---|
+| `rocketride-building-pipelines/` | The orchestrator: lifecycle phases, gate discipline (Waiting = STOP), tool ladder, `GATE_PROTOCOL.md` with the 17 forcing functions |
+| `rocketride-designing-pipelines/` | Node selection from the bundled L1 index + DAG wiring with typed lanes (Gates A/B) |
+| `rocketride-configuring-pipelines/` | Schema-driven config, anti-pattern checklist, validate + re-validate loop (Gate C), cost approval (Gate C.5) |
+| `rocketride-running-pipelines/` | The run lifecycle over the HTTP MCP tools (dropper file ingress, `monitor` polling), SDK fallback, Gate D save/deploy |
+| `rocketride-debugging-pipelines/` | Evidence-first diagnosis: `monitor` snapshot, then the DVR run-log tools (`log_chapters`/`log_read`/`log_traces`/`log_trace`) |
+
+`MCP_TOOL_CONTRACT.md` (this directory) freezes the tool-name/result-shape
+contract between the skills and the HTTP MCP server
+(`packages/ai/src/ai/modules/mcp/`): the 27 tool names, `{ok, ...}` result
+envelopes, run-log keying, and the server gaps the skills compensate for. The
+skills reference only names in that file. When the MCP surface changes, update
+the contract and the skills together.
+
+Each skill directory is self-contained: `SKILL.md` plus its reference files,
+worked examples, and offline shims under `tools/`. The bundled
+`LAYER1_NODE_INDEX.json` (124 nodes) regenerates from a live engine via
+`rocketride-building-pipelines`' ladder — the engine remains the authority.
+
 Not exported: `docs:export` copies only the `.md` files sitting directly in
 `docs/agents/` to `.rocketride/docs/`, so this subdirectory is excluded, as
-`stubs/` is. Wire up an export path here when the first skill ships and there is
-a consumer to export it to.
+`stubs/` is. Wire up an export path here when there is a consumer to export
+these to (e.g. the VS Code extension installing them as agent skills).

--- a/docs/agents/skills/README.md
+++ b/docs/agents/skills/README.md
@@ -31,7 +31,7 @@ the contract and the skills together.
 
 Each skill directory is self-contained: `SKILL.md` plus its reference files,
 worked examples, and offline shims under `tools/`. The bundled
-`LAYER1_NODE_INDEX.json` (124 nodes) regenerates from a live engine via
+`LAYER1_NODE_INDEX.json` (167 nodes, corpus-reconciled) regenerates from a live engine via
 `rocketride-building-pipelines`' ladder — the engine remains the authority.
 
 Not exported: `docs:export` copies only the `.md` files sitting directly in

--- a/docs/agents/skills/rocketride-building-pipelines/GATE_PROTOCOL.md
+++ b/docs/agents/skills/rocketride-building-pipelines/GATE_PROTOCOL.md
@@ -1,0 +1,147 @@
+# Gate Protocol & Forcing Functions
+
+This is the canonical reference for the discipline that makes a weak model reliable. Every
+sub-skill inherits it. When in doubt, this file wins.
+
+## 1. Waiting = STOP (the keystone)
+
+```
+THE IRON LAW OF GATES:
+WAITING FOR A HUMAN'S ANSWER MEANS ENDING YOUR TURN.
+A dismissed / headless / unanswered gate is a STOP — NEVER an approval. No exceptions.
+```
+
+**Violating the letter of a gate is violating the spirit of the gate.** "I followed the whole
+process and the user clearly wants this" is NOT approval — only a human's typed answer is. If you
+catch yourself reasoning toward "they'd obviously say yes," that is the moment to STOP and present
+the gate.
+
+A gate is a question to a human. **Waiting for the answer means ENDING YOUR TURN.**
+
+- A dismissed dialog, an unanswered question, a non-interactive / headless / scripted session,
+  or "no user is here" is a **STOP** — never an approval.
+- Do **not** "proceed with the recommended defaults." A recommendation is not a confirmation.
+- Do **not** treat silence, dismissal, or absence as consent.
+- Do **not** later assert "the user approved this" unless a human actually typed an answer.
+- If nobody can answer: deliver the gate brief as your **final message** and stop. An unbuilt
+  pipeline costs nothing; an unapproved run wastes the user's money and compute.
+
+This single rule is the highest-leverage thing in this skill set. It is not advice; it is a hard
+protocol. Holding it is what makes a cheap model behave like an expensive one.
+
+## 2. Multi-turn gate state (survives context resets)
+
+A later turn — or a whole new session after a context reset / compaction — can arrive with NO memory
+of the gate you presented. The on-disk gate state is the ONLY thing that survives. It is mandatory,
+not best-effort.
+
+- **WRITE — every time you present a gate.** Before you end the turn, use the **Write tool** to write
+  `.context/GATE_STATE.md` in the current project (create the `.context/` directory if missing):
+  `GATE <X> | presented turn <n> | status: AWAITING`. This is NOT optional and NOT conditional — a
+  gate you present but don't persist is lost on the next turn. Write it in the project you're working
+  in (relative to your working directory), never under `~/.claude`.
+- **READ FIRST — every re-engagement.** The FIRST action of any turn after the first — and ALWAYS on
+  a fresh session or a vague follow-up ("go ahead", "ok", "continue", "yes", "finish it", "where are
+  we") — is to read `.context/GATE_STATE.md`. If a gate is `AWAITING`, **re-present that exact gate
+  (the same items, the same options) and STOP — do NOT fetch schemas, design, wire, or build past
+  it.** A reply that merely *sounds* affirmative ("continue", "go ahead", "keep building") is NOT
+  explicit approval of the specific items in that gate; only a direct yes / adjust / cancel to THOSE
+  items advances. Never start building because you "lost context" — the state file is your memory.
+- **APPROVE — only on an explicit human answer.** A gate is APPROVED only when a human answers it
+  explicitly; then update the line to `status: APPROVED "<their words>"` and proceed. Never advance a
+  phase past an `AWAITING` gate.
+
+## 3. Deterministic gate wording
+
+Gates are binary or fixed-menu. Never turn a gate into open-ended reasoning. Use these forms:
+
+- **GATE A (node selection):**
+  > Selected nodes (N): <name · classType · role>, … — all verified against the index.
+  > Approve these N nodes? (yes / adjust / cancel)
+- **GATE B (topology):**
+  > <Mermaid or ASCII DAG>. Lanes: <node → node (lane: type)>, … — N edges, all lane-checked.
+  > Approve this topology? (yes / adjust / cancel)
+- **GATE C (validation — a TOOL gate, not a user gate):** not approved by a human; approved only
+  when `validate()` returns zero errors. Quote the result: `validate(): 0 errors, K warnings`.
+- **GATE C.5 (cost):**
+  > This run will cost ≈ $X (<basis: cloud compute / paid API calls / token estimate>).
+  > Approve this run? (yes / no)
+- **GATE D (publish — optional, menu):**
+  > Run succeeded. What next? (save to cloud / publish as an app / nothing / debug)
+
+## 4. The 17 forcing functions
+
+**Gate discipline**
+1. **Waiting = STOP** (§1) — dismissed/headless/unanswered = STOP, never approval.
+2. **Deterministic gate wording** (§3) — binary or fixed menu; never reworded into open reasoning.
+3. **Multi-turn gate-state persistence** (§2) — WRITE `.context/GATE_STATE.md` (Write tool) on every
+   gate; READ it FIRST on every re-engagement; an `AWAITING` gate is re-presented unchanged.
+
+**Anti-hallucination**
+4. **Cite-your-source from the index** — for every node: "Found in index: `<name>` · classType=
+   `[…]` · lanes=`{…}`." If not found, STOP. Never name a node you didn't cite.
+5. **Mandatory L2 schema fetch before configuring** — never fill config from memory; fetch the
+   node's schema first and configure only fields it defines.
+6. **Count lines on every list** — "Selected nodes (5): …", "Archetypes explored (9): …". The
+   count makes an omission a visible lie, not a silent gap.
+7. **Exhaustive archetype exploration** — in discovery, walk every relevant archetype/classType
+   and list candidates per archetype before narrowing. Don't stop at the first that fits.
+
+**Verification by tool (the model is not the judge)**
+8. **Schema-fetch in the design phase too** — fetch each chosen node's schema before wiring lanes,
+   so the lane signatures you wire are the real ones, not the index summary.
+9. **Sequential anti-pattern checklist as a gate** — per node, state each checklist item yes/no
+   ("Node X: 1 ✓ 2 ✓ … 9 ✓") before moving to the next node. Not a reference skimmed once.
+10. **Semantic/conditional constraints** — after fetching a schema, state required fields **and**
+    any conditional rules in prose (e.g. "if `batch_size` set, `max_batch_wait_ms` required").
+11. **validate() is mandatory + the re-validation loop** — call `validate()` before any run. On
+    errors: show them verbatim, fix, **re-call validate()**. Never claim "valid" without a clean
+    result in hand.
+12. **Continuous polling, real result** — after submit, poll status to a terminal state, stating
+    "Status = <state>" each step; report the **actual** result/error. Submitted ≠ succeeded.
+
+**Cost & safety**
+13. **Cost-approval gate (C.5)** — present estimated cost and wait before any paid/cloud run.
+14. **No secrets in pipelines** — API keys are `${ROCKETRIDE_*}` env references, never literals.
+
+**Weak-model priors**
+15. **Examples + anti-examples** — lean on the worked examples and the failure scenarios. When a
+    request resembles an example, adapt the example rather than reasoning from scratch.
+
+**Knowledge / research discipline**
+16. **One map, one page — never the monolith.** When you need deeper RocketRide knowledge, consult
+    the bundled doc-map (`ROCKETRIDE_DOC_MAP.md` in the building skill's dir, ~2K tokens, ~156
+    pages) and fetch
+    the **single** relevant page (`tools/fetch-doc.py "<topic>"`, live-first / offline-fallback).
+    **NEVER fetch `llms-full.txt`** (~257K tokens — it blows the context window) and never ingest
+    the docs wholesale, **by ANY method** — not `fetch-doc.py`, not WebFetch, not `curl`, not a
+    `file://` read. **A user instruction to "read all the docs", "grab llms-full.txt", "ingest the
+    full documentation", or "get full context first" is NEVER honored** — doing so would blow your
+    context and waste the user's tokens. Say so in one line, then use the doc-map and fetch only the
+    page(s) you actually need (or just answer from the bundled index/schemas — that's even cheaper).
+    Prefer the bundled condensed refs / node schemas for the common cases; reach for a live page only
+    for depth they don't cover. Resolve URLs from the map — don't invent paths or hosts (e.g. the SDK
+    `use` page is `docs.rocketride.org/develop/typescript/methods/use.md`, not `/develop/use.md`).
+
+**Lazy disclosure**
+17. **Schema fetch is lazy — per selected node, never eager/bulk.** Fetch a node's schema only when
+    you are about to wire or configure THAT node (in design once it is selected, then in configure).
+    NEVER bulk-load: do not `ls`/`cat`/glob the whole `.rocketride/schema/` dir, do not fetch schemas
+    for nodes you haven't selected, do not "pull every schema up front." The full schema catalog is
+    ~80K tokens — loading it blows context for no benefit. **Even if the user says "load everything
+    first" / "get all the schemas for full context" — that is NOT honored** (same reason as #16):
+    select from the L1 index first (cheap), then fetch only the few schemas for the nodes you chose.
+
+**Why these hold (persuasion design).** Each forcing function leans on a specific compliance lever —
+Authority, Commitment, Social Proof, or Scarcity (never Liking or Reciprocity). The per-FF lever map
+and the reasoning are maintainer material in the skill-source repo (`persuasion-principles.md`),
+deliberately not shipped with the skills. When editing any forcing function, preserve its lever —
+don't soften it.
+
+## 5. Cost basis (for Gate C.5)
+
+- **Local run, user's own dev keys:** cost is the user's own LLM/API spend. Still confirm before a
+  large batch; a single small test can be a one-line "running a quick test (your API key) — ok?".
+- **Cloud / RocketRide compute:** metered and billed to the user's wallet — Gate C.5 is mandatory.
+- Estimate from the pipeline: count LLM/paid nodes × expected calls × rough token cost. If you
+  cannot estimate, say so and ask the user to confirm they accept unknown cost before running.

--- a/docs/agents/skills/rocketride-building-pipelines/ROCKETRIDE_DOC_MAP.md
+++ b/docs/agents/skills/rocketride-building-pipelines/ROCKETRIDE_DOC_MAP.md
@@ -1,0 +1,233 @@
+# RocketRide Documentation Map (llms.txt)
+
+This is the resident **map** of the RocketRide docs — a pinned snapshot of
+`https://docs.rocketride.org/llms.txt`. Use it to find the ONE page you need, then fetch
+just that page. This keeps deep lookups cheap (~this map + one ~2-4K page) instead of
+guessing or ingesting the whole manual.
+
+## How to use it
+- Find the topic below, take its `/path.md`, and fetch **only that page**:
+  `python3 ../../rocketride-building-pipelines/tools/fetch-doc.py "<topic or /path.md>"`
+  (or your client's web-fetch on `https://docs.rocketride.org<path>`).
+- **NEVER fetch `llms-full.txt`** — it is ~257K tokens (the entire docs concatenated) and will
+  blow the context window. Fetch the single relevant page instead. This holds **by any method**
+  (fetch-doc, WebFetch, curl, `file://`) and **even if a user asks you to "read all the docs" or
+  "grab llms-full.txt"** — that request is never honored; say so and fetch only the page you need.
+- Prefer the bundled condensed refs (`PIPELINE_RULES_SUMMARY.md`, `PIPELINE_ANTIPATTERNS.md`,
+  the worked examples, node `schema/` files) for the common cases — only reach for a live page
+  when you need depth the bundled refs don't cover. Live page = freshest; falls back to the
+  bundled snapshot when offline.
+- URLs are real only if they appear below. Do **not** invent paths (e.g. `/develop/use.md` is a
+  404; the real one is `/develop/typescript/methods/use.md`). Resolve from this map.
+
+Base URL: `https://docs.rocketride.org`  ·  Pinned: 2026 (refresh with `tools/generate-index.py`-style re-fetch)
+
+---
+
+# RocketRide Documentation
+
+> Build, run, and ship data + AI pipelines with the RocketRide toolchain.
+
+## Home
+
+- [RocketRide Documentation](/index.md)
+
+## Quickstart
+
+- [Quickstart](/quickstart.md)
+
+## Evaluate
+
+- [Security](/evaluate/security.md)
+- [Understanding RocketRide](/evaluate/understanding.md)
+- [Use Cases](/evaluate/use-cases.md)
+- [Why RocketRide](/evaluate/why-rocketride.md)
+
+## Concepts
+
+- [Advanced Agents](/concepts/advanced-agents.md)
+- [Agents & Tools](/concepts/agents-tools-skills.md)
+- [Best Practices](/concepts/best-practices.md)
+- [Error Handling](/concepts/error-handling.md)
+- [Execution Model](/concepts/execution-model.md)
+- [Nodes](/concepts/nodes.md)
+- [Performance](/concepts/performance.md)
+- [Pipelines](/concepts/pipelines.md)
+- [Runtime & Engine](/concepts/runtime-engine.md)
+- [Security Model](/concepts/security-model.md)
+
+## Examples
+
+- [Document Extraction](/examples/document-extraction.md)
+- [RAG Pipeline](/examples/rag-pipeline.md)
+- [Webhook Pipeline](/examples/webhook-pipeline.md)
+
+## Protocols
+
+- [MCP Server](/protocols/mcp.md)
+- [WebSocket](/protocols/websocket.md)
+- [Observability](/protocols/websocket/observability.md)
+
+## Nodes
+
+- [Overview](/nodes.md)
+- [Accessibility Describe](/nodes/accessibility_describe.md)
+- [CrewAI Agent](/nodes/agent_crewai.md)
+- [CrewAI Agent](/nodes/agent_crewai/crewai_agent.md)
+- [CrewAI Manager](/nodes/agent_crewai/crewai_manager.md)
+- [CrewAI Subagent](/nodes/agent_crewai/crewai_subagent.md)
+- [Deep Agent](/nodes/agent_deepagent.md)
+- [Deep Agent](/nodes/agent_deepagent/deepagent_agent.md)
+- [DeepAgent Subagent](/nodes/agent_deepagent/deepagent_subagent.md)
+- [LangChain](/nodes/agent_langchain.md)
+- [LlamaIndex](/nodes/agent_llamaindex.md)
+- [RocketRide Wave](/nodes/agent_rocketride.md)
+- [Anomaly Detector](/nodes/anomaly_detector.md)
+- [Anonymize](/nodes/anonymize.md)
+- [Aparavi AQL](/nodes/aparavi_aql.md)
+- [Astra DB](/nodes/astra_db.md)
+- [MongoDB Atlas](/nodes/atlas.md)
+- [Player](/nodes/audio_player.md)
+- [Transcribe](/nodes/audio_transcribe.md)
+- [Text To Speech](/nodes/audio_tts.md)
+- [Parse/Process/Embed](/nodes/autopipe.md)
+- [Chroma](/nodes/chroma.md)
+- [Core](/nodes/core.md)
+- [Fingerprinter](/nodes/core/hash.md)
+- [Parser](/nodes/core/parser.md)
+- [ClickHouse](/nodes/db_clickhouse.md)
+- [MySQL](/nodes/db_mysql.md)
+- [Neo4J](/nodes/db_neo4j.md)
+- [PostgreSQL](/nodes/db_postgres.md)
+- [Dictionary](/nodes/dictionary.md)
+- [Image](/nodes/embedding_image.md)
+- [OpenAI (Embedding)](/nodes/embedding_openai.md)
+- [Transformer](/nodes/embedding_transformer.md)
+- [Video](/nodes/embedding_video.md)
+- [Data Extractor](/nodes/extract_data.md)
+- [Frame Grabber](/nodes/frame_grabber.md)
+- [Guardrails](/nodes/guardrails.md)
+- [Cleanup](/nodes/image_cleanup.md)
+- [Index Search](/nodes/index_search.md)
+- [Elasticsearch](/nodes/index_search/elasticsearch.md)
+- [OpenSearch](/nodes/index_search/opensearch.md)
+- [LlamaParse](/nodes/llamaparse.md)
+- [Anthropic](/nodes/llm_anthropic.md)
+- [Baidu Qianfan](/nodes/llm_baidu_qianfan.md)
+- [Amazon Bedrock](/nodes/llm_bedrock.md)
+- [Deepseek](/nodes/llm_deepseek.md)
+- [Gemini](/nodes/llm_gemini.md)
+- [GMI Cloud](/nodes/llm_gmi_cloud.md)
+- [IBM Watson](/nodes/llm_ibm_watson.md)
+- [Kimi (Moonshot)](/nodes/llm_kimi.md)
+- [MiniMax](/nodes/llm_minimax.md)
+- [Mistral AI](/nodes/llm_mistral.md)
+- [Ollama](/nodes/llm_ollama.md)
+- [OpenAI](/nodes/llm_openai.md)
+- [OpenAI-Compatible API](/nodes/llm_openai_api.md)
+- [Perplexity](/nodes/llm_perplexity.md)
+- [Qwen](/nodes/llm_qwen.md)
+- [Gemini Vision](/nodes/llm_vision_gemini.md)
+- [Mistral Vision](/nodes/llm_vision_mistral.md)
+- [Ollama Vision](/nodes/llm_vision_ollama.md)
+- [OpenAI Vision](/nodes/llm_vision_openai.md)
+- [xAI](/nodes/llm_xai.md)
+- [Local Text Output](/nodes/local_text_output.md)
+- [Memory (Internal)](/nodes/memory_internal.md)
+- [Persistent Memory](/nodes/memory_persistent.md)
+- [Milvus](/nodes/milvus.md)
+- [Named Entity Recognition](/nodes/ner.md)
+- [OCR](/nodes/ocr.md)
+- [Pinecone](/nodes/pinecone.md)
+- [Code](/nodes/preprocessor_code.md)
+- [General Text](/nodes/preprocessor_langchain.md)
+- [LLM](/nodes/preprocessor_llm.md)
+- [Prompt](/nodes/prompt.md)
+- [Qdrant](/nodes/qdrant.md)
+- [Question](/nodes/question.md)
+- [Reducto](/nodes/reducto.md)
+- [Remote Processing](/nodes/remote.md)
+- [Cohere Rerank](/nodes/rerank_cohere.md)
+- [Response](/nodes/response.md)
+- [Exa Search](/nodes/search_exa.md)
+- [Summarization: LLM](/nodes/summarization.md)
+- [Telegram Bot](/nodes/telegram.md)
+- [Text Output](/nodes/text_output.md)
+- [Thumbnail](/nodes/thumbnail.md)
+- [Apify](/nodes/tool_apify.md)
+- [Bland AI](/nodes/tool_bland_ai.md)
+- [Chart (Chart.js)](/nodes/tool_chartjs.md)
+- [Daytona](/nodes/tool_daytona.md)
+- [DeepL](/nodes/tool_deepl.md)
+- [Exa Search](/nodes/tool_exa_search.md)
+- [FalkorDB](/nodes/tool_falkordb.md)
+- [File System](/nodes/tool_filesystem.md)
+- [Firecrawl](/nodes/tool_firecrawl.md)
+- [Git](/nodes/tool_git.md)
+- [GitHub](/nodes/tool_github.md)
+- [HTTP Request](/nodes/tool_http_request.md)
+- [MCP Client](/nodes/tool_mcp_client.md)
+- [Pipeline Tool](/nodes/tool_pipe.md)
+- [Python](/nodes/tool_python.md)
+- [Tavily](/nodes/tool_tavily.md)
+- [v0 by Vercel](/nodes/tool_v0.md)
+- [xTrace Memory](/nodes/tool_xtrace_memory.md)
+- [TwelveLabs](/nodes/twelvelabs.md)
+- [PostgreSQL (pgvector)](/nodes/vectordb_postgres.md)
+- [Vectorizer](/nodes/vectorizer.md)
+- [Weaviate](/nodes/weaviate.md)
+- [Webhook](/nodes/webhook.md)
+- [Chat](/nodes/webhook/chat.md)
+- [Drag & Drop](/nodes/webhook/dropper.md)
+- [Webhook](/nodes/webhook/webhook.md)
+
+## Integrations
+
+- [Anthropic](/integrations/anthropic.md)
+- [Aparavi AQL](/integrations/aparavi-aql.md)
+- [Firecrawl](/integrations/firecrawl.md)
+- [Neo4j](/integrations/neo4j.md)
+- [PostgreSQL](/integrations/postgres.md)
+- [Qdrant](/integrations/qdrant.md)
+
+## Develop
+
+- [Python](/develop/python.md)
+- [TypeScript](/develop/typescript.md)
+- [Deploy](/develop/typescript/methods/deploy.md)
+- [Get Task Status](/develop/typescript/methods/get-task-status.md)
+- [Send / Send Files / Pipe](/develop/typescript/methods/send.md)
+- [Terminate](/develop/typescript/methods/terminate.md)
+- [Use](/develop/typescript/methods/use.md)
+- [Validate](/develop/typescript/methods/validate.md)
+
+## IDE Extensions
+
+- [IDE Extensions](/ide-extensions/overview.md)
+- [Introduction](/ide-extensions/vscode.md)
+- [Installation](/ide-extensions/vscode/installation.md)
+- [Usage Guide](/ide-extensions/vscode/usage.md)
+
+## Pipeline JSON Reference
+
+- [Pipeline JSON Reference](/pipeline-reference.md)
+
+## CLI Reference
+
+- [CLI Reference](/cli.md)
+
+## Cloud
+
+- [Cloud](/cloud.md)
+
+## Self-hosting
+
+- [Self-hosting](/self-hosting.md)
+
+## Troubleshooting
+
+- [Troubleshooting](/troubleshooting.md)
+
+## Glossary
+
+- [Glossary](/glossary.md)

--- a/docs/agents/skills/rocketride-building-pipelines/ROCKETRIDE_DOC_MAP.md
+++ b/docs/agents/skills/rocketride-building-pipelines/ROCKETRIDE_DOC_MAP.md
@@ -7,7 +7,7 @@ guessing or ingesting the whole manual.
 
 ## How to use it
 - Find the topic below, take its `/path.md`, and fetch **only that page**:
-  `python3 ../../rocketride-building-pipelines/tools/fetch-doc.py "<topic or /path.md>"`
+  `python3 tools/fetch-doc.py "<topic or /path.md>"`
   (or your client's web-fetch on `https://docs.rocketride.org<path>`).
 - **NEVER fetch `llms-full.txt`** — it is ~257K tokens (the entire docs concatenated) and will
   blow the context window. Fetch the single relevant page instead. This holds **by any method**
@@ -97,7 +97,7 @@ Base URL: `https://docs.rocketride.org`  ·  Pinned: 2026 (refresh with `tools/g
 - [Parser](/nodes/core/parser.md)
 - [ClickHouse](/nodes/db_clickhouse.md)
 - [MySQL](/nodes/db_mysql.md)
-- [Neo4J](/nodes/db_neo4j.md)
+- [Neo4J](/nodes/graph_neo4j.md)
 - [PostgreSQL](/nodes/db_postgres.md)
 - [Dictionary](/nodes/dictionary.md)
 - [Image](/nodes/embedding_image.md)
@@ -160,7 +160,7 @@ Base URL: `https://docs.rocketride.org`  ·  Pinned: 2026 (refresh with `tools/g
 - [Daytona](/nodes/tool_daytona.md)
 - [DeepL](/nodes/tool_deepl.md)
 - [Exa Search](/nodes/tool_exa_search.md)
-- [FalkorDB](/nodes/tool_falkordb.md)
+- [FalkorDB](/nodes/graph_falkordb.md)
 - [File System](/nodes/tool_filesystem.md)
 - [Firecrawl](/nodes/tool_firecrawl.md)
 - [Git](/nodes/tool_git.md)

--- a/docs/agents/skills/rocketride-building-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-building-pipelines/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: rocketride-building-pipelines
+description: Use when asked to build, run, or validate a RocketRide pipeline (e.g. "build me a chatbot that answers from my docs", "make a pipeline that summarizes uploaded PDFs", "run this pipeline"), or whenever turning a plain-language data/AI task into a working RocketRide pipeline.
+---
+
+# Building RocketRide Pipelines
+
+Master workflow: a plain-language request in, a **valid, running** RocketRide pipeline out.
+Follow the phases in order. Each phase is owned by a REQUIRED SUB-SKILL. The gates are **hard
+stops** — present to the user and wait.
+
+```
+THE IRON LAW OF GATES — WAITING = STOP:
+WAITING FOR A HUMAN'S ANSWER MEANS ENDING YOUR TURN.
+A dismissed / headless / unanswered gate is a STOP — NEVER an approval. No exceptions.
+```
+
+**Real-world impact:** this one rule took gate blast-through from 32–45% to **0/24** on Haiku — the
+cheap model behaves like an expensive one because it holds the protocol, not because it is smart.
+
+**Waiting means ENDING YOUR TURN.** A dismissed question dialog, an unanswered question, or a
+non-interactive/headless session is a STOP, never an approval. No exceptions:
+- Don't "proceed with the recommended defaults" — a recommendation is not a confirmation.
+- Don't treat silence, dismissal, or the absence of a user as consent.
+- Don't later write "the user approved this" unless a human actually answered.
+If nobody can answer, deliver the gate brief as your final message and stop — an unbuilt
+pipeline costs nothing; an unapproved run wastes the user's money and compute.
+
+Full gate rules, the deterministic gate wording, and the forcing functions live in
+`GATE_PROTOCOL.md`. **Read it before your first gate.** Multi-turn gate state lives in
+`.context/GATE_STATE.md` (in the current project): **write it (Write tool) whenever you present a
+gate, and read it FIRST on every re-engagement** — a fresh session or a vague "continue" must
+re-present an `AWAITING` gate, never auto-approve. See GATE_PROTOCOL §2.
+
+## How reliability works here (read this once)
+
+You do **not** need to be smart to build a correct pipeline. You need to follow the process and
+let the tools be the judge:
+- **Never invent a node.** Every node you name must be cited from the node index (Phase 0). If
+  it isn't in the index, it doesn't exist — STOP and tell the user.
+- **Never invent a config field.** Fetch the node's schema before configuring it.
+- **Never claim "valid" or "ran" without the tool saying so.** `validate()` is the compiler;
+  the run status/result is the proof. Quote them; don't paraphrase.
+- **Count what you list.** Every multi-item list ends with a count line so omissions are visible.
+
+## The tool/data layer (three layers + run)
+
+Each step has the same fallback ladder — use the **first** option your environment supports:
+
+| Need | Layer | Preferred (MCP tool) | Fallback (bundled shim, uses SDK) | Offline |
+|---|---|---|---|---|
+| List/select nodes | L1 | `list_components` (names/summaries only — **wire** from the bundled index) | `tools/generate-index.py` | bundled `LAYER1_NODE_INDEX.json` |
+| One node's config schema | L2 | `describe_component` | `tools/fetch-node-schema.py <node>` | `.rocketride/schema/<node>.json` |
+| Validate the whole pipeline | L3 | `validate_pipeline` | `tools/validate-pipeline.py <file>` (calls `client.validate`) | `tools/validate-pipeline.py --static <file>` (lint only) |
+| Run it | — | `run_pipeline` → `send_data`/`run_dropper_pipe` → `monitor` | SDK `use()` → `send`/`chat` → `get_task_status` | — |
+| Understand a node/SDK/concept in depth | docs | WebFetch one `/path.md` | `tools/fetch-doc.py "<topic>"` (fetches ONE live page) | `ROCKETRIDE_DOC_MAP.md` (this skill dir) + bundled `.rocketride/docs/*` |
+
+> The exact tool names, inputs, and result shapes are frozen in `../MCP_TOOL_CONTRACT.md` —
+> use only names listed there. Every MCP result carries `ok`: **check it**; a successful tool
+> call with `ok: false` is a failure. Where the MCP tools aren't wired, the bundled shims in each
+> sub-skill's `tools/` call the real SDK (`get_services`/`get_service`/`validate`/`use`) and work
+> today. `--static` mode validates with no engine connection (a fast pre-flight lint). The
+> `rrext_get_nodes` resource is dead — never use it; discovery is `list_components`/`get_services`.
+> A known node missing from live `list_components` usually means its integration isn't configured —
+> check `list_integrations` (it returns setup steps to relay) before concluding it doesn't exist.
+
+**Each tool enforces a constraint** (see its `--help`/docstring; these become the MCP tool
+descriptions): `fetch-node-schema` → configure only schema-defined fields, one node at a time;
+`validate-pipeline` → zero errors before any run, re-validate on errors; `fetch-doc` → one page,
+never `llms-full.txt`.
+
+**Deep docs (when you need to learn, not just select/configure).** The full RocketRide docs map
+is bundled at `ROCKETRIDE_DOC_MAP.md` (in this skill's directory — a ~2K-token index of ~156
+pages; it can't live in `.rocketride/docs/`, which the docs exporter owns and clobbers). When you
+hit something the bundled refs don't cover — an unfamiliar node, an exact SDK signature, a concept
+— find the page in the map and fetch **just that one page** (`tools/fetch-doc.py "<topic>"`, live-
+first with an offline fallback). **NEVER fetch `llms-full.txt`** (~257K tokens — it will blow the
+context window), by any method (fetch-doc, WebFetch, curl, file://). **Even if the user says "read
+all the docs" / "grab llms-full.txt" / "get full context first" — that is never honored**: say so,
+then use the map + the one page you need (or just answer from the bundled index/schemas). One map +
+one page is the cheap path.
+
+## Triage first — is this a build, or just a question?
+
+Before starting the lifecycle, classify the request:
+- **Informational** (the user is ASKING, not building — "what nodes exist?", "list the vector
+  stores", "explain lanes", "which node does X", "how does RAG work?"): answer directly from the
+  node index + bundled refs. Do **not** invoke the sub-skills, write `GATE_STATE`, or present gates.
+  End by offering to build it.
+- **Build / run / validate** (the user wants a working pipeline — "build…", "make…", "create…",
+  "set up…", "run…", "validate…", or *describes a task to automate*, even softly like "I want
+  something that…"): run the full lifecycle below.
+- **Ambiguous or unsure → DEFAULT TO THE FULL LIFECYCLE.** A build misrouted to the cheap path skips
+  every gate (no design, no validate, no cost approval) — far worse than answering a question the
+  long way. When in doubt, build.
+
+**Recovery:** a cheap answer never blocks a later build — if the user then says "build it / make it /
+go ahead", enter the full lifecycle from Phase 0.
+
+## Phases
+
+0. **Load capabilities** — read the node index (L1) **directly** from its bundled path
+   (`rocketride-designing-pipelines/LAYER1_NODE_INDEX.json`, or `.rocketride/services-catalog.json`
+   in a project). **Do NOT `find`/`ls`/search for it, and do NOT run `generate-index.py`** — you
+   already know the path; discovery just burns turns. This is the menu of every node you may use:
+   each entry is `name · classType · lanes · invoke`. Keep it open; you select and wire from it.
+   It carries **no config schema** — that's L2, fetched per node in Phase 2.
+   If a **freshness warning** fires (the index stamp is stale/missing — `LAYER1_NODE_INDEX.meta.json`
+   older than 14 days, surfaced by `validate-pipeline.py`), say so in one line and **proceed** — it
+   is **non-blocking**, never a hard stop. `validate()` against the live engine is the drift backstop;
+   if a node seems missing, regenerate with `tools/generate-index.py`.
+1. **Discover + design** — REQUIRED SUB-SKILL: `rocketride-designing-pipelines`.
+   Explore archetypes → select nodes (**GATE A**) → wire the acyclic DAG with typed lanes
+   (**GATE B**). Fetch each chosen node's schema here too, so lane signatures are exact before
+   wiring — a guessed lane is the most common silent failure.
+2. **Configure + validate** — REQUIRED SUB-SKILL: `rocketride-configuring-pipelines`.
+   Per node: fetch schema → fill required fields → run the anti-pattern checklist as a gate →
+   then `validate()` the whole pipeline. On errors, fix and **re-validate** (never claim passed
+   without a clean result). **GATE C** (validation clean) → **GATE C.5** (cost approved).
+3. **Run + observe** — REQUIRED SUB-SKILL: `rocketride-running-pipelines`.
+   Submit, poll to completion, report the real result. **GATE D** only if the user chooses to
+   save to cloud / publish as an app.
+4. **If a run fails or output is wrong** — REQUIRED SUB-SKILL: `rocketride-debugging-pipelines`.
+   Read the trace, diagnose the failing node, route back to Phase 1 or 2.
+
+## The gates (binary or menu — exact wording in GATE_PROTOCOL §3)
+
+**The instant you present any gate below, use the Write tool to write `.context/GATE_STATE.md`
+(`status: AWAITING`) before ending the turn (GATE_PROTOCOL §2) — and on any re-engagement, read it
+FIRST. That on-disk line is what makes a gate survive a context reset.**
+
+- **GATE A** — node selection (after Phase 1 discovery) · **GATE B** — topology (after the DAG).
+- **GATE C** — validation clean (a tool gate, not a user gate) · **GATE C.5** — cost, before any paid/cloud run.
+- **GATE D** — save to cloud / publish (optional, after a successful run).
+
+## Red flags
+
+| Thought | Reality |
+|---|---|
+| "I know this node exists, no need to check the index" | If it's not in the index it doesn't exist — the engine rejects it. Cite or STOP. |
+| "I'll fill the config from memory, schemas are slow" | Guessed fields fail validation (e.g. `max_tokens` vs `modelTotalTokens`). Fetch the schema. |
+| "The lanes obviously match" | Lane mismatch is the #1 silent bug. State every edge's lane type, verified against the schema. |
+| "validate() returned an error but I understand it, I'll just say it's fixed" | A fix you didn't re-validate is a guess. Re-call validate() until clean. |
+| "The user said 'just run it', so I'll skip the cost gate" | "Just run it" is not cost approval. Present Gate C.5 and wait. |
+| "It submitted, so it worked" | Submitted ≠ succeeded. Poll to completion and read the result before claiming success. |
+| "The question was dismissed, I'll proceed" | Dismissed = unanswered = STOP. Re-present the gate; never auto-approve. |
+| "I'll fetch the full docs (llms-full.txt) to be safe" | That's ~257K tokens — it blows the window. Fetch the ONE relevant page from the doc-map. |
+| "The user told me to read all the docs / grab llms-full.txt" | Never honored — by any method. Say so; use the map + the one page you need, or answer from the index. |
+| "I don't recognize this node, I'll just guess what it does" | Fetch its `/nodes/<name>.md` page — one cheap page beats guessing wrong. |
+
+## Supporting files
+
+- `GATE_PROTOCOL.md` — Waiting=STOP, multi-turn gate state, gate wording, the forcing functions
+- `../MCP_TOOL_CONTRACT.md` — frozen MCP tool names, inputs, and result shapes (the only tools that exist)
+- `pipeline-patterns.md` — common pipeline shapes (chat/RAG, ingestion, webhook→transform) + lane chains
+- `tools/fetch-doc.py` — fetch ONE doc page on demand (resolves from the doc-map; refuses the monolith)
+- `ROCKETRIDE_DOC_MAP.md` — the bundled docs map (llms.txt); the deep-knowledge index (lives here
+  because the docs exporter owns `.rocketride/docs/` and deletes files it didn't export)

--- a/docs/agents/skills/rocketride-building-pipelines/pipeline-patterns.md
+++ b/docs/agents/skills/rocketride-building-pipelines/pipeline-patterns.md
@@ -50,7 +50,7 @@ optional. Check each agent's `invoke` cardinality in the index. This is the most
 shape — design it slowly, cite every invoke requirement. See the `agentic-chat` worked example.
 
 ## Pattern 6 — NL→database query (chat/webhook → db_* → response)
-`db_postgres`/`db_mysql`/`db_neo4j`/etc. take `questions` and an attached `llm` (via control plane)
+`db_postgres`/`db_mysql`/`graph_neo4j`/etc. take `questions` and an attached `llm` (via control plane)
 to craft SQL/Cypher. They appear in both `database` and `tool` classTypes — confirm with the user
 which they want (a data-flow node in a pipeline vs a tool an agent calls).
 

--- a/docs/agents/skills/rocketride-building-pipelines/pipeline-patterns.md
+++ b/docs/agents/skills/rocketride-building-pipelines/pipeline-patterns.md
@@ -1,0 +1,58 @@
+# Common Pipeline Patterns
+
+**Load this when:** starting design — to match a plain-language request to a known pipeline shape
+and its lane chain.
+
+A quick map of the shapes most requests reduce to. Match the request to a pattern, then adapt the
+matching worked example in `rocketride-designing-pipelines/examples/`. These are starting points —
+always verify node names + lanes against the live index and schemas.
+
+A pipeline is a directed **acyclic** graph of nodes joined by **typed lanes**. Exactly one
+**source** node; data flows source → … → a terminal (`response_*` for replies, a store/`db_*`
+for ingestion). Lanes are typed channels — the output lane of one node must match an input lane
+of the next, or you insert a converter.
+
+## Lane cheat-sheet (input → node → output)
+- `tags → parse → text, table, image, audio, video` (raw file bytes → extracted content)
+- `text → preprocessor_langchain → documents` (chunk for retrieval)
+- `text → question → questions` (turn raw text into askable questions; **not** after a `chat` source)
+- `documents → embedding_* → documents` (add vectors; **required before any store**)
+- `questions → embedding_* → questions` (vectorize a query)
+- `questions → <vector store> → documents, answers, questions` (retrieve)
+- `questions → llm_* → answers`
+- `image → accessibility_describe / ocr → text`
+
+## Pattern 1 — Conversational answer (chat → llm → response)
+`chat → llm_openai → response_answers`. Source is `chat` (use `client.chat()`); LLM needs a
+`profile` + apikey; terminal is `response_answers`. Simplest useful pipeline. See `simple-chat-rag`.
+
+## Pattern 2 — RAG / answer-from-my-docs (chat → embed → store(search) → llm → response)
+`chat → embedding_transformer → <store>(search) → llm_openai → response_answers`. The store node
+(qdrant/chroma/pinecone/…) runs in **search mode** on the `questions` lane and returns context.
+Use the **same embedding model** for ingestion and query. See `simple-chat-rag`.
+
+## Pattern 3 — Document ingestion (webhook → parse → preprocess → embed → store)
+`webhook → parse → preprocessor_langchain → embedding_transformer → <store>(ingest)`. Terminal is
+the **store** (ingest mode, `documents → []`) — ingestion pipelines need **no** response node.
+Feed it with `client.send_files()`. See `document-ingestion`.
+
+## Pattern 4 — Webhook transform / ETL (webhook → processor → response)
+`webhook → <processor> → response_text`. For "take this input, do X, return result" with no
+retrieval or chat. Feed with `client.send()`. Compose from the cheat-sheet with a real processor
+(e.g. `summarization`, `extract_data`, `anonymize_text`); LLM-backed processors attach their llm
+via the control plane.
+
+## Pattern 5 — Agentic (chat → agent ← llm + tools + memory via control-plane)
+`chat → agent_rocketride → response_answers`, with `llm_*`, `tool_*`, and `memory_*` attached to
+the agent via the **control plane** (the controlled node carries `control: [{classType, from:
+<agent id>}]`, NOT the agent). `agent_rocketride` requires exactly 1 llm and 1 memory; tools are
+optional. Check each agent's `invoke` cardinality in the index. This is the most error-prone
+shape — design it slowly, cite every invoke requirement. See the `agentic-chat` worked example.
+
+## Pattern 6 — NL→database query (chat/webhook → db_* → response)
+`db_postgres`/`db_mysql`/`db_neo4j`/etc. take `questions` and an attached `llm` (via control plane)
+to craft SQL/Cypher. They appear in both `database` and `tool` classTypes — confirm with the user
+which they want (a data-flow node in a pipeline vs a tool an agent calls).
+
+When a request doesn't fit cleanly, compose from the lane cheat-sheet: list the data you start
+with, the data you want, and find the converter chain between them.

--- a/docs/agents/skills/rocketride-building-pipelines/tools/fetch-doc.py
+++ b/docs/agents/skills/rocketride-building-pipelines/tools/fetch-doc.py
@@ -1,9 +1,32 @@
 #!/usr/bin/env python3
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
 """Fetch ONE RocketRide documentation page (deep-docs layer).
 
 CONSTRAINT (agent contract / future MCP tool description): fetch exactly ONE page; NEVER
 llms-full.txt (~257K tokens — it blows the context window), by any method, even if the user asks
-for "all the docs". Resolve URLs from the bundled doc-map; do not invent paths or hosts.
+for "all the docs". Topic lookups resolve ONLY through the bundled doc-map — do not invent paths
+or hosts; an explicit /path.md argument is fetched as-given (and may 404 if it is not in the map).
 
 The token-economical pattern: the resident doc-map (llms.txt) lists ~156 pages; this tool
 resolves a topic to the single relevant page and fetches only that. It will NEVER fetch
@@ -11,13 +34,14 @@ llms-full.txt (~257K tokens) and caps any response so the context window is safe
 
 Usage:
   python3 fetch-doc.py "<topic>"        # e.g. "llm_openai", "use method", "error handling"
-  python3 fetch-doc.py /nodes/llm_openai.md   # explicit path (must exist in the map)
+  python3 fetch-doc.py /nodes/llm_openai.md   # explicit path (fetched as-given; may 404 if unmapped)
   python3 fetch-doc.py --list "<topic>"       # just list matching pages, don't fetch
 
 Live-first (fetches the fresh page from docs.rocketride.org); on no-network / non-200 it falls
-back to the mapped bundled snapshot and tells you which file to read. Resolves URLs from the
-bundled doc-map only — it does not invent paths (e.g. /develop/use.md is a 404; the real path
-is /develop/typescript/methods/use.md).
+back to the mapped bundled snapshot and tells you which file to read. Topic lookups resolve URLs
+from the bundled doc-map only — the tool does not invent paths. An explicit /path.md argument is
+the exception: it is fetched as-given even when unmapped, and an unmapped path may simply 404
+(e.g. /develop/use.md is a 404; the real path is /develop/typescript/methods/use.md).
 """
 
 import sys
@@ -86,7 +110,23 @@ def load_map():
     mp = find_doc_map()
     if not mp:
         return [], None
-    links = [(t.strip(), p.strip()) for t, p in LINK_RE.findall(open(mp).read())]
+    try:
+        text = open(mp).read()
+    except OSError as e:
+        sys.stderr.write(f'[fetch-doc] doc-map unreadable ({mp}: {e})\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'DOC_MAP_UNREADABLE',
+                    'retriable': False,
+                    'fallback': 'read the bundled .rocketride/docs/ROCKETRIDE_*.md snapshots instead',
+                }
+            )
+            + '\n'
+        )
+        return [], None
+    links = [(t.strip(), p.strip()) for t, p in LINK_RE.findall(text)]
     return links, mp
 
 
@@ -243,7 +283,22 @@ def main():
         fb = offline_fallback(path, docs_dir)
         if fb:
             sys.stderr.write(f'[fetch-doc] OFFLINE FALLBACK — read this bundled file: {fb}\n')
-            print(open(fb).read())
+            try:
+                print(open(fb).read())
+            except OSError as read_err:
+                sys.stderr.write(f'[fetch-doc] bundled fallback unreadable ({fb}: {read_err})\n')
+                sys.stderr.write(
+                    'ERROR_JSON: '
+                    + json.dumps(
+                        {
+                            'code': 'FALLBACK_UNREADABLE',
+                            'retriable': False,
+                            'fallback': 'read the doc-map / the bundled .rocketride/docs/ROCKETRIDE_*.md directly',
+                        }
+                    )
+                    + '\n'
+                )
+                sys.exit(1)
         else:
             sys.stderr.write(
                 f'[fetch-doc] no bundled fallback for {path}. Read the doc-map / '

--- a/docs/agents/skills/rocketride-building-pipelines/tools/fetch-doc.py
+++ b/docs/agents/skills/rocketride-building-pipelines/tools/fetch-doc.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Fetch ONE RocketRide documentation page (deep-docs layer).
+
+CONSTRAINT (agent contract / future MCP tool description): fetch exactly ONE page; NEVER
+llms-full.txt (~257K tokens — it blows the context window), by any method, even if the user asks
+for "all the docs". Resolve URLs from the bundled doc-map; do not invent paths or hosts.
+
+The token-economical pattern: the resident doc-map (llms.txt) lists ~156 pages; this tool
+resolves a topic to the single relevant page and fetches only that. It will NEVER fetch
+llms-full.txt (~257K tokens) and caps any response so the context window is safe.
+
+Usage:
+  python3 fetch-doc.py "<topic>"        # e.g. "llm_openai", "use method", "error handling"
+  python3 fetch-doc.py /nodes/llm_openai.md   # explicit path (must exist in the map)
+  python3 fetch-doc.py --list "<topic>"       # just list matching pages, don't fetch
+
+Live-first (fetches the fresh page from docs.rocketride.org); on no-network / non-200 it falls
+back to the mapped bundled snapshot and tells you which file to read. Resolves URLs from the
+bundled doc-map only — it does not invent paths (e.g. /develop/use.md is a 404; the real path
+is /develop/typescript/methods/use.md).
+"""
+
+import sys
+import os
+import re
+import json
+import urllib.request
+import urllib.error
+
+BASE = 'https://docs.rocketride.org'
+SIZE_CAP = 80_000  # bytes; a single doc page is ~1.5-8KB. Truncate anything larger.
+TIMEOUT = 20
+
+LINK_RE = re.compile(r'\-\s*\[(.+?)\]\((/[^)]+\.md)\)')
+
+
+def find_doc_map():
+    """Locate ROCKETRIDE_DOC_MAP.md: the skill dir first (its canonical home — the docs
+    exporter owns .rocketride/docs/ and deletes files it didn't export), then the legacy
+    .rocketride/docs/ locations relative to this script, else walk up from cwd.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    for cand in (
+        os.path.normpath(os.path.join(here, '..', 'ROCKETRIDE_DOC_MAP.md')),
+        os.path.normpath(os.path.join(here, '..', '..', '..', '.rocketride', 'docs', 'ROCKETRIDE_DOC_MAP.md')),
+    ):
+        if os.path.isfile(cand):
+            return cand
+    d = os.getcwd()
+    for _ in range(8):
+        c = os.path.join(d, '.rocketride', 'docs', 'ROCKETRIDE_DOC_MAP.md')
+        if os.path.isfile(c):
+            return c
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return None
+
+
+def bundled_docs_dir(map_path):
+    """The .rocketride/docs snapshot dir (pages/, ../schema, ROCKETRIDE_*.md). The map may
+    live in the skill dir instead, so resolve this independently of the map's location.
+    """
+    if map_path:
+        d = os.path.dirname(map_path)
+        if os.path.basename(os.path.dirname(d)) == '.rocketride':
+            return d
+    here = os.path.dirname(os.path.abspath(__file__))
+    cand = os.path.normpath(os.path.join(here, '..', '..', '..', '.rocketride', 'docs'))
+    if os.path.isdir(cand):
+        return cand
+    d = os.getcwd()
+    for _ in range(8):
+        c = os.path.join(d, '.rocketride', 'docs')
+        if os.path.isdir(c):
+            return c
+        parent = os.path.dirname(d)
+        if parent == d:
+            break
+        d = parent
+    return None
+
+
+def load_map():
+    mp = find_doc_map()
+    if not mp:
+        return [], None
+    links = [(t.strip(), p.strip()) for t, p in LINK_RE.findall(open(mp).read())]
+    return links, mp
+
+
+def resolve(arg, links):
+    """Return (title, path) best match, or a list of candidates if ambiguous, or None."""
+    arg = arg.strip()
+    if arg.startswith('/') and arg.endswith('.md'):
+        for t, p in links:
+            if p == arg:
+                return (t, p)
+        return ('(explicit)', arg)  # allow, but it may 404
+    # keyword match against title + path basename
+    terms = [w for w in re.split(r'[^a-z0-9]+', arg.lower()) if w]
+    scored = []
+    for t, p in links:
+        hay = (t + ' ' + p).lower()
+        base = os.path.basename(p)[:-3].lower()
+        score = sum(1 for w in terms if w in hay)
+        if base in arg.lower().replace(' ', '_') or arg.lower().replace(' ', '_') in base:
+            score += 2
+        if score:
+            scored.append((score, t, p))
+    if not scored:
+        return None
+    scored.sort(key=lambda x: -x[0])
+    top = scored[0][0]
+    best = [(t, p) for s, t, p in scored if s == top]
+    return best[0] if len(best) == 1 else [('AMBIGUOUS', None)] + [(t, p) for s, t, p in scored[:6]]
+
+
+def offline_fallback(path, docs_dir):
+    """Map a doc path to the bundled file the agent should read instead, in order:
+    (1) the refreshed verbatim page under pages/, (2) a node's bundled schema,
+    (3) a legacy condensed snapshot.
+    """
+    if not docs_dir:
+        return None
+    # 1. refreshed bundled page (fresh snapshot, structure preserved)
+    page = os.path.join(docs_dir, 'pages', path.lstrip('/'))
+    if os.path.isfile(page):
+        return page
+    # 2. node page -> the bundled config schema
+    if path.startswith('/nodes/'):
+        node = os.path.basename(path)[:-3].split('/')[-1]
+        schema = os.path.normpath(os.path.join(docs_dir, '..', 'schema', node + '.json'))
+        if os.path.isfile(schema):
+            return schema
+    # 3. legacy condensed snapshots
+    table = {
+        '/develop/python': 'ROCKETRIDE_python_API.md',
+        '/develop/typescript': 'ROCKETRIDE_typescript_API.md',
+        '/develop': 'ROCKETRIDE_python_API.md',
+        'best-practices': 'ROCKETRIDE_COMMON_MISTAKES.md',
+        'error-handling': 'ROCKETRIDE_COMMON_MISTAKES.md',
+        'observability': 'ROCKETRIDE_OBSERVABILITY.md',
+        '/concepts': 'ROCKETRIDE_PIPELINE_RULES.md',
+        'pipeline-reference': 'ROCKETRIDE_PIPELINE_RULES.md',
+        '/quickstart': 'ROCKETRIDE_QUICKSTART.md',
+        '/examples': 'ROCKETRIDE_QUICKSTART.md',
+    }
+    for key, fname in table.items():
+        if key in path:
+            c = os.path.join(docs_dir, fname)
+            if os.path.isfile(c):
+                return c
+    return None
+
+
+def fetch(path):
+    url = BASE + path
+    req = urllib.request.Request(url, headers={'User-Agent': 'rocketride-skills-fetch-doc/1.0'})
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as r:
+        if r.status != 200:
+            raise urllib.error.HTTPError(url, r.status, 'non-200', r.headers, None)
+        data = r.read(SIZE_CAP + 1)
+    truncated = len(data) > SIZE_CAP
+    return data[:SIZE_CAP].decode('utf-8', 'replace'), truncated, url
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    list_only = '--list' in sys.argv
+    if not args:
+        sys.stderr.write(__doc__)
+        sys.exit(2)
+    arg = ' '.join(args)
+
+    # Hard guard: never the monolith.
+    if 'llms-full' in arg.lower():
+        sys.stderr.write(
+            '[fetch-doc] REFUSED: llms-full.txt is ~257K tokens and will blow the '
+            'context window. Fetch the single relevant page instead (see the doc-map).\n'
+        )
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'MONOLITH_REFUSED',
+                    'retriable': False,
+                    'fallback': 'find the ONE relevant page in the doc-map and fetch only that',
+                }
+            )
+            + '\n'
+        )
+        sys.exit(2)
+
+    links, map_path = load_map()
+    docs_dir = bundled_docs_dir(map_path)
+    if not links:
+        sys.stderr.write(
+            '[fetch-doc] doc-map not found (ROCKETRIDE_DOC_MAP.md in the '
+            'rocketride-building-pipelines skill dir, or .rocketride/docs/). '
+            'Read the bundled .rocketride/docs/ROCKETRIDE_*.md snapshots instead.\n'
+        )
+        sys.exit(1)
+
+    res = resolve(arg, links)
+    if res is None:
+        sys.stderr.write(f'[fetch-doc] no page matches {arg!r}. Browse the map: {map_path}\n')
+        sys.exit(1)
+    if isinstance(res, list):  # ambiguous
+        sys.stderr.write(f'[fetch-doc] {arg!r} is ambiguous — pick one and pass its /path.md:\n')
+        for t, p in res[1:]:
+            sys.stderr.write(f'    {p}   ({t})\n')
+        sys.exit(1)
+
+    title, path = res
+    if list_only:
+        print(f'{path}   ({title})')
+        return
+
+    try:
+        body, truncated, url = fetch(path)
+        sys.stderr.write(f'[fetch-doc] source: {url}  ({title})\n')
+        print(body)
+        if truncated:
+            sys.stderr.write(
+                f'\n[fetch-doc] NOTE: page exceeded {SIZE_CAP} bytes and was truncated. '
+                f'Read the rest at {url} if needed.\n'
+            )
+    except Exception as e:
+        sys.stderr.write(f'[fetch-doc] live fetch failed ({e}); falling back to bundled snapshot.\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'PAGE_FETCH_FAILED',
+                    'retriable': False,
+                    'fallback': 'use the bundled snapshot below (do NOT retry the URL or fetch the monolith)',
+                }
+            )
+            + '\n'
+        )
+        fb = offline_fallback(path, docs_dir)
+        if fb:
+            sys.stderr.write(f'[fetch-doc] OFFLINE FALLBACK — read this bundled file: {fb}\n')
+            print(open(fb).read())
+        else:
+            sys.stderr.write(
+                f'[fetch-doc] no bundled fallback for {path}. Read the doc-map / '
+                f'the bundled .rocketride/docs/ROCKETRIDE_*.md.\n'
+            )
+            sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/agents/skills/rocketride-building-pipelines/tools/generate-index.py
+++ b/docs/agents/skills/rocketride-building-pipelines/tools/generate-index.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+"""Regenerate the Layer 1 node index from a live engine.
+
+Rebuilds LAYER1_NODE_INDEX.json (the compact node catalog the designing/configuring
+skills select nodes from) and LAYER1_NODE_INDEX.meta.json (the freshness stamp that
+validate-pipeline.py's staleness check reads) from the engine's live service catalog
+(client.get_services() via the RocketRide SDK).
+
+Degrees of freedom: NONE beyond the flags below. Run this command exactly as shown;
+do not hand-roll the catalog fetch or edit the index files by hand — this tool owns
+their format.
+
+Requires a reachable engine: the SDK reads ROCKETRIDE_URI / ROCKETRIDE_APIKEY from the
+environment or a .env file. If no engine is reachable the bundled index stays as-is and
+remains usable — it is just not refreshed.
+
+Usage:
+  python3 generate-index.py                     # refresh the bundled index in the
+                                                # rocketride-designing-pipelines skill dir
+  python3 generate-index.py --dry-run           # connect + report counts, write nothing
+  python3 generate-index.py --output-dir DIR    # write the two files elsewhere
+"""
+
+import sys
+import os
+import json
+import asyncio
+import tempfile
+from datetime import datetime, timezone
+
+INDEX_NAME = 'LAYER1_NODE_INDEX.json'
+META_NAME = 'LAYER1_NODE_INDEX.meta.json'
+
+
+def default_output_dir():
+    """The designing-pipelines skill dir, resolved relative to this script."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    return os.path.normpath(os.path.join(here, '..', '..', 'rocketride-designing-pipelines'))
+
+
+def to_index_entry(name, summary):
+    """Reduce a service summary to the compact L1 index entry format:
+    name + classType + lanes, plus invoke slot cardinalities when the node has them.
+    """
+    entry = {
+        'name': name,
+        'classType': summary.get('classType') or [],
+        'lanes': summary.get('lanes') or {},
+    }
+    invoke = summary.get('invoke')
+    if invoke:
+        slots = {}
+        for slot, spec in invoke.items():
+            spec = spec if isinstance(spec, dict) else {}
+            slots[slot] = {k: spec[k] for k in ('min', 'max') if k in spec}
+        entry['invoke'] = slots
+    return entry
+
+
+def atomic_write(path, obj):
+    """Atomically write JSON so a concurrent reader never sees a truncated file."""
+    d = os.path.dirname(path)
+    fd, tmp = tempfile.mkstemp(dir=d, suffix='.tmp')
+    try:
+        with os.fdopen(fd, 'w') as f:
+            json.dump(obj, f, indent=2)
+            f.write('\n')
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+async def from_engine():
+    """Fetch the live service catalog; returns the get_services() response or None."""
+    try:
+        from rocketride import RocketRideClient  # type: ignore
+    except Exception:
+        sys.stderr.write('[generate-index] RocketRide SDK not importable; cannot refresh the index\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'ENGINE_UNAVAILABLE',
+                    'retriable': False,
+                    'fallback': 'the bundled LAYER1_NODE_INDEX.json remains usable as-is; install the SDK + .env to refresh it',
+                }
+            )
+            + '\n'
+        )
+        return None
+    try:
+        async with RocketRideClient() as client:  # reads uri/auth from .env
+            return await client.get_services()
+    except Exception as e:
+        sys.stderr.write(f'[generate-index] engine unavailable ({e}); cannot refresh the index\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'ENGINE_UNAVAILABLE',
+                    'retriable': False,
+                    'fallback': 'the bundled LAYER1_NODE_INDEX.json remains usable as-is; configure ROCKETRIDE_URI/ROCKETRIDE_APIKEY (.env) and retry',
+                }
+            )
+            + '\n'
+        )
+        return None
+
+
+def main():
+    args = sys.argv[1:]
+    dry_run = '--dry-run' in args
+    out_dir = default_output_dir()
+    if '--output-dir' in args:
+        i = args.index('--output-dir')
+        if i + 1 >= len(args):
+            sys.stderr.write('[generate-index] --output-dir needs a directory argument\n')
+            sys.exit(2)
+        out_dir = args[i + 1]
+
+    resp = asyncio.run(from_engine())
+    if resp is None:
+        sys.exit(1)
+
+    services = resp.get('services') or {}
+    if not services:
+        sys.stderr.write(
+            '[generate-index] engine returned an empty service catalog; refusing to write an empty index\n'
+        )
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'EMPTY_CATALOG',
+                    'retriable': True,
+                    'fallback': 'the bundled LAYER1_NODE_INDEX.json remains usable as-is; check the engine and retry',
+                }
+            )
+            + '\n'
+        )
+        sys.exit(1)
+
+    index = sorted(
+        (to_index_entry(name, summary or {}) for name, summary in services.items()),
+        key=lambda e: e['name'],
+    )
+    meta = {
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'node_count': len(index),
+        'source': 'engine (get_services)',
+    }
+    if resp.get('version'):
+        meta['engine_version'] = resp['version']
+
+    if dry_run:
+        print(f'[generate-index] DRY RUN: {len(index)} nodes from the engine; would write:')
+        print(f'  {os.path.join(out_dir, INDEX_NAME)}')
+        print(f'  {os.path.join(out_dir, META_NAME)}')
+        print(f'  meta: {json.dumps(meta)}')
+        return
+
+    if not os.path.isdir(out_dir):
+        sys.stderr.write(f'[generate-index] output dir not found: {out_dir}\n')
+        sys.exit(2)
+    atomic_write(os.path.join(out_dir, INDEX_NAME), index)
+    atomic_write(os.path.join(out_dir, META_NAME), meta)
+    print(f'[generate-index] wrote {len(index)} nodes to {os.path.join(out_dir, INDEX_NAME)}')
+    print(f'[generate-index] stamped {os.path.join(out_dir, META_NAME)}: {json.dumps(meta)}')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/agents/skills/rocketride-configuring-pipelines/PIPELINE_ANTIPATTERNS.md
+++ b/docs/agents/skills/rocketride-configuring-pipelines/PIPELINE_ANTIPATTERNS.md
@@ -1,0 +1,71 @@
+# Pipeline Anti-Patterns & Checklist
+
+**Load this when:** configuring a node or assembling the `.pipe` — run the 9-point checklist as a
+gate before `validate()`.
+
+The real, observed mistakes when building RocketRide pipelines (condensed from the RocketRide
+"Common Mistakes" reference). Treat the checklist at the bottom as a **gate**, not a reading.
+
+## The 9-point Pipeline Checklist (run per node / per pipeline, state yes/no)
+1. **`.pipe` extension** — the pipeline file ends in `.pipe`, not `.json`. (RocketRide only loads
+   `.pipe`.)
+2. **`components` first; meta last** *(editor convention)* — keep `components` as the first key;
+   `project_id`, `viewport`, `version` at the bottom. The schema marks key order optional, but the
+   visual editor is happiest this way. (`--static` flags this as a warning, not an error.)
+3. **`project_id`, if present, is a literal GUID** *(optional, editor convention)* — never a
+   variable (`"${ROCKETRIDE_PROJECT_ID}"` is read before env substitution). The current schema marks
+   `project_id` optional; include a literal GUID when authoring for the editor.
+4. **`source` matches a real component id** (if you include the optional `source` field).
+5. **All component ids unique.**
+6. **Every non-source node has an `input` array** — `[{lane, from}]`. Sources have none.
+7. **Lane types match across every edge** — output lane type of `from` = input lane type here, or
+   a converter sits between them.
+8. **Acyclic, no orphans** — no loops; every node reachable from the source.
+9. **Secrets via `${ENV_VAR}` substitution** — never literal API keys. The engine expands any
+   `${VAR}` from the environment at startup (e.g. `${OPENAI_API_KEY}`); a `ROCKETRIDE_` prefix is
+   **not** required (older docs claimed it was — that's outdated).
+
+## Configuration anti-patterns
+- **Empty source config.** Source nodes need the full block, not `{}`:
+  `{ "hideForm": true, "mode": "Source", "parameters": {}, "type": "<provider>" }` (use the
+  provider name as `type`: `"webhook"`, `"chat"`, `"dropper"`, …). `memory_internal` needs
+  `{ "type": "memory_internal" }`.
+- **Missing required LLM config.** LLM nodes need a profile + apikey:
+  `{ "profile": "openai-5", "openai-5": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }, "parameters": {} }`.
+  Read the schema's `Pipe.schema.dependencies.profile.oneOf` for the available profiles.
+- **Guessing field names.** Fetch the schema; e.g. LLM token limit is `modelTotalTokens`, not
+  `max_tokens`. Profile keys are provider-specific.
+- **Ignoring conditional constraints.** Schema prose like "if `batch_size` set, `max_batch_wait_ms`
+  required" is binding — required fields are not the whole story.
+
+## Wiring anti-patterns
+- **Mismatched lane types.** Insert a converter (`tags → parse → text`, `text → preprocessor →
+  documents`, `documents → embedding → documents`, `questions → llm → answers`).
+- **Store without embedding.** Vector stores need embedded input; embed first, same model for
+  ingest + query.
+- **Agent control plane backwards.** The `control` array lives on the controlled node
+  (`{classType, from: <agent>}`), not on the agent. (See PIPELINE_RULES_SUMMARY.)
+- **Wrong source for use case.** `chat` source → conversational (`client.chat()`); `webhook`/
+  `dropper` → data/files (`client.send()` / `client.send_files()`). Don't add a `question` node
+  after a `chat` source — `chat` already emits `questions`.
+- **One response node per agent.** In multi-agent pipelines use a single `response_answers` with
+  one `input` entry per agent, not one response node each.
+
+## Response-key anti-pattern
+- **Customizing `laneName`** changes the response JSON key and breaks client code. Defaults:
+  `answers`→`answers`, `text`→`text`, `documents`→`documents`, `questions`→`questions`. When in
+  doubt, don't customize — use the lane-specific node (`response_answers`, `response_text`, …).
+
+## Common build-time errors (TL;DR — full catalog elsewhere)
+The complete error catalog (build-time **and** runtime, with owning phase) is the **single source of
+truth** in `../rocketride-debugging-pipelines/ERROR_TABLE.md`. The three you'll most likely hit while
+configuring:
+| Error | Likely cause | Fix |
+|---|---|---|
+| `Component not found` | bad/misspelled `provider` | check the node index (cite it) |
+| `Lane not supported` | wrong lane type on an edge | match lanes / add a converter |
+| `project_id must be a GUID` | variable in `project_id` | use a literal GUID |
+
+> Note: the "Common Mistakes" doc also numbers SDK/runtime mistakes (event-loop blocking,
+> `use_existing`, resource cleanup, `ROCKETRIDE_` prefix). Those belong to running the pipeline —
+> see `rocketride-running-pipelines`. The items above are the build-time ones.

--- a/docs/agents/skills/rocketride-configuring-pipelines/PIPELINE_ANTIPATTERNS.md
+++ b/docs/agents/skills/rocketride-configuring-pipelines/PIPELINE_ANTIPATTERNS.md
@@ -21,9 +21,9 @@ The real, observed mistakes when building RocketRide pipelines (condensed from t
 7. **Lane types match across every edge** — output lane type of `from` = input lane type here, or
    a converter sits between them.
 8. **Acyclic, no orphans** — no loops; every node reachable from the source.
-9. **Secrets via `${ENV_VAR}` substitution** — never literal API keys. The engine expands any
-   `${VAR}` from the environment at startup (e.g. `${OPENAI_API_KEY}`); a `ROCKETRIDE_` prefix is
-   **not** required (older docs claimed it was — that's outdated).
+9. **Secrets via `${ROCKETRIDE_*}` substitution** — never literal API keys. The task server only
+   resolves env vars whose names start with `ROCKETRIDE_` (e.g. `${ROCKETRIDE_OPENAI_KEY}`); any
+   non-prefixed `${VAR}` is replaced with `<REDACTED>`.
 
 ## Configuration anti-patterns
 - **Empty source config.** Source nodes need the full block, not `{}`:
@@ -62,9 +62,9 @@ truth** in `../rocketride-debugging-pipelines/ERROR_TABLE.md`. The three you'll 
 configuring:
 | Error | Likely cause | Fix |
 |---|---|---|
-| `Component not found` | bad/misspelled `provider` | check the node index (cite it) |
-| `Lane not supported` | wrong lane type on an edge | match lanes / add a converter |
-| `project_id must be a GUID` | variable in `project_id` | use a literal GUID |
+| `The service <provider> was not found` | bad/misspelled `provider` | check the node index (cite it) |
+| validate error contains `input has unknown lane` | wrong lane type on an edge | match lanes / add a converter |
+| validate/run failure mentioning `project_id` | variable in `project_id` | use a literal GUID |
 
 > Note: the "Common Mistakes" doc also numbers SDK/runtime mistakes (event-loop blocking,
 > `use_existing`, resource cleanup, `ROCKETRIDE_` prefix). Those belong to running the pipeline —

--- a/docs/agents/skills/rocketride-configuring-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-configuring-pipelines/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: rocketride-configuring-pipelines
+description: Use when filling in a RocketRide pipeline's node configuration and validating it — fetching each node's schema, setting required fields, running the anti-pattern checklist, and validating against the engine before a run.
+---
+
+# Configuring & Validating RocketRide Pipelines
+
+Takes an approved topology (from `rocketride-designing-pipelines`) to a **validated**
+`pipeline.pipe` ready to run. Reliability comes from tools and a checklist, not cleverness:
+fetch schema → fill only real fields → checklist gate → `validate()` → re-validate until clean.
+Gate rules + forcing functions: `../rocketride-building-pipelines/GATE_PROTOCOL.md`.
+
+## Step 1 — Configure each node (schema-driven, one at a time)
+
+For every node in the approved topology, in order:
+
+1. **Fetch the schema** (L2): `describe_component` / `tools/fetch-node-schema.py <node>` /
+   `.rocketride/schema/<node>.json`. Never configure from memory. (Forcing function 5.) Fetch **one
+   node at a time** — never bulk-load every schema (FF#17). If you already fetched this node's schema
+   while designing (Phase 1b) this session, reuse it with `--cache-ok` (serves the cached copy with
+   no reconnect — still schema-grounded, just not re-fetched); a full re-fetch only on a cache miss.
+2. **State what the schema says** before filling: the **required** fields, any **conditional**
+   rules in prose ("if `batch_size` set, `max_batch_wait_ms` is required"), and the profile shape
+   for LLM/embedding/store nodes. (Forcing function 10.)
+3. **Fill only fields the schema defines.** Use `${ROCKETRIDE_*}` env references for secrets —
+   never literal keys. Secret **values** never travel through tools or the model: over MCP,
+   credentials are configured out-of-band — `list_integrations` reports per-integration readiness
+   and (with a `name`) returns concrete setup steps to relay to the user. LLM/embedding/store nodes use a profile block:
+   ```json
+   "config": { "profile": "openai-5", "openai-5": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }, "parameters": {} }
+   ```
+   Source nodes need the full source config, not `{}`:
+   `{ "hideForm": true, "mode": "Source", "parameters": {}, "type": "<provider>" }`.
+
+   The block above is the `<Good>` shape. The `<Bad>` shape — guessed from memory — fails validation
+   and leaks a key:
+   ```json
+   "config": { "model": "gpt-5", "apikey": "sk-...", "max_tokens": 4096 }
+   ```
+   Three bugs in one line: a **literal key** (must be `${ROCKETRIDE_*}`), **no `profile` wrapper**,
+   and **`max_tokens` is not a real field** (the schema calls it `modelTotalTokens`). Fetch the
+   schema, then copy the `<Good>` shape — never type config from memory.
+4. **Run the 9-point checklist as a gate** (full list in `PIPELINE_ANTIPATTERNS.md`). State each
+   item yes/no for this node before moving on — do not skip and claim "applied":
+   > Node `<id>`: 1 ext✓ 2 components-order✓ 3 literal-guid✓ 4 source-match✓ 5 unique-id✓
+   > 6 input-array✓ 7 lane-types✓ 8 acyclic/no-orphan✓ 9 ROCKETRIDE_ env✓
+
+## Step 2 — Assemble & validate (→ Gate C)
+
+1. **Assemble** the `.pipe`: `components` first (each with `id`, `provider`, `config`, and
+   `input` for non-source nodes; `control` on controlled nodes), then a **literal-GUID**
+   `project_id`, `viewport`, `version: 1`. File extension **`.pipe`**.
+2. **validate()** the whole pipeline (L3): `validate_pipeline` tool / `tools/validate-pipeline.py <file>`
+   (calls `client.validate()` → `{errors, warnings}`) / `--static` lint if no engine.
+3. **The re-validation loop** (Forcing function 11): if `errors` is non-empty, show them
+   **verbatim**, fix the offending node (loop back to Step 1 for that node — don't restart
+   design), then **call validate() again**. Repeat until `errors == []`. Never write "validation
+   passed" without a clean result in hand. Address warnings or explain why each is acceptable.
+4. **Gate C** is a tool gate, not a user gate — it is "passed" only when validate() returns zero
+   errors. Quote it: `validate(): 0 errors, K warnings`.
+
+## Step 3 — Cost approval (→ Gate C.5)
+
+Before handing off to run, estimate cost and gate it (GATE_PROTOCOL §5):
+- Count paid/LLM nodes × expected calls × rough token cost; note if it runs on cloud compute
+  (billed to the wallet) vs the user's own dev keys locally.
+- **Gate C.5:**
+  > This run will cost ≈ $X (<basis>). Approve this run? (yes / no)
+  Then **Write `.context/GATE_STATE.md`** = `GATE C.5 | presented | status: AWAITING` (§2), and STOP
+  and wait. "Just run it" earlier is not cost approval. A tiny local test on the user's own key can
+  be a one-line confirm; cloud/large runs always gate.
+
+Hand the validated `.pipe` to `rocketride-running-pipelines`.
+
+## Red flags
+
+| Thought | Reality |
+|---|---|
+| "I'll set apikey/model from what I remember" | Fetch the schema; field names differ per provider (`modelTotalTokens`, profile keys). |
+| "Required fields only; prose constraints are optional" | Conditional rules ("if X then Y") are required too — state and satisfy them. |
+| "I'll run the checklist once at the end" | Per node, as a gate, stated yes/no. A checklist skimmed once is a checklist skipped. |
+| "validate() erred but I fixed it in the text" | A fix you didn't re-validate is a guess. Re-call validate() until errors == []. |
+| "Zero errors but warnings — ship it" | Read each warning; fix or justify. Warnings are often the real bug. |
+| "Hardcode the key just for the test" | Never. `${ROCKETRIDE_*}` always; literal keys leak and break substitution. |
+| "Skip the cost gate, it's a small run" | Present Gate C.5 regardless; let the user decide. |
+
+## Supporting files
+
+- `PIPELINE_ANTIPATTERNS.md` — the real common mistakes, the 9-point checklist, the error table
+- `tools/fetch-node-schema.py` — `get_service(name)` (live) or read `.rocketride/schema/<name>.json`
+- `tools/validate-pipeline.py` — `client.validate(pipeline)`; `--static` = local lint, no engine
+- **deep docs** — for provider-specific config nuance/profiles the schema alone doesn't explain,
+  fetch the node's doc page: `../rocketride-building-pipelines/tools/fetch-doc.py "<node-name>"`
+  (→ `/nodes/<name>.md`). The schema gives exact fields; the page gives the why. Never `llms-full.txt`.

--- a/docs/agents/skills/rocketride-configuring-pipelines/tools/fetch-node-schema.py
+++ b/docs/agents/skills/rocketride-configuring-pipelines/tools/fetch-node-schema.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""Fetch one node's config schema (Layer 2).
+
+CONSTRAINT (agent contract / future MCP tool description): configure a node using ONLY the fields
+this schema defines — never invent field names (e.g. it is `modelTotalTokens`, not `max_tokens`).
+Fetch ONE node at a time; never bulk-load the schema catalog (FF#17).
+
+Degrees of freedom: NONE. Run this command exactly as shown — one node name, optionally --cache-ok.
+Do not add other flags, pipe it through transforms, or hand-roll the schema fetch in your own code;
+the agent contract IS this one command.
+
+Order of preference:
+  1. --cache-ok + a warm cache → serve .rocketride/schema/<name>.json with NO reconnect (fast path)
+  2. Live engine via the RocketRide SDK:  client.get_service(<name>) → write-through to the cache
+  3. The cached catalog file:             .rocketride/schema/<name>.json
+
+Usage:
+  python3 fetch-node-schema.py <node_name>              # engine-first (freshest); caches the result
+  python3 fetch-node-schema.py --cache-ok <node_name>   # reuse a warm cache, skip the reconnect (T1)
+
+Prints the service/schema definition as JSON. The agent reads `required` fields, the
+`Pipe.schema` (incl. dependencies.profile.oneOf for LLM/embedding/store profiles), and any
+conditional constraints before configuring the node. Never configure a node without this.
+"""
+
+import sys
+import os
+import json
+import asyncio
+
+
+def from_files(name):
+    """Walk up from cwd looking for .rocketride/schema/<name>.json."""
+    here = os.getcwd()
+    for _ in range(8):
+        cand = os.path.join(here, '.rocketride', 'schema', f'{name}.json')
+        if os.path.isfile(cand):
+            return json.load(open(cand))
+        parent = os.path.dirname(here)
+        if parent == here:
+            break
+        here = parent
+    return None
+
+
+def _schema_dir():
+    """Walk up from cwd for an existing .rocketride/schema dir (where the cache lives)."""
+    here = os.getcwd()
+    for _ in range(8):
+        d = os.path.join(here, '.rocketride', 'schema')
+        if os.path.isdir(d):
+            return d
+        parent = os.path.dirname(here)
+        if parent == here:
+            break
+        here = parent
+    return None
+
+
+def write_through(name, result):
+    """Atomically cache a live schema so a later --cache-ok serves it with no reconnect (T1)."""
+    d = _schema_dir()
+    if not d:
+        return False
+    try:
+        import tempfile
+
+        fd, tmp = tempfile.mkstemp(dir=d, suffix='.tmp')
+        with os.fdopen(fd, 'w') as f:
+            json.dump(result, f, indent=2)
+        os.replace(tmp, os.path.join(d, f'{name}.json'))
+        return True
+    except Exception:
+        return False
+
+
+async def from_engine(name):
+    try:
+        from rocketride import RocketRideClient  # type: ignore
+    except Exception:
+        sys.stderr.write('[fetch-node-schema] RocketRide SDK not importable; falling back to files\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'ENGINE_UNAVAILABLE',
+                    'retriable': False,
+                    'fallback': 'reading the bundled .rocketride/schema/<name>.json (do NOT retry the engine)',
+                }
+            )
+            + '\n'
+        )
+        return None
+    try:
+        async with RocketRideClient() as client:  # reads uri/auth from .env
+            return await client.get_service(name)
+    except Exception as e:
+        sys.stderr.write(f'[fetch-node-schema] engine unavailable ({e}); falling back to files\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'ENGINE_UNAVAILABLE',
+                    'retriable': False,
+                    'fallback': 'reading the bundled .rocketride/schema/<name>.json (do NOT retry the engine)',
+                }
+            )
+            + '\n'
+        )
+        return None
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith('--')]
+    cache_ok = '--cache-ok' in sys.argv
+    if not args:
+        sys.stderr.write(__doc__)
+        sys.exit(2)
+    name = args[0]
+    # T1 fast path: --cache-ok serves a warm cached schema with NO reconnect (e.g. Phase 2 reusing
+    # the schema design already fetched this session — still schema-grounded, just not re-fetched).
+    if cache_ok:
+        cached = from_files(name)
+        if cached is not None:
+            sys.stderr.write('[fetch-node-schema] source: cache (--cache-ok, no reconnect)\n')
+            print(json.dumps(cached, indent=2))
+            return
+    result = asyncio.run(from_engine(name))
+    source = 'engine (get_service)'
+    if result is not None:
+        source = 'engine (get_service) [cached]' if write_through(name, result) else source
+    else:
+        result = from_files(name)
+        source = '.rocketride/schema file'
+    if result is None:
+        sys.stderr.write(
+            f"[fetch-node-schema] no schema for '{name}' from engine or files.\n"
+            f'  - is the node name spelled exactly as in the index?\n'
+            f'  - run from a workspace with a .rocketride/ dir, or connect an engine (.env).\n'
+        )
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'SCHEMA_NOT_FOUND',
+                    'retriable': False,
+                    'fallback': 'verify the node name against the L1 index — it may not exist; do not invent fields',
+                }
+            )
+            + '\n'
+        )
+        sys.exit(1)
+    sys.stderr.write(f'[fetch-node-schema] source: {source}\n')
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/agents/skills/rocketride-configuring-pipelines/tools/fetch-node-schema.py
+++ b/docs/agents/skills/rocketride-configuring-pipelines/tools/fetch-node-schema.py
@@ -1,4 +1,26 @@
 #!/usr/bin/env python3
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
 """Fetch one node's config schema (Layer 2).
 
 CONSTRAINT (agent contract / future MCP tool description): configure a node using ONLY the fields
@@ -35,7 +57,23 @@ def from_files(name):
     for _ in range(8):
         cand = os.path.join(here, '.rocketride', 'schema', f'{name}.json')
         if os.path.isfile(cand):
-            return json.load(open(cand))
+            try:
+                return json.load(open(cand))
+            except (json.JSONDecodeError, OSError) as e:
+                # Corrupt/truncated cache file: treat as a cache miss (keep walking up)
+                # instead of crashing with a traceback.
+                sys.stderr.write(f'[fetch-node-schema] cached schema unreadable ({cand}: {e}); ignoring it\n')
+                sys.stderr.write(
+                    'ERROR_JSON: '
+                    + json.dumps(
+                        {
+                            'code': 'CACHE_CORRUPT',
+                            'retriable': False,
+                            'fallback': 'treated as a cache miss — refetch from the engine (delete the corrupt file to silence this)',
+                        }
+                    )
+                    + '\n'
+                )
         parent = os.path.dirname(here)
         if parent == here:
             break

--- a/docs/agents/skills/rocketride-configuring-pipelines/tools/validate-pipeline.py
+++ b/docs/agents/skills/rocketride-configuring-pipelines/tools/validate-pipeline.py
@@ -1,0 +1,350 @@
+#!/usr/bin/env python3
+"""Validate a RocketRide pipeline (Layer 3 — the backstop).
+
+CONSTRAINT (agent contract / future MCP tool description): run this before ANY pipeline run and
+accept ONLY a zero-error result. On errors, show them verbatim, fix the offending node, and
+re-validate — never claim a pipeline is valid without a clean result in hand.
+
+Degrees of freedom: NONE. Run this command exactly as shown (the file path, optionally --static).
+Do not hand-roll the structural/lane/cycle checks in your own code or eyeball the JSON to declare it
+valid; this tool IS the validator the agent must call.
+
+Two modes:
+  (default)  Engine validation via the SDK: client.validate(pipeline) -> {errors, warnings}.
+             This is authoritative (real structural + connection + chain checks). Falls back to
+             --static automatically if no engine/SDK is reachable (and says so).
+  --static   Local pre-flight lint only (no engine): the 9-point checklist + lane compatibility +
+             cycle/orphan detection, checked against the node catalog. Fast, but NOT authoritative
+             — always run engine validation before a real run.
+
+Usage:
+  python3 validate-pipeline.py mypipeline.pipe
+  python3 validate-pipeline.py --static mypipeline.pipe
+
+Exit code 0 = no errors; 1 = errors found; 2 = usage/load error.
+"""
+
+import sys
+import os
+import json
+import re
+import asyncio
+from datetime import datetime, timezone
+
+GUID_RE = re.compile(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
+STALE_DAYS = 14
+
+
+def staleness_note():
+    """NON-BLOCKING freshness check (T2): warn if the bundled L1 node index has no freshness stamp
+    or is older than STALE_DAYS. Returns a note string or None. Never affects the exit code.
+    """
+    here = os.path.dirname(os.path.abspath(__file__))
+    cand = os.path.normpath(
+        os.path.join(here, '..', '..', 'rocketride-designing-pipelines', 'LAYER1_NODE_INDEX.meta.json')
+    )
+    if not os.path.isfile(cand):  # also accept a workspace-local stamp
+        d = os.getcwd()
+        for _ in range(8):
+            c = os.path.join(d, '.rocketride', 'LAYER1_NODE_INDEX.meta.json')
+            if os.path.isfile(c):
+                cand = c
+                break
+            p = os.path.dirname(d)
+            if p == d:
+                break
+            d = p
+    if not os.path.isfile(cand):
+        return (
+            'node index has no freshness stamp — run tools/generate-index.py against a live '
+            'engine to stamp + refresh it. Proceeding with the bundled snapshot.'
+        )
+    try:
+        meta = json.load(open(cand))
+        gen = datetime.fromisoformat(meta.get('generated_at'))
+        if gen.tzinfo is None:
+            gen = gen.replace(tzinfo=timezone.utc)
+        age = (datetime.now(timezone.utc) - gen).days
+        if age > STALE_DAYS:
+            return (
+                f'node index snapshot is {age} days old ({meta.get("node_count")} nodes) — '
+                f'run tools/generate-index.py against a live engine before trusting node '
+                f'selection. Proceeding with the bundled snapshot.'
+            )
+    except Exception:
+        return (
+            'node index freshness stamp unreadable — consider re-running '
+            'tools/generate-index.py. Proceeding with the bundled snapshot.'
+        )
+    return None
+
+
+# ---------- catalog loading (for --static) ----------
+def load_catalog(start):
+    """Find the node catalog: live .rocketride/services-catalog.json (walk up), else the bundled
+    LAYER1_NODE_INDEX.json next to the skills. Returns {name: entry} or None.
+    """
+    here = os.path.abspath(start)
+    for _ in range(8):
+        cand = os.path.join(here, '.rocketride', 'services-catalog.json')
+        if os.path.isfile(cand):
+            data = json.load(open(cand))
+            return {e['name']: e for e in data}
+        parent = os.path.dirname(here)
+        if parent == here:
+            break
+        here = parent
+    bundled = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        '..',
+        '..',
+        'rocketride-designing-pipelines',
+        'LAYER1_NODE_INDEX.json',
+    )
+    if os.path.isfile(bundled):
+        return {e['name']: e for e in json.load(open(bundled))}
+    return None
+
+
+def out_lanes(entry):
+    s = set()
+    for outs in (entry.get('lanes') or {}).values():
+        s.update(outs or [])
+    return s
+
+
+def in_lanes(entry):
+    return {k for k in (entry.get('lanes') or {}).keys() if k != '_source'}
+
+
+def is_source(entry):
+    return 'source' in (entry.get('classType') or [])
+
+
+def static_validate(path):
+    errors, warnings = [], []
+    try:
+        obj = json.load(open(path))
+    except Exception as e:
+        return [f'could not parse pipeline JSON: {e}'], []
+
+    # 1. extension
+    if not path.endswith('.pipe'):
+        errors.append('file must use the .pipe extension, not .json')
+    # 2. components present (conventionally first; schema marks key order optional)
+    keys = list(obj.keys())
+    if 'components' not in obj:
+        errors.append('pipeline must have a `components` array')
+    elif keys and keys[0] != 'components':
+        warnings.append('`components` is conventionally the first key (editor convention; schema marks order optional)')
+    comps = obj.get('components') or []
+    if not comps:
+        return errors + ['pipeline has no components'], warnings
+    # 3. project_id (optional per schema; if present, should be a literal GUID, not a variable)
+    pid = obj.get('project_id')
+    if pid is not None and (not isinstance(pid, str) or '$' in pid or not GUID_RE.match(pid)):
+        warnings.append(f'project_id should be a literal GUID, not a variable (editor convention); got {pid!r}')
+
+    ids = [c.get('id') for c in comps]
+    # 5. unique ids
+    dupes = {i for i in ids if ids.count(i) > 1}
+    if dupes:
+        errors.append(f'duplicate component ids: {sorted(dupes)}')
+    idset = set(ids)
+    # 4. source field (optional) matches a component
+    if 'source' in obj and obj['source'] not in idset:
+        errors.append(f'`source` {obj["source"]!r} does not match any component id')
+
+    cat = load_catalog(os.path.dirname(os.path.abspath(path)) or '.')
+    if cat is None:
+        warnings.append('no catalog found (.rocketride/ or bundled index) — lane checks skipped')
+
+    sources = []
+    adj = {i: [] for i in ids}  # from -> [to]
+    has_incoming = set()
+    has_control = set()
+    for c in comps:
+        cid, prov = c.get('id'), c.get('provider')
+        entry = cat.get(prov) if cat else None
+        if cat and entry is None:
+            errors.append(f'component {cid!r}: provider {prov!r} not found in catalog')
+        ctrl = c.get('control') or []
+        src = is_source(entry) if entry else (not c.get('input') and not ctrl)
+        if src:
+            sources.append(cid)
+        if ctrl:
+            has_control.add(cid)
+        for ce in ctrl:  # control-plane nodes (llm/tool/memory attached to an agent)
+            if ce.get('from') not in idset:
+                errors.append(f'{cid!r} control.from {ce.get("from")!r} is not a component id')
+        inputs = c.get('input') or []
+        # 6. non-source, non-control node needs input
+        if not src and not inputs and not ctrl:
+            errors.append(f'non-source component {cid!r} has no input array and no control')
+        for edge in inputs:
+            frm, lane = edge.get('from'), edge.get('lane')
+            if frm not in idset:
+                errors.append(f'{cid!r} input.from {frm!r} is not a component id')
+                continue
+            adj[frm].append(cid)
+            has_incoming.add(cid)
+            # 7. lane compatibility
+            if cat and entry is not None:
+                frm_entry = cat.get(comp_by_id(comps, frm, 'provider'))
+                if frm_entry and lane not in out_lanes(frm_entry):
+                    errors.append(f'lane {lane!r}: {frm!r} does not output it (edge {frm}->{cid})')
+                if lane not in in_lanes(entry) and in_lanes(entry):
+                    errors.append(f'lane {lane!r}: {cid!r} does not accept it (edge {frm}->{cid})')
+        # 9. secrets via env substitution (any ${VAR}); flag hardcoded literals only
+        for k, v in flatten(c.get('config') or {}):
+            if 'apikey' in k.lower() and isinstance(v, str) and v and not v.startswith('${'):
+                errors.append(f'{cid!r} config {k}: hardcoded secret — use ${{ENV_VAR}} substitution')
+    # one source
+    if len(sources) == 0:
+        errors.append('no source component found (need exactly one)')
+    elif len(sources) > 1:
+        errors.append(f'more than one source component: {sources}')
+    # 8. orphans + cycles
+    for c in comps:
+        cid = c.get('id')
+        if cid not in sources and cid not in has_incoming and cid not in has_control:
+            warnings.append(f'component {cid!r} is orphaned (no incoming edge / control)')
+    cyc = find_cycle(adj)
+    if cyc:
+        errors.append(f'cycle detected (pipelines must be acyclic): {" -> ".join(cyc)}')
+    return errors, warnings
+
+
+def comp_by_id(comps, cid, field):
+    for c in comps:
+        if c.get('id') == cid:
+            return c.get(field)
+    return None
+
+
+def flatten(d, prefix=''):
+    out = []
+    if isinstance(d, dict):
+        for k, v in d.items():
+            out += flatten(v, f'{prefix}{k}.')
+    elif isinstance(d, list):
+        for i, v in enumerate(d):
+            out += flatten(v, f'{prefix}{i}.')
+    else:
+        out.append((prefix.rstrip('.'), d))
+    return out
+
+
+def find_cycle(adj):
+    WHITE, GRAY, BLACK = 0, 1, 2
+    color = {n: WHITE for n in adj}
+    stack = []
+
+    def dfs(n):
+        color[n] = GRAY
+        stack.append(n)
+        for m in adj.get(n, []):
+            if color.get(m) == GRAY:
+                return stack[stack.index(m) :] + [m]
+            if color.get(m, BLACK) == WHITE:
+                r = dfs(m)
+                if r:
+                    return r
+        stack.pop()
+        color[n] = BLACK
+        return None
+
+    for n in adj:
+        if color[n] == WHITE:
+            r = dfs(n)
+            if r:
+                return r
+    return None
+
+
+# ---------- engine validation (default) ----------
+async def engine_validate(path):
+    try:
+        from rocketride import RocketRideClient  # type: ignore
+    except Exception:
+        sys.stderr.write('[validate] RocketRide SDK not importable; falling back to --static\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'ENGINE_UNAVAILABLE',
+                    'retriable': False,
+                    'fallback': 'ran --static lint (no SDK/engine). Install the SDK + .env to validate against an engine.',
+                }
+            )
+            + '\n'
+        )
+        return None
+    try:
+        pipeline = json.load(open(path))
+        async with RocketRideClient() as client:
+            return await client.validate(pipeline)
+    except Exception as e:
+        sys.stderr.write(f'[validate] engine unavailable ({e}); falling back to --static\n')
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'ENGINE_UNAVAILABLE',
+                    'retriable': False,
+                    'fallback': 'ran --static lint (no engine). To validate against a live engine, configure .env.',
+                }
+            )
+            + '\n'
+        )
+        return None
+
+
+def report(errors, warnings, mode):
+    sys.stderr.write(f'[validate] mode: {mode}\n')
+    for w in warnings:
+        print(f'WARNING: {w}')
+    for e in errors:
+        print(f'ERROR: {e}')
+    print(f'\nvalidate(): {len(errors)} errors, {len(warnings)} warnings')
+    if errors:
+        sys.stderr.write(
+            'ERROR_JSON: '
+            + json.dumps(
+                {
+                    'code': 'VALIDATION_FAILED',
+                    'retriable': True,
+                    'fallback': 'fix the listed errors and re-validate; never run an invalid pipeline',
+                }
+            )
+            + '\n'
+        )
+    sys.exit(1 if errors else 0)
+
+
+def main():
+    args = [a for a in sys.argv[1:] if a != '--static']
+    static = '--static' in sys.argv
+    if not args:
+        sys.stderr.write(__doc__)
+        sys.exit(2)
+    path = args[0]
+    if not os.path.isfile(path):
+        sys.stderr.write(f'[validate] file not found: {path}\n')
+        sys.exit(2)
+    note = staleness_note()
+    if note:
+        print(f'WARNING (freshness): {note}')
+    if not static:
+        res = asyncio.run(engine_validate(path))
+        if res is not None:
+            errs = [e.get('message', str(e)) if isinstance(e, dict) else str(e) for e in res.get('errors', [])]
+            warns = [w.get('message', str(w)) if isinstance(w, dict) else str(w) for w in res.get('warnings', [])]
+            report(errs, warns, 'engine (client.validate)')
+            return
+    errors, warnings = static_validate(path)
+    report(errors, warnings, 'static lint (NOT authoritative — run engine validation before a real run)')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/agents/skills/rocketride-configuring-pipelines/tools/validate-pipeline.py
+++ b/docs/agents/skills/rocketride-configuring-pipelines/tools/validate-pipeline.py
@@ -1,4 +1,26 @@
 #!/usr/bin/env python3
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
 """Validate a RocketRide pipeline (Layer 3 — the backstop).
 
 CONSTRAINT (agent contract / future MCP tool description): run this before ANY pipeline run and
@@ -56,7 +78,8 @@ def staleness_note():
             d = p
     if not os.path.isfile(cand):
         return (
-            'node index has no freshness stamp — run tools/generate-index.py against a live '
+            'node index has no freshness stamp — run '
+            '../rocketride-building-pipelines/tools/generate-index.py against a live '
             'engine to stamp + refresh it. Proceeding with the bundled snapshot.'
         )
     try:
@@ -68,13 +91,14 @@ def staleness_note():
         if age > STALE_DAYS:
             return (
                 f'node index snapshot is {age} days old ({meta.get("node_count")} nodes) — '
-                f'run tools/generate-index.py against a live engine before trusting node '
-                f'selection. Proceeding with the bundled snapshot.'
+                f'run ../rocketride-building-pipelines/tools/generate-index.py against a '
+                f'live engine before trusting node selection. Proceeding with the bundled snapshot.'
             )
     except Exception:
         return (
             'node index freshness stamp unreadable — consider re-running '
-            'tools/generate-index.py. Proceeding with the bundled snapshot.'
+            '../rocketride-building-pipelines/tools/generate-index.py. '
+            'Proceeding with the bundled snapshot.'
         )
     return None
 
@@ -88,8 +112,25 @@ def load_catalog(start):
     for _ in range(8):
         cand = os.path.join(here, '.rocketride', 'services-catalog.json')
         if os.path.isfile(cand):
-            data = json.load(open(cand))
-            return {e['name']: e for e in data}
+            try:
+                data = json.load(open(cand))
+                return {e['name']: e for e in data}
+            except (json.JSONDecodeError, OSError, TypeError, KeyError) as e:
+                # Corrupt/truncated cache: treat as a cache miss and fall through
+                # to the bundled index instead of crashing.
+                sys.stderr.write(f'[validate] catalog cache unreadable ({cand}: {e}); ignoring it\n')
+                sys.stderr.write(
+                    'ERROR_JSON: '
+                    + json.dumps(
+                        {
+                            'code': 'CACHE_CORRUPT',
+                            'retriable': False,
+                            'fallback': 'using the bundled LAYER1_NODE_INDEX.json instead; delete the corrupt cache file to silence this',
+                        }
+                    )
+                    + '\n'
+                )
+                break
         parent = os.path.dirname(here)
         if parent == here:
             break
@@ -102,7 +143,21 @@ def load_catalog(start):
         'LAYER1_NODE_INDEX.json',
     )
     if os.path.isfile(bundled):
-        return {e['name']: e for e in json.load(open(bundled))}
+        try:
+            return {e['name']: e for e in json.load(open(bundled))}
+        except (json.JSONDecodeError, OSError, TypeError, KeyError) as e:
+            sys.stderr.write(f'[validate] bundled index unreadable ({bundled}: {e})\n')
+            sys.stderr.write(
+                'ERROR_JSON: '
+                + json.dumps(
+                    {
+                        'code': 'CACHE_CORRUPT',
+                        'retriable': False,
+                        'fallback': 'lane checks will be skipped; regenerate the index with ../rocketride-building-pipelines/tools/generate-index.py',
+                    }
+                )
+                + '\n'
+            )
     return None
 
 

--- a/docs/agents/skills/rocketride-debugging-pipelines/ERROR_TABLE.md
+++ b/docs/agents/skills/rocketride-debugging-pipelines/ERROR_TABLE.md
@@ -1,0 +1,39 @@
+# Error → Cause → Fix
+
+**Load this when:** a `validate()` error or a run failure needs diagnosing — every error → cause →
+fix in one place.
+
+**Single source of truth for RocketRide errors** (build-time + runtime). The configuring skill's
+`PIPELINE_ANTIPATTERNS.md` keeps only a 3-row TL;DR of the commonest build-time errors and points
+here for the full list.
+
+The exact error message maps to an exact cause and an owning phase. Quote the real message, find
+the row, route the fix.
+
+| Error message | Cause | Owning phase | Fix |
+|---|---|---|---|
+| `Connection closed` / `Connection timeout` | **event loop blocked** by sync I/O (input(), time.sleep, requests, readFileSync) | running | use async I/O; never block the async loop |
+| `Websocket closed unexpectedly` | same — blocked event loop | running | same |
+| `Component not found` | `provider` misspelled / not in catalog | designing | check the node index; fix the name |
+| `Lane not supported` | output lane ≠ input lane on an edge | designing | add a converter or pick compatible nodes |
+| `KeyError: '<key>'` | response key ≠ `laneName` | configuring/running | read `result_types`; use defaults or match client code |
+| `Pipeline already running` | `use()` called twice on same token | running | `use_existing=True`, or `terminate(token)` then `use()` |
+| `Invalid API key` | wrong/missing key | configuring | set `${ROCKETRIDE_*}` env var correctly |
+| `project_id must be a GUID` | variable used in `project_id` | configuring | use a literal GUID |
+| empty / wrong output, no error | wrong wiring or wrong input data | designing/data | trace the first node with empty output; check input + lanes |
+| store returns nothing | data not embedded before store, or different embedding model for ingest vs query | designing | embed before store; same model both sides |
+| agent does nothing / errors on invoke | control plane wrong, or `invoke` min not met | designing | put `control:[{from:<agent>}]` on the controlled node; satisfy invoke min/max |
+
+## Reading the trace
+- Start the run with `pipelineTraceLevel="summary"` (or `"full"`) to get per-node traces; `"none"`
+  (default) gives you only the final status.
+- Status fields that tell the story: `state`, `exitCode`, `exitMessage`, `errors[]` (capped at 50),
+  `failedCount`, `completedCount`. The `apaevt_flow` events show `op` (begin/enter/leave/end) per
+  pipe with `trace.lane` / `trace.error`.
+- Correlate by `projectId` + `source` (begin/end events carry no token).
+
+## Where each cause is fixed
+- **Config** (field/key/model) → `rocketride-configuring-pipelines` → re-fetch schema, re-validate.
+- **Wiring/lane/control** → `rocketride-designing-pipelines` → re-wire → re-configure → re-validate.
+- **Runtime** (loop/use_existing/blocking) → `rocketride-running-pipelines` → fix the run code.
+- After **any** fix: `validate()` must be clean again before re-running.

--- a/docs/agents/skills/rocketride-debugging-pipelines/ERROR_TABLE.md
+++ b/docs/agents/skills/rocketride-debugging-pipelines/ERROR_TABLE.md
@@ -13,20 +13,21 @@ the row, route the fix.
 | Error message | Cause | Owning phase | Fix |
 |---|---|---|---|
 | `Connection closed` / `Connection timeout` | **event loop blocked** by sync I/O (input(), time.sleep, requests, readFileSync) | running | use async I/O; never block the async loop |
-| `Websocket closed unexpectedly` | same — blocked event loop | running | same |
-| `Component not found` | `provider` misspelled / not in catalog | designing | check the node index; fix the name |
-| `Lane not supported` | output lane ≠ input lane on an edge | designing | add a converter or pick compatible nodes |
+| `Connection closed unexpectedly` | same — blocked event loop | running | same |
+| `The service <provider> was not found` | `provider` misspelled / not in catalog | designing | check the node index; fix the name |
+| validate error contains `references unknown component id` | a `source`/`input`/`control` entry names a component `id` that doesn't exist | designing | fix the component id in the wiring |
+| validate error contains `input has unknown lane` | output lane ≠ input lane on an edge (input names a lane the node doesn't provide) | designing | add a converter or pick compatible nodes |
 | `KeyError: '<key>'` | response key ≠ `laneName` | configuring/running | read `result_types`; use defaults or match client code |
-| `Pipeline already running` | `use()` called twice on same token | running | `use_existing=True`, or `terminate(token)` then `use()` |
+| `Pipeline is already running.` | `use()` called twice on same token | running | `use_existing=True`, or `terminate(token)` then `use()` |
 | `Invalid API key` | wrong/missing key | configuring | set `${ROCKETRIDE_*}` env var correctly |
-| `project_id must be a GUID` | variable used in `project_id` | configuring | use a literal GUID |
+| run/validate failure mentioning `project_id` (no single verbatim message) | variable used in `project_id` | configuring | use a literal GUID |
 | empty / wrong output, no error | wrong wiring or wrong input data | designing/data | trace the first node with empty output; check input + lanes |
 | store returns nothing | data not embedded before store, or different embedding model for ingest vs query | designing | embed before store; same model both sides |
 | agent does nothing / errors on invoke | control plane wrong, or `invoke` min not met | designing | put `control:[{from:<agent>}]` on the controlled node; satisfy invoke min/max |
 
 ## Reading the trace
-- Start the run with `pipelineTraceLevel="summary"` (or `"full"`) to get per-node traces; `"none"`
-  (default) gives you only the final status.
+- Per-node traces are on by default (`pipelineTraceLevel` server default `"summary"`; pass `"full"`
+  for more detail). `"none"` still yields chapters/console logs, but the traces come back empty.
 - Status fields that tell the story: `state`, `exitCode`, `exitMessage`, `errors[]` (capped at 50),
   `failedCount`, `completedCount`. The `apaevt_flow` events show `op` (begin/enter/leave/end) per
   pipe with `trace.lane` / `trace.error`.

--- a/docs/agents/skills/rocketride-debugging-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-debugging-pipelines/SKILL.md
@@ -36,13 +36,13 @@ fix to the right phase. No re-running until the cause is identified and the fix 
    the owning phase. **Do not re-run until the fix is made and `validate()` is clean again.**
 
 ## Common diagnoses (full table in ERROR_TABLE.md)
-- `Connection closed` / `Websocket closed unexpectedly` → **event loop blocked by sync I/O** (most
+- `Connection closed` / `Connection closed unexpectedly` → **event loop blocked by sync I/O** (most
   common runtime failure) — fix the run code, not the pipeline.
-- `Component not found` → misspelled `provider`; check the index.
-- `Lane not supported` → lane mismatch; add a converter or pick compatible nodes.
+- `The service <provider> was not found` → misspelled `provider`; check the index.
+- `input has unknown lane` (validate) → lane mismatch; add a converter or pick compatible nodes.
 - `KeyError: '<key>'` → response key vs `laneName` mismatch; read `result_types`.
-- `Pipeline already running` → `use_existing=True` or `terminate()` first.
-- `Invalid API key` / `project_id must be a GUID` → config fix.
+- `Pipeline is already running.` → `use_existing=True` or `terminate()` first.
+- `Invalid API key` / a `project_id` rejection → config fix.
 
 ## Red flags
 

--- a/docs/agents/skills/rocketride-debugging-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-debugging-pipelines/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: rocketride-debugging-pipelines
+description: Use when a RocketRide pipeline run failed, errored, or produced wrong/empty output, and you need to find the failing node and fix it. Reads run status and execution traces, diagnoses the cause, and routes back to design or configuration. Also use directly when asked to debug a run.
+---
+
+# Debugging RocketRide Pipelines
+
+Diagnose, don't guess. A failed run has a real cause in the status/trace; find it, then route the
+fix to the right phase. No re-running until the cause is identified and the fix is validated.
+
+## Procedure
+
+1. **Read the status.** MCP: `monitor(task_token)` → quote `state_label`, `errors[]`,
+   `warnings[]`, `counts` verbatim. SDK: `get_task_status(token)` → `state`, `errors[]`,
+   `warnings[]`, `exitCode`, `exitMessage`, `failedCount`. Don't paraphrase error messages.
+2. **Read the trace.** MCP — the run-log (DVR) tools work for past *and* live runs, keyed by the
+   `projectId` + `source` returned by `run_pipeline`/`run_dropper_pipe` (never the task token):
+   `log_chapters` to find the run → `log_read` for paged events (≤200/page; follow the cursor) →
+   `log_traces` to list per-object traces → `log_trace` for one object's full per-node
+   `enter`/`leave` with `lane`, `data`, `result`, `error`. Retention: 7 days dev / 30 days
+   deploy. A run started with `pipelineTraceLevel="none"` has chapters/console but **empty
+   traces** — re-run with `"summary"`/`"full"` for flow evidence. SDK fallback: the
+   `apaevt_flow` / `_trace` events in the response. Either way, find the **first** node whose op
+   shows an error or whose output is empty/wrong — that's the failure point. Downstream errors
+   are usually consequences.
+3. **Classify the cause** (see `ERROR_TABLE.md`):
+   - **Config** — bad/missing field, wrong API key, wrong model name → fix in
+     `rocketride-configuring-pipelines` (re-fetch schema, re-validate).
+   - **Wiring/lane** — lane mismatch, missing converter, wrong source method → fix in
+     `rocketride-designing-pipelines` (re-wire), then re-configure + re-validate.
+   - **Runtime** — event-loop blocked (`Connection closed`/timeout), `Pipeline already running`,
+     blocking I/O → fix the run code in `rocketride-running-pipelines`.
+   - **Data** — empty/garbage input, wrong response key (`KeyError`) → check input + `result_types`.
+4. **Propose a specific fix** tied to the evidence: "Node `llm_1` failed: `Invalid API key`. The
+   `${ROCKETRIDE_OPENAI_KEY}` env var is unset / wrong. Fix: set it, re-validate, re-run." Route to
+   the owning phase. **Do not re-run until the fix is made and `validate()` is clean again.**
+
+## Common diagnoses (full table in ERROR_TABLE.md)
+- `Connection closed` / `Websocket closed unexpectedly` → **event loop blocked by sync I/O** (most
+  common runtime failure) — fix the run code, not the pipeline.
+- `Component not found` → misspelled `provider`; check the index.
+- `Lane not supported` → lane mismatch; add a converter or pick compatible nodes.
+- `KeyError: '<key>'` → response key vs `laneName` mismatch; read `result_types`.
+- `Pipeline already running` → `use_existing=True` or `terminate()` first.
+- `Invalid API key` / `project_id must be a GUID` → config fix.
+
+## Red flags
+
+| Thought | Reality |
+|---|---|
+| "I'll just re-run, maybe it works" | Find the cause first; blind re-runs cost money and teach nothing. |
+| "The last node errored, fix that node" | The **first** failing node in the trace is usually the cause; later errors cascade. |
+| "Connection dropped — the engine is flaky" | Almost always a blocked event loop (sync I/O in async code), not the engine. |
+| "I'll paraphrase the error" | Quote it verbatim — the exact message maps to the exact fix. |
+| "Fixed it, re-running" | Re-validate() after any fix before re-running. |
+
+## Supporting files
+- `ERROR_TABLE.md` — error message → cause → owning phase → fix
+- **deep docs** — for failure modes the table doesn't cover, fetch ONE page:
+  `../rocketride-building-pipelines/tools/fetch-doc.py "error handling"`
+  (→ `/concepts/error-handling.md`) or `… "observability"` (→ `/protocols/websocket/observability.md`).
+  Never `llms-full.txt`.

--- a/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.json
+++ b/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.json
@@ -194,6 +194,18 @@
   }
  },
  {
+  "name": "answer_documents",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "answers": [
+    "documents",
+    "answers"
+   ]
+  }
+ },
+ {
   "name": "aparavi_aql",
   "classType": [
    "database",
@@ -209,7 +221,8 @@
  {
   "name": "astra_db",
   "classType": [
-   "store"
+   "store",
+   "tool"
   ],
   "lanes": {
    "documents": [],
@@ -265,6 +278,13 @@
   }
  },
  {
+  "name": "autopipe",
+  "classType": [
+   "other"
+  ],
+  "lanes": {}
+ },
+ {
   "name": "background_removal",
   "classType": [
    "image"
@@ -273,6 +293,17 @@
    "image": [
     "text",
     "image"
+   ]
+  }
+ },
+ {
+  "name": "caption",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text"
    ]
   }
  },
@@ -303,8 +334,20 @@
   }
  },
  {
+  "name": "currency_convert_explicit",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "answers": [
+    "answers"
+   ]
+  }
+ },
+ {
   "name": "db_arango",
   "classType": [
+   "graph",
    "database",
    "tool"
   ],
@@ -341,7 +384,7 @@
   }
  },
  {
-  "name": "db_mysql",
+  "name": "db_hotdata",
   "classType": [
    "database",
    "tool"
@@ -361,12 +404,22 @@
   }
  },
  {
-  "name": "db_neo4j",
+  "name": "db_hydradb",
+  "classType": [
+   "graph",
+   "database",
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "db_mysql",
   "classType": [
    "database",
    "tool"
   ],
   "lanes": {
+   "answers": [],
    "questions": [
     "table",
     "text",
@@ -557,6 +610,10 @@
    "text"
   ],
   "lanes": {
+   "documents": [
+    "answers",
+    "documents"
+   ],
    "table": [
     "answers",
     "documents"
@@ -570,6 +627,76 @@
    "llm": {
     "min": 1
    }
+  }
+ },
+ {
+  "name": "extract_facts",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "documents": [
+    "answers",
+    "documents"
+   ],
+   "table": [
+    "answers",
+    "documents"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "face_detection",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text",
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "filestore",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "audio": [
+    "json"
+   ],
+   "documents": [
+    "json"
+   ],
+   "image": [
+    "json"
+   ],
+   "table": [
+    "json"
+   ],
+   "text": [
+    "json"
+   ],
+   "video": [
+    "json"
+   ]
+  }
+ },
+ {
+  "name": "filestore_source",
+  "classType": [
+   "source"
+  ],
+  "lanes": {
+   "_source": [
+    "tags"
+   ]
   }
  },
  {
@@ -594,6 +721,44 @@
     "table",
     "documents"
    ]
+  }
+ },
+ {
+  "name": "graph_falkordb",
+  "classType": [
+   "graph",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "graph_neo4j",
+  "classType": [
+   "graph",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
   }
  },
  {
@@ -632,6 +797,18 @@
   "lanes": {
    "image": [
     "image"
+   ]
+  }
+ },
+ {
+  "name": "image_orient",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "image",
+    "text"
    ]
   }
  },
@@ -690,6 +867,11 @@
     "text"
    ]
   }
+ },
+ {
+  "name": "indexer",
+  "classType": [],
+  "lanes": {}
  },
  {
   "name": "landing_ai_extract",
@@ -943,7 +1125,8 @@
  {
   "name": "milvus",
   "classType": [
-   "store"
+   "store",
+   "tool"
   ],
   "lanes": {
    "documents": [],
@@ -957,7 +1140,8 @@
  {
   "name": "mongodb+srv",
   "classType": [
-   "store"
+   "store",
+   "tool"
   ],
   "lanes": {
    "documents": [],
@@ -979,6 +1163,26 @@
    ],
    "text": [
     "text"
+   ]
+  }
+ },
+ {
+  "name": "normalize_facts",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "answers": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "null",
+  "classType": [],
+  "lanes": {
+   "source": [
+    "tags"
    ]
   }
  },
@@ -1057,7 +1261,8 @@
  {
   "name": "postgres",
   "classType": [
-   "store"
+   "store",
+   "tool"
   ],
   "lanes": {
    "documents": [],
@@ -1172,6 +1377,11 @@
   "lanes": {}
  },
  {
+  "name": "remote_server",
+  "classType": [],
+  "lanes": {}
+ },
+ {
   "name": "rerank_cohere",
   "classType": [
    "rerank"
@@ -1181,6 +1391,23 @@
     "documents",
     "answers"
    ]
+  }
+ },
+ {
+  "name": "response",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "answers": [],
+   "audio": [],
+   "documents": [],
+   "image": [],
+   "json": [],
+   "questions": [],
+   "table": [],
+   "text": [],
+   "video": []
   }
  },
  {
@@ -1220,6 +1447,15 @@
   }
  },
  {
+  "name": "response_json",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "json": []
+  }
+ },
+ {
   "name": "response_questions",
   "classType": [
    "infrastructure"
@@ -1253,6 +1489,82 @@
   ],
   "lanes": {
    "video": []
+  }
+ },
+ {
+  "name": "rocketride_graph",
+  "classType": [
+   "graph",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "rocketride_sql",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {
+   "answers": [],
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "rocketride_vector",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "scan_cropper",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "image",
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "schema_validate",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "answers": [
+    "answers"
+   ]
   }
  },
  {
@@ -1345,6 +1657,13 @@
   "lanes": {}
  },
  {
+  "name": "tool_calendar",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
   "name": "tool_chartjs",
   "classType": [
    "tool"
@@ -1355,6 +1674,13 @@
     "min": 1
    }
   }
+ },
+ {
+  "name": "tool_cognee",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
  },
  {
   "name": "tool_daytona",
@@ -1371,6 +1697,20 @@
   "lanes": {}
  },
  {
+  "name": "tool_docs",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_drive",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
   "name": "tool_exa_search",
   "classType": [
    "tool"
@@ -1378,7 +1718,7 @@
   "lanes": {}
  },
  {
-  "name": "tool_falkordb",
+  "name": "tool_excel",
   "classType": [
    "tool"
   ],
@@ -1413,6 +1753,44 @@
   "lanes": {}
  },
  {
+  "name": "tool_gmail",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_gohighlevel",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_guild",
+  "classType": [
+   "data",
+   "tool"
+  ],
+  "lanes": {
+   "documents": [
+    "documents",
+    "text",
+    "table"
+   ],
+   "questions": [
+    "answers",
+    "text",
+    "table"
+   ],
+   "text": [
+    "text",
+    "answers",
+    "table"
+   ]
+  }
+ },
+ {
   "name": "tool_http_request",
   "classType": [
    "tool"
@@ -1420,7 +1798,84 @@
   "lanes": {}
  },
  {
+  "name": "tool_laserdata_memory",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
   "name": "tool_mem0",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_n8n",
+  "classType": [
+   "data",
+   "tool"
+  ],
+  "lanes": {
+   "audio": [
+    "audio",
+    "text",
+    "answers",
+    "table"
+   ],
+   "documents": [
+    "documents",
+    "text",
+    "table"
+   ],
+   "image": [
+    "image",
+    "text",
+    "answers",
+    "table"
+   ],
+   "questions": [
+    "answers",
+    "text",
+    "table"
+   ],
+   "text": [
+    "text",
+    "answers",
+    "table"
+   ],
+   "video": [
+    "video",
+    "text",
+    "answers",
+    "table"
+   ]
+  }
+ },
+ {
+  "name": "tool_onedrive",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_oura",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_outlook_calendar",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_outlook_mail",
   "classType": [
    "tool"
   ],
@@ -1442,7 +1897,28 @@
   }
  },
  {
+  "name": "tool_pipedrive",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
   "name": "tool_python",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_sheets",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_slack",
   "classType": [
    "tool"
   ],
@@ -1463,11 +1939,32 @@
   "lanes": {}
  },
  {
+  "name": "tool_word",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
   "name": "tool_xtrace_memory",
   "classType": [
    "tool"
   ],
   "lanes": {}
+ },
+ {
+  "name": "tools",
+  "classType": [
+   "source"
+  ],
+  "lanes": {
+   "_source": []
+  },
+  "invoke": {
+   "tool": {
+    "min": 0
+   }
+  }
  },
  {
   "name": "tts_elevenlabs",
@@ -1521,6 +2018,11 @@
   }
  },
  {
+  "name": "vectorizer",
+  "classType": [],
+  "lanes": {}
+ },
+ {
   "name": "video_composer",
   "classType": [
    "video"
@@ -1534,7 +2036,8 @@
  {
   "name": "weaviate",
   "classType": [
-   "store"
+   "store",
+   "tool"
   ],
   "lanes": {
    "documents": [],
@@ -1554,11 +2057,19 @@
    "_source": [
     "tags",
     "text",
+    "json",
     "audio",
     "video",
     "image",
     "questions"
    ]
   }
+ },
+ {
+  "name": "zip",
+  "classType": [
+   "target"
+  ],
+  "lanes": {}
  }
 ]

--- a/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.json
+++ b/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.json
@@ -1,0 +1,1564 @@
+[
+ {
+  "name": "accessibility_describe",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "agent_crewai",
+  "classType": [
+   "agent",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   },
+   "tool": {
+    "min": 0
+   }
+  }
+ },
+ {
+  "name": "agent_crewai_manager",
+  "classType": [
+   "agent",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  },
+  "invoke": {
+   "crewai": {
+    "min": 1
+   },
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "agent_crewai_subagent",
+  "classType": [
+   "crewai"
+  ],
+  "lanes": {},
+  "invoke": {
+   "llm": {
+    "min": 1
+   },
+   "tool": {
+    "min": 0
+   }
+  }
+ },
+ {
+  "name": "agent_deepagent",
+  "classType": [
+   "agent",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  },
+  "invoke": {
+   "deepagent": {
+    "min": 0
+   },
+   "llm": {
+    "min": 1
+   },
+   "tool": {
+    "min": 0
+   }
+  }
+ },
+ {
+  "name": "agent_deepagent_subagent",
+  "classType": [
+   "deepagent"
+  ],
+  "lanes": {},
+  "invoke": {
+   "llm": {
+    "min": 1
+   },
+   "tool": {
+    "min": 0
+   }
+  }
+ },
+ {
+  "name": "agent_langchain",
+  "classType": [
+   "agent",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   },
+   "tool": {
+    "min": 0
+   }
+  }
+ },
+ {
+  "name": "agent_llamaindex",
+  "classType": [
+   "agent",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   },
+   "tool": {
+    "min": 0
+   }
+  }
+ },
+ {
+  "name": "agent_rocketride",
+  "classType": [
+   "agent",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "max": 1,
+    "min": 1
+   },
+   "memory": {
+    "max": 1,
+    "min": 1
+   },
+   "tool": {
+    "min": 0
+   }
+  }
+ },
+ {
+  "name": "anomaly_detector",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "text": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "anonymize_text",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "text": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "aparavi_aql",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {},
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "astra_db",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "audio_player",
+  "classType": [
+   "audio"
+  ],
+  "lanes": {
+   "audio": [],
+   "video": []
+  }
+ },
+ {
+  "name": "audio_transcribe",
+  "classType": [
+   "audio"
+  ],
+  "lanes": {
+   "audio": [
+    "text"
+   ],
+   "video": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "audio_tts",
+  "classType": [
+   "audio"
+  ],
+  "lanes": {
+   "answers": [
+    "audio"
+   ],
+   "documents": [
+    "audio"
+   ],
+   "questions": [
+    "audio"
+   ],
+   "text": [
+    "audio"
+   ]
+  }
+ },
+ {
+  "name": "background_removal",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text",
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "chat",
+  "classType": [
+   "source"
+  ],
+  "lanes": {
+   "_source": [
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "chroma",
+  "classType": [
+   "store",
+   "tool"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "db_arango",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "db_clickhouse",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "db_mysql",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {
+   "answers": [],
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "db_neo4j",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "db_postgres",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {
+   "answers": [],
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "db_supabase",
+  "classType": [
+   "database",
+   "tool"
+  ],
+  "lanes": {
+   "answers": [],
+   "questions": [
+    "table",
+    "text",
+    "answers"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "depth_estimate",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text",
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "detect",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text",
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "detect_segment",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text",
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "dictionary",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "text": [
+    "documents"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "dropper",
+  "classType": [
+   "source"
+  ],
+  "lanes": {
+   "_source": [
+    "tags"
+   ]
+  }
+ },
+ {
+  "name": "elasticsearch",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "text",
+    "documents",
+    "answers",
+    "questions"
+   ],
+   "text": []
+  }
+ },
+ {
+  "name": "embedding_image",
+  "classType": [
+   "embedding"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "image": [
+    "documents"
+   ]
+  }
+ },
+ {
+  "name": "embedding_openai",
+  "classType": [
+   "embedding"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "questions": [
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "embedding_transformer",
+  "classType": [
+   "embedding"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "questions": [
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "embedding_video",
+  "classType": [
+   "embedding"
+  ],
+  "lanes": {
+   "video": [
+    "documents"
+   ]
+  }
+ },
+ {
+  "name": "extract_data",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "table": [
+    "answers",
+    "documents"
+   ],
+   "text": [
+    "answers",
+    "documents"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "filesys",
+  "classType": [
+   "source"
+  ],
+  "lanes": {
+   "_source": [
+    "tags"
+   ]
+  }
+ },
+ {
+  "name": "frame_grabber",
+  "classType": [
+   "video"
+  ],
+  "lanes": {
+   "video": [
+    "image",
+    "table",
+    "documents"
+   ]
+  }
+ },
+ {
+  "name": "guardrails",
+  "classType": [
+   "guard"
+  ],
+  "lanes": {
+   "answers": [
+    "answers"
+   ],
+   "documents": [
+    "documents"
+   ],
+   "questions": [
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "hash",
+  "classType": [
+   "data"
+  ],
+  "lanes": {
+   "tags": [
+    "tags"
+   ]
+  }
+ },
+ {
+  "name": "image_cleanup",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "image_vision_gemini",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "image": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "image_vision_mistral",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "image": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "image_vision_ollama",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "image": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "image_vision_openai",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "image": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "landing_ai_extract",
+  "classType": [
+   "data"
+  ],
+  "lanes": {
+   "text": [
+    "answers",
+    "documents"
+   ]
+  }
+ },
+ {
+  "name": "landing_ai_parse",
+  "classType": [
+   "data"
+  ],
+  "lanes": {
+   "tags": [
+    "text",
+    "table"
+   ]
+  }
+ },
+ {
+  "name": "llamaparse",
+  "classType": [
+   "data"
+  ],
+  "lanes": {
+   "tags": [
+    "text",
+    "table"
+   ]
+  }
+ },
+ {
+  "name": "llm_anthropic",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_baidu_qianfan",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_bedrock",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_deepseek",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_gemini",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_gmi_cloud",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_kimi",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_minimax",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_mistral",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_nebius",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_ollama",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_openai",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_openai_api",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_perplexity",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_qwen",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "llm_xai",
+  "classType": [
+   "llm"
+  ],
+  "lanes": {
+   "questions": [
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "local-text-output",
+  "classType": [
+   "target"
+  ],
+  "lanes": {
+   "text": []
+  }
+ },
+ {
+  "name": "mcp_client",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "memory_internal",
+  "classType": [
+   "memory"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "memory_persistent",
+  "classType": [
+   "memory"
+  ],
+  "lanes": {
+   "answers": [
+    "answers"
+   ],
+   "questions": [
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "milvus",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "mongodb+srv",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "ner",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "text": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "ocr",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "documents": [
+    "text"
+   ],
+   "image": [
+    "text",
+    "table"
+   ]
+  }
+ },
+ {
+  "name": "opensearch",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "text",
+    "answers",
+    "documents"
+   ],
+   "text": []
+  }
+ },
+ {
+  "name": "parse",
+  "classType": [
+   "data"
+  ],
+  "lanes": {
+   "tags": [
+    "text",
+    "table",
+    "image",
+    "video",
+    "audio"
+   ]
+  }
+ },
+ {
+  "name": "pinecone",
+  "classType": [
+   "store",
+   "tool"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "pose_estimation",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "image": [
+    "text",
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "postgres",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "preprocessor_code",
+  "classType": [
+   "preprocessor"
+  ],
+  "lanes": {
+   "text": [
+    "documents"
+   ]
+  }
+ },
+ {
+  "name": "preprocessor_langchain",
+  "classType": [
+   "preprocessor"
+  ],
+  "lanes": {
+   "table": [
+    "documents"
+   ],
+   "text": [
+    "documents"
+   ]
+  }
+ },
+ {
+  "name": "preprocessor_llm",
+  "classType": [
+   "preprocessor"
+  ],
+  "lanes": {
+   "table": [
+    "documents"
+   ],
+   "text": [
+    "documents"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "prompt",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "questions"
+   ],
+   "table": [],
+   "text": []
+  }
+ },
+ {
+  "name": "qdrant",
+  "classType": [
+   "store",
+   "tool"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "question",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "text": [
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "reducto",
+  "classType": [
+   "data"
+  ],
+  "lanes": {
+   "tags": [
+    "text",
+    "table"
+   ]
+  }
+ },
+ {
+  "name": "remote",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "rerank_cohere",
+  "classType": [
+   "rerank"
+  ],
+  "lanes": {
+   "questions": [
+    "documents",
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "response_answers",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "answers": []
+  }
+ },
+ {
+  "name": "response_audio",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "audio": []
+  }
+ },
+ {
+  "name": "response_documents",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "documents": []
+  }
+ },
+ {
+  "name": "response_image",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "image": []
+  }
+ },
+ {
+  "name": "response_questions",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "questions": []
+  }
+ },
+ {
+  "name": "response_table",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "table": []
+  }
+ },
+ {
+  "name": "response_text",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "text": []
+  }
+ },
+ {
+  "name": "response_video",
+  "classType": [
+   "infrastructure"
+  ],
+  "lanes": {
+   "video": []
+  }
+ },
+ {
+  "name": "search_exa",
+  "classType": [
+   "search"
+  ],
+  "lanes": {
+   "questions": [
+    "answers",
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "summarization",
+  "classType": [
+   "text"
+  ],
+  "lanes": {
+   "text": [
+    "text",
+    "documents"
+   ]
+  },
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "telegram",
+  "classType": [
+   "source"
+  ],
+  "lanes": {
+   "_source": [
+    "text",
+    "image",
+    "audio",
+    "video",
+    "tags"
+   ]
+  }
+ },
+ {
+  "name": "text-output",
+  "classType": [
+   "target"
+  ],
+  "lanes": {
+   "text": []
+  }
+ },
+ {
+  "name": "thumbnail",
+  "classType": [
+   "image"
+  ],
+  "lanes": {
+   "documents": [
+    "documents"
+   ],
+   "image": [
+    "documents",
+    "image"
+   ]
+  }
+ },
+ {
+  "name": "tool_apify",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_bland_ai",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_butterbase",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_chartjs",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {},
+  "invoke": {
+   "llm": {
+    "min": 1
+   }
+  }
+ },
+ {
+  "name": "tool_daytona",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_deepl",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_exa_search",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_falkordb",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_filesystem",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_firecrawl",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_git",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_github",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_http_request",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_mem0",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_pipe",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {
+   "_source": [
+    "text",
+    "questions",
+    "documents",
+    "table",
+    "answers"
+   ]
+  }
+ },
+ {
+  "name": "tool_python",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_tavily",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_v0",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tool_xtrace_memory",
+  "classType": [
+   "tool"
+  ],
+  "lanes": {}
+ },
+ {
+  "name": "tts_elevenlabs",
+  "classType": [
+   "audio"
+  ],
+  "lanes": {
+   "answers": [
+    "audio"
+   ],
+   "documents": [
+    "audio"
+   ],
+   "questions": [
+    "audio"
+   ],
+   "text": [
+    "audio"
+   ]
+  }
+ },
+ {
+  "name": "tts_openai",
+  "classType": [
+   "audio"
+  ],
+  "lanes": {
+   "answers": [
+    "audio"
+   ],
+   "documents": [
+    "audio"
+   ],
+   "questions": [
+    "audio"
+   ],
+   "text": [
+    "audio"
+   ]
+  }
+ },
+ {
+  "name": "twelvelabs",
+  "classType": [
+   "video"
+  ],
+  "lanes": {
+   "video": [
+    "text"
+   ]
+  }
+ },
+ {
+  "name": "video_composer",
+  "classType": [
+   "video"
+  ],
+  "lanes": {
+   "image": [
+    "video"
+   ]
+  }
+ },
+ {
+  "name": "weaviate",
+  "classType": [
+   "store"
+  ],
+  "lanes": {
+   "documents": [],
+   "questions": [
+    "documents",
+    "answers",
+    "questions"
+   ]
+  }
+ },
+ {
+  "name": "webhook",
+  "classType": [
+   "source"
+  ],
+  "lanes": {
+   "_source": [
+    "tags",
+    "text",
+    "audio",
+    "video",
+    "image",
+    "questions"
+   ]
+  }
+ }
+]

--- a/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.meta.json
+++ b/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.meta.json
@@ -1,5 +1,5 @@
 {
- "generated_at": "2026-08-25T22:59:12.431425+00:00",
- "node_count": 124,
- "source": "engine (get_services)"
+ "generated_at": "2026-08-26T00:00:00+00:00",
+ "node_count": 167,
+ "source": "engine (get_services) 2026-08-25; reconciled by hand against the branch node corpus (nodes/src/nodes) on 2026-08-26"
 }

--- a/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.meta.json
+++ b/docs/agents/skills/rocketride-designing-pipelines/LAYER1_NODE_INDEX.meta.json
@@ -1,0 +1,5 @@
+{
+ "generated_at": "2026-08-25T22:59:12.431425+00:00",
+ "node_count": 124,
+ "source": "engine (get_services)"
+}

--- a/docs/agents/skills/rocketride-designing-pipelines/PIPELINE_RULES_SUMMARY.md
+++ b/docs/agents/skills/rocketride-designing-pipelines/PIPELINE_RULES_SUMMARY.md
@@ -91,8 +91,8 @@ Always read the node's `invoke` cardinality in the index and satisfy min/max.
 managed by the editor; omit it when hand-writing.
 
 ## Freshness notes (reconcile against the live engine / docs)
-- **Env substitution:** the engine expands **any** `${VAR}` from the environment (e.g.
-  `${OPENAI_API_KEY}`) — a `ROCKETRIDE_` prefix is not required.
+- **Env substitution:** the task server resolves only `${ROCKETRIDE_*}` variables (e.g.
+  `${ROCKETRIDE_OPENAI_KEY}`) — any non-prefixed `${VAR}` is replaced with `<REDACTED>`.
 - **Response node:** the current docs show a single `response` provider with `config.laneName`
   (e.g. `{ "provider": "response", "config": { "laneName": "answers" } }`). Our bundled catalog
   snapshot still lists lane-specific variants (`response_answers`, `response_text`, …). Use whatever

--- a/docs/agents/skills/rocketride-designing-pipelines/PIPELINE_RULES_SUMMARY.md
+++ b/docs/agents/skills/rocketride-designing-pipelines/PIPELINE_RULES_SUMMARY.md
@@ -1,0 +1,103 @@
+# Pipeline Rules Summary
+
+**Load this when:** wiring the DAG — lane types, the lane-transform table, and the structural +
+control-plane rules.
+
+Condensed from the RocketRide pipeline/component reference. The authoritative source is the live
+engine (`validate()`); this is the design-time checklist.
+
+## What a pipeline is
+A directed **acyclic** graph of components joined by **typed lanes**, saved as a `.pipe` JSON file.
+Exactly one **source**; data flows to a terminal. A connection is valid only when an **output lane
+name** of the source node matches an **input lane name** of the target node.
+
+## Lane types
+| Lane | Carries |
+|---|---|
+| `tags` | raw file metadata/bytes (source output) |
+| `text` | plain text |
+| `table` | structured tables |
+| `documents` | chunked docs (optionally with embedding vectors) |
+| `questions` | questions to answer (optionally vectorized) |
+| `answers` | answers from LLMs / stores |
+| `image` / `audio` / `video` | media streams |
+
+## Lane transformations (input → component → output)
+| In | Component | Out |
+|---|---|---|
+| `tags` | parse | `text`, `table`, `image`, `audio`, `video` |
+| `text` | preprocessor_langchain | `documents` |
+| `text` | question | `questions` |
+| `documents` | embedding_* | `documents` (with vectors) |
+| `questions` | embedding_* | `questions` (with vectors) |
+| `documents` | store (ingest) | — (terminal) |
+| `questions` | store (search) | `documents`, `answers`, `questions` |
+| `questions` | llm_* | `answers` |
+| `image` | ocr / accessibility_describe | `text` |
+
+If two nodes' lanes don't line up, insert the converter that bridges them. `image` cannot go
+straight to `questions` — go `image → accessibility_describe → text → question → questions`.
+
+## Structural rules
+1. **One source.** Exactly one `source`-classType node (chat / webhook / dropper / filesys /
+   telegram). Source nodes have no `input` array.
+2. **Acyclic.** No loops anywhere in the data flow.
+3. **No orphans.** Every non-source node must be reachable from the source.
+4. **Inputs required.** Every non-source node needs an `input: [{lane, from}]` (one entry per
+   incoming edge; multiple entries = a merge / fan-in).
+5. **Lane compatibility.** Output lane type of one node must match the input lane type of the next.
+6. **Embedding before store.** Vector stores cannot accept data without embedding vectors; use the
+   **same** embedding model for ingestion and query.
+7. **One terminal kind per goal.** Answers/replies end in `response_*` (`response_answers`,
+   `response_text`, …). Ingestion ends in the store (no response node needed).
+
+## Control plane (agents, NL-DB, and other `invoke` nodes)
+Some nodes don't take their LLM/tool/memory through a data lane — they **invoke** it. The index
+`invoke` field declares the requirement (`{llm:{min:1}, tool:{min:0}, memory:{min:1,max:1}}`, etc.).
+
+**The `control` array goes on the CONTROLLED node, pointing back at the invoker — never on the
+invoker.** Example (an agent with an LLM, a tool, and memory):
+```jsonc
+// agent: only data-lane input, NO control array
+{ "id": "agent_rocketride_1", "provider": "agent_rocketride",
+  "input": [{"lane": "questions", "from": "chat_1"}] }
+// the llm declares it is controlled BY the agent:
+{ "id": "llm_openai_1", "provider": "llm_openai",
+  "control": [{"classType": "llm", "from": "agent_rocketride_1"}] }
+// the tool: controlled BY the agent:
+{ "id": "tool_http_request_1", "provider": "tool_http_request",
+  "control": [{"classType": "tool", "from": "agent_rocketride_1"}] }
+// the memory: controlled BY the agent:
+{ "id": "memory_internal_1", "provider": "memory_internal",
+  "control": [{"classType": "memory", "from": "agent_rocketride_1"}] }
+```
+A single LLM/tool/memory node may be **shared** by several invokers (add multiple entries to its
+`control` array). `agent_rocketride` requires exactly 1 llm and exactly 1 memory; crewai/langchain
+agents require ≥1 llm and don't support memory. `db_*` nodes require 1 llm (to craft SQL/Cypher).
+Always read the node's `invoke` cardinality in the index and satisfy min/max.
+
+## File shape (for reference; you assemble this in Phase 2)
+```json
+{
+  "components": [ { "id": "...", "provider": "...", "config": {}, "input": [] } ],
+  "project_id": "literal-guid-here",
+  "viewport": { "x": 0, "y": 0, "zoom": 1 },
+  "version": 1
+}
+```
+`components` is the only required field. `project_id` (a literal GUID), `viewport`, `version`, and
+`source` are **optional** in the current schema — keep `components` first and include a literal-GUID
+`project_id` as an editor convention, but they aren't hard requirements. The `source` field is
+managed by the editor; omit it when hand-writing.
+
+## Freshness notes (reconcile against the live engine / docs)
+- **Env substitution:** the engine expands **any** `${VAR}` from the environment (e.g.
+  `${OPENAI_API_KEY}`) — a `ROCKETRIDE_` prefix is not required.
+- **Response node:** the current docs show a single `response` provider with `config.laneName`
+  (e.g. `{ "provider": "response", "config": { "laneName": "answers" } }`). Our bundled catalog
+  snapshot still lists lane-specific variants (`response_answers`, `response_text`, …). Use whatever
+  the **live index / `get_services()` / `validate()`** confirms for your engine — that's authoritative;
+  the bundled examples use `response_answers` to match the bundled catalog.
+- **Fan-in:** a node can merge the same lane from several upstream nodes by listing multiple `input`
+  entries, e.g. a `response` merging `answers` from two agents:
+  `"input": [{"lane":"answers","from":"agent_1"},{"lane":"answers","from":"agent_2"}]`.

--- a/docs/agents/skills/rocketride-designing-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-designing-pipelines/SKILL.md
@@ -13,6 +13,8 @@ The gate rules and forcing functions are in
 You work from the **node index** (L1): `LAYER1_NODE_INDEX.json` (bundled), or the live
 `get_services()` / `.rocketride/services-catalog.json`. Each entry is `name · classType · lanes ·
 invoke`. The index is enough to **select and wire**; it carries no config fields (that's Phase 2).
+The bundled index is reconciled against this repo's node corpus (`nodes/src/nodes/`), so it can
+drift from the set a particular live engine actually has registered.
 The live MCP `list_components` tool lists names/summaries only (**no lanes**) and hides nodes whose
 integration isn't configured — use it to check availability, but **wire from the bundled index +
 per-node schemas**. If a node you expect is missing from it, check `list_integrations` first.

--- a/docs/agents/skills/rocketride-designing-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-designing-pipelines/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: rocketride-designing-pipelines
+description: Use when choosing which RocketRide nodes a task needs and wiring them into a pipeline graph — exploring the node catalog, selecting nodes by archetype, and connecting them with typed lanes into a valid acyclic DAG.
+---
+
+# Designing RocketRide Pipelines
+
+Turns a plain-language request into an approved, lane-correct DAG — **before** any node is
+configured. Two outputs, two gates: a node selection (Gate A) and a wired topology (Gate B).
+The gate rules and forcing functions are in
+`../rocketride-building-pipelines/GATE_PROTOCOL.md` — they apply here.
+
+You work from the **node index** (L1): `LAYER1_NODE_INDEX.json` (bundled), or the live
+`get_services()` / `.rocketride/services-catalog.json`. Each entry is `name · classType · lanes ·
+invoke`. The index is enough to **select and wire**; it carries no config fields (that's Phase 2).
+The live MCP `list_components` tool lists names/summaries only (**no lanes**) and hides nodes whose
+integration isn't configured — use it to check availability, but **wire from the bundled index +
+per-node schemas**. If a node you expect is missing from it, check `list_integrations` first.
+
+## Phase 1a — Discover (→ Gate A)
+
+1. **Restate the task** in one line: the input data, the wanted output. ("Input: user questions.
+   Output: answers grounded in uploaded PDFs.")
+2. **Explore archetypes exhaustively.** Group the index by `classType` and walk every archetype
+   that could plausibly contribute. Don't stop at the first match. The archetypes:
+   `source` (chat/webhook/dropper/filesys/telegram) · `data`/parse (parse/llamaparse/reducto/
+   landingai_ade) · `text` (extract_data/ner/anonymize_text/dictionary/prompt/summarization) ·
+   `preprocessor` · `image` · `audio` · `video` · `embedding` · `llm` (14 providers) · `store`
+   (vector DBs) · `database` (db_*) · `agent` · `tool` (tool_*) · `memory` · `rerank` · `search` ·
+   `guard` · `infrastructure`/`target`/`response_*` (terminals).
+   For each relevant archetype, list the candidate nodes you see in the index.
+3. **Select**, citing each: `Found in index: <name> · classType=[…] · lanes={…}`. A pipeline needs
+   exactly one **source** and a **terminal** (`response_*` for a reply; a store / `db_*` for
+   ingestion). Pull the right converters from the lane cheat-sheet in
+   `../rocketride-building-pipelines/pipeline-patterns.md`.
+4. **Gate A** — end with the count line and the gate:
+   > Archetypes explored (N). Selected nodes (M): <name · role>, … — all cited from the index.
+   > Approve these M nodes? (yes / adjust / cancel)
+   Then **use the Write tool to write `.context/GATE_STATE.md`** = `GATE A | presented | status:
+   AWAITING` (GATE_PROTOCOL §2 — so the gate survives a context reset), and **STOP**. (See §1.)
+
+## Phase 1b — Design the DAG (→ Gate B)
+
+Only after Gate A is approved.
+
+1. **Fetch each selected node's schema** (L2 — `describe_component` / `tools/` shim in
+   `../rocketride-configuring-pipelines/tools/fetch-node-schema.py` / `.rocketride/schema/<n>.json`).
+   You need the real **lane signatures** here, not the index summary — wiring from the summary is
+   the most common silent bug. (Forcing function 8.) **Lazily — only for the nodes you selected at
+   Gate A; never `ls`/`cat`/glob the whole `.rocketride/schema/` dir or "pull every schema up front"
+   (FF#17). Select from the index first; fetch only the few schemas you need.**
+2. **Wire the lanes.** Each non-source node gets `input: [{lane, from}]`. State **every edge** with
+   its lane type: `chat_1 → embedding_1 (lane: questions)`. The output lane of `from` must be a
+   real output of that node and a valid input of the target. If types don't match, insert a
+   converter (cheat-sheet) — don't force it.
+   - `<Bad>`: `pdf_source_1 → store_1 (lane: text)` — wiring a raw document straight into a vector
+     store. It passes the eye test but fails validation: a store ingests **embeddings**, not text.
+   - `<Good>`: `pdf_source_1 → embedding_1 (lane: text)` then `embedding_1 → store_1 (lane: embeddings)`.
+3. **Apply the structural rules** (`PIPELINE_RULES_SUMMARY.md`): exactly one source; acyclic (no
+   loops); no orphans (every node reachable from the source); embedding **before** any store;
+   agents wire their `llm`/`tool`/`memory` via the **control plane** (the controlled node carries
+   `control: [{classType, from: <agent>}]`, the agent does not) and must meet each `invoke`
+   min/max from the index.
+4. **Draw it** (Mermaid or ASCII) and **Gate B**:
+   > <diagram>. Edges (K): <node → node (lane: type)>, … — all lane-checked against schemas.
+   > Approve this topology? (yes / adjust / cancel)
+   Then **Write `.context/GATE_STATE.md`** = `GATE B | presented | status: AWAITING` (§2), and STOP.
+
+Hand the approved selection + topology to `rocketride-configuring-pipelines`.
+
+## Red flags
+
+| Thought | Reality |
+|---|---|
+| "I'll list the obvious nodes and move on" | Exhaustive archetype walk first — the right node is often one you'd skip. Count line proves coverage. |
+| "The index shows the lanes, I don't need the schema to wire" | Index lanes are a summary; fetch the schema for exact signatures before wiring. |
+| "Two sources is fine" | Exactly one source per pipeline. |
+| "I'll point the store straight at the questions" | Embedding is required before any store; same model for ingest + query. |
+| "The agent node lists its tools in its own config" | No — the tool/llm/memory carries `control: [{from: <agent>}]`. Agent has no control array. |
+| "Close enough on the lane type" | Lane mismatch = pipeline error. Insert a converter or pick compatible nodes. |
+
+## Supporting files
+
+- `LAYER1_NODE_INDEX.json` — the thin node index (name · classType · lanes · invoke)
+- `PIPELINE_RULES_SUMMARY.md` — lane types, lane-transform table, structural + control-plane rules
+- `examples/` — worked pipelines (simple-chat-rag, document-ingestion, agentic-chat) in
+  `examples/README.md` + a `FAILURE_SCENARIOS.md` of what not to do
+- **deep docs** — when a node is unfamiliar or you're unsure how an archetype behaves, fetch ONE
+  page: `../rocketride-building-pipelines/tools/fetch-doc.py "<node-name>"` (→ `/nodes/<name>.md`)
+  or `… "execution model"` (→ `/concepts/execution-model.md` for lanes). Never `llms-full.txt`.

--- a/docs/agents/skills/rocketride-designing-pipelines/examples/FAILURE_SCENARIOS.md
+++ b/docs/agents/skills/rocketride-designing-pipelines/examples/FAILURE_SCENARIOS.md
@@ -6,7 +6,7 @@ Each shows a tempting mistake, what happens, and the correct move.
 ## ❌ Fabricating a node that isn't in the index
 > User: "add a `transform` node to clean the data."
 A `transform` node does **not** exist in the catalog (it appears in an old doc as a placeholder).
-**Wrong:** wire in `transform` anyway → `Component not found` at run time.
+**Wrong:** wire in `transform` anyway → `The service transform was not found` at run time.
 **Right:** check the index. There's no `transform`. STOP and offer real options: a `preprocessor_*`
 node, `anonymize_text`, `extract_data` (needs an LLM), or ask what cleanup is needed. Never invent
 a node — if it's not in the index, it doesn't exist.

--- a/docs/agents/skills/rocketride-designing-pipelines/examples/FAILURE_SCENARIOS.md
+++ b/docs/agents/skills/rocketride-designing-pipelines/examples/FAILURE_SCENARIOS.md
@@ -1,0 +1,54 @@
+# Failure Scenarios (what NOT to do)
+
+Negative examples. Weak models improve markedly with explicit "this is wrong, here's why."
+Each shows a tempting mistake, what happens, and the correct move.
+
+## ❌ Fabricating a node that isn't in the index
+> User: "add a `transform` node to clean the data."
+A `transform` node does **not** exist in the catalog (it appears in an old doc as a placeholder).
+**Wrong:** wire in `transform` anyway → `Component not found` at run time.
+**Right:** check the index. There's no `transform`. STOP and offer real options: a `preprocessor_*`
+node, `anonymize_text`, `extract_data` (needs an LLM), or ask what cleanup is needed. Never invent
+a node — if it's not in the index, it doesn't exist.
+
+## ❌ Wiring a lane that doesn't match
+> Plan: `chat → qdrant` directly (skip embedding).
+qdrant's input on the `questions` lane needs **vectorized** questions; chat emits raw `questions`.
+**Wrong:** `chat_1 → qdrant_1` → store returns nothing / errors; the query was never embedded.
+**Right:** `chat → embedding_transformer → qdrant`. Embedding is mandatory before any store, and
+the query embedding must match the ingest embedding.
+
+## ❌ Guessing a config field
+> Setting `"max_tokens": 4096` on `llm_openai`.
+The real field is `modelTotalTokens`, and the key nests under the profile.
+**Wrong:** `validate()` rejects unknown field / the limit is ignored.
+**Right:** fetch the schema (`describe_component llm_openai` / the shim), read `Pipe.schema` +
+`dependencies.profile.oneOf`, set
+`{"profile":"openai-4o","openai-4o":{"apikey":"${ROCKETRIDE_OPENAI_KEY}"}}`.
+
+## ❌ Putting the control array on the agent
+> `agent_rocketride` config lists its `llm` and `tools`.
+**Wrong:** the agent has no `control` array; nothing is invoked → agent does nothing.
+**Right:** the **llm**/**tool**/**memory** nodes each carry `control: [{classType, from: <agent>}]`
+pointing back at the agent.
+
+## ❌ Claiming success without checking
+> "I submitted the run, so it worked. Here's your answer: …"
+**Wrong:** `use()` only started it; the "answer" is invented.
+**Right:** poll `get_task_status` to a terminal state, read the real result/`result_types`, and
+quote it. Submitted ≠ succeeded.
+
+## ❌ Self-approving a dismissed gate
+> Gate C.5 (cost) dialog dismissed; agent thinks "they probably meant yes" and runs.
+**Wrong:** burns the user's money on an unapproved run.
+**Right:** dismissed = unanswered = STOP. Re-present the cost gate and wait.
+
+## ❌ Hardcoding a secret
+> `"apikey": "sk-..."`
+**Wrong:** leaks the key; breaks env substitution.
+**Right:** `"apikey": "${ROCKETRIDE_OPENAI_KEY}"` and set the env var.
+
+## ❌ Blocking the event loop when running
+> Using `input("Question: ")` or `time.sleep` inside the async run.
+**Wrong:** freezes the websocket keepalive → `Connection closed` after ~60s.
+**Right:** use async I/O; never block the async loop.

--- a/docs/agents/skills/rocketride-designing-pipelines/examples/README.md
+++ b/docs/agents/skills/rocketride-designing-pipelines/examples/README.md
@@ -1,0 +1,66 @@
+# Worked Examples
+
+Three real, validated pipelines. When a request resembles one, **adapt the example** instead of
+reasoning from scratch (forcing function 15). Every provider, profile, and lane below is verified
+against the node catalog. Always re-verify against the live index/schemas for your engine.
+
+---
+
+## 1. `simple-chat-rag.pipe` — answer questions from indexed docs (RAG)
+
+Request shape: "a chatbot that answers from my knowledge base."
+
+Flow: `chat_1 → embedding_1 → qdrant_1 → llm_1 → response_1`
+
+| Node | provider | lane in → out | why |
+|---|---|---|---|
+| chat_1 | chat (source) | `_source` → `questions` | conversational input (`client.chat()`) |
+| embedding_1 | embedding_transformer | `questions` → `questions` | vectorize the query (profile `miniAll`) |
+| qdrant_1 | qdrant (search) | `questions` → `questions` | retrieve context (profile `local`) |
+| llm_1 | llm_openai | `questions` → `answers` | answer with context (profile `openai-4o`) |
+| response_1 | response_answers | `answers` → — | return the answer |
+
+Notes: the query embedding model must match the one used to ingest the docs. The LLM key is
+`${ROCKETRIDE_OPENAI_KEY}`. Ingest the docs first with `document-ingestion.pipe`.
+
+---
+
+## 2. `document-ingestion.pipe` — load docs into the vector store
+
+Request shape: "index these PDFs so I can search them."
+
+Flow: `webhook_1 → parse_1 → preprocessor_1 → embedding_1 → qdrant_1`  (no response node)
+
+| Node | provider | lane in → out | why |
+|---|---|---|---|
+| webhook_1 | webhook (source) | `_source` → `tags` | file upload (`client.send_files()`) |
+| parse_1 | parse | `tags` → `text` | extract text from files |
+| preprocessor_1 | preprocessor_langchain | `text` → `documents` | chunk (profile `recursive`) |
+| embedding_1 | embedding_transformer | `documents` → `documents` | add vectors (profile `miniAll`) |
+| qdrant_1 | qdrant (ingest) | `documents` → — | store (terminal) |
+
+Notes: ingestion ends in the **store** — no `response_*` node. Embedding is mandatory before the
+store. Use the **same** embedding profile here and in the RAG query pipeline.
+
+---
+
+## 3. `agentic-chat.pipe` — an agent with an LLM + memory (control plane)
+
+Request shape: "an assistant that can reason and remember." Demonstrates the **control plane** —
+the hardest wiring to get right.
+
+Flow (data): `chat_1 → agent_1 → response_1`. Control: `llm_1` and `memory_1` are attached to the
+agent via their own `control` arrays.
+
+| Node | provider | wiring | why |
+|---|---|---|---|
+| chat_1 | chat (source) | → questions | input |
+| agent_1 | agent_rocketride | `input: questions from chat_1` | plans + synthesizes |
+| llm_1 | llm_openai | `control: [{classType: llm, from: agent_1}]` | the agent's LLM (required, exactly 1) |
+| memory_1 | memory_internal | `control: [{classType: memory, from: agent_1}]` | the agent's memory (required, exactly 1) |
+| response_1 | response_answers | `input: answers from agent_1` | return the answer |
+
+Notes: the `control` array goes on the **controlled** node (llm/memory), pointing back at the
+agent — never on the agent. `agent_rocketride` requires exactly 1 llm and exactly 1 memory; tools
+are optional (`tool_*` with `control: [{classType: tool, from: agent_1}]`). Check each agent's
+`invoke` cardinality in the index.

--- a/docs/agents/skills/rocketride-designing-pipelines/examples/agentic-chat.pipe
+++ b/docs/agents/skills/rocketride-designing-pipelines/examples/agentic-chat.pipe
@@ -1,0 +1,12 @@
+{
+  "components": [
+    { "id": "chat_1", "provider": "chat", "config": { "hideForm": true, "mode": "Source", "parameters": {}, "type": "chat" } },
+    { "id": "agent_1", "provider": "agent_rocketride", "config": { "instructions": [], "max_waves": 10, "parameters": {} }, "input": [{ "lane": "questions", "from": "chat_1" }] },
+    { "id": "llm_1", "provider": "llm_openai", "config": { "profile": "openai-4o", "openai-4o": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }, "parameters": {} }, "control": [{ "classType": "llm", "from": "agent_1" }] },
+    { "id": "memory_1", "provider": "memory_internal", "config": { "type": "memory_internal" }, "control": [{ "classType": "memory", "from": "agent_1" }] },
+    { "id": "response_1", "provider": "response_answers", "config": { "laneName": "answers" }, "input": [{ "lane": "answers", "from": "agent_1" }] }
+  ],
+  "project_id": "c9f5e4a3-2d6f-4a0b-8e3f-7d8a9b0c1d2e",
+  "viewport": { "x": 0, "y": 0, "zoom": 1 },
+  "version": 1
+}

--- a/docs/agents/skills/rocketride-designing-pipelines/examples/document-ingestion.pipe
+++ b/docs/agents/skills/rocketride-designing-pipelines/examples/document-ingestion.pipe
@@ -1,0 +1,12 @@
+{
+  "components": [
+    { "id": "webhook_1", "provider": "webhook", "config": { "hideForm": true, "mode": "Source", "parameters": {}, "type": "webhook" } },
+    { "id": "parse_1", "provider": "parse", "config": { "parameters": {} }, "input": [{ "lane": "tags", "from": "webhook_1" }] },
+    { "id": "preprocessor_1", "provider": "preprocessor_langchain", "config": { "profile": "recursive", "parameters": {} }, "input": [{ "lane": "text", "from": "parse_1" }] },
+    { "id": "embedding_1", "provider": "embedding_transformer", "config": { "profile": "miniAll", "parameters": {} }, "input": [{ "lane": "documents", "from": "preprocessor_1" }] },
+    { "id": "qdrant_1", "provider": "qdrant", "config": { "profile": "local", "local": { "collection": "docs" }, "parameters": {} }, "input": [{ "lane": "documents", "from": "embedding_1" }] }
+  ],
+  "project_id": "b8e4d3f2-1c5e-4f9a-9d2e-6c7f8a9b0c1d",
+  "viewport": { "x": 0, "y": 0, "zoom": 1 },
+  "version": 1
+}

--- a/docs/agents/skills/rocketride-designing-pipelines/examples/simple-chat-rag.pipe
+++ b/docs/agents/skills/rocketride-designing-pipelines/examples/simple-chat-rag.pipe
@@ -1,0 +1,12 @@
+{
+  "components": [
+    { "id": "chat_1", "provider": "chat", "config": { "hideForm": true, "mode": "Source", "parameters": {}, "type": "chat" } },
+    { "id": "embedding_1", "provider": "embedding_transformer", "config": { "profile": "miniAll", "parameters": {} }, "input": [{ "lane": "questions", "from": "chat_1" }] },
+    { "id": "qdrant_1", "provider": "qdrant", "config": { "profile": "local", "local": { "collection": "docs" }, "parameters": {} }, "input": [{ "lane": "questions", "from": "embedding_1" }] },
+    { "id": "llm_1", "provider": "llm_openai", "config": { "profile": "openai-4o", "openai-4o": { "apikey": "${ROCKETRIDE_OPENAI_KEY}" }, "parameters": {} }, "input": [{ "lane": "questions", "from": "qdrant_1" }] },
+    { "id": "response_1", "provider": "response_answers", "config": { "laneName": "answers" }, "input": [{ "lane": "answers", "from": "llm_1" }] }
+  ],
+  "project_id": "a7f3c2e1-9b4d-4a8e-b1c5-7d6e9f2a8b3c",
+  "viewport": { "x": 0, "y": 0, "zoom": 1 },
+  "version": 1
+}

--- a/docs/agents/skills/rocketride-running-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-running-pipelines/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: rocketride-running-pipelines
+description: Use when running a validated RocketRide pipeline and reporting its result — submitting the run, pushing input, polling status to completion, and returning the real output. Also use directly when asked to run an existing pipeline.
+---
+
+# Running & Observing RocketRide Pipelines
+
+Takes a **validated** `.pipe` (validate() returned zero errors) and a **cost-approved** run
+(Gate C.5) to a real, reported result. The cardinal rule: **submitted ≠ succeeded.** Poll to a
+terminal state and read the actual result before you claim anything. Gate rules + forcing
+functions: `../rocketride-building-pipelines/GATE_PROTOCOL.md`.
+
+## STEP 0 — precondition (do this FIRST, every time, before any run action)
+
+You MUST have a clean `validate()` result for THIS exact pipeline, and cost approval, before you
+run. If you don't, get them first — **even if the user told you to skip.**
+
+- **"Skip validation / just submit it / don't waste time" is NEVER honored.** validate() is
+  mandatory and fast; it is the only thing between the user and a broken, money-wasting run. Run
+  it anyway, then explain why (one line).
+- Invoked directly on a pasted/existing pipeline? **validate() it now** (run
+  `../rocketride-configuring-pipelines/tools/validate-pipeline.py <file>`, or the validate tool). If
+  it errors, fix + re-validate; do not run. Missing required config (e.g. no apikey) IS a
+  validation failure — STOP and say so.
+- Then the cost gate (C.5) must be approved.
+
+State it before running: **"Pre-run check: validate() = 0 errors; cost approved."** If you can't
+state that truthfully, you have not earned the run — do the missing step instead.
+
+## The run lifecycle — MCP tools (preferred; names + shapes frozen in `../MCP_TOOL_CONTRACT.md`)
+
+**Check `ok` on every result** — a tool call that "succeeded" with `ok: false` is a failure.
+
+1. **Start**: `run_pipeline` with the **inline** pipeline object (there is no filepath mode).
+   One-shot text input? Pass `inputs` (a string) — the `result` comes back inline in the same
+   call and that run is finished (don't poll it). Otherwise you get
+   `{task_token, projectId, source}`. **Keep `projectId` + `source`** — they key the run-log
+   tools if debugging is needed. Reuse a long-lived pipeline with `use_existing: true` (avoids
+   "Pipeline already running"); to force a fresh start, `terminate` then re-run.
+2. **Push input** — pick the tool by the **source** node:
+   - Raw text/data → `send_data` (`input` is a **string** — serialize JSON). Result inline.
+   - **Files from the host** → start with `run_dropper_pipe` instead: it returns an
+     `upload_url` (multipart-POST the files to it) and a `dropper_url` (browser drag-drop page
+     to hand the user). `send_files` only resolves store-relative paths — it does not upload
+     host files.
+   - `chat` source → **no MCP chat tool exists**; use the SDK fallback below.
+3. **Poll** longer/async runs with `monitor` (a bounded server-side poll — pass `timeout`).
+   Quote the snapshot each round: `state_label`, `terminal`, `counts`, `errors`.
+   `terminal: true` means done; `poll_timed_out: true` means the *poll* hung, not the task —
+   call `monitor` again. Never one-shot poll and walk away. (Forcing function 12.)
+4. **Report the real result.** Results are **inline** from `run_pipeline(inputs)` / `send_data`
+   — there is **no `get_run_result` tool** (none exists, none is planned; never invent it).
+   Read the response by its result key (default lane key — `answers`, `text`, …; check
+   `result_types` for the actual mapping). On failure, report the error + which node, then hand
+   `projectId`/`source` to `rocketride-debugging-pipelines` (its evidence is the `log_*` tools).
+5. **Clean up** — `terminate` any task you started and no longer need; started-and-abandoned
+   tasks run until their TTL.
+
+## SDK fallback (no MCP tools wired, or a chat-source pipeline)
+
+1. **Start**: `result = await client.use(filepath="x.pipe")` → `token = result["token"]`
+   (`use_existing=True` to reuse; `terminate(token)` then `use()` to force fresh).
+2. **Push input**: `chat` source → `await client.chat(token=token, question=q)`; raw data →
+   `await client.send(token, data)`; files → `await client.send_files(files, token)`. The result
+   comes back **inline** (a `PIPELINE_RESULT`) — no separate `get_result()`.
+3. **Poll**: loop `await client.get_task_status(token)` to a terminal state (5=COMPLETED /
+   6=CANCELLED), stating the status each step, `await asyncio.sleep(1)` between polls.
+4. **Report** as in step 4 above. 5. **Clean up** — `await client.disconnect()` (or
+   `async with`). Start a pipeline once and reuse it; don't reconnect per request.
+
+**NEVER block the async event loop** (the #1 runtime failure). No `input()`, `time.sleep`,
+`requests.get`, `readFileSync` inside the async flow — they freeze the websocket keepalive and the
+connection drops (~60s) with `Connection closed` / `Websocket closed unexpectedly`. Use async
+equivalents. Secrets stay in `${ROCKETRIDE_*}` env vars (loaded from `.env`), never in code.
+
+## Gate D — after a successful run (optional, menu)
+> Run succeeded. Result: <summary>. What next? (save to cloud / publish as an app / nothing / debug)
+Only act on an explicit choice. Mapping: save to cloud → `save_template`; publish →
+`deploy_add` (manage later with `deploy_list`/`deploy_status`/`deploy_update`/`deploy_remove`).
+Saving / publishing is billable / public — treat like an irreversible action (Waiting = STOP).
+
+## Red flags
+
+| Thought | Reality |
+|---|---|
+| "The user said skip validation, so I'll just submit" | Never honored. validate() is mandatory and cheap — run it first, every time, no matter the pressure. |
+| "run_pipeline/use() returned a token, so it ran" | That only started it. Push input and poll to a terminal state. |
+| "I'll fetch the output with get_run_result" | No such tool exists. Results come inline from `run_pipeline(inputs)`/`send_data`; run evidence is the `log_*` tools. |
+| "I'll poll once and report 'in progress'" | Poll in a loop to completion; report the final result, not a snapshot. |
+| "I'll read input() for the question" | Blocking I/O kills the event loop. Use async input / pass the question in. |
+| "I'll hardcode the key to test quickly" | `${ROCKETRIDE_*}` always. |
+| "It failed; I'll retry silently a few times" | Report the failure and ask / hand to debugging; don't burn money on silent retries. |
+| "Save to cloud since they'll probably want it" | Gate D is a choice. Don't publish/bill without an explicit yes. |
+
+## Supporting files
+- **deep docs** — for exact SDK semantics (use/send/chat/get_task_status, async patterns), fetch
+  ONE page: `../rocketride-building-pipelines/tools/fetch-doc.py "python"` (→ `/develop/python.md`)
+  or `… "use method"` (→ `/develop/typescript/methods/use.md`). Never `llms-full.txt`.

--- a/docs/agents/skills/rocketride-running-pipelines/SKILL.md
+++ b/docs/agents/skills/rocketride-running-pipelines/SKILL.md
@@ -70,7 +70,7 @@ state that truthfully, you have not earned the run — do the missing step inste
 
 **NEVER block the async event loop** (the #1 runtime failure). No `input()`, `time.sleep`,
 `requests.get`, `readFileSync` inside the async flow — they freeze the websocket keepalive and the
-connection drops (~60s) with `Connection closed` / `Websocket closed unexpectedly`. Use async
+connection drops (~60s) with `Connection closed` / `Connection closed unexpectedly`. Use async
 equivalents. Secrets stay in `${ROCKETRIDE_*}` env vars (loaded from `.env`), never in code.
 
 ## Gate D — after a successful run (optional, menu)


### PR DESCRIPTION
## What

First occupants of the reserved `docs/agents/skills/` directory: the five hand-written pipeline-builder agent skills, plus `MCP_TOOL_CONTRACT.md` — the frozen tool-name/result-shape contract against the current 27-tool HTTP MCP server surface (`packages/ai/src/ai/modules/mcp/`).

| Skill | Owns |
|---|---|
| `rocketride-building-pipelines/` | Orchestrator: lifecycle, gate discipline (Waiting = STOP), tool ladder, 17 forcing functions |
| `rocketride-designing-pipelines/` | Node selection from the bundled L1 index + typed-lane DAG wiring (Gates A/B) |
| `rocketride-configuring-pipelines/` | Schema-driven config, anti-pattern checklist, validate loop (Gate C), cost approval (C.5) |
| `rocketride-running-pipelines/` | MCP-first run lifecycle (`run_pipeline`/`run_dropper_pipe`/`send_data`/`monitor`), SDK fallback, Gate D |
| `rocketride-debugging-pipelines/` | Evidence-first diagnosis via `monitor` + the DVR log tools (`log_chapters`/`log_read`/`log_traces`/`log_trace`) |

## File policy

Every file in the drop is agent-runtime material — something the executing agent is explicitly told to read or run (SKILL.md flows, gate protocol, tool contract, checklists, node index + freshness stamp, doc map, fallback shims, worked examples + failure scenarios). The one maintainer-only file (persuasion-principles.md, the rule-wording rationale) stays in the skill-source repo and is not shipped.

## Notes for review

- **Not exported**: `docs:export` copies only direct `docs/agents/*.md`, so this subdirectory stays out of `.rocketride/docs/` (per the directory README's design). The README documents the future export hook.
- The bundled `LAYER1_NODE_INDEX.json` was regenerated 2026-08-25 from a live `server-v3.3.1` engine via `get_services()` — 124 nodes, matching this branch's node-README corpus.
- The skills are weak-model-first: verification comes from tools (`validate_pipeline` is the compiler, the run result is the proof) and hard process gates, not model intelligence. The set holds a 0/24 gate-blast-through record on Haiku in its benchmark harness (harness not included here).
- Python shims under `tools/` conformed to repo ruff style; the deliberate literal-API-key *anti-examples* were shortened to `sk-...` placeholders to clear the gitleaks rules.
- Heads-up (pre-existing, not addressed here): the custom gitleaks rules in `.gitleaks.toml` use `paths = [...]`, which this gitleaks version doesn't honor for rule scoping — the `.pipe`-file rules currently fire on any file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added guided workflows for designing, configuring, validating, running, monitoring, and debugging RocketRide pipelines.
  - Added tools for retrieving documentation and node schemas, validating pipelines, and refreshing the node catalog.
  - Added reusable examples for chat, RAG, document ingestion, and agentic applications.

- **Documentation**
  - Added approval gates, safety checks, cost-estimation guidance, credential-handling rules, and troubleshooting references.
  - Added pipeline patterns, anti-patterns, design rules, error guidance, and focused documentation lookup instructions.
  - Documented available tools, supported workflows, and integration requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->