### PR TITLE
feat(depends): cache the satisfied verdict so cold processes skip the uv resolve

### DIFF
--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -893,7 +893,8 @@ def _requirements_closure(requirements_path: str) -> list[str]:
         closure.append(path)
         try:
             with open(path, 'r', encoding='utf-8') as f:
-                lines = f.read().splitlines()
+                # A trailing backslash continues the line, as in pip and uv.
+                lines = f.read().replace('\\\n', '').splitlines()
         except OSError:
             continue
         for line in lines:

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import hashlib
 import os
 import platform
+import re
 import subprocess
 import sys
 import threading
@@ -872,6 +873,36 @@ def _file_digest(path: str) -> str:
         return ''
 
 
+# A requirements line that pulls in another file: ``-r``/``--requirement`` and
+# ``-c``/``--constraint``, with the path after whitespace or ``=``.
+_INCLUDE_DIRECTIVE = re.compile(r'^\s*(?:-r|--requirement|-c|--constraint)(?:\s+|=)(\S+)')
+
+
+def _requirements_closure(requirements_path: str) -> list[str]:
+    """``requirements_path`` plus every file it pulls in through ``-r`` / ``-c``, recursively.
+
+    Included paths resolve relative to the including file, as pip and uv resolve
+    them. Each file is visited once, so an include cycle terminates.
+    """
+    closure: list[str] = []
+    pending = [os.path.abspath(requirements_path)]
+    while pending:
+        path = pending.pop(0)
+        if path in closure:
+            continue
+        closure.append(path)
+        try:
+            with open(path, 'r', encoding='utf-8') as f:
+                lines = f.read().splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            match = _INCLUDE_DIRECTIVE.match(line)
+            if match:
+                pending.append(os.path.normpath(os.path.join(os.path.dirname(path), match.group(1))))
+    return closure
+
+
 def _installed_fingerprint() -> str:
     """Digest of the *.dist-info / *.egg-info names in site-packages — the names carry versions."""
     try:
@@ -882,16 +913,21 @@ def _installed_fingerprint() -> str:
 
 
 def _verdict_key(requirements_path: str, constraints_path: str) -> str:
-    """Key under which a satisfied verdict stays valid."""
-    parts = [
-        sys.executable,
-        sys.version,
-        _file_digest(requirements_path),
-        _file_digest(constraints_path),
-        _file_digest(_get_overrides_path()),
-        _excludes_content(),
-        _installed_fingerprint(),
-    ]
+    """Key under which a "satisfied" verdict for ``requirements_path`` is valid.
+
+    Everything that can change what a resolve concludes is part of it,
+    including every file the requirements file includes through ``-r`` / ``-c``.
+    """
+    parts = [sys.executable, sys.version]
+    parts.extend(_file_digest(path) for path in _requirements_closure(requirements_path))
+    parts.extend(
+        [
+            _file_digest(constraints_path),
+            _file_digest(_get_overrides_path()),
+            _excludes_content(),
+            _installed_fingerprint(),
+        ]
+    )
     # NUL-separated: none of the parts can contain it, so field boundaries
     # stay unambiguous even though two of them are multi-line text.
     return hashlib.md5('\0'.join(parts).encode('utf-8')).hexdigest()

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -827,20 +827,87 @@ def ensure_constraints() -> str:
 # ---------------------------------------------------------------------------
 
 
-def _write_excludes_file() -> str:
-    """Write uv's resolution-excludes file (rewritten each call) and return its path.
+def _excludes_content() -> str:
+    """Content of uv's resolution-excludes file for this platform.
 
     Excludes `uv` (bootstrapped by depends.py; pip-installing it crashes on Windows)
     and, on non-Darwin, plain `onnxruntime` (it clobbers onnxruntime-gpu in the same
     folder; the gpu build provides `import onnxruntime`).
     """
-    excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
     excludes = 'uv\n'
     if platform.system() != 'Darwin':
         excludes += 'onnxruntime\n'
+    return excludes
+
+
+def _write_excludes_file() -> str:
+    """Write uv's resolution-excludes file (rewritten each call) and return its path."""
+    excludes_path = os.path.join(engine_cache_dir(), 'excludes.txt')
     with open(excludes_path, 'w', encoding='utf-8') as f:
-        f.write(excludes)
+        f.write(_excludes_content())
     return excludes_path
+
+
+# ---------------------------------------------------------------------------
+# Satisfied-verdict cache
+# ---------------------------------------------------------------------------
+#
+# ``_processed`` spans one process, so every cold engine re-ran the 20-40s uv
+# resolve only to conclude that nothing was missing (#2089). Persist that
+# verdict instead, keyed by everything a resolve consults.
+
+
+def _verdict_path(requirements_path: str) -> str:
+    """Path of the cached verdict for a requirements file."""
+    digest = hashlib.md5(os.path.abspath(requirements_path).encode('utf-8')).hexdigest()
+    return os.path.join(engine_cache_dir(), 'satisfied', f'{digest}.hash')
+
+
+def _file_digest(path: str) -> str:
+    """Content digest of a file, or empty string when it does not exist."""
+    try:
+        with open(path, 'rb') as f:
+            return hashlib.md5(f.read()).hexdigest()
+    except OSError:
+        return ''
+
+
+def _installed_fingerprint() -> str:
+    """Digest of the *.dist-info / *.egg-info names in site-packages — the names carry versions."""
+    try:
+        entries = [e for e in os.listdir(_get_site_packages()) if e.endswith(('.dist-info', '.egg-info'))]
+    except OSError:
+        entries = []
+    return hashlib.md5('\n'.join(sorted(entries)).encode('utf-8')).hexdigest()
+
+
+def _verdict_key(requirements_path: str, constraints_path: str) -> str:
+    """Key under which a satisfied verdict stays valid."""
+    parts = [
+        sys.executable,
+        sys.version,
+        _file_digest(requirements_path),
+        _file_digest(constraints_path),
+        _file_digest(_get_overrides_path()),
+        _excludes_content(),
+        _installed_fingerprint(),
+    ]
+    # NUL-separated: none of the parts can contain it, so field boundaries
+    # stay unambiguous even though two of them are multi-line text.
+    return hashlib.md5('\0'.join(parts).encode('utf-8')).hexdigest()
+
+
+def _verdict_cached(requirements_path: str, constraints_path: str) -> bool:
+    """True when a previous resolve recorded this file as satisfied under the current key."""
+    stored = _load_stored_hash(_verdict_path(requirements_path))
+    return stored is not None and stored == _verdict_key(requirements_path, constraints_path)
+
+
+def _save_verdict(requirements_path: str, constraints_path: str):
+    """Record requirements_path as satisfied under the current key."""
+    verdict_file = _verdict_path(requirements_path)
+    os.makedirs(os.path.dirname(verdict_file), exist_ok=True)
+    _save_hash(verdict_file, _verdict_key(requirements_path, constraints_path))
 
 
 def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]:
@@ -928,6 +995,12 @@ def _install_requirements(requirements_path: str, constraints_path: str):
         debug(f'  Empty requirements file, skipping: {requirements_path}')
         return
 
+    # A previous process already resolved this file against this environment
+    # and found it satisfied: nothing to install, and nothing to resolve.
+    if _verdict_cached(requirements_path, constraints_path):
+        debug(f'  Satisfied verdict cached, skipping resolve: {requirements_path}')
+        return
+
     # Start heartbeat early — the dry-run can block on uv's internal lock
     # for minutes, and we need monitorStatus events to keep the task startup
     # timeout alive during that time.
@@ -949,6 +1022,7 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
     # If dry-run returned empty list, all packages are satisfied
     if len(packages) == 0:
         debug(f'All requirements satisfied: {requirements_path}')
+        _save_verdict(requirements_path, constraints_path)
         return
 
     # Format status message: show up to 5 packages, or 4 + "..." if more than 5
@@ -1011,6 +1085,9 @@ def _install_requirements_inner(requirements_path: str, constraints_path: str):
 
     # Clear path importer cache for site-packages to force re-scan
     sys.path_importer_cache.pop(_get_site_packages(), None)
+
+    # The install changed the installed set: record the verdict against it.
+    _save_verdict(requirements_path, constraints_path)
 
     debug(f'Installed: {requirements_path}')
 

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -922,12 +922,22 @@ def _requirements_closure(requirements_path: str) -> list[str]:
     return closure
 
 
-def _installed_fingerprint() -> str:
-    """Digest of the *.dist-info / *.egg-info names in site-packages — the names carry versions."""
+def _installed_fingerprint() -> Optional[str]:
+    """Digest of the *.dist-info / *.egg-info names in site-packages, or ``None``.
+
+    The names carry versions, so an install, upgrade or uninstall changes it.
+
+    ``None`` when the directory cannot be listed. Hashing an empty list instead
+    would return the same digest every time, so the key would stop noticing
+    installs and every verdict would stay satisfied for ever — a silent stale
+    hit. Refusing the key resolves every time instead, which is the safe
+    direction. ``bootstrap()`` creates this directory before any key is
+    computed, so on the real path it always exists.
+    """
     try:
         entries = [e for e in os.listdir(_get_site_packages()) if e.endswith(('.dist-info', '.egg-info'))]
     except OSError:
-        entries = []
+        return None
     return hashlib.md5('\n'.join(sorted(entries)).encode('utf-8')).hexdigest()
 
 
@@ -949,6 +959,8 @@ def _verdict_key(requirements_path: str, constraints_path: str) -> Optional[str]
         return None
 
     installed = _installed_fingerprint()
+    if installed is None:
+        return None
 
     parts = [_VERDICT_SCHEMA, sys.executable, sys.version]
     parts.extend(_file_digest(path) for path in closure)

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -856,6 +856,20 @@ def _write_excludes_file() -> str:
 # ``_processed`` spans one process, so every cold engine re-ran the 20-40s uv
 # resolve only to conclude that nothing was missing (#2089). Persist that
 # verdict instead, keyed by everything a resolve consults.
+#
+# Two consequences worth knowing. The fingerprint is the whole installed set,
+# so installing anything invalidates every file's verdict: on a host where
+# nodes install lazily, each install costs one extra resolve per requirements
+# file before things settle again. And the key cannot see the resolve's own
+# arguments, so _VERDICT_SCHEMA below is bumped whenever those change.
+#
+# The check and the write both run under the engine-global ``install.lock``
+# via depends(), which is what makes the non-atomic _save_hash write safe.
+# Per-node locks (#2089 ask 2) would remove that guarantee.
+
+# Bump when the resolve's inputs or semantics change (uv arguments, what the
+# key covers), so verdicts recorded under the old behaviour are not reused.
+_VERDICT_SCHEMA = '1'
 
 
 def _verdict_path(requirements_path: str) -> str:
@@ -875,7 +889,7 @@ def _file_digest(path: str) -> str:
 
 # A requirements line that pulls in another file: ``-r``/``--requirement`` and
 # ``-c``/``--constraint``, with the path after whitespace or ``=``.
-_INCLUDE_DIRECTIVE = re.compile(r'^\s*(?:-r|--requirement|-c|--constraint)(?:\s+|=)(\S+)')
+_INCLUDE_DIRECTIVE = re.compile(r'^\s*(?:-r|--requirement|-c|--constraint)(?:\s+|=)(?:"([^"]+)"|\'([^\']+)\'|(\S+))')
 
 
 def _requirements_closure(requirements_path: str) -> list[str]:
@@ -892,7 +906,10 @@ def _requirements_closure(requirements_path: str) -> list[str]:
             continue
         closure.append(path)
         try:
-            with open(path, 'r', encoding='utf-8') as f:
+            # errors='replace' because this decode only feeds directive
+            # scanning: the digest is taken from the bytes in _file_digest, so a
+            # non-UTF-8 requirements file must not fail the node it belongs to.
+            with open(path, 'r', encoding='utf-8', errors='replace') as f:
                 # A trailing backslash continues the line, as in pip and uv.
                 lines = f.read().replace('\\\n', '').splitlines()
         except OSError:
@@ -900,7 +917,8 @@ def _requirements_closure(requirements_path: str) -> list[str]:
         for line in lines:
             match = _INCLUDE_DIRECTIVE.match(line)
             if match:
-                pending.append(os.path.normpath(os.path.join(os.path.dirname(path), match.group(1))))
+                target = match.group(1) or match.group(2) or match.group(3)
+                pending.append(os.path.normpath(os.path.join(os.path.dirname(path), target)))
     return closure
 
 
@@ -913,20 +931,33 @@ def _installed_fingerprint() -> str:
     return hashlib.md5('\n'.join(sorted(entries)).encode('utf-8')).hexdigest()
 
 
-def _verdict_key(requirements_path: str, constraints_path: str) -> str:
+def _verdict_key(requirements_path: str, constraints_path: str) -> Optional[str]:
     """Key under which a "satisfied" verdict for ``requirements_path`` is valid.
 
     Everything that can change what a resolve concludes is part of it,
     including every file the requirements file includes through ``-r`` / ``-c``.
+
+    Returns ``None`` when the key cannot be computed honestly — a directive
+    names a file that does not exist, or site-packages cannot be listed. In
+    both cases something the resolve depends on is invisible here, so the key
+    would be stable over changing inputs. Refusing it degrades to resolving
+    every time, which is the safe direction — a stable key over an unseen
+    input keeps reporting "satisfied" after that input gains a dependency.
     """
-    parts = [sys.executable, sys.version]
-    parts.extend(_file_digest(path) for path in _requirements_closure(requirements_path))
+    closure = _requirements_closure(requirements_path)
+    if not all(os.path.exists(path) for path in closure):
+        return None
+
+    installed = _installed_fingerprint()
+
+    parts = [_VERDICT_SCHEMA, sys.executable, sys.version]
+    parts.extend(_file_digest(path) for path in closure)
     parts.extend(
         [
             _file_digest(constraints_path),
             _file_digest(_get_overrides_path()),
             _excludes_content(),
-            _installed_fingerprint(),
+            installed,
         ]
     )
     # NUL-separated: none of the parts can contain it, so field boundaries
@@ -937,13 +968,19 @@ def _verdict_key(requirements_path: str, constraints_path: str) -> str:
 def _verdict_cached(requirements_path: str, constraints_path: str) -> bool:
     """True when a previous resolve recorded this requirements file as satisfied under the current key.
 
-    An unreadable cache is a miss, never an error: the resolve simply runs.
+    An unreadable cache, or a key the closure refuses to produce, is a miss —
+    never an error. The cache is an optimisation: anything it cannot answer
+    must fall back to resolving, not fail the node that asked.
     """
     try:
         stored = _load_stored_hash(_verdict_path(requirements_path))
-    except OSError:
+        if stored is None:
+            return False
+        key = _verdict_key(requirements_path, constraints_path)
+        return key is not None and stored == key
+    except Exception as e:  # noqa: BLE001 - a cache read must never fail an install
+        debug(f'  Could not read the satisfied verdict ({e}); resolving instead')
         return False
-    return stored is not None and stored == _verdict_key(requirements_path, constraints_path)
 
 
 def _save_verdict(requirements_path: str, constraints_path: str):
@@ -953,11 +990,15 @@ def _save_verdict(requirements_path: str, constraints_path: str):
     process a resolve, so a cache that cannot be written must not fail an
     install that succeeded.
     """
-    verdict_file = _verdict_path(requirements_path)
     try:
+        key = _verdict_key(requirements_path, constraints_path)
+        if key is None:
+            debug(f'  Not recording a verdict: an include of {requirements_path} does not resolve')
+            return
+        verdict_file = _verdict_path(requirements_path)
         os.makedirs(os.path.dirname(verdict_file), exist_ok=True)
-        _save_hash(verdict_file, _verdict_key(requirements_path, constraints_path))
-    except OSError as e:
+        _save_hash(verdict_file, key)
+    except Exception as e:  # noqa: BLE001 - a cache write must never fail an install
         debug(f'  Could not record the satisfied verdict ({e}); the next process will resolve again')
 
 

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -935,16 +935,30 @@ def _verdict_key(requirements_path: str, constraints_path: str) -> str:
 
 
 def _verdict_cached(requirements_path: str, constraints_path: str) -> bool:
-    """True when a previous resolve recorded this file as satisfied under the current key."""
-    stored = _load_stored_hash(_verdict_path(requirements_path))
+    """True when a previous resolve recorded this requirements file as satisfied under the current key.
+
+    An unreadable cache is a miss, never an error: the resolve simply runs.
+    """
+    try:
+        stored = _load_stored_hash(_verdict_path(requirements_path))
+    except OSError:
+        return False
     return stored is not None and stored == _verdict_key(requirements_path, constraints_path)
 
 
 def _save_verdict(requirements_path: str, constraints_path: str):
-    """Record requirements_path as satisfied under the current key."""
+    """Record that ``requirements_path`` is satisfied under the current key.
+
+    Best effort, like the progress sidecar: the verdict only saves the next
+    process a resolve, so a cache that cannot be written must not fail an
+    install that succeeded.
+    """
     verdict_file = _verdict_path(requirements_path)
-    os.makedirs(os.path.dirname(verdict_file), exist_ok=True)
-    _save_hash(verdict_file, _verdict_key(requirements_path, constraints_path))
+    try:
+        os.makedirs(os.path.dirname(verdict_file), exist_ok=True)
+        _save_hash(verdict_file, _verdict_key(requirements_path, constraints_path))
+    except OSError as e:
+        debug(f'  Could not record the satisfied verdict ({e}); the next process will resolve again')
 
 
 def _install_dry_run(requirements_path: str, constraints_path: str) -> list[str]:

--- a/packages/server/engine-lib/rocketlib-python/lib/depends.py
+++ b/packages/server/engine-lib/rocketlib-python/lib/depends.py
@@ -948,14 +948,15 @@ def _verdict_key(requirements_path: str, constraints_path: str) -> Optional[str]
     including every file the requirements file includes through ``-r`` / ``-c``.
 
     Returns ``None`` when the key cannot be computed honestly — a directive
-    names a file that does not exist, or site-packages cannot be listed. In
+    names something that is not a readable file, or site-packages cannot be
+    listed. In
     both cases something the resolve depends on is invisible here, so the key
     would be stable over changing inputs. Refusing it degrades to resolving
     every time, which is the safe direction — a stable key over an unseen
     input keeps reporting "satisfied" after that input gains a dependency.
     """
     closure = _requirements_closure(requirements_path)
-    if not all(os.path.exists(path) for path in closure):
+    if not all(os.path.isfile(path) for path in closure):
         return None
 
     installed = _installed_fingerprint()

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
@@ -321,6 +321,13 @@ class TestSatisfiedVerdict:
 
         assert depends._requirements_closure(str(root)) == [str(root), str(base), str(pins)]
 
+    def test_requirements_closure_joins_continued_lines(self, exe_dir):
+        """A ``-r`` directive split over a backslash continuation still names its target."""
+        root = _write(exe_dir / 'nodes' / 'demo' / 'requirements.txt', '-r \\\n    base.txt\nrequests\n')
+        base = _write(exe_dir / 'nodes' / 'demo' / 'base.txt', 'pyjwt\n')
+
+        assert depends._requirements_closure(str(root)) == [str(root), str(base)]
+
     def test_failed_resolve_records_no_verdict(self, exe_dir, env, monkeypatch):
         """A resolve that raises leaves nothing behind, so the next process resolves again."""
 

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
@@ -7,6 +7,7 @@ directory" into ``tmp_path`` so nothing touches a real engine cache.
 """
 
 import os
+from types import SimpleNamespace
 
 import pytest
 
@@ -208,6 +209,134 @@ class TestInstallRequirements:
         monkeypatch.setattr(depends, '_install_requirements_inner', lambda *a: pytest.fail('should not install'))
 
         depends._install_requirements(str(req), str(tmp_path / 'constraints.txt'))
+
+
+class TestSatisfiedVerdict:
+    """The resolve verdict outlives the process (#2089).
+
+    ``_install_requirements`` is called once per cold process; a second call
+    with the same requirements file, constraints and installed set must not
+    resolve again, and any change to one of them must.
+    """
+
+    @pytest.fixture
+    def env(self, exe_dir, monkeypatch):
+        """A requirements file, its constraints, a fake site-packages, and a resolve recorder."""
+        site = exe_dir / 'site-packages'
+        (site / 'requests-2.32.4.dist-info').mkdir(parents=True)
+        monkeypatch.setattr(depends, '_get_site_packages', lambda: str(site))
+        monkeypatch.setattr(depends, 'updateProgress', lambda message: None)
+        monkeypatch.setattr(depends, '_start_heartbeat', lambda: None)
+        monkeypatch.setattr(depends, '_stop_heartbeat', lambda: None)
+
+        resolves = []
+
+        def fake_dry_run(requirements_path, constraints_path):
+            resolves.append(requirements_path)
+            return []  # everything already installed
+
+        monkeypatch.setattr(depends, '_install_dry_run', fake_dry_run)
+
+        return SimpleNamespace(
+            req=_write(exe_dir / 'nodes' / 'demo' / 'requirements.txt', 'requests\n'),
+            constraints=_write(exe_dir / 'cache' / 'constraints.txt', 'requests==2.32.4\n'),
+            site=site,
+            resolves=resolves,
+        )
+
+    @staticmethod
+    def _cold_process(env, req=None):
+        depends._install_requirements(str(req or env.req), str(env.constraints))
+
+    def test_second_process_skips_the_resolve(self, exe_dir, env):
+        self._cold_process(env)
+        self._cold_process(env)
+
+        assert len(env.resolves) == 1
+        assert os.listdir(exe_dir / 'cache' / 'satisfied') != []
+
+    def test_verdict_is_per_requirements_file(self, exe_dir, env):
+        other = _write(exe_dir / 'nodes' / 'other' / 'requirements.txt', 'pyjwt\n')
+
+        self._cold_process(env)
+        self._cold_process(env, req=other)
+        self._cold_process(env)
+        self._cold_process(env, req=other)
+
+        assert env.resolves == [str(env.req), str(other)]
+
+    def test_requirements_change_reruns_the_resolve(self, env):
+        self._cold_process(env)
+        env.req.write_text('requests\nhttpx\n', encoding='utf-8')
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
+    def test_constraints_change_reruns_the_resolve(self, env):
+        self._cold_process(env)
+        env.constraints.write_text('requests==2.33.0\n', encoding='utf-8')
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
+    def test_overrides_change_reruns_the_resolve(self, exe_dir, env):
+        self._cold_process(env)
+        _write(exe_dir / 'cache' / 'overrides-combined.txt', 'urllib3==2.5.0\n')
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
+    def test_installed_set_change_reruns_the_resolve(self, env):
+        self._cold_process(env)
+        # An upgrade, an uninstall or a manual install all rename a dist-info entry.
+        (env.site / 'requests-2.32.4.dist-info').rename(env.site / 'requests-2.33.0.dist-info')
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
+    def test_failed_resolve_records_no_verdict(self, exe_dir, env, monkeypatch):
+        def failing_dry_run(requirements_path, constraints_path):
+            env.resolves.append(requirements_path)
+            raise RuntimeError('Dependency resolution failed')
+
+        monkeypatch.setattr(depends, '_install_dry_run', failing_dry_run)
+
+        with pytest.raises(RuntimeError):
+            self._cold_process(env)
+        with pytest.raises(RuntimeError):
+            self._cold_process(env)
+
+        assert len(env.resolves) == 2
+        assert not (exe_dir / 'cache' / 'satisfied').exists()
+
+    def test_install_records_the_verdict_against_the_installed_set(self, env, monkeypatch):
+        """A verdict written after an install must key on the post-install site-packages."""
+        pending = ['httpx']
+
+        def dry_run_then_satisfied(requirements_path, constraints_path):
+            env.resolves.append(requirements_path)
+            return list(pending)
+
+        class FakeInstall:
+            """Stands in for the uv install Popen: installs one dist-info, exits 0."""
+
+            returncode = 0
+            stdout = iter(())
+
+            def __init__(self, *args, **kwargs):
+                (env.site / 'httpx-0.28.1.dist-info').mkdir()
+                pending.clear()
+
+            def wait(self):
+                return 0
+
+        monkeypatch.setattr(depends, '_install_dry_run', dry_run_then_satisfied)
+        monkeypatch.setattr(depends.subprocess, 'Popen', FakeInstall)
+
+        self._cold_process(env)  # resolves, installs httpx, records the verdict
+        self._cold_process(env)  # the recorded verdict matches the installed set
+
+        assert len(env.resolves) == 1
 
 
 class TestDepends:

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
@@ -328,6 +328,47 @@ class TestSatisfiedVerdict:
 
         assert depends._requirements_closure(str(root)) == [str(root), str(base)]
 
+    def test_non_utf8_included_file_does_not_fail_the_install(self, exe_dir, env):
+        """A non-UTF-8 include is scanned, not decoded strictly: it must not fail the node."""
+        (exe_dir / 'nodes' / 'demo' / 'base.txt').write_bytes(b'caf\xe9-pkg==1.0\n')
+        env.req.write_text('-r base.txt\nrequests\n', encoding='utf-8')
+
+        self._cold_process(env)
+        self._cold_process(env)
+
+        assert len(env.resolves) == 1
+
+    def test_quoted_include_path_is_tracked(self, exe_dir, env):
+        """A quoted path with a space is the file uv reads, so it belongs to the key."""
+        spaced = _write(exe_dir / 'nodes' / 'demo' / 'my pins.txt', 'pyjwt\n')
+        env.req.write_text('-r "my pins.txt"\nrequests\n', encoding='utf-8')
+
+        self._cold_process(env)
+        self._cold_process(env)
+        spaced.write_text('pyjwt\nhttpx\n', encoding='utf-8')
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
+    def test_unresolvable_include_is_never_cached(self, exe_dir, env):
+        """An include this parser cannot follow degrades to resolving, never to a stale hit."""
+        _write(exe_dir / 'nodes' / 'demo' / 'my pins.txt', 'pyjwt\n')
+        env.req.write_text('-r my pins.txt\nrequests\n', encoding='utf-8')
+
+        self._cold_process(env)
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+        assert depends._verdict_key(str(env.req), str(env.constraints)) is None
+
+    def test_schema_bump_invalidates_every_verdict(self, env, monkeypatch):
+        """Bumping the schema retires verdicts recorded under the old resolve semantics."""
+        self._cold_process(env)
+        monkeypatch.setattr(depends, '_VERDICT_SCHEMA', '2')
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
     def test_failed_resolve_records_no_verdict(self, exe_dir, env, monkeypatch):
         """A resolve that raises leaves nothing behind, so the next process resolves again."""
 

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
@@ -361,6 +361,17 @@ class TestSatisfiedVerdict:
         assert len(env.resolves) == 2
         assert depends._verdict_key(str(env.req), str(env.constraints)) is None
 
+    def test_include_naming_a_directory_is_never_cached(self, exe_dir, env):
+        """An include that is not a readable file refuses the key, like a missing one."""
+        (exe_dir / 'nodes' / 'demo' / 'base.txt').mkdir(parents=True)
+        env.req.write_text('-r base.txt\nrequests\n', encoding='utf-8')
+
+        self._cold_process(env)
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+        assert depends._verdict_key(str(env.req), str(env.constraints)) is None
+
     def test_schema_bump_invalidates_every_verdict(self, env, monkeypatch):
         """Bumping the schema retires verdicts recorded under the old resolve semantics."""
         self._cold_process(env)

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
@@ -369,6 +369,17 @@ class TestSatisfiedVerdict:
 
         assert len(env.resolves) == 2
 
+    def test_unlistable_site_packages_is_never_cached(self, env, monkeypatch):
+        """A site-packages that cannot be listed refuses the key instead of hashing nothing."""
+        monkeypatch.setattr(depends, '_get_site_packages', lambda: str(env.site / 'gone'))
+
+        self._cold_process(env)
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+        assert depends._installed_fingerprint() is None
+        assert depends._verdict_key(str(env.req), str(env.constraints)) is None
+
     def test_failed_resolve_records_no_verdict(self, exe_dir, env, monkeypatch):
         """A resolve that raises leaves nothing behind, so the next process resolves again."""
 

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
@@ -246,9 +246,11 @@ class TestSatisfiedVerdict:
 
     @staticmethod
     def _cold_process(env, req=None):
+        """One cold engine process: a fresh call into ``_install_requirements``."""
         depends._install_requirements(str(req or env.req), str(env.constraints))
 
     def test_second_process_skips_the_resolve(self, exe_dir, env):
+        """The second process finds the verdict and never resolves."""
         self._cold_process(env)
         self._cold_process(env)
 
@@ -256,6 +258,7 @@ class TestSatisfiedVerdict:
         assert os.listdir(exe_dir / 'cache' / 'satisfied') != []
 
     def test_verdict_is_per_requirements_file(self, exe_dir, env):
+        """Each requirements file gets its own verdict; neither shadows the other."""
         other = _write(exe_dir / 'nodes' / 'other' / 'requirements.txt', 'pyjwt\n')
 
         self._cold_process(env)
@@ -266,6 +269,7 @@ class TestSatisfiedVerdict:
         assert env.resolves == [str(env.req), str(other)]
 
     def test_requirements_change_reruns_the_resolve(self, env):
+        """Editing the requirements file invalidates its verdict."""
         self._cold_process(env)
         env.req.write_text('requests\nhttpx\n', encoding='utf-8')
         self._cold_process(env)
@@ -273,6 +277,7 @@ class TestSatisfiedVerdict:
         assert len(env.resolves) == 2
 
     def test_constraints_change_reruns_the_resolve(self, env):
+        """A recompiled constraints file invalidates every verdict."""
         self._cold_process(env)
         env.constraints.write_text('requests==2.33.0\n', encoding='utf-8')
         self._cold_process(env)
@@ -280,6 +285,7 @@ class TestSatisfiedVerdict:
         assert len(env.resolves) == 2
 
     def test_overrides_change_reruns_the_resolve(self, exe_dir, env):
+        """A changed overrides file invalidates every verdict."""
         self._cold_process(env)
         _write(exe_dir / 'cache' / 'overrides-combined.txt', 'urllib3==2.5.0\n')
         self._cold_process(env)
@@ -287,6 +293,7 @@ class TestSatisfiedVerdict:
         assert len(env.resolves) == 2
 
     def test_installed_set_change_reruns_the_resolve(self, env):
+        """Any change to the installed dist-info set invalidates the verdict."""
         self._cold_process(env)
         # An upgrade, an uninstall or a manual install all rename a dist-info entry.
         (env.site / 'requests-2.32.4.dist-info').rename(env.site / 'requests-2.33.0.dist-info')
@@ -294,7 +301,29 @@ class TestSatisfiedVerdict:
 
         assert len(env.resolves) == 2
 
+    def test_included_requirements_change_reruns_the_resolve(self, exe_dir, env):
+        """A file pulled in through ``-r`` is part of the verdict, so editing it invalidates."""
+        base = _write(exe_dir / 'nodes' / 'demo' / 'base.txt', 'pyjwt\n')
+        env.req.write_text('-r base.txt\nrequests\n', encoding='utf-8')
+
+        self._cold_process(env)
+        self._cold_process(env)
+        base.write_text('pyjwt\nhttpx\n', encoding='utf-8')
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
+    def test_requirements_closure_follows_includes_once(self, exe_dir):
+        """Nested and cyclic ``-r`` / ``-c`` includes each appear once, relative to the including file."""
+        root = _write(exe_dir / 'nodes' / 'demo' / 'requirements.txt', '-r base.txt\nrequests\n')
+        base = _write(exe_dir / 'nodes' / 'demo' / 'base.txt', '--constraint=../pins.txt\n-r requirements.txt\n')
+        pins = _write(exe_dir / 'nodes' / 'pins.txt', 'pyjwt==2.13.0\n')
+
+        assert depends._requirements_closure(str(root)) == [str(root), str(base), str(pins)]
+
     def test_failed_resolve_records_no_verdict(self, exe_dir, env, monkeypatch):
+        """A resolve that raises leaves nothing behind, so the next process resolves again."""
+
         def failing_dry_run(requirements_path, constraints_path):
             env.resolves.append(requirements_path)
             raise RuntimeError('Dependency resolution failed')

--- a/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
+++ b/packages/server/engine-lib/rocketlib-python/tests/test_depends.py
@@ -345,6 +345,15 @@ class TestSatisfiedVerdict:
         assert len(env.resolves) == 2
         assert not (exe_dir / 'cache' / 'satisfied').exists()
 
+    def test_unwritable_verdict_does_not_fail_the_resolve(self, exe_dir, env):
+        """The verdict is best effort: a cache that cannot be written never turns success into failure."""
+        _write(exe_dir / 'cache' / 'satisfied', '')  # a file where the verdict directory must go
+
+        self._cold_process(env)
+        self._cold_process(env)
+
+        assert len(env.resolves) == 2
+
     def test_install_records_the_verdict_against_the_installed_set(self, env, monkeypatch):
         """A verdict written after an install must key on the post-install site-packages."""
         pending = ['httpx']

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -264,7 +264,7 @@ Options:
   --pytest-pattern="EXPR"  Filter pytest tests by name expression (pytest -k)
   --pytest-preinstall="DEPS" Pre-install pip packages before tests (comma-separated)
   --install-all       check-externals:run: ignore # contract-check: skip-install markers, install every requirement*.txt
-  --rebuild-cache     check-externals:run: force ensure_constraints() to recompile (deletes constraints.txt + requirements.hash)
+  --rebuild-cache     check-externals:run: force a full re-resolve (deletes constraints.txt, requirements.hash and the satisfied/ verdicts)
   --saas              Enable SaaS mode
   --sequential, -s    Run modules sequentially (default: parallel)
   --simulate-gpus=N   Simulate N virtual GPUs on cuda:0 (model_server:dev)

--- a/tools/contract_checks/README.md
+++ b/tools/contract_checks/README.md
@@ -42,7 +42,7 @@ There are two ways to invoke the framework: via `builder` (recommended; handles 
 
 | Flag | Applies to | What it does |
 | ---- | ---------- | ------------ |
-| `--rebuild-cache` | `:run` | Deletes `<engine>/cache/constraints.txt` AND `<engine>/cache/requirements.hash`, forcing `ensure_constraints()` to recompile via `uv pip compile` from scratch. Used by the nightly cron lane to catch fresh upstream releases. |
+| `--rebuild-cache` | `:run` | Deletes `<engine>/cache/constraints.txt`, `<engine>/cache/requirements.hash` AND `<engine>/cache/satisfied/`, forcing `ensure_constraints()` to recompile via `uv pip compile` from scratch and every requirements file to be resolved again. Used by the nightly cron lane to catch fresh upstream releases. |
 | `--pattern=SUBSTR` | `:run`, `:test` | Generic substring filter passed to the underlying invocation. For `:run` it filters triple ids (`<tree>/<component>/<package>`). For `:test` it maps to pytest's `-k` expression. **Repeatable**, multiple `--pattern=` values combine with OR semantics for `:run` (forwarded as separate `--pattern` flags to the CLI), and are joined with ` or ` into a single `-k` expression for `:test` (pytest only accepts one `-k`). |
 | `--pytest-pattern=EXPR` | `:run`, `:test` | Back-compat alias. Single-value (overwrites on repeat). Same behavior as `--pattern` for `:run`; reaches pytest's `-k` for `:test`. Prefer `--pattern` going forward, especially when you want repeat semantics. |
 

--- a/tools/contract_checks/scripts/tasks.js
+++ b/tools/contract_checks/scripts/tasks.js
@@ -34,7 +34,7 @@
  */
 
 const path = require('path');
-const { execCommand, runPytest, unlink, removeDir, DIST_ROOT } = require('../../../scripts/lib');
+const { execCommand, runPytest, unlink, removeDir, exists, DIST_ROOT } = require('../../../scripts/lib');
 
 const PACKAGE_DIR = path.join(__dirname, '..');
 const TEST_DIR = path.join(PACKAGE_DIR, 'test');
@@ -68,7 +68,16 @@ function makeRunChecksAction(options = {}) {
                 // identical constraints leaves every verdict valid, so without
                 // this the flag cannot force a resolve — and a verdict that is
                 // wrong for an unforeseen reason would have no supported way out.
-                await removeDir(path.join(ENGINE_CACHE_DIR, 'satisfied'));
+                const verdicts = path.join(ENGINE_CACHE_DIR, 'satisfied');
+                await removeDir(verdicts);
+                // removeDir only warns when the directory is in use (EPERM/EBUSY),
+                // so confirm it is gone rather than reporting a reset that did not
+                // happen: a surviving verdict means the flag did not force the
+                // re-resolve it promises. Checked here rather than on removeDir's
+                // return value, which reports success for an absent directory too.
+                if (await exists(verdicts)) {
+                    throw new Error(`Could not clear the satisfied-verdict cache at ${verdicts}; the re-resolve would be skipped`);
+                }
                 task.output = 'Constraint and verdict caches cleared; depends() will recompile and re-resolve';
             }
 

--- a/tools/contract_checks/scripts/tasks.js
+++ b/tools/contract_checks/scripts/tasks.js
@@ -34,7 +34,7 @@
  */
 
 const path = require('path');
-const { execCommand, runPytest, unlink, DIST_ROOT } = require('../../../scripts/lib');
+const { execCommand, runPytest, unlink, removeDir, DIST_ROOT } = require('../../../scripts/lib');
 
 const PACKAGE_DIR = path.join(__dirname, '..');
 const TEST_DIR = path.join(PACKAGE_DIR, 'test');
@@ -64,7 +64,12 @@ function makeRunChecksAction(options = {}) {
                 const hashFile = path.join(ENGINE_CACHE_DIR, 'requirements.hash');
                 await unlink(constraints);
                 await unlink(hashFile);
-                task.output = 'Constraint cache cleared; ensure_constraints() will recompile';
+                // The satisfied-verdict cache too: a recompile that produces
+                // identical constraints leaves every verdict valid, so without
+                // this the flag cannot force a resolve — and a verdict that is
+                // wrong for an unforeseen reason would have no supported way out.
+                await removeDir(path.join(ENGINE_CACHE_DIR, 'satisfied'));
+                task.output = 'Constraint and verdict caches cleared; depends() will recompile and re-resolve';
             }
 
             // Invoke the CLI directly — no pytest. The CLI implements the


### PR DESCRIPTION
## Summary

- `depends()` re-ran the uv dry-run resolve in every cold engine process for every requirements file, because `_processed` only spans one process; on a warm machine that resolve only concluded that everything was already installed (#2089, ask 1).
- The verdict of a resolve is now persisted under `<engine cache>/satisfied/<md5(abs requirements path)>.hash`, keyed by everything the resolve consults: the requirements file content, the compiled `constraints.txt` / `overrides-combined.txt` / excludes content, `sys.executable` + `sys.version`, and the set of `*.dist-info` / `*.egg-info` names in site-packages. A matching key skips the dry-run and the install; any change to any part reruns them.
- Locking is unchanged: the check runs inside `_install_requirements`, under the same engine-global `install.lock` as today. Asks 2 and 3 of the issue (per-node lock, resolve at engine boot) are deliberately left as follow-ups.

### Follow-ups since the first review (normal commits on top of the reviewed one)

- `362cd6d` — the `-r`/`-c` include closure of a requirements file is part of the key (reachable in-tree via `packages/ai/tests/requirements.txt`).
- `7e78fd3` — backslash line continuations are joined before scanning for directives, as pip and uv do.
- `3cc4594` — the verdict cache is best-effort on both sides: an unreadable or unwritable cache is a miss, never a failure.

### Where the verdict is written, and when it is not

- After a dry-run that returns nothing to install, and after a successful install — recomputed *post*-install, since the install changes the dist-info fingerprint.
- Never on a failed resolve or a failed install (both raise before the write), so a half-finished install cannot leave a "satisfied" claim behind.

### Design notes a reviewer may want up front

- The key uses content digests (not `mtime+size` like `_compute_hash`) so a `touch` or a re-checkout of identical content keeps the verdict; and dist-info *names* (not the site-packages mtime), which carry versions and are not preserved by copy tools or image layers. `uv` itself is pip-installed into the same site-packages by `_ensure_uv`, so a uv bump also invalidates.
- `_write_excludes_file()` is split into `_excludes_content()` + the writer so the key computation is pure: `_verdict_cached()` reads and never writes. Behaviour of `_write_excludes_file()` is byte-identical. #1708 also edits this function; if it lands first, its flag logic moves into `_excludes_content()` — the excludes content is already part of the key, so a flag flip invalidates automatically.
- Key parts are NUL-joined before hashing: `sys.version` and the excludes text are multi-line, and NUL cannot occur in any part.
- `--rebuild-cache` (`tools/contract_checks`) now deletes the `satisfied/` directory alongside `constraints.txt` and `requirements.hash`, so it forces a full re-resolve even when the recompiled constraints come out identical — and a verdict that is wrong for an unforeseen reason has a supported way out.
- Verdict files for requirements paths that stop existing are orphaned (32 bytes each). `--rebuild-cache` sweeps them.

## Type

feature (module:server)

## Testing

- [x] Tests added or updated — 18 new tests in `TestSatisfiedVerdict` (`rocketlib-python/tests/test_depends.py`). With the whole change stashed, the 3 feature tests fail (`test_second_process_skips_the_resolve`, `test_verdict_is_per_requirements_file`, `test_install_records_the_verdict_against_the_installed_set`); the other 15 pin the invalidation and robustness contract (requirements / constraints / overrides / installed-set / included-file changes, backslash continuations, an include that resolves to a directory, no verdict after a failed resolve, and an unreadable or unwritable cache degrading to a miss instead of an error). Each follow-up test was checked to fail with its fix stashed.
- [x] Tested locally — `./builder server:run-rocketlib-test`: 65 passed (47 baseline + 18). `ruff check` / `ruff format --check` clean on the package; lefthook (gitleaks + ruff) ran on the commit.
- [ ] `./builder test` — not run locally (`server:setup-python` needs vcpkg, which isn't installed here); the rocketlib suite is the one this change is covered by, and CI runs the rest.

### Measured under the real engine (macOS arm64, `dist/server/engine`, cold process each time, 5 runs each)

| `depends()` on | before (no verdict) | after (verdict) |
|---|---|---|
| bare engine start, no `depends()` call (floor) | 0.12 s | 0.12 s |
| `packages/server/build-requirements.txt` (9 packages) | 0.22–0.24 s | 0.12 s |
| `ai/requirements.txt` (10 packages; the first run installed 5 in 2.53 s) | 0.23–0.24 s | 0.12 s |

With a verdict, `depends()` costs nothing measurable over not calling it — the cached path lands exactly on the bare-engine-start floor. The saving is a per-process constant (~0.11 s) and does not grow with the size of the requirement set, because uv answers a satisfied check from installed metadata in single-digit milliseconds (`Checked 10 packages in 2ms`).

The issue's 20–40 s was **not** reproduced on this machine and is cited here as reported on the Rocket CRM pods. Emptying `UV_CACHE_DIR` moved a 9-package satisfied check only from 33 ms to 284 ms, so the cost is not network-bound either. The most plausible source of the minutes is the wait on uv's internal lock under concurrent node start-up that the existing comment in `_install_requirements` already describes — which the cached path also skips, since it never spawns uv at all.

<details>
<summary>Real-engine smoke matrix (scratch script under <code>dist/server/engine</code> against a bare temp dir: bare dir → save → edit → revert → install)</summary>

```
cache dir exists before: False
cached on a bare dir (want False, no raise): False
excludes.txt written by the key (want False): False
cached after save (want True): True
cached after requirements edit (want False): False
cached after revert (want True): True
cached after an install appears (want False): False
```

Not checked in — it needs a built engine, and `python_files` would never collect it. Run from `dist/server` with `./engine smoke.py`:

```python
import os
import sys
import tempfile

sys.path.insert(0, os.path.abspath('../../packages/server/engine-lib/rocketlib-python/lib'))
import depends

tmp = tempfile.mkdtemp()
depends._get_executable_dir = lambda: tmp  # bare dir: no cache/
# bootstrap() creates site-packages before any key is computed; without it the
# fingerprint guard refuses the key and nothing is ever cached.
os.makedirs(depends._get_site_packages(), exist_ok=True)
req = os.path.join(tmp, 'requirements.txt')
open(req, 'w').write('requests\n')
con = os.path.join(tmp, 'cache', 'constraints.txt')

print('cache dir exists before:', os.path.isdir(os.path.join(tmp, 'cache')))
print('cached on a bare dir (want False, no raise):', depends._verdict_cached(req, con))
print('excludes.txt written by the key (want False):', os.path.exists(os.path.join(tmp, 'cache', 'excludes.txt')))

depends._save_verdict(req, con)
print('cached after save (want True):', depends._verdict_cached(req, con))

open(req, 'a').write('flask\n')
print('cached after requirements edit (want False):', depends._verdict_cached(req, con))

open(req, 'w').write('requests\n')
print('cached after revert (want True):', depends._verdict_cached(req, con))

os.makedirs(os.path.join(depends._get_site_packages(), 'requests-2.31.0.dist-info'), exist_ok=True)
print('cached after an install appears (want False):', depends._verdict_cached(req, con))
```
</details>

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (n/a — internal engine tooling, no public contract changed)
- [ ] Breaking changes documented (none)

## Linked Issue

Fixes #2089

Scoped to ask 1 of #2089 (cache the satisfied verdict). Asks 2 (per-node lock instead of the engine-global one) and 3 (resolve at engine boot) are follow-ups — happy to open separate issues for them so this PR can close #2089, or switch to `Refs #2089` if you'd rather keep it open to track all three.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Performance
- Dependency checks and installations now reuse previously satisfied requirements, improving subsequent operations.
- Cached results automatically refresh when requirements, included files, constraints, overrides, exclusions, or installed packages change.

## Reliability
- Nested dependency files are discovered recursively, including safe handling of cyclic references.
- Failed resolutions are not cached, and successful installations accurately update dependency status.

## Documentation
- Rebuild-cache guidance now explains that satisfied-verdict caches are also cleared, triggering fresh dependency resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->