### PR TITLE
feat(nodes): add hackjudge_engine deterministic verification node

### DIFF
--- a/nodes/src/nodes/hackjudge_engine/IGlobal.py
+++ b/nodes/src/nodes/hackjudge_engine/IGlobal.py
@@ -1,0 +1,56 @@
+"""Shared runtime state for the hackjudge_engine node.
+
+Imports the vendored, self-contained engine (nodes.hackjudge_engine._engine) and
+seeds the GitHub token used for repo fetches. Custom nodes run real Python (not
+the tool_python sandbox), so the engine's urllib GitHub fetches work normally.
+"""
+
+from __future__ import annotations
+
+import os
+
+from ai.common.config import Config
+from rocketlib import IGlobalBase, OPEN_MODE
+
+from ._engine import engine, fetch
+from ._engine import target as target_mod
+
+
+class IGlobal(IGlobalBase):
+    """Holds the vendored engine modules and the resolved GitHub token."""
+
+    engine = engine
+    target_mod = target_mod
+    fetch = fetch
+    github_token: str = ''
+
+    @staticmethod
+    def _get_token(cfg: dict, conn_config: dict) -> str:
+        token = str((cfg.get('github_token') or '')).strip()
+        if token:
+            return token
+        token = str((conn_config.get('github_token') or '')).strip()
+        if token:
+            return token
+        return str((os.environ.get('ROCKETRIDE_GITHUB_TOKEN') or '')).strip()
+
+    def beginGlobal(self) -> None:
+        if self.IEndpoint.endpoint.openMode == OPEN_MODE.CONFIG:
+            return
+
+        from depends import depends  # type: ignore
+
+        requirements = os.path.dirname(os.path.realpath(__file__)) + '/requirements.txt'
+        depends(requirements)
+
+        cfg = Config.getNodeConfig(self.glb.logicalType, self.glb.connConfig)
+        self.github_token = self._get_token(cfg, self.glb.connConfig)
+        # engine's lazy `from . import fetch as rb` shares this module, so seeding
+        # the module global here covers both the passed-in gh() and engine internals.
+        self.fetch.GH_TOKEN = self.github_token or self.fetch.github_token()
+
+    def validateConfig(self) -> None:
+        return
+
+    def endGlobal(self) -> None:
+        return

--- a/nodes/src/nodes/hackjudge_engine/IInstance.py
+++ b/nodes/src/nodes/hackjudge_engine/IInstance.py
@@ -1,0 +1,177 @@
+"""Per-request logic for hackjudge_engine.
+
+Consumes a JSON job on the questions lane and emits the deterministic verdict on
+the answers lane. Mirrors the deterministic half of the Hack Judge verify path
+(gather -> evaluate -> det_note -> evidence_lines); the LLM prose stays a separate
+llm_anthropic node downstream.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ai.common.schema import Answer, Question
+from rocketlib import IInstanceBase
+
+from .IGlobal import IGlobal
+
+
+def _job_text(question: Question) -> str:
+    """Pull the raw job string out of a question envelope (mirrors search_exa)."""
+    parts = []
+    if hasattr(question, 'questions'):
+        for item in getattr(question, 'questions') or []:
+            text = str(getattr(item, 'text', None) or item).strip()
+            if text:
+                parts.append(text)
+    if not parts and hasattr(question, 'text'):
+        text = str(getattr(question, 'text', None) or '').strip()
+        if text:
+            parts.append(text)
+    return '\n'.join(parts).strip()
+
+
+class IInstance(IInstanceBase):
+    IGlobal: IGlobal
+
+    def writeQuestions(self, question: Question) -> None:
+        engine = self.IGlobal.engine
+        target_mod = self.IGlobal.target_mod
+        fetch = self.IGlobal.fetch
+        if engine is None or fetch is None:
+            raise RuntimeError('hackjudge_engine: engine not initialized')
+
+        raw = _job_text(question)
+        if not raw:
+            raise ValueError('hackjudge_engine: empty job (expected a JSON body)')
+        try:
+            job = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(f'hackjudge_engine: job is not valid JSON: {e}') from e
+        if str(job.get('flow') or '') == 'verify' and str(job.get('next') or 'engine') != 'engine':
+            return  # not addressed to this stage; lane delivery is broadcast-like
+
+        url = str(job.get('repo_url') or job.get('github') or '').strip()
+        if not url:
+            raise ValueError('hackjudge_engine: job.repo_url is required')
+        event_date = job.get('event_date')
+        history_penalty = job.get('history_penalty', 0) or 0
+        cfg = job.get('target_config')
+
+        # None target => the legacy RocketRide-preset path (identical to the app's
+        # fallback when no custom target is selected).
+        target = None
+        tname = 'RocketRide'
+        if cfg:
+            tname = str(job.get('target_name') or cfg.get('name') or 'Target')
+            target = target_mod.Target.from_ui_config(tname, cfg)
+
+        pr = fetch.parse_repo(url)
+        project = str(job.get('project') or (pr[1] if pr else '') or '(unnamed)')
+
+        result = self._verdict(engine, fetch, url, target, tname, event_date, history_penalty, project)
+        if str(job.get('flow') or '') == 'verify' and self.instance.hasListener('questions'):
+            job['verdict'] = result
+            job['next'] = 'store'
+            self._forward(question, job)
+        else:
+            self._emit(question, result)
+
+    def _verdict(self, engine, fetch, url, target, tname, event_date, history_penalty, project):
+        if fetch.repo_missing(url):
+            return {
+                'project': project,
+                'github': url,
+                'repo_accessible': False,
+                'tag': 'None',
+                'backbone': 'No',
+                'score': 0.0,
+                'error': 'repository not found or not public',
+                'target_name': tname,
+                'engine_used': 'rocketride-node',
+            }
+
+        # meter the run: count every byte fetched (Rev 2 bills on KB processed)
+        meter = {'chars': 0}
+
+        def gh_metered(u):
+            status, text = fetch._gh(u)
+            if text:
+                meter['chars'] += len(text)
+            return status, text
+
+        evidence = engine.gather(url, gh_metered, event_date, history_penalty, target)
+        if not evidence.get('accessible'):
+            return {
+                'project': project,
+                'github': url,
+                'repo_accessible': False,
+                'tag': 'None',
+                'backbone': 'No',
+                'score': 0.0,
+                'error': 'repository not accessible',
+                'target_name': tname,
+                'engine_used': 'rocketride-node',
+            }
+
+        ev = engine.evaluate(evidence, target)
+        note = engine.det_note(ev)
+        return {
+            'project': project,
+            'github': url,
+            'repo_accessible': True,
+            'fetch_incomplete': bool(evidence.get('fetch_incomplete')),
+            'tag': ev['tag'],
+            'backbone': ev['backbone'],
+            'score': ev['score'],
+            'pipelines': ev['pipelines'],
+            'breakdown': ev['breakdown'],
+            'pipelines_called': ev['pipelines_called'],
+            'pipelines_total': ev.get('pipelines_total'),
+            'other_platforms': ev.get('other_platforms', []),
+            'event_window': ev.get('event_window'),
+            'reused_pipelines': ev.get('reused_pipelines', []),
+            'project_predates': ev.get('project_predates'),
+            'history_tampered': ev.get('history_tampered', []),
+            'earliest_commit': ev.get('earliest_commit', ''),
+            'repo_created_at': ev.get('repo_created_at', ''),
+            'history_penalty': ev.get('history_penalty'),
+            'platform': ev.get('platform') or {},
+            'target_name': tname,
+            'tech': ev.get('tech', []),
+            'notes': note,
+            'evidence': engine.evidence_lines(ev),
+            'explain_prompt': engine.explain_prompt(
+                ev, project, url, '', readme_head=evidence.get('readme_head', ''), target_name=tname
+            ),
+            'kb_processed': round(meter['chars'] / 1024, 2),
+            'engine_used': 'rocketride-node',
+        }
+
+    def _forward(self, question: Question, job: dict) -> None:
+        """Send the enriched flow envelope to the downstream questions listener."""
+        payload = json.dumps(job)
+        fwd = None
+        try:
+            fwd = Question()
+            fwd.addQuestion(payload)
+        except Exception:  # noqa: BLE001 - schema differences: mutate the inbound envelope instead
+            fwd = None
+        if fwd is None:
+            items = getattr(question, 'questions', None) or []
+            if items:
+                try:
+                    items[0].text = payload
+                except Exception:  # noqa: BLE001
+                    question.text = payload
+            fwd = question
+        self.instance.writeQuestions(fwd)
+
+    def _emit(self, question: Question, result: dict) -> None:
+        body = json.dumps(result)
+        if self.instance.hasListener('answers'):
+            answer = Answer(expectJson=getattr(question, 'expectJson', False))
+            answer.setAnswer(body)
+            self.instance.writeAnswers(answer)
+        if self.instance.hasListener('text'):
+            self.instance.writeText(body)

--- a/nodes/src/nodes/hackjudge_engine/IInstance.py
+++ b/nodes/src/nodes/hackjudge_engine/IInstance.py
@@ -70,7 +70,13 @@ class IInstance(IInstanceBase):
         project = str(job.get('project') or (pr[1] if pr else '') or '(unnamed)')
 
         result = self._verdict(engine, fetch, url, target, tname, event_date, history_penalty, project)
-        if str(job.get('flow') or '') == 'verify' and self.instance.hasListener('questions'):
+        is_flow = str(job.get('flow') or '') == 'verify'
+        if result.get('deferred'):
+            # a deferred repo must never continue down the verify flow: nothing to
+            # persist, nothing to settle - the caller retries the repository
+            self._emit(question, {**result, 'stage': 'engine'} if is_flow else result)
+            return
+        if is_flow and self.instance.hasListener('questions'):
             job['verdict'] = result
             job['next'] = 'store'
             self._forward(question, job)
@@ -101,6 +107,21 @@ class IInstance(IInstanceBase):
             return status, text
 
         evidence = engine.gather(url, gh_metered, event_date, history_penalty, target)
+        if evidence.get('fetch_incomplete'):
+            # deferred, not scored: no tag/score keys at all, so this can never be
+            # mistaken for a verdict downstream, and nothing is billed for the
+            # thrown-away fetch work
+            return {
+                'project': project,
+                'github': url,
+                'repo_accessible': True,
+                'deferred': True,
+                'error': 'evidence fetch incomplete - '
+                f'{evidence.get("note") or "file fetch(es) failed"}; retry this repository',
+                'target_name': tname,
+                'kb_processed': 0.0,
+                'engine_used': 'rocketride-node',
+            }
         if not evidence.get('accessible'):
             return {
                 'project': project,

--- a/nodes/src/nodes/hackjudge_engine/README.md
+++ b/nodes/src/nodes/hackjudge_engine/README.md
@@ -1,0 +1,68 @@
+# hackjudge_engine
+
+The verdict node of the Hack Judge suite: given a GitHub repository and a target
+product definition, it decides deterministically whether the project really used
+the product, and how deeply.
+
+## What it does
+
+Hackathon sponsors need to know which submissions actually built on their product
+and which only name-dropped it. This node fetches the repository, scans manifests,
+source files, pipelines and deploy configuration, and returns a scored verdict:
+
+- a tag (`Significant` / `Moderate` / `Less` / `None`) with the numeric score,
+- a backbone read (`Yes` / `Partial` / `No`): is the product load-bearing,
+- the evidence behind every point (files, call sites, markers),
+- `kb_processed`: the KB of source actually scanned, for metering,
+- a ready `explain_prompt` a downstream LLM node can use to write the
+  plain-English explanation of the verdict.
+
+The verdict itself never involves an LLM: same repo, same target, same answer.
+The engine is vendored under `_engine/` (see `VENDORED.md`) and is the same code
+validated against the production Hack Judge server, byte-identical verdicts on
+the full acceptance set.
+
+If any file fetch fails mid-scan the node returns `fetch_incomplete` instead of
+a verdict, so a flaky network can never shrink the evidence and change a score.
+The caller retries that repository; it is never judged on partial evidence.
+
+## Lanes
+
+| Lane in | Lane out | Description |
+| --- | --- | --- |
+| `questions` | `answers` | JSON job in, JSON verdict out |
+| `questions` | `questions` | The enriched envelope, forwarded to the next stage |
+
+## The verify flow envelope
+
+The Hack Judge pipeline wires several nodes onto one questions lane, so every
+record carries an address: `{"flow": "verify", "next": "<stage>"}`. This node
+only acts when `next` is `engine` (or unset) and drops everything else without
+fetching anything. After a verdict it stamps `next: "store"` and forwards, so
+persistence and token settlement happen downstream.
+
+## Job fields
+
+```json
+{"flow": "verify", "next": "engine",
+ "repo_url": "https://github.com/team/project",
+ "target": {"name": "LaserData", "dependency_names": "laser-sdk, ...", "...": "..."},
+ "event_date": "2026-08-03", "history_penalty": 2.0}
+```
+
+`target` accepts the same free-text config the Targets editor produces; omit it
+to judge against the built-in preset. `event_date` enables the commit-freshness
+and history-tamper checks with `history_penalty` as the judge-set deduction.
+
+## Config
+
+| Field | Meaning |
+| --- | --- |
+| `github_token` | GitHub token used for repository fetches (raises rate limits; read-only public scope is enough) |
+| `name` | Optional label for this instance |
+
+## Validation
+
+Parity-proven against the production server on a 21-repo acceptance set
+(identical verdicts, exact KB settlement) and exercised by the 12-check
+in-engine suite together with the account, store and tokens nodes.

--- a/nodes/src/nodes/hackjudge_engine/VENDORED.md
+++ b/nodes/src/nodes/hackjudge_engine/VENDORED.md
@@ -1,0 +1,34 @@
+# hackjudge_engine — vendored engine provenance
+
+The deterministic verification engine under `_engine/` is **vendored** from the
+Hack Judge app repo (`hackathon-usage-verifier`). It is copied in (not imported by
+path) so the node is self-contained inside the server tree.
+
+## What is vendored (and from where)
+
+| File in `_engine/` | Source (`hackathon-usage-verifier/`) | Verbatim? |
+| --- | --- | --- |
+| `engine.py` | `eval/engine.py` | Copy + 2 patched lines (below) |
+| `target.py` | `eval/target.py` | Verbatim |
+| `targets/*.json` | `eval/targets/*.json` | Verbatim |
+| `fetch.py` | extracted from `run_batch.py` | Minimal subset (stdlib only) |
+
+## The two patches applied to `engine.py`
+
+Both are import-only; no logic changes, so the verdict is identical:
+
+1. `from target import Target, load_preset` → `from .target import Target, load_preset`
+   (relative import, since the code now lives in the `_engine` subpackage).
+2. `import run_batch as rb` → `from . import fetch as rb` (both occurrences).
+   The engine only uses `rb.parse_repo` and `rb.OTHER_PLATFORMS`; `fetch.py`
+   provides both. This avoids pulling in `run_batch`'s `openpyxl` / `rocketride`
+   dependencies.
+
+## Resync when the source engine changes
+
+Re-copy `eval/engine.py`, `eval/target.py`, `eval/targets/` from the app repo,
+then re-apply the two `engine.py` patches. Parity is verified by running the app's
+`eval/run_eval.py` fixtures against `_engine/` and by the node parity harness.
+
+`fetch.py` is a hand-maintained subset — if `run_batch._gh` / `parse_repo` /
+`repo_missing` / `github_token` / `OTHER_PLATFORMS` change, update `fetch.py` too.

--- a/nodes/src/nodes/hackjudge_engine/__init__.py
+++ b/nodes/src/nodes/hackjudge_engine/__init__.py
@@ -1,0 +1,4 @@
+from .IGlobal import IGlobal
+from .IInstance import IInstance
+
+__all__ = ['IGlobal', 'IInstance']

--- a/nodes/src/nodes/hackjudge_engine/_engine/__init__.py
+++ b/nodes/src/nodes/hackjudge_engine/_engine/__init__.py
@@ -1,0 +1,3 @@
+# Vendored Hack Judge deterministic engine (self-contained subpackage).
+# Namespaced under nodes.hackjudge_engine._engine so `engine`/`target` never
+# collide with any built-in engine module. See ../VENDORED.md for provenance.

--- a/nodes/src/nodes/hackjudge_engine/_engine/engine.py
+++ b/nodes/src/nodes/hackjudge_engine/_engine/engine.py
@@ -715,7 +715,9 @@ def gather(
     st, tbody = gh(f'https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1')
     if st != 200:
         return {'accessible': True, 'fetch_incomplete': True, 'note': f'tree fetch failed (HTTP {st})'}
-    paths = [x.get('path', '') for x in json.loads(tbody).get('tree', [])]
+    # blobs only: directories and submodules 404 on raw fetches, and with the
+    # fetch-failure guard a non-file entry would defer the repo permanently
+    paths = [x.get('path', '') for x in json.loads(tbody).get('tree', []) if x.get('type') == 'blob']
 
     fetch_fails = [0]
 
@@ -877,7 +879,9 @@ def _gather_generic(url: str, gh, event_date: str | None, history_penalty: float
     st, tbody = gh(f'https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1')
     if st != 200:
         return {'accessible': True, 'fetch_incomplete': True, 'note': f'tree fetch failed (HTTP {st})'}
-    paths = [x.get('path', '') for x in json.loads(tbody).get('tree', [])]
+    # blobs only: directories and submodules 404 on raw fetches, and with the
+    # fetch-failure guard a non-file entry would defer the repo permanently
+    paths = [x.get('path', '') for x in json.loads(tbody).get('tree', []) if x.get('type') == 'blob']
 
     fetch_fails = [0]
 

--- a/nodes/src/nodes/hackjudge_engine/_engine/engine.py
+++ b/nodes/src/nodes/hackjudge_engine/_engine/engine.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import re
+from urllib.parse import quote
 
 from .target import Target, load_preset  # noqa: F401  (eval/ dir is on sys.path wherever engine is imported)
 
@@ -719,7 +720,9 @@ def gather(
     fetch_fails = [0]
 
     def raw(p):
-        st_f, body_f = gh(f'https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{p}')
+        # tree paths go into the URL verbatim otherwise: a space or '#' would 404
+        # on every attempt and wrongly defer the repo forever
+        st_f, body_f = gh(f'https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{quote(p)}')
         if st_f != 200:
             fetch_fails[0] += 1
             return ''
@@ -773,8 +776,6 @@ def gather(
     win = event_window(event_date)
     project_predates, tampered, earliest = None, [], ''
     if win:
-        from urllib.parse import quote
-
         for pe in pipes:
             st, cbody = gh(f'https://api.github.com/repos/{owner}/{repo}/commits?path={quote(pe["path"])}&per_page=100')
             first = None
@@ -881,7 +882,9 @@ def _gather_generic(url: str, gh, event_date: str | None, history_penalty: float
     fetch_fails = [0]
 
     def raw(p):
-        st_f, body_f = gh(f'https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{p}')
+        # tree paths go into the URL verbatim otherwise: a space or '#' would 404
+        # on every attempt and wrongly defer the repo forever
+        st_f, body_f = gh(f'https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{quote(p)}')
         if st_f != 200:
             fetch_fails[0] += 1
             return ''

--- a/nodes/src/nodes/hackjudge_engine/_engine/engine.py
+++ b/nodes/src/nodes/hackjudge_engine/_engine/engine.py
@@ -1,0 +1,1122 @@
+"""Deterministic RocketRide-usage evaluation engine.
+
+Measures usage from a repo's CODE (parsed `.pipe` files + source scan), scores it against the
+approved weights (SCORING_SPEC.md), and derives Tag + Backbone deterministically - no LLM. The
+LLM (elsewhere) only writes the human-readable prose from this evaluation.
+
+Split into:
+  • pure functions  - parse_pipe / sdk_metrics / pipe_called / evaluate  (network-free, unit-tested)
+  • gather(url, gh) - fetches the repo (given a `gh(url)->(status, text)` fetcher) into `evidence`
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+from .target import Target, load_preset  # noqa: F401  (eval/ dir is on sys.path wherever engine is imported)
+
+# The bundled preset (eval/targets/rocketride.json) mirrors the constants below verbatim -
+# it is the DB-seeded description of what this module's legacy path checks. The legacy
+# (pipeline-scoring) path below is kept byte-identical for fixture parity; targets with
+# pipeline_scoring=False route to the target-agnostic generic path at the bottom.
+ROCKETRIDE = load_preset()
+
+# ---------------------------------------------------------------- approved weights (SCORING_SPEC.md)
+W = {
+    'dependency': 1.0,  # C1  rocketride in a manifest
+    'pipeline_called': 2.0,  # B1  per pipeline proven to be called
+    'agent_node': 1.0,  # A3  a called pipeline contains an agent_* node
+    'complexity_mid': 0.5,  # A2  called pipeline has 4-8 nodes
+    'complexity_high': 1.0,  # A2  called pipeline has 9+ nodes
+    'tool_or_llm': 0.5,  # A4  called pipeline has a tool_* or llm_* node
+    'hosted': 1.0,  # C4  hosted-pipeline usage (id/env + adapter)
+    'sdk_callsites': 0.5,  # C2  >=3 SDK call-sites
+    'file_spread': 0.5,  # C3  >=2 distinct files use RocketRide
+    'uncalled_penalty': 1.0,  # B2  per pipeline present but NEVER called
+    'predates_penalty': 1.0,  # D4  flat, once per project: a called pipeline predates the event window
+}
+THRESHOLDS = {'significant': 4.0, 'moderate': 2.0, 'less': 1.0}
+_MAX_SCORED_PIPES = 6  # cap how many called pipelines score, so a big generated suite can't run away
+EVENT_GRACE_DAYS = 2  # commits within event_date ± this many days are fine (no reuse penalty)
+DEFAULT_HISTORY_PENALTY = 2.0  # judge-configurable deduction when a project's history predates the
+# window or a commit-date rewrite is detected (0 = flag only)
+
+_SDK_CALL = re.compile(r'\b(RocketRideClient|client\.use|client\.chat|client\.send|client\.connect)', re.I)
+_MANIFEST = re.compile(
+    r'(^|/)(package\.json|requirements\.txt|pyproject\.toml|Cargo\.toml|go\.mod'
+    r'|pom\.xml|build\.gradle(\.kts)?|Gemfile|composer\.json|[^/]+\.csproj)$',
+    re.I,
+)
+# scan beyond JS/Python - a pipeline can be called (or the SDK used) from any language
+_SRC_EXT = re.compile(r'\.(ts|tsx|js|jsx|mjs|cjs|py|rs|go|java|kt|rb|php|cs|swift|scala|sh)$', re.I)
+_SRC_HINT = re.compile(
+    r'rocket|pipeline|integration|agent|engine|config|api|route|server|main|index|app|relay|deploy', re.I
+)
+# a pipeline defined in code and handed straight to the SDK: client.use({ pipeline ... })
+_INLINE_PIPE = re.compile(r'client\.use\(\s*\{\s*pipeline\b', re.I)
+# a GENERIC runner: client.use(filepath=<variable>) / client.use({ filepath: <var> }) - the pipe path
+# is computed/passed in, so specific .pipe names never appear next to the call (NOUS pattern).
+_RUNNER = re.compile(r"""client\.use\(\s*\{?\s*(?:file)?path\s*[=:]\s*(?!['"])""", re.I)
+# SDK-less HTTP / webhook invocation: a raw call to the hosted API or a deployed pipeline's webhook
+# (any language, no SDK). This IS a real runtime call to RocketRide.
+_RR_HTTP = re.compile(r'api\.rocketride\.ai|rocketride\.ai/[\w/-]*(pipeline|webhook|hook|run|invoke)', re.I)
+# a deployed-pipeline URL / webhook / token env (ROCKETRIDE_*_URL / _WEBHOOK / _ENDPOINT) - NOT a bare
+# ROCKETRIDE_API_KEY (auth only), which stays excluded.
+_HOSTED_ENV = re.compile(r'rocketride_\w*(url|webhook|endpoint|hook)', re.I)
+# a committed .json is a pipeline (not package.json / config) only if it has provider-bearing nodes
+_PIPE_HINT = re.compile(
+    r'^(webhook|chat|prompt|response|source|memory|telegram)$|^(llm_|agent_|tool_|db_|embedding_|vector|response_|source_)',
+    re.I,
+)
+_JSON_PIPE_PATH = re.compile(r'pipeline|rocketride', re.I)
+_JSON_CONFIG = re.compile(
+    r'(package(-lock)?|tsconfig|composer|schema|manifest|settings|config)\.json$|node_modules', re.I
+)
+
+
+# ---------------------------------------------------------------- pure detectors
+def parse_pipe(text: str) -> dict | None:
+    """Node metrics for one .pipe JSON. None if unparseable."""
+    try:
+        d = json.loads(text)
+    except Exception:
+        return None
+    if not isinstance(d, dict):
+        return None
+    if isinstance(d.get('pipeline'), dict):
+        d = d['pipeline']  # unwrap the { "pipeline": {…} } envelope - the SDK loader does the same
+    # canvas exports use "components"; hand-written pipes sometimes use "nodes" (and "type" for
+    # the provider). Accept both so a valid pipeline isn't read as 0 nodes.
+    comps = d.get('components') or d.get('nodes') or []
+    providers = [str(c.get('provider') or c.get('type') or '') for c in comps]
+    return {
+        'nodes': len(comps),
+        'providers': providers,
+        'has_agent': any(p.startswith('agent_') for p in providers),
+        'has_llm': any(p.startswith('llm_') for p in providers),
+        'tool_count': sum(p.startswith('tool_') for p in providers),
+        'project_id': d.get('project_id') or '',
+    }
+
+
+def complexity_band(nodes: int) -> str:
+    return 'high' if nodes >= 9 else 'medium' if nodes >= 4 else 'low'
+
+
+def history_tamper_scan(commits: list, win: dict) -> tuple:
+    """Scan a repo's commit list for evidence of history rewriting. Git stamps every commit with an
+    AUTHOR date (when the work was originally made) and a COMMITTER date (when it was last
+    rewritten). A commit whose committer date sits in/after the event window while its author date
+    is OLDER than the window is pre-existing work re-stamped for the event (rebase / amend /
+    filter-branch) - git's own metadata records the rewrite.
+    Returns ([tampered commits], earliest_date_seen).
+    """
+    tampered, earliest = [], ''
+    for it in commits or []:
+        c = (it or {}).get('commit', {})
+        a = (c.get('author') or {}).get('date', '') or ''
+        m = (c.get('committer') or {}).get('date', '') or ''
+        for d in (a, m):
+            if d and (not earliest or d < earliest):
+                earliest = d
+        if a and m and a[:10] < win['start'] and m[:10] >= win['start']:
+            tampered.append({'sha': (it.get('sha') or '')[:7], 'author': a, 'committer': m})
+    return tampered[:5], earliest
+
+
+def event_window(event_date: str | None) -> dict | None:
+    """The allowed commit window for an event date (YYYY-MM-DD): event ± EVENT_GRACE_DAYS.
+    Pipelines whose history starts BEFORE the window are pre-existing work (reuse).
+    """
+    if not event_date:
+        return None
+    try:
+        from datetime import date, timedelta
+
+        d = date.fromisoformat(str(event_date)[:10])
+    except ValueError:
+        return None
+    g = timedelta(days=EVENT_GRACE_DAYS)
+    return {'event': d.isoformat(), 'start': (d - g).isoformat(), 'end': (d + g).isoformat()}
+
+
+def _looks_like_pipeline(m: dict | None) -> bool:
+    """True only if a parsed JSON is actually a pipeline (has provider-bearing nodes) - so a
+    package.json / config file is never mistaken for one.
+    """
+    return bool(m) and m['nodes'] > 0 and any(_PIPE_HINT.search(p) for p in m['providers'] if p)
+
+
+_INVOKE = ('client.use', 'client.send', 'client.chat', 'rocketride start')
+
+# tech-stack detection (for the dossier's "Built with" chips) - languages from file
+# extensions, frameworks from manifest contents. Deterministic, from code, never self-reported.
+_TECH_EXT = {
+    '.py': 'Python',
+    '.ts': 'TypeScript',
+    '.tsx': 'TypeScript',
+    '.js': 'JavaScript',
+    '.jsx': 'JavaScript',
+    '.mjs': 'JavaScript',
+    '.rs': 'Rust',
+    '.go': 'Go',
+    '.java': 'Java',
+    '.kt': 'Kotlin',
+    '.rb': 'Ruby',
+    '.php': 'PHP',
+    '.cs': 'C#',
+    '.swift': 'Swift',
+    '.scala': 'Scala',
+    '.vue': 'Vue',
+    '.svelte': 'Svelte',
+    '.sh': 'Shell',
+}
+_TECH_FRAMEWORKS = (
+    ('"next"', 'Next.js'),
+    ('"react"', 'React'),
+    ('"vite"', 'Vite'),
+    ('"tailwindcss"', 'Tailwind CSS'),
+    ('"express"', 'Express'),
+    ('"vue"', 'Vue'),
+    ('"svelte"', 'Svelte'),
+    ('fastapi', 'FastAPI'),
+    ('flask', 'Flask'),
+    ('django', 'Django'),
+    ('streamlit', 'Streamlit'),
+    ('gradio', 'Gradio'),
+    ('"electron"', 'Electron'),
+)
+
+
+def detect_tech(paths: list, manifest_texts: list, gh_languages: dict | None = None) -> list:
+    """Language + framework chips for a repo. Languages come from GitHub's own Linguist
+    detection (the /languages API - authoritative, same data as the repo's language bar)
+    when available, ranked by byte count; extension counting is only the offline fallback.
+    Frameworks come from manifest contents (Linguist doesn't know frameworks).
+    """
+    if gh_languages:
+        langs = [k for k, _ in sorted(gh_languages.items(), key=lambda kv: -kv[1])][:5]
+    else:
+        counts: dict = {}
+        for p in paths:
+            pl = p.lower()
+            if 'node_modules/' in pl or 'vendor/' in pl or '/dist/' in pl:
+                continue
+            dot = pl.rfind('.')
+            t = _TECH_EXT.get(pl[dot:]) if dot >= 0 else None
+            if t:
+                counts[t] = counts.get(t, 0) + 1
+        langs = [t for t, _ in sorted(counts.items(), key=lambda kv: -kv[1])][:5]
+    joined = ' '.join(manifest_texts).lower()
+    fws = [label for key, label in _TECH_FRAMEWORKS if key in joined and label not in langs]
+    return langs + fws[:5]
+
+
+def _gh_languages(gh, owner: str, repo: str) -> dict | None:
+    """GitHub Linguist language byte counts, or None if the call fails (fallback kicks in)."""
+    st, body = gh(f'https://api.github.com/repos/{owner}/{repo}/languages')
+    if st != 200:
+        return None
+    try:
+        d = json.loads(body)
+        return d if isinstance(d, dict) and d else None
+    except Exception:
+        return None
+
+
+def _first_site(source_files: list, rx, snippet: str) -> dict | None:
+    """First line matching `rx` across the source, as a call-site dict (for inline / runner patterns)."""
+    for f in source_files:
+        mt = rx.search(f['text'])
+        if mt:
+            return {'file': f['path'], 'line': f['text'][: mt.start()].count('\n') + 1, 'snippet': snippet}
+    return None
+
+
+def _call_sites(f: dict, base: str) -> list:
+    out = []
+    for i, line in enumerate(f['text'].splitlines(), 1):
+        ll = line.lower()
+        if base in ll or any(k in ll for k in _INVOKE):
+            out.append({'file': f['path'], 'line': i, 'snippet': line.strip()[:110]})
+    return out
+
+
+def pipe_called(pipe_path: str, source_files: list) -> tuple:
+    """A pipeline is 'called' when the code loads/runs it via the SDK. Two patterns count:
+      • strong     - a file names the pipe (its basename appears, even inside resolve(HERE, '...'))
+                     AND that same file invokes client.use/send/chat / `rocketride start`;
+      • cross-file - the basename is referenced in one file while the SDK is invoked in another
+                     (common when the path is a shared constant or built dynamically).
+    Returns (called, call_sites[]).
+    """
+    base = pipe_path.rsplit('/', 1)[-1].lower()
+    ref_files = [f for f in source_files if base in f['text'].lower()]
+    if not ref_files:
+        return False, []
+    # strong: same file names the pipe and drives the SDK
+    for f in ref_files:
+        if any(k in f['text'].lower() for k in _INVOKE):
+            return True, _call_sites(f, base)[:6]
+    # cross-file: pipe referenced here, SDK invoked somewhere else in the repo
+    if any(k in f['text'].lower() for f in source_files for k in _INVOKE):
+        sites = [s for f in ref_files for s in _call_sites(f, base)]
+        return True, sites[:6]
+    return False, []
+
+
+def sdk_metrics(source_files: list) -> dict:
+    """Deterministic SDK-depth metrics across the fetched source."""
+    callsites = files_using = 0
+    hosted = engine = False
+    for f in source_files:
+        t, low = f['text'], f['text'].lower()
+        n = len(_SDK_CALL.findall(t))
+        callsites += n
+        if n or 'from rocketride' in low or 'import rocketride' in low or '@rocketride' in low:
+            files_using += 1
+        # hosted-pipeline usage = a pipeline called by id / a deployed webhook + an adapter. A bare
+        # ROCKETRIDE_API_KEY is only authentication (present even for local-pipe projects like
+        # constructor) - it is NOT hosted-pipeline usage, so it must not score on its own.
+        if 'rocketride_pipeline' in low or 'lib/rocketride' in low or _HOSTED_ENV.search(low):
+            hosted = True
+        # a real runtime call to RocketRide - the local engine, the /v1 API, the hosted API host, or a
+        # deployed pipeline's webhook (raw HTTP, no SDK, any language). This is genuine invocation.
+        if 'ws://localhost:5565' in low or '/v1/pipelines' in low or _RR_HTTP.search(low):
+            engine = True
+    return {'callsites': callsites, 'file_spread': files_using, 'hosted': hosted, 'engine': engine}
+
+
+# ---------------------------------------------------------------- backbone + tag (deterministic)
+_AI_COMPETITORS = {'langchain', 'crewai'}  # a competing AI runtime demotes to Partial
+# butterbase/supabase/firebase/pinecone/etc. are data/gateway - they do NOT demote
+
+
+def _backbone(pipelines: list, sdk: dict, evidence: dict) -> str:
+    runs_orchestration = any(p['called'] and (p.get('has_agent') or p.get('has_llm')) for p in pipelines)
+    real = runs_orchestration or sdk['hosted'] or sdk['engine']
+    if not real:
+        return 'No'
+    if any(o in _AI_COMPETITORS for o in evidence.get('other_platforms', [])):
+        return 'Partial'
+    return 'Yes'
+
+
+def _tag(score: float, backbone: str, called: int, evidence: dict) -> str:
+    if evidence.get('overclaim') or not evidence.get('accessible', True):
+        return 'None'
+    if evidence.get('scaffold_only') and called == 0:
+        return 'Less'  # D1 cap: scaffold/branding only
+    if score >= THRESHOLDS['significant']:
+        return 'Significant' if backbone in ('Yes', 'Partial') else 'Moderate'  # gate
+    if score >= THRESHOLDS['moderate']:
+        return 'Moderate'
+    if score >= THRESHOLDS['less']:
+        return 'Less'
+    return 'None'
+
+
+def evaluate(evidence: dict, target: Target | None = None) -> dict:
+    """Score the gathered evidence → deterministic Tag / Backbone / ground-truth table.
+    `target=None` (or the pipeline-scoring preset) uses the legacy RocketRide path unchanged;
+    any other target routes to the target-agnostic generic path.
+    """
+    if target is not None and not target.pipeline_scoring:
+        return _evaluate_generic(evidence, target)
+    if not evidence.get('accessible'):
+        return {
+            'tag': 'None',
+            'backbone': 'No',
+            'score': 0.0,
+            'pipelines': [],
+            'sdk': {},
+            'breakdown': [],
+            'pipelines_called': 0,
+            'reason': 'inaccessible',
+        }
+
+    breakdown, score = [], 0.0
+
+    def add(label, pts):
+        nonlocal score
+        score += pts
+        breakdown.append({'signal': label, 'points': pts})
+
+    if evidence.get('dependency'):
+        add('dependency in manifest', W['dependency'])
+
+    sdk = evidence.get('sdk', {'callsites': 0, 'file_spread': 0, 'hosted': False, 'engine': False})
+
+    pipelines = []
+    for p in evidence.get('pipes', []):
+        m = p.get('metrics')
+        nodes = m['nodes'] if m else 0
+        pipelines.append(
+            {
+                'name': p['path'],
+                'nodes': nodes,
+                'complexity': complexity_band(nodes),
+                'has_agent': bool(m and m['has_agent']),
+                'has_llm': bool(m and m['has_llm']),
+                'tool_count': (m['tool_count'] if m else 0),
+                'providers': (m['providers'] if m else []),
+                'called': p.get('called', False),
+                'call_sites': p.get('call_sites', []),
+                'first_commit': p.get('first_commit'),
+            }
+        )
+
+    called_pipes = [e for e in pipelines if e['called']]
+    called = len(called_pipes)
+    # Does the repo genuinely run RocketRide pipelines? (SDK call-sites, live-engine calls, or an
+    # already-called pipe.) A bare hosted env-var alone does NOT count - see MCP AttackGraph.
+    repo_invokes = called > 0 or sdk.get('callsites', 0) > 0 or bool(sdk.get('engine'))
+
+    for e in called_pipes[:_MAX_SCORED_PIPES]:  # cap so a big generated suite can't run away
+        add(f'pipeline called: {e["name"]}', W['pipeline_called'])
+        if e['has_agent']:
+            add(f'agent node in {e["name"]}', W['agent_node'])
+        if e['nodes'] >= 9:
+            add(f'complexity high ({e["nodes"]} nodes)', W['complexity_high'])
+        elif e['nodes'] >= 4:
+            add(f'complexity mid ({e["nodes"]} nodes)', W['complexity_mid'])
+        if e['has_llm'] or e['tool_count']:
+            add(f'tool/llm node in {e["name"]}', W['tool_or_llm'])
+    if called > _MAX_SCORED_PIPES:
+        add(f'(+{called - _MAX_SCORED_PIPES} more called pipeline(s) - score capped)', 0.0)
+
+    # Uncalled pipes are "for show" ONLY when the repo never invokes RocketRide at all. Otherwise
+    # they're experiments / examples / runtime-generated - no credit, but NO penalty, so a big
+    # uncalled suite can never bury genuine usage (the NOUS / rocketride-server false-negative).
+    if not repo_invokes:
+        for e in pipelines:
+            if not e['called']:
+                add(f'PENALTY pipeline never called: {e["name"]}', -W['uncalled_penalty'])
+
+    # D4 - commit-history freshness: a CALLED pipeline whose history starts BEFORE the allowed
+    # event window (event ± grace days) is pre-existing work being reused for the hackathon.
+    # Flat −1 once per project, loudly flagged. ISO dates compare lexicographically.
+    win = evidence.get('event_window')
+    reused = []
+    if win:
+        for e in pipelines:
+            e['predates'] = bool(e['called'] and e.get('first_commit') and str(e['first_commit'])[:10] < win['start'])
+        reused = [e for e in pipelines if e.get('predates')]
+        if reused:
+            names = ', '.join(f'{e["name"]} (first commit {str(e["first_commit"])[:10]})' for e in reused[:4])
+            add(
+                f'PENALTY: pipeline predates event window {win["start"]}..{win["end"]} - {names}',
+                -W['predates_penalty'],
+            )
+
+    if sdk.get('hosted'):
+        add('hosted-pipeline usage', W['hosted'])
+    if sdk.get('callsites', 0) >= 3:
+        add(f'SDK call-sites ({sdk["callsites"]})', W['sdk_callsites'])
+    if sdk.get('file_spread', 0) >= 2:
+        add(f'SDK spread ({sdk["file_spread"]} files)', W['file_spread'])
+
+    # D5/D6 - event-integrity FLAGS (judge's call, when an event window is set). Each deducts the
+    # judge-configurable history penalty (default 2; 0 = flag only, a large value ≈ disqualify):
+    #   D5 project predates: ANY commit before the window start = the project wasn't built at the
+    #      event (old project + a few event-day commits).
+    #   D6 history tampered: git's author-vs-committer dates prove pre-window work was re-stamped
+    #      into the window (rebase/amend/filter-branch) - faked freshness.
+    project_predates = evidence.get('project_predates')
+    tampered = evidence.get('history_tampered') or []
+    pen = evidence.get('history_penalty')
+    pen = DEFAULT_HISTORY_PENALTY if pen is None else max(0.0, float(pen))
+    if win and project_predates:
+        pp_date = str(project_predates.get('date', ''))[:10]
+        early = str(evidence.get('earliest_commit', ''))[:10]
+        earliest = min(d for d in (pp_date, early) if d) if (pp_date or early) else '?'
+        add(
+            f'⚠ FLAGGED: project history predates the event window {win["start"]}..{win["end"]} - '
+            f'work goes back to {earliest} (latest pre-window commit '
+            f'{project_predates.get("sha", "?")} on {pp_date or "?"}); judge-set penalty',
+            -pen,
+        )
+    if win and tampered:
+        t0 = tampered[0]
+        add(
+            f'⚠ FLAGGED: commit-date rewrite detected - {t0["sha"]} authored '
+            f'{str(t0["author"])[:10]} but re-stamped {str(t0["committer"])[:10]} into the window; '
+            f'judge-set penalty',
+            -pen,
+        )
+
+    score = max(0.0, round(score, 1))
+    backbone = _backbone(pipelines, sdk, evidence)
+    tag = _tag(score, backbone, called, evidence)
+    # couple backbone to the verdict: a project with no real usage (None/Less) can't be the backbone
+    # of anything, so it never shows Yes/Partial. This makes contradictions like "None + Yes" impossible.
+    if tag in ('None', 'Less'):
+        backbone = 'No'
+    return {
+        'tag': tag,
+        'backbone': backbone,
+        'score': score,
+        'pipelines': pipelines,
+        'sdk': sdk,
+        'breakdown': breakdown,
+        'pipelines_called': called,
+        'tech': evidence.get('tech', []),
+        'pipelines_total': len(pipelines),
+        'other_platforms': evidence.get('other_platforms', []),
+        'event_window': win,
+        'history_penalty': pen if win else None,
+        'project_predates': project_predates if win else None,
+        'history_tampered': tampered if win else [],
+        'earliest_commit': evidence.get('earliest_commit', ''),
+        'repo_created_at': evidence.get('repo_created_at', ''),
+        'reused_pipelines': [{'name': e['name'], 'first_commit': e.get('first_commit')} for e in reused],
+    }
+
+
+# default deterministic-eval fields for short-circuit rows (no repo / inaccessible), so the UI +
+# Excel never see a missing key. Kept here so the app and the CLI use the exact same shape.
+ZERO_EVAL = {
+    'score': 0.0,
+    'pipelines': [],
+    'breakdown': [],
+    'pipelines_called': 0,
+    'pipelines_total': 0,
+    'other_platforms': [],
+    'event_window': None,
+    'reused_pipelines': [],
+    'project_predates': None,
+    'history_tampered': [],
+    'earliest_commit': '',
+    'repo_created_at': '',
+    'history_penalty': None,
+    'tech': [],
+}
+
+
+# ---------------------------------------------------------------- LLM prose helpers (shared: app + CLI)
+# The verdict is deterministic (evaluate()); the cloud LLM's ONLY job is to explain it in plain
+# English. These helpers build that prompt and parse the reply, so app and CLI never diverge.
+EXPLAIN_PROMPT = """You are documenting how a hackathon project used RocketRide, for a judge.
+
+The VERDICT has ALREADY been decided deterministically from the project's actual code - you must NOT
+change it. Your only job is to explain it in plain English, grounded entirely in the evidence table
+you are given (pipelines, their node counts, and whether each is actually CALLED in the code, with
+call sites).
+
+Return ONLY a strict JSON object - start with { and end with }, no prose outside it:
+{
+  "description": "<1-2 sentences: what the project does>",
+  "rocketride_usage": "<1-2 sentences: concretely how it uses RocketRide - name the pipeline(s), the
+                        node count, and whether/where they are called; ground every claim in the table>",
+  "justification": "<2-3 sentences: why the code earns THIS tag and backbone, citing the table (e.g.
+                     'the 7-node agent pipeline is loaded and run at relay.ts:83'). If a pipeline is
+                     present but never called, say so explicitly. If a pipeline predates the event
+                     window (reused), call that out.>",
+  "project_name": "<ONLY if the README clearly states the project's name - else omit>",
+  "team_members": "<ONLY if the README clearly lists team member names - comma-separated - else omit>"
+}
+Rules: cite ONLY what is in the evidence. Never contradict the verdict. If the tag is None, state that
+the code shows no real RocketRide usage. Write plainly and never use em dashes anywhere in your
+prose; use commas, periods, or parentheses instead."""
+
+
+def _iter_json_objects(text: str):
+    depth, start = 0, None
+    for i, ch in enumerate(text):
+        if ch == '{':
+            if depth == 0:
+                start = i
+            depth += 1
+        elif ch == '}' and depth > 0:
+            depth -= 1
+            if depth == 0 and start is not None:
+                yield text[start : i + 1]
+                start = None
+
+
+def extract_prose(text: str) -> dict:
+    """Pull the {description, rocketride_usage, justification} object out of the LLM reply, tolerating
+    any wrapping analysis. The verdict is NOT here - that's decided deterministically.
+    """
+    best: dict = {}
+    for cand in _iter_json_objects(text or ''):
+        try:
+            obj = json.loads(cand)
+        except Exception:
+            continue
+        if isinstance(obj, dict) and any(k in obj for k in ('description', 'rocketride_usage', 'justification')):
+            best = obj
+    return best
+
+
+def explain_prompt(
+    evaluation: dict, project: str, repo: str, feedback: str, readme_head: str = '', target_name: str = 'RocketRide'
+) -> str:
+    """Build the prose prompt: the deterministic verdict + the ground-truth table as fixed context.
+    `target_name` retargets every display-name mention (the wire key `rocketride_usage` is
+    lowercase and untouched, so parsing never changes).
+    """
+    payload = {
+        'verdict': {'tag': evaluation['tag'], 'backbone': evaluation['backbone'], 'score': evaluation['score']},
+        'score_breakdown': evaluation.get('breakdown', []),
+        'pipelines': [
+            {
+                'name': p['name'],
+                'nodes': p['nodes'],
+                'complexity': p['complexity'],
+                'has_agent': p['has_agent'],
+                'called': p['called'],
+                'first_commit': p.get('first_commit'),
+                'call_sites': [f'{s["file"]}:{s["line"]}' for s in p.get('call_sites', [])],
+            }
+            for p in evaluation.get('pipelines', [])
+        ],
+        'sdk': evaluation.get('sdk', {}),
+        'other_platforms': evaluation.get('other_platforms', []),
+        'event_window': evaluation.get('event_window'),
+        'reused_pipelines': evaluation.get('reused_pipelines', []),
+    }
+    if evaluation.get('platform'):
+        payload['platform_evidence'] = evaluation['platform']
+    readme_block = (
+        f'\n\nREADME EXCERPT (for project_name / team_members / description only):\n{readme_head[:2500]}'
+        if readme_head
+        else ''
+    )
+    # retarget display-name mentions only - "rocketride_usage" (the JSON wire key) is lowercase
+    # and therefore untouched by this case-sensitive replace
+    base = EXPLAIN_PROMPT if target_name == 'RocketRide' else EXPLAIN_PROMPT.replace('RocketRide', target_name)
+    return (
+        base
+        + f'\n\nPROJECT: {project}\nREPO: {repo}\n'
+        + 'TEAM FEEDBACK (context only - the verdict is already fixed from code): '
+        + f'{feedback or "(none provided)"}\n\nDETERMINISTIC EVALUATION (do not change the verdict):\n'
+        + json.dumps(payload, indent=2)
+        + readme_block
+    )
+
+
+def evidence_lines(ev: dict) -> list:
+    """Deterministic, judge-readable evidence bullets built straight from the metrics (no LLM)."""
+    lines = []
+    win = ev.get('event_window')
+    pen = ev.get('history_penalty')
+    pen_txt = f'−{pen:g} judge-set penalty' if pen else 'flag only - no deduction'
+    if win and ev.get('project_predates'):
+        pp = ev['project_predates']
+        pp_date = str(pp.get('date', ''))[:10]
+        early = str(ev.get('earliest_commit', ''))[:10]
+        earliest = min(d for d in (pp_date, early) if d) if (pp_date or early) else '?'
+        lines.append(
+            f'⚠ FLAGGED - project history predates the event window '
+            f'{win["start"]}..{win["end"]}: work goes back to {earliest}; latest pre-window '
+            f"commit {pp.get('sha', '?')} on {pp_date or '?'} ({pen_txt}; judge's call)"
+        )
+    if win and ev.get('history_tampered'):
+        for t in ev['history_tampered'][:3]:
+            lines.append(
+                f'⚠ FLAGGED - commit-date rewrite: {t["sha"]} authored '
+                f'{str(t["author"])[:10]} but re-stamped {str(t["committer"])[:10]} '
+                f"({pen_txt}; judge's call)"
+            )
+    if win and ev.get('reused_pipelines'):
+        for r in ev['reused_pipelines']:
+            lines.append(
+                f'⚠ REUSED PIPELINE: {r["name"]} first committed '
+                f'{str(r.get("first_commit") or "?")[:10]} - BEFORE the event window '
+                f'{win["start"]}..{win["end"]} (−1 penalty)'
+            )
+    for p in ev.get('pipelines', []):
+        where = '; '.join(f'{s["file"]}:{s["line"]}' for s in p.get('call_sites', [])[:3])
+        status = (
+            f'CALLED @ {where}'
+            if p['called'] and where
+            else 'CALLED'
+            if p['called']
+            else 'NOT called (present for show)'
+        )
+        fc = f', first commit {str(p["first_commit"])[:10]}' if p.get('first_commit') else ''
+        lines.append(
+            f'{p["name"]} - {p["nodes"]} nodes ({p["complexity"]}), '
+            f'{"agent" if p["has_agent"] else "no agent"} - {status}{fc}'
+        )
+    sdk = ev.get('sdk', {})
+    lines.append(
+        f'SDK: {sdk.get("callsites", 0)} call-site(s) across {sdk.get("file_spread", 0)} '
+        f'file(s)' + (', hosted/Cloud usage' if sdk.get('hosted') else '')
+    )
+    pf = ev.get('platform') or {}
+    if pf.get('domains'):
+        lines.append('Deployed on target platform: ' + ', '.join(pf['domains'][:3]))
+    if pf.get('files'):
+        lines.append('Target config/artifacts committed: ' + ', '.join(pf['files'][:3]))
+    if pf.get('markers'):
+        lines.append('Account/env markers: ' + ', '.join(pf['markers'][:4]))
+    if ev.get('other_platforms'):
+        lines.append('Other platforms in code: ' + ', '.join(ev['other_platforms']))
+    return lines
+
+
+def det_note(ev: dict) -> str:
+    note = (
+        f'Deterministic score {ev["score"]} -> {ev["tag"]} / backbone {ev["backbone"]}; '
+        f'{ev["pipelines_called"]}/{ev["pipelines_total"]} pipeline(s) called.'
+    )
+    pen = ev.get('history_penalty')
+    pen_txt = f'−{pen:g}' if pen else 'flag only'
+    if ev.get('project_predates'):
+        pp_date = str(ev['project_predates'].get('date', ''))[:10]
+        early = str(ev.get('earliest_commit', ''))[:10]
+        earliest = min(d for d in (pp_date, early) if d) if (pp_date or early) else '?'
+        note += (
+            f' ⚠ FLAGGED: project history predates the event window (work goes back to '
+            f"{earliest}; {pen_txt}, judge's call)."
+        )
+    if ev.get('history_tampered'):
+        t0 = ev['history_tampered'][0]
+        note += (
+            f' ⚠ FLAGGED: commit-date rewrite detected ({t0["sha"]}: authored '
+            f'{str(t0["author"])[:10]}, re-stamped {str(t0["committer"])[:10]}; {pen_txt}, '
+            f"judge's call)."
+        )
+    if ev.get('reused_pipelines'):
+        names = ', '.join(r['name'] for r in ev['reused_pipelines'][:3])
+        note += f' ⚠ REUSED PIPELINE(S) predating the event window: {names} (−1).'
+    return note
+
+
+# ---------------------------------------------------------------- gather (network; `gh` injected)
+def gather(
+    url: str, gh, event_date: str | None = None, history_penalty: float | None = None, target: Target | None = None
+) -> dict:
+    """Fetch a repo into an `evidence` dict. `gh(url) -> (status, text)`.
+    When `event_date` (YYYY-MM-DD) is given, each pipeline's first-commit date is fetched so
+    evaluate() can flag pre-existing (reused) pipelines against the event ± grace-day window.
+    `history_penalty` is the judge-set deduction for project-predates / tampered-history flags
+    (None -> DEFAULT_HISTORY_PENALTY; 0 = flag only). `target=None` / the preset = legacy
+    RocketRide gathering; other targets use the target-agnostic generic gatherer.
+    """
+    if target is not None and not target.pipeline_scoring:
+        return _gather_generic(url, gh, event_date, history_penalty, target)
+    from . import fetch as rb  # lazy: reuse repo helpers/constants without a hard import cycle
+
+    pr = rb.parse_repo(url)
+    if not pr:
+        return {'accessible': False, 'note': 'URL not parseable'}
+    owner, repo = pr
+    st, body = gh(f'https://api.github.com/repos/{owner}/{repo}')
+    if st != 200:
+        return {'accessible': False, 'status': st}
+    meta = json.loads(body)
+    branch = meta.get('default_branch', 'main')
+    created_at = meta.get('created_at', '')
+    st, tbody = gh(f'https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1')
+    if st != 200:
+        return {'accessible': True, 'fetch_incomplete': True, 'note': f'tree fetch failed (HTTP {st})'}
+    paths = [x.get('path', '') for x in json.loads(tbody).get('tree', [])]
+
+    fetch_fails = [0]
+
+    def raw(p):
+        st_f, body_f = gh(f'https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{p}')
+        if st_f != 200:
+            fetch_fails[0] += 1
+            return ''
+        return body_f
+
+    pipes = [{'path': pp, 'metrics': parse_pipe(raw(pp))} for pp in [p for p in paths if p.endswith('.pipe')][:12]]
+    # pipelines committed as .json (canvas "export as JSON" / reference copies), not config files
+    for jp in [p for p in paths if p.endswith('.json') and _JSON_PIPE_PATH.search(p) and not _JSON_CONFIG.search(p)][
+        :6
+    ]:
+        m = parse_pipe(raw(jp))
+        if _looks_like_pipeline(m):
+            pipes.append({'path': jp, 'metrics': m})
+
+    dependency, others = False, set()
+    manifest_texts = []
+    for mf in [p for p in paths if _MANIFEST.search(p)][:8]:
+        txt = raw(mf)
+        manifest_texts.append(txt)
+        if re.search(r'rocketride|@rocketride/sdk', txt, re.I):
+            dependency = True
+        others.update(o for o in rb.OTHER_PLATFORMS if o in txt.lower())
+
+    src = [p for p in paths if _SRC_EXT.search(p)]
+    rr = [p for p in src if 'rocketride' in p.lower()]  # RR in the path - strongest signal
+    kw = [p for p in src if p not in rr and _SRC_HINT.search(p)]
+    rest = [p for p in src if p not in rr and p not in kw]
+    source_files = []
+    for cf in (rr + kw + rest)[:40]:
+        txt = raw(cf)
+        source_files.append({'path': cf, 'text': txt})
+        others.update(o for o in rb.OTHER_PLATFORMS if o in txt.lower())
+
+    # an in-code pipeline handed to client.use({ pipeline: … }) - the committed .json is its
+    # definition/mirror, so it counts as called even if its filename never appears in the code.
+    inline_site = _first_site(source_files, _INLINE_PIPE, 'client.use({ pipeline: … }) - in-code pipeline')
+    # a generic runner - client.use(filepath=<variable>) - runs pipes whose names never appear next
+    # to the call (loaded dynamically / generated at runtime). Its pipes count as called-via-runner.
+    runner_site = _first_site(source_files, _RUNNER, 'client.use(filepath=<variable>) - pipes run via a generic runner')
+    for pe in pipes:
+        called, sites = pipe_called(pe['path'], source_files)
+        if not called and pe['path'].endswith('.json') and inline_site:
+            called, sites = True, [inline_site]
+        if not called and runner_site:
+            called, sites = True, [runner_site]
+        pe['called'], pe['call_sites'] = called, sites
+
+    # commit-history freshness (only when an event date was provided - one API call per pipe):
+    # earliest commit touching the pipe file, taking the older of author/committer date so a
+    # rebase can't hide pre-existing work.
+    win = event_window(event_date)
+    project_predates, tampered, earliest = None, [], ''
+    if win:
+        from urllib.parse import quote
+
+        for pe in pipes:
+            st, cbody = gh(f'https://api.github.com/repos/{owner}/{repo}/commits?path={quote(pe["path"])}&per_page=100')
+            first = None
+            if st == 200:
+                try:
+                    commits = json.loads(cbody)
+                    if isinstance(commits, list) and commits:
+                        c = commits[-1].get('commit', {})  # newest-first → last = earliest
+                        dates = [c.get('author', {}).get('date', ''), c.get('committer', {}).get('date', '')]
+                        first = min(d for d in dates if d) if any(dates) else None
+                except Exception:
+                    first = None
+            pe['first_commit'] = first
+        # WHOLE-PROJECT freshness: the entire project must be built inside the window. If ANY
+        # commit exists before the window start, the project predates the event (hard disqualifier).
+        st, cbody = gh(f'https://api.github.com/repos/{owner}/{repo}/commits?until={win["start"]}T00:00:00Z&per_page=1')
+        if st == 200:
+            try:
+                lst = json.loads(cbody)
+                if isinstance(lst, list) and lst:
+                    c = lst[0].get('commit', {})
+                    dates = [(c.get('author') or {}).get('date', ''), (c.get('committer') or {}).get('date', '')]
+                    d = min((x for x in dates if x), default='')
+                    if d:
+                        project_predates = {'date': d, 'sha': (lst[0].get('sha') or '')[:7]}
+            except Exception:
+                project_predates = None
+        # TAMPER scan: author-vs-committer date evidence of history rewriting (hard disqualifier)
+        st, cbody = gh(f'https://api.github.com/repos/{owner}/{repo}/commits?per_page=100')
+        if st == 200:
+            try:
+                tampered, earliest = history_tamper_scan(json.loads(cbody), win)
+            except Exception:
+                tampered, earliest = [], ''
+
+    # README - the repo's own title/head, used to label projects better than the repo slug
+    readme_title, readme_head = '', ''
+    readmes = sorted([p for p in paths if re.fullmatch(r'readme\.(md|rst|txt)', p, re.I)], key=len) or sorted(
+        [p for p in paths if p.lower().endswith('/readme.md')], key=len
+    )
+    if readmes:
+        head_lines = raw(readmes[0]).splitlines()[:60]
+        readme_head = '\n'.join(head_lines)
+        for ln in head_lines:
+            if ln.strip().startswith('# '):
+                readme_title = ln.strip().lstrip('# ').strip()
+                break
+
+    scaffold = any(p.endswith('.claude/rules/rocketride.md') for p in paths)
+    if fetch_fails[0]:
+        return {
+            'accessible': True,
+            'fetch_incomplete': True,
+            'note': f'{fetch_fails[0]} file fetch(es) failed - evidence would be partial',
+        }
+    return {
+        'accessible': True,
+        'file_count': len(paths),
+        'tech': detect_tech(paths, manifest_texts, _gh_languages(gh, owner, repo)),
+        'dependency': dependency,
+        'pipes': pipes,
+        'source_files': source_files,
+        'other_platforms': sorted(others),
+        'scaffold_only': scaffold and not (dependency or pipes),
+        'sdk': sdk_metrics(source_files),
+        'event_window': win,
+        'repo_created_at': created_at,
+        'history_penalty': history_penalty,
+        'project_predates': project_predates,
+        'history_tampered': tampered,
+        'earliest_commit': earliest,
+        'readme_title': readme_title,
+        'readme_head': readme_head,
+    }
+
+
+# ---------------------------------------------------------------- target-agnostic generic path
+# Everything below reads ONLY from the Target - no product names in code. Used for every
+# target whose config came from the Targets editor (pipeline_scoring=False).
+
+
+def _gather_generic(url: str, gh, event_date: str | None, history_penalty: float | None, t: Target) -> dict:
+    """Fetch a repo into evidence for an arbitrary target: dependency in manifests, invocation
+    call-sites, runtime API usage, env/key markers, committed artifacts, deploy-domain links,
+    plus the same project-level commit-history integrity checks as the preset path.
+    """
+    from . import fetch as rb
+
+    pr = rb.parse_repo(url)
+    if not pr:
+        return {'accessible': False, 'note': 'URL not parseable'}
+    owner, repo = pr
+    st, body = gh(f'https://api.github.com/repos/{owner}/{repo}')
+    if st != 200:
+        return {'accessible': False, 'status': st}
+    meta = json.loads(body)
+    branch = meta.get('default_branch', 'main')
+    created_at = meta.get('created_at', '')
+    st, tbody = gh(f'https://api.github.com/repos/{owner}/{repo}/git/trees/{branch}?recursive=1')
+    if st != 200:
+        return {'accessible': True, 'fetch_incomplete': True, 'note': f'tree fetch failed (HTTP {st})'}
+    paths = [x.get('path', '') for x in json.loads(tbody).get('tree', [])]
+
+    fetch_fails = [0]
+
+    def raw(p):
+        st_f, body_f = gh(f'https://raw.githubusercontent.com/{owner}/{repo}/{branch}/{p}')
+        if st_f != 200:
+            fetch_fails[0] += 1
+            return ''
+        return body_f
+
+    # committed artifacts / platform config files - path-substring evidence
+    artifact_files = [p for p in paths if any(tok in p.lower() for tok in (t.artifact_paths + t.platform_files))][:12]
+
+    # the global watchlist + this target's competitors, minus the target itself (a target must
+    # never count as its own competitor)
+    own = {t.slug, t.name.lower()} | set(t.import_hints)
+    watch = {
+        w
+        for w in (set(rb.OTHER_PLATFORMS) | set(t.competitors)) - set(t.neutral)
+        if not any(w in o or o in w for o in own)
+    }
+
+    dependency, others = False, set()
+    manifest_texts = []
+    for mf in [p for p in paths if _MANIFEST.search(p)][:8]:
+        txt = raw(mf)
+        manifest_texts.append(txt)
+        if t.dependency_rx and t.dependency_rx.search(txt):
+            dependency = True
+        others.update(o for o in watch if o in txt.lower())
+
+    src = [p for p in paths if _SRC_EXT.search(p)]
+    named = [p for p in src if t.name_in_path_rx and t.name_in_path_rx.search(p)]
+    hint = [p for p in src if p not in named and t.src_hint_rx and t.src_hint_rx.search(p)]
+    rest = [p for p in src if p not in named and p not in hint]
+    source_files, callsites, files_using = [], 0, 0
+    hosted = api_used = False
+    domain_hits, marker_hits = set(), set()
+    for cf in (named + hint + rest)[:40]:
+        txt = raw(cf)
+        low = txt.lower()
+        source_files.append({'path': cf, 'text': txt})
+        n = len(t.sdk_call_rx.findall(txt)) if t.sdk_call_rx else 0
+        callsites += n
+        if n or any(h in low for h in t.import_hints):
+            files_using += 1
+        if any(tok in low for tok in t.hosted_tokens):
+            hosted = True
+            marker_hits.update(tok for tok in t.platform_markers if tok in low)
+        if any(tok in low for tok in t.engine_tokens):
+            api_used = True
+        domain_hits.update(d for d in t.platform_domains if d in low)
+        others.update(o for o in watch if o in low)
+
+    # README - title/head + deploy-domain / marker evidence
+    readme_title, readme_head = '', ''
+    readmes = sorted([p for p in paths if re.fullmatch(r'readme\.(md|rst|txt)', p, re.I)], key=len) or sorted(
+        [p for p in paths if p.lower().endswith('/readme.md')], key=len
+    )
+    if readmes:
+        head_lines = raw(readmes[0]).splitlines()[:60]
+        readme_head = '\n'.join(head_lines)
+        for ln in head_lines:
+            if ln.strip().startswith('# '):
+                readme_title = ln.strip().lstrip('# ').strip()
+                break
+    rl = readme_head.lower()
+    domain_hits.update(d for d in t.platform_domains if d in rl)
+    marker_hits.update(m for m in t.platform_markers if m in rl)
+
+    # project-level commit-history integrity (identical logic to the preset path)
+    win = event_window(event_date)
+    project_predates, tampered, earliest = None, [], ''
+    if win:
+        st, cbody = gh(f'https://api.github.com/repos/{owner}/{repo}/commits?until={win["start"]}T00:00:00Z&per_page=1')
+        if st == 200:
+            try:
+                lst = json.loads(cbody)
+                if isinstance(lst, list) and lst:
+                    c = lst[0].get('commit', {})
+                    dates = [(c.get('author') or {}).get('date', ''), (c.get('committer') or {}).get('date', '')]
+                    d = min((x for x in dates if x), default='')
+                    if d:
+                        project_predates = {'date': d, 'sha': (lst[0].get('sha') or '')[:7]}
+            except Exception:
+                project_predates = None
+        st, cbody = gh(f'https://api.github.com/repos/{owner}/{repo}/commits?per_page=100')
+        if st == 200:
+            try:
+                tampered, earliest = history_tamper_scan(json.loads(cbody), win)
+            except Exception:
+                tampered, earliest = [], ''
+
+    if fetch_fails[0]:
+        return {
+            'accessible': True,
+            'fetch_incomplete': True,
+            'note': f'{fetch_fails[0]} file fetch(es) failed - evidence would be partial',
+        }
+    return {
+        'accessible': True,
+        'file_count': len(paths),
+        'tech': detect_tech(paths, manifest_texts, _gh_languages(gh, owner, repo)),
+        'dependency': dependency,
+        'pipes': [],
+        'source_files': source_files,
+        'other_platforms': sorted(others),
+        'scaffold_only': False,
+        'sdk': {'callsites': callsites, 'file_spread': files_using, 'hosted': hosted, 'engine': api_used},
+        'platform': {'domains': sorted(domain_hits), 'markers': sorted(marker_hits), 'files': artifact_files},
+        'event_window': win,
+        'repo_created_at': created_at,
+        'history_penalty': history_penalty,
+        'project_predates': project_predates,
+        'history_tampered': tampered,
+        'earliest_commit': earliest,
+        'readme_title': readme_title,
+        'readme_head': readme_head,
+        'target_name': t.name,
+    }
+
+
+def _evaluate_generic(evidence: dict, t: Target) -> dict:
+    """Deterministic scoring for an arbitrary target: dependency / invocation depth / runtime
+    API usage / env wiring / file spread / committed artifacts / deploy evidence, with the same
+    judge-set commit-history flags as the preset path.
+    """
+    Wt, TH = t.weights, t.thresholds
+    if not evidence.get('accessible'):
+        return {
+            'tag': 'None',
+            'backbone': 'No',
+            'score': 0.0,
+            'pipelines': [],
+            'sdk': {},
+            'breakdown': [],
+            'pipelines_called': 0,
+            'reason': 'inaccessible',
+        }
+
+    breakdown, score = [], 0.0
+
+    def add(label, pts):
+        nonlocal score
+        score += pts
+        breakdown.append({'signal': label, 'points': pts})
+
+    if evidence.get('dependency'):
+        add('dependency in manifest', Wt['dependency'])
+    sdk = evidence.get('sdk', {'callsites': 0, 'file_spread': 0, 'hosted': False, 'engine': False})
+    cs = sdk.get('callsites', 0)
+    if cs >= 3:
+        add(f'invocation call-sites ({cs})', Wt['invocation'])
+    if cs >= 8:
+        add('deep integration (8+ call-sites)', Wt['invocation_deep'])
+    if sdk.get('engine'):
+        add('runtime API usage', Wt['api_usage'])
+    if sdk.get('hosted'):
+        add('environment/key wiring', Wt['hosted'])
+    if sdk.get('file_spread', 0) >= 2:
+        add(f'usage across {sdk["file_spread"]} files', Wt['file_spread'])
+    pf = evidence.get('platform') or {}
+    if pf.get('files'):
+        add(f'target artifact committed: {pf["files"][0]}', Wt['artifact'])
+    if pf.get('domains'):
+        add('deployed on target platform: ' + ', '.join(pf['domains'][:2]), Wt['platform_deploy'])
+
+    # D5/D6 - the same judge-set event-integrity flags as the preset path
+    win = evidence.get('event_window')
+    project_predates = evidence.get('project_predates')
+    tampered = evidence.get('history_tampered') or []
+    pen = evidence.get('history_penalty')
+    pen = DEFAULT_HISTORY_PENALTY if pen is None else max(0.0, float(pen))
+    if win and project_predates:
+        pp_date = str(project_predates.get('date', ''))[:10]
+        early = str(evidence.get('earliest_commit', ''))[:10]
+        earliest = min(d for d in (pp_date, early) if d) if (pp_date or early) else '?'
+        add(
+            f'⚠ FLAGGED: project history predates the event window {win["start"]}..{win["end"]} - '
+            f'work goes back to {earliest} (latest pre-window commit '
+            f'{project_predates.get("sha", "?")} on {pp_date or "?"}); judge-set penalty',
+            -pen,
+        )
+    if win and tampered:
+        t0 = tampered[0]
+        add(
+            f'⚠ FLAGGED: commit-date rewrite detected - {t0["sha"]} authored '
+            f'{str(t0["author"])[:10]} but re-stamped {str(t0["committer"])[:10]} into the window; '
+            f'judge-set penalty',
+            -pen,
+        )
+
+    score = max(0.0, round(score, 1))
+    # backbone: real usage = code invocation, runtime API calls, or deployed-on-platform with
+    # corroborating wiring; a competitor in the codebase demotes primacy to Partial
+    real = (
+        cs > 0
+        or sdk.get('engine')
+        or (
+            bool(pf.get('domains')) and (bool(pf.get('files')) or bool(pf.get('markers')) or evidence.get('dependency'))
+        )
+    )
+    if not real:
+        backbone = 'No'
+    elif any(o in t.competitors for o in evidence.get('other_platforms', [])):
+        backbone = 'Partial'
+    else:
+        backbone = 'Yes'
+
+    if evidence.get('overclaim') or not evidence.get('accessible', True):
+        tag = 'None'
+    elif score >= TH['significant']:
+        tag = 'Significant' if backbone in ('Yes', 'Partial') else 'Moderate'
+    elif score >= TH['moderate']:
+        tag = 'Moderate'
+    elif score >= TH['less']:
+        tag = 'Less'
+    else:
+        tag = 'None'
+    if tag in ('None', 'Less'):
+        backbone = 'No'
+
+    return {
+        'tag': tag,
+        'backbone': backbone,
+        'score': score,
+        'pipelines': [],
+        'sdk': sdk,
+        'breakdown': breakdown,
+        'pipelines_called': 0,
+        'pipelines_total': 0,
+        'other_platforms': evidence.get('other_platforms', []),
+        'tech': evidence.get('tech', []),
+        'platform': pf,
+        'target_name': t.name,
+        'event_window': win,
+        'history_penalty': pen if win else None,
+        'project_predates': project_predates if win else None,
+        'history_tampered': tampered if win else [],
+        'earliest_commit': evidence.get('earliest_commit', ''),
+        'repo_created_at': evidence.get('repo_created_at', ''),
+        'reused_pipelines': [],
+    }

--- a/nodes/src/nodes/hackjudge_engine/_engine/fetch.py
+++ b/nodes/src/nodes/hackjudge_engine/_engine/fetch.py
@@ -1,0 +1,84 @@
+"""GitHub fetch + repo helpers for the Hack Judge engine.
+
+Vendored (minimal, stdlib-only) from the hackathon-usage-verifier run_batch.py so
+the node has NO openpyxl / rocketride-client dependency. engine.py's lazy
+`import run_batch as rb` is redirected here (see the two patched lines in
+_engine/engine.py); it only needs parse_repo + OTHER_PLATFORMS. IInstance also
+uses _gh / repo_missing / github_token. GH_TOKEN is seeded by IGlobal.beginGlobal.
+"""
+
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+# Seeded at runtime by IGlobal.beginGlobal (from node config / env). _gh reads it.
+GH_TOKEN = None
+
+MISSING = {'', 'na', 'n/a', 'none', 'nil', '-', 'tbd'}
+
+# Other major platforms - engine uses this to judge whether the target is the sole
+# backbone (Yes) or sits alongside another platform (Partial). Kept identical to
+# run_batch.OTHER_PLATFORMS.
+OTHER_PLATFORMS = [
+    'butterbase',
+    'supabase',
+    'xtrace',
+    'photon',
+    'langchain',
+    'crewai',
+    'firebase',
+    'pinecone',
+    'weaviate',
+]
+
+
+def _norm(s: str) -> str:
+    return (s or '').strip().lower()
+
+
+def repo_missing(url: str) -> bool:
+    return _norm(url) in {_norm(m) for m in MISSING} or 'github.com' not in url.lower()
+
+
+def github_token() -> str:
+    t = os.environ.get('ROCKETRIDE_GITHUB_TOKEN')
+    if t and not t.startswith('PASTE'):
+        return t
+    envf = Path('.env')
+    if envf.exists():
+        for line in envf.read_text(encoding='utf-8-sig').splitlines():
+            if line.strip().startswith('ROCKETRIDE_GITHUB_TOKEN='):
+                v = line.split('=', 1)[1].strip()
+                if v and not v.startswith('PASTE'):
+                    return v
+    return None
+
+
+def _gh(url: str, retries: int = 2) -> tuple:
+    headers = {'User-Agent': 'rr-verifier', 'Accept': 'application/vnd.github+json'}
+    if GH_TOKEN:
+        headers['Authorization'] = f'Bearer {GH_TOKEN}'
+    for attempt in range(retries + 1):
+        req = urllib.request.Request(url, headers=headers)
+        try:
+            with urllib.request.urlopen(req, timeout=30) as r:
+                return r.status, r.read().decode('utf-8', 'replace')
+        except urllib.error.HTTPError as e:
+            if e.code in (403, 429, 500, 502, 503) and attempt < retries:
+                time.sleep(1.5 * (attempt + 1))
+                continue
+            return e.code, ''
+        except Exception:
+            if attempt < retries:
+                time.sleep(1.0)
+                continue
+            return None, ''
+    return None, ''
+
+
+def parse_repo(url: str):
+    m = re.search(r'github\.com[/:]+([^/\s]+)/([^/\s#?]+)', url, re.I)
+    return (m.group(1), m.group(2).removesuffix('.git')) if m else None

--- a/nodes/src/nodes/hackjudge_engine/_engine/target.py
+++ b/nodes/src/nodes/hackjudge_engine/_engine/target.py
@@ -1,0 +1,190 @@
+"""TargetConfig - the product being verified, as data.
+
+The engine is purely target-agnostic: every check reads from a Target. Two construction
+paths:
+
+  • Target.from_preset(dict)  - trusted JSON (eval/targets/*.json) carrying explicit regex
+    sources. The bundled RocketRide preset reproduces the historical constants verbatim,
+    which is what guarantees fixture parity.
+  • Target.from_ui_config(name, dict) - an end user's saved target (free-text fields from
+    the Targets editor). Tokens are treated as LITERALS (regex-escaped); matching is
+    case-insensitive substring/alternation. No user input is ever compiled as raw regex.
+
+Nothing about any specific product (Butterbase, Supabase, ...) lives in code - only in
+config. `pipeline_scoring` selects the artifact-graph scoring path (RocketRide pipelines);
+generic targets score on dependency / invocation depth / API usage / platform evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+_TARGETS_DIR = Path(__file__).resolve().parent / 'targets'
+
+# generic-path weights (used when pipeline_scoring is off). Chosen so a genuinely
+# integrated product reaches Significant (>= 4.0) and a passing mention stays None/Less.
+GENERIC_WEIGHTS = {
+    'dependency': 1.0,  # the target's package in a manifest
+    'invocation': 1.5,  # >=3 invocation/call sites in code
+    'invocation_deep': 1.0,  # >=8 call sites - deep integration
+    'api_usage': 1.5,  # real runtime calls to the target's API hosts
+    'hosted': 0.5,  # env markers / keys wiring the target in
+    'file_spread': 0.5,  # >=2 distinct files touch the target
+    'artifact': 1.0,  # a target-specific config file/dir committed
+    'platform_deploy': 1.5,  # deployed on the target's domains (link in code/README)
+    'predates_penalty': 1.0,
+    'uncalled_penalty': 1.0,
+}
+GENERIC_THRESHOLDS = {'significant': 4.0, 'moderate': 2.0, 'less': 1.0}
+
+
+def _split_tokens(text: str | None) -> list[str]:
+    """Free-text field -> clean literal tokens. Splits on commas and pipes, strips
+    parenthetical hints and glob stars, drops empties and one-char noise.
+    """
+    out = []
+    for raw in re.split(r'[|,\n]', text or ''):
+        tok = re.sub(r'\([^)]*\)', '', raw).strip().strip('*').strip()
+        if len(tok) >= 2:
+            out.append(tok)
+    return out
+
+
+def _alt_regex(tokens: list[str]) -> re.Pattern | None:
+    if not tokens:
+        return None
+    return re.compile('|'.join(re.escape(t) for t in tokens), re.I)
+
+
+def _num_map(overrides: dict | None, defaults: dict) -> dict:
+    """Merge user-tuned rubric numbers over the defaults. Values arrive as strings from
+    the editor; anything unparseable or negative falls back to the default for that key,
+    and unknown keys are ignored (the engine only reads known signals).
+    """
+    out = dict(defaults)
+    for k, v in (overrides or {}).items():
+        if k in out:
+            try:
+                f = float(v)
+                if f >= 0:
+                    out[k] = f
+            except (TypeError, ValueError):
+                pass
+    return out
+
+
+@dataclass
+class Target:
+    slug: str
+    name: str
+    types: list = field(default_factory=lambda: ['code'])
+    pipeline_scoring: bool = False
+    # compiled matchers (regex for presets, escaped-literal alternations for user targets)
+    sdk_call_rx: re.Pattern | None = None
+    dependency_rx: re.Pattern | None = None
+    inline_pipe_rx: re.Pattern | None = None
+    runner_rx: re.Pattern | None = None
+    http_rx: re.Pattern | None = None
+    hosted_env_rx: re.Pattern | None = None
+    src_hint_rx: re.Pattern | None = None
+    name_in_path_rx: re.Pattern | None = None
+    # lowercase substring tokens
+    invoke_tokens: tuple = ()
+    import_hints: tuple = ()
+    hosted_tokens: tuple = ()
+    engine_tokens: tuple = ()
+    # artifacts
+    artifact_extensions: tuple = ()
+    json_pipelines: bool = False
+    artifact_paths: tuple = ()  # generic: path substrings that prove usage
+    # platform evidence
+    platform_domains: tuple = ()
+    platform_files: tuple = ()
+    platform_markers: tuple = ()
+    competitors: frozenset = frozenset()
+    neutral: frozenset = frozenset()
+    scaffold_paths: tuple = ()
+    weights: dict = field(default_factory=dict)
+    thresholds: dict = field(default_factory=dict)
+
+    # ---- construction ----
+    @classmethod
+    def from_preset(cls, cfg: dict) -> 'Target':
+        rx = cfg.get('regex', {})
+        tk = cfg.get('tokens', {})
+        pf = cfg.get('platform', {})
+        c = lambda k: re.compile(rx[k], re.I) if rx.get(k) else None  # noqa: E731
+        return cls(
+            slug=cfg['slug'],
+            name=cfg['name'],
+            types=cfg.get('types', ['code']),
+            pipeline_scoring=bool(cfg.get('pipeline_scoring')),
+            sdk_call_rx=c('sdk_call'),
+            dependency_rx=c('dependency'),
+            inline_pipe_rx=c('inline_pipe'),
+            runner_rx=c('runner'),
+            http_rx=c('http'),
+            hosted_env_rx=c('hosted_env'),
+            src_hint_rx=c('src_hint'),
+            name_in_path_rx=c('name_in_path'),
+            invoke_tokens=tuple(t.lower() for t in tk.get('invoke', [])),
+            import_hints=tuple(t.lower() for t in tk.get('import_hints', [])),
+            hosted_tokens=tuple(t.lower() for t in tk.get('hosted', [])),
+            engine_tokens=tuple(t.lower() for t in tk.get('engine', [])),
+            artifact_extensions=tuple(cfg.get('artifact_extensions', [])),
+            json_pipelines=bool(cfg.get('json_pipelines')),
+            platform_domains=tuple(t.lower() for t in pf.get('domains', [])),
+            platform_files=tuple(t.lower() for t in pf.get('files', [])),
+            platform_markers=tuple(t.lower() for t in pf.get('markers', [])),
+            competitors=frozenset(t.lower() for t in cfg.get('competitors', [])),
+            scaffold_paths=tuple(cfg.get('scaffold_paths', [])),
+            weights=dict(cfg.get('weights', {})),
+            thresholds=dict(cfg.get('thresholds', {})),
+        )
+
+    @classmethod
+    def from_ui_config(cls, name: str, cfg: dict) -> 'Target':
+        """Build from the Targets editor's free-text fields (all literals, never raw regex)."""
+        deps = _split_tokens(cfg.get('dependency_names'))
+        invoc = _split_tokens(cfg.get('invocation'))
+        hosted = _split_tokens(cfg.get('hosted_markers'))
+        cli = _split_tokens(cfg.get('cli_verbs'))
+        arts = _split_tokens(cfg.get('artifacts'))
+        domains = [t.lstrip('*.').lower() for t in _split_tokens(cfg.get('platform_domains'))]
+        pfiles = _split_tokens(cfg.get('platform_files'))
+        markers = _split_tokens(cfg.get('platform_markers'))
+        slug = re.sub(r'[^a-z0-9]+', '-', name.lower()).strip('-') or 'target'
+        # API-host-looking tokens (contain a dot) among invocation/hosted markers count as
+        # runtime-call evidence; the rest of hosted_markers are env/key wiring.
+        hosts = [t.lower() for t in (invoc + hosted) if '.' in t and ' ' not in t]
+        return cls(
+            slug=slug,
+            name=name,
+            types=list(cfg.get('types') or ['code']),
+            pipeline_scoring=False,
+            sdk_call_rx=_alt_regex(invoc + cli),
+            dependency_rx=_alt_regex(deps),
+            src_hint_rx=_alt_regex(
+                [name] + deps + ['api', 'client', 'server', 'main', 'index', 'app', 'config', 'lib']
+            ),
+            name_in_path_rx=_alt_regex([name] + deps),
+            invoke_tokens=tuple(t.lower() for t in invoc + cli),
+            import_hints=tuple(t.lower() for t in deps),
+            hosted_tokens=tuple(t.lower() for t in hosted + markers),
+            engine_tokens=tuple(dict.fromkeys(hosts + domains)),
+            artifact_paths=tuple(t.lower() for t in arts + pfiles),
+            platform_domains=tuple(dict.fromkeys(domains)),
+            platform_files=tuple(t.lower() for t in pfiles),
+            platform_markers=tuple(t.lower() for t in markers + hosted),
+            competitors=frozenset(t.lower() for t in _split_tokens(cfg.get('competitors'))),
+            neutral=frozenset(t.lower() for t in _split_tokens(cfg.get('neutral'))),
+            weights=_num_map(cfg.get('weights'), GENERIC_WEIGHTS),
+            thresholds=_num_map(cfg.get('thresholds'), GENERIC_THRESHOLDS),
+        )
+
+
+def load_preset(slug: str = 'rocketride') -> Target:
+    return Target.from_preset(json.loads((_TARGETS_DIR / f'{slug}.json').read_text(encoding='utf-8')))

--- a/nodes/src/nodes/hackjudge_engine/_engine/targets/rocketride.json
+++ b/nodes/src/nodes/hackjudge_engine/_engine/targets/rocketride.json
@@ -1,0 +1,41 @@
+{
+  "slug": "rocketride",
+  "name": "RocketRide",
+  "types": ["code", "platform"],
+  "pipeline_scoring": true,
+  "regex": {
+    "sdk_call": "\\b(RocketRideClient|client\\.use|client\\.chat|client\\.send|client\\.connect)",
+    "dependency": "rocketride|@rocketride/sdk",
+    "inline_pipe": "client\\.use\\(\\s*\\{\\s*pipeline\\b",
+    "runner": "client\\.use\\(\\s*\\{?\\s*(?:file)?path\\s*[=:]\\s*(?!['\"])",
+    "http": "api\\.rocketride\\.ai|rocketride\\.ai/[\\w/-]*(pipeline|webhook|hook|run|invoke)",
+    "hosted_env": "rocketride_\\w*(url|webhook|endpoint|hook)",
+    "src_hint": "rocket|pipeline|integration|agent|engine|config|api|route|server|main|index|app|relay|deploy",
+    "name_in_path": "rocketride"
+  },
+  "tokens": {
+    "invoke": ["client.use", "client.send", "client.chat", "rocketride start"],
+    "import_hints": ["from rocketride", "import rocketride", "@rocketride"],
+    "hosted": ["rocketride_pipeline", "lib/rocketride"],
+    "engine": ["ws://localhost:5565", "/v1/pipelines"]
+  },
+  "artifact_extensions": [".pipe"],
+  "json_pipelines": true,
+  "competitors": ["langchain", "crewai"],
+  "scaffold_paths": [".claude/rules/rocketride.md"],
+  "platform": { "domains": [], "files": [], "markers": [] },
+  "weights": {
+    "dependency": 1.0,
+    "pipeline_called": 2.0,
+    "agent_node": 1.0,
+    "complexity_mid": 0.5,
+    "complexity_high": 1.0,
+    "tool_or_llm": 0.5,
+    "hosted": 1.0,
+    "sdk_callsites": 0.5,
+    "file_spread": 0.5,
+    "uncalled_penalty": 1.0,
+    "predates_penalty": 1.0
+  },
+  "thresholds": { "significant": 4.0, "moderate": 2.0, "less": 1.0 }
+}

--- a/nodes/src/nodes/hackjudge_engine/hackjudge.svg
+++ b/nodes/src/nodes/hackjudge_engine/hackjudge.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M12 2 3 6v6c0 5 3.8 8.3 9 10 5.2-1.7 9-5 9-10V6l-9-4z"/>
+  <path d="m8.5 12 2.5 2.5 4.5-4.5"/>
+</svg>

--- a/nodes/src/nodes/hackjudge_engine/requirements.txt
+++ b/nodes/src/nodes/hackjudge_engine/requirements.txt
@@ -1,0 +1,2 @@
+# The Hack Judge engine is pure standard library (urllib, json, re, datetime,
+# dataclasses). No third-party dependencies.

--- a/nodes/src/nodes/hackjudge_engine/services.json
+++ b/nodes/src/nodes/hackjudge_engine/services.json
@@ -25,7 +25,7 @@
 	//
 	"node": "python",
 	"path": "nodes.hackjudge_engine",
-	"prefix": "hackjudge",
+	"prefix": "hackjudge_engine",
 	"icon": "hackjudge.svg",
 	"description": [
 		"Runs the Hack Judge deterministic verification engine in-process.",

--- a/nodes/src/nodes/hackjudge_engine/services.json
+++ b/nodes/src/nodes/hackjudge_engine/services.json
@@ -1,0 +1,72 @@
+{
+	//
+	// The displayable name of this node.
+	//
+	"title": "Hack Judge Engine",
+	//
+	// Endpoint protocol for this node.
+	//
+	"protocol": "hackjudge_engine://",
+	//
+	// Class type - a deterministic scoring node: takes a job on the questions lane
+	// and returns a verdict on the answers lane.
+	//
+	"classType": ["search"],
+	//
+	// invoke = a per-request processing node (not an ingestion sink).
+	//
+	"capabilities": ["invoke"],
+	//
+	// filter = a lane processor (as opposed to an endpoint/source).
+	//
+	"register": "filter",
+	//
+	// Runtime + import path. Built into the engine's node set (nodes.<name>).
+	//
+	"node": "python",
+	"path": "nodes.hackjudge_engine",
+	"prefix": "hackjudge",
+	"icon": "hackjudge.svg",
+	"description": [
+		"Runs the Hack Judge deterministic verification engine in-process.",
+		"Input (questions): a JSON job {repo_url, target_config?, event_date?, history_penalty?, target_name?}.",
+		"Output (answers): the full deterministic verdict (tag, backbone, score, breakdown, evidence)."
+	],
+	//
+	// Data flow: consume a question envelope, produce an answer (and optionally text).
+	//
+	"lanes": {
+		"questions": ["questions", "answers", "text"]
+	},
+	//
+	// Driver configuration. github_token authenticates GitHub REST/raw fetches;
+	// blank falls back to the ROCKETRIDE_GITHUB_TOKEN env var.
+	//
+	"preconfig": {
+		"default": "default",
+		"profiles": {
+			"default": {
+				"github_token": ""
+			}
+		}
+	},
+	"fields": {
+		"hackjudge_engine.github_token": {
+			"type": "string",
+			"title": "GitHub Token",
+			"description": "GitHub token for repo fetches (read-only public scope is enough). Blank falls back to ROCKETRIDE_GITHUB_TOKEN.",
+			"default": "",
+			"secure": true,
+			"ui": {
+				"ui:widget": "ApiKeyWidget"
+			}
+		}
+	},
+	"shape": [
+		{
+			"section": "Pipe",
+			"title": "Hack Judge Engine",
+			"properties": ["hackjudge_engine.github_token"]
+		}
+	]
+}

--- a/nodes/test/hackjudge_common_stubs.py
+++ b/nodes/test/hackjudge_common_stubs.py
@@ -1,0 +1,117 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""Shared import-time stubs for the hackjudge_* node tests.
+
+The hackjudge DB nodes import ``rocketlib`` and ``ai.common`` at module level,
+which only exist inside the engine. These tests exercise pure logic (password
+hashing, input validation, op dispatch), so the seams are stubbed exactly the
+way the agent_crewai tests do (see #1640 and the sys.modules guard): installed
+around the import and restored afterwards, so a full ``builder nodes:test``
+run with the real modules present is unaffected.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from contextlib import contextmanager
+from pathlib import Path
+
+NODES_DIR = Path(__file__).resolve().parent.parent / 'src' / 'nodes'
+
+_STUB_MODULE_NAMES = ('rocketlib', 'ai', 'ai.common', 'ai.common.schema', 'ai.common.config')
+
+
+def _build_stubs() -> dict:
+    mod_rocketlib = types.ModuleType('rocketlib')
+
+    class IInstanceBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class IGlobalBase:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    mod_rocketlib.IInstanceBase = IInstanceBase
+    mod_rocketlib.IGlobalBase = IGlobalBase
+    mod_rocketlib.OPEN_MODE = 0
+
+    mod_ai = types.ModuleType('ai')
+    mod_ai_common = types.ModuleType('ai.common')
+
+    mod_schema = types.ModuleType('ai.common.schema')
+
+    class Answer:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    class Question:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    mod_schema.Answer = Answer
+    mod_schema.Question = Question
+
+    mod_config = types.ModuleType('ai.common.config')
+
+    class Config(dict):
+        pass
+
+    mod_config.Config = Config
+
+    return {
+        'rocketlib': mod_rocketlib,
+        'ai': mod_ai,
+        'ai.common': mod_ai_common,
+        'ai.common.schema': mod_schema,
+        'ai.common.config': mod_config,
+    }
+
+
+@contextmanager
+def scoped_stubs():
+    original = {name: sys.modules.get(name) for name in _STUB_MODULE_NAMES}
+    sys.modules.update(_build_stubs())
+    try:
+        yield
+    finally:
+        for name, module in original.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+
+
+def import_node_module(node: str, module: str):
+    """Import ``<node>.<module>`` under stubs, off nodes/src/nodes directly
+    (importing through the ``nodes`` package would pull the engine-only
+    ``depends``).
+    """
+    while str(NODES_DIR) in sys.path:
+        sys.path.remove(str(NODES_DIR))
+    sys.path.insert(0, str(NODES_DIR))
+    with scoped_stubs():
+        return importlib.import_module(f'{node}.{module}')

--- a/nodes/test/hackjudge_engine/test_deferred.py
+++ b/nodes/test/hackjudge_engine/test_deferred.py
@@ -1,0 +1,106 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""A deferred gather must leave the node as a retry signal, never as a verdict.
+
+`IInstance._verdict` uses no instance state, so the unbound method runs with
+``self=None`` against the real vendored engine and a stubbed fetch module.
+The property under test is the review finding on #2137: a failed file fetch
+previously flowed on as ``tag: 'None', score: 0.0`` and was persisted and
+settled downstream as if it were a real verdict.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+import unittest
+from pathlib import Path
+
+from ..hackjudge_common_stubs import import_node_module
+
+inst = import_node_module('hackjudge_engine', 'IInstance')
+
+_NODE_DIR = Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'hackjudge_engine'
+while str(_NODE_DIR) in sys.path:
+    sys.path.remove(str(_NODE_DIR))
+sys.path.insert(0, str(_NODE_DIR))
+from _engine import engine as eng  # noqa: E402
+
+_META = {'default_branch': 'main', 'created_at': '2026-01-05T00:00:00Z'}
+_TREE = {
+    'tree': [
+        {'path': 'package.json', 'type': 'blob'},
+        {'path': 'src/app.js', 'type': 'blob'},
+    ]
+}
+_MANIFEST = json.dumps({'dependencies': {'rocketride': '^1.0.0'}})
+_APP_JS = 'const c = new RocketRideClient();\nclient.use({});\nclient.chat({});\n'
+
+
+def _fetch_stub(broken_paths=()):
+    def gh(url):
+        if url.endswith('/repos/acme/demo'):
+            return 200, json.dumps(_META)
+        if 'git/trees/' in url:
+            return 200, json.dumps(_TREE)
+        for path, body in (('package.json', _MANIFEST), ('src/app.js', _APP_JS)):
+            if url.endswith('/main/' + path):
+                if path in broken_paths:
+                    return 500, ''
+                return 200, body
+        return 404, ''
+
+    return types.SimpleNamespace(
+        repo_missing=lambda url: False,
+        parse_repo=lambda url: ('acme', 'demo'),
+        _gh=gh,
+    )
+
+
+def _run_verdict(fetch):
+    return inst.IInstance._verdict(
+        None, eng, fetch, 'https://github.com/acme/demo', None, 'RocketRide', None, 0, 'demo'
+    )
+
+
+class Deferred(unittest.TestCase):
+    def test_failed_fetch_returns_retry_signal_not_verdict(self):
+        res = _run_verdict(_fetch_stub(broken_paths=('src/app.js',)))
+        self.assertTrue(res.get('deferred'))
+        self.assertIn('retry', res.get('error', ''))
+        # no verdict keys at all: downstream cannot persist or settle this by accident
+        for key in ('tag', 'score', 'backbone', 'breakdown'):
+            self.assertNotIn(key, res, key)
+        self.assertEqual(res.get('kb_processed'), 0.0, 'thrown-away work must not be billed')
+
+    def test_healthy_fetch_still_returns_full_verdict(self):
+        res = _run_verdict(_fetch_stub())
+        self.assertNotIn('deferred', res)
+        self.assertIn(res['tag'], ('Significant', 'Moderate', 'Less', 'None'))
+        self.assertGreater(res['kb_processed'], 0.0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/nodes/test/hackjudge_engine/test_verdict.py
+++ b/nodes/test/hackjudge_engine/test_verdict.py
@@ -54,6 +54,7 @@ _TREE = {
         {'path': 'package.json', 'type': 'blob'},
         {'path': 'src/app.js', 'type': 'blob'},
         {'path': 'src/api.js', 'type': 'blob'},
+        {'path': 'src/My Component.js', 'type': 'blob'},
     ]
 }
 _MANIFEST = json.dumps({'dependencies': {'rocketride': '^1.0.0'}})
@@ -78,6 +79,7 @@ def _fake_gh(broken_paths=()):
             ('package.json', _MANIFEST),
             ('src/app.js', _APP_JS),
             ('src/api.js', _API_JS),
+            ('src/My%20Component.js', 'const x = new RocketRideClient();\n'),
         ):
             if url.endswith('/main/' + path):
                 if path in broken_paths:
@@ -112,6 +114,14 @@ class VerdictOffline(unittest.TestCase):
             'a failed file fetch must defer the repo, not shrink its evidence',
         )
         self.assertNotIn('sdk', ev, 'no partial evidence may escape a deferred gather')
+
+    def test_paths_with_spaces_are_url_encoded_not_deferred(self):
+        # 'src/My Component.js' is only served at its percent-encoded URL; an
+        # unencoded fetch 404s on every attempt and would wrongly defer the repo
+        # forever. file_spread proves the file was really fetched and scanned.
+        ev = eng.gather('https://github.com/acme/demo', _fake_gh())
+        self.assertFalse(ev.get('fetch_incomplete', False))
+        self.assertGreaterEqual(ev['sdk']['file_spread'], 3)
 
     def test_unreachable_repo_is_inaccessible_not_deferred(self):
         ev = eng.gather('https://github.com/acme/demo', lambda url: (404, ''))

--- a/nodes/test/hackjudge_engine/test_verdict.py
+++ b/nodes/test/hackjudge_engine/test_verdict.py
@@ -1,0 +1,122 @@
+# =============================================================================
+# MIT License
+# Copyright (c) 2026 Aparavi Software AG
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# =============================================================================
+
+"""The vendored verdict engine, exercised fully offline against a fake GitHub.
+
+The `_engine` subpackage is self-contained (no rocketlib / ai imports), so these
+tests drive the REAL gather + evaluate code with a stubbed `gh(url) -> (status,
+text)` callable. Two properties matter most:
+
+- a deterministic verdict from controlled evidence, and
+- the fetch-failure guard: a failed file download must defer the repository
+  (`fetch_incomplete`), never score it on partial evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import unittest
+from pathlib import Path
+
+# Import `_engine` with the node directory itself on sys.path: going through the
+# `hackjudge_engine` package would execute its __init__, which pulls rocketlib.
+_NODE_DIR = Path(__file__).resolve().parents[2] / 'src' / 'nodes' / 'hackjudge_engine'
+while str(_NODE_DIR) in sys.path:
+    sys.path.remove(str(_NODE_DIR))
+sys.path.insert(0, str(_NODE_DIR))
+
+from _engine import engine as eng  # noqa: E402
+
+_META = {'default_branch': 'main', 'created_at': '2026-01-05T00:00:00Z'}
+_TREE = {
+    'tree': [
+        {'path': 'package.json', 'type': 'blob'},
+        {'path': 'src/app.js', 'type': 'blob'},
+        {'path': 'src/api.js', 'type': 'blob'},
+    ]
+}
+_MANIFEST = json.dumps({'dependencies': {'rocketride': '^1.0.0'}})
+_APP_JS = (
+    "const { RocketRideClient } = require('rocketride');\n"
+    'const client = new RocketRideClient();\n'
+    "client.use({ pipeline: 'verify' });\n"
+    'client.chat({ token: t, question: q });\n'
+)
+_API_JS = "import { RocketRideClient } from 'rocketride';\nconst c = new RocketRideClient();\n"
+
+
+def _fake_gh(broken_paths=()):
+    """A gh(url) -> (status, text) stub serving one tiny fake repository."""
+
+    def gh(url):
+        if url.endswith('/repos/acme/demo'):
+            return 200, json.dumps(_META)
+        if 'git/trees/' in url:
+            return 200, json.dumps(_TREE)
+        for path, body in (
+            ('package.json', _MANIFEST),
+            ('src/app.js', _APP_JS),
+            ('src/api.js', _API_JS),
+        ):
+            if url.endswith('/main/' + path):
+                if path in broken_paths:
+                    return 500, ''
+                return 200, body
+        return 404, ''
+
+    return gh
+
+
+class VerdictOffline(unittest.TestCase):
+    def test_deterministic_verdict_from_controlled_evidence(self):
+        ev = eng.gather('https://github.com/acme/demo', _fake_gh())
+        self.assertTrue(ev.get('accessible'))
+        self.assertFalse(ev.get('fetch_incomplete', False))
+        self.assertTrue(ev.get('dependency'), 'manifest dependency must be found')
+        self.assertGreaterEqual(ev['sdk']['callsites'], 3)
+        self.assertGreaterEqual(ev['sdk']['file_spread'], 2)
+
+        res = eng.evaluate(ev)
+        self.assertIn(res['tag'], ('Significant', 'Moderate', 'Less', 'None'))
+        self.assertGreaterEqual(res['score'], 1.0)
+
+        again = eng.evaluate(eng.gather('https://github.com/acme/demo', _fake_gh()))
+        self.assertEqual((res['tag'], res['score']), (again['tag'], again['score']))
+
+    def test_failed_file_fetch_defers_instead_of_scoring(self):
+        ev = eng.gather('https://github.com/acme/demo', _fake_gh(broken_paths=('src/app.js',)))
+        self.assertTrue(ev.get('accessible'))
+        self.assertTrue(
+            ev.get('fetch_incomplete'),
+            'a failed file fetch must defer the repo, not shrink its evidence',
+        )
+        self.assertNotIn('sdk', ev, 'no partial evidence may escape a deferred gather')
+
+    def test_unreachable_repo_is_inaccessible_not_deferred(self):
+        ev = eng.gather('https://github.com/acme/demo', lambda url: (404, ''))
+        self.assertFalse(ev.get('accessible'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/nodes/test/hackjudge_engine/test_verdict.py
+++ b/nodes/test/hackjudge_engine/test_verdict.py
@@ -55,6 +55,11 @@ _TREE = {
         {'path': 'src/app.js', 'type': 'blob'},
         {'path': 'src/api.js', 'type': 'blob'},
         {'path': 'src/My Component.js', 'type': 'blob'},
+        # non-blob entries: a directory named like a source file is the trap - it
+        # 404s on raw fetch, and unfiltered it would defer the repo permanently
+        {'path': 'src/components', 'type': 'tree'},
+        {'path': 'vendor/bundle.js', 'type': 'tree'},
+        {'path': 'deps/sub.pipe', 'type': 'commit'},
     ]
 }
 _MANIFEST = json.dumps({'dependencies': {'rocketride': '^1.0.0'}})
@@ -122,6 +127,12 @@ class VerdictOffline(unittest.TestCase):
         ev = eng.gather('https://github.com/acme/demo', _fake_gh())
         self.assertFalse(ev.get('fetch_incomplete', False))
         self.assertGreaterEqual(ev['sdk']['file_spread'], 3)
+
+    def test_non_blob_tree_entries_are_ignored_not_fetched(self):
+        # 'vendor/bundle.js' is a DIRECTORY: raw fetch would 404 every time and
+        # wrongly defer the repo forever if the tree were not filtered to blobs
+        ev = eng.gather('https://github.com/acme/demo', _fake_gh())
+        self.assertFalse(ev.get('fetch_incomplete', False))
 
     def test_unreachable_repo_is_inaccessible_not_deferred(self):
         ev = eng.gather('https://github.com/acme/demo', lambda url: (404, ''))

--- a/packages/ai/src/ai/modules/mcp/credentials.json
+++ b/packages/ai/src/ai/modules/mcp/credentials.json
@@ -272,6 +272,27 @@
     ],
     "docs": "https://neo4j.com/docs/"
   },
+  "hackjudge_engine": {
+    "title": "hackjudge_engine",
+    "fields": [
+      {
+        "path": "hackjudge.github_token",
+        "title": "GitHub token (repo fetches)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_HACKJUDGE_GITHUB_TOKEN",
+        "review": true
+      },
+      {
+        "path": "hackjudge_engine.github_token",
+        "title": "GitHub token (repo fetches)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_HACKJUDGE_GITHUB_TOKEN",
+        "review": true
+      }
+    ]
+  },
   "image_vision_gemini": {
     "title": "image_vision_gemini",
     "fields": [

--- a/packages/ai/src/ai/modules/mcp/credentials.json
+++ b/packages/ai/src/ai/modules/mcp/credentials.json
@@ -1,1321 +1,1313 @@
 {
-  "accessibility_describe": {
-    "title": "accessibility_describe",
-    "fields": [
-      {
-        "path": "accessibility_describe.apikey",
-        "title": "accessibility_describe.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_ACCESSIBILITY_DESCRIBE_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "aparavi_aql": {
-    "title": "aparavi_aql",
-    "fields": [
-      {
-        "path": "aparavi.password",
-        "title": "aparavi.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_APARAVI_AQL_APARAVI_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "astra_db": {
-    "title": "astra_db",
-    "fields": [
-      {
-        "path": "Astra DB Vector Store.application_token",
-        "title": "Astra DB Vector Store.application_token",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_ASTRA_APPLICATION_TOKEN",
-        "review": true
-      },
-      {
-        "path": "astra_db.application_token",
-        "title": "astra_db.application_token",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_ASTRA_ASTRA_DB_APPLICATION_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "chroma": {
-    "title": "Chroma",
-    "fields": [
-      {
-        "path": "Chroma Vector Store.apikey",
-        "title": "Chroma API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_CHROMA_APIKEY"
-      }
-    ],
-    "docs": "https://docs.trychroma.com/"
-  },
-  "db_arango": {
-    "title": "ArangoDB",
-    "docs": "https://docs.arangodb.com/stable/",
-    "fields": [
-      {
-        "path": "arangodb.endpoint",
-        "title": "Connection endpoint",
-        "kind": "endpoint",
-        "required": true,
-        "suggests": "ROCKETRIDE_ARANGO_ENDPOINT"
-      },
-      {
-        "path": "arangodb.user",
-        "title": "User",
-        "kind": "identifier",
-        "required": true,
-        "suggests": "ROCKETRIDE_ARANGO_USER"
-      },
-      {
-        "path": "arangodb.password",
-        "title": "Password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_ARANGO_PASSWORD"
-      },
-      {
-        "path": "arangodb.database",
-        "title": "Database name",
-        "kind": "identifier",
-        "required": true,
-        "suggests": "ROCKETRIDE_ARANGO_DB"
-      },
-      {
-        "path": "arangodb.token",
-        "title": "Bearer token",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_ARANGO_TOKEN"
-      }
-    ]
-  },
-  "db_clickhouse": {
-    "title": "db_clickhouse",
-    "fields": [
-      {
-        "path": "clickhouse.password",
-        "title": "clickhouse.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_CLICKHOUSE_CLICKHOUSE_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "db_hotdata": {
-    "title": "db_hotdata",
-    "fields": [
-      {
-        "path": "hotdata.apikey",
-        "title": "hotdata.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_HOTDATA_HOTDATA_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "db_hydradb": {
-    "title": "db_hydradb",
-    "fields": [
-      {
-        "path": "hydradb.api_key",
-        "title": "hydradb.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_HYDRADB_HYDRADB_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "db_mysql": {
-    "title": "db_mysql",
-    "fields": [
-      {
-        "path": "mysql.password",
-        "title": "mysql.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_MYSQL_MYSQL_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "db_postgres": {
-    "title": "db_postgres",
-    "fields": [
-      {
-        "path": "postgresdb.password",
-        "title": "postgresdb.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_POSTGRES_POSTGRESDB_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "db_supabase": {
-    "title": "db_supabase",
-    "fields": [
-      {
-        "path": "postgresdb.password",
-        "title": "postgresdb.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_SUPABASE_POSTGRESDB_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "elasticsearch": {
-    "title": "elasticsearch",
-    "fields": [
-      {
-        "path": "Elasticsearch Vector Store.apikey",
-        "title": "Elasticsearch Vector Store.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_ELASTICSEARCH_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "embedding_openai": {
-    "title": "embedding_openai",
-    "fields": [
-      {
-        "path": "embedding.apikey",
-        "title": "embedding.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_OPENAI_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "graph_falkordb": {
-    "title": "FalkorDB",
-    "fields": [
-      {
-        "path": "graph_falkordb.password",
-        "title": "FalkorDB password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_FALKORDB_PASSWORD"
-      },
-      {
-        "path": "graph_falkordb.host",
-        "title": "Host",
-        "kind": "endpoint",
-        "required": true,
-        "suggests": "ROCKETRIDE_FALKORDB_HOST"
-      },
-      {
-        "path": "graph_falkordb.username",
-        "title": "Username",
-        "kind": "identifier",
-        "required": true,
-        "suggests": "ROCKETRIDE_FALKORDB_USER"
-      }
-    ],
-    "docs": "https://docs.falkordb.com/"
-  },
-  "graph_neo4j": {
-    "title": "Neo4j",
-    "fields": [
-      {
-        "path": "graph_neo4j.uri",
-        "title": "Connection URI",
-        "kind": "endpoint",
-        "required": true,
-        "suggests": "ROCKETRIDE_NEO4J_URI"
-      },
-      {
-        "path": "graph_neo4j.user",
-        "title": "User",
-        "kind": "identifier",
-        "required": true,
-        "suggests": "ROCKETRIDE_NEO4J_USER"
-      },
-      {
-        "path": "graph_neo4j.password",
-        "title": "Password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_NEO4J_PASSWORD"
-      },
-      {
-        "path": "graph_neo4j.token",
-        "title": "Bearer token",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_NEO4J_TOKEN"
-      },
-      {
-        "path": "graph_neo4j.database",
-        "title": "Database name",
-        "kind": "identifier",
-        "required": false,
-        "suggests": "ROCKETRIDE_NEO4J_DATABASE"
-      }
-    ],
-    "docs": "https://neo4j.com/docs/"
-  },
-  "hackjudge_engine": {
-    "title": "hackjudge_engine",
-    "fields": [
-      {
-        "path": "hackjudge.github_token",
-        "title": "GitHub token (repo fetches)",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_HACKJUDGE_GITHUB_TOKEN",
-        "review": true
-      },
-      {
-        "path": "hackjudge_engine.github_token",
-        "title": "GitHub token (repo fetches)",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_HACKJUDGE_GITHUB_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "image_vision_gemini": {
-    "title": "image_vision_gemini",
-    "fields": [
-      {
-        "path": "image_vision_gemini.apikey",
-        "title": "image_vision_gemini.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_IMAGE_GEMINI_IMAGE_VISION_GEMINI_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "image_vision_mistral": {
-    "title": "image_vision_mistral",
-    "fields": [
-      {
-        "path": "image_vision_mistral.apikey",
-        "title": "image_vision_mistral.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_IMAGE_MISTRAL_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "image_vision_openai": {
-    "title": "image_vision_openai",
-    "fields": [
-      {
-        "path": "image_vision_openai.apikey",
-        "title": "image_vision_openai.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_IMAGE_OPENAI_IMAGE_VISION_OPENAI_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "landing_ai_extract": {
-    "title": "landing_ai_extract",
-    "fields": [
-      {
-        "path": "landing_ai_extract.api_key",
-        "title": "landing_ai_extract.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_LANDING_EXTRACT_LANDING_AI_EXTRACT_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "landing_ai_parse": {
-    "title": "landing_ai_parse",
-    "fields": [
-      {
-        "path": "landing_ai_parse.api_key",
-        "title": "landing_ai_parse.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_LANDING_PARSE_LANDING_AI_PARSE_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "llamaparse": {
-    "title": "llamaparse",
-    "fields": [
-      {
-        "path": "llamaparse.api_key",
-        "title": "llamaparse.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_LLAMAPARSE_LLAMAPARSE_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_anthropic": {
-    "title": "Anthropic",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "Anthropic API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_ANTHROPIC_KEY"
-      }
-    ],
-    "docs": "https://docs.anthropic.com/en/api/overview"
-  },
-  "llm_baidu_qianfan": {
-    "title": "llm_baidu_qianfan",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_BAIDU_QIANFAN_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_bedrock": {
-    "title": "llm_bedrock",
-    "fields": [
-      {
-        "path": "llm.secretKey",
-        "title": "llm.secretKey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_BEDROCK_SECRET_KEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_deepseek": {
-    "title": "llm_deepseek",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_DEEPSEEK_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_gemini": {
-    "title": "Gemini",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "Google Gemini API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GEMINI_KEY"
-      },
-      {
-        "path": "gemini.apikey",
-        "title": "gemini.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GEMINI_GEMINI_APIKEY",
-        "review": true
-      }
-    ],
-    "docs": "https://ai.google.dev/gemini-api/docs"
-  },
-  "llm_gmi_cloud": {
-    "title": "llm_gmi_cloud",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GMI_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_kimi": {
-    "title": "llm_kimi",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_KIMI_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_minimax": {
-    "title": "llm_minimax",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_MINIMAX_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_mistral": {
-    "title": "llm_mistral",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_MISTRAL_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_openai": {
-    "title": "OpenAI",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "OpenAI API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_OPENAI_KEY"
-      }
-    ],
-    "docs": "https://platform.openai.com/docs/api-reference"
-  },
-  "llm_openai_api": {
-    "title": "OpenAI-Compatible API",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "OpenAI (or compatible endpoint) API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_OPENAI_KEY"
-      }
-    ],
-    "docs": "https://platform.openai.com/docs/api-reference"
-  },
-  "llm_perplexity": {
-    "title": "llm_perplexity",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_PERPLEXITY_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_qwen": {
-    "title": "llm_qwen",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_QWEN_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "llm_xai": {
-    "title": "llm_xai",
-    "fields": [
-      {
-        "path": "llm.apikey",
-        "title": "llm.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_XAI_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "mcp_client": {
-    "title": "mcp_client",
-    "fields": [
-      {
-        "path": "mcp_client.bearer",
-        "title": "mcp_client.bearer",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_MCP_CLIENT_MCP_CLIENT_BEARER",
-        "review": true
-      }
-    ]
-  },
-  "memory_persistent": {
-    "title": "memory_persistent",
-    "fields": [
-      {
-        "path": "memory.redis_password",
-        "title": "memory.redis_password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_PERSISTENT_REDIS_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "milvus": {
-    "title": "milvus",
-    "fields": [
-      {
-        "path": "Milvus Vector Store.apikey",
-        "title": "Milvus Vector Store.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_MILVUS_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "opensearch": {
-    "title": "opensearch",
-    "fields": [
-      {
-        "path": "opensearch.auth.password",
-        "title": "opensearch.auth.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_OPENSEARCH_OPENSEARCH_AUTH_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "pinecone": {
-    "title": "Pinecone",
-    "fields": [
-      {
-        "path": "Pinecone Vector Store.apikey",
-        "title": "Pinecone API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_PINECONE_APIKEY"
-      }
-    ],
-    "docs": "https://docs.pinecone.io/reference/api/introduction"
-  },
-  "postgres": {
-    "title": "postgres",
-    "fields": [
-      {
-        "path": "PostgreSQL Vector Store.password",
-        "title": "PostgreSQL Vector Store.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_POSTGRES_PASSWORD",
-        "review": true
-      },
-      {
-        "path": "vector.local.password",
-        "title": "vector.local.password",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_POSTGRES_VECTOR_LOCAL_PASSWORD",
-        "review": true
-      }
-    ]
-  },
-  "qdrant": {
-    "title": "Qdrant",
-    "fields": [
-      {
-        "path": "Qdrant Vector Store.apikey",
-        "title": "Qdrant API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_QDRANT_APIKEY"
-      }
-    ],
-    "docs": "https://qdrant.tech/documentation/"
-  },
-  "reducto": {
-    "title": "reducto",
-    "fields": [
-      {
-        "path": "reducto.api_key",
-        "title": "reducto.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_REDUCTO_REDUCTO_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "rerank_cohere": {
-    "title": "Cohere Rerank",
-    "fields": [
-      {
-        "path": "rerank.apikey",
-        "title": "Cohere API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_RERANK_COHERE_KEY"
-      }
-    ],
-    "docs": "https://docs.cohere.com/reference/rerank"
-  },
-  "search_exa": {
-    "title": "Exa Search",
-    "fields": [
-      {
-        "path": "search.apikey",
-        "title": "Exa API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_EXA_KEY"
-      },
-      {
-        "path": "search_exa.apikey",
-        "title": "Exa API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_EXA_KEY"
-      }
-    ],
-    "docs": "https://docs.exa.ai/reference/getting-started"
-  },
-  "telegram": {
-    "title": "telegram",
-    "fields": [
-      {
-        "path": "telegram.botToken",
-        "title": "telegram.botToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TELEGRAM_TELEGRAM_BOT_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_apify": {
-    "title": "tool_apify",
-    "fields": [
-      {
-        "path": "apify.apikey",
-        "title": "apify.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_APIFY_APIKEY",
-        "review": true
-      },
-      {
-        "path": "tool_apify.apikey",
-        "title": "tool_apify.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_APIFY_TOOL_APIFY_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_bland_ai": {
-    "title": "tool_bland_ai",
-    "fields": [
-      {
-        "path": "bland_ai.apikey",
-        "title": "bland_ai.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_BLAND_BLAND_AI_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_butterbase": {
-    "title": "tool_butterbase",
-    "fields": [
-      {
-        "path": "mcp_client.bearer",
-        "title": "mcp_client.bearer",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_BUTTERBASE_MCP_CLIENT_BEARER",
-        "review": true
-      }
-    ]
-  },
-  "tool_calendar": {
-    "title": "tool_calendar",
-    "fields": [
-      {
-        "path": "calendar.userToken",
-        "title": "calendar.userToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_CALENDAR_USER_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_cognee": {
-    "title": "tool_cognee",
-    "fields": [
-      {
-        "path": "cognee.api_key",
-        "title": "cognee.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_COGNEE_COGNEE_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_daytona": {
-    "title": "tool_daytona",
-    "fields": [
-      {
-        "path": "daytona.apikey",
-        "title": "daytona.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_DAYTONA_APIKEY",
-        "review": true
-      },
-      {
-        "path": "tool_daytona.apikey",
-        "title": "tool_daytona.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_DAYTONA_TOOL_DAYTONA_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_deepl": {
-    "title": "tool_deepl",
-    "fields": [
-      {
-        "path": "deepl.apikey",
-        "title": "deepl.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_DEEPL_APIKEY",
-        "review": true
-      },
-      {
-        "path": "tool_deepl.apikey",
-        "title": "tool_deepl.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_DEEPL_TOOL_DEEPL_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_docs": {
-    "title": "tool_docs",
-    "fields": [
-      {
-        "path": "docs.userToken",
-        "title": "docs.userToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_DOCS_USER_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_drive": {
-    "title": "tool_drive",
-    "fields": [
-      {
-        "path": "drive.userToken",
-        "title": "drive.userToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_DRIVE_USER_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_exa_search": {
-    "title": "tool_exa_search",
-    "fields": [
-      {
-        "path": "exa.apikey",
-        "title": "exa.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_EXA_APIKEY",
-        "review": true
-      },
-      {
-        "path": "tool_exa_search.apikey",
-        "title": "tool_exa_search.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_EXA_TOOL_EXA_SEARCH_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_excel": {
-    "title": "tool_excel",
-    "fields": [
-      {
-        "path": "excel.clientSecret",
-        "title": "Client Secret",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_EXCEL_CLIENT_SECRET",
-        "review": false
-      },
-      {
-        "path": "excel.userToken",
-        "title": "User Token (OAuth sign-in)",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_EXCEL_USER_TOKEN",
-        "review": false
-      }
-    ]
-  },
-  "tool_firecrawl": {
-    "title": "tool_firecrawl",
-    "fields": [
-      {
-        "path": "firecrawl.apikey",
-        "title": "firecrawl.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_FIRECRAWL_APIKEY",
-        "review": true
-      },
-      {
-        "path": "tool_firecrawl.apikey",
-        "title": "tool_firecrawl.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_FIRECRAWL_TOOL_FIRECRAWL_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_git": {
-    "title": "tool_git",
-    "fields": [
-      {
-        "path": "git.token",
-        "title": "git.token",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GIT_GIT_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_github": {
-    "title": "GitHub",
-    "fields": [
-      {
-        "path": "github.token",
-        "title": "GitHub personal access token",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GITHUB_TOKEN"
-      }
-    ],
-    "docs": "https://docs.github.com/en/rest"
-  },
-  "tool_gmail": {
-    "title": "tool_gmail",
-    "fields": [
-      {
-        "path": "gmail.userToken",
-        "title": "gmail.userToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GMAIL_USER_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_gohighlevel": {
-    "title": "tool_gohighlevel",
-    "fields": [
-      {
-        "path": "gohighlevel.privateIntegrationToken",
-        "title": "gohighlevel.privateIntegrationToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GOHIGHLEVEL_GOHIGHLEVEL_PRIVATE_INTEGRATION_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_guild": {
-    "title": "Guild.ai",
-    "fields": [
-      {
-        "path": "guild.apiKeyId",
-        "title": "Guild API key ID",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GUILD_KEY_ID"
-      },
-      {
-        "path": "guild.apiKeySecret",
-        "title": "Guild API key secret",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GUILD_KEY_SECRET"
-      },
-      {
-        "path": "tool_guild.apiKeyId",
-        "title": "Guild API key ID",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GUILD_KEY_ID"
-      },
-      {
-        "path": "tool_guild.apiKeySecret",
-        "title": "Guild API key secret",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_GUILD_KEY_SECRET"
-      }
-    ],
-    "docs": "https://docs.guild.ai/"
-  },
-  "tool_mem0": {
-    "title": "tool_mem0",
-    "fields": [
-      {
-        "path": "mem0.api_key",
-        "title": "mem0.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_MEM0_MEM0_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_n8n": {
-    "title": "tool_n8n",
-    "fields": [
-      {
-        "path": "n8n.apiKey",
-        "title": "n8n.apiKey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_N8N_API_KEY",
-        "review": true
-      },
-      {
-        "path": "n8n.webhookToken",
-        "title": "n8n.webhookToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_N8N_WEBHOOK_TOKEN",
-        "review": true
-      },
-      {
-        "path": "tool_n8n.apiKey",
-        "title": "tool_n8n.apiKey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_N8N_TOOL_N8N_API_KEY",
-        "review": true
-      },
-      {
-        "path": "tool_n8n.webhookPassword",
-        "title": "tool_n8n.webhookPassword",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_PASSWORD",
-        "review": true
-      },
-      {
-        "path": "tool_n8n.webhookToken",
-        "title": "tool_n8n.webhookToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_onedrive": {
-    "title": "tool_onedrive",
-    "fields": [
-      {
-        "path": "onedrive.clientSecret",
-        "title": "Client Secret",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_ONEDRIVE_CLIENT_SECRET",
-        "review": false
-      },
-      {
-        "path": "onedrive.userToken",
-        "title": "User Token (OAuth sign-in)",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_ONEDRIVE_USER_TOKEN",
-        "review": false
-      }
-    ]
-  },
-  "tool_oura": {
-    "title": "tool_oura",
-    "fields": [
-      {
-        "path": "oura.token",
-        "title": "oura.token",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_OURA_OURA_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_outlook_calendar": {
-    "title": "tool_outlook_calendar",
-    "fields": [
-      {
-        "path": "outlook_calendar.clientSecret",
-        "title": "Client Secret",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_OUTLOOK_CALENDAR_CLIENT_SECRET",
-        "review": false
-      },
-      {
-        "path": "outlook_calendar.userToken",
-        "title": "User Token (OAuth sign-in)",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_OUTLOOK_CALENDAR_USER_TOKEN",
-        "review": false
-      }
-    ]
-  },
-  "tool_outlook_mail": {
-    "title": "tool_outlook_mail",
-    "fields": [
-      {
-        "path": "outlook_mail.clientSecret",
-        "title": "Client Secret",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_OUTLOOK_MAIL_CLIENT_SECRET",
-        "review": false
-      },
-      {
-        "path": "outlook_mail.userToken",
-        "title": "User Token (OAuth sign-in)",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_OUTLOOK_MAIL_USER_TOKEN",
-        "review": false
-      }
-    ]
-  },
-  "tool_pipedrive": {
-    "title": "tool_pipedrive",
-    "fields": [
-      {
-        "path": "pipedrive.apiToken",
-        "title": "pipedrive.apiToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_PIPEDRIVE_PIPEDRIVE_API_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_sheets": {
-    "title": "tool_sheets",
-    "fields": [
-      {
-        "path": "sheets.userToken",
-        "title": "sheets.userToken",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_SHEETS_USER_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_slack": {
-    "title": "tool_slack",
-    "fields": [
-      {
-        "path": "slack.token",
-        "title": "slack.token",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_SLACK_SLACK_TOKEN",
-        "review": true
-      }
-    ]
-  },
-  "tool_tavily": {
-    "title": "tool_tavily",
-    "fields": [
-      {
-        "path": "tavily.apikey",
-        "title": "tavily.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TAVILY_APIKEY",
-        "review": true
-      },
-      {
-        "path": "tool_tavily.apikey",
-        "title": "tool_tavily.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TAVILY_TOOL_TAVILY_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_v0": {
-    "title": "tool_v0",
-    "fields": [
-      {
-        "path": "v0.apikey",
-        "title": "v0.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TOOL_V0_APIKEY",
-        "review": true
-      },
-      {
-        "path": "tool_v0.apikey",
-        "title": "tool_v0.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TOOL_V0_TOOL_V0_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "tool_word": {
-    "title": "tool_word",
-    "fields": [
-      {
-        "path": "word.clientSecret",
-        "title": "Client Secret",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_WORD_CLIENT_SECRET",
-        "review": false
-      },
-      {
-        "path": "word.userToken",
-        "title": "User Token (OAuth sign-in)",
-        "kind": "secret",
-        "required": false,
-        "suggests": "ROCKETRIDE_WORD_USER_TOKEN",
-        "review": false
-      }
-    ]
-  },
-  "tool_xtrace_memory": {
-    "title": "tool_xtrace_memory",
-    "fields": [
-      {
-        "path": "xtrace.api_key",
-        "title": "xtrace.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_XTRACE_API_KEY",
-        "review": true
-      },
-      {
-        "path": "xtrace_memory.api_key",
-        "title": "xtrace_memory.api_key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_XTRACE_XTRACE_MEMORY_API_KEY",
-        "review": true
-      }
-    ]
-  },
-  "tts_elevenlabs": {
-    "title": "ElevenLabs Text to Speech",
-    "fields": [
-      {
-        "path": "tts_elevenlabs.apikey",
-        "title": "ElevenLabs API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TTS_ELEVENLABS_KEY"
-      }
-    ],
-    "docs": "https://elevenlabs.io/docs/api-reference/introduction"
-  },
-  "tts_openai": {
-    "title": "OpenAI Text to Speech",
-    "fields": [
-      {
-        "path": "tts_openai.apikey",
-        "title": "OpenAI TTS API key",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TTS_OPENAI_KEY"
-      }
-    ],
-    "docs": "https://platform.openai.com/docs/guides/text-to-speech"
-  },
-  "twelvelabs": {
-    "title": "twelvelabs",
-    "fields": [
-      {
-        "path": "twelvelabs.apikey",
-        "title": "twelvelabs.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_TWELVELABS_APIKEY",
-        "review": true
-      }
-    ]
-  },
-  "weaviate": {
-    "title": "weaviate",
-    "fields": [
-      {
-        "path": "Weaviate Vector Store.apikey",
-        "title": "Weaviate Vector Store.apikey",
-        "kind": "secret",
-        "required": true,
-        "suggests": "ROCKETRIDE_WEAVIATE_APIKEY",
-        "review": true
-      }
-    ]
-  }
+    'accessibility_describe': {
+        'title': 'accessibility_describe',
+        'fields': [
+            {
+                'path': 'accessibility_describe.apikey',
+                'title': 'accessibility_describe.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ACCESSIBILITY_DESCRIBE_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'aparavi_aql': {
+        'title': 'aparavi_aql',
+        'fields': [
+            {
+                'path': 'aparavi.password',
+                'title': 'aparavi.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_APARAVI_AQL_APARAVI_PASSWORD',
+                'review': true,
+            }
+        ],
+    },
+    'astra_db': {
+        'title': 'astra_db',
+        'fields': [
+            {
+                'path': 'Astra DB Vector Store.application_token',
+                'title': 'Astra DB Vector Store.application_token',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ASTRA_APPLICATION_TOKEN',
+                'review': true,
+            },
+            {
+                'path': 'astra_db.application_token',
+                'title': 'astra_db.application_token',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ASTRA_ASTRA_DB_APPLICATION_TOKEN',
+                'review': true,
+            },
+        ],
+    },
+    'chroma': {
+        'title': 'Chroma',
+        'fields': [
+            {
+                'path': 'Chroma Vector Store.apikey',
+                'title': 'Chroma API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_CHROMA_APIKEY',
+            }
+        ],
+        'docs': 'https://docs.trychroma.com/',
+    },
+    'db_arango': {
+        'title': 'ArangoDB',
+        'docs': 'https://docs.arangodb.com/stable/',
+        'fields': [
+            {
+                'path': 'arangodb.endpoint',
+                'title': 'Connection endpoint',
+                'kind': 'endpoint',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ARANGO_ENDPOINT',
+            },
+            {
+                'path': 'arangodb.user',
+                'title': 'User',
+                'kind': 'identifier',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ARANGO_USER',
+            },
+            {
+                'path': 'arangodb.password',
+                'title': 'Password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ARANGO_PASSWORD',
+            },
+            {
+                'path': 'arangodb.database',
+                'title': 'Database name',
+                'kind': 'identifier',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ARANGO_DB',
+            },
+            {
+                'path': 'arangodb.token',
+                'title': 'Bearer token',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_ARANGO_TOKEN',
+            },
+        ],
+    },
+    'db_clickhouse': {
+        'title': 'db_clickhouse',
+        'fields': [
+            {
+                'path': 'clickhouse.password',
+                'title': 'clickhouse.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_CLICKHOUSE_CLICKHOUSE_PASSWORD',
+                'review': true,
+            }
+        ],
+    },
+    'db_hotdata': {
+        'title': 'db_hotdata',
+        'fields': [
+            {
+                'path': 'hotdata.apikey',
+                'title': 'hotdata.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_HOTDATA_HOTDATA_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'db_hydradb': {
+        'title': 'db_hydradb',
+        'fields': [
+            {
+                'path': 'hydradb.api_key',
+                'title': 'hydradb.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_HYDRADB_HYDRADB_API_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'db_mysql': {
+        'title': 'db_mysql',
+        'fields': [
+            {
+                'path': 'mysql.password',
+                'title': 'mysql.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_MYSQL_MYSQL_PASSWORD',
+                'review': true,
+            }
+        ],
+    },
+    'db_postgres': {
+        'title': 'db_postgres',
+        'fields': [
+            {
+                'path': 'postgresdb.password',
+                'title': 'postgresdb.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_POSTGRES_POSTGRESDB_PASSWORD',
+                'review': true,
+            }
+        ],
+    },
+    'db_supabase': {
+        'title': 'db_supabase',
+        'fields': [
+            {
+                'path': 'postgresdb.password',
+                'title': 'postgresdb.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_SUPABASE_POSTGRESDB_PASSWORD',
+                'review': true,
+            }
+        ],
+    },
+    'elasticsearch': {
+        'title': 'elasticsearch',
+        'fields': [
+            {
+                'path': 'Elasticsearch Vector Store.apikey',
+                'title': 'Elasticsearch Vector Store.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ELASTICSEARCH_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'embedding_openai': {
+        'title': 'embedding_openai',
+        'fields': [
+            {
+                'path': 'embedding.apikey',
+                'title': 'embedding.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_OPENAI_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'graph_falkordb': {
+        'title': 'FalkorDB',
+        'fields': [
+            {
+                'path': 'graph_falkordb.password',
+                'title': 'FalkorDB password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_FALKORDB_PASSWORD',
+            },
+            {
+                'path': 'graph_falkordb.host',
+                'title': 'Host',
+                'kind': 'endpoint',
+                'required': true,
+                'suggests': 'ROCKETRIDE_FALKORDB_HOST',
+            },
+            {
+                'path': 'graph_falkordb.username',
+                'title': 'Username',
+                'kind': 'identifier',
+                'required': true,
+                'suggests': 'ROCKETRIDE_FALKORDB_USER',
+            },
+        ],
+        'docs': 'https://docs.falkordb.com/',
+    },
+    'graph_neo4j': {
+        'title': 'Neo4j',
+        'fields': [
+            {
+                'path': 'graph_neo4j.uri',
+                'title': 'Connection URI',
+                'kind': 'endpoint',
+                'required': true,
+                'suggests': 'ROCKETRIDE_NEO4J_URI',
+            },
+            {
+                'path': 'graph_neo4j.user',
+                'title': 'User',
+                'kind': 'identifier',
+                'required': true,
+                'suggests': 'ROCKETRIDE_NEO4J_USER',
+            },
+            {
+                'path': 'graph_neo4j.password',
+                'title': 'Password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_NEO4J_PASSWORD',
+            },
+            {
+                'path': 'graph_neo4j.token',
+                'title': 'Bearer token',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_NEO4J_TOKEN',
+            },
+            {
+                'path': 'graph_neo4j.database',
+                'title': 'Database name',
+                'kind': 'identifier',
+                'required': false,
+                'suggests': 'ROCKETRIDE_NEO4J_DATABASE',
+            },
+        ],
+        'docs': 'https://neo4j.com/docs/',
+    },
+    'hackjudge_engine': {
+        'title': 'hackjudge_engine',
+        'fields': [
+            {
+                'path': 'hackjudge_engine.github_token',
+                'title': 'GitHub token (repo fetches)',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_GITHUB_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'image_vision_gemini': {
+        'title': 'image_vision_gemini',
+        'fields': [
+            {
+                'path': 'image_vision_gemini.apikey',
+                'title': 'image_vision_gemini.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_IMAGE_GEMINI_IMAGE_VISION_GEMINI_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'image_vision_mistral': {
+        'title': 'image_vision_mistral',
+        'fields': [
+            {
+                'path': 'image_vision_mistral.apikey',
+                'title': 'image_vision_mistral.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_IMAGE_MISTRAL_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'image_vision_openai': {
+        'title': 'image_vision_openai',
+        'fields': [
+            {
+                'path': 'image_vision_openai.apikey',
+                'title': 'image_vision_openai.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_IMAGE_OPENAI_IMAGE_VISION_OPENAI_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'landing_ai_extract': {
+        'title': 'landing_ai_extract',
+        'fields': [
+            {
+                'path': 'landing_ai_extract.api_key',
+                'title': 'landing_ai_extract.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_LANDING_EXTRACT_LANDING_AI_EXTRACT_API_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'landing_ai_parse': {
+        'title': 'landing_ai_parse',
+        'fields': [
+            {
+                'path': 'landing_ai_parse.api_key',
+                'title': 'landing_ai_parse.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_LANDING_PARSE_LANDING_AI_PARSE_API_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'llamaparse': {
+        'title': 'llamaparse',
+        'fields': [
+            {
+                'path': 'llamaparse.api_key',
+                'title': 'llamaparse.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_LLAMAPARSE_LLAMAPARSE_API_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_anthropic': {
+        'title': 'Anthropic',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'Anthropic API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ANTHROPIC_KEY',
+            }
+        ],
+        'docs': 'https://docs.anthropic.com/en/api/overview',
+    },
+    'llm_baidu_qianfan': {
+        'title': 'llm_baidu_qianfan',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_BAIDU_QIANFAN_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_bedrock': {
+        'title': 'llm_bedrock',
+        'fields': [
+            {
+                'path': 'llm.secretKey',
+                'title': 'llm.secretKey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_BEDROCK_SECRET_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_deepseek': {
+        'title': 'llm_deepseek',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_DEEPSEEK_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_gemini': {
+        'title': 'Gemini',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'Google Gemini API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GEMINI_KEY',
+            },
+            {
+                'path': 'gemini.apikey',
+                'title': 'gemini.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GEMINI_GEMINI_APIKEY',
+                'review': true,
+            },
+        ],
+        'docs': 'https://ai.google.dev/gemini-api/docs',
+    },
+    'llm_gmi_cloud': {
+        'title': 'llm_gmi_cloud',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GMI_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_kimi': {
+        'title': 'llm_kimi',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_KIMI_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_minimax': {
+        'title': 'llm_minimax',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_MINIMAX_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_mistral': {
+        'title': 'llm_mistral',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_MISTRAL_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_openai': {
+        'title': 'OpenAI',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'OpenAI API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_OPENAI_KEY',
+            }
+        ],
+        'docs': 'https://platform.openai.com/docs/api-reference',
+    },
+    'llm_openai_api': {
+        'title': 'OpenAI-Compatible API',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'OpenAI (or compatible endpoint) API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_OPENAI_KEY',
+            }
+        ],
+        'docs': 'https://platform.openai.com/docs/api-reference',
+    },
+    'llm_perplexity': {
+        'title': 'llm_perplexity',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_PERPLEXITY_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_qwen': {
+        'title': 'llm_qwen',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_QWEN_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'llm_xai': {
+        'title': 'llm_xai',
+        'fields': [
+            {
+                'path': 'llm.apikey',
+                'title': 'llm.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_XAI_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'mcp_client': {
+        'title': 'mcp_client',
+        'fields': [
+            {
+                'path': 'mcp_client.bearer',
+                'title': 'mcp_client.bearer',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_MCP_CLIENT_MCP_CLIENT_BEARER',
+                'review': true,
+            }
+        ],
+    },
+    'memory_persistent': {
+        'title': 'memory_persistent',
+        'fields': [
+            {
+                'path': 'memory.redis_password',
+                'title': 'memory.redis_password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_PERSISTENT_REDIS_PASSWORD',
+                'review': true,
+            }
+        ],
+    },
+    'milvus': {
+        'title': 'milvus',
+        'fields': [
+            {
+                'path': 'Milvus Vector Store.apikey',
+                'title': 'Milvus Vector Store.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_MILVUS_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'opensearch': {
+        'title': 'opensearch',
+        'fields': [
+            {
+                'path': 'opensearch.auth.password',
+                'title': 'opensearch.auth.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_OPENSEARCH_OPENSEARCH_AUTH_PASSWORD',
+                'review': true,
+            }
+        ],
+    },
+    'pinecone': {
+        'title': 'Pinecone',
+        'fields': [
+            {
+                'path': 'Pinecone Vector Store.apikey',
+                'title': 'Pinecone API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_PINECONE_APIKEY',
+            }
+        ],
+        'docs': 'https://docs.pinecone.io/reference/api/introduction',
+    },
+    'postgres': {
+        'title': 'postgres',
+        'fields': [
+            {
+                'path': 'PostgreSQL Vector Store.password',
+                'title': 'PostgreSQL Vector Store.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_POSTGRES_PASSWORD',
+                'review': true,
+            },
+            {
+                'path': 'vector.local.password',
+                'title': 'vector.local.password',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_POSTGRES_VECTOR_LOCAL_PASSWORD',
+                'review': true,
+            },
+        ],
+    },
+    'qdrant': {
+        'title': 'Qdrant',
+        'fields': [
+            {
+                'path': 'Qdrant Vector Store.apikey',
+                'title': 'Qdrant API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_QDRANT_APIKEY',
+            }
+        ],
+        'docs': 'https://qdrant.tech/documentation/',
+    },
+    'reducto': {
+        'title': 'reducto',
+        'fields': [
+            {
+                'path': 'reducto.api_key',
+                'title': 'reducto.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_REDUCTO_REDUCTO_API_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'rerank_cohere': {
+        'title': 'Cohere Rerank',
+        'fields': [
+            {
+                'path': 'rerank.apikey',
+                'title': 'Cohere API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_RERANK_COHERE_KEY',
+            }
+        ],
+        'docs': 'https://docs.cohere.com/reference/rerank',
+    },
+    'search_exa': {
+        'title': 'Exa Search',
+        'fields': [
+            {
+                'path': 'search.apikey',
+                'title': 'Exa API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_EXA_KEY',
+            },
+            {
+                'path': 'search_exa.apikey',
+                'title': 'Exa API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_EXA_KEY',
+            },
+        ],
+        'docs': 'https://docs.exa.ai/reference/getting-started',
+    },
+    'telegram': {
+        'title': 'telegram',
+        'fields': [
+            {
+                'path': 'telegram.botToken',
+                'title': 'telegram.botToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TELEGRAM_TELEGRAM_BOT_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_apify': {
+        'title': 'tool_apify',
+        'fields': [
+            {
+                'path': 'apify.apikey',
+                'title': 'apify.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_APIFY_APIKEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_apify.apikey',
+                'title': 'tool_apify.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_APIFY_TOOL_APIFY_APIKEY',
+                'review': true,
+            },
+        ],
+    },
+    'tool_bland_ai': {
+        'title': 'tool_bland_ai',
+        'fields': [
+            {
+                'path': 'bland_ai.apikey',
+                'title': 'bland_ai.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_BLAND_BLAND_AI_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'tool_butterbase': {
+        'title': 'tool_butterbase',
+        'fields': [
+            {
+                'path': 'mcp_client.bearer',
+                'title': 'mcp_client.bearer',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_BUTTERBASE_MCP_CLIENT_BEARER',
+                'review': true,
+            }
+        ],
+    },
+    'tool_calendar': {
+        'title': 'tool_calendar',
+        'fields': [
+            {
+                'path': 'calendar.userToken',
+                'title': 'calendar.userToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_CALENDAR_USER_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_cognee': {
+        'title': 'tool_cognee',
+        'fields': [
+            {
+                'path': 'cognee.api_key',
+                'title': 'cognee.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_COGNEE_COGNEE_API_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'tool_daytona': {
+        'title': 'tool_daytona',
+        'fields': [
+            {
+                'path': 'daytona.apikey',
+                'title': 'daytona.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_DAYTONA_APIKEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_daytona.apikey',
+                'title': 'tool_daytona.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_DAYTONA_TOOL_DAYTONA_APIKEY',
+                'review': true,
+            },
+        ],
+    },
+    'tool_deepl': {
+        'title': 'tool_deepl',
+        'fields': [
+            {
+                'path': 'deepl.apikey',
+                'title': 'deepl.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_DEEPL_APIKEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_deepl.apikey',
+                'title': 'tool_deepl.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_DEEPL_TOOL_DEEPL_APIKEY',
+                'review': true,
+            },
+        ],
+    },
+    'tool_docs': {
+        'title': 'tool_docs',
+        'fields': [
+            {
+                'path': 'docs.userToken',
+                'title': 'docs.userToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_DOCS_USER_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_drive': {
+        'title': 'tool_drive',
+        'fields': [
+            {
+                'path': 'drive.userToken',
+                'title': 'drive.userToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_DRIVE_USER_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_exa_search': {
+        'title': 'tool_exa_search',
+        'fields': [
+            {
+                'path': 'exa.apikey',
+                'title': 'exa.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_EXA_APIKEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_exa_search.apikey',
+                'title': 'tool_exa_search.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_EXA_TOOL_EXA_SEARCH_APIKEY',
+                'review': true,
+            },
+        ],
+    },
+    'tool_excel': {
+        'title': 'tool_excel',
+        'fields': [
+            {
+                'path': 'excel.clientSecret',
+                'title': 'Client Secret',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_EXCEL_CLIENT_SECRET',
+                'review': false,
+            },
+            {
+                'path': 'excel.userToken',
+                'title': 'User Token (OAuth sign-in)',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_EXCEL_USER_TOKEN',
+                'review': false,
+            },
+        ],
+    },
+    'tool_firecrawl': {
+        'title': 'tool_firecrawl',
+        'fields': [
+            {
+                'path': 'firecrawl.apikey',
+                'title': 'firecrawl.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_FIRECRAWL_APIKEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_firecrawl.apikey',
+                'title': 'tool_firecrawl.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_FIRECRAWL_TOOL_FIRECRAWL_APIKEY',
+                'review': true,
+            },
+        ],
+    },
+    'tool_git': {
+        'title': 'tool_git',
+        'fields': [
+            {
+                'path': 'git.token',
+                'title': 'git.token',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GIT_GIT_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_github': {
+        'title': 'GitHub',
+        'fields': [
+            {
+                'path': 'github.token',
+                'title': 'GitHub personal access token',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GITHUB_TOKEN',
+            }
+        ],
+        'docs': 'https://docs.github.com/en/rest',
+    },
+    'tool_gmail': {
+        'title': 'tool_gmail',
+        'fields': [
+            {
+                'path': 'gmail.userToken',
+                'title': 'gmail.userToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GMAIL_USER_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_gohighlevel': {
+        'title': 'tool_gohighlevel',
+        'fields': [
+            {
+                'path': 'gohighlevel.privateIntegrationToken',
+                'title': 'gohighlevel.privateIntegrationToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GOHIGHLEVEL_GOHIGHLEVEL_PRIVATE_INTEGRATION_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_guild': {
+        'title': 'Guild.ai',
+        'fields': [
+            {
+                'path': 'guild.apiKeyId',
+                'title': 'Guild API key ID',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GUILD_KEY_ID',
+            },
+            {
+                'path': 'guild.apiKeySecret',
+                'title': 'Guild API key secret',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GUILD_KEY_SECRET',
+            },
+            {
+                'path': 'tool_guild.apiKeyId',
+                'title': 'Guild API key ID',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GUILD_KEY_ID',
+            },
+            {
+                'path': 'tool_guild.apiKeySecret',
+                'title': 'Guild API key secret',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_GUILD_KEY_SECRET',
+            },
+        ],
+        'docs': 'https://docs.guild.ai/',
+    },
+    'tool_mem0': {
+        'title': 'tool_mem0',
+        'fields': [
+            {
+                'path': 'mem0.api_key',
+                'title': 'mem0.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_MEM0_MEM0_API_KEY',
+                'review': true,
+            }
+        ],
+    },
+    'tool_n8n': {
+        'title': 'tool_n8n',
+        'fields': [
+            {
+                'path': 'n8n.apiKey',
+                'title': 'n8n.apiKey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_N8N_API_KEY',
+                'review': true,
+            },
+            {
+                'path': 'n8n.webhookToken',
+                'title': 'n8n.webhookToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_N8N_WEBHOOK_TOKEN',
+                'review': true,
+            },
+            {
+                'path': 'tool_n8n.apiKey',
+                'title': 'tool_n8n.apiKey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_N8N_TOOL_N8N_API_KEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_n8n.webhookPassword',
+                'title': 'tool_n8n.webhookPassword',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_PASSWORD',
+                'review': true,
+            },
+            {
+                'path': 'tool_n8n.webhookToken',
+                'title': 'tool_n8n.webhookToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_TOKEN',
+                'review': true,
+            },
+        ],
+    },
+    'tool_onedrive': {
+        'title': 'tool_onedrive',
+        'fields': [
+            {
+                'path': 'onedrive.clientSecret',
+                'title': 'Client Secret',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_ONEDRIVE_CLIENT_SECRET',
+                'review': false,
+            },
+            {
+                'path': 'onedrive.userToken',
+                'title': 'User Token (OAuth sign-in)',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_ONEDRIVE_USER_TOKEN',
+                'review': false,
+            },
+        ],
+    },
+    'tool_oura': {
+        'title': 'tool_oura',
+        'fields': [
+            {
+                'path': 'oura.token',
+                'title': 'oura.token',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_OURA_OURA_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_outlook_calendar': {
+        'title': 'tool_outlook_calendar',
+        'fields': [
+            {
+                'path': 'outlook_calendar.clientSecret',
+                'title': 'Client Secret',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_OUTLOOK_CALENDAR_CLIENT_SECRET',
+                'review': false,
+            },
+            {
+                'path': 'outlook_calendar.userToken',
+                'title': 'User Token (OAuth sign-in)',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_OUTLOOK_CALENDAR_USER_TOKEN',
+                'review': false,
+            },
+        ],
+    },
+    'tool_outlook_mail': {
+        'title': 'tool_outlook_mail',
+        'fields': [
+            {
+                'path': 'outlook_mail.clientSecret',
+                'title': 'Client Secret',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_OUTLOOK_MAIL_CLIENT_SECRET',
+                'review': false,
+            },
+            {
+                'path': 'outlook_mail.userToken',
+                'title': 'User Token (OAuth sign-in)',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_OUTLOOK_MAIL_USER_TOKEN',
+                'review': false,
+            },
+        ],
+    },
+    'tool_pipedrive': {
+        'title': 'tool_pipedrive',
+        'fields': [
+            {
+                'path': 'pipedrive.apiToken',
+                'title': 'pipedrive.apiToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_PIPEDRIVE_PIPEDRIVE_API_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_sheets': {
+        'title': 'tool_sheets',
+        'fields': [
+            {
+                'path': 'sheets.userToken',
+                'title': 'sheets.userToken',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_SHEETS_USER_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_slack': {
+        'title': 'tool_slack',
+        'fields': [
+            {
+                'path': 'slack.token',
+                'title': 'slack.token',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_SLACK_SLACK_TOKEN',
+                'review': true,
+            }
+        ],
+    },
+    'tool_tavily': {
+        'title': 'tool_tavily',
+        'fields': [
+            {
+                'path': 'tavily.apikey',
+                'title': 'tavily.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TAVILY_APIKEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_tavily.apikey',
+                'title': 'tool_tavily.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TAVILY_TOOL_TAVILY_APIKEY',
+                'review': true,
+            },
+        ],
+    },
+    'tool_v0': {
+        'title': 'tool_v0',
+        'fields': [
+            {
+                'path': 'v0.apikey',
+                'title': 'v0.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TOOL_V0_APIKEY',
+                'review': true,
+            },
+            {
+                'path': 'tool_v0.apikey',
+                'title': 'tool_v0.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TOOL_V0_TOOL_V0_APIKEY',
+                'review': true,
+            },
+        ],
+    },
+    'tool_word': {
+        'title': 'tool_word',
+        'fields': [
+            {
+                'path': 'word.clientSecret',
+                'title': 'Client Secret',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_WORD_CLIENT_SECRET',
+                'review': false,
+            },
+            {
+                'path': 'word.userToken',
+                'title': 'User Token (OAuth sign-in)',
+                'kind': 'secret',
+                'required': false,
+                'suggests': 'ROCKETRIDE_WORD_USER_TOKEN',
+                'review': false,
+            },
+        ],
+    },
+    'tool_xtrace_memory': {
+        'title': 'tool_xtrace_memory',
+        'fields': [
+            {
+                'path': 'xtrace.api_key',
+                'title': 'xtrace.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_XTRACE_API_KEY',
+                'review': true,
+            },
+            {
+                'path': 'xtrace_memory.api_key',
+                'title': 'xtrace_memory.api_key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_XTRACE_XTRACE_MEMORY_API_KEY',
+                'review': true,
+            },
+        ],
+    },
+    'tts_elevenlabs': {
+        'title': 'ElevenLabs Text to Speech',
+        'fields': [
+            {
+                'path': 'tts_elevenlabs.apikey',
+                'title': 'ElevenLabs API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TTS_ELEVENLABS_KEY',
+            }
+        ],
+        'docs': 'https://elevenlabs.io/docs/api-reference/introduction',
+    },
+    'tts_openai': {
+        'title': 'OpenAI Text to Speech',
+        'fields': [
+            {
+                'path': 'tts_openai.apikey',
+                'title': 'OpenAI TTS API key',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TTS_OPENAI_KEY',
+            }
+        ],
+        'docs': 'https://platform.openai.com/docs/guides/text-to-speech',
+    },
+    'twelvelabs': {
+        'title': 'twelvelabs',
+        'fields': [
+            {
+                'path': 'twelvelabs.apikey',
+                'title': 'twelvelabs.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_TWELVELABS_APIKEY',
+                'review': true,
+            }
+        ],
+    },
+    'weaviate': {
+        'title': 'weaviate',
+        'fields': [
+            {
+                'path': 'Weaviate Vector Store.apikey',
+                'title': 'Weaviate Vector Store.apikey',
+                'kind': 'secret',
+                'required': true,
+                'suggests': 'ROCKETRIDE_WEAVIATE_APIKEY',
+                'review': true,
+            }
+        ],
+    },
 }

--- a/packages/ai/src/ai/modules/mcp/credentials.json
+++ b/packages/ai/src/ai/modules/mcp/credentials.json
@@ -1,1313 +1,1313 @@
 {
-    'accessibility_describe': {
-        'title': 'accessibility_describe',
-        'fields': [
-            {
-                'path': 'accessibility_describe.apikey',
-                'title': 'accessibility_describe.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ACCESSIBILITY_DESCRIBE_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'aparavi_aql': {
-        'title': 'aparavi_aql',
-        'fields': [
-            {
-                'path': 'aparavi.password',
-                'title': 'aparavi.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_APARAVI_AQL_APARAVI_PASSWORD',
-                'review': true,
-            }
-        ],
-    },
-    'astra_db': {
-        'title': 'astra_db',
-        'fields': [
-            {
-                'path': 'Astra DB Vector Store.application_token',
-                'title': 'Astra DB Vector Store.application_token',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ASTRA_APPLICATION_TOKEN',
-                'review': true,
-            },
-            {
-                'path': 'astra_db.application_token',
-                'title': 'astra_db.application_token',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ASTRA_ASTRA_DB_APPLICATION_TOKEN',
-                'review': true,
-            },
-        ],
-    },
-    'chroma': {
-        'title': 'Chroma',
-        'fields': [
-            {
-                'path': 'Chroma Vector Store.apikey',
-                'title': 'Chroma API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_CHROMA_APIKEY',
-            }
-        ],
-        'docs': 'https://docs.trychroma.com/',
-    },
-    'db_arango': {
-        'title': 'ArangoDB',
-        'docs': 'https://docs.arangodb.com/stable/',
-        'fields': [
-            {
-                'path': 'arangodb.endpoint',
-                'title': 'Connection endpoint',
-                'kind': 'endpoint',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ARANGO_ENDPOINT',
-            },
-            {
-                'path': 'arangodb.user',
-                'title': 'User',
-                'kind': 'identifier',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ARANGO_USER',
-            },
-            {
-                'path': 'arangodb.password',
-                'title': 'Password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ARANGO_PASSWORD',
-            },
-            {
-                'path': 'arangodb.database',
-                'title': 'Database name',
-                'kind': 'identifier',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ARANGO_DB',
-            },
-            {
-                'path': 'arangodb.token',
-                'title': 'Bearer token',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_ARANGO_TOKEN',
-            },
-        ],
-    },
-    'db_clickhouse': {
-        'title': 'db_clickhouse',
-        'fields': [
-            {
-                'path': 'clickhouse.password',
-                'title': 'clickhouse.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_CLICKHOUSE_CLICKHOUSE_PASSWORD',
-                'review': true,
-            }
-        ],
-    },
-    'db_hotdata': {
-        'title': 'db_hotdata',
-        'fields': [
-            {
-                'path': 'hotdata.apikey',
-                'title': 'hotdata.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_HOTDATA_HOTDATA_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'db_hydradb': {
-        'title': 'db_hydradb',
-        'fields': [
-            {
-                'path': 'hydradb.api_key',
-                'title': 'hydradb.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_HYDRADB_HYDRADB_API_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'db_mysql': {
-        'title': 'db_mysql',
-        'fields': [
-            {
-                'path': 'mysql.password',
-                'title': 'mysql.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_MYSQL_MYSQL_PASSWORD',
-                'review': true,
-            }
-        ],
-    },
-    'db_postgres': {
-        'title': 'db_postgres',
-        'fields': [
-            {
-                'path': 'postgresdb.password',
-                'title': 'postgresdb.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_POSTGRES_POSTGRESDB_PASSWORD',
-                'review': true,
-            }
-        ],
-    },
-    'db_supabase': {
-        'title': 'db_supabase',
-        'fields': [
-            {
-                'path': 'postgresdb.password',
-                'title': 'postgresdb.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_SUPABASE_POSTGRESDB_PASSWORD',
-                'review': true,
-            }
-        ],
-    },
-    'elasticsearch': {
-        'title': 'elasticsearch',
-        'fields': [
-            {
-                'path': 'Elasticsearch Vector Store.apikey',
-                'title': 'Elasticsearch Vector Store.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ELASTICSEARCH_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'embedding_openai': {
-        'title': 'embedding_openai',
-        'fields': [
-            {
-                'path': 'embedding.apikey',
-                'title': 'embedding.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_OPENAI_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'graph_falkordb': {
-        'title': 'FalkorDB',
-        'fields': [
-            {
-                'path': 'graph_falkordb.password',
-                'title': 'FalkorDB password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_FALKORDB_PASSWORD',
-            },
-            {
-                'path': 'graph_falkordb.host',
-                'title': 'Host',
-                'kind': 'endpoint',
-                'required': true,
-                'suggests': 'ROCKETRIDE_FALKORDB_HOST',
-            },
-            {
-                'path': 'graph_falkordb.username',
-                'title': 'Username',
-                'kind': 'identifier',
-                'required': true,
-                'suggests': 'ROCKETRIDE_FALKORDB_USER',
-            },
-        ],
-        'docs': 'https://docs.falkordb.com/',
-    },
-    'graph_neo4j': {
-        'title': 'Neo4j',
-        'fields': [
-            {
-                'path': 'graph_neo4j.uri',
-                'title': 'Connection URI',
-                'kind': 'endpoint',
-                'required': true,
-                'suggests': 'ROCKETRIDE_NEO4J_URI',
-            },
-            {
-                'path': 'graph_neo4j.user',
-                'title': 'User',
-                'kind': 'identifier',
-                'required': true,
-                'suggests': 'ROCKETRIDE_NEO4J_USER',
-            },
-            {
-                'path': 'graph_neo4j.password',
-                'title': 'Password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_NEO4J_PASSWORD',
-            },
-            {
-                'path': 'graph_neo4j.token',
-                'title': 'Bearer token',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_NEO4J_TOKEN',
-            },
-            {
-                'path': 'graph_neo4j.database',
-                'title': 'Database name',
-                'kind': 'identifier',
-                'required': false,
-                'suggests': 'ROCKETRIDE_NEO4J_DATABASE',
-            },
-        ],
-        'docs': 'https://neo4j.com/docs/',
-    },
-    'hackjudge_engine': {
-        'title': 'hackjudge_engine',
-        'fields': [
-            {
-                'path': 'hackjudge_engine.github_token',
-                'title': 'GitHub token (repo fetches)',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_GITHUB_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'image_vision_gemini': {
-        'title': 'image_vision_gemini',
-        'fields': [
-            {
-                'path': 'image_vision_gemini.apikey',
-                'title': 'image_vision_gemini.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_IMAGE_GEMINI_IMAGE_VISION_GEMINI_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'image_vision_mistral': {
-        'title': 'image_vision_mistral',
-        'fields': [
-            {
-                'path': 'image_vision_mistral.apikey',
-                'title': 'image_vision_mistral.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_IMAGE_MISTRAL_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'image_vision_openai': {
-        'title': 'image_vision_openai',
-        'fields': [
-            {
-                'path': 'image_vision_openai.apikey',
-                'title': 'image_vision_openai.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_IMAGE_OPENAI_IMAGE_VISION_OPENAI_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'landing_ai_extract': {
-        'title': 'landing_ai_extract',
-        'fields': [
-            {
-                'path': 'landing_ai_extract.api_key',
-                'title': 'landing_ai_extract.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_LANDING_EXTRACT_LANDING_AI_EXTRACT_API_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'landing_ai_parse': {
-        'title': 'landing_ai_parse',
-        'fields': [
-            {
-                'path': 'landing_ai_parse.api_key',
-                'title': 'landing_ai_parse.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_LANDING_PARSE_LANDING_AI_PARSE_API_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'llamaparse': {
-        'title': 'llamaparse',
-        'fields': [
-            {
-                'path': 'llamaparse.api_key',
-                'title': 'llamaparse.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_LLAMAPARSE_LLAMAPARSE_API_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_anthropic': {
-        'title': 'Anthropic',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'Anthropic API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ANTHROPIC_KEY',
-            }
-        ],
-        'docs': 'https://docs.anthropic.com/en/api/overview',
-    },
-    'llm_baidu_qianfan': {
-        'title': 'llm_baidu_qianfan',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_BAIDU_QIANFAN_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_bedrock': {
-        'title': 'llm_bedrock',
-        'fields': [
-            {
-                'path': 'llm.secretKey',
-                'title': 'llm.secretKey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_BEDROCK_SECRET_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_deepseek': {
-        'title': 'llm_deepseek',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_DEEPSEEK_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_gemini': {
-        'title': 'Gemini',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'Google Gemini API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GEMINI_KEY',
-            },
-            {
-                'path': 'gemini.apikey',
-                'title': 'gemini.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GEMINI_GEMINI_APIKEY',
-                'review': true,
-            },
-        ],
-        'docs': 'https://ai.google.dev/gemini-api/docs',
-    },
-    'llm_gmi_cloud': {
-        'title': 'llm_gmi_cloud',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GMI_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_kimi': {
-        'title': 'llm_kimi',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_KIMI_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_minimax': {
-        'title': 'llm_minimax',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_MINIMAX_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_mistral': {
-        'title': 'llm_mistral',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_MISTRAL_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_openai': {
-        'title': 'OpenAI',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'OpenAI API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_OPENAI_KEY',
-            }
-        ],
-        'docs': 'https://platform.openai.com/docs/api-reference',
-    },
-    'llm_openai_api': {
-        'title': 'OpenAI-Compatible API',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'OpenAI (or compatible endpoint) API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_OPENAI_KEY',
-            }
-        ],
-        'docs': 'https://platform.openai.com/docs/api-reference',
-    },
-    'llm_perplexity': {
-        'title': 'llm_perplexity',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_PERPLEXITY_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_qwen': {
-        'title': 'llm_qwen',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_QWEN_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'llm_xai': {
-        'title': 'llm_xai',
-        'fields': [
-            {
-                'path': 'llm.apikey',
-                'title': 'llm.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_XAI_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'mcp_client': {
-        'title': 'mcp_client',
-        'fields': [
-            {
-                'path': 'mcp_client.bearer',
-                'title': 'mcp_client.bearer',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_MCP_CLIENT_MCP_CLIENT_BEARER',
-                'review': true,
-            }
-        ],
-    },
-    'memory_persistent': {
-        'title': 'memory_persistent',
-        'fields': [
-            {
-                'path': 'memory.redis_password',
-                'title': 'memory.redis_password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_PERSISTENT_REDIS_PASSWORD',
-                'review': true,
-            }
-        ],
-    },
-    'milvus': {
-        'title': 'milvus',
-        'fields': [
-            {
-                'path': 'Milvus Vector Store.apikey',
-                'title': 'Milvus Vector Store.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_MILVUS_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'opensearch': {
-        'title': 'opensearch',
-        'fields': [
-            {
-                'path': 'opensearch.auth.password',
-                'title': 'opensearch.auth.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_OPENSEARCH_OPENSEARCH_AUTH_PASSWORD',
-                'review': true,
-            }
-        ],
-    },
-    'pinecone': {
-        'title': 'Pinecone',
-        'fields': [
-            {
-                'path': 'Pinecone Vector Store.apikey',
-                'title': 'Pinecone API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_PINECONE_APIKEY',
-            }
-        ],
-        'docs': 'https://docs.pinecone.io/reference/api/introduction',
-    },
-    'postgres': {
-        'title': 'postgres',
-        'fields': [
-            {
-                'path': 'PostgreSQL Vector Store.password',
-                'title': 'PostgreSQL Vector Store.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_POSTGRES_PASSWORD',
-                'review': true,
-            },
-            {
-                'path': 'vector.local.password',
-                'title': 'vector.local.password',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_POSTGRES_VECTOR_LOCAL_PASSWORD',
-                'review': true,
-            },
-        ],
-    },
-    'qdrant': {
-        'title': 'Qdrant',
-        'fields': [
-            {
-                'path': 'Qdrant Vector Store.apikey',
-                'title': 'Qdrant API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_QDRANT_APIKEY',
-            }
-        ],
-        'docs': 'https://qdrant.tech/documentation/',
-    },
-    'reducto': {
-        'title': 'reducto',
-        'fields': [
-            {
-                'path': 'reducto.api_key',
-                'title': 'reducto.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_REDUCTO_REDUCTO_API_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'rerank_cohere': {
-        'title': 'Cohere Rerank',
-        'fields': [
-            {
-                'path': 'rerank.apikey',
-                'title': 'Cohere API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_RERANK_COHERE_KEY',
-            }
-        ],
-        'docs': 'https://docs.cohere.com/reference/rerank',
-    },
-    'search_exa': {
-        'title': 'Exa Search',
-        'fields': [
-            {
-                'path': 'search.apikey',
-                'title': 'Exa API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_EXA_KEY',
-            },
-            {
-                'path': 'search_exa.apikey',
-                'title': 'Exa API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_EXA_KEY',
-            },
-        ],
-        'docs': 'https://docs.exa.ai/reference/getting-started',
-    },
-    'telegram': {
-        'title': 'telegram',
-        'fields': [
-            {
-                'path': 'telegram.botToken',
-                'title': 'telegram.botToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TELEGRAM_TELEGRAM_BOT_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_apify': {
-        'title': 'tool_apify',
-        'fields': [
-            {
-                'path': 'apify.apikey',
-                'title': 'apify.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_APIFY_APIKEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_apify.apikey',
-                'title': 'tool_apify.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_APIFY_TOOL_APIFY_APIKEY',
-                'review': true,
-            },
-        ],
-    },
-    'tool_bland_ai': {
-        'title': 'tool_bland_ai',
-        'fields': [
-            {
-                'path': 'bland_ai.apikey',
-                'title': 'bland_ai.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_BLAND_BLAND_AI_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'tool_butterbase': {
-        'title': 'tool_butterbase',
-        'fields': [
-            {
-                'path': 'mcp_client.bearer',
-                'title': 'mcp_client.bearer',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_BUTTERBASE_MCP_CLIENT_BEARER',
-                'review': true,
-            }
-        ],
-    },
-    'tool_calendar': {
-        'title': 'tool_calendar',
-        'fields': [
-            {
-                'path': 'calendar.userToken',
-                'title': 'calendar.userToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_CALENDAR_USER_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_cognee': {
-        'title': 'tool_cognee',
-        'fields': [
-            {
-                'path': 'cognee.api_key',
-                'title': 'cognee.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_COGNEE_COGNEE_API_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'tool_daytona': {
-        'title': 'tool_daytona',
-        'fields': [
-            {
-                'path': 'daytona.apikey',
-                'title': 'daytona.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_DAYTONA_APIKEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_daytona.apikey',
-                'title': 'tool_daytona.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_DAYTONA_TOOL_DAYTONA_APIKEY',
-                'review': true,
-            },
-        ],
-    },
-    'tool_deepl': {
-        'title': 'tool_deepl',
-        'fields': [
-            {
-                'path': 'deepl.apikey',
-                'title': 'deepl.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_DEEPL_APIKEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_deepl.apikey',
-                'title': 'tool_deepl.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_DEEPL_TOOL_DEEPL_APIKEY',
-                'review': true,
-            },
-        ],
-    },
-    'tool_docs': {
-        'title': 'tool_docs',
-        'fields': [
-            {
-                'path': 'docs.userToken',
-                'title': 'docs.userToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_DOCS_USER_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_drive': {
-        'title': 'tool_drive',
-        'fields': [
-            {
-                'path': 'drive.userToken',
-                'title': 'drive.userToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_DRIVE_USER_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_exa_search': {
-        'title': 'tool_exa_search',
-        'fields': [
-            {
-                'path': 'exa.apikey',
-                'title': 'exa.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_EXA_APIKEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_exa_search.apikey',
-                'title': 'tool_exa_search.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_EXA_TOOL_EXA_SEARCH_APIKEY',
-                'review': true,
-            },
-        ],
-    },
-    'tool_excel': {
-        'title': 'tool_excel',
-        'fields': [
-            {
-                'path': 'excel.clientSecret',
-                'title': 'Client Secret',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_EXCEL_CLIENT_SECRET',
-                'review': false,
-            },
-            {
-                'path': 'excel.userToken',
-                'title': 'User Token (OAuth sign-in)',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_EXCEL_USER_TOKEN',
-                'review': false,
-            },
-        ],
-    },
-    'tool_firecrawl': {
-        'title': 'tool_firecrawl',
-        'fields': [
-            {
-                'path': 'firecrawl.apikey',
-                'title': 'firecrawl.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_FIRECRAWL_APIKEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_firecrawl.apikey',
-                'title': 'tool_firecrawl.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_FIRECRAWL_TOOL_FIRECRAWL_APIKEY',
-                'review': true,
-            },
-        ],
-    },
-    'tool_git': {
-        'title': 'tool_git',
-        'fields': [
-            {
-                'path': 'git.token',
-                'title': 'git.token',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GIT_GIT_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_github': {
-        'title': 'GitHub',
-        'fields': [
-            {
-                'path': 'github.token',
-                'title': 'GitHub personal access token',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GITHUB_TOKEN',
-            }
-        ],
-        'docs': 'https://docs.github.com/en/rest',
-    },
-    'tool_gmail': {
-        'title': 'tool_gmail',
-        'fields': [
-            {
-                'path': 'gmail.userToken',
-                'title': 'gmail.userToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GMAIL_USER_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_gohighlevel': {
-        'title': 'tool_gohighlevel',
-        'fields': [
-            {
-                'path': 'gohighlevel.privateIntegrationToken',
-                'title': 'gohighlevel.privateIntegrationToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GOHIGHLEVEL_GOHIGHLEVEL_PRIVATE_INTEGRATION_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_guild': {
-        'title': 'Guild.ai',
-        'fields': [
-            {
-                'path': 'guild.apiKeyId',
-                'title': 'Guild API key ID',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GUILD_KEY_ID',
-            },
-            {
-                'path': 'guild.apiKeySecret',
-                'title': 'Guild API key secret',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GUILD_KEY_SECRET',
-            },
-            {
-                'path': 'tool_guild.apiKeyId',
-                'title': 'Guild API key ID',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GUILD_KEY_ID',
-            },
-            {
-                'path': 'tool_guild.apiKeySecret',
-                'title': 'Guild API key secret',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_GUILD_KEY_SECRET',
-            },
-        ],
-        'docs': 'https://docs.guild.ai/',
-    },
-    'tool_mem0': {
-        'title': 'tool_mem0',
-        'fields': [
-            {
-                'path': 'mem0.api_key',
-                'title': 'mem0.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_MEM0_MEM0_API_KEY',
-                'review': true,
-            }
-        ],
-    },
-    'tool_n8n': {
-        'title': 'tool_n8n',
-        'fields': [
-            {
-                'path': 'n8n.apiKey',
-                'title': 'n8n.apiKey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_N8N_API_KEY',
-                'review': true,
-            },
-            {
-                'path': 'n8n.webhookToken',
-                'title': 'n8n.webhookToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_N8N_WEBHOOK_TOKEN',
-                'review': true,
-            },
-            {
-                'path': 'tool_n8n.apiKey',
-                'title': 'tool_n8n.apiKey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_N8N_TOOL_N8N_API_KEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_n8n.webhookPassword',
-                'title': 'tool_n8n.webhookPassword',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_PASSWORD',
-                'review': true,
-            },
-            {
-                'path': 'tool_n8n.webhookToken',
-                'title': 'tool_n8n.webhookToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_TOKEN',
-                'review': true,
-            },
-        ],
-    },
-    'tool_onedrive': {
-        'title': 'tool_onedrive',
-        'fields': [
-            {
-                'path': 'onedrive.clientSecret',
-                'title': 'Client Secret',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_ONEDRIVE_CLIENT_SECRET',
-                'review': false,
-            },
-            {
-                'path': 'onedrive.userToken',
-                'title': 'User Token (OAuth sign-in)',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_ONEDRIVE_USER_TOKEN',
-                'review': false,
-            },
-        ],
-    },
-    'tool_oura': {
-        'title': 'tool_oura',
-        'fields': [
-            {
-                'path': 'oura.token',
-                'title': 'oura.token',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_OURA_OURA_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_outlook_calendar': {
-        'title': 'tool_outlook_calendar',
-        'fields': [
-            {
-                'path': 'outlook_calendar.clientSecret',
-                'title': 'Client Secret',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_OUTLOOK_CALENDAR_CLIENT_SECRET',
-                'review': false,
-            },
-            {
-                'path': 'outlook_calendar.userToken',
-                'title': 'User Token (OAuth sign-in)',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_OUTLOOK_CALENDAR_USER_TOKEN',
-                'review': false,
-            },
-        ],
-    },
-    'tool_outlook_mail': {
-        'title': 'tool_outlook_mail',
-        'fields': [
-            {
-                'path': 'outlook_mail.clientSecret',
-                'title': 'Client Secret',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_OUTLOOK_MAIL_CLIENT_SECRET',
-                'review': false,
-            },
-            {
-                'path': 'outlook_mail.userToken',
-                'title': 'User Token (OAuth sign-in)',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_OUTLOOK_MAIL_USER_TOKEN',
-                'review': false,
-            },
-        ],
-    },
-    'tool_pipedrive': {
-        'title': 'tool_pipedrive',
-        'fields': [
-            {
-                'path': 'pipedrive.apiToken',
-                'title': 'pipedrive.apiToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_PIPEDRIVE_PIPEDRIVE_API_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_sheets': {
-        'title': 'tool_sheets',
-        'fields': [
-            {
-                'path': 'sheets.userToken',
-                'title': 'sheets.userToken',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_SHEETS_USER_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_slack': {
-        'title': 'tool_slack',
-        'fields': [
-            {
-                'path': 'slack.token',
-                'title': 'slack.token',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_SLACK_SLACK_TOKEN',
-                'review': true,
-            }
-        ],
-    },
-    'tool_tavily': {
-        'title': 'tool_tavily',
-        'fields': [
-            {
-                'path': 'tavily.apikey',
-                'title': 'tavily.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TAVILY_APIKEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_tavily.apikey',
-                'title': 'tool_tavily.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TAVILY_TOOL_TAVILY_APIKEY',
-                'review': true,
-            },
-        ],
-    },
-    'tool_v0': {
-        'title': 'tool_v0',
-        'fields': [
-            {
-                'path': 'v0.apikey',
-                'title': 'v0.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TOOL_V0_APIKEY',
-                'review': true,
-            },
-            {
-                'path': 'tool_v0.apikey',
-                'title': 'tool_v0.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TOOL_V0_TOOL_V0_APIKEY',
-                'review': true,
-            },
-        ],
-    },
-    'tool_word': {
-        'title': 'tool_word',
-        'fields': [
-            {
-                'path': 'word.clientSecret',
-                'title': 'Client Secret',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_WORD_CLIENT_SECRET',
-                'review': false,
-            },
-            {
-                'path': 'word.userToken',
-                'title': 'User Token (OAuth sign-in)',
-                'kind': 'secret',
-                'required': false,
-                'suggests': 'ROCKETRIDE_WORD_USER_TOKEN',
-                'review': false,
-            },
-        ],
-    },
-    'tool_xtrace_memory': {
-        'title': 'tool_xtrace_memory',
-        'fields': [
-            {
-                'path': 'xtrace.api_key',
-                'title': 'xtrace.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_XTRACE_API_KEY',
-                'review': true,
-            },
-            {
-                'path': 'xtrace_memory.api_key',
-                'title': 'xtrace_memory.api_key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_XTRACE_XTRACE_MEMORY_API_KEY',
-                'review': true,
-            },
-        ],
-    },
-    'tts_elevenlabs': {
-        'title': 'ElevenLabs Text to Speech',
-        'fields': [
-            {
-                'path': 'tts_elevenlabs.apikey',
-                'title': 'ElevenLabs API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TTS_ELEVENLABS_KEY',
-            }
-        ],
-        'docs': 'https://elevenlabs.io/docs/api-reference/introduction',
-    },
-    'tts_openai': {
-        'title': 'OpenAI Text to Speech',
-        'fields': [
-            {
-                'path': 'tts_openai.apikey',
-                'title': 'OpenAI TTS API key',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TTS_OPENAI_KEY',
-            }
-        ],
-        'docs': 'https://platform.openai.com/docs/guides/text-to-speech',
-    },
-    'twelvelabs': {
-        'title': 'twelvelabs',
-        'fields': [
-            {
-                'path': 'twelvelabs.apikey',
-                'title': 'twelvelabs.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_TWELVELABS_APIKEY',
-                'review': true,
-            }
-        ],
-    },
-    'weaviate': {
-        'title': 'weaviate',
-        'fields': [
-            {
-                'path': 'Weaviate Vector Store.apikey',
-                'title': 'Weaviate Vector Store.apikey',
-                'kind': 'secret',
-                'required': true,
-                'suggests': 'ROCKETRIDE_WEAVIATE_APIKEY',
-                'review': true,
-            }
-        ],
-    },
+  "accessibility_describe": {
+    "title": "accessibility_describe",
+    "fields": [
+      {
+        "path": "accessibility_describe.apikey",
+        "title": "accessibility_describe.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_ACCESSIBILITY_DESCRIBE_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "aparavi_aql": {
+    "title": "aparavi_aql",
+    "fields": [
+      {
+        "path": "aparavi.password",
+        "title": "aparavi.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_APARAVI_AQL_APARAVI_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "astra_db": {
+    "title": "astra_db",
+    "fields": [
+      {
+        "path": "Astra DB Vector Store.application_token",
+        "title": "Astra DB Vector Store.application_token",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_ASTRA_APPLICATION_TOKEN",
+        "review": true
+      },
+      {
+        "path": "astra_db.application_token",
+        "title": "astra_db.application_token",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_ASTRA_ASTRA_DB_APPLICATION_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "chroma": {
+    "title": "Chroma",
+    "fields": [
+      {
+        "path": "Chroma Vector Store.apikey",
+        "title": "Chroma API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_CHROMA_APIKEY"
+      }
+    ],
+    "docs": "https://docs.trychroma.com/"
+  },
+  "db_arango": {
+    "title": "ArangoDB",
+    "docs": "https://docs.arangodb.com/stable/",
+    "fields": [
+      {
+        "path": "arangodb.endpoint",
+        "title": "Connection endpoint",
+        "kind": "endpoint",
+        "required": true,
+        "suggests": "ROCKETRIDE_ARANGO_ENDPOINT"
+      },
+      {
+        "path": "arangodb.user",
+        "title": "User",
+        "kind": "identifier",
+        "required": true,
+        "suggests": "ROCKETRIDE_ARANGO_USER"
+      },
+      {
+        "path": "arangodb.password",
+        "title": "Password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_ARANGO_PASSWORD"
+      },
+      {
+        "path": "arangodb.database",
+        "title": "Database name",
+        "kind": "identifier",
+        "required": true,
+        "suggests": "ROCKETRIDE_ARANGO_DB"
+      },
+      {
+        "path": "arangodb.token",
+        "title": "Bearer token",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_ARANGO_TOKEN"
+      }
+    ]
+  },
+  "db_clickhouse": {
+    "title": "db_clickhouse",
+    "fields": [
+      {
+        "path": "clickhouse.password",
+        "title": "clickhouse.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_CLICKHOUSE_CLICKHOUSE_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "db_hotdata": {
+    "title": "db_hotdata",
+    "fields": [
+      {
+        "path": "hotdata.apikey",
+        "title": "hotdata.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_HOTDATA_HOTDATA_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "db_hydradb": {
+    "title": "db_hydradb",
+    "fields": [
+      {
+        "path": "hydradb.api_key",
+        "title": "hydradb.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_HYDRADB_HYDRADB_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "db_mysql": {
+    "title": "db_mysql",
+    "fields": [
+      {
+        "path": "mysql.password",
+        "title": "mysql.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_MYSQL_MYSQL_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "db_postgres": {
+    "title": "db_postgres",
+    "fields": [
+      {
+        "path": "postgresdb.password",
+        "title": "postgresdb.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_POSTGRES_POSTGRESDB_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "db_supabase": {
+    "title": "db_supabase",
+    "fields": [
+      {
+        "path": "postgresdb.password",
+        "title": "postgresdb.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_SUPABASE_POSTGRESDB_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "elasticsearch": {
+    "title": "elasticsearch",
+    "fields": [
+      {
+        "path": "Elasticsearch Vector Store.apikey",
+        "title": "Elasticsearch Vector Store.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_ELASTICSEARCH_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "embedding_openai": {
+    "title": "embedding_openai",
+    "fields": [
+      {
+        "path": "embedding.apikey",
+        "title": "embedding.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_OPENAI_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "graph_falkordb": {
+    "title": "FalkorDB",
+    "fields": [
+      {
+        "path": "graph_falkordb.password",
+        "title": "FalkorDB password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_FALKORDB_PASSWORD"
+      },
+      {
+        "path": "graph_falkordb.host",
+        "title": "Host",
+        "kind": "endpoint",
+        "required": true,
+        "suggests": "ROCKETRIDE_FALKORDB_HOST"
+      },
+      {
+        "path": "graph_falkordb.username",
+        "title": "Username",
+        "kind": "identifier",
+        "required": true,
+        "suggests": "ROCKETRIDE_FALKORDB_USER"
+      }
+    ],
+    "docs": "https://docs.falkordb.com/"
+  },
+  "graph_neo4j": {
+    "title": "Neo4j",
+    "fields": [
+      {
+        "path": "graph_neo4j.uri",
+        "title": "Connection URI",
+        "kind": "endpoint",
+        "required": true,
+        "suggests": "ROCKETRIDE_NEO4J_URI"
+      },
+      {
+        "path": "graph_neo4j.user",
+        "title": "User",
+        "kind": "identifier",
+        "required": true,
+        "suggests": "ROCKETRIDE_NEO4J_USER"
+      },
+      {
+        "path": "graph_neo4j.password",
+        "title": "Password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_NEO4J_PASSWORD"
+      },
+      {
+        "path": "graph_neo4j.token",
+        "title": "Bearer token",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_NEO4J_TOKEN"
+      },
+      {
+        "path": "graph_neo4j.database",
+        "title": "Database name",
+        "kind": "identifier",
+        "required": false,
+        "suggests": "ROCKETRIDE_NEO4J_DATABASE"
+      }
+    ],
+    "docs": "https://neo4j.com/docs/"
+  },
+  "hackjudge_engine": {
+    "title": "hackjudge_engine",
+    "fields": [
+      {
+        "path": "hackjudge_engine.github_token",
+        "title": "GitHub token (repo fetches)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_GITHUB_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "image_vision_gemini": {
+    "title": "image_vision_gemini",
+    "fields": [
+      {
+        "path": "image_vision_gemini.apikey",
+        "title": "image_vision_gemini.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_IMAGE_GEMINI_IMAGE_VISION_GEMINI_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "image_vision_mistral": {
+    "title": "image_vision_mistral",
+    "fields": [
+      {
+        "path": "image_vision_mistral.apikey",
+        "title": "image_vision_mistral.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_IMAGE_MISTRAL_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "image_vision_openai": {
+    "title": "image_vision_openai",
+    "fields": [
+      {
+        "path": "image_vision_openai.apikey",
+        "title": "image_vision_openai.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_IMAGE_OPENAI_IMAGE_VISION_OPENAI_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "landing_ai_extract": {
+    "title": "landing_ai_extract",
+    "fields": [
+      {
+        "path": "landing_ai_extract.api_key",
+        "title": "landing_ai_extract.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_LANDING_EXTRACT_LANDING_AI_EXTRACT_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "landing_ai_parse": {
+    "title": "landing_ai_parse",
+    "fields": [
+      {
+        "path": "landing_ai_parse.api_key",
+        "title": "landing_ai_parse.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_LANDING_PARSE_LANDING_AI_PARSE_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "llamaparse": {
+    "title": "llamaparse",
+    "fields": [
+      {
+        "path": "llamaparse.api_key",
+        "title": "llamaparse.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_LLAMAPARSE_LLAMAPARSE_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_anthropic": {
+    "title": "Anthropic",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "Anthropic API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_ANTHROPIC_KEY"
+      }
+    ],
+    "docs": "https://docs.anthropic.com/en/api/overview"
+  },
+  "llm_baidu_qianfan": {
+    "title": "llm_baidu_qianfan",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_BAIDU_QIANFAN_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_bedrock": {
+    "title": "llm_bedrock",
+    "fields": [
+      {
+        "path": "llm.secretKey",
+        "title": "llm.secretKey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_BEDROCK_SECRET_KEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_deepseek": {
+    "title": "llm_deepseek",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_DEEPSEEK_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_gemini": {
+    "title": "Gemini",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "Google Gemini API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GEMINI_KEY"
+      },
+      {
+        "path": "gemini.apikey",
+        "title": "gemini.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GEMINI_GEMINI_APIKEY",
+        "review": true
+      }
+    ],
+    "docs": "https://ai.google.dev/gemini-api/docs"
+  },
+  "llm_gmi_cloud": {
+    "title": "llm_gmi_cloud",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GMI_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_kimi": {
+    "title": "llm_kimi",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_KIMI_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_minimax": {
+    "title": "llm_minimax",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_MINIMAX_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_mistral": {
+    "title": "llm_mistral",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_MISTRAL_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_openai": {
+    "title": "OpenAI",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "OpenAI API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_OPENAI_KEY"
+      }
+    ],
+    "docs": "https://platform.openai.com/docs/api-reference"
+  },
+  "llm_openai_api": {
+    "title": "OpenAI-Compatible API",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "OpenAI (or compatible endpoint) API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_OPENAI_KEY"
+      }
+    ],
+    "docs": "https://platform.openai.com/docs/api-reference"
+  },
+  "llm_perplexity": {
+    "title": "llm_perplexity",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_PERPLEXITY_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_qwen": {
+    "title": "llm_qwen",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_QWEN_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "llm_xai": {
+    "title": "llm_xai",
+    "fields": [
+      {
+        "path": "llm.apikey",
+        "title": "llm.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_XAI_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "mcp_client": {
+    "title": "mcp_client",
+    "fields": [
+      {
+        "path": "mcp_client.bearer",
+        "title": "mcp_client.bearer",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_MCP_CLIENT_MCP_CLIENT_BEARER",
+        "review": true
+      }
+    ]
+  },
+  "memory_persistent": {
+    "title": "memory_persistent",
+    "fields": [
+      {
+        "path": "memory.redis_password",
+        "title": "memory.redis_password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_PERSISTENT_REDIS_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "milvus": {
+    "title": "milvus",
+    "fields": [
+      {
+        "path": "Milvus Vector Store.apikey",
+        "title": "Milvus Vector Store.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_MILVUS_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "opensearch": {
+    "title": "opensearch",
+    "fields": [
+      {
+        "path": "opensearch.auth.password",
+        "title": "opensearch.auth.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_OPENSEARCH_OPENSEARCH_AUTH_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "pinecone": {
+    "title": "Pinecone",
+    "fields": [
+      {
+        "path": "Pinecone Vector Store.apikey",
+        "title": "Pinecone API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_PINECONE_APIKEY"
+      }
+    ],
+    "docs": "https://docs.pinecone.io/reference/api/introduction"
+  },
+  "postgres": {
+    "title": "postgres",
+    "fields": [
+      {
+        "path": "PostgreSQL Vector Store.password",
+        "title": "PostgreSQL Vector Store.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_POSTGRES_PASSWORD",
+        "review": true
+      },
+      {
+        "path": "vector.local.password",
+        "title": "vector.local.password",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_POSTGRES_VECTOR_LOCAL_PASSWORD",
+        "review": true
+      }
+    ]
+  },
+  "qdrant": {
+    "title": "Qdrant",
+    "fields": [
+      {
+        "path": "Qdrant Vector Store.apikey",
+        "title": "Qdrant API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_QDRANT_APIKEY"
+      }
+    ],
+    "docs": "https://qdrant.tech/documentation/"
+  },
+  "reducto": {
+    "title": "reducto",
+    "fields": [
+      {
+        "path": "reducto.api_key",
+        "title": "reducto.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_REDUCTO_REDUCTO_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "rerank_cohere": {
+    "title": "Cohere Rerank",
+    "fields": [
+      {
+        "path": "rerank.apikey",
+        "title": "Cohere API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_RERANK_COHERE_KEY"
+      }
+    ],
+    "docs": "https://docs.cohere.com/reference/rerank"
+  },
+  "search_exa": {
+    "title": "Exa Search",
+    "fields": [
+      {
+        "path": "search.apikey",
+        "title": "Exa API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_EXA_KEY"
+      },
+      {
+        "path": "search_exa.apikey",
+        "title": "Exa API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_EXA_KEY"
+      }
+    ],
+    "docs": "https://docs.exa.ai/reference/getting-started"
+  },
+  "telegram": {
+    "title": "telegram",
+    "fields": [
+      {
+        "path": "telegram.botToken",
+        "title": "telegram.botToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TELEGRAM_TELEGRAM_BOT_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_apify": {
+    "title": "tool_apify",
+    "fields": [
+      {
+        "path": "apify.apikey",
+        "title": "apify.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_APIFY_APIKEY",
+        "review": true
+      },
+      {
+        "path": "tool_apify.apikey",
+        "title": "tool_apify.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_APIFY_TOOL_APIFY_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_bland_ai": {
+    "title": "tool_bland_ai",
+    "fields": [
+      {
+        "path": "bland_ai.apikey",
+        "title": "bland_ai.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_BLAND_BLAND_AI_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_butterbase": {
+    "title": "tool_butterbase",
+    "fields": [
+      {
+        "path": "mcp_client.bearer",
+        "title": "mcp_client.bearer",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_BUTTERBASE_MCP_CLIENT_BEARER",
+        "review": true
+      }
+    ]
+  },
+  "tool_calendar": {
+    "title": "tool_calendar",
+    "fields": [
+      {
+        "path": "calendar.userToken",
+        "title": "calendar.userToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_CALENDAR_USER_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_cognee": {
+    "title": "tool_cognee",
+    "fields": [
+      {
+        "path": "cognee.api_key",
+        "title": "cognee.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_COGNEE_COGNEE_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_daytona": {
+    "title": "tool_daytona",
+    "fields": [
+      {
+        "path": "daytona.apikey",
+        "title": "daytona.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_DAYTONA_APIKEY",
+        "review": true
+      },
+      {
+        "path": "tool_daytona.apikey",
+        "title": "tool_daytona.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_DAYTONA_TOOL_DAYTONA_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_deepl": {
+    "title": "tool_deepl",
+    "fields": [
+      {
+        "path": "deepl.apikey",
+        "title": "deepl.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_DEEPL_APIKEY",
+        "review": true
+      },
+      {
+        "path": "tool_deepl.apikey",
+        "title": "tool_deepl.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_DEEPL_TOOL_DEEPL_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_docs": {
+    "title": "tool_docs",
+    "fields": [
+      {
+        "path": "docs.userToken",
+        "title": "docs.userToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_DOCS_USER_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_drive": {
+    "title": "tool_drive",
+    "fields": [
+      {
+        "path": "drive.userToken",
+        "title": "drive.userToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_DRIVE_USER_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_exa_search": {
+    "title": "tool_exa_search",
+    "fields": [
+      {
+        "path": "exa.apikey",
+        "title": "exa.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_EXA_APIKEY",
+        "review": true
+      },
+      {
+        "path": "tool_exa_search.apikey",
+        "title": "tool_exa_search.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_EXA_TOOL_EXA_SEARCH_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_excel": {
+    "title": "tool_excel",
+    "fields": [
+      {
+        "path": "excel.clientSecret",
+        "title": "Client Secret",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_EXCEL_CLIENT_SECRET",
+        "review": false
+      },
+      {
+        "path": "excel.userToken",
+        "title": "User Token (OAuth sign-in)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_EXCEL_USER_TOKEN",
+        "review": false
+      }
+    ]
+  },
+  "tool_firecrawl": {
+    "title": "tool_firecrawl",
+    "fields": [
+      {
+        "path": "firecrawl.apikey",
+        "title": "firecrawl.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_FIRECRAWL_APIKEY",
+        "review": true
+      },
+      {
+        "path": "tool_firecrawl.apikey",
+        "title": "tool_firecrawl.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_FIRECRAWL_TOOL_FIRECRAWL_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_git": {
+    "title": "tool_git",
+    "fields": [
+      {
+        "path": "git.token",
+        "title": "git.token",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GIT_GIT_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_github": {
+    "title": "GitHub",
+    "fields": [
+      {
+        "path": "github.token",
+        "title": "GitHub personal access token",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GITHUB_TOKEN"
+      }
+    ],
+    "docs": "https://docs.github.com/en/rest"
+  },
+  "tool_gmail": {
+    "title": "tool_gmail",
+    "fields": [
+      {
+        "path": "gmail.userToken",
+        "title": "gmail.userToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GMAIL_USER_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_gohighlevel": {
+    "title": "tool_gohighlevel",
+    "fields": [
+      {
+        "path": "gohighlevel.privateIntegrationToken",
+        "title": "gohighlevel.privateIntegrationToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GOHIGHLEVEL_GOHIGHLEVEL_PRIVATE_INTEGRATION_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_guild": {
+    "title": "Guild.ai",
+    "fields": [
+      {
+        "path": "guild.apiKeyId",
+        "title": "Guild API key ID",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GUILD_KEY_ID"
+      },
+      {
+        "path": "guild.apiKeySecret",
+        "title": "Guild API key secret",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GUILD_KEY_SECRET"
+      },
+      {
+        "path": "tool_guild.apiKeyId",
+        "title": "Guild API key ID",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GUILD_KEY_ID"
+      },
+      {
+        "path": "tool_guild.apiKeySecret",
+        "title": "Guild API key secret",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_GUILD_KEY_SECRET"
+      }
+    ],
+    "docs": "https://docs.guild.ai/"
+  },
+  "tool_mem0": {
+    "title": "tool_mem0",
+    "fields": [
+      {
+        "path": "mem0.api_key",
+        "title": "mem0.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_MEM0_MEM0_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_n8n": {
+    "title": "tool_n8n",
+    "fields": [
+      {
+        "path": "n8n.apiKey",
+        "title": "n8n.apiKey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_N8N_API_KEY",
+        "review": true
+      },
+      {
+        "path": "n8n.webhookToken",
+        "title": "n8n.webhookToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_N8N_WEBHOOK_TOKEN",
+        "review": true
+      },
+      {
+        "path": "tool_n8n.apiKey",
+        "title": "tool_n8n.apiKey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_N8N_TOOL_N8N_API_KEY",
+        "review": true
+      },
+      {
+        "path": "tool_n8n.webhookPassword",
+        "title": "tool_n8n.webhookPassword",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_PASSWORD",
+        "review": true
+      },
+      {
+        "path": "tool_n8n.webhookToken",
+        "title": "tool_n8n.webhookToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_N8N_TOOL_N8N_WEBHOOK_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_onedrive": {
+    "title": "tool_onedrive",
+    "fields": [
+      {
+        "path": "onedrive.clientSecret",
+        "title": "Client Secret",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_ONEDRIVE_CLIENT_SECRET",
+        "review": false
+      },
+      {
+        "path": "onedrive.userToken",
+        "title": "User Token (OAuth sign-in)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_ONEDRIVE_USER_TOKEN",
+        "review": false
+      }
+    ]
+  },
+  "tool_oura": {
+    "title": "tool_oura",
+    "fields": [
+      {
+        "path": "oura.token",
+        "title": "oura.token",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_OURA_OURA_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_outlook_calendar": {
+    "title": "tool_outlook_calendar",
+    "fields": [
+      {
+        "path": "outlook_calendar.clientSecret",
+        "title": "Client Secret",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_OUTLOOK_CALENDAR_CLIENT_SECRET",
+        "review": false
+      },
+      {
+        "path": "outlook_calendar.userToken",
+        "title": "User Token (OAuth sign-in)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_OUTLOOK_CALENDAR_USER_TOKEN",
+        "review": false
+      }
+    ]
+  },
+  "tool_outlook_mail": {
+    "title": "tool_outlook_mail",
+    "fields": [
+      {
+        "path": "outlook_mail.clientSecret",
+        "title": "Client Secret",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_OUTLOOK_MAIL_CLIENT_SECRET",
+        "review": false
+      },
+      {
+        "path": "outlook_mail.userToken",
+        "title": "User Token (OAuth sign-in)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_OUTLOOK_MAIL_USER_TOKEN",
+        "review": false
+      }
+    ]
+  },
+  "tool_pipedrive": {
+    "title": "tool_pipedrive",
+    "fields": [
+      {
+        "path": "pipedrive.apiToken",
+        "title": "pipedrive.apiToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_PIPEDRIVE_PIPEDRIVE_API_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_sheets": {
+    "title": "tool_sheets",
+    "fields": [
+      {
+        "path": "sheets.userToken",
+        "title": "sheets.userToken",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_SHEETS_USER_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_slack": {
+    "title": "tool_slack",
+    "fields": [
+      {
+        "path": "slack.token",
+        "title": "slack.token",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_SLACK_SLACK_TOKEN",
+        "review": true
+      }
+    ]
+  },
+  "tool_tavily": {
+    "title": "tool_tavily",
+    "fields": [
+      {
+        "path": "tavily.apikey",
+        "title": "tavily.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TAVILY_APIKEY",
+        "review": true
+      },
+      {
+        "path": "tool_tavily.apikey",
+        "title": "tool_tavily.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TAVILY_TOOL_TAVILY_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_v0": {
+    "title": "tool_v0",
+    "fields": [
+      {
+        "path": "v0.apikey",
+        "title": "v0.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TOOL_V0_APIKEY",
+        "review": true
+      },
+      {
+        "path": "tool_v0.apikey",
+        "title": "tool_v0.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TOOL_V0_TOOL_V0_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "tool_word": {
+    "title": "tool_word",
+    "fields": [
+      {
+        "path": "word.clientSecret",
+        "title": "Client Secret",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_WORD_CLIENT_SECRET",
+        "review": false
+      },
+      {
+        "path": "word.userToken",
+        "title": "User Token (OAuth sign-in)",
+        "kind": "secret",
+        "required": false,
+        "suggests": "ROCKETRIDE_WORD_USER_TOKEN",
+        "review": false
+      }
+    ]
+  },
+  "tool_xtrace_memory": {
+    "title": "tool_xtrace_memory",
+    "fields": [
+      {
+        "path": "xtrace.api_key",
+        "title": "xtrace.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_XTRACE_API_KEY",
+        "review": true
+      },
+      {
+        "path": "xtrace_memory.api_key",
+        "title": "xtrace_memory.api_key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_XTRACE_XTRACE_MEMORY_API_KEY",
+        "review": true
+      }
+    ]
+  },
+  "tts_elevenlabs": {
+    "title": "ElevenLabs Text to Speech",
+    "fields": [
+      {
+        "path": "tts_elevenlabs.apikey",
+        "title": "ElevenLabs API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TTS_ELEVENLABS_KEY"
+      }
+    ],
+    "docs": "https://elevenlabs.io/docs/api-reference/introduction"
+  },
+  "tts_openai": {
+    "title": "OpenAI Text to Speech",
+    "fields": [
+      {
+        "path": "tts_openai.apikey",
+        "title": "OpenAI TTS API key",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TTS_OPENAI_KEY"
+      }
+    ],
+    "docs": "https://platform.openai.com/docs/guides/text-to-speech"
+  },
+  "twelvelabs": {
+    "title": "twelvelabs",
+    "fields": [
+      {
+        "path": "twelvelabs.apikey",
+        "title": "twelvelabs.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_TWELVELABS_APIKEY",
+        "review": true
+      }
+    ]
+  },
+  "weaviate": {
+    "title": "weaviate",
+    "fields": [
+      {
+        "path": "Weaviate Vector Store.apikey",
+        "title": "Weaviate Vector Store.apikey",
+        "kind": "secret",
+        "required": true,
+        "suggests": "ROCKETRIDE_WEAVIATE_APIKEY",
+        "review": true
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## What this adds

The verdict node of the Hack Judge suite. Given a GitHub repository and a target product definition, it returns a deterministic verdict: tag (Significant / Moderate / Less / None), a backbone read, the evidence behind every point, `kb_processed` for metering, and a ready explain prompt a downstream LLM node can use for the plain-English explanation. No LLM in the verdict itself: same repo, same target, same answer.

The engine is vendored under `_engine/` (see `VENDORED.md` for provenance) and is deliberately self-contained: no rocketlib or ai imports, which is also what makes the offline tests possible.

## Correctness property worth calling out

A failed raw-file fetch used to read as an empty file, which could silently shrink evidence on an unstable network. Both gather paths now count non-200 fetches and return `fetch_incomplete` so the caller retries the repository instead of trusting partial evidence. There is a dedicated test for this.

## Validation

- Byte-identical verdicts against the production Hack Judge server on the full 21-repo acceptance set, exact KB settlement, roughly 2x faster than the server path.
- Offline pytest suite (`nodes/test/hackjudge_engine`) drives the real gather + evaluate against a stubbed GitHub: deterministic verdict from controlled evidence, the fetch-failure guard, inaccessible repos.
- Exercised end to end in a five-node verify pipeline together with the account, store and tokens nodes (their PRs are siblings of this one: `feat/hackjudge-account-node`, `feat/hackjudge-store-node`, `feat/hackjudge-tokens-node`).

## Notes for reviewers

- In the verify flow the node acts only on records addressed `{"flow": "verify", "next": "engine"}` and forwards everything else, so several nodes share one questions lane safely.
- Two platform observations from building this, happy to file as separate issues: (1) the current engine image cannot boot clean because `onnxruntime-gpu==1.20.1` is pinned in five requirement files and that version has been removed from PyPI; (2) a written question is delivered to every questions-consumer on the lane, not only the wired edge. The flow envelope handles it, but a line in the node-authoring docs would save the next team the surprise.

Part of the Hack Judge suite: four independently mergeable node PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic repository verification and scoring through the Hack Judge Engine.
  - Provides structured verdicts with classifications, scores, evidence, explanations, and fetch-status details.
  - Supports configurable verification targets and secure GitHub access settings.
  - Routes incomplete, invalid, or inaccessible jobs without scoring unreliable evidence.

- **Documentation**
  - Added setup, configuration, output, validation, and engine provenance guidance.

- **Tests**
  - Added offline coverage for successful evaluations, incomplete fetches, URL handling, and inaccessible repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->