### PR TITLE
fix(ai,client-python,client-typescript): give task failures a machine-readable code

### DIFF
--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -1664,7 +1664,7 @@ class Task(DAPBase):
 
             # If we were cancelled, throw an error
             if current_state == TASK_STATE.CANCELLED.value:
-                raise TaskError(TaskError.STOPPED, self._status.exitMessage)
+                raise TaskError(TaskError.STOPPED, self._status.exitMessage or 'Task was stopped')
 
             # Calculate timeouts
             time_since_last_event = time.time() - self._last_event_time

--- a/packages/ai/src/ai/modules/task/task_engine.py
+++ b/packages/ai/src/ai/modules/task/task_engine.py
@@ -67,7 +67,7 @@ from rocketride import (
 from .dbg_debugpy import DbgDebugpy
 from .dbg_stdio import DbgStdio
 from .pipeline import resolve_pipeline_env
-from .types import LAUNCH_TYPE
+from .types import LAUNCH_TYPE, TaskError
 from .task_conn import TaskConn
 from .task_metrics import TaskMetrics
 
@@ -1660,11 +1660,11 @@ class Task(DAPBase):
 
             # We completed it, so raise an error -- this is about being read to accept data
             if current_state == TASK_STATE.COMPLETED.value:
-                raise RuntimeError('Task has already completed')
+                raise TaskError(TaskError.COMPLETED, 'Task has already completed')
 
             # If we were cancelled, throw an error
             if current_state == TASK_STATE.CANCELLED.value:
-                raise RuntimeError(self._status.exitMessage)
+                raise TaskError(TaskError.STOPPED, self._status.exitMessage)
 
             # Calculate timeouts
             time_since_last_event = time.time() - self._last_event_time

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -90,7 +90,7 @@ from ai.account.models import AccountInfo, resolve_task_permissions
 from ai.account.store import Store
 from .task_conn import TaskConn
 from .task_engine import Task
-from .types import LAUNCH_TYPE
+from .types import LAUNCH_TYPE, TaskError
 from .pipeline import resolve_implied_source
 from .commands.cmd_monitor import owner_key
 
@@ -673,7 +673,7 @@ class TaskServer(DAPBase):
                     and control.source == source
                 ):
                     return _verify(control)
-            raise RuntimeError('Your pipeline is not running')
+            raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
         # Dev scope: the caller's own run — unique per user by construction.
         if account_info is not None:
@@ -685,7 +685,7 @@ class TaskServer(DAPBase):
                     and control.source == source
                 ):
                     return _verify(control)
-            raise RuntimeError('Your pipeline is not running')
+            raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
         # Legacy unscoped scan (OSS single-user / HTTP fallback): tolerate a
         # unique match; refuse to guess between several runs.
@@ -697,8 +697,8 @@ class TaskServer(DAPBase):
         if len(matches) == 1:
             return matches[0]
         if matches:
-            raise RuntimeError('Multiple pipelines are running for this project; specify a scope')
-        raise RuntimeError('Your pipeline is not running')
+            raise TaskError(TaskError.AMBIGUOUS, 'Multiple pipelines are running for this project; specify a scope')
+        raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
     def get_task_control_by_public_key(self, public_auth: str) -> TASK_CONTROL:
         """
@@ -719,7 +719,7 @@ class TaskServer(DAPBase):
                 return control
 
         # Couldn't find it
-        raise RuntimeError('Your pipeline is not running')
+        raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
     def get_task_control(
         self,
@@ -743,7 +743,7 @@ class TaskServer(DAPBase):
 
         control = self._task_control.get(token, None)
         if not control:
-            raise RuntimeError('Your pipeline is not running')
+            raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
         # Resolve against the TASK'S team (the old resolve_team_permissions
         # call raised on foreign teams instead of denying uniformly).
@@ -1074,7 +1074,7 @@ class TaskServer(DAPBase):
 
         # If not there, it wasn't running
         if not control:
-            raise RuntimeError('Your pipeline is not running')
+            raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
         # Ensure task is properly stopped and resources are cleaned up
         await control.task.stop_task()

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -713,7 +713,7 @@ class TaskServer(DAPBase):
             TASK_CONTROL: Complete task control structure with metadata and references
 
         Raises:
-            ValueError: If task doesn't exist
+            TaskError: Code TASK_NOT_REGISTERED if the key names no live task
         """
         # Look for it
         for control in self._task_control.values():
@@ -775,7 +775,8 @@ class TaskServer(DAPBase):
             Task: The authenticated task instance ready for operations
 
         Raises:
-            ValueError: If task doesn't exist
+            ValueError: If token is not specified
+            TaskError: Code TASK_NOT_REGISTERED if the token names no live task
 
         Usage:
         This method is the primary way to access task instances throughout
@@ -1038,7 +1039,8 @@ class TaskServer(DAPBase):
                         performance metrics, and completion information
 
         Raises:
-            ValueError: If task doesn't exist or API key validation fails
+            ValueError: If token is not specified
+            TaskError: Code TASK_NOT_REGISTERED if the token names no live task
         """
         # Perform secure task lookup with authentication
         task = self.get_task(token)
@@ -1061,7 +1063,7 @@ class TaskServer(DAPBase):
             TASK_CONTROL: The removed task control structure for caller cleanup
 
         Raises:
-            ValueError: If task doesn't exist or API key validation fails
+            TaskError: Code TASK_NOT_REGISTERED if the token names no live task
 
         Cleanup Process:
         1. Validate task ownership and existence
@@ -1072,7 +1074,9 @@ class TaskServer(DAPBase):
         6. Return control structure for additional caller-specific cleanup
         """
         # Remove task from central registry
-        control = self._task_control.pop(token)
+        # pop with a default: without one an unknown token raises KeyError and the
+        # TaskError below never runs, so the failure reaches the caller unclassified.
+        control = self._task_control.pop(token, None)
 
         # If not there, it wasn't running
         if not control:
@@ -1443,8 +1447,9 @@ class TaskServer(DAPBase):
                 - provider: Provider name (may be updated)
 
         Raises:
-            ValueError: If task doesn't exist, pipeline invalid, source not found,
+            ValueError: If pipeline invalid, source not found,
                     project_id/source don't match existing values, or token not provided
+            TaskError: Code TASK_NOT_REGISTERED if the token names no live task
             RuntimeError: If pipeline configuration missing, debugger attached,
                         apikey mismatch, or connection is not the launch owner
 
@@ -1595,7 +1600,8 @@ class TaskServer(DAPBase):
             Pipeline configuration information for the attached task
 
         Raises:
-            ValueError: If task doesn't exist or API key validation fails
+            ValueError: If token is not specified
+            TaskError: Code TASK_NOT_REGISTERED if the token names no live task
 
         Attachment Process:
         1. Validate task existence and ownership

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -590,7 +590,9 @@ class TaskServer(DAPBase):
             authorization (str): Authentication key
 
         Raises:
-            ValueError: If task doesn't exist
+            TaskError: Code TASK_NOT_REGISTERED if the key names no live task.
+                Subclasses RuntimeError; these two branches raised ValueError
+                before task errors carried codes.
         """
         if authorization.startswith('pk_'):
             for control in self._task_control.values():

--- a/packages/ai/src/ai/modules/task/task_server.py
+++ b/packages/ai/src/ai/modules/task/task_server.py
@@ -600,7 +600,7 @@ class TaskServer(DAPBase):
                         control,
                         ['task.data'],
                     )
-            raise ValueError('Your pipeline is not running')
+            raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
         if authorization.startswith('tk_'):
             control = self._task_control.get(authorization)
@@ -610,7 +610,7 @@ class TaskServer(DAPBase):
                     control,
                     ['task.control', 'task.data', 'task.monitor', 'task.debug', 'task.store'],
                 )
-            raise ValueError('Your pipeline is not running')
+            raise TaskError(TaskError.NOT_REGISTERED, 'Your pipeline is not running')
 
         # Not a task key — delegate to account layer
         return None

--- a/packages/ai/src/ai/modules/task/types.py
+++ b/packages/ai/src/ai/modules/task/types.py
@@ -91,3 +91,31 @@ class LAUNCH_TYPE(Enum):
     LAUNCH = 'launch'  # Create new task with full debugging capabilities
     ATTACH = 'attach'  # Connect to existing task instance for debugging
     EXECUTE = 'execute'  # Create new task optimized for batch processing
+
+
+class TaskError(RuntimeError):
+    """
+    A task lookup or readiness failure that carries a machine-readable code.
+
+    ``DAPBase.build_exception`` copies ``code`` onto the DAP error packet next to
+    the human-readable ``message``, so a client classifies the failure on the
+    code instead of matching the English text. Subclasses ``RuntimeError`` so
+    existing ``except RuntimeError`` handling is unchanged.
+
+    Codes:
+    - TASK_NOT_REGISTERED: the token, public key or project/source names no live
+      task — never started, terminated, replaced, or the engine restarted and
+      rebuilt its in-memory registry
+    - TASK_AMBIGUOUS: an unscoped lookup matched several running tasks
+    - TASK_COMPLETED: the task finished before the request could be served
+    - TASK_STOPPED: the task was stopped or cancelled before the request
+    """
+
+    NOT_REGISTERED = 'TASK_NOT_REGISTERED'
+    AMBIGUOUS = 'TASK_AMBIGUOUS'
+    COMPLETED = 'TASK_COMPLETED'
+    STOPPED = 'TASK_STOPPED'
+
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code = code

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -876,6 +876,19 @@ async def test_monitor_ttl_skips_task_with_zero_ttl(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_remove_task_unknown_token_carries_a_code():
+    """An unknown token reaches the TaskError guard, not a bare KeyError.
+
+    The registry pop had no default, so the guard below it was unreachable
+    for the one case it was written for.
+    """
+    ts = _make_server()
+    with pytest.raises(TaskError) as excinfo:
+        await ts.remove_task('tk_unknown')
+    assert excinfo.value.code == TaskError.NOT_REGISTERED
+
+
+@pytest.mark.asyncio
 async def test_remove_task_calls_stop_and_broadcasts():
     """remove_task pops the control, stops the task, and broadcasts a dashboard event."""
     ts = _make_server()

--- a/packages/ai/tests/ai/modules/task/test_task_server.py
+++ b/packages/ai/tests/ai/modules/task/test_task_server.py
@@ -30,6 +30,7 @@ import pytest
 
 from ai.modules.task import task_server as task_server_module
 from ai.modules.task.task_server import TaskServer
+from ai.modules.task.types import TaskError
 
 
 def _make_server(*, config=None, web_server=None):
@@ -486,6 +487,23 @@ def test_get_task_control_unknown_token_raises_runtime():
     ts = _make_server()
     with pytest.raises(RuntimeError, match='not running'):
         ts.get_task_control('tk_unknown')
+
+
+def test_get_task_control_unknown_token_carries_a_code():
+    """The failure is classifiable without matching the English message (#2097)."""
+    ts = _make_server()
+    with pytest.raises(TaskError) as excinfo:
+        ts.get_task_control('tk_unknown')
+    assert excinfo.value.code == TaskError.NOT_REGISTERED
+    assert isinstance(excinfo.value, RuntimeError)  # existing handlers still catch it
+
+
+def test_get_task_control_by_public_key_unknown_carries_a_code():
+    """A public key naming no live task reports TASK_NOT_REGISTERED."""
+    ts = _make_server()
+    with pytest.raises(TaskError) as excinfo:
+        ts.get_task_control_by_public_key('pk_unknown')
+    assert excinfo.value.code == TaskError.NOT_REGISTERED
 
 
 def test_get_task_control_with_require_denies_without_membership(monkeypatch):

--- a/packages/client-python/docs/index.md
+++ b/packages/client-python/docs/index.md
@@ -486,7 +486,27 @@ DAPException                    # Base DAP protocol error (has dap_result dict)
     └── ValidationException     # Invalid input/config
 ```
 
-All exceptions expose a `dap_result` dict with detailed server error context.
+All exceptions expose a `dap_result` dict with detailed server error context,
+plus `code` and `hint`:
+
+- `code` is the server's machine-readable classification, or `None`. Task
+  failures carry one: `TASK_NOT_REGISTERED` (the token names no live task —
+  never started, terminated, replaced, or the engine restarted),
+  `TASK_AMBIGUOUS`, `TASK_COMPLETED`, `TASK_STOPPED`. **Classify on `code`, not
+  on the message text**, which is written for people and may be reworded.
+- `hint` is troubleshooting text the SDK attached for a developer, or `None`.
+  It is kept out of `str(e)` so an application can show the message to an end
+  user without the developer checklist.
+
+```python
+except PipeException as e:
+    if e.code == 'TASK_NOT_REGISTERED':
+        await restart_pipeline()      # the task is gone; start a new one
+    else:
+        print(e)                      # safe to show
+        if e.hint:
+            log.debug(e.hint)         # developer detail
+```
 
 `AuthenticationException` is thrown on DAP auth failure. In persist mode the client catches it, calls `on_connect_error`, and does not retry so the app can fix credentials and call `connect()` again.
 

--- a/packages/client-python/src/rocketride/core/dap_base.py
+++ b/packages/client-python/src/rocketride/core/dap_base.py
@@ -741,7 +741,10 @@ class DAPBase:
 
         Returns:
             Dict[str, Any]: A complete DAP error response with trace information
-                        following the DAP specification format.
+                        following the DAP specification format. Carries a
+                        ``code`` next to ``message`` when the exception has a
+                        machine-readable one, so a client can classify the
+                        failure without matching the prose.
         """
         # Build the basic error response structure
         response = {
@@ -752,6 +755,12 @@ class DAPBase:
             'success': False,  # Indicate failure
             'message': str(e),  # Human-readable error description
         }
+
+        # A machine-readable code, when the exception carries one (the engine's
+        # TaskError does): clients classify on it instead of on the prose.
+        code = getattr(e, 'code', None)
+        if isinstance(code, str) and code:
+            response['code'] = code
 
         # Extract traceback information from the exception
         if hasattr(e, '__traceback__') and e.__traceback__ is not None:

--- a/packages/client-python/src/rocketride/core/exceptions.py
+++ b/packages/client-python/src/rocketride/core/exceptions.py
@@ -50,7 +50,7 @@ Usage:
         # Handle any other RocketRide errors
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 class DAPException(Exception):
@@ -99,6 +99,29 @@ class DAPException(Exception):
 
         # Store complete DAP result for detailed error analysis
         self.dap_result = dap_result or {}
+
+    @property
+    def code(self) -> Optional[str]:
+        """
+        Machine-readable error code sent by the server, or None.
+
+        Task failures carry one (``TASK_NOT_REGISTERED``, ``TASK_AMBIGUOUS``,
+        ``TASK_COMPLETED``, ``TASK_STOPPED``); classify on it rather than on
+        the message text, which is written for people.
+        """
+        code = self.dap_result.get('code')
+        return code if isinstance(code, str) else None
+
+    @property
+    def hint(self) -> Optional[str]:
+        """
+        Troubleshooting text the SDK attached for a developer, or None.
+
+        Kept apart from the message so an application can show the message
+        to an end user without the developer checklist.
+        """
+        hint = self.dap_result.get('hint')
+        return hint if isinstance(hint, str) else None
 
 
 class RocketRideException(DAPException):

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -192,7 +192,7 @@ class DataMixin(DAPClient):
                     'Common causes:\n'
                     "- Pipeline isn't running (wrong token or task terminated)\n"
                     '- Pipeline source must be chat, webhook, or dropper\n'
-                    '- MIME type doesn\'t match the source lane (try `mimetype="text/plain"`)\n'
+                    '- MIME type doesn\'t match the source lane (try `mime_type="text/plain"`)\n'
                 )
                 raise PipeException(response)
 

--- a/packages/client-python/src/rocketride/mixins/data.py
+++ b/packages/client-python/src/rocketride/mixins/data.py
@@ -183,16 +183,17 @@ class DataMixin(DAPClient):
             response = await self._client.request(request)
 
             if self._client.did_fail(response):
-                msg = response.get('message') or 'Failed to open a data pipe.'
-                msg = (
-                    f'{msg}\n\n'
+                # The server's message stays the message: an application may show
+                # it to an end user. The developer checklist rides along as `hint`
+                # (PipeException.hint), and `code` classifies the failure.
+                response = dict(response)
+                response['message'] = response.get('message') or 'Failed to open a data pipe.'
+                response['hint'] = (
                     'Common causes:\n'
                     "- Pipeline isn't running (wrong token or task terminated)\n"
                     '- Pipeline source must be chat, webhook, or dropper\n'
                     '- MIME type doesn\'t match the source lane (try `mimetype="text/plain"`)\n'
                 )
-                response = dict(response)
-                response['message'] = msg
                 raise PipeException(response)
 
             self._pipe_id = response.get('body', {}).get('pipe_id')

--- a/packages/client-python/tests/test_task_error_codes.py
+++ b/packages/client-python/tests/test_task_error_codes.py
@@ -1,0 +1,91 @@
+# MIT License
+#
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+"""Task failures carry a machine-readable code (#2097).
+
+``build_exception`` copies an exception's ``code`` onto the DAP error packet,
+and ``DAPException`` exposes ``code`` / ``hint`` so a caller classifies a
+failure without matching the English message.
+"""
+
+from rocketride.core.dap_base import DAPBase
+from rocketride.core.exceptions import DAPException, PipeException
+
+
+class _Base(DAPBase):
+    """DAPBase with the transport left out: only the packet builders are used."""
+
+    def __init__(self):
+        self._seq_counter = 0
+
+
+class _Coded(RuntimeError):
+    def __init__(self, code, message):
+        super().__init__(message)
+        self.code = code
+
+
+REQUEST = {'seq': 1, 'command': 'rrext_process'}
+
+
+def test_build_exception_carries_a_code_when_the_error_has_one():
+    """A coded exception reaches the wire with its code beside the message."""
+    packet = _Base().build_exception(REQUEST, _Coded('TASK_NOT_REGISTERED', 'Your pipeline is not running'))
+
+    assert packet['success'] is False
+    assert packet['message'] == 'Your pipeline is not running'
+    assert packet['code'] == 'TASK_NOT_REGISTERED'
+
+
+def test_build_exception_omits_the_code_for_a_plain_exception():
+    """A plain exception still produces the packet it produced before."""
+    packet = _Base().build_exception(REQUEST, RuntimeError('boom'))
+
+    assert 'code' not in packet
+    assert packet['message'] == 'boom'
+
+
+def test_build_exception_ignores_a_non_string_code():
+    """An unrelated attribute named code cannot inject a non-string into the packet."""
+    packet = _Base().build_exception(REQUEST, _Coded(42, 'boom'))
+
+    assert 'code' not in packet
+
+
+def test_exception_exposes_code_and_hint():
+    """The SDK exception surfaces both fields, and the message stays clean."""
+    e = PipeException(
+        {'message': 'Your pipeline is not running', 'code': 'TASK_NOT_REGISTERED', 'hint': 'Common causes:\n- ...'}
+    )
+
+    assert str(e) == 'Your pipeline is not running'
+    assert e.code == 'TASK_NOT_REGISTERED'
+    assert e.hint.startswith('Common causes:')
+
+
+def test_exception_code_and_hint_default_to_none():
+    """Neither field is required; both read as None when absent."""
+    e = DAPException({'message': 'boom'})
+
+    assert e.code is None
+    assert e.hint is None

--- a/packages/client-typescript/docs/guide/index.md
+++ b/packages/client-typescript/docs/guide/index.md
@@ -421,6 +421,29 @@ Used to parse chat response content. The client does not attach an `Answer` inst
 
 ## Exceptions
 
+Every exception extends `DAPException`, which exposes `dapResult` plus two
+optional fields:
+
+- `code` — the server's machine-readable classification, absent when the failure
+  has none. Task failures carry one: `TASK_NOT_REGISTERED` (the token names no
+  live task — never started, terminated, replaced, or the engine restarted),
+  `TASK_AMBIGUOUS`, `TASK_COMPLETED`, `TASK_STOPPED`. **Classify on `code`, not
+  on `message`**, which is written for people and may be reworded.
+- `hint` — troubleshooting text the SDK attached for a developer, absent when
+  there is none. Kept out of `message` so an application can show the message
+  to an end user without the developer checklist.
+
+```ts
+try {
+	await pipe.open();
+} catch (err) {
+	if (err instanceof PipeException) {
+		if (err.code === 'TASK_NOT_REGISTERED') await restartPipeline();
+		else console.error(err.message, err.hint);
+	}
+}
+```
+
 `AuthenticationException` extends `ConnectionException`; thrown on DAP auth failure. In persist mode the client calls `onConnectError` and does not retry authentication so the app can fix credentials and call `login()` or `connect()` again.
 
 `LoginAttemptCancelledError` extends `Error` directly. Its `reason` is the `LoginAttemptCancellationReason` union `'superseded' | 'logout' | 'detached'`. Catch it when overlapping lifecycle actions are expected; transport loss and other connection failures remain `ConnectionException` instances.

--- a/packages/client-typescript/docs/guide/index.md
+++ b/packages/client-typescript/docs/guide/index.md
@@ -421,7 +421,8 @@ Used to parse chat response content. The client does not attach an `Answer` inst
 
 ## Exceptions
 
-Every exception extends `DAPException`, which exposes `dapResult` plus two
+DAP-backed exceptions extend `DAPException` (`LoginAttemptCancelledError`
+extends `Error` directly, see below), which exposes `dapResult` plus two
 optional fields:
 
 - `code` — the server's machine-readable classification, absent when the failure

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -37,6 +37,7 @@ import { LogApi } from './log.js';
 import {
 	AuthenticationException,
 	ConnectionException,
+	DAPException,
 	LoginAttemptCancelledError,
 	type LoginAttemptCancellationReason,
 	PipeException,
@@ -1953,7 +1954,10 @@ export class RocketRideClient extends DAPClient {
 				}
 			}
 		} catch (error) {
-			// Return error response in standard format
+			// A typed SDK exception carries `code` and `hint` a caller can act on;
+			// rewrapping it as a plain Error would throw that away. Anything else
+			// is normalised to an Error as before.
+			if (error instanceof DAPException) throw error;
 			throw new Error(error instanceof Error ? error.message : String(error));
 		}
 	}

--- a/packages/client-typescript/src/client/client.ts
+++ b/packages/client-typescript/src/client/client.ts
@@ -147,9 +147,11 @@ export class DataPipe {
 		const response = await this._client.request(request);
 
 		if (this._client.didFail(response)) {
-			const base = response.message || 'Failed to open a data pipe.';
-			const msg = `${base}\n\n` + 'Common causes:\n' + "- Pipeline isn't running (wrong token or task terminated)\n" + '- Pipeline source must be chat, webhook, or dropper\n' + "- MIME type doesn't match the source lane (try mimeType='text/plain')\n";
-			throw new PipeException({ ...response, message: msg });
+			// The server's message stays the message: an application may show it to
+			// an end user. The developer checklist rides along as `hint`
+			// (PipeException.hint), and `code` classifies the failure.
+			const hint = 'Common causes:\n' + "- Pipeline isn't running (wrong token or task terminated)\n" + '- Pipeline source must be chat, webhook, or dropper\n' + "- MIME type doesn't match the source lane (try mimeType='text/plain')\n";
+			throw new PipeException({ ...response, message: response.message || 'Failed to open a data pipe.', hint });
 		}
 
 		this._pipeId = response.body?.pipe_id as number | undefined;

--- a/packages/client-typescript/src/client/exceptions/index.ts
+++ b/packages/client-typescript/src/client/exceptions/index.ts
@@ -32,11 +32,35 @@
 export class DAPException extends Error {
 	public readonly dapResult: Record<string, unknown>;
 
+	/**
+	 * Machine-readable error code sent by the server, when the failure has one.
+	 *
+	 * Task failures carry one (`TASK_NOT_REGISTERED`, `TASK_AMBIGUOUS`,
+	 * `TASK_COMPLETED`, `TASK_STOPPED`); classify on it rather than on the
+	 * message text, which is written for people and may be reworded.
+	 */
+	public readonly code?: string;
+
+	/**
+	 * Troubleshooting text the SDK attached for a developer, when there is any.
+	 *
+	 * Kept out of `message` so an application can show the message to an end
+	 * user without the developer checklist.
+	 */
+	public readonly hint?: string;
+
 	constructor(dapResult: Record<string, unknown>) {
 		const errorMessage = String(dapResult.message || 'Unknown DAP error');
 		super(errorMessage);
 		this.name = 'DAPException';
 		this.dapResult = dapResult || {};
+
+		// Optional so a frozen contract floor, whose ConnectionException predates
+		// these fields, stays assignable where a callback takes one as a parameter.
+		const code = this.dapResult.code;
+		if (typeof code === 'string') this.code = code;
+		const hint = this.dapResult.hint;
+		if (typeof hint === 'string') this.hint = hint;
 	}
 }
 

--- a/packages/client-typescript/tests/task-errors.test.ts
+++ b/packages/client-typescript/tests/task-errors.test.ts
@@ -129,11 +129,22 @@ describe('RocketRideClient.chat() failure', () => {
 		expect(e.hint).toContain('Common causes:');
 	});
 
-	it('still normalises a non-DAP failure to a plain Error', async () => {
-		const caught = await chatAndCatch(clientThatFailsOpen(notRunning), undefined as unknown as Question);
+	it('still normalises a non-DAP failure from the pipe to a plain Error', async () => {
+		// The failure has to come from inside the pipe interaction: a guard that
+		// trips before the pipe exists would exercise the catch without ever
+		// reaching the code path this test is about.
+		const client = new RocketRideClient({ env: {} });
+		const stub = client as unknown as Record<string, unknown>;
+		stub.buildRequest = () => ({ seq: 1, type: 'request', command: 'rrext_process' });
+		stub.request = async () => {
+			throw new Error('socket closed');
+		};
+		stub.didFail = (r: Record<string, unknown>) => r.success === false;
+
+		const caught = await chatAndCatch(client, {} as Question);
 
 		expect(caught).toBeInstanceOf(Error);
 		expect(caught).not.toBeInstanceOf(DAPException);
-		expect((caught as Error).message).toBe('Question cannot be empty');
+		expect((caught as Error).message).toBe('socket closed');
 	});
 });

--- a/packages/client-typescript/tests/task-errors.test.ts
+++ b/packages/client-typescript/tests/task-errors.test.ts
@@ -1,0 +1,96 @@
+/**
+ * MIT License
+ *
+ * Copyright (c) 2026 Aparavi Software AG
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Task failures carry a machine-readable code (#2097).
+ *
+ * `DAPException` exposes `code` / `hint` from the server packet, and
+ * `DataPipe.open()` keeps the server's message as the message while putting the
+ * developer checklist in `hint`.
+ */
+
+import { DataPipe, RocketRideClient } from '../src/client/client';
+import { DAPException, PipeException } from '../src/client/exceptions';
+
+/** A client stub: enough surface for DataPipe.open(), no transport. */
+function stubClient(response: Record<string, unknown>): RocketRideClient {
+	return {
+		buildRequest: (command: string, extra: Record<string, unknown>) => ({ command, ...extra }),
+		request: async () => response,
+		didFail: (r: Record<string, unknown>) => r.success === false,
+	} as unknown as RocketRideClient;
+}
+
+/** Open a pipe against a stub that fails, and return the exception it threw. */
+async function openAndCatch(response: Record<string, unknown>): Promise<PipeException> {
+	const pipe = new DataPipe(stubClient(response), 'tk_gone');
+	try {
+		await pipe.open();
+	} catch (e) {
+		return e as PipeException;
+	}
+	throw new Error('expected open() to reject');
+}
+
+describe('task error codes', () => {
+	it('exposes code and hint from the server packet', () => {
+		const e = new PipeException({ message: 'Your pipeline is not running', code: 'TASK_NOT_REGISTERED', hint: 'Common causes:\n- ...' });
+
+		expect(e.message).toBe('Your pipeline is not running');
+		expect(e.code).toBe('TASK_NOT_REGISTERED');
+		expect(e.hint).toMatch(/^Common causes:/);
+	});
+
+	it('leaves code and hint absent when the packet has neither', () => {
+		const e = new DAPException({ message: 'boom' });
+
+		expect(e.code).toBeUndefined();
+		expect(e.hint).toBeUndefined();
+		expect('code' in JSON.parse(JSON.stringify(e))).toBe(false);
+	});
+
+	it('ignores a non-string code', () => {
+		const e = new DAPException({ message: 'boom', code: 42 });
+
+		expect(e.code).toBeUndefined();
+	});
+
+	it('open() keeps the server message and moves the checklist to hint', async () => {
+		const err = await openAndCatch({ success: false, message: 'Your pipeline is not running', code: 'TASK_NOT_REGISTERED' });
+
+		expect(err).toBeInstanceOf(PipeException);
+		expect(err.message).toBe('Your pipeline is not running');
+		expect(err.message).not.toMatch(/Common causes/);
+		expect(err.code).toBe('TASK_NOT_REGISTERED');
+		expect(err.hint).toMatch(/^Common causes:/);
+	});
+
+	it('falls back to a generic message when the server sends none', async () => {
+		const err = await openAndCatch({ success: false });
+
+		expect(err.message).toBe('Failed to open a data pipe.');
+		expect(err.code).toBeUndefined();
+		expect(err.hint).toMatch(/^Common causes:/);
+	});
+});

--- a/packages/client-typescript/tests/task-errors.test.ts
+++ b/packages/client-typescript/tests/task-errors.test.ts
@@ -32,6 +32,7 @@
 
 import { DataPipe, RocketRideClient } from '../src/client/client';
 import { DAPException, PipeException } from '../src/client/exceptions';
+import type { Question } from '../src/client/schema/Question';
 
 /** A client stub: enough surface for DataPipe.open(), no transport. */
 function stubClient(response: Record<string, unknown>): RocketRideClient {
@@ -52,6 +53,8 @@ async function openAndCatch(response: Record<string, unknown>): Promise<PipeExce
 	}
 	throw new Error('expected open() to reject');
 }
+
+const notRunning = { success: false, message: 'Your pipeline is not running', code: 'TASK_NOT_REGISTERED' };
 
 describe('task error codes', () => {
 	it('exposes code and hint from the server packet', () => {
@@ -92,5 +95,45 @@ describe('task error codes', () => {
 		expect(err.message).toBe('Failed to open a data pipe.');
 		expect(err.code).toBeUndefined();
 		expect(err.hint).toMatch(/^Common causes:/);
+	});
+});
+
+describe('RocketRideClient.chat() failure', () => {
+	/** A real client whose pipe open() always fails with the given DAP response. */
+	function clientThatFailsOpen(response: Record<string, unknown>): RocketRideClient {
+		const client = new RocketRideClient({ env: {} });
+		const stub = client as unknown as Record<string, unknown>;
+		stub.buildRequest = () => ({ seq: 1, type: 'request', command: 'rrext_process' });
+		stub.request = async () => response;
+		stub.didFail = (r: Record<string, unknown>) => r.success === false;
+		return client;
+	}
+
+	/** Run chat() against a stub and return whatever it threw. */
+	async function chatAndCatch(client: RocketRideClient, question: Question): Promise<unknown> {
+		try {
+			await client.chat({ token: 'tk_dead', question });
+		} catch (err) {
+			return err;
+		}
+		throw new Error('expected chat() to reject');
+	}
+
+	it('rethrows the typed PipeException so chat callers keep code and hint', async () => {
+		const caught = await chatAndCatch(clientThatFailsOpen(notRunning), {} as Question);
+
+		expect(caught).toBeInstanceOf(PipeException);
+		const e = caught as PipeException;
+		expect(e.message).toBe('Your pipeline is not running');
+		expect(e.code).toBe('TASK_NOT_REGISTERED');
+		expect(e.hint).toContain('Common causes:');
+	});
+
+	it('still normalises a non-DAP failure to a plain Error', async () => {
+		const caught = await chatAndCatch(clientThatFailsOpen(notRunning), undefined as unknown as Question);
+
+		expect(caught).toBeInstanceOf(Error);
+		expect(caught).not.toBeInstanceOf(DAPException);
+		expect((caught as Error).message).toBe('Question cannot be empty');
 	});
 });

--- a/packages/server/docs/index.md
+++ b/packages/server/docs/index.md
@@ -68,7 +68,8 @@ whether the command worked; a successful response carries a `body`.
 ```
 
 On failure, `success` is `false` and the frame carries a `message` plus a
-`trace` (`file`, `lineno`) instead of a body:
+`trace` (`file`, `lineno`) instead of a body. A failure the engine can name
+also carries a machine-readable `code`:
 
 ```json
 {
@@ -77,10 +78,23 @@ On failure, `success` is `false` and the frame carries a `message` plus a
 	"request_seq": 1,
 	"command": "rrext_process",
 	"success": false,
-	"message": "Pipeline is not running",
-	"trace": { "file": "process.cpp", "lineno": 214 }
+	"message": "Your pipeline is not running",
+	"code": "TASK_NOT_REGISTERED",
+	"trace": { "file": "task_server.py", "lineno": 722 }
 }
 ```
+
+`message` is written for a person and may be reworded or translated; `code` is
+the contract. Classify a failure on `code` and never on the message text.
+Absent `code`, the failure has no named class — treat it as unclassified rather
+than inferring one from the prose.
+
+| `code` | Meaning |
+| --- | --- |
+| `TASK_NOT_REGISTERED` | The token, public key or project/source names no live task: never started, terminated, replaced by another client, or the engine restarted (the task registry is in-memory and rebuilt at boot, so every previously issued token is invalid after a restart). |
+| `TASK_AMBIGUOUS` | An unscoped lookup matched several running tasks; retry with a scope. |
+| `TASK_COMPLETED` | The task finished before the request could be served. |
+| `TASK_STOPPED` | The task was stopped or cancelled before the request. |
 
 ### Events
 

--- a/packages/server/docs/index.md
+++ b/packages/server/docs/index.md
@@ -96,6 +96,14 @@ than inferring one from the prose.
 | `TASK_COMPLETED` | The task finished before the request could be served. |
 | `TASK_STOPPED` | The task was stopped or cancelled before the request. |
 
+These codes ride command replies. A task key rejected while the connection is
+still being established — on the HTTP request or the WebSocket upgrade — is
+answered by the web layer with a generic `400 Bad request` carrying neither a
+message nor a code, deliberately, so that a rejected credential reveals nothing
+about why it was rejected. A client therefore cannot tell an invalidated task
+key from any other bad credential at connect time; the codes above appear only
+once a command is in flight.
+
 ### Events
 
 The engine pushes **events** that are not replies to any request: this is how


### PR DESCRIPTION
## Summary

- Task lookup failures raised a bare `RuntimeError`, so the only signal a client had was the English message. The issue reports the consuming app classifying these failures in `taskGone.ts` by matching three English strings — a contract nobody agreed to, and one reword or translation away from silently breaking (#2097, asks 1 and 2).
- Engine: a `TaskError` carrying a `code` at every task lookup in `task_server.py` — the registry lookups, both task-key authentication branches and the ambiguous-scope raise — and the two readiness raises in `task_engine.py`: `TASK_NOT_REGISTERED`, `TASK_AMBIGUOUS`, `TASK_COMPLETED`, `TASK_STOPPED`. Codes ride DAP command replies: a task key rejected at connect time is answered by the web layer with a generic `400` carrying neither message nor code, as noted in `packages/server/docs/index.md`.
- Protocol: `DAPBase.build_exception` copies a string `code` off the exception onto the error packet. Additive — an exception without one produces the same packet as before.
- SDKs: `code` and `hint` on `DAPException` (so every subclass inherits both), and `DataPipe.open()` stops concatenating its troubleshooting checklist onto the server's message.
- Ask 3 (re-registering a deterministic token on demand) is deliberately **not** here — it changes task lifetime semantics and deserves its own discussion.

### Backwards compatibility

Nine raise sites gained a code. Seven already raised `RuntimeError`, and
`TaskError` subclasses it with every message string unchanged, so
`except RuntimeError` and today’s string matching still work there. Pinned by an
assertion in `test_get_task_control_unknown_token_carries_a_code`.

**Two sites narrowed.** Both `authenticate()` branches (`pk_` and `tk_`) raised
`ValueError` before and now raise `TaskError`, so `except ValueError` no longer
catches them. The sole consumer is the web authenticator chain —
`TaskServer.authenticate` is registered once, at `task_server.py:256`, and
`_authenticate_credential_inner` catches broad `Exception`
(`ai/web/server.py:568-583`) — so nothing in-tree breaks. I considered the
`ToolNotFoundError(ValueError)` precedent
(`ai/common/agent/_internal/host.py:22-28`) and chose to state the narrowing
rather than add a dual-inheriting variant: that is new public API surface for
zero known consumers.

**A third changed exception type.** `remove_task` popped the registry without a
default, so an unknown token raised `KeyError` — on `develop` as well — before the
`TaskError` beneath it could run; that guard was dead code for exactly the case it
was written for. `826098e` pops with a default. `except KeyError` no longer catches
an unknown token, while `except RuntimeError` and the standard
`'Your pipeline is not running'` match now do — that case previously escaped as a
`KeyError` before the guard could run. The only in-tree caller passes
`control.token`, which is always present, so nothing in-tree reached it.

**Two message changes**, both deliberate:

- `str(e)` from a failed `pipe.open()` is now the server’s message alone; the
  "Common causes" checklist moved to `e.hint`, with one word corrected — it told
  callers to pass `mimetype=`, which `pipe()` does not accept (the parameter is
  `mime_type`). That is the point of ask 2 — an application can show the message
  to an end user without the developer checklist.
- A cancelled task whose `exitMessage` is empty now reports `'Task was stopped'`
  rather than an empty message. `_reset_status` (`task_engine.py:1899`) blanks it
  and is called from `restart_task` (`:1980`), so the empty window recurs on every
  restart rather than being a construction-time curiosity. `or` substitutes only on
  a falsy value, so a real `'Stopped'` (set at `:844`) passes through unchanged.

### One decision a reviewer may want up front

- **`code`/`hint` are optional readonly fields in TypeScript, not getters.** Getters declare required members, and `ConnectErrorCallback = (error: ConnectionException) => …` puts the exception in a contravariant parameter position: the frozen v1.3 floor's `ConnectionException` then fails to satisfy the live one and `client-typescript:regen` exits 1. Optional fields keep the floor assignable; regen is a verified no-op.

## Type

fix (module:ai, module:client-python, module:client-typescript)

## Testing

- [x] Tests added or updated — 15 new tests. Engine: 3 in `test_task_server.py`. Python SDK: 5 in a new `test_task_error_codes.py` (code carried / omitted for a plain exception / ignored when non-string, plus the `code` and `hint` accessors). TypeScript SDK: 7 in a new `tests/task-errors.test.ts` against a stub client, covering `open()` and `chat()`. Reverting `dap_base.py` + `exceptions.py` fails 3 of the 5 Python SDK tests — that is the "code reaches the wire" claim.
- [x] Tested locally:
  - `ai` suite: **2446 passed, 122 skipped**. Run as `engine -m pytest` after syncing `packages/ai/src/ai` and `packages/client-python/src/rocketride` into `dist/server` — the same invocation `ai:run-pytest` makes. `./builder ai:test` itself could not run here: it rebuilds `server:build-core`, which needs cmake (not installed on this machine).
  - `client-python`: **121 passed, 6 skipped** via `./builder client-python:test`, run after the only change that touches `client-python/src`; plus the new file's 5.
  - `client-typescript`: `npx jest tests/task-errors.test.ts` **5 passed**; `tsc --noEmit` clean; `node scripts/build.js client-typescript:regen` exits 0 and leaves `contract/index.ts`, `contract/latest.ts` and `contract-check.generated.ts` byte-identical.
  - `ruff check` / `ruff format --check` clean across `packages/ai` and `packages/client-python`. No prettier run on the TypeScript sources — neither file is prettier-clean on `develop`, and `--write` would add ~270 lines of unrelated churn.
- [ ] `./builder test` — not run locally (cmake/vcpkg absent); CI covers it on all three platforms.

### Docs

Per the co-located documentation rule, three docs ship with the change: the `code` field plus a table of the four values in `packages/server/docs/index.md`, and a `code`/`hint` section with an example in each SDK guide.

The engine-protocol example also gains two corrections it needed anyway: its message read `"Pipeline is not running"` (no such string is emitted — it is `"Your pipeline is not running"`) and it attributed the trace to `process.cpp` for a failure that raises from Python.

`./builder docs:build` **fails on this branch, and on `develop`, for an unrelated reason**: a broken link on `/nodes/llm_qwen`, from `nodes/src/nodes/llm_qwen/README.md:116` → `../../../../tools/sync_models/README.md`. That line is byte-identical on `develop` and `llm_qwen` is not in this diff. The target file exists and the relative path is correct on GitHub — it breaks only in the built site, because `docs:build` gathers co-located package docs and `tools/` is not among them. Happy to file it separately.

## Checklist

- [x] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
- [x] No secrets or credentials included
- [ ] Wiki updated (n/a — the co-located docs above are the surface that changed)
- [x] Breaking changes documented — see "Backwards compatibility": two sites narrowed from `ValueError`, one from `KeyError`, and two message texts changed

## Linked Issue

Fixes #2097

Scoped to asks 1 and 2; ask 3 left as a follow-up. Say the word if you'd rather this read `Refs #2097` so the issue stays open to track it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added machine-readable codes for task errors, including unregistered, ambiguous, completed, and stopped tasks.
- Exceptions now expose optional `code` and developer-focused `hint` fields.
- Preserved server error messages while separating troubleshooting guidance into `hint`.

## Bug Fixes
- Task failures now use consistent typed errors.
- Client SDKs preserve typed task exceptions and error metadata.

## Documentation
- Updated Python, TypeScript, and server documentation with error-handling guidance, recognized codes, and examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->