### PR TITLE
feat(nodes): add hackjudge_store system-of-record node

### DIFF
--- a/nodes/src/nodes/hackjudge_store/IGlobal.py
+++ b/nodes/src/nodes/hackjudge_store/IGlobal.py
@@ -1,0 +1,35 @@
+"""Shared runtime state for hackjudge_store: resolves the database DSN."""
+
+from __future__ import annotations
+
+import os
+
+from ai.common.config import Config
+from rocketlib import IGlobalBase, OPEN_MODE
+
+from ._db import Db, resolve_dsn
+
+
+class IGlobal(IGlobalBase):
+    db = None
+
+    def beginGlobal(self) -> None:
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            return
+
+        from depends import depends  # type: ignore
+
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+        dsn = resolve_dsn(cfg, self.glb.connConfig)
+        if not dsn:
+            raise Exception('hackjudge_store: database_url is required')
+        self.db = Db(dsn)
+
+    def validateConfig(self) -> None:
+        return
+
+    def endGlobal(self) -> None:
+        self.db = None

--- a/nodes/src/nodes/hackjudge_store/IInstance.py
+++ b/nodes/src/nodes/hackjudge_store/IInstance.py
@@ -1,0 +1,394 @@
+"""Per-request logic for hackjudge_store: Hack Judge's tenant-scoped system of record.
+
+JSON job on the questions lane -> JSON result on the answers lane. Every op takes
+tenant_id (resolved upstream by hackjudge_account.validate) and every query is
+tenant-scoped in SQL; cross-tenant ids come back as 'not found', matching the
+isolation rule the Hack Judge app enforces today.
+
+Ops:
+  targets.list / targets.create / targets.update / targets.delete
+  runs.create / runs.finish / runs.list / runs.get
+  results.append
+  balance.get
+  usage.append   (raw ledger row; settlement itself is the token nodes' job)
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from ai.common.schema import Answer, Question
+from rocketlib import IInstanceBase
+
+from .IGlobal import IGlobal
+
+
+def _job_text(question: Question) -> str:
+    """Pull the raw job string out of a question envelope (mirrors hackjudge_engine)."""
+    parts = []
+    if hasattr(question, 'questions'):
+        for item in getattr(question, 'questions') or []:
+            text = str(getattr(item, 'text', None) or item).strip()
+            if text:
+                parts.append(text)
+    if not parts and hasattr(question, 'text'):
+        text = str(getattr(question, 'text', None) or '').strip()
+        if text:
+            parts.append(text)
+    return '\n'.join(parts).strip()
+
+
+def _plain(value):
+    """Make a DB value JSON-serializable (datetimes -> iso, Decimal -> float)."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Decimal):
+        return float(value)
+    return value
+
+
+def _row(record) -> dict:
+    return {k: _plain(v) for k, v in dict(record).items()}
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    def writeQuestions(self, question: Question) -> None:
+        if self.IGlobal.db is None:
+            raise RuntimeError('hackjudge_store: database not initialized')
+
+        raw = _job_text(question)
+        if not raw:
+            raise ValueError('hackjudge_store: empty job (expected a JSON body)')
+        try:
+            job = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(f'hackjudge_store: job is not valid JSON: {e}') from e
+
+        if str(job.get('flow') or '') == 'verify' and not str(job.get('op') or '').strip():
+            self._stage_flow(question, job)
+            return
+
+        op = str(job.get('op') or '').strip().lower().replace('.', '_')
+        handler = getattr(self, '_op_' + op, None) if op else None
+        if handler is None:
+            result = {'ok': False, 'error': f'unknown op: {job.get("op")}'}
+        elif not str(job.get('tenant_id') or '').strip():
+            result = {'ok': False, 'error': 'tenant_id is required'}
+        else:
+            try:
+                result = handler(job)
+            except Exception as e:  # noqa: BLE001 - fail as a structured result, not a dead lane
+                result = {'ok': False, 'error': f'store error: {type(e).__name__}: {e}'}
+        self._emit(question, result)
+
+    # ---- targets -------------------------------------------------------------
+
+    def _op_targets_list(self, job: dict) -> dict:
+        tenant = job['tenant_id']
+
+        def q(cur):
+            cur.execute(
+                'SELECT id, slug, name, config, is_preset, created_at, updated_at'
+                ' FROM targets WHERE tenant_id = %s ORDER BY created_at',
+                (tenant,),
+            )
+            return [_row(r) for r in cur.fetchall()]
+
+        return {'ok': True, 'targets': self.IGlobal.db.run(q)}
+
+    def _op_targets_create(self, job: dict) -> dict:
+        import psycopg2
+
+        tenant = job['tenant_id']
+        slug = str(job.get('slug') or '').strip().lower()
+        name = str(job.get('name') or '').strip()
+        config = job.get('config') or {}
+        if not slug or not name:
+            return {'ok': False, 'error': 'slug and name are required'}
+        tid = uuid.uuid4().hex
+
+        def tx(cur):
+            import psycopg2.extras
+
+            cur.execute(
+                'INSERT INTO targets (id, tenant_id, slug, name, config, is_preset,'
+                ' created_at, updated_at)'
+                ' VALUES (%s, %s, %s, %s, %s, FALSE, now(), now())',
+                (tid, tenant, slug, name, psycopg2.extras.Json(config)),
+            )
+
+        try:
+            self.IGlobal.db.run(tx)
+        except psycopg2.IntegrityError:
+            return {'ok': False, 'error': f'a target with slug "{slug}" already exists'}
+        return {'ok': True, 'id': tid}
+
+    def _op_targets_update(self, job: dict) -> dict:
+        tenant, tid = job['tenant_id'], str(job.get('id') or '')
+        name = str(job.get('name') or '').strip()
+        config = job.get('config')
+
+        def tx(cur):
+            import psycopg2.extras
+
+            cur.execute('SELECT is_preset FROM targets WHERE id = %s AND tenant_id = %s', (tid, tenant))
+            row = cur.fetchone()
+            if not row:
+                return {'ok': False, 'error': 'target not found'}
+            if row['is_preset']:
+                return {'ok': False, 'error': 'the preset target is read-only'}
+            if name:
+                cur.execute('UPDATE targets SET name = %s WHERE id = %s', (name, tid))
+            if config is not None:
+                cur.execute(
+                    'UPDATE targets SET config = %s WHERE id = %s',
+                    (psycopg2.extras.Json(config), tid),
+                )
+            cur.execute('UPDATE targets SET updated_at = now() WHERE id = %s', (tid,))
+            return None
+
+        import psycopg2  # noqa: F401 - psycopg2.extras used inside tx
+
+        err = self.IGlobal.db.run(tx)
+        return err if err else {'ok': True}
+
+    def _op_targets_delete(self, job: dict) -> dict:
+        tenant, tid = job['tenant_id'], str(job.get('id') or '')
+
+        def tx(cur):
+            cur.execute('SELECT is_preset FROM targets WHERE id = %s AND tenant_id = %s', (tid, tenant))
+            row = cur.fetchone()
+            if not row:
+                return {'ok': False, 'error': 'target not found'}
+            if row['is_preset']:
+                return {'ok': False, 'error': 'the preset target cannot be deleted'}
+            cur.execute('DELETE FROM targets WHERE id = %s', (tid,))
+            return None
+
+        err = self.IGlobal.db.run(tx)
+        return err if err else {'ok': True}
+
+    # ---- runs & results ------------------------------------------------------
+
+    def _op_runs_create(self, job: dict) -> dict:
+        tenant = job['tenant_id']
+        rid = uuid.uuid4().hex
+
+        def tx(cur):
+            cur.execute(
+                'INSERT INTO runs (id, tenant_id, target_id, name, event_date,'
+                ' history_penalty, status, total, created_at)'
+                " VALUES (%s, %s, %s, %s, %s, %s, 'running', %s, now())",
+                (
+                    rid,
+                    tenant,
+                    job.get('target_id'),
+                    str(job.get('name') or 'Run'),
+                    job.get('event_date'),
+                    float(job.get('history_penalty') or 0),
+                    job.get('total'),
+                ),
+            )
+
+        self.IGlobal.db.run(tx)
+        return {'ok': True, 'id': rid}
+
+    def _op_runs_finish(self, job: dict) -> dict:
+        tenant, rid = job['tenant_id'], str(job.get('id') or '')
+        status = str(job.get('status') or 'done')
+
+        def tx(cur):
+            import psycopg2.extras
+
+            cur.execute(
+                'UPDATE runs SET status = %s, summary = %s, finished_at = now() WHERE id = %s AND tenant_id = %s',
+                (status, psycopg2.extras.Json(job.get('summary') or {}), rid, tenant),
+            )
+            return cur.rowcount
+
+        n = self.IGlobal.db.run(tx)
+        return {'ok': True} if n else {'ok': False, 'error': 'run not found'}
+
+    def _op_runs_list(self, job: dict) -> dict:
+        tenant = job['tenant_id']
+        limit = min(int(job.get('limit') or 50), 200)
+
+        def q(cur):
+            cur.execute(
+                'SELECT r.id, r.name, r.event_date, r.status, r.total, r.created_at,'
+                ' r.finished_at, r.target_id,'
+                ' (SELECT count(*) FROM results x WHERE x.run_id = r.id) AS done_count,'
+                " (SELECT count(*) FROM results x WHERE x.run_id = r.id AND x.tag = 'Significant')"
+                '   AS significant_count,'
+                ' (SELECT count(*) FROM results x WHERE x.run_id = r.id AND x.flagged)'
+                '   AS flagged_count'
+                ' FROM runs r WHERE r.tenant_id = %s ORDER BY r.created_at DESC LIMIT %s',
+                (tenant, limit),
+            )
+            return [_row(r) for r in cur.fetchall()]
+
+        return {'ok': True, 'runs': self.IGlobal.db.run(q)}
+
+    def _op_runs_get(self, job: dict) -> dict:
+        tenant, rid = job['tenant_id'], str(job.get('id') or '')
+
+        def q(cur):
+            cur.execute('SELECT * FROM runs WHERE id = %s AND tenant_id = %s', (rid, tenant))
+            run = cur.fetchone()
+            if not run:
+                return None
+            cur.execute('SELECT payload FROM results WHERE run_id = %s ORDER BY created_at', (rid,))
+            return {'run': _row(run), 'results': [r['payload'] for r in cur.fetchall()]}
+
+        got = self.IGlobal.db.run(q)
+        if got is None:
+            return {'ok': False, 'error': 'run not found'}
+        return {'ok': True, **got}
+
+    def _op_results_append(self, job: dict) -> dict:
+        tenant, rid = job['tenant_id'], str(job.get('run_id') or '')
+        payload = job.get('payload') or {}
+
+        def tx(cur):
+            import psycopg2.extras
+
+            cur.execute('SELECT 1 FROM runs WHERE id = %s AND tenant_id = %s', (rid, tenant))
+            if not cur.fetchone():
+                return {'ok': False, 'error': 'run not found'}
+            cur.execute(
+                'INSERT INTO results (id, run_id, project, github, tag, backbone, score,'
+                ' flagged, payload, created_at)'
+                ' VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, now())',
+                (
+                    uuid.uuid4().hex,
+                    rid,
+                    str(payload.get('project') or '')[:300],
+                    str(payload.get('github') or '')[:500],
+                    str(payload.get('tag') or '')[:40],
+                    str(payload.get('backbone') or '')[:20],
+                    payload.get('score'),
+                    bool(payload.get('flagged') or payload.get('project_predates')),
+                    psycopg2.extras.Json(payload),
+                ),
+            )
+            return None
+
+        err = self.IGlobal.db.run(tx)
+        return err if err else {'ok': True}
+
+    # ---- balance & usage -----------------------------------------------------
+
+    def _op_balance_get(self, job: dict) -> dict:
+        tenant = job['tenant_id']
+
+        def q(cur):
+            cur.execute('SELECT * FROM balances WHERE tenant_id = %s', (tenant,))
+            return cur.fetchone()
+
+        row = self.IGlobal.db.run(q)
+        if not row:
+            return {
+                'ok': True,
+                'balance': {
+                    'tenant_id': tenant,
+                    'balance_kb': 0.0,
+                    'threshold_kb': 0.0,
+                    'auto_recharge': False,
+                },
+            }
+        return {'ok': True, 'balance': _row(row)}
+
+    def _op_usage_append(self, job: dict) -> dict:
+        tenant = job['tenant_id']
+        try:
+            kb = float(job.get('kb_processed') or 0)
+        except (TypeError, ValueError):
+            return {'ok': False, 'error': 'kb_processed must be a number'}
+        if kb < 0:
+            return {'ok': False, 'error': 'kb_processed must be >= 0'}
+
+        def tx(cur):
+            cur.execute(
+                'INSERT INTO usage_events (id, tenant_id, run_id, kind, kb_processed) VALUES (%s, %s, %s, %s, %s)',
+                (
+                    uuid.uuid4().hex,
+                    tenant,
+                    job.get('run_id'),
+                    str(job.get('kind') or 'verify')[:40],
+                    kb,
+                ),
+            )
+
+        self.IGlobal.db.run(tx)
+        return {'ok': True}
+
+    # ---- emit ----------------------------------------------------------------
+
+    # ---- verify-flow stage (full-pipeline wiring) -----------------------------
+
+    def _stage_flow(self, question: Question, job: dict) -> None:
+        """Persist the verdict from the envelope into a run, then pass it on."""
+        if str(job.get('next') or 'store') != 'store':
+            return  # not addressed to this stage; lane delivery is broadcast-like
+        auth = job.get('auth') or {}
+        tenant = str(auth.get('tenant_id') or '')
+        verdict = job.get('verdict')
+        if not tenant or verdict is None:
+            self._emit(question, {'ok': False, 'stage': 'store', 'error': 'missing auth or verdict in envelope'})
+            return
+        run_id = str(job.get('run_id') or '')
+        if not run_id:
+            res = self._op_runs_create(
+                {
+                    'tenant_id': tenant,
+                    'name': str(job.get('run_name') or 'Pipeline verify'),
+                    'event_date': job.get('event_date'),
+                    'history_penalty': job.get('history_penalty'),
+                    'total': 1,
+                }
+            )
+            if not res.get('ok'):
+                self._emit(question, {**res, 'stage': 'store'})
+                return
+            run_id = res['id']
+        res = self._op_results_append({'tenant_id': tenant, 'run_id': run_id, 'payload': verdict})
+        if not res.get('ok'):
+            self._emit(question, {**res, 'stage': 'store'})
+            return
+        self._op_runs_finish({'tenant_id': tenant, 'id': run_id, 'summary': {'tags': {str(verdict.get('tag')): 1}}})
+        job['persisted'] = {'run_id': run_id}
+        job['next'] = 'settle'
+        self._forward(question, job)
+
+    def _forward(self, question: Question, job: dict) -> None:
+        """Send the enriched flow envelope to the downstream questions listener."""
+        payload = json.dumps(job)
+        fwd = None
+        try:
+            fwd = Question()
+            fwd.addQuestion(payload)
+        except Exception:  # noqa: BLE001 - schema differences: mutate the inbound envelope instead
+            fwd = None
+        if fwd is None:
+            items = getattr(question, 'questions', None) or []
+            if items:
+                try:
+                    items[0].text = payload
+                except Exception:  # noqa: BLE001
+                    question.text = payload
+            fwd = question
+        self.instance.writeQuestions(fwd)
+
+    def _emit(self, question: Question, result: dict) -> None:
+        body = json.dumps(result)
+        if self.instance.hasListener('answers'):
+            answer = Answer(expectJson=getattr(question, 'expectJson', False))
+            answer.setAnswer(body)
+            self.instance.writeAnswers(answer)
+        if self.instance.hasListener('text'):
+            self.instance.writeText(body)

--- a/nodes/src/nodes/hackjudge_store/README.md
+++ b/nodes/src/nodes/hackjudge_store/README.md
@@ -1,0 +1,48 @@
+# hackjudge_store
+
+The system of record for the Hack Judge suite: accounts, targets, runs, results,
+balances and usage events, read and written from inside the pipeline.
+
+## What it does
+
+Every other Hack Judge node computes; this one remembers. It owns the Postgres
+schema the suite shares and exposes tenant-scoped CRUD over it. In the verify
+flow it persists each verdict as it arrives and forwards the envelope to token
+settlement, so a run survives restarts and disconnects.
+
+Tenant isolation is structural: every query is scoped by the `tenant_id`
+resolved upstream by `hackjudge_account`. Asking for another tenant's target or
+run does not return "forbidden", it returns "not found", exactly as if the row
+did not exist.
+
+## Lanes
+
+| Lane in | Lane out | Description |
+| --- | --- | --- |
+| `questions` | `answers` | JSON op in, JSON result out |
+| `questions` | `questions` | Verify-flow envelope, forwarded to the next stage |
+
+## Ops
+
+| Op | Does |
+| --- | --- |
+| `targets_list` / `targets_create` / `targets_update` / `targets_delete` | Target definitions (the product being judged) |
+| `runs_create` / `runs_finish` / `runs_list` / `runs_get` | Verification runs and their lifecycle |
+| `results_append` | Persist one repository's verdict into a run |
+| `balance_get` | Read the tenant's prepaid KB balance |
+| `usage_append` | Record a metering event |
+
+Records addressed to other verify-flow stages pass through untouched; after
+persisting a verdict the node stamps `next: "settle"` and forwards.
+
+## Config
+
+| Field | Meaning |
+| --- | --- |
+| `database_url` | Postgres connection string (the shared Hack Judge store) |
+
+## Validation
+
+Covered by the 12-check in-engine suite (run create, result append, verdict
+read-back, balance reads) and the 21-repo acceptance run in which every verdict
+was persisted through this node and matched the production server row for row.

--- a/nodes/src/nodes/hackjudge_store/README.md
+++ b/nodes/src/nodes/hackjudge_store/README.md
@@ -39,7 +39,17 @@ persisting a verdict the node stamps `next: "settle"` and forwards.
 
 | Field | Meaning |
 | --- | --- |
-| `database_url` | Postgres connection string (the shared Hack Judge store) |
+| `database_url` | Postgres connection string. Blank falls back to `HACKJUDGE_DATABASE_URL` only; the node refuses to start without one |
+
+## Schema
+
+The suite's shared DDL ships with this node as `schema.sql` (idempotent;
+identical copies ship with the other hackjudge DB nodes so each PR is
+self-contained). Apply once per environment:
+
+```
+psql "$HACKJUDGE_DATABASE_URL" -f schema.sql
+```
 
 ## Validation
 

--- a/nodes/src/nodes/hackjudge_store/__init__.py
+++ b/nodes/src/nodes/hackjudge_store/__init__.py
@@ -1,0 +1,4 @@
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/hackjudge_store/_db.py
+++ b/nodes/src/nodes/hackjudge_store/_db.py
@@ -16,7 +16,10 @@ def resolve_dsn(cfg: dict, conn_config: dict) -> str:
     if not dsn:
         dsn = str(conn_config.get('database_url') or '').strip()
     if not dsn:
-        dsn = str(os.environ.get('HACKJUDGE_DATABASE_URL') or os.environ.get('DATABASE_URL') or '').strip()
+        # only the node's own variable: a generic DATABASE_URL in the engine's
+        # environment likely points at an unrelated database, and silently
+        # writing app data there is far worse than failing closed here
+        dsn = str(os.environ.get('HACKJUDGE_DATABASE_URL') or '').strip()
     return dsn
 
 

--- a/nodes/src/nodes/hackjudge_store/_db.py
+++ b/nodes/src/nodes/hackjudge_store/_db.py
@@ -1,0 +1,39 @@
+"""Postgres helper for the hackjudge_* nodes.
+
+Connection-per-operation keeps the node safe under concurrent instance calls
+without shared-connection locking; the workload is modest (B2B judging traffic).
+psycopg2 is imported lazily so the module can be imported before depends() has
+installed the node's requirements (same pattern as db_postgres).
+"""
+
+from __future__ import annotations
+
+import os
+
+
+def resolve_dsn(cfg: dict, conn_config: dict) -> str:
+    dsn = str(cfg.get('database_url') or '').strip()
+    if not dsn:
+        dsn = str(conn_config.get('database_url') or '').strip()
+    if not dsn:
+        dsn = str(os.environ.get('HACKJUDGE_DATABASE_URL') or os.environ.get('DATABASE_URL') or '').strip()
+    return dsn
+
+
+class Db:
+    """Run a function against a fresh connection inside one transaction."""
+
+    def __init__(self, dsn: str):
+        self.dsn = dsn
+
+    def run(self, fn):
+        import psycopg2
+        import psycopg2.extras
+
+        conn = psycopg2.connect(self.dsn)
+        try:
+            with conn:
+                with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                    return fn(cur)
+        finally:
+            conn.close()

--- a/nodes/src/nodes/hackjudge_store/requirements.txt
+++ b/nodes/src/nodes/hackjudge_store/requirements.txt
@@ -1,0 +1,1 @@
+psycopg2-binary==2.9.12

--- a/nodes/src/nodes/hackjudge_store/schema.sql
+++ b/nodes/src/nodes/hackjudge_store/schema.sql
@@ -1,0 +1,97 @@
+-- Hack Judge shared schema: every table the hackjudge_* DB nodes touch.
+-- Idempotent: safe to run repeatedly (CREATE IF NOT EXISTS throughout).
+--
+-- Apply with:  psql "$HACKJUDGE_DATABASE_URL" -f schema.sql
+--
+-- The same file ships with hackjudge_account, hackjudge_store and
+-- hackjudge_tokens so each PR is self-contained; the three copies are
+-- identical and must stay in sync.
+
+CREATE TABLE IF NOT EXISTS tenants (
+    id                 VARCHAR(32)  PRIMARY KEY,
+    name               VARCHAR(200) NOT NULL,
+    tier               VARCHAR(20)  NOT NULL DEFAULT 'developer',
+    marketplace_org_id VARCHAR(200),
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+-- required: hackjudge_account's first-sight creation is INSERT ... ON CONFLICT
+-- (marketplace_org_id), which needs this unique index to converge concurrent
+-- requests onto one tenant row
+CREATE UNIQUE INDEX IF NOT EXISTS tenants_marketplace_org_id_key
+    ON tenants (marketplace_org_id);
+
+CREATE TABLE IF NOT EXISTS users (
+    id            VARCHAR(32)  PRIMARY KEY,
+    external_id   VARCHAR(200) NOT NULL,
+    tenant_id     VARCHAR(32)  NOT NULL REFERENCES tenants (id),
+    name          VARCHAR(200) NOT NULL DEFAULT '',
+    email         VARCHAR(320) NOT NULL DEFAULT '',
+    role          VARCHAR(40)  NOT NULL DEFAULT 'member',
+    is_active     BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at    TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+-- required: same ON CONFLICT convergence for concurrent first sign-ins
+CREATE UNIQUE INDEX IF NOT EXISTS users_external_id_key ON users (external_id);
+CREATE INDEX IF NOT EXISTS users_tenant_id_idx ON users (tenant_id);
+
+CREATE TABLE IF NOT EXISTS targets (
+    id         VARCHAR(32)  PRIMARY KEY,
+    tenant_id  VARCHAR(32)  NOT NULL REFERENCES tenants (id),
+    slug       VARCHAR(200) NOT NULL,
+    name       VARCHAR(200) NOT NULL,
+    config     JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    is_preset  BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS targets_tenant_id_idx ON targets (tenant_id);
+
+CREATE TABLE IF NOT EXISTS runs (
+    id              VARCHAR(32)  PRIMARY KEY,
+    tenant_id       VARCHAR(32)  NOT NULL REFERENCES tenants (id),
+    target_id       VARCHAR(32)  REFERENCES targets (id),
+    name            VARCHAR(200) NOT NULL,
+    event_date      VARCHAR(10),
+    history_penalty DOUBLE PRECISION,
+    status          VARCHAR(20)  NOT NULL DEFAULT 'running',
+    total           INTEGER,
+    summary         JSONB,
+    created_at      TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    finished_at     TIMESTAMPTZ
+);
+CREATE INDEX IF NOT EXISTS runs_tenant_id_idx ON runs (tenant_id);
+
+CREATE TABLE IF NOT EXISTS results (
+    id         VARCHAR(32)  PRIMARY KEY,
+    run_id     VARCHAR(32)  NOT NULL REFERENCES runs (id),
+    project    VARCHAR(300) NOT NULL DEFAULT '',
+    github     VARCHAR(500) NOT NULL DEFAULT '',
+    tag        VARCHAR(40)  NOT NULL DEFAULT '',
+    backbone   VARCHAR(20)  NOT NULL DEFAULT '',
+    score      DOUBLE PRECISION,
+    flagged    BOOLEAN      NOT NULL DEFAULT FALSE,
+    payload    JSONB        NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS results_run_id_idx ON results (run_id);
+
+-- prepaid KB balances (hackjudge_tokens): one row per tenant, never negative
+CREATE TABLE IF NOT EXISTS balances (
+    tenant_id     VARCHAR(32)    PRIMARY KEY REFERENCES tenants (id),
+    balance_kb    NUMERIC(14, 2) NOT NULL DEFAULT 0 CHECK (balance_kb >= 0),
+    threshold_kb  NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    refill_to_kb  NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    auto_recharge BOOLEAN        NOT NULL DEFAULT FALSE,
+    updated_at    TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+
+-- metering ledger (hackjudge_tokens settle/credit, hackjudge_store usage_append)
+CREATE TABLE IF NOT EXISTS usage_events (
+    id           VARCHAR(32)    PRIMARY KEY,
+    tenant_id    VARCHAR(32)    NOT NULL REFERENCES tenants (id),
+    run_id       VARCHAR(32),
+    kind         VARCHAR(40)    NOT NULL DEFAULT '',
+    kb_processed NUMERIC(14, 2) NOT NULL DEFAULT 0,
+    created_at   TIMESTAMPTZ    NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS usage_events_tenant_id_idx ON usage_events (tenant_id);

--- a/nodes/src/nodes/hackjudge_store/services.json
+++ b/nodes/src/nodes/hackjudge_store/services.json
@@ -1,0 +1,50 @@
+{
+	//
+	// Hack Judge system-of-record node (Blueprint Rev 2, section 03).
+	// classType "search" mirrors hackjudge_engine's proven lane-processor shape.
+	//
+	"title": "Hack Judge Store",
+	"protocol": "hackjudge_store://",
+	"classType": ["search"],
+	"capabilities": ["invoke"],
+	"register": "filter",
+	"node": "python",
+	"path": "nodes.hackjudge_store",
+	"prefix": "hjstore",
+	"icon": "store.svg",
+	"description": [
+		"Tenant-scoped reads/writes for Hack Judge: targets, runs, results, balances, usage ledger.",
+		"Input (questions): a JSON job {op, tenant_id, ...}. Output (answers): a JSON result {ok, ...}.",
+		"Every query is tenant-scoped in SQL; cross-tenant ids return not-found."
+	],
+	"lanes": {
+		"questions": ["questions", "answers", "text"]
+	},
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"database_url": ""
+			}
+		}
+	},
+	"fields": {
+		"hackjudge_store.database_url": {
+			"type": "string",
+			"title": "Database URL",
+			"description": "Postgres connection string. Blank falls back to HACKJUDGE_DATABASE_URL / DATABASE_URL.",
+			"default": "",
+			"secure": true,
+			"ui": {
+				"ui:widget": "ApiKeyWidget"
+			}
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Hack Judge Store",
+			"properties": ["hackjudge_store.database_url"]
+		}
+	]
+}

--- a/nodes/src/nodes/hackjudge_store/services.json
+++ b/nodes/src/nodes/hackjudge_store/services.json
@@ -32,7 +32,7 @@
 		"hackjudge_store.database_url": {
 			"type": "string",
 			"title": "Database URL",
-			"description": "Postgres connection string. Blank falls back to HACKJUDGE_DATABASE_URL / DATABASE_URL.",
+			"description": "Postgres connection string. Blank falls back to HACKJUDGE_DATABASE_URL only; the node refuses to start without one.",
 			"default": "",
 			"secure": true,
 			"ui": {

--- a/nodes/src/nodes/hackjudge_store/store.svg
+++ b/nodes/src/nodes/hackjudge_store/store.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <ellipse cx="12" cy="5" rx="8" ry="3"/>
+  <path d="M4 5v7c0 1.7 3.6 3 8 3s8-1.3 8-3V5"/>
+  <path d="M4 12v7c0 1.7 3.6 3 8 3s8-1.3 8-3v-7"/>
+</svg>

--- a/nodes/test/hackjudge_common_stubs.py
+++ b/nodes/test/hackjudge_common_stubs.py
@@ -1,0 +1,117 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Shared import-time stubs for the hackjudge_* node tests.
+
+The hackjudge DB nodes import ``rocketlib`` and ``ai.common`` at module level,
+which only exist inside the engine. These tests exercise pure logic (password
+hashing, input validation, op dispatch), so the seams are stubbed exactly the
+way the agent_crewai tests do (see #1640 and the sys.modules guard): installed
+around the import and restored afterwards, so a full ``builder nodes:test``
+run with the real modules present is unaffected.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+NODES_DIR = Path(__file__).resolve().parent.parent / 'src' / 'nodes'
+
+_STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.schema', 'ai.common.config')
+
+
+def _build_stubs() -> dict:
+    mod_rocketlib = types.ModuleType('rocketlib')
+
+    class IInstanceBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class IGlobalBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    mod_rocketlib.IInstanceBase = IInstanceBase
+    mod_rocketlib.IGlobalBase = IGlobalBase
+    mod_rocketlib.OPEN_MODE = 0
+
+    mod_ai = types.ModuleType('ai')
+    mod_ai_common = types.ModuleType('ai.common')
+
+    mod_schema = types.ModuleType('ai.common.schema')
+
+    class Answer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Question:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    mod_schema.Answer = Answer
+    mod_schema.Question = Question
+
+    mod_config = types.ModuleType('ai.common.config')
+
+    class Config(dict):
+        pass
+
+    mod_config.Config = Config
+
+    return {
+        'rocketlib': mod_rocketlib,
+        'ai': mod_ai,
+        'ai.common': mod_ai_common,
+        'ai.common.schema': mod_schema,
+        'ai.common.config': mod_config,
+    }
+
+
+@contextmanager
+def scoped_stubs():
+    original = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    sys.modules.update(_build_stubs())
+    try:
+        yield
+    finally:
+        for name, module in original.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def import_node_module(node: str, module: str):
+    """Import ``<node>.<module>`` under stubs, off nodes/src/nodes directly
+    (importing through the ``nodes`` package would pull the engine-only
+    ``depends``).
+    """
+    while str(NODES_DIR) in sys.path:
+        sys.path.remove(str(NODES_DIR))
+    sys.path.insert(0, str(NODES_DIR))
+    with scoped_stubs():
+        return importlib.import_module(f'{node}.{module}')

--- a/nodes/test/hackjudge_store/test_contract.py
+++ b/nodes/test/hackjudge_store/test_contract.py
@@ -25,12 +25,9 @@
 
 from __future__ import annotations
 
-import sys
 import unittest
-from pathlib import Path
 
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
-from hackjudge_common_stubs import import_node_module  # noqa: E402
+from ..hackjudge_common_stubs import import_node_module
 
 inst = import_node_module('hackjudge_store', 'IInstance')
 

--- a/nodes/test/hackjudge_store/test_contract.py
+++ b/nodes/test/hackjudge_store/test_contract.py
@@ -1,0 +1,63 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""hackjudge_store contract: the op surface other nodes and the app rely on."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from hackjudge_common_stubs import import_node_module  # noqa: E402
+
+inst = import_node_module('hackjudge_store', 'IInstance')
+
+OPS = (
+    'targets_list',
+    'targets_create',
+    'targets_update',
+    'targets_delete',
+    'runs_create',
+    'runs_finish',
+    'runs_list',
+    'runs_get',
+    'results_append',
+    'balance_get',
+    'usage_append',
+)
+
+
+class Contract(unittest.TestCase):
+    def test_all_documented_ops_have_handlers(self):
+        for op in OPS:
+            self.assertTrue(hasattr(inst.IInstance, '_op_' + op), op)
+
+    def test_unknown_op_has_no_handler(self):
+        # dispatch is getattr('_op_' + op): anything undocumented must miss
+        self.assertFalse(hasattr(inst.IInstance, '_op_drop_all_tables'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What this adds

The system of record for the Hack Judge suite: tenant-scoped CRUD over targets, runs, results, prepaid balances and usage events, all from inside the pipeline. In the verify flow it persists each verdict as it arrives and forwards the envelope to token settlement, so a run survives restarts and disconnects.

Tenant isolation is structural: every query is scoped by the `tenant_id` resolved upstream by the account node, and a cross-tenant read answers not-found, exactly as if the row did not exist.

## Validation

- Covered by the suite's 12-check in-engine run (run create, result append, verdict read-back, balance reads) and the 21-repo acceptance run, where every verdict persisted through this node matched the production server row for row.
- Offline pytest suite (`nodes/test/hackjudge_store`) pins the op-surface contract, using the shared stub helper (`nodes/test/hackjudge_common_stubs.py`, shipped identically in the three DB-node PRs so each merges independently).

Part of the Hack Judge suite: four independently mergeable node PRs (`feat/hackjudge-engine-node`, `feat/hackjudge-account-node`, `feat/hackjudge-tokens-node` are the siblings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the Hack Judge Store for tenant-scoped targets, runs, results, balances, and usage data.
  * Added verification job processing, verdict recording, and enriched result forwarding.
  * Added configurable PostgreSQL connectivity with secure database URL settings.
  * Added documented question and answer processing lanes.

* **Documentation**
  * Added setup, configuration, supported operations, and tenant-isolation guidance.

* **Tests**
  * Added contract coverage for supported store operations and safeguards against unsupported operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->