### PR TITLE
seo(docs): add Bing Webmaster verification meta tag

### DIFF
--- a/packages/docs/docusaurus.config.ts
+++ b/packages/docs/docusaurus.config.ts
@@ -27,6 +27,28 @@ const config: Config = {
 	url: 'https://docs.rocketride.org/',
 	baseUrl: '/',
 
+	// Bing Webmaster site verification. Docusaurus injects this into every page's
+	// <head> at build time, which is what Bing's crawler scans. Renders only on
+	// docs.rocketride.org (this package is built and deployed by .github/workflows/
+	// docs.yml to GitHub Pages; the docs subpackage is NOT bundled into any
+	// self-hosted RocketRide install, so the tag does not ride into other people's
+	// deployments).
+	//
+	// The same tag verifies rocketride.org (Webflow head code) and
+	// news.rocketride.ai (Ghost code injection); Bing issues one tag per account.
+	// Public value, safe to commit: it proves domain ownership to Bing but grants
+	// no capability by itself. Do not remove after verification succeeds -- removal
+	// drops the verification per Bing's own guidance.
+	headTags: [
+		{
+			tagName: 'meta',
+			attributes: {
+				name: 'msvalidate.01',
+				content: '3A430890C971A1BA3BAEA33678904734',
+			},
+		},
+	],
+
 	// Inter for body + headings (loaded from Google Fonts).
 	stylesheets: ['https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap'],
 


### PR DESCRIPTION
## Summary

Adds a single Bing Webmaster verification meta tag to `packages/docs/docusaurus.config.ts` via Docusaurus `headTags`. Renders into every `docs.rocketride.org` page's `<head>` at build time, which is what Bing's crawler scans for site verification.

```html
<meta name="msvalidate.01" content="3A430890C971A1BA3BAEA33678904734" />
```

## Why now

SEO program is being kicked off (Mithilesh, 2026-08-27 runbook). The KPI row "Pages indexed (Bing + Google)" currently reads `unmeasured`. Bing coverage matters specifically because ChatGPT retrieves from Bing's index — being absent from Bing means being invisible in ChatGPT answers regardless of content quality. The Bing property for `docs.rocketride.org` is already added on the Webmaster side; it's Not verified until this tag ships.

Same tag verifies `rocketride.org` (Webflow head code, in flight) and `news.rocketride.ai` (Ghost code injection, in flight). Bing issues one tag per account.

## Scoping and safety

The `packages/docs` subpackage is built and deployed **only** by `.github/workflows/docs.yml` to GitHub Pages under `docs.rocketride.org`. It is NOT bundled into any self-hosted RocketRide install (grep confirms no `packages/docs` reference in the Dockerfile, docker-compose, or release workflows), so this tag does not ride into other people's deployments.

The tag value is public information by design — it proves domain ownership to Bing but grants no capability by itself. Committing it in a public MIT repo is safe.

## Test plan

- [ ] CI: `Docs` workflow builds green
- [ ] After merge + deploy: `curl -s https://docs.rocketride.org/ | grep msvalidate` returns the meta tag
- [ ] Bing Webmaster Tools: click Verify on `https://docs.rocketride.org/` → status flips to Verified

## Do not remove

Per Bing's own guidance, removing the tag after verification succeeds drops the verification. The tag stays.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Bing Webmaster verification metadata to documentation pages.
  * Enables site ownership verification through Bing Webmaster Tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->